### PR TITLE
Possible fix for the import dialog crash.

### DIFF
--- a/src/gui/camera_import_dialog.c
+++ b/src/gui/camera_import_dialog.c
@@ -561,6 +561,7 @@ static void _camera_import_dialog_run(_camera_import_dialog_t *data)
 void dt_camera_import_dialog_new(dt_camera_import_dialog_param_t *params)
 {
   _camera_import_dialog_t data;
+  memset(&data, 0, sizeof(_camera_import_dialog_t)); // needed to initialize pointers to null
   data.params = params;
   _camera_import_dialog_new(&data);
   _camera_import_dialog_run(&data);


### PR DESCRIPTION
If the memory is not initialized to 0 here, the import.value pointer
is not initialized. And it is g_free'd in the code before assigning a
new value.