### PR TITLE
add strlcpy() implementation for UTF8 strings

### DIFF
--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -193,6 +193,51 @@ gchar* dt_util_fix_path(const gchar* path)
 
   return rpath;
 }
+
+/**
+ * dt_utf8_strlcpy:
+ * @dest: buffer to fill with characters from @src
+ * @src: UTF-8 encoded string
+ * @n: size of @dest
+ *
+ * Like the BSD-standard strlcpy() function, but
+ * is careful not to truncate in the middle of a character.
+ * The @src string must be valid UTF-8 encoded text.
+ * (Use g_utf8_validate() on all text before trying to use UTF-8
+ * utility functions with it.)
+ *
+ * Return value: strlen(src)
+ * Implementation by Philip Page, see https://bugzilla.gnome.org/show_bug.cgi?id=520116
+ **/
+size_t dt_utf8_strlcpy(char *dest, const char *src,size_t n)
+{
+  register const gchar *s = src;
+  while (s - src < n  &&  *s)
+  {
+    s = g_utf8_next_char(s);
+  }
+
+  if (s - src >= n)
+  {
+    /* We need to truncate; back up one. */
+    s = g_utf8_prev_char(s);
+    strncpy(dest, src, s - src);
+    dest[s - src] = '\0';
+    /* Find the full length for return value. */
+    while (*s)
+    {
+      s = g_utf8_next_char(s);
+    }
+  }
+  else
+  {
+      /* Plenty of room, just copy */
+    strncpy(dest, src, s - src);
+    dest[s - src] = '\0';
+  }
+  return s - src;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-space on;

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -33,6 +33,7 @@ guint dt_util_str_occurence(const gchar *haystack,const gchar *needle);
 gchar* dt_util_glist_to_str(const gchar* separator, GList * items, const unsigned int count);
 /** fixes the given path by replacing a possible tilde with the correct home directory */
 gchar* dt_util_fix_path(const gchar* path);
+size_t dt_utf8_strlcpy(char *dest, const char *src, size_t n);
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1738,49 +1738,49 @@ void gui_init(struct dt_iop_module_t *self)
   int pos = -1;
   dt_iop_lensfun_modifier_t *modifier;
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("none"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("none"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_NONE;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("all"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("all"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_ALL;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("distortion & TCA"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("distortion & TCA"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_DIST_TCA;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("distortion & vignetting"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("distortion & vignetting"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_DIST_VIGN;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("TCA & vignetting"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("TCA & vignetting"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_TCA_VIGN;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("only distortion"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("only distortion"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_DIST;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("only TCA"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("only TCA"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_TCA;
   modifier->pos = ++pos;
 
   modifier = (dt_iop_lensfun_modifier_t *)g_malloc0(sizeof(dt_iop_lensfun_modifier_t));
-  g_strlcpy(modifier->name, _("only vignetting"), sizeof(modifier->name));
+  dt_utf8_strlcpy(modifier->name, _("only vignetting"), sizeof(modifier->name));
   g->modifiers = g_list_append(g->modifiers, modifier);
   modifier->modflag = LENSFUN_MODFLAG_VIGN;
   modifier->pos = ++pos;

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -543,26 +543,26 @@ gui_init (dt_lib_module_t *self)
 
   dt_lib_export_profile_t *prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
   g_strlcpy(prof->filename, "sRGB", sizeof(prof->filename));
-  g_strlcpy(prof->name, _("sRGB (web-safe)"), sizeof(prof->name));
+  dt_utf8_strlcpy(prof->name, _("sRGB (web-safe)"), sizeof(prof->name));
   int pos;
   prof->pos = 1;
   d->profiles = g_list_append(d->profiles, prof);
 
   prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
   g_strlcpy(prof->filename, "adobergb", sizeof(prof->filename));
-  g_strlcpy(prof->name, _("Adobe RGB"), sizeof(prof->name));
+  dt_utf8_strlcpy(prof->name, _("Adobe RGB"), sizeof(prof->name));
   prof->pos = 2;
   d->profiles = g_list_append(d->profiles, prof);
 
   prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
   g_strlcpy(prof->filename, "X profile", sizeof(prof->filename));
-  g_strlcpy(prof->name, "X profile", sizeof(prof->name));
+  dt_utf8_strlcpy(prof->name, "X profile", sizeof(prof->name));
   prof->pos = 3;
   d->profiles = g_list_append(d->profiles, prof);
 
   prof = (dt_lib_export_profile_t *)g_malloc0(sizeof(dt_lib_export_profile_t));
   g_strlcpy(prof->filename, "linear_rgb", sizeof(prof->filename));
-  g_strlcpy(prof->name, _("linear RGB"), sizeof(prof->name));
+  dt_utf8_strlcpy(prof->name, _("linear RGB"), sizeof(prof->name));
   pos = prof->pos = 4;
   d->profiles = g_list_append(d->profiles, prof);
 


### PR DESCRIPTION
..and use it where applicable.

This fixed problem described by Alexandre - Unicode strings are cut in the middle of a Unicode character, see http://sourceforge.net/mailarchive/forum.php?thread_name=CAFjkzc01AC3DHvt7juvp2OC0iPFOaCbd5sHHzNFuPp_g6Ta9iw%40mail.gmail.com&forum_name=darktable-devel.
