### PR TITLE
[Bug #9017] Fix output of embedded preview in Pentax (k-x) DNG

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1062,6 +1062,12 @@ int dt_exif_read_blob(uint8_t *buf, const char *path, const int imgid, const int
         exifData.erase(pos);
       if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Pentax.PreviewOffset"))) != exifData.end())
         exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.PentaxDng.PreviewResolution"))) != exifData.end())
+        exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.PentaxDng.PreviewLength"))) != exifData.end())
+        exifData.erase(pos);
+      if((pos = exifData.findKey(Exiv2::ExifKey("Exif.PentaxDng.PreviewOffset"))) != exifData.end())
+        exifData.erase(pos);
 
       // Minolta thumbnail data
       if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Minolta.Thumbnail"))) != exifData.end())


### PR DESCRIPTION
Fixes http://darktable.org/redmine/issues/9017

PentaxDng part was not cleared.