### PR TITLE
Allow enlarging a print by using negative borders.

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -93,6 +93,8 @@ static double units[3] = {1.0, 0.1, 1.0/25.4};
 
 static void _update_slider (dt_lib_print_settings_t *ps);
 
+static const int min_borders = -100; // this is in mm
+
 int
 position ()
 {
@@ -515,10 +517,14 @@ _update_slider (dt_lib_print_settings_t *ps)
   const int pa_max_height = ps->prt.paper.height - ps->prt.printer.hw_margin_top - ps->prt.printer.hw_margin_bottom - min_size;
   const int pa_max_width  = ps->prt.paper.width  - ps->prt.printer.hw_margin_left - ps->prt.printer.hw_margin_right - min_size;
 
-  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_top),    0, (pa_max_height - ps->prt.page.margin_bottom) * units[ps->unit]);
-  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_left),   0, (pa_max_width - ps->prt.page.margin_right) * units[ps->unit]);
-  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_right),  0, (pa_max_width - ps->prt.page.margin_left) * units[ps->unit]);
-  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_bottom), 0, (pa_max_height - ps->prt.page.margin_top) * units[ps->unit]);
+  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_top),
+                             min_borders * units[ps->unit], (pa_max_height - ps->prt.page.margin_bottom) * units[ps->unit]);
+  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_left),
+                             min_borders * units[ps->unit], (pa_max_width - ps->prt.page.margin_right) * units[ps->unit]);
+  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_right),
+                             min_borders * units[ps->unit], (pa_max_width - ps->prt.page.margin_left) * units[ps->unit]);
+  gtk_spin_button_set_range (GTK_SPIN_BUTTON(ps->b_bottom),
+                             min_borders * units[ps->unit], (pa_max_height - ps->prt.page.margin_top) * units[ps->unit]);
 }
 
 static void

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -187,33 +187,36 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr, int32_t width, int32
   // display non-printable area
   cairo_set_source_rgb (cr, 0.1, 0.1, 0.1);
 
+  const int np1x = px + (np_left / pg_width) * pwidth;
+  const int np1y = py + (np_top / pg_height) * pheight;
+  const int np2x = pright - (np_right / pg_width) * pwidth;
+  const int np2y = pbottom - (np_bottom / pg_height) * pheight;
+
   // top-left
-  int npx = px + (np_left / pg_width) * pwidth;
-  int npy = py + (np_top / pg_height) * pheight;
-  cairo_move_to (cr, npx-10, npy);
-  cairo_line_to (cr, npx, npy); cairo_line_to (cr, npx, npy-10);
+  cairo_move_to (cr, np1x-10, np1y);
+  cairo_line_to (cr, np1x, np1y); cairo_line_to (cr, np1x, np1y-10);
   cairo_stroke (cr);
 
   // top-right
-  npx = pright - (np_right / pg_width) * pwidth;
   // npy = p_y + (np_top / pg_height) * p_height;
-  cairo_move_to (cr, npx+10, npy);
-  cairo_line_to (cr, npx, npy); cairo_line_to (cr, npx, npy-10);
+  cairo_move_to (cr, np2x+10, np1y);
+  cairo_line_to (cr, np2x, np1y); cairo_line_to (cr, np2x, np1y-10);
   cairo_stroke (cr);
 
   // bottom-left
-  npx = px + (np_left / pg_width) * pwidth;
-  npy = pbottom - (np_bottom / pg_height) * pheight;
-  cairo_move_to (cr, npx-10, npy);
-  cairo_line_to (cr, npx, npy); cairo_line_to (cr, npx, npy+10);
+  cairo_move_to (cr, np1x-10, np2y);
+  cairo_line_to (cr, np1x, np2y); cairo_line_to (cr, np1x, np2y+10);
   cairo_stroke (cr);
 
   // bottom-right
-  npx = pright - (np_right / pg_width) * pwidth;
-  // npy = p_bottom - (np_bottom / pg_height) * p_height;
-  cairo_move_to (cr, npx+10, npy);
-  cairo_line_to (cr, npx, npy); cairo_line_to (cr, npx, npy+10);
+  cairo_move_to (cr, np2x+10, np2y);
+  cairo_line_to (cr, np2x, np2y); cairo_line_to (cr, np2x, np2y+10);
   cairo_stroke (cr);
+
+  // clip to this area to ensure that the image won't be larger, this is needed when using negative margin to enlarge the print
+
+  cairo_rectangle (cr, np1x, np1y, np2x-np1x, np2y-np1y);
+  cairo_clip(cr);
 
   cairo_set_source_rgb (cr, 0.77, 0.77, 0.77);
   cairo_rectangle (cr, ax, ay, awidth, aheight);


### PR DESCRIPTION
The negative borders will allow for enlarging the image to fit in the
longer side on the whole page. This makes it possible to print an image
without the same aspect as the page on a borderless printer.

(working for me and reported as working fine on the mailing-list).