### PR TITLE
Various fixes to jobs and cache. Fixes #10637. Fixes #10634

### DIFF
--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -169,11 +169,11 @@ restart:
     const pthread_t writer = dt_pthread_rwlock_get_writer(&entry->lock);
     if(mode == 'w')
     {
-      assert(writer == pthread_self());
+      assert(pthread_equal(writer, pthread_self()));
     }
     else
     {
-      assert(writer != pthread_self());
+      assert(!pthread_equal(writer, pthread_self()));
     }
 #endif
 

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -247,6 +247,15 @@ restart:
     goto restart;
   }
 
+  if(entry->_lock_demoting)
+  {
+    // oops, we are currently demoting (rw -> r) lock to this entry in some thread. do not touch!
+    dt_pthread_rwlock_unlock(&entry->lock);
+    dt_pthread_mutex_unlock(&cache->lock);
+    g_usleep(5);
+    goto restart;
+  }
+
   gboolean removed = g_hash_table_remove(cache->hashtable, GINT_TO_POINTER(key));
   (void)removed; // make non-assert compile happy
   assert(removed);

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -163,6 +163,19 @@ restart:
     cache->lru = g_list_remove_link(cache->lru, entry->link);
     cache->lru = g_list_concat(cache->lru, entry->link);
     dt_pthread_mutex_unlock(&cache->lock);
+
+#ifdef _DEBUG
+    const pthread_t writer = dt_pthread_rwlock_get_writer(&entry->lock);
+    if(mode == 'w')
+    {
+      assert(writer == pthread_self());
+    }
+    else
+    {
+      assert(writer != pthread_self());
+    }
+#endif
+
     return entry;
   }
 

--- a/src/common/cache.h
+++ b/src/common/cache.h
@@ -30,6 +30,7 @@ typedef struct dt_cache_entry_t
   size_t cost;
   GList *link;
   dt_pthread_rwlock_t lock;
+  int _lock_demoting;
   uint32_t key;
 }
 dt_cache_entry_t;

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -218,6 +218,11 @@ static inline int dt_pthread_rwlock_destroy(dt_pthread_rwlock_t *lock)
   return res;
 }
 
+static inline pthread_t dt_pthread_rwlock_get_writer(dt_pthread_rwlock_t *lock)
+{
+  return lock->writer;
+}
+
 #define dt_pthread_rwlock_unlock(A) dt_pthread_rwlock_unlock_with_caller(A, __FILE__, __LINE__)
 static inline int dt_pthread_rwlock_unlock_with_caller(dt_pthread_rwlock_t *rwlock, const char *file, int line)
 {

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -242,7 +242,7 @@ static inline int dt_pthread_rwlock_rdlock_with_caller(dt_pthread_rwlock_t *rwlo
 {
   const int res = pthread_rwlock_rdlock(&rwlock->lock);
   assert(!res);
-  assert(!(res && (rwlock->writer == pthread_self())));
+  assert(!(res && pthread_equal(rwlock->writer, pthread_self())));
   __sync_fetch_and_add(&(rwlock->cnt), 1);
   if(!res)
     snprintf(rwlock->name, sizeof(rwlock->name), "r:%s:%d", file, line);
@@ -266,7 +266,7 @@ static inline int dt_pthread_rwlock_tryrdlock_with_caller(dt_pthread_rwlock_t *r
 {
   const int res = pthread_rwlock_tryrdlock(&rwlock->lock);
   assert(!res || (res == EBUSY));
-  assert(!(res && (rwlock->writer == pthread_self())));
+  assert(!(res && pthread_equal(rwlock->writer, pthread_self())));
   if(!res)
   {
     __sync_fetch_and_add(&(rwlock->cnt), 1);

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -223,7 +223,7 @@ static inline int dt_pthread_rwlock_unlock_with_caller(dt_pthread_rwlock_t *rwlo
 
   assert(!res);
 
-  rwlock->cnt --;
+  __sync_fetch_and_sub(&(rwlock->cnt), 1);
   assert(rwlock->cnt >= 0);
   if(!res) snprintf(rwlock->name, sizeof(rwlock->name), "u:%s:%d", file, line);
   return res;
@@ -234,7 +234,7 @@ static inline int dt_pthread_rwlock_rdlock_with_caller(dt_pthread_rwlock_t *rwlo
 {
   const int res = pthread_rwlock_rdlock(&rwlock->lock);
   assert(!res);
-  rwlock->cnt ++;
+  __sync_fetch_and_add(&(rwlock->cnt), 1);
   if(!res)
     snprintf(rwlock->name, sizeof(rwlock->name), "r:%s:%d", file, line);
   return res;
@@ -244,7 +244,7 @@ static inline int dt_pthread_rwlock_wrlock_with_caller(dt_pthread_rwlock_t *rwlo
 {
   const int res = pthread_rwlock_wrlock(&rwlock->lock);
   assert(!res);
-  rwlock->cnt ++;
+  __sync_fetch_and_add(&(rwlock->cnt), 1);
   if(!res)
     snprintf(rwlock->name, sizeof(rwlock->name), "w:%s:%d", file, line);
   return res;
@@ -256,7 +256,7 @@ static inline int dt_pthread_rwlock_tryrdlock_with_caller(dt_pthread_rwlock_t *r
   assert(!res || (res == EBUSY));
   if(!res)
   {
-    rwlock->cnt ++;
+    __sync_fetch_and_add(&(rwlock->cnt), 1);
     snprintf(rwlock->name, sizeof(rwlock->name), "tr:%s:%d", file, line);
   }
   return res;
@@ -268,7 +268,7 @@ static inline int dt_pthread_rwlock_trywrlock_with_caller(dt_pthread_rwlock_t *r
   assert(!res || (res == EBUSY));
   if(!res)
   {
-    rwlock->cnt ++;
+    __sync_fetch_and_add(&(rwlock->cnt), 1);
     snprintf(rwlock->name, sizeof(rwlock->name), "tw:%s:%d", file, line);
   }
   return res;

--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2009--2014 johannes hanika.
+    copyright (c) 2015 LebedevRI
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -236,6 +237,7 @@ static inline int dt_pthread_rwlock_rdlock_with_caller(dt_pthread_rwlock_t *rwlo
 {
   const int res = pthread_rwlock_rdlock(&rwlock->lock);
   assert(!res);
+  assert(!(res && (rwlock->writer == pthread_self())));
   __sync_fetch_and_add(&(rwlock->cnt), 1);
   if(!res)
     snprintf(rwlock->name, sizeof(rwlock->name), "r:%s:%d", file, line);
@@ -259,6 +261,7 @@ static inline int dt_pthread_rwlock_tryrdlock_with_caller(dt_pthread_rwlock_t *r
 {
   const int res = pthread_rwlock_tryrdlock(&rwlock->lock);
   assert(!res || (res == EBUSY));
+  assert(!(res && (rwlock->writer == pthread_self())));
   if(!res)
   {
     __sync_fetch_and_add(&(rwlock->cnt), 1);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -536,12 +536,14 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
 {
   dt_develop_t dev;
   dt_dev_init(&dev, 0);
+  dt_dev_load_image(&dev, imgid);
+
   dt_mipmap_buffer_t buf;
   if(thumbnail_export && dt_conf_get_bool("plugins/lighttable/low_quality_thumbnails"))
     dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, DT_MIPMAP_F, DT_MIPMAP_BLOCKING, 'r');
   else
     dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, DT_MIPMAP_FULL, DT_MIPMAP_BLOCKING, 'r');
-  dt_dev_load_image(&dev, imgid);
+
   const dt_image_t *img = &dev.image_storage;
   const int wd = img->width;
   const int ht = img->height;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -45,15 +45,19 @@
 #define DT_MIPMAP_CACHE_FILE_VERSION 23
 #define DT_MIPMAP_CACHE_DEFAULT_FILE_NAME "mipmaps"
 
-#define DT_MIPMAP_BUFFER_DSC_FLAG_GENERATE (1 << 0)
-#define DT_MIPMAP_BUFFER_DSC_FLAG_INVALIDATE (1 << 1)
+typedef enum dt_mipmap_buffer_dsc_flags
+{
+  DT_MIPMAP_BUFFER_DSC_FLAG_NONE = 0,
+  DT_MIPMAP_BUFFER_DSC_FLAG_GENERATE = 1 << 0,
+  DT_MIPMAP_BUFFER_DSC_FLAG_INVALIDATE = 1 << 1
+} dt_mipmap_buffer_dsc_flags;
 
 struct dt_mipmap_buffer_dsc
 {
   uint32_t width;
   uint32_t height;
   size_t size;
-  uint32_t flags;
+  dt_mipmap_buffer_dsc_flags flags;
   uint32_t pre_monochrome_demosaiced;
   /* NB: sizeof must be a multiple of 4*sizeof(float) */
 } __attribute__((packed, aligned(16)));

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -671,10 +671,12 @@ void dt_mipmap_cache_get_with_caller(
       // note that concurrencykit has rw locks that can be demoted from w->r without losing the lock in between.
       if(mode == 'r')
       {
+        entry->_lock_demoting = 1;
         // drop the write lock
         dt_cache_release(&_get_cache(cache, mip)->cache, entry);
         // get a read lock
-        buf->cache_entry = dt_cache_get(&_get_cache(cache, mip)->cache, key, mode);
+        buf->cache_entry = entry = dt_cache_get(&_get_cache(cache, mip)->cache, key, mode);
+        entry->_lock_demoting = 0;
         dsc = (struct dt_mipmap_buffer_dsc *)buf->cache_entry->data;
       }
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -687,11 +687,11 @@ void dt_mipmap_cache_get_with_caller(
     const pthread_t writer = dt_pthread_rwlock_get_writer(&(buf->cache_entry->lock));
     if(mode == 'w')
     {
-      assert(writer == pthread_self());
+      assert(pthread_equal(writer, pthread_self()));
     }
     else
     {
-      assert(writer != pthread_self());
+      assert(!pthread_equal(writer, pthread_self()));
     }
 #endif
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -677,6 +677,19 @@ void dt_mipmap_cache_get_with_caller(
         buf->cache_entry = dt_cache_get(&_get_cache(cache, mip)->cache, key, mode);
         dsc = (struct dt_mipmap_buffer_dsc *)buf->cache_entry->data;
       }
+
+#ifdef _DEBUG
+      const pthread_t writer = dt_pthread_rwlock_get_writer(&(buf->cache_entry->lock));
+      if(mode == 'w')
+      {
+        assert(writer == pthread_self());
+      }
+      else
+      {
+        assert(writer != pthread_self());
+      }
+#endif
+
       /* raise signal that mipmaps has been flushed to cache */
       g_idle_add(_raise_signal_mipmap_updated, 0);
     }

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -108,6 +108,7 @@ void dt_control_init(dt_control_t *s)
   pthread_cond_init(&s->cond, NULL);
   dt_pthread_mutex_init(&s->cond_mutex, NULL);
   dt_pthread_mutex_init(&s->queue_mutex, NULL);
+  dt_pthread_mutex_init(&s->res_mutex, NULL);
   dt_pthread_mutex_init(&s->run_mutex, NULL);
   dt_pthread_mutex_init(&(s->global_mutex), NULL);
   dt_pthread_mutex_init(&(s->progress_system.mutex), NULL);
@@ -212,6 +213,7 @@ void dt_control_cleanup(dt_control_t *s)
   dt_pthread_mutex_destroy(&s->queue_mutex);
   dt_pthread_mutex_destroy(&s->cond_mutex);
   dt_pthread_mutex_destroy(&s->log_mutex);
+  dt_pthread_mutex_destroy(&s->res_mutex);
   dt_pthread_mutex_destroy(&s->run_mutex);
   dt_pthread_mutex_destroy(&s->progress_system.mutex);
   if(s->accelerator_list)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -180,6 +180,7 @@ typedef struct dt_control_t
   pthread_cond_t cond;
   int32_t num_threads;
   pthread_t *thread, kick_on_workers_thread;
+  dt_job_t **job;
 
   GList *queues[DT_JOB_QUEUE_MAX];
   size_t queue_length[DT_JOB_QUEUE_MAX];

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -185,6 +185,7 @@ typedef struct dt_control_t
   GList *queues[DT_JOB_QUEUE_MAX];
   size_t queue_length[DT_JOB_QUEUE_MAX];
 
+  dt_pthread_mutex_t res_mutex;
   dt_job_t *job_res[DT_CTL_WORKER_RESERVED];
   uint8_t new_res[DT_CTL_WORKER_RESERVED];
   pthread_t thread_res[DT_CTL_WORKER_RESERVED];

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -40,6 +40,7 @@ typedef struct _dt_job_t
 {
   dt_job_execute_callback execute;
   void *params;
+  size_t params_size;
   dt_job_destroy_callback params_destroy;
   int32_t result;
 
@@ -93,6 +94,16 @@ void dt_control_job_set_params(_dt_job_t *job, void *params, dt_job_destroy_call
 {
   if(!job || dt_control_job_get_state(job) != DT_JOB_STATE_INITIALIZED) return;
   job->params = params;
+  job->params_size = 0;
+  job->params_destroy = callback;
+}
+
+void dt_control_job_set_params_with_size(dt_job_t *job, void *params, size_t params_size,
+                                         dt_job_destroy_callback callback)
+{
+  if(!job || dt_control_job_get_state(job) != DT_JOB_STATE_INITIALIZED) return;
+  job->params = params;
+  job->params_size = params_size;
   job->params_destroy = callback;
 }
 

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -60,13 +60,13 @@ typedef struct _dt_job_t
    match
     we don't want to compare result, priority or state since these will change during the course of
    processing.
-    TODO: somehow compare params. maybe we have to pass the sizeof(params) when setting the params to do a
-   memcmp, or maybe even
-          allow to pass a comparator for that.
+    NOTE: maybe allow to pass a comparator for params.
  */
 static inline int dt_control_job_equal(_dt_job_t *j1, _dt_job_t *j2)
 {
   if(!j1 || !j2) return 0;
+  if(j1->params_size != 0 && j1->params_size == j2->params_size)
+    return (memcmp(j1->params, j2->params, j1->params_size) == 0);
   return (j1->execute == j2->execute && j1->state_changed_cb == j2->state_changed_cb && j1->queue == j2->queue
           && (g_strcmp0(j1->description, j2->description) == 0));
 }

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -439,6 +439,7 @@ int dt_control_add_job(dt_control_t *control, dt_job_queue_t queue_id, _dt_job_t
 }
 
 static __thread int threadid = -1;
+static __thread pthread_t pthreadid = -1;
 
 int32_t dt_control_get_threadid()
 {
@@ -502,6 +503,7 @@ static void *dt_control_work(void *ptr)
   threadid = params->threadid;
   free(params);
   // int32_t threadid = dt_control_get_threadid();
+  pthreadid = pthread_self();
   while(dt_control_running())
   {
     // dt_print(DT_DEBUG_CONTROL, "[control_work] %d\n", threadid);

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -66,7 +66,8 @@ static inline int dt_control_job_equal(_dt_job_t *j1, _dt_job_t *j2)
 {
   if(!j1 || !j2) return 0;
   if(j1->params_size != 0 && j1->params_size == j2->params_size)
-    return (memcmp(j1->params, j2->params, j1->params_size) == 0);
+    return (j1->execute == j2->execute && j1->state_changed_cb == j2->state_changed_cb
+            && j1->queue == j2->queue && (memcmp(j1->params, j2->params, j1->params_size) == 0));
   return (j1->execute == j2->execute && j1->state_changed_cb == j2->state_changed_cb && j1->queue == j2->queue
           && (g_strcmp0(j1->description, j2->description) == 0));
 }
@@ -456,7 +457,6 @@ int dt_control_add_job(dt_control_t *control, dt_job_queue_t queue_id, _dt_job_t
 }
 
 static __thread int threadid = -1;
-static __thread pthread_t pthreadid = -1;
 
 int32_t dt_control_get_threadid()
 {
@@ -520,7 +520,6 @@ static void *dt_control_work(void *ptr)
   threadid = params->threadid;
   free(params);
   // int32_t threadid = dt_control_get_threadid();
-  pthreadid = pthread_self();
   while(dt_control_running())
   {
     // dt_print(DT_DEBUG_CONTROL, "[control_work] %d\n", threadid);

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -179,14 +179,14 @@ static int32_t dt_control_run_job_res(dt_control_t *control, int32_t res)
   if(((unsigned int)res) >= DT_CTL_WORKER_RESERVED) return -1;
 
   _dt_job_t *job = NULL;
-  dt_pthread_mutex_lock(&control->queue_mutex);
+  dt_pthread_mutex_lock(&control->res_mutex);
   if(control->new_res[res])
   {
     job = control->job_res[res];
     control->job_res[res] = NULL; // this job belongs to us now, the queue may not touch it any longer
   }
   control->new_res[res] = 0;
-  dt_pthread_mutex_unlock(&control->queue_mutex);
+  dt_pthread_mutex_unlock(&control->res_mutex);
   if(!job) return -1;
 
   /* change state to running */
@@ -323,7 +323,7 @@ int32_t dt_control_add_job_res(dt_control_t *control, _dt_job_t *job, int32_t re
   }
 
   // TODO: pthread cancel and restart in tough cases?
-  dt_pthread_mutex_lock(&control->queue_mutex);
+  dt_pthread_mutex_lock(&control->res_mutex);
 
   // if there is a job in the queue we have to discard that first
   if(control->job_res[res])
@@ -340,7 +340,7 @@ int32_t dt_control_add_job_res(dt_control_t *control, _dt_job_t *job, int32_t re
   control->job_res[res] = job;
   control->new_res[res] = 1;
 
-  dt_pthread_mutex_unlock(&control->queue_mutex);
+  dt_pthread_mutex_unlock(&control->res_mutex);
 
   dt_pthread_mutex_lock(&control->cond_mutex);
   pthread_cond_broadcast(&control->cond);

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -65,7 +65,7 @@ typedef struct _dt_job_t
 static inline int dt_control_job_equal(_dt_job_t *j1, _dt_job_t *j2)
 {
   return (j1->execute == j2->execute && j1->state_changed_cb == j2->state_changed_cb && j1->queue == j2->queue
-          && g_strcmp0(j1->description, j2->description));
+          && (g_strcmp0(j1->description, j2->description) == 0));
 }
 
 static void dt_control_job_set_state(_dt_job_t *job, dt_job_state_t state)

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -22,6 +22,7 @@
 #define DT_CONTROL_JOBS_H
 
 #include <inttypes.h>
+#include <stddef.h>
 
 #define DT_CONTROL_DESCRIPTION_LEN 256
 // reserved workers
@@ -69,6 +70,10 @@ dt_job_state_t dt_control_job_get_state(dt_job_t *job);
 void dt_control_job_wait(dt_job_t *job);
 /** set job params and a callback to destroy those params */
 void dt_control_job_set_params(dt_job_t *job, void *params, dt_job_destroy_callback callback);
+/** set job params (with size params_size) and a callback to destroy those params.
+  * NOTE: in most cases you want dt_control_job_set_params() */
+void dt_control_job_set_params_with_size(dt_job_t *job, void *params, size_t params_size,
+                                         dt_job_destroy_callback callback);
 /** get job params. WARNING: you must not free them. dt_control_job_dispose() will take care of that */
 void *dt_control_job_get_params(const dt_job_t *job);
 

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -50,7 +50,7 @@ dt_job_t *dt_image_load_job_create(int32_t id, dt_mipmap_size_t mip)
     dt_control_job_dispose(job);
     return NULL;
   }
-  dt_control_job_set_params(job, params, free);
+  dt_control_job_set_params_with_size(job, params, sizeof(dt_image_load_t), free);
   params->imgid = id;
   params->mip = mip;
   return job;


### PR DESCRIPTION
Changes:
* Proper job deduplication - e.g. do not generate same thumbnail in parallel by several workers
* Some infrastructure for deadlock detection in dtpthread (only in debug build)
* True and correct mipmap cache entry lock demoting. Previously there were cases when we ask for 'r' lock and would *still* get 'w'.
* Also, in some cases, when we previously would demote the lock (by unlocking and then locking 'r'), that entry could have already got gc'd in the meantime and locking 'r' would return empty, newly allocated 'w' locked entry, so we need to workaround it.
* Some assert()'s that may help detect similar cases in the future faster...

Overall, i expect that those changes will result in somewhat faster DT (especially LT!), but i'm failing to do any performance comparisons because with git master, *without those changes*, DT sometimes fails to render all the LT thumbnails...