### PR TITLE
CLI: prevent XMP file overriding

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -140,6 +140,8 @@ int main(int argc, char *arg[])
   m_arg[m_argc++] = "darktable-cli";
   m_arg[m_argc++] = "--library";
   m_arg[m_argc++] = ":memory:";
+  m_arg[m_argc++] = "--conf";
+  m_arg[m_argc++] = "write_sidecar_files=FALSE";
   for(; k < argc; k++) m_arg[m_argc++] = arg[k];
   m_arg[m_argc] = NULL;
 


### PR DESCRIPTION
Fixes bugreport in dt-dev from Joerg Beyer
