### PR TITLE
Fix the fuji rotated size to match dcraw exactly

### DIFF
--- a/src/external/rawspeed/RawSpeed/RafDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/RafDecoder.cpp
@@ -171,7 +171,7 @@ void RafDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
       rotationPos = new_size.x - 1;
     }
 
-    iPoint2D final_size(rotatedsize, rotatedsize);
+    iPoint2D final_size(rotatedsize, rotatedsize-1);
     RawImage rotated = RawImage::create(final_size, TYPE_USHORT16, 1);
     rotated->clearArea(iRectangle2D(iPoint2D(0,0), rotated->dim));
     rotated->fujiRotationPos = rotationPos;

--- a/src/external/rawspeed/RawSpeed/RawImage.h
+++ b/src/external/rawspeed/RawSpeed/RawImage.h
@@ -98,9 +98,8 @@ public:
   uint32 mBadPixelMapPitch;
   bool mDitherScale;           // Should upscaling be done with dither to minimize banding?
 
-  // How many pixels far down the left edge the image corner is when the image
-  // is rotated 45 degrees in Fuji rotated sensors.
-  // On the right edge the opposite corner is fujiRotationPos+1 from the bottom.
+  // How many pixels far down the left edge and far up the right edge the image 
+  // corners are when the image is rotated 45 degrees in Fuji rotated sensors.
   uint32 fujiRotationPos;
 
   // Aspect ratio of the pixels, usually 1 but some cameras need scaling


### PR DESCRIPTION
The rotated image raws in the fujis that need rotation doesn't need to be square, it can have one less pixel. That way the image corners end up the same number of pixels from the pre-rotation corners, which may help in the 45degree rotation.
