### PR TITLE
[Post-1.4] Never use selected_images in control_jobs (remove/delete).

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -313,11 +313,58 @@ int32_t dt_control_flip_images_job_run(dt_job_t *job)
   return 0;
 }
 
+static char *_get_image_list(GList *l)
+{
+  const int size = g_list_length(l);
+  char *buffer = malloc (size*8);
+  int imgid;
+  char num[8];
+  gboolean first=true;
+
+  buffer[0]='\0';
+
+  while(l)
+  {
+    imgid = GPOINTER_TO_INT(l->data);
+    snprintf(num,8,"%s%6d",first?"":",",imgid);
+    strcat(buffer,num);
+    l = g_list_next(l);
+    first=false;
+  }
+  return buffer;
+}
+
+static void _set_remove_flag(char *imgs)
+{
+  sqlite3_stmt *stmt = NULL;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE images SET flags = (flags|?1) WHERE id IN (?2)", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, DT_IMAGE_REMOVE);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, imgs, -1, SQLITE_STATIC);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+}
+
+static GList *_get_full_pathname(char *imgs)
+{
+  sqlite3_stmt *stmt = NULL;
+  GList *list = NULL;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT DISTINCT folder || '/' || filename FROM images, film_rolls WHERE images.film_id = film_rolls.id AND images.id IN (?1)", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, imgs, -1, SQLITE_STATIC);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    list = g_list_append(list, g_strdup((const gchar *)sqlite3_column_text(stmt, 0)));
+  }
+  sqlite3_finalize(stmt);
+  return list;
+}
+
 int32_t dt_control_remove_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
   dt_control_image_enumerator_t *t1 = (dt_control_image_enumerator_t *)job->param;
   GList *t = t1->index;
+  char *imgs = _get_image_list(t);
   int total = g_list_length(t);
   char message[512]= {0};
   double fraction=0;
@@ -326,10 +373,10 @@ int32_t dt_control_remove_images_job_run(dt_job_t *job)
   sqlite3_stmt *stmt = NULL;
 
   // check that we can safely remove the image
-  char query[1024];
   gboolean remove_ok = TRUE;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT id FROM images WHERE id IN (SELECT imgid FROM selected_images) AND flags&?1=?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT id FROM images WHERE id IN (?2) AND flags&?1=?1", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, DT_IMAGE_LOCAL_COPY);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, imgs, -1, SQLITE_STATIC);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -346,24 +393,19 @@ int32_t dt_control_remove_images_job_run(dt_job_t *job)
   {
     dt_control_log(_("cannot remove local copy when the original file is not accessible."));
     dt_control_backgroundjobs_destroy(darktable.control, jid);
+    free(imgs);
     return 0;
   }
 
   // update remove status
-  sprintf(query, "update images set flags = (flags | %d) where id in (select imgid from selected_images)",DT_IMAGE_REMOVE);
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);
+  _set_remove_flag(imgs);
 
   dt_collection_update(darktable.collection);
 
   // We need a list of files to regenerate .xmp files if there are duplicates
-  GList *list = NULL;
+  GList *list = _get_full_pathname(imgs);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select distinct folder || '/' || filename from images, film_rolls where images.film_id = film_rolls.id and images.id in (select imgid from selected_images)", -1, &stmt, NULL);
-  while(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    list = g_list_append(list, g_strdup((const gchar *)sqlite3_column_text(stmt, 0)));
-  }
-  sqlite3_finalize(stmt);
+  free(imgs);
 
   while(t)
   {
@@ -394,6 +436,7 @@ int32_t dt_control_delete_images_job_run(dt_job_t *job)
   int imgid = -1;
   dt_control_image_enumerator_t *t1 = (dt_control_image_enumerator_t *)job->param;
   GList *t = t1->index;
+  char *imgs = _get_image_list(t);
   int total = g_list_length(t);
   char message[512]= {0};
   double fraction=0;
@@ -402,22 +445,14 @@ int32_t dt_control_delete_images_job_run(dt_job_t *job)
 
   sqlite3_stmt *stmt;
 
-  char query[1024];
-  sprintf(query, "update images set flags = (flags | %d) where id in (select imgid from selected_images)",DT_IMAGE_REMOVE);
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);
+  _set_remove_flag(imgs);
 
   dt_collection_update(darktable.collection);
 
   // We need a list of files to regenerate .xmp files if there are duplicates
-  GList *list = NULL;
+  GList *list = _get_full_pathname(imgs);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select distinct folder || '/' || filename from images, film_rolls where images.film_id = film_rolls.id and images.id in (select imgid from selected_images)", -1, &stmt, NULL);
-
-  if(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    list = g_list_append(list, g_strdup((const gchar *)sqlite3_column_text(stmt, 0)));
-  }
-  sqlite3_finalize(stmt);
+  free(imgs);
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select count(id) from images where filename in (select filename from images where id = ?1) and film_id in (select film_id from images where id = ?1)", -1, &stmt, NULL);
   while(t)


### PR DESCRIPTION
Indeed between the time we click on delete and the time where the
SQL statements get executed there is a small window where the
user could click on some images and change the selection.

This could even been far more a problem with scripts like Lua.

Instead of using the selected_images table we now properly get the images
to work on from the list associated with the job.

Take the opportunity to refactor some code for better sharing. This fix
an obvious bug where in dt_control_delete_images_job_run we where getting
only the first images for checking for duplicates.

Looks too complex for 1.4 so I have set to Post-1.4 but this fixes a real bug while deleting and a possible race condition but probably difficult to reproduce (except with a script).
