### PR TITLE
Rework src/CMakeLists.txt: set dev. flags after building bundled libs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -394,6 +394,54 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 #
 # Build external deps
 #
+if(USE_LUA)
+  find_package(Lua52 5.2) # add EXACT if 5.3 doesn't work for us
+  if(LUA52_FOUND)
+    message(STATUS "Lua support: Enabled")
+    include_directories(SYSTEM ${LUA52_INCLUDE_DIRS})
+    list(APPEND LIBS ${LUA52_LIBRARIES})
+  else()
+    if(DONT_USE_INTERNAL_LUA)
+      message(STATUS "Lua support: System library not found (to use darktable's version use -DDONT_USE_INTERNAL_LUA=Off)")
+      set(USE_LUA OFF)
+    else(DONT_USE_INTERNAL_LUA)
+      message(STATUS "Lua support: System library not found (using darktable's version)")
+      include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/lua/src)
+      add_subdirectory(external/lua)
+      list(APPEND LIBS lua)
+    endif(DONT_USE_INTERNAL_LUA)
+  endif(LUA52_FOUND)
+
+  if(USE_LUA)
+    add_definitions("-DUSE_LUA")
+    FILE(GLOB SOURCE_FILES_LUA
+      "lua/call.c"
+      "lua/configuration.c"
+      "lua/database.c"
+      "lua/events.c"
+      "lua/film.c"
+      "lua/format.c"
+      "lua/glist.c"
+      "lua/gui.c"
+      "lua/image.c"
+      "lua/init.c"
+      "lua/lib.c"
+      "lua/lua.c"
+      "lua/luastorage.c"
+      "lua/modules.c"
+      "lua/preferences.c"
+      "lua/print.c"
+      "lua/storage.c"
+      "lua/styles.c"
+      "lua/tags.c"
+      "lua/types.c"
+      "lua/view.c"
+      )
+    set(SOURCES ${SOURCES} ${SOURCE_FILES_LUA})
+  endif(USE_LUA)
+else(USE_LUA)
+  message(STATUS "Lua support: Disabled")
+endif(USE_LUA)
 
 #
 # the libraw part is a bit of a hack:
@@ -614,6 +662,15 @@ add_subdirectory(cli)
 if(BUILD_CMSTEST)
   add_subdirectory(cmstest)
 endif(BUILD_CMSTEST)
+
+# build opengl slideshow viewer?
+if(BUILD_SLIDESHOW)
+  find_package(SDL)
+  find_package(OpenGL)
+  if(SDL_FOUND AND OPENGL_FOUND)
+    add_subdirectory(dtview)
+  endif(SDL_FOUND AND OPENGL_FOUND)
+endif(BUILD_SLIDESHOW)
 
 #
 # build darktable executable


### PR DESCRIPTION
PLEASE REVIEW CAREFULLY!

Fact: currently, if we set CFLAGS to -Werror, libraw will fail ()
Problem: we need to somehow be able to set CFLAGS to -Werror without affecting our external "bundled" sources.

Why? They are external dependencies, even if we will fix all issues [shown by -Werror] in them, we would need to upstream them, or updating them will be extremely difficult.

Solution:
1. set base cflags - optimisation only
2. build all bundled external source - src/external/*
3. append our development CFLAGS (-Werror ...)
4. build our sources

Additional benefit: -Werror is now can almost be enabled for clang too (no more fails in src/external/)
