### PR TITLE
IOP Levels: add automatic mode

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -296,6 +296,7 @@ dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt_dev
   module->histogram_params.roi = NULL;
   module->histogram_params.bins_count = 64;
   module->histogram_bins_count = 0;
+  module->histogram_pixels = 0;
   module->multi_priority = 0;
   for(int k=0; k<3; k++)
   {

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -241,6 +241,8 @@ typedef struct dt_iop_module_t
   dt_dev_histogram_params_t histogram_params;
   /** INFO: count of histogram bins during last histogram capture. */
   uint32_t histogram_bins_count;
+  /** INFO: count of pixels used during last histogram capture. */
+  uint32_t histogram_pixels;
   /** set to 1 if you want the mask to be transferred into alpha channel during next eval. gui mode only. */
   int32_t request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the module in focus. gui mode only. */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -332,6 +332,7 @@ histogram_collect(dt_iop_module_t *module, const void *pixel, const dt_iop_roi_t
   dt_histogram_max_helper(histogram_params, cst, histogram, histogram_max);
 
   module->histogram_bins_count = histogram_params->bins_count;
+  module->histogram_pixels = (roi->width - roi->x) * (roi->height - roi->y);
 
   free(histogram_params);
 }
@@ -376,6 +377,7 @@ histogram_collect_cl(int devid, dt_iop_module_t *module, cl_mem img, const dt_io
   dt_histogram_max_helper(histogram_params, cst, histogram, histogram_max);
 
   module->histogram_bins_count = histogram_params->bins_count;
+  module->histogram_pixels = (roi->width - roi->x) * (roi->height - roi->y);
 
   free(histogram_params);
   if(tmpbuf) dt_free_align(tmpbuf);

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -190,11 +190,7 @@ static void dt_iop_levels_compute_levels_automatic(dt_iop_module_t *self, dt_dev
 
   if(self->histogram == NULL) return;
 
-  uint32_t total = 0;
-  for(uint32_t i=0; i < self->histogram_params.bins_count; i++)
-  {
-    total += self->histogram[4*i];
-  }
+  uint32_t total = self->histogram_pixels;
 
   float thr[3];
   for(int k=0; k < 3; k++)


### PR DESCRIPTION
Now you can set black/gray/white percentiles, and store as a preset - will work as expected.
