### PR TITLE
Swap red/blue pixels on the NX300 so demosaic works properly

### DIFF
--- a/src/external/rawspeed/RawSpeed/SrwDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/SrwDecoder.cpp
@@ -181,6 +181,19 @@ void SrwDecoder::decodeCompressed( TiffIFD* raw )
       img_up2 += 16;
     }
   }
+
+  // Swap red and blue pixels to get the final CFA pattern
+  for (uint32 y = 0; y < height-1; y+=2) {
+    ushort16* topline = (ushort16*)mRaw->getData(0, y);
+    ushort16* bottomline = (ushort16*)mRaw->getData(0, y+1);
+    for (uint32 x = 0; x < width-1; x += 2) {
+      ushort16 temp = topline[1];
+      topline[1] = bottomline[0];
+      bottomline[0] = temp;
+      topline += 2;
+      bottomline += 2;
+    }
+  }
 }
 
 

--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -4100,8 +4100,8 @@
 	<Camera make="SAMSUNG" model="NX300" decoder_version="3">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
 			<Color x="1" y="1">GREEN</Color>
 		</CFA>
 		<Crop x="45" y="25" width="-11" height="-29"/>


### PR DESCRIPTION
Either the red and blue pixels are swapped in the data when compared to their physical positions or the dcraw decoding method produces an image with that swap that then needs to be undone. The rawspeed code seems to be a cleaner version of the dcraw code but without the final swap step.
