### PR TITLE
tonecurve: display usual guides whatever histogram mode is chosen

### DIFF
--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -709,9 +709,6 @@ static gboolean dt_iop_tonecurve_expose(GtkWidget *widget, GdkEventExpose *event
   // draw grid
   cairo_set_line_width(cr, .4);
   cairo_set_source_rgb (cr, .1, .1, .1);
-  if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
-    dt_draw_waveform_lines(cr, 0, 0, width, height);
-  else
   dt_draw_grid(cr, 4, 0, 0, width, height);
 
   // if autoscale_ab is on: do not display a and b curves


### PR DESCRIPTION
The tonecurve module displays the histogram as its widget background
and currently changes the way guide lines are drawn depending on
histogram widget mode.

However the tonecurve module doesn't work in any new fancy histogram
way, so no use to take care about new guide lines for these modes.
