### PR TITLE
Grab focus of main area when the mouse enter it.

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -508,6 +508,8 @@ void dt_view_manager_mouse_enter(dt_view_manager_t *vm)
   if(vm->current_view < 0) return;
   dt_view_t *v = vm->view + vm->current_view;
   if(v->mouse_enter) v->mouse_enter(v);
+  /* raise widget */
+  gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 }
 
 void dt_view_manager_mouse_moved(dt_view_manager_t *vm, double x, double y, double pressure, int which)


### PR DESCRIPTION
After clicking on the left panel or rigth panel, the next key-events
are redirected to those panels. For example after selecting a metadata
entry, moving over the lightable and pusing 'z' (full preview) won't
work. Actually the 'z' is enterred into the metadata entry. The same
applies to all actions on the side panels.

Fixes #10508