### PR TITLE
Add send_to_trash config and better feedback on error

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -206,7 +206,7 @@
   <dtconfig prefs="gui">
     <name>send_to_trash</name>
     <type>bool</type>
-    <default>false</default>
+    <default>true</default>
     <shortdescription>send files to trash when erasing images</shortdescription>
     <longdescription>send files to trash instead of permanently deleting files on system that supports it</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -204,6 +204,13 @@
     <longdescription>always ask the user before any image file is deleted.</longdescription>
   </dtconfig>
   <dtconfig prefs="gui">
+    <name>send_to_trash</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>send files to trash when erasing images</shortdescription>
+    <longdescription>send files to trash instead of permanently deleting files on system that supports it</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui">
     <name>ask_before_move</name>
     <type>bool</type>
     <default>true</default>

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -746,7 +746,7 @@ static gint _dt_delete_file_display_modal_dialog(int send_to_trash, const char *
 
   gdk_threads_add_idle(_dt_delete_dialog_main_thread, &modal_dialog);
   while (modal_dialog.dialog_result == GTK_RESPONSE_NONE)
-    pthread_cond_wait(&modal_dialog.cond, &modal_dialog.mutex);
+    dt_pthread_cond_wait(&modal_dialog.cond, &modal_dialog.mutex);
 
   dt_pthread_mutex_unlock(&modal_dialog.mutex);
   dt_pthread_mutex_destroy(&modal_dialog.mutex);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -663,50 +663,166 @@ static int32_t dt_control_remove_images_job_run(dt_job_t *job)
   return 0;
 }
 
-
-static void delete_file_from_disk(const char *filename)
+typedef struct _dt_delete_modal_dialog_t
 {
-  const char *filename_display = NULL;
-  GError *gerror = NULL;
-  GFileInfo *gfileinfo = NULL;
-  gboolean delete_success = FALSE;
+  int send_to_trash;
+  const char *filename;
+  const char *error_message;
+
+  gint dialog_result;
+
+  dt_pthread_mutex_t mutex;
+  pthread_cond_t cond;
+} _dt_delete_modal_dialog_t;
+
+enum _dt_delete_status
+{
+  _DT_DELETE_STATUS_UNKNOWN = 0,
+  _DT_DELETE_STATUS_OK_TO_REMOVE = 1,
+  _DT_DELETE_STATUS_SKIP_FILE = 2,
+  _DT_DELETE_STATUS_STOP_PROCESSING = 3
+};
+
+enum _dt_delete_dialog_choice
+{
+  _DT_DELETE_DIALOG_CHOICE_DELETE = 1,
+  _DT_DELETE_DIALOG_CHOICE_REMOVE = 2,
+  _DT_DELETE_DIALOG_CHOICE_CONTINUE = 3,
+  _DT_DELETE_DIALOG_CHOICE_STOP = 4
+};
+
+static gboolean _dt_delete_dialog_main_thread(gpointer user_data)
+{
+  _dt_delete_modal_dialog_t* modal_dialog = (_dt_delete_modal_dialog_t*)user_data;
+  dt_pthread_mutex_lock(&modal_dialog->mutex);
+
+  GtkWidget *dialog = gtk_message_dialog_new(
+      GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)),
+      GTK_DIALOG_DESTROY_WITH_PARENT,
+      GTK_MESSAGE_QUESTION,
+      GTK_BUTTONS_NONE,
+      modal_dialog->send_to_trash
+        ? _("Could not send %s to trash%s%s")
+        : _("Could not physically delete %s%s%s"),
+      modal_dialog->filename,
+      modal_dialog->error_message != NULL ? ": " : "",
+      modal_dialog->error_message != NULL ? modal_dialog->error_message : "");
+
+  if (modal_dialog->send_to_trash)
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("Physically delete"), _DT_DELETE_DIALOG_CHOICE_DELETE);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Only remove from the collection"), _DT_DELETE_DIALOG_CHOICE_REMOVE);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Skip to next file"), _DT_DELETE_DIALOG_CHOICE_CONTINUE);
+  gtk_dialog_add_button(GTK_DIALOG(dialog), _("Stop process"), _DT_DELETE_DIALOG_CHOICE_STOP);
+
+  gtk_window_set_title(
+      GTK_WINDOW(dialog),
+      modal_dialog->send_to_trash
+        ? _("trashing error")
+        : _("deletion error"));
+  modal_dialog->dialog_result = gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+
+  pthread_cond_signal(&modal_dialog->cond);
+
+  dt_pthread_mutex_unlock(&modal_dialog->mutex);
+
+  // Don't call again on next idle time
+  return FALSE;
+}
+
+static gint _dt_delete_file_display_modal_dialog(int send_to_trash, const char *filename, const char *error_message)
+{
+  _dt_delete_modal_dialog_t modal_dialog;
+  modal_dialog.send_to_trash = send_to_trash;
+  modal_dialog.filename = filename;
+  modal_dialog.error_message = error_message;
+
+  modal_dialog.dialog_result = GTK_RESPONSE_NONE;
+
+  dt_pthread_mutex_init(&modal_dialog.mutex, NULL);
+  pthread_cond_init(&modal_dialog.cond, NULL);
+
+  dt_pthread_mutex_lock(&modal_dialog.mutex);
+
+  gdk_threads_add_idle(_dt_delete_dialog_main_thread, &modal_dialog);
+  while (modal_dialog.dialog_result == GTK_RESPONSE_NONE)
+    pthread_cond_wait(&modal_dialog.cond, &modal_dialog.mutex);
+
+  dt_pthread_mutex_unlock(&modal_dialog.mutex);
+  dt_pthread_mutex_destroy(&modal_dialog.mutex);
+  pthread_cond_destroy(&modal_dialog.cond);
+
+  return modal_dialog.dialog_result;
+}
+
+static enum _dt_delete_status delete_file_from_disk(const char *filename)
+{
+  enum _dt_delete_status delete_status = _DT_DELETE_STATUS_UNKNOWN;
 
   GFile *gfile = g_file_new_for_path(filename);
   int send_to_trash = dt_conf_get_bool("send_to_trash");
 
-  if (send_to_trash)
+  while (delete_status == _DT_DELETE_STATUS_UNKNOWN)
   {
-    delete_success = g_file_trash(gfile, NULL /*cancellable*/, &gerror);
-  }
-  else
-  {
-    delete_success = g_file_delete(gfile, NULL /*cancellable*/, &gerror);
+    gboolean delete_success = FALSE;
+    GError *gerror = NULL;
+    if (send_to_trash)
+    {
+      delete_success = g_file_trash(gfile, NULL /*cancellable*/, &gerror);
+    }
+    else
+    {
+      delete_success = g_file_delete(gfile, NULL /*cancellable*/, &gerror);
+    }
+
+    if (delete_success)
+    {
+      delete_status = _DT_DELETE_STATUS_OK_TO_REMOVE;
+    }
+    else
+    {
+      const char *filename_display = NULL;
+      GFileInfo *gfileinfo = g_file_query_info(
+          gfile,
+          G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
+          G_FILE_QUERY_INFO_NONE,
+          NULL /*cancellable*/,
+          NULL /*error*/);
+      if (gfileinfo != NULL)
+        filename_display = g_file_info_get_attribute_string(
+            gfileinfo,
+            G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME);
+
+      gint res = _dt_delete_file_display_modal_dialog(
+          send_to_trash,
+          filename_display == NULL ? filename : filename_display,
+          gerror == NULL ? NULL : gerror->message);
+
+      if (send_to_trash && res == _DT_DELETE_DIALOG_CHOICE_DELETE)
+      {
+        // Loop again, this time delete instead of trashing
+        delete_status = _DT_DELETE_STATUS_UNKNOWN;
+        send_to_trash = FALSE;
+      }
+      else if (res == _DT_DELETE_DIALOG_CHOICE_REMOVE)
+      {
+        delete_status = _DT_DELETE_STATUS_OK_TO_REMOVE;
+      }
+      else if (res == _DT_DELETE_DIALOG_CHOICE_CONTINUE)
+      {
+        delete_status = _DT_DELETE_STATUS_SKIP_FILE;
+      }
+      else
+      {
+        delete_status = _DT_DELETE_STATUS_STOP_PROCESSING;
+      }
+    }
   }
 
-  if (!delete_success)
-  {
-    gfileinfo = g_file_query_info(
-        gfile,
-        G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
-        G_FILE_QUERY_INFO_NONE,
-        NULL /*cancellable*/,
-        NULL /*error*/);
-    if (gfileinfo != NULL)
-      filename_display = g_file_info_get_attribute_string(
-          gfileinfo,
-          G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME);
-
-    dt_control_log(
-        send_to_trash ? _("Could not send %s to trash%s%s") : _("Could not physically delete %s%s%s"),
-        filename_display == NULL ? filename : filename_display,
-        gerror != NULL && gerror->message != NULL ? ": " : "",
-        gerror != NULL && gerror->message != NULL ? gerror->message : "");
-  }
-
-  if (gfileinfo != NULL)
-    g_object_unref(gfileinfo);
   if (gfile != NULL)
     g_object_unref(gfile);
+
+  return delete_status;
 }
 
 
@@ -719,7 +835,10 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
   guint total = g_list_length(t);
   char message[512] = { 0 };
   double fraction = 0;
-  snprintf(message, sizeof(message), ngettext("deleting %d image", "deleting %d images", total), total);
+  if (dt_conf_get_bool("send_to_trash"))
+    snprintf(message, sizeof(message), ngettext("trashing %d image", "trashing %d images", total), total);
+  else
+    snprintf(message, sizeof(message), ngettext("deleting %d image", "deleting %d images", total), total);
   dt_progress_t *progress = dt_control_progress_create(darktable.control, TRUE, message);
 
   sqlite3_stmt *stmt;
@@ -739,6 +858,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
                               -1, &stmt, NULL);
   while(t)
   {
+    enum _dt_delete_status delete_status = _DT_DELETE_STATUS_UNKNOWN;
     imgid = GPOINTER_TO_INT(t->data);
     char filename[PATH_MAX] = { 0 };
     gboolean from_cache = FALSE;
@@ -754,8 +874,10 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
     if(duplicates == 1)
     {
       // there are no further duplicates so we can remove the source data file
+      delete_status = delete_file_from_disk(filename);
+      if (delete_status != _DT_DELETE_STATUS_OK_TO_REMOVE)
+        goto delete_next_file;
       dt_image_remove(imgid);
-      delete_file_from_disk(filename);
 
       // all sidecar files - including left-overs - can be deleted;
       // left-overs can result when previously duplicates have been REMOVED;
@@ -804,7 +926,9 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
       GList *file_iter = g_list_first(files);
       while(file_iter != NULL)
       {
-        delete_file_from_disk(file_iter->data);
+        delete_status = delete_file_from_disk(file_iter->data);
+        if (delete_status != _DT_DELETE_STATUS_OK_TO_REMOVE)
+          break;
         file_iter = g_list_next(file_iter);
       }
 
@@ -818,14 +942,20 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
       dt_image_path_append_version(imgid, filename, sizeof(filename));
       g_strlcat(filename, ".xmp", sizeof(filename));
 
-      dt_image_remove(imgid);
-      delete_file_from_disk(filename);
+      delete_status = delete_file_from_disk(filename);
+      if (delete_status == _DT_DELETE_STATUS_OK_TO_REMOVE)
+        dt_image_remove(imgid);
     }
 
+delete_next_file:
     t = g_list_delete_link(t, t);
     fraction = 1.0 / total;
     dt_control_progress_set_progress(darktable.control, progress, fraction);
+    if (delete_status == _DT_DELETE_STATUS_STOP_PROCESSING)
+      break;
   }
+  while (t)
+    t = g_list_delete_link(t, t);
   params->index = NULL;
   sqlite3_finalize(stmt);
 
@@ -1240,6 +1370,7 @@ void dt_control_delete_images()
   // first get all selected images, to avoid the set changing during ui interaction
   dt_job_t *job
       = dt_control_generic_images_job_create(&dt_control_delete_images_job_run, "delete images", 0, NULL);
+  int send_to_trash = dt_conf_get_bool("send_to_trash");
   if(dt_conf_get_bool("ask_before_delete"))
   {
     GtkWidget *dialog;
@@ -1255,14 +1386,14 @@ void dt_control_delete_images()
 
     dialog = gtk_message_dialog_new(
         GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        dt_conf_get_bool("send_to_trash")
-          ? ngettext("do you really want to send %d selected image to trash?",
-                     "do you really want to send %d selected images to trash?", number)
-          : ngettext("do you really want to physically delete %d selected image from disk?",
-                     "do you really want to physically delete %d selected images from disk?", number),
+        send_to_trash
+        ? ngettext("do you really want to send %d selected image to trash?",
+          "do you really want to send %d selected images to trash?", number)
+        : ngettext("do you really want to physically delete %d selected image from disk?",
+          "do you really want to physically delete %d selected images from disk?", number),
         number);
 
-    gtk_window_set_title(GTK_WINDOW(dialog), _("delete images?"));
+    gtk_window_set_title(GTK_WINDOW(dialog), send_to_trash ? _("trash images?") : _("delete images?"));
     gint res = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
     if(res != GTK_RESPONSE_YES)

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -136,11 +136,21 @@ else
   return _("delete");
 }
 
+static const char* _image_get_delete_button_tooltip()
+{
+if (dt_conf_get_bool("send_to_trash"))
+  return _("send file to trash");
+else
+  return _("physically delete from disk");
+}
+
+
 static void _image_preference_changed(gpointer instance, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t*)user_data;
   dt_lib_image_t *d = (dt_lib_image_t *)self->data;
   gtk_button_set_label(GTK_BUTTON(d->delete_button), _image_get_delete_button_label());
+  g_object_set(G_OBJECT(d->delete_button), "tooltip-text", _image_get_delete_button_tooltip(), (char *)NULL);
 }
 
 int position()
@@ -169,7 +179,7 @@ void gui_init(dt_lib_module_t *self)
 
   button = gtk_button_new_with_label(_image_get_delete_button_label());
   d->delete_button = button;
-  g_object_set(G_OBJECT(button), "tooltip-text", _("physically delete from disk"), (char *)NULL);
+  g_object_set(G_OBJECT(button), "tooltip-text", _image_get_delete_button_tooltip(), (char *)NULL);
   gtk_grid_attach(grid, button, 2, line++, 2, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(1));
 


### PR DESCRIPTION
Related to the recent patch on the mailing list with addition after feedback:
* The title of the "delete" button changes to "trash" when the preference changes
* The warning message now asks the user if he wants to delete the file or trash it depending on the preference
* Trashing is now "on" by default
* Since I'm not sure if a modal dialog is allowed in a secondary thread, for now I show a pop-up if there is an error trashing a file. Also, errors when deleting use the same pop-up instead of being silent.