### PR TITLE
xtrans: apply Markesteijn red/blue interpolation fix

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -713,15 +713,21 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           }
 
         /* Interpolate red for blue pixels and vice versa:              */
-        for(int row = top + 4; row < mrow - 4; row++)
-          for(int col = left + 4; col < mcol - 4; col++)
+        for(int row = top + 6; row < mrow - 6; row++)
+          for(int col = left + 6; col < mcol - 6; col++)
           {
             int f = 2 - FCxtrans(row + yoff + 12, col + xoff + 12, xtrans);
             if(f == 1) continue;
             float(*rfx)[3] = &rgb[0][row - top][col - left];
-            int i = (row - sgrow) % 3 ? TS : 1;
+            int c = (row - sgrow) % 3 ? TS : 1;
+            int h = 3 * (c ^ TS ^ 1);
             for(int d = 0; d < 4; d++, rfx += TS * TS)
+            {
+              int i = d > 1 || ((d ^ c) & 1) ||
+                ((fabsf(rfx[0][1]-rfx[c][1]) + fabsf(rfx[0][1]-rfx[-c][1])) <
+                 2.f*(fabsf(rfx[0][1]-rfx[h][1]) + fabsf(rfx[0][1]-rfx[-h][1]))) ? c:h;
               rfx[0][f] = CLIPF((rfx[i][f] + rfx[-i][f] + 2 * rfx[0][1] - rfx[i][1] - rfx[-i][1]) / 2);
+            }
           }
 
         /* Fill in red and blue for 2x2 blocks of green:                */


### PR DESCRIPTION
from dcraw 9.24's Markesteijn interpolation for x-trans images, via Ingo Weyrich of rawtherapee who has updated rawtherapee (https://code.google.com/p/rawtherapee/issues/detail?id=2415#c233) and passed on notice of this change to Tobias Ellinghaus.

This change eliminates moire in some cases (sample RAF is from dpreview.com studio test for X-E2 run through dt):

![xtrans_redblue_interp_moire_fix](https://cloud.githubusercontent.com/assets/2311860/6404758/ab272d22-bde9-11e4-8b6d-0e11604554d8.jpg)

On the other hand, it can also produce new glitches (this sample RAF is from imaging-resource.com's X-M1 images, run through dt):

![xtrans_glitch](https://cloud.githubusercontent.com/assets/2311860/6404772/d5ddff82-bde9-11e4-9568-26803314533b.jpg)
