### PR TITLE
Only remove thumbnail from mipmap and file cache if it was actually changed

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -641,6 +641,9 @@ void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolea
   dt_dev_invalidate_all(dev);
   dt_pthread_mutex_unlock(&dev->history_mutex);
 
+  //Invalidate mipmaps
+  dev->history_was_changed = TRUE;
+
   if(dev->gui_attached)
   {
     /* signal that history has changed */
@@ -743,6 +746,11 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
   // printf("dev popping all history items >= %d\n", cnt);
   dt_pthread_mutex_lock(&dev->history_mutex);
   darktable.gui->reset = 1;
+  if(cnt != dev->history_end)
+  {
+      //History really changes -> invalidate mipmaps
+      dev->history_was_changed = TRUE;
+  }
   dev->history_end = cnt;
   // reset gui params for all modules
   GList *modules = dev->iop;
@@ -1161,6 +1169,8 @@ void dt_dev_read_history(dt_develop_t *dev)
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
   }
   sqlite3_finalize(stmt);
+
+  dev->history_was_changed = FALSE;
 }
 
 

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -112,6 +112,7 @@ typedef struct dt_develop_t
   dt_pthread_mutex_t history_mutex;
   int32_t history_end;
   GList *history;
+  gboolean history_was_changed;
 
   // operations pipeline
   int32_t iop_instance;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -502,9 +502,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   // commit image ops to db
   dt_dev_write_history(dev);
 
-  // be sure light table will update the thumbnail
-  // TODO: only if image changed!
-  // if()
+  if(dev->history_was_changed)
   {
     dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
     dt_image_synch_xmp(dev->image_storage.id);
@@ -1292,8 +1290,7 @@ void leave(dt_view_t *self)
   dt_dev_write_history(dev);
 
   // be sure light table will regenerate the thumbnail:
-  // TODO: only if changed!
-  // if()
+  if(dev->history_was_changed)
   {
     dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
     // dump new xmp data


### PR DESCRIPTION
When changing the current image in darktable mode, the thumbnail is recomputed even if there was no change. This is even worse than it seems,
because the thumbnail (for some reason) is computed twice. With '-d perf' or breakpoint on dt_image_load_job_create, I clearly see that for each change of image in the film strip,
_two_ "thumbnails", one "full" and one "preview" are computed. When I remove the dt_mipmap_cache_remove from dt_dev_change_image(), only the "full" and "preview" are computed.

This is not a patch (yet). I would like to fix it and make this an actual patch. Can someone give me a hint please?
a) Could I just move dt_mipmap_cache_remove() to dt_dev_add_history_item()?
b) Could I set a flag 'changed' in dt_dev_add_history_item() and check that one in dt_dev_change_image()?
c) something else?