### PR TITLE
scalepixels: first draft of scaling fix

### DIFF
--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -149,7 +149,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   roi_in->height = hw[0];
   roi_in->width = hw[1];
 
-  float reduction_ratio = MAX(hw[0] / (piece->iheight * 1.0f), hw[1] / (piece->iwidth * 1.0f));
+  float reduction_ratio = MAX(hw[0] / (piece->buf_in.height * 1.0f), hw[1] / (piece->buf_in.width * 1.0f));
   if (reduction_ratio > 1.0f)
   {
     roi_in->height /= reduction_ratio;

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -151,12 +151,16 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
   // If possible try to get an image that's strictly larger than what we want to output
   float hw[2] = {roi_out->height, roi_out->width};
-  transform(piece, hw);
+  transform(piece, hw); // transform() is used reversed here intentionally
+  roi_in->height = hw[0];
+  roi_in->width = hw[1];
 
-  // Now restrict it to something we can actually produce if that's too big
-  // FIXME: For some reason piece->iwidth is sometimes larger than roi_out->width
-  roi_in->height = MIN(piece->iheight, (int) ceilf(hw[0]));
-  roi_in->width = MIN(piece->iwidth, (int) ceilf(hw[1]));
+  float reduction_ratio = MAX(hw[0] / (piece->iheight * 1.0f), hw[1] / (piece->iwidth * 1.0f));
+  if (reduction_ratio > 1.0f)
+  {
+    roi_in->height /= reduction_ratio;
+    roi_in->width /= reduction_ratio;
+  }
 
   fprintf(stderr, "Ended modify_roi_in with %dx%d from %dx%d\n", roi_in->width, roi_in->height, roi_out->width, roi_out->height);
 }

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -184,10 +184,10 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
   const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
-  dt_iop_scalepixels_data_t *d = piece->data;
+  const dt_iop_scalepixels_data_t * const d = piece->data;
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ovoid, interpolation, d)
+#pragma omp parallel for schedule(static) default(none) shared(ovoid, interpolation)
 #endif
   // (slow) point-by-point transformation.
   // TODO: optimize with scanlines and linear steps between?
@@ -196,8 +196,8 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
     float *out = ((float *)ovoid) + (size_t)4 * j * roi_out->width;
     for(int i = 0; i < roi_out->width; i++, out += 4)
     {
-      float x = MIN(i*d->x_scale, roi_in->width);
-      float y = MIN(j*d->y_scale, roi_in->height);
+      float x = i*d->x_scale;
+      float y = j*d->y_scale;
 
       dt_interpolation_compute_pixel4c(interpolation, (float *)ivoid, out, x, y, roi_in->width,
                                        roi_in->height, ch_width);

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -162,10 +162,11 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   d->x_scale = (roi_in->width * 1.0f) / (roi_out->width * 1.0f);
   d->y_scale = (roi_in->height * 1.0f) / (roi_out->height * 1.0f);
 
+  roi_in->scale = roi_out->scale * MAX(d->x_scale, d->y_scale);
   roi_in->x = roi_out->x * d->x_scale;
   roi_in->y = roi_out->y * d->y_scale;
 
-  fprintf(stderr, "Ended modify_roi_in with %dx%d from %dx%d\n", roi_in->width, roi_in->height, roi_out->width, roi_out->height);
+  fprintf(stderr, "Ended modify_roi_in with %dx%d from %dx%d with scale %f from scale %f\n", roi_in->width, roi_in->height, roi_out->width, roi_out->height, roi_in->scale, roi_out->scale);
 }
 
 void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, const void *const ivoid,

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -136,8 +136,6 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
   if(roi_out->y < 0) roi_out->y = 0;
   if(roi_out->width < 1) roi_out->width = 1;
   if(roi_out->height < 1) roi_out->height = 1;
-
-  fprintf(stderr, "Ended modify_roi_out with %dx%d from %dx%d\n", roi_out->width, roi_out->height, roi_in->width, roi_in->height);
 }
 
 void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,
@@ -165,8 +163,6 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   roi_in->scale = roi_out->scale * MAX(d->x_scale, d->y_scale);
   roi_in->x = roi_out->x * d->x_scale;
   roi_in->y = roi_out->y * d->y_scale;
-
-  fprintf(stderr, "Ended modify_roi_in with %dx%d from %dx%d with scale %f from scale %f\n", roi_in->width, roi_in->height, roi_out->width, roi_out->height, roi_in->scale, roi_out->scale);
 }
 
 void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, const void *const ivoid,
@@ -176,9 +172,6 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
   const int ch_width = ch * roi_in->width;
   const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
   dt_iop_scalepixels_data_t *d = piece->data;
-
-  fprintf(stderr, "scales are %f and %f\n", d->x_scale, d->y_scale);
-  fprintf(stderr, "Going to convert %dx%d into %dx%d\n", roi_in->width, roi_in->height, roi_out->width, roi_out->height);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) default(none) shared(ovoid, interpolation, d)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -88,8 +88,20 @@ static void transform(const dt_dev_pixelpipe_iop_t *const piece, float *p)
   }
 }
 
+static void precalculate_scale(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+{
+  // Since the scaling is calculated by modify_roi_in use that to get them
+  // This doesn't seem strictly needed but since clipping.c also does it we try
+  // and avoid breaking any assumptions elsewhere in the code
+  dt_iop_roi_t roi_out, roi_in;
+  roi_out.width = piece->buf_in.width;
+  roi_out.height = piece->buf_in.height;
+  self->modify_roi_in(self, piece, &roi_out, &roi_in);
+}
+
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
 {
+  precalculate_scale(self, piece);
   dt_iop_scalepixels_data_t *d = piece->data;
 
   for(size_t i = 0; i < points_count * 2; i += 2)
@@ -104,6 +116,7 @@ int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, floa
 int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points,
                           size_t points_count)
 {
+  precalculate_scale(self, piece);
   dt_iop_scalepixels_data_t *d = piece->data;
 
   for(size_t i = 0; i < points_count * 2; i += 2)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -195,7 +195,7 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
 void commit_params(dt_iop_module_t *self, const dt_iop_params_t *const params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_scalepixels_params_t *p = self->params;
+  const dt_iop_scalepixels_params_t *p = params;
   dt_iop_scalepixels_data_t *d = piece->data;
 
   d->pixel_aspect_ratio = p->pixel_aspect_ratio;


### PR DESCRIPTION
This aims at solving the problem of PR #1043 properly (within scalepixels). Here's what I've done:
  * Changed modify_roi_in() to ask for the largest image that makes sense for the output we want. So if we want to produce 100x200 ask for 200x200 instead of 100x100.
  * Changed process() to do whatever scaling is implied by the width/height dimensions of roi_in and roi_out.

For some reason this results in the images in the darkroom and thumbnails to only occupy the top left quadrant of the image area. I suspect distort_transform() and distort_backtransform() need to be changed as well.