### PR TITLE
Handle --disable-opencl cmdline option in dt_init()

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -486,6 +486,10 @@ int dt_init(int argc, char *argv[], const int init_gui, lua_State *L)
   char *configdir_from_command = NULL;
   char *cachedir_from_command = NULL;
 
+#ifdef HAVE_OPENCL
+  gboolean exclude_opencl = FALSE;
+#endif
+
 #ifdef USE_LUA
   char *lua_command = NULL;
 #endif
@@ -652,6 +656,12 @@ int dt_init(int argc, char *argv[], const int init_gui, lua_State *L)
         lua_command = argv[++k];
 #else
         ++k;
+#endif
+      }
+      else if(!strcmp(argv[k], "--disable-opencl"))
+      {
+#ifdef HAVE_OPENCL
+        exclude_opencl = TRUE;
 #endif
       }
       else if(!strcmp(argv[k], "--"))
@@ -821,7 +831,7 @@ int dt_init(int argc, char *argv[], const int init_gui, lua_State *L)
 
   darktable.opencl = (dt_opencl_t *)calloc(1, sizeof(dt_opencl_t));
 #ifdef HAVE_OPENCL
-  dt_opencl_init(darktable.opencl, argc, argv);
+  dt_opencl_init(darktable.opencl, exclude_opencl);
 #endif
 
   darktable.blendop = (dt_blendop_t *)calloc(1, sizeof(dt_blendop_t));

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -83,7 +83,12 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl)
   const int opencl_memory_requirement = MAX(200, dt_conf_get_int("opencl_memory_requirement"));
   dt_conf_set_int("opencl_memory_requirement", opencl_memory_requirement);
 
-  if(exclude_opencl) goto finally;
+  if(exclude_opencl)
+  {
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] do not try to find and use an opencl runtime library due to "
+                              "explicit user request\n");
+    goto finally;
+  }
 
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl related configuration options:\n");
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] \n");

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -46,7 +46,7 @@ static void dt_opencl_priority_parse(dt_opencl_t *cl, char *configstr, int *prio
 /** parse a complete priority string */
 static void dt_opencl_priorities_parse(dt_opencl_t *cl, const char *configstr);
 
-void dt_opencl_init(dt_opencl_t *cl, const int argc, char *argv[])
+void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl)
 {
   char *str;
   dt_pthread_mutex_init(&cl->lock, NULL);
@@ -77,22 +77,11 @@ void dt_opencl_init(dt_opencl_t *cl, const int argc, char *argv[])
   cl->dev_priority_export = NULL;
   cl->dev_priority_thumbnail = NULL;
 
-  int exclude_opencl = 0;
-
   // user selectable parameter defines minimum requirement on GPU memory
   // default is 768MB
   // values below 200 will be (re)set to 200
   const int opencl_memory_requirement = MAX(200, dt_conf_get_int("opencl_memory_requirement"));
   dt_conf_set_int("opencl_memory_requirement", opencl_memory_requirement);
-
-
-  for(int k = 0; k < argc; k++)
-    if(!strcmp(argv[k], "--disable-opencl"))
-    {
-      dt_print(DT_DEBUG_OPENCL, "[opencl_init] do not try to find and use an opencl runtime library due to "
-                                "explicit user request\n");
-      exclude_opencl = 1;
-    }
 
   if(exclude_opencl) goto finally;
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -130,7 +130,7 @@ typedef struct dt_opencl_t
 } dt_opencl_t;
 
 /** inits the opencl subsystem. */
-void dt_opencl_init(dt_opencl_t *cl, const int argc, char *argv[]);
+void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl);
 
 /** cleans up the opencl subsystem. */
 void dt_opencl_cleanup(dt_opencl_t *cl);


### PR DESCRIPTION
"--disable-opencl" cmdline option was parsed in dt_opencl_init(), after the bulk of options are parsed in dt_init(). Since e095b18 causes dt_init() to fail on unknown options, "--disable-opencl" should be parsed in dt_init(), not dt_opencl_init(). This fixes #10338.

Any command line options destined for gegl_init() may still cause an error? See Tobias Ellinghaus's comment to bug 10338: "GLib options work after --." 