### PR TITLE
ensure to leave preview mode when exiting lighttable

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -956,7 +956,7 @@ int dt_control_key_pressed_override(guint key, guint state)
     dt_conf_set_bool(key, header);
 
     /* show/hide the actual header panel */
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, header);
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, header, TRUE);
     gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
     return 1;
   }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -256,14 +256,14 @@ borders_button_pressed (GtkWidget *w, GdkEventButton *event, gpointer user_data)
     case 0: // left border
     {
       g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name, _ui_panel_config_names[DT_UI_PANEL_LEFT]);
-      dt_ui_panel_show(ui, DT_UI_PANEL_LEFT, !dt_conf_get_bool(key));
+      dt_ui_panel_show(ui, DT_UI_PANEL_LEFT, !dt_conf_get_bool(key), TRUE);
     }
     break;
 
     case 1:  // right border
     {
       g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name, _ui_panel_config_names[DT_UI_PANEL_RIGHT]);
-      dt_ui_panel_show(ui, DT_UI_PANEL_RIGHT, !dt_conf_get_bool(key));
+      dt_ui_panel_show(ui, DT_UI_PANEL_RIGHT, !dt_conf_get_bool(key), TRUE);
     }
     break;
 
@@ -271,12 +271,12 @@ borders_button_pressed (GtkWidget *w, GdkEventButton *event, gpointer user_data)
     {
       g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name, _ui_panel_config_names[DT_UI_PANEL_CENTER_TOP]);
       gboolean show = !dt_conf_get_bool(key);
-      dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_TOP, show);
+      dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_TOP, show, TRUE);
 
       /* special case show header */
       g_snprintf(key, sizeof(key), "%s/ui/show_header", cv->module_name);
       if (dt_conf_get_bool(key))
-        dt_ui_panel_show(ui, DT_UI_PANEL_TOP, show);
+        dt_ui_panel_show(ui, DT_UI_PANEL_TOP, show, TRUE);
 
     }
     break;
@@ -286,8 +286,8 @@ borders_button_pressed (GtkWidget *w, GdkEventButton *event, gpointer user_data)
     {
       g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name, _ui_panel_config_names[DT_UI_PANEL_CENTER_BOTTOM]);
       gboolean show = !dt_conf_get_bool(key);
-      dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_BOTTOM, show);
-      dt_ui_panel_show(ui, DT_UI_PANEL_BOTTOM, show);
+      dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_BOTTOM, show, TRUE);
+      dt_ui_panel_show(ui, DT_UI_PANEL_BOTTOM, show, TRUE);
     }
     break;
   }
@@ -1336,7 +1336,7 @@ void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui)
   {
     /* restore previous panel view states */
     for (int k=0; k<DT_UI_PANEL_SIZE; k++)
-      dt_ui_panel_show(ui, k, (state>>k)&1);
+      dt_ui_panel_show(ui, k, (state>>k)&1, TRUE);
 
     /* reset state */
     state = 0;
@@ -1349,7 +1349,7 @@ void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui)
 
     /* hide all panels */
     for (int k=0; k<DT_UI_PANEL_SIZE; k++)
-      dt_ui_panel_show(ui, k, FALSE);
+      dt_ui_panel_show(ui, k, FALSE, TRUE);
   }
 
   /* store new state */
@@ -1369,7 +1369,7 @@ void dt_ui_restore_panels(dt_ui_t *ui)
   {
     /* hide all panels */
     for (int k=0; k<DT_UI_PANEL_SIZE; k++)
-      dt_ui_panel_show(ui, k, FALSE);
+      dt_ui_panel_show(ui, k, FALSE, TRUE);
   }
   else
   {
@@ -1403,16 +1403,19 @@ void dt_ui_border_show(dt_ui_t *ui, gboolean show)
   }
 }
 
-void dt_ui_panel_show(dt_ui_t *ui,const dt_ui_panel_t p, gboolean show)
+void dt_ui_panel_show(dt_ui_t *ui,const dt_ui_panel_t p, gboolean show, gboolean write)
 {
   //if(!GTK_IS_WIDGET(ui->panels[p])) return;
   g_return_if_fail(GTK_IS_WIDGET(ui->panels[p]));
 
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-  g_snprintf(key, sizeof(key), "%s/ui/%s_visible",cv->module_name, _ui_panel_config_names[p]);
-  dt_conf_set_bool(key, show);
-
+  if (write)
+  {
+    char key[512];
+    g_snprintf(key, sizeof(key), "%s/ui/%s_visible",cv->module_name, _ui_panel_config_names[p]);
+    dt_conf_set_bool(key, show);
+  }
+  
   if(show)
     gtk_widget_show(ui->panels[p]);
   else

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -191,7 +191,7 @@ void dt_ui_container_focus_widget(struct dt_ui_t *ui, const dt_ui_container_t c,
 /** \brief removes all child widgets from container */
 void dt_ui_container_clear(struct dt_ui_t *ui, const dt_ui_container_t c);
 /** \brief shows/hide a panel */
-void dt_ui_panel_show(struct dt_ui_t *ui,const dt_ui_panel_t, gboolean show);
+void dt_ui_panel_show(struct dt_ui_t *ui,const dt_ui_panel_t, gboolean show, gboolean write);
 /** show or hide outermost borders with expand arrows */
 void dt_ui_border_show(struct dt_ui_t *ui, gboolean show);
 /** \brief restore saved state of panel visibility for current view */

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1458,6 +1458,17 @@ void leave(dt_view_t *self)
   dt_library_t *lib = (dt_library_t *)self->data;
   lib->button = 0;
   lib->pan = 0;
+  
+  // exit the full preview state if needed
+  if (lib->full_preview_id !=-1)
+  {
+    lib->full_preview_id = -1;
+    lib->full_preview_rowid = -1;
+    dt_control_set_mouse_over_id(-1);
+    
+    lib->full_preview = 0;
+    lib->display_focus = 0;
+  }
 }
 
 void reset(dt_view_t *self)
@@ -1725,11 +1736,11 @@ int key_released(dt_view_t *self, guint key, guint state)
     lib->full_preview_rowid = -1;
     dt_control_set_mouse_over_id(-1);
 
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT,   ( lib->full_preview & 1));
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT,  ( lib->full_preview & 2));
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, ( lib->full_preview & 4));
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP,    ( lib->full_preview & 8));
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP,    ( lib->full_preview & 16));
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT,   ( lib->full_preview & 1), FALSE);
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT,  ( lib->full_preview & 2), FALSE);
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, ( lib->full_preview & 4), FALSE);
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP,    ( lib->full_preview & 8), FALSE);
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP,    ( lib->full_preview & 16), FALSE);
 
     lib->full_preview = 0;
     lib->display_focus = 0;
@@ -1775,15 +1786,15 @@ int key_pressed(dt_view_t *self, guint key, guint state)
 
       // let's hide some gui components
       lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_LEFT)&1) << 0;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE);
+      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE, FALSE);
       lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_RIGHT)&1) << 1;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE);
+      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE, FALSE);
       lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM)&1) << 2;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, FALSE);
+      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, FALSE, FALSE);
       lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP)&1) << 3;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, FALSE);
+      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, FALSE, FALSE);
       lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_TOP)&1) << 4;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE);
+      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, FALSE);
 
       // preview with focus detection
       if (state == accels->lighttable_preview_display_focus.accel_mods) {

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -326,10 +326,10 @@ void enter(dt_view_t *self)
 {
   dt_slideshow_t *d = (dt_slideshow_t*)self->data;
 
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, FALSE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE, TRUE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE, TRUE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, TRUE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, FALSE, TRUE);
   // also hide arrows
   dt_ui_border_show(darktable.gui->ui, FALSE);
 


### PR DESCRIPTION
correct some ui problem when one enter darkroom by pressing d when watching images in full preview. When you go back to lighttable, your are still in full preview mode (even without the z key pressed) and panels are hiden.
