### PR TITLE
render last distort fct thread safe

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -30,6 +30,7 @@
 #include "common/image.h"
 
 struct dt_iop_module_t;
+struct dt_iop_roi_t;
 
 typedef struct dt_dev_history_item_t
 {
@@ -317,9 +318,10 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *
                                   float *points, size_t points_count);
 int dt_dev_distort_backtransform_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
                                       float *points, size_t points_count);
-/** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
-struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe,
-                                                           struct dt_iop_module_t *module);
+/** get the sizes of an iop in and out buffers in the given pipe */
+gboolean dt_dev_get_iop_buffer_sizes(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe,
+                                     struct dt_iop_module_t *module, struct dt_iop_roi_t *buf_in,
+                                     struct dt_iop_roi_t *buf_out);
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -537,13 +537,13 @@ static inline int _brush_cyclic_cursor(int n, int nb)
 /** get all points of the brush and the border */
 /** this takes care of gaps and iop distortions */
 static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, int prio_max,
-                                    dt_dev_pixelpipe_t *pipe, float pipe_iwidth, float pipe_iheight,
-                                    float **points, int *points_count, float **border, int *border_count,
-                                    float **payload, int *payload_count, int source)
+                                    dt_dev_pixelpipe_t *pipe, float **points, int *points_count,
+                                    float **border, int *border_count, float **payload, int *payload_count,
+                                    int source)
 {
   double start2 = dt_get_wtime();
 
-  float wd = pipe_iwidth, ht = pipe_iheight;
+  float wd = pipe->iwidth, ht = pipe->iheight;
 
   *points = NULL;
   *points_count = 0;
@@ -941,12 +941,8 @@ static void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t 
 static int dt_brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
                                       int *points_count, float **border, int *border_count, int source)
 {
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
-  float pipe_iwidth = dev->preview_pipe->iwidth;
-  float pipe_iheight = dev->preview_pipe->iheight;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
-  return _brush_get_points_border(dev, form, 999999, dev->preview_pipe, pipe_iwidth, pipe_iheight, points,
-                                  points_count, border, border_count, NULL, NULL, source);
+  return _brush_get_points_border(dev, form, 999999, dev->preview_pipe, points, points_count, border,
+                                  border_count, NULL, NULL, source);
 }
 
 /** find relative position within a brush segment that is closest to the point given by coordinates x and y;
@@ -1182,10 +1178,10 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
   {
     if(gui->creation)
     {
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       float wd = darktable.develop->preview_pipe->backbuf_width;
       float ht = darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
 
       if(!gui->guipoints) gui->guipoints = dt_masks_dynbuf_init(200000, "brush guipoints");
       if(!gui->guipoints) return 1;
@@ -1226,10 +1222,10 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
       if(!gpt) return 0;
       // we start the form dragging
       gui->source_dragging = TRUE;
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->dx = gpt->source[2] - gui->posx;
       gui->dy = gpt->source[3] - gui->posy;
       return 1;
@@ -1238,10 +1234,10 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
     {
       gui->form_dragging = TRUE;
       gui->point_edited = -1;
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->dx = gpt->points[2] - gui->posx;
       gui->dy = gpt->points[3] - gui->posy;
       return 1;
@@ -1305,18 +1301,16 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
         // we add a new point to the brush
         dt_masks_point_brush_t *bzpt = (dt_masks_point_brush_t *)(malloc(sizeof(dt_masks_point_brush_t)));
 
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
         float wd = darktable.develop->preview_pipe->backbuf_width;
         float ht = darktable.develop->preview_pipe->backbuf_height;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
         float pts[2] = { pzx * wd, pzy * ht };
         dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
         // set coordinates
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
         bzpt->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
         bzpt->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
         bzpt->ctrl1[0] = bzpt->ctrl1[1] = bzpt->ctrl2[0] = bzpt->ctrl2[1] = -1.0;
         bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
@@ -1345,10 +1339,10 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
       {
         // we move the entire segment
         gui->seg_dragging = gui->seg_selected;
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
         gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
         gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
         gui->dx = gpt->points[gui->seg_selected * 6 + 2] - gui->posx;
         gui->dy = gpt->points[gui->seg_selected * 6 + 3] - gui->posy;
       }
@@ -1522,10 +1516,8 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
 
       for(int i = 0; i < gui->guipoints_count; i++)
       {
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
         guipoints[i * 2] /= darktable.develop->preview_pipe->iwidth;
         guipoints[i * 2 + 1] /= darktable.develop->preview_pipe->iheight;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
       }
 
       // we consolidate pen pressure readings into payload
@@ -1627,16 +1619,14 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
 
     // we get point0 new values
     dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)g_list_first(form->points)->data;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
     float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     // we move all points
     GList *points = g_list_first(form->points);
@@ -1669,16 +1659,14 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
     gui->source_dragging = FALSE;
 
     // we change the source value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -1708,16 +1696,14 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
       return 1;
     }
     gui->scrollx = gui->scrolly = 0;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
     float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     point->corner[0] += dx;
     point->corner[1] += dy;
@@ -1743,15 +1729,14 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
     dt_masks_point_brush_t *point
         = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->feather_dragging);
     gui->feather_dragging = -1;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     int p1x, p1y, p2x, p2y;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     _brush_feather_to_ctrl(point->corner[0] * darktable.develop->preview_pipe->iwidth,
                            point->corner[1] * darktable.develop->preview_pipe->iheight, pts[0], pts[1], &p1x,
                            &p1y, &p2x, &p2y, TRUE);
@@ -1759,7 +1744,6 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
     point->ctrl1[1] = (float)p1y / darktable.develop->preview_pipe->iheight;
     point->ctrl2[0] = (float)p2x / darktable.develop->preview_pipe->iwidth;
     point->ctrl2[1] = (float)p2y / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     point->state = DT_MASKS_POINT_STATE_USER;
 
@@ -1796,9 +1780,9 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   int closeup = dt_control_get_dev_closeup();
   float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
-  dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
   float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
-  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
   if(!gui) return 0;
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
@@ -1807,10 +1791,10 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   {
     if(gui->guipoints)
     {
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       dt_masks_dynbuf_add(gui->guipoints, pzx * darktable.develop->preview_pipe->backbuf_width);
       dt_masks_dynbuf_add(gui->guipoints, pzy * darktable.develop->preview_pipe->backbuf_height);
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       const float border = dt_masks_dynbuf_get(gui->guipoints_payload, -4);
       const float hardness = dt_masks_dynbuf_get(gui->guipoints_payload, -3);
       const float density = dt_masks_dynbuf_get(gui->guipoints_payload, -2);
@@ -1822,28 +1806,26 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     }
     else
     {
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     }
     dt_control_queue_redraw_center();
     return 1;
   }
   else if(gui->point_dragging >= 0)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     dt_masks_point_brush_t *bzpt
         = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->point_dragging);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     pzx = pts[0] / darktable.develop->preview_pipe->iwidth;
     pzy = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     bzpt->ctrl1[0] += pzx - bzpt->corner[0];
     bzpt->ctrl2[0] += pzx - bzpt->corner[0];
     bzpt->ctrl1[1] += pzy - bzpt->corner[1];
@@ -1864,16 +1846,14 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     dt_masks_point_brush_t *point
         = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->seg_dragging);
     dt_masks_point_brush_t *point2 = (dt_masks_point_brush_t *)g_list_nth_data(form->points, pos2);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
     float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     // we move all points
     point->corner[0] += dx;
@@ -1902,17 +1882,16 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   }
   else if(gui->feather_dragging >= 0)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     dt_masks_point_brush_t *point
         = (dt_masks_point_brush_t *)g_list_nth_data(form->points, gui->feather_dragging);
 
     int p1x, p1y, p2x, p2y;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     _brush_feather_to_ctrl(point->corner[0] * darktable.develop->preview_pipe->iwidth,
                            point->corner[1] * darktable.develop->preview_pipe->iheight, pts[0], pts[1], &p1x,
                            &p1y, &p2x, &p2y, TRUE);
@@ -1920,7 +1899,6 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     point->ctrl1[1] = (float)p1y / darktable.develop->preview_pipe->iheight;
     point->ctrl2[0] = (float)p2x / darktable.develop->preview_pipe->iwidth;
     point->ctrl2[1] = (float)p2y / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     point->state = DT_MASKS_POINT_STATE_USER;
 
     _brush_init_ctrl_points(form);
@@ -1932,10 +1910,10 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   }
   else if(gui->point_border_dragging >= 0)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
 
     int k = gui->point_border_dragging;
 
@@ -1951,12 +1929,10 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float nx = point->corner[0] * darktable.develop->preview_pipe->iwidth;
     float ny = point->corner[1] * darktable.develop->preview_pipe->iheight;
     float nr = sqrtf((pts[0] - nx) * (pts[0] - nx) + (pts[1] - ny) * (pts[1] - ny));
     float bdr = nr / fminf(darktable.develop->preview_pipe->iwidth, darktable.develop->preview_pipe->iheight);
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     point->border[0] = point->border[1] = bdr;
 
@@ -1968,10 +1944,10 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   }
   else if(gui->form_dragging || gui->source_dragging)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1986,10 +1962,10 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   // are we near a point or feather ?
   guint nb = g_list_length(form->points);
 
-  dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
-  pzx *= darktable.develop->preview_pipe->backbuf_width,
-      pzy *= darktable.develop->preview_pipe->backbuf_height;
-  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
+  pzx *= darktable.develop->preview_pipe->backbuf_width;
+  pzy *= darktable.develop->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
 
   if((gui->group_selected == index) && gui->point_edited >= 0)
   {
@@ -2091,10 +2067,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   // in creation mode
   if(gui->creation)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->iwidth;
     float ht = darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     if(gui->guipoints_count == 0)
     {
@@ -2468,9 +2442,8 @@ static int dt_brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_io
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                               piece->pipe->iheight, &points, &points_count, &border, &border_count, NULL,
-                               NULL, 1))
+  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                               &border, &border_count, NULL, NULL, 1))
   {
     free(points);
     free(border);
@@ -2519,9 +2492,8 @@ static int dt_brush_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                               piece->pipe->iheight, &points, &points_count, &border, &border_count, NULL,
-                               NULL, 0))
+  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                               &border, &border_count, NULL, NULL, 0))
   {
     free(points);
     free(border);
@@ -2602,9 +2574,8 @@ static int dt_brush_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   // we get buffers for all points
   float *points = NULL, *border = NULL, *payload = NULL;
   int points_count, border_count, payload_count;
-  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                               piece->pipe->iheight, &points, &points_count, &border, &border_count, &payload,
-                               &payload_count, 0))
+  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                               &border, &border_count, &payload, &payload_count, 0))
   {
     free(points);
     free(border);
@@ -2739,9 +2710,8 @@ static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
   float *points = NULL, *border = NULL, *payload = NULL;
 
   int points_count, border_count, payload_count;
-  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                               piece->pipe->iheight, &points, &points_count, &border, &border_count, &payload,
-                               &payload_count, 0))
+  if(!_brush_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                               &border, &border_count, &payload, &payload_count, 0))
   {
     free(points);
     free(border);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -130,10 +130,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     if(!gpt) return 0;
     // we start the form dragging
     gui->source_dragging = TRUE;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->dx = gpt->source[0] - gui->posx;
     gui->dy = gpt->source[1] - gui->posy;
     return 1;
@@ -144,10 +144,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     if(!gpt) return 0;
     // we start the form dragging
     gui->form_dragging = TRUE;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -168,16 +168,14 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(malloc(sizeof(dt_masks_point_circle_t)));
 
     // we change the center value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     circle->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     circle->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     if(form->type & DT_MASKS_CLONE)
     {
@@ -238,10 +236,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       if(!gui2) return 1;
       gui2->source_dragging = TRUE;
       gui2->group_edited = gui2->group_selected = pos2;
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui2->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui2->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui2->dx = 0.0;
       gui2->dy = 0.0;
       gui2->scrollx = pzx;
@@ -294,16 +292,14 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     gui->form_dragging = FALSE;
 
     // we change the center value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     circle->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     circle->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -329,18 +325,16 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     else
     {
       // we change the center value
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       float wd = darktable.develop->preview_pipe->backbuf_width;
       float ht = darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
 
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
       form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     }
     dt_masks_write_form(form, darktable.develop);
 
@@ -362,10 +356,10 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
 {
   if(gui->form_dragging || gui->source_dragging)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -374,13 +368,13 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
+    float npzx = pzx * darktable.develop->preview_pipe->backbuf_width;
+    float npzy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     int in, inb, near, ins;
-    dt_circle_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
-                           pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, &in, &inb,
-                           &near, &ins);
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_circle_get_distance(npzx, npzy, as, gui, index, &in, &inb, &near, &ins);
     if(ins)
     {
       gui->form_selected = TRUE;
@@ -562,10 +556,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
 static int dt_circle_get_points(dt_develop_t *dev, float x, float y, float radius, float **points,
                                 int *points_count)
 {
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   float wd = dev->preview_pipe->iwidth;
   float ht = dev->preview_pipe->iheight;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
 
   // how many points do we need ?
   float r = radius * MIN(wd, ht);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -130,8 +130,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     if(!gpt) return 0;
     // we start the form dragging
     gui->source_dragging = TRUE;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     gui->dx = gpt->source[0] - gui->posx;
     gui->dy = gpt->source[1] - gui->posy;
     return 1;
@@ -142,8 +144,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     if(!gpt) return 0;
     // we start the form dragging
     gui->form_dragging = TRUE;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -164,12 +168,16 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(malloc(sizeof(dt_masks_point_circle_t)));
 
     // we change the center value
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     circle->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     circle->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     if(form->type & DT_MASKS_CLONE)
     {
@@ -230,8 +238,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       if(!gui2) return 1;
       gui2->source_dragging = TRUE;
       gui2->group_edited = gui2->group_selected = pos2;
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       gui2->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui2->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
       gui2->dx = 0.0;
       gui2->dy = 0.0;
       gui2->scrollx = pzx;
@@ -284,12 +294,16 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     gui->form_dragging = FALSE;
 
     // we change the center value
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     circle->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     circle->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -315,14 +329,18 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     else
     {
       // we change the center value
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       float wd = darktable.develop->preview_pipe->backbuf_width;
       float ht = darktable.develop->preview_pipe->backbuf_height;
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
       float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
 
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
       form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     }
     dt_masks_write_form(form, darktable.develop);
 
@@ -344,8 +362,10 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
 {
   if(gui->form_dragging || gui->source_dragging)
   {
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -354,11 +374,13 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
     int in, inb, near, ins;
     dt_circle_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
                            pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, &in, &inb,
                            &near, &ins);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     if(ins)
     {
       gui->form_selected = TRUE;
@@ -540,8 +562,10 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
 static int dt_circle_get_points(dt_develop_t *dev, float x, float y, float radius, float **points,
                                 int *points_count)
 {
+  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   float wd = dev->preview_pipe->iwidth;
   float ht = dev->preview_pipe->iheight;
+  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
 
   // how many points do we need ?
   float r = radius * MIN(wd, ht);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -269,8 +269,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     if(!gpt) return 0;
     // we start the source dragging
     gui->source_dragging = TRUE;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     gui->dx = gpt->source[0] - gui->posx;
     gui->dy = gpt->source[1] - gui->posy;
     return 1;
@@ -281,8 +283,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     gui->point_dragging = gui->point_selected;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -297,8 +301,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -329,12 +335,16 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
         = (dt_masks_point_ellipse_t *)(malloc(sizeof(dt_masks_point_ellipse_t)));
 
     // we change the center value
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     ellipse->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     if(form->type & DT_MASKS_CLONE)
     {
@@ -411,8 +421,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       if(!gui2) return 1;
       gui2->source_dragging = TRUE;
       gui2->group_edited = gui2->group_selected = pos2;
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       gui2->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui2->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
       gui2->dx = 0.0;
       gui2->dy = 0.0;
       gui2->scrollx = pzx;
@@ -465,12 +477,16 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     gui->form_dragging = FALSE;
 
     // we change the center value
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     ellipse->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -540,8 +556,10 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     // we end the form rotating
     gui->form_rotating = FALSE;
 
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float x = pzx * wd;
     float y = pzy * ht;
 
@@ -640,14 +658,18 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     else
     {
       // we change the center value
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       float wd = darktable.develop->preview_pipe->backbuf_width;
       float ht = darktable.develop->preview_pipe->backbuf_height;
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
       float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
 
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
       form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     }
     dt_masks_write_form(form, darktable.develop);
 
@@ -669,8 +691,10 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
 {
   if(gui->form_dragging || gui->form_rotating || gui->source_dragging || gui->point_dragging >= 1)
   {
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -679,6 +703,7 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
     float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     float y = pzy * darktable.develop->preview_pipe->backbuf_height;
@@ -686,6 +711,7 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
     dt_ellipse_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
                             pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, &in, &inb,
                             &near, &ins);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     if(ins)
     {
       gui->form_selected = TRUE;
@@ -978,8 +1004,10 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
 static int dt_ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
                                  float rotation, float **points, int *points_count)
 {
+  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
+  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   const float v1 = (rotation / 180.0f) * M_PI;
   const float v2 = (rotation - 90.0f) / 180.0f * M_PI;
   float a, b, v;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -269,10 +269,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     if(!gpt) return 0;
     // we start the source dragging
     gui->source_dragging = TRUE;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->dx = gpt->source[0] - gui->posx;
     gui->dy = gpt->source[1] - gui->posy;
     return 1;
@@ -283,10 +283,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     gui->point_dragging = gui->point_selected;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -301,10 +301,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -335,16 +335,14 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
         = (dt_masks_point_ellipse_t *)(malloc(sizeof(dt_masks_point_ellipse_t)));
 
     // we change the center value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     ellipse->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     if(form->type & DT_MASKS_CLONE)
     {
@@ -421,10 +419,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       if(!gui2) return 1;
       gui2->source_dragging = TRUE;
       gui2->group_edited = gui2->group_selected = pos2;
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui2->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui2->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui2->dx = 0.0;
       gui2->dy = 0.0;
       gui2->scrollx = pzx;
@@ -477,16 +475,14 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     gui->form_dragging = FALSE;
 
     // we change the center value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     ellipse->center[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     ellipse->center[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -556,10 +552,10 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     // we end the form rotating
     gui->form_rotating = FALSE;
 
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float x = pzx * wd;
     float y = pzy * ht;
 
@@ -658,18 +654,16 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
     else
     {
       // we change the center value
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       float wd = darktable.develop->preview_pipe->backbuf_width;
       float ht = darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
 
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
       form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     }
     dt_masks_write_form(form, darktable.develop);
 
@@ -691,10 +685,10 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
 {
   if(gui->form_dragging || gui->form_rotating || gui->source_dragging || gui->point_dragging >= 1)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -703,15 +697,13 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
     float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     float y = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     int in, inb, near, ins;
-    dt_ellipse_get_distance(pzx * darktable.develop->preview_pipe->backbuf_width,
-                            pzy * darktable.develop->preview_pipe->backbuf_height, as, gui, index, &in, &inb,
-                            &near, &ins);
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_ellipse_get_distance(x, y, as, gui, index, &in, &inb, &near, &ins);
     if(ins)
     {
       gui->form_selected = TRUE;
@@ -1004,10 +996,8 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
 static int dt_ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
                                  float rotation, float **points, int *points_count)
 {
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   const float v1 = (rotation / 180.0f) * M_PI;
   const float v2 = (rotation - 90.0f) / 180.0f * M_PI;
   float a, b, v;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -128,8 +128,10 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -151,12 +153,16 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
         = (dt_masks_point_gradient_t *)(malloc(sizeof(dt_masks_point_gradient_t)));
 
     // we change the offset value
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gradient->anchor[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
     const float steepness = 0.0f; // MIN(1.0f,dt_conf_get_float("plugins/darkroom/masks/gradient/steepness"));
@@ -236,13 +242,17 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     gui->form_dragging = FALSE;
 
     // we change the center value
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gradient->anchor[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -263,8 +273,10 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     // we end the form rotating
     gui->form_rotating = FALSE;
 
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     float x = pzx * wd;
     float y = pzy * ht;
 
@@ -298,8 +310,10 @@ static int dt_gradient_events_mouse_moved(struct dt_iop_module_t *module, float 
 {
   if(gui->form_dragging || gui->form_rotating)
   {
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -308,10 +322,12 @@ static int dt_gradient_events_mouse_moved(struct dt_iop_module_t *module, float 
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
     int in, inb, near, ins;
     float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     float y = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_gradient_get_distance(x, y, as, gui, index, &in, &inb, &near, &ins);
 
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
@@ -515,8 +531,10 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
   *points = NULL;
   *points_count = 0;
 
+  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
+  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   const float distance = 0.1f * fminf(wd, ht);
 
   const float xmax = wd - 1.0f;
@@ -654,8 +672,10 @@ static int dt_gradient_get_points_border(dt_develop_t *dev, float x, float y, fl
   float *points1 = NULL, *points2 = NULL;
   int points_count1 = 0, points_count2 = 0;
 
+  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
+  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   const float scale = sqrtf(wd * wd + ht * ht);
 
   const float v1 = (-(rotation - 90.0f) / 180.0f) * M_PI;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -128,10 +128,10 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -153,16 +153,14 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
         = (dt_masks_point_gradient_t *)(malloc(sizeof(dt_masks_point_gradient_t)));
 
     // we change the offset value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gradient->anchor[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
     const float steepness = 0.0f; // MIN(1.0f,dt_conf_get_float("plugins/darkroom/masks/gradient/steepness"));
@@ -242,17 +240,15 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     gui->form_dragging = FALSE;
 
     // we change the center value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     gradient->anchor[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     gradient->anchor[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -273,10 +269,10 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     // we end the form rotating
     gui->form_rotating = FALSE;
 
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float x = pzx * wd;
     float y = pzy * ht;
 
@@ -310,10 +306,10 @@ static int dt_gradient_events_mouse_moved(struct dt_iop_module_t *module, float 
 {
   if(gui->form_dragging || gui->form_rotating)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -322,12 +318,12 @@ static int dt_gradient_events_mouse_moved(struct dt_iop_module_t *module, float 
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();
     float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
     int in, inb, near, ins;
     float x = pzx * darktable.develop->preview_pipe->backbuf_width;
     float y = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     dt_gradient_get_distance(x, y, as, gui, index, &in, &inb, &near, &ins);
 
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
@@ -531,10 +527,8 @@ static int dt_gradient_get_points(dt_develop_t *dev, float x, float y, float rot
   *points = NULL;
   *points_count = 0;
 
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   const float distance = 0.1f * fminf(wd, ht);
 
   const float xmax = wd - 1.0f;
@@ -672,10 +666,8 @@ static int dt_gradient_get_points_border(dt_develop_t *dev, float x, float y, fl
   float *points1 = NULL, *points2 = NULL;
   int points_count1 = 0, points_count2 = 0;
 
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   const float wd = dev->preview_pipe->iwidth;
   const float ht = dev->preview_pipe->iheight;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   const float scale = sqrtf(wd * wd + ht * ht);
 
   const float v1 = (-(rotation - 90.0f) / 180.0f) * M_PI;

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -127,9 +127,9 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   int closeup = dt_control_get_dev_closeup();
   float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
-  dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
   float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
-  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
 
   // we first don't do anything if we are inside a scrolling session
 
@@ -188,10 +188,10 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     int inside, inside_border, near, inside_source;
     inside = inside_border = inside_source = 0;
     near = -1;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
-    float xx = pzx * darktable.develop->preview_pipe->backbuf_width,
-          yy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
+    float xx = pzx * darktable.develop->preview_pipe->backbuf_width;
+    float yy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     if(sel->type & DT_MASKS_CIRCLE)
       dt_circle_get_distance(xx, yy, as, gui, pos, &inside, &inside_border, &near, &inside_source);
     else if(sel->type & DT_MASKS_PATH)

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -127,7 +127,9 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   int closeup = dt_control_get_dev_closeup();
   float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
   float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
   // we first don't do anything if we are inside a scrolling session
 
@@ -186,8 +188,10 @@ static int dt_group_events_mouse_moved(struct dt_iop_module_t *module, float pzx
     int inside, inside_border, near, inside_source;
     inside = inside_border = inside_source = 0;
     near = -1;
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float xx = pzx * darktable.develop->preview_pipe->backbuf_width,
           yy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     if(sel->type & DT_MASKS_CIRCLE)
       dt_circle_get_distance(xx, yy, as, gui, pos, &inside, &inside_border, &near, &inside_source);
     else if(sel->type & DT_MASKS_PATH)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1306,8 +1306,10 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   if(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE) || (form->type & DT_MASKS_GRADIENT))
      && gui->creation)
     return;
+  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   if(wd < 1.0 || ht < 1.0) return;
   float pzx, pzy;
   dt_dev_get_pointer_zoom_pos(dev, pointerx, pointery, &pzx, &pzy);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1306,10 +1306,10 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   if(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE) || (form->type & DT_MASKS_GRADIENT))
      && gui->creation)
     return;
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&dev->preview_pipe->backbuf_mutex);
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
+  dt_pthread_mutex_unlock(&dev->preview_pipe->backbuf_mutex);
   if(wd < 1.0 || ht < 1.0) return;
   float pzx, pzy;
   dt_dev_get_pointer_zoom_pos(dev, pointerx, pointery, &pzx, &pzy);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -498,13 +498,12 @@ static int _path_find_self_intersection(int *inter, int nb_corners, float *borde
 /** get all points of the path and the border */
 /** this take care of gaps and self-intersection and iop distortions */
 static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, int prio_max,
-                                   dt_dev_pixelpipe_t *pipe, float pipe_iwidth, float pipe_iheight,
-                                   float **points, int *points_count, float **border, int *border_count,
-                                   int source)
+                                   dt_dev_pixelpipe_t *pipe, float **points, int *points_count,
+                                   float **border, int *border_count, int source)
 {
   double start2 = dt_get_wtime();
 
-  float wd = pipe_iwidth, ht = pipe_iheight;
+  float wd = pipe->iwidth, ht = pipe->iheight;
 
   dt_masks_dynbuf_t *dpoints = NULL, *dborder = NULL;
 
@@ -818,12 +817,8 @@ static void dt_path_get_distance(float x, int y, float as, dt_masks_form_gui_t *
 static int dt_path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
                                      int *points_count, float **border, int *border_count, int source)
 {
-  dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
-  float pipe_iwidth = dev->preview_pipe->iwidth;
-  float pipe_iheight = dev->preview_pipe->iheight;
-  dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
-  return _path_get_points_border(dev, form, 999999, dev->preview_pipe, pipe_iwidth, pipe_iheight, points,
-                                 points_count, border, border_count, source);
+  return _path_get_points_border(dev, form, 999999, dev->preview_pipe, points, points_count, border,
+                                 border_count, source);
 }
 
 static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
@@ -1001,17 +996,15 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
       int nb = g_list_length(form->points);
       // change the values
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       float wd = darktable.develop->preview_pipe->backbuf_width;
       float ht = darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       float pts[2] = { pzx * wd, pzy * ht };
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
       bzpt->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
       bzpt->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
       bzpt->ctrl1[0] = bzpt->ctrl1[1] = bzpt->ctrl2[0] = bzpt->ctrl2[1] = -1.0;
       bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
@@ -1021,10 +1014,8 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       if(nb == 0)
       {
         dt_masks_point_path_t *bzpt2 = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
         bzpt2->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
         bzpt2->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
         bzpt2->ctrl1[0] = bzpt2->ctrl1[1] = bzpt2->ctrl2[0] = bzpt2->ctrl2[1] = -1.0;
         bzpt2->border[0] = bzpt2->border[1] = MAX(0.005f, masks_border);
         bzpt2->state = DT_MASKS_POINT_STATE_NORMAL;
@@ -1061,10 +1052,10 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       if(!gpt) return 0;
       // we start the form dragging
       gui->source_dragging = TRUE;
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->dx = gpt->source[2] - gui->posx;
       gui->dy = gpt->source[3] - gui->posy;
       return 1;
@@ -1073,10 +1064,10 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
     {
       gui->form_dragging = TRUE;
       gui->point_edited = -1;
-      dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
       gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+      dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
       gui->dx = gpt->points[2] - gui->posx;
       gui->dy = gpt->points[3] - gui->posy;
       return 1;
@@ -1141,17 +1132,15 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
         // we add a new point to the path
         dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)(malloc(sizeof(dt_masks_point_path_t)));
         // change the values
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
         float wd = darktable.develop->preview_pipe->backbuf_width;
         float ht = darktable.develop->preview_pipe->backbuf_height;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
         float pts[2] = { pzx * wd, pzy * ht };
         dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
         bzpt->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
         bzpt->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
         bzpt->ctrl1[0] = bzpt->ctrl1[1] = bzpt->ctrl2[0] = bzpt->ctrl2[1] = -1.0;
         bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
@@ -1176,10 +1165,10 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       {
         // we move the entire segment
         gui->seg_dragging = gui->seg_selected;
-        dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
         gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
         gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+        dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
         gui->dx = gpt->points[gui->seg_selected * 6 + 2] - gui->posx;
         gui->dy = gpt->points[gui->seg_selected * 6 + 3] - gui->posy;
       }
@@ -1306,16 +1295,14 @@ static int dt_path_events_button_released(struct dt_iop_module_t *module, float 
 
     // we get point0 new values
     dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_first(form->points)->data;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
     float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     // we move all points
     GList *points = g_list_first(form->points);
@@ -1348,16 +1335,14 @@ static int dt_path_events_button_released(struct dt_iop_module_t *module, float 
     gui->source_dragging = FALSE;
 
     // we change the source value
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     form->source[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
     form->source[1] = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     dt_masks_write_form(form, darktable.develop);
 
     // we recreate the form points
@@ -1388,16 +1373,14 @@ static int dt_path_events_button_released(struct dt_iop_module_t *module, float 
       return 1;
     }
     gui->scrollx = gui->scrolly = 0;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
     float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     point->corner[0] += dx;
     point->corner[1] += dy;
@@ -1424,15 +1407,14 @@ static int dt_path_events_button_released(struct dt_iop_module_t *module, float 
     dt_masks_point_path_t *point
         = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->feather_dragging);
     gui->feather_dragging = -1;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     int p1x, p1y, p2x, p2y;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     _path_feather_to_ctrl(point->corner[0] * darktable.develop->preview_pipe->iwidth,
                           point->corner[1] * darktable.develop->preview_pipe->iheight, pts[0], pts[1], &p1x,
                           &p1y, &p2x, &p2y, gpt->clockwise);
@@ -1440,7 +1422,6 @@ static int dt_path_events_button_released(struct dt_iop_module_t *module, float 
     point->ctrl1[1] = (float)p1y / darktable.develop->preview_pipe->iheight;
     point->ctrl2[0] = (float)p2x / darktable.develop->preview_pipe->iwidth;
     point->ctrl2[1] = (float)p2y / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     point->state = DT_MASKS_POINT_STATE_USER;
 
@@ -1478,19 +1459,19 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   int closeup = dt_control_get_dev_closeup();
   float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, closeup ? 2 : 1, 1);
-  dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
   float as = 0.005f / zoom_scale * darktable.develop->preview_pipe->backbuf_width;
-  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
   if(!gui) return 0;
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
   if(gui->point_dragging >= 0)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     if(gui->creation && g_list_length(form->points) > 3)
     {
@@ -1508,10 +1489,8 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
 
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     dt_masks_point_path_t *bzpt = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->point_dragging);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     pzx = pts[0] / darktable.develop->preview_pipe->iwidth;
     pzy = pts[1] / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     bzpt->ctrl1[0] += pzx - bzpt->corner[0];
     bzpt->ctrl2[0] += pzx - bzpt->corner[0];
     bzpt->ctrl1[1] += pzy - bzpt->corner[1];
@@ -1531,16 +1510,14 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     int pos2 = (gui->seg_dragging + 1) % g_list_length(form->points);
     dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->seg_dragging);
     dt_masks_point_path_t *point2 = (dt_masks_point_path_t *)g_list_nth_data(form->points, pos2);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd + gui->dx, pzy * ht + gui->dy };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float dx = pts[0] / darktable.develop->preview_pipe->iwidth - point->corner[0];
     float dy = pts[1] / darktable.develop->preview_pipe->iheight - point->corner[1];
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     // we move all points
     point->corner[0] += dx;
@@ -1569,17 +1546,16 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   }
   else if(gui->feather_dragging >= 0)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     float pts[2] = { pzx * wd, pzy * ht };
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
     dt_masks_point_path_t *point
         = (dt_masks_point_path_t *)g_list_nth_data(form->points, gui->feather_dragging);
 
     int p1x, p1y, p2x, p2y;
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     _path_feather_to_ctrl(point->corner[0] * darktable.develop->preview_pipe->iwidth,
                           point->corner[1] * darktable.develop->preview_pipe->iheight, pts[0], pts[1], &p1x,
                           &p1y, &p2x, &p2y, gpt->clockwise);
@@ -1587,7 +1563,6 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     point->ctrl1[1] = (float)p1y / darktable.develop->preview_pipe->iheight;
     point->ctrl2[0] = (float)p2x / darktable.develop->preview_pipe->iwidth;
     point->ctrl2[1] = (float)p2y / darktable.develop->preview_pipe->iheight;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
     point->state = DT_MASKS_POINT_STATE_USER;
 
     _path_init_ctrl_points(form);
@@ -1599,10 +1574,10 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   }
   else if(gui->point_border_dragging >= 0)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     float wd = darktable.develop->preview_pipe->backbuf_width;
     float ht = darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
 
     int k = gui->point_border_dragging;
 
@@ -1618,12 +1593,10 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
     dt_dev_distort_backtransform(darktable.develop, pts, 1);
 
     dt_masks_point_path_t *point = (dt_masks_point_path_t *)g_list_nth_data(form->points, k);
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
     float nx = point->corner[0] * darktable.develop->preview_pipe->iwidth;
     float ny = point->corner[1] * darktable.develop->preview_pipe->iheight;
     float nr = sqrtf((pts[0] - nx) * (pts[0] - nx) + (pts[1] - ny) * (pts[1] - ny));
     float bdr = nr / fminf(darktable.develop->preview_pipe->iwidth, darktable.develop->preview_pipe->iheight);
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
 
     point->border[0] = point->border[1] = bdr;
 
@@ -1635,10 +1608,10 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   }
   else if(gui->form_dragging || gui->source_dragging)
   {
-    dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+    dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1653,10 +1626,10 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   // are we near a point or feather ?
   guint nb = g_list_length(form->points);
 
-  dt_pthread_mutex_lock(&darktable.develop->preview_pipe_mutex);
-  pzx *= darktable.develop->preview_pipe->backbuf_width,
-      pzy *= darktable.develop->preview_pipe->backbuf_height;
-  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
+  pzx *= darktable.develop->preview_pipe->backbuf_width;
+  pzy *= darktable.develop->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
 
   if((gui->group_selected == index) && gui->point_edited >= 0)
   {
@@ -1968,8 +1941,8 @@ static int dt_path_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                              piece->pipe->iheight, &points, &points_count, &border, &border_count, 1))
+  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                              &border, &border_count, 1))
   {
     free(points);
     free(border);
@@ -2024,8 +1997,8 @@ static int dt_path_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                              piece->pipe->iheight, &points, &points_count, &border, &border_count, 0))
+  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                              &border, &border_count, 0))
   {
     free(points);
     free(border);
@@ -2109,8 +2082,8 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
   // we get buffers for all points
   float *points = NULL, *border = NULL;
   int points_count, border_count;
-  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                              piece->pipe->iheight, &points, &points_count, &border, &border_count, 0))
+  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                              &border, &border_count, 0))
   {
     free(points);
     free(border);
@@ -2534,9 +2507,8 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   // we get buffers for all points
   float *points = NULL, *border = NULL, *cpoints = NULL;
   int points_count, border_count;
-  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, piece->pipe->iwidth,
-                              piece->pipe->iheight, &points, &points_count, &border, &border_count, 0)
-     || (points_count <= 2))
+  if(!_path_get_points_border(module->dev, form, module->priority, piece->pipe, &points, &points_count,
+                              &border, &border_count, 0) || (points_count <= 2))
   {
     free(points);
     free(border);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -511,6 +511,7 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
   if(!dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, points, 4))
     return 0;
 
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   g->clip_max_x = points[0] / self->dev->preview_pipe->backbuf_width;
   g->clip_max_y = points[1] / self->dev->preview_pipe->backbuf_height;
   g->clip_max_w = (points[2] - points[0]) / self->dev->preview_pipe->backbuf_width;
@@ -521,6 +522,7 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
   g->clip_y = points[5] / self->dev->preview_pipe->backbuf_height;
   g->clip_w = (points[6] - points[4]) / self->dev->preview_pipe->backbuf_width;
   g->clip_h = (points[7] - points[5]) / self->dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   g->clip_x = fmaxf(g->clip_x, g->clip_max_x);
   g->clip_y = fmaxf(g->clip_y, g->clip_max_y);
   g->clip_w = fminf(g->clip_w, g->clip_max_w);
@@ -1214,8 +1216,10 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       g->clip_h = fabsf(p->ch) - p->cy;
       if(g->clip_x > 0 || g->clip_y > 0 || g->clip_h < 1.0f || g->clip_w < 1.0f)
       {
+        dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
         g->old_width = self->dev->preview_pipe->backbuf_width;
         g->old_height = self->dev->preview_pipe->backbuf_height;
+        dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
       }
       else
       {
@@ -2138,16 +2142,23 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   // we don't do anything if the image is not ready
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   if(self->dev->preview_pipe->backbuf_width == g->old_width
      && self->dev->preview_pipe->backbuf_height == g->old_height)
+  {
+    dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
     return;
+  }
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   g->old_width = g->old_height = -1;
 
   // reapply box aspect to be sure that the ratio has not been modified by the keystone transform
   apply_box_aspect(self, GRAB_HORIZONTAL);
 
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   float zoom_y = dt_control_get_dev_zoom_y();
   float zoom_x = dt_control_get_dev_zoom_x();
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
@@ -2552,15 +2563,22 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
   // we don't do anything if the image is not ready
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   if((self->dev->preview_pipe->backbuf_width == g->old_width
       && self->dev->preview_pipe->backbuf_height == g->old_height)
     ||self->dev->preview_loading
     )
+  {
+    dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
     return 0;
+  }
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   g->old_width = g->old_height = -1;
 
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float wd = self->dev->preview_pipe->backbuf_width;
   float ht = self->dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   int closeup = dt_control_get_dev_closeup();
   float zoom_scale = dt_dev_get_zoom_scale(self->dev, zoom, closeup ? 2 : 1, 1);
@@ -2770,8 +2788,10 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       }
       apply_box_aspect(self, grab);
       // we save crop params too
+      dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
       float wd = self->dev->preview_pipe->backbuf_width;
       float ht = self->dev->preview_pipe->backbuf_height;
+      dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
       float points[4]
           = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
       if(dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999,
@@ -2887,8 +2907,10 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
     p->cw = p->ch = 1.0f;
   }
   // we want value in iop space
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float wd = self->dev->preview_pipe->backbuf_width;
   float ht = self->dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   float points[4]
       = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
   if(dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999,
@@ -2916,9 +2938,14 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
 {
   dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
   // we don't do anything if the image is not ready
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   if(self->dev->preview_pipe->backbuf_width == g->old_width
      && self->dev->preview_pipe->backbuf_height == g->old_height)
+  {
+    dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
     return 0;
+  }
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   g->old_width = g->old_height = -1;
 
   if(g->straightening)
@@ -2958,9 +2985,14 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
   dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
   // we don't do anything if the image is not ready
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   if(self->dev->preview_pipe->backbuf_width == g->old_width
      && self->dev->preview_pipe->backbuf_height == g->old_height)
+  {
+    dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
     return 0;
+  }
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   g->old_width = g->old_height = -1;
 
   // avoid unexpected back to lt mode:
@@ -3000,8 +3032,10 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
                          p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
         dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, pts, 4);
 
+        dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
         float xx = pzx * self->dev->preview_pipe->backbuf_width,
               yy = pzy * self->dev->preview_pipe->backbuf_height;
+        dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
         float c[2] = { (MIN(pts[4], pts[2]) + MAX(pts[0], pts[6])) / 2.0f,
                        (MIN(pts[5], pts[7]) + MAX(pts[1], pts[3])) / 2.0f };
         float ext = DT_PIXEL_APPLY_DPI(10.0) / (zoom_scale);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -196,9 +196,11 @@ static int set_grad_from_points(struct dt_iop_module_t *self, float xa, float ya
                                 float *rotation, float *offset)
 {
   // we want absolute positions
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float pts[4]
       = { xa * self->dev->preview_pipe->backbuf_width, ya * self->dev->preview_pipe->backbuf_height,
           xb * self->dev->preview_pipe->backbuf_width, yb * self->dev->preview_pipe->backbuf_height };
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, pts, 2);
   dt_iop_roi_t buf_in, buf_out;
   if(!dt_dev_get_iop_buffer_sizes(self->dev, self->dev->preview_pipe, self, &buf_in, &buf_out)) return 0;
@@ -378,10 +380,12 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
 
   if(!dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, pts, 2))
     return 0;
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   *xa = pts[0] / self->dev->preview_pipe->backbuf_width;
   *ya = pts[1] / self->dev->preview_pipe->backbuf_height;
   *xb = pts[2] / self->dev->preview_pipe->backbuf_width;
   *yb = pts[3] / self->dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   return 1;
 }
 
@@ -392,8 +396,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   float zoom_y = dt_control_get_dev_zoom_y();
   float zoom_x = dt_control_get_dev_zoom_x();
   dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
@@ -577,17 +583,12 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
   if(g->dragging > 0)
   {
-    // dt_iop_graduatednd_params_t *p   = (dt_iop_graduatednd_params_t *)self->params;
-    // float wd = self->dev->preview_pipe->backbuf_width;
-    // float ht = self->dev->preview_pipe->backbuf_height;
     float pzx, pzy;
     dt_dev_get_pointer_zoom_pos(self->dev, x, y, &pzx, &pzy);
     pzx += 0.5f;
     pzy += 0.5f;
 
     float r = 0.0, o = 0.0;
-    // float pts[4];
-    // dt_dev_distort_backtransform(self->dev,pts,2);
     set_grad_from_points(self, g->xa, g->ya, g->xb, g->yb, &r, &o);
 
     // if this is a "line dragging, we reset extremities, to be sure they are not outside the image
@@ -602,7 +603,6 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
     }
     self->dt->gui->reset = 1;
     dt_bauhaus_slider_set(g->scale3, r);
-    // dt_bauhaus_slider_set(g->scale4,o);
     self->dt->gui->reset = 0;
     p->rotation = r;
     p->offset = o;
@@ -895,8 +895,7 @@ static void rotation_callback(GtkWidget *slider, gpointer user_data)
   if(self->dt->gui->reset) return;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
-  // float wd = self->dev->preview_pipe->backbuf_width;
-  // float ht = self->dev->preview_pipe->backbuf_height;
+
   p->rotation = dt_bauhaus_slider_get(slider);
   set_points_from_grad(self, &g->xa, &g->ya, &g->xb, &g->yb, p->rotation, p->offset);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -946,10 +945,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->gslider1, p->hue);
   dt_bauhaus_slider_set(g->gslider2, p->saturation);
 
-  // float wd = self->dev->preview_pipe->backbuf_width;
-  // float ht = self->dev->preview_pipe->backbuf_height;
   g->define = 0;
-  // set_points_from_grad(self,&g->xa,&g->ya,&g->xb,&g->yb,p->rotation,p->offset);
   update_saturation_slider_end_color(g->gslider2, p->hue);
 }
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -200,11 +200,12 @@ static int set_grad_from_points(struct dt_iop_module_t *self, float xa, float ya
       = { xa * self->dev->preview_pipe->backbuf_width, ya * self->dev->preview_pipe->backbuf_height,
           xb * self->dev->preview_pipe->backbuf_width, yb * self->dev->preview_pipe->backbuf_height };
   dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, pts, 2);
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
-  pts[0] /= (float)piece->buf_out.width;
-  pts[2] /= (float)piece->buf_out.width;
-  pts[1] /= (float)piece->buf_out.height;
-  pts[3] /= (float)piece->buf_out.height;
+  dt_iop_roi_t buf_in, buf_out;
+  if(!dt_dev_get_iop_buffer_sizes(self->dev, self->dev->preview_pipe, self, &buf_in, &buf_out)) return 0;
+  pts[0] /= (float)buf_out.width;
+  pts[2] /= (float)buf_out.width;
+  pts[1] /= (float)buf_out.height;
+  pts[3] /= (float)buf_out.height;
 
   // we first need to find the rotation angle
   // weird dichotomic solution : we may use something more cool ...
@@ -273,9 +274,9 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
   const float sinv = sin(v);
   float pts[4];
 
-  dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
-  if(!piece) return 0;
-  float wp = piece->buf_out.width, hp = piece->buf_out.height;
+  dt_iop_roi_t buf_in, buf_out;
+  if(!dt_dev_get_iop_buffer_sizes(self->dev, self->dev->preview_pipe, self, &buf_in, &buf_out)) return 0;
+  float wp = buf_out.width, hp = buf_out.height;
 
   // if sinv=0 then this is just the offset
   if(sinv == 0)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2405,8 +2405,10 @@ void gui_post_expose (struct dt_iop_module_t *module,
   if (!g)
     return;
 
+  dt_pthread_mutex_lock(&develop->preview_pipe->backbuf_mutex);
   const float bb_width = develop->preview_pipe->backbuf_width;
   const float bb_height = develop->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&develop->preview_pipe->backbuf_mutex);
   const float iscale = develop->preview_pipe->iscale;
   const float scale = MAX (bb_width, bb_height);
   if (bb_width < 1.0 || bb_height < 1.0)
@@ -2481,8 +2483,10 @@ static void get_point_scale(struct dt_iop_module_t *module, float x, float y, fl
   dt_dev_get_pointer_zoom_pos(darktable.develop, x, y, &pzx, &pzy);
   pzx += 0.5f;
   pzy += 0.5f;
+  dt_pthread_mutex_lock(&darktable.develop->preview_pipe->backbuf_mutex);
   float wd = darktable.develop->preview_pipe->backbuf_width;
   float ht = darktable.develop->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&darktable.develop->preview_pipe->backbuf_mutex);
   float pts[2] = { pzx * wd, pzy * ht };
   dt_dev_distort_backtransform(darktable.develop, pts, 1);
   float nx = pts[0] / darktable.develop->preview_pipe->iwidth;

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -370,10 +370,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   //   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
 
-  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&self->dev->preview_pipe->backbuf_mutex);
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
-  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe->backbuf_mutex);
   float bigger_side, smaller_side;
   if(wd >= ht)
   {
@@ -464,10 +464,10 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 {
   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
-  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
+  dt_pthread_mutex_lock(&self->dev->preview_pipe->backbuf_mutex);
   float wd = self->dev->preview_pipe->backbuf_width;
   float ht = self->dev->preview_pipe->backbuf_height;
-  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe->backbuf_mutex);
   float bigger_side, smaller_side;
   if(wd >= ht)
   {

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -370,8 +370,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   //   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
 
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   float bigger_side, smaller_side;
   if(wd >= ht)
   {
@@ -462,8 +464,10 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
 {
   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
   dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
+  dt_pthread_mutex_lock(&self->dev->preview_pipe_mutex);
   float wd = self->dev->preview_pipe->backbuf_width;
   float ht = self->dev->preview_pipe->backbuf_height;
+  dt_pthread_mutex_unlock(&self->dev->preview_pipe_mutex);
   float bigger_side, smaller_side;
   if(wd >= ht)
   {


### PR DESCRIPTION
until now dt_dev_get_iop_buffer_sizes didn't lock anything, so it was not really thread safe as this fct is mainly use in gui threads.
-> lock it like other dt_dev_distort_\* fct
-> only deal with buffer size (other values are not relevant in this case)
-> return copies of buffer sizes

~~This PR depends of PR #1126~~
