### PR TITLE
Spelling corrections

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -907,7 +907,7 @@ libraw_thumb_fail:
           if( gp_camera_file_get(c->active_camera->gpcam, path, filename, GP_FILE_TYPE_EXIF,exif,c->gpcontext) < GP_OK )
           {
             exif=NULL;
-            dt_print(DT_DEBUG_CAMCTL,"[camera_control] failed to retreive exif of file %s\n",filename);
+            dt_print(DT_DEBUG_CAMCTL,"[camera_control] failed to retrieve exif of file %s\n",filename);
           }
         }
 

--- a/src/lua/events.c
+++ b/src/lua/events.c
@@ -114,7 +114,7 @@ static int register_keyed_event(lua_State* L) {
   }
   lua_getfield(L,-1,luaL_checkstring(L,3));
   if(!lua_isnil(L,-1)) 
-    return luaL_error(L,"key already registerd for event : %s",luaL_checkstring(L,3));
+    return luaL_error(L,"key already registered for event : %s",luaL_checkstring(L,3));
   lua_pop(L,1);
 
   lua_pushvalue(L,2);


### PR DESCRIPTION
These are untranslated strings, so they should be safe from string freeze restrictions.
