### PR TITLE
In full view on the lighttable, wrap around.

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -876,7 +876,17 @@ expose_zoomable (dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, in
   }
   else if(zoom < 1.01)
   {
+    if(zoom==1 && zoom_x < 0) // full view, wrap around
+    {
+      zoom_x = wd*DT_LIBRARY_MAX_ZOOM-wd;
+      zoom_y -=ht;
+    }
     if(zoom_x < 0)                         zoom_x = 0;
+    if(zoom==1 && zoom_x > wd*DT_LIBRARY_MAX_ZOOM-wd) // full view, wrap around
+    {
+      zoom_x = 0;
+      zoom_y +=ht;
+    }
     if(zoom_x > wd*DT_LIBRARY_MAX_ZOOM-wd) zoom_x = wd*DT_LIBRARY_MAX_ZOOM-wd;
     if(zoom_y < 0)                         zoom_y = 0;
     if(zoom_y > ht*lib->collection_count/MIN(DT_LIBRARY_MAX_ZOOM, zoom)-ht)


### PR DESCRIPTION
That is when pressing right arrow on the last image in a row we move
to the next image on the following row. Same thing for left arrow on
the first image of a row.

This makes reviewing all images more friendly.
