### PR TITLE
Minor ui cleanup

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1996,7 +1996,7 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
 
   /* add module label */
   char label[128];
-  g_snprintf(label,128,"<span size=\"larger\">%s</span> %s",module->name(),module->multi_name);
+  g_snprintf(label,128,"<span weight=\"bold\">%s</span> %s",module->name(),module->multi_name);
   hw[idx] = gtk_label_new("");
   gtk_label_set_markup(GTK_LABEL(hw[idx++]),label);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -771,7 +771,7 @@ dt_lib_gui_get_expander (dt_lib_module_t *module)
 
   /* add module label */
   char label[128];
-  g_snprintf(label,128,"<span size=\"larger\">%s</span>",module->name());
+  g_snprintf(label,128,"<span weight=\"bold\">%s</span>",module->name());
   hw[idx] = gtk_label_new("");
   gtk_label_set_markup(GTK_LABEL(hw[idx++]),label);
 


### PR DESCRIPTION
A typo fix and a minor clean-up. To me the module labels are more readable that way. The /size=larger/
in the span seemed to have no effect in fact.
