### PR TITLE
rawspeed: implement a safer way to bounds check

### DIFF
--- a/src/external/rawspeed/RawSpeed/AriDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/AriDecoder.cpp
@@ -32,9 +32,9 @@ AriDecoder::AriDecoder(FileMap* file) : RawDecoder(file) {
   try {
     ByteStream *s;
     if (getHostEndianness() == little) {
-      s = new ByteStream(mFile->getData(8), mFile->getSize()- 8);
+      s = new ByteStream(mFile, 8);
     } else {
-      s = new ByteStreamSwap(mFile->getData(8), mFile->getSize()- 8);
+      s = new ByteStreamSwap(mFile, 8);
     }
     mDataOffset = s->getInt();
     uint32 someNumber = s->getInt(); // Value: 3?
@@ -81,7 +81,7 @@ RawImage AriDecoder::decodeRawInternal() {
 
 void AriDecoder::decodeThreaded(RawDecoderThread * t) {
   uint32 startOff = mDataOffset + t->start_y * ((mWidth * 12) / 8);
-  BitPumpMSB32 bits(mFile->getData(startOff), mFile->getSize()-startOff);
+  BitPumpMSB32 bits(mFile, startOff);
   
   uint32 hw = mWidth >> 1;
   for (uint32 y = t->start_y; y < t->end_y; y++) {

--- a/src/external/rawspeed/RawSpeed/BitPumpJPEG.cpp
+++ b/src/external/rawspeed/RawSpeed/BitPumpJPEG.cpp
@@ -38,6 +38,19 @@ BitPumpJPEG::BitPumpJPEG(const uchar8* _buffer, uint32 _size) :
   init();
 }
 
+BitPumpJPEG::BitPumpJPEG(FileMap *f, uint32 offset, uint32 _size) :
+    size(_size + sizeof(uint32)), mLeft(0), off(0), stuffed(0) {
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
+BitPumpJPEG::BitPumpJPEG(FileMap *f, uint32 offset) :
+    mLeft(0), off(0), stuffed(0) {
+  size = f->getSize() + sizeof(uint32); 
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
 __inline void BitPumpJPEG::init() {
   memset(current_buffer,0,16);
   fill();

--- a/src/external/rawspeed/RawSpeed/BitPumpJPEG.h
+++ b/src/external/rawspeed/RawSpeed/BitPumpJPEG.h
@@ -36,6 +36,8 @@ class BitPumpJPEG
 public:
   BitPumpJPEG(ByteStream *s);
   BitPumpJPEG(const uchar8* _buffer, uint32 _size );
+  BitPumpJPEG(FileMap *f, uint32 offset, uint32 _size );
+  BitPumpJPEG(FileMap *f, uint32 offset );
 	uint32 getBitsSafe(uint32 nbits);
 	uint32 getBitSafe();
 	uchar8 getByteSafe();
@@ -132,7 +134,7 @@ protected:
   void _fill();
   const uchar8* buffer;
   uchar8 current_buffer[16];
-  const uint32 size;            // This if the end of buffer.
+  uint32 size;            // This if the end of buffer.
   int mLeft;
   uint32 off;                  // Offset in bytes
   int stuffed;              // How many bytes has been stuffed?

--- a/src/external/rawspeed/RawSpeed/BitPumpMSB.cpp
+++ b/src/external/rawspeed/RawSpeed/BitPumpMSB.cpp
@@ -38,6 +38,19 @@ BitPumpMSB::BitPumpMSB(const uchar8* _buffer, uint32 _size) :
   init();
 }
 
+BitPumpMSB::BitPumpMSB(FileMap *f, uint32 offset, uint32 _size) :
+    size(_size + sizeof(uint32)), mLeft(0), off(0) {
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
+BitPumpMSB::BitPumpMSB(FileMap *f, uint32 offset) :
+    mLeft(0), off(0) {
+  size = f->getSize() + sizeof(uint32); 
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
 __inline void BitPumpMSB::init() {
   mStuffed = 0;
   memset(current_buffer,0,16);

--- a/src/external/rawspeed/RawSpeed/BitPumpMSB.h
+++ b/src/external/rawspeed/RawSpeed/BitPumpMSB.h
@@ -36,6 +36,8 @@ class BitPumpMSB
 public:
   BitPumpMSB(ByteStream *s);
   BitPumpMSB(const uchar8* _buffer, uint32 _size );
+  BitPumpMSB(FileMap *f, uint32 offset, uint32 _size );
+  BitPumpMSB(FileMap *f, uint32 offset );
 	uint32 getBitsSafe(uint32 nbits);
 	uint32 getBitSafe();
 	uchar8 getByteSafe();
@@ -131,7 +133,7 @@ protected:
   void __inline init();
   uchar8 current_buffer[16];
   const uchar8* buffer;
-  const uint32 size;            // This if the end of buffer.
+  uint32 size;            // This if the end of buffer.
   char mLeft;
   uint32 off;                  // Offset in bytes
   int mStuffed;

--- a/src/external/rawspeed/RawSpeed/BitPumpMSB16.cpp
+++ b/src/external/rawspeed/RawSpeed/BitPumpMSB16.cpp
@@ -37,6 +37,19 @@ BitPumpMSB16::BitPumpMSB16(const uchar8* _buffer, uint32 _size) :
   init();
 }
 
+BitPumpMSB16::BitPumpMSB16(FileMap *f, uint32 offset, uint32 _size) :
+    size(_size + sizeof(uint32)), mLeft(0), mCurr(0), off(0) {
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
+BitPumpMSB16::BitPumpMSB16(FileMap *f, uint32 offset) :
+    mLeft(0), mCurr(0), off(0) {
+  size = f->getSize() + sizeof(uint32); 
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
 __inline void BitPumpMSB16::init() {
   mStuffed = 0;
   _fill();

--- a/src/external/rawspeed/RawSpeed/BitPumpMSB16.h
+++ b/src/external/rawspeed/RawSpeed/BitPumpMSB16.h
@@ -40,6 +40,8 @@ class BitPumpMSB16
 public:
   BitPumpMSB16(ByteStream *s);
   BitPumpMSB16(const uchar8* _buffer, uint32 _size );
+  BitPumpMSB16(FileMap *f, uint32 offset, uint32 _size );
+  BitPumpMSB16(FileMap *f, uint32 offset );
 	uint32 getBitsSafe(uint32 nbits);
 	uint32 getBitSafe();
 	uchar8 getByteSafe();
@@ -94,7 +96,7 @@ public:
 protected:
   void __inline init();
   const uchar8* buffer;
-  const uint32 size;            // This if the end of buffer.
+  uint32 size;            // This if the end of buffer.
   uint32 mLeft;
   uint64 mCurr;
   uint32 off;                  // Offset in bytes

--- a/src/external/rawspeed/RawSpeed/BitPumpMSB32.cpp
+++ b/src/external/rawspeed/RawSpeed/BitPumpMSB32.cpp
@@ -37,6 +37,19 @@ BitPumpMSB32::BitPumpMSB32(const uchar8* _buffer, uint32 _size) :
   init();
 }
 
+BitPumpMSB32::BitPumpMSB32(FileMap *f, uint32 offset, uint32 _size) :
+    size(_size + sizeof(uint32)), mLeft(0), mCurr(0), off(0) {
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
+BitPumpMSB32::BitPumpMSB32(FileMap *f, uint32 offset) :
+    mLeft(0), mCurr(0), off(0) {
+  size = f->getSize() + sizeof(uint32); 
+  buffer = f->getDataWrt(offset, size);
+  init();
+}
+
 __inline void BitPumpMSB32::init() {
   mStuffed = 0;
   _fill();

--- a/src/external/rawspeed/RawSpeed/BitPumpMSB32.h
+++ b/src/external/rawspeed/RawSpeed/BitPumpMSB32.h
@@ -40,6 +40,8 @@ class BitPumpMSB32
 public:
   BitPumpMSB32(ByteStream *s);
   BitPumpMSB32(const uchar8* _buffer, uint32 _size );
+  BitPumpMSB32(FileMap *f, uint32 offset, uint32 _size );
+  BitPumpMSB32(FileMap *f, uint32 offset );
 	uint32 getBitsSafe(uint32 nbits);
 	uint32 getBitSafe();
 	uchar8 getByteSafe();
@@ -94,7 +96,7 @@ public:
 protected:
   void __inline init();
   const uchar8* buffer;
-  const uint32 size;            // This if the end of buffer.
+  uint32 size;            // This if the end of buffer.
   uint32 mLeft;
   uint64 mCurr;
   uint32 off;                  // Offset in bytes

--- a/src/external/rawspeed/RawSpeed/ByteStream.cpp
+++ b/src/external/rawspeed/RawSpeed/ByteStream.cpp
@@ -34,6 +34,19 @@ ByteStream::ByteStream(const ByteStream *b) :
 
 }
 
+ByteStream::ByteStream(FileMap *f, uint32 offset, uint32 _size) :
+    size(_size) {
+  buffer = f->getData(offset, size);
+  off = 0;
+}
+
+ByteStream::ByteStream(FileMap *f, uint32 offset)
+{
+  size = f->getSize() - offset;
+  buffer = f->getData(offset, size);
+  off = 0;
+}
+
 ByteStream::~ByteStream(void) {
 
 }

--- a/src/external/rawspeed/RawSpeed/ByteStream.h
+++ b/src/external/rawspeed/RawSpeed/ByteStream.h
@@ -23,6 +23,7 @@
 #define BYTE_STREAM_H
 
 #include "IOException.h"
+#include "FileMap.h"
 #include <stack>
 
 namespace RawSpeed {
@@ -32,6 +33,8 @@ class ByteStream
 public:
   ByteStream(const uchar8* _buffer, uint32 _size);
   ByteStream(const ByteStream* b);
+  ByteStream(FileMap *f, uint32 offset, uint32 count);
+  ByteStream(FileMap *f, uint32 offset);
   virtual ~ByteStream(void);
   uint32 peekByte();
   uint32 getOffset() {return off;}
@@ -52,7 +55,7 @@ public:
   void popOffset();
 protected:
   const uchar8* buffer;
-  const uint32 size;            // This if the end of buffer.
+  uint32 size;            // This if the end of buffer.
   uint32 off;                  // Offset in bytes (this is next byte to deliver)
   stack<uint32> offset_stack;
 };

--- a/src/external/rawspeed/RawSpeed/ByteStreamSwap.cpp
+++ b/src/external/rawspeed/RawSpeed/ByteStreamSwap.cpp
@@ -12,6 +12,14 @@ ByteStreamSwap::ByteStreamSwap( const ByteStreamSwap* b ) :
 ByteStream(b)
 {}
 
+ByteStreamSwap::ByteStreamSwap( FileMap *f, uint32 offset, uint32 _size ) : 
+ByteStream(f, offset, _size)
+{}
+
+ByteStreamSwap::ByteStreamSwap( FileMap *f, uint32 offset ) : 
+ByteStream(f, offset)
+{}
+
 ByteStreamSwap::~ByteStreamSwap(void)
 {
 }

--- a/src/external/rawspeed/RawSpeed/ByteStreamSwap.h
+++ b/src/external/rawspeed/RawSpeed/ByteStreamSwap.h
@@ -13,6 +13,8 @@ class ByteStreamSwap :
 public:
   ByteStreamSwap(const uchar8* _buffer, uint32 _size);
   ByteStreamSwap(const ByteStreamSwap* b);
+  ByteStreamSwap(FileMap *f, uint32 offset, uint32 count);
+  ByteStreamSwap(FileMap *f, uint32 offset);
   virtual ushort16 getShort();
   virtual int getInt();
   virtual ~ByteStreamSwap(void);

--- a/src/external/rawspeed/RawSpeed/CiffEntry.cpp
+++ b/src/external/rawspeed/RawSpeed/CiffEntry.cpp
@@ -29,23 +29,18 @@ namespace RawSpeed {
 CiffEntry::CiffEntry(FileMap* f, uint32 value_data, uint32 offset) {
   own_data = NULL;
   CHECKSIZE(offset);
-  unsigned short p = *(unsigned short*)f->getData(offset);
+  unsigned short p = *(unsigned short*)f->getData(offset, 2);
   tag = (CiffTag) (p & 0x3fff);
   ushort16 datalocation = (p & 0xc000);
   type = (CiffDataType) (p & 0x3800);
   if (datalocation == 0x0000) { // Data is offset in value_data
-    count = *(int*)f->getData(offset + 2);
-    data_offset = *(uint32*)f->getData(offset + 6) + value_data;
-    CHECKSIZE(data_offset);
-    CHECKSIZE(data_offset + count);
-    if (data_offset + count < data_offset) {
-      ThrowCPE("CRW data offset+count overflows");
-    }
-    data = f->getDataWrt(data_offset);
+    count = *(int*)f->getData(offset + 2, 4);
+    data_offset = *(uint32*)f->getData(offset + 6, 4) + value_data;
+    data = f->getDataWrt(data_offset, count);
   } else if (datalocation == 0x4000) { // Data is stored directly in entry
-    data_offset = offset +2;
+    data_offset = offset + 2;
     count = 8; // Maximum of 8 bytes of data (the size and offset fields)
-    data = f->getDataWrt(data_offset);
+    data = f->getDataWrt(data_offset, count);
   } else
     ThrowCPE("Don't understand data location 0x%x\n", datalocation);
 }

--- a/src/external/rawspeed/RawSpeed/CiffIFD.cpp
+++ b/src/external/rawspeed/RawSpeed/CiffIFD.cpp
@@ -26,21 +26,12 @@
 
 namespace RawSpeed {
 
-#ifdef CHECKSIZE
-#undef CHECKSIZE
-#endif
-
-#define CHECKSIZE(A) if (A > size) ThrowCPE("Error reading CIFF structure (invalid size). File Corrupt")
-
 CiffIFD::CiffIFD(FileMap* f, uint32 start, uint32 end) {
   mFile = f;
   uint32 size = f->getSize();
-  CHECKSIZE(start);
-  CHECKSIZE(end);
 
-  uint32 valuedata_size = *(uint32 *) f->getData(end-4);
-  CHECKSIZE(start+valuedata_size);
-  ushort16 dircount = *(ushort16 *) f->getData(start+valuedata_size);
+  uint32 valuedata_size = *(uint32 *) f->getData(end-4, 4);
+  ushort16 dircount = *(ushort16 *) f->getData(start+valuedata_size, 2);
 
 //  fprintf(stderr, "Found %d entries between %d and %d after %d data bytes\n", 
 //                  dircount, start, end, valuedata_size);

--- a/src/external/rawspeed/RawSpeed/CiffParser.cpp
+++ b/src/external/rawspeed/RawSpeed/CiffParser.cpp
@@ -38,23 +38,13 @@ CiffParser::~CiffParser(void) {
   mRootIFD = NULL;
 }
 
-#ifdef CHECKSIZE
-#undef CHECKSIZE
-#endif
-#ifdef CHECKPTR
-#undef CHECKPTR
-#endif
-
-#define CHECKSIZE(A) if (A >= mInput->getSize()) throw CiffParserException("Error reading CIFF structure (size out of bounds). File Corrupt")
-#define CHECKPTR(A) if ((int)A >= ((int)(mInput->data) + size))) throw CiffParserException("Error reading CIFF structure (size out of bounds). File Corrupt")
-
 void CiffParser::parseData() {
   if (little != getHostEndianness())
     ThrowCPE("CIFF parsing not supported on big-endian architectures yet");
 
-  const unsigned char* data = mInput->getData(0);
   if (mInput->getSize() < 16)
     ThrowCPE("Not a CIFF file (size too small)");
+  const unsigned char* data = mInput->getData(0, 16);
 
   if (data[0] != 0x49 || data[1] != 0x49)
     ThrowCPE("Not a CIFF file (ID)");

--- a/src/external/rawspeed/RawSpeed/Cr2Decoder.cpp
+++ b/src/external/rawspeed/RawSpeed/Cr2Decoder.cpp
@@ -58,9 +58,9 @@ RawImage Cr2Decoder::decodeRawInternal() {
 
     ByteStream *b;
     if (getHostEndianness() == big)
-      b = new ByteStream(mFile->getData(off+41), mFile->getSize());
+      b = new ByteStream(mFile, off+41);
     else
-      b = new ByteStreamSwap(mFile->getData(off+41), mFile->getSize());
+      b = new ByteStreamSwap(mFile, off+41);
     uint32 height = b->getShort();
     uint32 width = b->getShort();
 

--- a/src/external/rawspeed/RawSpeed/CrwDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/CrwDecoder.cpp
@@ -334,8 +334,8 @@ void CrwDecoder::decodeRaw(bool lowbits, uint32 dec_table, uint32 width, uint32 
   initHuffTables (dec_table);
 
   uint32 offset = 540 + lowbits*height*width/4;
-  ByteStream input(mFile->getData(offset), mFile->getSize() - offset);
-  BitPumpJPEG pump(mFile->getData(offset),mFile->getSize() - offset);
+  ByteStream input(mFile, offset);
+  BitPumpJPEG pump(mFile, offset);
 
   for (uint32 row=0; row < height; row+=8) {
     ushort16 *dest = (ushort16*) & mRaw->getData()[row*width*2];
@@ -367,7 +367,7 @@ void CrwDecoder::decodeRaw(bool lowbits, uint32 dec_table, uint32 width, uint32 
     // Add the uncompressed 2 low bits to the decoded 8 high bits
     if (lowbits) {
       offset = 26 + row*width/4;
-      ByteStream lowbit_input(mFile->getData(offset), height*width/4);
+      ByteStream lowbit_input(mFile, offset, height*width/4);
       uint32 lines = MIN(height-row, 8); // Process 8 rows or however are left
       for (uint32 i=0; i < width/4*lines; i++) {
         uint32 c = ((uint32) lowbit_input.getByte());

--- a/src/external/rawspeed/RawSpeed/DcrDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/DcrDecoder.cpp
@@ -55,7 +55,7 @@ RawImage DcrDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+  ByteStream input(mFile, off);
 
   int compression = raw->getEntry(COMPRESSION)->getInt();
   if (65000 == compression) {

--- a/src/external/rawspeed/RawSpeed/DcsDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/DcsDecoder.cpp
@@ -61,7 +61,7 @@ RawImage DcsDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+  ByteStream input(mFile, off);
 
   TiffEntry *linearization = mRootIFD->getEntryRecursive(GRAYRESPONSECURVE);
   if (!linearization || linearization->count != 256 || linearization->type != TIFF_SHORT)

--- a/src/external/rawspeed/RawSpeed/DngDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/DngDecoder.cpp
@@ -211,7 +211,7 @@ RawImage DngDecoder::decodeRawInternal() {
           DngStrip slice = slices[i];
           if (hints.find("ignore_bytecount") != hints.end())
             slice.count = mFile->getSize() - slice.offset;
-          ByteStream in(mFile->getData(slice.offset), slice.count);
+          ByteStream in(mFile, slice.offset, slice.count);
           iPoint2D size(width, slice.h);
           iPoint2D pos(0, slice.offsetY);
 

--- a/src/external/rawspeed/RawSpeed/DngDecoderSlices.cpp
+++ b/src/external/rawspeed/RawSpeed/DngDecoderSlices.cpp
@@ -175,7 +175,7 @@ void DngDecoderSlices::decodeSlice(DngDecoderThread* t) {
         jerr.error_exit = my_error_throw;
         CHECKSIZE(e.byteOffset);
         CHECKSIZE(e.byteOffset+e.byteCount);
-        JPEG_MEMSRC(&dinfo, (unsigned char*)mFile->getData(e.byteOffset), e.byteCount);
+        JPEG_MEMSRC(&dinfo, (unsigned char*)mFile->getData(e.byteOffset, e.byteCount), e.byteCount);
 
         if (JPEG_HEADER_OK != jpeg_read_header(&dinfo, TRUE))
           ThrowRDE("DngDecoderSlices: Unable to read JPEG header");

--- a/src/external/rawspeed/RawSpeed/ErfDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/ErfDecoder.cpp
@@ -52,7 +52,7 @@ RawImage ErfDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+  ByteStream input(mFile, off);
 
   Decode12BitRawBEWithControl(input, width, height);
 

--- a/src/external/rawspeed/RawSpeed/FileMap.cpp
+++ b/src/external/rawspeed/RawSpeed/FileMap.cpp
@@ -38,6 +38,16 @@ FileMap::FileMap(uchar8* _data, uint32 _size): data(_data), size(_size) {
   mOwnAlloc = false;
 }
 
+FileMap::FileMap(FileMap *f, uint32 offset) {
+  size = f->getSize()-offset;
+  data = f->getDataWrt(offset, size);
+  mOwnAlloc = false;
+}
+
+FileMap::FileMap(FileMap *f, uint32 offset, uint32 size) {
+  data = f->getDataWrt(offset, size);
+  mOwnAlloc = false;
+}
 
 FileMap::~FileMap(void) {
   if (data && mOwnAlloc) {
@@ -67,10 +77,10 @@ void FileMap::corrupt(int errors) {
   }
 }
 
-const uchar8* FileMap::getData( uint32 offset )
+const uchar8* FileMap::getData( uint32 offset, uint32 count )
 {
-  if (offset >= size)
-    throw IOException("FileMap: Attempting to read out of file.");
+  if (offset < 0 || count <= 0 || offset+count > size)
+    throw IOException("FileMap: Attempting to read file out of bounds.");
   return &data[offset];
 }
 } // namespace RawSpeed

--- a/src/external/rawspeed/RawSpeed/FileMap.h
+++ b/src/external/rawspeed/RawSpeed/FileMap.h
@@ -39,11 +39,17 @@ namespace RawSpeed {
 class FileMap
 {
 public:
-  FileMap(uint32 _size);                 // Allocates the data array itself
-  FileMap(uchar8* _data, uint32 _size);  // Data already allocated, if possible allocate 16 extra bytes.
+  // Allocates the data array itself
+  FileMap(uint32 _size);
+  // Data already allocated, if possible allocate 16 extra bytes.
+  FileMap(uchar8* _data, uint32 _size);
+  // A subset reusing the same data and starting at offset
+  FileMap(FileMap *f, uint32 offset);
+  // A subset reusing the same data and starting at offset, with size bytes
+  FileMap(FileMap *f, uint32 offset, uint32 size);
   ~FileMap(void);
-  const uchar8* getData(uint32 offset);
-  uchar8* getDataWrt(uint32 offset) {return &data[offset];}
+  const uchar8* getData(uint32 offset, uint32 count);
+  uchar8* getDataWrt(uint32 offset, uint32 count) {return (uchar8 *)getData(offset,count);}
   uint32 getSize() {return size;}
   bool isValid(uint32 offset) {return offset<=size;}
   FileMap* clone();

--- a/src/external/rawspeed/RawSpeed/FileReader.cpp
+++ b/src/external/rawspeed/RawSpeed/FileReader.cpp
@@ -61,7 +61,7 @@ FileMap* FileReader::readFile() {
 #else
   FileMap *fileData = new FileMap(size);
 
-  dest = (char *)fileData->getDataWrt(0);
+  dest = (char *)fileData->getDataWrt(0, size);
   bytes_read = fread(dest, 1, size, file);
   fclose(file);
   if (size != bytes_read) {
@@ -86,7 +86,7 @@ FileMap* FileReader::readFile() {
   FileMap *fileData = new FileMap(f_size.LowPart);
 
   DWORD bytes_read;
-  if (! ReadFile(file_h, fileData->getDataWrt(0), fileData->getSize(), &bytes_read, NULL)) {
+  if (! ReadFile(file_h, fileData->getDataWrt(0, fileData->getSize()), fileData->getSize(), &bytes_read, NULL)) {
     CloseHandle(file_h);
     delete fileData;
     throw FileIOException("Could not read file.");

--- a/src/external/rawspeed/RawSpeed/FileWriter.cpp
+++ b/src/external/rawspeed/RawSpeed/FileWriter.cpp
@@ -46,7 +46,7 @@ void FileWriter::writeFile(FileMap* filemap, uint32 size) {
   if (file == NULL)
     throw FileIOException("Could not open file.");
 
-  src = (char *)filemap->getData(0);
+  src = (char *)filemap->getData(0, filemap->getSize());
   bytes_written = fwrite(src, 1, size ? size : filemap->getSize(), file);
   fclose(file);
   if (size != bytes_written) {
@@ -61,7 +61,7 @@ void FileWriter::writeFile(FileMap* filemap, uint32 size) {
   }
 
   DWORD bytes_written;
-  if (! WriteFile(file_h, filemap->getData(0), size ? size : filemap->getSize(), &bytes_written, NULL)) {
+  if (! WriteFile(file_h, filemap->getData(0, filemap->getSize()), size ? size : filemap->getSize(), &bytes_written, NULL)) {
     CloseHandle(file_h);
     throw FileIOException("Could not read file.");
   }

--- a/src/external/rawspeed/RawSpeed/KdcDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/KdcDecoder.cpp
@@ -67,7 +67,7 @@ RawImage KdcDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize()-off);
+  ByteStream input(mFile, off);
 
   Decode12BitRawBE(input, width, height);
 

--- a/src/external/rawspeed/RawSpeed/LJpegDecompressor.cpp
+++ b/src/external/rawspeed/RawSpeed/LJpegDecompressor.cpp
@@ -113,9 +113,9 @@ void LJpegDecompressor::getSOF(SOFInfo* sof, uint32 offset, uint32 size) {
     Endianness host_endian = getHostEndianness();
     // JPEG is big endian
     if (host_endian == big)
-      input = new ByteStream(mFile->getData(offset), size);
+      input = new ByteStream(mFile, offset, size);
     else 
-      input = new ByteStreamSwap(mFile->getData(offset), size);
+      input = new ByteStreamSwap(mFile, offset, size);
 
     if (getNextMarker(false) != M_SOI)
       ThrowRDE("LJpegDecompressor::getSOF: Image did not start with SOI. Probably not an LJPEG");
@@ -150,9 +150,9 @@ void LJpegDecompressor::startDecoder(uint32 offset, uint32 size, uint32 offsetX,
     Endianness host_endian = getHostEndianness();
     // JPEG is big endian
     if (host_endian == big)
-      input = new ByteStream(mFile->getData(offset), size);
+      input = new ByteStream(mFile, offset, size);
     else 
-      input = new ByteStreamSwap(mFile->getData(offset), size);
+      input = new ByteStreamSwap(mFile, offset, size);
 
     if (getNextMarker(false) != M_SOI)
       ThrowRDE("LJpegDecompressor::startDecoder: Image did not start with SOI. Probably not an LJPEG");

--- a/src/external/rawspeed/RawSpeed/MefDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/MefDecoder.cpp
@@ -51,7 +51,7 @@ RawImage MefDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+  ByteStream input(mFile, off);
 
   Decode12BitRawBE(input, width, height);
   return mRaw;

--- a/src/external/rawspeed/RawSpeed/NakedDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/NakedDecoder.cpp
@@ -81,7 +81,7 @@ RawImage NakedDecoder::decodeRawInternal() {
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
 
-  ByteStream input(mFile->getData(offset), mFile->getSize()-offset);
+  ByteStream input(mFile, offset);
   iPoint2D pos(0, 0);
   readUncompressedRaw(input, mRaw->dim, pos, width*bits/8, bits, bo);
 

--- a/src/external/rawspeed/RawSpeed/NefDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/NefDecoder.cpp
@@ -133,7 +133,7 @@ are only needed for the D100, thanks to a bug in some cameras
 that tags all images as "compressed".
 */
 bool NefDecoder::D100IsCompressed(uint32 offset) {
-  const uchar8 *test = mFile->getData(offset);
+  const uchar8 *test = mFile->getData(offset, 256);
   int i;
 
   for (i = 15; i < 256; i += 16)
@@ -230,7 +230,7 @@ void NefDecoder::DecodeUncompressed() {
   offY = 0;
   for (uint32 i = 0; i < slices.size(); i++) {
     NefSlice slice = slices[i];
-    ByteStream in(mFile->getData(slice.offset), slice.count);
+    ByteStream in(mFile, slice.offset, slice.count);
     iPoint2D size(width, slice.h);
     iPoint2D pos(0, offY);
     try {
@@ -338,7 +338,7 @@ void NefDecoder::DecodeD100Uncompressed() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(offset), mFile->getSize()-offset);
+  ByteStream input(mFile, offset);
 
   Decode12BitRawBEWithControl(input, width, height);
 }
@@ -355,7 +355,7 @@ void NefDecoder::DecodeSNefUncompressed() {
   mRaw->isCFA = false;
   mRaw->createData();
 
-  ByteStream in(mFile->getData(offset), mFile->getSize()-offset);
+  ByteStream in(mFile, offset);
 
   DecodeNikonSNef(in, width, height);
 }

--- a/src/external/rawspeed/RawSpeed/NikonDecompressor.cpp
+++ b/src/external/rawspeed/RawSpeed/NikonDecompressor.cpp
@@ -98,7 +98,7 @@ void NikonDecompressor::DecompressNikon(ByteStream *metadata, uint32 w, uint32 h
   }
 
   uint32 x, y;
-  BitPumpMSB bits(mFile->getData(offset), size);
+  BitPumpMSB bits(mFile, offset, size);
   uchar8 *draw = mRaw->getData();
   ushort16 *dest;
   uint32 pitch = mRaw->pitch;

--- a/src/external/rawspeed/RawSpeed/OrfDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/OrfDecoder.cpp
@@ -73,7 +73,7 @@ RawImage OrfDecoder::decodeRawInternal() {
   mRaw->createData();
 
   // We add 3 bytes slack, since the bitpump might be a few bytes ahead.
-  ByteStream input(mFile->getData(off), MIN(size+3, mFile->getSize() - off));
+  ByteStream input(mFile, off, size+3);
 
   try {
     if (offsets->count != 1 || (hints.find(string("force_uncompressed")) != hints.end()))

--- a/src/external/rawspeed/RawSpeed/PentaxDecompressor.cpp
+++ b/src/external/rawspeed/RawSpeed/PentaxDecompressor.cpp
@@ -113,7 +113,7 @@ void PentaxDecompressor::decodePentax(TiffIFD *root, uint32 offset, uint32 size)
   mUseBigtable = true;
   createHuffmanTable(dctbl1);
 
-  pentaxBits = new BitPumpMSB(mFile->getData(offset), size);
+  pentaxBits = new BitPumpMSB(mFile, offset, size);
   uchar8 *draw = mRaw->getData();
   ushort16 *dest;
   uint32 w = mRaw->dim.x;

--- a/src/external/rawspeed/RawSpeed/RafDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/RafDecoder.cpp
@@ -91,7 +91,7 @@ RawImage RafDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width*(double_width ? 2 : 1), height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+  ByteStream input(mFile, off);
   iPoint2D pos(0, 0);
 
   if (double_width) {

--- a/src/external/rawspeed/RawSpeed/RawDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/RawDecoder.cpp
@@ -79,7 +79,7 @@ void RawDecoder::decodeUncompressed(TiffIFD *rawIFD, BitOrder order) {
   offY = 0;
   for (uint32 i = 0; i < slices.size(); i++) {
     RawSlice slice = slices[i];
-    ByteStream in(mFile->getData(slice.offset), slice.count);
+    ByteStream in(mFile, slice.offset, slice.count);
     iPoint2D size(width, slice.h);
     iPoint2D pos(0, offY);
     bitPerPixel = (int)((uint64)((uint64)slice.count * 8u) / (slice.h * width));

--- a/src/external/rawspeed/RawSpeed/RawParser.cpp
+++ b/src/external/rawspeed/RawSpeed/RawParser.cpp
@@ -44,11 +44,12 @@ RawParser::~RawParser(void) {
 }
 
 RawDecoder* RawParser::getDecoder(CameraMetaData* meta) {
-  const unsigned char* data = mInput->getData(0);
   // We need some data.
   // For now it is 104 bytes for RAF images.
   if (mInput->getSize() <=  104)
     ThrowRDE("File too small");
+
+  const unsigned char* data = mInput->getData(0, 104);
 
   // MRW images are easy to check for, let's try that first
   if (MrwDecoder::isMRW(mInput)) {
@@ -87,12 +88,12 @@ RawDecoder* RawParser::getDecoder(CameraMetaData* meta) {
 
     // Open the IFDs and merge them
     try {
-      FileMap *m1 = new FileMap(mInput->getDataWrt(first_ifd), mInput->getSize()-first_ifd);
+      FileMap *m1 = new FileMap(mInput, first_ifd);
       FileMap *m2 = NULL;
       TiffParser p(m1);
       p.parseData();
       if (second_ifd) {
-        m2 = new FileMap(mInput->getDataWrt(second_ifd), mInput->getSize()-second_ifd);
+        m2 = new FileMap(mInput, second_ifd);
         try {
           TiffParser p2(m2);
           p2.parseData();
@@ -173,7 +174,7 @@ RawDecoder* RawParser::getDecoder(CameraMetaData* meta) {
 void RawParser::ParseFuji(uint32 offset, TiffIFD *target_ifd)
 {
   try {
-    ByteStreamSwap bytes(mInput->getData(offset), mInput->getSize()-offset);
+    ByteStreamSwap bytes(mInput, offset);
     uint32 entries = bytes.getUInt();
 
     if (entries > 255)

--- a/src/external/rawspeed/RawSpeed/Rw2Decoder.cpp
+++ b/src/external/rawspeed/RawSpeed/Rw2Decoder.cpp
@@ -69,7 +69,7 @@ RawImage Rw2Decoder::decodeRawInternal() {
     mRaw->createData();
 
     uint32 size = mFile->getSize() - off;
-    input_start = new ByteStream(mFile->getData(off), mFile->getSize() - off);
+    input_start = new ByteStream(mFile, off);
 
     if (size >= width*height*2) {
       // It's completely unpacked little-endian
@@ -98,7 +98,7 @@ RawImage Rw2Decoder::decodeRawInternal() {
     if (!mFile->isValid(off))
       ThrowRDE("RW2 Decoder: Invalid image data offset, cannot decode.");
 
-    input_start = new ByteStream(mFile->getData(off), mFile->getSize() - off);
+    input_start = new ByteStream(mFile, off);
     DecodeRw2();
   }
   // Read blacklevels

--- a/src/external/rawspeed/RawSpeed/SrwDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/SrwDecoder.cpp
@@ -123,9 +123,9 @@ void SrwDecoder::decodeCompressed( TiffIFD* raw )
   if (NULL != b)
     delete b;
   if (getHostEndianness() == little)
-    b = new ByteStream(mFile->getData(0), mFile->getSize());
+    b = new ByteStream(mFile, 0);
   else
-    b = new ByteStreamSwap(mFile->getData(0), mFile->getSize());
+    b = new ByteStreamSwap(mFile, 0);
   b->setAbsoluteOffset(compressed_offset);
 
   for (uint32 y = 0; y < height; y++) {
@@ -135,7 +135,7 @@ void SrwDecoder::decodeCompressed( TiffIFD* raw )
     int len[4];
     for (int i = 0; i < 4; i++)
       len[i] = y < 2 ? 7 : 4;
-    BitPumpMSB32 bits(mFile->getData(line_offset),mFile->getSize() - line_offset);
+    BitPumpMSB32 bits(mFile, line_offset);
     int op[4];
     ushort16* img = (ushort16*)mRaw->getData(0, y);
     ushort16* img_up = (ushort16*)mRaw->getData(0, max(0, (int)y - 1));
@@ -249,7 +249,7 @@ void SrwDecoder::decodeCompressed2( TiffIFD* raw, int bits)
     }
   }
 
-  BitPumpMSB pump(mFile->getData(offset),mFile->getSize() - offset);
+  BitPumpMSB pump(mFile, offset);
   for (uint32 y = 0; y < height; y++) {
     ushort16* img = (ushort16*)mRaw->getData(0, y);
     for (uint32 x = 0; x < width; x++) {
@@ -290,7 +290,7 @@ int32 SrwDecoder::samsungDiff (BitPumpMSB &pump, encTableItem *tbl)
 void SrwDecoder::decodeCompressed3( TiffIFD* raw, int bits)
 {
   uint32 offset = raw->getEntry(STRIPOFFSETS)->getInt();
-  BitPumpMSB32 startpump(mFile->getData(offset),mFile->getSize() - offset);
+  BitPumpMSB32 startpump(mFile, offset);
 
   // Process the initial metadata bits, we only really use initVal, width and
   // height (the last two match the TIFF values anyway)
@@ -333,7 +333,7 @@ void SrwDecoder::decodeCompressed3( TiffIFD* raw, int bits)
     // Align pump to 16byte boundary
     if ((line_offset & 0xf) != 0)
       line_offset += 16 - (line_offset & 0xf);
-    BitPumpMSB32 pump(mFile->getData(offset+line_offset),mFile->getSize()-offset-line_offset);
+    BitPumpMSB32 pump(mFile, offset+line_offset);
 
     ushort16* img = (ushort16*)mRaw->getData(0, row);
     ushort16* img_up = (ushort16*)mRaw->getData(0, max(0, (int)row - 1));

--- a/src/external/rawspeed/RawSpeed/ThreefrDecoder.cpp
+++ b/src/external/rawspeed/RawSpeed/ThreefrDecoder.cpp
@@ -48,7 +48,7 @@ RawImage ThreefrDecoder::decodeRawInternal() {
 
   mRaw->dim = iPoint2D(width, height);
   mRaw->createData();
-  ByteStream input(mFile->getData(off), mFile->getSize() - off);
+  ByteStream input(mFile, off);
 
   HasselbladDecompressor l(mFile, mRaw);
   map<string,string>::iterator pixelOffset = hints.find("pixelBaseOffset");

--- a/src/external/rawspeed/RawSpeed/TiffEntry.cpp
+++ b/src/external/rawspeed/RawSpeed/TiffEntry.cpp
@@ -36,17 +36,17 @@ TiffEntry::TiffEntry(FileMap* f, uint32 offset, uint32 up_offset) {
   parent_offset = up_offset;
   own_data = NULL;
   file = f;
-  unsigned short* p = (unsigned short*)f->getData(offset);
+  unsigned short* p = (unsigned short*)f->getData(offset, 2);
   tag = (TiffTag)p[0];
   type = (TiffDataType)p[1];
-  count = *(int*)f->getData(offset + 4);
+  count = *(int*)f->getData(offset + 4, 4);
   if (type > 13)
     ThrowTPE("Error reading TIFF structure. Unknown Type 0x%x encountered.", type);
   uint32 bytesize = count << datashifts[type];
   if (bytesize <= 4) {
-    data = f->getDataWrt(offset + 8);
+    data = f->getDataWrt(offset + 8, bytesize);
   } else { // offset
-    data_offset = *(uint32*)f->getData(offset + 8);
+    data_offset = *(uint32*)f->getData(offset + 8, 4);
     fetchData();
   }
 #ifdef _DEBUG
@@ -61,13 +61,12 @@ TiffEntry::TiffEntry(FileMap* f, uint32 offset, uint32 up_offset) {
 }
 
 void TiffEntry::fetchData() {
-  FileMap *f = file; // CHECKSIZE uses f
   if(file) {
     uint32 bytesize = count << datashifts[type];
-    CHECKSIZE(data_offset + bytesize);
-    data = file->getDataWrt(data_offset);
+    data = file->getDataWrt(data_offset, bytesize);
   }
 }
+
 
 TiffEntry::TiffEntry(TiffTag _tag, TiffDataType _type, uint32 _count, const uchar8* _data )
 {

--- a/src/external/rawspeed/RawSpeed/TiffEntryBE.cpp
+++ b/src/external/rawspeed/RawSpeed/TiffEntryBE.cpp
@@ -29,7 +29,7 @@ TiffEntryBE::TiffEntryBE(FileMap* f, uint32 offset, uint32 up_offset) {
   file = f;
   parent_offset = up_offset;
   type = TIFF_UNDEFINED;  // We set type to undefined to avoid debug assertion errors.
-  data = f->getDataWrt(offset);
+  data = f->getDataWrt(offset, 8);
   tag = (TiffTag)getShort();
   data += 2;
   TiffDataType _type = (TiffDataType)getShort();
@@ -40,13 +40,10 @@ TiffEntryBE::TiffEntryBE(FileMap* f, uint32 offset, uint32 up_offset) {
   if (type > 13)
     ThrowTPE("Error reading TIFF structure. Unknown Type 0x%x encountered.", type);
   uint32 bytesize = count << datashifts[type];
-  if (bytesize <= 4) {
-    data = f->getDataWrt(offset + 8);
-  } else { // offset
-    data = f->getDataWrt(offset + 8);
+  data = f->getDataWrt(offset + 8, 4);
+  if (bytesize > 4) { // it's an offset
     data_offset = (unsigned int)data[0] << 24 | (unsigned int)data[1] << 16 | (unsigned int)data[2] << 8 | (unsigned int)data[3];
-    CHECKSIZE(data_offset + bytesize);
-    data = f->getDataWrt(data_offset);
+    data = f->getDataWrt(data_offset, bytesize);
   }
 #ifdef _DEBUG
   debug_intVal = 0xC0CAC01A;

--- a/src/external/rawspeed/RawSpeed/TiffIFDBE.cpp
+++ b/src/external/rawspeed/RawSpeed/TiffIFDBE.cpp
@@ -36,7 +36,7 @@ TiffIFDBE::TiffIFDBE(FileMap* f, uint32 offset) {
   int entries;
   CHECKSIZE(offset);
 
-  const unsigned char* data = f->getData(offset);
+  const unsigned char* data = f->getData(offset, 2);
   entries = (unsigned short)data[0] << 8 | (unsigned short)data[1];    // Directory entries in this IFD
 
   CHECKSIZE(offset + 2 + entries*4);
@@ -77,7 +77,7 @@ TiffIFDBE::TiffIFDBE(FileMap* f, uint32 offset) {
       mEntry[t->tag] = t;
     }
   }
-  data = f->getDataWrt(offset + 2 + entries * 12);
+  data = f->getDataWrt(offset + 2 + entries * 12, 4);
   nextIFD = (unsigned int)data[0] << 24 | (unsigned int)data[1] << 16 | (unsigned int)data[2] << 8 | (unsigned int)data[3];
 }
 

--- a/src/external/rawspeed/RawSpeed/TiffParser.cpp
+++ b/src/external/rawspeed/RawSpeed/TiffParser.cpp
@@ -65,10 +65,10 @@ TiffParser::~TiffParser(void) {
 #define CHECKPTR(A) if ((int)A >= ((int)(mInput->data) + size))) throw TiffParserException("Error reading TIFF structure (size out of bounds). File Corrupt")
 
 void TiffParser::parseData() {
-  const unsigned char* data = mInput->getData(0);
   if (mInput->getSize() < 16)
     throw TiffParserException("Not a TIFF file (size too small)");
 
+  const unsigned char* data = mInput->getData(0, 4);
   if (data[0] != 0x49 || data[1] != 0x49) {
     tiff_endian = big;
     if (data[0] != 0x4D || data[1] != 0x4D)
@@ -91,7 +91,7 @@ void TiffParser::parseData() {
     mRootIFD = new TiffIFDBE();
 
   uint32 nextIFD;
-  data = mInput->getData(4);
+  data = mInput->getData(4, 4);
   if (tiff_endian == host_endian) {
     nextIFD = *(int*)data;
   } else {

--- a/src/external/rawspeed/RawSpeed/X3fParser.cpp
+++ b/src/external/rawspeed/RawSpeed/X3fParser.cpp
@@ -35,9 +35,9 @@ X3fParser::X3fParser(FileMap* file) {
     ThrowRDE("X3F file too small");
 
   if (getHostEndianness() == little)
-    bytes = new ByteStream(file->getData(0), size);
+    bytes = new ByteStream(file, 0, size);
   else
-    bytes = new ByteStreamSwap(file->getData(0), size);
+    bytes = new ByteStreamSwap(file, 0, size);
   try {
     try {
       // Read signature


### PR DESCRIPTION
Rawspeed works by reading the whole file into memory and then indexing into it. This together with using file inputs as offsets can lead to out of bounds reads in memory. Implement a better internal API to make these checks both easier to write and harder to skip. This covers three main cases:

1) Whenever we are accessing data directly from the file we used to do something like:
```cpp
uchar8 *data = mFile->getData(offset);
```
Replace that with:
```cpp
uchar8 *data = mFile->getData(offset, len);
```
and then do proper bounds checking to make sure we can safely read len bytes from the returned pointer.

2)  When we want to read a byte stream we will often do something like:
```cpp
ByteStream in(mFile->getData(off), mFile->getSize()-off);
```
which basically means we allow reading from the offset all the way to the end of the file. Make that simpler by just doing:
```cpp
ByteStream in(mFile, off);
```
and have that do all the needed bounds checking.

3) When we want to read a byte stream up to a certain number of bytes we will do something like:
```cpp
ByteStream in(mFile->getData(off), len);
```
which may be unsafe if len > mFile->getSize()-off. Instead do:
```cpp
ByteStream in(mFile, off, len);
```
and that will make sure the bounds checking is done properly.