### PR TITLE
Create a unique index constraint for imgid/color for color_labels table.

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -425,6 +425,8 @@ void dt_control_create_database_schema()
                         "create table color_labels (imgid integer, color integer)",
                         NULL, NULL, NULL);
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
+                        "create unique index color_labels_idx ON color_labels(imgid,color)", NULL, NULL, NULL);
+  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
                         "create table meta_data (id integer,key integer,value varchar)",
                         NULL, NULL, NULL);
   // quick hack to detect if the db is already used by another process
@@ -579,6 +581,8 @@ void dt_control_init(dt_control_t *s)
       sqlite3_exec(dt_database_get(darktable.db),
                    "create table color_labels (imgid integer, color integer)",
                    NULL, NULL, NULL);
+      sqlite3_exec(dt_database_get(darktable.db),
+                   "create unique index color_labels_idx ON color_labels(imgid,color)", NULL, NULL, NULL);
       sqlite3_exec(dt_database_get(darktable.db),
                    "drop table mipmaps", NULL, NULL, NULL);
       sqlite3_exec(dt_database_get(darktable.db),


### PR DESCRIPTION
This is a constraint that must be obeyed, nice to let SQLite a
chance to check.

Found while working on lr 2 dt import for rating. Now we can use:

   INSERT OR IGNORE INTO color_labels VALUES (5643,3)

And it will not add a duplicate entry into color_labels.
