### PR TITLE
Fix base curve presets for Canon on Spanish locale

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -2597,7 +2597,7 @@ msgstr "similar a canon eos"
 
 #: ../src/iop/basecurve.c:100
 msgid "canon eos like alternate"
-msgstr "similar a canon eos"
+msgstr "similar a canon eos (alternativo)"
 
 #: ../src/iop/basecurve.c:101
 msgid "nikon like"


### PR DESCRIPTION
The translation for "canon eos like" and "canon eos like alternate" is the same. The result is that no base curve is automatically applied to Canon EOS cameras, except the 5D Mark II
