### PR TITLE
fix: make profiling for images in local dir work again when no isos are speci...

### DIFF
--- a/tools/noise/gen-profile
+++ b/tools/noise/gen-profile
@@ -243,6 +243,8 @@ list_input_images
 # Take the required shots.
 if [ "$tethering_enabled" ]; then
 	auto_capture_images
+else
+	iso_settings=$images_for_iso_settings
 fi
 
 files_list="$profiling_dir/output-files-list.txt"

--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -420,7 +420,7 @@ get_camera_raw_setting() {
 }
 
 get_camera_iso_settings() {
-	local iso_setting
+	local iso_settings
 	iso_settings=$(gphoto2 --get-config /main/imgsettings/iso | awk '
 /^Choice: [0-9]+ [0-9]+$/ {
 	iso = $0;


### PR DESCRIPTION
...fied (when not taking them automatically with gphoto2)

Just needed very little changes,...
This didn't work since the last changes, probably because the focus (and testing) was only on automatically taking pictures with gphoto2.
