### PR TITLE
*BSD: Don't define _XOPEN_SOURCE

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -19,7 +19,10 @@
 #define DARKTABLE_H
 
 // just to be sure. the build system should set this for us already:
-#ifndef _XOPEN_SOURCE
+#if defined __DragonFly__ || defined __FreeBSD__ || \
+    defined __NetBSD__ || defined __OpenBSD__
+  #define _WITH_DPRINTF
+#elif !defined _XOPEN_SOURCE
   #define _XOPEN_SOURCE 700 // for localtime_r and dprintf
 #endif
 #ifdef HAVE_CONFIG_H

--- a/src/common/file_location.c
+++ b/src/common/file_location.c
@@ -17,11 +17,15 @@
 */
 
 /* getpwnam_r availibility check */
-#if defined __APPLE__ || defined _POSIX_C_SOURCE >= 1 || defined _XOPEN_SOURCE || defined _BSD_SOURCE || defined _SVID_SOURCE || defined _POSIX_SOURCE
+#if defined __APPLE__ || defined _POSIX_C_SOURCE >= 1 || \
+    defined _XOPEN_SOURCE || defined _BSD_SOURCE || defined _SVID_SOURCE || \
+    defined _POSIX_SOURCE || defined __DragonFly__ || defined __FreeBSD__ || \
+    defined __NetBSD__ || defined __OpenBSD__
 #include <pwd.h>
 #include <sys/types.h>
 #include "darktable.h"
 #include "config.h"
+#define HAVE_GETPWNAM_R 1
 #endif
 
 #ifdef HAVE_CONFIG_H
@@ -37,7 +41,7 @@ gchar* dt_loc_get_home_dir(const gchar* user)
     return g_strdup((home_dir != NULL) ? home_dir : g_get_home_dir());
   }
 
-#if defined _POSIX_C_SOURCE >= 1 || defined _XOPEN_SOURCE || defined _BSD_SOURCE || defined _SVID_SOURCE || defined _POSIX_SOURCE
+#if defined HAVE_GETPWNAM_R
   /* if the given username is not the same as the current one, we try
    * to retreive the pw dir from the password file entry */
   struct passwd pwd;

--- a/src/common/points.h
+++ b/src/common/points.h
@@ -22,7 +22,9 @@
 
 // lamer version for obsolete archs:
 
-#ifndef _XOPEN_SOURCE
+#if !defined _XOPEN_SOURCE && \
+    !defined(__DragonFly__) && !defined(__FreeBSD__) && \
+    !defined(__NetBSD__) && !defined(__OpenBSD__)
 #define _XOPEN_SOURCE
 #endif
 


### PR DESCRIPTION
Unlike Linux, defining _XOPEN_SOURCE on *BSD will restrict the namespace
to what X/Open defines, hiding other symbols.

And by default, _XOPEN_SOURCE, _BSD_SOURCE, _POSIX_SOURCE, etc. are not
defined. They are defined only when the namespace is restricted to one
of them.
