### PR TITLE
Make sure profile_cnt is initialized.

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1566,6 +1566,7 @@ void gui_update(dt_iop_module_t *self)
   }
   else
   {
+    g->profile_cnt = dt_noiseprofile_get_matching(&self->dev->image_storage, g->profiles, MAX_PROFILES);
     for(int i=0;i<g->profile_cnt;i++)
     {
       if(!memcmp(g->profiles[i]->a, p->a, sizeof(float)*3) &&
@@ -1588,6 +1589,7 @@ void gui_init(dt_iop_module_t *self)
   g->mode     = dt_bauhaus_combobox_new(self);
   g->radius   = dt_bauhaus_slider_new_with_range(self, 0.0f, 4.0f, 1., 2.f, 0);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
+  g->profile_cnt = 0;
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->mode, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->radius, TRUE, TRUE, 0);


### PR DESCRIPTION
A possible fix for a crash I have observed in the denoise profile iop. Using gdb I have found that when a applying a style with a denoise profile to a jpeg image without any exif (so not camera, lens or whatever information) the g->profile_cnt was read uninitialized.

Even if this is correct (which I'm not sure) there is still something wrong. To reproduce:

0 start dt
1 ppen a jpeg file (not tested with RAW) without any modification:
2. activate denoise profile (change whatever parameter)
3. add new instance of denoise profile (change whaterver parameter)
4. swicth to lighttable

At this point I have a crash:

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff6dbbad5 in ?? () from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
(gdb) bt
#0  0x00007ffff6dbbad5 in ?? ()

   from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#1  0x00007ffff6dac09b in gtk_widget_unparent ()

   from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#2  0x00007ffff6bddb33 in ?? ()

   from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#3  0x00007ffff74585f4 in g_cclosure_marshal_VOID__OBJECTv ()

   from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#4  0x00007ffff745506a in ?? ()

   from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#5  0x00007ffff746f317 in g_signal_emit_valist ()

   from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#6  0x00007ffff746fa72 in g_signal_emit ()

   from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#7  0x00007ffff6daeb45 in ?? ()

   from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#8  0x00007ffff745b500 in g_object_run_dispose ()

   from /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
#9  0x00007ffff6bdda6a in ?? ()

   from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
#10 0x00007ffff7aafbbe in dt_view_manager_switch (vm=0x880fb0, k=k@entry=0)

```
at /home/obry/dev/OpenSource/builds/darktable/src/src/views/view.c:267
```
#11 0x00007ffff7a4dde7 in dt_ctl_switch_mode_to (mode=mode@entry=DT_LIBRARY)

```
at /home/obry/dev/OpenSource/builds/darktable/src/src/control/control.c:1444
```
#12 0x00007fffa6e48b6f in _lib_viewswitcher_button_press_callback (

```
w=<optimized out>, ev=<optimized out>, user_data=<optimized out>)
at /home/obry/dev/OpenSource/builds/darktable/src/src/libs/tools/viewswitcher.c:223
```
#13 0x00007ffff6c8f119 in ?? ()

   from /usr/lib/x86_64-linux-gnu/libgtk-x11-2.0.so.0
