### PR TITLE
Fix bug #9888 my checking for db_info table

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -200,10 +200,10 @@ lock_again:
   /* now that we got a functional database we should make sure we won't be trampling on a
      darktable 1.5+ schema */
   sqlite3_stmt *stmt;
-  int rc = sqlite3_prepare_v2(db->handle, "select value from db_info where key = 'version'", -1, &stmt, NULL);
+  int rc = sqlite3_prepare_v2(db->handle, "select count(*) from db_info", -1, &stmt, NULL);
   if(rc == SQLITE_OK && sqlite3_step(stmt) == SQLITE_ROW) {
     // We're in a darktable 1.5+ database, abandon ship
-    fprintf(stderr, "[init] You seem to be trying to run darktable 1.4 on a 1.5+ database, aborting\n");
+    fprintf(stderr, "[init] error: can't open new database schema\n");
     sqlite3_close(db->handle);
     g_free(dbname);
     g_free(db->lockfile);


### PR DESCRIPTION
Darktable 1.4.1 will happily open a darktable 1.5+ database and then spew a bunch of errors. This has a risk  of database corruption. darktable 1.5 has a much fancier db versioning scheme but for 1.4.x all we need to do is check if the db_info table exists and if it does abort as we know we're in a 1.5+ database.
