### PR TITLE
blacklist FUJI cameras with X-TRANS sensors to prevent LibRaw from crash...

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -302,6 +302,35 @@ return_label:
   return ret;
 }
 
+// we do not support non-Bayer raw images; make sure we skip those in order
+// to prevent LibRaw from crashing
+static gboolean 
+_blacklisted_raw(const gchar *maker, const gchar *model)
+{
+  typedef struct blacklist_t {
+    const gchar *maker;
+    const gchar *model;
+  } blacklist_t;
+
+  blacklist_t blacklist[] = { { "fujifilm",                        "x-pro1" },
+                              { "fujifilm",                        "x-e1"   },
+                              { "fujifilm",                        "x-e2"   },
+                              { "fujifilm",                        "x-m1"   },
+                              { NULL,                              NULL     } };
+
+  gboolean blacklisted = FALSE;
+
+  for(blacklist_t *i = blacklist; i->maker != NULL; i++)
+    if(!g_ascii_strncasecmp(maker, i->maker, strlen(i->maker)) &&
+       !g_ascii_strncasecmp(model, i->model, strlen(i->model)))
+    {
+      blacklisted = TRUE;
+      break;
+    }
+  return blacklisted;
+}
+
+
 // open a raw file, libraw path:
 dt_imageio_retval_t
 dt_imageio_open_raw(
@@ -311,6 +340,9 @@ dt_imageio_open_raw(
 {
   if(!img->exif_inited)
     (void) dt_exif_read(img, filename);
+
+  if(_blacklisted_raw(img->exif_maker, img->exif_model)) return DT_IMAGEIO_FILE_CORRUPTED;
+
   int ret;
   libraw_data_t *raw = libraw_init(0);
   libraw_processed_image_t *image = NULL;


### PR DESCRIPTION
This commit adds a blacklist of FUJI cameras with X-TRANS sensors to dt_imageio_open_raw().

This prevents LibRaw from crashing while trying to read those RAW files and would solve issue #9731.

While we clearly state that we do not support those strange sensor designs it is certainly not up to pro-standards
if darktable crashes when reading these raws.

Maybe someone could review.
