### PR TITLE
Add doubleclick to reset support to levels module

### DIFF
--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -504,23 +504,6 @@ static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *e
   return TRUE;
 }
 
-/** Reset the module and redraws the gui */
-static void dt_iop_levels_reset(dt_iop_module_t *self)
-{
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
-  dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
-
-  p->levels[0] = 0;
-  p->levels[1] = 0.5;
-  p->levels[2] = 1;
-  p->levels_preset = 0;
-
-  c->drag_start_percentage = 0.5;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-  gtk_widget_queue_draw(self->widget);
-}
-
 static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
   // set active point
@@ -529,7 +512,16 @@ static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *ev
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
 
     if(event->type == GDK_2BUTTON_PRESS) {
-      dt_iop_levels_reset(self);
+      // Reset
+      dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+      memcpy(self->params, self->default_params, self->params_size);
+
+      // Needed in case the user scrolls or drags immediately after a reset,
+      // as drag_start_percentage is only updated when the mouse is moved.
+      c->drag_start_percentage = 0.5;
+
+      dt_dev_add_history_item(darktable.develop, self, TRUE);
+      gtk_widget_queue_draw(self->widget);
     } else {
       dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
       c->dragging = 1;

--- a/src/iop/levels.h
+++ b/src/iop/levels.h
@@ -69,8 +69,6 @@ void gui_cleanup  (struct dt_iop_module_t *self);
 
 void process (struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out);
 
-static void dt_iop_levels_reset(dt_iop_module_t *self);
-
 static gboolean dt_iop_levels_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_data);
 static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data);
 static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data);


### PR DESCRIPTION
New: Doubleclick resets the levels module.

(Second attempt, this time resetting the module the hanatos way.)
