### PR TITLE
NikonCompressor: Allow to inline setWithLookUp in tight decompressor loop

### DIFF
--- a/src/external/rawspeed/CMakeLists.txt
+++ b/src/external/rawspeed/CMakeLists.txt
@@ -14,5 +14,6 @@ else(WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif(WIN32)
 
+add_definitions(-std=c++11)
 add_library(rawspeed STATIC ${RAWSPEED_SOURCES})
 target_link_libraries(rawspeed ${RAWSPEED_LIBS})

--- a/src/external/rawspeed/RawSpeed/NikonDecompressor.cpp
+++ b/src/external/rawspeed/RawSpeed/NikonDecompressor.cpp
@@ -107,6 +107,8 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   int pLeft2 = 0;
   uint32 cw = w / 2;
   uint32 random = bits.peekBits(24);
+  //allow gcc to devirtualize the calls below
+  RawImageDataU16* rawdata = (RawImageDataU16*)mRaw.get();
   for (y = 0; y < h; y++) {
     if (split && y == split) {
       initTable(huffSelect + 1);
@@ -116,14 +118,14 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
     pUp2[y&1] += HuffDecodeNikon(bits);
     pLeft1 = pUp1[y&1];
     pLeft2 = pUp2[y&1];
-    mRaw->setWithLookUp(clampbits(pLeft1,15), (uchar8*)dest++, &random);
-    mRaw->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++, &random);
+    rawdata->setWithLookUp(clampbits(pLeft1,15), (uchar8*)dest++, &random);
+    rawdata->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++, &random);
     for (x = 1; x < cw; x++) {
       bits.checkPos();
       pLeft1 += HuffDecodeNikon(bits);
       pLeft2 += HuffDecodeNikon(bits);
-      mRaw->setWithLookUp(clampbits(pLeft1,15), (uchar8*)dest++, &random);
-      mRaw->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++, &random);
+      rawdata->setWithLookUp(clampbits(pLeft1,15), (uchar8*)dest++, &random);
+      rawdata->setWithLookUp(clampbits(pLeft2,15), (uchar8*)dest++, &random);
     }
   }
 

--- a/src/external/rawspeed/RawSpeed/RawImageDataU16.cpp
+++ b/src/external/rawspeed/RawSpeed/RawImageDataU16.cpp
@@ -479,31 +479,4 @@ void RawImageDataU16::doLookup( int start_y, int end_y )
   ThrowRDE("Table lookup with multiple components not implemented");
 }
 
-
-// setWithLookUp will set a single pixel by using the lookup table if supplied,
-// You must supply the destination where the value should be written, and a pointer to
-// a value that will be used to store a random counter that can be reused between calls.
-void RawImageDataU16::setWithLookUp(ushort16 value, uchar8* dst, uint32* random) {
-  ushort16* dest = (ushort16*)dst;
-  if (table == NULL) {
-    *dest = value;
-    return;
-  }
-  if (table->dither) {
-    uint32* t = (uint32*)table->tables;
-    uint32 lookup = t[value];
-    uint32 base = lookup & 0xffff;
-    uint32 delta = lookup >> 16;
-    uint32 r = *random;
-    
-    uint32 pix = base + ((delta * (r&2047) + 1024) >> 12);
-    *random = 15700 *(r & 65535) + (r >> 16);
-    *dest = pix;
-    return;
-  }
-  ushort16* t = (ushort16*)table->tables;
-  *dest = t[value];
-}
-
-
 } // namespace RawSpeed


### PR DESCRIPTION
Before this patch, gcc had to do a virtual function call in NikonDecompressor::DecompressNikon() in each loop iteration (over all pixels).
Now, through "final" and inline declaration, gcc can devirtualize and inline the function call to speed up the loop considerably.

This patch makes
    `darktable-cli --generate-cache`
15% faster; measured by 10 runs with 6 raw images each.

In general it would be faster to replace the RawImageDataU16 - RawImageData inhertiance by an RawImageData<uint16_t> template approach to allow the compiler to use the static types at compile time.