### PR TITLE
Have a msgctxt for 'export' where it's a verb.

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -612,7 +612,7 @@ static void init_tab_accels(GtkWidget *book)
   g_signal_connect(G_OBJECT(button), "clicked",
                    G_CALLBACK(update_accels_model), (gpointer)model);
 
-  button = gtk_button_new_with_label(_("export"));
+  button = gtk_button_new_with_label(C_("import", "export"));
   gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked",
                    G_CALLBACK(import_export), (gpointer)1);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -665,7 +665,7 @@ gui_init (dt_lib_module_t *self)
 
   // Export button
 
-  GtkButton *button = GTK_BUTTON(gtk_button_new_with_label(_("export")));
+  GtkButton *button = GTK_BUTTON(gtk_button_new_with_label(C_("export", "export")));
   d->export_button = button;
   g_object_set(G_OBJECT(button), "tooltip-text", _("export with current settings (ctrl-e)"), (char *)NULL);
   gtk_table_attach(GTK_TABLE(self->widget), GTK_WIDGET(button), 1, 2, 11, 12, GTK_EXPAND|GTK_FILL, 0, 0, 0);

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -405,7 +405,7 @@ gui_init (dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX (hbox2),importButton,TRUE,TRUE,0);
 
   // export button
-  GtkWidget *exportButton = gtk_button_new_with_label(_("export"));
+  GtkWidget *exportButton = gtk_button_new_with_label(C_("styles", "export"));
   d->export_button = exportButton;
   g_object_set (exportButton, "tooltip-text", _("export the selected style into a style file"), (char *)NULL);
   g_signal_connect (exportButton, "clicked", G_CALLBACK(export_clicked),d);


### PR DESCRIPTION
The reason for this is that in english, 'export' is a verb ('to export')
as well as a noun ('an export').  For example in Swedish, the verb is
'exportera' while the noun is 'export', and therefore, a separation of
some kind is needed.  So far, this hasn't been needed as all uses of
the string 'export' have been verbs.  However, the noun has recently
showed up in src/common/imageio.c.

Personally, I would have preferred having the contexts 'verb' and 'noun'
for this case, but this is not how things have been done so far in dt.
