### PR TITLE
dt-curve-tool OpenMP conversion

### DIFF
--- a/tools/basecurve/CMakeLists.txt
+++ b/tools/basecurve/CMakeLists.txt
@@ -13,6 +13,12 @@ set(CMAKE_CXX_FLAGS "${CC_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/modules")
 find_library(M_LIBRARY m)
 find_package(Exiv2 REQUIRED)

--- a/tools/basecurve/dt-curve-tool.c
+++ b/tools/basecurve/dt-curve-tool.c
@@ -319,11 +319,14 @@ enum module_type
 static void
 linearize_8bit(
   int width, int height,
-  uint8_t* s,
-  float* d)
+  uint8_t* _s,
+  float* _d)
 {
   // XXX support ICC profiles here ?
+#pragma omp parallel for
   for (int y=0; y<height; y++) {
+    float* d = _d + 3*width*y;
+    uint8_t* s = _s + 3*width*y;
     for (int x=0; x<width; x++) {
       d[0] = linearize_sRGB((float)s[0]/255.f);
       d[1] = linearize_sRGB((float)s[1]/255.f);
@@ -337,10 +340,13 @@ linearize_8bit(
 static void
 linearize_16bit(
   int width, int height,
-  uint16_t* s,
-  float* d)
+  uint16_t* _s,
+  float* _d)
 {
+#pragma omp parallel for
   for (int y=0; y<height; y++) {
+    float* d = _d + 3*width*y;
+    uint16_t* s = _s + 3*width*y;
     for (int x=0; x<width; x++) {
       d[0] = (float)s[0]/65535.f;
       d[1] = (float)s[1]/65535.f;


### PR DESCRIPTION
Two loops were good candidates for an easy OpenMP conversion.

powf is now 85% of the perf profile. Unless we come up w/ parallelization in dt-curve-tool-helper (as convert, dcraw and so on are so slow) or a powf optimized replacement, i see no easy gain now.
