### PR TITLE
read ratings from xmp metadata on import

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -348,7 +348,7 @@ int dt_exif_read(dt_image_t *img, const char* path)
       int stars = xmpPos->toLong();
       if ( stars == 0 )
       {
-        stars = 1;
+        stars = dt_conf_get_int("ui_last/import_initial_rating");
       }
       else 
       {


### PR DESCRIPTION
The new Canon 7D firmware has the ability to set ratings in-camera. They are saved in the XMP property Xmp.xmp.Rating (from 0 to 5). Note that, unlike darktable, Canon sets this value to 0 by default, even for photos that were not rated using the new tool, so this is a change in behavior.
