### PR TITLE
Use a smaller text area for entering the watermark text.

### DIFF
--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1246,7 +1246,7 @@ void gui_init(struct dt_iop_module_t *self)
   // Simple text
   label = dtgtk_reset_label_new(_("text"), self, &g->text, 0);
   g->text = gtk_entry_new();
-  gtk_entry_set_width_chars(GTK_ENTRY(g->text), 27);
+  gtk_entry_set_width_chars(GTK_ENTRY(g->text), 20);
   g_object_set(G_OBJECT(g->text), "tooltip-text", _("text string, tag:\n$(WATERMARK_TEXT)"), (char *)NULL);
   dt_gui_key_accel_block_on_focus_connect(g->text);
   gtk_grid_attach(GTK_GRID(self->widget), label, 0, line++, 1, 1);


### PR DESCRIPTION
This avoid the iop to be wider than the panel a goes outside of
the screen.

Should be part of 2.0 I think.