### PR TITLE
fix: Visualize some sliders better:

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -69,6 +69,8 @@ typedef struct dt_bauhaus_slider_data_t
   int   grad_cnt;        // how many stops
   float grad_pos[10];    // and position of these.
 
+  int fill_feedback;   // fill the slider with brighter part up to the handle?
+
   char format[24];// numeric value is printed with this string
 
   int   is_dragging;     // indicates is mouse is dragging slider
@@ -225,6 +227,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w);
 // slider:
 GtkWidget* dt_bauhaus_slider_new(dt_iop_module_t *self);
 GtkWidget* dt_bauhaus_slider_new_with_range(dt_iop_module_t *self, float min, float max, float step, float defval, int digits);
+GtkWidget* dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, float min, float max, float step, float defval, int digits, int feedback);
 
 // outside doesn't see the real type, we cast it internally.
 void dt_bauhaus_slider_set(GtkWidget *w, float pos);

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -216,6 +216,15 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
+static inline void
+update_saturation_slider_end_color(
+  GtkWidget* slider,
+  float hue)
+{
+  float rgb[3];
+  hsl2rgb(rgb, hue, 1.0, 0.5);
+  dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
+}
 
 static void
 lightness_callback (GtkWidget *slider, gpointer user_data)
@@ -246,11 +255,8 @@ hue_callback(GtkWidget *slider, gpointer user_data)
 
   const float hue = dt_bauhaus_slider_get(g->gslider1);
   //fprintf(stderr," hue: %f, saturation: %f\n",hue,dtgtk_gradient_slider_get_value(g->gslider2));
-  float saturation = 1.0f;
-  float color[3];
-  hsl2rgb(color, hue, saturation, 0.5f);
 
-  dt_bauhaus_slider_set_stop(g->gslider2, 1.0f, color[0], color[1], color[2]);  // Update saturation end color
+  update_saturation_slider_end_color(g->gslider2, p->hue);
 
   gtk_widget_queue_draw(GTK_WIDGET(g->gslider2));
 
@@ -396,6 +402,8 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->scale1, p->lightness);
   dt_bauhaus_slider_set(g->scale2, p->source_lightness_mix);
 
+  update_saturation_slider_end_color(g->gslider2, p->hue);
+
 #if 0 // could update quad drawing color here
   float color[3];
   hsl2rgb(color,p->hue,p->saturation,0.5);
@@ -442,7 +450,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_vbox_new(FALSE, DT_BAUHAUS_SPACE);
 
   /* hue slider */
-  g->gslider1 = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
+  g->gslider1 = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 1.0f, 0.01f, 0.0f, 2, 0);
   dt_bauhaus_slider_set_stop(g->gslider1, 0.0f, 1.0f, 0.0f, 0.0f);
   // dt_bauhaus_slider_set_format(g->gslider1, "");
   dt_bauhaus_widget_set_label(g->gslider1, NULL, _("hue"));
@@ -460,7 +468,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->gslider2 = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
   // dt_bauhaus_slider_set_format(g->gslider2, "");
   dt_bauhaus_widget_set_label(g->gslider2, NULL, _("saturation"));
-  dt_bauhaus_slider_set_stop(g->gslider2, 0.0f, 1.0f, 1.0f, 1.0f);
+  dt_bauhaus_slider_set_stop(g->gslider2, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(g->gslider2, 1.0f, 1.0f, 1.0f, 1.0f);
   g_object_set(G_OBJECT(g->gslider2), "tooltip-text", _("select the saturation shadow tone"), (char *)NULL);
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -936,6 +936,16 @@ void cleanup_pipe (struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_de
 #endif
 }
 
+static inline void
+update_saturation_slider_end_color(
+  GtkWidget* slider,
+  float hue)
+{
+  float rgb[3];
+  hsl2rgb(rgb, hue, 1.0, 0.5);
+  dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
+}
+
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)self;
@@ -951,6 +961,7 @@ void gui_update(struct dt_iop_module_t *self)
   //float ht = self->dev->preview_pipe->backbuf_height;
   g->define = 0;
   //set_points_from_grad(self,&g->xa,&g->ya,&g->xb,&g->yb,p->rotation,p->offset);
+  update_saturation_slider_end_color(g->gslider2, p->hue);
 }
 
 void init(dt_iop_module_t *module)
@@ -986,11 +997,8 @@ hue_callback(GtkWidget *slider, gpointer user_data)
 
   const float hue = dt_bauhaus_slider_get(g->gslider1);
   //fprintf(stderr," hue: %f, saturation: %f\n",hue,dtgtk_gradient_slider_get_value(g->gslider2));
-  float saturation = 1.0f;
-  float color[3];
-  hsl2rgb(color, hue, saturation, 0.5f);
 
-  dt_bauhaus_slider_set_stop(g->gslider2, 1.0f, color[0], color[1], color[2]);  // Update saturation end color
+  update_saturation_slider_end_color(g->gslider2, hue);
 
   if(self->dt->gui->reset)
     return;
@@ -1050,7 +1058,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale3), TRUE, TRUE, 0);
 
   /* hue slider */
-  g->gslider1 = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
+  g->gslider1 = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 1.0f, 0.01f, 0.0f, 2, 0);
   dt_bauhaus_slider_set_stop(g->gslider1, 0.0f, 1.0f, 0.0f, 0.0f);
   // dt_bauhaus_slider_set_format(g->gslider1, "");
   dt_bauhaus_widget_set_label(g->gslider1, NULL, _("hue"));
@@ -1069,7 +1077,7 @@ void gui_init(struct dt_iop_module_t *self)
   /* saturation slider */
   g->gslider2 = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
   dt_bauhaus_widget_set_label(g->gslider2, NULL, _("saturation"));
-  dt_bauhaus_slider_set_stop(g->gslider2, 0.0f, 1.0f, 1.0f, 1.0f);
+  dt_bauhaus_slider_set_stop(g->gslider2, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(g->gslider2, 1.0f, 1.0f, 1.0f, 1.0f);
   g_object_set(G_OBJECT(g->gslider2), "tooltip-text", _("select the saturation of filter"), (char *)NULL);
   g_signal_connect (G_OBJECT (g->gslider2), "value-changed",

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -316,6 +316,25 @@ update_saturation_slider_end_color(
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }
 
+static inline void
+update_balance_slider_colors(
+  GtkWidget* slider,
+  float hue1,
+  float hue2)
+{
+  float rgb[3];
+  if (hue1 != -1)
+  {
+    hsl2rgb(rgb, hue1, 1.0, 0.5);
+    dt_bauhaus_slider_set_stop(slider, 0.0, rgb[0], rgb[1], rgb[2]);
+  }
+  if (hue2 != -1)
+  {
+    hsl2rgb(rgb, hue2, 1.0, 0.5);
+    dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
+  }
+}
+
 static void
 hue_callback(GtkWidget *slider, gpointer user_data)
 {
@@ -334,6 +353,7 @@ hue_callback(GtkWidget *slider, gpointer user_data)
     saturation = p->shadow_saturation;
     colorpicker = GTK_WIDGET(g->colorpick1);
     sat_slider = g->gslider2;
+    update_balance_slider_colors(g->scale1, -1, hue);
   }
   else
   {
@@ -341,6 +361,7 @@ hue_callback(GtkWidget *slider, gpointer user_data)
     saturation=p->highlight_saturation;
     colorpicker=GTK_WIDGET(g->colorpick2);
     sat_slider=g->gslider4;
+    update_balance_slider_colors(g->scale1, hue, -1);
   }
 
   update_colorpicker_fg(colorpicker, hue, saturation);
@@ -502,6 +523,8 @@ void gui_update(struct dt_iop_module_t *self)
   update_colorpicker_fg(GTK_WIDGET(g->colorpick2), p->highlight_hue, p->highlight_saturation);
   update_saturation_slider_end_color(g->gslider2, p->shadow_hue);
   update_saturation_slider_end_color(g->gslider4, p->highlight_hue);
+
+  update_balance_slider_colors(g->scale1, p->highlight_hue, p->shadow_hue);
 }
 
 void init(dt_iop_module_t *module)
@@ -545,7 +568,7 @@ gui_init_tab(
 
   // hue slider
   GtkWidget* hue;
-  *pphue = hue =( dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2));
+  *pphue = hue =( dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 1.0f, 0.01f, 0.0f, 2, 0));
   dt_bauhaus_slider_set_stop(hue, 0.0f, 1.0f, 0.0f, 0.0f);
   dt_bauhaus_widget_set_label(hue, NULL, _("hue"));
   dt_bauhaus_slider_set_stop(hue, 0.166f, 1.0f, 1.0f, 0.0f);
@@ -560,7 +583,7 @@ gui_init_tab(
   GtkWidget* saturation;
   *ppsaturation = saturation = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
   dt_bauhaus_widget_set_label(saturation, NULL, _("saturation"));
-  dt_bauhaus_slider_set_stop(saturation, 0.0f, 1.0f, 1.0f, 1.0f);
+  dt_bauhaus_slider_set_stop(saturation, 0.0f, 0.2f, 0.2f, 0.2f);
   dt_bauhaus_slider_set_stop(saturation, 1.0f, 1.0f, 1.0f, 1.0f);
   g_object_set(G_OBJECT(saturation), "tooltip-text", _("select the saturation tone"), (char *)NULL);
 
@@ -596,8 +619,10 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(vbox), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
-  g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0.1, p->balance*100.0, 2);
+  g->scale1 = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0, 100.0, 0.1, p->balance*100.0, 2, 0);
   dt_bauhaus_slider_set_format(g->scale1, "%.2f");
+  dt_bauhaus_slider_set_stop(g->scale1, 0.0f, 0.5f, 0.5f, 0.5f);
+  dt_bauhaus_slider_set_stop(g->scale1, 1.0f, 0.5f, 0.5f, 0.5f);
   dt_bauhaus_widget_set_label(g->scale1, NULL, _("balance"));
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(g->scale1), TRUE, TRUE, 0);
 


### PR DESCRIPTION
- Balance sliders dont get highlighted at the left side of the handle, does not make sense for them
- Slider highlighting is done by luminosity change only, so colored sliders retain their color (use CAIRO_OPERATOR_HSL_LUMINOSITY)
- split toning's balance is now also colored in the two colors to balance between
- increase slider coloring slightly from 0.2f to 0.25f
