### PR TITLE
For comments: limiting the thumbnail cache sizes to < 640x480 to better support large screens

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -668,8 +668,8 @@ void dt_mipmap_cache_init(dt_mipmap_cache_t *cache)
   // cache these, can't change at runtime:
   cache->mip[DT_MIPMAP_F].max_width  = wd;
   cache->mip[DT_MIPMAP_F].max_height = ht;
-  cache->mip[DT_MIPMAP_F-1].max_width  = wd;
-  cache->mip[DT_MIPMAP_F-1].max_height = ht;
+  cache->mip[DT_MIPMAP_F-1].max_width  = MIN(640,wd);
+  cache->mip[DT_MIPMAP_F-1].max_height = MIN(480,ht);
   for(int k=DT_MIPMAP_F-2; k>=DT_MIPMAP_0; k--)
   {
     cache->mip[k].max_width  = cache->mip[k+1].max_width  / 2;


### PR DESCRIPTION
Here's a quick hack that made darktable work much better in my current setup (limited memory, large screen). I set the DT_MIPMAP_3 size to 640x480 max, whatever the max_width and max_height was set to in the preferences. This gave me a larger number of slots for thumbnails while at the same time letting me fill the screen in darkroom and lighttable Z mode (partially fixing #9884).

Curious why this couldn't be the default. It seems creating very large thumbnails doesn't make much sense past a certain point. Even at 4K resolutions 640x480 would give you 6x4 thumbnails if you filled the whole space. Since the lighttable ads borders it will give you even more
