### PR TITLE
Fix a few external dependencies detection.

### DIFF
--- a/cmake/modules/FindColord.cmake
+++ b/cmake/modules/FindColord.cmake
@@ -2,10 +2,10 @@ SET(COLORD_FIND_REQUIRED ${Colord_FIND_REQUIRED})
 
 include(Prebuilt)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (PKG_CONFIG_FOUND)
   include(FindPkgConfig)
   pkg_check_modules(COLORD colord)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+endif (PKG_CONFIG_FOUND)
 
 if (COLORD_FOUND)
   set(COLORD ON CACHE BOOL "Build with libcolord support.")

--- a/cmake/modules/FindDBUSGLIB.cmake
+++ b/cmake/modules/FindDBUSGLIB.cmake
@@ -1,9 +1,9 @@
 include(Prebuilt)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (PKG_CONFIG_FOUND)
   include(FindPkgConfig)
   pkg_check_modules(DBUSGLIB REQUIRED dbus-glib-1)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+endif (PKG_CONFIG_FOUND)
 
 if (DBUSGLIB_FOUND)
   set(DBUSGLIB ON CACHE BOOL "Build with dbus-glib message bus support.")

--- a/cmake/modules/FindVTE.cmake
+++ b/cmake/modules/FindVTE.cmake
@@ -1,9 +1,9 @@
 include(Prebuilt)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (PKG_CONFIG_FOUND)
   include(FindPkgConfig)
   pkg_check_modules(VTE vte)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+endif (PKG_CONFIG_FOUND)
 
 if (VTE_FOUND)
   set(VTE ON CACHE BOOL "Build with VTE support.")


### PR DESCRIPTION
Hello, would you consider to merge this commit? It specify to check a few pkg-config based dependencies based on the fact that pkg-config is available, not on the condition the OS is Linux (since they can be available on other systems such as BSDs or osX).

Thanks
