### PR TITLE
Makes the watermark alignment active button visible.

### DIFF
--- a/data/darktable.gtkrc.in
+++ b/data/darktable.gtkrc.in
@@ -235,6 +235,13 @@ style "clearlooks-header-panel-label"
         fg[NORMAL]      = "white"
 }
 
+style "clearlooks-watermark-align-button"
+{
+        bg[NORMAL]      = "white"
+        bg[ACTIVE]      = "#858585"
+        bg[PRELIGHT]    = "white"
+}
+
 style "metacity-frame"
 {
   # Normal base color
@@ -301,6 +308,7 @@ widget "*.darktable_label" style "clearlooks-header"
 widget "*.view_label" style "clearlooks-header"
 #widget_class "BasePWidget.GtkEventBox.GtkTable.GtkFrame" style "clearlooks-panel"
 widget "gtk-tooltip*" style "clearlooks-tooltips"
+widget "*.watermark_align_button" style "clearlooks-watermark-align-button"
 class "GtkNotebook" style "clearlooks-notebook"
 #class "GtkProgressBar" style "clearlooks-progressbar"
 #widget_class "*.GtkComboBox.GtkButton" style "clearlooks-combo"

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1026,6 +1026,7 @@ void gui_init(struct dt_iop_module_t *self)
     g->dtba[i] = DTGTK_TOGGLEBUTTON (dtgtk_togglebutton_new (dtgtk_cairo_paint_alignment,CPF_STYLE_FLAT|(CPF_SPECIAL_FLAG<<(i+1))));
     gtk_widget_set_size_request (GTK_WIDGET (g->dtba[i]),16,16);
     gtk_table_attach (GTK_TABLE (bat), GTK_WIDGET (g->dtba[i]), (i%3),(i%3)+1,(i/3),(i/3)+1,0,0,0,0);
+    gtk_widget_set_name(GTK_WIDGET (g->dtba[i]), "watermark_align_button");
     g_signal_connect (G_OBJECT (g->dtba[i]), "toggled",G_CALLBACK (alignment_callback), self);
   }
   GtkWidget *hbox2 = gtk_hbox_new(FALSE,0);


### PR DESCRIPTION
This is done by introducing a new style (configurable) and a
new name for those buttons.

This is something that has bothered me since some time. The actual active alignment button was almost indiscernible from the others has the background were all very close.

But there is still an issue when you open the watermark iop for the first time or if you collapse it and reopen it the active button is not refreshed. Did not found a solution
yet... Gtk experts any idea?

Of course it would be nice to have this minor usability fix in 1.2.
