### PR TITLE
Fix the lighttable refresh when scrolling with the mouse wheel.

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -705,6 +705,7 @@ void dt_mipmap_cache_get_with_caller(
     buf->imgid = 0;
     buf->size = DT_MIPMAP_NONE;
     buf->width = buf->height = 0;
+    g_idle_add(_raise_signal_mipmap_updated, 0);
   }
 }
 


### PR DESCRIPTION
Another attempt to fix this issue. I have double checked that there is no infinite loop/refresh.