### PR TITLE
Set properly Subject Distance for Nikon cameras. Fixes #8541

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -415,7 +415,19 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       img->exif_focal_length = pos->toFloat ();
     }
 
-    if ( (pos=Exiv2::subjectDistance(exifData))
+    if ( (pos=exifData.findKey(Exiv2::ExifKey("Exif.NikonLd2.FocusDistance")))
+         != exifData.end() && pos->size())
+    {
+      float value = pos->toFloat();
+      img->exif_focus_distance = (0.01 * pow(10, value/40));
+    }
+    else if ( (pos=exifData.findKey(Exiv2::ExifKey("Exif.NikonLd3.FocusDistance")))
+         != exifData.end() && pos->size())
+    {
+      float value = pos->toFloat();
+      img->exif_focus_distance = (0.01 * pow(10, value/40));
+    }
+    else if ( (pos=Exiv2::subjectDistance(exifData))
          != exifData.end() && pos->size())
     {
       img->exif_focus_distance = pos->toFloat ();

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -211,7 +211,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     snprintf(value, vl, "%.0f", img->exif_focal_length);
     _metadata_update_value(d->metadata[md_exif_focal_length], value);
 
-    snprintf(value, vl, "%.0f", img->exif_focus_distance);
+    snprintf(value, vl, "%.2f m", img->exif_focus_distance);
     _metadata_update_value(d->metadata[md_exif_focus_distance], value);
 
     snprintf(value, vl, "%.0f", img->exif_iso);


### PR DESCRIPTION
This properly calculates Subject Distance for Nikon cameras. It seems that Canon stopped providing it because it was inaccurate. Data for other cameras is also not taken into consideration unless they set the standard tag.

Images need to be reimported to get the new values.
