### PR TITLE
opencl implementation of Markesteijn demosaicing algorithm for x-trans sensors

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -10,3 +10,4 @@ Stuff that belongs in here:
 The release team should empty this file after each release.
 ==========================================================================================
 opencl implementation of vng/vng4 demosaicing methods
+opencl implementation of Markesteijn demosaicing method for x-trans sensors

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -134,6 +134,13 @@
     <shortdescription>checksum representing the setup of opencl devices on this computer</shortdescription>
     <longdescription>darktable re-checks the performance benchmarks of your system in case your setup has changed, which is indicated by a change versus the stored checksum in this config variable; darktable de-activates opencl if the GPU benchmark lies below the one of the CPU.</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>opencl_enable_markesteijn</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>whether to process markesteijn demosaicing in the OpenCL codepath</shortdescription>
+    <longdescription>markesteijn is a very demanding demosaicing method for x-trans sensors. the OpenCL codepath will only give advantage on very performant GPUs - else a slowdown is to be expected. users should benchmark their system and then decide if they switch this on or off.</longdescription>
+  </dtconfig>
   <dtconfig prefs="gui">
     <name>never_use_embedded_thumb</name>
     <type>bool</type>

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -88,7 +88,7 @@ markesteijn_border_interpolate(read_only image2d_t in, write_only image2d_t out,
 }
 
 
-// Copy current tile from in to image buffer.
+// copy image from image object to buffer.
 kernel void
 markesteijn_initial_copy(read_only image2d_t in, global float *rgb, const int width, const int height,
                          const int rin_x, const int rin_y, global const unsigned char (*const xtrans)[6])
@@ -397,9 +397,7 @@ markesteijn_solitary_green(global float *rgb, global float *aux, const int width
 }
 
 
-// Recalculate green from interpolated values of closer pixels.
-// only used for Markesteijn-3, this is an expensive step
-// as it processes a loop over several global buffers
+// recalculate green from interpolated values of closer pixels.
 kernel void
 markesteijn_recalculate_green(global float *rgb_0, global float *rgb_1, global float *rgb_2, global float *rgb_3,
                               global float *gminmax, const int width, const int height, const int rin_x, const int rin_y, 
@@ -699,7 +697,7 @@ markesteijn_homo_threshold(global float *drv, global float *thresh, const int wi
   if(x < 9 || x >= width-9 || y < 9 || y >= height-9) return;
 
   // note: although *thresh points to a buffer of size width*height*4*sizeof(float) we only need one
-  // float per cell, so we actually only use one quarter of the buffer
+  // float per cell, so we actually use only a quarter of the buffer
 
   const int glidx = mad24(y, width, x);
   

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -20,7 +20,11 @@
 
 #include "common.h"
 
-constant char2 dir[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(1, 1), (char2)(-1, 1) };
+// directions along the both axes and both diagonals
+constant const char2 dir[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(1, 1), (char2)(-1, 1) };
+// all possible offsets of a neighboring pixel in x/y directions
+constant const char2 offs[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(-1, 0), (char2)(0, -1) };
+
 
 // temporary be here to fill in image borders
 kernel void
@@ -101,10 +105,8 @@ hexidx4(const char2 hex, const int stride)
 }
 
 
-// possible offsets of a neighboring pixel in x/y directions
-constant const char2 dir2nd[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(-1, 0), (char2)(0, -1) };
 
-// Set green1 and green3 of red/blud pixel pairs to the minimum and maximum allowed values
+// find minimum and maximum allowed green values of red/blue pixel pairs
 kernel void
 markesteijn_green_minmax(global float *rgb, global float *gminmax, const int width, const int height, 
                          const int rin_x, const int rin_y, const char2 sgreen, global const unsigned char (*const xtrans)[6], 
@@ -177,9 +179,9 @@ markesteijn_green_minmax(global float *rgb, global float *gminmax, const int wid
   global const char2 *hex2nd = hex;               // initialized here only to prevent compiler warning
   for (int n = 0; n < 4; n++)
   {
-    if(FCxtrans(y + dir2nd[n].y + rin_y, x + dir2nd[n].x + rin_x, xtrans) == 1) continue; // this is a green pixel
-    buff2nd = buff + mad24(dir2nd[n].y, stride, dir2nd[n].x);
-    hex2nd = allhex[(y + dir2nd[n].y) % 3][(x + dir2nd[n].x) % 3];
+    if(FCxtrans(y + offs[n].y + rin_y, x + offs[n].x + rin_x, xtrans) == 1) continue; // this is a green pixel
+    buff2nd = buff + mad24(offs[n].y, stride, offs[n].x);
+    hex2nd = allhex[(y + offs[n].y) % 3][(x + offs[n].x) % 3];
   }
   
   // we have found the second pixel: now include it into min/max calculation
@@ -217,7 +219,7 @@ markesteijn_interpolate_green(global float *rgb_0, global float *rgb_1, global f
   const int lsz = mul24(xlsz, ylsz);
 
   // stride and maximum capacity of local buffer
-  // cells of 4*float per pixel with a border of 6 cells
+  // cells of 4*float per pixel with a surrounding border of 6 cells
   const int stride = xlsz + 2*6;
   const int maxbuf = mul24(stride, ylsz + 2*6);
 
@@ -237,7 +239,7 @@ markesteijn_interpolate_green(global float *rgb_0, global float *rgb_1, global f
     const int xx = xul + bufidx % stride;
     const int yy = yul + bufidx / stride;
     const int inidx = mad24(yy, width, xx);
-    float4 pixel = (inidx >= 0 && inidx < rgb_0_max) ? vload4(inidx, rgb_0) : (float4)0.0f;
+    const float4 pixel = (inidx >= 0 && inidx < rgb_0_max) ? vload4(inidx, rgb_0) : (float4)0.0f;
     vstore4(pixel, bufidx, buffer);
   }
   
@@ -256,9 +258,9 @@ markesteijn_interpolate_green(global float *rgb_0, global float *rgb_1, global f
   if(f == 1) return;
 
 
-  // get min/max of this pixel
-  float gmin = (gminmax + 2 * mad24(y, width, x))[0];
-  float gmax = (gminmax + 2 * mad24(y, width, x))[1];
+  // receive min/max of this pixel
+  const float gmin = (gminmax + 2 * mad24(y, width, x))[0];
+  const float gmax = (gminmax + 2 * mad24(y, width, x))[1];
   
   global const char2 *const hex = allhex[y % 3][x % 3];
 
@@ -280,19 +282,322 @@ markesteijn_interpolate_green(global float *rgb_0, global float *rgb_1, global f
                                     - (buff - 3 * hexidx4(hex[4 + c], stride))[f]);
   }  
   
-  float out[4];
-  for(int c = 0; c < 4; c++)
-  {
-    // note: the original C99 code makes use of the fact that (boolean)TRUE is translates to (int)1.
-    //       in OpenCL (boolean)TRUE is represented by (int)-1, though.
-    const int d = (!((y - sgreen.y) % 3)) ? 1 : 0;
-    out[c ^ d] = clamp(color[c], gmin, gmax);
-  }
-
   global float *rgb[4] = { rgb_0, rgb_1, rgb_2, rgb_3 };
   const int glidx = 4 * mad24(y, width, x);
 
   for(int c = 0; c < 4; c++)
-    (rgb[c] + glidx)[1] = out[c];
+  {
+    // note: the original C99 code makes use of the fact that (boolean)TRUE translates to (int)1.
+    //       in OpenCL (boolean)TRUE is represented by (int)-1, though.
+    const int d = (!((y - sgreen.y) % 3)) ? 1 : 0;
+    (rgb[c ^ d] + glidx)[1] = clamp(color[c], gmin, gmax);
+  }
 }
  
+float
+sqr(const float x)
+{
+  return x * x;
+}
+
+// interpolate red and blue values for solitary green pixels
+kernel void
+markesteijn_solitary_green(global float *rgb, global float *aux, const int width, const int height,
+                           const int rin_x, const int rin_y, const int d, const char2 dir, const int hcomp,
+                           const char2 sgreen, global const unsigned char (*const xtrans)[6], local float *buffer)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+  
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of 4*float per pixel with a surrounding border of 2 cells
+  const int stride = xlsz + 2*2;
+  const int maxbuf = mul24(stride, ylsz + 2*2);
+
+  // coordinates of top left pixel of buffer
+  // this is 2 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 2;
+  const int yul = mul24(ygid, ylsz) - 2;
+
+  // total size of rgb (in units of 4*float)
+  const int rgb_max = mul24(width, height);
+  
+  // we locally buffer rgb to speed-up reading
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    const int inidx = mad24(yy, width, xx);
+    const float4 pixel = (inidx >= 0 && inidx < rgb_max) ? vload4(inidx, rgb) : (float4)0.0f;
+    vstore4(pixel, bufidx, buffer);
+  }
+  
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  // center the local buffer around current x,y-Pixel
+  local float *buff = buffer +  4 * mad24(ylid + 2, stride, xlid + 2);
+  
+  // take sufficient border into account
+  if(x < 2 || x >= width-2 || y < 2 || y >= height-2) return;
+  
+  // we only work on solitary green pixels
+  if((x - sgreen.x) % 3 != 0 || (y - sgreen.y) % 3 != 0) return;
+  
+  // the color of the pixel right to this one
+  int h = FCxtrans(y + rin_y, x + 1 + rin_x, xtrans);
+  
+  // the complement according to this run
+  h ^= hcomp;
+  
+  // center aux and rgb around current pixel
+  const int glidx = 4 * mad24(y, width, x);
+  aux += glidx;
+  rgb += glidx;
+  
+  const float odiff = aux[3];
+  float diff = 0.0f;
+  float color[4] = { 0.0f };
+  
+  const int i = 4 * mad24(dir.y, stride, dir.x);
+
+  for(int c = 0; c < 2; c++, h ^= 2)
+  {
+    const int off = i << c;
+    float g = 2.0f * buff[1] - (buff + off)[1] - (buff - off)[1];
+    color[h] = g + (buff + off)[h] + (buff - off)[h];
+    diff = (d > 1) ? sqr((buff + off)[1] - (buff - off)[1] - (buff + off)[h] + (buff - off)[h]) 
+                     + sqr(g)
+                   : diff;
+  }
+  
+  if((d > 1) && (d & 1) && (odiff < diff))
+  {
+    for(int c = 0; c < 2; c++) color[c * 2] = aux[c * 2];
+  }
+  
+  if((d < 2) || (d & 1))
+  {
+    for(int c = 0; c < 2; c++) rgb[c * 2] = clamp(color[c * 2] / 2.0f, 0.0f, 1.0f);
+  }
+  
+  color[3] = diff;
+  for(int c = 0; c < 4; c++) aux[c] = color[c];
+}
+
+
+// Recalculate green from interpolated values of closer pixels.
+// only used for Markesteijn-3, this is an expensive step
+// as it processes a loop over several global buffers
+kernel void
+markesteijn_recalculate_green(global float *rgb_0, global float *rgb_1, global float *rgb_2, global float *rgb_3,
+                              global float *gminmax, const int width, const int height, const int rin_x, const int rin_y, 
+                              const char2 sgreen, global const unsigned char (*const xtrans)[6], 
+                              global const char2 (*const allhex)[3][8])
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  // take sufficient border into account
+  if(x < 5 || x >= width-5 || y < 5 || y >= height-5) return;
+  
+  global float *rgb[4] = { rgb_0, rgb_1, rgb_2, rgb_3 };
+  
+  // the color of this pixel
+  const int f = FCxtrans(y + rin_y, x + rin_x, xtrans);
+  
+  // we only work on non-green pixels
+  if(f == 1) return;
+
+  // receive min/max of this pixel
+  const float gmin = (gminmax + 2 * mad24(y, width, x))[0];
+  const float gmax = (gminmax + 2 * mad24(y, width, x))[1];
+  
+  global const char2 *const hex = allhex[y % 3][x % 3];
+
+  const int glidx = 4 * mad24(y, width, x);  
+
+  for(int d = 3; d < 6; d++)
+  {
+    const int id = (d - 2) ^ (!((y - sgreen.y) % 3) ? 1 : 0);
+    global float *rfx = rgb[id] + glidx;
+    const float val = (rfx - 2 * hexidx4(hex[d], width))[1]
+                       + 2.0f * (rfx + hexidx4(hex[d], width))[1]
+                       - (rfx - 2 * hexidx4(hex[d], width))[f]
+                       - 2.0f * (rfx + hexidx4(hex[d], width))[f]
+                       + 3.0f * (rfx)[f];
+                       
+    rfx[1] = clamp(val / 3.0f, gmin, gmax);
+  }
+}
+
+
+// interpolate red for blue pixels and vice versa
+kernel void
+markesteijn_red_and_blue(global float *rgb, const int width, const int height, const int rin_x, const int rin_y,
+                         const char2 sgreen, global const unsigned char (*const xtrans)[6], local float *buffer)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+  
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of 4*float per pixel with a surrounding border of 1 cell
+  const int stride = xlsz + 2*1;
+  const int maxbuf = mul24(stride, ylsz + 2*1);
+
+  // coordinates of top left pixel of buffer
+  // this is 1 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 1;
+  const int yul = mul24(ygid, ylsz) - 1;
+
+  // total size of rgb (in units of 4*float)
+  const int rgb_max = mul24(width, height);
+  
+  // we locally buffer rgb to speed-up reading
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    const int inidx = mad24(yy, width, xx);
+    const float4 pixel = (inidx >= 0 && inidx < rgb_max) ? vload4(inidx, rgb) : (float4)0.0f;
+    vstore4(pixel, bufidx, buffer);
+  }
+  
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  // center the local buffer around current x,y-Pixel
+  local float *buff = buffer +  4 * mad24(ylid + 1, stride, xlid + 1);
+  
+  // take sufficient border into account
+  if(x < 1 || x >= width-1 || y < 1 || y >= height-1) return;
+  
+  // the "other" color relative to this pixel's one
+  const int f = 2 -  FCxtrans(y + rin_y, x + rin_x, xtrans);
+  
+  // we don't work on green pixels
+  if(f == 1) return;
+  
+  // center rgb around current pixel
+  rgb += 4 * mad24(y, width, x);
+  
+  // in which direction to sample (y or x)
+  const int off = (y - sgreen.y) % 3 ? 4 * stride : 4;
+
+  rgb[f] = clamp(((buff + off)[f] + (buff - off)[f] + 2.0f * buff[1] - (buff + off)[1] - (buff - off)[1]) / 2.0f, 0.0f, 1.0f);
+}
+
+
+// interpolate red and blue for 2x2 blocks of green
+kernel void
+markesteijn_interpolate_twoxtwo(global float *rgb, const int width, const int height, const int rin_x, const int rin_y, 
+                                const int d, const char2 sgreen, global const unsigned char (*const xtrans)[6], 
+                                global const char2 (*const allhex)[3][8], local float *buffer)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+  
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of 4*float per pixel with a surrounding border of 2 cells
+  const int stride = xlsz + 2*2;
+  const int maxbuf = mul24(stride, ylsz + 2*2);
+
+  // coordinates of top left pixel of buffer
+  // this is 2 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 2;
+  const int yul = mul24(ygid, ylsz) - 2;
+
+  // total size of rgb (in units of 4*float)
+  const int rgb_max = mul24(width, height);
+  
+  // we locally buffer rgb to speed-up reading
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    const int inidx = mad24(yy, width, xx);
+    const float4 pixel = (inidx >= 0 && inidx < rgb_max) ? vload4(inidx, rgb) : (float4)0.0f;
+    vstore4(pixel, bufidx, buffer);
+  }
+  
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  // center the local buffer around current x,y-Pixel
+  local float *buff = buffer +  4 * mad24(ylid + 2, stride, xlid + 2);
+  
+  // take sufficient border into account
+  if(x < 1 || x >= width-1 || y < 1 || y >= height-1) return;
+  
+  // we only work on pixels within an 2x2 block of green.
+  // for all other pixels which are in the same row or column
+  // as the solitary green pixel we skip
+  if((y - sgreen.y) % 3 == 0 || (x - sgreen.x) % 3 == 0) return;
+  
+  // center rgb around current pixel
+  rgb += 4 * mad24(y, width, x);
+  
+  // get hexagon of surrounding pixels
+  global const char2 *const hex = allhex[y % 3][x % 3];
+  
+  const int idx = hexidx4(hex[d], stride);
+  const int idx1 = hexidx4(hex[d + 1], stride);
+  
+  float m[5];
+  if(idx + idx1)
+  {
+    m[0] = 3.0f;
+    m[1] = -2.0f;
+    m[2] = -1.0f;
+    m[3] = 2.0f;
+    m[4] = 1.0f / 3.0f;
+  }
+  else
+  {
+    m[0] = 2.0f;
+    m[1] = -1.0f;
+    m[2] = -1.0f;
+    m[3] = 1.0f;
+    m[4] = 1.0f / 2.0f;
+  }
+  
+  const float g = m[0] * buff[1] + m[1] * (buff + idx)[1] + m[2] * (buff + idx1)[1];
+  
+  for(int c = 0; c < 4; c += 2)
+    rgb[c] = clamp((g + m[3] * (buff + idx)[c] + (buff + idx1)[c]) * m[4], 0.0f, 1.0f);
+}
+
+

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -22,7 +22,7 @@
 constant const char2 dir[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(1, 1), (char2)(-1, 1) };
 
 // all possible offsets of a neighboring pixel in x/y directions
-constant const char2 offs[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(-1, 0), (char2)(0, -1) };
+constant const char2 nboff[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(-1, 0), (char2)(0, -1) };
 
 int
 hexidx1(const char2 hex, const int stride)
@@ -182,9 +182,9 @@ markesteijn_green_minmax(global float *rgb, global float *gminmax, const int wid
   global const char2 *hex2nd = hex;               // initialized here only to prevent compiler warning
   for (int n = 0; n < 4; n++)
   {
-    if(FCxtrans(y + offs[n].y + rin_y, x + offs[n].x + rin_x, xtrans) == 1) continue; // this is a green pixel
-    buff2nd = buff + mad24(offs[n].y, stride, offs[n].x);
-    hex2nd = allhex[(y + offs[n].y) % 3][(x + offs[n].x) % 3];
+    if(FCxtrans(y + nboff[n].y + rin_y, x + nboff[n].x + rin_x, xtrans) == 1) continue; // this is a green pixel
+    buff2nd = buff + mad24(nboff[n].y, stride, nboff[n].x);
+    hex2nd = allhex[(y + nboff[n].y) % 3][(x + nboff[n].x) % 3];
   }
   
   // we have found the second pixel: now include it into min/max calculation
@@ -969,18 +969,3 @@ markesteijn_final(read_only image2d_t in, write_only image2d_t out, const int wi
   write_imagef(out, (int2)(x, y), pixel); 
 }
 
-
-kernel void
-markesteijn_probe(global float *in, write_only image2d_t out, const int width, const int height)
-{
-  const int x = get_global_id(0);
-  const int y = get_global_id(1);
-
-  // take sufficient border into account
-  if(x < 11 || x >= width-11 || y < 11 || y >= height-11) return;
-  
-  const int glidx = mad24(y, width, x);
-  float4 pixel = vload4(glidx, in);
-
-  write_imagef(out, (int2)(x, y), pixel); 
-}

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -1,0 +1,298 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Ulrich Pegelow.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma OPENCL EXTENSION cl_amd_printf : enable
+
+#include "common.h"
+
+constant char2 dir[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(1, 1), (char2)(-1, 1) };
+
+// temporary be here to fill in image borders
+kernel void
+markesteijn_border_interpolate(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+                               const int rin_x, const int rin_y, global const unsigned char (*const xtrans)[6])
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  const int border = 11;
+  const int avgwindow = 1;
+
+  if(x >= border && x < width-border && y >= border && y < height-border) return;
+
+  float o[4] = { 0.0f };
+  float sum[4] = { 0.0f };
+  int count[4] = { 0 };
+
+  for(int j = y-avgwindow; j <= y+avgwindow; j++)
+    for(int i = x-avgwindow; i <= x+avgwindow; i++)
+    {
+      if(j >= 0 && i >= 0 && j < height && i < width)
+      {
+        int f = FCxtrans(j + rin_y, i + rin_x, xtrans);
+        sum[f] += read_imagef(in, sampleri, (int2)(i, j)).x;
+        count[f]++;
+      }
+    }
+
+  float i = read_imagef(in, sampleri, (int2)(x, y)).x;
+
+  int f = FCxtrans(y + rin_y, x + rin_x, xtrans);
+
+  for(int c = 0; c < 3; c++)
+  {
+    if(c != f && count[c] != 0)
+      o[c] = sum[c] / count[c];
+    else
+      o[c] = i;
+  }
+
+  write_imagef (out, (int2)(x, y), (float4)(o[0], o[1], o[2], o[3]));
+}
+
+
+// Copy current tile from in to image buffer.
+kernel void
+markesteijn_initial_copy(read_only image2d_t in, global float *rgb, const int width, const int height,
+                         const int rin_x, const int rin_y, global const unsigned char (*const xtrans)[6])
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  global float *pix = rgb + 4 * mad24(y, width, x);
+  
+  const int f = FCxtrans(y + rin_y, x + rin_x, xtrans);
+  
+  float p = read_imagef(in, sampleri, (int2)(x, y)).x;
+  
+  for(int c = 0; c < 3; c++) 
+    pix[c] = (c == f) ? p : 0.0f;
+}
+
+int
+hexidx1(const char2 hex, const int stride)
+{
+  return mad24(hex.y, stride, hex.x);
+}
+
+int
+hexidx4(const char2 hex, const int stride)
+{
+  return mul24(mad24(hex.y, stride, hex.x), 4);
+}
+
+
+// possible offsets of a neighboring pixel in x/y directions
+constant const char2 dir2nd[4] = { (char2)(1, 0), (char2)(0, 1), (char2)(-1, 0), (char2)(0, -1) };
+
+// Set green1 and green3 of red/blud pixel pairs to the minimum and maximum allowed values
+kernel void
+markesteijn_green_minmax(global float *rgb, global float *gminmax, const int width, const int height, 
+                         const int rin_x, const int rin_y, const char2 sgreen, global const unsigned char (*const xtrans)[6], 
+                         global const char2 (*const allhex)[3][8], local float *buffer)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+  
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of 1*float per pixel with a surrounding border of 3 cells
+  const int stride = xlsz + 2*3;
+  const int maxbuf = mul24(stride, ylsz + 2*3);
+
+  // coordinates of top left pixel of buffer
+  // this is 3 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 3;
+  const int yul = mul24(ygid, ylsz) - 3;
+
+  // total size of rgb (in units of 1*float)
+  const int rgb_max = mul24(width, height);
+  
+  // we locally buffer rgb_0[1] (i.e. green) to speed-up reading
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    const int inidx = mad24(yy, width, xx);
+    buffer[bufidx] = (inidx >= 0 && inidx < rgb_max) ? (rgb + 4 * inidx)[1] : 0.0f;
+  }
+  
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  // center the local buffer around current x,y-Pixel
+  local float *buff = buffer +  mad24(ylid + 3, stride, xlid + 3);
+  
+  // take sufficient border into account
+  if(x < 3 || x >= width-3 || y < 3 || y >= height-3) return;
+  
+  // the color of this pixel
+  const int f = FCxtrans(y + rin_y, x + rin_x, xtrans);
+  
+  // we only work on non-green pixels
+  if(f == 1) return;
+
+  // get min/max of *this* pixel
+  float gmin = FLT_MAX;
+  float gmax = FLT_MIN;
+  global const char2 *const hex = allhex[y % 3][x % 3];
+  for(int c = 0; c < 6; c++)
+  {
+    const float val = buff[hexidx1(hex[c], stride)];
+    if(gmin > val) gmin = val;
+    if(gmax < val) gmax = val;
+  }
+
+  // find the *one* neighboring non-green pixel in four directions
+  local float *buff2nd = buff;                    // initialized here only to prevent compiler warning
+  global const char2 *hex2nd = hex;               // initialized here only to prevent compiler warning
+  for (int n = 0; n < 4; n++)
+  {
+    if(FCxtrans(y + dir2nd[n].y + rin_y, x + dir2nd[n].x + rin_x, xtrans) == 1) continue; // this is a green pixel
+    buff2nd = buff + mad24(dir2nd[n].y, stride, dir2nd[n].x);
+    hex2nd = allhex[(y + dir2nd[n].y) % 3][(x + dir2nd[n].x) % 3];
+  }
+  
+  // we have found the second pixel: now include it into min/max calculation
+  for(int c = 0; c < 6; c++)
+  {
+    const float val = buff2nd[hexidx1(hex2nd[c], stride)];
+    if(gmin > val) gmin = val;
+    if(gmax < val) gmax = val;
+  }
+  
+  const int glidx = mad24(y, width, x);
+  vstore2((float2)(gmin, gmax), glidx, gminmax);
+}
+ 
+
+
+// Interpolate green horizontally, vertically, and along both diagonals
+kernel void
+markesteijn_interpolate_green(global float *rgb_0, global float *rgb_1, global float *rgb_2, global float *rgb_3,
+                              global float *gminmax, const int width, const int height, const int rin_x, const int rin_y, 
+                              const char2 sgreen, global const unsigned char (*const xtrans)[6], 
+                              global const char2 (*const allhex)[3][8], local float *buffer)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  const int xlsz = get_local_size(0);
+  const int ylsz = get_local_size(1);
+  const int xlid = get_local_id(0);
+  const int ylid = get_local_id(1);
+  const int xgid = get_group_id(0);
+  const int ygid = get_group_id(1);
+  
+  // individual control variable in this work group and the work group size
+  const int l = mad24(ylid, xlsz, xlid);
+  const int lsz = mul24(xlsz, ylsz);
+
+  // stride and maximum capacity of local buffer
+  // cells of 4*float per pixel with a border of 6 cells
+  const int stride = xlsz + 2*6;
+  const int maxbuf = mul24(stride, ylsz + 2*6);
+
+  // coordinates of top left pixel of buffer
+  // this is 6 pixel left and above of the work group origin
+  const int xul = mul24(xgid, xlsz) - 6;
+  const int yul = mul24(ygid, ylsz) - 6;
+
+  // total size of rgb_0 (in units of 4*float)
+  const int rgb_0_max = mul24(width, height);
+  
+  // we locally buffer rgb_0 to speed-up reading
+  for(int n = 0; n <= maxbuf/lsz; n++)
+  {
+    const int bufidx = mad24(n, lsz, l);
+    if(bufidx >= maxbuf) continue;
+    const int xx = xul + bufidx % stride;
+    const int yy = yul + bufidx / stride;
+    const int inidx = mad24(yy, width, xx);
+    float4 pixel = (inidx >= 0 && inidx < rgb_0_max) ? vload4(inidx, rgb_0) : (float4)0.0f;
+    vstore4(pixel, bufidx, buffer);
+  }
+  
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  // center the local buffer around current x,y-Pixel
+  local float *buff = buffer + 4 * mad24(ylid + 6, stride, xlid + 6);
+  
+  // take sufficient border into account
+  if(x < 3 || x >= width-3 || y < 3 || y >= height-3) return;
+  
+  // the color of this pixel
+  const int f = FCxtrans(y + rin_y, x + rin_x, xtrans);
+  
+  // we only work on non-green pixels
+  if(f == 1) return;
+
+
+  // get min/max of this pixel
+  float gmin = (gminmax + 2 * mad24(y, width, x))[0];
+  float gmax = (gminmax + 2 * mad24(y, width, x))[1];
+  
+  global const char2 *const hex = allhex[y % 3][x % 3];
+
+  float color[8];
+  
+  color[0] = 0.6796875f * ((buff + hexidx4(hex[1], stride))[1] + (buff + hexidx4(hex[0], stride))[1])
+             - 0.1796875f * ((buff + 2 * hexidx4(hex[1], stride))[1] + (buff + 2 * hexidx4(hex[0], stride))[1]);
+                     
+  color[1] = 0.87109375f * (buff + hexidx4(hex[3], stride))[1] 
+             + 0.13f * (buff + hexidx4(hex[2], stride))[1]
+             + 0.359375f * ((buff)[f] - (buff - hexidx4(hex[2], stride))[f]);
+                     
+  for(int c = 0; c < 2; c++)
+  {
+    color[2 + c] = 0.640625f * (buff + hexidx4(hex[4 + c], stride))[1] 
+                   + 0.359375f * (buff - 2 * hexidx4(hex[4 + c], stride))[1]
+                   + 0.12890625f * (2.0f * (buff)[f]
+                                    - (buff + 3 * hexidx4(hex[4 + c], stride))[f] 
+                                    - (buff - 3 * hexidx4(hex[4 + c], stride))[f]);
+  }  
+  
+  float out[4];
+  for(int c = 0; c < 4; c++)
+  {
+    // note: the original C99 code makes use of the fact that (boolean)TRUE is translates to (int)1.
+    //       in OpenCL (boolean)TRUE is represented by (int)-1, though.
+    const int d = (!((y - sgreen.y) % 3)) ? 1 : 0;
+    out[c ^ d] = clamp(color[c], gmin, gmax);
+  }
+
+  global float *rgb[4] = { rgb_0, rgb_1, rgb_2, rgb_3 };
+  const int glidx = 4 * mad24(y, width, x);
+
+  for(int c = 0; c < 4; c++)
+    (rgb[c] + glidx)[1] = out[c];
+}
+ 

--- a/data/kernels/demosaic_markesteijn.cl
+++ b/data/kernels/demosaic_markesteijn.cl
@@ -42,52 +42,6 @@ sqr(const float x)
   return x * x;
 }
 
-// temporary be here to fill in image borders
-kernel void
-markesteijn_border_interpolate(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
-                               const int rin_x, const int rin_y, global const unsigned char (*const xtrans)[6])
-{
-  const int x = get_global_id(0);
-  const int y = get_global_id(1);
-
-  if(x >= width || y >= height) return;
-
-  const int border = 11;
-  const int avgwindow = 1;
-
-  if(x >= border && x < width-border && y >= border && y < height-border) return;
-
-  float o[4] = { 0.0f };
-  float sum[4] = { 0.0f };
-  int count[4] = { 0 };
-
-  for(int j = y-avgwindow; j <= y+avgwindow; j++)
-    for(int i = x-avgwindow; i <= x+avgwindow; i++)
-    {
-      if(j >= 0 && i >= 0 && j < height && i < width)
-      {
-        int f = FCxtrans(j + rin_y, i + rin_x, xtrans);
-        sum[f] += read_imagef(in, sampleri, (int2)(i, j)).x;
-        count[f]++;
-      }
-    }
-
-  float i = read_imagef(in, sampleri, (int2)(x, y)).x;
-
-  int f = FCxtrans(y + rin_y, x + rin_x, xtrans);
-
-  for(int c = 0; c < 3; c++)
-  {
-    if(c != f && count[c] != 0)
-      o[c] = sum[c] / count[c];
-    else
-      o[c] = i;
-  }
-
-  write_imagef (out, (int2)(x, y), (float4)(o[0], o[1], o[2], o[3]));
-}
-
-
 // copy image from image object to buffer.
 kernel void
 markesteijn_initial_copy(read_only image2d_t in, global float *rgb, const int width, const int height,

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -16,3 +16,4 @@ bloom.cl                12
 colorreconstruction.cl  13
 demosaic_other.cl       14
 demosaic_vng.cl         15
+demosaic_markesteijn.cl 16

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -75,6 +75,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl)
   cl->async_pixelpipe = dt_conf_get_bool("opencl_async_pixelpipe");
   cl->synch_cache = dt_conf_get_bool("opencl_synch_cache");
   cl->micro_nap = dt_conf_get_int("opencl_micro_nap");
+  cl->enable_markesteijn = dt_conf_get_bool("opencl_enable_markesteijn");
   cl->crc = 0;
   cl->dlocl = NULL;
   cl->dev_priority_image = NULL;
@@ -126,6 +127,9 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl)
            dt_conf_get_bool("opencl_avoid_atomics"));
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_omit_whitebalance: %d\n",
            dt_conf_get_bool("opencl_omit_whitebalance"));
+  dt_print(DT_DEBUG_OPENCL, "[opencl_init] opencl_enable_markesteijn: %d\n",
+           dt_conf_get_bool("opencl_enable_markesteijn"));
+
 
   dt_print(DT_DEBUG_OPENCL, "[opencl_init] \n");
 

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -110,6 +110,7 @@ typedef struct dt_opencl_t
   int async_pixelpipe;
   int number_event_handles;
   int synch_cache;
+  int enable_markesteijn;
   int micro_nap;
   int enabled;
   int stopped;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2413,6 +2413,8 @@ restart:
                "[opencl] frequent opencl errors encountered; disabling opencl for this session!\n");
       dt_control_log(
           _("darktable discovered problems with your OpenCL setup; disabling OpenCL for this session!"));
+      // also remove "opencl" from capabilities so that the preference entry is greyed out
+      dt_capabilities_remove("opencl");
     }
 
     dt_dev_pixelpipe_flush_caches(pipe);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1819,17 +1819,10 @@ process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->data;
   const dt_image_t *img = &self->dev->image_storage;
+
   const float threshold = 0.0001f * img->exif_iso;
-
-  if(roi_out->scale >= 1.00001f)
-  {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaic with upscaling not yet supported by opencl code\n");
-    return FALSE;
-  }
-
   const int devid = piece->pipe->devid;
   const int qual = get_quality();
-
   const int demosaicing_method = data->demosaicing_method;
 
   // we check if we need ultra-high quality thumbnail for this size
@@ -2044,14 +2037,6 @@ process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int colors = (filters4 == 9u) ? 3 : 4;
   const int prow = (filters4 == 9u) ? 6 : 8;
   const int pcol = (filters4 == 9u) ? 6 : 2;
-
-
-  if(roi_out->scale >= 1.00001f)
-  {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaic with upscaling not yet supported by opencl code\n");
-    return FALSE;
-  }
-
   const int devid = piece->pipe->devid;
   const int qual = get_quality();
 
@@ -2463,12 +2448,6 @@ process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   dt_iop_demosaic_global_data_t *gd = (dt_iop_demosaic_global_data_t *)self->data;
 
   const dt_image_t *img = &self->dev->image_storage;
-
-  if(roi_out->scale >= 1.00001f)
-  {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] demosaic with upscaling not yet supported by opencl code\n");
-    return FALSE;
-  }
 
   const int devid = piece->pipe->devid;
   const int qual = get_quality();

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -16,12 +16,6 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-#pragma GCC diagnostic ignored "-Wunused-function"
-
-#define DEBUG 0
-
 #include "develop/imageop.h"
 #include "common/opencl.h"
 #include "bauhaus/bauhaus.h"
@@ -126,7 +120,6 @@ typedef struct dt_iop_demosaic_global_data_t
   int kernel_markesteijn_zero;
   int kernel_markesteijn_accu;
   int kernel_markesteijn_final;
-  int kernel_markesteijn_probe;
 } dt_iop_demosaic_global_data_t;
 
 typedef struct dt_iop_demosaic_data_t
@@ -3163,18 +3156,6 @@ process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_markesteijn_final, sizes);
     if(err != CL_SUCCESS) goto error;
 
-#if DEBUG
-    sizes[0] = ROUNDUPWD(width);
-    sizes[1] = ROUNDUPHT(height);
-    sizes[2] = 1;
-    dt_opencl_set_kernel_arg(devid, gd->kernel_markesteijn_probe, 0, sizeof(cl_mem), (void *)&dev_rgbv[7]);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_markesteijn_probe, 1, sizeof(cl_mem), (void *)&dev_tmp);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_markesteijn_probe, 2, sizeof(int), (void *)&width);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_markesteijn_probe, 3, sizeof(int), (void *)&height);
-    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_markesteijn_probe, sizes);
-    if(err != CL_SUCCESS) goto error;
-#endif
-
     // manage borders
     sizes[0] = ROUNDUPWD(width);
     sizes[1] = ROUNDUPHT(height);
@@ -3571,7 +3552,6 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_markesteijn_zero = dt_opencl_create_kernel(markesteijn, "markesteijn_zero");
   gd->kernel_markesteijn_accu = dt_opencl_create_kernel(markesteijn, "markesteijn_accu");
   gd->kernel_markesteijn_final = dt_opencl_create_kernel(markesteijn, "markesteijn_final");
-  gd->kernel_markesteijn_probe = dt_opencl_create_kernel(markesteijn, "markesteijn_probe");
 }
 
 void cleanup(dt_iop_module_t *module)
@@ -3618,7 +3598,6 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_markesteijn_zero);
   dt_opencl_free_kernel(gd->kernel_markesteijn_accu);
   dt_opencl_free_kernel(gd->kernel_markesteijn_final);
-    dt_opencl_free_kernel(gd->kernel_markesteijn_probe);
   free(module->data);
   module->data = NULL;
 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3237,9 +3237,16 @@ process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem d
   {
     return process_vng_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
   }
-  else if((demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3))
+  else if(demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN || demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3)
   {
-    return process_markesteijn_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
+    // only use markesteijn demosaicing on GPU if the corresponding config option is enabled.
+    if(darktable.opencl->enable_markesteijn)
+      return process_markesteijn_cl(self, piece, dev_in, dev_out, roi_in, roi_out);
+    else
+    {
+      dt_print(DT_DEBUG_OPENCL, "[opencl_demosaic] Markesteijn demosaicing with OpenCL not enabled (see 'opencl_enable_markesteijn')\n");
+      return FALSE;
+    }
   }
   else
   {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1569,7 +1569,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 1) ||
       piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT ||
       uhq_thumb ||
-      roi_out->scale > 0.8f;
+      roi_out->scale > 0.667f;
 
   const float *const pixels = (float *)i;
 
@@ -3218,7 +3218,7 @@ process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem d
       (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 1) ||
       piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT ||
       uhq_thumb ||
-      roi_out->scale > 0.8f;
+      roi_out->scale > 0.667f;
 
   if(demosaicing_method ==  DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME || demosaicing_method == DT_IOP_DEMOSAIC_PPG)
   {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2945,6 +2945,9 @@ process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
     if(dev_gminmax != NULL) dt_opencl_release_mem_object(dev_gminmax);
     dev_gminmax = NULL;
 
+    // jump back to the first set of rgb buffers (this is a noop for Markesteijn-1)
+    dev_rgb = dev_rgbv;
+
     // prepare derivatives buffers
     for(int n = 0; n < ndir; n++)
     {


### PR DESCRIPTION
As the title says. It's already mostly functional. Some work to be done for a better border handling.

The Markesteijn algorithm is a real memory hog. Take the slow global memory accesses of the typical OpenCL device, then it's clear that the speed-up versus CPU is not too impressive - maybe a factor of 2 versus CPU with a rather fast GPU. Slow GPUs might easily be slower than the CPU. Finally there should be a config variable so that users can activate the OpenCL codepath for Markesteijn after doing some benchmarking.