### PR TITLE
[RFC] Monochrome demosaicing. Fixes #10492

### DIFF
--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -1,0 +1,38 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2015 LebedevRI.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+
+/**
+ * Propagate only channel into each of 3 channels, creating monochrome image
+ */
+__kernel void
+passthrough_monochrome (__read_only image2d_t in, __write_only image2d_t out, const int width, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 color;
+  const float4 pc = read_imagef(in, sampleri, (int2)(x, y));
+
+  color.xyz = pc.x;
+
+  write_imagef (out, (int2)(x, y), color);
+}

--- a/data/kernels/demosaic_other.cl
+++ b/data/kernels/demosaic_other.cl
@@ -36,3 +36,45 @@ passthrough_monochrome (__read_only image2d_t in, __write_only image2d_t out, co
 
   write_imagef (out, (int2)(x, y), color);
 }
+
+/**
+ * downscales and clips a mosaiced buffer (in) to the given region of interest (r_*)
+ * and writes it to out in float4 format.
+ */
+__kernel void
+clip_and_zoom_demosaic_passthrough_monochrome(__read_only image2d_t in, __write_only image2d_t out, const int width, const int height,
+    const int r_x, const int r_y, const int rin_wd, const int rin_ht, const float r_scale, const unsigned int filters)
+{
+  // global id is pixel in output image (float4)
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 color = (float4)(0.0f, 0.0f, 0.0f, 0.0f);
+  float weight = 0.0f;
+
+  // pixel footprint on input buffer, radius:
+  const float px_footprint = 1.0f/r_scale;
+  // how many pixels can be sampled inside that area
+  const int samples = round(px_footprint);
+
+  const float2 f = (float2)((x + r_x) * px_footprint, (y + r_y) * px_footprint);
+  int2 p = (int2)((int)f.x, (int)f.y);
+  const float2 d = (float2)(f.x - p.x, f.y - p.y);
+
+  for(int j=0;j<=samples+1;j++) for(int i=0;i<=samples+1;i++)
+  {
+    const int xx = p.x + i;
+    const int yy = p.y + j;
+
+    float xfilter = (i == 0) ? 1.0f - d.x : ((i == samples+1) ? d.x : 1.0f);
+    float yfilter = (j == 0) ? 1.0f - d.y : ((j == samples+1) ? d.y : 1.0f);
+
+    float px = read_imagef(in, sampleri, (int2)(xx, yy)).x;
+    color += yfilter*xfilter*(float4)(px, px, px, 0.0f);
+    weight += yfilter*xfilter;
+  }
+  color = weight > 0.0f ? color/weight : (float4)0.0f;
+  write_imagef (out, (int2)(x, y), color);
+}

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -14,3 +14,4 @@ bilateral.cl            10
 denoiseprofile.cl       11
 bloom.cl                12
 colorreconstruction.cl  13
+demosaic_other.cl       14

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -389,7 +389,7 @@ static void _get_image_dimension (int32_t imgid, int32_t *iwidth, int32_t *iheig
   if(res)
   {
     // set mem pointer to 0, won't be used.
-    dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f);
+    dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f, 0);
     dt_dev_pixelpipe_create_nodes(&pipe, &dev);
     dt_dev_pixelpipe_synch_all(&pipe, &dev);
     dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,

--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -256,7 +256,7 @@ void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid, int b
     if(res)
     {
       // set mem pointer to 0, won't be used.
-      dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f);
+      dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f, 0);
       dt_dev_pixelpipe_create_nodes(&pipe, &dev);
       dt_dev_pixelpipe_synch_all(&pipe, &dev);
       dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -647,7 +647,8 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
     g_list_free(stls);
   }
 
-  dt_dev_pixelpipe_set_input(&pipe, &dev, (float *)buf.buf, buf.width, buf.height, 1.0);
+  dt_dev_pixelpipe_set_input(&pipe, &dev, (float *)buf.buf, buf.width, buf.height, 1.0,
+                             buf.pre_monochrome_demosaiced);
   dt_dev_pixelpipe_create_nodes(&pipe, &dev);
   dt_dev_pixelpipe_synch_all(&pipe, &dev);
   dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -66,6 +66,8 @@ typedef struct dt_mipmap_buffer_t
   uint32_t imgid;
   int32_t width, height;
   uint8_t *buf;
+  // buffer is pre-demosaiced and the demosaicing method is monochrome
+  int pre_monochrome_demosaiced;
   dt_cache_entry_t *cache_entry;
 } dt_mipmap_buffer_t;
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -212,7 +212,7 @@ void dt_dev_process_preview_job(dt_develop_t *dev)
   }
   // init pixel pipeline for preview.
   dt_dev_pixelpipe_set_input(dev->preview_pipe, dev, (float *)buf.buf, buf.width, buf.height,
-                             dev->image_storage.width / (float)buf.width);
+                             dev->image_storage.width / (float)buf.width, buf.pre_monochrome_demosaiced);
 
   if(dev->preview_loading)
   {
@@ -295,7 +295,8 @@ void dt_dev_process_image_job(dt_develop_t *dev)
     return;
   }
 
-  dt_dev_pixelpipe_set_input(dev->pipe, dev, (float *)buf.buf, buf.width, buf.height, 1.0);
+  dt_dev_pixelpipe_set_input(dev->pipe, dev, (float *)buf.buf, buf.width, buf.height, 1.0,
+                             buf.pre_monochrome_demosaiced);
 
   if(dev->image_loading)
   {

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -513,6 +513,11 @@ void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const i
                                              const int32_t out_stride, const int32_t in_stride,
                                              const uint32_t filters);
 
+void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome(float *out, const uint16_t *const in,
+                                                          const struct dt_iop_roi_t *const roi_out,
+                                                          const struct dt_iop_roi_t *const roi_in,
+                                                          const int32_t out_stride, const int32_t in_stride);
+
 /** clip and zoom mosaiced from half size, crop away black borders. */
 void dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(float *out, const uint16_t *const in,
                                                          struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -520,6 +520,12 @@ void dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(float *out, const uint1
                                                          const int32_t out_stride, const int32_t in_stride,
                                                          const dt_image_t *img);
 
+void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(float *out, const float *const in,
+                                                            const struct dt_iop_roi_t *const roi_out,
+                                                            const struct dt_iop_roi_t *const roi_in,
+                                                            const int32_t out_stride,
+                                                            const int32_t in_stride);
+
 void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in,
                                                const struct dt_iop_roi_t *const roi_out,
                                                const struct dt_iop_roi_t *const roi_in,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -142,12 +142,13 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
 }
 
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, float *input, int width,
-                                int height, float iscale)
+                                int height, float iscale, int pre_monochrome_demosaiced)
 {
   pipe->iwidth = width;
   pipe->iheight = height;
   pipe->iscale = iscale;
   pipe->input = input;
+  pipe->pre_monochrome_demosaiced = pre_monochrome_demosaiced;
   pipe->image = dev->image_storage;
 }
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -121,6 +121,8 @@ typedef struct dt_dev_pixelpipe_t
   int mask_display;
   // input data based on this timestamp:
   int input_timestamp;
+  // input data was pre-demosaiced and the demosaicing method is monochrome
+  int pre_monochrome_demosaiced;
   dt_dev_pixelpipe_type_t type;
   // the final output pixel format this pixelpipe will be converted to
   dt_imageio_levels_t levels;
@@ -148,7 +150,7 @@ int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t
 int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries);
 // constructs a new input gegl_buffer from given RGB float array.
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, float *input, int width,
-                                int height, float iscale);
+                                int height, float iscale, int pre_monochrome_demosaiced);
 
 // returns the dimensions of the full image after processing.
 void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, int width_in,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1572,9 +1572,14 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
                                                         roo.width, roi.width,
                                                         img->xtrans);
     else
-      dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi,
-                                                roo.width, roi.width,
-                                                data->filters, clip);
+    {
+      if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
+        dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width,
+                                                               roi.width);
+      else
+        dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
+                                                  data->filters, clip);
+    }
   }
   if(data->color_smoothing) color_smoothing(o, roi_out, data->color_smoothing);
 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1477,8 +1477,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
   const int qual = get_quality();
   int demosaicing_method = data->demosaicing_method;
-  if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual < 2
-     && roi_out->scale <= .99999f) // only overwrite setting if quality << requested and in dr mode
+  if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual < 2 && roi_out->scale <= .99999f
+     && // only overwrite setting if quality << requested and in dr mode
+     ((img->filters != 9u) && (demosaicing_method != DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)))
     demosaicing_method = (img->filters != 9u) ? DT_IOP_DEMOSAIC_PPG : DT_IOP_DEMOSAIC_MARKESTEIJN;
 
   // we check if we need ultra-high quality thumbnail for this size


### PR DESCRIPTION
So this is mostly feature-complete except a few caveats so i though this is as good time as any to show the code.

Caveat: after you set demosaicing mode to passthrough (monochrome),
thumbnail will be displayed right only after you re-open image in DR,
or even restart DT - too good caching :)

Also, **dt_iop_clip_and_zoom_demosaic_passthrough_monochrome()**, **dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f()** and **kernel clip_and_zoom_demosaic_passthrough_monochrome** need proofreading !!!