### PR TITLE
fix: possible deadlock during different import because of signals raised...

### DIFF
--- a/src/common/film.c
+++ b/src/common/film.c
@@ -430,6 +430,7 @@ void dt_film_import1(dt_film_t *film)
 
   // only redraw at the end, to not spam the cpu with exposure events
   dt_control_queue_redraw_center();
+  dt_control_signal_raise(darktable.signals,DT_SIGNAL_TAG_CHANGED);
 
   dt_control_backgroundjobs_destroy(darktable.control, jid);
   //dt_control_signal_raise(darktable.signals , DT_SIGNAL_FILMROLLS_IMPORTED);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -624,6 +624,10 @@ uint32_t dt_image_import(const int32_t film_id, const char *filename, gboolean o
   g_free(globbuf);
 
   dt_control_signal_raise(darktable.signals,DT_SIGNAL_IMAGE_IMPORT,id);
+  // the following line would look logical with new_tags_set being the return value
+  // from dt_tag_new above, but this could lead to too rapid signals, being able to lock up the
+  // keywords side pane when trying to use it, which can lock up the whole dt GUI ..
+  //if (new_tags_set) dt_control_signal_raise(darktable.signals,DT_SIGNAL_TAG_CHANGED);
   return id;
 }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -74,10 +74,16 @@ gboolean dt_tag_new(const char *name,guint *tagid)
   if( tagid != NULL)
     *tagid=id;
 
-  /* raise signal of tags change to refresh keywords module */
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-
   return TRUE;
+}
+
+gboolean dt_tag_new_from_gui(const char *name,guint *tagid)
+{
+  gboolean ret = dt_tag_new(name,tagid);
+  /* if everything went fine, raise signal of tags change to refresh keywords module in GUI */
+  if (ret)
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  return ret;
 }
 
 guint dt_tag_remove(const guint tagid, gboolean final)

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -31,6 +31,9 @@ dt_tag_t;
 /** creates a new tag, returns tagid \param[in] name the tag name. \param[in] tagid a pointer to tagid of new tag, this can be NULL \return false if failed to create a tag and indicates that tagid is invalid to use. \note If tag already exists the existing tag id is returned. */
 gboolean dt_tag_new(const char *name,guint *tagid);
 
+/** creates a new tag, returns tagid \param[in] name the tag name. \param[in] tagid a pointer to tagid of new tag, this can be NULL \return false if failed to create a tag and indicates that tagid is invalid to use. \note If tag already exists the existing tag id is returned. This function will also raise a DT_SIGNAL_TAG_CHANGED signal if necessary, so keywords GUI can refresh. */
+gboolean dt_tag_new_from_gui(const char *name,guint *tagid);
+
 /** get the name of specified id */
 const gchar *dt_tag_get_name(const guint tagid);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1245,7 +1245,7 @@ void leave(dt_view_t *self)
   // tag image as changed
   // TODO: only tag the image when there was a real change.
   guint tagid = 0;
-  dt_tag_new("darktable|changed",&tagid);
+  dt_tag_new_from_gui("darktable|changed",&tagid);
   dt_tag_attach(tagid, dev->image_storage.id);
   // commit image ops to db
   dt_dev_write_history(dev);


### PR DESCRIPTION
... for keywords, probably fixes: #9330 and maybe some other deadlock issues that were due to keywords/tags being involved

With these files / functions I was not sure if they should maybe rather use "dt_tag_new_from_gui", so a signal will be raised from them again, as dt_tag_new is now "silenced" in this regard:
./src/common/imageio.c: dt_imageio_open_raw function
./src/commin/imageio__._: dt_imageio_open_\* functions
./src/libs/tagging.c:
Check if all functions that use dt_tag_string_list additionally would need to raise the signal (because dt_tag_string_list uses dt_tag_new)
./src/common/styles.c: dt_styles_apply_to_image function
./src/develop/develop.c: dt_dev_write_history function
./src/develop/lightroom.c: dt_lightroom_import function

With dt_exif_read (that also uses dt_tag_new) I am relatively sure (though not 100% ;-) ) that probably non of them needs to raise DT_SIGNAL_TAG_CHANGED
