### PR TITLE
Preload images in the full-size preview and simplify SQL a bit

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2318,4 +2318,11 @@
     <shortdescription>overwrite the screen's ppd setting</shortdescription>
     <longdescription>if this value is > 0.0 then it is used as the screen's ppd setting which is used for HiDPI support</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/preview/full_size_preload_count</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>preload images for full-size preview</shortdescription>
+    <longdescription>number of images to load in advance in the background when showing full-size preview</longdescription>
+  </dtconfig>
 </dtconfiglist>

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1183,65 +1183,74 @@ int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int32_t hei
   if(lib->track < -2) offset--;
   lib->track = 0;
 
-  if(offset)
+  /* If more than one image is selected, iterate over these. */
+  /* If only one image is selected, scroll through all known images. */
+
+  int sel_img_count = 0;
   {
-    /* If more than one image is selected, iterate over these. */
-    /* If only one image is selected, scroll through all known images. */
-
-    int sel_img_count = 0;
-    {
-      sqlite3_stmt *stmt;
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select COUNT(*) from selected_images", -1,
-                                  &stmt, NULL);
-      if(sqlite3_step(stmt) == SQLITE_ROW)
-      {
-        sel_img_count = sqlite3_column_int(stmt, 0);
-      }
-      sqlite3_finalize(stmt);
-    }
-
-    const dt_image_t *img = dt_image_cache_get(darktable.image_cache, lib->full_preview_id, 'r');
-
-    /* Build outer select criteria */
-    gchar *filter_criteria
-        = g_strdup_printf("INNER JOIN memory.collected_images AS col ON s1.imgid=col.imgid WHERE col.rowid "
-                          "%s %d ORDER BY rowid %s LIMIT 1",
-                          (offset > 0) ? ">" : "<", lib->full_preview_rowid, (offset > 0) ? "ASC" : "DESC");
-    dt_image_cache_read_release(darktable.image_cache, img);
-
     sqlite3_stmt *stmt;
-    gchar *stmt_string = NULL;
-    if(sel_img_count > 1)
-    {
-      stmt_string = g_strdup_printf(
-          "SELECT col.imgid AS id, col.rowid FROM (SELECT imgid FROM selected_images) AS s1 %s",
-          filter_criteria);
-
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), stmt_string, -1, &stmt, NULL);
-    }
-    else
-    {
-      /* We need to augment the current main query a bit to fetch the
-       * row we need. */
-      const char *main_query = sqlite3_sql(lib->statements.main_query);
-      stmt_string = g_strdup_printf("SELECT col.imgid AS id, col.rowid FROM (%s) AS s1 %s", main_query,
-                                    filter_criteria);
-
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), stmt_string, -1, &stmt, NULL);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, 0);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, -1);
-    }
-    g_free(stmt_string);
-    g_free(filter_criteria);
-
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "select COUNT(*) from selected_images", -1,
+                                &stmt, NULL);
     if(sqlite3_step(stmt) == SQLITE_ROW)
     {
+      sel_img_count = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+  }
+
+  sqlite3_stmt *stmt;
+  gchar *stmt_string = NULL;
+  /* How many images to preload in advance. */
+  int preload_num = dt_conf_get_int("plugins/lighttable/preview/full_size_preload_count");
+  preload_num = CLAMPS(preload_num, 0, 99999);
+  stmt_string = g_strdup_printf("SELECT col.imgid AS id, col.rowid FROM memory.collected_images AS col %s WHERE col.rowid %s %d ORDER BY col.rowid %s LIMIT %d",
+                                (sel_img_count <= 1) ?
+                                  /* We want to operate on the currently collected images, so there's no need to match against the selection */
+                                  "" :
+                                  /* Limit the matches to the current selection */
+                                  "INNER JOIN selected_images AS sel ON col.imgid = sel.imgid",
+                                (offset >= 0) ? ">" : "<",
+                                lib->full_preview_rowid,
+                                /* Direction of our navigation -- when showing for the first time, i.e. when offset == 0, assume forward navigation */
+                                (offset >= 0) ? "ASC" : "DESC",
+                                preload_num);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), stmt_string, -1, &stmt, NULL);
+
+  /* Walk through the "next" images, activate preload and find out where to go if moving */
+  int preload_stack[preload_num];
+  for(int i = 0; i < preload_num; ++i)
+  {
+    preload_stack[i] = -1;
+  }
+  int count = 0;
+
+  while (sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    /* Check if we're about to move */
+    if(count == 0 && offset != 0)
+    {
+      /* We're moving, so let's update the "next image" bits */
       lib->full_preview_id = sqlite3_column_int(stmt, 0);
       lib->full_preview_rowid = sqlite3_column_int(stmt, 1);
       dt_control_set_mouse_over_id(lib->full_preview_id);
     }
+    /* Store the image details for preloading, see below. */
+    preload_stack[count] = sqlite3_column_int(stmt, 0);
+    ++count;
+  }
+  g_free(stmt_string);
+  sqlite3_finalize(stmt);
 
-    sqlite3_finalize(stmt);
+  dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
+  /* Preload these images.
+   * The job queue is not a queue, but a stack, so we have to do it backwards.
+   * Simply swapping DESC and ASC in the SQL won't help because we rely on the LIMIT clause, and
+   * that LIMIT has to work with the "correct" sort order. One could use a subquery, but I don't
+   * think that would be terribly elegant, either. */
+  while(--count >= 0 && preload_stack[count] != -1)
+  {
+    dt_mipmap_buffer_t buf;
+    dt_mipmap_cache_get(darktable.mipmap_cache, &buf, preload_stack[count], mip, DT_MIPMAP_PREFETCH, 'r');
   }
 
   lib->image_over = DT_VIEW_DESERT;


### PR DESCRIPTION
The previous version of these SQL statements were a result of a few
years of incremental changes; under certain circumstances it was doing a
subquery and joining the result back with the original table. This
change simplifies the logic a bit -- the patch is best viewed when
ignoring indentation.

The real motivation was however speculative preload of a couple of next
images. Loading them in background cuts the latency when the user
navigates images that have expensive IOPs in theit history stacks. See
http://thread.gmane.org/gmane.comp.graphics.darktable.user/7832 for
details.