### PR TITLE
Prettify fullscreen metadata

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1012,6 +1012,19 @@
     <longdescription>the maximum number of geotagged images drawn on the map. increasing this number can slow drawing of the map down.</longdescription>
   </dtconfig>
   <dtconfig prefs="gui">
+    <name>plugins/lighttable/metadata/layout</name>
+    <type>
+      <enum>
+        <option>overlay</option>
+        <option>top</option>
+        <option>bottom</option>
+      </enum>
+    </type>
+    <default>overlay</default>
+    <shortdescription>layout of metadata in lighttable view</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig prefs="gui">
     <name>plugins/lighttable/metadata_view/pretty_location</name>
     <type>bool</type>
     <default>true</default>

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1264,7 +1264,7 @@ int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int32_t hei
     dt_mipmap_cache_get(darktable.mipmap_cache, NULL, preload_stack[count], mip, DT_MIPMAP_PREFETCH, 'r');
 
   lib->image_over = DT_VIEW_DESERT;
-  cairo_set_source_rgb(cr, .1, .1, .1);
+  cairo_set_source_rgb(cr, 0.2, 0.2, 0.2);
   cairo_paint(cr);
 
   const int frows = 5, fcols = 5;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -942,7 +942,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
       if(zoom == 1 && !image_only)
       {
         const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
-        scale = fminf((width-2*tb) / (float)buf.width, (height-2*tb) / (float)buf.height);
+        scale = fminf((width-2*tb) / (float)buf.width, (height-2*tb) / (float)buf.height) * 0.95f;
       }
       else
         scale = fminf(width * imgwd / (float)buf.width, height * imgwd / (float)buf.height);
@@ -954,7 +954,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
     if (image_only) // in this case we want to display the picture exactly at (px, py)
       cairo_translate(cr, px, py);
     else
-      cairo_translate(cr, width / 2.0, height / 2.0);
+      cairo_translate(cr, width / 2.0, height / 2.0 * 1.045f);
 
     cairo_scale(cr, scale, scale);
 
@@ -988,28 +988,19 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
       cairo_set_source_rgb(cr, bordercol, bordercol, bordercol);
       if(buf.buf && (selected || zoom == 1))
       {
-        const float border = zoom == 1 ? 16 / scale : 2 / scale;
-        cairo_set_line_width(cr, 1. / scale);
         if(zoom == 1)
         {
-          // draw shadow around border
-          cairo_set_source_rgb(cr, 0.2, 0.2, 0.2);
+          cairo_set_line_width(cr, 0.5 / scale);
+          // draw line around border
+          cairo_set_source_rgb(cr, 0.0, 0.0, 0.0);
           cairo_stroke(cr);
           // cairo_new_path(cr);
           cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
-          float alpha = 1.0f;
-          for(int k = 0; k < 16; k++)
-          {
-            cairo_rectangle(cr, 0, 0, buf.width, buf.height);
-            cairo_new_sub_path(cr);
-            cairo_rectangle(cr, -k / scale, -k / scale, buf.width + 2. * k / scale, buf.height + 2. * k / scale);
-            cairo_set_source_rgba(cr, 0, 0, 0, alpha);
-            alpha *= 0.6f;
-            cairo_fill(cr);
-          }
         }
         else
         {
+          const float border = 2 / scale;
+          cairo_set_line_width(cr, 1. / scale);
           cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
           cairo_new_sub_path(cr);
           cairo_rectangle(cr, -border, -border, buf.width + 2. * border, buf.height + 2. * border);
@@ -1056,7 +1047,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
       if(zoom != 1)
         y = 0.90 * height;
       else
-        y = .12 * fscale;
+        y = .023 * fscale;
       const gboolean image_is_rejected = (img && ((img->flags & 0x7) == 6));
 
       if(img)
@@ -1065,7 +1056,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
           if(zoom != 1)
             x = (0.41 + k * 0.12) * width;
           else
-            x = (.08 + k * 0.04) * fscale;
+            x = (.06 + k * 0.04) * fscale;
 
           if(!image_is_rejected) // if rejected: draw no stars
           {
@@ -1093,7 +1084,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
       if(zoom != 1)
         x = 0.11 * width;
       else
-        x = .04 * fscale;
+        x = .02 * fscale;
 
       if(draw_metadata && image_is_rejected) cairo_set_source_rgb(cr, 1., 0., 0.);
 
@@ -1227,8 +1218,8 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
     if(width > DECORATION_SIZE_LIMIT)
     {
       // color labels:
-      const float x = zoom == 1 ? (0.07) * fscale : .21 * width;
-      const float y = zoom == 1 ? 0.17 * fscale : 0.1 * height;
+      const float x = zoom == 1 ? 0.43 * fscale : .21 * width;
+      const float y = zoom == 1 ? 0.02 * fscale : 0.1 * height;
       const float r = zoom == 1 ? 0.01 * fscale : 0.03 * width;
 
       /* clear and reset prepared statement */
@@ -1266,21 +1257,28 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
 
   if(draw_metadata && img && (zoom == 1))
   {
-    // some exif data
     cairo_set_source_rgb(cr, .7, .7, .7);
-    cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-    cairo_set_font_size(cr, .025 * fscale);
+    cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+    cairo_set_font_size(cr, .026 * fscale);
 
-    cairo_move_to(cr, .02 * fscale, .04 * fscale);
-    // cairo_show_text(cr, img->filename);
+    int y = .032 * fscale;
+
+    // Display the image name centered
+    cairo_text_extents_t extents;
+    cairo_text_extents(cr, img->filename, &extents);
+    cairo_move_to(cr, width/2 - extents.width/2, y);
     cairo_text_path(cr, img->filename);
+
+    // Display exif info right aligned
     char exifline[50];
-    cairo_move_to(cr, .02 * fscale, .08 * fscale);
     dt_image_print_exif(img, exifline, 50);
+    cairo_text_extents(cr, exifline, &extents);
+    cairo_move_to(cr, width - extents.width - 0.02 * fscale, y);
     cairo_text_path(cr, exifline);
+
+    // Write everything out
     cairo_fill_preserve(cr);
     cairo_set_line_width(cr, 1.0);
-    cairo_set_source_rgb(cr, 0.3, 0.3, 0.3);
     cairo_stroke(cr);
   }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1027,6 +1027,13 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
   {
     if(draw_metadata && width > DECORATION_SIZE_LIMIT)
     {
+      if (zoom == 1)
+      {
+        cairo_set_source_rgb(cr, 0.1, 0.1, 0.1);
+        cairo_rectangle(cr, 0, 0, width, 0.045 * fscale);
+        cairo_fill(cr);
+      }
+
       // draw mouseover hover effects, set event hook for mouse button down!
       cairo_set_line_width(cr, 1.5);
       cairo_set_source_rgb(cr, outlinecol, outlinecol, outlinecol);
@@ -1219,7 +1226,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
     {
       // color labels:
       const float x = zoom == 1 ? 0.43 * fscale : .21 * width;
-      const float y = zoom == 1 ? 0.02 * fscale : 0.1 * height;
+      const float y = zoom == 1 ? 0.025 * fscale : 0.1 * height;
       const float r = zoom == 1 ? 0.01 * fscale : 0.03 * width;
 
       /* clear and reset prepared statement */

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -786,8 +786,14 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
   const int imgsel = dt_control_get_mouse_over_id(); //  darktable.control->global_settings.lib_image_mouse_over_id;
 
   const float fscale = fminf(width, height);
-  const int metadata_height = 0; //0.045f * fscale;
-  const int metadata_pos = 0; //height-metadata_height;
+  int metadata_height = 0;
+  int metadata_pos = 0;
+  gchar *str = dt_conf_get_string("plugins/lighttable/metadata/layout");
+  if(strcmp("overlay", str)) // We are either in top or bottom
+    metadata_height = 0.045f * fscale;
+  if(!strcmp("bottom", str))
+    metadata_pos = height-metadata_height;
+  g_free(str);
 
   if (draw_selected)
   {


### PR DESCRIPTION
Make the fullscreen metadata not overlap the image by putting it all on a single line at the top of the screen. Since the text is not over the image make the font look nicer by not being bold and having a single solid color. Replace the drop shadow with a simple thin black border around the image. An example of the outcome is here:

http://scratch.corujas.net/prettify-fullscreen-metadata.png

From my point of view this looks _much_ better than what we have now:
- The metadata no longer overlaps the image which is what I actually want to look at when processing
- The text looks much better as it no longer needs to be bold and dual tone to try and stand out over any image background. It now looks much sharper and readable
- The drop shadow is replaced by a much simpler black border all around the image which doesn't distract nearly as much

We discussed this on IRC and both houz and LebedevRI disliked that this slightly reduces the image size. I find this a much better tradeoff though as the size reduction is minimal and if we really want to display metadata and the image at the same time doing it overlapped looks very bad to my eyes.
