### PR TITLE
Clean-up multi-instance in created or updated style.

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -85,6 +85,22 @@ dt_styles_exists (const char *name)
   return (dt_styles_get_id_by_name(name))!=0?TRUE:FALSE;
 }
 
+static void
+_dt_style_cleanup_multi_instance(int id)
+{
+  sqlite3_stmt *stmt;
+
+  /* let's clean-up the style multi-instance. What we want to do is have a unique multi_priority value for each iop.
+     Furthermore this value must start to 0 and increment one by one for each multi-instance of the same module. On
+     SQLite there is no notion of ROW_NUMBER, so we use rather ressource consuming SQL statement, but as a style has
+     never a huge number of items that's not a real issue. */
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "update style_items set multi_priority=(select COUNT(0)-1 from style_items sty2 where sty2.num<=style_items.num and sty2.operation=style_items.operation and sty2.styleid=?1), multi_name=multi_priority where styleid=?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, id);
+  sqlite3_step (stmt);
+  sqlite3_finalize (stmt);
+}
+
 static gboolean
 dt_styles_create_style_header(const char *name, const char *description)
 {
@@ -192,6 +208,8 @@ dt_styles_update (const char *name, const char *newname, const char *newdescript
 
   _dt_style_update_from_image(id,imgid,filter,update);
 
+  _dt_style_cleanup_multi_instance(id);
+
   /* backup style to disk */
   char stylesdir[1024];
   dt_loc_get_user_config_dir(stylesdir, 1024);
@@ -220,7 +238,6 @@ dt_styles_update (const char *name, const char *newname, const char *newdescript
 
   g_free(desc);
 }
-
 
 void
 dt_styles_create_from_style (const char *name, const char *newname, const char *description, GList *filter, int imgid, GList *update)
@@ -267,6 +284,8 @@ dt_styles_create_from_style (const char *name, const char *newname, const char *
     /* insert items from imgid if defined */
 
     _dt_style_update_from_image(id,imgid,filter,update);
+
+    _dt_style_cleanup_multi_instance(id);
 
     /* backup style to disk */
     char stylesdir[1024];
@@ -326,6 +345,8 @@ dt_styles_create_from_image (const char *name,const char *description,int32_t im
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
     sqlite3_step (stmt);
     sqlite3_finalize (stmt);
+
+    _dt_style_cleanup_multi_instance(id);
 
     /* backup style to disk */
     char stylesdir[1024];
@@ -496,7 +517,7 @@ dt_styles_get_item_list (const char *name, gboolean params, int imgid)
       // get all items from the style
       //    UNION
       // get all items from history, not in the style : select only the last operation, that is max(num)
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select num, operation, enabled, (select max(num) from history where imgid=?2 and operation=style_items.operation group by multi_priority),multi_name from style_items where styleid=?1 UNION select -1,history.operation,history.enabled,history.num,multi_name from history where imgid=?2 and history.enabled=1 and (history.operation not in (select operation from style_items where styleid=?1) or (history.multi_priority not in (select multi_priority from style_items where styleid=?1 and operation=history.operation))) group by operation having max(num) order by num desc", -1, &stmt, NULL);
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select num, operation, enabled, (select max(num) from history where imgid=?2 and operation=style_items.operation group by multi_priority),multi_name from style_items where styleid=?1 UNION select -1,history.operation,history.enabled,history.num,multi_name from history where imgid=?2 and history.enabled=1 and (history.operation not in (select operation from style_items where styleid=?1) or (history.op_params not in (select op_params from style_items where styleid=?1 and operation=history.operation)) or (history.blendop_params not in (select blendop_params from style_items where styleid=?1 and operation=history.operation))) group by operation having max(num) order by num desc", -1, &stmt, NULL);
       DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
     }
     else


### PR DESCRIPTION
We really want to have the multi_priority starting from 0 and increasing
one by one for every multi-instance module.

This is an attempt to fix multi-instance and style. Ideally something similar should be done for partial copy/paste, but it seems lot more difficult to implement.

Anyway, please test/review this if possible as we need this for 1.2 I would say.
