### PR TITLE
Show correct number of images for deletion

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1163,6 +1163,11 @@ void dt_control_remove_images()
     GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
     int number = dt_collection_get_selected_count(darktable.collection);
+
+    // Do not use number from selection if an image outside the selection is hovered
+    if (dt_view_get_image_to_act_on() != -1)
+      number = 1;
+
     // Do not show the dialog if no image is selected:
     if(number == 0)
     {
@@ -1199,6 +1204,11 @@ void dt_control_delete_images()
     GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
     int number = dt_collection_get_selected_count(darktable.collection);
+
+    // Do not use number from selection if an image outside the selection is hovered
+    if (dt_view_get_image_to_act_on() != -1)
+      number = 1;
+
     // Do not show the dialog if no image is selected:
     if(number == 0)
     {


### PR DESCRIPTION
This also fixes issue with deleting images when none are selected,
but one is hovered.