### PR TITLE
rawspeed/cameras.xml: added alias for Canon 350D

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -217,6 +217,7 @@
 			<Alias id="Digital Rebel XT">Canon EOS DIGITAL REBEL XT</Alias>
 			<Alias id="Kiss Digital N">Canon EOS Kiss Digital N</Alias>
 			<Alias id="EOS 350D">Canon EOS 350D</Alias>
+			<Alias id="EOS 350 Digital">Canon EOS 350D Digital</Alias>
 		</Aliases>
 	</Camera>
 	<Camera make="Canon" model="Canon EOS 40D" decoder_version="2">


### PR DESCRIPTION
Support for my old Canon EOS 350D was broken for quite a while, finally found some time to look into it tonight. Turns out that rawspeed extracts the model string `Canon EOS 350D Digital`, which it tries to match against `Canon EOS 350D DIGITAL`.

As I am new to the darktable code base, I am not sure if my proposed fix does the job, or if some case-insensitivity should be added to the string matching?!