### PR TITLE
Cross-compile for windows without errors and opencl support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ endif()
 if(WIN32)
   message("-- Win32 build detected, setting default features")
   set(USE_CAMERA_SUPPORT OFF)
+  set(USE_COLORD OFF)
 endif(WIN32)
 
 # Check if this is source package build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -380,12 +380,15 @@ if(WIN32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mms-bitfields")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mms-bitfields")
 
-  SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "-Wl,--no-undefined -static-libgcc -Wl,-O1 -Wl,--as-needed -Wl,--sort-common -s")
-  SET(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "-Wl,--no-undefined -static-libgcc -Wl,-O1 -Wl,--as-needed -Wl,--sort-common -s")
+  SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "-Wl,--no-undefined -static-libgcc -Wl,-O1 -Wl,--as-needed -Wl,--sort-common")
+  SET(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "-Wl,--no-undefined -static-libgcc -Wl,-O1 -Wl,--as-needed -Wl,--sort-common")
 
   list(APPEND LIBS ws2_32)
   list(APPEND LIBS msvcrt) # Needed for _aligned_alloc()
   list(APPEND SOURCES "win/getrusage.c")
+  list(APPEND SOURCES "win/wintime.c")
+
+  #add_definitions("-D__STDC_FORMAT_MACROS")
 endif(WIN32)
 
 if(NOT CUSTOM_CFLAGS)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -238,13 +238,13 @@ gboolean dt_supported_image(const gchar *filename)
 static void strip_semicolons_from_keymap(const char *path)
 {
   char pathtmp[PATH_MAX] = { 0 };
-  FILE *fin = fopen(path, "r");
+  FILE *fin = fopen(path, "rb");
   FILE *fout;
   int i;
   int c = '\0';
 
   snprintf(pathtmp, sizeof(pathtmp), "%s_tmp", path);
-  fout = fopen(pathtmp, "w");
+  fout = fopen(pathtmp, "wb");
 
   // First ignoring the first three lines
   for(i = 0; i < 3; i++)
@@ -768,10 +768,10 @@ int dt_init(int argc, char *argv[], const int init_gui, lua_State *L)
   const gchar *lang = dt_conf_get_string("ui_last/gui_language");
   if(lang != NULL && lang[0] != '\0')
   {
-    setenv("LANGUAGE", lang, 1);
+    g_setenv("LANGUAGE", lang, 1);
     if(setlocale(LC_ALL, lang) != NULL) gtk_disable_setlocale();
     setlocale(LC_MESSAGES, lang);
-    setenv("LANG", lang, 1);
+    g_setenv("LANG", lang, 1);
   }
   g_free((gchar *)lang);
 
@@ -1157,7 +1157,7 @@ void dt_configure_defaults()
   const int threads = dt_get_num_threads();
   const size_t mem = dt_get_total_memory();
   const int bits = (sizeof(void *) == 4) ? 32 : 64;
-  fprintf(stderr, "[defaults] found a %d-bit system with %zu kb ram and %d cores (%d atom based)\n", bits,
+  fprintf(stderr, "[defaults] found a %d-bit system with %" PRIu64 " kb ram and %d cores (%d atom based)\n", bits,
           mem, threads, atom_cores);
   if(mem > (2u << 20) && threads > 4)
   {

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -468,6 +468,11 @@ static inline size_t dt_get_total_memory()
   size_t length = sizeof(uint64_t);
   sysctl(mib, 2, (void *)&physical_memory, &length, (void *)NULL, 0);
   return physical_memory / 1024;
+#elif defined(_WIN32)
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx( &status );
+  return (size_t)status.ullTotalPhys / 1024;
 #else
   // assume 2GB until we have a better solution.
   fprintf(stderr, "Unknown memory size. Assuming 2GB\n");

--- a/src/common/dlopencl.c
+++ b/src/common/dlopencl.c
@@ -29,7 +29,7 @@
 #include <signal.h>
 
 #if defined(WIN32)
-static const char *ocllib[] = { "OpenCL", NULL };
+static const char *ocllib[] = { "/windows/system32/OpenCL", NULL };
 #elif defined(__APPLE__)
 static const char *ocllib[] = { "/System/Library/Frameworks/OpenCL.framework/Versions/Current/OpenCL", NULL };
 #else

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -64,6 +64,9 @@ extern "C" {
 #include "common/debug.h"
 #include "control/conf.h"
 #include "develop/imageop.h"
+#ifdef _WIN32
+#include "win/wintime.h"
+#endif
 }
 
 static void _exif_import_tags(dt_image_t *img, Exiv2::XmpData::iterator &pos);

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -36,6 +36,9 @@
 #include <time.h>
 #include <errno.h>
 #include <math.h>
+#ifdef _WIN32
+#include "win/wintime.h"
+#endif
 
 #ifdef STANDALONE
 #define PACKAGE_STRING "darktable pdf library"

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -23,8 +23,8 @@
 #include <pwd.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "darktable.h"
 #endif
+#include "darktable.h"
 
 #include <sys/stat.h>
 

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -229,7 +229,7 @@ static inline void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *ove
     if(!f) return;
     while(!feof(f))
     {
-      gchar *line_pattern = g_strdup_printf("%%%zu[^\n]\n", sizeof(line) - 1);
+      gchar *line_pattern = g_strdup_printf("%%%" PRIu64 "[^\r\n]\n", sizeof(line) - 1);
       read = fscanf(f, line_pattern, line);
       g_free(line_pattern);
       if(read > 0)

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -367,7 +367,7 @@ int dt_control_add_job(dt_control_t *control, dt_job_queue_t queue_id, _dt_job_t
   GList **queue = &control->queues[queue_id];
   size_t length = control->queue_length[queue_id];
 
-  dt_print(DT_DEBUG_CONTROL, "[add_job] %zu | ", length);
+  dt_print(DT_DEBUG_CONTROL, "[add_job] %" PRIu64 " | ", length);
   dt_control_job_print(job);
   dt_print(DT_DEBUG_CONTROL, "\n");
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -16,6 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <glib.h>
 #include <glib/gprintf.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -919,7 +920,7 @@ static void auto_apply_presets(dt_develop_t *dev)
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                     "SELECT rowid FROM memory.history ORDER BY rowid ASC", -1, &stmt, NULL);
         while(sqlite3_step(stmt) == SQLITE_ROW)
-          rowids = g_list_append(rowids, (void *)(long)sqlite3_column_int(stmt, 0));
+          rowids = g_list_append(rowids, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
         sqlite3_finalize(stmt);
 
         // update num accordingly
@@ -929,7 +930,7 @@ static void auto_apply_presets(dt_develop_t *dev)
 
         while(r)
         {
-          snprintf(query, sizeof(query), "UPDATE memory.history SET num=%d WHERE rowid=%ld", v, (long)(r->data));
+          snprintf(query, sizeof(query), "UPDATE memory.history SET num=%d WHERE rowid=%d", v, GPOINTER_TO_INT(r->data));
           DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);
           v++;
           r = g_list_next(r);

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -744,7 +744,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
       size_t ooffs = (ty * tile_ht) * opitch + (tx * tile_wd) * out_bpp;
 
 
-      dt_print(DT_DEBUG_DEV, "[default_process_tiling_ptp] tile (%zu, %zu) with %zu x %zu at origin [%zu, %zu]\n",
+      dt_print(DT_DEBUG_DEV, "[default_process_tiling_ptp] tile (%" PRIu64 ", %" PRIu64 ") with %" PRIu64 " x %" PRIu64 " at origin [%"PRIu64 ", %" PRIu64 "]\n",
                tx, ty, wd, ht, tx * tile_wd, ty * tile_ht);
 
 /* prepare input tile buffer */
@@ -1067,7 +1067,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
       size_t ooffs = ((size_t)oroi_good.y - roi_out->y) * opitch
                      + ((size_t)oroi_good.x - roi_out->x) * out_bpp;
 
-      dt_print(DT_DEBUG_DEV, "[default_process_tiling_roi] tile (%zu, %zu) with %d x %d at origin [%d, %d]\n",
+      dt_print(DT_DEBUG_DEV, "[default_process_tiling_roi] tile (%" PRIu64 ", %" PRIu64 ") with %d x %d at origin [%d, %d]\n",
                tx, ty, iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
 
 
@@ -1383,7 +1383,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
 
 
       dt_print(DT_DEBUG_OPENCL,
-               "[default_process_tiling_cl_ptp] tile (%zu, %zu) with %zu x %zu at origin [%zu, %zu]\n", tx, ty, wd,
+               "[default_process_tiling_cl_ptp] tile (%" PRIu64 ", %" PRIu64 ") with %" PRIu64 " x %" PRIu64 " at origin [%" PRIu64 ", %" PRIu64 "]\n", tx, ty, wd,
                ht, tx * tile_wd, ty * tile_ht);
 
       /* get input and output buffers */
@@ -1821,7 +1821,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
                      + ((size_t)oroi_good.x - roi_out->x) * out_bpp;
 
       dt_print(DT_DEBUG_OPENCL,
-               "[default_process_tiling_cl_roi] tile (%zu, %zu) with %d x %d at origin [%d, %d]\n", tx, ty,
+               "[default_process_tiling_cl_roi] tile (%" PRIu64 ", %" PRIu64 ") with %d x %d at origin [%d, %d]\n", tx, ty,
                iroi_full.width, iroi_full.height, iroi_full.x, iroi_full.y);
 
       /* origin and region of full input tile */

--- a/src/dtview/main.c
+++ b/src/dtview/main.c
@@ -327,9 +327,13 @@ int main(int argc, char *arg[])
   // init dt without gui:
   if(dt_init(m_argc, m_arg, 0, NULL)) exit(1);
   running = init(m_argc, m_arg);
-
+#ifndef _WIN32
   srand48(SDL_GetTicks());
   if(use_random) random_state = drand48() * INT_MAX;
+#else
+  srand(SDL_GetTicks());
+  if(use_random) random_state = rand();
+#endif
   if(repeat < 0) repeat = random_state;
   while(running)
   {
@@ -363,6 +367,8 @@ int main(int argc, char *arg[])
   }
 
   dtv_shutdown();
+
+  exit(0);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/external/rawspeed/RawSpeed/Camera.cpp
+++ b/src/external/rawspeed/RawSpeed/Camera.cpp
@@ -1,6 +1,9 @@
+#define __STDC_FORMAT_MACROS
+
 #include "StdAfx.h"
 #include "Camera.h"
 #include <iostream>
+#include <inttypes.h>
 /*
     RawSpeed - RAW file decoder.
 
@@ -195,7 +198,7 @@ void Camera::parseCFA(xml_node &cur) {
     }
     const char* key = cur.first_child().value();
     if ((int)strlen(key) != cfa.size.x) {
-      ThrowCME("Invalid number of colors in definition for row %d in camera %s %s. Expected %d, found %zu.", y, make.c_str(), model.c_str(),  cfa.size.x, strlen(key));
+      ThrowCME("Invalid number of colors in definition for row %d in camera %s %s. Expected %d, found %" PRIu64 ".", y, make.c_str(), model.c_str(),  cfa.size.x, strlen(key));
     }
     for (int x = 0; x < cfa.size.x; x++) {
     	char v = (char)tolower((int)key[x]);

--- a/src/external/rawspeed/RawSpeed/LJpegDecompressor.cpp
+++ b/src/external/rawspeed/RawSpeed/LJpegDecompressor.cpp
@@ -1,6 +1,9 @@
+#define __STDC_FORMAT_MACROS
+
 #include "StdAfx.h"
 #include "LJpegDecompressor.h"
 #include "ByteStreamSwap.h"
+#include "inttypes.h"
 
 /*
     RawSpeed - RAW file decoder.
@@ -472,7 +475,7 @@ void LJpegDecompressor::createBigTable(HuffmanTable *htbl) {
   if (!htbl->bigTable)
     htbl->bigTable = (int*)_aligned_malloc(size * sizeof(int), 16);
   if (!htbl->bigTable)
-	ThrowRDE("Out of memory, failed to allocate %lu bytes", size*sizeof(int));
+	ThrowRDE("Out of memory, failed to allocate %" PRIu64 " bytes", size*sizeof(int));
   for (uint32 i = 0; i < size; i++) {
     ushort16 input = i << 2; // Calculate input value
     int code = input >> 8;   // Get 8 bits

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -422,9 +422,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
         }
 
         // convert from world space:
-        float rad10[2] = { circle->radius, circle->radius };
+        float radten[2] = { circle->radius, circle->radius };
         float radf[2];
-        masks_point_denormalize(piece, roi_in, rad10, 1, radf);
+        masks_point_denormalize(piece, roi_in, radten, 1, radf);
 
         const int rad = MIN(radf[0], radf[1]);
         const int posx = points[0] - rad;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -41,6 +41,9 @@
 #include "common/metadata.h"
 #include "common/utility.h"
 #include "common/file_location.h"
+#ifdef _WIN32
+#include "win/wintime.h"
+#endif
 
 #define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 DT_MODULE_INTROSPECTION(4, dt_iop_watermark_params_t)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1331,7 +1331,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
         int k = 0;
         while(!feof(f))
         {
-          gchar *line_pattern = g_strdup_printf("%%%zu[^\n]", sizeof(line) - 1);
+          gchar *line_pattern = g_strdup_printf("%%%" PRIu64 "[^\n]", sizeof(line) - 1);
           const int read = fscanf(f, line_pattern, line);
           g_free(line_pattern);
           if(read != 1) break;

--- a/src/win/win.h
+++ b/src/win/win.h
@@ -8,6 +8,7 @@
 
 #undef __STRICT_ANSI__
 #define XMD_H
+#include <winsock2.h>
 #include <windows.h>
 
 // ugly hack to make our code work. windows.h has some terrible includes which define these things
@@ -18,7 +19,10 @@
 #undef grp2
 
 #define sleep(n) Sleep(1000 * n)
+
+#ifndef HAVE_BOOLEAN
 #define HAVE_BOOLEAN
+#endif
 
 #endif
 

--- a/src/win/wintime.c
+++ b/src/win/wintime.c
@@ -1,0 +1,25 @@
+#include "wintime.h"
+#include <string.h>
+
+struct tm *localtime_r(const time_t *timep, struct tm *result)
+{
+  struct tm *ret = localtime(timep);
+
+  if (ret)
+  {
+    memcpy(result, ret, sizeof(struct tm));
+  }
+  return result;
+}
+
+struct tm *gmtime_r(const time_t *timep, struct tm *result)
+{
+  struct tm *ret = gmtime(timep);
+
+  if (ret)
+  {
+    memcpy(result, ret, sizeof(struct tm));
+  }
+
+  return result;
+}

--- a/src/win/wintime.h
+++ b/src/win/wintime.h
@@ -1,0 +1,9 @@
+#ifndef __WINTIME_H__
+#define __WINTIME_H__
+
+#include <time.h>
+
+extern struct tm *localtime_r(const time_t *timep, struct tm *result);
+extern struct tm *gmtime_r(const time_t *timep, struct tm *result);
+
+#endif


### PR DESCRIPTION
Fixed compiler warnings end errors while cross-compiling with mingw64
Added support for opencl on windows. Compiled kernels are stored as <name>.bin and md5 sum is stored as <name>.md5