### PR TITLE
Undo redo history

### DIFF
--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -45,6 +45,7 @@ typedef struct dt_signal_description
 
 
 static GType uint_arg[] = { G_TYPE_UINT };
+static GType pointer_arg[] = { G_TYPE_POINTER };
 static GType pointer_2arg[] = { G_TYPE_POINTER, G_TYPE_POINTER };
 static GType image_export_arg[]
     = { G_TYPE_UINT, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_POINTER, G_TYPE_POINTER, G_TYPE_POINTER };
@@ -91,6 +92,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     NULL, NULL, FALSE }, // DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED
   { "dt-develop-history-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,
     NULL, NULL, FALSE }, // DT_SIGNAL_HISTORY_CHANGE
+  { "dt-develop-module-remove", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1,
+    pointer_arg, NULL, TRUE }, // DT_SIGNAL_MODULE_REMOVE
   { "dt-develop-image-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,
     NULL, NULL, FALSE }, // DT_SIGNAL_DEVELOP_IMAGE_CHANGE
   { "dt-control-profile-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -64,7 +64,7 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   { "dt-viewmanager-view-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2,
     pointer_2arg, NULL, FALSE }, // DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED
   { "dt-viewmanager-filmstrip-activate", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,
-    NULL, NULL }, // DT_SIGNAL_VIEWMANAGER_FILMSTRIP_ACTIVATE
+    NULL, NULL, FALSE }, // DT_SIGNAL_VIEWMANAGER_FILMSTRIP_ACTIVATE
 
   { "dt-collection-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,
     NULL, NULL, FALSE }, // DT_SIGNAL_COLLECTION_CHANGED

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -111,6 +111,12 @@ typedef enum dt_signal_t
     */
   DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
 
+  /** \brief This signal is raised when a module is removed from the history stack
+    1 module
+    no returned value
+    */
+  DT_SIGNAL_DEVELOP_MODULE_REMOVE,
+
   /** \brief This signal is rasied when image is changed in darkroom */
   DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1610,6 +1610,7 @@ void dt_dev_module_remove(dt_develop_t *dev, dt_iop_module_t *module)
   if(dev->gui_attached && del)
   {
     /* signal that history has changed */
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE, module);
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
     /* redraw */
     dt_control_queue_redraw_center();

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -674,6 +674,14 @@ void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolea
   }
 }
 
+void dt_dev_free_history_item(gpointer data)
+{
+  dt_dev_history_item_t *item = (dt_dev_history_item_t *)data;
+  free(item->params);
+  free(item->blend_params);
+  free(item);
+}
+
 void dt_dev_reload_history_items(dt_develop_t *dev)
 {
   dev->focus_hash = 0;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1566,6 +1566,21 @@ dt_iop_module_t *dt_dev_module_duplicate(dt_develop_t *dev, dt_iop_module_t *bas
   return module;
 }
 
+void dt_dev_invalidate_history_module(GList *list, dt_iop_module_t *module)
+{
+  while (list)
+  {
+    dt_dev_history_item_t *hitem = (dt_dev_history_item_t *)list->data;
+    if (hitem->module == module)
+    {
+      hitem->module = NULL;
+      // set the multi_name to the module op name to be able to recreate the multi-instance later
+      strncpy(hitem->multi_name, module->op, sizeof(hitem->multi_name));
+    }
+    list = list->next;
+  }
+}
+
 void dt_dev_module_remove(dt_develop_t *dev, dt_iop_module_t *module)
 {
   // if(darktable.gui->reset) return;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -38,6 +38,7 @@
 #include "develop/imageop.h"
 #include "develop/lightroom.h"
 #include "develop/masks.h"
+#include "views/undo.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -139,9 +139,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
   }
   while(dev->history)
   {
-    free(((dt_dev_history_item_t *)dev->history->data)->params);
-    free(((dt_dev_history_item_t *)dev->history->data)->blend_params);
-    free((dt_dev_history_item_t *)dev->history->data);
+    dt_dev_free_history_item(((dt_dev_history_item_t *)dev->history->data));
     dev->history = g_list_delete_link(dev->history, dev->history);
   }
   while(dev->iop)
@@ -567,9 +565,7 @@ void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolea
       GList *next = g_list_next(history);
       dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
       // printf("removing obsoleted history item: %s\n", hist->module->op);
-      free(hist->params);
-      free(hist->blend_params);
-      free(history->data);
+      dt_dev_free_history_item(hist);
       dev->history = g_list_delete_link(dev->history, history);
       history = next;
     }
@@ -692,9 +688,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
   {
     GList *next = g_list_next(history);
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    free(hist->params);
-    free(hist->blend_params);
-    free(history->data);
+    dt_dev_free_history_item(hist);
     dev->history = g_list_delete_link(dev->history, history);
     history = next;
   }
@@ -1134,8 +1128,6 @@ void dt_dev_read_history(dt_develop_t *dev)
          || hist->module->legacy_params(hist->module, sqlite3_column_blob(stmt, 4), labs(modversion),
                                         hist->params, labs(hist->module->version())))
       {
-        free(hist->params);
-        free(hist->blend_params);
         fprintf(stderr, "[dev_read_history] module `%s' version mismatch: history is %d, dt %d.\n",
                 hist->module->op, modversion, hist->module->version());
         const char *fname = dev->image_storage.filename + strlen(dev->image_storage.filename);
@@ -1143,7 +1135,7 @@ void dt_dev_read_history(dt_develop_t *dev)
         if(fname > dev->image_storage.filename) fname++;
         dt_control_log(_("%s: module `%s' version mismatch: %d != %d"), fname, hist->module->op,
                        hist->module->version(), modversion);
-        free(hist);
+        dt_dev_free_history_item(hist);
         continue;
       }
       else
@@ -1591,9 +1583,7 @@ void dt_dev_module_remove(dt_develop_t *dev, dt_iop_module_t *module)
       {
         // printf("removing obsoleted history item: %s %s %p %p\n", hist->module->op, hist->module->multi_name,
         //        module, hist->module);
-        free(hist->params);
-        free(hist->blend_params);
-        free(hist);
+        dt_dev_free_history_item(hist);
         dev->history = g_list_delete_link(dev->history, elem);
         dev->history_end--;
         del = 1;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -248,6 +248,7 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt);
 void dt_dev_write_history(dt_develop_t *dev);
 void dt_dev_read_history(dt_develop_t *dev);
 void dt_dev_free_history_item(gpointer data);
+void dt_dev_invalidate_history_module(GList *list, struct dt_iop_module_t *module);
 
 void dt_dev_invalidate(dt_develop_t *dev);
 // also invalidates preview (which is unaffected by resize/zoom/pan)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -247,6 +247,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev);
 void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt);
 void dt_dev_write_history(dt_develop_t *dev);
 void dt_dev_read_history(dt_develop_t *dev);
+void dt_dev_free_history_item(gpointer data);
 
 void dt_dev_invalidate(dt_develop_t *dev);
 // also invalidates preview (which is unaffected by resize/zoom/pan)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -228,6 +228,7 @@ static void _history_undo_data_free(gpointer data)
   dt_undo_history_t *hist = (dt_undo_history_t *)data;
   GList *snapshot = hist->snapshot;
   g_list_free_full(snapshot, dt_dev_free_history_item);
+  free(data);
 }
 
 static void _lib_history_change_callback(gpointer instance, gpointer user_data)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -49,6 +49,7 @@ static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer use
 static void _lib_history_create_style_button_clicked_callback(GtkWidget *widget, gpointer user_data);
 /* signal callback for history change */
 static void _lib_history_change_callback(gpointer instance, gpointer user_data);
+static void _lib_history_module_remove_callback(gpointer instance, dt_iop_module_t *module, gpointer user_data);
 
 
 
@@ -129,11 +130,14 @@ void gui_init(dt_lib_module_t *self)
   /* connect to history change signal for updating the history view */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
                             G_CALLBACK(_lib_history_change_callback), self);
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE,
+                            G_CALLBACK(_lib_history_module_remove_callback), self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_history_change_callback), self);
+  dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_history_module_remove_callback), self);
 
   dt_lib_history_t *d = (dt_lib_history_t *)self->data;
   g_list_free_full(d->prev.snapshot, dt_dev_free_history_item);
@@ -232,6 +236,13 @@ static void _history_undo_data_free(gpointer data)
   GList *snapshot = hist->snapshot;
   g_list_free_full(snapshot, dt_dev_free_history_item);
   free(data);
+}
+
+static void _lib_history_module_remove_callback(gpointer instance, dt_iop_module_t *module, gpointer user_data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_history_t *d = (dt_lib_history_t *)self->data;
+  dt_dev_invalidate_history_module(d->prev.snapshot, module);
 }
 
 static void _lib_history_change_callback(gpointer instance, gpointer user_data)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -135,6 +135,9 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_history_change_callback), self);
 
+  dt_lib_history_t *d = (dt_lib_history_t *)self->data;
+  g_list_free_full(d->prev.snapshot, dt_dev_free_history_item);
+
   g_free(self->data);
   self->data = NULL;
 }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -250,7 +250,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
     /* record undo/redo history snapshot */
     if (d->prev.snapshot != NULL)
     {
-      dt_undo_history_t *hist = g_malloc(sizeof(dt_undo_history_t));
+      dt_undo_history_t *hist = malloc(sizeof(dt_undo_history_t));
       hist->snapshot=d->prev.snapshot;
       hist->end=d->prev.end;
       dt_undo_record(darktable.undo, self, DT_UNDO_HISTORY, (dt_undo_data_t *)hist, &pop_undo, _history_undo_data_free);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1073,8 +1073,9 @@ static void _view_map_filmstrip_activate_callback(gpointer instance, gpointer us
   }
 }
 
-static void pop_undo(dt_view_t *self, dt_undo_type_t type, dt_undo_data_t *data)
+static void pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data)
 {
+  dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
 
   if(type == DT_UNDO_GEOTAG)
@@ -1103,7 +1104,7 @@ static void _push_position(dt_view_t *self, int imgid, float longitude, float la
   geotag->latitude = latitude;
   geotag->elevation = elevation;
 
-  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, &pop_undo);
+  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, &pop_undo, NULL);
 }
 
 static void _get_image_location(dt_view_t *self, int imgid, float *longitude, float *latitude, float *elevation)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1104,7 +1104,7 @@ static void _push_position(dt_view_t *self, int imgid, float longitude, float la
   geotag->latitude = latitude;
   geotag->elevation = elevation;
 
-  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, &pop_undo, NULL);
+  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, &pop_undo, free);
 }
 
 static void _get_image_location(dt_view_t *self, int imgid, float *longitude, float *latitude, float *elevation)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -845,7 +845,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
 void init_key_accels(dt_view_t *self)
 {
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);
-  dt_accel_register_view(self, NC_("accel", "redo"), GDK_KEY_r, GDK_CONTROL_MASK);
+  dt_accel_register_view(self, NC_("accel", "redo"), GDK_KEY_y, GDK_CONTROL_MASK);
   // Film strip shortcuts
   dt_accel_register_view(self, NC_("accel", "toggle film strip"), GDK_KEY_f, GDK_CONTROL_MASK);
 }
@@ -853,10 +853,14 @@ void init_key_accels(dt_view_t *self)
 static gboolean _view_map_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                         GdkModifierType modifier, gpointer data)
 {
-  if(keyval == GDK_KEY_z)
-    dt_undo_do_undo(darktable.undo, DT_UNDO_GEOTAG);
-  else
-    dt_undo_do_redo(darktable.undo, DT_UNDO_GEOTAG);
+  dt_undo_do_undo(darktable.undo, DT_UNDO_GEOTAG);
+  return TRUE;
+}
+
+static gboolean _view_map_redo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                        GdkModifierType modifier, gpointer data)
+{
+  dt_undo_do_redo(darktable.undo, DT_UNDO_GEOTAG);
   return TRUE;
 }
 
@@ -871,8 +875,10 @@ static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *accele
 
 void connect_key_accels(dt_view_t *self)
 {
+  // undo/redo
   GClosure *closure = g_cclosure_new(G_CALLBACK(_view_map_undo_callback), (gpointer)self, NULL);
   dt_accel_connect_view(self, "undo", closure);
+  closure = g_cclosure_new(G_CALLBACK(_view_map_redo_callback), (gpointer)self, NULL);
   dt_accel_connect_view(self, "redo", closure);
   // Film strip shortcuts
   closure = g_cclosure_new(G_CALLBACK(film_strip_key_accel), (gpointer)self, NULL);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -38,6 +38,11 @@
 
 DT_MODULE(1)
 
+typedef struct dt_undo_geotag_t
+{
+  int imgid;
+  float longitude, latitude, elevation;
+} dt_undo_geotag_t;
 
 typedef struct dt_map_t
 {

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1097,7 +1097,7 @@ static void pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *da
 
 static void _push_position(dt_view_t *self, int imgid, float longitude, float latitude, float elevation)
 {
-  dt_undo_geotag_t *geotag = g_malloc(sizeof(dt_undo_geotag_t));
+  dt_undo_geotag_t *geotag = malloc(sizeof(dt_undo_geotag_t));
 
   geotag->imgid = imgid;
   geotag->longitude = longitude;

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -48,7 +48,6 @@ static void _free_undo_data(void *p)
 {
   dt_undo_item_t *item = (dt_undo_item_t *)p;
   if (item->free_data) item->free_data(item->data);
-  free(item->data);
   g_free(item);
 }
 

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -48,7 +48,7 @@ static void _free_undo_data(void *p)
 {
   dt_undo_item_t *item = (dt_undo_item_t *)p;
   if (item->free_data) item->free_data(item->data);
-  g_free(item->data);
+  free(item->data);
 }
 
 void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -49,6 +49,7 @@ static void _free_undo_data(void *p)
   dt_undo_item_t *item = (dt_undo_item_t *)p;
   if (item->free_data) item->free_data(item->data);
   free(item->data);
+  g_free(item);
 }
 
 void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
@@ -140,8 +141,8 @@ static void dt_undo_clear_list(GList **list, uint32_t filter)
     if(item->type & filter)
     {
       //  remove this element
-      _free_undo_data((void *)item);
       *list = g_list_remove(*list, item);
+      _free_undo_data((void *)item);
     }
     l = next;
   };

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -154,7 +154,7 @@ void dt_undo_do_undo(dt_undo_t *self, uint32_t filter)
   dt_pthread_mutex_unlock(&self->mutex);
 }
 
-static void dt_undo_clear_list(GList **list, uint32_t filter)
+static void _undo_clear_list(GList **list, uint32_t filter)
 {
   GList *l = g_list_first(*list);
 
@@ -177,8 +177,8 @@ static void dt_undo_clear_list(GList **list, uint32_t filter)
 void dt_undo_clear(dt_undo_t *self, uint32_t filter)
 {
   dt_pthread_mutex_lock(&self->mutex);
-  dt_undo_clear_list(&self->undo_list, filter);
-  dt_undo_clear_list(&self->redo_list, filter);
+  _undo_clear_list(&self->undo_list, filter);
+  _undo_clear_list(&self->redo_list, filter);
   self->undo_list = NULL;
   self->redo_list = NULL;
   dt_pthread_mutex_unlock(&self->mutex);

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -184,6 +184,31 @@ void dt_undo_clear(dt_undo_t *self, uint32_t filter)
   dt_pthread_mutex_unlock(&self->mutex);
 }
 
+static void _undo_iterate(GList *list, uint32_t filter, gpointer user_data,
+                          void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item))
+{
+  GList *l = g_list_first(list);
+
+  // check for first item that is matching the given pattern
+
+  while(l)
+  {
+    dt_undo_item_t *item = (dt_undo_item_t *)l->data;
+    if(item->type & filter)
+    {
+      apply(user_data, item->type, item->data);
+    }
+    l = l->next;
+  };
+}
+
+void dt_undo_iterate(dt_undo_t *self, uint32_t filter, gpointer user_data,
+                     void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item))
+{
+  _undo_iterate(self->undo_list, filter, user_data, apply);
+  _undo_iterate(self->redo_list, filter, user_data, apply);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -30,37 +30,12 @@ typedef struct dt_undo_item_t
   void (*free_data)(gpointer data);
 } dt_undo_item_t;
 
-static void _undo_clear_list_for_module(GList *list, dt_iop_module_t *module)
-{
-  while(list)
-  {
-    dt_undo_item_t *item = (dt_undo_item_t *)list->data;
-    if(item->type == DT_UNDO_HISTORY)
-    {
-      dt_undo_history_t *hist = (dt_undo_history_t *)item->data;
-      dt_dev_invalidate_history_module(hist->snapshot, module);
-    }
-    list = list->next;
-  }
-}
-
-static void _undo_module_remove_callback(gpointer instance, dt_iop_module_t *module, gpointer user_data)
-{
-  dt_undo_t *udata = (dt_undo_t *)user_data;
-  dt_pthread_mutex_lock(&udata->mutex);
-  _undo_clear_list_for_module (udata->undo_list, module);
-  _undo_clear_list_for_module (udata->redo_list, module);
-  dt_pthread_mutex_unlock(&udata->mutex);
-}
-
 dt_undo_t *dt_undo_init(void)
 {
   dt_undo_t *udata = malloc(sizeof(dt_undo_t));
   udata->undo_list = NULL;
   udata->redo_list = NULL;
   dt_pthread_mutex_init(&udata->mutex, NULL);
-  dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE,
-                            G_CALLBACK(_undo_module_remove_callback), udata);
   return udata;
 }
 
@@ -68,7 +43,6 @@ void dt_undo_cleanup(dt_undo_t *self)
 {
   dt_undo_clear(self, DT_UNDO_ALL);
   dt_pthread_mutex_destroy(&self->mutex);
-  dt_control_signal_disconnect (darktable.signals, G_CALLBACK(_undo_module_remove_callback), self);
 }
 
 static void _free_undo_data(void *p)

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -1,7 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2009--2010 johannes hanika.
-    copyright (c) 2012 tobias ellinghaus.
+    copyright (c) 2016 pascal obry
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/views/undo.c
+++ b/src/views/undo.c
@@ -49,14 +49,14 @@ static void _free_undo_data(void *p)
 {
   dt_undo_item_t *item = (dt_undo_item_t *)p;
   if (item->free_data) item->free_data(item->data);
-  g_free(item);
+  free(item);
 }
 
 void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
                     void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item),
                     void (*free_data)(gpointer data))
 {
-  dt_undo_item_t *item = g_malloc(sizeof(dt_undo_item_t));
+  dt_undo_item_t *item = malloc(sizeof(dt_undo_item_t));
 
   item->user_data = user_data;
   item->type      = type;

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -51,8 +51,9 @@ dt_undo_t *dt_undo_init(void);
 void dt_undo_cleanup(dt_undo_t *self);
 
 // record a change that will be insered into the undo list
-void dt_undo_record(dt_undo_t *self, dt_view_t *view, dt_undo_type_t type, dt_undo_data_t *data,
-                    void (*undo)(dt_view_t *view, dt_undo_type_t type, dt_undo_data_t *item));
+void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
+                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item),
+                    void (*free_data)(gpointer data));
 
 //  undo an element which correspond to filter. filter here is expected to be
 //  a set of dt_undo_type_t.

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -27,9 +27,10 @@
 typedef enum dt_undo_type_t
 {
   DT_UNDO_GEOTAG = 1,
+  DT_UNDO_HISTORY = 2,
 } dt_undo_type_t;
 
-#define DT_UNDO_ALL (DT_UNDO_GEOTAG)
+#define DT_UNDO_ALL (DT_UNDO_GEOTAG | DT_UNDO_HISTORY)
 
 //  types that are known by the undo module are declared here to be shared by
 //  all the views supporting undo.
@@ -38,6 +39,12 @@ typedef struct dt_undo_geotag_t
   int imgid;
   float longitude, latitude, elevation;
 } dt_undo_geotag_t;
+
+typedef struct dt_undo_history_t
+{
+  GList *snapshot;
+  int end;
+} dt_undo_history_t;
 
 typedef void *dt_undo_data_t;
 

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -31,14 +31,6 @@ typedef enum dt_undo_type_t
 
 #define DT_UNDO_ALL (DT_UNDO_GEOTAG | DT_UNDO_HISTORY)
 
-//  types that are known by the undo module are declared here to be shared by
-//  all the views supporting undo.
-typedef struct dt_undo_history_t
-{
-  GList *snapshot;
-  int end;
-} dt_undo_history_t;
-
 typedef void *dt_undo_data_t;
 
 typedef struct dt_undo_t

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -33,12 +33,6 @@ typedef enum dt_undo_type_t
 
 //  types that are known by the undo module are declared here to be shared by
 //  all the views supporting undo.
-typedef struct dt_undo_geotag_t
-{
-  int imgid;
-  float longitude, latitude, elevation;
-} dt_undo_geotag_t;
-
 typedef struct dt_undo_history_t
 {
   GList *snapshot;

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -20,7 +20,6 @@
 #define DT_UNDO_H
 
 #include "common/dtpthread.h"
-#include "views/view.h"
 #include <glib.h>
 
 //  types that are known by the undo module
@@ -71,6 +70,9 @@ void dt_undo_do_redo(dt_undo_t *self, uint32_t filter);
 
 //  removes all items which correspond to filter in the undo/redo lists
 void dt_undo_clear(dt_undo_t *self, uint32_t filter);
+
+void dt_undo_iterate(dt_undo_t *self, uint32_t filter, gpointer user_data,
+                     void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item));
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -1,7 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2009--2010 johannes hanika.
-    copyright (c) 2012 tobias ellinghaus.
+    copyright (c) 2016 pascal obry
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -25,11 +25,10 @@
 //  types that are known by the undo module
 typedef enum dt_undo_type_t
 {
-  DT_UNDO_GEOTAG = 1,
-  DT_UNDO_HISTORY = 2,
+  DT_UNDO_GEOTAG = 1 << 0,
+  DT_UNDO_HISTORY = 1 << 1,
+  DT_UNDO_ALL = DT_UNDO_GEOTAG | DT_UNDO_HISTORY
 } dt_undo_type_t;
-
-#define DT_UNDO_ALL (DT_UNDO_GEOTAG | DT_UNDO_HISTORY)
 
 typedef void *dt_undo_data_t;
 


### PR DESCRIPTION
First iteration after IRC discussion. This implementation is even immune against a wrong "compress history". That is, compress and then ctrl-z and hop, history is back.