### PR TITLE
Call show() on moduleslist items so that they show up correctly

### DIFF
--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -180,6 +180,7 @@ static void _lib_modulelist_populate_callback(gpointer instance, gpointer user_d
                        GTK_FILL | GTK_EXPAND | GTK_SHRINK,
                        GTK_SHRINK,
                        0, 0);
+      gtk_widget_show_all(module->showhide);
       if(ti < 5) ti++;
       else
       {


### PR DESCRIPTION
This PR should fix [#8919](http://darktable.org/redmine/issues/8919).

`gtk_widget_show_all` is called on moduleslist's before it is populated, so that it had no effect on widgets that are added later.
