### PR TITLE
Crop and rotate 16:10 aspect ratio preset

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -45,7 +45,7 @@
 DT_MODULE(3)
 
 // number of gui ratios in combo box
-#define NUM_RATIOS 11
+#define NUM_RATIOS 12
 
 /** flip H/V, rotate an image, then clip the buffer. */
 typedef enum dt_iop_clipping_flags_t
@@ -1066,6 +1066,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->aspect_presets, _("square"));
   dt_bauhaus_combobox_add(g->aspect_presets, _("DIN"));
   dt_bauhaus_combobox_add(g->aspect_presets, _("16:9"));
+  dt_bauhaus_combobox_add(g->aspect_presets, _("16:10"));
   dt_bauhaus_combobox_add(g->aspect_presets, _("10:8 in print"));
 
   int act = dt_conf_get_int("plugins/darkroom/clipping/aspect_preset");
@@ -1134,10 +1135,11 @@ void _iop_clipping_update_ratios(dt_iop_module_t *self)
   g->aspect_ratios[7] = 1.0;
   g->aspect_ratios[8] = sqrtf(2.0);
   g->aspect_ratios[9] = 16.0f/9.0f;
-  g->aspect_ratios[10] = 244.5f/203.2f;
+  g->aspect_ratios[10] = 16.0f/10.0f;
+  g->aspect_ratios[11] = 244.5f/203.2f;
 
   // if adding new presets, make sure to change this as well:
-  assert(NUM_RATIOS == 11);
+  assert(NUM_RATIOS == 12);
 
   /* swap default fixed ratios for portraits */
   if (g->aspect_ratios[1] < 1.0)


### PR DESCRIPTION
For issue [#8996](http://www.darktable.org/redmine/issues/8996), from the attached patch.
