### PR TITLE
Fix the Nikon D5100 white point

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -1117,7 +1117,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-46" height="0"/>
-		<Sensor black="0" white="65536"/>
+		<Sensor black="0" white="15892"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3100"  decoder_version="2">
 		<CFA width="2" height="2">


### PR DESCRIPTION
Fix the bogus 65536 value set in cameras.xml to the one the Adobe DNG converter reports. I don't think this makes an actual difference as the rawspeed NEF decoder probably sets its own whitepoint and ignores this value. Still, no reason not to have the right one in the file.
