### PR TITLE
Allow multiple instances of "base curve"

### DIFF
--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -213,7 +213,7 @@ int groups()
 
 int flags()
 {
-  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_ONE_INSTANCE;
+  return IOP_FLAGS_ALLOW_TILING;
 }
 
 


### PR DESCRIPTION
When I'm working on a picture that already has a base curve on it, I sometimes want to tweak the curve a bit more, but doing so with the preset curve is really quite difficult. I'm fairly new to this, so I assume that this is correct: by allowing multiple instances, I can throw a new base curve on top of the current one and tweak it without having to worry about destroying the preset curve. In my testing, it seemed to work just fine. Though as a newbie on this, I just want to be sure: was there a reason that base curve was limited to a single instance that I'm missing?