### PR TITLE
Darkroom: leave(): lock pipe mutexes before cleaning pipes. Maybe fixes #10770

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1759,7 +1759,12 @@ void leave(dt_view_t *self)
   }
 
   // clear gui.
+
+  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&dev->pipe_mutex);
+
   dev->gui_leaving = 1;
+
   dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
 
@@ -1790,6 +1795,9 @@ void leave(dt_view_t *self)
   }
 
   dt_pthread_mutex_unlock(&dev->history_mutex);
+
+  dt_pthread_mutex_unlock(&dev->pipe_mutex);
+  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
 
   // cleanup visible masks
   if(dev->form_gui)


### PR DESCRIPTION
This is basically a follow-up for #1034 / cb86adc5b5584ef40fd3823a35124ade0c462ac4

What i think is happening:
1. in darkroom, trigger pipe reprocessing by changing params of some iop
2. switch to lighttable

Sometimes, i suppose, darkroom.c leave() might clean pipes
(dt_dev_pixelpipe_cleanup_nodes()) before another thread
dt_dev_process_image_job_run() runs dt_dev_pixelpipe_create_nodes()

The following sequence diagram explains this issue:
```
               CPU 1                                       CPU 2
pipe reprocessing is triggered
async job to process pipe is created.
                                    dt_control_run_job_res()
                                      dt_dev_process_image_job_run()
user clicks on "lighttable"             dt_dev_process_image_job()
dt_view_manager_switch()                  locks dev->pipe_mutex
  darkroom -> leave()                       dev->image_loading == 1
    dev->gui_leaving = 1                     dt_dev_pixelpipe_create_nodes()
    cleans dev->iop list                        accesses dev->iop list
      for each entry                              at some point, accesses
        free buffers                              entry with pointers == NULL,
        set pointer to null                       but not removed from list yet
        remove entry from list                    => NULL pointer dereference.
    dev->iop == NULL;
```

So now:
1. Darkroom: leave(): sets dev->gui_leaving = 1 thread-safely.
   In all other places, either one or both mutexes are locked
   during access to dev->gui_leaving.
2. If we are leaving gui, and have just freed dev->iop list,
   dt_dev_process_preview_job()/dt_dev_process_image_job()
   will not be accessing it, instead they will immediately quit.
**3. !!! For some reason, darkroom pipes do not abort when leaving dr,
   but finish. (No, doing dev->gui_leaving = 1; before lock does not help)**

Anyway, i do not see how else to explain ``params=0x0, blendop_params=0x0``.