### PR TITLE
[Post-1.4] store clipping results.

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2308,6 +2308,18 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
       }
     }
   }
+
+  static int mouse_button_1=0;
+  if(darktable.control->button_down_which==1){
+    // TODO block other gui events
+    mouse_button_1=1;
+  }
+  else if(mouse_button_1==1){ //mouse 1 released
+    mouse_button_1=0;
+    commit_box (self, g, p);
+    // TODO history
+    // TODO unblock other gui events
+  }
 }
 
 //determine the distance between the segment [(xa,ya)(xb,yb)] and the point (xc,yc)


### PR DESCRIPTION
clipping.c:btni1release
darkroom.c (inactive) call gui_focus on modechange

rebased / cleaned-up by pascal obry.

See original discussion on #345.
