### PR TITLE
reload_defaults before gui_update/gui_init when changing images

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -583,6 +583,7 @@ dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
     if (module->multi_priority == mp_base) //if the module is the "base" instance, we keep it
     {
       module->multi_priority = 0;
+      dt_iop_reload_defaults(module);
       dt_iop_gui_update(module);
     }
     else  //else we delete it and remove it from the panel
@@ -618,6 +619,7 @@ dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
     {
       if (!dt_iop_is_hidden(module))
       {
+        dt_iop_reload_defaults(module);
         module->gui_init(module);
         //we search the base iop corresponding
         GList *mods = g_list_first(dev->iop);


### PR DESCRIPTION
This fixes the colorin bug for me (no more warning) and seems to be quite stable. I'm not sure about the second change in the diff though as it only happens on multiple instance modules. It does seem like we should always do reload_defaults before gui_update/gui_init so it looks right. The order of events is now:

```
# Open a D1x NEF in darkroom
3 Running reload_defaults for colorin
3 Running gui_init for colorin
3 Running reload_defaults for colorin
3 Running gui_update for colorin
3 Running gui_update for colorin

# Press space to move to the next image
4 Running reload_defaults for colorin
4 Running gui_update for colorin
4 Running reload_defaults for colorin
4 Running gui_update for colorin
3 Running reload_defaults for colorin
4 Running gui_update for colorin

# Press backspace to move back
3 Running reload_defaults for colorin
3 Running gui_update for colorin
3 Running reload_defaults for colorin
3 Running gui_update for colorin
4 Running reload_defaults for colorin
3 Running gui_update for colorin
```

We're still doing a lot of extra calls of course. On export we still only do 1 reload_defaults call so that's still correct.
