### PR TITLE
Allow valid UTF-8 sequences in the metadata editor

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -134,9 +134,16 @@ int position()
   return 299;
 }
 
-/* helper which eliminates non-ascii and non-printable characters from a string */
+/* helper which eliminates non-printable characters from a string
+
+Strings which are already in valid UTF-8 are retained.
+*/
 static void _filter_non_printable(char *string, int length)
 {
+  /* explicitly tell the validator to ignore the trailing nulls, otherwise this fails */
+  if (g_utf8_validate(string, -1, 0))
+    return;
+
   unsigned char *str = (unsigned char *)string;
   int n = 0;
 


### PR DESCRIPTION
The offending code was added in response to bug #8744. GTK is documented to
expect valid UTF-8 sequences as input, and is free to crash on invalid input
otherwise. The original fix, however, simply replaced non-ASCII characters with
dots which is clearly not accept able for someone named like me. This change
instead skips this replacement when the string is a valid UTF-8 sequence.

The g_utf8_validate must be invoked without the size being passed. If we pass
around the expected size, then this function fails because it hits the first
NUL byte, a terminator, prior to hitting the length limit, and this is
documented to return false.
