### PR TITLE
Fix missing translations for moving/copying images.

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: DarkTable 0.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-03-08 15:15+0100\n"
-"PO-Revision-Date: 2013-03-08 15:22+0100\n"
+"POT-Creation-Date: 2013-03-17 12:12+0100\n"
+"PO-Revision-Date: 2013-03-17 12:14+0100\n"
 "Last-Translator: Pascal Obry <pascal@obry.net>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -33,11 +33,11 @@ msgstr "taille des panneaux latéraux en pixels"
 #: ../build/src/preferences_gen.h:1285 ../build/src/preferences_gen.h:1306
 #: ../build/src/preferences_gen.h:1325 ../build/src/preferences_gen.h:1366
 #: ../build/src/preferences_gen.h:1388 ../build/src/preferences_gen.h:1410
-#: ../build/src/preferences_gen.h:1433 ../build/src/preferences_gen.h:1456
-#: ../build/src/preferences_gen.h:1475 ../build/src/preferences_gen.h:1494
-#: ../build/src/preferences_gen.h:1517 ../build/src/preferences_gen.h:1536
-#: ../build/src/preferences_gen.h:1555 ../build/src/preferences_gen.h:1587
-#: ../build/src/preferences_gen.h:1622 ../build/src/preferences_gen.h:1654
+#: ../build/src/preferences_gen.h:1432 ../build/src/preferences_gen.h:1455
+#: ../build/src/preferences_gen.h:1474 ../build/src/preferences_gen.h:1493
+#: ../build/src/preferences_gen.h:1516 ../build/src/preferences_gen.h:1535
+#: ../build/src/preferences_gen.h:1554 ../build/src/preferences_gen.h:1586
+#: ../build/src/preferences_gen.h:1621 ../build/src/preferences_gen.h:1653
 #, c-format
 msgid "double click to reset to `%s'"
 msgstr "double-cliquer pour réinitialiser `%s'"
@@ -266,7 +266,7 @@ msgstr ""
 msgid "host memory limit (in MB) for tiling"
 msgstr "mémoire limite (en Mo) pour le tuilage"
 
-#: ../build/src/preferences_gen.h:1436
+#: ../build/src/preferences_gen.h:1435
 msgid ""
 "this variable controls the maximum amount of memory (in MB) a module may use "
 "during image processing. lower values will force memory hungry modules to "
@@ -279,12 +279,12 @@ msgstr ""
 "valeurs inférieures à 500 sont considérées égales à 500. nécessite un "
 "redémarrage."
 
-#: ../build/src/preferences_gen.h:1443
+#: ../build/src/preferences_gen.h:1442
 msgid "minimum amount of memory (in MB) for a single buffer in tiling"
 msgstr ""
 "quantité minimale de mémoire (en Mo) pour la mémoire-tampon d'une tuile"
 
-#: ../build/src/preferences_gen.h:1459
+#: ../build/src/preferences_gen.h:1458
 msgid ""
 "if set to a positive, non-zero value this variable defines the minimum "
 "amount of memory (in MB) that tiling should take for a single image buffer. "
@@ -294,11 +294,11 @@ msgstr ""
 "quantité de mémoire minimale (en Mo) que le tuilage doit utiliser pour la "
 "mémoire-tampon. surcharge 'host_memory_limit'. nécessite un redémarrage."
 
-#: ../build/src/preferences_gen.h:1466
+#: ../build/src/preferences_gen.h:1465
 msgid "write sidecar file for each image"
 msgstr "écrire un fichier xmp redondant pour chaque image"
 
-#: ../build/src/preferences_gen.h:1478
+#: ../build/src/preferences_gen.h:1477
 msgid ""
 "these redundant files can later be re-imported into a different database, "
 "preserving your changes to the image."
@@ -306,11 +306,11 @@ msgstr ""
 "ces fichiers pourront être réimportés dans une base de données différente "
 "par la suite, tout en préservant les modifications apportées aux images."
 
-#: ../build/src/preferences_gen.h:1485
+#: ../build/src/preferences_gen.h:1484
 msgid "activate opencl support"
 msgstr "activer le support d'OpenCL"
 
-#: ../build/src/preferences_gen.h:1497
+#: ../build/src/preferences_gen.h:1496
 msgid ""
 "if found, use opencl runtime on your system for improved processing speed. "
 "can be switched on and off at any time."
@@ -318,23 +318,23 @@ msgstr ""
 "si OpenCL est présent sur votre système, darktable l'utilise pour améliorer "
 "les performances. peut être désactivé à tout moment."
 
-#: ../build/src/preferences_gen.h:1501
+#: ../build/src/preferences_gen.h:1500
 msgid "not available on this system"
 msgstr "non disponible sur cette plateforme"
 
-#: ../build/src/preferences_gen.h:1508
+#: ../build/src/preferences_gen.h:1507
 msgid "always use littlecms2 during export"
 msgstr "toujours utiliser littlecms2 pendant l'exportation"
 
-#: ../build/src/preferences_gen.h:1520
+#: ../build/src/preferences_gen.h:1519
 msgid "this is about 28x as slow as the default."
 msgstr "à peu près 28x plus lent que l'option par défaut."
 
-#: ../build/src/preferences_gen.h:1527
+#: ../build/src/preferences_gen.h:1526
 msgid "do high quality resampling during export"
 msgstr "ré-échantillonnage de haute qualité lors de l'exportation"
 
-#: ../build/src/preferences_gen.h:1539
+#: ../build/src/preferences_gen.h:1538
 msgid ""
 "the image will first be processed in full resolution, and downscaled at the "
 "very end. this can result in better quality sometimes, but will always be "
@@ -343,11 +343,11 @@ msgstr ""
 "l'image est développée en résolution maximale, puis échantillonnée à la fin. "
 "cela permet d'améliorer parfois la qualité mais est toujours plus lent."
 
-#: ../build/src/preferences_gen.h:1546
+#: ../build/src/preferences_gen.h:1545
 msgid "dithering for darkroom mode"
 msgstr "homogénéisation pour la vue en chambre noire"
 
-#: ../build/src/preferences_gen.h:1558
+#: ../build/src/preferences_gen.h:1557
 msgid ""
 "center view will be dithered if this option is on and module dithering is "
 "activated (default for new images). switch this to off if you can accept "
@@ -358,11 +358,11 @@ msgstr ""
 "images). désactiver pour avoir une vitesse de développement légèrement plus "
 "rapide au prix de l'apparition de bandes."
 
-#: ../build/src/preferences_gen.h:1565
+#: ../build/src/preferences_gen.h:1564
 msgid "demosaicing for zoomed out darkroom mode"
 msgstr "méthode de dématriçage pour la vue en chambre noire"
 
-#: ../build/src/preferences_gen.h:1590
+#: ../build/src/preferences_gen.h:1589
 msgid ""
 "interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, "
 "but not as sharp. middle ground is using ppg + interpolation modes specified "
@@ -373,11 +373,11 @@ msgstr ""
 "l'exportation. 'ppg' et les modes d'interpolation ci-dessous représente la "
 "voie moyenne"
 
-#: ../build/src/preferences_gen.h:1597
+#: ../build/src/preferences_gen.h:1596
 msgid "pixel interpolator"
 msgstr "algorithme d'interpolation"
 
-#: ../build/src/preferences_gen.h:1625
+#: ../build/src/preferences_gen.h:1624
 msgid ""
 "pixel interpolator used in rotation and lens correction (bilinear, bicubic, "
 "lanczos2, lanczos3)."
@@ -385,11 +385,11 @@ msgstr ""
 "algorithme d'interpolation utilisé pour la rotation et la correction des "
 "objectifs (bilinéaire, bicubique, lanczos2, lanczos3)"
 
-#: ../build/src/preferences_gen.h:1632
+#: ../build/src/preferences_gen.h:1631
 msgid "password storage backend to use"
 msgstr "stockage à utiliser pour les mots de passe"
 
-#: ../build/src/preferences_gen.h:1657
+#: ../build/src/preferences_gen.h:1656
 msgid "the storage backend for password storage: none, kwallet, gnome keyring"
 msgstr ""
 "interface pour trousseau de mots de passe : aucun, kwallet, gnome keyring"
@@ -530,13 +530,13 @@ msgstr ""
 "sur une autre"
 
 #: ../src/common/history.c:209 ../src/common/history.c:222
-#: ../src/common/styles.c:530 ../src/develop/develop.c:1090
+#: ../src/common/styles.c:537 ../src/develop/develop.c:1090
 #: ../src/libs/live_view.c:406
 msgid "on"
 msgstr "activé"
 
 #: ../src/common/history.c:209 ../src/common/history.c:222
-#: ../src/common/styles.c:530 ../src/develop/blend_gui.c:1028
+#: ../src/common/styles.c:537 ../src/develop/blend_gui.c:1028
 #: ../src/develop/develop.c:1090 ../src/imageio/format/j2k.c:602
 #: ../src/iop/demosaic.c:1329 ../src/iop/vignette.c:1120
 #: ../src/libs/history.c:155 ../src/libs/live_view.c:405
@@ -563,11 +563,11 @@ msgstr "image '%s\" non disponible"
 #. If a style is to be applied during export, add the iop params into the history
 #. set export style to "none" by default
 #: ../src/common/imageio.c:554 ../src/common/variables.c:220
-#: ../src/control/control.c:120 ../src/iop/clipping.c:1354
-#: ../src/iop/clipping.c:1593 ../src/iop/clipping.c:1611
-#: ../src/iop/clipping.c:1655 ../src/iop/clipping.c:1672
-#: ../src/iop/lens.c:1692 ../src/libs/export.c:157 ../src/libs/export.c:159
-#: ../src/libs/export.c:592 ../src/libs/live_view.c:324
+#: ../src/control/control.c:120 ../src/iop/clipping.c:1451
+#: ../src/iop/clipping.c:1689 ../src/iop/clipping.c:1707
+#: ../src/iop/clipping.c:1750 ../src/iop/clipping.c:1767
+#: ../src/iop/lens.c:1694 ../src/libs/export.c:158 ../src/libs/export.c:161
+#: ../src/libs/export.c:594 ../src/libs/live_view.c:324
 #: ../src/libs/live_view.c:336 ../src/libs/live_view.c:354
 #, c-format
 msgid "none"
@@ -585,51 +585,51 @@ msgid_plural "applying rating %d to %d images"
 msgstr[0] "application de %d étoile(s) à %d image"
 msgstr[1] "application de %d étoile(s) à %d images"
 
-#: ../src/common/ratings.c:65
+#: ../src/common/ratings.c:66
 msgid "no images selected to apply rating"
 msgstr "aucune image sélectionnée pour appliquer les étoiles"
 
-#: ../src/common/styles.c:93
+#: ../src/common/styles.c:94
 #, c-format
 msgid "style with name '%s' already exists"
 msgstr "le style '%s' existe déjà"
 
-#: ../src/common/styles.c:287 ../src/common/styles.c:346
+#: ../src/common/styles.c:288 ../src/common/styles.c:347
 #, c-format
 msgid "style named '%s' successfully created"
 msgstr "le style '%s' a été créé"
 
 #. fail :(
-#: ../src/common/styles.c:366 ../src/common/styles.c:385
+#: ../src/common/styles.c:367 ../src/common/styles.c:386
 #: ../src/views/darkroom.c:446
 msgid "no image selected!"
 msgstr "aucune image sélectionnée"
 
-#: ../src/common/styles.c:614
+#: ../src/common/styles.c:621
 #, c-format
 msgid "failed to overwrite style file for %s"
 msgstr "impossible de remplacer le style %s"
 
-#: ../src/common/styles.c:620
+#: ../src/common/styles.c:627
 #, c-format
 msgid "style file for %s exists"
 msgstr "le fichier du style '%s' existe"
 
-#: ../src/common/styles.c:667
+#: ../src/common/styles.c:674
 #, c-format
 msgid "style %s was successfully saved"
 msgstr "le style '%s' a été sauvegardé"
 
-#: ../src/common/styles.c:860
+#: ../src/common/styles.c:867
 #, c-format
 msgid "style %s was successfully imported"
 msgstr "le style '%s' a été importé"
 
-#: ../src/control/control.c:1371 ../src/control/control.c:1374
+#: ../src/control/control.c:1355 ../src/control/control.c:1358
 msgid "working.."
 msgstr "en cours..."
 
-#: ../src/control/control.c:1455
+#: ../src/control/control.c:1439
 #, c-format
 msgid "switch to %s mode"
 msgstr "passer en mode %s"
@@ -827,6 +827,26 @@ msgid "copy image?"
 msgid_plural "copy images?"
 msgstr[0] "copier l'image ?"
 msgstr[1] "copier les images ?"
+
+#: ../src/control/jobs/control_jobs.c:898
+#, c-format
+msgid "moving %d image"
+msgstr "déplacement de %d image"
+
+#: ../src/control/jobs/control_jobs.c:898
+#, c-format
+msgid "moving %d images"
+msgstr "déplacement de %d images"
+
+#: ../src/control/jobs/control_jobs.c:904
+#, c-format
+msgid "copying %d image"
+msgstr "copie de %d image"
+
+#: ../src/control/jobs/control_jobs.c:904
+#, c-format
+msgid "copying %d images"
+msgstr "copie de %d images"
 
 #: ../src/control/jobs/control_jobs.c:936
 msgid "failed to get parameters from storage module, aborting export.."
@@ -1129,7 +1149,7 @@ msgstr "non limité"
 msgid "blend mode"
 msgstr "mode de fusion"
 
-#: ../src/develop/blend_gui.c:1086 ../src/iop/watermark.c:919
+#: ../src/develop/blend_gui.c:1086 ../src/iop/watermark.c:1015
 msgid "opacity"
 msgstr "opacité"
 
@@ -1772,7 +1792,7 @@ msgstr "iso"
 
 #. exposure
 #: ../src/gui/preferences.c:460 ../src/gui/preferences.c:1378
-#: ../src/gui/presets.c:453 ../src/iop/exposure.c:42 ../src/iop/exposure.c:392
+#: ../src/gui/presets.c:453 ../src/iop/exposure.c:42 ../src/iop/exposure.c:397
 #: ../src/iop/relight.c:384 ../src/libs/metadata_view.c:86
 msgid "exposure"
 msgstr "exposition"
@@ -1791,8 +1811,8 @@ msgstr "ouverture"
 msgid "focal length"
 msgstr "focale"
 
-#: ../src/gui/preferences.c:481 ../src/iop/borders.c:1023
-#: ../src/iop/exposure.c:397 ../src/iop/levels.c:286
+#: ../src/gui/preferences.c:481 ../src/iop/borders.c:1066
+#: ../src/iop/exposure.c:402 ../src/iop/levels.c:286
 #: ../src/iop/tonecurve.c:554
 msgid "auto"
 msgstr "auto"
@@ -1822,7 +1842,7 @@ msgstr "importation"
 
 #. Export button
 #. export button
-#: ../src/gui/preferences.c:608 ../src/libs/export.c:618
+#: ../src/gui/preferences.c:608 ../src/libs/export.c:620
 #: ../src/libs/styles.c:409
 msgid "export"
 msgstr "exporter"
@@ -2016,7 +2036,7 @@ msgid "enter a description for the new style, this description is searchable"
 msgstr "entrer une description pour le nouveau style (recherche)"
 
 #: ../src/gui/styles_dialog.c:350 ../src/gui/styles_dialog.c:363
-#: ../src/gui/hist_dialog.c:160
+#: ../src/gui/hist_dialog.c:181
 msgid "include"
 msgstr "inclure"
 
@@ -2025,7 +2045,7 @@ msgid "update"
 msgstr "modifier"
 
 #: ../src/gui/styles_dialog.c:392 ../src/gui/styles_dialog.c:399
-#: ../src/gui/hist_dialog.c:171
+#: ../src/gui/hist_dialog.c:192
 msgid "item"
 msgstr "élément"
 
@@ -2033,20 +2053,20 @@ msgstr "élément"
 msgid "can't create style out of unaltered image"
 msgstr "impossible de créer un style depuis une image non développée"
 
-#: ../src/gui/hist_dialog.c:129
+#: ../src/gui/hist_dialog.c:150
 msgid "select parts"
 msgstr "sélectionner les modules à copier"
 
-#: ../src/gui/hist_dialog.c:207
+#: ../src/gui/hist_dialog.c:228
 msgid "can't copy history out of unaltered image"
 msgstr "impossible de copier le développement d'une image non développée"
 
-#: ../src/imageio/format/copy.c:143 ../src/libs/copy_history.c:253
+#: ../src/imageio/format/copy.c:144 ../src/libs/copy_history.c:256
 #: ../src/libs/image.c:158
 msgid "copy"
 msgstr "copier"
 
-#: ../src/imageio/format/copy.c:154
+#: ../src/imageio/format/copy.c:155
 msgid ""
 "do a 1:1 copy of the selected files.\n"
 "the global options below do not apply!"
@@ -2054,7 +2074,7 @@ msgstr ""
 "effectue une copie conforme des fichiers.\n"
 "les options ci-dessous ne s'appliquent pas !"
 
-#: ../src/imageio/format/exr.cc:151
+#: ../src/imageio/format/exr.cc:152
 msgid "openexr"
 msgstr "openexr"
 
@@ -2070,7 +2090,7 @@ msgstr "jp2"
 msgid "j2k"
 msgstr "j2k"
 
-#: ../src/imageio/format/j2k.c:588 ../src/imageio/format/jpeg.c:668
+#: ../src/imageio/format/j2k.c:588 ../src/imageio/format/jpeg.c:669
 #: ../src/libs/camera.c:617
 msgid "quality"
 msgstr "qualité"
@@ -2091,11 +2111,11 @@ msgstr "cinema2k, 48fps"
 msgid "cinema4k, 24fps"
 msgstr "cinema4k, 24fps"
 
-#: ../src/imageio/format/jpeg.c:648
+#: ../src/imageio/format/jpeg.c:649
 msgid "8-bit jpg"
 msgstr "jpeg 8-bits"
 
-#: ../src/imageio/format/pfm.c:96
+#: ../src/imageio/format/pfm.c:97
 msgid "float pfm"
 msgstr "pfm en flottant"
 
@@ -2111,7 +2131,7 @@ msgstr "8-bits"
 msgid "16-bit"
 msgstr "16-bits"
 
-#: ../src/imageio/format/ppm.c:102
+#: ../src/imageio/format/ppm.c:103
 msgid "16-bit ppm"
 msgstr "ppm 16-bits"
 
@@ -2146,7 +2166,7 @@ msgstr "impossible d'écrire dans le répertoire %s !"
 #: ../src/imageio/storage/disk.c:238 ../src/imageio/storage/email.c:106
 #: ../src/imageio/storage/facebook.c:1185 ../src/imageio/storage/flickr.c:669
 #: ../src/imageio/storage/gallery.c:379 ../src/imageio/storage/gallery.c:398
-#: ../src/imageio/storage/picasa.c:1467
+#: ../src/imageio/storage/picasa.c:1479
 #, c-format
 msgid "could not export to file `%s'!"
 msgstr "impossible d'exporter le fichier %s !"
@@ -2181,7 +2201,7 @@ msgstr ""
 "navigateur. connectez-vous à votre compte facebook et autorisez darktable à "
 "charger des fichiers pour continuer."
 
-#: ../src/imageio/storage/facebook.c:600 ../src/imageio/storage/picasa.c:824
+#: ../src/imageio/storage/facebook.c:600 ../src/imageio/storage/picasa.c:832
 msgid ""
 "step 2: paste your browser url and click the ok button once you are done."
 msgstr "étape 2 : coller l'url du navigateur cliquez sur \"ok\""
@@ -2190,37 +2210,37 @@ msgstr "étape 2 : coller l'url du navigateur cliquez sur \"ok\""
 msgid "Facebook authentication"
 msgstr "authentification facebook"
 
-#: ../src/imageio/storage/facebook.c:614 ../src/imageio/storage/picasa.c:838
+#: ../src/imageio/storage/facebook.c:614 ../src/imageio/storage/picasa.c:846
 msgid "url:"
 msgstr "url :"
 
-#: ../src/imageio/storage/facebook.c:634 ../src/imageio/storage/picasa.c:858
+#: ../src/imageio/storage/facebook.c:634 ../src/imageio/storage/picasa.c:866
 msgid "please enter the validation url"
 msgstr "entrer l'url de validation"
 
-#: ../src/imageio/storage/facebook.c:645 ../src/imageio/storage/picasa.c:870
+#: ../src/imageio/storage/facebook.c:645 ../src/imageio/storage/picasa.c:878
 msgid "the given url is not valid, it should look like: "
 msgstr "l'url donnée n'est pas valide, elle devrait ressembler à :"
 
-#: ../src/imageio/storage/facebook.c:751 ../src/imageio/storage/picasa.c:1001
+#: ../src/imageio/storage/facebook.c:751 ../src/imageio/storage/picasa.c:1009
 msgid "new account"
 msgstr "nouveau compte"
 
-#: ../src/imageio/storage/facebook.c:758 ../src/imageio/storage/picasa.c:1008
+#: ../src/imageio/storage/facebook.c:758 ../src/imageio/storage/picasa.c:1016
 msgid "other account"
 msgstr "autre compte"
 
-#: ../src/imageio/storage/facebook.c:789 ../src/imageio/storage/picasa.c:1038
+#: ../src/imageio/storage/facebook.c:789 ../src/imageio/storage/picasa.c:1046
 msgid "unable to retreive the album list"
 msgstr "impossible de rafraîchir la liste d'album"
 
 #: ../src/imageio/storage/facebook.c:797 ../src/imageio/storage/flickr.c:387
-#: ../src/imageio/storage/flickr.c:415 ../src/imageio/storage/picasa.c:1046
+#: ../src/imageio/storage/flickr.c:415 ../src/imageio/storage/picasa.c:1054
 msgid "create new album"
 msgstr "créer un nouvel album"
 
-#: ../src/imageio/storage/facebook.c:919 ../src/imageio/storage/picasa.c:1094
-#: ../src/imageio/storage/picasa.c:1254
+#: ../src/imageio/storage/facebook.c:919 ../src/imageio/storage/picasa.c:1102
+#: ../src/imageio/storage/picasa.c:1262
 msgid "logout"
 msgstr "se déconnecter"
 
@@ -2228,8 +2248,8 @@ msgstr "se déconnecter"
 #: ../src/imageio/storage/facebook.c:923 ../src/imageio/storage/facebook.c:936
 #: ../src/imageio/storage/facebook.c:963
 #: ../src/imageio/storage/facebook.c:1066 ../src/imageio/storage/flickr.c:525
-#: ../src/imageio/storage/picasa.c:1100 ../src/imageio/storage/picasa.c:1258
-#: ../src/imageio/storage/picasa.c:1271 ../src/imageio/storage/picasa.c:1350
+#: ../src/imageio/storage/picasa.c:1108 ../src/imageio/storage/picasa.c:1266
+#: ../src/imageio/storage/picasa.c:1279 ../src/imageio/storage/picasa.c:1358
 msgid "login"
 msgstr "connexion"
 
@@ -2241,17 +2261,17 @@ msgstr "album web facebook"
 #. xmp
 #: ../src/imageio/storage/facebook.c:1013 ../src/imageio/storage/flickr.c:479
 #: ../src/imageio/storage/gallery.c:167 ../src/imageio/storage/latex.c:167
-#: ../src/imageio/storage/picasa.c:1299 ../src/libs/collect.h:38
+#: ../src/imageio/storage/picasa.c:1307 ../src/libs/collect.h:38
 #: ../src/libs/metadata.c:298 ../src/libs/metadata_view.c:95
 msgid "title"
 msgstr "titre"
 
 #: ../src/imageio/storage/facebook.c:1014 ../src/imageio/storage/flickr.c:480
-#: ../src/imageio/storage/picasa.c:1300
+#: ../src/imageio/storage/picasa.c:1308
 msgid "summary"
 msgstr "résumé"
 
-#: ../src/imageio/storage/facebook.c:1015 ../src/imageio/storage/picasa.c:1301
+#: ../src/imageio/storage/facebook.c:1015 ../src/imageio/storage/picasa.c:1309
 msgid "privacy"
 msgstr "vie privée"
 
@@ -2271,15 +2291,15 @@ msgstr "public"
 msgid "Friends of Friends"
 msgstr "amis d'amis"
 
-#: ../src/imageio/storage/facebook.c:1194 ../src/imageio/storage/picasa.c:1476
+#: ../src/imageio/storage/facebook.c:1194 ../src/imageio/storage/picasa.c:1488
 msgid "unable to create album, no title provided"
 msgstr "impossible de créer un album, titre manquant"
 
-#: ../src/imageio/storage/facebook.c:1201 ../src/imageio/storage/picasa.c:1483
+#: ../src/imageio/storage/facebook.c:1201 ../src/imageio/storage/picasa.c:1495
 msgid "unable to create album"
 msgstr "impossible de créer un nouvel album"
 
-#: ../src/imageio/storage/facebook.c:1211 ../src/imageio/storage/picasa.c:1493
+#: ../src/imageio/storage/facebook.c:1211 ../src/imageio/storage/picasa.c:1505
 msgid "unable to export photo to webalbum"
 msgstr "impossible d'exporter les photos vers l'album web"
 
@@ -2414,7 +2434,7 @@ msgid "enter the title of the book"
 msgstr "entrer le titre du livre"
 
 #. //////////// build & show the validation dialog
-#: ../src/imageio/storage/picasa.c:821
+#: ../src/imageio/storage/picasa.c:829
 msgid ""
 "step 1: a new window or tab of your browser should have been loaded. you "
 "have to login into your picasa account there and authorize darktable to "
@@ -2424,24 +2444,24 @@ msgstr ""
 "navigateur. Connectez-vous à votre compte picasa et autorisez darktable à "
 "charger des fichiers pour continuer."
 
-#: ../src/imageio/storage/picasa.c:832
+#: ../src/imageio/storage/picasa.c:840
 msgid "picasa authentication"
 msgstr "authentification picasa"
 
-#: ../src/imageio/storage/picasa.c:1286
+#: ../src/imageio/storage/picasa.c:1294
 msgid "picasa webalbum"
 msgstr "album web picasa"
 
-#: ../src/imageio/storage/picasa.c:1343
+#: ../src/imageio/storage/picasa.c:1351
 msgid "private"
 msgstr "privé"
 
-#: ../src/imageio/storage/picasa.c:1345
+#: ../src/imageio/storage/picasa.c:1353
 msgid "public"
 msgstr "public"
 
 #. this makes sense only if the export was successful
-#: ../src/imageio/storage/picasa.c:1511
+#: ../src/imageio/storage/picasa.c:1522
 #, c-format
 msgid "%d/%d exported to picasa webalbum"
 msgstr "%d/%d exportée(s) vers picasa web"
@@ -2754,155 +2774,155 @@ msgstr "force"
 msgid "the strength of bloom"
 msgstr "force de la lumière d'arrière-plan"
 
-#: ../src/iop/borders.c:136
+#: ../src/iop/borders.c:166
 msgid "framing"
 msgstr "cadre décoratif"
 
-#: ../src/iop/borders.c:158
+#: ../src/iop/borders.c:188
 msgctxt "accel"
 msgid "border size"
 msgstr "taille du cadre"
 
-#: ../src/iop/borders.c:159
+#: ../src/iop/borders.c:189
 msgctxt "accel"
 msgid "pick border color from image"
 msgstr "choisir la couleur de la bordure dans l'image"
 
-#: ../src/iop/borders.c:161
+#: ../src/iop/borders.c:191
 msgctxt "accel"
 msgid "frame line size"
 msgstr "taille du cadre interne"
 
-#: ../src/iop/borders.c:162
+#: ../src/iop/borders.c:192
 msgctxt "accel"
 msgid "pick frame line color from image"
 msgstr "choisir la couleur du cadre dans l'image"
 
-#: ../src/iop/borders.c:505
+#: ../src/iop/borders.c:548
 msgid "15:10 postcard white"
 msgstr "15x10 blanc"
 
-#: ../src/iop/borders.c:508
+#: ../src/iop/borders.c:551
 msgid "15:10 postcard black"
 msgstr "15x10 noir"
 
-#: ../src/iop/borders.c:753
+#: ../src/iop/borders.c:796
 msgid "select border color"
 msgstr "sélectionne la couleur de la bordure"
 
-#: ../src/iop/borders.c:790
+#: ../src/iop/borders.c:833
 msgid "select frame line color"
 msgstr "sélectionne la couleur du cadre"
 
 #. add import singel image buttons
-#: ../src/iop/borders.c:940 ../src/iop/clipping.c:1631
+#: ../src/iop/borders.c:983 ../src/iop/clipping.c:1727
 #: ../src/libs/import.c:814
 msgid "image"
 msgstr "image"
 
-#: ../src/iop/borders.c:941
+#: ../src/iop/borders.c:984
 msgid "3:1"
 msgstr "3:1"
 
-#: ../src/iop/borders.c:942
+#: ../src/iop/borders.c:985
 msgid "95:33"
 msgstr "95:33"
 
-#: ../src/iop/borders.c:943
+#: ../src/iop/borders.c:986
 msgid "2:1"
 msgstr "2:1"
 
-#: ../src/iop/borders.c:944 ../src/iop/clipping.c:1640
+#: ../src/iop/borders.c:987 ../src/iop/clipping.c:1736
 msgid "16:9"
 msgstr "16:9"
 
-#: ../src/iop/borders.c:945 ../src/iop/clipping.c:1632
+#: ../src/iop/borders.c:988 ../src/iop/clipping.c:1728
 msgid "golden cut"
 msgstr "rapport d'or"
 
-#: ../src/iop/borders.c:946 ../src/iop/clipping.c:1634
+#: ../src/iop/borders.c:989 ../src/iop/clipping.c:1730
 msgid "3:2"
 msgstr "3:2"
 
-#: ../src/iop/borders.c:947
+#: ../src/iop/borders.c:990
 msgid "A4"
 msgstr "A4"
 
-#: ../src/iop/borders.c:948 ../src/iop/clipping.c:1639
+#: ../src/iop/borders.c:991 ../src/iop/clipping.c:1735
 msgid "DIN"
 msgstr "DIN"
 
-#: ../src/iop/borders.c:949 ../src/iop/clipping.c:1636
+#: ../src/iop/borders.c:992 ../src/iop/clipping.c:1732
 msgid "4:3"
 msgstr "4:3"
 
-#: ../src/iop/borders.c:950 ../src/iop/clipping.c:1638
+#: ../src/iop/borders.c:993 ../src/iop/clipping.c:1734
 msgid "square"
 msgstr "carré"
 
-#: ../src/iop/borders.c:951
+#: ../src/iop/borders.c:994
 msgid "constant border"
 msgstr "cadre constant"
 
-#: ../src/iop/borders.c:973 ../src/iop/borders.c:978
+#: ../src/iop/borders.c:1016 ../src/iop/borders.c:1021
 msgid "center"
 msgstr "centré"
 
-#: ../src/iop/borders.c:974 ../src/iop/borders.c:979
+#: ../src/iop/borders.c:1017 ../src/iop/borders.c:1022
 msgid "1/3"
 msgstr "1/3"
 
-#: ../src/iop/borders.c:975 ../src/iop/borders.c:980
+#: ../src/iop/borders.c:1018 ../src/iop/borders.c:1023
 msgid "3/8"
 msgstr "3/8"
 
-#: ../src/iop/borders.c:976 ../src/iop/borders.c:981
+#: ../src/iop/borders.c:1019 ../src/iop/borders.c:1024
 msgid "5/8"
 msgstr "5/8"
 
-#: ../src/iop/borders.c:977 ../src/iop/borders.c:982
+#: ../src/iop/borders.c:1020 ../src/iop/borders.c:1025
 msgid "2/3"
 msgstr "2/3"
 
-#: ../src/iop/borders.c:1007
+#: ../src/iop/borders.c:1050
 msgid "border size"
 msgstr "taille du cadre"
 
-#: ../src/iop/borders.c:1010
+#: ../src/iop/borders.c:1053
 msgid "size of the border in percent of the full image"
 msgstr "taille du cadre en pourcentage de l'image"
 
-#: ../src/iop/borders.c:1015 ../src/iop/clipping.c:1629
+#: ../src/iop/borders.c:1058 ../src/iop/clipping.c:1725
 msgid "aspect"
 msgstr "aspect"
 
-#: ../src/iop/borders.c:1019
+#: ../src/iop/borders.c:1062
 msgid "select the aspect ratio or right click and type your own (w:h)"
 msgstr ""
 "sélectionne les dimensions ou permet par clic-droit\n"
 "d'entrer des dimensions personnalisées (l:h)"
 
-#: ../src/iop/borders.c:1022 ../src/iop/flip.c:81
+#: ../src/iop/borders.c:1065 ../src/iop/flip.c:81
 msgid "orientation"
 msgstr "orientation"
 
-#: ../src/iop/borders.c:1024
+#: ../src/iop/borders.c:1067
 msgid "portait"
 msgstr "portrait"
 
-#: ../src/iop/borders.c:1025
+#: ../src/iop/borders.c:1068
 msgid "landscape"
 msgstr "paysage"
 
-#: ../src/iop/borders.c:1026
+#: ../src/iop/borders.c:1069
 msgid "aspect ratio orientation of the image with border"
 msgstr "orientation de l'image avec le cadre"
 
-#: ../src/iop/borders.c:1032
+#: ../src/iop/borders.c:1075
 msgid "horizontal position"
 msgstr "position horizontale"
 
-#: ../src/iop/borders.c:1035
+#: ../src/iop/borders.c:1078
 msgid ""
 "select the horizontal position ratio relative to top or right click and type "
 "your own (y:h)"
@@ -2910,11 +2930,11 @@ msgstr ""
 "sélectionne la position horizontale par rapport au côté supérieur\n"
 "ou permet par clic-droit d'entrer des dimensions personnalisées (y:h)"
 
-#: ../src/iop/borders.c:1038
+#: ../src/iop/borders.c:1081
 msgid "vertical position"
 msgstr "position verticale"
 
-#: ../src/iop/borders.c:1041
+#: ../src/iop/borders.c:1084
 msgid ""
 "select the vertical position ratio relative to left or right click and type "
 "your own (x:w)"
@@ -2922,35 +2942,35 @@ msgstr ""
 "sélectionne la position horizontale par rapport au côté supérieur\n"
 "ou permet par clic-droit d'entrer des dimensions personnalisées (x:l)"
 
-#: ../src/iop/borders.c:1045
+#: ../src/iop/borders.c:1088
 msgid "frame line size"
 msgstr "taille du cadre interne"
 
-#: ../src/iop/borders.c:1048
+#: ../src/iop/borders.c:1091
 msgid "size of the frame line in percent of min border width"
 msgstr "taille du cadre interne en pourcentage de l'image"
 
-#: ../src/iop/borders.c:1052
+#: ../src/iop/borders.c:1095
 msgid "frame line offset"
 msgstr "décalage du cadre interne"
 
-#: ../src/iop/borders.c:1055
+#: ../src/iop/borders.c:1098
 msgid "offset of the frame line beginning on picture side"
 msgstr "décalage du cadre interne à partir du côté de l'image"
 
-#: ../src/iop/borders.c:1061
+#: ../src/iop/borders.c:1104
 msgid "border color"
 msgstr "couleur de la bordure"
 
-#: ../src/iop/borders.c:1064
+#: ../src/iop/borders.c:1107
 msgid "pick border color from image"
 msgstr "choisir la couleur de la bordure dans l'image"
 
-#: ../src/iop/borders.c:1076
+#: ../src/iop/borders.c:1119
 msgid "frame line color"
 msgstr "couleur du cadre interne"
 
-#: ../src/iop/borders.c:1079
+#: ../src/iop/borders.c:1122
 msgid "pick frame line color from image"
 msgstr "choisir la couleur du cadre interne dans l'image"
 
@@ -3053,181 +3073,181 @@ msgstr "taille des caractéristiques à preserver"
 msgid "strength of the effect"
 msgstr "force de l'effet"
 
-#: ../src/iop/clipping.c:222
+#: ../src/iop/clipping.c:302
 msgid "crop and rotate"
 msgstr "recadrer et pivoter"
 
-#: ../src/iop/clipping.c:1276
+#: ../src/iop/clipping.c:1352
 msgid "invalid ratio format. it should be \"number:number\""
 msgstr "format de dimension non reconnu. il devrait être  \"nombre:nombre\""
 
-#: ../src/iop/clipping.c:1355 ../src/iop/clipping.c:1595
-#: ../src/iop/clipping.c:1612
+#: ../src/iop/clipping.c:1452 ../src/iop/clipping.c:1691
+#: ../src/iop/clipping.c:1708
 msgid "vertical"
 msgstr "verticale"
 
-#: ../src/iop/clipping.c:1356 ../src/iop/clipping.c:1594
-#: ../src/iop/clipping.c:1613
+#: ../src/iop/clipping.c:1453 ../src/iop/clipping.c:1690
+#: ../src/iop/clipping.c:1709
 msgid "horizontal"
 msgstr "horizontale"
 
-#: ../src/iop/clipping.c:1357 ../src/iop/clipping.c:1614
+#: ../src/iop/clipping.c:1454 ../src/iop/clipping.c:1710
 msgid "full"
 msgstr "les deux"
 
-#: ../src/iop/clipping.c:1358
+#: ../src/iop/clipping.c:1455
 msgid "old system"
 msgstr "système précédent"
 
-#: ../src/iop/clipping.c:1359
+#: ../src/iop/clipping.c:1456
 msgid "correction applied"
 msgstr "correction appliquée"
 
-#: ../src/iop/clipping.c:1592 ../src/iop/clipping.c:1671
+#: ../src/iop/clipping.c:1688 ../src/iop/clipping.c:1766
 #: ../src/libs/live_view.c:335
 msgid "flip"
 msgstr "symétrie miroir"
 
-#: ../src/iop/clipping.c:1596 ../src/iop/clipping.c:1675
+#: ../src/iop/clipping.c:1692 ../src/iop/clipping.c:1770
 #: ../src/libs/live_view.c:339
 msgid "both"
 msgstr "les deux"
 
-#: ../src/iop/clipping.c:1598
+#: ../src/iop/clipping.c:1694
 msgid "mirror image horizontally and/or vertically"
 msgstr "retourne l'image horizontalement et/ou horizontalement"
 
-#: ../src/iop/clipping.c:1603
+#: ../src/iop/clipping.c:1699
 msgid "angle"
 msgstr "rotation"
 
-#: ../src/iop/clipping.c:1606
+#: ../src/iop/clipping.c:1702
 msgid "right-click and drag a line on the image to drag a straight line"
 msgstr "clic-droit et tracer une ligne pour indiquer l'horizontale"
 
-#: ../src/iop/clipping.c:1610
+#: ../src/iop/clipping.c:1706
 msgid "keystone"
 msgstr "perspective"
 
-#: ../src/iop/clipping.c:1615
+#: ../src/iop/clipping.c:1711
 msgid "set perspective correction for your image"
 msgstr "règle la correction de perspective"
 
-#: ../src/iop/clipping.c:1620
+#: ../src/iop/clipping.c:1716
 msgid "automatic cropping"
 msgstr "recadrage"
 
-#: ../src/iop/clipping.c:1621
+#: ../src/iop/clipping.c:1717
 msgid "no"
 msgstr "non"
 
-#: ../src/iop/clipping.c:1622
+#: ../src/iop/clipping.c:1718
 msgid "yes"
 msgstr "oui"
 
-#: ../src/iop/clipping.c:1623
+#: ../src/iop/clipping.c:1719
 msgid "automatically crop to avoid black edges"
 msgstr "recadre automatique pour éviter les bords noirs"
 
-#: ../src/iop/clipping.c:1630
+#: ../src/iop/clipping.c:1726
 msgid "free"
 msgstr "libre"
 
-#: ../src/iop/clipping.c:1633
+#: ../src/iop/clipping.c:1729
 msgid "1:2"
 msgstr "1:2"
 
-#: ../src/iop/clipping.c:1635
+#: ../src/iop/clipping.c:1731
 msgid "7:5"
 msgstr "7:5"
 
-#: ../src/iop/clipping.c:1637
+#: ../src/iop/clipping.c:1733
 msgid "5:4"
 msgstr "5:4"
 
-#: ../src/iop/clipping.c:1641
+#: ../src/iop/clipping.c:1737
 msgid "16:10"
 msgstr "16:10"
 
-#: ../src/iop/clipping.c:1642
+#: ../src/iop/clipping.c:1738
 msgid "10:8 in print"
 msgstr "10:8 in print"
 
-#: ../src/iop/clipping.c:1648
+#: ../src/iop/clipping.c:1743
 msgid "set the aspect ratio (w:h)"
 msgstr "rapport largeur/hauteur"
 
-#: ../src/iop/clipping.c:1654 ../src/libs/live_view.c:323
+#: ../src/iop/clipping.c:1749 ../src/libs/live_view.c:323
 msgid "guides"
 msgstr "guides"
 
-#: ../src/iop/clipping.c:1656 ../src/libs/live_view.c:325
+#: ../src/iop/clipping.c:1751 ../src/libs/live_view.c:325
 msgid "grid"
 msgstr "grille"
 
-#: ../src/iop/clipping.c:1657 ../src/libs/live_view.c:326
+#: ../src/iop/clipping.c:1752 ../src/libs/live_view.c:326
 msgid "rules of thirds"
 msgstr "règle des tiers"
 
-#: ../src/iop/clipping.c:1658 ../src/libs/live_view.c:327
+#: ../src/iop/clipping.c:1753 ../src/libs/live_view.c:327
 msgid "diagonal method"
 msgstr "diagonales"
 
-#: ../src/iop/clipping.c:1659 ../src/libs/live_view.c:328
+#: ../src/iop/clipping.c:1754 ../src/libs/live_view.c:328
 msgid "harmonious triangles"
 msgstr "triangles harmonieux"
 
-#: ../src/iop/clipping.c:1660 ../src/libs/live_view.c:329
+#: ../src/iop/clipping.c:1755 ../src/libs/live_view.c:329
 msgid "golden mean"
 msgstr "nombre d'or"
 
-#: ../src/iop/clipping.c:1666 ../src/libs/live_view.c:330
+#: ../src/iop/clipping.c:1761 ../src/libs/live_view.c:330
 msgid "display guide lines to help compose your photograph"
 msgstr "affiche des guides pour vous aider à composer votre photo"
 
-#: ../src/iop/clipping.c:1673 ../src/libs/live_view.c:337
+#: ../src/iop/clipping.c:1768 ../src/libs/live_view.c:337
 msgid "horizontally"
 msgstr "horizontale"
 
-#: ../src/iop/clipping.c:1674 ../src/libs/live_view.c:338
+#: ../src/iop/clipping.c:1769 ../src/libs/live_view.c:338
 msgid "vertically"
 msgstr "verticale"
 
-#: ../src/iop/clipping.c:1676 ../src/libs/live_view.c:340
+#: ../src/iop/clipping.c:1771 ../src/libs/live_view.c:340
 msgid "flip guides"
 msgstr "retourne les guides"
 
-#: ../src/iop/clipping.c:1681 ../src/libs/live_view.c:344
+#: ../src/iop/clipping.c:1776 ../src/libs/live_view.c:344
 msgid "extra"
 msgstr "guides additionnels"
 
-#: ../src/iop/clipping.c:1682 ../src/libs/live_view.c:345
+#: ../src/iop/clipping.c:1777 ../src/libs/live_view.c:345
 msgid "golden sections"
 msgstr "sections d'or"
 
-#: ../src/iop/clipping.c:1683 ../src/libs/live_view.c:346
+#: ../src/iop/clipping.c:1778 ../src/libs/live_view.c:346
 msgid "golden spiral sections"
 msgstr "sections de spirale d'or"
 
-#: ../src/iop/clipping.c:1684 ../src/libs/live_view.c:347
+#: ../src/iop/clipping.c:1779 ../src/libs/live_view.c:347
 msgid "golden spiral"
 msgstr "spirale d'or"
 
-#: ../src/iop/clipping.c:1685 ../src/iop/lens.c:1698
+#: ../src/iop/clipping.c:1780 ../src/iop/lens.c:1700
 #: ../src/libs/live_view.c:348 ../src/libs/tools/filter.c:101
 msgid "all"
 msgstr "tout"
 
-#: ../src/iop/clipping.c:1686 ../src/libs/live_view.c:349
+#: ../src/iop/clipping.c:1781 ../src/libs/live_view.c:349
 msgid "show some extra guides"
 msgstr "afficher des guides supplémentaires"
 
-#: ../src/iop/clipping.c:2691
+#: ../src/iop/clipping.c:2782
 msgctxt "accel"
 msgid "commit"
 msgstr "valider"
 
-#: ../src/iop/clipping.c:2693
+#: ../src/iop/clipping.c:2784
 msgctxt "accel"
 msgid "angle"
 msgstr "rotation"
@@ -3302,7 +3322,7 @@ msgid "unsupported input profile has been replaced by linear rgb!"
 msgstr "profil d'entrée non supporté, remplacé par linéaire RVB !"
 
 #: ../src/iop/colorin.c:782 ../src/iop/denoiseprofile.c:1595
-#: ../src/libs/export.c:559
+#: ../src/libs/export.c:561
 msgid "profile"
 msgstr "profil"
 
@@ -3336,12 +3356,13 @@ msgstr "sRGB (ex: jpg)"
 
 #: ../src/iop/colorin.c:803 ../src/iop/colorout.c:894
 #: ../src/iop/colorout.c:895 ../src/iop/colorout.c:896
+#: ../src/libs/export.c:508
 msgid "Adobe RGB"
 msgstr "Adobe RGB"
 
 #: ../src/iop/colorin.c:805 ../src/iop/colorout.c:882
 #: ../src/iop/colorout.c:883 ../src/iop/colorout.c:884
-#: ../src/libs/export.c:518
+#: ../src/libs/export.c:520
 msgid "linear RGB"
 msgstr "linéaire RVB"
 
@@ -3422,23 +3443,23 @@ msgid "output intent"
 msgstr "rendu (sortie)"
 
 #: ../src/iop/colorout.c:851 ../src/iop/colorout.c:858
-#: ../src/libs/export.c:487
+#: ../src/libs/export.c:489
 msgid "perceptual"
 msgstr "perceptif"
 
 #: ../src/iop/colorout.c:852 ../src/iop/colorout.c:859
-#: ../src/libs/export.c:488
+#: ../src/libs/export.c:490
 msgid "relative colorimetric"
 msgstr "colorimétrie relative"
 
 #: ../src/iop/colorout.c:853 ../src/iop/colorout.c:860
-#: ../src/libs/export.c:489
+#: ../src/libs/export.c:491
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "saturation"
 
 #: ../src/iop/colorout.c:854 ../src/iop/colorout.c:861
-#: ../src/libs/export.c:490
+#: ../src/libs/export.c:492
 msgid "absolute colorimetric"
 msgstr "colorimétrie absolue"
 
@@ -3459,12 +3480,12 @@ msgid "display profile"
 msgstr "profil (écran)"
 
 #. the system display profile is only suitable for display purposes
-#: ../src/iop/colorout.c:878 ../src/libs/export.c:571
+#: ../src/iop/colorout.c:878 ../src/libs/export.c:573
 msgid "system display profile"
 msgstr "système"
 
 #: ../src/iop/colorout.c:888 ../src/iop/colorout.c:889
-#: ../src/iop/colorout.c:890 ../src/libs/export.c:499
+#: ../src/iop/colorout.c:890 ../src/libs/export.c:501
 msgid "sRGB (web-safe)"
 msgstr "sRGB (web)"
 
@@ -3677,7 +3698,7 @@ msgstr "profil pour iso %d trouvé"
 msgid "interpolated from iso %d and %d"
 msgstr "interpolé depuis iso %d et %d"
 
-#: ../src/iop/denoiseprofile.c:1596 ../src/iop/lens.c:1843
+#: ../src/iop/denoiseprofile.c:1596 ../src/iop/lens.c:1845
 msgid "mode"
 msgstr "mode"
 
@@ -3805,19 +3826,19 @@ msgctxt "accel"
 msgid "auto-exposure"
 msgstr "exposition auto"
 
-#: ../src/iop/exposure.c:385
+#: ../src/iop/exposure.c:390
 msgid "adjust the black level"
 msgstr "ajuste les niveaux de noir"
 
-#: ../src/iop/exposure.c:387
+#: ../src/iop/exposure.c:392
 msgid "black"
 msgstr "noir"
 
-#: ../src/iop/exposure.c:390
+#: ../src/iop/exposure.c:395
 msgid "adjust the exposure correction"
 msgstr "ajuste la correction d'exposition [IL]"
 
-#: ../src/iop/exposure.c:400
+#: ../src/iop/exposure.c:405
 msgid "percentage of bright values clipped out"
 msgstr "pourcentage de valeurs hautes tronquées"
 
@@ -4133,7 +4154,7 @@ msgstr "choisir la couleur du film dans l'image"
 msgid "lens correction"
 msgstr "correction des objectifs"
 
-#: ../src/iop/lens.c:71 ../src/iop/vignette.c:158 ../src/iop/watermark.c:115
+#: ../src/iop/lens.c:71 ../src/iop/vignette.c:158 ../src/iop/watermark.c:163
 msgctxt "accel"
 msgid "scale"
 msgstr "échelle"
@@ -4178,7 +4199,7 @@ msgctxt "accel"
 msgid "select corrections"
 msgstr "sélectionne les corrections"
 
-#: ../src/iop/lens.c:1048
+#: ../src/iop/lens.c:1052
 #, c-format
 msgid ""
 "maker:\t\t%s\n"
@@ -4191,7 +4212,7 @@ msgstr ""
 "monture :\t\t%s\n"
 " facteur de recadrage :\t%.1f"
 
-#: ../src/iop/lens.c:1316
+#: ../src/iop/lens.c:1318
 #, c-format
 msgid ""
 "maker:\t\t%s\n"
@@ -4210,136 +4231,136 @@ msgstr ""
 "type:\t\t%s\n"
 "monture:\t\t%s"
 
-#: ../src/iop/lens.c:1362
+#: ../src/iop/lens.c:1364
 msgid "mm"
 msgstr "mm"
 
-#: ../src/iop/lens.c:1363
+#: ../src/iop/lens.c:1365
 msgid "focal length (mm)"
 msgstr "longeur focale (mm)"
 
-#: ../src/iop/lens.c:1390
+#: ../src/iop/lens.c:1392
 msgid "f/"
 msgstr "f/"
 
-#: ../src/iop/lens.c:1391
+#: ../src/iop/lens.c:1393
 msgid "f-number (aperture)"
 msgstr "ouverture"
 
-#: ../src/iop/lens.c:1406
+#: ../src/iop/lens.c:1408
 msgid "d"
 msgstr "d"
 
-#: ../src/iop/lens.c:1407
+#: ../src/iop/lens.c:1409
 msgid "distance to subject"
 msgstr "distance au sujet"
 
-#: ../src/iop/lens.c:1704
+#: ../src/iop/lens.c:1706
 msgid "distortion & TCA"
 msgstr "distorsion et chromatisme"
 
-#: ../src/iop/lens.c:1710
+#: ../src/iop/lens.c:1712
 msgid "distortion & vignetting"
 msgstr "distorsion et vignettage"
 
-#: ../src/iop/lens.c:1716
+#: ../src/iop/lens.c:1718
 msgid "TCA & vignetting"
 msgstr "chromatisme et vignettage"
 
-#: ../src/iop/lens.c:1722
+#: ../src/iop/lens.c:1724
 msgid "only distortion"
 msgstr "distorsion seulement"
 
-#: ../src/iop/lens.c:1728
+#: ../src/iop/lens.c:1730
 msgid "only TCA"
 msgstr "chromatisme seulement"
 
-#: ../src/iop/lens.c:1734
+#: ../src/iop/lens.c:1736
 msgid "only vignetting"
 msgstr "vignettage seulement"
 
-#: ../src/iop/lens.c:1757
+#: ../src/iop/lens.c:1759
 msgid "find camera"
 msgstr "boîtier"
 
-#: ../src/iop/lens.c:1774
+#: ../src/iop/lens.c:1776
 msgid "find lens"
 msgstr "objectif"
 
-#: ../src/iop/lens.c:1803
+#: ../src/iop/lens.c:1805
 msgid "corrections"
 msgstr "corrections"
 
-#: ../src/iop/lens.c:1805
+#: ../src/iop/lens.c:1807
 msgid "which corrections to apply"
 msgstr "sélectionne les types de correction à effectuer"
 
-#: ../src/iop/lens.c:1820
+#: ../src/iop/lens.c:1822
 msgid "geometry"
 msgstr "géométrie"
 
-#: ../src/iop/lens.c:1822
+#: ../src/iop/lens.c:1824
 msgid "target geometry"
 msgstr "géométrie des images (distorsion)"
 
-#: ../src/iop/lens.c:1823
+#: ../src/iop/lens.c:1825
 msgid "rectilinear"
 msgstr "rectilinéaire"
 
-#: ../src/iop/lens.c:1824
+#: ../src/iop/lens.c:1826
 msgid "fish-eye"
 msgstr "fisheye"
 
-#: ../src/iop/lens.c:1825
+#: ../src/iop/lens.c:1827
 msgid "panoramic"
 msgstr "panoramique"
 
-#: ../src/iop/lens.c:1826
+#: ../src/iop/lens.c:1828
 msgid "equirectangular"
 msgstr "equi-rectangulaire"
 
-#: ../src/iop/lens.c:1833
+#: ../src/iop/lens.c:1835
 msgid "auto scale"
 msgstr "échelle auto"
 
-#: ../src/iop/lens.c:1834 ../src/iop/vignette.c:1126
-#: ../src/iop/watermark.c:922
+#: ../src/iop/lens.c:1836 ../src/iop/vignette.c:1126
+#: ../src/iop/watermark.c:1018
 msgid "scale"
 msgstr "échelle"
 
-#: ../src/iop/lens.c:1845
+#: ../src/iop/lens.c:1847
 msgid "correct distortions or apply them"
 msgstr "corrige ou applique des distorsions"
 
-#: ../src/iop/lens.c:1846
+#: ../src/iop/lens.c:1848
 msgid "correct"
 msgstr "retouche"
 
-#: ../src/iop/lens.c:1847
+#: ../src/iop/lens.c:1849
 msgid "distort"
 msgstr "déforme"
 
-#: ../src/iop/lens.c:1854
+#: ../src/iop/lens.c:1856
 msgid "transversal chromatic aberration red"
 msgstr "aberrations chromatiques transversales rouge"
 
-#: ../src/iop/lens.c:1855
+#: ../src/iop/lens.c:1857
 msgid "tca red"
 msgstr "rouge"
 
-#: ../src/iop/lens.c:1860
+#: ../src/iop/lens.c:1862
 msgid "transversal chromatic aberration blue"
 msgstr "aberrations chromatiques transversales bleu"
 
-#: ../src/iop/lens.c:1861
+#: ../src/iop/lens.c:1863
 msgid "tca blue"
 msgstr "bleu"
 
-#: ../src/iop/lens.c:1868
+#: ../src/iop/lens.c:1870
 msgid "corrections done: "
 msgstr "corrections effectuées :"
 
-#: ../src/iop/lens.c:1869
+#: ../src/iop/lens.c:1871
 msgid "which corrections have actually been done"
 msgstr "corrections réellement effectuées"
 
@@ -5161,52 +5182,52 @@ msgstr "ratio entre la largeur et la hauteur"
 msgid "add some level of random noise to prevent banding"
 msgstr "ajoute du bruit aléatoire pour éviter l'apparition de bandes"
 
-#: ../src/iop/watermark.c:92
+#: ../src/iop/watermark.c:140
 msgid "watermark"
 msgstr "filigrane"
 
-#: ../src/iop/watermark.c:113
+#: ../src/iop/watermark.c:161
 msgctxt "accel"
 msgid "refresh"
 msgstr "rafraîchir"
 
-#: ../src/iop/watermark.c:114
+#: ../src/iop/watermark.c:162
 msgctxt "accel"
 msgid "opacity"
 msgstr "opacité"
 
-#: ../src/iop/watermark.c:116
+#: ../src/iop/watermark.c:164
 msgctxt "accel"
 msgid "x offset"
 msgstr "décalage x"
 
-#: ../src/iop/watermark.c:117
+#: ../src/iop/watermark.c:165
 msgctxt "accel"
 msgid "y offset"
 msgstr "décalage y"
 
-#: ../src/iop/watermark.c:904
+#: ../src/iop/watermark.c:1000
 msgid "marker"
 msgstr "fichier"
 
-#: ../src/iop/watermark.c:905
+#: ../src/iop/watermark.c:1001
 msgid "alignment"
 msgstr "alignement"
 
-#: ../src/iop/watermark.c:943
+#: ../src/iop/watermark.c:1039
 msgid "x offset"
 msgstr "décalage x"
 
-#: ../src/iop/watermark.c:946
+#: ../src/iop/watermark.c:1042
 msgid "y offset"
 msgstr "décalage y"
 
 #. Let's add some tooltips and hook up some signals...
-#: ../src/iop/watermark.c:952
+#: ../src/iop/watermark.c:1048
 msgid "the opacity of the watermark"
 msgstr "opacité du filigrane"
 
-#: ../src/iop/watermark.c:953
+#: ../src/iop/watermark.c:1049
 msgid "the scale of the watermark"
 msgstr "taille du filigrane"
 
@@ -5710,7 +5731,7 @@ msgstr "tous les fichiers"
 msgid "error loading file '%s'"
 msgstr "erreur de chargement du fichier '%s'"
 
-#: ../src/libs/copy_history.c:255
+#: ../src/libs/copy_history.c:258
 msgid ""
 "copy part history stack of\n"
 "first selected image (ctrl-shift-c)"
@@ -5719,11 +5740,11 @@ msgstr ""
 "de la première image \n"
 "sélectionnée (ctrl-shift-c)"
 
-#: ../src/libs/copy_history.c:258
+#: ../src/libs/copy_history.c:261
 msgid "copy all"
 msgstr "tout copier"
 
-#: ../src/libs/copy_history.c:260
+#: ../src/libs/copy_history.c:263
 msgid ""
 "copy history stack of\n"
 "first selected image (ctrl-c)"
@@ -5733,11 +5754,11 @@ msgstr ""
 "sélectionnée (ctrl-c)"
 
 # lorsque l'action engendre une suppression physique non annulable, on emploie le terme "supprimer"
-#: ../src/libs/copy_history.c:263
+#: ../src/libs/copy_history.c:266
 msgid "discard"
 msgstr "supprimer"
 
-#: ../src/libs/copy_history.c:265
+#: ../src/libs/copy_history.c:268
 msgid ""
 "discard history stack of\n"
 "all selected images"
@@ -5745,11 +5766,11 @@ msgstr ""
 "supprime le développement des\n"
 "images sélectionnées"
 
-#: ../src/libs/copy_history.c:271
+#: ../src/libs/copy_history.c:274
 msgid "paste"
 msgstr "coller"
 
-#: ../src/libs/copy_history.c:272
+#: ../src/libs/copy_history.c:275
 msgid ""
 "paste part history stack to\n"
 "all selected images (ctrl-shift-v)"
@@ -5757,11 +5778,11 @@ msgstr ""
 "applique partiellement le développement\n"
 "à toutes les images sélectionnées (ctrl-shift-v)"
 
-#: ../src/libs/copy_history.c:277
+#: ../src/libs/copy_history.c:280
 msgid "paste all"
 msgstr "tout coller"
 
-#: ../src/libs/copy_history.c:278
+#: ../src/libs/copy_history.c:281
 msgid ""
 "paste history stack to\n"
 "all selected images (ctrl-v)"
@@ -5769,23 +5790,23 @@ msgstr ""
 "applique le développement à\n"
 "toutes les images sélectionnées (ctrl-v)"
 
-#: ../src/libs/copy_history.c:283
+#: ../src/libs/copy_history.c:286
 msgid "append"
 msgstr "empiler"
 
-#: ../src/libs/copy_history.c:284
+#: ../src/libs/copy_history.c:287
 msgid "overwrite"
 msgstr "écraser"
 
-#: ../src/libs/copy_history.c:285
+#: ../src/libs/copy_history.c:288
 msgid "how to handle existing history"
 msgstr "gestion des développements pré-existants"
 
-#: ../src/libs/copy_history.c:292
+#: ../src/libs/copy_history.c:295
 msgid "load sidecar file"
 msgstr "charger"
 
-#: ../src/libs/copy_history.c:294
+#: ../src/libs/copy_history.c:297
 msgid ""
 "open an xmp sidecar file\n"
 "and apply it to selected images"
@@ -5793,48 +5814,48 @@ msgstr ""
 "charge un fichier de développement xmp\n"
 "et l'applique aux images sélectionnées"
 
-#: ../src/libs/copy_history.c:297
+#: ../src/libs/copy_history.c:300
 msgid "write sidecar files"
 msgstr "sauver en xmp"
 
-#: ../src/libs/copy_history.c:299
+#: ../src/libs/copy_history.c:302
 msgid "write history stack and tags to xmp sidecar files"
 msgstr ""
 "écrit le développement et les mots-clés\n"
 "dans un fichier attaché xmp"
 
-#: ../src/libs/copy_history.c:337
+#: ../src/libs/copy_history.c:340
 msgctxt "accel"
 msgid "copy all"
 msgstr "tout copier"
 
-#: ../src/libs/copy_history.c:338
+#: ../src/libs/copy_history.c:341
 msgctxt "accel"
 msgid "copy"
 msgstr "copier"
 
 # lorsque l'action engendre une suppression physique non annulable, on emploie le terme "supprimer"
-#: ../src/libs/copy_history.c:339
+#: ../src/libs/copy_history.c:342
 msgctxt "accel"
 msgid "discard"
 msgstr "supprimer"
 
-#: ../src/libs/copy_history.c:340
+#: ../src/libs/copy_history.c:343
 msgctxt "accel"
 msgid "paste all"
 msgstr "tout coller"
 
-#: ../src/libs/copy_history.c:341
+#: ../src/libs/copy_history.c:344
 msgctxt "accel"
 msgid "paste"
 msgstr "coller"
 
-#: ../src/libs/copy_history.c:342
+#: ../src/libs/copy_history.c:345
 msgctxt "accel"
 msgid "load sidecar files"
 msgstr "charger un fichier xmp"
 
-#: ../src/libs/copy_history.c:343
+#: ../src/libs/copy_history.c:346
 msgctxt "accel"
 msgid "write sidecar files"
 msgstr "sauver en xmp"
@@ -5843,19 +5864,19 @@ msgstr "sauver en xmp"
 msgid "export selected"
 msgstr "exportation de la sélection"
 
-#: ../src/libs/export.c:420
+#: ../src/libs/export.c:422
 msgid "target storage"
 msgstr "stockage cible"
 
-#: ../src/libs/export.c:440
+#: ../src/libs/export.c:442
 msgid "file format"
 msgstr "format de fichier"
 
-#: ../src/libs/export.c:455
+#: ../src/libs/export.c:457
 msgid "global options"
 msgstr "options globales"
 
-#: ../src/libs/export.c:459
+#: ../src/libs/export.c:461
 msgid ""
 "maximum output width\n"
 "set to 0 for no scaling"
@@ -5864,7 +5885,7 @@ msgstr ""
 "0 pour ne pas changer \n"
 "d'échelle "
 
-#: ../src/libs/export.c:461
+#: ../src/libs/export.c:463
 msgid ""
 "maximum output height\n"
 "set to 0 for no scaling"
@@ -5881,47 +5902,43 @@ msgstr ""
 #. g_signal_connect (G_OBJECT (d->height), "focus-in-event",  G_CALLBACK(focus_in),  NULL);
 #. g_signal_connect (G_OBJECT (d->height), "focus-out-event", G_CALLBACK(focus_out), NULL);
 #.
-#: ../src/libs/export.c:473
+#: ../src/libs/export.c:475
 msgid "max size"
 msgstr "taille max"
 
-#: ../src/libs/export.c:478
+#: ../src/libs/export.c:480
 msgid "x"
 msgstr "x"
 
-#: ../src/libs/export.c:482
+#: ../src/libs/export.c:484
 msgid "intent"
 msgstr "rendu"
 
 #. gtk_table_attach(GTK_TABLE(self->widget), GTK_WIDGET(d->profile), 1, 2, 9, 10, GTK_EXPAND|GTK_FILL, 0, 0, 0);
-#: ../src/libs/export.c:486 ../src/libs/export.c:566
+#: ../src/libs/export.c:488 ../src/libs/export.c:568
 msgid "image settings"
 msgstr "paramètres d'image"
 
-#: ../src/libs/export.c:506
-msgid "Adobe RGB (compatible)"
-msgstr "Adobe RGB (compatible)"
-
-#: ../src/libs/export.c:579
+#: ../src/libs/export.c:581
 #, c-format
 msgid "output icc profiles in %s/color/out or %s/color/out"
 msgstr "profils ICC de sortie dans %s/color/out ou %s/color/out"
 
 #. Add style combo
-#: ../src/libs/export.c:585
+#: ../src/libs/export.c:587
 msgid "style"
 msgstr "style"
 
-#: ../src/libs/export.c:602
+#: ../src/libs/export.c:604
 msgid "temporary style to append while exporting"
 msgstr "style temporaire à ajouter lors de l'exportation"
 
-#: ../src/libs/export.c:620
+#: ../src/libs/export.c:622
 msgid "export with current settings (ctrl-e)"
 msgstr "exporte avec les réglages actuels (ctrl-e)"
 
 #. enable shortcut to export with current export settings:
-#: ../src/libs/export.c:823 ../src/libs/styles.c:69
+#: ../src/libs/export.c:825 ../src/libs/styles.c:69
 #: ../src/views/darkroom.c:1587
 msgctxt "accel"
 msgid "export"
@@ -7108,37 +7125,37 @@ msgstr "bandeau"
 #. setup rating key accelerators
 #. Initializing accelerators
 #. Rating keys
-#: ../src/libs/tools/filmstrip.c:158 ../src/views/lighttable.c:1628
+#: ../src/libs/tools/filmstrip.c:158 ../src/views/lighttable.c:1582
 msgctxt "accel"
 msgid "rate desert"
 msgstr "sans étoile"
 
-#: ../src/libs/tools/filmstrip.c:159 ../src/views/lighttable.c:1629
+#: ../src/libs/tools/filmstrip.c:159 ../src/views/lighttable.c:1583
 msgctxt "accel"
 msgid "rate 1"
 msgstr "1 étoile"
 
-#: ../src/libs/tools/filmstrip.c:160 ../src/views/lighttable.c:1630
+#: ../src/libs/tools/filmstrip.c:160 ../src/views/lighttable.c:1584
 msgctxt "accel"
 msgid "rate 2"
 msgstr "2 étoiles"
 
-#: ../src/libs/tools/filmstrip.c:161 ../src/views/lighttable.c:1631
+#: ../src/libs/tools/filmstrip.c:161 ../src/views/lighttable.c:1585
 msgctxt "accel"
 msgid "rate 3"
 msgstr "3 étoiles"
 
-#: ../src/libs/tools/filmstrip.c:162 ../src/views/lighttable.c:1632
+#: ../src/libs/tools/filmstrip.c:162 ../src/views/lighttable.c:1586
 msgctxt "accel"
 msgid "rate 4"
 msgstr "4 étoiles"
 
-#: ../src/libs/tools/filmstrip.c:163 ../src/views/lighttable.c:1633
+#: ../src/libs/tools/filmstrip.c:163 ../src/views/lighttable.c:1587
 msgctxt "accel"
 msgid "rate 5"
 msgstr "5 étoiles"
 
-#: ../src/libs/tools/filmstrip.c:164 ../src/views/lighttable.c:1634
+#: ../src/libs/tools/filmstrip.c:164 ../src/views/lighttable.c:1588
 msgctxt "accel"
 msgid "rate reject"
 msgstr "rejeter"
@@ -7176,27 +7193,27 @@ msgstr "cloner l'image"
 
 #. setup color label accelerators
 #. Color keys
-#: ../src/libs/tools/filmstrip.c:184 ../src/views/lighttable.c:1647
+#: ../src/libs/tools/filmstrip.c:184 ../src/views/lighttable.c:1601
 msgctxt "accel"
 msgid "color red"
 msgstr "couleur rouge"
 
-#: ../src/libs/tools/filmstrip.c:185 ../src/views/lighttable.c:1648
+#: ../src/libs/tools/filmstrip.c:185 ../src/views/lighttable.c:1602
 msgctxt "accel"
 msgid "color yellow"
 msgstr "couleur jaune"
 
-#: ../src/libs/tools/filmstrip.c:186 ../src/views/lighttable.c:1649
+#: ../src/libs/tools/filmstrip.c:186 ../src/views/lighttable.c:1603
 msgctxt "accel"
 msgid "color green"
 msgstr "couleur verte"
 
-#: ../src/libs/tools/filmstrip.c:187 ../src/views/lighttable.c:1650
+#: ../src/libs/tools/filmstrip.c:187 ../src/views/lighttable.c:1604
 msgctxt "accel"
 msgid "color blue"
 msgstr "couleur bleue"
 
-#: ../src/libs/tools/filmstrip.c:188 ../src/views/lighttable.c:1651
+#: ../src/libs/tools/filmstrip.c:188 ../src/views/lighttable.c:1605
 msgctxt "accel"
 msgid "color purple"
 msgstr "couleur violette"
@@ -7259,7 +7276,7 @@ msgstr "préférences"
 msgid "hinter"
 msgstr "rendu"
 
-#: ../src/libs/tools/lighttable.c:58 ../src/views/lighttable.c:117
+#: ../src/libs/tools/lighttable.c:58 ../src/views/lighttable.c:120
 msgid "lighttable"
 msgstr "table lumineuse"
 
@@ -7291,7 +7308,7 @@ msgstr "zoom mini"
 msgid "module toolbox"
 msgstr "boîte à outils de module"
 
-#: ../src/libs/tools/ratings.c:49
+#: ../src/libs/tools/ratings.c:50
 msgid "ratings"
 msgstr "étoiles"
 
@@ -7452,59 +7469,59 @@ msgstr ""
 "ou modifier les filtres de collection dans le menu de collection à gauche."
 
 #. Navigation keys
-#: ../src/views/lighttable.c:1637
+#: ../src/views/lighttable.c:1591
 msgctxt "accel"
 msgid "navigate up"
 msgstr "aller en haut"
 
-#: ../src/views/lighttable.c:1639
+#: ../src/views/lighttable.c:1593
 msgctxt "accel"
 msgid "navigate down"
 msgstr "aller en bas"
 
-#: ../src/views/lighttable.c:1641
+#: ../src/views/lighttable.c:1595
 msgctxt "accel"
 msgid "navigate page up"
 msgstr "défiler par page vers le haut"
 
-#: ../src/views/lighttable.c:1643
+#: ../src/views/lighttable.c:1597
 msgctxt "accel"
 msgid "navigate page down"
 msgstr "défiler par page vers le bas"
 
 #. Scroll keys
-#: ../src/views/lighttable.c:1654
+#: ../src/views/lighttable.c:1608
 msgctxt "accel"
 msgid "scroll up"
 msgstr "défiler en arrière"
 
-#: ../src/views/lighttable.c:1656
+#: ../src/views/lighttable.c:1610
 msgctxt "accel"
 msgid "scroll down"
 msgstr "défiler en avant"
 
-#: ../src/views/lighttable.c:1658
+#: ../src/views/lighttable.c:1612
 msgctxt "accel"
 msgid "scroll left"
 msgstr "défiler vers la gauche"
 
-#: ../src/views/lighttable.c:1660
+#: ../src/views/lighttable.c:1614
 msgctxt "accel"
 msgid "scroll right"
 msgstr "défiler vers la droite "
 
-#: ../src/views/lighttable.c:1662
+#: ../src/views/lighttable.c:1616
 msgctxt "accel"
 msgid "scroll center"
 msgstr "défiler vers le centre"
 
-#: ../src/views/lighttable.c:1664
+#: ../src/views/lighttable.c:1618
 msgctxt "accel"
 msgid "realign images to grid"
 msgstr "aligner les images sur la grille"
 
 #. Preview key
-#: ../src/views/lighttable.c:1668
+#: ../src/views/lighttable.c:1622
 msgctxt "accel"
 msgid "preview"
 msgstr "aperçu"
@@ -7522,6 +7539,9 @@ msgstr "défaire"
 msgctxt "accel"
 msgid "redo"
 msgstr "refaire"
+
+#~ msgid "Adobe RGB (compatible)"
+#~ msgstr "Adobe RGB (compatible)"
 
 #~ msgid "run indexer"
 #~ msgstr "indexer les images"
@@ -7925,11 +7945,6 @@ msgstr "refaire"
 
 #~ msgid "AMaZE"
 #~ msgstr "AMaZE"
-
-#~ msgid "moving %d image"
-#~ msgid_plural "moving %d images"
-#~ msgstr[0] "déplacement de %d image"
-#~ msgstr[1] "déplacement de %d images"
 
 #~ msgid "could not attach xmp data to file `%s'!"
 #~ msgstr "impossible de sauver le fichier attaché xmp du fichier %s !"

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -895,13 +895,13 @@ void dt_control_copy_images_job_init(dt_job_t *job)
 int32_t dt_control_move_images_job_run(dt_job_t *job)
 {
   return _generic_dt_control_fileop_images_job_run(job, &dt_image_move,
-         "moving %d image", "moving %d images");
+         _("moving %d image"), _("moving %d images"));
 }
 
 int32_t dt_control_copy_images_job_run(dt_job_t *job)
 {
   return _generic_dt_control_fileop_images_job_run(job, &dt_image_copy,
-         "copying %d image", "copying %d images");
+         _("copying %d image"), _("copying %d images"));
 }
 
 int32_t dt_control_export_job_run(dt_job_t *job)


### PR DESCRIPTION
Two messages were not properly part of the translations circuitry
as not around _().

For after 1.2 I suppose.
