### PR TITLE
Update the 'active' group of modules automatically when history changes

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -138,7 +138,10 @@ dt_history_copy_and_paste_on_image (int32_t imgid, int32_t dest_imgid, gboolean 
 
   /* if current image in develop reload history */
   if (dt_dev_is_current_image(darktable.develop, dest_imgid))
+  {
     dt_dev_reload_history_items (darktable.develop);
+    dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
+  }
 
   /* update xmp file */
   dt_image_synch_xmp(dest_imgid);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -220,7 +220,10 @@ dt_styles_apply_to_image(const char *name,gboolean duplicate, int32_t imgid)
 
     /* if current image in develop reload history */
     if (dt_dev_is_current_image(darktable.develop, imgid))
+    {
       dt_dev_reload_history_items (darktable.develop);
+      dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
+    }
 
     /* update xmp file */
     dt_image_synch_xmp(imgid);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -217,6 +217,7 @@ static void _lib_history_compress_clicked_callback (GtkWidget *widget, gpointer 
   sqlite3_finalize(stmt);
 
   dt_dev_reload_history_items(darktable.develop);
+  dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }
 
 static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer user_data)
@@ -244,6 +245,7 @@ static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer use
   /* revert to given history item. */
   long int num = (long int)g_object_get_data(G_OBJECT(widget),"history-number");
   dt_dev_pop_history_items (darktable.develop, num);
+  dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 
 }
 


### PR DESCRIPTION
This is the pull request implementing the changes discussed at http://darktable.org/redmine/issues/8908
