### PR TITLE
Use rawspeed makermodel to lookup adobe_coeffs

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -967,6 +967,8 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[0] = NAN;
   img->wb_coeffs[1] = NAN;
   img->wb_coeffs[2] = NAN;
+  img->XYZ_to_CAM[0][0] = NAN;
+  memset(img->raw_makermodel, 0, sizeof(img->raw_makermodel));
   img->cache_entry = 0;
 }
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -154,6 +154,10 @@ typedef struct dt_image_t
   float wb_coeffs[3];
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;
+
+  /* color matrix for the image */
+  float XYZ_to_CAM[4][3];
+  char raw_makermodel[128];
 } dt_image_t;
 
 // image buffer operations:

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -38,6 +38,7 @@ extern "C" {
 #include "common/colorspaces.h"
 #include "common/file_location.h"
 #include <stdint.h>
+#include "external/adobe_coeff.c"
 }
 
 // define this function, it is only declared in rawspeed:
@@ -139,6 +140,11 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     img->raw_black_level = r->blackLevel;
     img->raw_white_point = r->whitePoint;
+
+    string makermodel = r->metadata.make + " " + r->metadata.model;
+    strncpy(img->raw_makermodel, makermodel.c_str(), sizeof(img->raw_makermodel));
+    img->raw_makermodel[sizeof(img->raw_makermodel)-1] = '\0'; // Make sure we NULL terminate
+    dt_dcraw_adobe_coeff(img->raw_makermodel, (float(*)[12])img->XYZ_to_CAM);
 
     if(r->blackLevelSeparate[0] == -1 || r->blackLevelSeparate[1] == -1 || r->blackLevelSeparate[2] == -1
        || r->blackLevelSeparate[3] == -1)

--- a/src/external/adobe_coeff.c
+++ b/src/external/adobe_coeff.c
@@ -13,7 +13,7 @@ static void dt_dcraw_adobe_coeff(const char *name, float cam_xyz[1][12])
 {
   static const struct {
     const char *prefix;
-    short black, maximum, trans[12];
+    int black, maximum, trans[12];
   } table[] = {
     { "AGFAPHOTO DC-833m", 0, 0, { 11438,-3762,-1115,-2409,9914,2497,-1227,2295,5300 } }, /* DJC */
     { "Apple QuickTake", 0, 0, { 21392,-5653,-3353,2406,8010,-415,7166,1427,2078 } },	/* DJC */
@@ -528,7 +528,7 @@ static void dt_dcraw_adobe_coeff(const char *name, float cam_xyz[1][12])
     { "SONY SLT-A99", 128, 0, { 6344,-1612,-462,-4863,12477,2681,-865,1786,6899 } },
   };
 
-  for (int i=0; i < sizeof(table)/sizeof(table[1]); i++) {
+  for (unsigned i=0; i < sizeof(table)/sizeof(table[1]); i++) {
     if (!strncmp (name, table[i].prefix, strlen(table[i].prefix))) {
       if (strcmp(name, table[i].prefix))
         fprintf(stderr, "[adobe_coeff] Warning: partial matching of \"%s\" to \"%s\"\n", name, table[i].prefix);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -38,7 +38,6 @@
 #include "bauhaus/bauhaus.h"
 
 // for Kelvin temperature and bogus WB
-#include "external/adobe_coeff.c"
 #include "external/cie_colorimetric_tables.c"
 #include "common/colorspaces.h"
 
@@ -668,13 +667,8 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[3])
   }
 
   // color matrix
-  char makermodel[1024];
-  dt_colorspaces_get_makermodel(makermodel, sizeof(makermodel), module->dev->image_storage.exif_maker,
-                                module->dev->image_storage.exif_model);
-  float XYZ_to_CAM[4][3];
-  XYZ_to_CAM[0][0] = NAN;
-  dt_dcraw_adobe_coeff(makermodel, (float(*)[12])XYZ_to_CAM);
-  if(!isnan(XYZ_to_CAM[0][0]))
+  dt_image_t img = module->dev->image_storage;
+  if(!isnan(img.XYZ_to_CAM[0][0]))
   {
     // sRGB D65
     const double RGB_to_XYZ[3][3] = { { 0.4124564, 0.3575761, 0.1804375 },
@@ -687,7 +681,7 @@ static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[3])
       for(int j = 0; j < 3; j++)
       {
         RGB_to_CAM[i][j] = 0.0;
-        for(int k = 0; k < 3; k++) RGB_to_CAM[i][j] += XYZ_to_CAM[i][k] * RGB_to_XYZ[k][j];
+        for(int k = 0; k < 3; k++) RGB_to_CAM[i][j] += img.XYZ_to_CAM[i][k] * RGB_to_XYZ[k][j];
       }
     }
 
@@ -737,13 +731,8 @@ static int prepare_wb_matrices(dt_iop_module_t *module)
   }
 
   // prepare matrices for Kelvin temperature
-  char makermodel[1024];
-  dt_colorspaces_get_makermodel(makermodel, sizeof(makermodel), module->dev->image_storage.exif_maker,
-                                module->dev->image_storage.exif_model);
-
-  float XYZ_to_CAM[4][3];
-  dt_dcraw_adobe_coeff(makermodel, (float(*)[12])XYZ_to_CAM);
-  if(!isnan(XYZ_to_CAM[0][0]))
+  dt_image_t img = module->dev->image_storage;
+  if(!isnan(img.XYZ_to_CAM[0][0]))
   {
     double RGB_to_CAM[3][3];
     for(int i = 0; i < 3; i++)
@@ -751,7 +740,7 @@ static int prepare_wb_matrices(dt_iop_module_t *module)
       for(int j = 0; j < 3; j++)
       {
         RGB_to_CAM[i][j] = 0.0;
-        for(int k = 0; k < 3; k++) RGB_to_CAM[i][j] += XYZ_to_CAM[i][k] * RGB_to_XYZ[k][j];
+        for(int k = 0; k < 3; k++) RGB_to_CAM[i][j] += img.XYZ_to_CAM[i][k] * RGB_to_XYZ[k][j];
       }
     }
 


### PR DESCRIPTION
Use the make and model from rawspeed to index into adobe_coeffs. This is still incomplete but will allow us to:

  * Have working color matrices even for cameras not supported by libexiv2 (some Leafs, all of the CHDK raws, etc)
  * Have only a single matrix for all the aliases for a given camera

So far this is just the basic code for comments on the approach, what's still needed is:

  * Use raw_makermodel for all matrices, not just the adobe_coeffs one
  * Convert all the matrices naming to the same used by rawspeed
  * Extend rawspeed to give us a canonical name per camera instead of whatever the camera reported (to get aliases working neatly)