### PR TITLE
clip&rotate: fix bug in flip function, fix for #10511

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -556,8 +556,8 @@ clip_rotate_bilinear(read_only image2d_t in, write_only image2d_t out, const int
 
   float2 pi, po;
   
-  pi.x = roi_out.x + x ;
-  pi.y = roi_out.y + y ;
+  pi.x = roi_out.x + x + 0.5f;
+  pi.y = roi_out.y + y + 0.5f;
   
   pi.x -= flip ? t.y * scale_out : t.x * scale_out;
   pi.y -= flip ? t.x * scale_out : t.y * scale_out;
@@ -571,8 +571,8 @@ clip_rotate_bilinear(read_only image2d_t in, write_only image2d_t out, const int
 
   if (k_space.z > 0.0f) keystone_backtransform(&po,k_space,ka,ma,mb);
 
-  po.x -= roi_in.x;
-  po.y -= roi_in.y;
+  po.x -= roi_in.x + 0.5f;
+  po.y -= roi_in.y + 0.5f;
 
   const int ii = (int)po.x;
   const int jj = (int)po.y;
@@ -601,8 +601,8 @@ clip_rotate_bicubic(read_only image2d_t in, write_only image2d_t out, const int 
 
   float2 pi, po;
   
-  pi.x = roi_out.x + x ;
-  pi.y = roi_out.y + y ;
+  pi.x = roi_out.x + x + 0.5f;
+  pi.y = roi_out.y + y + 0.5f;
   
   pi.x -= flip ? t.y * scale_out : t.x * scale_out;
   pi.y -= flip ? t.x * scale_out : t.y * scale_out;
@@ -616,8 +616,8 @@ clip_rotate_bicubic(read_only image2d_t in, write_only image2d_t out, const int 
 
   if (k_space.z > 0.0f) keystone_backtransform(&po,k_space,ka,ma,mb);
 
-  po.x -= roi_in.x;
-  po.y -= roi_in.y;
+  po.x -= roi_in.x + 0.5f;
+  po.y -= roi_in.y + 0.5f;
 
   int tx = po.x;
   int ty = po.y;
@@ -662,8 +662,8 @@ clip_rotate_lanczos2(read_only image2d_t in, write_only image2d_t out, const int
 
   float2 pi, po;
   
-  pi.x = roi_out.x + x ;
-  pi.y = roi_out.y + y ;
+  pi.x = roi_out.x + x + 0.5f;
+  pi.y = roi_out.y + y + 0.5f;
   
   pi.x -= flip ? t.y * scale_out : t.x * scale_out;
   pi.y -= flip ? t.x * scale_out : t.y * scale_out;
@@ -677,8 +677,8 @@ clip_rotate_lanczos2(read_only image2d_t in, write_only image2d_t out, const int
 
   if (k_space.z > 0.0f) keystone_backtransform(&po,k_space,ka,ma,mb);
 
-  po.x -= roi_in.x;
-  po.y -= roi_in.y;
+  po.x -= roi_in.x + 0.5f;
+  po.y -= roi_in.y + 0.5f;
 
   int tx = po.x;
   int ty = po.y;
@@ -724,8 +724,8 @@ clip_rotate_lanczos3(read_only image2d_t in, write_only image2d_t out, const int
 
   float2 pi, po;
   
-  pi.x = roi_out.x + x ;
-  pi.y = roi_out.y + y ;
+  pi.x = roi_out.x + x + 0.5f;
+  pi.y = roi_out.y + y + 0.5f;
   
   pi.x -= flip ? t.y * scale_out : t.x * scale_out;
   pi.y -= flip ? t.x * scale_out : t.y * scale_out;
@@ -739,8 +739,8 @@ clip_rotate_lanczos3(read_only image2d_t in, write_only image2d_t out, const int
 
   if (k_space.z > 0.0f) keystone_backtransform(&po,k_space,ka,ma,mb);
 
-  po.x -= roi_in.x ;
-  po.y -= roi_in.y ;
+  po.x -= roi_in.x + 0.5f;
+  po.y -= roi_in.y + 0.5f;
 
   int tx = (int)po.x;
   int ty = (int)po.y;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -866,8 +866,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       {
         float pi[2], po[2];
 
-        pi[0] = roi_out->x - roi_out->scale * d->enlarge_x + roi_out->scale * d->cix + i;
-        pi[1] = roi_out->y - roi_out->scale * d->enlarge_y + roi_out->scale * d->ciy + j;
+        pi[0] = roi_out->x - roi_out->scale * d->enlarge_x + roi_out->scale * d->cix + i + 0.5f;
+        pi[1] = roi_out->y - roi_out->scale * d->enlarge_y + roi_out->scale * d->ciy + j + 0.5f;
 
         // transform this point using matrix m
         if(d->flip)
@@ -888,8 +888,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
         po[0] += d->tx * roi_in->scale;
         po[1] += d->ty * roi_in->scale;
         if(d->k_apply == 1) keystone_backtransform(po, k_space, ma, mb, md, me, mg, mh, kxa, kya);
-        po[0] -= roi_in->x;
-        po[1] -= roi_in->y;
+        po[0] -= roi_in->x + 0.5f;
+        po[1] -= roi_in->y + 0.5f;
 
         dt_interpolation_compute_pixel4c(interpolation, (float *)ivoid, out, po[0], po[1], roi_in->width,
                                          roi_in->height, ch_width);


### PR DESCRIPTION
Due to rounding issues the old flipping code would lead to an undefined (1px black) line at
one or two of the image borders - the image is shifted by one pixel relative to its buffer.
With this fix images are now correctly positioned in the buffer, however, this leads to a
-1px offset versus the old code. I would call it a bug fix without the need to deal with
legacy history stacks.