### PR TITLE
src/CMakeLists.txt: Set CMP0011 to NEW

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
 
+cmake_policy(SET CMP0011 NEW)
+
 include(CheckCCompilerFlag)
 
 #


### PR DESCRIPTION
This fixes a warning reported by CMake regarding a change of behavior
with the include() and find_package() commands.

See "cmake --help-policy CMP0011"
