### PR TITLE
Add keyboard shortcuts to control the brush hardness and opacity. Fixes #9723, Refs #10145

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -67,6 +67,14 @@ static gboolean _brush_size_up_callback(GtkAccelGroup *accel_group, GObject *acc
                                         GdkModifierType modifier, gpointer data);
 static gboolean _brush_size_down_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                           GdkModifierType modifier, gpointer data);
+static gboolean _brush_hardness_up_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                            GdkModifierType modifier, gpointer data);
+static gboolean _brush_hardness_down_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                              GdkModifierType modifier, gpointer data);
+static gboolean _brush_opacity_up_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                           GdkModifierType modifier, gpointer data);
+static gboolean _brush_opacity_down_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                             GdkModifierType modifier, gpointer data);
 
 static void _update_softproof_gamut_checking(dt_develop_t *d);
 
@@ -1339,6 +1347,40 @@ static gboolean _brush_size_down_callback(GtkAccelGroup *accel_group, GObject *a
   return TRUE;
 }
 
+static gboolean _brush_hardness_up_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                            GdkModifierType modifier, gpointer data)
+{
+  dt_develop_t *dev = (dt_develop_t *)data;
+
+  if(dev->form_visible) dt_masks_events_mouse_scrolled(dev->gui_module, 0, 0, 0, GDK_SHIFT_MASK);
+  return TRUE;
+}
+static gboolean _brush_hardness_down_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                              GdkModifierType modifier, gpointer data)
+{
+  dt_develop_t *dev = (dt_develop_t *)data;
+
+  if(dev->form_visible) dt_masks_events_mouse_scrolled(dev->gui_module, 0, 0, 1, GDK_SHIFT_MASK);
+  return TRUE;
+}
+
+static gboolean _brush_opacity_up_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                           GdkModifierType modifier, gpointer data)
+{
+  dt_develop_t *dev = (dt_develop_t *)data;
+
+  if(dev->form_visible) dt_masks_events_mouse_scrolled(dev->gui_module, 0, 0, 0, GDK_CONTROL_MASK);
+  return TRUE;
+}
+static gboolean _brush_opacity_down_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                             GdkModifierType modifier, gpointer data)
+{
+  dt_develop_t *dev = (dt_develop_t *)data;
+
+  if(dev->form_visible) dt_masks_events_mouse_scrolled(dev->gui_module, 0, 0, 1, GDK_CONTROL_MASK);
+  return TRUE;
+}
+
 void gui_init(dt_view_t *self)
 {
   dt_develop_t *dev = (dt_develop_t *)self->data;
@@ -2200,6 +2242,14 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "brush larger"), GDK_KEY_bracketright, 0);
   dt_accel_register_view(self, NC_("accel", "brush smaller"), GDK_KEY_bracketleft, 0);
 
+  // brush hardness +/-
+  dt_accel_register_view(self, NC_("accel", "increase brush hardness"), GDK_KEY_braceright, 0);
+  dt_accel_register_view(self, NC_("accel", "decrease brush hardness"), GDK_KEY_braceleft, 0);
+
+  // brush opacity +/-
+  dt_accel_register_view(self, NC_("accel", "increase brush opacity"), GDK_KEY_greater, 0);
+  dt_accel_register_view(self, NC_("accel", "decrease brush opacity"), GDK_KEY_less, 0);
+
   // fullscreen view
   dt_accel_register_view(self, NC_("accel", "full preview"), GDK_KEY_z, 0);
 }
@@ -2251,6 +2301,18 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "brush larger", closure);
   closure = g_cclosure_new(G_CALLBACK(_brush_size_down_callback), (gpointer)self->data, NULL);
   dt_accel_connect_view(self, "brush smaller", closure);
+
+  // brush hardness +/-
+  closure = g_cclosure_new(G_CALLBACK(_brush_hardness_up_callback), (gpointer)self->data, NULL);
+  dt_accel_connect_view(self, "increase brush hardness", closure);
+  closure = g_cclosure_new(G_CALLBACK(_brush_hardness_down_callback), (gpointer)self->data, NULL);
+  dt_accel_connect_view(self, "decrease brush hardness", closure);
+
+  // brush opacity +/-
+  closure = g_cclosure_new(G_CALLBACK(_brush_opacity_up_callback), (gpointer)self->data, NULL);
+  dt_accel_connect_view(self, "increase brush opacity", closure);
+  closure = g_cclosure_new(G_CALLBACK(_brush_opacity_down_callback), (gpointer)self->data, NULL);
+  dt_accel_connect_view(self, "decrease brush opacity", closure);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
When using a tablet and a stylus you don't always have a way to scroll
up and down. So we are forced to get back to the mouse to change brush
hardness and opacity. This patch adds four key accels : { and } are
standards shortcuts to change the brush hardness. ( and ) was free so I
choose them to change the brush opacity.

Of course, now it's also possible to map the tablets buttons to these
keys.