### PR TITLE
dt_mipmap_cache_release(): do not notify if wasn't open as 'w'

### DIFF
--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -67,6 +67,7 @@ typedef struct dt_mipmap_buffer_t
   int32_t width, height;
   uint8_t *buf;
   dt_cache_entry_t *cache_entry;
+  char mode;
 } dt_mipmap_buffer_t;
 
 typedef struct dt_mipmap_cache_one_t


### PR DESCRIPTION
Else, LT always redraws.

Fixes 70dd638cc47b587b5826df0d8754b7821c2dc527