### PR TITLE
MI: really use MI names stored in history items

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -729,6 +729,9 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
     memcpy(hist->module->blend_params, hist->blend_params, sizeof(dt_develop_blend_params_t));
 
     hist->module->enabled = hist->enabled;
+    if (hist->multi_name) snprintf(hist->module->multi_name, sizeof(hist->module->multi_name), "%s", hist->multi_name);
+    else memset(hist->module->multi_name, 0, sizeof(hist->module->multi_name));
+
     history = g_list_next(history);
   }
   // update all gui modules
@@ -921,8 +924,8 @@ void dt_dev_read_history(dt_develop_t *dev)
         if (module->multi_priority == multi_priority)
         {
           hist->module = module;
-          if(multi_name && strcmp(module->multi_name, multi_name))
-            snprintf(module->multi_name, sizeof(module->multi_name), "%s", multi_name);
+          if(multi_name) snprintf(module->multi_name, sizeof(module->multi_name), "%s", multi_name);
+          else memset(module->multi_name, 0, sizeof(module->multi_name));
           break;
         }
         else if (multi_priority > 0)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -909,6 +909,12 @@ void dt_iop_gui_update_header(dt_iop_module_t *module)
   _iop_gui_update_header(module);
 }
 
+static void _iop_gui_update_label(dt_iop_module_t *module)
+{
+  if (!module->header) return;
+  GtkWidget *lab = g_list_nth_data(gtk_container_get_children(GTK_CONTAINER(module->header)),5);
+  _iop_panel_label(lab, module);
+}
 
 void dt_iop_reload_defaults(dt_iop_module_t *module)
 {
@@ -1301,6 +1307,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
     module->gui_update(module);
     dt_iop_gui_update_blending(module);
     dt_iop_gui_update_expanded(module);
+    _iop_gui_update_label(module);
     if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), module->enabled);
   }
   darktable.gui->reset = reset;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -192,7 +192,11 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
   {
     dt_dev_history_item_t *hitem = (dt_dev_history_item_t *)(history->data);
 
-    gchar *label = dt_history_item_get_name(hitem->module);
+    gchar *label;
+    if(!hitem->multi_name[0] || strcmp(hitem->multi_name, "0") == 0)
+      label = g_strdup_printf("%s", hitem->module->name());
+    else label = g_strdup_printf("%s %s", hitem->module->name(), hitem->multi_name);
+
     GtkWidget *widget =_lib_history_create_button(self,num,label,hitem->enabled);
     g_free(label);
 


### PR DESCRIPTION
Solve 2 bugs : 
- history lib : display the multi name contained in the history item, instead of the one of the one actually set for the module instance.
- when rewind to a previous history item, rename the module instance whith the name stored in the history item.
  All this because module instance name may change in time: for ex : when copy/paste an instance with a different name.

I think this is safe to merge (mainly cosmetic changes) but feel free to comment or delay after 1.6
