### PR TITLE
Properly initialize list before entering the loop.

### DIFF
--- a/src/gui/camera_import_dialog.c
+++ b/src/gui/camera_import_dialog.c
@@ -493,6 +493,7 @@ static void _camera_import_dialog_run(_camera_import_dialog_t *data)
                      _("select the images from the list below that you want to import into a new filmroll"));
   gboolean all_good = FALSE;
   g_signal_connect(G_OBJECT(data->dialog), "delete-event", G_CALLBACK(_dialog_close), data);
+  data->params->result = NULL;
   while(!all_good)
   {
     gint result = gtk_dialog_run(GTK_DIALOG(data->dialog));


### PR DESCRIPTION
In the loop we have:

      g_list_free(data->params->result);
      data->params->result = NULL;

But if data->params->result is not initilized we are freeing uninitialized
memory. The import dialog then crash.


I think I have found the issue I had recently with the import dialog crashing. Looks safe and I was not able to reproduce the crash with this in place.