### PR TITLE
lighttable: have only one fullscreen mode

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -25,6 +25,9 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 
+#define DT_LIBRARY_MIN_ZOOM 2
+#define DT_LIBRARY_MAX_ZOOM 13
+
 DT_MODULE(1)
 
 typedef struct dt_lib_tool_lighttable_t
@@ -109,7 +112,7 @@ void gui_init(dt_lib_module_t *self)
 
 
   /* create horizontal zoom slider */
-  d->zoom = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 1, 21, 1);
+  d->zoom = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, DT_LIBRARY_MIN_ZOOM, DT_LIBRARY_MAX_ZOOM, 1);
   gtk_widget_set_size_request(GTK_WIDGET(d->zoom), DT_PIXEL_APPLY_DPI(140), -1);
   gtk_scale_set_draw_value(GTK_SCALE(d->zoom), FALSE);
   gtk_range_set_increments(GTK_RANGE(d->zoom), 1, 1);
@@ -275,7 +278,6 @@ static void _lib_lighttable_layout_changed(GtkComboBox *widget, gpointer user_da
   dt_control_queue_redraw_center();
 }
 
-#define DT_LIBRARY_MAX_ZOOM 13
 static void _lib_lighttable_set_zoom(dt_lib_module_t *self, gint zoom)
 {
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
@@ -288,7 +290,7 @@ static gboolean _lib_lighttable_key_accel_zoom_max_callback(GtkAccelGroup *accel
 {
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
-  gtk_range_set_value(GTK_RANGE(d->zoom), 1);
+  gtk_range_set_value(GTK_RANGE(d->zoom), DT_LIBRARY_MIN_ZOOM);
   // FIXME: scroll to active image
   return TRUE;
 }
@@ -310,8 +312,8 @@ static gboolean _lib_lighttable_key_accel_zoom_in_callback(GtkAccelGroup *accel_
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
   int zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
-  if(zoom <= 1)
-    zoom = 1;
+  if(zoom <= DT_LIBRARY_MIN_ZOOM)
+    zoom = DT_LIBRARY_MIN_ZOOM;
   else
     zoom--;
   gtk_range_set_value(GTK_RANGE(d->zoom), zoom);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -934,7 +934,7 @@ after_drawing:
 
 // TODO: this is also defined in lib/tools/lighttable.c
 //       fix so this value is shared.. DT_CTL_SET maybe ?
-
+#define DT_LIBRARY_MIN_ZOOM 2
 #define DT_LIBRARY_MAX_ZOOM 13
 
 static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
@@ -2253,8 +2253,8 @@ void init_key_accels(dt_view_t *self)
   // Preview key
   dt_accel_register_view(self, NC_("accel", "preview"), GDK_KEY_z, 0);
   dt_accel_register_view(self, NC_("accel", "preview with focus detection"), GDK_KEY_z, GDK_CONTROL_MASK);
-  dt_accel_register_view(self, NC_("accel", "sticky preview"), 0, 0);
-  dt_accel_register_view(self, NC_("accel", "sticky preview with focus detection"), 0, 0);
+  dt_accel_register_view(self, NC_("accel", "sticky preview"), GDK_KEY_f, 0);
+  dt_accel_register_view(self, NC_("accel", "sticky preview with focus detection"), GDK_KEY_f, GDK_MOD1_MASK);
   dt_accel_register_view(self, NC_("accel", "exit sticky preview"), 0, 0);
 }
 


### PR DESCRIPTION
We had two ways of doing a single image view in darktable, setting the lighttable to zoom=1 (Alt-1) and using the fullscreen preview (Z or the sticky fullscreen mode). Sticky fullscreen is almost indistinguishable from Alt-1 so this unifies it by doing the following:
  * The lightable can now only zoom between 2 and 13 (DT_LIBRARY_MIN_ZOOM and DT_LIBRARY_MAX_ZOOM)
  * Sticky fullscreen now has a default keybinding (F for normal, Alt-F for focus preview)

We could complete this making it fully discoverable by adding a fullscreen toggle button next to the zoom slider.