### PR TITLE
GTK3: Use cairo for drawing

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -1281,9 +1281,9 @@ gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer 
 void *dt_control_expose(void *voidptr)
 {
   int width, height, pointerx, pointery;
-  if(!darktable.gui->s) return NULL;
-  width  = cairo_image_surface_get_width(darktable.gui->s);
-  height = cairo_image_surface_get_height(darktable.gui->s);
+  if(!darktable.gui->surface) return NULL;
+  width  = cairo_image_surface_get_width(darktable.gui->surface);
+  height = cairo_image_surface_get_height(darktable.gui->surface);
   GtkWidget *widget = dt_ui_center(darktable.gui->ui);
   gtk_widget_get_pointer(widget, &pointerx, &pointery);
 
@@ -1400,7 +1400,7 @@ void *dt_control_expose(void *voidptr)
 
   cairo_destroy(cr);
 
-  cairo_t *cr_pixmap = cairo_create(darktable.gui->s);
+  cairo_t *cr_pixmap = cairo_create(darktable.gui->surface);
   cairo_set_source_surface (cr_pixmap, cst, 0, 0);
   cairo_paint(cr_pixmap);
   cairo_destroy(cr_pixmap);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -51,7 +51,7 @@ typedef struct dt_gui_gtk_t
 
   dt_gui_widgets_t widgets;
 
-  cairo_surface_t *s;
+  cairo_surface_t *surface;
   GtkMenu *presets_popup_menu;
   char *last_preset;
 


### PR DESCRIPTION
In GTK+ 3, the GDK drawing API (which closely mimics the X drawing API, which is itself modeled after PostScript) has been removed. All drawing in GTK+ 3 is done via cairo.

The GdkGC and GdkImage objects, as well as all the functions using them, are gone. This includes the gdk_draw family of functions like gdk_draw_rectangle() and gdk_draw_drawable(). As GdkGC is roughly equivalent to cairo_t and GdkImage was used for drawing images to GdkWindows, which cairo supports automatically, a transition is usually straightforward.

See https://developer.gnome.org/gtk3/3.9/gtk-migrating-2-to-3.html#id-1.6.3.3.8
