### PR TITLE
Remove non existing command

### DIFF
--- a/doc/darktable.pod
+++ b/doc/darktable.pod
@@ -178,8 +178,6 @@ apply/revert currently selected cropping frame
 
 =over
 
-=item B<darktable-faster> first copies the library to ram and then starts dt. On close, it is copied back, so even in case of crashes no data loss is anticipated.
-
 =item B<darktable-viewer> screensaver version of dt. Shows the last active collection in full screen as a slideshow.
 
 =back


### PR DESCRIPTION
darktable-faster has been removed for a long time, but the man page was
not updated. This has been corrected.

Signed-off-by: madanyang toganm@opensuse.org
