### PR TITLE
Feature #8758 - enable/disable overwriting files during disk export

### DIFF
--- a/data/darktableconfig.xml
+++ b/data/darktableconfig.xml
@@ -812,6 +812,13 @@
     <shortdescription>ask before deleting a tag</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig prefs="gui">
+    <name>plugins/imageio/storage/disk/overwrite_existing_files</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>overwrite existing files when export to disk</shortdescription>
+    <longdescription>if checked, export module will overwrite existing files! You can override this using export module checkbox</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>ui_last/expander_metadata</name>
     <type>int</type>

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -244,7 +244,6 @@ void dt_gui_preferences_show()
     gtk_tree_path_free(darktable.control->accel_remap_path);
     darktable.control->accel_remap_path = NULL;
   }
-
 }
 
 static void tree_insert_presets(GtkTreeStore *tree_model){


### PR DESCRIPTION
- Add checkbutton in disk export module
- Add new option in gui tab preference
## Notes:
1. todo-> update checkbutton when exit option dialog
2. choose if reset to default (option value) the checkbutton value after image export
