### PR TITLE
provide official opensuse spec file with darktable.changes

### DIFF
--- a/packaging/opensuse/darktable.changes
+++ b/packaging/opensuse/darktable.changes
@@ -1,0 +1,216 @@
+-------------------------------------------------------------------
+Sat Apr 28 06:48:17 UTC 2012 - toganm@opensuse.org
+
+- Update to release 1.0.3
+  + Usability improvements:
+    * Filmstrip centers on selected image
+  + Behavioral changes:
+    * Improved (hierarchical) tag export for flickr and friends
+  + Camera support:
+    * Improved Sony NEX-7 support
+    * Initial camera support for Nikon D800 and Sony SLT-A57
+    * White balance updates for Canon EOS Rebel T3, Olympus E-5 & Nikon
+      D800
+  + Various:
+    * New subtle denoise preset for equalizer
+    * Various build fixes
+    * Numerous other fixes
+ 
+
+-------------------------------------------------------------------
+Thu Mar 15 07:52:17 UTC 2012 - toganm@opensuse.org
+
+- Upgrade to release 1.0
+  + new cameras supported
+    * Leica M9
+    * NX100/NX5/NX10/NX11
+    * Panasonic DMC-GX1
+    * Pentax K-r
+    * Canon Powershot S100
+    * Olympus XZ-1
+    * Olympus E-P3
+    * Sony DSLR A330
+    * Sony NEX-5N
+    * Canon EOS 1000D
+    * Canon EOS 600D
+    * Sony Alpha 390
+    * Fuji Finepix HS20EXR 
+  + new and updated translations (we now have chinese!)
+  + new image cache
+    * faster concurrent access and insertion
+    * reduces needed memory
+    * more thumbnails stored on disk
+    * read embedded jpegs for creating thumbnails (faster folder
+      import)
+  + increased general speed on sqlite3 (journaled, pagesize
+    optimizations)
+  + reworked, modular ui
+  + keyboard shortcuts support - key accelerators (GSoC)
+  + quicktool bar: exposure, presets and styles
+  + new color picker
+  + web gallery export now with next/prev buttons per image
+  + removed gconf: not used anymore, we have our own backend
+  + bugfixes
+  + there have been issues with memory on 32-bit systems. seems to
+    be okay currently, but something to keep in mind. use 64-bits
+    if you can
+-------------------------------------------------------------------
+Tue Feb 28 12:06:27 UTC 2012 - fcrozat@suse.com
+
+- Add darktable-fix-deprecation.patch to fix glib deprecation.
+
+-------------------------------------------------------------------
+Tue Nov  8 09:07:37 UTC 2011 - toganm@opensuse.org
+
+- Upgrade to release 0.9.3:
+  + sse optimizations
+    * non-local means
+    * graduated density
+    * velvia
+    * color management
+    * equalizer
+    * zone system
+
+  + updated translations
+    * ru,fr,es,ja,it,sq,pl,nl,de
+
+  + more presets
+    * split toning
+    * tone curve
+    * equalizer
+    * color zones
+
+  + lots of bugfixes
+    * tiling code (low mem/opencl)
+    * gcc 4.6 compat
+  + updates
+    * libraw 0.14b2
+    * rawspeed r379
+   as well as more basecurves and color matrices.
+
+- added Mesa-devel to BuildRequires
+-------------------------------------------------------------------
+Sun Sep 18 17:17:12 UTC 2011 - jengelh@medozas.de
+
+- Remove redundant tags/sections from specfile
+  (cf. packaging guidelines)
+
+-------------------------------------------------------------------
+Tue Sep 13 22:36:51 UTC 2011 - toganm@opensuse.org
+
+- Added dbus-1-glib-devel to BuildRequires 
+
+-------------------------------------------------------------------
+Sat Sep  3 13:13:43 UTC 2011 - toganm@opensuse.org
+
+- Update to bugfix release 0.9.2:
+  + there are no new features, just
+    * updated translations
+    * tiling for memory hungry operations and as workaround for old
+      opencl 1.0 drivers
+    * new color matrices and white balance presets
+    * a lot of stability issues have been resolved
+    * a lot of performance improvements (more sse code, better
+      opencl code)
+  + Removed 0001-Remove-dependancy-on-git.patch
+-------------------------------------------------------------------
+Tue Jul 26 07:14:25 UTC 2011 - toganm@opensuse.org
+
+- Updated to bugfix release 0.9.1 
+  + new rawspeed, dcraw, libraw
+  + fixed various segfaults and deadlocks
+  + the pipeline is now more real HDR (no more gamut clipping in
+    between)
+  + fixed a nasty bug which could cause complete loss of history
+    for an image
+  + darktable-faster now plays nicely with darktablerc (non-gconf)
+  + lots of opencl improvements
+  + updated translations
+  + second part of our GSoC: customizable keyboard shortcuts!
+
+
+
+-------------------------------------------------------------------
+Tue Jul  5 13:56:48 UTC 2011 - toganm@opensuse.org
+
+-Release 0.9:
+    + run-time switchable opencl to exploit all the power of your GPU
+      whenever you decide to install the driver
+    + many new plugins, including a spot removal tool, better denoising
+      (on raw pixels and non-local means) and many more
+    + blend operations, overlay your plugin only 20 percent if you want
+    + spot removal tool
+    + low light vision tool
+    + non-local-means denoising (relatively fast for nlmeans, but still
+      slow)
+    + first part of the google summer of code project
+      already merged
+    + framing plugin (adds postcard borders to match
+      given aspect ratio)
+    + tonemapping a lot faster now (probably the fastest high-dimensional
+      bilateral filter)
+    + changed images come with the darktable|changed tag
+
+- removed darktable-08 related patches as they are now in the upstream
+- use RPM optflags
+-------------------------------------------------------------------
+Fri Jun 17 16:14:09 UTC 2011 - fcrozat@suse.com
+
+- Add darktable-0.8-unused_variables.patch and
+  darktable-0.8-clean_up_set_but_unused_variables.patch to fix
+  build with gcc 4.6
+- Add darktable-0.8-default_generic_optimizations.patch and
+  darktable-0.8-binary_package_build.patch: don't optimize build
+  for build system.
+- Ensure package is build with debuginfo.
+
+-------------------------------------------------------------------
+Fri Jun 10 13:39:01 UTC 2011 - fcrozat@suse.com
+
+- Add libflickcurl-devel BuildRequires to get Flickr upload
+  support.
+
+-------------------------------------------------------------------
+Thu Mar  3 23:20:59 UTC 2011 - toganm@opensuse.org
+
+- Fix building for x86_64  
+
+-------------------------------------------------------------------
+Wed Feb 23 16:45:28 UTC 2011 - fcrozat@novell.com
+
+- Release 0.8:
+  + much faster image loading due to rawspeed, an awesome new
+    library by klaus post @rawstudio
+  + lots of performance improvements in our caches and pixel
+    pipelines (together with the above like 5x--10x)
+  + gpu computing using opencl (for graphics boards that support
+    it) for a lot of common plugins, to give a huge performance
+    boost
+  + overhauled collection plugin for more flexible image
+    collections
+  + metadata editor (set author and copyright information etc)
+  + fast demosaicing now done on roi and in floating point
+  + HDR bracketing and tone mapping (somewhat experimental)
+  + flickr upload
+  + lots of new color matrices and white balance presets
+  + lots of bugfixes
+  + Updated translations
+
+-------------------------------------------------------------------
+Mon Dec 13 13:53:26 UTC 2010 - fcrozat@novell.com
+
+- Release 0.7.1 : 
+ * some more white balance presets
+ * layout fixes for overlong profile names
+ * styles now actually work
+
+-------------------------------------------------------------------
+Tue Nov 23 16:04:01 UTC 2010 - bitshuffler@opensuse.org
+
+- Update to 0.7.
+
+-------------------------------------------------------------------
+Wed Sep  1 17:52:38 UTC 2010 - bitshuffler@opensuse.org
+
+- Initial package
+

--- a/packaging/opensuse/darktable.spec
+++ b/packaging/opensuse/darktable.spec
@@ -1,100 +1,99 @@
 #
-# spec file for package darktable (Version 0.8)
+# spec file for package darktable
 #
-# Copyright (c) 2011 Ulrich Pegelow
-# This file and all modifications and additions to the pristine
-# package are under the same license as the package itself.
+# Copyright (c) 2012 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-# norootforbuild
 
-Name:		darktable
-Version:	0.8
-Release:	1.1
-License:	GPLv3+
-Summary:	Raw Photo Viewer and Organiser
-URL:		http://www.darktable.org/
-Group:		Productivity/Graphics/Viewers
-Source0:	%{name}-%{version}.tar.gz
-BuildRequires:	gcc-c++ libglade2-devel libtiff-devel cairo-devel libexiv2-devel
-BuildRequires:	sqlite3-devel lensfun-devel liblcms-devel
-BuildRequires:	intltool update-desktop-files fdupes
-BuildRoot:	%{_tmppath}/%{name}-%{version}-build
+Name:           darktable
+Version:        1.0.3
+Release:        0
+Url:            http://darktable.sourceforge.net
+Source0:        %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  Mesa-devel
+BuildRequires:  OpenEXR-devel
+BuildRequires:  cmake
+BuildRequires:  dbus-1-glib-devel
+BuildRequires:  fdupes
+BuildRequires:  gcc-c++
+BuildRequires:  gnome-keyring-devel
+BuildRequires:  gtk2-devel
+BuildRequires:  intltool
+BuildRequires:  lensfun-devel
+BuildRequires:  libcurl-devel
+BuildRequires:  libexiv2-devel
+BuildRequires:  libflickcurl-devel
+BuildRequires:  libglade2-devel
+BuildRequires:  libgphoto2-devel
+BuildRequires:  libjpeg-devel
+BuildRequires:  liblcms2-devel
+BuildRequires:  librsvg-devel
+BuildRequires:  libtiff-devel
+BuildRequires:  pkg-config
+BuildRequires:  sqlite3-devel
+BuildRequires:  update-desktop-files
+
+Summary:        A virtual Lighttable and Darkroom
+License:        GPL-3.0+
+Group:          Productivity/Graphics/Viewers
 
 %description
-darktable is a virtual lighttable and darkroom for photographers: it manages
-your digital negatives in a database and lets you view them through a zoomable
+darktable is a virtual lighttable and darkroom for photographers: it manages 
+your digital negatives in a database and lets you view them through a zoomable 
 lighttable. it also enables you to develop raw images and enhance them.
 
-Authors:
---------
-    Alexander Rabtchevich
-    Alexandre Prokoudine
-    Christian Himpel
-    Gregor Quade
-    Henrik Andersson
-    Johannes Hanika
-    Pascal de Bruijn
-    Richard Hughes
-    Sébastien Delcoigne
-    Thomas Costis
-
-
-%define prefix   /usr
 
 %prep
-
 %setup -q
 
 %build
-
-export CXXFLAGS="$RPM_OPT_FLAGS"  
-export CFLAGS="$CXXFLAGS" 
-
-mkdir -p build
+[ ! -d "build" ] && mkdir  build
 cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=%prefix -DCMAKE_BUILD_TYPE=Release \
-	-DINSTALL_IOP_EXPERIMENTAL=OFF -DINSTALL_IOP_LEGACY=ON ..
+export CXXFLAGS="%{optflags} -fno-strict-aliasing "  
+export CFLAGS="$CXXFLAGS"
 
-make %{?jobs:-j %jobs} 
+cmake \
+        -DCMAKE_INSTALL_PREFIX=%{_prefix} -DLIB_INSTALL=%{_lib} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBINARY_PACKAGE_BUILD=1 \
+        -DINSTALL_IOP_EXPERIMENTAL=Off -DINSTALL_IOP_LEGACY=Off .. 
+%__make %{_smp_mflags} VERBOSE=1
 
 %install
-
 cd build
-make install DESTDIR="$RPM_BUILD_ROOT"
+%make_install
+cd ..
+%suse_update_desktop_file darktable
+find %{buildroot}%{_libdir} -name "*.la" -delete
+%find_lang darktable
 
-mkdir -p %{buildroot}/usr/share/doc/packages
-%{__mv} %{buildroot}%{_datadir}/doc/%{name} %{buildroot}/usr/share/doc/packages
-%find_lang %{name}
-%suse_update_desktop_file -i %{name}
-%fdupes -s %{buildroot}%{_datadir}
+%__mkdir_p %{buildroot}%{_defaultdocdir}
+%__mv %{buildroot}%{_datadir}/doc/darktable %{buildroot}%{_defaultdocdir}
 
+%fdupes %{buildroot}
 
-
-%clean
-[ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
-
-%pre -f build/%{name}.schemas_pre
-
-%preun -f build/%{name}.schemas_preun
-
-%posttrans -f build/%{name}.schemas_posttrans
-
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
-
-%files -f build/%{name}.lang -f build/%{name}.schemas_list
+%files -f darktable.lang
 %defattr(-,root,root)
-%doc %{_defaultdocdir}/%{name}
-%{_bindir}/*
-%{_datadir}/%{name}
-%{_libdir}/%{name}
-%{_mandir}/man1/*
-%{_datadir}/applications/%{name}.desktop
-/usr/share/icons/*/*/apps/darktable.*
+%doc doc/AUTHORS doc/TODO doc/LICENSE
+%{_bindir}/darktable
+%{_bindir}/darktable-cltest
+%{_libdir}/darktable
+%{_datadir}/applications/darktable.desktop
+%{_datadir}/darktable
+%{_datadir}/icons/hicolor/*/apps/darktable.*
+%{_mandir}/man1/darktable.1.*
 
 %changelog
-* Sat May 14 2011 - ulrich.pegelow@tongareva.de
-- Initial release


### PR DESCRIPTION
For a long time the opensuse spec file in the git sources have not been reflective to the actual opensuse spec file this commits provides the official spec file for opensuse packages
