### PR TITLE
Import directory fix

### DIFF
--- a/src/common/film.c
+++ b/src/common/film.c
@@ -306,7 +306,7 @@ static GList *_film_recursive_get_files(const gchar *path, gboolean recursive, G
     if(filename[0] == '.') continue;
 
     /* build full path for filename */
-    fullname = g_build_filename(G_DIR_SEPARATOR_S, path, filename, NULL);
+    fullname = g_build_path(G_DIR_SEPARATOR_S, path, filename, NULL);
 
     /* recurse into directory if we hit one and we doing a recursive import */
     if(recursive && g_file_test(fullname, G_FILE_TEST_IS_DIR))

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -665,7 +665,7 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
     if(handle != INVALID_HANDLE_VALUE)
     {
       do
-        files = g_list_append(files, g_strdup(data.cFileName));
+        files = g_list_append(files, g_build_path(G_DIR_SEPARATOR_S, imgpath, data.cFileName, NULL));
       while(FindNextFile(handle, &data));
     }
 #else


### PR DESCRIPTION
Made importing a directory work: g_build_filename erroneously prepends \\ to path, g_build_path does not.