### PR TITLE
GTK3: Do not use deprecated symbols. Part 2/2: GDK

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -566,6 +566,13 @@ add_definitions("-D__GDK_KEYSYMS_COMPAT_H__")
 #
 add_definitions("-DGSEAL_ENABLE")
 
+#
+#  Do not use deprecated symbols
+#
+add_definitions("-DGDK_DISABLE_DEPRECATED")
+#add_definitions("-DGTK_DISABLE_DEPRECATED")
+add_definitions("-Werror=implicit-function-declaration")
+
 ###### GTK+3 port ######
 
 

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -800,7 +800,7 @@ void dt_control_change_cursor(dt_cursor_t curs)
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
   GdkCursor* cursor = gdk_cursor_new(curs);
   gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-  gdk_cursor_destroy(cursor);
+  gdk_cursor_unref(cursor);
 }
 
 int dt_control_running()
@@ -1282,7 +1282,7 @@ void *dt_control_expose(void *voidptr)
 {
   int width, height, pointerx, pointery;
   if(!darktable.gui->pixmap) return NULL;
-  gdk_drawable_get_size(darktable.gui->pixmap, &width, &height);
+  gdk_pixmap_get_size(darktable.gui->pixmap, &width, &height);
   GtkWidget *widget = dt_ui_center(darktable.gui->ui);
   gtk_widget_get_pointer(widget, &pointerx, &pointery);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1719,9 +1719,7 @@ dt_iop_gui_reset_callback(GtkButton *button, dt_iop_module_t *module)
 static void
 _preset_popup_position(GtkMenu *menu, gint *x,gint *y,gboolean *push_in, gpointer data)
 {
-  gint w,h;
   GtkRequisition requisition;
-  gdk_window_get_size(gtk_widget_get_window(GTK_WIDGET(data)),&w,&h);
   gdk_window_get_origin (gtk_widget_get_window(GTK_WIDGET(data)), x, y);
   gtk_widget_size_request (GTK_WIDGET (menu), &requisition);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -463,13 +463,12 @@ static gboolean
 expose (GtkWidget *da, GdkEventExpose *event, gpointer user_data)
 {
   dt_control_expose(NULL);
-  if(darktable.gui->pixmap)
-    gdk_draw_drawable(gtk_widget_get_window(da),
-                      gtk_widget_get_style(da)->fg_gc[gtk_widget_get_state(da)], darktable.gui->pixmap,
-                      // Only copy the area that was exposed.
-                      event->area.x, event->area.y,
-                      event->area.x, event->area.y,
-                      event->area.width, event->area.height);
+  if(darktable.gui->pixmap) {
+    cairo_t *cr = gdk_cairo_create (gtk_widget_get_window(da));
+    gdk_cairo_set_source_pixmap (cr, darktable.gui->pixmap, event->area.x, event->area.y);
+    cairo_paint (cr);
+    cairo_destroy (cr);
+  }
 
   if(darktable.lib->proxy.colorpicker.module)
   {
@@ -628,7 +627,12 @@ configure (GtkWidget *da, GdkEventConfigure *event, gpointer user_data)
     int minw = oldw, minh = oldh;
     if(event->width  < minw) minw = event->width;
     if(event->height < minh) minh = event->height;
-    gdk_draw_drawable(tmppixmap, gtk_widget_get_style(da)->fg_gc[gtk_widget_get_state(da)], darktable.gui->pixmap, 0, 0, 0, 0, minw, minh);
+
+    cairo_t *cr = gdk_cairo_create (tmppixmap);
+    gdk_cairo_set_source_pixmap (cr, darktable.gui->pixmap, 0, 0);
+    cairo_paint (cr);
+    cairo_destroy (cr);
+
     //we're done with our old pixmap, so we can get rid of it and replace it with our properly-sized one.
     g_object_unref(darktable.gui->pixmap);
     darktable.gui->pixmap = tmppixmap;

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -359,7 +359,9 @@ _lib_geotagging_show_offset_window(GtkWidget *widget, dt_lib_module_t *self)
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *center = dt_ui_center(darktable.gui->ui);
   gdk_window_get_origin(gtk_widget_get_window(center), &px, &py);
-  gdk_window_get_size(gtk_widget_get_window(center),&center_w,&center_h);
+
+  center_w = gdk_window_get_width(gtk_widget_get_window(center));
+  center_h = gdk_window_get_height(gtk_widget_get_window(center));
 
   d->floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
   gtk_widget_set_can_focus(d->floating_window, TRUE);
@@ -400,7 +402,9 @@ _lib_geotagging_show_offset_window(GtkWidget *widget, dt_lib_module_t *self)
   gtk_widget_show_all(d->floating_window);
   gtk_widget_grab_focus(d->floating_window_entry);
 
-  gdk_window_get_size(gtk_widget_get_window(d->floating_window), &window_w, &window_h);
+  window_w = gdk_window_get_width(gtk_widget_get_window(d->floating_window));
+  window_h = gdk_window_get_height(gtk_widget_get_window(d->floating_window));
+
   x = px + 0.5*(center_w-window_w);
   y = py + center_h - 20 - window_h;
   gtk_window_move(GTK_WINDOW(d->floating_window), x, y);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -635,11 +635,13 @@ dt_lib_gui_reset_callback (GtkButton *button, gpointer user_data)
 static void
 _preset_popup_posistion(GtkMenu *menu, gint *x,gint *y,gboolean *push_in, gpointer data)
 {
-  gint w,h;
-  gint ww,wh;
+  gint w;
+  gint ww;
   GtkRequisition requisition;
-  gdk_window_get_size(gtk_widget_get_window(GTK_WIDGET(data)),&w,&h);
-  gdk_window_get_size(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)),&ww,&wh);
+
+  w = gdk_window_get_width(gtk_widget_get_window(GTK_WIDGET(data)));
+  ww = gdk_window_get_width(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)));
+
   gdk_window_get_origin (gtk_widget_get_window(GTK_WIDGET(data)), x, y);
 
   gtk_widget_size_request (GTK_WIDGET (menu), &requisition);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -590,7 +590,10 @@ _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *acceleratable, guint 
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *center = dt_ui_center(darktable.gui->ui);
   gdk_window_get_origin(gtk_widget_get_window(center), &px, &py);
-  gdk_window_get_size(gtk_widget_get_window(center),&w,&h);
+
+  w = gdk_window_get_width(gtk_widget_get_window(center));
+  h = gdk_window_get_height(gtk_widget_get_window(center));
+
   x = px + 0.5*(w-FLOATING_ENTRY_WIDTH);
   y = py + h - 50;
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -962,7 +962,10 @@ static gboolean _overexposed_show_popup(gpointer user_data)
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
   gtk_widget_show_all(d->overexposed.floating_window);
   gdk_window_get_origin(gtk_widget_get_window(d->overexposed.button), &px, &py);
-  gdk_window_get_size(gtk_widget_get_window(d->overexposed.floating_window), &window_w, &window_h);
+
+  window_w = gdk_window_get_width(gtk_widget_get_window(d->overexposed.floating_window));
+  window_h = gdk_window_get_height(gtk_widget_get_window(d->overexposed.floating_window));
+
   gtk_widget_translate_coordinates(d->overexposed.button, window, 0, 0, &wx, &wy);
   x = px + wx - window_w + 5;
   y = py + wy - window_h - 5;


### PR DESCRIPTION
Over the years, a number of functions, and in some cases, entire widgets have been deprecated.
These deprecations are clearly spelled out in the API reference, with hints about the recommended replacements.
The API reference for GTK+ 2 also includes an index of all deprecated symbols.

In this part, only GDK deprecated functions are disabled (-DGDK_DISABLE_DEPRECATED -Werror=implicit-function-declaration)

See https://developer.gnome.org/gtk3/3.9/gtk-migrating-2-to-3.html#id-1.6.3.3.4
