### PR TITLE
Activate multi-instance support for the exposure module.

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -51,7 +51,7 @@ groups ()
 int
 flags ()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_SUPPORTS_BLENDING;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_SUPPORTS_BLENDING;
 }
 
 void init_key_accels(dt_iop_module_so_t *self)


### PR DESCRIPTION
Since we have masks on the exposure module it makes more sense to also allow multiple instance of this module.
