### PR TITLE
Histogram rework

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -967,7 +967,7 @@ void dt_dev_read_history(dt_develop_t *dev)
     if(!hist->module && find_op)
     {
       // we have to add a new instance of this module and set index to modindex
-      dt_iop_module_t *new_module = (dt_iop_module_t *)malloc(sizeof(dt_iop_module_t));
+      dt_iop_module_t *new_module = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
       if(!dt_iop_load_module(new_module, find_op->so, dev))
       {
         new_module->multi_priority = multi_priority;
@@ -1364,7 +1364,7 @@ void dt_dev_average_delay_update(const dt_times_t *start, uint32_t *average_dela
 dt_iop_module_t *dt_dev_module_duplicate(dt_develop_t *dev, dt_iop_module_t *base, int priority)
 {
   // we create the new module
-  dt_iop_module_t *module = (dt_iop_module_t *)malloc(sizeof(dt_iop_module_t));
+  dt_iop_module_t *module = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
   if(dt_iop_load_module(module, base->so, base->dev)) return NULL;
   module->instance = base->instance;
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -329,9 +329,6 @@ static int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t 
   module->hide_enable_button = 0;
   module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   module->request_histogram = DT_REQUEST_ONLY_IN_GUI;
-  module->request_histogram_source = DT_DEV_PIXELPIPE_PREVIEW;
-  module->histogram_params.roi = NULL;
-  module->histogram_params.bins_count = 64;
   module->histogram_stats.bins_count = 0;
   module->histogram_stats.pixels = 0;
   module->multi_priority = 0;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -101,34 +101,6 @@ typedef void dt_iop_gui_data_t;
 typedef void dt_iop_data_t;
 typedef void dt_iop_global_data_t;
 
-// params to be used to collect histogram
-typedef struct dt_dev_histogram_collection_params_t
-{
-  /** histogram_collect: if NULL, correct is set; else should be set manually */
-  const struct dt_histogram_roi_t *roi;
-  /** count of histogram bins. */
-  uint32_t bins_count;
-} dt_dev_histogram_collection_params_t;
-
-// params used to collect histogram during last histogram capture
-typedef struct dt_dev_histogram_stats_t
-{
-  /** count of histogram bins. */
-  uint32_t bins_count;
-  /** count of pixels sampled during histogram capture. */
-  uint32_t pixels;
-  /** count of channels: 1 for RAW, 3 for rgb/Lab. */
-  uint32_t ch;
-} dt_dev_histogram_stats_t;
-
-/** when to collect histogram */
-typedef enum dt_dev_request_flags_t
-{
-  DT_REQUEST_NONE = 0,
-  DT_REQUEST_ON = 1 << 0,
-  DT_REQUEST_ONLY_IN_GUI = 1 << 1
-} dt_dev_request_flags_t;
-
 /** color picker request */
 typedef enum dt_dev_request_colorpick_flags_t
 {
@@ -258,12 +230,6 @@ typedef struct dt_iop_module_t
   dt_dev_request_colorpick_flags_t request_color_pick;
   /** (bitwise) set if you want an histogram generated during next eval */
   dt_dev_request_flags_t request_histogram;
-  /** set to source for histogram */
-  dt_dev_pixelpipe_type_t request_histogram_source;
-  /** set histogram generation params */
-  dt_dev_histogram_collection_params_t histogram_params;
-  /** stats of captured histogram */
-  dt_dev_histogram_stats_t histogram_stats;
   /** set to 1 if you want the mask to be transferred into alpha channel during next eval. gui mode only. */
   int32_t request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the module in focus. gui mode only. */
@@ -278,6 +244,8 @@ typedef struct dt_iop_module_t
   float picked_output_color[3], picked_output_color_min[3], picked_output_color_max[3];
   /** pointer to pre-module histogram data; if available: histogram_bins_count bins with 4 channels each */
   uint32_t *histogram;
+  /** stats of captured histogram */
+  dt_dev_histogram_stats_t histogram_stats;
   /** maximum levels in histogram, one per channel */
   uint32_t histogram_max[4];
   /** reference for dlopened libs. */

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -17,6 +17,7 @@
 */
 #ifndef DT_DEV_PIXELPIPE_H
 #define DT_DEV_PIXELPIPE_H
+#include <stdint.h>
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -32,6 +33,34 @@ typedef enum dt_dev_pixelpipe_type_t
   DT_DEV_PIXELPIPE_ANY = DT_DEV_PIXELPIPE_EXPORT | DT_DEV_PIXELPIPE_FULL | DT_DEV_PIXELPIPE_PREVIEW
                          | DT_DEV_PIXELPIPE_THUMBNAIL
 } dt_dev_pixelpipe_type_t;
+
+/** when to collect histogram */
+typedef enum dt_dev_request_flags_t
+{
+  DT_REQUEST_NONE = 0,
+  DT_REQUEST_ON = 1 << 0,
+  DT_REQUEST_ONLY_IN_GUI = 1 << 1
+} dt_dev_request_flags_t;
+
+// params to be used to collect histogram
+typedef struct dt_dev_histogram_collection_params_t
+{
+  /** histogram_collect: if NULL, correct is set; else should be set manually */
+  const struct dt_histogram_roi_t *roi;
+  /** count of histogram bins. */
+  uint32_t bins_count;
+} dt_dev_histogram_collection_params_t;
+
+// params used to collect histogram during last histogram capture
+typedef struct dt_dev_histogram_stats_t
+{
+  /** count of histogram bins. */
+  uint32_t bins_count;
+  /** count of pixels sampled during histogram capture. */
+  uint32_t pixels;
+  /** count of channels: 1 for RAW, 3 for rgb/Lab. */
+  uint32_t ch;
+} dt_dev_histogram_stats_t;
 
 typedef void dt_iop_params_t;
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -46,7 +46,14 @@ typedef struct dt_dev_pixelpipe_iop_t
   struct dt_dev_pixelpipe_t *pipe; // the pipe this piece belongs to
   void *data;                      // to be used by the module to store stuff per pipe piece
   void *blendop_data;              // to be used by the module to store blendop per pipe piece
-  int enabled;         // used to disable parts of the pipe for export, independent on module itself.
+  int enabled; // used to disable parts of the pipe for export, independent on module itself.
+
+  dt_dev_request_flags_t request_histogram;              // (bitwise) set if you want an histogram captured
+  dt_dev_histogram_collection_params_t histogram_params; // set histogram generation params
+  uint32_t *histogram; // pointer to histogram data; histogram_bins_count bins with 4 channels each
+  dt_dev_histogram_stats_t histogram_stats; // stats of captured histogram
+  uint32_t histogram_max[4];                // maximum levels in histogram, one per channel
+
   float iscale;        // input actually just downscaled buffer? iscale*iwidth = actual width
   int iwidth, iheight; // width and height of input buffer
   uint64_t hash;       // hash of params and enabled.

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -1,7 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2009--2010 johannes hanika.
-    copyright (c) 2014 LebedevRI.
+    copyright (c) 2014-2015 LebedevRI.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -83,9 +83,9 @@ typedef struct dt_iop_exposure_gui_data_t
   GtkWidget *deflicker_histogram_source;
   uint32_t *deflicker_histogram; // used to cache histogram of source file
   dt_dev_histogram_stats_t deflicker_histogram_stats;
-  gboolean reprocess_on_next_expose;
   GtkLabel *deflicker_used_EC;
   float deflicker_computed_exposure;
+  dt_pthread_mutex_t lock;
 } dt_iop_exposure_gui_data_t;
 
 typedef struct dt_iop_exposure_data_t
@@ -260,9 +260,9 @@ static int compute_correction(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 {
   dt_iop_exposure_data_t *d = (dt_iop_exposure_data_t *)piece->data;
 
-  if(histogram == NULL) return 1;
-
   *correction = NAN;
+
+  if(histogram == NULL) return 1;
 
   const size_t total = (size_t)histogram_stats->ch * histogram_stats->pixels;
 
@@ -303,10 +303,28 @@ static int compute_correction(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 static void commit_params_late(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_exposure_data_t *d = (dt_iop_exposure_data_t *)piece->data;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
   if(d->mode == EXPOSURE_MODE_DEFLICKER)
   {
-    compute_correction(self, piece, self->histogram, &self->histogram_stats, &d->exposure);
+    if(g && piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
+    {
+      dt_pthread_mutex_lock(&g->lock);
+      d->exposure = g->deflicker_computed_exposure;
+      dt_pthread_mutex_unlock(&g->lock);
+    }
+
+    if(piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW || isnan(d->exposure))
+    {
+      compute_correction(self, piece, piece->histogram, &piece->histogram_stats, &d->exposure);
+    }
+  }
+
+  if(g && piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+  {
+    dt_pthread_mutex_lock(&g->lock);
+    g->deflicker_computed_exposure = d->exposure;
+    dt_pthread_mutex_unlock(&g->lock);
   }
 }
 
@@ -316,12 +334,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 {
   dt_iop_exposure_data_t *d = (dt_iop_exposure_data_t *)piece->data;
   dt_iop_exposure_global_data_t *gd = (dt_iop_exposure_global_data_t *)self->data;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  if(d->mode == EXPOSURE_MODE_DEFLICKER)
-  {
-    commit_params_late(self, piece);
-  }
+  commit_params_late(self, piece);
 
   cl_int err = -999;
   const float black = d->black;
@@ -341,10 +355,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_exposure, sizes);
   if(err != CL_SUCCESS) goto error;
   for(int k = 0; k < 3; k++) piece->pipe->processed_maximum[k] *= scale;
-  if(g != NULL && self->dev->gui_attached && piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
-  {
-    g->deflicker_computed_exposure = d->exposure;
-  }
+
   return TRUE;
 
 error:
@@ -357,12 +368,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
              const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
 {
   dt_iop_exposure_data_t *d = (dt_iop_exposure_data_t *)piece->data;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  if(d->mode == EXPOSURE_MODE_DEFLICKER)
-  {
-    commit_params_late(self, piece);
-  }
+  commit_params_late(self, piece);
 
   const float black = d->black;
   const float white = exposure2white(d->exposure);
@@ -384,11 +391,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   if(piece->pipe->mask_display) dt_iop_alpha_copy(i, o, roi_out->width, roi_out->height);
 
   for(int k = 0; k < 3; k++) piece->pipe->processed_maximum[k] *= scale;
-
-  if(g != NULL && self->dev->gui_attached && piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
-  {
-    g->deflicker_computed_exposure = d->exposure;
-  }
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
@@ -401,17 +403,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->black = p->black;
   d->exposure = p->exposure;
 
-  if(pipe->type == DT_DEV_PIXELPIPE_PREVIEW) piece->request_histogram &= ~(DT_REQUEST_ON);
+  piece->request_histogram &= ~(DT_REQUEST_ON);
   piece->request_histogram |= (DT_REQUEST_ONLY_IN_GUI);
-
-  piece->histogram_params.bins_count = 16384; // we neeed really maximally reliable histogram
-
-  if(self->dev->gui_attached)
-  {
-    g->reprocess_on_next_expose = FALSE;
-  }
-
-  gboolean histogram_is_good = ((self->histogram_stats.bins_count == 16384) && (self->histogram != NULL));
 
   d->deflicker_percentile = p->deflicker_percentile;
   d->deflicker_target_level = p->deflicker_target_level;
@@ -420,7 +413,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     if(p->deflicker_histogram_source == DEFLICKER_HISTOGRAM_SOURCE_SOURCEFILE)
     {
-      if(self->dev->gui_attached)
+      if(g)
       {
         // histogram is precomputed and cached
         compute_correction(self, piece, g->deflicker_histogram, &g->deflicker_histogram_stats, &d->exposure);
@@ -439,39 +432,25 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     {
       if(p->deflicker_histogram_source == DEFLICKER_HISTOGRAM_SOURCE_THUMBNAIL)
       {
+        d->mode = EXPOSURE_MODE_DEFLICKER;
+
         piece->request_histogram |= (DT_REQUEST_ON);
 
-        gboolean failed = !histogram_is_good;
+        if(!self->dev->gui_attached) piece->request_histogram &= ~(DT_REQUEST_ONLY_IN_GUI);
 
-        if(self->dev->gui_attached && histogram_is_good)
-        {
-          /*
-           * if in GUI, user might zoomed main view => we would get histogram of
-           * only part of image, so if in GUI we must always use histogram of
-           * preview pipe, which is always full-size and have biggest size
-           */
-          d->mode = EXPOSURE_MODE_DEFLICKER;
-          commit_params_late(self, piece);
-          d->mode = EXPOSURE_MODE_MANUAL;
+        piece->histogram_params.bins_count = 16384;
 
-          if(isnan(d->exposure)) failed = TRUE;
-        }
-        else if(failed || !(self->dev->gui_attached && histogram_is_good))
-        {
-          d->mode = EXPOSURE_MODE_DEFLICKER;
-          // commit_params_late() will compute correct d->exposure later
-          piece->request_histogram &= ~(DT_REQUEST_ONLY_IN_GUI);
+        /*
+         * in principle, we do not need/want histogram in FULL pipe
+         * because we will use histogram from preview pipe there,
+         * but it might happen that for some reasons we do not have
+         * histogram of preview pipe yet - e.g. on first pipe run
+         * (just after setting mode to automatic)
+         */
 
-          if(failed && self->dev->gui_attached)
-          {
-            /*
-             * but sadly we do not yet have a histogram to do so, so this time
-             * we process asif not in gui, and in expose() immediately
-             * reprocess, thus everything works as expected
-             */
-            g->reprocess_on_next_expose = TRUE;
-          }
-        }
+        d->exposure = NAN;
+
+        // commit_params_late() will compute exposure later
       }
     }
   }
@@ -542,10 +521,10 @@ void gui_update(struct dt_iop_module_t *self)
   free(g->deflicker_histogram);
   g->deflicker_histogram = NULL;
 
-  g->reprocess_on_next_expose = FALSE;
-
   gtk_label_set_text(g->deflicker_used_EC, "");
+  dt_pthread_mutex_lock(&g->lock);
   g->deflicker_computed_exposure = NAN;
+  dt_pthread_mutex_unlock(&g->lock);
 
   switch(p->mode)
   {
@@ -868,6 +847,7 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
+  dt_pthread_mutex_lock(&g->lock);
   if(!isnan(g->deflicker_computed_exposure))
   {
     gchar *str = g_strdup_printf("%.2fEV", g->deflicker_computed_exposure);
@@ -877,16 +857,8 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
     darktable.gui->reset = 0;
 
     g_free(str);
-    g->deflicker_computed_exposure = NAN;
   }
-
-  if(self->enabled && g->reprocess_on_next_expose)
-  {
-    g->reprocess_on_next_expose = FALSE;
-    // FIXME: or just use dev->pipe->changed |= DT_DEV_PIPE_SYNCH; ?
-    dt_dev_reprocess_all(self->dev);
-    return FALSE;
-  }
+  dt_pthread_mutex_unlock(&g->lock);
 
   if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE) return FALSE;
 
@@ -913,7 +885,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->deflicker_histogram = NULL;
 
-  g->reprocess_on_next_expose = FALSE;
+  dt_pthread_mutex_init(&g->lock, NULL);
 
   /* register hooks with current dev so that  histogram
      can interact with this module.
@@ -1013,7 +985,10 @@ void gui_init(struct dt_iop_module_t *self)
   g_object_set(G_OBJECT(g->deflicker_used_EC), "tooltip-text",
                _("what exposure correction have actually been used"), (char *)NULL);
   gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(g->deflicker_used_EC), FALSE, FALSE, 0);
+
+  dt_pthread_mutex_lock(&g->lock);
   g->deflicker_computed_exposure = NAN;
+  dt_pthread_mutex_unlock(&g->lock);
 
   gtk_box_pack_start(GTK_BOX(g->vbox_deflicker), GTK_WIDGET(hbox1), FALSE, FALSE, 0);
 
@@ -1036,10 +1011,13 @@ void gui_init(struct dt_iop_module_t *self)
 void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+
   free(g->deflicker_histogram);
   g->deflicker_histogram = NULL;
   g_list_free(g->deflicker_histogram_sources);
   g_list_free(g->modes);
+
+  dt_pthread_mutex_destroy(&g->lock);
 
   free(self->gui_data);
   self->gui_data = NULL;

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -362,9 +362,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)p1;
   dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
 
-  self->request_histogram |= (DT_REQUEST_ONLY_IN_GUI);
-  self->request_histogram_source = (DT_DEV_PIXELPIPE_PREVIEW);
-  self->histogram_params.bins_count = 64;
+  piece->request_histogram |= (DT_REQUEST_ONLY_IN_GUI);
+  if(pipe->type == DT_DEV_PIXELPIPE_PREVIEW) piece->request_histogram |= (DT_REQUEST_ON);
+  piece->histogram_params.bins_count = 64;
 
   if(self->dev->gui_attached)
   {
@@ -375,7 +375,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   if(p->mode == LEVELS_MODE_AUTOMATIC)
   {
-    self->histogram_params.bins_count = 16384;
+    piece->histogram_params.bins_count = 16384;
 
     d->percentiles[0] = p->percentiles[0];
     d->percentiles[1] = p->percentiles[1];
@@ -400,8 +400,8 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
     {
       d->mode = LEVELS_MODE_AUTOMATIC;
       // commit_params_late() will compute LUT later
-      self->request_histogram &= ~(DT_REQUEST_ONLY_IN_GUI);
-      self->request_histogram_source = (DT_DEV_PIXELPIPE_ANY);
+      piece->request_histogram &= ~(DT_REQUEST_ONLY_IN_GUI);
+      piece->request_histogram |= (DT_REQUEST_ON);
 
       if(failed && self->dev->gui_attached)
       {

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1,7 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2009--2011 johannes hanika.
-    copyright (c) 2014 LebedevRI.
+    copyright (c) 2014-2015 LebedevRI.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -42,7 +42,6 @@
 DT_MODULE_INTROSPECTION(2, dt_iop_levels_params_t)
 
 static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data);
-static gboolean dt_iop_levels_vbox_automatic_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data);
 static gboolean dt_iop_levels_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data);
 static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
 static gboolean dt_iop_levels_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
@@ -93,7 +92,8 @@ typedef struct dt_iop_levels_gui_data_t
   GtkWidget *percentile_black;
   GtkWidget *percentile_grey;
   GtkWidget *percentile_white;
-  gboolean reprocess_on_next_expose;
+  float auto_levels[3];
+  dt_pthread_mutex_t lock;
 } dt_iop_levels_gui_data_t;
 
 typedef struct dt_iop_levels_data_t
@@ -175,32 +175,32 @@ static void dt_iop_levels_compute_levels_manual(const uint32_t *histogram, float
   levels[1] = levels[0] / 2 + levels[2] / 2;
 }
 
-static void dt_iop_levels_compute_levels_automatic(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+static void dt_iop_levels_compute_levels_automatic(dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_levels_data_t *d = (dt_iop_levels_data_t *)piece->data;
 
-  if(self->histogram == NULL) return;
-
-  uint32_t total = self->histogram_stats.pixels;
+  uint32_t total = piece->histogram_stats.pixels;
 
   float thr[3];
   for(int k = 0; k < 3; k++)
   {
-    thr[k] = total * d->percentiles[k] / 100.0f;
+    thr[k] = (float)total * d->percentiles[k] / 100.0f;
     d->levels[k] = NAN;
   }
 
+  if(piece->histogram == NULL) return;
+
   // find min and max levels
-  uint32_t n = 0;
-  for(uint32_t i = 0; i < self->histogram_stats.bins_count; i++)
+  size_t n = 0;
+  for(uint32_t i = 0; i < piece->histogram_stats.bins_count; i++)
   {
-    n += self->histogram[4 * i];
+    n += piece->histogram[4 * i];
 
     for(int k = 0; k < 3; k++)
     {
       if(isnan(d->levels[k]) && (n >= thr[k]))
       {
-        d->levels[k] = (float)i / (float)(self->histogram_stats.bins_count - 1);
+        d->levels[k] = (float)i / (float)(piece->histogram_stats.bins_count - 1);
       }
     }
   }
@@ -211,7 +211,7 @@ static void dt_iop_levels_compute_levels_automatic(dt_iop_module_t *self, dt_dev
     d->levels[1] = (1.0f - center) * d->levels[0] + center * d->levels[2];
 }
 
-static void compute_lut(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+static void compute_lut(dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_levels_data_t *d = (dt_iop_levels_data_t *)piece->data;
 
@@ -235,11 +235,36 @@ static void compute_lut(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_levels_data_t *d = (dt_iop_levels_data_t *)piece->data;
+  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
 
   if(d->mode == LEVELS_MODE_AUTOMATIC)
   {
-    dt_iop_levels_compute_levels_automatic(self, piece);
-    compute_lut(self, piece);
+    if(g && piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
+    {
+      dt_pthread_mutex_lock(&g->lock);
+      d->levels[0] = g->auto_levels[0];
+      d->levels[1] = g->auto_levels[1];
+      d->levels[2] = g->auto_levels[2];
+      dt_pthread_mutex_unlock(&g->lock);
+
+      compute_lut(piece);
+    }
+
+    if(piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW || isnan(d->levels[0]) || isnan(d->levels[1])
+       || isnan(d->levels[2]))
+    {
+      dt_iop_levels_compute_levels_automatic(piece);
+      compute_lut(piece);
+    }
+
+    if(g && piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW && d->mode == LEVELS_MODE_AUTOMATIC)
+    {
+      dt_pthread_mutex_lock(&g->lock);
+      g->auto_levels[0] = d->levels[0];
+      g->auto_levels[1] = d->levels[1];
+      g->auto_levels[2] = d->levels[2];
+      dt_pthread_mutex_unlock(&g->lock);
+    }
   }
 }
 
@@ -335,6 +360,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(err != CL_SUCCESS) goto error;
 
   dt_opencl_release_mem_object(dev_lut);
+
   return TRUE;
 
 error:
@@ -360,67 +386,53 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 {
   dt_iop_levels_data_t *d = (dt_iop_levels_data_t *)piece->data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)p1;
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
+
+  if(pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+    piece->request_histogram |= (DT_REQUEST_ON);
+  else
+    piece->request_histogram &= ~(DT_REQUEST_ON);
 
   piece->request_histogram |= (DT_REQUEST_ONLY_IN_GUI);
-  if(pipe->type == DT_DEV_PIXELPIPE_PREVIEW) piece->request_histogram |= (DT_REQUEST_ON);
+
   piece->histogram_params.bins_count = 64;
-
-  if(self->dev->gui_attached)
-  {
-    g->reprocess_on_next_expose = FALSE;
-  }
-
-  gboolean histogram_is_good = ((self->histogram_stats.bins_count == 16384) && (self->histogram != NULL));
 
   if(p->mode == LEVELS_MODE_AUTOMATIC)
   {
+    d->mode = LEVELS_MODE_AUTOMATIC;
+
+    piece->request_histogram |= (DT_REQUEST_ON);
+    self->request_histogram &= ~(DT_REQUEST_ON);
+
+    if(!self->dev->gui_attached) piece->request_histogram &= ~(DT_REQUEST_ONLY_IN_GUI);
+
     piece->histogram_params.bins_count = 16384;
 
-    d->percentiles[0] = p->percentiles[0];
-    d->percentiles[1] = p->percentiles[1];
-    d->percentiles[2] = p->percentiles[2];
+    /*
+     * in principle, we do not need/want histogram in FULL pipe
+     * because we will use histogram from preview pipe there,
+     * but it might happen that for some reasons we do not have
+     * histogram of preview pipe yet - e.g. on first pipe run
+     * (just after setting mode to automatic)
+     */
 
-    gboolean failed = !histogram_is_good;
-
-    if(self->dev->gui_attached && histogram_is_good)
+    for(int k = 0; k < 3; k++)
     {
-      /*
-       * if in GUI, user might zoomed main view => we would get histogram of
-       * only part of image, so if in GUI we must always use histogram of
-       * preview pipe, which is always full-size and have biggest size
-       */
-      d->mode = LEVELS_MODE_AUTOMATIC;
-      commit_params_late(self, piece);
-      d->mode = LEVELS_MODE_MANUAL;
-
-      if(isnan(d->levels[0]) || isnan(d->levels[1]) || isnan(d->levels[2])) failed = TRUE;
+      d->levels[k] = NAN;
+      d->percentiles[k] = p->percentiles[k];
     }
-    else if(failed || !(self->dev->gui_attached && histogram_is_good))
-    {
-      d->mode = LEVELS_MODE_AUTOMATIC;
-      // commit_params_late() will compute LUT later
-      piece->request_histogram &= ~(DT_REQUEST_ONLY_IN_GUI);
-      piece->request_histogram |= (DT_REQUEST_ON);
 
-      if(failed && self->dev->gui_attached)
-      {
-        /*
-         * but sadly we do not yet have a histogram to do so, so this time we
-         * process asif not in gui, and in expose() immediately reprocess,
-         * thus everything works as expected
-         */
-        g->reprocess_on_next_expose = TRUE;
-      }
-    }
+    // commit_params_late() will compute LUT later
   }
   else
   {
     d->mode = LEVELS_MODE_MANUAL;
+
+    self->request_histogram |= (DT_REQUEST_ON);
+
     d->levels[0] = p->levels[0];
     d->levels[1] = p->levels[1];
     d->levels[2] = p->levels[2];
-    compute_lut(self, piece);
+    compute_lut(piece);
   }
 }
 
@@ -458,6 +470,12 @@ void gui_update(dt_iop_module_t *self)
       gtk_widget_show(GTK_WIDGET(g->vbox_manual));
       break;
   }
+
+  dt_pthread_mutex_lock(&g->lock);
+  g->auto_levels[0] = NAN;
+  g->auto_levels[1] = NAN;
+  g->auto_levels[2] = NAN;
+  dt_pthread_mutex_unlock(&g->lock);
 
   gtk_widget_queue_draw(self->widget);
 }
@@ -512,7 +530,13 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
-  c->reprocess_on_next_expose = FALSE;
+  dt_pthread_mutex_init(&c->lock, NULL);
+
+  dt_pthread_mutex_lock(&c->lock);
+  c->auto_levels[0] = NAN;
+  c->auto_levels[1] = NAN;
+  c->auto_levels[2] = NAN;
+  dt_pthread_mutex_unlock(&c->lock);
 
   c->modes = NULL;
 
@@ -619,8 +643,6 @@ void gui_init(dt_iop_module_t *self)
       break;
   }
 
-  g_signal_connect(G_OBJECT(c->vbox_automatic), "draw", G_CALLBACK(dt_iop_levels_vbox_automatic_draw), self);
-
   g_signal_connect(G_OBJECT(c->mode), "value-changed", G_CALLBACK(dt_iop_levels_mode_callback), self);
   g_signal_connect(G_OBJECT(c->percentile_black), "value-changed",
                    G_CALLBACK(dt_iop_levels_percentiles_callback), self);
@@ -640,6 +662,8 @@ void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
   g_list_free(g->modes);
+
+  dt_pthread_mutex_destroy(&g->lock);
 
   free(self->gui_data);
   self->gui_data = NULL;
@@ -829,21 +853,6 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
   cairo_paint(crf);
   cairo_surface_destroy(cst);
   return TRUE;
-}
-
-static gboolean dt_iop_levels_vbox_automatic_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
-
-  if(self->enabled && g->reprocess_on_next_expose)
-  {
-    g->reprocess_on_next_expose = FALSE;
-    // FIXME: or just use dev->pipe->changed |= DT_DEV_PIPE_SYNCH; ?
-    dt_dev_reprocess_all(self->dev);
-  }
-
-  return FALSE;
 }
 
 /**

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -456,6 +456,12 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_tonecurve_data_t *d = (dt_iop_tonecurve_data_t *)(piece->data);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)p1;
+
+  if(pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+    piece->request_histogram |= (DT_REQUEST_ON);
+  else
+    piece->request_histogram &= ~(DT_REQUEST_ON);
+
   for(int ch = 0; ch < ch_max; ch++)
   {
     // take care of possible change of curve type or number of nodes (not yet implemented in UI)


### PR DESCRIPTION
Rewritten pixelpipe: histogram capture code.
Now histogram is per module per pipe, therefore it is much more thread-safe (though i might still need to add a lock around access to module->histogram (which is always from preview pipe, if was requested))
And then significantly increased usability of auto modes of levels and exposure iop.