### PR TITLE
Update image infos in dr mode when switching using keyboard

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -557,6 +557,9 @@ dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   // make signals work again, but only after focus event,
   // to avoid crop/rotate for example to add another history item.
   darktable.gui->reset = 0;
+  
+  int32_t mouse_over_id = dev->image_storage.id;
+  DT_CTL_SET_GLOBAL(lib_image_mouse_over_id, mouse_over_id);
 
   // prefetch next few from first selected image on.
   dt_view_filmstrip_prefetch();


### PR DESCRIPTION
When navigating between images in darkroom mode using keyboard shortcuts (space/backspace) the "image information" panel isn't updated until the mouse is moved.

This patch fixes this by raising the "mouse moved" signal when the image changes.

Although it works exactly as expected, I'm really unsure this is the best to do the trick. At least it works.

(Patch related to [#8827](http://darktable.org/redmine/issues/8827) and [#8953](http://darktable.org/redmine/issues/8953)).
