### PR TITLE
[Post-1.4] Add option to filter images drawn on map

### DIFF
--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -78,6 +78,9 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] =
   {"dt-image-export-multiple",NULL,NULL,G_TYPE_NONE,g_cclosure_marshal_VOID__POINTER,1,pointer_arg},      // DT_SIGNAL_IMAGE_EXPORT_MULTIPLE
   {"dt-image-export-tmpfile",NULL,NULL,G_TYPE_NONE,g_cclosure_marshal_generic,6,image_export_arg},        // DT_SIGNAL_IMAGE_EXPORT_TMPFILE
   {"dt-imageio-storage-change",NULL,NULL,G_TYPE_NONE,g_cclosure_marshal_VOID__VOID,0,NULL},               // DT_SIGNAL_IMAGEIO_STORAGE_CHANGE
+
+
+  {"dt-preferences-changed",NULL,NULL,G_TYPE_NONE,g_cclosure_marshal_VOID__VOID,0,NULL},        // DT_SIGNAL_PREFERENCES_CHANGE
 };
 
 static  GType _signal_type;

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -142,6 +142,12 @@ typedef enum dt_signal_t
     */
   DT_SIGNAL_IMAGEIO_STORAGE_CHANGE,
 
+  /** \brief This signal is raised after preferences have been changes
+    1 dt_view_t* : the view
+    no return
+    */
+  DT_SIGNAL_PREFERENCES_CHANGE,
+
   /* do not touch !*/
   DT_SIGNAL_COUNT
 }

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -257,9 +257,7 @@ void dt_gui_preferences_show()
     darktable.control->accel_remap_path = NULL;
   }
 
-#ifdef HAVE_MAP
-  dt_view_map_check_preference_change(darktable.view_manager);
-#endif
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE);
 }
 
 static void tree_insert_presets(GtkTreeStore *tree_model)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -75,7 +75,7 @@ static void _view_map_set_map_source(const dt_view_t *view, OsmGpsMapSource_t ma
 /* wrapper for setting the map source in the GObject */
 static void _view_map_set_map_source_g_object(const dt_view_t *view, OsmGpsMapSource_t map_source);
 /* proxy function to check if preferences have changed */
-static void _view_map_check_preference_change(const dt_view_t *view);
+static void _view_map_check_preference_change(gpointer instance, gpointer user_data);
 /* callback when the collection changs */
 static void _view_map_collection_change(gpointer instance, gpointer user_data);
 /* callback when an image is selected in filmstrip, centers map */
@@ -327,6 +327,9 @@ void init(dt_view_t *self)
   /* connect collection changed signal */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
       G_CALLBACK(_view_map_collection_change), (gpointer)self);
+  /* connect preference changed signal */
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+      G_CALLBACK(_view_map_check_preference_change), (gpointer)self);
 }
 
 void cleanup(dt_view_t *self)
@@ -798,8 +801,9 @@ static void _view_map_set_map_source(const dt_view_t *view, OsmGpsMapSource_t ma
   _view_map_set_map_source_g_object(view, map_source);
 }
 
-static void _view_map_check_preference_change(const dt_view_t *view)
+static void _view_map_check_preference_change(gpointer instance, gpointer user_data)
 {
+  dt_view_t *view = (dt_view_t*)user_data;
   dt_map_t *lib = (dt_map_t*)view->data;
 
   if(_view_map_prefs_changed(lib))

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1475,12 +1475,6 @@ void dt_view_map_set_map_source(const dt_view_manager_t *vm, OsmGpsMapSource_t m
   if (vm->proxy.map.view)
     vm->proxy.map.set_map_source(vm->proxy.map.view, map_source);
 }
-
-void dt_view_map_check_preference_change(const dt_view_manager_t *vm)
-{
-  if (vm->proxy.map.view)
-    vm->proxy.map.check_preference_change(vm->proxy.map.view);
-}
 #endif
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -346,7 +346,6 @@ void dt_view_filmstrip_prefetch();
 void dt_view_map_center_on_location(const dt_view_manager_t *vm, gdouble lon, gdouble lat, gdouble zoom);
 void dt_view_map_show_osd(const dt_view_manager_t *vm, gboolean enabled);
 void dt_view_map_set_map_source(const dt_view_manager_t *vm, OsmGpsMapSource_t map_source);
-void dt_view_map_check_preference_change(const dt_view_manager_t *vm);
 #endif
 
 #endif


### PR DESCRIPTION
This reduces the images drawn on the map to the current collection/
filter, increasing the performance and reducing the mess on the map when
many images are geotagged within the current map section.
Also, changing map preferences doesn't require a restart any more.
