### PR TITLE
redo #include <tr1/memory> vs #include <memory> logic

### DIFF
--- a/src/common/imageio_exr.hh
+++ b/src/common/imageio_exr.hh
@@ -21,7 +21,11 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
-#if __cplusplus >= 201103L || defined(__clang__)
+#ifndef __has_include
+#define __has_include(x) 1
+#endif
+
+#if !__has_include(<tr1/memory>)
 #include <memory>
 #else
 #include <tr1/memory>
@@ -60,7 +64,7 @@ public:
   }
 
   uint32_t size;
-#if __cplusplus >= 201103L || defined(__clang__)
+#if !__has_include(<tr1/memory>)
   std::shared_ptr<uint8_t> data;
 #else
   std::tr1::shared_ptr<uint8_t> data;


### PR DESCRIPTION
<tr1/memory> is for libstdc++, <memory> is for libc++ and alike ones.
On OS X clang can link against either of them depending on the passed options,
so checking the compiler doesn't actually work.
Neither does work checking the __cplusplus macros because it depends only on the presence of -std=c++11 switch,
so it may be not >= 201103L but we will still have to use <memory> with libc++.
For some reason <memory> include is present even when using libstdc++,
so I check for the presence of <tr1/memory> instead, it works as expected.
If there's a compiler that doesn't support both <tr1/memory> and __has_include()
then the logic in this commit will fail, but I don't have a better solution.
Let's hope it handles all practical cases ATM.

P.S.
Tested only on OS X and Linux with GCC, so please check other configurations.
