### PR TITLE
move dt_is_aligned to header to allow inling in rawprepare

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1089,11 +1089,6 @@ void dt_free_align(void *mem)
 }
 #endif
 
-inline gboolean dt_is_aligned(const void *pointer, size_t byte_count)
-{
-  return (uintptr_t)pointer % byte_count == 0;
-}
-
 void dt_show_times(const dt_times_t *start, const char *prefix, const char *suffix, ...)
 {
   dt_times_t end;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -231,7 +231,12 @@ void dt_free_align(void *mem);
 #else
 #define dt_free_align(A) free(A)
 #endif
-gboolean dt_is_aligned(const void *pointer, size_t byte_count);
+
+inline gboolean dt_is_aligned(const void *pointer, size_t byte_count)
+{
+    return (uintptr_t)pointer % byte_count == 0;
+}
+
 int dt_capabilities_check(char *capability);
 void dt_capabilities_add(char *capability);
 void dt_capabilities_remove(char *capability);


### PR DESCRIPTION
dt_is_aligned was declared 'inline', but defined in a source file (darktable.c),
thus it could not be inlined.
By moving it to the header (darktable.h), it can be inlined when used
in rawprepare.c:process(). This speeds up my benchmark (darktable-cli --verbose --generate-cache --core --library ~/.config/darktable/library.db with 6 raw images, no opencl) by 10%.