### PR TITLE
Iop temperature bogus wb

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -858,21 +858,24 @@ cmsHPROFILE dt_colorspaces_create_output_profile(const int imgid)
   return output;
 }
 
-cmsHPROFILE dt_colorspaces_create_cmatrix_profile(float cmatrix[3][4])
+void dt_colorspaces_create_cmatrix(float cmatrix[4][3], float mat[3][3])
 {
-  float mat[3][3];
   // sRGB D65, the linear part:
   const float rgb_to_xyz[3][3] = { { 0.4124564, 0.3575761, 0.1804375 },
                                    { 0.2126729, 0.7151522, 0.0721750 },
                                    { 0.0193339, 0.1191920, 0.9503041 } };
 
   for(int c = 0; c < 3; c++)
+  {
     for(int j = 0; j < 3; j++)
     {
-      mat[c][j] = 0;
-      for(int k = 0; k < 3; k++) mat[c][j] += rgb_to_xyz[c][k] * cmatrix[k][j];
+      mat[c][j] = 0.0f;
+      for(int k = 0; k < 3; k++)
+      {
+        mat[c][j] += rgb_to_xyz[k][j] * cmatrix[c][k];
+      }
     }
-  return dt_colorspaces_create_xyzmatrix_profile(mat);
+  }
 }
 
 cmsHPROFILE dt_colorspaces_create_xyzimatrix_profile(float mat[3][3])

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -51,8 +51,8 @@ cmsHPROFILE dt_colorspaces_create_adobergb_profile(void);
 /** create a ICC virtual profile for XYZ. */
 cmsHPROFILE dt_colorspaces_create_xyz_profile(void);
 
-/** create a profile from a color matrix from dcraw. */
-cmsHPROFILE dt_colorspaces_create_cmatrix_profile(float cmatrix[3][4]);
+/** create a RGB matrix from a color matrix from dcraw. */
+void dt_colorspaces_create_cmatrix(float cmatrix[4][3], float mat[3][3]);
 
 /** create a profile from a camera->xyz matrix. */
 cmsHPROFILE dt_colorspaces_create_xyzmatrix_profile(float cam_xyz[3][3]);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -623,6 +623,13 @@ void reload_defaults(dt_iop_module_t *module)
     }
 
     // did not find preset either?
+    if(!is_monochrom && !found && !calculate_bogus_daylight_wb(module, tmp.coeffs))
+    {
+      // found camera matrix and used it to calculate bogus daylight wb
+      found = 1;
+    }
+
+    // and no cam matrix too???
     if(!found && !is_monochrom)
     {
       // final security net: hardcoded default that fits most cams.

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2009--2013 johannes hanika.
+    copyright (c) 2015 LebedevRI.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -563,15 +564,9 @@ void reload_defaults(dt_iop_module_t *module)
   // raw images need wb:
   module->default_enabled = dt_image_is_raw(&module->dev->image_storage);
 
-  // get white balance coefficients, as shot
-  char filename[PATH_MAX] = { 0 };
-
   /* check if file is raw / hdr */
   if(dt_image_is_raw(&module->dev->image_storage))
   {
-    gboolean from_cache = TRUE;
-    dt_image_full_path(module->dev->image_storage.id, filename, sizeof(filename), &from_cache);
-
     char makermodel[1024];
     char *model = makermodel;
     dt_colorspaces_get_makermodel_split(makermodel, sizeof(makermodel), &model,
@@ -658,11 +653,11 @@ void reload_defaults(dt_iop_module_t *module)
       else
       {
         // if we didn't find anything for daylight wb, look for a wb preset with appropriate name.
-        // we're normalising that to be D65
+        // we're normalizing that to be D65
         for(int i = 0; i < wb_preset_count; i++)
         {
           if(!strcmp(wb_preset[i].make, makermodel) && !strcmp(wb_preset[i].model, model)
-             && !strcasecmp(wb_preset[i].name, Daylight) && wb_preset[i].tuning == 0)
+             && !strcmp(wb_preset[i].name, Daylight) && wb_preset[i].tuning == 0)
           {
             for(int k = 0; k < 3; k++) g->daylight_wb[k] = wb_preset[i].channel[k];
             break;


### PR DESCRIPTION
This fixes a regression (008f559554233700f66f2cd3e5fc0bac0aeda5d8) in [bogus] kelvin temperature display.

Note: libraw was still using partial matching to get cam matrix, so in some cases displayed Kelvin temperature will be different from what it was before.

TODO: some better conversion between multipliers <-> Kelvin?