### PR TITLE
Fix regression, bump masks version

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -280,7 +280,7 @@ error:
   return 1;
 }
 
-int
+static int
 dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt_develop_t *dev)
 {
   module->dt = &darktable;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -409,8 +409,6 @@ typedef struct dt_iop_module_t
 }
 dt_iop_module_t;
 
-int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, struct dt_develop_t *dev);
-
 /** loads and inits the modules in the plugins/ directory. */
 void dt_iop_load_modules_so();
 /** cleans up the dlopen refs. */


### PR DESCRIPTION
So, this is basically it.

TODO:
~~3. Implement magic button that will (semi-manually) recover masks created with DT version between 0a3a5574fdc9b33792fda4d29be8445545ea8a92 and `this pr merge commit`.~~ not needed.
