### PR TITLE
Remove -Werror from all builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -302,7 +302,9 @@ if(NOT CUSTOM_CFLAGS)
 if(NOT APPLE AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
   # apple build fails on deprecated warnings..
   # and too many warnings reported by Clang for now
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+
+  # gcc 4.8 build fails on deprecated warnings too
+  #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 endif(NOT APPLE AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
 
 if(NOT BINARY_PACKAGE_BUILD)


### PR DESCRIPTION
Build on gcc 4.8 fails due to warnings about locally defined typedef in gmacros.h
http://pastebin.com/CKfvR1mN
