### PR TITLE
Fix the deletion of colorlabels when operating on a selection in lighttable.

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -63,7 +63,7 @@ void dt_colorlabels_toggle_label_selection (const int color)
 {
   sqlite3_stmt *stmt;
   // store away all previously unlabeled images in selection:
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "insert into memory.color_labels_temp select a.imgid from selected_images as a join color_labels as b on a.imgid = b.imgid where b.color = ?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "insert or replace into memory.color_labels_temp select a.imgid from selected_images as a join color_labels as b on a.imgid = b.imgid where b.color = ?1", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, color);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);


### PR DESCRIPTION
This is a possible fix for the bug described here http://darktable.org/redmine/issues/8915

In more details: the problem lies in the fact that the `selected_images` table can contain multiple occurrences of the same `imgid`. This causes the insertion statement to fail because `PRIMARY KEY` is set on `cololabels_temp.imgid`.

I'm not familiar enough with darktable's inner workings to know if these duplicate entries in `selected_images` are normal or not. If not then it's there that the problem is really located and should be worked on, and this PR shouldn't be merged.
