### PR TITLE
Make the colorpicker & geotagging button labels translatable.

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -332,7 +332,7 @@ static void _add_sample(GtkButton *widget, gpointer self)
   gtk_box_pack_start(GTK_BOX(sample->container), sample->output_label,
                      TRUE, TRUE, 0);
 
-  sample->delete_button = gtk_button_new_from_stock(GTK_STOCK_REMOVE);
+  sample->delete_button = gtk_button_new_with_label(_("remove"));
   gtk_box_pack_start(GTK_BOX(sample->container), sample->delete_button,
                      FALSE, FALSE, 0);
 
@@ -596,7 +596,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(data->samples_mode_selector), "changed",
                    G_CALLBACK(_samples_mode_changed), self);
 
-  data->add_sample_button = gtk_button_new_from_stock(GTK_STOCK_ADD);
+  data->add_sample_button = gtk_button_new_with_label(_("add"));
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->add_sample_button,
                      FALSE, FALSE, 0);

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -393,8 +393,8 @@ _lib_geotagging_show_offset_window(GtkWidget *widget, dt_lib_module_t *self)
   g_signal_connect(d->floating_window_entry, "key-press-event", G_CALLBACK(_lib_geotagging_floating_key_press), self);
 
   GtkWidget *hbox = gtk_hbox_new(TRUE, 5);
-  GtkWidget *cancel_button = gtk_button_new_from_stock(GTK_STOCK_CANCEL);
-  GtkWidget *ok_button = gtk_button_new_from_stock(GTK_STOCK_OK);
+  GtkWidget *cancel_button = gtk_button_new_with_label(_("cancel"));
+  GtkWidget *ok_button = gtk_button_new_with_label(_("ok"));
 
   gtk_box_pack_start(GTK_BOX(hbox), cancel_button, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), ok_button, TRUE, TRUE, 0);


### PR DESCRIPTION
This is to control the casing of the button as dt style is to be
all lower-case.

For #9998.
