### PR TITLE
Silence unneeded exiv2/tiff debug output by default

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -111,7 +111,7 @@ const char dt_supported_extensions[] = "3fr,arw,bay,bmq,cap,cine,cr2,crw,cs1,dc2
 static int usage(const char *argv0)
 {
   printf("usage: %s [-d "
-         "{all,cache,camctl,control,dev,fswatch,input,lighttable,masks,memory,nan,opencl,perf,pwstorage,sql}]"
+         "{all,cache,camctl,camsupport,control,dev,fswatch,input,lighttable,masks,memory,nan,opencl,perf,pwstorage,print,sql}]"
          " [IMG_1234.{RAW,..}|image_folder/]",
          argv0);
 #ifdef HAVE_OPENCL
@@ -621,6 +621,8 @@ int dt_init(int argc, char *argv[], const int init_gui, lua_State *L)
           darktable.unmuted |= DT_DEBUG_LUA; // lua errors are reported on console
         else if(!strcmp(argv[k + 1], "print"))
           darktable.unmuted |= DT_DEBUG_PRINT; // print errors are reported on console
+        else if(!strcmp(argv[k + 1], "camsupport"))
+          darktable.unmuted |= DT_DEBUG_CAMERA_SUPPORT; // camera support warnings are reported on console
         else
           return usage(argv[0]);
         k++;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -165,7 +165,8 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_MASKS = 1 << 12,
   DT_DEBUG_LUA = 1 << 13,
   DT_DEBUG_INPUT = 1 << 14,
-  DT_DEBUG_PRINT = 1 << 15
+  DT_DEBUG_PRINT = 1 << 15,
+  DT_DEBUG_CAMERA_SUPPORT = 1 << 16,
 } dt_debug_thread_t;
 
 typedef struct darktable_t

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2347,13 +2347,16 @@ int dt_exif_xmp_write(const int imgid, const char *filename)
 
 static void dt_exif_log_handler(int log_level, const char *message)
 {
-  if(log_level >= Exiv2::LogMsg::level()) fprintf(stderr, "[exiv2] %s\n", message);
+  if(log_level >= Exiv2::LogMsg::level())
+  {
+    // We don't seem to need \n in the format string as exiv2 includes it
+    // in the messages themselves
+    dt_print(DT_DEBUG_CAMERA_SUPPORT, "[exiv2] %s", message);
+  }
 }
 
 void dt_exif_init()
 {
-  // mute exiv2:
-  //   Exiv2::LogMsg::setLevel(Exiv2::LogMsg::mute);
   // preface the exiv2 messages with "[exiv2] "
   Exiv2::LogMsg::setHandler(&dt_exif_log_handler);
 

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -41,6 +41,8 @@ typedef enum dt_imageio_levels_t
   IMAGEIO_CHANNEL_MASK = 0xFF00
 } dt_imageio_levels_t;
 
+// Checks that the image is indeed an ldr image
+gboolean dt_imageio_is_ldr(const char *filename);
 
 // opens the file using pfm, hdr, exr.
 dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -187,7 +187,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   t.mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, t.image);
   if(!t.mipbuf)
   {
-    fprintf(stderr, "[tiff_open] could not alloc full buffer for image `%s'\n", t.image->filename);
+    fprintf(stderr, "[tiff_open] error: could not alloc full buffer for image `%s'\n", t.image->filename);
     TIFFClose(t.tiff);
     return DT_IMAGEIO_CACHE_FULL;
   }
@@ -195,7 +195,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   /* dont depend on planar config if spp == 1 */
   if(t.spp > 1 && config != PLANARCONFIG_CONTIG)
   {
-    fprintf(stderr, "[tiff_open] warning: planar config other than contig is not supported.\n");
+    fprintf(stderr, "[tiff_open] error: planar config other than contig is not supported.\n");
     TIFFClose(t.tiff);
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
@@ -216,7 +216,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
     ok = _read_planar_f(&t);
   else
   {
-    fprintf(stderr, "[tiff_open] error: Not an supported tiff image format.");
+    fprintf(stderr, "[tiff_open] error: Not a supported tiff image format.");
     ok = 0;
   }
 

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -162,7 +162,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   TIFFGetField(t.tiff, TIFFTAG_PLANARCONFIG, &config);
   t.scanlinesize = TIFFScanlineSize(t.tiff);
 
-  fprintf(stderr, "[tiff_open] %dx%d %dbpp, %d samples per pixel.\n", t.width, t.height, t.bpp, t.spp);
+  dt_print(DT_DEBUG_CAMERA_SUPPORT, "[tiff_open] %dx%d %dbpp, %d samples per pixel.\n", t.width, t.height, t.bpp, t.spp);
 
   // we only support 8/16 and 32 bits per pixel formats.
   if(t.bpp != 8 && t.bpp != 16 && t.bpp != 32)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -913,7 +913,7 @@ void reload_defaults(dt_iop_module_t *module)
       use_eprofile = (img->profile_size > 0);
     }
 #endif
-    else if(!strcmp(ext, "tif") || !strcmp(ext, "tiff"))
+    else if((!strcmp(ext, "tif") || !strcmp(ext, "tiff")) && dt_imageio_is_ldr(filename))
     {
       img->profile_size = dt_imageio_tiff_read_profile(filename, &img->profile);
       use_eprofile = (img->profile_size > 0);


### PR DESCRIPTION
Our console output is quite noisy and exiv2 is a big culprit. I move the exiv2 and one tiff message to a new DT_DEBUG_CAMERA_SUPPORT that is disabled by default. This makes the output much nicer (from 5684 lines to 743 when exporting my full test collection).