### PR TITLE
[9131] Camera information visible in full screen

### DIFF
--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -346,75 +346,12 @@ static void _toggle_capture_mode_clicked(GtkWidget *widget, gpointer user_data)
 
 }
 
-
-#define BAR_HEIGHT 18 /* also change in views/capture.c */
-static void _expose_info_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx, int32_t pointery)
-{
-  dt_lib_camera_t *lib=(dt_lib_camera_t *)self->data;
-
-  // Draw infobar background at top
-  cairo_set_source_rgb (cr, .0,.0,.0);
-  cairo_rectangle(cr, 0, 0, width, BAR_HEIGHT);
-  cairo_fill (cr);
-
-  cairo_set_source_rgb (cr,.8,.8,.8);
-
-  // Draw left aligned value camera model value
-  cairo_text_extents_t te;
-  char model[4096]= {0};
-  sprintf(model+strlen(model),"%s", lib->data.camera_model );
-  cairo_text_extents (cr, model, &te);
-  cairo_move_to (cr,5, 1+BAR_HEIGHT - te.height / 2 );
-  cairo_show_text(cr, model);
-
-  // Draw right aligned battary value
-  const char *battery_value=dt_camctl_camera_get_property(darktable.camctl,NULL,"batterylevel");
-  char battery[4096]= {0};
-  sprintf(battery,"%s: %s", _("battery"), battery_value?battery_value:_("n/a"));
-  cairo_text_extents (cr, battery, &te);
-  cairo_move_to(cr,width-te.width-5, 1+BAR_HEIGHT - te.height / 2 );
-  cairo_show_text(cr, battery);
-
-  // Let's cook up the middle part of infobar
-  gchar center[1024]= {0};
-  for(int i=0; i<g_list_length(lib->gui.properties); i++)
-  {
-    dt_lib_camera_property_t *prop=(dt_lib_camera_property_t *)g_list_nth_data(lib->gui.properties,i);
-    if( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(prop->osd)) == TRUE )
-    {
-      g_strlcat(center,"      ",1024);
-      g_strlcat(center,prop->name,1024);
-      g_strlcat(center,": ",1024);
-      g_strlcat(center,gtk_combo_box_get_active_text(prop->values),1024);
-    }
-  }
-  g_strlcat(center,"      ",1024);
-
-  // Now lets put it in center view...
-  cairo_text_extents (cr, center, &te);
-  cairo_move_to(cr,(width/2)-(te.width/2), 1+BAR_HEIGHT - te.height / 2 );
-  cairo_show_text(cr, center);
-
-
-}
-
-static void _expose_settings_bar(dt_lib_module_t *self, cairo_t *cr,int32_t width, int32_t height, int32_t pointerx, int32_t pointery)
-{
-  /*// Draw control bar at bottom
-  cairo_set_source_rgb (cr, .0,.0,.0);
-  cairo_rectangle(cr, 0, height-BAR_HEIGHT, width, BAR_HEIGHT);
-  cairo_fill (cr);*/
-}
-
 void
 gui_post_expose(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx, int32_t pointery)
 {
   // Setup cairo font..
   cairo_set_font_size (cr, 11.5);
   cairo_select_font_face (cr, "Sans",CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-
-  _expose_info_bar(self,cr,width,height,pointerx,pointery);
-  _expose_settings_bar(self,cr,width,height,pointerx,pointery);
 }
 
 void

--- a/src/libs/capture.c
+++ b/src/libs/capture.c
@@ -1,4 +1,4 @@
-/*
+ /*
     This file is part of darktable,
     copyright (c) 2010-2011 henrik andersson.
 
@@ -33,9 +33,13 @@ typedef  struct dt_lib_capture_t
   /** Gui part of the module */
   struct
   {
-    GtkLabel *label1;                           // Jobcode
-    GtkEntry *entry1;                         // Jobcode
-    GtkButton *button1;                     // create new
+    GtkLabel *label_battery;       // battery label
+    GtkLabel *label_battery_value; // battery value label
+
+    GtkLabel *label_jobcode;       // jobcode label
+    GtkEntry *entry_jobcode;       // jobcode entry
+
+    GtkButton *button_create;      // create button
   } gui;
 
   /** Data part of the module */
@@ -80,10 +84,10 @@ create_callback(GtkButton *button, gpointer user_data)
   dt_lib_module_t *self=(dt_lib_module_t *)user_data;
   dt_lib_capture_t *lib=self->data;
 
-  dt_conf_set_string("plugins/capture/jobcode", gtk_entry_get_text(lib->gui.entry1) );
+  dt_conf_set_string("plugins/capture/jobcode", gtk_entry_get_text(lib->gui.entry_jobcode) );
   dt_conf_set_int("plugins/capture/current_filmroll", -1);
 
-  dt_view_tethering_set_job_code(darktable.view_manager, gtk_entry_get_text( lib->gui.entry1 ) );
+  dt_view_tethering_set_job_code(darktable.view_manager, gtk_entry_get_text( lib->gui.entry_jobcode ) );
 }
 
 void
@@ -98,33 +102,54 @@ gui_init (dt_lib_module_t *self)
 
   // Setup gui
   self->widget = gtk_vbox_new(FALSE, 5);
-  GtkBox *hbox, *vbox1, *vbox2;
+  GtkBox *hbox_battery, *vbox1_battery, *vbox2_battery;
+  GtkBox *hbox_jobcode, *vbox1_jobcode, *vbox2_jobcode;
 
-  // Session settings
-  //gtk_box_pack_start(GTK_BOX(self->widget), dtgtk_label_new("session settings",DARKTABLE_LABEL_TAB|DARKTABLE_LABEL_ALIGN_RIGHT), TRUE, TRUE, 0);
-  hbox = GTK_BOX(gtk_hbox_new(FALSE, 5));
-  vbox1 = GTK_BOX(gtk_vbox_new(TRUE, 5));
-  vbox2 = GTK_BOX(gtk_vbox_new(TRUE, 5));
+  // Battery
+  hbox_battery = GTK_BOX(gtk_hbox_new(FALSE, 5));
+  vbox1_battery = GTK_BOX(gtk_vbox_new(TRUE, 5));
+  vbox2_battery = GTK_BOX(gtk_vbox_new(TRUE, 5));
 
-  lib->gui.label1 = GTK_LABEL(gtk_label_new(_("jobcode")));
-  gtk_misc_set_alignment(GTK_MISC(lib->gui.label1 ), 0.0, 0.5);
-  gtk_box_pack_start(vbox1, GTK_WIDGET(lib->gui.label1), TRUE, TRUE, 0);
+  lib->gui.label_battery = GTK_LABEL(gtk_label_new(_("battery")));
+  gtk_misc_set_alignment(GTK_MISC(lib->gui.label_battery ), 0.0, 0.5);
+  gtk_box_pack_start(vbox1_battery, GTK_WIDGET(lib->gui.label_battery), TRUE, TRUE, 0);
 
-  lib->gui.entry1 = GTK_ENTRY(gtk_entry_new());
-  dt_gui_key_accel_block_on_focus (GTK_WIDGET (lib->gui.entry1));
-  gtk_box_pack_start(vbox2, GTK_WIDGET(lib->gui.entry1), TRUE, TRUE, 0);
+  const char *battery_value=dt_camctl_camera_get_property(darktable.camctl,NULL,"batterylevel");
+  lib->gui.label_battery_value = GTK_LABEL(gtk_label_new(battery_value?battery_value:_("n/a")));
+  gtk_misc_set_alignment(GTK_MISC(lib->gui.label_battery_value ), 0.0, 0.5);
+  gtk_box_pack_start(vbox2_battery, GTK_WIDGET(lib->gui.label_battery_value), TRUE, TRUE, 0);
 
-  lib->gui.button1 = GTK_BUTTON(gtk_button_new_with_label( _("create") ));
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(vbox1), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(vbox2), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(lib->gui.button1), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox_battery), GTK_WIDGET(vbox1_battery), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox_battery), GTK_WIDGET(vbox2_battery), TRUE, TRUE, 0);
 
-  g_signal_connect (G_OBJECT (lib->gui.button1), "clicked",
+  // Jobcode
+  hbox_jobcode = GTK_BOX(gtk_hbox_new(FALSE, 5));
+  vbox1_jobcode = GTK_BOX(gtk_vbox_new(TRUE, 5));
+  vbox2_jobcode = GTK_BOX(gtk_vbox_new(TRUE, 5));
+
+  lib->gui.label_jobcode = GTK_LABEL(gtk_label_new(_("jobcode")));
+  gtk_misc_set_alignment(GTK_MISC(lib->gui.label_jobcode ), 0.0, 0.5);
+  gtk_box_pack_start(vbox1_jobcode, GTK_WIDGET(lib->gui.label_jobcode), TRUE, TRUE, 0);
+
+  lib->gui.entry_jobcode = GTK_ENTRY(gtk_entry_new());
+  dt_gui_key_accel_block_on_focus (GTK_WIDGET (lib->gui.entry_jobcode));
+  gtk_box_pack_start(vbox2_jobcode, GTK_WIDGET(lib->gui.entry_jobcode), TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(hbox_jobcode), GTK_WIDGET(vbox1_jobcode), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox_jobcode), GTK_WIDGET(vbox2_jobcode), TRUE, TRUE, 0);
+
+  // Create button
+  lib->gui.button_create = GTK_BUTTON(gtk_button_new_with_label( _("create") ));
+
+  // Pack widget
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox_battery), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox_jobcode), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(lib->gui.button_create), TRUE, TRUE, 0);
+
+  g_signal_connect (G_OBJECT (lib->gui.button_create), "clicked",
                     G_CALLBACK (create_callback), self);
 
-  gtk_entry_set_text(lib->gui.entry1, dt_conf_get_string("plugins/capture/jobcode") );
-
+  gtk_entry_set_text(lib->gui.entry_jobcode, dt_conf_get_string("plugins/capture/jobcode") );
 }
 
 void

--- a/src/views/capture.c
+++ b/src/views/capture.c
@@ -334,7 +334,7 @@ void configure(dt_view_t *self, int wd, int ht)
 }
 
 #define MARGIN	20
-#define BAR_HEIGHT 18 /* see libs/camera.c */
+#define BAR_HEIGHT 18
 void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx, int32_t pointery)
 {
   dt_capture_t *lib=(dt_capture_t*)self->data;


### PR DESCRIPTION
This pull request removes the status bar that is overlayed with the image in tethered mode. Instead the battery information is displayed as part of the session data.

The result is that reviewing images shows the full image now.
