### PR TITLE
strdup locale to avoid use-after-free

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -53,7 +53,7 @@ void dt_opencl_init(dt_opencl_t *cl, const int argc, char *argv[])
 
   // work-around to fix a bug in some AMD OpenCL compilers, which would fail parsing certain numerical constants if locale is different from "C".
   // we save the current locale, set locale to "C", and restore the previous setting after OpenCL is initialized
-  char *locale = setlocale(LC_ALL, NULL);
+  char *locale = strdup(setlocale(LC_ALL, NULL));
   setlocale(LC_ALL, "C");
 
   int handles = dt_conf_get_int("opencl_number_event_handles");
@@ -432,7 +432,11 @@ finally:
     cl->bilateral = dt_bilateral_init_cl_global();
     cl->gaussian = dt_gaussian_init_cl_global();
   }
-  if(locale) setlocale(LC_ALL, locale);
+  if(locale)
+  {
+    setlocale(LC_ALL, locale);
+    free(locale);
+  }
   return;
 }
 


### PR DESCRIPTION
Found by clang AddressSanitizer

To be sure you can use the returned string encoding the currently selected locale at a later time, you must make a copy of the string. It is not guaranteed that the returned pointer remains valid over time.
From https://www.gnu.org/software/libc/manual/html_node/Setting-the-Locale.html
