### PR TITLE
Libjpeg-turbo fixes (aka faster on-disk jpeg cache)

### DIFF
--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2009--2010 johannes hanika.
+    copyright (c) 2015 LebedevRI.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -98,10 +99,51 @@ int dt_imageio_jpeg_decompress_header(const void *in, size_t length, dt_imageio_
   }
 
   jpg->dinfo.src = &(jpg->src);
-  // jpg->dinfo.buffered_image = TRUE;
   jpeg_read_header(&(jpg->dinfo), TRUE);
+#ifdef JCS_EXTENSIONS
+  jpg->dinfo.out_color_space = JCS_EXT_RGBX;
+  jpg->dinfo.out_color_components = 4;
+#else
+  jpg->dinfo.out_color_space = JCS_RGB;
+  jpg->dinfo.out_color_components = 3;
+#endif
+  // jpg->dinfo.buffered_image = TRUE;
   jpg->width = jpg->dinfo.image_width;
   jpg->height = jpg->dinfo.image_height;
+  return 0;
+}
+
+#ifdef JCS_EXTENSIONS
+static int decompress_jsc(dt_imageio_jpeg_t *jpg, uint8_t *out)
+{
+  uint8_t *tmp = out;
+  while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
+  {
+    if(jpeg_read_scanlines(&(jpg->dinfo), &tmp, 1) != 1)
+    {
+      return 1;
+    }
+    tmp += 4 * jpg->width;
+  }
+  return 0;
+}
+#endif
+
+static int decompress_plain(dt_imageio_jpeg_t *jpg, uint8_t *out)
+{
+  JSAMPROW row_pointer[1];
+  row_pointer[0] = (uint8_t *)malloc(jpg->dinfo.output_width * jpg->dinfo.num_components);
+  uint8_t *tmp = out;
+  while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
+    if(jpeg_read_scanlines(&(jpg->dinfo), row_pointer, 1) != 1)
+    {
+      free(row_pointer[0]);
+      return 1;
+    }
+  for(unsigned int i = 0; i < jpg->dinfo.image_width; i++)
+    for(int k = 0; k < 3; k++) tmp[4 * i + k] = row_pointer[0][3 * i + k];
+  tmp += 4 * jpg->width;
+  free(row_pointer[0]);
   return 0;
 }
 
@@ -114,25 +156,54 @@ int dt_imageio_jpeg_decompress(dt_imageio_jpeg_t *jpg, uint8_t *out)
     jpeg_destroy_decompress(&(jpg->dinfo));
     return 1;
   }
-  (void)jpeg_start_decompress(&(jpg->dinfo));
-  JSAMPROW row_pointer[1];
-  row_pointer[0] = (uint8_t *)malloc(jpg->dinfo.output_width * jpg->dinfo.num_components);
-  uint8_t *tmp = out;
-  while(jpg->dinfo.output_scanline < jpg->dinfo.image_height)
+
+#ifdef JCS_EXTENSIONS
+  /*
+   * Do a run-time detection for JCS_EXTENSIONS:
+   * it might have been only available at build-time
+   */
+  int jcs_alpha_valid = 1;
+  if(setjmp(jerr.setjmp_buffer))
   {
-    if(jpeg_read_scanlines(&(jpg->dinfo), row_pointer, 1) != 1)
+    if(jpg->dinfo.out_color_space == JCS_EXT_RGBX && jpg->dinfo.out_color_components == 4)
     {
-      free(row_pointer[0]);
+      // ok, no JCS_EXTENSIONS, fall-back to slow plain code.
+      jpg->dinfo.out_color_components = 3;
+      jpg->dinfo.out_color_space = JCS_RGB;
+      jcs_alpha_valid = 0;
+    }
+    else
+    {
+      jpeg_destroy_decompress(&(jpg->dinfo));
       return 1;
     }
-    for(unsigned int i = 0; i < jpg->dinfo.image_width; i++)
-      for(int k = 0; k < 3; k++) tmp[4 * i + k] = row_pointer[0][3 * i + k];
-    tmp += 4 * jpg->width;
   }
+#endif
+
+  (void)jpeg_start_decompress(&(jpg->dinfo));
+
+  if(setjmp(jerr.setjmp_buffer))
+  {
+    jpeg_destroy_decompress(&(jpg->dinfo));
+    return 1;
+  }
+
+#ifdef JCS_EXTENSIONS
+  if(jcs_alpha_valid)
+  {
+    if(decompress_jsc(jpg, out)) return 1;
+  }
+  else
+  {
+    if(decompress_plain(jpg, out)) return 1;
+  }
+#else
+  if(decompress_plain(jpg, out)) return 1;
+#endif
+
   // jpg->dinfo.src = NULL;
   (void)jpeg_finish_decompress(&(jpg->dinfo));
   jpeg_destroy_decompress(&(jpg->dinfo));
-  free(row_pointer[0]);
   return 0;
 }
 

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -130,7 +130,7 @@ int dt_imageio_jpeg_decompress(dt_imageio_jpeg_t *jpg, uint8_t *out)
     tmp += 4 * jpg->width;
   }
   // jpg->dinfo.src = NULL;
-  // (void)jpeg_finish_decompress(&(jpg->dinfo)); // ???
+  (void)jpeg_finish_decompress(&(jpg->dinfo));
   jpeg_destroy_decompress(&(jpg->dinfo));
   free(row_pointer[0]);
   return 0;
@@ -520,7 +520,7 @@ int dt_imageio_jpeg_read(dt_imageio_jpeg_t *jpg, uint8_t *out)
         for(int k = 0; k < 3; k++) tmp[4 * i + k] = row_pointer[0][3 * i + k];
     tmp += 4 * jpg->width;
   }
-  // (void)jpeg_finish_decompress(&(jpg->dinfo));
+  (void)jpeg_finish_decompress(&(jpg->dinfo));
   jpeg_destroy_decompress(&(jpg->dinfo));
   free(row_pointer[0]);
   fclose(jpg->f);

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -449,7 +449,7 @@ int read_image(dt_imageio_module_data_t *jpg_tmp, uint8_t *out)
         for(int k = 0; k < 3; k++) tmp[4 * i + k] = row_pointer[0][3 * i + k];
     tmp += 4 * jpg->width;
   }
-  // (void)jpeg_finish_decompress(&(jpg->dinfo));
+  (void)jpeg_finish_decompress(&(jpg->dinfo));
   jpeg_destroy_decompress(&(jpg->dinfo));
   free(row_pointer[0]);
   fclose(jpg->f);


### PR DESCRIPTION
Libjpeg-turbo can natively handle input/output with 4-ch buffer.
1. If such support does not exist at compile-time, code is pretty much the same as it was without this PR.
2. If such support exists at compile-time, do a run-time check for this functionality
2.1. If such support exists at compile-time and run-time, let Libjpeg take care of 4-th channel
2.2. If such support exists at compile-time and does not exist at run-time, handle 4-th channel ourselves.

These two files are so messy that i *do* expect this to break in some cases, but i will not be able to know in which, until there is a bugreport :/

This *might* (i hope) somewhat increase speed of on-disk jpeg cache, just a little bit :)

FIXME: think about refactoring src/common/imageio_jpeg.c and src/imageio/format/jpeg.c !!!