### PR TITLE
exposure: make auto button a button (not a toggle)

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -724,22 +724,11 @@ static void autoexp_callback(GtkWidget *button, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF) return;
 
-  if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
-    self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
-  else
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-
-  dt_iop_request_focus(self);
-
-  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
-  {
-    dt_lib_colorpicker_set_area(darktable.lib, 0.99);
-    dt_dev_reprocess_all(self->dev);
-  }
-  else
-    dt_control_queue_redraw();
-
+  self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+  dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+  dt_dev_reprocess_all(self->dev);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 


### PR DESCRIPTION
In the sequence of the gui changes to exposure here's a simple tweak suggestion. Since this is now a button and not a checkbox make it act like a button instead (every press activates auto if it isn't yet). To leave auto mode just change the exposure sliders manually as was already possible and was needed anyway for anything to change.