### PR TITLE
darkroom: implement full preview shortcut

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -139,7 +139,7 @@ typedef struct dt_control_accels_t
   GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right,
       lighttable_left, lighttable_center, lighttable_preview, lighttable_preview_display_focus,
       lighttable_preview_sticky, lighttable_preview_sticky_focus, lighttable_preview_sticky_exit,
-      global_sideborders, global_header, slideshow_start;
+      global_sideborders, global_header, darkroom_preview, slideshow_start;
 
 } dt_control_accels_t;
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -50,6 +50,7 @@ const gchar *dt_dev_histogram_type_names[DT_DEV_HISTOGRAM_N] = { "logarithmic", 
 void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
   memset(dev, 0, sizeof(dt_develop_t));
+  dev->full_preview = FALSE;
   dev->preview_downsampling = 1.0f;
   dev->gui_module = NULL;
   dev->timestamp = 0;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -123,6 +123,13 @@ typedef struct dt_develop_t
   struct dt_masks_form_t *form_visible;
   struct dt_masks_form_gui_t *form_gui;
 
+  //full preview stuff
+  int full_preview;
+  int full_preview_last_zoom, full_preview_last_closeup;
+  float full_preview_last_zoom_x, full_preview_last_zoom_y;
+  struct dt_iop_module_t *full_preview_last_module;
+  int full_preview_masks_state;
+
   /* proxy for communication between plugins and develop/darkroom */
   struct
   {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1254,10 +1254,9 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
     grp->formid = 0;
     dt_masks_group_ungroup(grp, form);
   }
-  if(!(module->flags() & IOP_FLAGS_NO_MASKS))
-  {
-    bd->masks_shown = value;
-  }
+
+  if (bd) bd->masks_shown = value;
+
   dt_masks_change_form_gui(grp);
   darktable.develop->form_gui->edit_mode = value;
   if(value && form)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -146,6 +146,9 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_focus);
   dt_accel_path_view(path, sizeof(path), "lighttable", "exit sticky preview");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_exit);
+  // darkroom
+  dt_accel_path_view(path, sizeof(path), "darkroom", "full preview");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_preview);
 
 
   // Global

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -178,7 +178,10 @@ void expose(
     surface = dt_cairo_image_surface_create_for_data(dev->pipe->backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     wd /= darktable.gui->ppd;
     ht /= darktable.gui->ppd;
-    cairo_set_source_rgb(cr, .2, .2, .2);
+    if(dev->full_preview)
+      cairo_set_source_rgb(cr, .1, .1, .1);
+    else
+      cairo_set_source_rgb(cr, .2, .2, .2);
     cairo_paint(cr);
     cairo_translate(cr, .5f * (width - wd), .5f * (height - ht));
     if(closeup)


### PR DESCRIPTION
This can be very useful to have a quick look at a preview of your work, without any distracting things.
basically, this is TAB + some little things : 
- hide all panels
- apply crop if any
- hide all overlays (grid, masks, vignette, ...)
- zoom to fit

When the key is released, you come back to the exact state you where before. (panels, zooms, overlays, ...)
I've currently mapped the shortcut to "Z" as an analogy with lighttable...
I've tried to implement this as less intrusive as possible.