### PR TITLE
Removed check for ambiguous return values for lens lookups.

### DIFF
--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -787,7 +787,7 @@ void commit_params (struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pi
     const lfLens **lens = lf_db_find_lenses_hd(dt_iop_lensfun_db, camera, NULL,
                           p->lens, LF_SEARCH_SORT_AND_UNIQUIFY);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
-    if(lens && !lens[1])
+    if(lens)
     {
       lf_lens_copy(d->lens, lens[0]);
       if(p->tca_override)
@@ -1690,7 +1690,7 @@ static float get_autoscale(dt_iop_module_t *self, dt_iop_lensfun_params_t *p, co
   {
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfLens **lenslist = lf_db_find_lenses_hd (dt_iop_lensfun_db, camera, NULL, p->lens, LF_SEARCH_SORT_AND_UNIQUIFY);
-    if(lenslist && !lenslist[1])
+    if(lenslist)
     {
       // create dummy modifier
       lfModifier *modifier = lf_modifier_new(lenslist[0], p->crop, self->dev->image_storage.width, self->dev->image_storage.height);
@@ -1875,7 +1875,7 @@ void gui_init(struct dt_iop_module_t *self)
     const lfLens **lenslist = lf_db_find_lenses_hd (dt_iop_lensfun_db, g->camera,
                               make [0] ? make : NULL,
                               model [0] ? model : NULL, LF_SEARCH_SORT_AND_UNIQUIFY);
-    if(lenslist && !lenslist[1]) lens_set (self, lenslist[0]);
+    if(lenslist) lens_set (self, lenslist[0]);
     lf_free (lenslist);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   }


### PR DESCRIPTION
It can _never_ be guaranteed that the return list of lenses of lensfun contains only one entry, even if the lens model name was exactly correct.  Lenses with a longer lens name (containing the shorter one) will also be returned.  However, it is guaranteed that the exact match will be returned as the zeroth list element.

Example to test: The 18-135mm Canon EF-S lens comes in two variants, one with STM and one without.  The short form is not auto-detected without this fix.  See e.g. the CR2 file linked in http://www.darktable.org/redmine/issues/9812
