### PR TITLE
fix: make all remaining colorpickers disappear after they get disabled

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -461,6 +461,8 @@ _blendop_blendif_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *mo
   /* set the area sample size*/
   if (module->request_color_pick)
     dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+  else
+    dt_control_queue_redraw();
 
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
   dt_iop_request_focus(module);

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -517,6 +517,8 @@ request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *self)
   /* use point sample */
   if (self->request_color_pick)
     dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+  else
+    dt_control_queue_redraw();
 
   if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
   dt_iop_request_focus(self);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -946,6 +946,8 @@ request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *self)
   /* set the area sample size*/
   if (self->request_color_pick)
     dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+  else
+    dt_control_queue_redraw();
 
   if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
   dt_iop_request_focus(self);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -300,6 +300,10 @@ autoexp_callback (GtkToggleButton *button, dt_iop_module_t *self)
     dt_lib_colorpicker_set_area(darktable.lib, 0.99);
     dt_dev_reprocess_all(self->dev);
   }
+  else
+  {
+    dt_control_queue_redraw();
+  }
 
   gtk_widget_set_sensitive(GTK_WIDGET(g->autoexpp), gtk_toggle_button_get_active(button));
 

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -99,6 +99,10 @@ request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *self)
     if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
     dt_iop_request_focus(self);
   }
+  else
+  {
+    dt_control_queue_redraw();
+  }
 }
 
 static gboolean

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -223,6 +223,8 @@ picker_callback (GtkDarktableToggleButton *button, gpointer user_data)
   /* set the area sample size*/
   if (self->request_color_pick)
     dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+  else
+    dt_control_queue_redraw();
 
   if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
   dt_iop_request_focus(self);


### PR DESCRIPTION
These should be all now, except colortransfer, which still seems to work a bit strange. As the supposed behavior is unknown, no changes were made there.
