### PR TITLE
Allow WB coefficients where the second is 1.0f

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -483,7 +483,7 @@ void reload_defaults(dt_iop_module_t *module)
       {
         for(int k=0; k<3; k++) tmp.coeffs[k] = raw->color.pre_mul[k];
       }
-      if(tmp.coeffs[0] == 0 || tmp.coeffs[2] == 0)
+      if(tmp.coeffs[0] == 0 || tmp.coeffs[1] == 0 || tmp.coeffs[2] == 0)
       {
         // could not get useful info, try presets:
         for(int i=0; i<wb_preset_count; i++)
@@ -504,7 +504,7 @@ void reload_defaults(dt_iop_module_t *module)
       if (!(!strncmp(module->dev->image_storage.exif_maker, "Leica Camera AG", 15) && !strncmp(module->dev->image_storage.exif_model, "M9 monochrom", 12)))
       {
         dt_control_log(_("failed to read camera white balance information!"));
-        fprintf(stderr, "[temperature] failed to read camera white balance information!\n"));
+        fprintf(stderr, "[temperature] failed to read camera white balance information!\n");
 
         // final security net: hardcoded default that fits most cams.
         tmp.coeffs[0] = 2.0f;


### PR DESCRIPTION
The temperature.c revamp didn't like cameras that have the coefficients in the form (X;1,0;Z) which is actually the canonical form the code tries to arrive at.
