### PR TITLE
Lots of various fixes for jobs-related memory leaks

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -748,7 +748,7 @@ void dt_camctl_detect_cameras(const dt_camctl_t *c)
 
 static int _detect_cameras_callback(dt_job_t *job)
 {
-  const dt_camctl_t *c = dt_control_job_get_params(job);
+  dt_camctl_t *c = dt_control_job_get_params(job);
   dt_camctl_detect_cameras(c);
   return 0;
 }

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -557,7 +557,8 @@ dt_camctl_t *dt_camctl_new()
   dt_job_t *job = dt_control_job_create(&_detect_cameras_callback, "detect connected cameras");
   if(job)
   {
-    dt_control_job_set_params(job, camctl);
+    // FIXME: is this not leaking?
+    dt_control_job_set_params(job, camctl, NULL);
     dt_control_add_job(darktable.control, DT_JOB_QUEUE_SYSTEM_BG, job);
   }
 

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -743,7 +743,7 @@ void dt_camctl_detect_cameras(const dt_camctl_t *c)
 
 static int _detect_cameras_callback(dt_job_t *job)
 {
-  dt_camctl_t *c = dt_control_job_get_params(job);
+  const dt_camctl_t *c = dt_control_job_get_params(job);
   dt_camctl_detect_cameras(c);
   return 0;
 }

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -557,7 +557,6 @@ dt_camctl_t *dt_camctl_new()
   dt_job_t *job = dt_control_job_create(&_detect_cameras_callback, "detect connected cameras");
   if(job)
   {
-    // FIXME: is this not leaking?
     dt_control_job_set_params(job, camctl, NULL);
     dt_control_add_job(darktable.control, DT_JOB_QUEUE_SYSTEM_BG, job);
   }
@@ -577,11 +576,14 @@ static void dt_camctl_camera_destroy(dt_camera_t *cam)
   }
   g_free(cam->model);
   g_free(cam->port);
+  dt_pthread_mutex_destroy(&cam->config_lock);
+  dt_pthread_mutex_destroy(&cam->live_view_pixbuf_mutex);
+  dt_pthread_mutex_destroy(&cam->live_view_synch);
   // TODO: cam->jobqueue
   g_free(cam);
 }
 
-void dt_camctl_destroy(const dt_camctl_t *camctl)
+void dt_camctl_destroy(dt_camctl_t *camctl)
 {
   // Go thru all c->cameras and release them..
   for(GList *it = g_list_first(camctl->cameras); it != NULL; it = g_list_delete_link(it, it))
@@ -591,6 +593,9 @@ void dt_camctl_destroy(const dt_camctl_t *camctl)
   gp_context_unref(camctl->gpcontext);
   gp_abilities_list_free(camctl->gpcams);
   gp_port_info_list_free(camctl->gpports);
+  dt_pthread_mutex_destroy(&camctl->lock);
+  dt_pthread_mutex_destroy(&camctl->listeners_lock);
+  g_free(camctl);
 }
 
 

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -206,7 +206,7 @@ typedef enum dt_camera_preview_flags_t
 /** Initializes the gphoto and cam control, returns NULL if failed */
 dt_camctl_t *dt_camctl_new();
 /** Destroys the came control */
-void dt_camctl_destroy(const dt_camctl_t *c);
+void dt_camctl_destroy(dt_camctl_t *c);
 /** Registers a listener of camera control */
 void dt_camctl_register_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener);
 /** Unregisters a listener of camera control */

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -129,10 +129,10 @@ static int _cancel = 0;
 
 static int _detect_printers_callback(dt_job_t *job)
 {
-  const dt_prtctl_t *pctl = dt_control_job_get_params(job);
+  dt_prtctl_t *pctl = dt_control_job_get_params(job);
   int res;
 #if ((CUPS_VERSION_MAJOR == 1) && (CUPS_VERSION_MINOR >= 6)) || CUPS_VERSION_MAJOR > 1
-  res = cupsEnumDests(CUPS_MEDIA_FLAGS_DEFAULT, 30000, &_cancel, 0, 0, _dest_cb, (void *)pctl);
+  res = cupsEnumDests(CUPS_MEDIA_FLAGS_DEFAULT, 30000, &_cancel, 0, 0, _dest_cb, pctl);
 #else
   cups_dest_t *dests;
   const int num_dests = cupsGetDests(&dests);

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -163,7 +163,7 @@ void dt_printers_discovery(void (*cb)(dt_printer_info_t *pr, void *user_data), v
   dt_job_t *job = dt_control_job_create(&_detect_printers_callback, "detect connected printers");
   if(job)
   {
-    dt_control_job_set_params(job, prtctl);
+    dt_control_job_set_params(job, prtctl, g_free);
     dt_control_add_job(darktable.control, DT_JOB_QUEUE_SYSTEM_BG, job);
   }
 }

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -129,10 +129,10 @@ static int _cancel = 0;
 
 static int _detect_printers_callback(dt_job_t *job)
 {
-  dt_prtctl_t *pctl = dt_control_job_get_params(job);
+  const dt_prtctl_t *pctl = dt_control_job_get_params(job);
   int res;
 #if ((CUPS_VERSION_MAJOR == 1) && (CUPS_VERSION_MINOR >= 6)) || CUPS_VERSION_MAJOR > 1
-  res = cupsEnumDests(CUPS_MEDIA_FLAGS_DEFAULT, 30000, &_cancel, 0, 0, _dest_cb, pctl);
+  res = cupsEnumDests(CUPS_MEDIA_FLAGS_DEFAULT, 30000, &_cancel, 0, 0, _dest_cb, (void *)pctl);
 #else
   cups_dest_t *dests;
   const int num_dests = cupsGetDests(&dests);
@@ -143,7 +143,6 @@ static int _detect_printers_callback(dt_job_t *job)
   cupsFreeDests(num_dests, dests);
   res=1;
 #endif
-  g_free(pctl);
   return !res;
 }
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1017,7 +1017,7 @@ void dt_cleanup()
   dt_opencl_cleanup(darktable.opencl);
   free(darktable.opencl);
 #ifdef HAVE_GPHOTO2
-  dt_camctl_destroy(darktable.camctl);
+  dt_camctl_destroy((dt_camctl_t *)darktable.camctl);
 #endif
   dt_pwstorage_destroy(darktable.pwstorage);
   dt_fswatch_destroy(darktable.fswatch);

--- a/src/common/dbus.c
+++ b/src/common/dbus.c
@@ -109,7 +109,7 @@ static void _handle_method_call(GDBusConnection *connection, const gchar *sender
     dt_job_t *job = dt_control_job_create(&dbus_callback_job, "lua: on dbus");
     if(job)
     {
-      dt_control_job_set_params(job, invocation);
+      dt_control_job_set_params(job, invocation, NULL);
       dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_BG, job);
       // we don't finish the invocation, the async task will do this for us
     }

--- a/src/common/dbus.c
+++ b/src/common/dbus.c
@@ -60,7 +60,7 @@ static const gchar introspection_xml[] = "<node>"
 #ifdef USE_LUA
 static int32_t dbus_callback_job(dt_job_t *job)
 {
-  GDBusMethodInvocation *invocation = dt_control_job_get_params(job);
+  GDBusMethodInvocation *invocation = (GDBusMethodInvocation *)dt_control_job_get_params(job);
   lua_State *L = darktable.lua_state.state;
   GVariant *parameters = g_dbus_method_invocation_get_parameters(invocation);
   const gchar *command;

--- a/src/common/dbus.c
+++ b/src/common/dbus.c
@@ -60,7 +60,7 @@ static const gchar introspection_xml[] = "<node>"
 #ifdef USE_LUA
 static int32_t dbus_callback_job(dt_job_t *job)
 {
-  GDBusMethodInvocation *invocation = (GDBusMethodInvocation *)dt_control_job_get_params(job);
+  GDBusMethodInvocation *invocation = dt_control_job_get_params(job);
   lua_State *L = darktable.lua_state.state;
   GVariant *parameters = g_dbus_method_invocation_get_parameters(invocation);
   const gchar *command;

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -446,12 +446,12 @@ void dt_film_import1(dt_film_t *film)
           dt_film_remove(cfr->id);
         }
         dt_film_cleanup(cfr);
-        g_free(cfr);
+        free(cfr);
         cfr = NULL;
       }
 
       /* initialize and create a new film to import to */
-      cfr = g_malloc(sizeof(dt_film_t));
+      cfr = malloc(sizeof(dt_film_t));
       dt_film_init(cfr);
       dt_film_new(cfr, cdn);
     }
@@ -466,6 +466,8 @@ void dt_film_import1(dt_film_t *film)
 
 
   } while((image = g_list_next(image)) != NULL);
+
+  g_list_free_full(images, g_free);
 
   // only redraw at the end, to not spam the cpu with exposure events
   dt_control_queue_redraw_center();
@@ -495,6 +497,8 @@ void dt_film_import1(dt_film_t *film)
       }
     }
   }
+
+  free(cfr);
 }
 
 

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -87,10 +87,11 @@ dt_job_state_t dt_control_job_get_state(_dt_job_t *job)
   return state;
 }
 
-void dt_control_job_set_params(_dt_job_t *job, void *params)
+void dt_control_job_set_params(_dt_job_t *job, void *params, dt_job_destroy_callback callback)
 {
   if(!job || dt_control_job_get_state(job) != DT_JOB_STATE_INITIALIZED) return;
   job->params = params;
+  job->params_destroy = callback;
 }
 
 void *dt_control_job_get_params(const _dt_job_t *job)

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -94,7 +94,7 @@ void dt_control_job_set_params(_dt_job_t *job, void *params, dt_job_destroy_call
   job->params_destroy = callback;
 }
 
-void *dt_control_job_get_params(const _dt_job_t *job)
+const void *dt_control_job_get_params(const _dt_job_t *job)
 {
   if(!job) return NULL;
   return job->params;
@@ -125,6 +125,7 @@ void dt_control_job_dispose(_dt_job_t *job)
 {
   if(!job) return;
   dt_control_job_set_state(job, DT_JOB_STATE_DISPOSED);
+  if(job->params_destroy) job->params_destroy(job->params);
   dt_pthread_mutex_destroy(&job->state_mutex);
   dt_pthread_mutex_destroy(&job->wait_mutex);
   free(job);

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -39,6 +39,7 @@ typedef struct _dt_job_t
 {
   dt_job_execute_callback execute;
   void *params;
+  dt_job_destroy_callback params_destroy;
   int32_t result;
 
   dt_pthread_mutex_t state_mutex;
@@ -110,6 +111,10 @@ dt_job_t *dt_control_job_create(dt_job_execute_callback execute, const char *msg
 
   job->execute = execute;
   job->state = DT_JOB_STATE_INITIALIZED;
+
+  job->params = NULL;
+  job->params_destroy = NULL;
+
   dt_pthread_mutex_init(&job->state_mutex, NULL);
   dt_pthread_mutex_init(&job->wait_mutex, NULL);
   return job;

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -382,6 +382,7 @@ int dt_control_add_job(dt_control_t *control, dt_job_queue_t queue_id, _dt_job_t
     {
       GList *last = g_list_last(*queue);
       dt_control_job_set_state((_dt_job_t *)last->data, DT_JOB_STATE_DISCARDED);
+      dt_control_job_dispose((_dt_job_t *)last->data);
       *queue = g_list_delete_link(*queue, last);
       length--;
     }

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -94,7 +94,7 @@ void dt_control_job_set_params(_dt_job_t *job, void *params, dt_job_destroy_call
   job->params_destroy = callback;
 }
 
-const void *dt_control_job_get_params(const _dt_job_t *job)
+void *dt_control_job_get_params(const _dt_job_t *job)
 {
   if(!job) return NULL;
   return job->params;
@@ -112,9 +112,6 @@ dt_job_t *dt_control_job_create(dt_job_execute_callback execute, const char *msg
 
   job->execute = execute;
   job->state = DT_JOB_STATE_INITIALIZED;
-
-  job->params = NULL;
-  job->params_destroy = NULL;
 
   dt_pthread_mutex_init(&job->state_mutex, NULL);
   dt_pthread_mutex_init(&job->wait_mutex, NULL);

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -67,8 +67,9 @@ void dt_control_job_cancel(dt_job_t *job);
 dt_job_state_t dt_control_job_get_state(dt_job_t *job);
 /** wait for a job to finish execution. */
 void dt_control_job_wait(dt_job_t *job);
-/** accessors for internal fields */
-void dt_control_job_set_params(dt_job_t *job, void *params);
+/** set job params and a callback to destroy those params */
+void dt_control_job_set_params(dt_job_t *job, void *params, dt_job_destroy_callback callback);
+/** get job params. WARNING: you must not free them. dt_control_job_dispose() will take care of that */
 void *dt_control_job_get_params(const dt_job_t *job);
 
 struct dt_control_t;

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -70,7 +70,7 @@ void dt_control_job_wait(dt_job_t *job);
 /** set job params and a callback to destroy those params */
 void dt_control_job_set_params(dt_job_t *job, void *params, dt_job_destroy_callback callback);
 /** get job params. WARNING: you must not free them. dt_control_job_dispose() will take care of that */
-const void *dt_control_job_get_params(const dt_job_t *job);
+void *dt_control_job_get_params(const dt_job_t *job);
 
 struct dt_control_t;
 void dt_control_jobs_init(struct dt_control_t *control);

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -70,7 +70,7 @@ void dt_control_job_wait(dt_job_t *job);
 /** set job params and a callback to destroy those params */
 void dt_control_job_set_params(dt_job_t *job, void *params, dt_job_destroy_callback callback);
 /** get job params. WARNING: you must not free them. dt_control_job_dispose() will take care of that */
-void *dt_control_job_get_params(const dt_job_t *job);
+const void *dt_control_job_get_params(const dt_job_t *job);
 
 struct dt_control_t;
 void dt_control_jobs_init(struct dt_control_t *control);

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -54,6 +54,7 @@ typedef struct _dt_job_t dt_job_t;
 
 typedef int32_t (*dt_job_execute_callback)(dt_job_t *);
 typedef void (*dt_job_state_change_callback)(dt_job_t *, dt_job_state_t state);
+typedef void (*dt_job_destroy_callback)(void *data);
 
 /** create a new initialized job */
 dt_job_t *dt_control_job_create(dt_job_execute_callback execute, const char *msg, ...);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -71,14 +71,14 @@ typedef struct dt_camera_import_t
 void *dt_camera_previews_job_get_data(const dt_job_t *job)
 {
   if(!job) return NULL;
-  const dt_camera_get_previews_t *params = dt_control_job_get_params(job);
+  dt_camera_get_previews_t *params = dt_control_job_get_params(job);
   if(!params) return NULL;
   return params->data;
 }
 
 static int32_t dt_camera_capture_job_run(dt_job_t *job)
 {
-  const dt_camera_capture_t *params = dt_control_job_get_params(job);
+  dt_camera_capture_t *params = dt_control_job_get_params(job);
   int total;
   char message[512] = { 0 };
   double fraction = 0;
@@ -225,7 +225,7 @@ dt_job_t *dt_camera_capture_job_create(const char *jobcode, uint32_t delay, uint
 
 static int32_t dt_camera_get_previews_job_run(dt_job_t *job)
 {
-  const dt_camera_get_previews_t *params = dt_control_job_get_params(job);
+  dt_camera_get_previews_t *params = dt_control_job_get_params(job);
 
   dt_camctl_register_listener(darktable.camctl, params->listener);
   dt_camctl_get_previews(darktable.camctl, params->flags, params->camera);
@@ -317,7 +317,7 @@ static const char *_camera_request_image_path(const dt_camera_t *camera, void *d
 
 static int32_t dt_camera_import_job_run(dt_job_t *job)
 {
-  dt_camera_import_t *params = (dt_camera_import_t *)dt_control_job_get_params(job);
+  dt_camera_import_t *params = dt_control_job_get_params(job);
   dt_control_log(_("starting to import images from camera"));
 
   if(!dt_import_session_ready(params->shared.session))
@@ -338,7 +338,7 @@ static int32_t dt_camera_import_job_run(dt_job_t *job)
 
   // register listener
   dt_camctl_listener_t listener = { 0 };
-  listener.data = (void *)params;
+  listener.data = params;
   listener.image_downloaded = _camera_import_image_downloaded;
   listener.request_image_path = _camera_request_image_path;
   listener.request_image_filename = _camera_request_image_filename;

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -194,7 +194,7 @@ dt_job_t *dt_camera_capture_job_create(const char *jobcode, uint32_t delay, uint
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
 
   params->shared.session = dt_import_session_new();
   dt_import_session_set_name(params->shared.session, jobcode);
@@ -229,7 +229,7 @@ dt_job_t *dt_camera_get_previews_job_create(dt_camera_t *camera, dt_camctl_liste
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
 
   params->listener = g_malloc(sizeof(dt_camctl_listener_t));
   memcpy(params->listener, listener, sizeof(dt_camctl_listener_t));
@@ -333,7 +333,7 @@ dt_job_t *dt_camera_import_job_create(const char *jobcode, GList *images, struct
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
 
   /* intitialize import session for camera import job */
   params->shared.session = dt_import_session_new();

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -71,14 +71,14 @@ typedef struct dt_camera_import_t
 void *dt_camera_previews_job_get_data(const dt_job_t *job)
 {
   if(!job) return NULL;
-  dt_camera_get_previews_t *params = dt_control_job_get_params(job);
+  const dt_camera_get_previews_t *params = dt_control_job_get_params(job);
   if(!params) return NULL;
   return params->data;
 }
 
 static int32_t dt_camera_capture_job_run(dt_job_t *job)
 {
-  dt_camera_capture_t *params = dt_control_job_get_params(job);
+  const dt_camera_capture_t *params = dt_control_job_get_params(job);
   int total;
   char message[512] = { 0 };
   double fraction = 0;
@@ -117,7 +117,6 @@ static int32_t dt_camera_capture_job_run(dt_job_t *job)
     if(params->brackets)
     {
       dt_control_log(_("please set your camera to manual mode first!"));
-      free(params);
       return 1;
     }
   }
@@ -179,7 +178,6 @@ static int32_t dt_camera_capture_job_run(dt_job_t *job)
   {
     g_list_free_full(values, g_free);
   }
-  free(params);
   return 0;
 }
 
@@ -208,13 +206,14 @@ dt_job_t *dt_camera_capture_job_create(const char *jobcode, uint32_t delay, uint
 
 static int32_t dt_camera_get_previews_job_run(dt_job_t *job)
 {
-  dt_camera_get_previews_t *params = dt_control_job_get_params(job);
+  const dt_camera_get_previews_t *params = dt_control_job_get_params(job);
 
   dt_camctl_register_listener(darktable.camctl, params->listener);
   dt_camctl_get_previews(darktable.camctl, params->flags, params->camera);
   dt_camctl_unregister_listener(darktable.camctl, params->listener);
+
+  // FIXME: leak
   g_free(params->listener);
-  free(params);
   return 0;
 }
 
@@ -283,13 +282,12 @@ static const char *_camera_request_image_path(const dt_camera_t *camera, void *d
 
 static int32_t dt_camera_import_job_run(dt_job_t *job)
 {
-  dt_camera_import_t *params = dt_control_job_get_params(job);
+  dt_camera_import_t *params = (dt_camera_import_t *)dt_control_job_get_params(job);
   dt_control_log(_("starting to import images from camera"));
 
   if(!dt_import_session_ready(params->shared.session))
   {
     dt_control_log("Failed to import images from camera.");
-    free(params);
     return 1;
   }
 
@@ -305,7 +303,7 @@ static int32_t dt_camera_import_job_run(dt_job_t *job)
 
   // register listener
   dt_camctl_listener_t listener = { 0 };
-  listener.data = params;
+  listener.data = (void *)params;
   listener.image_downloaded = _camera_import_image_downloaded;
   listener.request_image_path = _camera_request_image_path;
   listener.request_image_filename = _camera_request_image_filename;
@@ -316,8 +314,8 @@ static int32_t dt_camera_import_job_run(dt_job_t *job)
   dt_camctl_unregister_listener(darktable.camctl, &listener);
   dt_control_progress_destroy(darktable.control, params->progress);
 
+  // FIXME: leak
   dt_import_session_destroy(params->shared.session);
-  free(params);
 
   return 0;
 }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -151,7 +151,6 @@ static int32_t _generic_dt_control_fileop_images_job_run(dt_job_t *job,
   dt_film_remove_empty();
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
-  free(params);
   return 0;
 }
 
@@ -176,14 +175,15 @@ static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback ex
 
 static void dt_control_generic_images_job_cleanup(dt_job_t *job)
 {
-  dt_control_image_enumerator_job_selected_cleanup(dt_control_job_get_params(job));
+  dt_control_image_enumerator_job_selected_cleanup(
+      (dt_control_image_enumerator_t *)dt_control_job_get_params(job));
   dt_control_job_dispose(job);
 }
 
 static int32_t dt_control_write_sidecar_files_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -211,7 +211,6 @@ static int32_t dt_control_write_sidecar_files_job_run(dt_job_t *job)
     t = g_list_delete_link(t, t);
   }
   sqlite3_finalize(stmt);
-  free(params);
   return 0;
 }
 
@@ -393,7 +392,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
 
 static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
 {
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   const guint total = g_list_length(t);
   char message[512] = { 0 };
@@ -473,7 +472,6 @@ end:
 
   dt_control_progress_destroy(darktable.control, progress);
   dt_control_queue_redraw_center();
-  free(params);
   return 0;
 }
 
@@ -481,7 +479,7 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
   int newimgid = -1;
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   guint total = g_list_length(t);
   char message[512] = { 0 };
@@ -500,14 +498,13 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
   dt_control_progress_destroy(darktable.control, progress);
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
-  free(params);
   return 0;
 }
 
 static int32_t dt_control_flip_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   const int cw = params->flag;
   GList *t = params->index;
   guint total = g_list_length(t);
@@ -525,7 +522,6 @@ static int32_t dt_control_flip_images_job_run(dt_job_t *job)
   }
   dt_control_progress_destroy(darktable.control, progress);
   dt_control_queue_redraw_center();
-  free(params);
   return 0;
 }
 
@@ -582,7 +578,7 @@ static GList *_get_full_pathname(char *imgs)
 static int32_t dt_control_remove_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   char *imgs = _get_image_list(t);
   guint total = g_list_length(t);
@@ -615,7 +611,6 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
     dt_control_log(_("cannot remove local copy when the original file is not accessible."));
     dt_control_progress_destroy(darktable.control, progress);
     free(imgs);
-    free(params);
     return 0;
   }
 
@@ -649,7 +644,6 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
   dt_film_remove_empty();
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
-  free(params);
   return 0;
 }
 
@@ -657,7 +651,7 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
 static int32_t dt_control_delete_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   char *imgs = _get_image_list(t);
   guint total = g_list_length(t);
@@ -784,13 +778,12 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
   dt_film_remove_empty();
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
   dt_control_queue_redraw_center();
-  free(params);
   return 0;
 }
 
 static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
 {
-  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   struct dt_gpx_t *gpx = NULL;
   uint32_t cntr = 0;
@@ -873,7 +866,6 @@ static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
   g_free(d->filename);
   g_free(d->tz);
   g_free(params->data);
-  free(params);
   return 0;
 
 bail_out:
@@ -882,7 +874,6 @@ bail_out:
   g_free(d->filename);
   g_free(d->tz);
   g_free(params->data);
-  free(params);
   return 1;
 }
 
@@ -947,7 +938,6 @@ static int32_t dt_control_local_copy_images_job_run(dt_job_t *job)
 
   dt_control_progress_destroy(control, progress);
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
-  free(params);
   return 0;
 }
 
@@ -1072,7 +1062,6 @@ end:
   mformat->free_params(mformat, fdata);
 
   g_free(params->data);
-  free(params);
   return 0;
 }
 
@@ -1093,6 +1082,7 @@ static dt_job_t *dt_control_gpx_apply_job_create(const gchar *filename, int32_t 
   else
     dt_control_image_enumerator_job_selected_init(params);
 
+  // FIXME: leaks
   dt_control_gpx_apply_t *data = (dt_control_gpx_apply_t *)malloc(sizeof(dt_control_gpx_apply_t));
   data->filename = g_strdup(filename);
   data->tz = g_strdup(tz);
@@ -1346,7 +1336,6 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
     dt_control_log(_("failed to get parameters from storage module `%s', aborting export.."),
                    mstorage->name(mstorage));
     free(data);
-    free(params);
     dt_control_job_dispose(job);
     return;
   }
@@ -1376,7 +1365,6 @@ static int32_t dt_control_time_offset_job_run(dt_job_t *job)
   if(!t || offset == 0)
   {
     g_free(params->data);
-    free(params);
     return 1;
   }
 
@@ -1409,7 +1397,6 @@ static int32_t dt_control_time_offset_job_run(dt_job_t *job)
   if(progress) dt_control_progress_destroy(darktable.control, progress);
 
   g_free(params->data);
-  free(params);
   return 0;
 }
 

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -192,7 +192,7 @@ static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback ex
 static int32_t dt_control_write_sidecar_files_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -401,7 +401,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
 
 static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
 {
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   const guint total = g_list_length(t);
   char message[512] = { 0 };
@@ -488,7 +488,7 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
   int newimgid = -1;
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   guint total = g_list_length(t);
   char message[512] = { 0 };
@@ -513,7 +513,7 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
 static int32_t dt_control_flip_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   const int cw = params->flag;
   GList *t = params->index;
   guint total = g_list_length(t);
@@ -587,7 +587,7 @@ static GList *_get_full_pathname(char *imgs)
 static int32_t dt_control_remove_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   char *imgs = _get_image_list(t);
   guint total = g_list_length(t);
@@ -660,7 +660,7 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
 static int32_t dt_control_delete_images_job_run(dt_job_t *job)
 {
   int imgid = -1;
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   char *imgs = _get_image_list(t);
   guint total = g_list_length(t);
@@ -792,7 +792,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
 
 static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
 {
-  const dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
+  dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   GList *t = params->index;
   struct dt_gpx_t *gpx = NULL;
   uint32_t cntr = 0;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -167,7 +167,7 @@ static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback ex
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   dt_control_image_enumerator_job_selected_init(params);
   params->flag = flag;
   params->data = data;
@@ -1087,7 +1087,7 @@ static dt_job_t *dt_control_gpx_apply_job_create(const gchar *filename, int32_t 
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   if(filmid != -1)
     dt_control_image_enumerator_job_film_init(params, filmid);
   else
@@ -1330,7 +1330,7 @@ void dt_control_export(GList *imgid_list, int max_width, int max_height, int for
     dt_control_job_dispose(job);
     return;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   params->index = imgid_list;
   dt_control_export_t *data = (dt_control_export_t *)malloc(sizeof(dt_control_export_t));
   data->max_width = max_width;
@@ -1424,7 +1424,7 @@ static dt_job_t *dt_control_time_offset_job_create(const long int offset, int im
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   if(imgid != -1)
     params->index = g_list_append(params->index, GINT_TO_POINTER(imgid));
   else

--- a/src/control/jobs/develop_jobs.c
+++ b/src/control/jobs/develop_jobs.c
@@ -21,7 +21,7 @@
 
 static int32_t dt_dev_process_preview_job_run(dt_job_t *job)
 {
-  dt_develop_t *dev = (dt_develop_t *)dt_control_job_get_params(job);
+  dt_develop_t *dev = dt_control_job_get_params(job);
   dt_dev_process_preview_job(dev);
   return 0;
 }
@@ -36,7 +36,7 @@ dt_job_t *dt_dev_process_preview_job_create(dt_develop_t *dev)
 
 static int32_t dt_dev_process_image_job_run(dt_job_t *job)
 {
-  dt_develop_t *dev = (dt_develop_t *)dt_control_job_get_params(job);
+  dt_develop_t *dev = dt_control_job_get_params(job);
   dt_dev_process_image_job(dev);
   return 0;
 }

--- a/src/control/jobs/develop_jobs.c
+++ b/src/control/jobs/develop_jobs.c
@@ -21,7 +21,7 @@
 
 static int32_t dt_dev_process_preview_job_run(dt_job_t *job)
 {
-  dt_develop_t *dev = dt_control_job_get_params(job);
+  dt_develop_t *dev = (dt_develop_t *)dt_control_job_get_params(job);
   dt_dev_process_preview_job(dev);
   return 0;
 }
@@ -36,7 +36,7 @@ dt_job_t *dt_dev_process_preview_job_create(dt_develop_t *dev)
 
 static int32_t dt_dev_process_image_job_run(dt_job_t *job)
 {
-  dt_develop_t *dev = dt_control_job_get_params(job);
+  dt_develop_t *dev = (dt_develop_t *)dt_control_job_get_params(job);
   dt_dev_process_image_job(dev);
   return 0;
 }

--- a/src/control/jobs/develop_jobs.c
+++ b/src/control/jobs/develop_jobs.c
@@ -30,7 +30,7 @@ dt_job_t *dt_dev_process_preview_job_create(dt_develop_t *dev)
 {
   dt_job_t *job = dt_control_job_create(&dt_dev_process_preview_job_run, "develop process preview");
   if(!job) return NULL;
-  dt_control_job_set_params(job, dev);
+  dt_control_job_set_params(job, dev, NULL);
   return job;
 }
 
@@ -45,7 +45,7 @@ dt_job_t *dt_dev_process_image_job_create(dt_develop_t *dev)
 {
   dt_job_t *job = dt_control_job_create(&dt_dev_process_image_job_run, "develop process image");
   if(!job) return NULL;
-  dt_control_job_set_params(job, dev);
+  dt_control_job_set_params(job, dev, NULL);
   return job;
 }
 

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -27,7 +27,7 @@ typedef struct dt_film_import1_t
 
 static int32_t dt_film_import1_run(dt_job_t *job)
 {
-  dt_film_import1_t *params = dt_control_job_get_params(job);
+  const dt_film_import1_t *params = dt_control_job_get_params(job);
   dt_film_import1(params->film);
   dt_pthread_mutex_lock(&params->film->images_mutex);
   params->film->ref--;
@@ -38,10 +38,11 @@ static int32_t dt_film_import1_run(dt_job_t *job)
     {
       dt_film_remove(params->film->id);
     }
+
+    // FIXME: leak
     dt_film_cleanup(params->film);
     free(params->film);
   }
-  free(params);
   return 0;
 }
 

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -38,12 +38,18 @@ static int32_t dt_film_import1_run(dt_job_t *job)
     {
       dt_film_remove(params->film->id);
     }
-
-    // FIXME: leak
-    dt_film_cleanup(params->film);
-    free(params->film);
   }
   return 0;
+}
+
+static void dt_film_import1_cleanup(void *p)
+{
+  dt_film_import1_t *params = p;
+
+  dt_film_cleanup(params->film);
+  free(params->film);
+
+  free(params);
 }
 
 dt_job_t *dt_film_import1_create(dt_film_t *film)
@@ -56,7 +62,7 @@ dt_job_t *dt_film_import1_create(dt_film_t *film)
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params, free);
+  dt_control_job_set_params(job, params, dt_film_import1_cleanup);
   params->film = film;
   dt_pthread_mutex_lock(&film->images_mutex);
   film->ref++;

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -55,7 +55,7 @@ dt_job_t *dt_film_import1_create(dt_film_t *film)
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   params->film = film;
   dt_pthread_mutex_lock(&film->images_mutex);
   film->ref++;

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -27,7 +27,7 @@ typedef struct dt_film_import1_t
 
 static int32_t dt_film_import1_run(dt_job_t *job)
 {
-  const dt_film_import1_t *params = dt_control_job_get_params(job);
+  dt_film_import1_t *params = dt_control_job_get_params(job);
   dt_film_import1(params->film);
   dt_pthread_mutex_lock(&params->film->images_mutex);
   params->film->ref--;

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -29,7 +29,7 @@ typedef struct dt_image_load_t
 
 static int32_t dt_image_load_job_run(dt_job_t *job)
 {
-  const dt_image_load_t *params = dt_control_job_get_params(job);
+  dt_image_load_t *params = dt_control_job_get_params(job);
 
   // hook back into mipmap_cache:
   dt_mipmap_buffer_t buf;
@@ -66,7 +66,7 @@ static int32_t dt_image_import_job_run(dt_job_t *job)
 {
   int id;
   char message[512] = { 0 };
-  const dt_image_import_t *params = dt_control_job_get_params(job);
+  dt_image_import_t *params = dt_control_job_get_params(job);
 
   snprintf(message, sizeof(message), _("importing image %s"), params->filename);
   dt_progress_t *progress = dt_control_progress_create(darktable.control, TRUE, message);

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -29,7 +29,7 @@ typedef struct dt_image_load_t
 
 static int32_t dt_image_load_job_run(dt_job_t *job)
 {
-  dt_image_load_t *params = dt_control_job_get_params(job);
+  const dt_image_load_t *params = dt_control_job_get_params(job);
 
   // hook back into mipmap_cache:
   dt_mipmap_buffer_t buf;
@@ -37,7 +37,6 @@ static int32_t dt_image_load_job_run(dt_job_t *job)
 
   // drop read lock, as this is only speculative async loading.
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-  free(params);
   return 0;
 }
 
@@ -67,9 +66,7 @@ static int32_t dt_image_import_job_run(dt_job_t *job)
 {
   int id;
   char message[512];
-  dt_image_import_t *params;
-
-  params = dt_control_job_get_params(job);
+  const dt_image_import_t *params = dt_control_job_get_params(job);
   message[0] = 0;
 
   snprintf(message, sizeof(message), _("importing image %s"), params->filename);
@@ -84,7 +81,6 @@ static int32_t dt_image_import_job_run(dt_job_t *job)
 
   dt_control_progress_set_progress(darktable.control, progress, 1.0);
   dt_control_progress_destroy(darktable.control, progress);
-  free(params);
   return 0;
 }
 

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -51,7 +51,7 @@ dt_job_t *dt_image_load_job_create(int32_t id, dt_mipmap_size_t mip)
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   params->imgid = id;
   params->mip = mip;
   return job;
@@ -99,7 +99,7 @@ dt_job_t *dt_image_import_job_create(uint32_t filmid, const char *filename)
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params);
+  dt_control_job_set_params(job, params, free);
   params->filename = g_strdup(filename);
   params->film_id = filmid;
   return job;

--- a/src/control/progress.c
+++ b/src/control/progress.c
@@ -114,6 +114,7 @@ void dt_control_progress_destroy(dt_control_t *control, dt_progress_t *progress)
 
   // free the object
   dt_pthread_mutex_destroy(&progress->mutex);
+  g_free(progress->message);
   free(progress);
 }
 

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -328,7 +328,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
-  if(!params) return NULL;
+  if(!params) return;
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)params;
   dt_variables_params_destroy(d->vp);
   free(params);

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -328,6 +328,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
+  if(!params) return NULL;
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)params;
   dt_variables_params_destroy(d->vp);
   free(params);

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -174,7 +174,7 @@ int set_params(dt_imageio_module_storage_t *self, const void *params, const int 
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
-  if(!params) return NULL;
+  if(!params) return;
   free(params);
 }
 

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -174,6 +174,7 @@ int set_params(dt_imageio_module_storage_t *self, const void *params, const int 
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
+  if(!params) return NULL;
   free(params);
 }
 

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -1407,6 +1407,7 @@ void *get_params(struct dt_imageio_module_storage_t *self)
 
 void free_params(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data)
 {
+  if(!data) return NULL;
   dt_storage_facebook_param_t *p = (dt_storage_facebook_param_t *)data;
   fb_api_destroy(p->facebook_ctx);
   g_free(p);

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -1407,7 +1407,7 @@ void *get_params(struct dt_imageio_module_storage_t *self)
 
 void free_params(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data)
 {
-  if(!data) return NULL;
+  if(!data) return;
   dt_storage_facebook_param_t *p = (dt_storage_facebook_param_t *)data;
   fb_api_destroy(p->facebook_ctx);
   g_free(p);

--- a/src/imageio/storage/flickr.c
+++ b/src/imageio/storage/flickr.c
@@ -853,7 +853,7 @@ int supported(dt_imageio_module_storage_t *storage, dt_imageio_module_format_t *
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
-  if(!params) return NULL;
+  if(!params) return;
 
   dt_storage_flickr_params_t *d = (dt_storage_flickr_params_t *)params;
 

--- a/src/imageio/storage/flickr.c
+++ b/src/imageio/storage/flickr.c
@@ -853,6 +853,8 @@ int supported(dt_imageio_module_storage_t *storage, dt_imageio_module_format_t *
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
+  if(!params) return NULL;
+
   dt_storage_flickr_params_t *d = (dt_storage_flickr_params_t *)params;
 
   _flickr_api_free(d->flickr_api); // TODO

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -531,7 +531,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
-  if(!params) return NULL;
+  if(!params) return;
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)params;
   dt_variables_params_destroy(d->vp);
   free(params);

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -531,6 +531,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
+  if(!params) return NULL;
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)params;
   dt_variables_params_destroy(d->vp);
   free(params);

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -449,7 +449,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
-  if(!params) return NULL;
+  if(!params) return;
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)params;
   dt_variables_params_destroy(d->vp);
   free(params);

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -449,6 +449,7 @@ void *get_params(dt_imageio_module_storage_t *self)
 
 void free_params(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *params)
 {
+  if(!params) return NULL;
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)params;
   dt_variables_params_destroy(d->vp);
   free(params);

--- a/src/imageio/storage/picasa.c
+++ b/src/imageio/storage/picasa.c
@@ -1566,6 +1566,7 @@ void *get_params(struct dt_imageio_module_storage_t *self)
 
 void free_params(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data)
 {
+  if(!data) return NULL;
   PicasaContext *ctx = (PicasaContext *)data;
   picasa_api_destroy(ctx);
 }

--- a/src/imageio/storage/picasa.c
+++ b/src/imageio/storage/picasa.c
@@ -1566,7 +1566,7 @@ void *get_params(struct dt_imageio_module_storage_t *self)
 
 void free_params(struct dt_imageio_module_storage_t *self, dt_imageio_module_data_t *data)
 {
-  if(!data) return NULL;
+  if(!data) return;
   PicasaContext *ctx = (PicasaContext *)data;
   picasa_api_destroy(ctx);
 }

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -304,7 +304,7 @@ void dt_lua_do_chunk_later(lua_State *L, int nargs)
 
   if(job)
   {
-    dt_control_job_set_params(job, GINT_TO_POINTER(reference));
+    dt_control_job_set_params(job, GINT_TO_POINTER(reference), NULL);
     dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG, job);
   }
 }
@@ -490,7 +490,7 @@ void dt_lua_do_chunk_async(lua_CFunction pusher,dt_lua_async_call_arg_type arg_t
     }
     va_end(ap);
     
-    dt_control_job_set_params(job, data);
+    dt_control_job_set_params(job, data, free);
     dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG, job);
   }
 }

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -431,7 +431,6 @@ static int32_t async_callback_job(dt_job_t *job)
   dt_lua_do_chunk_silent(L,nargs,0);
   dt_lua_redraw_screen();
   g_list_free(data->extra);
-  free(data);
   dt_lua_unlock();
   return 0;
 }

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -254,7 +254,7 @@ typedef struct
 
 static int32_t free_param_wrapper_job(dt_job_t *job)
 {
-  free_param_wrapper_data *params = dt_control_job_get_params(job);
+  const free_param_wrapper_data *params = dt_control_job_get_params(job);
   lua_storage_t *d = params->data;
   if(d->data_created)
   {
@@ -265,7 +265,6 @@ static int32_t free_param_wrapper_job(dt_job_t *job)
     dt_lua_unlock();
   }
   free(d);
-  free(params);
   return 0;
 }
 

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -254,7 +254,7 @@ typedef struct
 
 static int32_t free_param_wrapper_job(dt_job_t *job)
 {
-  const free_param_wrapper_data *params = dt_control_job_get_params(job);
+  free_param_wrapper_data *params = dt_control_job_get_params(job);
   lua_storage_t *d = params->data;
   if(d->data_created)
   {

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -280,7 +280,7 @@ static void free_params_wrapper(struct dt_imageio_module_storage_t *self, dt_ima
     dt_control_job_dispose(job);
     return;
   }
-  dt_control_job_set_params(job, t);
+  dt_control_job_set_params(job, t, free);
   t->data = (lua_storage_t *)data;
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_SYSTEM_FG, job);
 }

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -194,7 +194,7 @@ static int process_next_image(dt_slideshow_t *d)
 
 static int32_t process_job_run(dt_job_t *job)
 {
-  dt_slideshow_t *d = (dt_slideshow_t *)dt_control_job_get_params(job);
+  dt_slideshow_t *d = dt_control_job_get_params(job);
   process_next_image(d);
   return 0;
 }

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -203,7 +203,7 @@ static dt_job_t *process_job_create(dt_slideshow_t *d)
 {
   dt_job_t *job = dt_control_job_create(&process_job_run, "process slideshow image");
   if(!job) return NULL;
-  dt_control_job_set_params(job, d);
+  dt_control_job_set_params(job, d, NULL);
   return job;
 }
 

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -194,7 +194,7 @@ static int process_next_image(dt_slideshow_t *d)
 
 static int32_t process_job_run(dt_job_t *job)
 {
-  dt_slideshow_t *d = dt_control_job_get_params(job);
+  dt_slideshow_t *d = (dt_slideshow_t *)dt_control_job_get_params(job);
   process_next_image(d);
   return 0;
 }


### PR DESCRIPTION
Reasons:
* When we discard job, we would leak ALL memory related to the jobs, even params, because currently
job is supposed to free params by itself.
* When we run job, but it exits half-way, because of inadvertence we could also leak some things.

Solution:
Put *dt_control_job_dispose()* in charge of freeing memory. Since it *should* be called at the end of every job life, that is the best place for it.

Recipe:
* Make *dt_control_job_set_params()* also receive and store function pointer that will be called to free job's memory.
* Make sure that job does not free it's params.
* If params for this job contains pointers to newly-allocated memory (or it will be allocated in other jobs, see *dt_control_image_enumerator_alloc()*), refactor all this allocation into a function.
* If params for this job contains pointers to newly-allocated memory, or something else that needs to be cleaned (see *dt_control_image_enumerator_cleanup()*), refactor all this into a function, and pass it into *dt_control_job_set_params()*.