### PR TITLE
colorzones: fix correctly specify the version of presets (bug #9449)

### DIFF
--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -400,7 +400,7 @@ void init_presets (dt_iop_module_so_t *self)
   p.equalizer_x[DT_IOP_COLORZONES_C][3] = 0.50;
   p.equalizer_x[DT_IOP_COLORZONES_C][4] = 0.51;
   p.equalizer_x[DT_IOP_COLORZONES_C][6] = 15./16.;
-  dt_gui_presets_add_generic(_("red black white"), self->op, 2, &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("red black white"), self->op, self->version(), &p, sizeof(p), 1);
 
   // black white and skin tones
 
@@ -418,7 +418,7 @@ void init_presets (dt_iop_module_so_t *self)
   p.equalizer_x[DT_IOP_COLORZONES_C][2] = 0.25f;
   p.equalizer_x[DT_IOP_COLORZONES_C][1] = 0.16f;
   p.equalizer_y[DT_IOP_COLORZONES_C][1] = 0.3f;
-  dt_gui_presets_add_generic(_("black white and skin tones"), self->op, 2, &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("black white and skin tones"), self->op, self->version(), &p, sizeof(p), 1);
 
   // polarizing filter
 
@@ -436,7 +436,7 @@ void init_presets (dt_iop_module_so_t *self)
     p.equalizer_y[DT_IOP_COLORZONES_C][k] += (k-2.5)/(DT_IOP_COLORZONES_BANDS-2.0) * 0.25;
   for(int k=4; k<DT_IOP_COLORZONES_BANDS; k++)
     p.equalizer_y[DT_IOP_COLORZONES_L][k] -= (k-3.5)/(DT_IOP_COLORZONES_BANDS-3.0) * 0.35;
-  dt_gui_presets_add_generic(_("polarizing filter"), self->op, 2, &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("polarizing filter"), self->op, self->version(), &p, sizeof(p), 1);
 
   // natural skin tone
 
@@ -464,7 +464,7 @@ void init_presets (dt_iop_module_so_t *self)
   p.equalizer_y[DT_IOP_COLORZONES_C][6] = 0.468932;
   p.equalizer_x[DT_IOP_COLORZONES_C][7] = 1.000000;
   p.equalizer_y[DT_IOP_COLORZONES_C][7] = 0.468932;
-  dt_gui_presets_add_generic(_("natural skin tones"), self->op, 2, &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("natural skin tones"), self->op, self->version(), &p, sizeof(p), 1);
 
   // black and white film
 
@@ -492,7 +492,7 @@ void init_presets (dt_iop_module_so_t *self)
   p.equalizer_y[DT_IOP_COLORZONES_L][6] = 0.613040;
   p.equalizer_x[DT_IOP_COLORZONES_L][7] = 1.000000;
   p.equalizer_y[DT_IOP_COLORZONES_L][7] = 0.613040;
-  dt_gui_presets_add_generic(_("black & white film"), self->op, 2, &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("black & white film"), self->op, self->version(), &p, sizeof(p), 1);
 
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "commit", NULL, NULL, NULL);
 }


### PR DESCRIPTION
Hi,
this is a fix of bug #9449 : [1.2.1] Color zones presets inactive. 

colorzones: fix correctly specify the version of presets
using self->version() rather than a constant number in order to not add a new bug when merging on master because of colorzones module version is different (3 instead of 2 on this branch)
This replace de previous fix commit 6a19c6694de6ddb27f76b63532a35a51857eaf92.

I don't know if this is the correct way to define presets module version, but it is used on some other modules...

Regards
Loic G.
