### PR TITLE
Display the full localized name of operation in styles creation dialog.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -160,8 +160,9 @@ dt_history_get_items(int32_t imgid)
     char name[512]= {0};
     dt_history_item_t *item=g_malloc (sizeof (dt_history_item_t));
     item->num = sqlite3_column_int (stmt, 0);
-    g_snprintf(name,512,"%s (%s)",sqlite3_column_text (stmt, 1),(sqlite3_column_int (stmt, 2)!=0)?_("on"):_("off"));
+    g_snprintf(name,512,"%s (%s)",dt_iop_get_localized_name((char*)sqlite3_column_text(stmt, 1)), (sqlite3_column_int(stmt, 2)!=0)?_("on"):_("off"));
     item->name = g_strdup (name);
+    item->op = g_strdup((gchar *)sqlite3_column_text(stmt, 1));
     result = g_list_append (result,item);
   }
   return result;

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -39,6 +39,7 @@ void dt_history_delete_on_selection();
 typedef struct dt_history_item_t
 {
   guint num;
+  gchar *op;
   gchar *name;
 } dt_history_item_t;
 

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -310,7 +310,7 @@ _gui_styles_dialog_run (gboolean edit,const char *name,int imgid)
         GList *modules = g_list_first(darktable.develop->iop);
         if (modules)
         {
-          GList *result = g_list_find_custom (modules, item->name, _g_list_find_module_by_name); // (dt_iop_module_t *)(modules->data);
+          GList *result = g_list_find_custom (modules, item->op, _g_list_find_module_by_name); // (dt_iop_module_t *)(modules->data);
           if( result )
           {
             module = (dt_iop_module_t *)(result->data);
@@ -328,6 +328,7 @@ _gui_styles_dialog_run (gboolean edit,const char *name,int imgid)
                             DT_STYLE_ITEMS_COL_NUM, (guint)item->num,
                             -1);
 
+        g_free(item->op);
         g_free(item->name);
         g_free(item);
       }


### PR DESCRIPTION
This pull request implements a possible solution to this ticket: http://darktable.org/redmine/issues/8913
