### PR TITLE
Added preserve luminosity option to channel mixer module.

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -147,7 +147,8 @@ typedef  enum _channelmixer_output_t
 
 __kernel void
 channelmixer (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-              const int gray_mix_mode, global const float *red, global const float *green, global const float *blue)
+              const int gray_mix_mode, global const float *red, global const float *green, global const float *blue,
+              global const float *weights)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -169,11 +170,11 @@ channelmixer (read_only image2d_t in, write_only image2d_t out, const int width,
     pixel = HSL_2_RGB(hsl);
   }
 
-  float graymix = clamp(pixel.x * red[CHANNEL_GRAY]+ pixel.y * green[CHANNEL_GRAY] + pixel.z * blue[CHANNEL_GRAY], 0.0f, 1.0f);
+  float graymix = clamp((pixel.x * red[CHANNEL_GRAY] + pixel.y * green[CHANNEL_GRAY] + pixel.z * blue[CHANNEL_GRAY]) / weights[CHANNEL_GRAY], 0.0f, 1.0f);
 
-  float rmix = clamp(pixel.x * red[CHANNEL_RED] + pixel.y * green[CHANNEL_RED] + pixel.z * blue[CHANNEL_RED], 0.0f, 1.0f);
-  float gmix = clamp(pixel.x * red[CHANNEL_GREEN] + pixel.y * green[CHANNEL_GREEN] + pixel.z * blue[CHANNEL_GREEN], 0.0f, 1.0f);
-  float bmix = clamp(pixel.x * red[CHANNEL_BLUE] + pixel.y * green[CHANNEL_BLUE] + pixel.z * blue[CHANNEL_BLUE], 0.0f, 1.0f);
+  float rmix = clamp((pixel.x * red[CHANNEL_RED] + pixel.y * green[CHANNEL_RED] + pixel.z * blue[CHANNEL_RED]) / weights[CHANNEL_RED], 0.0f, 1.0f);
+  float gmix = clamp((pixel.x * red[CHANNEL_GREEN] + pixel.y * green[CHANNEL_GREEN] + pixel.z * blue[CHANNEL_GREEN]) / weights[CHANNEL_GREEN], 0.0f, 1.0f);
+  float bmix = clamp((pixel.x * red[CHANNEL_BLUE] + pixel.y * green[CHANNEL_BLUE] + pixel.z * blue[CHANNEL_BLUE]) / weights[CHANNEL_BLUE], 0.0f, 1.0f);
 
   pixel = gray_mix_mode ? (float4)(graymix, graymix, graymix, pixel.w) : (float4)(rmix, gmix, bmix, pixel.w);
 

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -109,6 +109,36 @@ typedef struct dt_iop_channelmixer_global_data_t
   int kernel_channelmixer;
 } dt_iop_channelmixer_global_data_t;
 
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
+                  void *new_params, const int new_version)
+{
+  if (old_version == 1 && new_version == 2)
+  {
+    typedef struct dt_iop_channelmixer_params_v1_t
+    {
+      float red[7];
+      float green[7];
+      float blue[7];
+    } dt_iop_channelmixer_params_v1_t;
+
+    dt_iop_channelmixer_params_v1_t *params_v1 = (dt_iop_channelmixer_params_v1_t *) old_params;
+    dt_iop_channelmixer_params_t params = (dt_iop_channelmixer_params_t){ { 0, 0, 0, 1, 0, 0, 0 },
+                                                                          { 0, 0, 0, 0, 1, 0, 0 },
+                                                                          { 0, 0, 0, 0, 0, 1, 0 },
+                                                                          { 0, 0, 0, 0, 0, 0, 0 } };
+    for (int i = 0; i < 7; i++) // Better not use CHANNEL_SIZE for further compatibility
+    {
+      params.red[i] = params_v1->red[i];
+      params.green[i] = params_v1->green[i];
+      params.blue[i] = params_v1->blue[i];
+    }
+
+    memcpy(new_params, &params, sizeof(dt_iop_channelmixer_params_t));
+    return 0;
+  }
+
+  return 1;
+}
 
 const char *name()
 {

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -83,7 +83,7 @@ typedef struct dt_iop_channelmixer_params_t
   /** amount of blue to mix value -1.0 - 1.0 */
   float blue[CHANNEL_SIZE];
   /** preserve or not luminosity */
-  bool luminosity[CHANNEL_SIZE];
+  int luminosity[CHANNEL_SIZE];
 } dt_iop_channelmixer_params_t;
 
 typedef struct dt_iop_channelmixer_gui_data_t
@@ -101,7 +101,7 @@ typedef struct dt_iop_channelmixer_data_t
   float red[CHANNEL_SIZE];
   float green[CHANNEL_SIZE];
   float blue[CHANNEL_SIZE];
-  bool luminosity[CHANNEL_SIZE];
+  int luminosity[CHANNEL_SIZE];
 } dt_iop_channelmixer_data_t;
 
 typedef struct dt_iop_channelmixer_global_data_t
@@ -121,19 +121,23 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
       float blue[7];
     } dt_iop_channelmixer_params_v1_t;
 
-    dt_iop_channelmixer_params_v1_t *params_v1 = (dt_iop_channelmixer_params_v1_t *) old_params;
-    dt_iop_channelmixer_params_t params = (dt_iop_channelmixer_params_t){ { 0, 0, 0, 1, 0, 0, 0 },
-                                                                          { 0, 0, 0, 0, 1, 0, 0 },
-                                                                          { 0, 0, 0, 0, 0, 1, 0 },
-                                                                          { 0, 0, 0, 0, 0, 0, 0 } };
+    dt_iop_channelmixer_params_v1_t *o = (dt_iop_channelmixer_params_v1_t *) old_params;
+    dt_iop_channelmixer_params_t *n = (dt_iop_channelmixer_params_t *) new_params;
+
+    // start with a fresh copy of default parameters
+    *n = (dt_iop_channelmixer_params_t){ { 0, 0, 0, 1, 0, 0, 0 },
+                                         { 0, 0, 0, 0, 1, 0, 0 },
+                                         { 0, 0, 0, 0, 0, 1, 0 },
+                                         { 0, 0, 0, 0, 0, 0, 0 } };
+
+    // Copy old values
     for (int i = 0; i < 7; i++) // Better not use CHANNEL_SIZE for further compatibility
     {
-      params.red[i] = params_v1->red[i];
-      params.green[i] = params_v1->green[i];
-      params.blue[i] = params_v1->blue[i];
+      n->red[i] = o->red[i];
+      n->green[i] = o->green[i];
+      n->blue[i] = o->blue[i];
     }
 
-    memcpy(new_params, &params, sizeof(dt_iop_channelmixer_params_t));
     return 0;
   }
 


### PR DESCRIPTION
This is the code that adds a preserve luminosity toggle button to the channel mixer module. It was explained here http://article.gmane.org/gmane.comp.graphics.darktable.devel/6786