### PR TITLE
Make sure that buffer is null terminated

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -764,8 +764,8 @@ void dt_bauhaus_slider_set_default(GtkWidget *widget, float def)
 void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const char *label)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
-  memset(w->label, 0, 256); // keep valgrind happy
-  strncpy(w->label, label, 256);
+  memset(w->label, 0, sizeof(w->label)); // keep valgrind happy
+  strncpy(w->label, label, sizeof(w->label)-1);
 
   if(w->module)
   {
@@ -998,7 +998,7 @@ void dt_bauhaus_combobox_set_text(GtkWidget *widget, const char *text)
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   if(!d->editable) return;
-  strncpy(d->text, text, sizeof(d->text));
+  strncpy(d->text, text, sizeof(d->text)-1);
 }
 
 void dt_bauhaus_combobox_set(GtkWidget *widget, int pos)
@@ -1812,7 +1812,7 @@ dt_bauhaus_slider_set_format(GtkWidget *widget, const char *format)
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  strncpy(d->format, format, 24);
+  strncpy(d->format, format, sizeof(d->format)-1);
 }
 
 static void

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -309,13 +309,13 @@ static inline void dt_print_mem_usage()
   while (getline(&line, &len, f) != -1)
   {
     if (!strncmp(line, "VmPeak:", 7))
-      strncpy(vmpeak, line + 8, 64);
+      strncpy(vmpeak, line + 8, sizeof(vmpeak)-1);
     else if (!strncmp(line, "VmSize:", 7))
-      strncpy(vmsize, line + 8, 64);
+      strncpy(vmsize, line + 8, sizeof(vmsize)-1);
     else if (!strncmp(line, "VmRSS:", 6))
-      strncpy(vmrss, line + 8, 64);
+      strncpy(vmrss, line + 8, sizeof(vmrss)-1);
     else if (!strncmp(line, "VmHWM:", 6))
-      strncpy(vmhwm, line + 8, 64);
+      strncpy(vmhwm, line + 8, sizeof(vmhwm)-1);
   }
   free(line);
   fclose(f);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1188,7 +1188,7 @@ static void _exif_import_tags(dt_image_t *img,Exiv2::XmpData::iterator &pos)
   {
     char tagbuf[1024];
     const char *tag2 = pos->toString(i).c_str();
-    strncpy(tagbuf, tag2, 1024);
+    strncpy(tagbuf, tag2, sizeof(tagbuf)-1);
     int tagid = -1;
     char *tag = tagbuf;
     while(tag)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1628,7 +1628,7 @@ cl_event *dt_opencl_events_get_slot(const int devid, const char *tag)
     (*totallost)++;
     if (tag != NULL)
     {
-      strncpy((*eventtags)[*numevents-1].tag, tag, DT_OPENCL_EVENTNAMELENGTH);
+      strncpy((*eventtags)[*numevents-1].tag, tag, DT_OPENCL_EVENTNAMELENGTH-1);
     }
     else
     {

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -1732,7 +1732,7 @@ int dt_control_key_pressed_override(guint key, guint state)
       {
         // TODO: handle '.'-separated things separately
         // this is a static list, and tab cycles through the list
-        strncpy(vimkey_input, darktable.control->vimkey + 5, 256);
+        strncpy(vimkey_input, darktable.control->vimkey + 5, sizeof(vimkey_input)-1);
         autocomplete = dt_bauhaus_vimkey_complete(darktable.control->vimkey + 5);
         autocomplete = g_list_append(autocomplete, vimkey_input); // remember input to cycle back
       }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1158,7 +1158,7 @@ void dt_control_export(GList *imgid_list,int max_width, int max_height, int form
   data->format_index = format_index;
   data->storage_index = storage_index;
   data->high_quality = high_quality;
-  strncpy(data->style,style,128);
+  strncpy(data->style,style,sizeof(data->style)-1);
   t->data = data;
   dt_control_signal_raise(darktable.signals,DT_SIGNAL_IMAGE_EXPORT_MULTIPLE,t);
   dt_control_add_job(darktable.control, &job);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1450,7 +1450,7 @@ _collect_blend_modes(GList **list, const char *name, unsigned int mode)
 {
   dt_iop_blend_mode_t *bm;
   bm = g_malloc(sizeof(dt_iop_blend_mode_t));
-  strncpy(bm->name, name, 128);
+  strncpy(bm->name, name, sizeof(bm->name)-1);
   bm->mode = mode;
   *list = g_list_append(*list , bm);
 }

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -658,7 +658,7 @@ aspect_changed (GtkWidget *combo, dt_iop_module_t *self)
   }
   else if (which < DT_IOP_BORDERS_ASPECT_COUNT)
   {
-    strncpy(p->aspect_text, text, 20);
+    strncpy(p->aspect_text, text, sizeof(p->aspect_text)-1);
     p->aspect = g->aspect_ratios[which];
   }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -697,14 +697,14 @@ position_h_changed (GtkWidget *combo, dt_iop_module_t *self)
       {
         p->pos_h = atof(text);
       }
-      strncpy(p->pos_h_text, text, 20);
+      strncpy(p->pos_h_text, text, sizeof(p->pos_h_text)-1);
       p->pos_h = MAX(p->pos_h, 0);
       p->pos_h = MIN(p->pos_h, 1);
     }
   }
   else if (which < DT_IOP_BORDERS_POSITION_H_COUNT)
   {
-    strncpy(p->pos_h_text, text, 20);
+    strncpy(p->pos_h_text, text, sizeof(p->pos_h_text)-1);
     p->pos_h = g->pos_h_ratios[which];
   }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -741,7 +741,7 @@ position_v_changed (GtkWidget *combo, dt_iop_module_t *self)
   }
   else if (which < DT_IOP_BORDERS_POSITION_H_COUNT)
   {
-    strncpy(p->pos_v_text, text, 20);
+    strncpy(p->pos_v_text, text, sizeof(p->pos_v_text)-1);
     p->pos_v = g->pos_h_ratios[which];
   }
   dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1459,7 +1459,7 @@ void reload_defaults(dt_iop_module_t *module)
     char name[512];
     g->profile_cnt = dt_noiseprofile_get_matching(&module->dev->image_storage, g->profiles, MAX_PROFILES);
     g->interpolated = dt_noiseprofiles[0]; // default to generic poissonian
-    strncpy(name, _(g->interpolated.name), 512);
+    strncpy(name, _(g->interpolated.name), sizeof(name)-1);
 
     const int iso = module->dev->image_storage.exif_iso;
     for(int i=1; i<g->profile_cnt; i++)

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -130,7 +130,7 @@ legacy_params (dt_iop_module_t *self, const void *const old_params, const int ol
     n->yoffset = o->yoffset;
     n->alignment = o->alignment;
     n->sizeto = DT_SCALE_IMAGE;
-    strncpy(n->filename, o->filename, 64);
+    strncpy(n->filename, o->filename, sizeof(n->filename)-1);
     return 0;
   }
   return 1;

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -101,7 +101,7 @@ export_button_clicked (GtkWidget *widget, gpointer user_data)
   char* tmp = dt_conf_get_string("plugins/lighttable/export/style");
   if (tmp)
   {
-    strncpy (style, tmp, 128);
+    strncpy (style, tmp, sizeof(style)-1);
     g_free(tmp);
   }
   
@@ -745,7 +745,7 @@ get_params (dt_lib_module_t *self, int *size)
 
   if (fdata)
   {
-    strncpy(fdata->style, style, 128);
+    strncpy(fdata->style, style, sizeof(fdata->style)-1);
   }
 
   if(!iccprofile)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -734,7 +734,7 @@ static void _tree_cell_edited (GtkCellRendererText *cell, gchar *path_string, gc
 
   //first, we need to update the mask name
 
-  strncpy(form->name,new_text,128);
+  strncpy(form->name,new_text,sizeof(form->name)-1);
   dt_masks_write_form(form,darktable.develop);
 
   //and we update the cell text


### PR DESCRIPTION
That fixes issues like CID 1087769

Coverity: If the buffer is treated as a null terminated string in later operations, a buffer overflow or over-read may occur.
