### PR TITLE
Fix D750 12-bit RAW format support (correct black/white level)

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -1560,20 +1560,6 @@
 		<Crop x="2" y="0" width="4282" height="2844"/>
 		<Sensor black="0" white="16383"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="12bit-uncompressed">
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="150" white="3880"/>
-		<Hints>
-			<Hint name="msb_override" value=""/>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="12bit-compressed">
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -1584,20 +1570,6 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="150" white="3880"/>
 		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D750" mode="14bit-uncompressed">
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="600" white="15520"/>
-		<Hints>
-			<Hint name="msb_override" value=""/>
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>


### PR DESCRIPTION
This adds all four RAW modes for the Nikon D750 (copied from D810).
