### PR TITLE
[Post-1.4] Use a loose search in the lensfun database.

### DIFF
--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -2018,7 +2018,7 @@ void gui_update(struct dt_iop_module_t *self)
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfLens **lenslist = lf_db_find_lenses_hd (dt_iop_lensfun_db, g->camera,
                               make [0] ? make : NULL,
-                              model [0] ? model : NULL, 0);
+                              model [0] ? model : NULL, 1);
     if(lenslist) lens_set (self, lenslist[0]);
     else         lens_set (self, NULL);
     lf_free (lenslist);


### PR DESCRIPTION
The issue is that most of my lenses were not properly found. The exif
reports:

   Nikon AF-S Zoom-Nikkor 24-70mm f/2.8G ED

And the lens fun database contains:

   Nikkor 24-70mm f/2.8G ED

Using a strict match we get zero results. Using the lensfun loose
match the lens is properly found and set into the module.

Looking at the lens.c evolution it seems that this loose search has never been activated. Don't know why, but
it seems to be working just fine in my case. We had many report about lens mis-match on the mailing-list,
is there good reasons to not activate this loose search?
