### PR TITLE
add hash utility functions

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -320,6 +320,17 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, struct dt_dev_pixelpipe
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);
+/*
+ * hash functions
+ */
+/** generate hash value out of all module settings of pixelpipe */
+uint64_t dt_dev_hash(dt_develop_t *dev);
+/** same function, but we can specify iop with priority between pmin and pmax */
+uint64_t dt_dev_hash_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, int pmin, int pmax);
+/** generate hash value out of module settings of all distorting modules of pixelpipe */
+uint64_t dt_dev_hash_distort(dt_develop_t *dev);
+/** same function, but we can specify iop with priority between pmin and pmax */
+uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, int pmin, int pmax);
 
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
these functions generate a hash value out of the settings of all active
modules, and all active distorting modules, respectively. modules can
thereby keep track if the pixelpipe has likely changed and if they need
to reprocess, re-read image buffers or recalculate overlay coordinates.