### PR TITLE
Exposure IOP: disable Deflicker for 1.6 release

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -202,6 +202,7 @@ legacy_params (dt_iop_module_t *self, const void *const old_params, const int ol
   return 1;
 }
 
+/*
 void init_presets (dt_iop_module_so_t *self)
 {
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "begin", NULL, NULL, NULL);
@@ -217,6 +218,7 @@ void init_presets (dt_iop_module_so_t *self)
 
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "commit", NULL, NULL, NULL);
 }
+*/
 
 static void
 deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histogram,
@@ -945,8 +947,10 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->mode, C_("mode", "manual"));
   g->modes = g_list_append(g->modes, GUINT_TO_POINTER(EXPOSURE_MODE_MANUAL));
 
+/*
   dt_bauhaus_combobox_add(g->mode, _("automatic"));
   g->modes = g_list_append(g->modes, GUINT_TO_POINTER(EXPOSURE_MODE_DEFLICKER));
+*/
 
   dt_bauhaus_combobox_set_default(g->mode, 0);
   dt_bauhaus_combobox_set(g->mode, g_list_index(g->modes, GUINT_TO_POINTER(p->mode)));


### PR DESCRIPTION
It is not fully ready.

The exact problem: calculated exposure compensation for same params
(target level and percentile) differs between my deflicker implementation
and "reference implementation" (ML deflick.mo)

Fix _will_ alter computation results(computed exposure), and that is accepteble
only for something that was not released yet.

This does not break old (1.5) history stacks.

!!! TO BE REVERTED ONCE 1.6 IS RELEASED !!!
