### PR TITLE
TIFF: treat 32-bit TIFF files as HDR instead of LDR

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -530,8 +530,6 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   {
     img->filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
-    img->flags &= ~DT_IMAGE_HDR;
-    img->flags |= DT_IMAGE_LDR;
     return ret;
   }
 

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -208,12 +208,19 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
 
   int ok = 1;
 
+  img->flags &= ~DT_IMAGE_HDR;
+  img->flags |= DT_IMAGE_LDR;
+
   if(t.bpp == 8 && t.sampleformat == SAMPLEFORMAT_UINT && config == PLANARCONFIG_CONTIG)
     ok = _read_planar_8(&t);
   else if(t.bpp == 16 && t.sampleformat == SAMPLEFORMAT_UINT && config == PLANARCONFIG_CONTIG)
     ok = _read_planar_16(&t);
   else if(t.bpp == 32 && t.sampleformat == SAMPLEFORMAT_IEEEFP && config == PLANARCONFIG_CONTIG)
+  {
     ok = _read_planar_f(&t);
+    img->flags |= DT_IMAGE_HDR;
+    img->flags &= ~DT_IMAGE_LDR;
+  }
   else
   {
     fprintf(stderr, "[tiff_open] error: Not an supported tiff image format.");


### PR DESCRIPTION
This change causes 32-bit floating point TIFF files to be treated as HDRs.

All of my HDRs are in this format, instead of OpenEXR, because storing in EXR causes me to lose almost all my (EXIF) metadata.