### PR TITLE
Clipping changes.

### DIFF
--- a/data/darktableconfig.xml
+++ b/data/darktableconfig.xml
@@ -1862,8 +1862,8 @@
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/clipping/custom_aspect</name>
-    <type>float</type>
-    <default>1.5</default>
+    <type>string</type>
+    <default>3:2</default>
     <shortdescription>last chosen custom aspect ratio</shortdescription>
     <longdescription/>
   </dtconfig>
@@ -1872,6 +1872,13 @@
     <type>int</type>
     <default>1</default>
     <shortdescription>last chosen aspect ratio preset</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/clipping/aspect_flipped</name>
+    <type>bool</type>
+    <default>FALSE</default>
+    <shortdescription>indicate if last aspect ratio preset is flipped</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig>


### PR DESCRIPTION
- Save the flipped state of the aspect ratio preset along with the preset
  itself.  (plugins/darkroom/clipping/aspect_flipped)
- Change the saved custom_aspect to be a string with the actual custom
  aspect.  This is so the user will see what he/she entered instead of a
  computed value.
- When the user enters an aspect ratio of his/her own, actually save it
  too.  (plugins/darkroom/clipping/custom_aspect)
- Handle the saved presets better when starting up.

Fixes #9151, #9143
