### PR TITLE
Removed image from tagged_images when purged

### DIFF
--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -13,6 +13,7 @@ do
   then
     echo "removing non existent file $FD/$FL with ID = $ID"
     sqlite3 $DBFILE "delete from images where id=$ID"
+    sqlite3 $DBFILE "delete from tagged_images where imgid=$ID"
   fi
 done
 rm $TMPFILE


### PR DESCRIPTION
The `tools/purge_non_existing_images.sh` file deleted all images from the database which were not available anymore on disk. It left, however, all entries of the images in the `tagged_images` table of the database. This meant that running `purge_unused_tags.sh` after `purge_non_existing_images.sh` did not remove the orphaned tags.

It seems to me it makes more sense to remove the images from the tagged_images table as well (thus also keeping database integrity).
Since it is a one-liner I did not create a branch as per your documentation.