### PR TITLE
Markesteijn tile fix

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -855,7 +855,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           int col = 11;
           uint8_t v5sum[5] = { 0 };
           for(int v = -2; v <= 2; v++)
-            for(int h = -2; h <= 2; h++) v5sum[(col + h) % 5] += homo[d][row + v][col + h];
+            for(int h = -4; h <= 0; h++) v5sum[(col + h) % 5] += homo[d][row + v][col + h + 2];
           homosum[d][row][col] = v5sum[0] + v5sum[1] + v5sum[2] + v5sum[3] + v5sum[4];
           // calculate by rolling through column sums
           for(col++; col < mcol - 11; col++)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -852,11 +852,11 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
       for(int d = 0; d < ndir; d++)
         for(int row = 11; row < mrow - 11; row++)
         {
-          int col = 11;
+          // start before first column where homo[d][row][col+2] != 0,
+          // so can know v5sum and homosum[d][row][col] will be 0
+          int col = 6;
           uint8_t v5sum[5] = { 0 };
-          for(int v = -2; v <= 2; v++)
-            for(int h = -4; h <= 0; h++) v5sum[(col + h) % 5] += homo[d][row + v][col + h + 2];
-          homosum[d][row][col] = v5sum[0] + v5sum[1] + v5sum[2] + v5sum[3] + v5sum[4];
+          homosum[d][row][col] = 0;
           // calculate by rolling through column sums
           for(col++; col < mcol - 11; col++)
           {


### PR DESCRIPTION
This fixes an off-by-two error when initializing 5x5 sums of homogeneity maps. This happens at the left edge of each tile processed by Markesteijn demosaic. The second commit then simplifies the code, based upon the knowledge that homogeneity maps are 0-padded at their edges, and hence the initial sums will always be 0 if we start far enough to the left. This should produce slightly less compiled code and have no noticeable change in performance.

Thank you to upegelow for noticing that there were regular patterns of small differences between this CPU-based code and his OpenCL code. These were a sign of this bug.