### PR TITLE
rawspeed: single code path for 3 & 1 channel sraw

### DIFF
--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -352,47 +352,25 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
   void *buf = dt_mipmap_cache_alloc(mbuf, img);
   if(!buf) return DT_IMAGEIO_CACHE_FULL;
 
-  if(img->cpp == 1)
-  {
-/*
- * monochrome image (e.g. Leica M9 monochrom),
- * we need to copy data from only channel to each of 3 channels
- */
-
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static) shared(r, img, buf)
 #endif
-    for(int j = 0; j < img->height; j++)
-    {
-      const uint16_t *in = (uint16_t *) r->getData(0, j);
-      float *out = ((float *)buf) + (size_t)4 * j * img->width;
+  for(int j = 0; j < img->height; j++)
+  {
+    const uint16_t *in = (uint16_t *) r->getData(0, j);
+    float *out = ((float *)buf) + (size_t)4 * j * img->width;
 
-      for(int i = 0; i < img->width; i++, in += img->cpp, out += 4)
+    for(int i = 0; i < img->width; i++, in += img->cpp, out += 4)
+    {
+      if(img->cpp == 1)
       {
-        for(int k = 0; k < 3; k++)
-        {
-          out[k] = (float)*in / (float)UINT16_MAX;
-        }
+        // monochrome image (e.g. Leica M9 monochrom),
+        // we need to copy data from only channel to each of 3 channels
+        out[0] = out[1] = out[3] = (float)*in / (float)UINT16_MAX;
       }
-    }
-  }
-  else if(img->cpp == 3)
-  {
-/*
- * standard 3-ch image
- * just copy 3 ch to 3 ch
- */
-
-#ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(r, img, buf)
-#endif
-    for(int j = 0; j < img->height; j++)
-    {
-      const uint16_t *in = (uint16_t *) r->getData(0, j);
-      float *out = ((float *)buf) + (size_t)4 * j * img->width;
-
-      for(int i = 0; i < img->width; i++, in += img->cpp, out += 4)
+      else if(img->cpp == 3)
       {
+        // standard 3-ch image, just copy 3 ch to 3 ch
         for(int k = 0; k < 3; k++)
         {
           out[k] = (float)in[k] / (float)UINT16_MAX;


### PR DESCRIPTION
Make the 1-channel and 3-channel sraw code simpler by having a single code path and pushing the conditional into the inner loop. Any sensible CPU will predict that branch 100% of the time so there shouldn't really be any performance impact.

@LebedevRI unless there are openmp implications to this the code becomes a bit simpler and should be just as fast.