### PR TITLE
Fix (for nikon d5100): Read ISO from EXIF differently (similar to inside exiv2's "fixiso" setti...

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -405,10 +405,21 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     if ( (pos=Exiv2::isoSpeed(exifData) )
          != exifData.end() && pos->size())
     {
-      std::ostringstream os;
-      pos->write(os, &exifData);
-      const char * exifstr = os.str().c_str();
-      img->exif_iso = (float) std::atof( exifstr );
+      // if standard exif iso tag, use the old way of interpreting the return value to be more regression-save
+      if (strcmp(pos->key().c_str(), "Exif.Photo.ISOSpeedRatings") == 0)
+      {
+        int isofield = pos->count () > 1  ? 1 : 0;
+        img->exif_iso = pos->toFloat (isofield);
+      }
+      else
+      {
+        std::ostringstream os;
+        pos->write(os, &exifData);
+        const char * exifstr = os.str().c_str();
+        img->exif_iso = (float) std::atof( exifstr );
+        // beware the following does not result in the same!:
+        //img->exif_iso = (float) std::atof( pos->toString().c_str() );
+      }
     }
 #if EXIV2_MINOR_VERSION>19
     /* Read focal length  */


### PR DESCRIPTION
...ng), and hope this will be the correct way now (works for d5100 at least, please check that other ISO readouts are not broken now!)

This fixes http://darktable.org/redmine/issues/9178 but might be experimental - but it is exactly the same way as exiv2 handles this with the cmd tool!

For D200 this also still works and Sony Nex-C3
