### PR TITLE
Use "#!/bin/sh" instead of "#!/bin/bash"

### DIFF
--- a/tools/beautify_style.sh
+++ b/tools/beautify_style.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # this uses astyle to standardize our indentation/braces etc
 

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 git log ^release-1.0.5 HEAD| grep ^Author: | sed 's/ <.*//; s/^Author: //' | sort | uniq -c | sort -nr
 
 echo "are you sure these guys received proper credit in the about dialog?"
-read
+read answer
 
 # prefix rc with ~, so debian thinks its less than
 dt_decoration=$(git describe --tags $branch | sed 's,^release-,,;s,-,+,;s,-,~,;' | sed 's/rc/~rc/')

--- a/tools/publish_htdocs.sh
+++ b/tools/publish_htdocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # usage: publish_html.sh <sf_username>
 

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 DBFILE=~/.config/darktable/library.db
 QUERY="select A.id,B.folder,A.filename from images as A join film_rolls as B on A.film_id = B.id"

--- a/tools/update_modelines.sh
+++ b/tools/update_modelines.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # this appends modelines to all source and header files to make sure kate and
 # vim know how to format their stuff.

--- a/tools/update_wb_presets_from_ufraw.sh
+++ b/tools/update_wb_presets_from_ufraw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Script updates our wb_presets which we regularly steal from UFRaw.
 #
@@ -12,14 +12,14 @@ wget http://ufraw.cvs.sourceforge.net/viewvc/ufraw/ufraw/wb_presets.c?content-ty
 
 echo "Processing ${TEMP_FILE} into ${OUT_FILE}, this may take a while"
 
-IFS='\n'
+IFS="\n"
 cat ${TEMP_FILE} | while read LINE; do
-  if [[ "${LINE}" == '#include "ufraw.h"' ]]; then
+  if [ "${LINE}" = '#include "ufraw.h"' ]; then
     echo '#ifdef HAVE_CONFIG_H'
     echo '#include "config.h"'
     echo '#endif'
     echo ''
-  elif [[ "${LINE}" == '#include <glib/gi18n.h>' ]]; then
+  elif [ "${LINE}" = '#include <glib/gi18n.h>' ]; then
     echo '#include <glib.h>'
     echo '#include <glib/gi18n.h>'
     echo ''

--- a/tools/update_web_usermanual.sh
+++ b/tools/update_web_usermanual.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd build 
 rm -r doc/usermanual
 make darktable-usermanual-html


### PR DESCRIPTION
None of the scripts requires Bash extensions. Moreover, `bash(1)` is not
always under `/bin`.

Only minor changes required:
- The `read` command needs a variable name as its argument.
- Use `[ "$var" = "value" ]` instead of `[[ "$var" == "value" ]]`.
