### PR TITLE
tif: use correct type for planar config

### DIFF
--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -156,7 +156,7 @@ dt_imageio_open_tiff(
     (void) dt_exif_read(img, filename);
 
   tiff_t t;
-  uint32_t config;
+  uint16_t config;
 
   t.image = img;
 


### PR DESCRIPTION
Fix import of TIF generated by DT itself, enfuse, align_stack_image
for example
