### PR TITLE
Do no lock camera in dt_camctl_import.

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -879,7 +879,6 @@ gboolean _camera_initialize(const dt_camctl_t *c, dt_camera_t *cam)
 void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *images)
 {
   // dt_camctl_t *camctl=(dt_camctl_t *)c;
-  _camctl_lock(c, cam);
 
   GList *ifile = g_list_first(images);
 
@@ -925,7 +924,6 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
     } while((ifile = g_list_next(ifile)));
 
   _dispatch_control_status(c, CAMERA_CONTROL_AVAILABLE);
-  _camctl_unlock(c);
 }
 
 


### PR DESCRIPTION
The camera is locked while entering in the tether mode in
dt_camctl_tether_mode and is only released when leaving the
tether mode.

Fix lock when capturing pictures.

For #10900