### PR TITLE
CYGM bayer pattern support

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1633,29 +1633,29 @@ static void dt_colorspaces_pseudoinverse(double (*in)[3], double (*out)[3], int 
 {
   double work[3][6], num;
 
-  for (int i = 0; i < 3; i++) {
-    for (int j = 0; j < 6; j++)
+  for(int i = 0; i < 3; i++) {
+    for(int j = 0; j < 6; j++)
       work[i][j] = j == i+3;
-    for (int j = 0; j < 3; j++)
-      for (int k = 0; k < size; k++)
+    for(int j = 0; j < 3; j++)
+      for(int k = 0; k < size; k++)
         work[i][j] += in[k][i] * in[k][j];
   }
-  for (int i = 0; i < 3; i++) {
+  for(int i = 0; i < 3; i++) {
     num = work[i][i];
-    for (int j = 0; j < 6; j++)
+    for(int j = 0; j < 6; j++)
       work[i][j] /= num;
-    for (int k = 0; k < 3; k++) {
-      if (k==i) continue;
+    for(int k = 0; k < 3; k++) {
+      if(k==i) continue;
       num = work[k][i];
-      for (int j = 0; j < 6; j++)
+      for(int j = 0; j < 6; j++)
         work[k][j] -= work[i][j] * num;
     }
   }
-  for (int i = 0; i < size; i++)
-    for (int j = 0; j < 3; j++)
+  for(int i = 0; i < size; i++)
+    for(int j = 0; j < 3; j++)
     {
       out[i][j] = 0.0f;
-      for (int k = 0; k < 3; k++)
+      for(int k = 0; k < 3; k++)
         out[i][j] += work[j][k+3] * in[i][k];
     }
 }
@@ -1676,20 +1676,20 @@ static void dt_colorspaces_4bayermatrix(const char *name, double cam_rgb[4][3])
     return;
 
   // Multiply out XYZ colorspace
-  for (int i = 0; i < 4; i++)
-    for (int j = 0; j < 3; j++)
+  for(int i = 0; i < 4; i++)
+    for(int j = 0; j < 3; j++)
     {
       cam_rgb[i][j] = 0.0f;
-      for (int k = 0; k < 3; k++)
+      for(int k = 0; k < 3; k++)
         cam_rgb[i][j] += cam_xyz[i][k] * xyz_rgb[k][j];
     }
 
   // Normalize cam_rgb so that cam_rgb * (1,1,1) is (1,1,1,1)
-  for (int i = 0; i < 4; i++) {
+  for(int i = 0; i < 4; i++) {
     double num = 0.0f;
-    for (int j = 0; j < 3; j++)
+    for(int j = 0; j < 3; j++)
       num += cam_rgb[i][j];
-    for (int j = 0; j < 3; j++)
+    for(int j = 0; j < 3; j++)
       cam_rgb[i][j] /= num;
   }
 }
@@ -1709,21 +1709,21 @@ static void dt_colorspaces_inverse4bayermatrix(const char *name, double out_cam[
 
   // Invert the matrix into 3x4
   dt_colorspaces_pseudoinverse (cam_rgb, inverse, 4);
-  for (int i = 0; i < 3; i++)
-    for (int j = 0; j < 4; j++)
+  for(int i = 0; i < 3; i++)
+    for(int j = 0; j < 4; j++)
       rgb_cam[i][j] = inverse[j][i];
 
   // Finally apply the Rec2020 profile
-  for (int i = 0; i < 3; i++)
-    for (int j = 0; j < 4; j++)
+  for(int i = 0; i < 3; i++)
+    for(int j = 0; j < 4; j++)
     {
       out_cam[i][j] = 0.0f;
-      for (int k = 0; k < 3; k++)
+      for(int k = 0; k < 3; k++)
         out_cam[i][j] += rec2020_rgb[i][k] * rgb_cam[k][j];
     }
 }
 
-void cmyg_convert(float *out, int num, const char *camera)
+void dt_colorspaces_cygm_to_rgb(float *out, int num, const char *camera)
 {
   // Start with a fallback matrix in place
   double rgb_cam[3][4] = {
@@ -1752,7 +1752,7 @@ void cmyg_convert(float *out, int num, const char *camera)
   }
 }
 
-void cmyg_backconvert(float *out, int num, const char *camera)
+void dt_colorspaces_rgb_to_cygm(float *out, int num, const char *camera)
 {
   // Start with a fallback matrix in place
   double cam_rgb[4][3] = {

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1782,6 +1782,9 @@ void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int nu
 
 void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4])
 {
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(out, num, CAM_to_RGB) schedule(static)
+#endif
   for(int i = 0; i < num; i++)
   {
     float *in = &out[i*4];
@@ -1796,6 +1799,9 @@ void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4])
 
 void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3])
 {
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(out, num, RGB_to_CAM) schedule(static)
+#endif
   for(int i = 0; i < num; i++)
   {
     float *in = &out[i*3];

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1745,7 +1745,7 @@ int dt_colorspaces_conversion_matrices_rgb(const char *name, double out_RGB_to_C
       for(int j = 0; j < 4; j++)
         CAM_to_RGB[i][j] = inverse[j][i];
 
-    static const double REC2020_to_XYZ[3][3] = {
+    const double REC2020_to_XYZ[3][3] = {
       { 0.673492, 0.279037, -0.001938 },
       { 0.165665, 0.675354, 0.029984 },
       { 0.125046, 0.045609, 0.796860 },

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1697,7 +1697,7 @@ int dt_colorspaces_conversion_matrices_xyz(const char *name, float in_XYZ_to_CAM
 // Converted from dcraw's cam_xyz_coeff()
 int dt_colorspaces_conversion_matrices_rgb(const char *name, double out_RGB_to_CAM[4][3], double out_CAM_to_RGB[3][4], double mul[4])
 {
-  double RGB_to_CAM[4][3], CAM_to_RGB[3][4];
+  double RGB_to_CAM[4][3];
 
   float XYZ_to_CAM[4][3];
   XYZ_to_CAM[0][0] = NAN;
@@ -1743,24 +1743,7 @@ int dt_colorspaces_conversion_matrices_rgb(const char *name, double out_RGB_to_C
     dt_colorspaces_pseudoinverse (RGB_to_CAM, inverse, 4);
     for(int i = 0; i < 3; i++)
       for(int j = 0; j < 4; j++)
-        CAM_to_RGB[i][j] = inverse[j][i];
-
-    const double REC2020_to_XYZ[3][3] = {
-      { 0.673492, 0.279037, -0.001938 },
-      { 0.165665, 0.675354, 0.029984 },
-      { 0.125046, 0.045609, 0.796860 },
-    };
-
-    // Finally apply the Rec2020 profile
-    for(int i = 0; i < 3; i++)
-    {
-      for(int j = 0; j < 4; j++)
-      {
-        out_CAM_to_RGB[i][j] = 0.0f;
-        for(int k = 0; k < 3; k++)
-          out_CAM_to_RGB[i][j] += REC2020_to_XYZ[i][k] * CAM_to_RGB[k][j];
-      }
-    }
+        out_CAM_to_RGB[i][j] = inverse[j][i];
   }
 
   return TRUE;

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1771,7 +1771,7 @@ void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4])
   for(int i = 0; i < num; i++)
   {
     float *in = &out[i*4];
-    float o[3] = {0.0f};
+    float o[3] = {0.0f,0.0f,0.0f};
     for(int c = 0; c < 3; c++)
       for(int k = 0; k < 4; k++)
         o[c] += CAM_to_RGB[c][k] * in[k];
@@ -1785,7 +1785,7 @@ void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3])
   for(int i = 0; i < num; i++)
   {
     float *in = &out[i*3];
-    float o[4] = {0.0f};
+    float o[4] = {0.0f,0.0f,0.0f,0.0f};
     for(int c = 0; c < 4; c++)
       for(int k = 0; k < 3; k++)
         o[c] += RGB_to_CAM[c][k] * in[k];

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1629,7 +1629,7 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_profile(dt_colorspaces_
   return _get_profile(darktable.color_profiles, type, filename, direction);
 }
 
-static void dt_colorspaces_pseudoinverse(double (*in)[3], double (*out)[3], int size)
+void dt_colorspaces_pseudoinverse(double (*in)[3], double (*out)[3], int size)
 {
   double work[3][6], num;
 

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -202,11 +202,11 @@ dt_colorspaces_get_profile(dt_colorspaces_color_profile_type_t type, const char 
  * make sure that darktable.color_profiles->xprofile_lock is held when calling this! */
 void dt_colorspaces_update_display_transforms();
 
-/** get a 4x3 matrix to convert RGB to CYGM or RGBE sensor data*/
-void dt_colorspaces_4bayermatrix(const char *name, double cam_rgb[4][3]);
+/** convert CMYG buffer to RGB */
+void cmyg_convert(float *out, int num, const char *camera);
 
-/** get a 3x4 matrix to convert CYGM or RGBE sensor data to RGB in Rec2020 */
-void dt_colorspaces_inverse4bayermatrix(const char *name, double rgb_cam[3][4]);
+/** convert RGB buffer to CMYG */
+void cmyg_backconvert(float *out, int num, const char *camera);
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -202,6 +202,12 @@ dt_colorspaces_get_profile(dt_colorspaces_color_profile_type_t type, const char 
  * make sure that darktable.color_profiles->xprofile_lock is held when calling this! */
 void dt_colorspaces_update_display_transforms();
 
+/** get a 4x3 matrix to convert RGB to CYGM or RGBE sensor data*/
+void dt_colorspaces_4bayermatrix(const char *name, double cam_rgb[4][3]);
+
+/** get a 3x4 matrix to convert CYGM or RGBE sensor data to RGB in Rec2020 */
+void dt_colorspaces_inverse4bayermatrix(const char *name, double rgb_cam[3][4]);
+
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -208,6 +208,9 @@ int dt_colorspaces_conversion_matrices_xyz(const char *name, float in_XYZ_to_CAM
 /** Calculate CAM->RGB, RGB->CAM matrices and default WB multipliers */
 int dt_colorspaces_conversion_matrices_rgb(const char *name, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], double mul[4]);
 
+/** Applies CYGM WB coeffs to an image that's already been converted to RGB by dt_colorspaces_cygm_to_rgb */
+void dt_colorspaces_cygm_apply_coeffs_to_rgb(float *out, const float *in, int num, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], float coeffs[4]);
+
 /** convert CYGM buffer to RGB */
 void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4]);
 

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -202,14 +202,17 @@ dt_colorspaces_get_profile(dt_colorspaces_color_profile_type_t type, const char 
  * make sure that darktable.color_profiles->xprofile_lock is held when calling this! */
 void dt_colorspaces_update_display_transforms();
 
-/** pseudoinverse taken from dcraw that allows inverting 3x4 into 4x3 */
-void dt_colorspaces_pseudoinverse(double (*in)[3], double (*out)[3], int size);
+/** Calculate CAM->XYZ, XYZ->CAM matrices **/
+int dt_colorspaces_conversion_matrices_xyz(const char *name, float in_XYZ_to_CAM[9], double XYZ_to_CAM[4][3], double CAM_to_XYZ[3][4]);
+
+/** Calculate CAM->RGB, RGB->CAM matrices and default WB multipliers */
+int dt_colorspaces_conversion_matrices_rgb(const char *name, double RGB_to_CAM[4][3], double CAM_to_RGB[3][4], double mul[4]);
 
 /** convert CYGM buffer to RGB */
-void dt_colorspaces_cygm_to_rgb(float *out, int num, const char *camera);
+void dt_colorspaces_cygm_to_rgb(float *out, int num, double CAM_to_RGB[3][4]);
 
 /** convert RGB buffer to CYGM */
-void dt_colorspaces_rgb_to_cygm(float *out, int num, const char *camera);
+void dt_colorspaces_rgb_to_cygm(float *out, int num, double RGB_to_CAM[4][3]);
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -202,6 +202,9 @@ dt_colorspaces_get_profile(dt_colorspaces_color_profile_type_t type, const char 
  * make sure that darktable.color_profiles->xprofile_lock is held when calling this! */
 void dt_colorspaces_update_display_transforms();
 
+/** pseudoinverse taken from dcraw that allows inverting 3x4 into 4x3 */
+void dt_colorspaces_pseudoinverse(double (*in)[3], double (*out)[3], int size);
+
 /** convert CYGM buffer to RGB */
 void dt_colorspaces_cygm_to_rgb(float *out, int num, const char *camera);
 

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -202,11 +202,11 @@ dt_colorspaces_get_profile(dt_colorspaces_color_profile_type_t type, const char 
  * make sure that darktable.color_profiles->xprofile_lock is held when calling this! */
 void dt_colorspaces_update_display_transforms();
 
-/** convert CMYG buffer to RGB */
-void cmyg_convert(float *out, int num, const char *camera);
+/** convert CYGM buffer to RGB */
+void dt_colorspaces_cygm_to_rgb(float *out, int num, const char *camera);
 
-/** convert RGB buffer to CMYG */
-void cmyg_backconvert(float *out, int num, const char *camera);
+/** convert RGB buffer to CYGM */
+void dt_colorspaces_rgb_to_cygm(float *out, int num, const char *camera);
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1010,6 +1010,7 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[0] = NAN;
   img->wb_coeffs[1] = NAN;
   img->wb_coeffs[2] = NAN;
+  img->wb_coeffs[3] = NAN;
   img->cache_entry = 0;
 }
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -179,7 +179,7 @@ typedef struct dt_image_t
   uint8_t xtrans[6][6];
 
   /* White balance coeffs from the raw */
-  float wb_coeffs[3];
+  float wb_coeffs[4];
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -65,7 +65,9 @@ typedef enum
   // image has an associated .txt file for overlay
   DT_IMAGE_HAS_TXT = 4096,
   // image has an associated wav file
-  DT_IMAGE_HAS_WAV = 8192
+  DT_IMAGE_HAS_WAV = 8192,
+  // image is a bayer pattern with 4 colors (e.g., CYGM or RGBE)
+  DT_IMAGE_4BAYER = 16384,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -245,6 +245,8 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     img->bpp = r->getBpp();
     img->filters = r->cfa.getDcrawFilter();
+    if (img->filters == 0xb4b4b4b4 || img->filters == 0x9c9c9c9c)
+      img->flags |= DT_IMAGE_4BAYER;
     if(img->filters)
     {
       img->flags &= ~DT_IMAGE_LDR;

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -234,7 +234,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     m.reset();
 
     // Grab the WB
-    for(int i = 0; i < 3; i++) img->wb_coeffs[i] = r->metadata.wbCoeffs[i];
+    for(int i = 0; i < 4; i++) img->wb_coeffs[i] = r->metadata.wbCoeffs[i];
 
     img->filters = 0u;
     if(!r->isCFA)

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1055,8 +1055,6 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
         {
           dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(out, (const uint16_t *)buf.buf, &roi_out,
                                                               &roi_in, roi_out.width, roi_in.width, image);
-          if (image->filters == 0xb4b4b4b4) // CYGM bayer patterns
-            dt_colorspaces_cygm_to_rgb(out, roi_out.width*roi_out.height, image->camera_makermodel);
         }
       }
     }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1055,6 +1055,8 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
         {
           dt_iop_clip_and_zoom_demosaic_half_size_crop_blacks(out, (const uint16_t *)buf.buf, &roi_out,
                                                               &roi_in, roi_out.width, roi_in.width, image);
+          if (image->filters == 0xb4b4b4b4) // CYGM bayer patterns
+            dt_colorspaces_cygm_to_rgb(out, roi_out.width*roi_out.height, image->camera_makermodel);
         }
       }
     }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2267,7 +2267,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const i
 
           if(!((pc >= 60000) ^ (MAX(MAX(p1, p2), MAX(p3, p4)) >= 60000)))
           {
-            if(filters == 0xb4b4b4b4) // CYGM so lets keep all four values
+            if(filters == 0xb4b4b4b4 || filters == 0x9c9c9c9c) // CYGM or RGBE so lets keep all four values
               sum = _mm_add_epi32(sum, _mm_set_epi32(p3, p4, p2, p1));
             else
               sum = _mm_add_epi32(sum, _mm_set_epi32(0, p4, p3 + p2, p1));
@@ -2275,7 +2275,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const i
           }
         }
 
-      if(filters == 0xb4b4b4b4)
+      if(filters == 0xb4b4b4b4 || filters == 0x9c9c9c9c)
         col = _mm_mul_ps(
             _mm_cvtepi32_ps(sum),
             _mm_div_ps(_mm_set_ps(1.0f / 65535.0f, 1.0f / 65535.0f, 1.0f / 65535.0f, 1.0f / 65535.0f),

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2267,14 +2267,24 @@ void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const i
 
           if(!((pc >= 60000) ^ (MAX(MAX(p1, p2), MAX(p3, p4)) >= 60000)))
           {
-            sum = _mm_add_epi32(sum, _mm_set_epi32(0, p4, p3 + p2, p1));
+            if(filters == 0xb4b4b4b4) // CYGM so lets keep all four values
+              sum = _mm_add_epi32(sum, _mm_set_epi32(p3, p4, p2, p1));
+            else
+              sum = _mm_add_epi32(sum, _mm_set_epi32(0, p4, p3 + p2, p1));
             num++;
           }
         }
 
-      col = _mm_mul_ps(
-          _mm_cvtepi32_ps(sum),
-          _mm_div_ps(_mm_set_ps(0.0f, 1.0f / 65535.0f, 0.5f / 65535.0f, 1.0f / 65535.0f), _mm_set1_ps(num)));
+      if(filters == 0xb4b4b4b4)
+        col = _mm_mul_ps(
+            _mm_cvtepi32_ps(sum),
+            _mm_div_ps(_mm_set_ps(1.0f / 65535.0f, 1.0f / 65535.0f, 1.0f / 65535.0f, 1.0f / 65535.0f),
+            _mm_set1_ps(num)));
+      else
+         col = _mm_mul_ps(
+            _mm_cvtepi32_ps(sum),
+            _mm_div_ps(_mm_set_ps(0.0f, 1.0f / 65535.0f, 0.5f / 65535.0f, 1.0f / 65535.0f),
+            _mm_set1_ps(num)));
       _mm_stream_ps(outc, col);
       outc += 4;
     }

--- a/src/external/rawspeed/RawSpeed/ArwDecoder.h
+++ b/src/external/rawspeed/RawSpeed/ArwDecoder.h
@@ -46,6 +46,7 @@ protected:
   void DecodeARW(ByteStream &input, uint32 w, uint32 h);
   void DecodeARW2(ByteStream &input, uint32 w, uint32 h, uint32 bpp);
   void DecodeUncompressed(TiffIFD* raw);
+  void SonyDecrypt(uint32 *buffer, uint32 len, uint32 key);
   void GetWB();
   TiffIFD *mRootIFD;
   ByteStream *in;

--- a/src/external/rawspeed/RawSpeed/CrwDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/CrwDecoder.cpp
@@ -134,21 +134,12 @@ void CrwDecoder::decodeMetaDataInternal(CameraMetaData *meta) {
   if(mRootIFD->hasEntryRecursive((CiffTag)0x102c)) {
     CiffEntry *entry = mRootIFD->getEntryRecursive((CiffTag)0x102c);
     if (entry->type == CIFF_SHORT && entry->getShort() > 512) {
-      /* G1 */
-
+      // G1/Pro90 CYGM pattern
       const ushort16 *data = entry->getShortArray();
-
-      // RGB? (second green level looks bogus)
-      float cam_mul[4];
-      for(int c = 0; c < 4; c++)
-      {
-        cam_mul[c ^ 2] = (float) data[60 + c];
-      }
-
-      const float green = cam_mul[1];
-      mRaw->metadata.wbCoeffs[0] = cam_mul[0] / green;
-      mRaw->metadata.wbCoeffs[1] = 1.0f;
-      mRaw->metadata.wbCoeffs[2] = cam_mul[2] / green;
+      mRaw->metadata.wbCoeffs[0] = (float) data[62];
+      mRaw->metadata.wbCoeffs[1] = (float) data[63];
+      mRaw->metadata.wbCoeffs[2] = (float) data[60];
+      mRaw->metadata.wbCoeffs[3] = (float) data[61];
     } else if (entry->type == CIFF_SHORT) {
       /* G2, S30, S40 */
 

--- a/src/external/rawspeed/RawSpeed/RawImage.cpp
+++ b/src/external/rawspeed/RawSpeed/RawImage.cpp
@@ -63,6 +63,7 @@ ImageMetaData::ImageMetaData(void) {
   wbCoeffs[0] = NAN;
   wbCoeffs[1] = NAN;
   wbCoeffs[2] = NAN;
+  wbCoeffs[3] = NAN;
 }
 
 RawImageData::~RawImageData(void) {

--- a/src/external/rawspeed/RawSpeed/RawImage.h
+++ b/src/external/rawspeed/RawSpeed/RawImage.h
@@ -73,7 +73,7 @@ public:
   double pixelAspectRatio;
 
   // White balance coefficients of the image
-  float wbCoeffs[3];
+  float wbCoeffs[4];
 
   // How many pixels far down the left edge and far up the right edge the image 
   // corners are when the image is rotated 45 degrees in Fuji rotated sensors.

--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -7229,6 +7229,20 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="3965"/>
 	</Camera>
+	<Camera make="SONY" model="DSC-F828">
+		<ID make="Sony" model="DSC-F828">Sony DSC-F828</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">YELLOW</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Crop x="0" y="0" width="0" height="0"/>
+		<Sensor black="495" white="16383"/>
+		<Hints>
+			<Hint name="srf_format" value=""/>
+		</Hints>
+	</Camera>
 	<Camera make="SONY" model="DSC-R1">
 		<ID make="Sony" model="DSC-R1">Sony DSC-R1</ID>
 		<CFA width="2" height="2">

--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -7232,12 +7232,12 @@
 	<Camera make="SONY" model="DSC-F828">
 		<ID make="Sony" model="DSC-F828">Sony DSC-F828</ID>
 		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">YELLOW</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
+			<Color x="0" y="0">YELLOW</Color>
+			<Color x="1" y="0">RED</Color>
+			<Color x="0" y="1">BLUE</Color>
+			<Color x="1" y="1">GREEN</Color>
 		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
+		<Crop x="5" y="0" width="-67" height="0"/>
 		<Sensor black="495" white="16383"/>
 		<Hints>
 			<Hint name="srf_format" value=""/>

--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -1039,10 +1039,10 @@
 	<Camera make="Canon" model="Canon PowerShot G1">
 		<ID make="Canon" model="PowerShot G1">Canon PowerShot G1</ID>
 		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
+			<Color x="0" y="0">FUJI_GREEN</Color>
+			<Color x="1" y="0">MAGENTA</Color>
+			<Color x="0" y="1">YELLOW</Color>
+			<Color x="1" y="1">CYAN</Color>
 		</CFA>
 		<Crop x="4" y="8" width="-52" height="-2"/>
 		<Sensor black="31" white="1023"/>
@@ -2419,10 +2419,10 @@
 	<Camera make="NIKON" model="E5700" decoder_version="4">
 		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
-			<Color x="0" y="0">BLUE</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">RED</Color>
+			<Color x="0" y="0">FUJI_GREEN</Color>
+			<Color x="1" y="0">MAGENTA</Color>
+			<Color x="0" y="1">YELLOW</Color>
+			<Color x="1" y="1">CYAN</Color>
 		</CFA>
 		<Crop x="0" y="0" width="2576" height="1924"/>
 		<Sensor black="0" white="4095"/>

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1042,7 +1042,9 @@ void reload_defaults(dt_iop_module_t *module)
     use_eprofile = TRUE; // the image has a profile assigned
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
-  if(use_eprofile)
+  if(img->filters == 0xb4b4b4b4)
+    tmp.type = DT_COLORSPACE_LIN_REC2020;
+  else if(use_eprofile)
     tmp.type = DT_COLORSPACE_EMBEDDED_ICC;
   else if(module->dev->image_storage.colorspace == DT_IMAGE_COLORSPACE_SRGB)
     tmp.type = DT_COLORSPACE_SRGB;

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1042,7 +1042,7 @@ void reload_defaults(dt_iop_module_t *module)
     use_eprofile = TRUE; // the image has a profile assigned
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
-  if(img->filters == 0xb4b4b4b4)
+  if(img->filters == 0xb4b4b4b4 || img->filters == 0x9c9c9c9c)
     tmp.type = DT_COLORSPACE_LIN_REC2020;
   else if(use_eprofile)
     tmp.type = DT_COLORSPACE_EMBEDDED_ICC;
@@ -1120,7 +1120,8 @@ static void update_profile_list(dt_iop_module_t *self)
   else
     dt_dcraw_adobe_coeff(self->dev->image_storage.camera_makermodel, (float(*)[12])cam_xyz);
 
-  if(!isnan(cam_xyz[0]) && self->dev->image_storage.filters != 0xb4b4b4b4)
+  if(!isnan(cam_xyz[0]) && self->dev->image_storage.filters != 0xb4b4b4b4
+                        && self->dev->image_storage.filters != 0x9c9c9c9c)
   {
     prof = (dt_colorspaces_color_profile_t *)calloc(1, sizeof(dt_colorspaces_color_profile_t));
     g_strlcpy(prof->name, dt_colorspaces_get_name(DT_COLORSPACE_STANDARD_MATRIX, ""), sizeof(prof->name));

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1043,7 +1043,7 @@ void reload_defaults(dt_iop_module_t *module)
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
   if(img->flags & DT_IMAGE_4BAYER) // 4Bayer images have been pre-converted to rec2020
-    tmp.type = DT_COLORSPACE_LIN_REC2020;
+    tmp.type = DT_COLORSPACE_LIN_REC709;
   else if(use_eprofile)
     tmp.type = DT_COLORSPACE_EMBEDDED_ICC;
   else if(module->dev->image_storage.colorspace == DT_IMAGE_COLORSPACE_SRGB)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1120,7 +1120,7 @@ static void update_profile_list(dt_iop_module_t *self)
   else
     dt_dcraw_adobe_coeff(self->dev->image_storage.camera_makermodel, (float(*)[12])cam_xyz);
 
-  if(!isnan(cam_xyz[0]))
+  if(!isnan(cam_xyz[0]) && self->dev->image_storage.filters != 0xb4b4b4b4)
   {
     prof = (dt_colorspaces_color_profile_t *)calloc(1, sizeof(dt_colorspaces_color_profile_t));
     g_strlcpy(prof->name, dt_colorspaces_get_name(DT_COLORSPACE_STANDARD_MATRIX, ""), sizeof(prof->name));

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1042,7 +1042,7 @@ void reload_defaults(dt_iop_module_t *module)
     use_eprofile = TRUE; // the image has a profile assigned
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
-  if(img->filters == 0xb4b4b4b4 || img->filters == 0x9c9c9c9c)
+  if(img->flags & DT_IMAGE_4BAYER) // 4Bayer images have been pre-converted to rec2020
     tmp.type = DT_COLORSPACE_LIN_REC2020;
   else if(use_eprofile)
     tmp.type = DT_COLORSPACE_EMBEDDED_ICC;
@@ -1120,8 +1120,7 @@ static void update_profile_list(dt_iop_module_t *self)
   else
     dt_dcraw_adobe_coeff(self->dev->image_storage.camera_makermodel, (float(*)[12])cam_xyz);
 
-  if(!isnan(cam_xyz[0]) && self->dev->image_storage.filters != 0xb4b4b4b4
-                        && self->dev->image_storage.filters != 0x9c9c9c9c)
+  if(!isnan(cam_xyz[0]) && !(self->dev->image_storage.flags & DT_IMAGE_4BAYER))
   {
     prof = (dt_colorspaces_color_profile_t *)calloc(1, sizeof(dt_colorspaces_color_profile_t));
     g_strlcpy(prof->name, dt_colorspaces_get_name(DT_COLORSPACE_STANDARD_MATRIX, ""), sizeof(prof->name));

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1635,7 +1635,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       {
         vng_interpolate(tmp, in, &roo, &roi, data->filters, img->xtrans, only_vng_linear);
         if (img->filters == 0xb4b4b4b4)
-          cmyg_convert(tmp, roo.width*roo.height, img->camera_makermodel);
+          dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, img->camera_makermodel);
       }
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
         demosaic_ppg(tmp, in, &roo, &roi, data->filters,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1243,10 +1243,8 @@ static void cmyg_convert(float *out, int height, int width, const char *camera)
     for(int c = 0; c < 3; c++)
       for(int k = 0; k < 4; k++)
         o[c] += rgb_cam[c][k] * in[k];
-    // FIXME: The WB application either needs to move to temperature.c or it needs to use the correct multipliers
-    in[0] = o[0] * 1.0f;
-    in[1] = o[1] * 1.0f;
-    in[2] = o[2] * 0.65f;
+    for(int c = 0; c < 3; c++)
+      in[c] = o[c];
   }
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1561,7 +1561,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT ||
       uhq_thumb ||
       roi_out->scale > (data->filters == 9u ? 0.333f : 0.5f) ||
-      img->filters == 0xb4b4b4b4 || img->filters == 0x9c9c9c9c;
+      (img->flags & DT_IMAGE_4BAYER); // half_size_f doesn't support 4bayer images
 
   // we check if we can stop at the linear interpolation step in VNG
   // instead of going the full way
@@ -1607,7 +1607,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     {
       float *in = (float *)pixels;
 
-      if(img->filters != 0xb4b4b4b4 && img->filters != 0x9c9c9c9c && data->green_eq != DT_IOP_GREEN_EQ_NO)
+      if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO)
       {
         in = (float *)dt_alloc_align(16, (size_t)roi_in->height * roi_in->width * sizeof(float));
         switch(data->green_eq)
@@ -1631,10 +1631,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
       if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
         passthrough_monochrome(tmp, in, &roo, &roi);
-      else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || img->filters == 0xb4b4b4b4 || img->filters == 0x9c9c9c9c)
+      else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || (img->flags & DT_IMAGE_4BAYER))
       {
         vng_interpolate(tmp, in, &roo, &roi, data->filters, img->xtrans, only_vng_linear);
-        if (img->filters == 0xb4b4b4b4 || img->filters == 0x9c9c9c9c)
+        if (img->flags & DT_IMAGE_4BAYER)
           dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, img->camera_makermodel);
       }
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1081,9 +1081,9 @@ static void vng_interpolate(float *out, const float *const in, const dt_iop_roi_
   const int pcol = (filters == 9) ? 6 : 2;
   const int colors = (filters == 9) ? 3 : 4;
 
-  // separate out G1 and G2 in Bayer patterns
-  unsigned int filters4;
-  if(filters == 9)
+  // separate out G1 and G2 in RGGB Bayer patterns
+  unsigned int filters4 = filters;
+  if(filters == 9 || filters == 0xb4b4b4b4) // x-trans or CYGM
     filters4 = filters;
   else if((filters & 3) == 1)
     filters4 = filters | 0x03030303u;
@@ -1210,7 +1210,7 @@ static void vng_interpolate(float *out, const float *const in, const dt_iop_roi_
   memcpy(out + (4 * ((height - 3) * width + 2)), brow[1] + 2, (size_t)(width - 4) * 4 * sizeof(*out));
   free(buffer);
 
-  if(filters4 != 9)
+  if(filters != 9 && filters != 0xb4b4b4b4) // x-trans or CYGM
 // for Bayer mix the two greens to make VNG4
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(out) schedule(static)
@@ -1560,7 +1560,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0) ||
       piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT ||
       uhq_thumb ||
-      roi_out->scale > (data->filters == 9u ? 0.333f : 0.5f);
+      roi_out->scale > (data->filters == 9u ? 0.333f : 0.5f) ||
+      img->filters == 0xb4b4b4b4;
 
   // we check if we can stop at the linear interpolation step in VNG
   // instead of going the full way
@@ -1606,7 +1607,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     {
       float *in = (float *)pixels;
 
-      if(data->green_eq != DT_IOP_GREEN_EQ_NO)
+      if(img->filters != 0xb4b4b4b4 && data->green_eq != DT_IOP_GREEN_EQ_NO)
       {
         in = (float *)dt_alloc_align(16, (size_t)roi_in->height * roi_in->width * sizeof(float));
         switch(data->green_eq)
@@ -1630,7 +1631,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
       if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
         passthrough_monochrome(tmp, in, &roo, &roi);
-      else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4)
+      else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || img->filters == 0xb4b4b4b4)
         vng_interpolate(tmp, in, &roo, &roi, data->filters, img->xtrans, only_vng_linear);
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
         demosaic_ppg(tmp, in, &roo, &roi, data->filters,

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -118,6 +118,8 @@ typedef struct dt_iop_demosaic_global_data_t
   int kernel_markesteijn_zero;
   int kernel_markesteijn_accu;
   int kernel_markesteijn_final;
+
+  double CAM_to_RGB[3][4];
 } dt_iop_demosaic_global_data_t;
 
 typedef struct dt_iop_demosaic_data_t
@@ -1532,6 +1534,8 @@ static int get_thumb_quality(int width, int height)
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
              const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
 {
+  dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->data;
+
   const dt_image_t *img = &self->dev->image_storage;
   const float threshold = 0.0001f * img->exif_iso;
 
@@ -1635,7 +1639,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       {
         vng_interpolate(tmp, in, &roo, &roi, data->filters, img->xtrans, only_vng_linear);
         if (img->flags & DT_IMAGE_4BAYER)
-          dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, img->camera_makermodel);
+          dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, gd->CAM_to_RGB);
       }
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
         demosaic_ppg(tmp, in, &roo, &roi, data->filters,
@@ -3618,6 +3622,18 @@ void reload_defaults(dt_iop_module_t *module)
     module->default_enabled = 0;
 
   if(module->dev->image_storage.filters == 9u) tmp.demosaicing_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
+
+  // Get and store the matrix to go from camera to RGB for 4Bayer images
+  dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)module->data;
+  if (module->dev->image_storage.flags & DT_IMAGE_4BAYER)
+  {
+    char *camera = module->dev->image_storage.camera_makermodel;
+    if (!dt_colorspaces_conversion_matrices_rgb(camera, NULL, gd->CAM_to_RGB, NULL))
+    {
+      fprintf(stderr, "[colorspaces] `%s' color matrix not found for 4bayer image!\n", camera);
+      dt_control_log(_("[colorspaces] `%s' color matrix not found for 4bayer image!\n"), camera);
+    }
+  }
 
 end:
   memcpy(module->params, &tmp, sizeof(dt_iop_demosaic_params_t));

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1644,7 +1644,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       else
         amaze_demosaic_RT(self, piece, in, tmp, &roi, &roo, data->filters);
 
-      if(data->green_eq != DT_IOP_GREEN_EQ_NO) dt_free_align(in);
+      if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO) dt_free_align(in);
     }
 
     if(scaled)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -479,7 +479,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     const int ch = piece->colors;
 
     float rgb_coeffs[4] = {d->coeffs[0], d->coeffs[1], d->coeffs[2], d->coeffs[3]};
-    if (!isnan(d->coeffs[3]))
+    if (isnormal(d->coeffs[3]))
     { // We're in a 4 coeff image and we need to convert these coeffs to RGB
       dt_colorspaces_cygm_to_rgb(rgb_coeffs, 1, piece->pipe->image.camera_makermodel);
     }
@@ -521,7 +521,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   cl_int err = -999;
   int kernel = -1;
 
-  if (!isnan(d->coeffs[3]))
+  if (isnormal(d->coeffs[3]))
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_temperature] temperature for CYGM not yet supported by opencl code\n");
     return FALSE;
@@ -1082,7 +1082,7 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   for(int k = 0; k < 3; k++) p->coeffs[k] = fmaxf(0.0f, fminf(8.0f, p->coeffs[k]));
 
   // If we're in a CMYG image we need to create CMYG coeffs from the RGB ones
-  if (!isnan(p->coeffs[3])) dt_colorspaces_rgb_to_cygm(p->coeffs, 1, self->dev->image_storage.camera_makermodel);
+  if (isnormal(p->coeffs[3])) dt_colorspaces_rgb_to_cygm(p->coeffs, 1, self->dev->image_storage.camera_makermodel);
 
   gui_update_from_coeffs(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -891,8 +891,7 @@ void reload_defaults(dt_iop_module_t *module)
     // Only check the first three values, the fourth is usually NAN for RGB
     for(int k = 0; k < 3; k++)
     {
-      if(isnan(module->dev->image_storage.wb_coeffs[k]) ||
-         (k < 3 && module->dev->image_storage.wb_coeffs[k] == 0.0f))
+      if(isnan(module->dev->image_storage.wb_coeffs[k]) || module->dev->image_storage.wb_coeffs[k] == 0.0f)
       {
         found = 0;
         break;
@@ -1164,13 +1163,13 @@ static void apply_preset(dt_iop_module_t *self)
     case -1: // just un-setting.
       return;
     case 0: // camera wb
-      for(int k = 0; k < 3; k++) p->coeffs[k] = fp->coeffs[k];
+      for(int k = 0; k < 4; k++) p->coeffs[k] = fp->coeffs[k];
       break;
     case 1: // camera neutral wb
-      for(int k = 0; k < 3; k++) p->coeffs[k] = g->daylight_wb[k];
+      for(int k = 0; k < 4; k++) p->coeffs[k] = g->daylight_wb[k];
       break;
     case 2: // spot wb, expose callback will set p->coeffs.
-      for(int k = 0; k < 3; k++) p->coeffs[k] = fp->coeffs[k];
+      for(int k = 0; k < 4; k++) p->coeffs[k] = fp->coeffs[k];
       dt_iop_request_focus(self);
       self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
@@ -1261,7 +1260,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
 
-  for(int k = 0; k < 3; k++) g->daylight_wb[k] = 1.0;
+  for(int k = 0; k < 4; k++) g->daylight_wb[k] = 1.0;
   g->scale_tint
       = dt_bauhaus_slider_new_with_range(self, DT_IOP_LOWEST_TINT, DT_IOP_HIGHEST_TINT, .01, 1.0, 3);
   g->scale_k = dt_bauhaus_slider_new_with_range(self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -128,6 +128,7 @@ static int ignore_missing_wb(dt_image_t *img)
     "Kodak DCS560C",
     "Kodak DCS460D",
     "Nikon E5700",
+    "Sony DSC-F828",
   };
 
   for(int i=0; i < sizeof(ignored_cameras)/sizeof(ignored_cameras[1]); i++)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -612,12 +612,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       fprintf(stderr, "[temperature] `%s' color matrix not found for 4bayer image!\n", camera);
       dt_control_log(_("[temperature] `%s' color matrix not found for 4bayer image!\n"), camera);
     }
-    else if (self->gui_data)
-    {
-      // Copy RGB_to_CAM matrix to gui_data as well so be able to use it for spot WB
-      dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-      memcpy(g->RGB_to_CAM, d->RGB_to_CAM, sizeof(double)*12);
-    }
   }
 }
 
@@ -835,6 +829,16 @@ static void prepare_matrices(dt_iop_module_t *module)
   {
     fprintf(stderr, "[temperature] `%s' color matrix not found for image!\n", camera);
     dt_control_log(_("[temperature] `%s' color matrix not found for image!\n"), camera);
+  }
+
+  if (module->dev->image_storage.flags & DT_IMAGE_4BAYER)
+  {
+    // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
+    if (!dt_colorspaces_conversion_matrices_rgb(camera, g->RGB_to_CAM, NULL, NULL))
+    {
+      fprintf(stderr, "[temperature] `%s' color matrix not found for 4bayer image!\n", camera);
+      dt_control_log(_("[temperature] `%s' color matrix not found for 4bayer image!\n"), camera);
+    }
   }
 }
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -384,6 +384,20 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
         *out = *in * d->coeffs[FCxtrans(j, i, roi_out, xtrans)];
     }
   }
+  else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters == 0xb4b4b4b4)
+  { // CYGM float mosaiced
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, d) schedule(static)
+#endif
+    for(int j = 0; j < roi_out->height; j++)
+    {
+      const float *in = ((float *)ivoid) + (size_t)j * roi_out->width;
+      float *out = ((float *)ovoid) + (size_t)j * roi_out->width;
+      for(int i = 0; i < roi_out->width; i++, out++, in++)
+        // FIXME: Either just use memcpy or do the actual WB application starting from an inverted matrix
+        *out = *in;
+    }
+  }
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
   { // bayer float mosaiced
 #ifdef _OPENMP

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -387,28 +387,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   }
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters == 0xb4b4b4b4)
   { // CYGM float mosaiced
-    // Start with a fallback matrix in place
-    double cam_rgb[4][3] = {
-      {1,0,0},
-      {0,1,0},
-      {0,0,1},
-      {0,0,0},
-    };
-    cam_rgb[0][0] = NAN;
-    const char *camera = piece->pipe->image.camera_makermodel;
-    dt_colorspaces_4bayermatrix(camera,cam_rgb);
-    if(isnan(cam_rgb[0][0]))
-    {
-      fprintf(stderr, "[temperature] `%s' color matrix not found for 4bayer image!\n", camera);
-      dt_control_log(_("[temperature] `%s' color matrix not found for 4bayer image!\n"), camera);
-      cam_rgb[0][0] = 1.0f;
-    }
-
     float cmyg_coeffs[4] = {0.0f};
-    for(int c = 0; c < 4; c++)
-      for(int k = 0; k < 3; k++)
-        cmyg_coeffs[c] += cam_rgb[c][k] * d->coeffs[k];
-
+    for(int i = 0; i < 3; i++)
+      cmyg_coeffs[i] = d->coeffs[i];
+    cmyg_backconvert(cmyg_coeffs, 1, piece->pipe->image.camera_makermodel);
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, cmyg_coeffs) schedule(static)
 #endif

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2,6 +2,7 @@
     This file is part of darktable,
     copyright (c) 2009--2013 johannes hanika.
     copyright (c) 2015 LebedevRI.
+    copyright (c) 2016 Pedro Côrte-Real
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -523,6 +524,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 {
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
   dt_iop_temperature_global_data_t *gd = (dt_iop_temperature_global_data_t *)self->data;
+  const dt_image_t *img = &self->dev->image_storage;
 
   const int devid = piece->pipe->devid;
   const int filters = dt_image_filter(&piece->pipe->image);
@@ -530,7 +532,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   cl_int err = -999;
   int kernel = -1;
 
-  if (isnormal(d->coeffs[3]))
+  if(img->flags & DT_IMAGE_4BAYER)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_temperature] temperature for CYGM not yet supported by opencl code\n");
     return FALSE;
@@ -960,7 +962,7 @@ gui:
            && !strcmp(wb_preset[i].model, module->dev->image_storage.camera_model)
            && !strcmp(wb_preset[i].name, Daylight) && wb_preset[i].tuning == 0)
         {
-          for(int k = 0; k < 3; k++) g->daylight_wb[k] = wb_preset[i].channel[k];
+          for(int k = 0; k < 4; k++) g->daylight_wb[k] = wb_preset[i].channel[k];
           break;
         }
       }
@@ -1168,7 +1170,7 @@ static void apply_preset(dt_iop_module_t *self)
         if(wb_preset[i].tuning == tune)
         {
           // got exact match!
-          for(int k = 0; k < 3; k++) p->coeffs[k] = wb_preset[i].channel[k];
+          for(int k = 0; k < 4; k++) p->coeffs[k] = wb_preset[i].channel[k];
           found = TRUE;
           break;
         }
@@ -1203,7 +1205,7 @@ static void apply_preset(dt_iop_module_t *self)
 
         wb_data interpolated = {.tuning = tune };
         dt_wb_preset_interpolate(&wb_preset[min_id], &wb_preset[max_id], &interpolated);
-        for(int k = 0; k < 3; k++) p->coeffs[k] = interpolated.channel[k];
+        for(int k = 0; k < 4; k++) p->coeffs[k] = interpolated.channel[k];
       }
     }
     break;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -104,6 +104,7 @@ static int ignore_missing_wb(dt_image_t *img)
     "Kodak EOS DCS 1",
     "Kodak DCS560C",
     "Kodak DCS460D",
+    "Nikon E5700",
   };
 
   for(int i=0; i < sizeof(ignored_cameras)/sizeof(ignored_cameras[1]); i++)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1290,7 +1290,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->scale_tint, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->scale_k, TRUE, TRUE, 0);
-  if (isnormal(p->coeffs[3]))
+  if (isnormal(p->coeffs[3]) && self->dev->image_storage.filters == 0xb4b4b4b4)
   {
     dt_bauhaus_widget_set_label(g->scale_r, NULL, _("green"));
     dt_bauhaus_widget_set_label(g->scale_g, NULL, _("magenta"));
@@ -1306,10 +1306,12 @@ void gui_init(struct dt_iop_module_t *self)
     dt_bauhaus_widget_set_label(g->scale_r, NULL, _("red"));
     dt_bauhaus_widget_set_label(g->scale_g, NULL, _("green"));
     dt_bauhaus_widget_set_label(g->scale_b, NULL, _("blue"));
-    dt_bauhaus_widget_set_label(g->scale_g2, NULL, _("green2"));
+    dt_bauhaus_widget_set_label(g->scale_g2, NULL, _("emerald"));
     gtk_box_pack_start(GTK_BOX(self->widget), g->scale_r, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(self->widget), g->scale_g, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(self->widget), g->scale_b, TRUE, TRUE, 0);
+    if(self->dev->image_storage.filters == 0x9c9c9c9c)
+      gtk_box_pack_start(GTK_BOX(self->widget), g->scale_g2, TRUE, TRUE, 0);
   }
 
   g->presets = dt_bauhaus_combobox_new(self);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -387,19 +387,19 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   }
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters == 0xb4b4b4b4)
   { // CYGM float mosaiced
-    float cmyg_coeffs[4] = {0.0f};
+    float cygm_coeffs[4] = {0.0f};
     for(int i = 0; i < 3; i++)
-      cmyg_coeffs[i] = d->coeffs[i];
-    cmyg_backconvert(cmyg_coeffs, 1, piece->pipe->image.camera_makermodel);
+      cygm_coeffs[i] = d->coeffs[i];
+    dt_colorspaces_rgb_to_cygm(cygm_coeffs, 1, piece->pipe->image.camera_makermodel);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, cmyg_coeffs) schedule(static)
+#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, cygm_coeffs) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
       const float *in = ((float *)ivoid) + (size_t)j * roi_out->width;
       float *out = ((float *)ovoid) + (size_t)j * roi_out->width;
       for(int i = 0; i < roi_out->width; i++, out++, in++)
-        *out = *in * cmyg_coeffs[FC(j, i, filters)];
+        *out = *in * cygm_coeffs[FC(j, i, filters)];
     }
   }
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1080,6 +1080,10 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   p->coeffs[2] /= p->coeffs[1];
   p->coeffs[1] = 1.0;
   for(int k = 0; k < 3; k++) p->coeffs[k] = fmaxf(0.0f, fminf(8.0f, p->coeffs[k]));
+
+  // If we're in a CMYG image we need to create CMYG coeffs from the RGB ones
+  if (!isnan(p->coeffs[3])) dt_colorspaces_rgb_to_cygm(p->coeffs, 1, self->dev->image_storage.camera_makermodel);
+
   gui_update_from_coeffs(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   return FALSE;


### PR DESCRIPTION
Some old cameras like the Canon G1 or the Nikon E5700 use a CYGM bayer pattern. This was broken in demosaic.c as we assumed the pattern always included two greens. As it turns out the VNG4 method works just fine with these images if we just let it. The output still seems quite a bit noisier than the dcraw output but maybe dcraw is doing some additional post-processing by default.