### PR TITLE
Fix: Set offset_changed to FALSE after rendering

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -826,6 +826,8 @@ after_drawing:
     }
   }
 
+  lib->offset_changed = FALSE;
+
   free(query_ids);
   //oldpan = pan;
   if(darktable.unmuted & DT_DEBUG_CACHE)


### PR DESCRIPTION
Before that patch, the logic is:

gboolean offset_changed = FALSE;
offset_changed = lib->offset_changed;
/\* check if offset was changed and we need to prefetch thumbs */
if (offset_changed)
{
 ...
}

But lib->offset_changed was never set to FALSE once it became true. This patch sets it to FALSE after rendering once.
