### PR TITLE
Backport enough dcraw code to get WB for NX3000

### DIFF
--- a/src/external/LibRaw/internal/dcraw_common.cpp
+++ b/src/external/LibRaw/internal/dcraw_common.cpp
@@ -5543,6 +5543,15 @@ int CLASS parse_tiff_ifd (int base)
 #ifdef LIBRAW_LIBRARY_BUILD
         color_flags.rgb_cam_state = LIBRAW_COLORSTATE_LOADED;
 #endif
+        break;
+      case 40976:
+	strip_offset = get4();
+	switch (tiff_ifd[ifd].comp) {
+    /* These are wrong, should be samsung_load_raw and samsung2_load_raw, we
+       just have this here to enable just enough parsing to get the whitebalance */
+	  case 32770: load_raw = &CLASS packed_load_raw;  break;
+	  case 32772: load_raw = &CLASS packed_load_raw;
+	}
 	break;
       case 46275:			/* Imacon tags */
 	strcpy (make, "Imacon");
@@ -5943,9 +5952,9 @@ void CLASS apply_tiff()
 #endif
     }
   if (!dng_version)
-    if ( (tiff_samples == 3 && tiff_ifd[raw].bytes &&
-	  tiff_bps != 14 && tiff_bps != 2048 && tiff_compress != 32770)
-      || (tiff_bps == 8 && !strstr(make,"KODAK") && !strstr(make,"Kodak") &&
+    if ( (tiff_samples == 3 && tiff_ifd[raw].bytes && tiff_bps != 14 &&
+	  (tiff_compress & -16) != 32768)
+      || (tiff_bps == 8 && !strcasestr(make,"Kodak") &&
 	  !strstr(model2,"DEBUG RAW")))
       is_raw = 0;
   for (i=0; i < tiff_nifds; i++)


### PR DESCRIPTION
Should fix bug #10146
