### PR TITLE
arrows and switching filters issue

### DIFF
--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -246,6 +246,7 @@ static void _lib_filter_combobox_changed(GtkComboBox *widget, gpointer user_data
 
   /* set the star filter in collection */
   dt_collection_set_rating(darktable.collection, i);
+  dt_control_set_mouse_over_id(-1); // may me I'm storing mouse_over_id (arrows)
 
   /* update the gui accordingly */
   _lib_filter_sync_combobox_and_comparator(user_data);


### PR DESCRIPTION
issue:
* filter collection as "all"
* select some images (not rated 2 stars ) using arrows
* filter as "stars == 2". That images are not here and the selection is empty.
* press 2
* filter as "stars == "3"
* filter as "stars == "2"

When we pressed "2" we rated an image not in the current collection, so, invisible.
Bug introduced with arrows support.
