### PR TITLE
Hacky fix to remember "all except rejected" filter selection across view changes

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -97,9 +97,9 @@ dt_collection_update (const dt_collection_t *collection)
     wq = dt_util_dstrcat(wq, " %s (flags & %d) != %d", (need_operator)?"and":((need_operator=1)?"":""), DT_IMAGE_REMOVE, DT_IMAGE_REMOVE);
 
     if (collection->params.filter_flags & COLLECTION_FILTER_ATLEAST_RATING)
-      wq = dt_util_dstrcat(wq, " %s (flags & 7) >= %d and (flags & 7) != 6", (need_operator)?"and":((need_operator=1)?"":""), collection->params.rating);
+      wq = dt_util_dstrcat(wq, " %s (flags & 7) >= %d and (flags & 7) != 6", (need_operator)?"and":((need_operator=1)?"":""), collection->params.rating == 7 ? 0 : collection->params.rating);
     else if (collection->params.filter_flags & COLLECTION_FILTER_EQUAL_RATING)
-      wq = dt_util_dstrcat(wq, " %s (flags & 7) == %d", (need_operator)?"and":((need_operator=1)?"":""), collection->params.rating);
+      wq = dt_util_dstrcat(wq, " %s (flags & 7) == %d", (need_operator)?"and":((need_operator=1)?"":""), collection->params.rating == 7 ? 0 : collection->params.rating);
 
     if (collection->params.filter_flags & COLLECTION_FILTER_ALTERED)
       wq = dt_util_dstrcat(wq, " %s id in (select imgid from history where imgid=id)", (need_operator)?"and":((need_operator=1)?"":"") );

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -176,16 +176,11 @@ static void _lib_filter_combobox_changed (GtkComboBox *widget, gpointer user_dat
     dt_collection_set_filter_flags (darktable.collection, dt_collection_get_filter_flags (darktable.collection) & ~(COLLECTION_FILTER_ATLEAST_RATING|COLLECTION_FILTER_EQUAL_RATING));
   else if (i == 1 || i == 7)
     dt_collection_set_filter_flags (darktable.collection, (dt_collection_get_filter_flags (darktable.collection) | COLLECTION_FILTER_EQUAL_RATING) & ~COLLECTION_FILTER_ATLEAST_RATING);
-  else if (i == 8)
-    dt_collection_set_filter_flags (darktable.collection, (dt_collection_get_filter_flags (darktable.collection) | COLLECTION_FILTER_EQUAL_RATING) | COLLECTION_FILTER_ATLEAST_RATING);
   else
     dt_collection_set_filter_flags (darktable.collection, dt_collection_get_filter_flags (darktable.collection) | COLLECTION_FILTER_ATLEAST_RATING );
 
   /* set the star filter in collection */
-  if (i == 8)
-    dt_collection_set_rating(darktable.collection, 0);
-  else
-    dt_collection_set_rating(darktable.collection, i-1);
+  dt_collection_set_rating(darktable.collection, i-1);
 
   /* update the query and view */
   _lib_filter_update_query(user_data);


### PR DESCRIPTION
Fix for bug reported by Jens Fedler on DT Dev List: "all except rejected" filter selection not kept across view changes".

It's caused by "all except rejected" and "unstarred only" filter using the same star filter setting 0 (zero) for the query. This is setting is used to reinitialize the combo box after switching the view.
