### PR TITLE
Generalize c9f81bb fix to FindColor, FindDBUSGLIB and FindVTE modules.

### DIFF
--- a/cmake/modules/FindColord.cmake
+++ b/cmake/modules/FindColord.cmake
@@ -1,11 +1,16 @@
 SET(COLORD_FIND_REQUIRED ${Colord_FIND_REQUIRED})
 
 include(Prebuilt)
+include(LibFindMacros)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  include(FindPkgConfig)
-  pkg_check_modules(COLORD colord)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+libfind_pkg_check_modules(COLORD colord)
+foreach(i ${COLORD_LIBRARIES})
+  find_library(_colord_LIBRARY NAMES ${i} HINTS ${COLORD_LIBRARY_DIRS})
+  list(APPEND COLORD_LIBRARY ${_colord_LIBRARY})
+  unset(_colord_LIBRARY CACHE)
+endforeach(i)
+set(COLORD_LIBRARIES ${COLORD_LIBRARY})
+unset(COLORD_LIBRARY CACHE)
 
 if (COLORD_FOUND)
   set(COLORD ON CACHE BOOL "Build with libcolord support.")

--- a/cmake/modules/FindDBUSGLIB.cmake
+++ b/cmake/modules/FindDBUSGLIB.cmake
@@ -1,9 +1,14 @@
 include(Prebuilt)
+include(LibFindMacros)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  include(FindPkgConfig)
-  pkg_check_modules(DBUSGLIB REQUIRED dbus-glib-1)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+libfind_pkg_check_modules(DBUSGLIB dbus-glib-1)
+foreach(i ${DBUSGLIB_LIBRARIES})
+  find_library(_dbusglib_LIBRARY NAMES ${i} HINTS ${DBUSGLIB_LIBRARY_DIRS})
+  list(APPEND DBUSGLIB_LIBRARY ${_dbusglib_LIBRARY})
+  unset(_dbusglib_LIBRARY CACHE)
+endforeach(i)
+set(DBUSGLIB_LIBRARIES ${DBUSGLIB_LIBRARY})
+unset(DBUSGLIB_LIBRARY CACHE)
 
 if (DBUSGLIB_FOUND)
   set(DBUSGLIB ON CACHE BOOL "Build with dbus-glib message bus support.")

--- a/cmake/modules/FindVTE.cmake
+++ b/cmake/modules/FindVTE.cmake
@@ -1,9 +1,14 @@
 include(Prebuilt)
+include(LibFindMacros)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  include(FindPkgConfig)
-  pkg_check_modules(VTE vte)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+libfind_pkg_check_modules(VTE vte)
+foreach(i ${VTE_LIBRARIES})
+  find_library(_vte_LIBRARY NAMES ${i} HINTS ${VTE_LIBRARY_DIRS})
+  list(APPEND VTE_LIBRARY ${_vte_LIBRARY})
+  unset(_vte_LIBRARY CACHE)
+endforeach(i)
+set(VTE_LIBRARIES ${VTE_LIBRARY})
+unset(VTE_LIBRARY CACHE)
 
 if (VTE_FOUND)
   set(VTE ON CACHE BOOL "Build with VTE support.")


### PR DESCRIPTION
As discussed in a previous pull request, could a few pkg-config based library search be fixed for non-linux platforms? Those are based on c9f81bb, and were tested on FreeBSD and MacOSX.
