### PR TITLE
Use a light blue for module labels.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1944,7 +1944,7 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
 
   /* add module label */
   char label[128];
-  g_snprintf(label,128,"<span size=\"larger\">%s</span> %s",module->name(),module->multi_name);
+  g_snprintf(label,128,"<span foreground=\"#8E9FC3\" size=\"larger\">%s</span> %s",module->name(),module->multi_name);
   hw[idx] = gtk_label_new("");
   gtk_label_set_markup(GTK_LABEL(hw[idx++]),label);
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -815,7 +815,7 @@ dt_lib_gui_get_expander (dt_lib_module_t *module)
 
   /* add module label */
   char label[128];
-  g_snprintf(label,128,"<span size=\"larger\">%s</span>",module->name());
+  g_snprintf(label,128,"<span foreground=\"#8E9FC3\" size=\"larger\">%s</span>",module->name());
   hw[idx] = gtk_label_new("");
   gtk_label_set_markup(GTK_LABEL(hw[idx++]),label);
 


### PR DESCRIPTION
This strike-out a bit more and ends-up more readable given the number of
module in darktable at this point.

I had proposed a bold label and it was rejected. I'm using more and more darktable and I really feel that I'm having hesitation/difficulties to see where are the modules. All the text being white the different modules does not strike out enough and I loose time "parsing" the screen. At first I thought that with the habit it will be easier, but not much and after all this time using darktable this is not satisfactory for me.

So, this simple patch adds a light blue color to the module labels. Looks better to me.
Please use it, look at this and tell me what you think.
