### PR TITLE
Fix local-copies tag attach/detach.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1265,7 +1265,7 @@ int32_t dt_image_copy(const int32_t imgid, const int32_t filmid)
   return newid;
 }
 
-void dt_image_local_copy_set(const int32_t imgid)
+int dt_image_local_copy_set(const int32_t imgid)
 {
   gchar srcpath[PATH_MAX] = { 0 };
   gchar destpath[PATH_MAX] = { 0 };
@@ -1279,7 +1279,7 @@ void dt_image_local_copy_set(const int32_t imgid)
   if(!g_file_test(srcpath, G_FILE_TEST_IS_REGULAR))
   {
     dt_control_log(_("cannot create local copy when the original file is not accessible."));
-    return;
+    return 1;
   }
 
   if(!g_file_test(destpath, G_FILE_TEST_EXISTS))
@@ -1295,7 +1295,7 @@ void dt_image_local_copy_set(const int32_t imgid)
       dt_control_log(_("cannot create local copy."));
       g_object_unref(dest);
       g_object_unref(src);
-      return;
+      return 1;
     }
 
     g_object_unref(dest);
@@ -1311,6 +1311,7 @@ void dt_image_local_copy_set(const int32_t imgid)
   dt_image_cache_read_release(darktable.image_cache, img);
 
   dt_control_queue_redraw_center();
+  return 0;
 }
 
 static int _nb_other_local_copy_for(const int32_t imgid)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -269,7 +269,7 @@ int32_t dt_image_move(const int32_t imgid, const int32_t filmid);
 /** physically cope image to the folder of the film roll with filmid and
  *  duplicate update database entries. */
 int32_t dt_image_copy(const int32_t imgid, const int32_t filmid);
-void dt_image_local_copy_set(const int32_t imgid);
+int dt_image_local_copy_set(const int32_t imgid);
 int dt_image_local_copy_reset(const int32_t imgid);
 /* check whether it is safe to remove a file */
 gboolean dt_image_safe_remove(const int32_t imgid);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -863,13 +863,13 @@ static int32_t dt_control_local_copy_images_job_run(dt_job_t *job)
     imgid = GPOINTER_TO_INT(t->data);
     if(is_copy)
     {
-      dt_image_local_copy_set(imgid);
-      dt_tag_attach(tagid, imgid);
+      if (dt_image_local_copy_set(imgid) == 0)
+        dt_tag_attach(tagid, imgid);
     }
     else
     {
-      dt_image_local_copy_reset(imgid);
-      dt_tag_detach(tagid, imgid);
+      if (dt_image_local_copy_reset(imgid) == 0)
+        dt_tag_detach(tagid, imgid);
     }
     t = g_list_delete_link(t, t);
 


### PR DESCRIPTION
We want to set the tag only if the local copy action has been done.
