### PR TITLE
Don't switch group if module activated via hotkey is already visible

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -351,6 +351,8 @@ void dt_iop_cleanup_module(dt_iop_module_t *module);
 void dt_iop_init_pipe(struct dt_iop_module_t *module, struct dt_dev_pixelpipe_t *pipe, struct dt_dev_pixelpipe_iop_t *piece);
 /** checks if iop do have an ui */
 gboolean dt_iop_is_hidden(dt_iop_module_t *module);
+/** checks whether iop is shown in specified group */
+gboolean dt_iop_shown_in_group(dt_iop_module_t *module, uint32_t group);
 /** cleans up gui of module and of blendops */
 void dt_iop_gui_cleanup_module(dt_iop_module_t *module);
 /** updates the gui params and the enabled switch. */


### PR DESCRIPTION
When you activate module via hotkey, "native" group is that module is selected even if module is already shown in current group ("favorites" or "active"). This is inconvenient because even if you use only favorite modules you still have to switch group back to "favorites" every time.
