### PR TITLE
Fix rotated jpeg thumbs

### DIFF
--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -239,7 +239,7 @@ void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid, int b
     offy[2 * k + 1] = y + stddevy;
   }
 
-  if(dt_image_altered(imgid))
+  // could use dt_image_altered() here, but it ignores flip module
   {
     dt_develop_t dev;
     dt_dev_init(&dev, 0);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -549,22 +549,6 @@ int dt_image_altered(const uint32_t imgid)
   int altered = 0;
   sqlite3_stmt *stmt;
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "select orientation != 0 from images where id = ?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  if(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    /*
-     * if image orientation != ORIENTATION_NONE, then we _need_ to consider
-     * image as altered, or else e.g. FD works uncorrectly on portrait images
-     * just after "history stack" -> "discard"
-     */
-    altered = sqlite3_column_int(stmt, 0);
-  }
-  sqlite3_finalize(stmt);
-
-  if(altered) return 1;
-
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select operation from history where imgid = ?1",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
@@ -576,6 +560,7 @@ int dt_image_altered(const uint32_t imgid)
     // (that's currently the only use of this function)
     if(!op) continue; // can happen while importing or something like that
     if(!strcmp(op, "basecurve")) continue;
+    if(!strcmp(op, "flip")) continue;
     if(!strcmp(op, "sharpen")) continue;
     if(!strcmp(op, "dither")) continue;
     if(!strcmp(op, "highlights")) continue;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -373,26 +373,8 @@ void dt_image_flip(const int32_t imgid, const int32_t cw)
   // this is light table only:
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(darktable.develop->image_storage.id == imgid && cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM) return;
-  dt_image_orientation_t orientation = ORIENTATION_NULL;
-  sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "select * from history where imgid = ?1 and operation = 'flip' and "
-                              "num in (select MAX(num) from history where imgid = ?1 and "
-                              "operation = 'flip')",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  if(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    if(sqlite3_column_bytes(stmt, 4) >= 4) orientation = *(int32_t *)sqlite3_column_blob(stmt, 4);
-  }
-  sqlite3_finalize(stmt);
 
-  if(orientation == ORIENTATION_NULL)
-  {
-    const dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
-    orientation = dt_image_orientation(img);
-    dt_image_cache_read_release(darktable.image_cache, img);
-  }
+  dt_image_orientation_t orientation = dt_image_get_orientation(imgid);
 
   if(cw == 1)
   {

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -197,6 +197,7 @@ int32_t dt_image_duplicate(const int32_t imgid);
 /** flips the image, clock wise, if given flag. */
 void dt_image_flip(const int32_t imgid, const int32_t cw);
 void dt_image_set_flip(const int32_t imgid, const dt_image_orientation_t user_flip);
+dt_image_orientation_t dt_image_get_orientation(const int imgid);
 /** set image location lon/lat */
 void dt_image_set_location(const int32_t imgid, double lon, double lat);
 /** returns 1 if there is history data found for this image, 0 else. */

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -895,7 +895,6 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, const uint3
   int res = 1;
 
   const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, imgid, 'r');
-  const dt_image_orientation_t orientation = dt_image_orientation(cimg);
   // the orientation for this camera is not read correctly from exiv2, so we need
   // to go the full path (as the thumbnail will be flipped the wrong way round)
   const int incompatible = !strncmp(cimg->exif_maker, "Phase One", 9);
@@ -903,6 +902,8 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, const uint3
 
   if(!altered && !dt_conf_get_bool("never_use_embedded_thumb") && !incompatible)
   {
+    const dt_image_orientation_t orientation = dt_image_get_orientation(imgid);
+
     // try to load the embedded thumbnail in raw
     gboolean from_cache = TRUE;
     memset(filename, 0, sizeof(filename));
@@ -934,7 +935,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, const uint3
       if(!res)
       {
         // scale to fit
-        dt_iop_flip_and_zoom_8(tmp, thumb_width, thumb_height, buf, wd, ht, ORIENTATION_NONE, width, height);
+        dt_iop_flip_and_zoom_8(tmp, thumb_width, thumb_height, buf, wd, ht, orientation, width, height);
         free(tmp);
       }
     }


### PR DESCRIPTION
Mainly, this fixes an issue i introduced in #584 - even if raw thumbnails were disabled, they were used not only for "changed" images, but for all those images, that were shot non-horizontally.