### PR TITLE
fix blurry d1x images

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -353,6 +353,12 @@ restart:
   }
 
   scale = dt_dev_get_zoom_scale(dev, zoom, 1.0f, 0) * darktable.gui->ppd;
+
+  dev->pipe->overprocess = 1.0f;
+  if(!strcmp(dev->image_storage.camera_makermodel, "Nikon D1X"))
+    dev->pipe->overprocess = MIN(1.0f, scale*2.0f)/scale;
+  scale *= dev->pipe->overprocess;
+
   window_width = dev->width * darktable.gui->ppd;
   window_height = dev->height * darktable.gui->ppd;
   if(closeup)
@@ -360,8 +366,8 @@ restart:
     window_width /= 2;
     window_height /= 2;
   }
-  const int wd = MIN(window_width, dev->pipe->processed_width * scale);
-  const int ht = MIN(window_height, dev->pipe->processed_height * scale);
+  const int wd = MIN(window_width*dev->pipe->overprocess, dev->pipe->processed_width * scale);
+  const int ht = MIN(window_height*dev->pipe->overprocess, dev->pipe->processed_height * scale);
   x = MAX(0, scale * dev->pipe->processed_width  * (.5 + zoom_x) - wd / 2);
   y = MAX(0, scale * dev->pipe->processed_height * (.5 + zoom_y) - ht / 2);
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -143,6 +143,7 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->levels = IMAGEIO_RGB | IMAGEIO_INT8;
   dt_pthread_mutex_init(&(pipe->backbuf_mutex), NULL);
   dt_pthread_mutex_init(&(pipe->busy_mutex), NULL);
+  pipe->overprocess = 1.0f;
   return 1;
 }
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -130,6 +130,7 @@ typedef struct dt_dev_pixelpipe_t
   int devid;
   // image struct as it was when the pixelpipe was initialized. copied to avoid race conditions.
   dt_image_t image;
+  float overprocess;
 } dt_dev_pixelpipe_t;
 
 struct dt_develop_t;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -189,19 +189,22 @@ void expose(
     ht = dev->pipe->backbuf_height;
     stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
     surface = dt_cairo_image_surface_create_for_data(dev->pipe->backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
+
     wd /= darktable.gui->ppd;
     ht /= darktable.gui->ppd;
+
     if(dev->full_preview)
       cairo_set_source_rgb(cr, .1, .1, .1);
     else
       cairo_set_source_rgb(cr, .2, .2, .2);
     cairo_paint(cr);
-    cairo_translate(cr, .5f * (width - wd), .5f * (height - ht));
+    cairo_translate(cr, .5f * (width - wd/dev->pipe->overprocess), .5f * (height - ht/dev->pipe->overprocess));
     if(closeup)
     {
       cairo_scale(cr, 2.0, 2.0);
       cairo_translate(cr, -.25f * wd, -.25f * ht);
     }
+    cairo_scale(cr, 1.0f/dev->pipe->overprocess, 1.0f/dev->pipe->overprocess);
     cairo_rectangle(cr, 0, 0, wd, ht);
     cairo_set_source_surface(cr, surface, 0, 0);
     cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);


### PR DESCRIPTION
D1X images are stretched by scalepixels to generate a square pixel image. When doing processing at a smaller resolution to display in darkroom/thumbnails this means we are scaling up a scaled down image which leads to poor output. This is a hack to make darkroom ask for double the processing size and then scale that down. Ideally this would be fixed inside scalepixels itself. This doesn't fix thumbnail generation.

Ideally this would be handled by scalepixels instead by tweaking modify_roi_in and modify_roi_out. Last time around I couldn't make that work so I'm trying this instead. The changes aren't really that complex but I still don't like them. It adds special cases for an irrelevant camera to core code so shouldn't really be the way forward.