### PR TITLE
Try and fix the theming in gtk 3.10

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -6,10 +6,17 @@ if(USE_OPENCL)
 	add_subdirectory(kernels)
 endif(USE_OPENCL)
 
+# Generate and instal darktable.css
 #
-# FIXME: gtk3-3.10: s/checked/active/
-#
-install(FILES darktable.css DESTINATION ${SHARE_INSTALL}/darktable)
+MESSAGE( "PC_GTK3_VERSION is ${PC_GTK3_VERSION}" )
+
+if ("${PC_GTK3_VERSION}" VERSION_GREATER "3.13.6")
+  set(GTK_CSS_CLASS "checked")
+else ()
+  set(GTK_CSS_CLASS "active")
+endif ()
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/darktable.css.in ${CMAKE_CURRENT_BINARY_DIR}/darktable.css )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/darktable.css DESTINATION ${SHARE_INSTALL}/darktable)
 
 #
 # web gallery export support files:

--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -84,8 +84,8 @@ GtkAlignment
   background-color: shade(@selected_bg_color, 1.2);
   background-image: none;
 }
-#lib-plugin-ui .button:checked,
-.button:checked
+#lib-plugin-ui .button:${GTK_CSS_CLASS},
+.button:${GTK_CSS_CLASS}
 {
   border-style:none;
   background-image:none;


### PR DESCRIPTION
:active was the correct name before 3.13.7 and now :checked is. We special case it on compile and then potentially fail at runtime if the user compiles with 3.13.6 and runs with 3.13.7. Usually it shouldn't be a big issue.
