### PR TITLE
Use Exif.OlympusEq.LensType for Olympus FT lenses

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -530,6 +530,10 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     {
       dt_strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
     }
+    else if ( (pos=exifData.findKey(Exiv2::ExifKey("Exif.OlympusEq.LensType"))) != exifData.end() && pos->size())
+    {
+      dt_strlcpy_to_utf8(img->exif_lens, sizeof(img->exif_lens), pos, exifData);
+    }
 #if EXIV2_MINOR_VERSION>20
     else if ( (pos=exifData.findKey(Exiv2::ExifKey("Exif.OlympusEq.LensModel"))) != exifData.end() && pos->size())
     {


### PR DESCRIPTION
Previously, lens correction didn't match my lenses. With the current trunk of lensfun and this change, everything looks right. Tested with three Olympus FT, three Olympus MFT und three Lumix MFT lenses.

Fixes Bug #9794
