### PR TITLE
bauhaus: add callback feature to bauhaus slider

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -696,10 +696,11 @@ void dt_bauhaus_slider_set_hard_min(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  d->hard_min = val;
+  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  d->hard_min = rawval;
   d->min = MAX(d->min, d->hard_min);
   d->soft_min = MAX(d->soft_min, d->hard_min);
-  if(val > d->hard_max) dt_bauhaus_slider_set_hard_max(widget,val);
+  if(rawval > d->hard_max) dt_bauhaus_slider_set_hard_max(widget,val);
   if(pos < val)
   {
     dt_bauhaus_slider_set_soft(widget,val);
@@ -714,7 +715,7 @@ float dt_bauhaus_slider_get_hard_min(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return d->hard_min;
+  return (d->callback == NULL ? d->hard_min : d->callback(d->hard_min, DT_BAUHAUS_GET));
 }
 
 void dt_bauhaus_slider_set_hard_max(GtkWidget* widget, float val)
@@ -722,10 +723,11 @@ void dt_bauhaus_slider_set_hard_max(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  d->hard_max = val;
+  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  d->hard_max = rawval;
   d->max = MIN(d->max, d->hard_max);
   d->soft_max = MIN(d->soft_max, d->hard_max);
-  if(val < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
+  if(rawval < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
   if(pos > val) {
 
     dt_bauhaus_slider_set_soft(widget,val);
@@ -740,7 +742,7 @@ float dt_bauhaus_slider_get_hard_max(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return d->hard_max;
+  return (d->callback == NULL ? d->hard_max : d->callback(d->hard_max, DT_BAUHAUS_GET));
 }
 
 void dt_bauhaus_slider_set_soft_min(GtkWidget* widget, float val)
@@ -748,11 +750,12 @@ void dt_bauhaus_slider_set_soft_min(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  d->soft_min = val;
+  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  d->soft_min = rawval;
   d->hard_min = MIN(d->hard_min,d->soft_min);
   d->min =  d->soft_min;
-  if(val > d->soft_max) dt_bauhaus_slider_set_soft_max(widget,val);
-  if(val > d->hard_max) dt_bauhaus_slider_set_hard_max(widget,val);
+  if(rawval > d->soft_max) dt_bauhaus_slider_set_soft_max(widget,val);
+  if(rawval > d->hard_max) dt_bauhaus_slider_set_hard_max(widget,val);
   if(pos < val) 
   {
     dt_bauhaus_slider_set_soft(widget,val);
@@ -767,7 +770,7 @@ float dt_bauhaus_slider_get_soft_min(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return d->soft_min;
+  return (d->callback == NULL ? d->soft_min : d->callback(d->soft_min, DT_BAUHAUS_GET));
 }
 
 void dt_bauhaus_slider_set_soft_max(GtkWidget* widget, float val)
@@ -775,11 +778,12 @@ void dt_bauhaus_slider_set_soft_max(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  d->soft_max = val;
+  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  d->soft_max = rawval;
   d->hard_max = MAX(d->soft_max, d->hard_max);
   d->max =  d->soft_max;
-  if(val < d->soft_min) dt_bauhaus_slider_set_soft_min(widget,val);
-  if(val < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
+  if(rawval < d->soft_min) dt_bauhaus_slider_set_soft_min(widget,val);
+  if(rawval < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
   if(pos > val) {
     dt_bauhaus_slider_set_soft(widget,val);
   } else {
@@ -791,22 +795,23 @@ float dt_bauhaus_slider_get_soft_max(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return d->soft_max;
+  return (d->callback == NULL ? d->soft_max : d->callback(d->soft_max, DT_BAUHAUS_GET));
 }
 
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  d->defpos = (def - d->min) / (d->max - d->min);
+  float val = d->callback == NULL ? def : d->callback(def, DT_BAUHAUS_SET);
+  d->defpos = (val - d->min) / (d->max - d->min);
 }
 
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  d->hard_min = hard_min;
-  d->hard_max = hard_max;
+  d->hard_min = d->callback == NULL ? hard_min : d->callback(hard_min, DT_BAUHAUS_SET);
+  d->hard_max = d->callback == NULL ? hard_max : d->callback(hard_max, DT_BAUHAUS_SET);
 }
 
 void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const char *label)
@@ -927,6 +932,7 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
   d->is_dragging = 0;
   d->is_changed = 0;
   d->timeout_handle = 0;
+  d->callback = NULL;
 
   g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(dt_bauhaus_slider_button_press),
                    (gpointer)NULL);
@@ -1109,10 +1115,11 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+  float rawstop = d->callback == NULL ? stop : d->callback(stop, DT_BAUHAUS_SET);
   // need to replace stop?
   for(int k = 0; k < d->grad_cnt; k++)
   {
-    if(d->grad_pos[k] == stop)
+    if(d->grad_pos[k] == rawstop)
     {
       d->grad_col[k][0] = r;
       d->grad_col[k][1] = g;
@@ -1124,7 +1131,7 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   if(d->grad_cnt < 10)
   {
     int k = d->grad_cnt++;
-    d->grad_pos[k] = stop;
+    d->grad_pos[k] = rawstop;
     d->grad_col[k][0] = r;
     d->grad_col[k][1] = g;
     d->grad_col[k][2] = b;
@@ -1505,7 +1512,8 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_save(cr);
       char text[256];
       const float f = d->min + (d->oldpos + mouse_off) * (d->max - d->min);
-      snprintf(text, sizeof(text), d->format, f);
+      const float fc = d->callback == NULL ? f : d->callback(f, DT_BAUHAUS_GET);
+      snprintf(text, sizeof(text), d->format, fc);
       show_pango_text(cr, text, wd - 4 - ht, 0, 0, TRUE, TRUE, FALSE);
 
       cairo_restore(cr);
@@ -1656,7 +1664,8 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
         // TODO: merge that text with combo
         char text[256];
         const float f = d->min + d->pos * (d->max - d->min);
-        snprintf(text, sizeof(text), d->format, f);
+        const float fc = d->callback == NULL ? f : d->callback(f, DT_BAUHAUS_GET);
+        snprintf(text, sizeof(text), d->format, fc);
         show_pango_text(cr, text, width - 4 - height, 0, 0, TRUE, TRUE, FALSE);
       }
       // label on top of marker:
@@ -1864,7 +1873,8 @@ float dt_bauhaus_slider_get(GtkWidget *widget)
   if(d->max == d->min) {
     return d->max;
   }
-  return d->min + d->pos * (d->max - d->min);
+  float rawval = d->min + d->pos * (d->max - d->min);
+  return (d->callback == NULL ? rawval : d->callback(rawval, DT_BAUHAUS_GET));
 }
 
 void dt_bauhaus_slider_set(GtkWidget *widget, float pos)
@@ -1873,7 +1883,8 @@ void dt_bauhaus_slider_set(GtkWidget *widget, float pos)
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  dt_bauhaus_slider_set_normalized(w, (pos - d->min) / (d->max - d->min));
+  float rawval = (d->callback == NULL ? pos : d->callback(pos, DT_BAUHAUS_SET));
+  dt_bauhaus_slider_set_normalized(w, (rawval - d->min) / (d->max - d->min));
 }
 
 float dt_bauhaus_slider_get_step(GtkWidget *widget)
@@ -1909,12 +1920,21 @@ void dt_bauhaus_slider_set_format(GtkWidget *widget, const char *format)
   g_strlcpy(d->format, format, sizeof(d->format));
 }
 
+void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(float value, dt_bauhaus_callback_t dir))
+{
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_SLIDER) return;
+  dt_bauhaus_slider_data_t *d = &w->data.slider;
+  d->callback = callback;
+}
+
 void dt_bauhaus_slider_set_soft(GtkWidget *widget, float pos)
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float rpos = CLAMP(pos, d->hard_min, d->hard_max);
+  float rawval = (d->callback == NULL ? pos : d->callback(pos, DT_BAUHAUS_SET));
+  float rpos = CLAMP(rawval, d->hard_min, d->hard_max);
   d->min = MIN(d->min, rpos);
   d->max = MAX(d->max, rpos);
   rpos = (rpos - d->min) / (d->max - d->min);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -696,7 +696,7 @@ void dt_bauhaus_slider_set_hard_min(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
   d->hard_min = rawval;
   d->min = MAX(d->min, d->hard_min);
   d->soft_min = MAX(d->soft_min, d->hard_min);
@@ -715,7 +715,7 @@ float dt_bauhaus_slider_get_hard_min(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return (d->callback == NULL ? d->hard_min : d->callback(d->hard_min, DT_BAUHAUS_GET));
+  return d->callback(widget, d->hard_min, DT_BAUHAUS_GET);
 }
 
 void dt_bauhaus_slider_set_hard_max(GtkWidget* widget, float val)
@@ -723,7 +723,7 @@ void dt_bauhaus_slider_set_hard_max(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
   d->hard_max = rawval;
   d->max = MIN(d->max, d->hard_max);
   d->soft_max = MIN(d->soft_max, d->hard_max);
@@ -742,7 +742,7 @@ float dt_bauhaus_slider_get_hard_max(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return (d->callback == NULL ? d->hard_max : d->callback(d->hard_max, DT_BAUHAUS_GET));
+  return d->callback(widget, d->hard_max, DT_BAUHAUS_GET);
 }
 
 void dt_bauhaus_slider_set_soft_min(GtkWidget* widget, float val)
@@ -750,7 +750,7 @@ void dt_bauhaus_slider_set_soft_min(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
   d->soft_min = rawval;
   d->hard_min = MIN(d->hard_min,d->soft_min);
   d->min =  d->soft_min;
@@ -770,7 +770,7 @@ float dt_bauhaus_slider_get_soft_min(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return (d->callback == NULL ? d->soft_min : d->callback(d->soft_min, DT_BAUHAUS_GET));
+  return d->callback(widget, d->soft_min, DT_BAUHAUS_GET);
 }
 
 void dt_bauhaus_slider_set_soft_max(GtkWidget* widget, float val)
@@ -778,7 +778,7 @@ void dt_bauhaus_slider_set_soft_max(GtkWidget* widget, float val)
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float pos = dt_bauhaus_slider_get(widget);
-  float rawval = (d->callback == NULL ? val : d->callback(val, DT_BAUHAUS_SET));
+  float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
   d->soft_max = rawval;
   d->hard_max = MAX(d->soft_max, d->hard_max);
   d->max =  d->soft_max;
@@ -795,14 +795,14 @@ float dt_bauhaus_slider_get_soft_max(GtkWidget* widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return (d->callback == NULL ? d->soft_max : d->callback(d->soft_max, DT_BAUHAUS_GET));
+  return d->callback(widget, d->soft_max, DT_BAUHAUS_GET);
 }
 
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float val = d->callback == NULL ? def : d->callback(def, DT_BAUHAUS_SET);
+  float val = d->callback(widget, def, DT_BAUHAUS_SET);
   d->defpos = (val - d->min) / (d->max - d->min);
 }
 
@@ -810,8 +810,8 @@ void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min,
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  d->hard_min = d->callback == NULL ? hard_min : d->callback(hard_min, DT_BAUHAUS_SET);
-  d->hard_max = d->callback == NULL ? hard_max : d->callback(hard_max, DT_BAUHAUS_SET);
+  d->hard_min = d->callback(widget, hard_min, DT_BAUHAUS_SET);
+  d->hard_max = d->callback(widget, hard_max, DT_BAUHAUS_SET);
 }
 
 void dt_bauhaus_widget_set_label(GtkWidget *widget, const char *section, const char *label)
@@ -881,6 +881,12 @@ void dt_bauhaus_widget_set_quad_toggle(GtkWidget *widget, int toggle)
   w->quad_toggle = toggle;
 }
 
+static float _default_linear_callback(GtkWidget *self, float value, dt_bauhaus_callback_t dir)
+{
+  // regardless of dir: input <-> output
+  return value;
+}
+
 static void dt_bauhaus_slider_destroy(dt_bauhaus_widget_t *widget, gpointer user_data)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
@@ -932,7 +938,7 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
   d->is_dragging = 0;
   d->is_changed = 0;
   d->timeout_handle = 0;
-  d->callback = NULL;
+  d->callback = _default_linear_callback;
 
   g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(dt_bauhaus_slider_button_press),
                    (gpointer)NULL);
@@ -1115,7 +1121,7 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float rawstop = d->callback == NULL ? stop : d->callback(stop, DT_BAUHAUS_SET);
+  float rawstop = d->callback(widget, stop, DT_BAUHAUS_SET);
   // need to replace stop?
   for(int k = 0; k < d->grad_cnt; k++)
   {
@@ -1512,7 +1518,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_save(cr);
       char text[256];
       const float f = d->min + (d->oldpos + mouse_off) * (d->max - d->min);
-      const float fc = d->callback == NULL ? f : d->callback(f, DT_BAUHAUS_GET);
+      const float fc = d->callback(widget, f, DT_BAUHAUS_GET);
       snprintf(text, sizeof(text), d->format, fc);
       show_pango_text(cr, text, wd - 4 - ht, 0, 0, TRUE, TRUE, FALSE);
 
@@ -1664,7 +1670,7 @@ static gboolean dt_bauhaus_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
         // TODO: merge that text with combo
         char text[256];
         const float f = d->min + d->pos * (d->max - d->min);
-        const float fc = d->callback == NULL ? f : d->callback(f, DT_BAUHAUS_GET);
+        const float fc = d->callback(widget, f, DT_BAUHAUS_GET);
         snprintf(text, sizeof(text), d->format, fc);
         show_pango_text(cr, text, width - 4 - height, 0, 0, TRUE, TRUE, FALSE);
       }
@@ -1874,7 +1880,7 @@ float dt_bauhaus_slider_get(GtkWidget *widget)
     return d->max;
   }
   float rawval = d->min + d->pos * (d->max - d->min);
-  return (d->callback == NULL ? rawval : d->callback(rawval, DT_BAUHAUS_GET));
+  return d->callback(widget, rawval, DT_BAUHAUS_GET);
 }
 
 void dt_bauhaus_slider_set(GtkWidget *widget, float pos)
@@ -1883,7 +1889,7 @@ void dt_bauhaus_slider_set(GtkWidget *widget, float pos)
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float rawval = (d->callback == NULL ? pos : d->callback(pos, DT_BAUHAUS_SET));
+  float rawval = d->callback(widget, pos, DT_BAUHAUS_SET);
   dt_bauhaus_slider_set_normalized(w, (rawval - d->min) / (d->max - d->min));
 }
 
@@ -1920,12 +1926,12 @@ void dt_bauhaus_slider_set_format(GtkWidget *widget, const char *format)
   g_strlcpy(d->format, format, sizeof(d->format));
 }
 
-void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(float value, dt_bauhaus_callback_t dir))
+void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(GtkWidget *self, float value, dt_bauhaus_callback_t dir))
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  d->callback = callback;
+  d->callback = (callback == NULL ? _default_linear_callback : callback);
 }
 
 void dt_bauhaus_slider_set_soft(GtkWidget *widget, float pos)
@@ -1933,7 +1939,7 @@ void dt_bauhaus_slider_set_soft(GtkWidget *widget, float pos)
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float rawval = (d->callback == NULL ? pos : d->callback(pos, DT_BAUHAUS_SET));
+  float rawval = d->callback(widget, pos, DT_BAUHAUS_SET);
   float rpos = CLAMP(rawval, d->hard_min, d->hard_max);
   d->min = MIN(d->min, rpos);
   d->max = MAX(d->max, rpos);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -85,7 +85,7 @@ typedef struct dt_bauhaus_slider_data_t
   int is_dragging;      // indicates is mouse is dragging slider
   int is_changed;       // indicates new data
   guint timeout_handle; // used to store id of timeout routine
-  float (*callback)(float, dt_bauhaus_callback_t); // callback function
+  float (*callback)(GtkWidget*, float, dt_bauhaus_callback_t); // callback function
 } dt_bauhaus_slider_data_t;
 
 // data portion for a combobox
@@ -258,7 +258,7 @@ void dt_bauhaus_slider_set_format(GtkWidget *w, const char *format);
 void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g, float b);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max);
-void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(float value, dt_bauhaus_callback_t dir));
+void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(GtkWidget *self, float value, dt_bauhaus_callback_t dir));
 
 // combobox:
 void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* widget,dt_iop_module_t *self);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -55,6 +55,12 @@ typedef enum dt_bauhaus_type_t
   // TODO: all the fancy color sliders..
 } dt_bauhaus_type_t;
 
+typedef enum dt_bauhaus_callback_t
+{
+  DT_BAUHAUS_SET = 1,
+  DT_BAUHAUS_GET = 2
+} dt_bauhaus_callback_t;
+
 // data portion for a slider
 typedef struct dt_bauhaus_slider_data_t
 {
@@ -79,6 +85,7 @@ typedef struct dt_bauhaus_slider_data_t
   int is_dragging;      // indicates is mouse is dragging slider
   int is_changed;       // indicates new data
   guint timeout_handle; // used to store id of timeout routine
+  float (*callback)(float, dt_bauhaus_callback_t); // callback function
 } dt_bauhaus_slider_data_t;
 
 // data portion for a combobox
@@ -251,6 +258,7 @@ void dt_bauhaus_slider_set_format(GtkWidget *w, const char *format);
 void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g, float b);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max);
+void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(float value, dt_bauhaus_callback_t dir));
 
 // combobox:
 void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* widget,dt_iop_module_t *self);


### PR DESCRIPTION
A callback function can be defined to enable a transparent conversion
between the linear slider position and a potentially non-linear outer
value. Typical use case is a logarithmic slider scale which can be defined
by a callback function as:

```
static float log_callback(float inval, dt_bauhaus_callback_t dir)
{
  float outval;
  switch(dir)
  {
    case DT_BAUHAUS_SET:
      outval = log10(fmax(inval, 1e-15f));
      break;
    case DT_BAUHAUS_GET:
      outval = exp(M_LN10 * inval);
      break;
    default:
      outval = inval;
  }
  return outval;
}
```

Note that after a callback is installed all interface functions that set or get
absolute slider values will go through the callback. Exception:
dt_bauhaus_slider_get_step() which returns a delta in linear coordinates.