### PR TITLE
Improve filter on import

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -484,7 +484,7 @@ void view_popup_menu_onSearchFilmroll (GtkWidget *menuitem, gpointer userdata)
       g_free(query);
 
       /* reset filter so that view isn't empty */
-      dt_view_filter_reset_for_import(darktable.view_manager);
+      dt_view_filter_reset(darktable.view_manager, FALSE);
 
       /* update collection to view missing filmroll */
       _lib_folders_update_collection(new_path);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -704,7 +704,7 @@ static void _lib_import_single_image_callback(GtkWidget *widget,gpointer user_da
     int filmid = 0;
 
     /* reset filter so that view isn't empty */
-    dt_view_filter_reset_for_import(darktable.view_manager);
+    dt_view_filter_reset(darktable.view_manager, TRUE);
 
     while(it)
     {
@@ -771,7 +771,7 @@ static void _lib_import_folder_callback(GtkWidget *widget,gpointer user_data)
     GSList *it = list;
 
     /* reset filter so that view isn't empty */
-    dt_view_filter_reset_for_import(darktable.view_manager);
+    dt_view_filter_reset(darktable.view_manager, TRUE);
 
     /* for each selected folder add import job */
     while(it)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -36,7 +36,7 @@ typedef struct dt_lib_tool_filter_t
 dt_lib_tool_filter_t;
 
 /* proxy function to intelligently reset filter */
-static void _lib_filter_reset_for_import(dt_lib_module_t *self);
+static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter);
 
 /* callback for filter combobox change */
 static void _lib_filter_combobox_changed(GtkComboBox *widget, gpointer user_data);
@@ -156,7 +156,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* initialize proxy */
   darktable.view_manager->proxy.filter.module = self;
-  darktable.view_manager->proxy.filter.reset_filter = _lib_filter_reset_for_import;
+  darktable.view_manager->proxy.filter.reset_filter = _lib_filter_reset;
 
 }
 
@@ -234,27 +234,35 @@ static void _lib_filter_update_query(dt_lib_module_t *self)
 }
 
 static void
-_lib_filter_reset_for_import(dt_lib_module_t *self)
+_lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter)
 {
   dt_lib_tool_filter_t *dropdowns = (dt_lib_tool_filter_t *)self->data;
 
-  /* initial import rating setting */
-  int initial_rating = dt_conf_get_int("ui_last/import_initial_rating");
+  if (smart_filter == TRUE)
+  {
+    /* initial import rating setting */
+    int initial_rating = dt_conf_get_int("ui_last/import_initial_rating");
 
-  /* current selection in filter dropdown */
-  int current_filter = gtk_combo_box_get_active(GTK_COMBO_BOX(dropdowns->filter));
+    /* current selection in filter dropdown */
+    int current_filter = gtk_combo_box_get_active(GTK_COMBO_BOX(dropdowns->filter));
 
-  /* convert filter dropdown to rating: 2-6 is 1-5 stars, for anything else, assume 0 stars */
-  int current_filter_rating = (current_filter >= 2 && current_filter <= 6) ? current_filter - 1 : 0;
+    /* convert filter dropdown to rating: 2-6 is 1-5 stars, for anything else, assume 0 stars */
+    int current_filter_rating = (current_filter >= 2 && current_filter <= 6) ? current_filter - 1 : 0;
 
-  /* new filter is the lesser of the initial rating and the current filter rating */
-  int new_filter_rating = MIN(initial_rating, current_filter_rating);
+    /* new filter is the lesser of the initial rating and the current filter rating */
+    int new_filter_rating = MIN(initial_rating, current_filter_rating);
 
-  /* convert new filter rating to filter dropdown selector */
-  int new_filter = (new_filter_rating >= 1 && new_filter_rating <= 5) ? new_filter_rating + 1 : new_filter_rating;
+    /* convert new filter rating to filter dropdown selector */
+    int new_filter = (new_filter_rating >= 1 && new_filter_rating <= 5) ? new_filter_rating + 1 : new_filter_rating;
 
-  /* Reset to new filter dropdown item */
-  gtk_combo_box_set_active(GTK_COMBO_BOX(dropdowns->filter), new_filter);
+    /* Reset to new filter dropdown item */
+    gtk_combo_box_set_active(GTK_COMBO_BOX(dropdowns->filter), new_filter);
+  }
+  else
+  {
+    /* Reset to topmost item, 'all' */
+    gtk_combo_box_set_active(GTK_COMBO_BOX(dropdowns->filter), 0);
+  }
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1193,10 +1193,10 @@ void dt_view_toggle_selection(int imgid)
 /**
  * \brief Reset filter
  */
-void dt_view_filter_reset_for_import(const dt_view_manager_t *vm)
+void dt_view_filter_reset(const dt_view_manager_t *vm, gboolean smart_filter)
 {
   if (vm->proxy.filter.module && vm->proxy.filter.reset_filter)
-    vm->proxy.filter.reset_filter(vm->proxy.filter.module);
+    vm->proxy.filter.reset_filter(vm->proxy.filter.module, smart_filter);
 }
 
 void dt_view_filmstrip_scroll_relative(const int diff, int offset)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -180,7 +180,7 @@ typedef struct dt_view_manager_t
     struct
     {
       struct dt_lib_module_t *module;
-      void (*reset_filter)(struct dt_lib_module_t *);
+      void (*reset_filter)(struct dt_lib_module_t *, gboolean smart_filter);
     } filter;
 
     /* module collection proxy object */
@@ -315,7 +315,7 @@ void dt_view_collection_update(const dt_view_manager_t *vm);
 /*
  * Filter dropdown proxy
  */
-void dt_view_filter_reset_for_import(const dt_view_manager_t *vm);
+void dt_view_filter_reset(const dt_view_manager_t *vm, gboolean smart_filter);
 
 /*
  * NEW filmstrip api


### PR DESCRIPTION
This commit adds intelligent handling for the filter to be applied to the lighttable view upon importing images. The commit message below describes it in more detail:

Instead of showing all images, we set the filter to the smaller of the default import rating and the current filter. This ensures that the imported images are shown, but that we don't reduce the filter unnecessarily.

This is my first time (ever!) editing and submitting a pull request for C (or any compiled application) code, so go easy. ;-)
