### PR TITLE
Adding a .travis.yml file to use the travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+
+before_install:
+
+  - sudo apt-get install intltool libatk1.0-dev libcairo2-dev libsoup2.4-dev
+    libexiv2-dev libfontconfig1-dev libfreetype6-dev libgomp1 libgtk2.0-dev
+    libjpeg-dev libtiff4-dev liblcms2-dev liblensfun-dev libpng12-dev
+    libsqlite3-dev libstdc++6-4.4-dev libxml2-dev libopenexr-dev
+    libcurl4-gnutls-dev libgphoto2-2-dev libdbus-glib-1-dev
+    libgnome-keyring-dev fop librsvg2-dev libflickcurl-dev cmake liblua5.2-dev
+    libcolord-dev libjson-glib-dev libgtk-3-dev
+
+script:
+
+  - ./build.sh
+
+notifications:
+  email: false


### PR DESCRIPTION
From wikipedia:

Travis CI is a hosted, distributed continuous integration service used
to build and test projects hosted at GitHub.

Travis CI is configured by adding a file named .travis.yml, which is a
YAML format text file, to the root directory of the GitHub repository.

Travis CI automatically detects when a commit has been made and pushed
to a GitHub repository that is using Travis CI, and each time this
happens, it will try to build the project and run tests. This includes
commits to all branches, not just to the master branch. When that
process has completed, it will notify a developer in the way it has been
configured to do so — for example, by sending an email containing the
test results (showing success or failure), or by posting a message on an
IRC channel. It can be configured to run the tests on a range of
different machines, with different software installed (such as older
versions of a programming language, to test for compatibility).