### PR TITLE
Detect some more Nikon ISOs for at least Nikon D200.

### DIFF
--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -216,10 +216,19 @@ get_image_iso() {
 
 	# Then try some brand specific values if still not found.
 
+	# TODO: try to use exiv2's "fixiso" option for reading only, possibly talk with exiv2
+	# developers to get an option that only displays the correct iso
+
 	if [ "$iso" = "" ]; then
 		case "$(get_image_camera_maker "$1")" in
 		NIKON*)
 			iso=$(exiv2 -g Exif.NikonIi.ISO -Pt "$1" 2>/dev/null || :)
+			if [ "$iso" = "" ]; then
+				iso=$(exiv2 -g Exif.Nikon3.ISOSpeed -Pt "$1" 2>/dev/null || :)
+			fi
+			if [ "$iso" = "" ]; then
+				iso=$(exiv2 -g Exif.Nikon3.ISOSettings -Pt "$1" 2>/dev/null || :)
+			fi
 			;;
 		esac
 	fi


### PR DESCRIPTION
Beware, this is only a hotfix and should be done in a better way later (exiv2 gives a cmd option 'fixiso', but which is only a file-manipulating option currently - using the 'fixiso' method of exiv2 should probably be the desired way to handle it, also INSIDE darktable to be able to use this profiling data correctly! - maybe ask the exiv2 devs about this?)
