### PR TITLE
Make FindSaxon.cmake work on Fedora 23, Fixes #10873

### DIFF
--- a/cmake/modules/FindSaxon.cmake
+++ b/cmake/modules/FindSaxon.cmake
@@ -52,6 +52,7 @@ if (JAVA_RUNTIME)
   find_file (SAXON
     NAMES saxon.jar saxon6.jar saxon-6.5.5.jar saxon-6.5.4.jar saxon-6.5.3.jar
     PATH_SUFFIXES share/java
+                  share/java/saxon
                   share/java/saxon6
                   share/saxon-6.5/lib 
     DOC "location of saxon 6.5.x JAR file"
@@ -65,6 +66,7 @@ if (JAVA_RUNTIME)
                   share/xml/docbook-xsl/extensions
                   share/xml/docbook/xsl/extensions
                   share/java
+                  share/java/saxon
                   share/java/docbook-xsl-saxon
                   share/saxon-6.5/lib
     DOC "location of saxon 6.5.x DocBook XSL extension JAR file"


### PR DESCRIPTION
saxon.jar is installed in /usr/share/java/saxon on Fedora 23