### PR TITLE
add filter selecting only unrejected images.

### DIFF
--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -106,7 +106,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_combo_box_append_text(GTK_COMBO_BOX(widget), "★ ★ ★ ★ +");
   gtk_combo_box_append_text(GTK_COMBO_BOX(widget), "★ ★ ★ ★ ★ ");
   gtk_combo_box_append_text(GTK_COMBO_BOX(widget), _("rejected only"));
-  gtk_combo_box_append_text(GTK_COMBO_BOX(widget), _("unrejected only"));
+  gtk_combo_box_append_text(GTK_COMBO_BOX(widget), _("all but rejected"));
 
   /* select the last selected value */
   gtk_combo_box_set_active(GTK_COMBO_BOX(widget),


### PR DESCRIPTION
A discussion on the dt users list showed that currently there is no way in DT to display only images which are not rejected (or have 0+ stars respectively). This is a problem if people choose to import their images with a initial zero star rating as they can only select to filter for 1+ or 0 stars, but not 0+ stars.

This patch adds the missing 0+ stars (or "unrejected only") filter. Please review.
