### PR TITLE
PFM: change write algo

### DIFF
--- a/src/imageio/format/pfm.c
+++ b/src/imageio/format/pfm.c
@@ -52,7 +52,7 @@ int write_image (dt_imageio_module_data_t *data, const char *filename, const voi
       if(cnt != pfm->width) status = 1;
       else status = 0;
     }
-    free(buf_line);
+    dt_free_align(buf_line);
     buf_line = NULL;
     fclose(f);
   }


### PR DESCRIPTION
Measurements were performed on a series of export of 100 images for each write algorithm.
Images was exported to ST3000DM001-9YN166 using this dt-cli:

```
for i in `seq 1 100`
do
 /usr/local/bin/darktable-cli 5DM30001.CR2 5DM30001.CR2.xmp darktable_exported/5DM30001.pfm
done
```

Image history stack was empty - all modules that could be disabled was disabled.
Current implementation seems to be worst, and proposed seems to be best.

Spreadsheet with performance measurement results: [link](https://docs.google.com/spreadsheets/d/1h188xaHnrlR64_m_mlFKl_6ihzf7X0muK313SRihPnw/edit?usp=sharing)
SQL dump of measurements: [link](https://drive.google.com/file/d/0B0f1NIO0-n9AZGN6dlI3bHZIc00/edit?usp=sharing)
Query: 

```
SELECT `id`,`algo`,CONCAT(`meas_name`,' ',`measurement`) AS name,MIN(`value`),MAX(`value`),AVG(`value`),STD(`value`) FROM `data` GROUP BY `algo`,`name` ORDER BY `name` ASC
```
