### PR TITLE
Make the full-screen mode obey the no-metadata flag.

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -211,13 +211,13 @@ void dt_vm_remove_child(GtkWidget *widget, gpointer data)
   gtk_container_remove(GTK_CONTAINER(data), widget);
 }
 
-/* 
+/*
    When expanders get destoyed, they destroy the child
    so remove the child before that
    */
 static void _remove_child(GtkWidget *child,GtkContainer *container)
 {
-    if(DTGTK_IS_EXPANDER(child)) 
+    if(DTGTK_IS_EXPANDER(child))
     {
       GtkWidget * evb = dtgtk_expander_get_body_event_box(DTGTK_EXPANDER(child));
       gtk_container_remove(GTK_CONTAINER(evb),dtgtk_expander_get_body(DTGTK_EXPANDER(child)));
@@ -283,7 +283,7 @@ int dt_view_manager_switch(dt_view_manager_t *vm, int k)
     }
 
     /* remove all widgets in all containers */
-    for(int l = 0; l < DT_UI_CONTAINER_SIZE; l++) 
+    for(int l = 0; l < DT_UI_CONTAINER_SIZE; l++)
       dt_ui_container_destroy_children(darktable.gui->ui, l);
     vm->current_view = -1;
     return 0;
@@ -799,13 +799,16 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
 // on my machine with 7 image per row it seems grouping has the largest
 // impact from around 400ms -> 55ms per redraw.
 
+  // active if zoom>1 or in the proper area
+  const gboolean in_metadata_zone = (px < width / 2 && py < height / 2) || (zoom > 1);
+
   const gboolean draw_thumb = TRUE;
-  const gboolean draw_colorlabels = !image_only;
-  const gboolean draw_local_copy = !image_only;
+  const gboolean draw_colorlabels = !image_only && (darktable.gui->show_overlays || in_metadata_zone);
+  const gboolean draw_local_copy = !image_only && (darktable.gui->show_overlays || in_metadata_zone);
   const gboolean draw_grouping = !image_only;
   const gboolean draw_selected = !image_only;
   const gboolean draw_history = !image_only;
-  const gboolean draw_metadata = !image_only;
+  const gboolean draw_metadata = !image_only && (darktable.gui->show_overlays || in_metadata_zone);
   const gboolean draw_audio = !image_only;
 
   cairo_save(cr);


### PR DESCRIPTION
The metadata are drawn in full-screen (zoom == 1) mode:
  - if the metadata selector is on
  - if the mouse is over the metadata area (top-left square)

This gives a way to not display the metadata over the image in full
screen mode (zoom == 1).