### PR TITLE
Metadata viewer tweaks

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -232,8 +232,15 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     snprintf(value, vl, "%.0f mm", img->exif_focal_length);
     _metadata_update_value(d->metadata[md_exif_focal_length], value);
 
-    snprintf(value, vl, "%.2f m", img->exif_focus_distance);
-    _metadata_update_value(d->metadata[md_exif_focus_distance], value);
+    if (isnan(img->exif_focus_distance) || fpclassify(img->exif_focus_distance) == FP_ZERO)
+    {
+      _metadata_update_value(d->metadata[md_exif_focus_distance], NODATA_STRING);
+    }
+    else
+    {
+      snprintf(value, vl, "%.2f m", img->exif_focus_distance);
+      _metadata_update_value(d->metadata[md_exif_focus_distance], value);
+    }
 
     snprintf(value, vl, "%.0f", img->exif_iso);
     _metadata_update_value(d->metadata[md_exif_iso], value);


### PR DESCRIPTION
- Don't show focus distance when it isn't usable (which is kind of weird, I'd have expected the Canon 6D + 24-105 to support this, but even the `exiv2 -pv` doesn't show anything useful)
- Add "mm" units for the focal length
- Spell out "ISO" in capital letters. I went as far as looking to the source code to see why ISO wasn't displayed by default before I realized that it's "iso", not "ISO".
