### PR TITLE
Use Pango for text layout.

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1578,18 +1578,27 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   if(darktable.bauhaus->keys_cnt)
   {
     cairo_save(cr);
-    cairo_text_extents_t ext;
+    PangoLayout *layout;
+    PangoRectangle ink;
+    PangoFontDescription *desc = pango_font_description_from_string("sans-serif bold");
+    layout = pango_cairo_create_layout(cr);
+    pango_layout_set_font_description(layout, desc);
     set_text_color(cr, 1);
     set_value_font(cr);
+    const int line_height = get_line_height();
+    pango_font_description_set_absolute_size(desc,(MIN(3 * line_height, .2 * height)) * PANGO_SCALE);
+
     // make extra large, but without dependency on popup window height
     // (that might differ for comboboxes for example). only fall back
     // to height dependency if the popup is really small.
-    const int line_height = get_line_height();
-    cairo_set_font_size(cr, MIN(3 * line_height, .2 * height));
-    cairo_text_extents(cr, darktable.bauhaus->keys, &ext);
-    cairo_move_to(cr, wd - 4 - ht - ext.width, height * 0.5);
-    cairo_show_text(cr, darktable.bauhaus->keys); // FIXME: pango
+    pango_layout_set_text(layout, darktable.bauhaus->keys, -1);
+    pango_layout_get_pixel_extents(layout, &ink, NULL);
+    cairo_move_to(cr, wd - 4 - ht - ink.width, height * 0.5);
+    pango_cairo_show_layout(cr, layout);
     cairo_restore(cr);
+    pango_font_description_free(desc);
+    g_object_unref(layout);
+
   }
   if(darktable.bauhaus->cursor_visible)
   {

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -984,14 +984,22 @@ void dtgtk_cairo_paint_overlays(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 // TODO: Find better icon
 void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags)
 {
+  PangoLayout *layout;
+  PangoRectangle ink;
+  PangoFontDescription *desc = pango_font_description_from_string("sans-serif bold");
+  pango_font_description_set_absolute_size(desc,(2) * PANGO_SCALE);
+  layout = pango_cairo_create_layout(cr);
+  pango_layout_set_font_description(layout, desc);
   gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
-  cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-  cairo_set_font_size(cr, 2);
-  cairo_move_to(cr, -0.3, 1.2);
-  cairo_show_text(cr, "G");
+  pango_layout_set_text(layout, "G", -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, -0.3, 1.2 - ink.width);
+  pango_cairo_show_layout(cr, layout);
+  pango_font_description_free(desc);
+  g_object_unref(layout);
 }
 
 void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags)

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -341,20 +341,27 @@ static void _expose_info_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, 
   cairo_set_source_rgb(cr, .8, .8, .8);
 
   // Draw left aligned value camera model value
-  cairo_text_extents_t te;
+  PangoLayout *layout;
+  PangoRectangle ink;
+  PangoFontDescription *desc = pango_font_description_from_string("Sans bold");
+  layout = pango_cairo_create_layout(cr);
+  pango_font_description_set_absolute_size(desc, (11.5) * PANGO_SCALE);
+  pango_layout_set_font_description(layout, desc);
   char model[4096] = { 0 };
   sprintf(model + strlen(model), "%s", lib->data.camera_model);
-  cairo_text_extents(cr, model, &te);
-  cairo_move_to(cr, 5, 1 + BAR_HEIGHT - te.height / 2);
-  cairo_show_text(cr, model);
+  pango_layout_set_text(layout, model, -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, 5, 1 + BAR_HEIGHT - ink.height / 2);
+  pango_cairo_show_layout(cr, layout);
 
   // Draw right aligned battery value
   const char *battery_value = dt_camctl_camera_get_property(darktable.camctl, NULL, "batterylevel");
   char battery[4096] = { 0 };
   snprintf(battery, sizeof(battery), "%s: %s", _("battery"), battery_value ? battery_value : _("n/a"));
-  cairo_text_extents(cr, battery, &te);
-  cairo_move_to(cr, width - te.width - 5, 1 + BAR_HEIGHT - te.height / 2);
-  cairo_show_text(cr, battery);
+  pango_layout_set_text(layout, battery, -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, width - ink.width - 5, 1 + BAR_HEIGHT - ink.height / 2);
+  pango_cairo_show_layout(cr, layout);
 
   // Let's cook up the middle part of infobar
   gchar center[1024] = { 0 };
@@ -372,9 +379,12 @@ static void _expose_info_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, 
   g_strlcat(center, "      ", sizeof(center));
 
   // Now lets put it in center view...
-  cairo_text_extents(cr, center, &te);
-  cairo_move_to(cr, (width / 2) - (te.width / 2), 1 + BAR_HEIGHT - te.height / 2);
-  cairo_show_text(cr, center);
+  pango_layout_set_text(layout, center, -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, (width / 2) - (ink.width / 2), 1 + BAR_HEIGHT - ink.height / 2);
+  pango_cairo_show_layout(cr, layout);
+  pango_font_description_free(desc);
+  g_object_unref(layout);
 }
 
 static void _expose_settings_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -401,17 +401,23 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   }
 
   cairo_set_source_rgb(cr, .25, .25, .25);
-  cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-  cairo_set_font_size(cr, .1 * height);
+  PangoLayout *layout;
+  PangoRectangle ink;
+  PangoFontDescription *desc = pango_font_description_from_string("sans-serif bold");
+  layout = pango_cairo_create_layout(cr);
+  pango_font_description_set_absolute_size(desc,(.1 * height) * PANGO_SCALE);
+  pango_layout_set_font_description(layout, desc);
 
   char exifline[50];
-  cairo_move_to(cr, .02 * width, .98 * height);
   dt_image_print_exif(&dev->image_storage, exifline, 50);
+  pango_layout_set_text(layout, exifline, -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, .02 * width, .98 * height - ink.height - ink.y);
   cairo_save(cr);
   //   cairo_show_text(cr, exifline);
   cairo_set_line_width(cr, 2.0);
   cairo_set_source_rgba(cr, 1, 1, 1, 0.3);
-  cairo_text_path(cr, exifline);
+  pango_cairo_layout_path(cr, layout);
   cairo_stroke_preserve(cr);
   cairo_set_source_rgb(cr, .25, .25, .25);
   cairo_fill(cr);
@@ -433,6 +439,8 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   cairo_set_source_surface(crf, cst, 0, 0);
   cairo_paint(crf);
   cairo_surface_destroy(cst);
+  pango_font_description_free(desc);
+  g_object_unref(layout);
   return TRUE;
 }
 

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -249,18 +249,22 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
     if(fabsf(cur_scale - min_scale) > 0.001f)
     {
       /* Zoom % */
+      PangoLayout *layout;
+      PangoRectangle ink;
+      PangoFontDescription *desc = pango_font_description_from_string("sans-serif bold");
+      layout = pango_cairo_create_layout(cr);
+      pango_font_description_set_absolute_size(desc,(DT_PIXEL_APPLY_DPI(11)) * PANGO_SCALE);
+      pango_layout_set_font_description(layout, desc);
       cairo_translate(cr, 0, height);
       cairo_set_source_rgba(cr, 1., 1., 1., 0.5);
-      cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-      cairo_set_font_size(cr, DT_PIXEL_APPLY_DPI(11));
 
       char zoomline[5];
       snprintf(zoomline, sizeof(zoomline), "%.0f%%", cur_scale * 100);
 
-      cairo_text_extents_t ext;
-      cairo_text_extents(cr, zoomline, &ext);
-      h = d->zoom_h = ext.height;
-      w = d->zoom_w = ext.width;
+      pango_layout_set_text(layout, zoomline, -1);
+      pango_layout_get_pixel_extents(layout, &ink, NULL);
+      h = d->zoom_h = ink.height;
+      w = d->zoom_w = ink.width;
 
       cairo_move_to(cr, width - w - h * 1.1, 0);
 
@@ -271,13 +275,16 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
       gtk_style_context_get(context, gtk_widget_get_state_flags(widget), "background-color", &color, NULL);
 
       gdk_cairo_set_source_rgba(cr, color);
-      cairo_text_path(cr, zoomline);
+      pango_cairo_layout_path(cr, layout);
       cairo_stroke_preserve(cr);
       cairo_set_source_rgb(cr, 0.6, 0.6, 0.6);
       cairo_fill(cr);
       cairo_restore(cr);
 
       gdk_rgba_free(color);
+      pango_font_description_free(desc);
+      g_object_unref(layout);
+
     }
     else
     {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -401,17 +401,23 @@ void expose(
   {
     gchar *label = darktable.color_profiles->mode == DT_PROFILE_GAMUTCHECK ? _("gamut check") : _("soft proof");
     cairo_set_source_rgba(cri, 0.5, 0.5, 0.5, 0.5);
-    cairo_text_extents_t te;
-    cairo_select_font_face(cri, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-    cairo_set_font_size(cri, 20);
-    cairo_text_extents(cri, label, &te);
-    cairo_move_to(cri, te.height * 2, height - (te.height * 2));
-    cairo_text_path(cri, label);
+    PangoLayout *layout;
+    PangoRectangle ink;
+    PangoFontDescription *desc = pango_font_description_from_string("sans-serif bold");
+    layout = pango_cairo_create_layout(cri);
+    pango_font_description_set_absolute_size(desc,(20) * PANGO_SCALE);
+    pango_layout_set_font_description(layout, desc);
+    pango_layout_set_text(layout, label, -1);
+    pango_layout_get_pixel_extents(layout, &ink, NULL);
+    cairo_move_to(cri, ink.height * 2, height - (ink.height * 3));
+    pango_cairo_layout_path(cri, layout);
     cairo_set_source_rgb(cri, 0.7, 0.7, 0.7);
     cairo_fill_preserve(cri);
     cairo_set_line_width(cri, 0.7);
     cairo_set_source_rgb(cri, 0.3, 0.3, 0.3);
     cairo_stroke(cri);
+    pango_font_description_free(desc);
+    g_object_unref(layout);
   }
 }
 


### PR DESCRIPTION
 Use Pango for text layout to support languages that require complex text layout such as Arabic, Hebrew, and Indic language.The cairo_show_text() is part of cairo toy text API and should not be used in serious applications, see: http://cairographics.org/manual/cairo-text.html#cairo-show-text
