### PR TITLE
Lens IOP: fix 2 issues

### DIFF
--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1116,6 +1116,24 @@ void reload_defaults(dt_iop_module_t *module)
       const lfLens **lens = lf_db_find_lenses_hd(gd->db, cam[0], NULL,
                                                  tmp.lens, LF_SEARCH_SORT_AND_UNIQUIFY);
       dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
+
+      if(!lens && islower(cam[0]->Mount[0]))
+      {
+        /*
+         * This is a fixed-lens camera, and LF returned no lens.
+         * (reasons: lens is "(65535)" or lens is correct lens name,
+         *  but LF have it as "fixed lens")
+         *
+         * Let's unset lens name and re-run lens query
+         */
+        g_strlcpy(tmp.lens, "", sizeof(tmp.lens));
+
+        dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
+        lens = lf_db_find_lenses_hd(gd->db, cam[0], NULL,
+                                    tmp.lens, LF_SEARCH_SORT_AND_UNIQUIFY);
+        dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
+      }
+
       if(lens)
       {
         int lens_i = 0;


### PR DESCRIPTION
First one is for those rare cases when lens is non-rectilienar (fisheye), we would not only fix distortions, but also convert geometry to rectilinear [#8493](http://www.darktable.org/redmine/issues/8493)

And second one is for lens auto-detection for fixed-lens cameras. Such images contains no info about lens in EXIF, but we can reliably detect such cases due to LenFun, and set correct lens automatically [#9028](http://www.darktable.org/redmine/issues/9028)

Note that [#9028](http://www.darktable.org/redmine/issues/9028) is a feature request, however the fix is pretty straight-forward and robust, and without it, ALL images from fixed-lens cameras require manual lens selection - takes a lot of time.
So IMO it should be merged, even now that we are in feature freeze.
