### PR TITLE
take into account roi offset in VNG demosaic

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1113,7 +1113,7 @@ static void vng_interpolate(float *out, const float *const in, const dt_iop_roi_
       }
       float thold = gmin + (gmax * 0.5f);
       float sum[4] = { 0.0f };
-      int color = fcol(row, col, filters4, xtrans);
+      int color = fcol(row + roi_in->y, col + roi_in->x, filters4, xtrans);
       int num = 0;
       for(g = 0; g < 8; g++, ip += 2) /* Average the neighbors */
       {


### PR DESCRIPTION
Currently changes in roi->x and ->y for x-trans images produce errors in VNG demosaic when x%6 or y%6 != 0.

This came up from emailing with upegelow regarding his work on an OpenCL implementation. This PR is in advance of his checking in a significant improvement to VNG.

To see this bug, open an x-trans image with thin detail in darkroom mode at 200%. Drag slightly left/right, and changes in detail will appear:

![vng shift error](https://cloud.githubusercontent.com/assets/2311860/12126560/e174c6ba-b3bf-11e5-9eda-0b5d6de05e0d.png)
