### PR TITLE
masks: avoid jumping and flickering

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1553,11 +1553,16 @@ int dt_dev_distort_backtransform(dt_develop_t *dev, float *points, size_t points
 int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
                                   float *points, size_t points_count)
 {
+  dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_first(dev->iop);
   GList *pieces = g_list_first(pipe->nodes);
   while(modules)
   {
-    if(!pieces) return 0;
+    if(!pieces)
+    {
+      dt_pthread_mutex_unlock(&dev->history_mutex);
+      return 0;
+    }
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
     if(piece->enabled && module->priority <= pmax && module->priority >= pmin)
@@ -1567,17 +1572,23 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, i
     modules = g_list_next(modules);
     pieces = g_list_next(pieces);
   }
+  dt_pthread_mutex_unlock(&dev->history_mutex);
   return 1;
 }
 
 int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
                                       float *points, size_t points_count)
 {
+  dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(dev->iop);
   GList *pieces = g_list_last(pipe->nodes);
   while(modules)
   {
-    if(!pieces) return 0;
+    if(!pieces)
+    {
+      dt_pthread_mutex_unlock(&dev->history_mutex);
+      return 0;
+    }
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
     if(piece->enabled && module->priority <= pmax && module->priority >= pmin)
@@ -1587,6 +1598,7 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
     modules = g_list_previous(modules);
     pieces = g_list_previous(pieces);
   }
+  dt_pthread_mutex_unlock(&dev->history_mutex);
   return 1;
 }
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -419,6 +419,13 @@ static void transform(float *x, float *o, const float *m, const float t_h, const
 
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
 {
+  // we first need to be sure that all data values are computed
+  // this is done in modify_roi_out fct, so we create tmp roi
+  dt_iop_roi_t roi_out, roi_in;
+  roi_in.width = piece->buf_in.width;
+  roi_in.height = piece->buf_in.height;
+  self->modify_roi_out(self, piece, &roi_out, &roi_in);
+
   dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
 
   const float rx = piece->buf_in.width;
@@ -462,6 +469,13 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
 int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points,
                           size_t points_count)
 {
+  // we first need to be sure that all data values are computed
+  // this is done in modify_roi_out fct, so we create tmp roi
+  dt_iop_roi_t roi_out, roi_in;
+  roi_in.width = piece->buf_in.width;
+  roi_in.height = piece->buf_in.height;
+  self->modify_roi_out(self, piece, &roi_out, &roi_in);
+
   dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
 
   const float rx = piece->buf_in.width;


### PR DESCRIPTION
this is a new version of https://github.com/darktable-org/darktable/pull/784, much simpler

to securise pipe acces across thread in distort fct, we use the dev->history_mutex.

There was another pb specific to clipping iop, where we can have some data value not already computed, as the computing is done in modify_roi_out