### PR TITLE
remove stderr from openmp shared(...)

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -941,7 +941,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
   const __attribute__((__unused__)) int num_threads = 1;
 #if !defined(__SUNOS__) && !defined(__NetBSD__) && !defined(__WIN32__)
 #pragma omp parallel default(none) private(imgid)                                                            \
-    shared(control, fraction, w, h, stderr, mformat, mstorage, t, sdata, job, progress, darktable, settings) \
+    shared(control, fraction, w, h, mformat, mstorage, t, sdata, job, progress, darktable, settings) \
         num_threads(num_threads) if(num_threads > 1)
 #else
 #pragma omp parallel private(imgid) shared(control, fraction, w, h, mformat, mstorage, t, sdata, job,        \

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2276,7 +2276,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__) && !defined(__WIN32__)
-#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, d, stderr)
+#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, d)
 #else
 #pragma omp parallel for shared(i, roi_out, o, mask, blend, d)
 #endif
@@ -2327,7 +2327,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
     {
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__WIN32__)
-#pragma omp parallel for default(none) shared(roi_out, mask, stderr)
+#pragma omp parallel for default(none) shared(roi_out, mask)
 #else
 #pragma omp parallel for shared(roi_out, mask)
 #endif
@@ -2342,7 +2342,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 /* now apply blending with per-pixel opacity value as defined in mask */
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__WIN32__)
-#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, stderr)
+#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend)
 #else
 #pragma omp parallel for shared(i, roi_out, o, mask, blend)
 #endif

--- a/src/tests/cache.c
+++ b/src/tests/cache.c
@@ -50,7 +50,7 @@ int main(int argc, char *arg[])
   dt_cache_set_allocate_callback(&cache, alloc_dummy, NULL);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(guided) shared(cache, stderr) num_threads(16)
+#pragma omp parallel for default(none) schedule(guided) shared(cache) num_threads(16)
 #endif
   for(int k = 0; k < 100000; k++)
   {
@@ -93,7 +93,7 @@ int main(int argc, char *arg[])
     dt_cache_set_allocate_callback(&cache2, alloc_dummy, NULL);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(guided) shared(cache2, stderr) num_threads(16)
+#pragma omp parallel for default(none) schedule(guided) shared(cache2) num_threads(16)
 #endif
     for(int k = 0; k < 100000; k++)
     {


### PR DESCRIPTION
stderr is not a variable and should not be used in shared(...). this also unbreaks compilation against musl-libc.
