### PR TITLE
get_matrix_from_profile(): if there is a LUT, give up. Fixes #10552

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -92,12 +92,18 @@ static void mat3mul(float *dst, const float *const m1, const float *const m2)
 }
 
 static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                  float *lutb, const int lutsize, const int input)
+                                                  float *lutb, const int lutsize, const int input,
+                                                  const int intent)
 {
   // create an OpenCL processable matrix + tone curves from an cmsHPROFILE:
 
   // check this first:
   if(!cmsIsMatrixShaper(prof)) return 1;
+
+  // if this profile contains LUT, it might also contain swapped matrix,
+  // so the only right way to handle it is to let LCMS apply it.
+  const int UsedDirection = input ? LCMS_USED_AS_INPUT : LCMS_USED_AS_OUTPUT;
+  if(cmsIsCLUT(prof, intent, UsedDirection)) return 1;
 
   cmsToneCurve *red_curve = cmsReadTag(prof, cmsSigRedTRCTag);
   cmsToneCurve *green_curve = cmsReadTag(prof, cmsSigGreenTRCTag);
@@ -179,15 +185,15 @@ static int dt_colorspaces_get_matrix_from_profile(cmsHPROFILE prof, float *matri
 }
 
 int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                 float *lutb, const int lutsize)
+                                                 float *lutb, const int lutsize, const int intent)
 {
-  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 1);
+  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 1, intent);
 }
 
 int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                  float *lutb, const int lutsize)
+                                                  float *lutb, const int lutsize, const int intent)
 {
-  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 0);
+  return dt_colorspaces_get_matrix_from_profile(prof, matrix, lutr, lutg, lutb, lutsize, 0, intent);
 }
 
 cmsHPROFILE dt_colorspaces_create_lab_profile()

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -94,11 +94,11 @@ void dt_Lab_to_XYZ(const float *Lab, float *XYZ);
 /** extracts tonecurves and color matrix prof to XYZ from a given input profile, returns 0 on success (curves
  * and matrix are inverted for input) */
 int dt_colorspaces_get_matrix_from_input_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                 float *lutb, const int lutsize);
+                                                 float *lutb, const int lutsize, const int intent);
 
 /** extracts tonecurves and color matrix prof to XYZ from a given output profile, returns 0 on success. */
 int dt_colorspaces_get_matrix_from_output_profile(cmsHPROFILE prof, float *matrix, float *lutr, float *lutg,
-                                                  float *lutb, const int lutsize);
+                                                  float *lutb, const int lutsize, const int intent);
 
 /** searches for the given profile name in the user config dir ~/.config/darktable/color/<inout> and
  * /usr/share/darktable/.. */

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -713,7 +713,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   {
     // user wants us to clip to a given RGB profile
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                    LUT_SAMPLES))
+                                                    LUT_SAMPLES, p->intent))
     {
       piece->process_cl_ready = 0;
       d->cmatrix[0] = NAN;
@@ -725,16 +725,16 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     {
       float lutr[1], lutg[1], lutb[1];
       float omat[9];
-      dt_colorspaces_get_matrix_from_output_profile(d->nrgb, omat, lutr, lutg, lutb, 1);
+      dt_colorspaces_get_matrix_from_output_profile(d->nrgb, omat, lutr, lutg, lutb, 1, p->intent);
       mat3mul(d->nmatrix, omat, d->cmatrix);
-      dt_colorspaces_get_matrix_from_input_profile(d->nrgb, d->lmatrix, lutr, lutg, lutb, 1);
+      dt_colorspaces_get_matrix_from_input_profile(d->nrgb, d->lmatrix, lutr, lutg, lutb, 1, p->intent);
     }
   }
   else
   {
     // default mode: unbound processing
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                    LUT_SAMPLES))
+                                                    LUT_SAMPLES, p->intent))
     {
       piece->process_cl_ready = 0;
       d->cmatrix[0] = NAN;
@@ -769,7 +769,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     snprintf(iccprofile, sizeof(iccprofile), "linear_rec709_rgb");
     d->input = dt_colorspaces_create_linear_rec709_rgb_profile();
     if(dt_colorspaces_get_matrix_from_input_profile(d->input, d->cmatrix, d->lut[0], d->lut[1], d->lut[2],
-                                                    LUT_SAMPLES))
+                                                    LUT_SAMPLES, p->intent))
     {
       piece->process_cl_ready = 0;
       d->cmatrix[0] = NAN;


### PR DESCRIPTION
If profile contains only a LUT, we would fall-back to LCMS codepath.
If profile contains a matrix + LUT, we would just use matrix in our
fast matrix codepath.

But, if profile contains a LUT, it might contain a swapped matrix, so
some apps (like us right now) would use matrix, and get an image with
swapped colors, and some would use LUT and get image with right colors.

The matrix in a XYZLUT profile is intended for older outdated CMS
implementations and should not be used.

Falling back to matrix used to kinda-sorta make sense when our fastpath
was an order of magnitude faster than our LCMS2 path,
which is no longer true. (pr #495 + pr #509)