### PR TITLE
Load raw raw data part 2

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -52,18 +52,20 @@ rawprepare_1f(read_only image2d_t in, write_only image2d_t out,
 kernel void
 rawprepare_4f(read_only image2d_t in, write_only image2d_t out,
               const int width, const int height,
+              const int cx, const int cy,
               global const float *black, global const float *div)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
-  if(x >= width || y >= height) return;
+  if(x < cx || y < cy) return;
+  if(x >= width + cx || y >= height + cy) return;
 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
   pixel.xyz = (pixel.xyz - black[0]) / div[0];
   pixel.xyz = max(0.0f, pixel.xyz);
 
-  write_imagef(out, (int2)(x, y), pixel);
+  write_imagef(out, (int2)(x-cx, y-cy), pixel);
 }
 
 kernel void

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -31,20 +31,22 @@ BL(const int row, const int col)
 kernel void
 rawprepare_1f(read_only image2d_t in, write_only image2d_t out,
               const int width, const int height,
+              const int cx, const int cy,
               global const float *sub, global const float *div,
               const int rx, const int ry)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
-  if(x >= width || y >= height) return;
+  if(x < cx || y < cy) return;
+  if(x >= width + cx || y >= height + cy) return;
 
   const float pixel = read_imageui(in, sampleri, (int2)(x, y)).x;
 
-  const int id = BL(ry+y, rx+x);
+  const int id = BL(ry+cy+y, rx+cx+x);
   const float pixel_scaled = max(0.0f, (pixel - sub[id])) / div[id];
 
-  write_imagef(out, (int2)(x, y), (float4)(pixel_scaled, 0.0f, 0.0f, 0.0f));
+  write_imagef(out, (int2)(x-cx, y-cy), (float4)(pixel_scaled, 0.0f, 0.0f, 0.0f));
 }
 
 kernel void

--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -221,7 +221,12 @@ void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid, int b
   cairo_save(cr);
   cairo_translate(cr, width / 2.0, height / 2.0f);
 
-  int wd = buffer_width, ht = buffer_height;
+  const dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
+  dt_image_t image = *img;
+  dt_image_cache_read_release(darktable.image_cache, img);
+
+  // FIXME: get those from rawprepare IOP somehow !!!
+  int wd = buffer_width + image.crop_x, ht = buffer_height + image.crop_y;
 
   // array with cluster positions
   float pos[fs * 6], *offx = pos + fs * 2, *offy = pos + fs * 4;
@@ -229,7 +234,9 @@ void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid, int b
   {
     const float stddevx = sqrtf(focus[k].x2 - focus[k].x * focus[k].x);
     const float stddevy = sqrtf(focus[k].y2 - focus[k].y * focus[k].y);
-    float x = focus[k].x, y = focus[k].y;
+
+    // FIXME: get those from rawprepare IOP somehow !!!
+    float x = focus[k].x + image.crop_x, y = focus[k].y + image.crop_y;
 
     pos[2 * k + 0] = x;
     pos[2 * k + 1] = y;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -928,6 +928,7 @@ uint32_t dt_image_import(const int32_t film_id, const char *filename, gboolean o
 void dt_image_init(dt_image_t *img)
 {
   img->width = img->height = 0;
+  img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
   img->orientation = ORIENTATION_NULL;
   img->legacy_flip.legacy = 0;
   img->legacy_flip.user_flip = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -120,7 +120,11 @@ typedef struct dt_image_t
   char filename[DT_MAX_FILENAME_LEN];
 
   // common stuff
+
+  // to understand this, look at comment for dt_histogram_roi_t
   int32_t width, height;
+  int32_t crop_x, crop_y, crop_width, crop_height;
+
   // used by library
   int32_t num, flags, film_id, id, group_id, version;
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -152,6 +152,7 @@ typedef struct dt_image_t
   float pixel_aspect_ratio;
 
   /* filter for Fuji X-Trans images, only used if filters == 9u */
+  uint8_t xtrans_uncropped[6][6];
   uint8_t xtrans[6][6];
 
   /* White balance coeffs from the raw */

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -51,6 +51,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
     img->film_id = sqlite3_column_int(stmt, 2);
     img->width = sqlite3_column_int(stmt, 3);
     img->height = sqlite3_column_int(stmt, 4);
+    img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
     img->filename[0] = img->exif_maker[0] = img->exif_model[0] = img->exif_lens[0]
         = img->exif_datetime_taken[0] = '\0';
     str = (char *)sqlite3_column_text(stmt, 5);

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -198,7 +198,10 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
         iPoint2D tl_margin = r->getCropOffset();
         for(int i = 0; i < 6; ++i)
           for(int j = 0; j < 6; ++j)
+          {
+            img->xtrans_uncropped[j][i] = r->cfa.getColorAt(i % 6, j % 6);
             img->xtrans[j][i] = r->cfa.getColorAt((i + tl_margin.x) % 6, (j + tl_margin.y) % 6);
+          }
       }
     }
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -836,12 +836,13 @@ static void _init_f(float *out, uint32_t *width, uint32_t *height, const uint32_
       if(image->bpp == sizeof(float))
       {
         dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(out, (const float *)buf.buf, &roi_out, &roi_in,
-                                                          roi_out.width, roi_in.width, image->xtrans);
+                                                          roi_out.width, roi_in.width,
+                                                          image->xtrans_uncropped);
       }
       else
       {
         dt_iop_clip_and_zoom_demosaic_third_size_xtrans(out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
-                                                        roi_out.width, roi_in.width, image->xtrans);
+                                                        roi_out.width, roi_in.width, image->xtrans_uncropped);
       }
     }
   }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -821,13 +821,13 @@ static void _init_f(float *out, uint32_t *width, uint32_t *height, const uint32_
       // Bayer
       if(image->bpp == sizeof(float))
       {
-        dt_iop_clip_and_zoom_demosaic_half_size_f(out, (const float *)buf.buf, &roi_out, &roi_in,
-                                                  roi_out.width, roi_in.width, dt_image_filter(image), 1.0f);
+        dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks_f(out, (const float *)buf.buf, &roi_out, &roi_in,
+                                                              roi_out.width, roi_in.width, image, 1.0f);
       }
       else
       {
-        dt_iop_clip_and_zoom_demosaic_half_size(out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
-                                                roi_out.width, roi_in.width, dt_image_filter(image));
+        dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
+                                                            roi_out.width, roi_in.width, image);
       }
     }
     else

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2026,6 +2026,60 @@ static int FC(const int row, const int col, const unsigned int filters)
   return filters >> ((((row) << 1 & 14) + ((col)&1)) << 1) & 3;
 }
 
+uint32_t dt_iop_adjust_filters_to_crop(const dt_image_t *img)
+{
+  uint32_t filters = dt_image_filter(img);
+
+  // FIXME: get those from rawprepare IOP somehow !!! (img->crop_{x,y})
+
+  // if black y offset is odd, need to switch pattern by one row:
+  // 0x16161616 <-> 0x61616161
+  // 0x49494949 <-> 0x94949494
+  if(img->crop_y & 1)
+  {
+    switch(filters)
+    {
+      case 0x16161616u:
+        filters = 0x61616161u;
+        break;
+      case 0x49494949u:
+        filters = 0x94949494u;
+        break;
+      case 0x61616161u:
+        filters = 0x16161616u;
+        break;
+      case 0x94949494u:
+        filters = 0x49494949u;
+        break;
+      default:
+        filters = 0;
+        break;
+    }
+  }
+  if(img->crop_x & 1)
+  {
+    switch(filters)
+    {
+      case 0x16161616u:
+        filters = 0x49494949u;
+        break;
+      case 0x49494949u:
+        filters = 0x16161616u;
+        break;
+      case 0x61616161u:
+        filters = 0x94949494u;
+        break;
+      case 0x94949494u:
+        filters = 0x61616161u;
+        break;
+      default:
+        filters = 0;
+        break;
+    }
+  }
+  return filters;
+}
+
 /**
  * downscales and clips a mosaiced buffer (in) to the given region of interest (r_*)
  * and writes it to out in float4 format.
@@ -2122,6 +2176,22 @@ void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const i
   float perf = (tm2.tv_sec-tm1.tv_sec)*1000.0f + (tm2.tv_usec-tm1.tv_usec)/1000.0f;
   printf("time spent: %.4f\n",perf/100.0f);
 #endif
+}
+
+void dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(float *out, const uint16_t *const in,
+                                                         dt_iop_roi_t *const roi_out,
+                                                         const dt_iop_roi_t *const roi_in,
+                                                         const int32_t out_stride, const int32_t in_stride,
+                                                         const dt_image_t *img)
+{
+  /*
+   * rawprepare iop will do the actual cropping
+   * here we just need to adjust filters to the crop!
+   */
+
+  const uint32_t filters = dt_iop_adjust_filters_to_crop(img);
+
+  dt_iop_clip_and_zoom_demosaic_half_size(out, in, roi_out, roi_in, roi_out->width, in_stride, filters);
 }
 
 #if 0 // gets rid of pink artifacts, but doesn't do sub-pixel sampling, so shows some staircasing artifacts.
@@ -2386,6 +2456,22 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in
   _mm_sfence();
 }
 #endif
+
+void dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks_f(float *out, const float *const in,
+                                                           const struct dt_iop_roi_t *const roi_out,
+                                                           const struct dt_iop_roi_t *const roi_in,
+                                                           const int32_t out_stride, const int32_t in_stride,
+                                                           const dt_image_t *img, const float clip)
+{
+  /*
+   * rawprepare iop will do the actual cropping
+   * here we just need to adjust filters to the crop!
+   */
+
+  const uint32_t filters = dt_iop_adjust_filters_to_crop(img);
+
+  dt_iop_clip_and_zoom_demosaic_half_size_f(out, in, roi_out, roi_in, out_stride, in_stride, filters, clip);
+}
 
 static uint8_t FCxtrans(size_t row, size_t col, const dt_iop_roi_t *const roi,
                         const uint8_t (*const xtrans)[6])

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -529,6 +529,8 @@ int dt_iop_clip_and_zoom_cl(int devid, cl_mem dev_out, cl_mem dev_in,
                             const struct dt_iop_roi_t *const roi_in);
 #endif
 
+uint32_t dt_iop_adjust_filters_to_crop(const dt_image_t *img);
+
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,
@@ -536,11 +538,24 @@ void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const i
                                              const int32_t out_stride, const int32_t in_stride,
                                              const uint32_t filters);
 
+/** clip and zoom mosaiced from half size, crop away black borders. */
+void dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(float *out, const uint16_t *const in,
+                                                         struct dt_iop_roi_t *const roi_out,
+                                                         const struct dt_iop_roi_t *const roi_in,
+                                                         const int32_t out_stride, const int32_t in_stride,
+                                                         const dt_image_t *img);
+
 void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in,
                                                const struct dt_iop_roi_t *const roi_out,
                                                const struct dt_iop_roi_t *const roi_in,
                                                const int32_t out_stride, const int32_t in_stride,
                                                const uint32_t filters, const float clip);
+
+void dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks_f(float *out, const float *const in,
+                                                           const struct dt_iop_roi_t *const roi_out,
+                                                           const struct dt_iop_roi_t *const roi_in,
+                                                           const int32_t out_stride, const int32_t in_stride,
+                                                           const dt_image_t *img, const float clip);
 
 /** x-trans sensor downscaling */
 void dt_iop_clip_and_zoom_demosaic_third_size_xtrans(float *out, const uint16_t *const in,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -529,8 +529,6 @@ int dt_iop_clip_and_zoom_cl(int devid, cl_mem dev_out, cl_mem dev_in,
                             const struct dt_iop_roi_t *const roi_in);
 #endif
 
-uint32_t dt_iop_adjust_filters_to_crop(const dt_image_t *img);
-
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -24,7 +24,7 @@
 #include "develop/pixelpipe.h"
 #include "common/opencl.h"
 
-#define DEVELOP_MASKS_VERSION (2)
+#define DEVELOP_MASKS_VERSION (3)
 
 /**forms types */
 typedef enum dt_masks_type_t

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -622,12 +622,138 @@ static int dt_masks_legacy_params_v1_to_v2(dt_develop_t *dev, void *params)
   }
 }
 
+static void dt_masks_legacy_params_v2_to_v3_transform(const dt_image_t *img, float *points)
+{
+  const float w = (float)img->width, h = (float)img->height;
+
+  const float cx = (float)img->crop_x, cy = (float)img->crop_y;
+
+  const float cw = (float)(img->width - img->crop_x - img->crop_width),
+              ch = (float)(img->height - img->crop_y - img->crop_height);
+
+  /*
+   * masks coordinates are normalized, so we need to:
+   * 1. de-normalize them by image original cropped dimensions
+   * 2. un-crop them by adding top-left crop coordinates
+   * 3. normalize them by the image fully uncropped dimensions
+   */
+  points[0] = ((points[0] * cw) + cx) / w;
+  points[1] = ((points[1] * ch) + cy) / h;
+}
+
+static void dt_masks_legacy_params_v2_to_v3_transform_only_rescale(const dt_image_t *img, float *points,
+                                                                   size_t points_count)
+{
+  const float w = (float)img->width, h = (float)img->height;
+
+  const float cw = (float)(img->width - img->crop_x - img->crop_width),
+              ch = (float)(img->height - img->crop_y - img->crop_height);
+
+  /*
+   * masks coordinates are normalized, so we need to:
+   * 1. de-normalize them by minimal of image original cropped dimensions
+   * 2. normalize them by the minimal of image fully uncropped dimensions
+   */
+  for(size_t i = 0; i < points_count; i++) points[i] = ((points[i] * MIN(cw, ch))) / MIN(w, h);
+}
+
+static int dt_masks_legacy_params_v2_to_v3(dt_develop_t *dev, void *params)
+{
+  /*
+   * difference: before v3 images were originally cropped on load
+   * after v3: images are cropped in rawprepare iop.
+   */
+
+  dt_masks_form_t *m = (dt_masks_form_t *)params;
+
+  const dt_image_t *img = &(dev->image_storage);
+
+  if(img->crop_x == 0 && img->crop_y == 0 && img->crop_width == 0 && img->crop_height == 0)
+  {
+    // image has no "raw cropping", we're fine!
+    m->version = 3;
+    return 0;
+  }
+  else
+  {
+    GList *p = g_list_first(m->points);
+
+    if(!p) return 1;
+
+    if(m->type & DT_MASKS_CIRCLE)
+    {
+      dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)p->data;
+      dt_masks_legacy_params_v2_to_v3_transform(img, circle->center);
+      dt_masks_legacy_params_v2_to_v3_transform_only_rescale(img, &circle->radius, 1);
+      dt_masks_legacy_params_v2_to_v3_transform_only_rescale(img, &circle->border, 1);
+    }
+    else if(m->type & DT_MASKS_PATH)
+    {
+      while(p)
+      {
+        dt_masks_point_path_t *path = (dt_masks_point_path_t *)p->data;
+        dt_masks_legacy_params_v2_to_v3_transform(img, path->corner);
+        dt_masks_legacy_params_v2_to_v3_transform(img, path->ctrl1);
+        dt_masks_legacy_params_v2_to_v3_transform(img, path->ctrl2);
+        dt_masks_legacy_params_v2_to_v3_transform_only_rescale(img, path->border, 2);
+
+        p = g_list_next(p);
+      }
+    }
+    else if(m->type & DT_MASKS_GRADIENT)
+    {
+      dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)p->data;
+      dt_masks_legacy_params_v2_to_v3_transform(img, gradient->anchor);
+    }
+    else if(m->type & DT_MASKS_ELLIPSE)
+    {
+      dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)p->data;
+      dt_masks_legacy_params_v2_to_v3_transform(img, ellipse->center);
+      dt_masks_legacy_params_v2_to_v3_transform_only_rescale(img, ellipse->radius, 2);
+      dt_masks_legacy_params_v2_to_v3_transform_only_rescale(img, &ellipse->border, 1);
+    }
+    else if(m->type & DT_MASKS_BRUSH)
+    {
+      while(p)
+      {
+        dt_masks_point_brush_t *brush = (dt_masks_point_brush_t *)p->data;
+        dt_masks_legacy_params_v2_to_v3_transform(img, brush->corner);
+        dt_masks_legacy_params_v2_to_v3_transform(img, brush->ctrl1);
+        dt_masks_legacy_params_v2_to_v3_transform(img, brush->ctrl2);
+        dt_masks_legacy_params_v2_to_v3_transform_only_rescale(img, brush->border, 2);
+
+        p = g_list_next(p);
+      }
+    }
+
+    if(m->type & DT_MASKS_CLONE)
+    {
+      // NOTE: can be: DT_MASKS_CIRCLE, DT_MASKS_ELLIPSE, DT_MASKS_PATH
+      dt_masks_legacy_params_v2_to_v3_transform(img, m->source);
+    }
+
+    m->version = 3;
+
+    return 0;
+  }
+}
+
 int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_version, const int new_version)
 {
   int res = 1;
   if(old_version == 1 && new_version == 2)
   {
     res = dt_masks_legacy_params_v1_to_v2(dev, params);
+  }
+  if(old_version == 2 && new_version == 3)
+  {
+    res = dt_masks_legacy_params_v2_to_v3(dev, params);
+  }
+
+  if(old_version == 1 && new_version == 3)
+  {
+    res = dt_masks_legacy_params_v1_to_v2(dev, params);
+    if(!res) res = dt_masks_legacy_params_v2_to_v3(dev, params);
   }
 
   return res;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -225,9 +225,14 @@ static void deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histog
 
   dt_dev_histogram_collection_params_t histogram_params = self->histogram_params;
 
-  dt_histogram_roi_t histogram_roi = {
-    .width = image.width, .height = image.height, .crop_x = 0, .crop_y = 0, .crop_width = 0, .crop_height = 0
-  };
+  dt_histogram_roi_t histogram_roi = {.width = image.width,
+                                      .height = image.height,
+
+                                      // FIXME: get those from rawprepare IOP somehow !!!
+                                      .crop_x = image.crop_x,
+                                      .crop_y = image.crop_y,
+                                      .crop_width = image.crop_width,
+                                      .crop_height = image.crop_height };
 
   histogram_params.roi = &histogram_roi;
 

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1944,9 +1944,14 @@ static float get_autoscale(dt_iop_module_t *self, dt_iop_lensfun_params_t *p, co
         = lf_db_find_lenses_hd(dt_iop_lensfun_db, camera, NULL, p->lens, LF_SEARCH_SORT_AND_UNIQUIFY);
     if(lenslist)
     {
+      const dt_image_t *img = &(self->dev->image_storage);
+
+      // FIXME: get those from rawprepare IOP somehow !!!
+      const int iwd = img->width - img->crop_x - img->crop_width,
+                iht = img->height - img->crop_x - img->crop_height;
+
       // create dummy modifier
-      lfModifier *modifier = lf_modifier_new(lenslist[0], p->crop, self->dev->image_storage.width,
-                                             self->dev->image_storage.height);
+      lfModifier *modifier = lf_modifier_new(lenslist[0], p->crop, iwd, iht);
       (void)lf_modifier_initialize(modifier, lenslist[0], LF_PF_F32, p->focal, p->aperture, p->distance, 1.0f,
                                    p->target_geom, p->modify_flags, p->inverse);
       scale = lf_modifier_get_auto_scale(modifier, p->inverse);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -127,7 +127,7 @@ int output_bpp(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
 static int BL(const dt_iop_roi_t *const roi_out, const dt_iop_rawprepare_data_t *const d, const int row,
               const int col)
 {
-  return ((((row + roi_out->y) & 1) << 1) + ((col + roi_out->x) & 1));
+  return ((((row + roi_out->y + d->y) & 1) << 1) + ((col + roi_out->x + d->x) & 1));
 }
 
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *ovoid,

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -337,6 +337,9 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   else
   {
     kernel = gd->kernel_rawprepare_4f;
+    const float scale = roi_in->scale / piece->iscale;
+    cx = d->x * scale;
+    cy = d->y * scale;
   }
 
   dev_sub = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 4, d->sub);
@@ -414,9 +417,6 @@ void commit_params(dt_iop_module_t *self, const dt_iop_params_t *const params, d
   }
 
   if(!dt_image_is_raw(&piece->pipe->image) || piece->pipe->image.bpp == sizeof(float)) piece->enabled = 0;
-
-  if(!(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && dt_image_filter(&piece->pipe->image)))
-    piece->process_cl_ready = 0;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -49,6 +49,7 @@ typedef struct dt_iop_rawprepare_gui_data_t
 
 typedef struct dt_iop_rawprepare_data_t
 {
+  int32_t x, y, width, height; // crop, now unused, for future expansion
   float sub[4];
   float div[4];
 } dt_iop_rawprepare_data_t;
@@ -133,6 +134,9 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_rawprepare_data_t *const d = (dt_iop_rawprepare_data_t *)piece->data;
+
+  // fprintf(stderr, "roi in %d %d %d %d\n", roi_in->x, roi_in->y, roi_in->width, roi_in->height);
+  // fprintf(stderr, "roi out %d %d %d %d\n", roi_out->x, roi_out->y, roi_out->width, roi_out->height);
 
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && dt_image_filter(&piece->pipe->image))
   { // raw mosaic
@@ -278,6 +282,11 @@ void commit_params(dt_iop_module_t *self, const dt_iop_params_t *const params, d
   const dt_iop_rawprepare_params_t *const p = (dt_iop_rawprepare_params_t *)params;
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
+  d->x = p->x;
+  d->y = p->y;
+  d->width = p->width;
+  d->height = p->height;
+
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && dt_image_filter(&piece->pipe->image))
   {
     const float white = (float)p->raw_white_point;
@@ -329,7 +338,11 @@ void reload_defaults(dt_iop_module_t *self)
 
   const dt_image_t *const image = &(self->dev->image_storage);
 
-  tmp = (dt_iop_rawprepare_params_t){.raw_black_level_separate[0] = image->raw_black_level_separate[0],
+  tmp = (dt_iop_rawprepare_params_t){.x = image->crop_x,
+                                     .y = image->crop_y,
+                                     .width = image->crop_width,
+                                     .height = image->crop_height,
+                                     .raw_black_level_separate[0] = image->raw_black_level_separate[0],
                                      .raw_black_level_separate[1] = image->raw_black_level_separate[1],
                                      .raw_black_level_separate[2] = image->raw_black_level_separate[2],
                                      .raw_black_level_separate[3] = image->raw_black_level_separate[3],

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -66,6 +66,11 @@ const char *name()
   return C_("modulename", "raw black/white point");
 }
 
+int operation_tags()
+{
+  return IOP_TAG_DISTORT;
+}
+
 int flags()
 {
   return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_ONE_INSTANCE
@@ -123,6 +128,41 @@ int output_bpp(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe
     return sizeof(float);
   else
     return 4 * sizeof(float);
+}
+
+int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
+{
+  dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
+
+  const float scale = piece->buf_in.scale / piece->iscale;
+
+  const float x = (float)d->x * scale, y = (float)d->y * scale;
+
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] -= x;
+    points[i + 1] -= y;
+  }
+
+  return 1;
+}
+
+int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points,
+                          size_t points_count)
+{
+  dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
+
+  const float scale = piece->buf_in.scale / piece->iscale;
+
+  const float x = (float)d->x * scale, y = (float)d->y * scale;
+
+  for(size_t i = 0; i < points_count * 2; i += 2)
+  {
+    points[i] += x;
+    points[i + 1] += y;
+  }
+
+  return 1;
 }
 
 // we're not scaling here (bayer input), so just crop borders

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -295,10 +295,11 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   }
 
   // now we set the values
-  roi_in->x = CLAMP(roix, 0, piece->pipe->iwidth * roi_in->scale - 1);
-  roi_in->y = CLAMP(roiy, 0, piece->pipe->iheight * roi_in->scale - 1);
-  roi_in->width = CLAMP(roir - roi_in->x, 1, piece->pipe->iwidth * roi_in->scale + .5f - roi_in->x);
-  roi_in->height = CLAMP(roib - roi_in->y, 1, piece->pipe->iheight * roi_in->scale + .5f - roi_in->y);
+  const float scwidth = piece->buf_in.width * roi_in->scale, scheight = piece->buf_in.height * roi_in->scale;
+  roi_in->x = CLAMP(roix, 0, scwidth - 1);
+  roi_in->y = CLAMP(roiy, 0, scheight - 1);
+  roi_in->width = CLAMP(roir - roi_in->x, 1, scwidth + .5f - roi_in->x);
+  roi_in->height = CLAMP(roib - roi_in->y, 1, scheight + .5f - roi_in->y);
 }
 
 static void masks_point_denormalize(dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *roi,

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -338,19 +338,19 @@ static int masks_get_delta(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
 
   if(form->type & DT_MASKS_PATH)
   {
-    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)g_list_nth_data(form->points, 0);
+    dt_masks_point_path_t *pt = (dt_masks_point_path_t *)form->points->data;
 
     res = masks_point_calc_delta(self, piece, roi, pt->corner, form->source, dx, dy);
   }
   else if(form->type & DT_MASKS_CIRCLE)
   {
-    dt_masks_point_circle_t *pt = (dt_masks_point_circle_t *)g_list_nth_data(form->points, 0);
+    dt_masks_point_circle_t *pt = (dt_masks_point_circle_t *)form->points->data;
 
     res = masks_point_calc_delta(self, piece, roi, pt->center, form->source, dx, dy);
   }
   else if(form->type & DT_MASKS_ELLIPSE)
   {
-    dt_masks_point_ellipse_t *pt = (dt_masks_point_ellipse_t *)g_list_nth_data(form->points, 0);
+    dt_masks_point_ellipse_t *pt = (dt_masks_point_ellipse_t *)form->points->data;
 
     res = masks_point_calc_delta(self, piece, roi, pt->center, form->source, dx, dy);
   }


### PR DESCRIPTION
This is the last step before we can implement (**native**) support for [Dual ISO](http://www.magiclantern.fm/forum/?topic=7139.0) as an IOP.

It requires loading the raw data without cropping black borders off upon load, but cropping them in the pipe.

Therefore, masks version needs to be bumped, and update procedure implemented... :(

I have checked all the blend masks types using color contrast iop and exposure iop.
I have checked all the clone mask types in spots iop.
They all seem identical(as in, no regressions) to me.

@AlicVB, @upegelow please do carefully check your test images/history stacks for regressions. (most importantly: blend *masks*, *spots iop*, c&r).
