### PR TITLE
Fix dr leave deadlock

### DIFF
--- a/src/common/dtpthread.h
+++ b/src/common/dtpthread.h
@@ -89,7 +89,7 @@ static inline int dt_pthread_mutex_init_with_caller(dt_pthread_mutex_t *mutex,
                                                     const int line, const char *function)
 {
   memset(mutex, 0x0, sizeof(dt_pthread_mutex_t));
-  snprintf(mutex->name, 256, "%s:%d (%s)", file, line, function);
+  snprintf(mutex->name, sizeof(mutex->name), "%s:%d (%s)", file, line, function);
 #if defined(__OpenBSD__)
   if(attr == NULL)
   {
@@ -116,8 +116,8 @@ static inline int dt_pthread_mutex_lock_with_caller(dt_pthread_mutex_t *mutex, c
   mutex->time_locked = dt_pthread_get_wtime();
   double wait = mutex->time_locked - t0;
   mutex->time_sum_wait += wait;
-  char name[256];
-  snprintf(name, sizeof(name), "%s:%d (%s)", file, line, function);
+  char *name = mutex->name;
+  snprintf(mutex->name, sizeof(mutex->name), "%s:%d (%s)", file, line, function);
   int min_wait_slot = 0;
   for(int k = 0; k < TOPN; k++)
   {
@@ -144,8 +144,8 @@ static inline int dt_pthread_mutex_trylock_with_caller(dt_pthread_mutex_t *mutex
   mutex->time_locked = dt_pthread_get_wtime();
   double wait = mutex->time_locked - t0;
   mutex->time_sum_wait += wait;
-  char name[256];
-  snprintf(name, sizeof(name), "%s:%d (%s)", file, line, function);
+  char *name = mutex->name;
+  snprintf(mutex->name, sizeof(mutex->name), "%s:%d (%s)", file, line, function);
   int min_wait_slot = 0;
   for(int k = 0; k < TOPN; k++)
   {
@@ -169,8 +169,8 @@ static inline int dt_pthread_mutex_unlock_with_caller(dt_pthread_mutex_t *mutex,
   const double locked = t0 - mutex->time_locked;
   mutex->time_sum_locked += locked;
 
-  char name[256];
-  snprintf(name, sizeof(name), "%s:%d (%s)", file, line, function);
+  char *name = mutex->name;
+  snprintf(mutex->name, sizeof(mutex->name), "%s:%d (%s)", file, line, function);
   int min_locked_slot = 0;
   for(int k = 0; k < TOPN; k++)
   {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1765,10 +1765,10 @@ void leave(dt_view_t *self)
 
   // clear gui.
   dev->gui_leaving = 1;
-  dt_pthread_mutex_lock(&dev->history_mutex);
   dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
 
+  dt_pthread_mutex_lock(&dev->history_mutex);
   while(dev->history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(dev->history->data);


### PR DESCRIPTION
See commit message of second commit for detailed explanation.
There doesn't seem to be any reason to hold a lock on dev->history_mutex for dt_dev_pixelpipe_cleanup_nodes() calls, so i do not see any obvious issues here yet...