### PR TITLE
[Bug #9017] Fix output of embedded preview in Pentax k-x DNG

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1062,6 +1062,14 @@ int dt_exif_read_blob(uint8_t *buf, const char *path, const int imgid, const int
         exifData.erase(pos);
       if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Pentax.PreviewOffset"))) != exifData.end())
         exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Pentax.PreviewImageSize"))) != exifData.end())
+        exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Pentax.PreviewImageLength"))) != exifData.end())
+        exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Pentax.PreviewImageStart"))) != exifData.end())
+        exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Pentax.PreviewImageBorders"))) != exifData.end())
+        exifData.erase(pos);
 
       // Minolta thumbnail data
       if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Minolta.Thumbnail"))) != exifData.end())


### PR DESCRIPTION
This fixes for Pentax k-x DNGs:

http://darktable.org/redmine/issues/9017

