### PR TITLE
local color picker: fix for #10706

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -816,7 +816,7 @@ static gboolean _blendop_blendif_draw(GtkWidget *widget, cairo_t *cr, dt_iop_mod
   }
 
   darktable.gui->reset = 1;
-  if(module->request_color_pick != DT_REQUEST_COLORPICK_OFF)
+  if((module->request_color_pick != DT_REQUEST_COLORPICK_OFF) && (raw_min[0] != INFINITY))
   {
     _blendif_scale(data->csp, raw_mean, picker_mean);
     _blendif_scale(data->csp, raw_min, picker_min);

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -598,38 +598,41 @@ static gboolean borders_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *se
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
-  if(fabsf(p->color[0] - self->picked_output_color[0]) < 0.0001f
-     && fabsf(p->color[1] - self->picked_output_color[1]) < 0.0001f
-     && fabsf(p->color[2] - self->picked_output_color[2]) < 0.0001f)
+  // interrupt if no valid color reading
+  if(self->picked_color_min[0] == INFINITY) return FALSE;
+
+  if(fabsf(p->color[0] - self->picked_color[0]) < 0.0001f
+     && fabsf(p->color[1] - self->picked_color[1]) < 0.0001f
+     && fabsf(p->color[2] - self->picked_color[2]) < 0.0001f)
   {
     // interrupt infinite loops
     return FALSE;
   }
 
-  if(fabsf(p->frame_color[0] - self->picked_output_color[0]) < 0.0001f
-     && fabsf(p->frame_color[1] - self->picked_output_color[1]) < 0.0001f
-     && fabsf(p->frame_color[2] - self->picked_output_color[2]) < 0.0001f)
+  if(fabsf(p->frame_color[0] - self->picked_color[0]) < 0.0001f
+     && fabsf(p->frame_color[1] - self->picked_color[1]) < 0.0001f
+     && fabsf(p->frame_color[2] - self->picked_color[2]) < 0.0001f)
   {
     // interrupt infinite loops
     return FALSE;
   }
 
-  GdkRGBA c = (GdkRGBA){.red = self->picked_output_color[0],
-                        .green = self->picked_output_color[1],
-                        .blue = self->picked_output_color[2],
+  GdkRGBA c = (GdkRGBA){.red = self->picked_color[0],
+                        .green = self->picked_color[1],
+                        .blue = self->picked_color[2],
                         .alpha = 1.0 };
   if(g->active_colorpick == g->frame_colorpick)
   {
-    p->frame_color[0] = self->picked_output_color[0];
-    p->frame_color[1] = self->picked_output_color[1];
-    p->frame_color[2] = self->picked_output_color[2];
+    p->frame_color[0] = self->picked_color[0];
+    p->frame_color[1] = self->picked_color[1];
+    p->frame_color[2] = self->picked_color[2];
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->frame_colorpick), &c);
   }
   else
   {
-    p->color[0] = self->picked_output_color[0];
-    p->color[1] = self->picked_output_color[1];
-    p->color[2] = self->picked_output_color[2];
+    p->color[0] = self->picked_color[0];
+    p->color[1] = self->picked_color[1];
+    p->color[2] = self->picked_color[2];
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpick), &c);
   }
 


### PR DESCRIPTION
also make sure that picker in parametric masks does not show bogus results
if the picker location lies outside of the image coordinate space

@devs: could someone please review