### PR TITLE
Add way to customize the panel labels.

### DIFF
--- a/data/darktable.gtkrc.in
+++ b/data/darktable.gtkrc.in
@@ -230,6 +230,11 @@ style "clearlooks-scrollbar" = "clearlooks-defaults"
 	GtkScrollbar::focus-padding     = 0
 }
 
+style "clearlooks-header-panel-label"
+{
+        fg[NORMAL]      = "white"
+}
+
 style "metacity-frame"
 {
   # Normal base color
@@ -269,6 +274,7 @@ widget "*.plugins_vbox_left.GtkEventBox" style "clearlooks-brightbg"
 #widget "*.GtkEventBox.GtkVBox.GtkHBox.GtkButton" style "clearlooks-vbrightbg"
 
 widget "*.header_label" style "clearlooks-header"
+widget "*.panel_label" style "clearlooks-header-panel-label"
 
 widget "*.right.GtkEventBox" style "clearlooks-brightbg"
 widget "*.left.GtkEventBox" style "clearlooks-brightbg"

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1946,6 +1946,7 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   char label[128];
   g_snprintf(label,128,"<span size=\"larger\">%s</span> %s",module->name(),module->multi_name);
   hw[idx] = gtk_label_new("");
+  gtk_widget_set_name(hw[idx], "panel_label");
   gtk_label_set_markup(GTK_LABEL(hw[idx++]),label);
 
   /* add multi instaces menu button */

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -817,6 +817,7 @@ dt_lib_gui_get_expander (dt_lib_module_t *module)
   char label[128];
   g_snprintf(label,128,"<span size=\"larger\">%s</span>",module->name());
   hw[idx] = gtk_label_new("");
+  gtk_widget_set_name(hw[idx], "panel_label");
   gtk_label_set_markup(GTK_LABEL(hw[idx++]),label);
 
   /* add reset button if module has implementation */


### PR DESCRIPTION
All is said in the subject. With the following ~/.config/darktable/darktable.gtkrc I'm able to change the color of the module label. The default color is not changed.

   include "/opt/darktable/share/darktable/darktable.gtkrc"
   style "clearlooks-header-panel-label"
   {
           fg[NORMAL]      = "#8E9FC3"
   }
   widget "*.panel_label" style "clearlooks-header-panel-label"

I think this can go safely into master.
