### PR TITLE
GTK3: Use accessor functions instead of direct access

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -561,6 +561,11 @@ add_definitions("-DGTK_DISABLE_SINGLE_INCLUDES")
 #
 add_definitions("-D__GDK_KEYSYMS_COMPAT_H__")
 
+#
+# Use accessor functions instead of direct access
+#
+add_definitions("-DGSEAL_ENABLE")
+
 ###### GTK+3 port ######
 
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -270,8 +270,10 @@ dt_bauhaus_root_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer
     const float tol = 50;
     gint wx, wy;
     GtkWidget *widget = darktable.bauhaus->popup_window;
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
     gdk_window_get_origin (gtk_widget_get_window (widget), &wx, &wy);
-    if(event->x_root > wx + widget->allocation.width + tol || event->y_root > wy + widget->allocation.height + tol ||
+    if(event->x_root > wx + allocation.width + tol || event->y_root > wy + allocation.height + tol ||
         event->x_root < (int)wx - tol || event->y_root < (int)wy - tol)
     {
       dt_bauhaus_widget_reject(darktable.bauhaus->current);
@@ -291,8 +293,10 @@ dt_bauhaus_root_button_press(GtkWidget *wd, GdkEventButton *event, gpointer user
     const float tol = 0;
     gint wx, wy;
     GtkWidget *widget = darktable.bauhaus->popup_window;
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
     gdk_window_get_origin (gtk_widget_get_window (widget), &wx, &wy);
-    if((event->x_root > wx + widget->allocation.width + tol || event->y_root > wy + widget->allocation.height + tol ||
+    if((event->x_root > wx + allocation.width + tol || event->y_root > wy + allocation.height + tol ||
         event->x_root < (int)wx - tol || event->y_root < (int)wy - tol))
     {
       dt_bauhaus_widget_reject(darktable.bauhaus->current);
@@ -309,7 +313,9 @@ combobox_popup_scroll(int up)
 {
   gint wx, wy;
   GtkWidget *w = GTK_WIDGET(darktable.bauhaus->current);
-  const int ht = w->allocation.height;
+  GtkAllocation allocation_w;
+  gtk_widget_get_allocation(w, &allocation_w);
+  const int ht = allocation_w.height;
   const int skip = ht + get_line_space();
   gdk_window_get_origin (gtk_widget_get_window (w), &wx, &wy);
   dt_bauhaus_combobox_data_t *d = &darktable.bauhaus->current->data.combobox;
@@ -346,14 +352,20 @@ dt_bauhaus_popup_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer user_
 static gboolean
 dt_bauhaus_popup_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
+  GtkAllocation allocation_popup_window;
+  gtk_widget_get_allocation(darktable.bauhaus->popup_window, &allocation_popup_window);
   gtk_widget_queue_draw(darktable.bauhaus->popup_area);
   dt_bauhaus_widget_t *w = darktable.bauhaus->current;
-  int width = darktable.bauhaus->popup_window->allocation.width, height = darktable.bauhaus->popup_window->allocation.height;
+  GtkAllocation allocation_w;
+  gtk_widget_get_allocation(GTK_WIDGET(w), &allocation_w);
+  int width = allocation_popup_window.width, height = allocation_popup_window.height;
   // coordinate transform is in vain because we're only ever called after a button release.
   // that means the system is always the one of the popup.
   // that also means that we can't have hovering combobox entries while still holding the button. :(
   const float ex = event->x;
   const float ey = event->y;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
 
   switch(w->type)
   {
@@ -366,8 +378,8 @@ dt_bauhaus_popup_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointe
       dt_bauhaus_slider_data_t *d = &w->data.slider;
       const float mouse_off = get_slider_line_offset(
                                 d->oldpos, d->scale, ex/width,
-                                ey/height, GTK_WIDGET(w)->allocation.height/(float)height,
-                                widget->allocation.width);
+                                ey/height, allocation_w.height/(float)height,
+                                allocation.width);
       if(!darktable.bauhaus->change_active)
       {
         if((darktable.bauhaus->mouse_line_distance < 0 && mouse_off >= 0) ||
@@ -398,7 +410,7 @@ dt_bauhaus_popup_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpoint
   // all that doesn't seem to work (more events are created than necessary, exits at random
   // during popup already etc.
 #if 0
-  // if(event->x > widget->allocation.width + 20 || event->y > widget->allocation.height + 20 ||
+  // if(event->x > allocation.width + 20 || event->y > allocation.height + 20 ||
   // event->x < -20 || event->y < -20)
   if(!event->state)
   {
@@ -463,7 +475,7 @@ static void
 window_show(GtkWidget *w, gpointer user_data)
 {
   /* grabbing might not succeed immediately... */
-  if (gdk_keyboard_grab(w->window, FALSE, GDK_CURRENT_TIME) != GDK_GRAB_SUCCESS)
+  if (gdk_keyboard_grab(gtk_widget_get_window(w), FALSE, GDK_CURRENT_TIME) != GDK_GRAB_SUCCESS)
   {
     // never happened so far:
     /* ...wait a while and try again */
@@ -1039,9 +1051,11 @@ dt_bauhaus_draw_indicator(dt_bauhaus_widget_t *w, float pos, cairo_t *cr)
 {
   // draw scale indicator
   GtkWidget *widget = GTK_WIDGET(w);
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   if(w->type != DT_BAUHAUS_SLIDER) return;
-  const int wd = widget->allocation.width;
-  const int ht = widget->allocation.height;
+  const int wd = allocation.width;
+  const int ht = allocation.height;
   cairo_save(cr);
   // dt_bauhaus_slider_data_t *d = &w->data.slider;
 
@@ -1107,8 +1121,10 @@ static void
 dt_bauhaus_draw_quad(dt_bauhaus_widget_t *w, cairo_t *cr)
 {
   GtkWidget *widget = GTK_WIDGET(w);
-  int width  = widget->allocation.width;
-  int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width  = allocation.width;
+  int height = allocation.height;
   if(w->quad_paint)
   {
     cairo_save(cr);
@@ -1153,9 +1169,11 @@ dt_bauhaus_draw_baseline(dt_bauhaus_widget_t *w, cairo_t *cr)
 {
   // draw line for orientation in slider
   GtkWidget *widget = GTK_WIDGET(w);
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   if(w->type != DT_BAUHAUS_SLIDER) return;
-  const int wd = widget->allocation.width;
-  const int ht = widget->allocation.height;
+  const int wd = allocation.width;
+  const int ht = allocation.height;
   cairo_save(cr);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
 
@@ -1227,7 +1245,11 @@ static void
 dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
 {
   GtkWidget *widget = GTK_WIDGET(w);
-  int width = darktable.bauhaus->popup_window->allocation.width, height = darktable.bauhaus->popup_window->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  GtkAllocation allocation_popup_window;
+  gtk_widget_get_allocation(darktable.bauhaus->popup_window, &allocation_popup_window);
+  int width = allocation_popup_window.width, height = allocation_popup_window.height;
   switch(w->type)
   {
     case DT_BAUHAUS_COMBOBOX:
@@ -1235,7 +1257,7 @@ dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
       // only set to what's in the filtered list.
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       int active = darktable.bauhaus->end_mouse_y >= 0
-                   ? (darktable.bauhaus->end_mouse_y / (widget->allocation.height + get_line_space()))
+                   ? (darktable.bauhaus->end_mouse_y / (allocation.height + get_line_space()))
                    : d->active;
       GList *it = d->labels;
       int k = 0, i = 0, kk = 0, match = 1;
@@ -1285,8 +1307,8 @@ dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
       dt_bauhaus_slider_data_t *d = &w->data.slider;
       const float mouse_off = get_slider_line_offset(
                                 d->oldpos, d->scale, darktable.bauhaus->end_mouse_x/width,
-                                darktable.bauhaus->end_mouse_y/height, widget->allocation.height/(float)height,
-                                widget->allocation.width);
+                                darktable.bauhaus->end_mouse_y/height, allocation.height/(float)height,
+                                allocation.width);
       dt_bauhaus_slider_set_normalized(w, d->oldpos + mouse_off);
       d->oldpos = d->pos;
       break;
@@ -1299,12 +1321,16 @@ dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
 static gboolean
 dt_bauhaus_popup_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_data)
 {
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   dt_bauhaus_widget_t *w = darktable.bauhaus->current;
   // dimensions of the popup
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   // dimensions of the original line
   GtkWidget *current = GTK_WIDGET(w);
-  int wd = current->allocation.width, ht = current->allocation.height;
+  GtkAllocation allocation_current;
+  gtk_widget_get_allocation(current, &allocation_current);
+  int wd = allocation_current.width, ht = allocation_current.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -1480,8 +1506,10 @@ dt_bauhaus_popup_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_
 static gboolean
 dt_bauhaus_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_data)
 {
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
-  const int width = widget->allocation.width, height = widget->allocation.height;
+  const int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -1593,7 +1621,9 @@ dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
       gtk_widget_get_allocation(GTK_WIDGET(w), &tmp);
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
       gtk_widget_set_size_request(darktable.bauhaus->popup_area, tmp.width, (tmp.height+get_line_space()) * d->num_labels);
-      const int ht = GTK_WIDGET(w)->allocation.height;
+      GtkAllocation allocation_w;
+      gtk_widget_get_allocation(GTK_WIDGET(w), &allocation_w);
+      const int ht = allocation_w.height;
       const int skip = ht + get_line_space();
       offset = - d->active * skip;
       darktable.bauhaus->mouse_x = 0;
@@ -1668,6 +1698,8 @@ dt_bauhaus_combobox_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer us
 static gboolean
 dt_bauhaus_combobox_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   if(w->type != DT_BAUHAUS_COMBOBOX) return FALSE;
   if(w->module) // tethering uses these with module == NULL
@@ -1675,7 +1707,7 @@ dt_bauhaus_combobox_button_press(GtkWidget *widget, GdkEventButton *event, gpoin
   GtkAllocation tmp;
   gtk_widget_get_allocation(GTK_WIDGET(w), &tmp);
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
-  if(w->quad_paint && (event->x > widget->allocation.width - widget->allocation.height))
+  if(w->quad_paint && (event->x > allocation.width - allocation.height))
   {
     g_signal_emit_by_name(G_OBJECT(w), "quad-pressed");
     return TRUE;
@@ -1919,11 +1951,13 @@ dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_
 static gboolean
 dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   dt_iop_request_focus(w->module);
   GtkAllocation tmp;
   gtk_widget_get_allocation(GTK_WIDGET(w), &tmp);
-  if(w->quad_paint && (event->x > widget->allocation.width - widget->allocation.height))
+  if(w->quad_paint && (event->x > allocation.width - allocation.height))
   {
     g_signal_emit_by_name(G_OBJECT(w), "quad-pressed");
     return TRUE;

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -219,14 +219,16 @@ int dt_control_load_config(dt_control_t *c)
 int dt_control_write_config(dt_control_t *c)
 {
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   gint x, y;
   gtk_window_get_position(GTK_WINDOW(widget), &x, &y);
   dt_conf_set_int ("ui_last/window_x",  x);
   dt_conf_set_int ("ui_last/window_y",  y);
-  dt_conf_set_int ("ui_last/window_w",  widget->allocation.width);
-  dt_conf_set_int ("ui_last/window_h",  widget->allocation.height);
+  dt_conf_set_int ("ui_last/window_w",  allocation.width);
+  dt_conf_set_int ("ui_last/window_h",  allocation.height);
   dt_conf_set_bool("ui_last/maximized",
-                   (gdk_window_get_state(widget->window) & GDK_WINDOW_STATE_MAXIMIZED));
+                   (gdk_window_get_state(gtk_widget_get_window(widget)) & GDK_WINDOW_STATE_MAXIMIZED));
 
   sqlite3_stmt *stmt;
   dt_pthread_mutex_lock(&(darktable.control->global_mutex));
@@ -308,7 +310,7 @@ void dt_ctl_set_display_profile()
   GdkScreen *screen = gtk_widget_get_screen(widget);
   if ( screen==NULL )
     screen = gdk_screen_get_default();
-  int monitor = gdk_screen_get_monitor_at_window (screen, widget->window);
+  int monitor = gdk_screen_get_monitor_at_window (screen, gtk_widget_get_window(widget));
   char *atom_name;
   if (monitor > 0)
     atom_name = g_strdup_printf("_ICC_PROFILE_%d", monitor);
@@ -336,7 +338,7 @@ void dt_ctl_set_display_profile()
   GdkScreen *screen = gtk_widget_get_screen(widget);
   if ( screen==NULL )
     screen = gdk_screen_get_default();
-  int monitor = gdk_screen_get_monitor_at_window(screen, widget->window);
+  int monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(widget));
 
   CMProfileRef prof = NULL;
   CMGetProfileByAVID(monitor, &prof);
@@ -785,7 +787,7 @@ void dt_control_change_cursor(dt_cursor_t curs)
 {
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
   GdkCursor* cursor = gdk_cursor_new(curs);
-  gdk_window_set_cursor(widget->window, cursor);
+  gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
   gdk_cursor_destroy(cursor);
 }
 
@@ -1396,8 +1398,10 @@ void *dt_control_expose(void *voidptr)
 
 gboolean dt_control_expose_endmarker(GtkWidget *widget, GdkEventExpose *event, gpointer user_data)
 {
-  const int width = widget->allocation.width;
-  const int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  const int width = allocation.width;
+  const int height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   dt_draw_endmarker(cr, width, height, (long int)user_data);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1721,11 +1721,13 @@ _preset_popup_position(GtkMenu *menu, gint *x,gint *y,gboolean *push_in, gpointe
 {
   gint w,h;
   GtkRequisition requisition;
-  gdk_window_get_size(GTK_WIDGET(data)->window,&w,&h);
-  gdk_window_get_origin (GTK_WIDGET(data)->window, x, y);
+  gdk_window_get_size(gtk_widget_get_window(GTK_WIDGET(data)),&w,&h);
+  gdk_window_get_origin (gtk_widget_get_window(GTK_WIDGET(data)), x, y);
   gtk_widget_size_request (GTK_WIDGET (menu), &requisition);
 
-  (*y)+=GTK_WIDGET(data)->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(GTK_WIDGET(data), &allocation);
+  (*y)+=allocation.height;
 }
 
 static void

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -870,7 +870,7 @@ void dt_masks_reset_show_masks_icons(void)
     {
       dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t*)m->blend_data;
       bd->masks_shown = DT_MASKS_EDIT_OFF;
-      GTK_TOGGLE_BUTTON(bd->masks_edit)->active = 0;
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
       gtk_widget_queue_draw(bd->masks_edit);
     }
     modules = g_list_next(modules);

--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -84,12 +84,14 @@ _button_expose (GtkWidget *widget, GdkEventExpose *event)
 
   /* begin cairo drawing */
   cairo_t *cr;
-  cr = gdk_cairo_create (widget->window);
+  cr = gdk_cairo_create (gtk_widget_get_window(widget));
 
-  int x = widget->allocation.x;
-  int y = widget->allocation.y;
-  int width = widget->allocation.width;
-  int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int x = allocation.x;
+  int y = allocation.y;
+  int width = allocation.width;
+  int height = allocation.height;
 
   /* draw standard button background if not transparent */
   if( (flags & CPF_STYLE_FLAT ))
@@ -108,8 +110,8 @@ _button_expose (GtkWidget *widget, GdkEventExpose *event)
   else if( !(flags & CPF_BG_TRANSPARENT) )
   {
     /* draw default boxed button */
-    gtk_paint_box (widget->style, widget->window,
-                   GTK_WIDGET_STATE (widget),
+    gtk_paint_box (gtk_widget_get_style(widget), gtk_widget_get_window(widget),
+                   gtk_widget_get_state(widget),
                    GTK_SHADOW_OUT, NULL, widget, "button",
                    x, y, width, height);
   }
@@ -138,7 +140,7 @@ _button_expose (GtkWidget *widget, GdkEventExpose *event)
     int lx=x+2, ly=y+((height/2.0)-(ph/2.0));
     if (DTGTK_BUTTON (widget)->icon) lx += width;
     GdkRectangle t= {x,y,x+width,y+height};
-    gtk_paint_layout(style,widget->window, GTK_STATE_NORMAL,TRUE,&t,widget,"label",lx,ly,layout);
+    gtk_paint_layout(style,gtk_widget_get_window(widget), GTK_STATE_NORMAL,TRUE,&t,widget,"label",lx,ly,layout);
   }
 
   return FALSE;

--- a/src/dtgtk/icon.c
+++ b/src/dtgtk/icon.c
@@ -64,12 +64,14 @@ _icon_expose (GtkWidget *widget, GdkEventExpose *event)
 
   /* begin cairo drawing */
   cairo_t *cr;
-  cr = gdk_cairo_create (widget->window);
+  cr = gdk_cairo_create (gtk_widget_get_window(widget));
 
-  int x = widget->allocation.x;
-  int y = widget->allocation.y;
-  int width = widget->allocation.width;
-  int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int x = allocation.x;
+  int y = allocation.y;
+  int width = allocation.width;
+  int height = allocation.height;
 
   /*
       cairo_rectangle (cr,x,y,width,height);

--- a/src/dtgtk/label.c
+++ b/src/dtgtk/label.c
@@ -60,11 +60,11 @@ static void  _label_size_request(GtkWidget *widget,GtkRequisition *requisition)
 
   widget->allocation = *allocation;
 
-  if (GTK_WIDGET_REALIZED(widget)) {
+  if (gtk_widget_get_realized(widget)) {
      gdk_window_move_resize(
-         widget->window,
-         allocation->x, allocation->y,
-         allocation->width, allocation->height
+         gtk_widget_get_window(widget),
+         allocation.x, allocation.y,
+         allocation.width, allocation.height
      );
    }
 }*/
@@ -92,10 +92,12 @@ static gboolean _label_expose(GtkWidget *widget, GdkEventExpose *event)
   if(style->depth == -1) return FALSE;
   int state = gtk_widget_get_state(widget);
 
-  int x = widget->allocation.x;
-  int y = widget->allocation.y;
-  int width = widget->allocation.width;
-  int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int x = allocation.x;
+  int y = allocation.y;
+  int width = allocation.width;
+  int height = allocation.height;
 
   // Formatting the display of text and draw it...
   PangoLayout *layout;
@@ -111,7 +113,7 @@ static gboolean _label_expose(GtkWidget *widget, GdkEventExpose *event)
   // Begin cairo drawing
 
   cairo_t *cr;
-  cr = gdk_cairo_create(widget->window);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   cairo_set_source_rgba(cr,
                         /* style->fg[state].red/65535.0,
@@ -177,7 +179,7 @@ static gboolean _label_expose(GtkWidget *widget, GdkEventExpose *event)
   int lx=x+4, ly=y+((height/2.0)-(ph/2.0));
   if( DTGTK_LABEL(widget)->flags&DARKTABLE_LABEL_ALIGN_RIGHT ) lx=x+width-pw-6;
   else if( DTGTK_LABEL(widget)->flags&DARKTABLE_LABEL_ALIGN_CENTER ) lx=(width/2.0)-(pw/2.0);
-  gtk_paint_layout(style,widget->window, state,TRUE,&t,widget,"label",lx,ly,layout);
+  gtk_paint_layout(style,gtk_widget_get_window(widget), state,TRUE,&t,widget,"label",lx,ly,layout);
 
   return FALSE;
 }

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -85,12 +85,12 @@ static void _togglebutton_size_allocate(GtkWidget *widget, GtkAllocation *alloca
   g_return_if_fail(DTGTK_IS_TOGGLEBUTTON(widget));
   g_return_if_fail(allocation != NULL);
 
-  widget->allocation = *allocation;
+  gtk_widget_get_allocation(widget, allocation);
 
-  if (GTK_WIDGET_REALIZED(widget))
+  if (gtk_widget_get_realized(widget))
   {
     gdk_window_move_resize(
-      widget->window,
+      gtk_widget_get_window(widget),
       allocation->x, allocation->y,
       allocation->width, allocation->height
     );
@@ -142,12 +142,14 @@ static gboolean _togglebutton_expose(GtkWidget *widget, GdkEventExpose *event)
 
   /* begin cairo drawing */
   cairo_t *cr;
-  cr = gdk_cairo_create (widget->window);
+  cr = gdk_cairo_create (gtk_widget_get_window(widget));
 
-  int x = widget->allocation.x;
-  int y = widget->allocation.y;
-  int width = widget->allocation.width;
-  int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int x = allocation.x;
+  int y = allocation.y;
+  int width = allocation.width;
+  int height = allocation.height;
 
   /* draw standard button background if not transparent nor flat styled */
   if( (flags & CPF_STYLE_FLAT ))
@@ -166,8 +168,8 @@ static gboolean _togglebutton_expose(GtkWidget *widget, GdkEventExpose *event)
   else if( !(flags & CPF_BG_TRANSPARENT) )
   {
     /* draw default boxed button */
-    gtk_paint_box (widget->style, widget->window,
-                   GTK_WIDGET_STATE (widget),
+    gtk_paint_box (gtk_widget_get_style(widget), gtk_widget_get_window(widget),
+                   gtk_widget_get_state(widget),
                    GTK_SHADOW_OUT, NULL, widget, "button",
                    x, y, width, height);
   }
@@ -210,7 +212,7 @@ static gboolean _togglebutton_expose(GtkWidget *widget, GdkEventExpose *event)
     int lx=x+2, ly=y+((height/2.0)-(ph/2.0));
     //if (DTGTK_TOGGLEBUTTON (widget)->icon) lx += width;
     //GdkRectangle t={x,y,x+width,y+height};
-    //gtk_paint_layout(style,widget->window, state,TRUE,&t,widget,"togglebutton",lx,ly,layout);
+    //gtk_paint_layout(style,gtk_widget_get_window(widget), state,TRUE,&t,widget,"togglebutton",lx,ly,layout);
     cairo_translate(cr, lx, ly);
     pango_cairo_show_layout (cr,layout);
   }

--- a/src/dtgtk/tristatebutton.c
+++ b/src/dtgtk/tristatebutton.c
@@ -100,12 +100,12 @@ static void _tristatebutton_size_allocate(GtkWidget *widget, GtkAllocation *allo
 
   widget->allocation = *allocation;
 
-  if (GTK_WIDGET_REALIZED(widget))
+  if (gtk_widget_get_realized(widget))
   {
     gdk_window_move_resize(
-      widget->window,
-      allocation->x, allocation->y,
-      allocation->width, allocation->height
+      gtk_widget_get_window(widget),
+      allocation.x, allocation.y,
+      allocation.width, allocation.height
     );
   }
 }
@@ -151,12 +151,14 @@ static gboolean _tristatebutton_expose(GtkWidget *widget, GdkEventExpose *event)
 
   /* begin cairo drawing */
   cairo_t *cr;
-  cr = gdk_cairo_create (widget->window);
+  cr = gdk_cairo_create (gtk_widget_get_window(widget));
 
-  int x = widget->allocation.x;
-  int y = widget->allocation.y;
-  int width = widget->allocation.width;
-  int height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int x = allocation.x;
+  int y = allocation.y;
+  int width = allocation.width;
+  int height = allocation.height;
 
   /* draw standard button background if not transparent nor flat styled */
   if( (flags & CPF_STYLE_FLAT ))
@@ -218,8 +220,8 @@ static gboolean _tristatebutton_expose(GtkWidget *widget, GdkEventExpose *event)
       /* Draw the pixbuf */
       gint pbw = gdk_pixbuf_get_width (pixbuf);
       gint pbh = gdk_pixbuf_get_height (pixbuf);
-      gdk_cairo_set_source_pixbuf (cr, pixbuf, widget->allocation.x+((widget->allocation.width/2)-(pbw/2)),
-                                   widget->allocation.y+((widget->allocation.height/2)-(pbh/2)));
+      gdk_cairo_set_source_pixbuf (cr, pixbuf, allocation.x+((allocation.width/2)-(pbw/2)),
+                                   allocation.y+((allocation.height/2)-(pbh/2)));
       cairo_paint (cr);
     }
   }

--- a/src/gui/contrast.c
+++ b/src/gui/contrast.c
@@ -127,7 +127,7 @@ dt_gui_contrast_init ()
 
   /* realize window to ensure style is applied before copy */
   gtk_widget_realize(window);
-  _main_window_orginal_style = gtk_style_copy (window->style);
+  _main_window_orginal_style = gtk_style_copy (gtk_widget_get_style(window));
 
   /* get clearlooks-brightbg original style */
 
@@ -135,7 +135,7 @@ dt_gui_contrast_init ()
   GtkWidget *ev = gtk_event_box_new();
   dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_LEFT_CENTER,ev);
   gtk_widget_realize(ev);
-  _module_orginal_style = gtk_style_copy (ev->style);
+  _module_orginal_style = gtk_style_copy (gtk_widget_get_style(ev));
 
   gtk_widget_destroy(ev);
 

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -619,7 +619,10 @@ static gchar *facebook_get_user_auth_token(dt_storage_facebook_gui_data_t *ui)
   GtkWidget *hbox = gtk_hbox_new(FALSE, 5);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(gtk_label_new(_("URL:"))), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(entry), TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(fb_auth_dialog->vbox), hbox, TRUE, TRUE, 0);
+
+  GtkBox *fbauthdialog_vbox = 0;
+  g_object_get(G_OBJECT(fb_auth_dialog), "vbox", &fbauthdialog_vbox, NULL);
+  gtk_box_pack_end(fbauthdialog_vbox, hbox, TRUE, TRUE, 0);
 
   gtk_widget_show_all(GTK_WIDGET(fb_auth_dialog));
 

--- a/src/imageio/storage/picasa.c
+++ b/src/imageio/storage/picasa.c
@@ -839,7 +839,10 @@ static int picasa_get_user_auth_token(dt_storage_picasa_gui_data_t *ui)
   GtkWidget *hbox = gtk_hbox_new(FALSE, 5);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(gtk_label_new(_("URL:"))), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(entry), TRUE, TRUE, 0);
-  gtk_box_pack_end(GTK_BOX(picasa_auth_dialog->vbox), hbox, TRUE, TRUE, 0);
+
+  GtkBox *picasaauthdialog_vbox = 0;
+  g_object_get(G_OBJECT(picasa_auth_dialog), "vbox", &picasaauthdialog_vbox, NULL);
+  gtk_box_pack_end(picasaauthdialog_vbox, hbox, TRUE, TRUE, 0);
 
   gtk_widget_show_all(GTK_WIDGET(picasa_auth_dialog));
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1003,7 +1003,9 @@ area_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_data)
   int ch2 = (int)c->channel2;
   for(int k=0; k<BANDS; k++) dt_draw_curve_set_point(c->minmax_curve, k, p.x[ch2][k], p.y[ch2][k]);
   const int inset = INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg, match color of the notebook tabs:
@@ -1251,7 +1253,9 @@ area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
   dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
   const int inset = INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width)/(float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
   int ch2 = c->channel;
@@ -1341,7 +1345,9 @@ area_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
     dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
     reset_mix(self);
     const int inset = INSET;
-    int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
+    int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
     c->mouse_pick = dt_draw_curve_calc_value(c->minmax_curve, CLAMP(event->x - inset, 0, width)/(float)width);
     c->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
     c->dragging = 1;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -475,7 +475,9 @@ dt_iop_basecurve_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_
   dt_iop_estimate_exp(x, y, 4, unbounded_coeffs);
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg
@@ -581,8 +583,10 @@ gboolean dt_iop_basecurve_motion_notify(GtkWidget *widget, GdkEventMotion *event
   int nodes = p->basecurve_nodes[ch];
   dt_iop_basecurve_node_t *basecurve = p->basecurve[ch];
 
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   c->mouse_x = CLAMP(event->x - inset, 0, width);
   c->mouse_y = CLAMP(event->y - inset, 0, height);
 
@@ -692,9 +696,11 @@ dt_iop_basecurve_button_press(GtkWidget *widget, GdkEventButton *event, gpointer
 static gboolean
 area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   GtkRequisition r;
-  r.width  = widget->allocation.width;
-  r.height = widget->allocation.width;
+  r.width  = allocation.width;
+  r.height = allocation.width;
   gtk_widget_size_request(widget, &r);
   return TRUE;
 }

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -777,7 +777,10 @@ frame_offset_callback (GtkWidget *slider, dt_iop_module_t *self)
 static void
 colorpick_button_callback(GtkButton *button, GtkColorSelectionDialog *csd)
 {
-  gtk_dialog_response(GTK_DIALOG(csd), (GTK_WIDGET(button)==csd->ok_button)?GTK_RESPONSE_ACCEPT:0);
+  GtkWidget *okButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+
+  gtk_dialog_response(GTK_DIALOG(csd), (GTK_WIDGET(button)==okButton)?GTK_RESPONSE_ACCEPT:0);
 }
 
 static void
@@ -793,9 +796,14 @@ colorpick_callback (GtkDarktableButton *button, dt_iop_module_t *self)
 
   GtkColorSelectionDialog  *csd = GTK_COLOR_SELECTION_DIALOG(gtk_color_selection_dialog_new(_("select border color")));
   gtk_window_set_transient_for(GTK_WINDOW(csd), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  g_signal_connect (G_OBJECT (csd->ok_button), "clicked",
+
+  GtkWidget *okButton, *cancelButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+  g_object_get(G_OBJECT(csd), "cancel-button", &cancelButton, NULL);
+
+  g_signal_connect (G_OBJECT (okButton), "clicked",
                     G_CALLBACK (colorpick_button_callback), csd);
-  g_signal_connect (G_OBJECT (csd->cancel_button), "clicked",
+  g_signal_connect (G_OBJECT (cancelButton), "clicked",
                     G_CALLBACK (colorpick_button_callback), csd);
 
   GtkColorSelection *cs = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(csd));
@@ -830,9 +838,14 @@ frame_colorpick_callback (GtkDarktableButton *button, dt_iop_module_t *self)
 
   GtkColorSelectionDialog  *csd = GTK_COLOR_SELECTION_DIALOG(gtk_color_selection_dialog_new(_("select frame line color")));
   gtk_window_set_transient_for(GTK_WINDOW(csd), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  g_signal_connect (G_OBJECT (csd->ok_button), "clicked",
+
+  GtkWidget *okButton, *cancelButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+  g_object_get(G_OBJECT(csd), "cancel-button", &cancelButton, NULL);
+
+  g_signal_connect (G_OBJECT (okButton), "clicked",
                     G_CALLBACK (colorpick_button_callback), csd);
-  g_signal_connect (G_OBJECT (csd->cancel_button), "clicked",
+  g_signal_connect (G_OBJECT (cancelButton), "clicked",
                     G_CALLBACK (colorpick_button_callback), csd);
 
   GtkColorSelection *cs = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(csd));

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -434,7 +434,7 @@ dt_iop_area_expose(GtkWidget *widget, GdkEventExpose *event, dt_iop_module_t *se
                     (int)floor(flt_light * 255 + 0.5));
 
 
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   if(width % 2 == 0) width--;
   if(height % 2 == 0) height--;
   double center_x = (float)width / 2.0, center_y = (float)height / 2.0;
@@ -442,7 +442,7 @@ dt_iop_area_expose(GtkWidget *widget, GdkEventExpose *event, dt_iop_module_t *se
   double r_outside = diameter / 2.0, r_inside = r_outside * 0.87;
   double r_outside_2 = r_outside * r_outside, r_inside_2 = r_inside * r_inside;
 
-  cr = gdk_cairo_create(widget->window);
+  cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   // clear the background
   cairo_set_source_rgb(cr, flt_bg, flt_bg, flt_bg);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -324,7 +324,9 @@ dt_iop_colorcorrection_expose(GtkWidget *widget, GdkEventExpose *event, gpointer
   dt_iop_colorcorrection_params_t *p  = (dt_iop_colorcorrection_params_t *)self->params;
 
   const int inset = DT_COLORCORRECTION_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg
@@ -395,7 +397,9 @@ dt_iop_colorcorrection_motion_notify(GtkWidget *widget, GdkEventMotion *event, g
   dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
   const int inset = DT_COLORCORRECTION_INSET;
-  int width = widget->allocation.width - 2*inset, height = widget->allocation.height - 2*inset;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width - 2*inset, height = allocation.height - 2*inset;
   const float mouse_x = CLAMP(event->x - inset, 0, width);
   const float mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
   const float ma = (2.0*mouse_x - width) *DT_COLORCORRECTION_MAX/(float)width;

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -908,8 +908,10 @@ cluster_preview_expose (GtkWidget *widget, GdkEventExpose *event, dt_iop_module_
   }
 
 
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   const int inset = 5;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   cairo_set_source_rgb (cr, .2, .2, .2);

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -587,7 +587,7 @@ cluster_preview_expose (GtkWidget *widget, GdkEventExpose *event, dt_iop_module_
   dt_iop_colortransfer_params_t *p = (dt_iop_colortransfer_params_t *)&g->flowback;
   if(!g->flowback_set) p = (dt_iop_colortransfer_params_t *)self->params;
   const int inset = 5;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   cairo_set_source_rgb (cr, .2, .2, .2);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -576,8 +576,11 @@ colorzones_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_data)
     dt_draw_curve_set_point(c->minmax_curve, DT_IOP_COLORZONES_BANDS+1, p.equalizer_x[ch][1]+1.0, p.equalizer_y[ch][1]);
   else
     dt_draw_curve_set_point(c->minmax_curve, DT_IOP_COLORZONES_BANDS+1, p.equalizer_x[ch][1]+1.0, p.equalizer_y[ch][DT_IOP_COLORZONES_BANDS-1]);
+
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   const int inset = DT_IOP_COLORZONES_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg, match color of the notebook tabs:
@@ -816,8 +819,11 @@ colorzones_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
+
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   const int inset = DT_IOP_COLORZONES_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width)/(float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
   if(c->dragging)
@@ -884,8 +890,11 @@ colorzones_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_
   else if(event->button == 1)
   {
     c->drag_params = *(dt_iop_colorzones_params_t *)self->params;
+
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
     const int inset = DT_IOP_COLORZONES_INSET;
-    int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+    int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
     c->mouse_pick = dt_draw_curve_calc_value(c->minmax_curve, CLAMP(event->x - inset, 0, width)/(float)width);
     c->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
     c->dragging = 1;

--- a/src/iop/densitycurve.c
+++ b/src/iop/densitycurve.c
@@ -879,7 +879,7 @@ static gboolean dt_iop_densitycurve_button_press(GtkWidget *widget, GdkEventButt
     dt_iop_densitycurve_params_t *p = (dt_iop_densitycurve_params_t *)self->params;
 
     const int inset = DT_GUI_CURVE_EDITOR_INSET;
-    int width = widget->allocation.width, height = widget->allocation.height;
+    int width = allocation.width, height = allocation.height;
     width -= 2*inset;
     height -= 2*inset;
     const float mx = CLAMP(event->x - inset, 0, width)/(float)width;
@@ -945,7 +945,7 @@ static gboolean dt_iop_densitycurve_expose(GtkWidget *widget, GdkEventExpose *ev
   dt_iop_densitycurve_sort(user_data);
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
 
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
@@ -1067,7 +1067,7 @@ static gboolean dt_iop_densitycurve_motion_notify(GtkWidget *widget, GdkEventMot
   dt_iop_densitycurve_gui_data_t *c = (dt_iop_densitycurve_gui_data_t *)self->gui_data;
 //  dt_iop_densitycurve_params_t *p = (dt_iop_densitycurve_params_t *)self->params;
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width); // variate only y coordinate
   c->mouse_x = CLAMP(event->x - inset, 0, width);
   c->mouse_y = CLAMP(event->y - inset, 0, height);
@@ -1128,7 +1128,7 @@ static gboolean dt_iop_densitycurve_keypress_notify(GtkWidget *widget, GdkEventK
   dt_iop_densitycurve_gui_data_t *c = (dt_iop_densitycurve_gui_data_t *)self->gui_data;
   dt_iop_densitycurve_params_t *p = (dt_iop_densitycurve_params_t *)self->params;
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   width -= 2*inset;
   height -= 2*inset;
 
@@ -1327,7 +1327,7 @@ dt_iop_zonesystem_bar_expose (GtkWidget *widget, dt_iop_zonesystem_params_t *p)
   //dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
 
   const int inset = DT_ZONESYSTEM_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -391,7 +391,7 @@ static gboolean dt_iop_equalizer_expose(GtkWidget *widget, GdkEventExpose *event
   int ch = (int)c->channel;
   for(int k=0; k<DT_IOP_EQUALIZER_BANDS; k++) dt_draw_curve_set_point(c->minmax_curve, k, p.equalizer_x[ch][k], p.equalizer_y[ch][k]);
   const int inset = DT_GUI_EQUALIZER_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg
@@ -548,7 +548,7 @@ static gboolean dt_iop_equalizer_motion_notify(GtkWidget *widget, GdkEventMotion
   dt_iop_equalizer_gui_data_t *c = (dt_iop_equalizer_gui_data_t *)self->gui_data;
   dt_iop_equalizer_params_t *p = (dt_iop_equalizer_params_t *)self->params;
   const int inset = DT_GUI_EQUALIZER_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width)/(float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
   if(c->dragging)
@@ -603,7 +603,7 @@ static gboolean dt_iop_equalizer_button_press(GtkWidget *widget, GdkEventButton 
     dt_iop_equalizer_gui_data_t *c = (dt_iop_equalizer_gui_data_t *)self->gui_data;
     c->drag_params = *(dt_iop_equalizer_params_t *)self->params;
     const int inset = DT_GUI_EQUALIZER_INSET;
-    int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+    int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
     c->mouse_pick = dt_draw_curve_calc_value(c->minmax_curve, CLAMP(event->x - inset, 0, width)/(float)width);
     c->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
     c->dragging = 1;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -141,7 +141,10 @@ expose (GtkWidget *widget, GdkEventExpose *event, dt_iop_module_t *self)
 static void
 colorpick_button_callback(GtkButton *button, GtkColorSelectionDialog *csd)
 {
-  gtk_dialog_response(GTK_DIALOG(csd), (GTK_WIDGET(button)==csd->ok_button)?GTK_RESPONSE_ACCEPT:0);
+  GtkWidget *okButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+
+  gtk_dialog_response(GTK_DIALOG(csd), (GTK_WIDGET(button)==okButton)?GTK_RESPONSE_ACCEPT:0);
 }
 
 static void
@@ -153,9 +156,14 @@ colorpicker_callback (GtkDarktableButton *button, dt_iop_module_t *self)
 
   GtkColorSelectionDialog  *csd = GTK_COLOR_SELECTION_DIALOG(gtk_color_selection_dialog_new(_("select color of film material")));
   gtk_window_set_transient_for(GTK_WINDOW(csd), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  g_signal_connect (G_OBJECT (csd->ok_button), "clicked",
+
+  GtkWidget *okButton, *cancelButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+  g_object_get(G_OBJECT(csd), "cancel-button", &cancelButton, NULL);
+
+  g_signal_connect (G_OBJECT (okButton), "clicked",
                     G_CALLBACK (colorpick_button_callback), csd);
-  g_signal_connect (G_OBJECT (csd->cancel_button), "clicked",
+  g_signal_connect (G_OBJECT (cancelButton), "clicked",
                     G_CALLBACK (colorpick_button_callback), csd);
 
   GtkColorSelection *cs = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(csd));

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -355,7 +355,9 @@ static gboolean dt_iop_levels_expose(GtkWidget *widget, GdkEventExpose *event, g
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
   dt_develop_t *dev = darktable.develop;
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -592,7 +594,9 @@ static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *e
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   if(!c->dragging)
   {
     c->mouse_x = CLAMP(event->x - inset, 0, width);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -493,7 +493,9 @@ lowlight_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user_data)
   dt_draw_curve_set_point(c->transition_curve, DT_IOP_LOWLIGHT_BANDS+1, p.transition_x[1]+1.0, p.transition_y[DT_IOP_LOWLIGHT_BANDS-1]);
 
   const int inset = DT_IOP_LOWLIGHT_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -652,7 +654,9 @@ lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_d
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
   const int inset = DT_IOP_LOWLIGHT_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width)/(float)width;
   c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
   if(c->dragging)
@@ -722,7 +726,9 @@ lowlight_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_da
     dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
     c->drag_params = *(dt_iop_lowlight_params_t *)self->params;
     const int inset = DT_IOP_LOWLIGHT_INSET;
-    int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
+    int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
     c->mouse_pick = dt_draw_curve_calc_value(c->transition_curve, CLAMP(event->x - inset, 0, width)/(float)width);
     c->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height)/(float)height;
     c->dragging = 1;

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -376,7 +376,9 @@ dt_iop_monochrome_expose(GtkWidget *widget, GdkEventExpose *event, gpointer user
   dt_iop_monochrome_params_t *p  = (dt_iop_monochrome_params_t *)self->params;
 
   const int inset = DT_COLORCORRECTION_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg
@@ -433,7 +435,9 @@ static gboolean dt_iop_monochrome_motion_notify(GtkWidget *widget, GdkEventMotio
   if(g->dragging)
   {
     const int inset = DT_COLORCORRECTION_INSET;
-    int width = widget->allocation.width - 2*inset, height = widget->allocation.height - 2*inset;
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
+    int width = allocation.width - 2*inset, height = allocation.height - 2*inset;
     const float mouse_x = CLAMP(event->x - inset, 0, width);
     const float mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
     p->a = PANEL_WIDTH*(mouse_x - width  * 0.5f)/(float)width;
@@ -463,7 +467,9 @@ static gboolean dt_iop_monochrome_button_press(GtkWidget *widget, GdkEventButton
     else
     {
       const int inset = DT_COLORCORRECTION_INSET;
-      int width = widget->allocation.width - 2*inset, height = widget->allocation.height - 2*inset;
+      GtkAllocation allocation;
+      gtk_widget_get_allocation(widget, &allocation);
+      int width = allocation.width - 2*inset, height = allocation.height - 2*inset;
       const float mouse_x = CLAMP(event->x - inset, 0, width);
       const float mouse_y = CLAMP(height - 1 - event->y + inset, 0, height);
       p->a = PANEL_WIDTH*(mouse_x - width  * 0.5f)/(float)width;

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -388,7 +388,10 @@ static void
 colorpick_button_callback(GtkButton *button,gpointer user_data)
 {
   GtkColorSelectionDialog  *csd=(GtkColorSelectionDialog  *)user_data;
-  gtk_dialog_response(GTK_DIALOG(csd),(GTK_WIDGET(button)==csd->ok_button)?GTK_RESPONSE_ACCEPT:0);
+  GtkWidget *okButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+
+  gtk_dialog_response(GTK_DIALOG(csd), (GTK_WIDGET(button)==okButton)?GTK_RESPONSE_ACCEPT:0);
 }
 
 static void
@@ -401,11 +404,16 @@ colorpick_callback (GtkDarktableButton *button, gpointer user_data)
 
   GtkColorSelectionDialog  *csd = GTK_COLOR_SELECTION_DIALOG(gtk_color_selection_dialog_new(_("select tone color")));
   gtk_window_set_transient_for(GTK_WINDOW(csd), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  g_signal_connect (G_OBJECT (csd->ok_button), "clicked",
-                    G_CALLBACK (colorpick_button_callback), csd);
-  g_signal_connect (G_OBJECT (csd->cancel_button), "clicked",
-                    G_CALLBACK (colorpick_button_callback), csd);
 
+  GtkWidget *okButton, *cancelButton = 0;
+  g_object_get(G_OBJECT(csd), "ok-button", &okButton, NULL);
+  g_object_get(G_OBJECT(csd), "cancel-button", &cancelButton, NULL);
+
+  g_signal_connect (G_OBJECT (okButton), "clicked",
+                    G_CALLBACK (colorpick_button_callback), csd);
+  g_signal_connect (G_OBJECT (cancelButton), "clicked",
+                    G_CALLBACK (colorpick_button_callback), csd);
+  
   GtkColorSelection *cs = GTK_COLOR_SELECTION(gtk_color_selection_dialog_get_color_selection(csd));
   GdkColor c;
   float color[3],h,s,l;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -159,7 +159,7 @@ static void _add_path(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *sel
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
     return;
   }
   //we want to be sure that the iop has focus
@@ -179,7 +179,7 @@ static void _add_circle(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *s
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
     return;
   }
   //we want to be sure that the iop has focus
@@ -199,7 +199,7 @@ static void _add_ellipse(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
     return;
   }
   //we want to be sure that the iop has focus

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -422,8 +422,10 @@ static gboolean
 area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
   GtkRequisition r;
-  r.width  = widget->allocation.width;
-  r.height = widget->allocation.width;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  r.width  = allocation.width;
+  r.height = allocation.width;
   gtk_widget_size_request(widget, &r);
   return TRUE;
 }
@@ -653,7 +655,9 @@ static gboolean dt_iop_tonecurve_expose(GtkWidget *widget, GdkEventExpose *event
   dt_iop_estimate_exp(x, y, 4, unbounded_coeffs);
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   // clear bg
@@ -856,7 +860,9 @@ static gboolean dt_iop_tonecurve_motion_notify(GtkWidget *widget, GdkEventMotion
   if (autoscale_ab && ch != ch_L) goto finally;
 
   const int inset = DT_GUI_CURVE_EDITOR_INSET;
-  int height = widget->allocation.height - 2*inset, width = widget->allocation.width - 2*inset;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int height = allocation.height - 2*inset, width = allocation.width - 2*inset;
   c->mouse_x = CLAMP(event->x - inset, 0, width);
   c->mouse_y = CLAMP(event->y - inset, 0, height);
 

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -502,7 +502,9 @@ dt_iop_zonesystem_bar_expose (GtkWidget *widget, GdkEventExpose *event, dt_iop_m
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
 
   const int inset = DT_ZONESYSTEM_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
 
@@ -596,7 +598,9 @@ static gboolean dt_iop_zonesystem_bar_button_press(GtkWidget *widget, GdkEventBu
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
   dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
   const int inset = DT_ZONESYSTEM_INSET;
-  int width = widget->allocation.width - 2*inset;/*, height = widget->allocation.height - 2*inset;*/
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width - 2*inset;/*, height = allocation.height - 2*inset;*/
 
   /* calculate zonemap */
   float zonemap[MAX_ZONE_SYSTEM_SIZE]= {-1};
@@ -674,7 +678,9 @@ dt_iop_zonesystem_bar_motion_notify (GtkWidget *widget, GdkEventMotion *event, d
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
   dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
   const int inset = DT_ZONESYSTEM_INSET;
-  int width = widget->allocation.width - 2*inset, height = widget->allocation.height - 2*inset;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width - 2*inset, height = allocation.height - 2*inset;
 
   /* calculate zonemap */
   float zonemap[MAX_ZONE_SYSTEM_SIZE]= {-1};
@@ -722,7 +728,9 @@ static gboolean
 dt_iop_zonesystem_preview_expose (GtkWidget *widget, GdkEventExpose *event, dt_iop_module_t *self)
 {
   const int inset = 2;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
 
   dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -362,7 +362,7 @@ _lib_geotagging_show_offset_window(GtkWidget *widget, dt_lib_module_t *self)
   gdk_window_get_size(gtk_widget_get_window(center),&center_w,&center_h);
 
   d->floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  GTK_WIDGET_SET_FLAGS(d->floating_window, GTK_CAN_FOCUS);
+  gtk_widget_set_can_focus(d->floating_window, TRUE);
   gtk_window_set_decorated(GTK_WINDOW(d->floating_window), FALSE);
   gtk_window_set_has_frame(GTK_WINDOW(d->floating_window), FALSE);
   gtk_window_set_type_hint(GTK_WINDOW(d->floating_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -88,8 +88,8 @@ static void _lib_histogram_change_callback(gpointer instance, gpointer user_data
 //   dt_develop_t *dev = darktable.develop;
 //   dt_pthread_mutex_lock(&dev->histogram_waveform_mutex);
 //
-//   int width = widget->allocation.width;
-//   int height = widget->allocation.height;
+//   int width = allocation.width;
+//   int height = allocation.height;
 //   width -= 2 * 4 * DT_HIST_INSET;
 //   height -= 2 * DT_HIST_INSET;
 //
@@ -250,7 +250,9 @@ static gboolean _lib_histogram_expose_callback(GtkWidget *widget, GdkEventExpose
   float *hist = dev->histogram;
   float hist_max = dev->histogram_type == DT_DEV_HISTOGRAM_LINEAR?dev->histogram_max:logf(1.0 + dev->histogram_max);
   const int inset = DT_HIST_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
   GtkStyle *style=gtk_rc_get_style_by_paths(gtk_settings_get_default(), NULL,"GtkWidget", GTK_TYPE_WIDGET);
@@ -438,16 +440,18 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
   if(!hooks_available)
     return TRUE;
 
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
   if (d->dragging && d->highlight == 2)
   {
     float white = d->white - (event->x - d->button_down_x)*
-                  1.0f/(float)widget->allocation.width;
+                  1.0f/(float)allocation.width;
     dt_dev_exposure_set_white(darktable.develop, white);
   }
   else if(d->dragging && d->highlight == 1)
   {
     float black = d->black - (event->x - d->button_down_x)*
-                  .1f/(float)widget->allocation.width;
+                  .1f/(float)allocation.width;
     dt_dev_exposure_set_black(darktable.develop, black);
   }
   else
@@ -455,7 +459,7 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
     const float offs = 4*DT_HIST_INSET;
     const float x = event->x - offs;
     const float y = event->y - DT_HIST_INSET;
-    const float pos = x / (float)(widget->allocation.width - 2*offs);
+    const float pos = x / (float)(allocation.width - 2*offs);
 
 
     if(pos < 0 || pos > 1.0);

--- a/src/libs/keywords.c
+++ b/src/libs/keywords.c
@@ -326,7 +326,7 @@ static void _lib_keywords_drag_data_get_callback(GtkWidget *w,
     path = gtk_tree_model_get_path(model,&iter);
     gchar *sp = gtk_tree_path_to_string(path);
 
-    gtk_selection_data_set(data,data->target, 8, (const guchar *)sp, strlen(sp));
+    gtk_selection_data_set(data, gtk_selection_data_get_target(data), 8, (const guchar *)sp, strlen(sp));
   }
 
 }
@@ -404,12 +404,12 @@ static void _lib_keywords_drag_data_received_callback(GtkWidget *w,
   GtkTreeViewDropPosition dpos;
   GtkTreeModel *model = gtk_tree_view_get_model(d->view);
 
-  if (data->format == 8)
+  if (gtk_selection_data_get_format(data) == 8)
   {
     if (gtk_tree_view_get_dest_row_at_pos(d->view, x, y, &dpath, &dpos))
     {
       /* fetch tree iter of source and dest dnd operation */
-      GtkTreePath *spath = gtk_tree_path_new_from_string((char *)data->data);
+      GtkTreePath *spath = gtk_tree_path_new_from_string((char *)gtk_selection_data_get_data(data));
 
       char dtag[1024];
       char stag[1024];

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -638,9 +638,9 @@ _preset_popup_posistion(GtkMenu *menu, gint *x,gint *y,gboolean *push_in, gpoint
   gint w,h;
   gint ww,wh;
   GtkRequisition requisition;
-  gdk_window_get_size(GTK_WIDGET(data)->window,&w,&h);
-  gdk_window_get_size(dt_ui_main_window(darktable.gui->ui)->window,&ww,&wh);
-  gdk_window_get_origin (GTK_WIDGET(data)->window, x, y);
+  gdk_window_get_size(gtk_widget_get_window(GTK_WIDGET(data)),&w,&h);
+  gdk_window_get_size(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)),&ww,&wh);
+  gdk_window_get_origin (gtk_widget_get_window(GTK_WIDGET(data)), x, y);
 
   gtk_widget_size_request (GTK_WIDGET (menu), &requisition);
 
@@ -648,7 +648,9 @@ _preset_popup_posistion(GtkMenu *menu, gint *x,gint *y,gboolean *push_in, gpoint
   if (*x < ww/2)
     (*x)+=w-requisition.width;
 
-  (*y)+=GTK_WIDGET(data)->allocation.height;
+  GtkAllocation allocation_data;
+  gtk_widget_get_allocation(GTK_WIDGET(data), &allocation_data);
+  (*y)+=allocation_data.height;
 }
 
 static void

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -105,7 +105,7 @@ static void _bt_add_circle (GtkWidget *widget, GdkEventButton *e, dt_iop_module_
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
   }
   else _tree_add_circle(NULL,NULL);
 }
@@ -127,7 +127,7 @@ static void _bt_add_ellipse (GtkWidget *widget, GdkEventButton *e, dt_iop_module
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
   }
   else _tree_add_ellipse(NULL,NULL);
 }
@@ -150,7 +150,7 @@ static void _bt_add_path (GtkWidget *widget, GdkEventButton *e, dt_iop_module_t 
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
   }
   else _tree_add_path(NULL,NULL);
 }
@@ -172,7 +172,7 @@ static void _bt_add_gradient (GtkWidget *widget, GdkEventButton *e, dt_iop_modul
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
   }
   else _tree_add_gradient(NULL,NULL);
 }
@@ -196,7 +196,7 @@ static void _bt_add_brush (GtkWidget *widget, GdkEventButton *e, dt_iop_module_t
     dt_masks_form_t *form = darktable.develop->form_visible;
     if (form) dt_masks_free_form(form);
     dt_masks_change_form_gui(NULL);
-    GTK_TOGGLE_BUTTON(widget)->active = FALSE;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
   }
   else _tree_add_brush(NULL,NULL);
 }
@@ -769,7 +769,7 @@ static void _tree_selection_change (GtkTreeSelection *selection,dt_lib_masks_t *
           {
             dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t*)module->blend_data;
             bd->masks_shown = 1;
-            GTK_TOGGLE_BUTTON(bd->masks_edit)->active = 1;
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
             gtk_widget_queue_draw (bd->masks_edit);
           }
         }
@@ -1207,11 +1207,10 @@ static void _lib_masks_recreate_list(dt_lib_module_t *self)
 
   //if (lm->treeview) gtk_widget_destroy(lm->treeview);
   //we set the add shape icons inactive
-  GTK_TOGGLE_BUTTON(lm->bt_circle)->active = FALSE;
-  GTK_TOGGLE_BUTTON(lm->bt_ellipse)->active = FALSE;
-  GTK_TOGGLE_BUTTON(lm->bt_path)->active = FALSE;
-  GTK_TOGGLE_BUTTON(lm->bt_gradient)->active = FALSE;
-
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(lm->bt_circle), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(lm->bt_ellipse), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(lm->bt_path), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(lm->bt_gradient), FALSE);
 
   GtkTreeStore *treestore;
   //we store : text ; *module ; groupid ; formid

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -101,8 +101,8 @@ void gui_init(dt_lib_module_t *self)
                         | GDK_STRUCTURE_MASK);
 
   /* connect callbacks */
-  GTK_WIDGET_UNSET_FLAGS (self->widget, GTK_DOUBLE_BUFFERED);
-  GTK_WIDGET_SET_FLAGS   (self->widget, GTK_APP_PAINTABLE);
+  gtk_widget_set_double_buffered(self->widget, FALSE);
+  gtk_widget_set_app_paintable(self->widget, TRUE);
   g_signal_connect (G_OBJECT (self->widget), "expose-event",
                     G_CALLBACK (_lib_navigation_expose_callback), self);
   g_signal_connect (G_OBJECT (self->widget), "button-press-event",
@@ -140,7 +140,9 @@ static gboolean _lib_navigation_expose_callback(GtkWidget *widget, GdkEventExpos
   dt_lib_navigation_t *d = (dt_lib_navigation_t *)self->data;
 
   const int inset = DT_NAVIGATION_INSET;
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
 
   dt_develop_t *dev = darktable.develop;
 
@@ -343,7 +345,9 @@ void _lib_navigation_set_position(dt_lib_module_t *self, double x, double y, int
 static gboolean _lib_navigation_motion_notify_callback(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  _lib_navigation_set_position(self, event->x, event->y, widget->allocation.width, widget->allocation.height);
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  _lib_navigation_set_position(self, event->x, event->y, allocation.width, allocation.height);
   gint x, y; // notify gtk for motion_hint.
   gdk_window_get_pointer(event->window, &x, &y, NULL);
   return TRUE;
@@ -417,8 +421,10 @@ static gboolean _lib_navigation_button_press_callback(GtkWidget *widget, GdkEven
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_navigation_t *d = (dt_lib_navigation_t *)self->data;
 
-  int w = widget->allocation.width;
-  int h = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int w = allocation.width;
+  int h = allocation.height;
   if (event->x >= w-2*DT_NAVIGATION_INSET-d->zoom_h-d->zoom_w && event->y <= w-2*DT_NAVIGATION_INSET && event->y >= h-2*DT_NAVIGATION_INSET-d->zoom_h && event->y <= h-2*DT_NAVIGATION_INSET)
   {
     //we show the zoom menu

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -602,7 +602,7 @@ _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *acceleratable, guint 
 
   d->floating_tag_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
   /* stackoverflow.com/questions/1925568/how-to-give-keyboard-focus-to-a-pop-up-gtk-window */
-  GTK_WIDGET_SET_FLAGS(d->floating_tag_window, GTK_CAN_FOCUS);
+  gtk_widget_set_can_focus(d->floating_tag_window, TRUE);
   gtk_window_set_decorated(GTK_WINDOW(d->floating_tag_window), FALSE);
   gtk_window_set_has_frame(GTK_WINDOW(d->floating_tag_window), FALSE);
   gtk_window_set_type_hint(GTK_WINDOW(d->floating_tag_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -115,7 +115,7 @@ static gboolean _lib_darktable_expose_callback(GtkWidget *widget, GdkEventExpose
   GtkStyle *style=gtk_rc_get_style_by_paths(gtk_settings_get_default(), NULL,"GtkWidget", GTK_TYPE_WIDGET);
   if(!style) style = gtk_rc_get_style(widget);
 
-  cairo_t *cr = gdk_cairo_create(widget->window);
+  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   /* fill background */
   cairo_set_source_rgb(cr, style->bg[0].red/65535.0, style->bg[0].green/65535.0, style->bg[0].blue/65535.0);

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -479,7 +479,7 @@ static gboolean _lib_filmstrip_size_handle_button_callback(GtkWidget *w, GdkEven
     if (e->type == GDK_BUTTON_PRESS)
     {
       /* store current  mousepointer position */
-      gdk_window_get_pointer(dt_ui_main_window(darktable.gui->ui)->window, &d->size_handle_x, &d->size_handle_y, NULL);
+      gdk_window_get_pointer(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)), &d->size_handle_x, &d->size_handle_y, NULL);
       gtk_widget_get_size_request(d->filmstrip, NULL, &d->size_handle_height);
       d->size_handle_is_dragging = TRUE;
     }
@@ -496,7 +496,7 @@ static gboolean _lib_filmstrip_size_handle_motion_notify_callback(GtkWidget *w, 
   if (d->size_handle_is_dragging)
   {
     gint x,y,sx,sy;
-    gdk_window_get_pointer (dt_ui_main_window(darktable.gui->ui)->window, &x, &y, NULL);
+    gdk_window_get_pointer (gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)), &x, &y, NULL);
     gtk_widget_get_size_request (d->filmstrip,&sx,&sy);
     sy = CLAMP(d->size_handle_height+(d->size_handle_y - y), 64,400);
 
@@ -692,8 +692,10 @@ static gboolean _lib_filmstrip_expose_callback(GtkWidget *widget, GdkEventExpose
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
 
-  int32_t width = widget->allocation.width;
-  int32_t height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int32_t width = allocation.width;
+  int32_t height = allocation.height;
 
   gdouble pointerx = strip->pointerx;
   gdouble pointery = strip->pointery;
@@ -705,7 +707,7 @@ static gboolean _lib_filmstrip_expose_callback(GtkWidget *widget, GdkEventExpose
   DT_CTL_SET_GLOBAL(lib_image_mouse_over_id, -1);
 
   /* create cairo surface */
-  cairo_t *cr = gdk_cairo_create(widget->window);
+  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(widget));
 
   /* fill background */
   cairo_set_source_rgb (cr, .2, .2, .2);
@@ -1088,7 +1090,7 @@ _lib_filmstrip_dnd_get_callback(GtkWidget *widget, GdkDragContext *context, GtkS
     case DND_TARGET_IMGID:
     {
       int id = ((count == 1) ? mouse_over_id : -1);
-      gtk_selection_data_set(selection_data, selection_data-> target, _DWORD, (guchar*) &id, sizeof(id));
+      gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _DWORD, (guchar*) &id, sizeof(id));
       break;
     }
     default: // return the location of the file as a last resort
@@ -1100,7 +1102,7 @@ _lib_filmstrip_dnd_get_callback(GtkWidget *widget, GdkDragContext *context, GtkS
         gboolean from_cache = TRUE;
         dt_image_full_path(mouse_over_id, pathname, DT_MAX_PATH_LEN, &from_cache);
         gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
-        gtk_selection_data_set(selection_data, selection_data-> target, _BYTE, (guchar*) uri, strlen(uri));
+        gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _BYTE, (guchar*) uri, strlen(uri));
         g_free(uri);
       }
       else
@@ -1119,7 +1121,7 @@ _lib_filmstrip_dnd_get_callback(GtkWidget *widget, GdkDragContext *context, GtkS
         }
         sqlite3_finalize(stmt);
         gchar* uri_list = dt_util_glist_to_str("\r\n", images, count);
-        gtk_selection_data_set(selection_data, selection_data-> target, _BYTE, (guchar*) uri_list, strlen(uri_list));
+        gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _BYTE, (guchar*) uri_list, strlen(uri_list));
         g_free(uri_list);
       }
       break;

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -94,8 +94,8 @@ void gui_init(dt_lib_module_t *self)
                         | GDK_STRUCTURE_MASK);
 
   /* connect callbacks */
-  GTK_WIDGET_UNSET_FLAGS (da, GTK_DOUBLE_BUFFERED);
-  GTK_WIDGET_SET_FLAGS   (da, GTK_APP_PAINTABLE);
+  gtk_widget_set_double_buffered(da, FALSE);
+  gtk_widget_set_app_paintable(da, TRUE);
   g_signal_connect (G_OBJECT (da), "expose-event",
                     G_CALLBACK (_lib_ratings_expose_callback), self);
   g_signal_connect (G_OBJECT (da), "button-press-event",
@@ -127,7 +127,9 @@ static gboolean _lib_ratings_expose_callback(GtkWidget *widget, GdkEventExpose *
 
   if(!darktable.control->running) return TRUE;
 
-  int width = widget->allocation.width, height = widget->allocation.height;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
 
   /* get current style */
   GtkStyle *style=gtk_rc_get_style_by_paths(gtk_settings_get_default(), NULL,"GtkWidget", GTK_TYPE_WIDGET);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1125,7 +1125,7 @@ void enter(dt_view_t *self)
     GtkWidget *alignment = gtk_alignment_new(0.5, 0.5, 1, 1);
     GtkWidget *vbox = gtk_vbox_new(TRUE, 5);
 
-    GTK_WIDGET_SET_FLAGS(dev->overexposed.floating_window, GTK_CAN_FOCUS);
+    gtk_widget_set_can_focus(dev->overexposed.floating_window, TRUE);
     gtk_window_set_decorated(GTK_WINDOW(dev->overexposed.floating_window), FALSE);
     gtk_window_set_has_frame(GTK_WINDOW(dev->overexposed.floating_window), FALSE);
     gtk_window_set_type_hint(GTK_WINDOW(dev->overexposed.floating_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1236,9 +1236,9 @@ drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, gint x, gint 
 {
   gboolean success = FALSE;
 
-  if((selection_data != NULL) && (selection_data->length >= 0))
+  if((selection_data != NULL) && (gtk_selection_data_get_length(selection_data) >= 0))
   {
-    gchar **uri_list = g_strsplit_set((gchar*)selection_data->data, "\r\n", 0);
+    gchar **uri_list = g_strsplit_set((gchar*)gtk_selection_data_get_data(selection_data), "\r\n", 0);
     if(uri_list)
     {
       gchar **image_to_load = uri_list;

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -712,9 +712,9 @@ drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, gint x, gint 
 
   gboolean success = FALSE;
 
-  if((selection_data != NULL) && (selection_data->length >= 0) && target_type == DND_TARGET_IMGID)
+  if((selection_data != NULL) && (gtk_selection_data_get_length(selection_data) >= 0) && target_type == DND_TARGET_IMGID)
   {
-    int *imgid = (int*)selection_data->data;
+    int *imgid = (int*)gtk_selection_data_get_data(selection_data);
     if(*imgid > 0)
     {
       _view_map_add_image_to_map(self, *imgid, x, y);
@@ -748,7 +748,7 @@ _view_map_dnd_get_callback(GtkWidget *widget, GdkDragContext *context, GtkSelect
   switch (target_type)
   {
     case DND_TARGET_IMGID:
-      gtk_selection_data_set(selection_data, selection_data-> target, _DWORD, (guchar*) &imgid, sizeof(imgid));
+      gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _DWORD, (guchar*) &imgid, sizeof(imgid));
       break;
     default: // return the location of the file as a last resort
     case DND_TARGET_URI:
@@ -757,7 +757,7 @@ _view_map_dnd_get_callback(GtkWidget *widget, GdkDragContext *context, GtkSelect
       gboolean from_cache = TRUE;
       dt_image_full_path(imgid, pathname, DT_MAX_PATH_LEN, &from_cache);
       gchar *uri = g_strdup_printf("file://%s", pathname); // TODO: should we add the host?
-      gtk_selection_data_set(selection_data, selection_data-> target, _BYTE, (guchar*) uri, strlen(uri));
+      gtk_selection_data_set(selection_data, gtk_selection_data_get_target(selection_data), _BYTE, (guchar*) uri, strlen(uri));
       g_free(uri);
       break;
     }
@@ -772,9 +772,9 @@ static void _view_map_dnd_remove_callback(GtkWidget *widget, GdkDragContext *con
 
   gboolean success = FALSE;
 
-  if((selection_data != NULL) && (selection_data->length >= 0) && target_type == DND_TARGET_IMGID)
+  if((selection_data != NULL) && (gtk_selection_data_get_length(selection_data) >= 0) && target_type == DND_TARGET_IMGID)
   {
-    int *imgid = (int*)selection_data->data;
+    int *imgid = (int*)gtk_selection_data_get_data(selection_data);
     if(*imgid > 0)
     {
       //  the image was dropped into the filmstrip, let's remove it in this case


### PR DESCRIPTION
GTK+ 3 removes many implementation details and struct members from its public headers.

Quote:
While it may be painful to convert, this helps us keep API and ABI compatibility when we change internal interfaces.

See https://developer.gnome.org/gtk3/3.9/gtk-migrating-2-to-3.html#id-1.6.3.3.5
