### PR TITLE
src/develop/masks/path.c: fix int -> float (compile error w/ GCC6)

### DIFF
--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2555,8 +2555,8 @@ static int dt_path_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   // now check if feather is at least partially within roi
   for(int i = nb_corner * 3; i < border_count; i++)
   {
-    int xx = border[i * 2];
-    int yy = border[i * 2 + 1];
+    float xx = border[i * 2];
+    float yy = border[i * 2 + 1];
     if(isnan(xx))
     {
       if(isnan(yy)) break; // that means we have to skip the end of the border path


### PR DESCRIPTION
no idea why in this instance xx and yy coordinates were ints (border is float *), they are floats in every comparable code segment.

and isnan() of an int doesn't make any sense (this is probably a newly caught warning/error with GCC6). this change fixes compilation with GCC6 and doesn't break with older GCC (5.3.1).