### PR TITLE
mipmap_cache: DT_MIPMAP_BEST_EFFORT: only load MIP_0 if it exists on disc

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -734,7 +734,7 @@ void dt_mipmap_cache_get_with_caller(
     {
       char filename[PATH_MAX] = {0};
       snprintf(filename, sizeof(filename), "%s.d/%d/%d.jpg", cache->cachedir, mip, key);
-      if(!g_file_test(filename, G_FILE_TEST_EXISTS))
+      if(g_file_test(filename, G_FILE_TEST_EXISTS))
         dt_mipmap_cache_get(cache, 0, imgid, DT_MIPMAP_0, DT_MIPMAP_PREFETCH_DISK, 0);
     }
     // nothing found :(


### PR DESCRIPTION
The current check is wrong, and only loads/creates the MIP_0 if it does
not exist on the disc. This is opposite to what the comment above says
and also increases loading times.
If no MIP for that image exists, DT_MIPMAP_BEST_EFFORT should only
create the requested MIP and no other levels before.

Assume that no MIP for an image exists either on disc nor in memory.
When lighttable then want to show an image, it requests  DT_MIPMAP_BEST_EFFORT with e.g. MIP_3. Currently, darktable then first renders MIP_0 and afterwards MIP_3 with full pixel pipe.
With this patch, only MIP_3 is rendered, shortening the time until the user sees the picture.

(MIP_0 can then easily be obtained by scaling, see https://github.com/darktable-org/darktable/pull/961)