### PR TITLE
Local copy first

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1362,16 +1362,16 @@ int dt_image_local_copy_reset(const int32_t imgid)
 
   // get name of local copy
 
-  _image_local_copy_full_path(imgid, destpath, sizeof(destpath));
+  _image_local_copy_full_path(imgid, locppath, sizeof(locppath));
 
   // remove cached file, but double check that this is really into the cache. We really want to avoid deleting
   // a user's original file.
 
   dt_loc_get_user_cache_dir(cachedir, sizeof(cachedir));
 
-  if(g_file_test(destpath, G_FILE_TEST_EXISTS) && strstr(destpath, cachedir))
+  if(g_file_test(locppath, G_FILE_TEST_EXISTS) && strstr(locppath, cachedir))
   {
-    GFile *dest = g_file_new_for_path(destpath);
+    GFile *dest = g_file_new_for_path(locppath);
 
     // first sync the xmp with the original picture
 
@@ -1385,11 +1385,11 @@ int dt_image_local_copy_reset(const int32_t imgid)
     g_object_unref(dest);
 
     // delete xmp if any
-    dt_image_path_append_version(imgid, destpath, sizeof(destpath));
-    g_strlcat(destpath, ".xmp", sizeof(destpath));
-    dest = g_file_new_for_path(destpath);
+    dt_image_path_append_version(imgid, locppath, sizeof(locppath));
+    g_strlcat(locppath, ".xmp", sizeof(locppath));
+    dest = g_file_new_for_path(locppath);
 
-    if(g_file_test(destpath, G_FILE_TEST_EXISTS)) g_file_delete(dest, NULL, NULL);
+    if(g_file_test(locppath, G_FILE_TEST_EXISTS)) g_file_delete(dest, NULL, NULL);
     g_object_unref(dest);
 
     // update cache, remove local copy flags

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1044,7 +1044,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
       if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
       {
         dt_control_log(_("image `%s' is currently unavailable"), image->filename);
-        fprintf(stderr, "image `%s' is currently unavailable", imgfilename);
+        fprintf(stderr, "image `%s' is currently unavailable\n", imgfilename);
         // dt_image_remove(imgid);
         dt_image_cache_read_release(darktable.image_cache, image);
       }


### PR DESCRIPTION
Recently discussed on the mailing-list. This makes using the local-copy first and then make it possible to have fast workflow on SSD drive even though the original file is still accessible.