### PR TITLE
Add keywords to darktable.desktop

### DIFF
--- a/data/darktable.desktop
+++ b/data/darktable.desktop
@@ -29,8 +29,8 @@ Version=1.0
 Type=Application
 Categories=Graphics;Photography;GTK;
 # TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Keywords=graphics;photography;raw
-Keywords[sv]=grafik;fotografi;rå
+Keywords=graphics;photography;raw;
+Keywords[sv]=grafik;fotografi;rå;
 
 Exec=darktable %U
 TryExec=darktable


### PR DESCRIPTION
Add keywords, as recommended here:

 http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html,
 http://bugs.debian.org/693918, and
 https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords
