### PR TITLE
BUG : not same behavior btw opencl and CPU if you do "extreme" keystone

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -469,7 +469,8 @@ clip_rotate_bicubic(read_only image2d_t in, write_only image2d_t out, const int 
     float wy = interpolation_func_bicubic((float)(ty + jj) - po.y);
     float w = wx * wy;
 
-    pixel += read_imagef(in, sampleri, (int2)(tx + ii, ty + jj)) * w;
+    if (tx+ii>=0 && tx+ii<in_width && ty+jj>=0 && ty+jj<in_height)
+      pixel += read_imagef(in, sampleri, (int2)(tx + ii, ty + jj)) * w;
     weight += w;
   }
 
@@ -522,7 +523,8 @@ clip_rotate_lanczos2(read_only image2d_t in, write_only image2d_t out, const int
     float wy = interpolation_func_lanczos(2, (float)(ty + jj) - po.y);
     float w = wx * wy;
 
-    pixel += read_imagef(in, sampleri, (int2)(tx + ii, ty + jj)) * w;
+    if (tx+ii>=0 && tx+ii<in_width && ty+jj>=0 && ty+jj<in_height)
+      pixel += read_imagef(in, sampleri, (int2)(tx + ii, ty + jj)) * w;
     weight += w;
   }
 
@@ -576,7 +578,8 @@ clip_rotate_lanczos3(read_only image2d_t in, write_only image2d_t out, const int
     float wy = interpolation_func_lanczos(3, (float)(ty + jj) - po.y);
     float w = wx * wy;
 
-    pixel += read_imagef(in, sampleri, (int2)(tx + ii, ty + jj)) * w;
+    if (tx+ii>=0 && tx+ii<in_width && ty+jj>=0 && ty+jj<in_height)
+      pixel += read_imagef(in, sampleri, (int2)(tx + ii, ty + jj)) * w;
     weight += w;
   }
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -624,9 +624,9 @@ void gui_focus (struct dt_iop_module_t *self, gboolean in)
       // need to get gui stuff for the first time for this image,
       // and advice the pipe to redraw in full:
       g->clip_x = p->cx;
-      g->clip_w = p->cw - p->cx;
+      g->clip_w = fabsf(p->cw) - p->cx;
       g->clip_y = p->cy;
-      g->clip_h = p->ch - p->cy;
+      g->clip_h = fabsf(p->ch) - p->cy;
       // flip one bit to trigger the cache:
       uint32_t hack = *(uint32_t*)&p->cy;
       hack ^= 1;
@@ -903,9 +903,9 @@ void gui_update(struct dt_iop_module_t *self)
   // reset gui draw box to what we have in the parameters:
   g->applied = 1;
   g->clip_x = p->cx;
-  g->clip_w = p->cw - p->cx;
+  g->clip_w = fabsf(p->cw) - p->cx;
   g->clip_y = p->cy;
-  g->clip_h = p->ch - p->cy;
+  g->clip_h = fabsf(p->ch) - p->cy;
 }
 
 void init(dt_iop_module_t *module)


### PR DESCRIPTION
This correct 2 small bug in the clipping module

BUG : not same behaviour btw opencl and CPU if you do "extreme" keystone
BUG : clipping render if the image is flipped

this PR include the patch, I've pushed on the ML
