### PR TITLE
Issue #8644 - switching plugins on and off expands/retracts plugins

### DIFF
--- a/data/darktableconfig.xml
+++ b/data/darktableconfig.xml
@@ -127,6 +127,14 @@
     <shortdescription>number of folder levels to show in lists</shortdescription>
     <longdescription>the number of folder levels to show in film roll names, starting from the right</longdescription>
   </dtconfig>
+  <dtconfig prefs="gui">
+    <name>darkroom/ui/expand_enabled_plugin</name>
+    <type>bool</type>
+    <default>TRUE</default>
+    <shortdescription>expand panel plugin when enabled/disabled</shortdescription>
+    <longdescription>If selected, automatically open and close plugin panels, when plugin is switched on/off.</longdescription>
+  </dtconfig>
+
   <dtconfig>
     <name>config_version</name>
     <type>int</type>

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -412,7 +412,7 @@ dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)
     else module->enabled = 0;
     dt_dev_add_history_item(module->dev, module, FALSE);
     // close parent expander.
-    dt_iop_gui_set_expanded(module, module->enabled);
+    if (dt_conf_get_bool("darkroom/ui/expand_enabled_plugin")) dt_iop_gui_set_expanded(module, module->enabled);
   }
   char tooltip[512];
   snprintf(tooltip, 512, module->enabled ? _("%s is switched on") : _("%s is switched off"), module->name());


### PR DESCRIPTION
- Add new option in global preferences to choose if autoexpand module panel when switch on/off
