### PR TITLE
dt_mipmap_cache_get_with_caller(): after relocking, update dsc

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -660,6 +660,7 @@ void dt_mipmap_cache_get_with_caller(
         dt_cache_release(&_get_cache(cache, mip)->cache, entry);
         // get a read lock
         buf->cache_entry = dt_cache_get(&_get_cache(cache, mip)->cache, key, mode);
+        dsc = (struct dt_mipmap_buffer_dsc *)buf->cache_entry->data;
       }
 #endif
       /* raise signal that mipmaps has been flushed to cache */


### PR DESCRIPTION
Basically, gc might free that entry right after we drop write lock,
so when we acquire read lock dsc may already be invalid,
so we need to get dsc from the actual entry we just 'r'-locked.

Seems to fix following ASan issue:
```
=================================================================
==15436==ERROR: AddressSanitizer: heap-use-after-free on address 0x6130000c7140 at pc 0x7fe1ebceab95 bp 0x7fe1d1cf7160 sp 0x7fe1d1cf7158
READ of size 4 at 0x6130000c7140 thread T7
    0 0x7fe1ebceab94 in dt_mipmap_cache_get_with_caller /home/lebedevri/darktable/src/common/mipmap_cache.c:670
    1 0x7fe1ebcc77de in dt_imageio_export_with_flags /home/lebedevri/darktable/src/common/imageio.c:536
    2 0x7fe1ebce3fc2 in _init_8 /home/lebedevri/darktable/src/common/mipmap_cache.c:986
    3 0x7fe1ebceaade in dt_mipmap_cache_get_with_caller /home/lebedevri/darktable/src/common/mipmap_cache.c:651
    4 0x7fe1ebd3ed7f in dt_image_load_job_run /home/lebedevri/darktable/src/control/jobs/image_jobs.c:36
    5 0x7fe1ebd3392a in dt_control_run_job /home/lebedevri/darktable/src/control/jobs.c:274
    6 0x7fe1ebd33b49 in dt_control_work /home/lebedevri/darktable/src/control/jobs.c:472
    7 0x7fe1e7e380a3 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x80a3)
    8 0x7fe1e44d604c in clone (/lib/x86_64-linux-gnu/libc.so.6+0xe604c)

0x6130000c7140 is located 0 bytes inside of 288-byte region [0x6130000c7140,0x6130000c7260)
freed by thread T8 here:
    0 0x7fe1ec17c14a in free (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x9414a)
    1 0x7fe1ebce6cd7 in dt_mipmap_cache_deallocate_dynamic /home/lebedevri/darktable/src/common/mipmap_cache.c:373
    2 0x7fe1ebc52e2e in dt_cache_gc /home/lebedevri/darktable/src/common/cache.c:275
    3 0x7fe1ebc533a2 in dt_cache_get_with_caller /home/lebedevri/darktable/src/common/cache.c:176
    4 0x7fe1ebcea654 in dt_mipmap_cache_get_with_caller /home/lebedevri/darktable/src/common/mipmap_cache.c:592
    5 0x7fe1ebcc77de in dt_imageio_export_with_flags /home/lebedevri/darktable/src/common/imageio.c:536
    6 0x7fe1ebce3fc2 in _init_8 /home/lebedevri/darktable/src/common/mipmap_cache.c:986
    7 0x7fe1ebceaade in dt_mipmap_cache_get_with_caller /home/lebedevri/darktable/src/common/mipmap_cache.c:651
    8 0x7fe1ebd3ed7f in dt_image_load_job_run /home/lebedevri/darktable/src/control/jobs/image_jobs.c:36
    9 0x7fe1ebd3392a in dt_control_run_job /home/lebedevri/darktable/src/control/jobs.c:274
    10 0x7fe1ebd33b49 in dt_control_work /home/lebedevri/darktable/src/control/jobs.c:472
    11 0x7fe1e7e380a3 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x80a3)

previously allocated by thread T7 here:
    0 0x7fe1ec17cd2e in posix_memalign (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x94d2e)
    1 0x7fe1ebc7382e in dt_alloc_align /home/lebedevri/darktable/src/common/darktable.c:1080
    2 0x7fe1ebce6f23 in dt_mipmap_cache_alloc /home/lebedevri/darktable/src/common/mipmap_cache.c:180
    3 0x7fe1ebccd308 in dt_imageio_open_jpeg /home/lebedevri/darktable/src/common/imageio_jpeg.c:704
    4 0x7fe1ebcc6a80 in dt_imageio_open_ldr /home/lebedevri/darktable/src/common/imageio.c:479
    5 0x7fe1ebcc9df1 in dt_imageio_open /home/lebedevri/darktable/src/common/imageio.c:908
    6 0x7fe1ebcea90f in dt_mipmap_cache_get_with_caller /home/lebedevri/darktable/src/common/mipmap_cache.c:621
    7 0x7fe1ebcc77de in dt_imageio_export_with_flags /home/lebedevri/darktable/src/common/imageio.c:536
    8 0x7fe1ebce3fc2 in _init_8 /home/lebedevri/darktable/src/common/mipmap_cache.c:986
    9 0x7fe1ebceaade in dt_mipmap_cache_get_with_caller /home/lebedevri/darktable/src/common/mipmap_cache.c:651
    10 0x7fe1ebd3ed7f in dt_image_load_job_run /home/lebedevri/darktable/src/control/jobs/image_jobs.c:36
    11 0x7fe1ebd3392a in dt_control_run_job /home/lebedevri/darktable/src/control/jobs.c:274
    12 0x7fe1ebd33b49 in dt_control_work /home/lebedevri/darktable/src/control/jobs.c:472
    13 0x7fe1e7e380a3 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x80a3)

Thread T7 created by T0 here:
    0 0x7fe1ec11e444 in pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x36444)
    1 0x7fe1ebd34aa2 in dt_control_jobs_init /home/lebedevri/darktable/src/control/jobs.c:498
    2 0x7fe1ebd2643f in dt_control_init /home/lebedevri/darktable/src/control/control.c:327
    3 0x7fe1ebc77445 in dt_init /home/lebedevri/darktable/src/common/darktable.c:808
    4 0x400cb8 in main /home/lebedevri/darktable/src/main.c:24
    5 0x7fe1e4411b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)

Thread T8 created by T0 here:
    0 0x7fe1ec11e444 in pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x36444)
    1 0x7fe1ebd34aa2 in dt_control_jobs_init /home/lebedevri/darktable/src/control/jobs.c:498
    2 0x7fe1ebd2643f in dt_control_init /home/lebedevri/darktable/src/control/control.c:327
    3 0x7fe1ebc77445 in dt_init /home/lebedevri/darktable/src/common/darktable.c:808
    4 0x400cb8 in main /home/lebedevri/darktable/src/main.c:24
    5 0x7fe1e4411b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)

SUMMARY: AddressSanitizer: heap-use-after-free /home/lebedevri/darktable/src/common/mipmap_cache.c:670 dt_mipmap_cache_get_with_caller
Shadow bytes around the buggy address:
  0x0c2680010dd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2680010de0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2680010df0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2680010e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2680010e10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c2680010e20: fa fa fa fa fa fa fa fa[fd]fd fd fd fd fd fd fd
  0x0c2680010e30: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2680010e40: fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c2680010e50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2680010e60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2680010e70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==15436==ABORTING
```