### PR TITLE
Add script to synchronize from Lr database.

### DIFF
--- a/tools/lightroom/README
+++ b/tools/lightroom/README
@@ -1,0 +1,29 @@
+
+Rating, color labels, geo-tagging and selected status on Lightroom are only
+on the SQLite database and not exported into the XMP sidecar.
+
+To synchronize those settings from Lightroom into darktable here are two
+helper scripts.
+
+1. get_lr_data.sh
+
+   To be run once, the parameter is the SQLite Lightroom catalog.
+
+   This script will create $HOME/.config/darktable/lr.db
+
+2. sync_dt.sh
+
+   Do not take any parameter, this script will synchronize the rating,
+   color labels and selected status from lr.db to darktable's library.db.
+
+   It must be run after importing some images that have been edited with
+   Lightroom. It will get the data for the new images.
+
+   Note that you'll probably need to edit this script to add the proper
+   color label name for your country. Currently only English and French
+   are supported. Feel free to contribute patches.
+
+   To get all the names, run the following on the console (after
+   get_lr_data.sh has been runned):
+
+   echo "SELECT DISTINCT (colorLabels) from data;" | sqlite3 ~/.config/darktable/lr.db

--- a/tools/lightroom/get_lr_data.sh
+++ b/tools/lightroom/get_lr_data.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+if [ "$1" = "" ]; then
+    echo usage: $0 lr_catalogue_name
+    exit 1
+fi
+
+DT=$HOME/.config/darktable
+
+cat<<EOF | sqlite3 "$1" > /tmp/extract
+SELECT rating, pick, colorLabels, pathFromRoot||originalFilename, gpsLatitude, gpsLongitude, hasGPS FROM Adobe_images, AgLibraryFile, AgLibraryFolder, AgHarvestedExifMetadata WHERE AgLibraryFile.id_local=rootFile AND AgLibraryFile.folder=AgLibraryFolder.id_local AND AgHarvestedExifMetadata.image=Adobe_images.id_local;
+EOF
+
+rm -f $DT/lr.db
+
+cat<<EOF | sqlite3 $DT/lr.db
+CREATE TABLE data (
+   rating  INTEGER,
+   pick    INTEGER,
+   colorLabels VARCHAR,
+   filename VARCHAR,
+   gpsLatitude, gpsLongitude, hasGPS);
+
+.import /tmp/extract data
+EOF

--- a/tools/lightroom/sync_dt.sh
+++ b/tools/lightroom/sync_dt.sh
@@ -1,0 +1,84 @@
+#! /bin/sh
+
+DT=$HOME/.config/darktable
+
+if [ ! -f $DT/lr.db ]; then
+    echo please, create lr.db using get_lr_data.sh first
+    exit 1
+fi
+
+# select only images with flags=1 (this is the default value when imported)
+
+cat<<EOF | sqlite3 $DT/library.db > /tmp/data
+select images.id, folder || '/' || filename from images, film_rolls where flags&7=1 and film_rolls.id=images.film_id;
+CREATE UNIQUE INDEX IF NOT EXISTS color_labels_idx ON color_labels(imgid,color);
+EOF
+
+cat<<EOF | sqlite3 $DT/lr.db
+DROP TABLE IF EXISTS files;
+
+CREATE TABLE files (
+   id INTEGER,
+   dt_filename VARCHAR);
+
+.import /tmp/data files
+EOF
+
+inject_data()
+{
+    echo "$1;" >> $DT/lrsync.log
+    echo "$1;" | sqlite3 $DT/library.db
+}
+
+parse_data()
+{
+    id=$1
+    rating=$2
+    pick=$3
+    color=$4
+    gpslat=$5
+    gpslon=$6
+    hasgps=$7
+
+    if [ $pick = 1 ]; then
+        if [ $rating != "''" ]; then
+            inject_data "UPDATE images SET flags=flags|$rating WHERE images.id=$id"
+        fi
+
+    elif [ $pick = -1 ]; then
+        # rejected
+        inject_data "UPDATE images SET flags=flags|6 WHERE images.id=$id"
+
+    else
+        # pick=0 (not selected), set to 0 star
+        inject_data "UPDATE images SET flags=flags&~7 WHERE images.id=$id"
+    fi
+
+    case "$color" in
+        Rouge|Red)
+            inject_data "INSERT OR IGNORE INTO color_labels VALUES ($id,0)"
+            ;;
+        Jaune|Yellow)
+            inject_data "INSERT OR IGNORE INTO color_labels VALUES ($id,1)"
+            ;;
+        Vert|Green)
+            inject_data "INSERT OR IGNORE INTO color_labels VALUES ($id,2)"
+            ;;
+        Bleu|Blue)
+            inject_data "INSERT OR IGNORE INTO color_labels VALUES ($id,3)"
+            ;;
+        \'\')
+            ;;
+        *)
+            inject_data "INSERT OR IGNORE INTO color_labels VALUES ($id,4)"
+            ;;
+    esac
+
+    if [ $hasgps != 0 ]; then
+        inject_data "UPDATE images SET longitude=$gpslon, latitude=$gpslat WHERE images.id=$id"
+    fi
+}
+
+cat<<EOF | sqlite3 -separator ' ' $DT/lr.db | while read id rating pick color gpslat gpslon hgps; do parse_data $id "$rating" "$pick" "$color" "$gpslat" "$gpslon" "$hgps"; done
+SELECT id, QUOTE(rating), pick, QUOTE(colorLabels), QUOTE(gpsLatitude), QUOTE(gpsLongitude), hasGPS FROM data, files WHERE files.dt_filename like '%'||data.filename;
+EOF


### PR DESCRIPTION
These scripts can be used to synchronize rating, geo-tagging,
selected status and color labels from Lightroom.

This cannot be automatized as it needs access to the Lr catalog (SQLite database). So the
scripts here are helpers that can be run manually when needed to get valuable information
from Lightroom catalog to the darktable one.

I think merging into the main darktable repo will make those scritps more visible and will help people migrating.

Ok?
