### PR TITLE
allow initial star rating of 5

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -395,7 +395,7 @@ uint32_t dt_image_import(const int32_t film_id, const char *filename, gboolean o
   sqlite3_finalize(stmt);
 
   uint32_t flags = dt_conf_get_int("ui_last/import_initial_rating");
-  if(flags < 0 || flags > 4)
+  if(flags < 0 || flags > 5)
   {
     flags = 1;
     dt_conf_set_int("ui_last/import_initial_rating", 1);


### PR DESCRIPTION
initial import rating was constrained to 0..4 on import (not in the gui), and when set to 5, was reset to 1 on import
