### PR TITLE
exiv: read Exif.Photo.FocalLengthIn35mmFilm tag if available to calcu…

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -572,6 +572,16 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         img->exif_focal_length = pos->toFloat();
     }
 
+    /* Read focal length in 35mm if available and try to calculate crop factor */
+    if(FIND_EXIF_TAG("Exif.Photo.FocalLengthIn35mmFilm"))
+    {
+      const float focal_length_35mm = pos->toFloat();
+      if(focal_length_35mm > 0.0f && img->exif_focal_length > 0.0f)
+        img->exif_crop = focal_length_35mm / img->exif_focal_length;
+      else
+        img->exif_crop = 1.0f;
+    }
+
     if(FIND_EXIF_TAG("Exif.NikonLd2.FocusDistance"))
     {
       float value = pos->toFloat();


### PR DESCRIPTION
…late exif_crop

this tag is certainly not available for all cameras. however, if it's there we
can get a good guess of the camera's crop factor instead of just setting it to 1.0.