### PR TITLE
Variable number of "grid" crop guides

### DIFF
--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -13,19 +13,27 @@ dt_guides_q_rect(dt_QRect_t *R1, float left, float top, float width, float heigh
 
 
 void
-dt_guides_draw_simple_grid(cairo_t *cr, const float left, const float top,  const float right, const float bottom, float zoom_scale)
+dt_guides_draw_simple_grid(cairo_t *cr, const float left, const float top,  const float right, const float bottom, float zoom_scale, int num_cells)
 {
-  // cairo_set_operator(cr, CAIRO_OPERATOR_XOR);
-  cairo_set_line_width(cr, 1.0/zoom_scale);
-  cairo_set_source_rgb(cr, .2, .2, .2);
-  dt_draw_grid(cr, 3, left, top, right, bottom);
-  cairo_translate(cr, 1.0/zoom_scale, 1.0/zoom_scale);
-  cairo_set_source_rgb(cr, .8, .8, .8);
-  dt_draw_grid(cr, 3, left, top, right, bottom);
+  //cairo_set_operator(cr, CAIRO_OPERATOR_XOR);
+
+  // draw all grid lines
   cairo_set_source_rgba(cr, .8, .8, .8, 0.5);
   double dashes = 5.0/zoom_scale;
   cairo_set_dash(cr, &dashes, 1, 0);
-  dt_draw_grid(cr, 9, left, top, right, bottom);
+  dt_draw_grid(cr, num_cells, left, top, right, bottom);
+
+  // draw highlights:
+  cairo_set_line_width(cr, 1.0/zoom_scale);
+  cairo_set_source_rgb(cr, .9, .9, .9);
+
+  // thirds...
+  if (num_cells%3 == 0)
+    dt_draw_grid(cr, 3, left, top, right, bottom);
+
+  // ...and centers
+  if (num_cells % 2 == 0)
+    dt_draw_grid(cr, 2, left, top, right, bottom);
 }
 
 

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -28,7 +28,7 @@ dt_QRect_t;
 
 void dt_guides_q_rect(dt_QRect_t *R1, float left, float top, float width, float height);
 
-void dt_guides_draw_simple_grid(cairo_t *cr, const float left, const float top,  const float right, const float bottom, float zoom_scale);
+void dt_guides_draw_simple_grid(cairo_t *cr, const float left, const float top,  const float right, const float bottom, float zoom_scale, int num_cells);
 
 void dt_guides_draw_diagonal_method(cairo_t *cr, const float x, const float y, const float w, const float h);
 

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -93,7 +93,7 @@ typedef struct dt_lib_live_view_t
 
   GtkWidget *live_view, *live_view_zoom, *rotate_ccw, *rotate_cw, *flip;
   GtkWidget *focus_out_small, *focus_out_big, *focus_in_small, *focus_in_big;
-  GtkWidget *guide_selector, *flip_guides, *golden_extras;
+  GtkWidget *guide_selector, *flip_guides, *golden_extras, *grid_cells;
   GtkWidget *overlay, *overlay_id_box, *overlay_id, *overlay_mode, *overlay_splitline;
 }
 dt_lib_live_view_t;
@@ -111,6 +111,11 @@ guides_presets_changed (GtkWidget *combo, dt_lib_live_view_t *lib)
     gtk_widget_set_visible(GTK_WIDGET(lib->golden_extras), TRUE);
   else
     gtk_widget_set_visible(GTK_WIDGET(lib->golden_extras), FALSE);
+
+  if (which == GUIDE_GRID)
+    gtk_widget_set_visible(GTK_WIDGET(lib->grid_cells), TRUE);
+  else
+    gtk_widget_set_visible(GTK_WIDGET(lib->grid_cells), FALSE);
 }
 
 static void
@@ -354,6 +359,12 @@ gui_init (dt_lib_module_t *self)
   dt_bauhaus_combobox_add(lib->golden_extras, _("all"));
   g_object_set(G_OBJECT(lib->golden_extras), "tooltip-text", _("show some extra guides"), (char *)NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), lib->golden_extras, TRUE, TRUE, 0);
+
+  lib->grid_cells = dt_bauhaus_slider_new_with_range(NULL, 1.0, 30.0, 1.0, 9.0, 0.0);
+  dt_bauhaus_widget_set_label(lib->grid_cells, NULL, _("grid cells"));
+  dt_bauhaus_slider_set_format(lib->grid_cells, "%.0f");
+  g_object_set(G_OBJECT(lib->grid_cells), "tooltip-text", _("number of grid cells"), (char *)NULL);
+  gtk_box_pack_start(GTK_BOX(self->widget), lib->grid_cells, TRUE, TRUE, 0);
 
   lib->overlay = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(lib->overlay, NULL, _("overlay"));
@@ -677,7 +688,7 @@ gui_post_expose(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t heigh
   switch(which)
   {
     case GUIDE_GRID:
-      dt_guides_draw_simple_grid(cr, left, top, right, bottom, 1.0);
+      dt_guides_draw_simple_grid(cr, left, top, right, bottom, 1.0, dt_bauhaus_slider_get(lib->grid_cells));
       break;
 
     case GUIDE_DIAGONAL:


### PR DESCRIPTION
When cropping an image using "grid" guides, user has no control over the grid size. I thought it would be a nice feature to make grid size variable, and sources confirm that such idea has been considered earlier (iop/clipping.c: "TODO: make the number of lines configurable with a slider?").

Following patch adds "grid cells" slider to "grid" crop guides. Value can now be set anywhere between 2 (lowest value that make sense) and 30 (to allow "thirds" split with high, but reasonable number of cells). Defaults to 9 for backward compatibility.

I've kept the feature of "highlighting" guides that split the view in thirds, if applicable. Additionally, I've added highlights for guides that split the view in halves.
