### PR TITLE
When exporting with a style we want to append the modules.

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -274,6 +274,7 @@ int main(int argc, char *arg[])
   fdata->max_width = (w != 0 && fdata->max_width > w) ? w : fdata->max_width;
   fdata->max_height = (h != 0 && fdata->max_height > h) ? h : fdata->max_height;
   fdata->style[0] = '\0';
+  fdata->style_append = 0;
 
   if(storage->initialize_store)
   {

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -676,13 +676,20 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
         if(strncmp(m->op, s->name, strlen(m->op)) == 0)
         {
           dt_dev_history_item_t *h = malloc(sizeof(dt_dev_history_item_t));
+          dt_iop_module_t *sty_module = m;
+
+          if (format_params->style_append && !(m->flags() & IOP_FLAGS_ONE_INSTANCE))
+          {
+            sty_module = dt_dev_module_duplicate(m->dev, m, 0);
+            if(!sty_module) return 1;
+          }
 
           h->params = s->params;
           h->blend_params = s->blendop_params;
           h->enabled = s->enabled;
-          h->module = m;
+          h->module = sty_module;
           h->multi_priority = 1;
-          g_strlcpy(h->multi_name, "", sizeof(h->multi_name));
+          g_strlcpy(h->multi_name, "<style>", sizeof(h->multi_name));
 
           if(m->legacy_params && (s->module_version != m->version()))
           {

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -52,6 +52,7 @@ typedef struct dt_imageio_module_data_t
   int max_width, max_height;
   int width, height;
   char style[128];
+  gboolean style_append;
 } dt_imageio_module_data_t;
 
 struct dt_imageio_module_format_t;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -957,6 +957,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
     fdata->max_width = (w != 0 && fdata->max_width > w) ? w : fdata->max_width;
     fdata->max_height = (h != 0 && fdata->max_height > h) ? h : fdata->max_height;
     g_strlcpy(fdata->style, settings->style, sizeof(fdata->style));
+    fdata->style_append = settings->style_append;
     guint num = 0;
     // Invariant: the tagid for 'darktable|changed' will not change while this function runs. Is this a
     // sensible assumption?
@@ -1275,7 +1276,7 @@ void dt_control_reset_local_copy_images()
 }
 
 void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, char *style)
+                       gboolean high_quality, char *style, gboolean style_append)
 {
   dt_job_t *job = dt_control_job_create(&dt_control_export_job_run, "export");
   if(!job) return;
@@ -1309,6 +1310,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
   data->sdata = sdata;
   data->high_quality = high_quality;
   g_strlcpy(data->style, style, sizeof(data->style));
+  data->style_append = style_append;
   params->data = data;
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_IMAGE_EXPORT_MULTIPLE, params);
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG, job);

--- a/src/control/jobs/control_jobs.h
+++ b/src/control/jobs/control_jobs.h
@@ -29,6 +29,7 @@ typedef struct dt_control_export_t
                                    // is dispatched, but we have to keep that information
   gboolean high_quality;
   char style[128];
+  gboolean style_append;
 } dt_control_export_t;
 
 typedef struct dt_control_image_enumerator_t
@@ -52,7 +53,7 @@ void dt_control_copy_images();
 void dt_control_set_local_copy_images();
 void dt_control_reset_local_copy_images();
 void dt_control_export(GList *imgid_list, int max_width, int max_height, int format_index, int storage_index,
-                       gboolean high_quality, char *style);
+                       gboolean high_quality, char *style, gboolean style_append);
 void dt_control_merge_hdr();
 
 void dt_control_seed_denoise();

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -30,13 +30,14 @@
 #include "common/imageio_format.h"
 #define DT_TIFFIO_STRIPE 64
 
-DT_MODULE(1)
+DT_MODULE(2)
 
 typedef struct dt_imageio_tiff_t
 {
   int max_width, max_height;
   int width, height;
   char style[128];
+  gboolean style_append;
   int bpp;
   int compress;
   TIFF *handle;
@@ -278,6 +279,40 @@ size_t params_size(dt_imageio_module_format_t *self)
   return sizeof(dt_imageio_tiff_t) - sizeof(TIFF *);
 }
 
+void *legacy_params(dt_imageio_module_format_t *self, const void *const old_params,
+                    const size_t old_params_size, const int old_version, const int new_version,
+                    size_t *new_size)
+{
+  if(old_version == 1 && new_version == 2)
+  {
+    typedef struct dt_imageio_tiff_v1_t
+    {
+      int max_width, max_height;
+      int width, height;
+      char style[128];
+      gboolean style_append;
+      int bpp;
+      int compress;
+      TIFF *handle;
+    } dt_imageio_tiff_v1_t;
+
+    dt_imageio_tiff_v1_t *o = (dt_imageio_tiff_v1_t *)old_params;
+    dt_imageio_tiff_t *n = (dt_imageio_tiff_t *)malloc(sizeof(dt_imageio_tiff_t));
+
+    n->max_width = o->max_width;
+    n->max_height = o->max_height;
+    n->width = o->width;
+    n->height = o->height;
+    g_strlcpy(n->style, o->style, sizeof(o->style));
+    n->style_append = 0;
+    n->bpp = o->bpp;
+    n->compress = o->compress;
+    n->handle = o->handle;
+    *new_size = self->params_size(self);
+    return n;
+  }
+  return NULL;
+}
 void *get_params(dt_imageio_module_format_t *self)
 {
   dt_imageio_tiff_t *d = (dt_imageio_tiff_t *)calloc(1, sizeof(dt_imageio_tiff_t));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -822,9 +822,10 @@ static gboolean export_key_accel_callback(GtkAccelGroup *accel_group, GObject *a
   int storage_index = dt_imageio_get_index_of_storage(dt_imageio_get_storage_by_name(storage_name));
   gboolean high_quality = dt_conf_get_bool("plugins/lighttable/export/high_quality_processing");
   char *style = dt_conf_get_string("plugins/lighttable/export/style");
+  gboolean style_append = dt_conf_get_bool("plugins/lighttable/export/style_append");
   // darkroom is for single images, so only export the one the user is working on
   GList *l = g_list_append(NULL, GINT_TO_POINTER(dev->image_storage.id));
-  dt_control_export(l, max_width, max_height, format_index, storage_index, high_quality, style);
+  dt_control_export(l, max_width, max_height, format_index, storage_index, high_quality, style, style_append);
   g_free(format_name);
   g_free(storage_name);
   g_free(style);


### PR DESCRIPTION
Instead of replacing the module's parameters in the image history
it is better to append the style module (as new instances) to be
able to adjust the current image (adding some light for example).

Until now the style during export was mostly usable when applying
a style with modules not in the developed images.
