### PR TITLE
Second (small) edit to user manual

### DIFF
--- a/doc/usermanual/lighttable/concepts/localcopies.xml
+++ b/doc/usermanual/lighttable/concepts/localcopies.xml
@@ -13,20 +13,19 @@
   </indexterm>
 
   <para>
-    Quite commonly users have huge image collections which they store on an external storage
-    medium like a RAID NAS. It is a frequent wish to be able to develop some of the images while
-    travelling using a notebook and later synchronize them to the external storage. Copying
-    images manually from external storage to the notebook and back is prone to errors and
-    cumbersome.
+    Many users have huge image collections which they store on an external storage
+    medium like a RAID NAS. So it is a common use case to develop some of the images while
+    travelling using a notebook and then later synchronize them to the external storage. But copying
+    images manually from external storage to the notebook and back is cumbersome and prone to errors.
   </para>
 
   <para>
-    The local copies feature of darktable has been designed to directly support those use cases.
-    With the help of this feature you can create local copies of selected pictures on the local
-    drive of your computer. This copy is then used when the original image is not accessible. At
-    a later point, when connected again with your external storage medium, you can synchronize
-    back the XMP sidecar files, deleting the local copy of your input image. These operations
-    can be found in the <quote>selected images</quote> panel (see
+    The <quote>cache locally</quote> feature of darktable has been designed to directly support
+    those use cases. You can create local copies of selected pictures on your computer's local
+    drive. This local copy is then used when the original image from external storage is not accessible.
+    At a later point, when connected again with your external storage medium, you can synchronize
+    the XMP sidecar files, deleting the local copy of your input image. These operations
+    can be found in the <emphasis>selected images</emphasis> panel (see
     <xref linkend="selected_images"/>).
   </para>
 


### PR DESCRIPTION
There is some inconsistency in the docs, where sometimes the feature in the _selected images_ panel of lighttable mode is referred to as "local copies" and sometimes it's called "local cache" or "cache locally." 

Here, my edits in `doc/usermanual/lighttable/concepts/localcopies.xml` changed "local copies" to "cache locally," to match the actual label on the button in Darktable. However, the user manual section title, section id, and file name still say "local copies." (Or "localcopies" or "local_copies"...) It seems to me that it would be better to change the title, id, file name, and all links and references to these to be "local _cache_" or something like that, to keep everything consistent. But I wanted to get some feedback before I changed things that much.

I also notice the use of `local_copies` in various `src` files. For the sake of consistency, it might help to also rename those functions, but I don't know C/++ well enough to feel comfortable making such changes.

What do you think?
