### PR TITLE
Check params_size for the proper module.

### DIFF
--- a/src/imageio/format/copy.c
+++ b/src/imageio/format/copy.c
@@ -123,7 +123,7 @@ free_params(dt_imageio_module_format_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_format_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   return 0;
 }
 

--- a/src/imageio/format/exr.cc
+++ b/src/imageio/format/exr.cc
@@ -128,7 +128,7 @@ extern "C"
   int
     set_params(dt_imageio_module_format_t *self, const void *params, const int size)
     {
-      if(size != (int)params_size(self)) return 1;
+      if(size != (int)self->params_size(self)) return 1;
       return 0;
     }
 

--- a/src/imageio/format/j2k.c
+++ b/src/imageio/format/j2k.c
@@ -514,7 +514,7 @@ free_params(dt_imageio_module_format_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_format_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_j2k_t *d = (dt_imageio_j2k_t *)params;
   dt_imageio_j2k_gui_t *g = (dt_imageio_j2k_gui_t *)self->gui_data;
   if(d->format == JP2_CFMT) gtk_toggle_button_set_active(g->jp2, TRUE);

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -472,7 +472,7 @@ free_params(dt_imageio_module_format_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_format_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_jpeg_t *d = (dt_imageio_jpeg_t *)params;
   dt_imageio_jpeg_gui_data_t *g = (dt_imageio_jpeg_gui_data_t *)self->gui_data;
   dtgtk_slider_set_value(g->quality, d->quality);

--- a/src/imageio/format/png.c
+++ b/src/imageio/format/png.c
@@ -356,7 +356,7 @@ free_params(dt_imageio_module_format_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_format_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_png_t *d = (dt_imageio_png_t *)params;
   dt_imageio_png_gui_t *g = (dt_imageio_png_gui_t *)self->gui_data;
   if(d->bpp < 12) gtk_toggle_button_set_active(g->b8, TRUE);

--- a/src/imageio/format/ppm.c
+++ b/src/imageio/format/ppm.c
@@ -78,7 +78,7 @@ free_params(dt_imageio_module_format_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_format_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   return 0;
 }
 

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -205,7 +205,7 @@ free_params(dt_imageio_module_format_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_format_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_tiff_t *d = (dt_imageio_tiff_t *)params;
   dt_imageio_tiff_gui_t *g = (dt_imageio_tiff_gui_t *)self->gui_data;
   if(d->bpp < 12) gtk_toggle_button_set_active(g->b8, TRUE);

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -292,7 +292,7 @@ free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)params;
   disk_t *g = (disk_t *)self->gui_data;
   gtk_entry_set_text(GTK_ENTRY(g->entry), d->filename);

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -143,7 +143,7 @@ get_params(dt_imageio_module_storage_t *self)
 int
 set_params(dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   return 0;
 }
 

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -1310,7 +1310,7 @@ void free_params(struct dt_imageio_module_storage_t *self, dt_imageio_module_dat
 
 int set_params(struct dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   // gui stuff not updated, as sensitive user data is not stored in the preset.
   // TODO: store name/hash in kwallet/etc module and get encrypted stuff from there!
   return 0;

--- a/src/imageio/storage/flickr.c
+++ b/src/imageio/storage/flickr.c
@@ -863,7 +863,7 @@ get_params(dt_imageio_module_storage_t *self)
 int
 set_params(dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   // gui stuff not updated, as sensitive user data is not stored in the preset.
   // TODO: store name/hash in kwallet/etc module and get encrypted stuff from there!
   return 0;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -530,7 +530,7 @@ free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)params;
   gallery_t *g = (gallery_t *)self->gui_data;
   gtk_entry_set_text(GTK_ENTRY(g->entry), d->filename);

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -457,7 +457,7 @@ free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 int
 set_params(dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)params;
   latex_t *g = (latex_t *)self->gui_data;
   gtk_entry_set_text(GTK_ENTRY(g->entry), d->filename);

--- a/src/imageio/storage/picasa.c
+++ b/src/imageio/storage/picasa.c
@@ -1612,7 +1612,7 @@ void free_params(struct dt_imageio_module_storage_t *self, dt_imageio_module_dat
 
 int set_params(struct dt_imageio_module_storage_t *self, const void *params, const int size)
 {
-  if(size != params_size(self)) return 1;
+  if(size != self->params_size(self)) return 1;
 
   PicasaContext *d = (PicasaContext *) params;
   dt_storage_picasa_gui_data_t *g = (dt_storage_picasa_gui_data_t *)self->gui_data;


### PR DESCRIPTION
This is a regression introduced in 1f9e0b and c04c61. The consequence is
that the params_size called was the default one. And a size mismatch was
always detected which in turns triggered the deletion of the export preset.

Quite high priority fix as on Git master export presets are deleted as soon as they
are used. Please review and let me know if I can merge if this looks correct to you. Thanks.
