### PR TITLE
Made lensfun lookups for one lens really unique.  Fixes bug #9662.

### DIFF
--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -785,9 +785,9 @@ void commit_params (struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pi
   {
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfLens **lens = lf_db_find_lenses_hd(dt_iop_lensfun_db, camera, NULL,
-                          p->lens, 0);
+                          p->lens, LF_SEARCH_SORT_AND_UNIQUIFY);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
-    if(lens)
+    if(lens && !lens[1])
     {
       lf_lens_copy(d->lens, lens[0]);
       if(p->tca_override)
@@ -1689,7 +1689,7 @@ static float get_autoscale(dt_iop_module_t *self, dt_iop_lensfun_params_t *p, co
   if(p->lens[0] != '\0')
   {
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
-    const lfLens **lenslist = lf_db_find_lenses_hd (dt_iop_lensfun_db, camera, NULL, p->lens, 0);
+    const lfLens **lenslist = lf_db_find_lenses_hd (dt_iop_lensfun_db, camera, NULL, p->lens, LF_SEARCH_SORT_AND_UNIQUIFY);
     if(lenslist && !lenslist[1])
     {
       // create dummy modifier
@@ -1874,7 +1874,7 @@ void gui_init(struct dt_iop_module_t *self)
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfLens **lenslist = lf_db_find_lenses_hd (dt_iop_lensfun_db, g->camera,
                               make [0] ? make : NULL,
-                              model [0] ? model : NULL, 0);
+                              model [0] ? model : NULL, LF_SEARCH_SORT_AND_UNIQUIFY);
     if(lenslist && !lenslist[1]) lens_set (self, lenslist[0]);
     lf_free (lenslist);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);


### PR DESCRIPTION
Please review the first hunk thoroughly because I don't understand what "commit_params" does.

The second hunk is actually solving the issue: autoscaling now works also for lenses with multiple calibration entries in lensfun, e.g. the Canon 50mm f/1.4 on an APS-C camera.

And the third hunk is commented out anyway.  No idea what it does, but I'm sure that it is correct now as far as lens object lookup is concerned.
