### PR TITLE
css: fix GtkAboutDialog bits

### DIFF
--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -431,6 +431,11 @@ GtkDialog .button:hover *
   border-color:  shade(@selected_bg_color, 1.7);
 }
 
+GtkDialog .button GtkLabel
+{
+  background-color: transparent;
+}
+
 GtkDialog GtkEventBox *
 {
    background-color: transparent;
@@ -491,4 +496,20 @@ GtkNotebook GtkMenuItem:hover
 .undershoot.right
 {
   background: none;
+}
+
+GtkAboutDialog
+{
+  background-color: @bg_color;
+}
+
+GtkAboutDialog GtkBox,
+GtkAboutDialog GtkBox *
+{
+  background-color: @bg_color;
+}
+
+GtkAboutDialog GtkHeaderBar
+{
+  padding: 2px;
 }


### PR DESCRIPTION
This fixes the GtkDialogBox visuals:
- ensures all elements have a homogeneous background color
- fixes the GtkLabel background in the GtkToggleButtons used in that dialog box (was opaque, needs to be transparent in our case)

Checked on Debian SID with GTK 3.18, needs visual review on older GTK releases.