### PR TITLE
Implemented ratings and other toggle buttons

### DIFF
--- a/data/darktable.gtkrc.in
+++ b/data/darktable.gtkrc.in
@@ -1,4 +1,5 @@
 # from art.gnome.org: marble-look, adjusted
+
 style "clearlooks-default"
 {
 
@@ -69,6 +70,11 @@ style "clearlooks-default"
     contrast = 1.0
 # sunkenmenubar = 1
   }
+
+  color["dt-stars-fill"] = "#e69926" # yellow stars
+  color["dt-stars-outline"] = "#FFe64c" # yellow stars
+#  color["dt-stars-fill"] = "#222222" # gray stars
+#  color["dt-stars-outline"] = "#050505" # gray stars
 }
 
 style "clearlooks-wide" = "clearlooks-default"

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -554,6 +554,7 @@ void dtgtk_cairo_paint_styles(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags
 
 }
 
+
 void dtgtk_cairo_paint_LR(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
 {
   gint s=w<h?w:h;
@@ -577,6 +578,151 @@ void dtgtk_cairo_paint_LR(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
 
   cairo_arc (cr, 0.4, 0.35, 0.15, -M_PI/2.0, M_PI/2.0);
   cairo_stroke(cr);
+}
+
+inline void
+dtgtk_cairo_paint_star(cairo_t *cr, float x, float y, float r1, float r2)
+{
+  const float d = 2.0*M_PI*0.1f;
+  const float dx[10] = {sinf(0.0), sinf(d), sinf(2*d), sinf(3*d), sinf(4*d), sinf(5*d), sinf(6*d), sinf(7*d), sinf(8*d), sinf(9*d)};
+  const float dy[10] = {cosf(0.0), cosf(d), cosf(2*d), cosf(3*d), cosf(4*d), cosf(5*d), cosf(6*d), cosf(7*d), cosf(8*d), cosf(9*d)};
+  cairo_move_to(cr, x+r1*dx[0], y-r1*dy[0]);
+  for(int k=1; k<10; k++)
+    if(k&1) cairo_line_to(cr, x+r2*dx[k], y-r2*dy[k]);
+    else    cairo_line_to(cr, x+r1*dx[k], y-r1*dy[k]);
+  cairo_close_path(cr);
+}
+
+void dtgtk_cairo_paint_toggle_stars (cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
+{
+  cairo_save(cr);
+
+  dtgtk_cairo_paint_star(cr, x + w/2, y + h/2, w, w*0.67);
+  
+  if (flags & CPF_ACTIVE)
+    cairo_set_source_rgb(cr, 0.9, 0.7, 0.15);
+  else
+    cairo_set_source_rgb(cr, 0.7, 0.7, 0.7);
+  cairo_fill_preserve(cr);
+
+  cairo_restore(cr);
+}
+
+void dtgtk_cairo_paint_toggle_labels_tint (cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
+{
+    for (int k = 0; k<5; k++)
+    { 
+      int realw = w * 1.75;
+      int realx = x + (w/2) - realw/2;
+
+      cairo_save(cr);
+
+      /* fill base color */
+      cairo_rectangle(cr, realx+k*(realw/5.0), y + (h - realw) / 2, realw/5, realw);
+
+      if (!(flags & CPF_ACTIVE))
+        cairo_set_source_rgba (cr,0.6,0.6,0.6,1);
+      else switch(k)
+      {
+        case  0:
+          cairo_set_source_rgba (cr,1,0.0,0.0,0.3);
+          break; // red
+        case  1:
+          cairo_set_source_rgba (cr,1,1.0,0.0,0.3);
+          break; // yellow
+        case  2:
+          cairo_set_source_rgba (cr,0.0,1,0.0,0.3);
+          break; // green
+        case  3:
+          cairo_set_source_rgba (cr,0.0,0.0,1,0.3);
+          break; // blue
+        case  4:
+          cairo_set_source_rgba (cr,1,0.0,1.0,0.3);
+          break; // purple
+        default:
+          cairo_set_source_rgba (cr,1,1,1,0.3);
+          break; // gray
+      }
+      cairo_fill (cr);
+
+
+      cairo_restore(cr);
+    }
+}
+
+inline void
+dtgtk_cairo_paint_altered(cairo_t *cr, const float x, const float y, const float r)
+{
+  cairo_new_sub_path(cr);
+  cairo_arc(cr, x, y, r, 0, 2.0f*M_PI);
+  const float dx = r*cosf(M_PI/8.0f), dy = r*sinf(M_PI/8.0f);
+  cairo_move_to(cr, x-dx, y-dy);
+  cairo_curve_to(cr, x, y-2*dy, x, y+2*dy, x+dx, y+dy);
+  cairo_move_to(cr, x-.20*dx, y+.8*dy);
+  cairo_line_to(cr, x-.80*dx, y+.8*dy);
+  cairo_move_to(cr, x+.20*dx, y-.8*dy);
+  cairo_line_to(cr, x+.80*dx, y-.8*dy);
+  cairo_move_to(cr, x+.50*dx, y-.8*dy-0.3*dx);
+  cairo_line_to(cr, x+.50*dx, y-.8*dy+0.3*dx);
+  cairo_stroke(cr);
+}
+
+void dtgtk_cairo_paint_toggle_altered (cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
+{
+  cairo_save(cr);
+  cairo_translate(cr, x + w/2, y+h/2);
+  cairo_set_line_width(cr, 1);
+
+  if (!(flags & CPF_ACTIVE))
+    cairo_set_source_rgb (cr,0.6,0.6,0.6);
+  else 
+    cairo_set_source_rgb (cr,1.0,1.0,1.0);
+  
+  dtgtk_cairo_paint_altered(cr, 0, 0, w/1.25);
+
+  cairo_restore(cr);
+}
+
+void dtgtk_cairo_paint_toggle_reject (cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
+{
+  cairo_save(cr);
+  
+  if (!(flags & CPF_ACTIVE))
+    cairo_set_source_rgb (cr,0.6,0.6,0.6);
+  else 
+    cairo_set_source_rgb(cr, 1., 0., 0.);
+
+  cairo_set_line_width(cr, 2.5);
+  cairo_translate(cr, x + w/2, y+h/2);
+ 
+  float xy1 = -w/1.35;
+  float xy2 = w/1.35;
+  
+  //reject cross:
+  cairo_move_to(cr, xy1, xy1);
+  cairo_line_to(cr, xy2, xy2);
+  cairo_move_to(cr, xy2, xy1);
+  cairo_line_to(cr, xy1, xy2);
+  cairo_close_path(cr);
+  cairo_stroke(cr);
+  cairo_restore(cr);
+}
+
+void dtgtk_cairo_paint_toggle_labels (cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)
+{
+  cairo_save(cr);
+  cairo_translate(cr, x + w/2, y+h/2);
+
+  cairo_arc (cr, 0.5, 0.5, w/1.2, 0.0, 2.0*M_PI);
+
+  if (!(flags & CPF_ACTIVE))
+    cairo_set_source_rgb (cr,0.6,0.6,0.6);
+  else 
+    cairo_set_source_rgb (cr,1,0.0,0.0);
+
+  cairo_fill (cr);
+
+  cairo_restore(cr);
 }
 
 void dtgtk_cairo_paint_label (cairo_t *cr,gint x,gint y,gint w,gint h,gint flags)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -83,6 +83,16 @@ void dtgtk_cairo_paint_refresh(cairo_t *cr,gint x,gint y,gint w,gint h,gint flag
 void dtgtk_cairo_paint_cancel(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
 /** paint two boxes indicating portrait/landscape flip */
 void dtgtk_cairo_paint_aspectflip(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
+/** Paint a toggle labels background icon */
+void dtgtk_cairo_paint_toggle_labels_tint(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
+/** Paint a toggle rejects icon */
+void dtgtk_cairo_paint_toggle_reject(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
+/** Paint a toggle altered icon */
+void dtgtk_cairo_paint_toggle_altered(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
+/** Paint a toggle labels icon */
+void dtgtk_cairo_paint_toggle_labels(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
+/** Paint a toggle stars icon */
+void dtgtk_cairo_paint_toggle_stars(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
 /** Paint a color label icon */
 void dtgtk_cairo_paint_label(cairo_t *cr,gint x,gint y,gint w,gint h,gint flags);
 /** paint a color picker icon - a pipette for bigger buttons */
@@ -123,6 +133,11 @@ void dtgtk_cairo_paint_rect_portrait(cairo_t *cr,gint x,gint y,gint w,gint h,gin
 void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);
 /** paint a duplicate/multi instance indicator */
 void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);
+
+/** paint a star (as used for ratings) */
+void dtgtk_cairo_paint_star(cairo_t *cr, float x, float y, float r1, float r2);
+/** paint a history label */
+void dtgtk_cairo_paint_altered(cairo_t *cr, const float x, const float y, const float r);
 
 /** paint active modulgroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -747,7 +747,31 @@ dt_gui_gtk_init(dt_gui_gtk_t *gui, int argc, char *argv[])
 
   if(g_file_test(gtkrc, G_FILE_TEST_EXISTS))
     gtk_rc_parse (gtkrc);
-
+   
+  GtkStyle *style = gtk_rc_get_style_by_paths(gtk_settings_get_default(), NULL, "GtkWidget", GTK_TYPE_WIDGET);
+  GdkColor star_fill;
+  star_fill.red = 65535;
+  star_fill.green = 65535;
+  star_fill.blue = 0;
+  GdkColor star_outline;
+  star_outline.red = 65535;
+  star_outline.green = 65535;
+  star_outline.blue = 0;
+  
+  // colors are in 0..65535
+  if(style)
+  {
+    gtk_style_lookup_color(style, "dt-stars-fill", &star_fill);
+    gtk_style_lookup_color(style, "dt-stars-outline", &star_outline);
+  }
+  
+  darktable.gui->star_color_fill[0] = (1.0/ 65535) * star_fill.red;
+  darktable.gui->star_color_fill[1] = (1.0/ 65535) * star_fill.green;
+  darktable.gui->star_color_fill[2] = (1.0/ 65535) * star_fill.blue;
+  darktable.gui->star_color_outline[0] = (1.0/ 65535) * star_outline.red;
+  darktable.gui->star_color_outline[1] = (1.0/ 65535) * star_outline.green;
+  darktable.gui->star_color_outline[2] = (1.0/ 65535) * star_outline.blue;
+  
   // Initializing the shortcut groups
   darktable.control->accelerators = gtk_accel_group_new();
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -57,10 +57,18 @@ typedef struct dt_gui_gtk_t
 
   int32_t reset;
   float bgcolor[3];
-
+  float star_color_outline[3];
+  float star_color_fill[3];
+  
   int32_t center_tooltip; // 0 = no tooltip, 1 = new tooltip, 2 = old tooltip
 
   gboolean grouping;
+  gboolean show_ratings_on_all_images;  
+  gboolean show_colorlabel_dots;
+  gboolean show_colorlabel_tint;
+  gboolean show_history_labels;
+  gboolean show_rejects;
+  
   int32_t expanded_group_id;
 
   double dpi;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -29,10 +29,21 @@ DT_MODULE(1)
 
 typedef struct dt_lib_tool_preferences_t
 {
-  GtkWidget *preferences_button, *grouping_button;
+  GtkWidget *preferences_button, *grouping_button, *ratings_button, *colorlabels_button, *colorlabels_tint_button, *history_labels_toggle, *rejects_toggle;
 }
 dt_lib_tool_preferences_t;
 
+
+/* callback for history label button */
+static void _lib_toggle_altered_button_clicked(GtkWidget *widget, gpointer user_data);
+/* callback for rejects button */
+static void _lib_toggle_rejects_button_clicked(GtkWidget *widget, gpointer user_data);
+/* callback for color labels tint button */
+static void _lib_toggle_colorlabels_tint_button_clicked(GtkWidget *widget, gpointer user_data);
+/* callback for color labels button */
+static void _lib_toggle_colorlabels_button_clicked(GtkWidget *widget, gpointer user_data);
+/* callback for ratings button */
+static void _lib_toggle_ratings_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for grouping button */
 static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for preference button */
@@ -63,6 +74,17 @@ int position()
   return 1001;
 }
 
+static inline GtkWidget* create_button(dt_lib_module_t *self, DTGTKCairoPaintIconFunc paint, char* tooltip, GCallback callback, gboolean active)
+{
+  GtkWidget *button = dtgtk_togglebutton_new(paint, CPF_STYLE_FLAT);
+  gtk_widget_set_size_request(button, 18,18);
+  gtk_box_pack_start(GTK_BOX(self->widget), button, FALSE, FALSE, 2);
+  g_object_set(G_OBJECT(button), "tooltip-text", tooltip, (char *)NULL);
+  g_signal_connect (G_OBJECT (button), "clicked", callback, NULL);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), active);
+  return button;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -70,29 +92,61 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   self->widget = gtk_hbox_new(FALSE,2);
-
+ 
+  /* create the history label toggle button */
+  darktable.gui->show_history_labels = dt_conf_get_bool("ui_last/show_history_labels");
+  d->history_labels_toggle = create_button(self,
+    dtgtk_cairo_paint_toggle_altered, 
+    darktable.gui->show_history_labels ? _("show history labels for active image only") : _("show history labels for all images"), 
+    G_CALLBACK (_lib_toggle_altered_button_clicked),
+    darktable.gui->show_history_labels);
+  
+    /* create the rejects toggle button */
+  darktable.gui->show_rejects = dt_conf_get_bool("ui_last/show_rejects");
+  d->rejects_toggle = create_button(self,
+    dtgtk_cairo_paint_toggle_reject, 
+    darktable.gui->show_rejects ? _("show reject cross for active image only") : _("show reject cross for all images"), 
+    G_CALLBACK (_lib_toggle_rejects_button_clicked),
+    darktable.gui->show_rejects);
+  
+  /* create the label tint toggle button */
+  darktable.gui->show_colorlabel_tint = dt_conf_get_bool("ui_last/show_colorlabel_background");
+  d->colorlabels_tint_button = create_button(self,
+    dtgtk_cairo_paint_toggle_labels_tint, 
+    darktable.gui->show_colorlabel_tint ? _("remove label tint on image backgrounds") : _("tint image background with label color"), 
+    G_CALLBACK (_lib_toggle_colorlabels_tint_button_clicked),
+    darktable.gui->show_colorlabel_tint);
+  
+  /* create the colorlabel toggle button */
+  darktable.gui->show_colorlabel_dots = dt_conf_get_bool("ui_last/show_colorlabel_dots");
+  d->colorlabels_button = create_button(self,
+    dtgtk_cairo_paint_toggle_labels, 
+    darktable.gui->show_colorlabel_dots ? _("hide color label dots") : _("show color label dots"), 
+    G_CALLBACK (_lib_toggle_colorlabels_button_clicked),
+    darktable.gui->show_colorlabel_dots);
+  
+  /* create the ratings toggle button */
+  darktable.gui->show_ratings_on_all_images = dt_conf_get_bool("ui_last/show_ratings_on_all_images");
+  d->ratings_button = create_button(self,
+    dtgtk_cairo_paint_toggle_stars, 
+    darktable.gui->show_ratings_on_all_images ? _("show ratings for active image only") : _("show ratings for all images"), 
+    G_CALLBACK (_lib_toggle_ratings_button_clicked),
+    darktable.gui->show_ratings_on_all_images);
+  
   /* create the grouping button */
-  d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, CPF_STYLE_FLAT);
-  gtk_widget_set_size_request(d->grouping_button, 18,18);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->grouping_button, FALSE, FALSE, 2);
-  if(darktable.gui->grouping)
-    g_object_set(G_OBJECT(d->grouping_button), "tooltip-text", _("expand grouped images"), (char *)NULL);
-  else
-    g_object_set(G_OBJECT(d->grouping_button), "tooltip-text", _("collapse grouped images"), (char *)NULL);
-  g_signal_connect (G_OBJECT (d->grouping_button), "clicked",
-                    G_CALLBACK (_lib_filter_grouping_button_clicked),
-                    NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->grouping_button), darktable.gui->grouping);
-
+  darktable.gui->show_history_labels = dt_conf_get_bool("ui_last/grouping");
+  d->grouping_button = create_button(self,
+    dtgtk_cairo_paint_grouping, 
+    darktable.gui->grouping ? _("expand grouped images") : _("collapse grouped images"), 
+    G_CALLBACK (_lib_filter_grouping_button_clicked),
+    darktable.gui->grouping);
+  
   /* create the preference button */
-  d->preferences_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT);
-  gtk_widget_set_size_request(d->preferences_button, 18,18);
-  gtk_box_pack_end(GTK_BOX(self->widget), d->preferences_button, FALSE, FALSE, 2);
-  g_object_set(G_OBJECT(d->preferences_button), "tooltip-text", _("show global preferences"),
-               (char *)NULL);
-  g_signal_connect (G_OBJECT (d->preferences_button), "clicked",
-                    G_CALLBACK (_lib_preferences_button_clicked),
-                    NULL);
+  d->preferences_button = create_button(self,
+    dtgtk_cairo_paint_preferences, 
+    _("show global preferences"), 
+    G_CALLBACK (_lib_preferences_button_clicked),
+    FALSE);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -104,6 +158,66 @@ void gui_cleanup(dt_lib_module_t *self)
 void _lib_preferences_button_clicked (GtkWidget *widget, gpointer user_data)
 {
   dt_gui_preferences_show();
+}
+
+static void _lib_toggle_altered_button_clicked (GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->show_history_labels = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  if(darktable.gui->show_history_labels)
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show history label for active image only"), (char *)NULL);
+  else
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show history label for all images"), (char *)NULL);
+  dt_conf_set_bool("ui_last/show_history_labels", darktable.gui->show_history_labels);
+  darktable.gui->expanded_group_id = -1;
+  dt_collection_update_query(darktable.collection);
+}
+
+static void _lib_toggle_rejects_button_clicked (GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->show_rejects = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  if(darktable.gui->show_rejects)
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show reject cross for active image only"), (char *)NULL);
+  else
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show reject cross for all images"), (char *)NULL);
+  dt_conf_set_bool("ui_last/show_rejects", darktable.gui->show_rejects);
+  darktable.gui->expanded_group_id = -1;
+  dt_collection_update_query(darktable.collection);
+}
+
+static void _lib_toggle_colorlabels_tint_button_clicked (GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->show_colorlabel_tint = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  if(darktable.gui->show_colorlabel_tint)
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("hide color label background"), (char *)NULL);
+  else
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show color label background"), (char *)NULL);
+  dt_conf_set_bool("ui_last/show_colorlabel_background", darktable.gui->show_colorlabel_tint);
+  darktable.gui->expanded_group_id = -1;
+  dt_collection_update_query(darktable.collection);
+}
+
+static void _lib_toggle_colorlabels_button_clicked (GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->show_colorlabel_dots = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  if(darktable.gui->show_colorlabel_dots)
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("hide color label dots"), (char *)NULL);
+  else
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show color label dots"), (char *)NULL);
+  dt_conf_set_bool("ui_last/show_colorlabel_dots", darktable.gui->show_colorlabel_dots);
+  darktable.gui->expanded_group_id = -1;
+  dt_collection_update_query(darktable.collection);
+}
+
+static void _lib_toggle_ratings_button_clicked (GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->show_ratings_on_all_images = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  if(darktable.gui->show_ratings_on_all_images)
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show ratings for active image only"), (char *)NULL);
+  else
+    g_object_set(G_OBJECT(widget), "tooltip-text", _("show ratings for all images"), (char *)NULL);
+  dt_conf_set_bool("ui_last/show_ratings_on_all_images", darktable.gui->show_ratings_on_all_images);
+  darktable.gui->expanded_group_id = -1;
+  dt_collection_update_query(darktable.collection);
 }
 
 static void _lib_filter_grouping_button_clicked (GtkWidget *widget, gpointer user_data)
@@ -120,6 +234,11 @@ static void _lib_filter_grouping_button_clicked (GtkWidget *widget, gpointer use
 
 void init_key_accels(dt_lib_module_t *self)
 {
+  dt_accel_register_lib(self, NC_("accel", "toggle history label display"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "toggle reject cross display"), 0, 0); 
+  dt_accel_register_lib(self, NC_("accel", "toggle color label background tint"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "toggle color label display"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "toggle rating star display"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "grouping"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "preferences"), 0, 0);
 }
@@ -128,6 +247,11 @@ void connect_key_accels(dt_lib_module_t *self)
 {
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t*)self->data;
 
+  dt_accel_connect_button_lib(self, "toggle history label display", d->history_labels_toggle);
+  dt_accel_connect_button_lib(self, "toggle reject cross display", d->rejects_toggle);
+  dt_accel_connect_button_lib(self, "toggle color label background tint", d->colorlabels_tint_button);
+  dt_accel_connect_button_lib(self, "toggle color label display", d->colorlabels_button);
+  dt_accel_connect_button_lib(self, "toggle rating star display", d->ratings_button);
   dt_accel_connect_button_lib(self, "grouping", d->grouping_button);
   dt_accel_connect_button_lib(self, "preferences", d->preferences_button);
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -292,12 +292,6 @@ void init(dt_view_t *self)
   lib->full_preview=0;
   lib->full_preview_id=-1;
 
-  GtkStyle *style = gtk_rc_get_style_by_paths(gtk_settings_get_default(), "dt-stars", NULL, GTK_TYPE_NONE);
-
-  lib->star_color.red = (255/ 65535) * style->fg[GTK_STATE_NORMAL].red;
-  lib->star_color.blue = (255/ 65535) * style->fg[GTK_STATE_NORMAL].blue;
-  lib->star_color.green = (255/ 65535) * style->fg[GTK_STATE_NORMAL].green;
-
   /* setup collection listener and initialize main_query statement */
   dt_control_signal_connect(darktable.signals,
                             DT_SIGNAL_COLLECTION_CHANGED,

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -31,6 +31,7 @@
 #include "views/view.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "dtgtk/paint.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -597,35 +598,35 @@ void dt_view_set_scrollbar(dt_view_t *view, float hpos, float hsize, float hwins
   gtk_widget_queue_draw(widget);
 }
 
-static inline void
-dt_view_draw_altered(cairo_t *cr, const float x, const float y, const float r)
-{
-  cairo_new_sub_path(cr);
-  cairo_arc(cr, x, y, r, 0, 2.0f*M_PI);
-  const float dx = r*cosf(M_PI/8.0f), dy = r*sinf(M_PI/8.0f);
-  cairo_move_to(cr, x-dx, y-dy);
-  cairo_curve_to(cr, x, y-2*dy, x, y+2*dy, x+dx, y+dy);
-  cairo_move_to(cr, x-.20*dx, y+.8*dy);
-  cairo_line_to(cr, x-.80*dx, y+.8*dy);
-  cairo_move_to(cr, x+.20*dx, y-.8*dy);
-  cairo_line_to(cr, x+.80*dx, y-.8*dy);
-  cairo_move_to(cr, x+.50*dx, y-.8*dy-0.3*dx);
-  cairo_line_to(cr, x+.50*dx, y-.8*dy+0.3*dx);
-  cairo_stroke(cr);
-}
+//static inline void
+//dt_view_draw_altered(cairo_t *cr, const float x, const float y, const float r)
+//{
+//  cairo_new_sub_path(cr);
+//  cairo_arc(cr, x, y, r, 0, 2.0f*M_PI);
+//  const float dx = r*cosf(M_PI/8.0f), dy = r*sinf(M_PI/8.0f);
+//  cairo_move_to(cr, x-dx, y-dy);
+//  cairo_curve_to(cr, x, y-2*dy, x, y+2*dy, x+dx, y+dy);
+//  cairo_move_to(cr, x-.20*dx, y+.8*dy);
+//  cairo_line_to(cr, x-.80*dx, y+.8*dy);
+//  cairo_move_to(cr, x+.20*dx, y-.8*dy);
+//  cairo_line_to(cr, x+.80*dx, y-.8*dy);
+//  cairo_move_to(cr, x+.50*dx, y-.8*dy-0.3*dx);
+//  cairo_line_to(cr, x+.50*dx, y-.8*dy+0.3*dx);
+//  cairo_stroke(cr);
+//}
 
-static inline void
-dt_view_star(cairo_t *cr, float x, float y, float r1, float r2)
-{
-  const float d = 2.0*M_PI*0.1f;
-  const float dx[10] = {sinf(0.0), sinf(d), sinf(2*d), sinf(3*d), sinf(4*d), sinf(5*d), sinf(6*d), sinf(7*d), sinf(8*d), sinf(9*d)};
-  const float dy[10] = {cosf(0.0), cosf(d), cosf(2*d), cosf(3*d), cosf(4*d), cosf(5*d), cosf(6*d), cosf(7*d), cosf(8*d), cosf(9*d)};
-  cairo_move_to(cr, x+r1*dx[0], y-r1*dy[0]);
-  for(int k=1; k<10; k++)
-    if(k&1) cairo_line_to(cr, x+r2*dx[k], y-r2*dy[k]);
-    else    cairo_line_to(cr, x+r1*dx[k], y-r1*dy[k]);
-  cairo_close_path(cr);
-}
+//static inline void
+//dt_view_star(cairo_t *cr, float x, float y, float r1, float r2)
+//{
+//  const float d = 2.0*M_PI*0.1f;
+//  const float dx[10] = {sinf(0.0), sinf(d), sinf(2*d), sinf(3*d), sinf(4*d), sinf(5*d), sinf(6*d), sinf(7*d), sinf(8*d), sinf(9*d)};
+//  const float dy[10] = {cosf(0.0), cosf(d), cosf(2*d), cosf(3*d), cosf(4*d), cosf(5*d), cosf(6*d), cosf(7*d), cosf(8*d), cosf(9*d)};
+//  cairo_move_to(cr, x+r1*dx[0], y-r1*dy[0]);
+//  for(int k=1; k<10; k++)
+//    if(k&1) cairo_line_to(cr, x+r2*dx[k], y-r2*dy[k]);
+//    else    cairo_line_to(cr, x+r1*dx[k], y-r1*dy[k]);
+//  cairo_close_path(cr);
+//}
 
 
 void
@@ -639,7 +640,7 @@ dt_view_image_expose(
   int32_t px,
   int32_t py,
   gboolean full_preview)
-{
+{ 
   const double start = dt_get_wtime();
   // some performance tuning stuff, for your pleasure.
   // on my machine with 7 image per row it seems grouping has the largest
@@ -664,7 +665,7 @@ dt_view_image_expose(
 #endif
 
   cairo_save (cr);
-  float bgcol = 0.4, fontcol = 0.425, bordercol = 0.1, outlinecol = 0.2;
+  float bgcol = 0.25, fontcol = 0.425, bordercol = 0.1, outlinecol = 0.15;
   int selected = 0, altered = 0, imgsel = -1, is_grouped = 0;
   // this is a gui thread only thing. no mutex required:
   imgsel = darktable.control->global_settings.lib_image_mouse_over_id;
@@ -707,15 +708,15 @@ dt_view_image_expose(
 
   if(selected == 1)
   {
-    outlinecol = 0.4;
-    bgcol = 0.6;
-    fontcol = 0.5;
+    bgcol = 0.4;
+    fontcol = 0.3;
+    outlinecol = 0.2;
   }
   if(imgsel == imgid)
   {
-    bgcol = 0.8;  // mouse over
-    fontcol = 0.7;
-    outlinecol = 0.6;
+    bgcol = 0.6;  // mouse over
+    fontcol = 0.5;
+    outlinecol = 0.4;
     // if the user points at this image, we really want it:
     if(!img)
       img = dt_image_cache_read_get(darktable.image_cache, imgid);
@@ -776,6 +777,82 @@ dt_view_image_expose(
     imgid,
     mip,
     0);
+  
+  #if DRAW_COLORLABELS == 1
+  // TODO: cache in image struct!
+  if (dt_conf_get_bool("ui_last/show_colorlabel_background")){
+    /* clear and reset prepared statement */
+    DT_DEBUG_SQLITE3_CLEAR_BINDINGS(darktable.view_manager->statements.get_color);
+    DT_DEBUG_SQLITE3_RESET(darktable.view_manager->statements.get_color);
+
+    /* setup statement and iterate rows */
+    DT_DEBUG_SQLITE3_BIND_INT(darktable.view_manager->statements.get_color, 1, imgid);
+    int numlabels = 0; 
+    int8_t colorlabels =0;
+    while(sqlite3_step(darktable.view_manager->statements.get_color) == SQLITE_ROW)
+    {
+      int col = sqlite3_column_int(darktable.view_manager->statements.get_color, 0);
+      colorlabels |= 1 << col;
+      numlabels ++;
+    }
+    
+    float stripwidth = (float)width/(float)numlabels;
+    float xstart = 0;
+
+    if (colorlabels & 0x1)
+    {
+       cairo_save(cr);
+       cairo_set_source_rgba (cr,1,0.0,0.0,0.125);
+       cairo_rectangle (cr, xstart, 0, stripwidth, height);
+       cairo_fill (cr);
+       cairo_restore(cr);
+
+       xstart += stripwidth;
+    }
+    if (colorlabels & 0x2)
+    {
+       cairo_save(cr);
+        cairo_set_source_rgba (cr,1,1.0,0.0,0.125);
+       cairo_rectangle (cr, xstart, 0, stripwidth, height);
+       cairo_fill (cr);
+       cairo_restore(cr);
+       
+       xstart += stripwidth;
+    }
+    if (colorlabels & 0x4)
+    {
+       cairo_save(cr);
+       cairo_set_source_rgba (cr,0.0,1,0.0,0.125);
+       cairo_rectangle (cr, xstart, 0, stripwidth, height);
+       cairo_fill (cr);
+       cairo_restore(cr);
+       
+       xstart += stripwidth;
+    }
+    if (colorlabels & 0x8)
+    {
+       cairo_save(cr);
+       cairo_set_source_rgba (cr,0.0,0.0,1,0.125);
+       cairo_rectangle (cr, xstart, 0, stripwidth, height);
+       cairo_fill (cr);
+       cairo_restore(cr);
+       
+       xstart += stripwidth;
+    }
+    if (colorlabels & 0x16)
+    {
+       cairo_save(cr);
+       cairo_set_source_rgba (cr,1,0.0,1.0,0.125);
+       cairo_rectangle (cr, xstart, 0, stripwidth, height);
+       cairo_fill (cr);
+       cairo_restore(cr);
+       
+       xstart += stripwidth;
+    }
+  }
+    
+#endif
+  
 #if DRAW_THUMB == 1
   float scale = 1.0;
   // decompress image, if necessary. if compression is off, scratchmem will be == NULL,
@@ -860,10 +937,29 @@ dt_view_image_expose(
   }
   cairo_restore(cr);
 #endif
+  
   if(buf.buf)
     dt_mipmap_cache_read_release(darktable.mipmap_cache, &buf);
 
   const float fscale = fminf(width, height);
+  float r1, r2;
+  if(zoom != 1)
+  {
+    r1 = 0.038*width;
+    r2 = 0.018*width;
+  }
+  else
+  {
+    r1 = 0.015*fscale;
+    r2 = 0.007*fscale;
+  }
+
+  float x, y;
+   if(zoom != 1) y = 0.92*height;
+  else y = .12*fscale;
+
+  gboolean image_is_rejected = (img && ((img->flags & 0x7) == 6));
+  
   if(imgsel == imgid || full_preview)
   {
     // draw mouseover hover effects, set event hook for mouse button down!
@@ -871,75 +967,10 @@ dt_view_image_expose(
     cairo_set_line_width(cr, 1.5);
     cairo_set_source_rgb(cr, outlinecol, outlinecol, outlinecol);
     cairo_set_line_join (cr, CAIRO_LINE_JOIN_ROUND);
-    float r1, r2;
-    if(zoom != 1)
-    {
-      r1 = 0.05*width;
-      r2 = 0.022*width;
-    }
-    else
-    {
-      r1 = 0.015*fscale;
-      r2 = 0.007*fscale;
-    }
-
-    float x, y;
-    if(zoom != 1) y = 0.90*height;
-    else y = .12*fscale;
-    gboolean image_is_rejected = (img && ((img->flags & 0x7) == 6));
-
-    if(img) for(int k=0; k<5; k++)
-      {
-        if(zoom != 1) x = (0.41+k*0.12)*width;
-        else x = (.08+k*0.04)*fscale;
-
-        if(!image_is_rejected) //if rejected: draw no stars
-        {
-          dt_view_star(cr, x, y, r1, r2);
-          if((px - x)*(px - x) + (py - y)*(py - y) < r1*r1)
-          {
-            *image_over = DT_VIEW_STAR_1 + k;
-            cairo_fill(cr);
-          }
-          else if((img->flags & 0x7) > k)
-          {
-            cairo_fill_preserve(cr);
-            cairo_set_source_rgb(cr, 1.0-bordercol, 1.0-bordercol, 1.0-bordercol);
-            cairo_stroke(cr);
-            cairo_set_source_rgb(cr, outlinecol, outlinecol, outlinecol);
-          }
-          else cairo_stroke(cr);
-        }
-      }
 
     //Image rejected?
     if(zoom !=1) x = 0.11*width;
     else x = .04*fscale;
-
-    if (image_is_rejected)
-      cairo_set_source_rgb(cr, 1., 0., 0.);
-
-    if((px - x)*(px - x) + (py - y)*(py - y) < r1*r1)
-    {
-      *image_over = DT_VIEW_REJECT; //mouse sensitive
-      cairo_new_sub_path(cr);
-      cairo_arc(cr, x, y, (r1+r2)*.5, 0, 2.0f*M_PI);
-      cairo_stroke(cr);
-    }
-
-    if (image_is_rejected)
-      cairo_set_line_width(cr, 2.5);
-
-    //reject cross:
-    cairo_move_to(cr, x-r2, y-r2);
-    cairo_line_to(cr, x+r2, y+r2);
-    cairo_move_to(cr, x+r2, y-r2);
-    cairo_line_to(cr, x-r2, y+r2);
-    cairo_close_path(cr);
-    cairo_stroke(cr);
-    cairo_set_source_rgb(cr, outlinecol, outlinecol, outlinecol);
-    cairo_set_line_width(cr, 1.5);
-
 
     // image part of a group?
     if(is_grouped && darktable.gui && darktable.gui->grouping)
@@ -967,34 +998,148 @@ dt_view_image_expose(
       if(img && abs(px-_x-.5*s) <= .8*s && abs(py-_y-.5*s) <= .8*s)
         *image_over = DT_VIEW_GROUP;
     }
+  }
+  
+  // reject cross
 
-    // image altered?
-    if(altered)
+  if (imgsel == imgid || full_preview || (image_is_rejected && dt_conf_get_bool("ui_last/show_rejects")))
+  {
+    cairo_save(cr);
+
+    float reject_width = (r1+r2)/1.5;
+
+    float x1, y1;
+    if(zoom !=1) x1 = 0.11*width - reject_width /2 ;
+      else x1 = .04*fscale  - reject_width /2;
+    if(zoom != 1) y1 = x1;
+    else y1 = .12*fscale  - reject_width /2;
+    
+    if (image_is_rejected)
     {
-      // align to right
-      float s = (r1+r2)*.5;
-      if(zoom != 1)
+      cairo_set_source_rgb(cr, 1., 0., 0.);
+      cairo_set_line_width(cr, 2.5);
+    }
+
+    if ((imgsel == imgid || full_preview))
+    {    
+      float x2 = x1 + reject_width;
+      float y2 = y1 + reject_width;
+      
+      int hover_effect = (px > x1 && px < x2 && py > y1 && py < y2) ? 1 : 0;
+
+      if (hover_effect)
       {
-        x = width*0.9;
-        y = height*0.1;
-      }
-      else x = (.04+7*0.04)*fscale;
-      dt_view_draw_altered(cr, x, y, s);
-      //g_print("px = %d, x = %.4f, py = %d, y = %.4f\n", px, x, py, y);
-      if(img && abs(px-x) <= 1.2*s && abs(py-y) <= 1.2*s) // mouse hovers over the altered-icon -> history tooltip!
-      {
-        darktable.gui->center_tooltip = 1;
+        *image_over = DT_VIEW_REJECT; //mouse sensitive
+        cairo_new_sub_path(cr);
+        cairo_arc(cr, x1 + reject_width/2, y1 + reject_width/2, (r1+r2)*.5, 0, 2.0f*M_PI);
+        cairo_stroke(cr);
       }
     }
+        
+    cairo_move_to(cr, x1, y1);
+    cairo_line_to(cr, x1+reject_width, y1+reject_width);
+    cairo_move_to(cr, x1+reject_width, y1);
+    cairo_line_to(cr, x1, y1+reject_width);
+    cairo_close_path(cr);
+    cairo_stroke(cr);
+    cairo_set_source_rgb(cr, outlinecol, outlinecol, outlinecol);
+    cairo_set_line_width(cr, 1.5);
+    cairo_restore(cr);
   }
+  
+  // rating stars
+  if(img )
+  {
+    cairo_save(cr);
+    float star_width = r1 * 2.5;
+    float rectx1;
+    if(zoom != 1) rectx1 = 0.1*width;
+      else rectx1 = .08*fscale;
+    float rectx2 = rectx1+ 5*star_width;
+    float recty1 = y -r1;
+    float recty2 = y + r1 * 2;
+    float x = rectx1;
+    cairo_set_line_width(cr, r1*0.2);
+    
+    if ((imgsel == imgid || full_preview))
+    {
+      int star_under_mouse =  (px > rectx1 && px < rectx2 && py > recty1 && py < recty2) ? (px - rectx1 +r1)/ star_width : -1;
 
+      if (star_under_mouse >= 0)
+        *image_over = DT_VIEW_STAR_1 + star_under_mouse;
+
+      for(int k=0; k<5; k++)
+      {
+        dtgtk_cairo_paint_star(cr, x, y, r1, r2);
+        if(star_under_mouse >= k)
+        {
+            cairo_set_source_rgb(cr, darktable.gui->star_color_fill[0], darktable.gui->star_color_fill[1], darktable.gui->star_color_fill[2]);
+            cairo_fill_preserve(cr);
+            cairo_set_source_rgb(cr, darktable.gui->star_color_outline[0], darktable.gui->star_color_outline[1], darktable.gui->star_color_outline[2]);
+            cairo_stroke(cr);
+        }
+        else if((img->flags & 0x7) > k && star_under_mouse < 0 && !image_is_rejected)
+        {
+            dtgtk_cairo_paint_star(cr, x, y, r1, r2);
+            cairo_set_source_rgb(cr, darktable.gui->star_color_fill[0], darktable.gui->star_color_fill[1], darktable.gui->star_color_fill[2]);
+            cairo_fill_preserve(cr);
+            cairo_set_source_rgb(cr, darktable.gui->star_color_outline[0], darktable.gui->star_color_outline[1], darktable.gui->star_color_outline[2]);
+            cairo_stroke(cr);
+        }
+        else
+        {
+          cairo_set_source_rgb(cr, 0.75, 0.75, 0.75);
+          cairo_fill_preserve(cr);
+          cairo_set_source_rgb(cr, 0.85, 0.85, 0.85);
+          cairo_stroke(cr);
+        }
+        x += star_width;
+      }
+    }
+    else if (!image_is_rejected && dt_conf_get_bool("ui_last/show_ratings_on_all_images")) 
+    {
+      for(int k=0; k<5; k++)
+      {
+        if((img->flags & 0x7) > k)
+        {
+            dtgtk_cairo_paint_star(cr, x, y, r1, r2);
+            cairo_set_source_rgb(cr, darktable.gui->star_color_fill[0], darktable.gui->star_color_fill[1], darktable.gui->star_color_fill[2]);
+            cairo_fill_preserve(cr);
+            cairo_set_source_rgb(cr, darktable.gui->star_color_outline[0], darktable.gui->star_color_outline[1], darktable.gui->star_color_outline[2]);
+            cairo_stroke(cr);
+        }
+        x += star_width;
+      }
+    }
+    cairo_restore(cr);
+  }
+  
+  // image altered?
+  if(altered && ((imgsel == imgid || full_preview) || dt_conf_get_bool("ui_last/show_history_labels")))
+  {
+    // align to right
+    float s = (r1+r2)*.5;
+    if(zoom != 1)
+    {
+      x = width*0.9;
+      y = height*0.1;
+    }
+    else x = (.04+7*0.04)*fscale;
+    dtgtk_cairo_paint_altered(cr, x, y, s);
+    //g_print("px = %d, x = %.4f, py = %d, y = %.4f\n", px, x, py, y);
+    if(img && abs(px-x) <= 1.2*s && abs(py-y) <= 1.2*s) // mouse hovers over the altered-icon -> history tooltip!
+    {
+      darktable.gui->center_tooltip = 1;
+    }
+  }
+  
   // kill all paths, in case img was not loaded yet, or is blocked:
   cairo_new_path(cr);
 
-#if DRAW_COLORLABELS == 1
+
   // TODO: make mouse sensitive, just as stars!
   // TODO: cache in image struct!
-  {
+  if (dt_conf_get_bool("ui_last/show_colorlabel_dots")){
     // color labels:
     const float x = zoom == 1 ? (0.07)*fscale : .21*width;
     const float y = zoom == 1 ? 0.17*fscale: 0.1*height;
@@ -1015,7 +1160,7 @@ dt_view_image_expose(
       cairo_restore(cr);
     }
   }
-#endif
+
 
   if(img && (zoom == 1))
   {


### PR DESCRIPTION
Implemented 5 toggle buttons that allow the user to show various information either for all images or only the active image. This includes ratings, color labels (traditional and background tint style), history label, and reject cross. In addition, the colors for the rating stars are now read from darktable.gtkrc.in.

see it in action here: http://www.youtube.com/watch?v=Yexe33P8GBM&feature=youtu.be
