### PR TITLE
demosaic: s/yoff/xoff/

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -596,7 +596,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           else
           {
             // mirror a border pixel if beyond image edge
-            const int c = FCxtrans(row + yoff + 18, col + yoff + 18, NULL, xtrans);
+            const int c = FCxtrans(row + yoff + 18, col + xoff + 18, NULL, xtrans);
             for(int cc = 0; cc < 3; cc++)
               if(cc != c)
                 pix[cc] = 0.0f;


### PR DESCRIPTION
Fix typo which snuck into 8a5d0a8. This will clean up edges on CPU version of 3-pass Markesteijn demosaic.