### PR TITLE
darktable-cli --generate-cache: simplify logic & fix ctrl-c behavior

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -81,53 +81,26 @@ static void generate_thumbnail_cache()
     sqlite3_finalize(stmt);
     return;
   }
-  const int cache_quality = MIN(100, MAX(10, dt_conf_get_int("database_cache_quality")));
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const int32_t imgid = sqlite3_column_int(stmt, 0);
-    // check whether all of these files are already there
-    int all_exist = 1;
     for(int k=max_mip;k>=DT_MIPMAP_0;k--)
     {
       snprintf(filename, sizeof(filename), "%s.d/%d/%d.jpg", darktable.mipmap_cache->cachedir, k, imgid);
-      all_exist &= !access(filename, R_OK); 
-    }
-    if(all_exist) goto next;
-    dt_mipmap_buffer_t buf;
-    // get largest thumbnail for this image
-    // this one will take care of itself, we'll just write out the lower thumbs manually:
-    dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, max_mip, DT_MIPMAP_BLOCKING, 'r');
-    if(buf.width > 8 && buf.height > 8) // don't create for skulls
-    for(int k=max_mip-1;k>=DT_MIPMAP_0;k--)
-    {
-      uint32_t width, height;
-      const int wd = darktable.mipmap_cache->max_width[k];
-      const int ht = darktable.mipmap_cache->max_height[k];
-      // use exactly the same mechanism as the cache internally to rescale the thumbnail:
-      dt_iop_flip_and_zoom_8(buf.buf, buf.width, buf.height, tmp, wd, ht, 0, &width, &height);
-
-      snprintf(filename, sizeof(filename), "%s.d/%d/%d.jpg", darktable.mipmap_cache->cachedir, k, imgid);
-      FILE *f = fopen(filename, "wb");
-      if(f)
+      //check if that thumbnail is already on disc
+      if(access(filename, R_OK))
       {
-        // allocate temp memory:
-        uint8_t *blob = (uint8_t *)malloc(bufsize);
-        if(!blob) goto write_error;
-        const int32_t length
-          = dt_imageio_jpeg_compress(tmp, blob, width, height, cache_quality);
-        assert(length <= bufsize);
-        int written = fwrite(blob, sizeof(uint8_t), length, f);
-        if(written != length)
-        {
-write_error:
-          unlink(filename);
-        }
-        free(blob);
-        fclose(f);
+        dt_mipmap_buffer_t buf;
+        //Generate thumbnail and store in mipmap cache.
+        //Lower mip levels will be generate from higher ones by downscaling, thus the pixelpipe is only
+        //run for max_mip.
+        //The thumbnails will be written to disc when the cache is full or latest at the end
+        //by dt_cleanup() -> dt_mipmap_cache_cleanup().
+        dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, k, DT_MIPMAP_BLOCKING, 'r');
+        dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
       }
     }
-    dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-next:
+
     counter ++;
     fprintf(stderr, "\rimage %zu/%zu (%.02f%%)            ", counter, image_count,
             100.0 * counter / (float)image_count);

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -101,6 +101,8 @@ static void generate_thumbnail_cache()
       }
     }
 
+    dt_mimap_cache_evict(darktable.mipmap_cache, imgid); //write to disc
+
     counter ++;
     fprintf(stderr, "\rimage %zu/%zu (%.02f%%)            ", counter, image_count,
             100.0 * counter / (float)image_count);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -786,6 +786,7 @@ dt_mipmap_size_t dt_mipmap_cache_get_matching_size(const dt_mipmap_cache_t *cach
   return best;
 }
 
+// invalidates and remove thumbnails from cache. They will be deleted from disc if existing
 void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid)
 {
   // get rid of all ldr thumbnails:
@@ -798,7 +799,17 @@ void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid)
     dsc->flags |= DT_MIPMAP_BUFFER_DSC_FLAG_INVALIDATE;
     dt_cache_release(&_get_cache(cache, k)->cache, entry);
 
-    dt_cache_remove(&_get_cache(cache, k)->cache, key); // this would write jpg backing thumbs again, if it wasn't for the flag
+    dt_cache_remove(&_get_cache(cache, k)->cache, key); // due to DT_MIPMAP_BUFFER_DSC_FLAG_INVALIDATE, removes thumbnail from disc
+  }
+}
+
+// evict thumbnails from cache. They will be written to disc if not existing
+void dt_mimap_cache_evict(dt_mipmap_cache_t *cache, const uint32_t imgid)
+{
+  for(int k = DT_MIPMAP_0; k < DT_MIPMAP_F; k++)
+  {
+    const uint32_t key = get_key(imgid, k);
+    dt_cache_remove(&_get_cache(cache, k)->cache, key); //write thumbnail to disc if not existing there
   }
 }
 

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -137,8 +137,11 @@ void dt_mipmap_cache_write_get_with_caller(
 // drop a lock
 void dt_mipmap_cache_release(dt_mipmap_cache_t *cache, dt_mipmap_buffer_t *buf);
 
-// remove thumbnails, so they will be regenerated:
+// invalidates and remove thumbnails from cache. They will be deleted from disc if existing
 void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid);
+
+// evict thumbnails from cache. They will be written to disc if not existing
+void dt_mimap_cache_evict(dt_mipmap_cache_t *cache, const uint32_t imgid);
 
 // return the closest mipmap size
 // for the given window you wish to draw.


### PR DESCRIPTION
The first commit simplifies the logic in generate_thumbnail_cache(),
because it is actually duplicated from the logic inside the mipmap cache.
This depends on https://github.com/darktable-org/darktable/pull/961 for generating smaller mip levels by downscaling.

The second commit changes the time at which thumbnails are written to disc.
Previously, when the user aborts 'darktable-cli --generate-cache'
by CTRL-C, possible none of the already generated thumbnails would make it
to the disc. Now, each thumbnail is written to disc after being generated.