### PR TITLE
We in zoom to display a single image, ensure that the selection is updat...

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -614,6 +614,12 @@ end_query_cache:
         cairo_save(cr);
         // if(iir == 1) dt_image_prefetch(image, DT_IMAGE_MIPF);
         dt_view_image_expose(&(lib->image_over), id, cr, wd, iir == 1 ? height : ht, iir, img_pointerx, img_pointery, FALSE);
+        if (iir==1)
+        {
+          // we are on the single-image display at a time, in this case we want the selection to be updated to contain
+          // this single image.
+          dt_selection_select_single(darktable.selection, id);
+        }
 
         cairo_restore(cr);
       }
@@ -1037,6 +1043,12 @@ expose_zoomable (dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, in
         // if(zoom == 1) dt_image_prefetch(image, DT_IMAGE_MIPF);
         dt_view_image_expose(&(lib->image_over), id, cr, wd, zoom == 1 ? height : ht, zoom, img_pointerx, img_pointery, FALSE);
         cairo_restore(cr);
+        if (zoom==1)
+        {
+          // we are on the single-image display at a time, in this case we want the selection to be updated to contain
+          // this single image.
+          dt_selection_select_single(darktable.selection, id);
+        }
       }
       else goto failure;
       cairo_translate(cr, wd, 0.0f);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -24,6 +24,7 @@
 #include "common/mipmap_cache.h"
 #include "common/debug.h"
 #include "common/history.h"
+#include "common/selection.h"
 #include "libs/lib.h"
 #include "control/conf.h"
 #include "control/control.h"


### PR DESCRIPTION
...ed.

Not doing that we will keep the last selected image into the selected_images
table and the remove/delete operations will not operate on the currently
displayed image.

For #9431.

To be tested a bit more but I believe this fixes the #9431 issue.
