### PR TITLE
RFC: Add API header for IOP

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -81,7 +81,7 @@ typedef unsigned int u_int;
 #include "common/poison.h"
 #endif
 
-#define DT_MODULE_VERSION 13 // version of dt's module interface
+#define DT_MODULE_VERSION 14 // version of dt's module interface
 
 // every module has to define this:
 #ifdef _DEBUG

--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -155,7 +155,7 @@ error:
 }
 
 
-void dt_gaussian_blur(dt_gaussian_t *g, float *in, float *out)
+void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 {
 
   const int width = g->width;
@@ -173,7 +173,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, float *in, float *out)
 
 // vertical blur column by column
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(in, out, temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,  \
+#pragma omp parallel for default(none) shared(temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,           \
                                               coefn) schedule(static)
 #endif
   for(int i = 0; i < width; i++)
@@ -245,7 +245,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, float *in, float *out)
 
 // horizontal blur line by line
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(out, temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,      \
+#pragma omp parallel for default(none) shared(temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,           \
                                               coefn) schedule(static)
 #endif
   for(int j = 0; j < height; j++)
@@ -319,7 +319,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, float *in, float *out)
 
 
 #if defined(__SSE__)
-static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, float *in, float *out)
+static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, const float *const in, float *const out)
 {
 
   const int width = g->width;
@@ -340,8 +340,7 @@ static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, float *in, float *out)
 
 // vertical blur column by column
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(in, out, temp, a0, a1, a2, a3, b1, b2, coefp,                  \
-                                              coefn) schedule(static)
+#pragma omp parallel for default(none) shared(temp, a0, a1, a2, a3, b1, b2, coefp, coefn) schedule(static)
 #endif
   for(int i = 0; i < width; i++)
   {
@@ -409,8 +408,7 @@ static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, float *in, float *out)
 
 // horizontal blur line by line
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(out, temp, a0, a1, a2, a3, b1, b2, coefp,                      \
-                                              coefn) schedule(static)
+#pragma omp parallel for default(none) shared(temp, a0, a1, a2, a3, b1, b2, coefp, coefn) schedule(static)
 #endif
   for(size_t j = 0; j < height; j++)
   {
@@ -478,7 +476,7 @@ static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, float *in, float *out)
 }
 #endif
 
-void dt_gaussian_blur_4c(dt_gaussian_t *g, float *in, float *out)
+void dt_gaussian_blur_4c(dt_gaussian_t *g, const float *const in, float *const out)
 {
   if(darktable.codepath.OPENMP_SIMD) return dt_gaussian_blur(g, in, out);
 #if defined(__SSE__)

--- a/src/common/gaussian.h
+++ b/src/common/gaussian.h
@@ -48,9 +48,9 @@ size_t dt_gaussian_memory_use(const int width, const int height, const int chann
 
 size_t dt_gaussian_singlebuffer_size(const int width, const int height, const int channels);
 
-void dt_gaussian_blur(dt_gaussian_t *g, float *in, float *out);
+void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out);
 
-void dt_gaussian_blur_4c(dt_gaussian_t *g, float *in, float *out);
+void dt_gaussian_blur_4c(dt_gaussian_t *g, const float *const in, float *const out);
 
 void dt_gaussian_free(dt_gaussian_t *g);
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2426,8 +2426,9 @@ static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, flo
   }
 }
 
-void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i,
-                              void *o, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out)
+void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                              const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                              const struct dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;           // the number of channels in the buffer
   const int bch = (ch == 1) ? 1 : ch - 1; // the number of channels to blend (all but alpha)
@@ -2645,9 +2646,9 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__) && !defined(__WIN32__)
-#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, d, stderr)
+#pragma omp parallel for default(none) shared(mask, blend, d, stderr)
 #else
-#pragma omp parallel for shared(i, roi_out, o, mask, blend, d)
+#pragma omp parallel for shared(mask, blend, d)
 #endif
 #endif
     for(size_t y = 0; y < roi_out->height; y++)
@@ -2696,9 +2697,9 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
     {
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__WIN32__)
-#pragma omp parallel for default(none) shared(roi_out, mask, stderr)
+#pragma omp parallel for default(none) shared(mask, stderr)
 #else
-#pragma omp parallel for shared(roi_out, mask)
+#pragma omp parallel for shared(mask)
 #endif
 #endif
       for(size_t k = 0; k < (size_t)roi_out->height * roi_out->width; k++)
@@ -2711,9 +2712,9 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 /* now apply blending with per-pixel opacity value as defined in mask */
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__WIN32__)
-#pragma omp parallel for default(none) shared(i, roi_out, o, mask, blend, stderr)
+#pragma omp parallel for default(none) shared(mask, blend, stderr)
 #else
-#pragma omp parallel for shared(i, roi_out, o, mask, blend)
+#pragma omp parallel for shared(mask, blend)
 #endif
 #endif
   for(size_t y = 0; y < roi_out->height; y++)

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -367,8 +367,9 @@ typedef struct dt_iop_gui_blend_data_t
 void dt_develop_blend_init(dt_blendop_t *gd);
 
 /** apply blend */
-void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i,
-                              void *o, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                              const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                              const struct dt_iop_roi_t *const roi_out);
 
 /** get blend version */
 int dt_develop_blend_version(void);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -177,8 +177,9 @@ static int default_distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe
   return 1;
 }
 
-static void default_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i,
-                            void *o, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out)
+static void default_process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                            const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                            const struct dt_iop_roi_t *const roi_out)
 {
   if(darktable.codepath.OPENMP_SIMD && self->process_plain)
     self->process_plain(self, piece, i, o, roi_in, roi_out);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -121,6 +121,8 @@ struct dt_iop_module_so_t;
 struct dt_iop_module_t;
 typedef struct dt_iop_module_so_t
 {
+  // !!! MUST BE KEPT IN SYNC WITH src/iop/iop_api.h !!!
+
   /** opened module. */
   GModule *module;
   /** string identifying this operation. */
@@ -229,6 +231,8 @@ typedef struct dt_iop_module_so_t
 
 typedef struct dt_iop_module_t
 {
+  // !!! MUST BE KEPT IN SYNC WITH src/iop/iop_api.h !!!
+
   /** opened module. */
   GModule *module;
   /** string identifying this operation. */

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -200,20 +200,24 @@ typedef struct dt_iop_module_so_t
   int (*legacy_params)(struct dt_iop_module_t *self, const void *const old_params, const int old_version,
                        void *new_params, const int new_version);
 
-  void (*process)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                  const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
-  void (*process_tiling)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                         const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                         const int bpp);
-  void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                        const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
-  void (*process_sse2)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                       const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
-  int (*process_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                    const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
-  int (*process_tiling_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i,
-                           void *o, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                           const int bpp);
+  void (*process)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                  void *const o, const struct dt_iop_roi_t *const roi_in,
+                  const struct dt_iop_roi_t *const roi_out);
+  void (*process_tiling)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                         const struct dt_iop_roi_t *const roi_out, const int bpp);
+  void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                        const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                        const struct dt_iop_roi_t *const roi_out);
+  void (*process_sse2)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                       const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                       const struct dt_iop_roi_t *const roi_out);
+  int (*process_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                    void *const o, const struct dt_iop_roi_t *const roi_in,
+                    const struct dt_iop_roi_t *const roi_out);
+  int (*process_tiling_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                           const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                           const struct dt_iop_roi_t *const roi_out, const int bpp);
 
   int (*distort_transform)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
                            size_t points_count);
@@ -388,26 +392,30 @@ typedef struct dt_iop_module_t
     * scaled to the same size width*height and contain a max of 3 floats. other color
     * formats may be filled by this callback, if the pipeline can handle it. */
   /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
-  void (*process)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                  const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+  void (*process)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                  void *const o, const struct dt_iop_roi_t *const roi_in,
+                  const struct dt_iop_roi_t *const roi_out);
   /** a tiling variant of process(). */
-  void (*process_tiling)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                         const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                         const int bpp);
+  void (*process_tiling)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                         const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                         const struct dt_iop_roi_t *const roi_out, const int bpp);
   /** WARNING: in IOP implementation, it is called process()!!! */
   /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
-  void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                        const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+  void (*process_plain)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                        const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                        const struct dt_iop_roi_t *const roi_out);
   /** a variant process(), that can contain SSE2 intrinsics. */
-  void (*process_sse2)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                       const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+  void (*process_sse2)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                       const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                       const struct dt_iop_roi_t *const roi_out);
   /** the opencl equivalent of process(). */
-  int (*process_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                    const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+  int (*process_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                    void *const o, const struct dt_iop_roi_t *const roi_in,
+                    const struct dt_iop_roi_t *const roi_out);
   /** a tiling variant of process_cl(). */
-  int (*process_tiling_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i,
-                           void *o, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
-                           const int bpp);
+  int (*process_tiling_cl)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                           const void *const i, void *const o, const struct dt_iop_roi_t *const roi_in,
+                           const struct dt_iop_roi_t *const roi_out, const int bpp);
 
   /** this functions are used for distort iop
    * points is an array of float {x1,y1,x2,y2,...}

--- a/src/develop/pixelpipe.h
+++ b/src/develop/pixelpipe.h
@@ -64,7 +64,10 @@ typedef struct dt_dev_histogram_stats_t
   uint32_t ch;
 } dt_dev_histogram_stats_t;
 
+#ifndef DT_IOP_PARAMS_T
+#define DT_IOP_PARAMS_T
 typedef void dt_iop_params_t;
+#endif
 
 #include "develop/pixelpipe_hb.h"
 

--- a/src/develop/tiling.h
+++ b/src/develop/tiling.h
@@ -40,19 +40,21 @@ typedef struct dt_develop_tiling_t
   unsigned yalign;
 } dt_develop_tiling_t;
 
-int default_process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                              void *ovid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                              const int bpp);
+int default_process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                              const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
+                              const dt_iop_roi_t *const roi_out, const int bpp);
 
-int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                      void *ovid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out, const int bpp);
+int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                      const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
+                      const dt_iop_roi_t *const roi_out, const int bpp);
 
-void default_process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                            void *ovid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                            const int bpp);
+void default_process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                            const void *const ivoid, void *const ovid, const dt_iop_roi_t *const roi_in,
+                            const dt_iop_roi_t *const roi_out, const int bpp);
 
-void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                    void *ovid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out, const int bpp);
+void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                    const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
+                    const dt_iop_roi_t *const roi_out, const int bpp);
 
 void default_tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                              const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.6)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
 
+add_definitions(-include iop/iop_api.h)
+
 macro (add_iop _lib _src)
   string(LENGTH ${_lib} _lib_namelength)
   if(${_lib_namelength} GREATER 19)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -19,28 +19,29 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
 #include "bauhaus/bauhaus.h"
+#include "common/colorspaces.h"
+#include "common/debug.h"
+#include "common/interpolation.h"
+#include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "control/control.h"
-#include "common/debug.h"
-#include "common/opencl.h"
-#include "common/interpolation.h"
-#include "common/colorspaces.h"
-#include "dtgtk/resetlabel.h"
 #include "dtgtk/button.h"
+#include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
-#include "gui/gtk.h"
-#include "gui/presets.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
 #include "gui/guides.h"
+#include "gui/presets.h"
+#include "iop/iop_api.h"
+#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 // Inspiration for this module comes from the program ShiftN (http://www.shiftn.de) by
 // Marcus Hebel.

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1892,8 +1892,8 @@ error:
 }
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_ashift_data_t *data = (dt_iop_ashift_data_t *)piece->data;
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
@@ -1908,8 +1908,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
              data->orthocorr, data->aspect, piece->buf_in.width, piece->buf_in.height, ASHIFT_HOMOGRAPH_INVERTED);
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ivoid, ovoid, roi_in, roi_out, ihomograph,    \
-                                                               interpolation)
+#pragma omp parallel for schedule(static) default(none) shared(ihomograph, interpolation)
 #endif
   // go over all pixels of output image
   for(int j = 0; j < roi_out->height; j++)
@@ -2006,7 +2005,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_ashift_data_t *d = (dt_iop_ashift_data_t *)piece->data;
   dt_iop_ashift_global_data_t *gd = (dt_iop_ashift_global_data_t *)self->data;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -444,8 +444,8 @@ static int get_scales(float (*thrs)[4], float (*boost)[4], float *sharp, const d
 
 #if defined(__SSE__)
 /* just process the supplied image buffer, upstream default_process_tiling() does the rest */
-void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                  void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
   float thrs[MAX_NUM_SCALES][4];
@@ -525,7 +525,7 @@ error:
 #ifdef HAVE_OPENCL
 /* this version is adapted to the new global tiling mechanism. it no longer does tiling by itself. */
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_atrous_data_t *d = (dt_iop_atrous_data_t *)piece->data;
   float thrs[MAX_NUM_SCALES][4];

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -28,6 +28,7 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #include <memory.h>
 #include <stdlib.h>

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -262,7 +262,7 @@ void init_presets(dt_iop_module_so_t *self)
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_basecurve_data_t *d = (dt_iop_basecurve_data_t *)piece->data;
   dt_iop_basecurve_global_data_t *gd = (dt_iop_basecurve_global_data_t *)self->data;
@@ -301,15 +301,15 @@ error:
 }
 #endif
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   float *in = (float *)i;
   float *out = (float *)o;
   const int ch = piece->colors;
   dt_iop_basecurve_data_t *d = (dt_iop_basecurve_data_t *)(piece->data);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, out, d, in) schedule(static)
+#pragma omp parallel for default(none) shared(out, d, in) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -29,6 +29,7 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -806,7 +806,7 @@ static gboolean area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_d
   return TRUE;
 }
 
-static gboolean scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
+static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
@@ -879,7 +879,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(dt_iop_basecurve_leave_notify), self);
   g_signal_connect(G_OBJECT(c->area), "enter-notify-event", G_CALLBACK(dt_iop_basecurve_enter_notify), self);
   g_signal_connect(G_OBJECT(c->area), "configure-event", G_CALLBACK(area_resized), self);
-  g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(scrolled), self);
+  g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_scrolled), self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -19,12 +19,13 @@
 #include "config.h"
 #endif
 // our includes go first:
-#include "develop/imageop.h"
-#include "develop/tiling.h"
 #include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
+#include "develop/imageop.h"
+#include "develop/tiling.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -74,7 +74,7 @@ int groups()
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_bilat_data_t *d = (dt_iop_bilat_data_t *)piece->data;
   // the total scale is composed of scale before input to the pipeline (iscale),
@@ -161,8 +161,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 
 /** process, all real work is done here. */
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -30,6 +30,7 @@ extern "C" {
 #include "develop/tiling.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -95,8 +95,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->scale5));
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_bilateral_data_t *data = (dt_iop_bilateral_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -137,8 +137,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     for(int l = -rad; l <= rad; l++)
       for(int k = -rad; k <= rad; k++) m[l * wd + k] /= weight;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(ivoid, ovoid, roi_in, roi_out, m, mat,        \
-                                                               isig2col) private(in, out)
+#pragma omp parallel for default(none) schedule(static) shared(m, mat, isig2col) private(in, out)
 #endif
     for(int j = rad; j < roi_out->height - rad; j++)
     {

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -27,6 +27,7 @@
 #include "develop/tiling.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -107,8 +107,8 @@ void connect_key_accels(dt_iop_module_t *self)
 #define GAUSS(a, b, c, x) (a * pow(2.718281828, (-pow((x - b), 2) / (pow(c, 2)))))
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_bloom_data_t *data = (dt_iop_bloom_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -127,8 +127,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 /* get the thresholded lights into buffer */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ivoid, ovoid, roi_out, roi_in, data,                           \
-                                              blurlightness) schedule(static)
+#pragma omp parallel for default(none) shared(data, blurlightness) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -147,7 +146,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(blurlightness, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(blurlightness) schedule(static)
 #endif
     for(int y = 0; y < roi_out->height; y++)
     {
@@ -179,7 +178,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     const int opoffs = -(hr + 1) * roi_out->width;
     const int npoffs = (hr)*roi_out->width;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(blurlightness, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(blurlightness) schedule(static)
 #endif
     for(int x = 0; x < roi_out->width; x++)
     {
@@ -212,7 +211,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 /* screen blend lightness with original */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, data, blurlightness) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data, blurlightness) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -240,7 +239,7 @@ static int bucket_next(unsigned int *state, unsigned int max)
 }
 
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_bloom_data_t *d = (dt_iop_bloom_data_t *)piece->data;
   const dt_iop_bloom_global_data_t *gd = (dt_iop_bloom_global_data_t *)self->data;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -18,20 +18,21 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "develop/develop.h"
-#include "develop/imageop.h"
-#include "control/control.h"
-#include "control/conf.h"
+#include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/opencl.h"
-#include "bauhaus/bauhaus.h"
+#include "control/conf.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "dtgtk/button.h"
 #include "dtgtk/resetlabel.h"
 #include "dtgtk/togglebutton.h"
-#include "dtgtk/button.h"
 #include "gui/accelerators.h"
-#include "gui/gtk.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #include <stdlib.h>
 #include <math.h>

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -312,8 +312,8 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   roi_in->height = MIN(roi_out->scale * piece->buf_in.height, MAX(1, roi_in->height));
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
 
@@ -392,7 +392,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_borders_data_t *d = (dt_iop_borders_data_t *)piece->data;
   dt_iop_borders_global_data_t *gd = (dt_iop_borders_global_data_t *)self->data;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -22,6 +22,7 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1300,8 +1300,8 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
 
 /** process, all real work is done here. */
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   CA_correct(self, piece, (float *)i, (float *)o, roi_in, roi_out);
 }

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -142,8 +142,8 @@ void connect_key_accels(dt_iop_module_t *self)
 }
 #endif
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_channelmixer_data_t *data = (dt_iop_channelmixer_data_t *)piece->data;
   const gboolean gray_mix_mode = (data->red[CHANNEL_GRAY] != 0.0 || data->green[CHANNEL_GRAY] != 0.0
@@ -153,7 +153,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   const int ch = piece->colors;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ivoid, ovoid, roi_in, roi_out, data) schedule(static)
+#pragma omp parallel for default(none) shared(data) schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -233,7 +233,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_channelmixer_data_t *data = (dt_iop_channelmixer_data_t *)piece->data;
   dt_iop_channelmixer_global_data_t *gd = (dt_iop_channelmixer_global_data_t *)self->data;

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -29,6 +29,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -73,8 +73,8 @@ int flags()
   return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_DEPRECATED;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_rlce_data_t *data = (dt_iop_rlce_data_t *)piece->data;
   const int ch = piece->colors;
@@ -83,7 +83,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   float *luminance = (float *)malloc(((size_t)roi_out->width * roi_out->height) * sizeof(float));
 // double lsmax=0.0,lsmin=1.0;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(luminance, roi_in, roi_out, ivoid)
+#pragma omp parallel for default(none) schedule(static) shared(luminance)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -108,7 +108,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 // CLAHE
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(luminance, roi_in, roi_out, ivoid, ovoid)
+#pragma omp parallel for default(none) schedule(static) shared(luminance)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -18,19 +18,20 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "common/darktable.h"
+#include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
+#include "common/darktable.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
 #include "dtgtk/resetlabel.h"
 #include "gui/gtk.h"
-#include "bauhaus/bauhaus.h"
+#include "iop/iop_api.h"
+#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
-#include <stdlib.h>
 #include <math.h>
-#include <assert.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -800,8 +800,8 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
 // 3rd (final) pass: you get this input region (may be different from what was requested above),
 // do your best to fill the output region!
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
 
@@ -815,7 +815,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
      && roi_in->height == roi_out->height)
   {
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(d, ovoid, ivoid, roi_in, roi_out)
+#pragma omp parallel for schedule(static) default(none) shared(d)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -841,8 +841,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     keystone_get_matrix(k_space, kxa, kxb, kxc, kxd, kya, kyb, kyc, kyd, &ma, &mb, &md, &me, &mg, &mh);
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none)                                                      \
-    shared(d, ivoid, ovoid, roi_in, roi_out, interpolation, k_space, ma, mb, md, me, mg, mh)
+#pragma omp parallel for schedule(static) default(none) shared(d, interpolation, k_space, ma, mb, md, me,    \
+                                                               mg, mh)
 #endif
     // (slow) point-by-point transformation.
     // TODO: optimize with scanlines and linear steps between?
@@ -889,7 +889,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_clipping_data_t *d = (dt_iop_clipping_data_t *)piece->data;
   dt_iop_clipping_global_data_t *gd = (dt_iop_clipping_global_data_t *)self->data;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -20,19 +20,20 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "develop/develop.h"
-#include "develop/imageop.h"
-#include "develop/tiling.h"
-#include "control/control.h"
-#include "control/conf.h"
+#include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/interpolation.h"
 #include "common/opencl.h"
-#include "bauhaus/bauhaus.h"
+#include "control/conf.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "develop/tiling.h"
 #include "gui/accelerators.h"
-#include "gui/guides.h"
 #include "gui/gtk.h"
+#include "gui/guides.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #include <stdlib.h>
 #include <math.h>

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -30,6 +30,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -106,7 +106,7 @@ void connect_key_accels(dt_iop_module_t *self)
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colisa_data_t *d = (dt_iop_colisa_data_t *)piece->data;
   dt_iop_colisa_global_data_t *gd = (dt_iop_colisa_global_data_t *)self->data;
@@ -166,8 +166,8 @@ error:
 }
 #endif
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colisa_data_t *data = (dt_iop_colisa_data_t *)piece->data;
   float *in = (float *)ivoid;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -95,8 +95,8 @@ int groups()
 }
 
 // see http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html for the transformation matrices
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorbalance_data_t *d = (dt_iop_colorbalance_data_t *)piece->data;
   const int ch = piece->colors;
@@ -135,7 +135,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   };
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(i, o, roi_in, roi_out)
+#pragma omp parallel for default(none) schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -183,7 +183,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorbalance_data_t *d = (dt_iop_colorbalance_data_t *)piece->data;
   dt_iop_colorbalance_global_data_t *gd = (dt_iop_colorbalance_global_data_t *)self->data;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -23,12 +23,13 @@ http://www.youtube.com/watch?v=JVoUgR6bhBc
 #include "config.h"
 #endif
 // our includes go first:
-#include "develop/imageop.h"
 #include "bauhaus/bauhaus.h"
-#include "dtgtk/drawingarea.h"
-#include "gui/gtk.h"
 #include "common/colorspaces.h"
 #include "common/opencl.h"
+#include "develop/imageop.h"
+#include "dtgtk/drawingarea.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -174,8 +174,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                  void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   assert(dt_iop_module_colorspace(self) == iop_cs_Lab);
@@ -190,7 +190,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 // iterate over all output pixels (same coordinates as input)
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(i, o, roi_in, roi_out, d)
+#pragma omp parallel for default(none) schedule(static) shared(d)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -230,7 +230,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorcontrast_data_t *data = (dt_iop_colorcontrast_data_t *)piece->data;
   dt_iop_colorcontrast_global_data_t *gd = (dt_iop_colorcontrast_global_data_t *)self->data;

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -24,14 +24,16 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
-#include "develop/imageop.h"
-#include "control/control.h"
 #include "common/opencl.h"
+#include "control/control.h"
+#include "develop/imageop.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
+#include <assert.h>
 #include <gtk/gtk.h>
 #include <stdlib.h>
-#include <assert.h>
+
 #if defined(__SSE__)
 #include <xmmintrin.h>
 #endif

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -114,8 +114,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->slider));
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorcorrection_data_t *d = (dt_iop_colorcorrection_data_t *)piece->data;
   float *in = (float *)i;
@@ -134,7 +134,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorcorrection_data_t *d = (dt_iop_colorcorrection_data_t *)piece->data;
   dt_iop_colorcorrection_global_data_t *gd = (dt_iop_colorcorrection_global_data_t *)self->data;

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -18,16 +18,17 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/opencl.h"
-#include "develop/develop.h"
 #include "control/control.h"
-#include "gui/accelerators.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
 #include "dtgtk/drawingarea.h"
+#include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
-#include "bauhaus/bauhaus.h"
-#include "develop/imageop.h"
+#include "iop/iop_api.h"
 
 #include <stdlib.h>
 #include <math.h>

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -34,6 +34,7 @@
 #include "common/imageio_png.h"
 #include "common/imageio_tiff.h"
 #include "develop/imageop_math.h"
+#include "iop/iop_api.h"
 
 #include "external/adobe_coeff.c"
 #if defined(__SSE__)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -361,7 +361,7 @@ static float lerp_lut(const float *const lut, const float v)
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorin_data_t *d = (dt_iop_colorin_data_t *)piece->data;
   dt_iop_colorin_global_data_t *gd = (dt_iop_colorin_global_data_t *)self->data;
@@ -728,8 +728,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   const int ch = piece->colors;
@@ -745,7 +745,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     float *in = (float *)ivoid;
     float *out = (float *)ovoid;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_in, roi_out, out, in) schedule(static)
+#pragma omp parallel for default(none) shared(out, in) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -827,7 +827,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   {
 // use general lcms2 fallback
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ivoid, ovoid, roi_out)
+#pragma omp parallel for schedule(static) default(none)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -124,8 +124,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "source mix", GTK_WIDGET(g->scale2));
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   float *in, *out;
   dt_iop_colorize_data_t *d = (dt_iop_colorize_data_t *)piece->data;
@@ -138,7 +138,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   const float Lmlmix = L - (mix * 100.0f) / 2.0f;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ivoid, ovoid, roi_out) private(in, out) schedule(static)
+#pragma omp parallel for default(none) private(in, out) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -160,7 +160,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorize_data_t *data = (dt_iop_colorize_data_t *)piece->data;
   dt_iop_colorize_global_data_t *gd = (dt_iop_colorize_global_data_t *)self->data;

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -21,11 +21,12 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -422,8 +422,8 @@ static void kmeans(const float *col, const int width, const int height, const in
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colormapping_data_t *data = (dt_iop_colormapping_data_t *)piece->data;
   dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
@@ -545,7 +545,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colormapping_data_t *data = (dt_iop_colormapping_data_t *)piece->data;
   dt_iop_colormapping_global_data_t *gd = (dt_iop_colormapping_global_data_t *)self->data;

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -19,20 +19,21 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "bauhaus/bauhaus.h"
+#include "common/bilateral.h"
+#include "common/bilateralcl.h"
 #include "common/colorspaces.h"
+#include "common/opencl.h"
+#include "common/points.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "control/control.h"
-#include "common/points.h"
-#include "common/opencl.h"
-#include "gui/accelerators.h"
 #include "dtgtk/drawingarea.h"
-#include "gui/gtk.h"
-#include "bauhaus/bauhaus.h"
 #include "dtgtk/resetlabel.h"
-#include "common/bilateral.h"
-#include "common/bilateralcl.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <stdlib.h>
 #include <math.h>

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -209,7 +209,7 @@ static float lerp_lut(const float *const lut, const float v)
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorout_data_t *d = (dt_iop_colorout_data_t *)piece->data;
   dt_iop_colorout_global_data_t *gd = (dt_iop_colorout_global_data_t *)self->data;
@@ -458,8 +458,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_colorout_data_t *const d = (dt_iop_colorout_data_t *)piece->data;
   const int ch = piece->colors;
@@ -470,7 +470,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 // fprintf(stderr,"Using cmatrix codepath\n");
 // convert to rgb using matrix
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(roi_in, roi_out, ivoid, ovoid)
+#pragma omp parallel for schedule(static) default(none)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -501,7 +501,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     // fprintf(stderr,"Using xform codepath\n");
     const __m128 outofgamutpixel = _mm_set_ps(0.0f, 1.0f, 1.0f, 0.0f);
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ivoid, ovoid, roi_out)
+#pragma omp parallel for schedule(static) default(none)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -28,6 +28,7 @@
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #if defined(__SSE__)
 #include <xmmintrin.h>

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -500,8 +500,10 @@ static void dt_iop_colorreconstruct_bilateral_blur(dt_iop_colorreconstruct_bilat
   blur_line(b->buf, 1, b->size_x, b->size_x * b->size_y, b->size_x, b->size_y, b->size_z);
 }
 
-static void dt_iop_colorreconstruct_bilateral_slice(const dt_iop_colorreconstruct_bilateral_t *const b, const float *const in, float *out,
-                                                    const float threshold, const dt_iop_roi_t *roi, const float iscale)
+static void dt_iop_colorreconstruct_bilateral_slice(const dt_iop_colorreconstruct_bilateral_t *const b,
+                                                    const float *const in, float *const out,
+                                                    const float threshold, const dt_iop_roi_t *const roi,
+                                                    const float iscale)
 {
   if(!b) return;
 
@@ -510,7 +512,7 @@ static void dt_iop_colorreconstruct_bilateral_slice(const dt_iop_colorreconstruc
   const int oy = b->size_x;
   const int oz = b->size_y * b->size_x;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(out, roi)
+#pragma omp parallel for default(none)
 #endif
   for(int j = 0; j < roi->height; j++)
   {
@@ -580,8 +582,8 @@ static void dt_iop_colorreconstruct_bilateral_slice(const dt_iop_colorreconstruc
 }
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorreconstruct_data_t *data = (dt_iop_colorreconstruct_data_t *)piece->data;
   dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
@@ -1066,7 +1068,7 @@ static cl_int dt_iop_colorreconstruct_bilateral_slice_cl(dt_iop_colorreconstruct
 }
 
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorreconstruct_data_t *d = (dt_iop_colorreconstruct_data_t *)piece->data;
   dt_iop_colorreconstruct_global_data_t *gd = (dt_iop_colorreconstruct_global_data_t *)self->data;

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -19,23 +19,24 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
 #include "bauhaus/bauhaus.h"
+#include "common/colorspaces.h"
+#include "common/debug.h"
+#include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "control/control.h"
-#include "common/debug.h"
-#include "common/opencl.h"
-#include "common/colorspaces.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
+#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define DT_COLORRECONSTRUCT_BILATERAL_MAX_RES_S 500
 #define DT_COLORRECONSTRUCT_BILATERAL_MAX_RES_R 100

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -230,7 +230,7 @@ static int get_cluster(const float *col, const int n, float mean[n][2])
   return cluster;
 }
 
-static void kmeans(const float *col, const dt_iop_roi_t *roi, const int n, float mean_out[n][2],
+static void kmeans(const float *col, const dt_iop_roi_t *const roi, const int n, float mean_out[n][2],
                    float var_out[n][2])
 {
   // TODO: check params here:
@@ -253,7 +253,7 @@ static void kmeans(const float *col, const dt_iop_roi_t *roi, const int n, float
     for(int k = 0; k < n; k++) cnt[k] = 0;
 // randomly sample col positions inside roi
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(roi, col, var, mean, mean_out, cnt)
+#pragma omp parallel for default(none) schedule(static) shared(col, var, mean, mean_out, cnt)
 #endif
     for(int s = 0; s < samples; s++)
     {
@@ -310,8 +310,8 @@ static void kmeans(const float *col, const dt_iop_roi_t *roi, const int n, float
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // FIXME: this returns nan!!
   dt_iop_colortransfer_data_t *data = (dt_iop_colortransfer_data_t *)piece->data;
@@ -346,7 +346,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
     int hist[HISTN];
     capture_histogram(in, roi_in, hist);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(roi_out, data, in, out, hist)
+#pragma omp parallel for default(none) schedule(static) shared(data, in, out, hist)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {
@@ -370,7 +370,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 // for all pixels: find input cluster, transfer to mapped target cluster
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(roi_out, data, mean, var, mapio, in, out)
+#pragma omp parallel for default(none) schedule(static) shared(data, mean, var, mapio, in, out)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -19,12 +19,13 @@
 #include "config.h"
 #endif
 #include "common/colorspaces.h"
+#include "common/points.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
-#include "common/points.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <stdlib.h>
 #include <math.h>

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -193,13 +193,13 @@ static float strength(float value, float strength)
   return value + (value - 0.5) * (strength / 100.0);
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorzones_data_t *d = (dt_iop_colorzones_data_t *)(piece->data);
   const int ch = piece->colors;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(roi_in, roi_out, d, i, o)
+#pragma omp parallel for default(none) schedule(static) shared(d)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -239,7 +239,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorzones_data_t *d = (dt_iop_colorzones_data_t *)piece->data;
   dt_iop_colorzones_global_data_t *gd = (dt_iop_colorzones_global_data_t *)self->data;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -18,18 +18,19 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/opencl.h"
-#include "develop/develop.h"
-#include "control/control.h"
 #include "control/conf.h"
+#include "control/control.h"
+#include "develop/develop.h"
 #include "dtgtk/drawingarea.h"
-#include "gui/gtk.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
 #include "gui/presets.h"
-#include "bauhaus/bauhaus.h"
+#include "iop/iop_api.h"
 
 #include <stdlib.h>
 #include <math.h>

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -137,8 +137,8 @@ static inline void fib_latt(int *const x, int *const y, float radius, int step, 
 // most are chosen arbitrarily and/or by experiment/trial+error ... I am sorry ;-)
 // and having everything user-defineable would be just too much
 // -----------------------------------------------------------------------------------------
-void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, const void *const i,
+             void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_defringe_data_t *d = (dt_iop_defringe_data_t *)piece->data;
   assert(dt_iop_module_colorspace(module) == iop_cs_Lab);

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -24,6 +24,7 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -29,6 +29,7 @@
 #include "develop/tiling.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <memory.h>
 #include <stdlib.h>

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1208,9 +1208,6 @@ static void vng_interpolate(float *out, const float *const in, const dt_iop_roi_
 static void passthrough_monochrome(float *out, const float *const in, dt_iop_roi_t *const roi_out,
                                    const dt_iop_roi_t *const roi_in)
 {
-  roi_out->x = 0;
-  roi_out->y = 0;
-
   // we never want to access the input out of bounds though:
   assert(roi_in->width >= roi_out->width);
   assert(roi_in->height >= roi_out->height);
@@ -1235,9 +1232,6 @@ static void passthrough_monochrome(float *out, const float *const in, dt_iop_roi
 static void demosaic_ppg(float *out, const float *in, dt_iop_roi_t *roi_out, const dt_iop_roi_t *roi_in,
                          const int filters, const float thrs)
 {
-  // snap to start of mosaic block:
-  roi_out->x = 0; // MAX(0, roi_out->x & ~1);
-  roi_out->y = 0; // MAX(0, roi_out->y & ~1);
   // offsets only where the buffer ends:
   const int offx = 3; // MAX(0, 3 - roi_out->x);
   const int offy = 3; // MAX(0, 3 - roi_out->y);
@@ -1455,6 +1449,15 @@ static void demosaic_ppg(float *out, const float *in, dt_iop_roi_t *roi_out, con
   if(median) dt_free_align((float *)in);
 }
 
+void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,
+                    const dt_iop_roi_t *const roi_in)
+{
+  *roi_out = *roi_in;
+
+  // snap to start of mosaic block:
+  roi_out->x = 0; // MAX(0, roi_out->x & ~1);
+  roi_out->y = 0; // MAX(0, roi_out->y & ~1);
+}
 
 // which roi input is needed to process to this output?
 // roi_out is unchanged, full buffer in is full buffer out.

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -497,8 +497,8 @@ static void eaw_synthesize(float *const out, const float *const in, const float 
 
 // =====================================================================================
 
-void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                      void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
@@ -646,8 +646,8 @@ void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
   if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, width, height);
 }
 
-void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                     void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
@@ -687,8 +687,7 @@ void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece
 // do this in parallel with a little threading overhead. could parallelize the outer loops with a bit more
 // memory
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide)                           \
-    shared(kj, ki, roi_out, roi_in, in, ovoid, Sa)
+#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide) shared(kj, ki, in, Sa)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {
@@ -821,7 +820,7 @@ void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece
   }
 // normalize
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(ovoid, roi_out, d)
+#pragma omp parallel for default(none) schedule(static) shared(d)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -855,7 +854,7 @@ static int bucket_next(unsigned int *state, unsigned int max)
 }
 
 int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
-                       cl_mem dev_out, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+                       cl_mem dev_out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
   dt_iop_denoiseprofile_global_data_t *gd = (dt_iop_denoiseprofile_global_data_t *)self->data;
@@ -1055,7 +1054,7 @@ error:
 
 
 int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
-                        cl_mem dev_out, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+                        cl_mem dev_out, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)piece->data;
   dt_iop_denoiseprofile_global_data_t *gd = (dt_iop_denoiseprofile_global_data_t *)self->data;
@@ -1366,7 +1365,7 @@ error:
 
 
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
 
@@ -1382,8 +1381,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 #endif // HAVE_OPENCL
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
   if(d->mode == MODE_NLMEANS)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -29,6 +29,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -30,6 +30,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -182,8 +182,9 @@ static inline float clipnan(const float x)
   return r;
 }
 
-void process_floyd_steinberg(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                             void *ovoid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_floyd_steinberg(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+                             const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
+                             const dt_iop_roi_t *const roi_out)
 {
   dt_iop_dither_data_t *data = (dt_iop_dither_data_t *)piece->data;
 
@@ -258,7 +259,7 @@ void process_floyd_steinberg(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ivoid, ovoid) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
   for(int j = 0; j < height; j++)
   {
@@ -372,8 +373,8 @@ float tpdf(unsigned int urandom)
 }
 
 
-void process_random(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                    const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_random(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                    void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_dither_data_t *data = (dt_iop_dither_data_t *)piece->data;
 
@@ -387,7 +388,7 @@ void process_random(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   memset(tea_states, 0, 2 * dt_get_num_threads() * sizeof(unsigned int));
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, tea_states) schedule(static)
+#pragma omp parallel for default(none) shared(tea_states) schedule(static)
 #endif
   for(int j = 0; j < height; j++)
   {
@@ -411,8 +412,8 @@ void process_random(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
 }
 
 
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_dither_data_t *data = (dt_iop_dither_data_t *)piece->data;
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -18,18 +18,19 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "iop/equalizer_eaw.h"
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -100,8 +100,8 @@ int flags()
 
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   float *in = (float *)i;
   float *out = (float *)o;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -316,7 +316,7 @@ static void compute_correction(dt_iop_module_t *self, dt_iop_params_t *p1, const
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_exposure_data_t *d = (dt_iop_exposure_data_t *)piece->data;
   dt_iop_exposure_global_data_t *gd = (dt_iop_exposure_global_data_t *)self->data;
@@ -366,8 +366,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                  void *const o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_exposure_data_t *const d = (const dt_iop_exposure_data_t *const)piece->data;
 
@@ -376,7 +376,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   const __m128 scalev = _mm_set1_ps(d->scale);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, i, o) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -44,6 +44,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #define exposure2white(x) exp2f(-(x))
 #define white2exposure(x) -dt_log2f(fmaxf(0.001, x))

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -68,7 +68,7 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   if(roi_out->scale >= 1.00001f)
   {
@@ -91,13 +91,13 @@ error:
 }
 #endif
 
-void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, const void *const ivoid,
-             void *ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_clip_and_zoom_roi(ovoid, ivoid, roi_out, roi_in, roi_out->width, roi_in->width);
 }
 
-void commit_params(dt_iop_module_t *self, const dt_iop_params_t *const params, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   if(piece->pipe->type != DT_DEV_PIXELPIPE_EXPORT) piece->enabled = 0;

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -23,6 +23,7 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "develop/tiling.h"
+#include "iop/iop_api.h"
 
 DT_MODULE_INTROSPECTION(1, dt_iop_finalscale_params_t)
 

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -284,8 +284,8 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
 // 3rd (final) pass: you get this input region (may be different from what was requested above),
 // do your best to fill the output region!
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_flip_data_t *d = (dt_iop_flip_data_t *)piece->data;
 
@@ -298,7 +298,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_flip_data_t *data = (dt_iop_flip_data_t *)piece->data;
   const dt_iop_flip_global_data_t *gd = (dt_iop_flip_global_data_t *)self->data;

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -26,19 +26,20 @@
 #include <gdk/gdkkeysyms.h>
 #include <assert.h>
 
-#include "develop/develop.h"
-#include "develop/imageop.h"
-#include "control/control.h"
-#include "control/conf.h"
 #include "common/debug.h"
 #include "common/imageio.h"
 #include "common/opencl.h"
-#include "dtgtk/resetlabel.h"
+#include "control/conf.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
 #include "dtgtk/button.h"
+#include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
-#include "gui/gtk.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 DT_MODULE_INTROSPECTION(2, dt_iop_flip_params_t)
 

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -23,10 +23,11 @@
 #include <assert.h>
 #include <string.h>
 
-#include "develop/develop.h"
 #include "control/control.h"
+#include "develop/develop.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 DT_MODULE_INTROSPECTION(1, dt_iop_gamma_params_t)
 

--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -58,8 +58,8 @@ int flags()
   return IOP_FLAGS_HIDDEN | IOP_FLAGS_ONE_INSTANCE;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_gamma_data_t *d = (dt_iop_gamma_data_t *)piece->data;
   const int ch = piece->colors;
@@ -68,7 +68,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   {
     const float yellow[3] = { 1.0f, 1.0f, 0.0f };
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, o, i, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {
@@ -89,7 +89,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   else
   {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, o, i, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -29,6 +29,7 @@
 #include "develop/tiling.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -127,8 +127,9 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
-static inline void process_reinhard(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                                    void *ovoid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
+static inline void process_reinhard(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+                                    const void *const ivoid, void *const ovoid,
+                                    const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                                     dt_iop_global_tonemap_data_t *data)
 {
   float *in = (float *)ivoid;
@@ -136,7 +137,7 @@ static inline void process_reinhard(struct dt_iop_module_t *self, dt_dev_pixelpi
   const int ch = piece->colors;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, data) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -149,9 +150,9 @@ static inline void process_reinhard(struct dt_iop_module_t *self, dt_dev_pixelpi
   }
 }
 
-static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                                 void *ovoid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                                 dt_iop_global_tonemap_data_t *data)
+static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+                                 const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
+                                 const dt_iop_roi_t *const roi_out, dt_iop_global_tonemap_data_t *data)
 {
   dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
   float *in = (float *)ivoid;
@@ -200,7 +201,7 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   const float bl = logf(fmaxf(eps, data->drago.bias)) / logf(0.5);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, lwmax) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, lwmax) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -214,8 +215,9 @@ static inline void process_drago(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   }
 }
 
-static inline void process_filmic(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid,
-                                  void *ovoid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
+static inline void process_filmic(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+                                  const void *const ivoid, void *const ovoid,
+                                  const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                                   dt_iop_global_tonemap_data_t *data)
 {
   float *in = (float *)ivoid;
@@ -223,7 +225,7 @@ static inline void process_filmic(struct dt_iop_module_t *self, dt_dev_pixelpipe
   const int ch = piece->colors;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, data) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -237,8 +239,8 @@ static inline void process_filmic(struct dt_iop_module_t *self, dt_dev_pixelpipe
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_global_tonemap_data_t *data = (dt_iop_global_tonemap_data_t *)piece->data;
   const float scale = piece->iscale / roi_in->scale;
@@ -280,7 +282,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_global_tonemap_data_t *d = (dt_iop_global_tonemap_data_t *)piece->data;
   dt_iop_global_tonemap_global_data_t *gd = (dt_iop_global_tonemap_global_data_t *)self->data;

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -651,8 +651,8 @@ int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state)
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_graduatednd_data_t *data = (dt_iop_graduatednd_data_t *)piece->data;
   const int ch = piece->colors;
@@ -689,7 +689,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   if(data->density > 0)
   {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, color, data, ivoid, ovoid) schedule(static)
+#pragma omp parallel for default(none) shared(color, data) schedule(static)
 #endif
     for(int y = 0; y < roi_out->height; y++)
     {
@@ -737,7 +737,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   else
   {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, color, data, ivoid, ovoid) schedule(static)
+#pragma omp parallel for default(none) shared(color, data) schedule(static)
 #endif
     for(int y = 0; y < roi_out->height; y++)
     {
@@ -789,7 +789,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_graduatednd_data_t *data = (dt_iop_graduatednd_data_t *)piece->data;
   dt_iop_graduatednd_global_data_t *gd = (dt_iop_graduatednd_global_data_t *)self->data;

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -36,6 +36,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #if defined(__SSE__)
 #include <xmmintrin.h>

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -24,11 +24,12 @@
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
 

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -368,8 +368,8 @@ static unsigned int _hash_string(char *s)
   return h;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_grain_data_t *data = (dt_iop_grain_data_t *)piece->data;
 
@@ -387,7 +387,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   // pixelpipe iscale)
   const double filtermul = piece->iscale / (roi_out->scale * wd);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, roi_in, ovoid, ivoid, data, hash)
+#pragma omp parallel for default(none) shared(data, hash)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -33,6 +33,7 @@
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -98,7 +98,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_highlights_data_t *d = (dt_iop_highlights_data_t *)piece->data;
   dt_iop_highlights_global_data_t *gd = (dt_iop_highlights_global_data_t *)self->data;
@@ -154,7 +154,8 @@ int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpi
     return 4 * sizeof(float);
 }
 
-static inline void _interpolate_color_xtrans(void *ivoid, void *ovoid, const dt_iop_roi_t *const roi_in,
+static inline void _interpolate_color_xtrans(const void *const ivoid, void *const ovoid,
+                                             const dt_iop_roi_t *const roi_in,
                                              const dt_iop_roi_t *const roi_out, int dim, int dir, int other,
                                              const float *clip, const uint8_t (*const xtrans)[6],
                                              const int pass)
@@ -304,8 +305,9 @@ static inline void _interpolate_color_xtrans(void *ivoid, void *ovoid, const dt_
   }
 }
 
-static inline void _interpolate_color(void *ivoid, void *ovoid, const dt_iop_roi_t *roi_out, int dim, int dir,
-                                      int other, const float *clip, const uint32_t filters, const int pass)
+static inline void _interpolate_color(const void *const ivoid, void *const ovoid,
+                                      const dt_iop_roi_t *const roi_out, int dim, int dir, int other,
+                                      const float *clip, const uint32_t filters, const int pass)
 {
   float ratio = 1.0f;
   float *in, *out;
@@ -403,10 +405,11 @@ static inline void _interpolate_color(void *ivoid, void *ovoid, const dt_iop_roi
   }
 }
 
-static void process_lch_xtrans(void *ivoid, void *ovoid, const int width, const int height, const float clip)
+static void process_lch_xtrans(const void *const ivoid, void *const ovoid, const int width, const int height,
+                               const float clip)
 {
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ovoid, ivoid)
+#pragma omp parallel for schedule(static) default(none)
 #endif
   for(int j = 0; j < height; j++)
   {
@@ -536,8 +539,8 @@ static void process_clip(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
     dt_unreachable_codepath();
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int filters = dt_image_filter(&piece->pipe->image);
   dt_iop_highlights_data_t *data = (dt_iop_highlights_data_t *)piece->data;
@@ -564,7 +567,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       {
         const dt_image_t *img = &self->dev->image_storage;
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(ovoid, ivoid, roi_in, roi_out, img)
+#pragma omp parallel for schedule(dynamic) default(none) shared(img)
 #endif
         for(int j = 0; j < roi_out->height; j++)
         {
@@ -572,7 +575,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
           _interpolate_color_xtrans(ivoid, ovoid, roi_in, roi_out, 0, -1, j, clips, img->xtrans, 1);
         }
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(ovoid, ivoid, roi_in, roi_out, img)
+#pragma omp parallel for schedule(dynamic) default(none) shared(img)
 #endif
         for(int i = 0; i < roi_out->width; i++)
         {
@@ -583,7 +586,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
       }
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(ovoid, ivoid, roi_in, roi_out, data, piece)
+#pragma omp parallel for schedule(dynamic) default(none) shared(data, piece)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {
@@ -593,7 +596,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 // up/down directions
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(ovoid, ivoid, roi_in, roi_out, data, piece)
+#pragma omp parallel for schedule(dynamic) default(none) shared(data, piece)
 #endif
       for(int i = 0; i < roi_out->width; i++)
       {
@@ -609,7 +612,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
         break;
       }
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) shared(ovoid, ivoid, roi_in, roi_out, data, piece)
+#pragma omp parallel for schedule(dynamic) default(none) shared(data, piece)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -24,13 +24,14 @@
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "control/control.h"
-#include "common/opencl.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
 

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -128,7 +128,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_highpass_data_t *d = (dt_iop_highpass_data_t *)piece->data;
   dt_iop_highpass_global_data_t *gd = (dt_iop_highpass_global_data_t *)self->data;
@@ -276,8 +276,8 @@ error:
 #endif
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_highpass_data_t *data = (dt_iop_highpass_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -286,7 +286,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 /* create inverted image and then blur */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(in, out, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(in, out) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
     out[ch * k] = 100.0f - LCLIP(in[ch * k]); // only L in Lab space
@@ -363,7 +363,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
   const float contrast_scale = ((data->contrast / 100.0) * 7.5);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, data) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -30,6 +30,7 @@
 #include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -194,8 +194,8 @@ static int process_xtrans(const void *const i, void *o, const dt_iop_roi_t *cons
  * correcting pairs of hot pixels in adjacent sites. Replacement using
  * the maximum produces fewer artifacts when inadvertently replacing
  * non-hot pixels. */
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_image_t *img = &self->dev->image_storage;
   dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)self->gui_data;
@@ -222,7 +222,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 // Bayer sensor array
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, i, o) reduction(+ : fixed) schedule(static)
+#pragma omp parallel for default(none) reduction(+ : fixed) schedule(static)
 #endif
   for(int row = 2; row < roi_out->height - 2; row++)
   {

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -233,8 +233,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_invert_data_t *d = (dt_iop_invert_data_t *)piece->data;
 
@@ -254,7 +254,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && (filters == 9u))
   { // xtrans float mosaiced
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -273,7 +273,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     const __m128 val_max = _mm_set1_ps(1.0f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -315,7 +315,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     const __m128 film = _mm_set_ps(1.0f, d->color[2], d->color[1], d->color[0]);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {
@@ -337,7 +337,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_invert_data_t *d = (dt_iop_invert_data_t *)piece->data;
   dt_iop_invert_global_data_t *gd = (dt_iop_invert_global_data_t *)self->data;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -34,6 +34,7 @@
 #include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 DT_MODULE_INTROSPECTION(1, dt_iop_invert_params_t)
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -30,6 +30,10 @@ extern "C" {
 #include <glib.h>
 #include <stdint.h>
 
+#ifdef HAVE_OPENCL
+#include <CL/cl.h>
+#endif
+
 struct dt_iop_module_so_t;
 struct dt_iop_module_t;
 struct dt_dev_pixelpipe_t;
@@ -151,8 +155,8 @@ void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 
 #ifdef HAVE_OPENCL
 /** the opencl equivalent of process(). */
-int process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-               const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+int process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
+               cl_mem dev_out, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
 /** a tiling variant of process_cl(). */
 int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
                       const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out, const int bpp);

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -1,0 +1,181 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2009--2012 johannes hanika.
+    copyright (c) 2011 henrik andersson.
+    copyright (c) 2012 tobias ellinghaus.
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_IOP_API_H
+#define DT_IOP_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cairo/cairo.h>
+#include <glib.h>
+#include <stdint.h>
+
+struct dt_iop_module_so_t;
+struct dt_iop_module_t;
+struct dt_dev_pixelpipe_t;
+struct dt_dev_pixelpipe_iop_t;
+struct dt_iop_roi_t;
+struct dt_develop_tiling_t;
+
+#ifndef DT_IOP_PARAMS_T
+#define DT_IOP_PARAMS_T
+typedef void dt_iop_params_t;
+#endif
+
+/* early definition of modules to do type checking */
+
+// !!! MUST BE KEPT IN SYNC WITH dt_iop_module_so_t and dt_iop_module_t defined in src/develop/imageop.h !!!
+
+/** this initializes static, hardcoded presets for this module and is called only once per run of dt. */
+void init_presets(struct dt_iop_module_so_t *self);
+/** called once per module, at startup. */
+void init_global(struct dt_iop_module_so_t *self);
+/** called once per module, at shutdown. */
+void cleanup_global(struct dt_iop_module_so_t *self);
+
+/** version of the parameters in the database. */
+int version();
+/** get name of the module, to be translated. */
+const char *name();
+/** get the groups this module belongs to. */
+int groups();
+/** get the iop module flags. */
+int flags();
+
+int operation_tags();
+int operation_tags_filter();
+
+/** how many bytes per pixel in the output. */
+int output_bpp(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+               struct dt_dev_pixelpipe_iop_t *piece);
+/** report back info for tiling: memory usage and overlap. Memory usage: factor * input_size + overhead */
+void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                     const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
+                     struct dt_develop_tiling_t *tiling);
+
+/** callback methods for gui. */
+/** synch gtk interface with gui params, if necessary. */
+void gui_update(struct dt_iop_module_t *self);
+/** reset ui to defaults */
+void gui_reset(struct dt_iop_module_t *self);
+/** construct widget. */
+void gui_init(struct dt_iop_module_t *self);
+/** destroy widget. */
+void gui_cleanup(struct dt_iop_module_t *self);
+/** optional method called after darkroom expose. */
+void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
+                     int32_t pointerx, int32_t pointery);
+/** optional callback to be notified if the module acquires gui focus/loses it. */
+void gui_focus(struct dt_iop_module_t *self, gboolean in);
+
+/** Optional callback for keyboard accelerators */
+void init_key_accels(struct dt_iop_module_so_t *so);
+void original_init_key_accels(struct dt_iop_module_so_t *so);
+/** Key accelerator registration callbacks */
+void connect_key_accels(struct dt_iop_module_t *self);
+void original_connect_key_accels(struct dt_iop_module_t *self);
+void disconnect_key_accels(struct dt_iop_module_t *self);
+
+/** optional event callbacks */
+int mouse_leave(struct dt_iop_module_t *self);
+int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressure, int which);
+int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
+int button_pressed(struct dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
+                   uint32_t state);
+int key_pressed(struct dt_iop_module_t *self, uint16_t which);
+
+int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t state);
+void configure(struct dt_iop_module_t *self, int width, int height);
+
+void init(struct dt_iop_module_t *self); // this MUST set params_size!
+void original_init(struct dt_iop_module_t *self);
+void cleanup(struct dt_iop_module_t *self);
+
+/** this inits the piece of the pipe, allocing piece->data as necessary. */
+void init_pipe(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+               struct dt_dev_pixelpipe_iop_t *piece);
+/** this resets the params to factory defaults. used at the beginning of each history synch. */
+/** this commits (a mutex will be locked to synch pipe/gui) the given history params to the pixelpipe piece.
+ */
+void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, struct dt_dev_pixelpipe_t *pipe,
+                   struct dt_dev_pixelpipe_iop_t *piece);
+/** this is the chance to update default parameters, after the full raw is loaded. */
+void reload_defaults(struct dt_iop_module_t *self);
+
+/** this destroys all resources needed by the piece of the pixelpipe. */
+void cleanup_pipe(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                  struct dt_dev_pixelpipe_iop_t *piece);
+void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                   const struct dt_iop_roi_t *roi_out, struct dt_iop_roi_t *roi_in);
+void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
+                    struct dt_iop_roi_t *roi_out, const struct dt_iop_roi_t *roi_in);
+int legacy_params(struct dt_iop_module_t *self, const void *const old_params, const int old_version,
+                  void *new_params, const int new_version);
+
+/** this is the temp homebrew callback to operations.
+  * x,y, and scale are just given for orientation in the framebuffer. i and o are
+  * scaled to the same size width*height and contain a max of 3 floats. other color
+  * formats may be filled by this callback, if the pipeline can handle it. */
+/** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
+void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
+             const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+/** a tiling variant of process(). */
+void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
+                    const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out, const int bpp);
+
+#if defined(__SSE2__)
+/** a variant process(), that can contain SSE2 intrinsics. */
+void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
+                  const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+#endif
+
+#ifdef HAVE_OPENCL
+/** the opencl equivalent of process(). */
+int process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
+               const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+/** a tiling variant of process_cl(). */
+int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
+                      const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out, const int bpp);
+#endif
+
+/** this functions are used for distort iop
+ * points is an array of float {x1,y1,x2,y2,...}
+ * size is 2*points_count */
+/** points before the iop is applied => point after processed */
+int distort_transform(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
+                      size_t points_count);
+/** reverse points after the iop is applied => point before process */
+int distort_backtransform(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
+                          size_t points_count);
+
+// FIXME: introspection?
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-space on;

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -141,25 +141,30 @@ int legacy_params(struct dt_iop_module_t *self, const void *const old_params, co
   * scaled to the same size width*height and contain a max of 3 floats. other color
   * formats may be filled by this callback, if the pipeline can handle it. */
 /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
-void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+             void *const o, const struct dt_iop_roi_t *const roi_in,
+             const struct dt_iop_roi_t *const roi_out);
 /** a tiling variant of process(). */
-void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                    const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out, const int bpp);
+void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                    void *const o, const struct dt_iop_roi_t *const roi_in,
+                    const struct dt_iop_roi_t *const roi_out, const int bpp);
 
 #if defined(__SSE2__)
 /** a variant process(), that can contain SSE2 intrinsics. */
-void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                  const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                  void *const o, const struct dt_iop_roi_t *const roi_in,
+                  const struct dt_iop_roi_t *const roi_out);
 #endif
 
 #ifdef HAVE_OPENCL
 /** the opencl equivalent of process(). */
 int process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
-               cl_mem dev_out, const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out);
+               cl_mem dev_out, const struct dt_iop_roi_t *const roi_in,
+               const struct dt_iop_roi_t *const roi_out);
 /** a tiling variant of process_cl(). */
-int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-                      const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out, const int bpp);
+int process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
+                      void *const o, const struct dt_iop_roi_t *const roi_in,
+                      const struct dt_iop_roi_t *const roi_out, const int bpp);
 #endif
 
 /** this functions are used for distort iop

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -19,26 +19,27 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
-#include <gtk/gtk.h>
-#include <inttypes.h>
-#include <ctype.h>
-#include <lensfun.h>
+#include "bauhaus/bauhaus.h"
+#include "common/interpolation.h"
+#include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "common/opencl.h"
-#include "common/interpolation.h"
-#include "control/control.h"
 #include "dtgtk/button.h"
 #include "dtgtk/resetlabel.h"
-#include "bauhaus/bauhaus.h"
 #include "gui/accelerators.h"
-#include "gui/gtk.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+#include <assert.h>
+#include <ctype.h>
+#include <gtk/gtk.h>
+#include <inttypes.h>
+#include <lensfun.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if LF_VERSION < ((0 << 24) | (2 << 16) | (9 << 8) | 0)
 #define LF_SEARCH_SORT_AND_UNIQUIFY 2

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -328,7 +328,7 @@ static char *_lens_sanitize(const char *orig_lens)
   }
 }
 
-void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *ovoid,
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_lensfun_data_t *const d = (dt_iop_lensfun_data_t *)piece->data;
@@ -367,7 +367,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       void *buf = dt_alloc_align(16, bufsize * dt_get_num_threads() * sizeof(float));
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(buf, modifier, ovoid) schedule(static)
+#pragma omp parallel for default(none) shared(buf, modifier) schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
@@ -421,7 +421,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     if(modflags & LF_MODIFY_VIGNETTING)
     {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ovoid, modifier) schedule(static)
+#pragma omp parallel for default(none) shared(modifier) schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
@@ -462,7 +462,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       void *buf2 = dt_alloc_align(16, buf2size * sizeof(float) * dt_get_num_threads());
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(buf2, buf, modifier, ovoid) schedule(static)
+#pragma omp parallel for default(none) shared(buf2, buf, modifier) schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
@@ -525,7 +525,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lensfun_data_t *d = (dt_iop_lensfun_data_t *)piece->data;
   dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)self->data;
@@ -613,7 +613,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
     {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, roi_in, tmpbuf, d, modifier) schedule(static)
+#pragma omp parallel for default(none) shared(tmpbuf, d, modifier) schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
@@ -649,7 +649,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(modflags & LF_MODIFY_VIGNETTING)
     {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, roi_in, tmpbuf, modifier, d) schedule(static)
+#pragma omp parallel for default(none) shared(tmpbuf, modifier, d) schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {
@@ -688,7 +688,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(modflags & LF_MODIFY_VIGNETTING)
     {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, roi_in, tmpbuf, modifier, d) schedule(static)
+#pragma omp parallel for default(none) shared(tmpbuf, modifier, d) schedule(static)
 #endif
       for(int y = 0; y < roi_in->height; y++)
       {
@@ -722,7 +722,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(modflags & (LF_MODIFY_TCA | LF_MODIFY_DISTORTION | LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE))
     {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, roi_in, tmpbuf, d, modifier) schedule(static)
+#pragma omp parallel for default(none) shared(tmpbuf, d, modifier) schedule(static)
 #endif
       for(int y = 0; y < roi_out->height; y++)
       {

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -268,8 +268,8 @@ static void commit_params_late(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   }
 }
 
-void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *const roi_out)
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;
   const dt_iop_levels_data_t *const d = (dt_iop_levels_data_t *)piece->data;
@@ -280,7 +280,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ovoid) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -327,7 +327,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
 #ifdef HAVE_OPENCL
 int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *const roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_levels_data_t *d = (dt_iop_levels_data_t *)piece->data;
   dt_iop_levels_global_data_t *gd = (dt_iop_levels_global_data_t *)self->data;

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -36,6 +36,7 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
 #define DT_GUI_CURVE_INFL .3f

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1286,12 +1286,8 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   return _distort_xtransform(self, piece, points, points_count, FALSE);
 }
 
-void process (struct dt_iop_module_t *module,
-              dt_dev_pixelpipe_iop_t *piece,
-              const float *in,
-              float *out,
-              const dt_iop_roi_t *roi_in,
-              const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, const void *const in,
+             void *const out, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
 {
   // 1. copy the whole image (we'll change only a small part of it)
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -20,19 +20,21 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <complex.h>
-#include <assert.h>
 #include "bauhaus/bauhaus.h"
-#include "develop/imageop.h"
-#include "control/control.h"
-#include "control/conf.h"
 #include "common/interpolation.h"
 #include "common/opencl.h"
+#include "control/conf.h"
+#include "control/control.h"
+#include "develop/imageop.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
+#include <assert.h>
 #include <cairo.h>
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -113,8 +113,8 @@ static float lookup(const float *lut, const float i)
   return lut[bin1] * f + lut[bin0] * (1. - f);
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lowlight_data_t *d = (dt_iop_lowlight_data_t *)(piece->data);
   const int ch = piece->colors;
@@ -130,7 +130,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   dt_Lab_to_XYZ(Lab_sw, XYZ_sw);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(roi_in, roi_out, d, i, o, XYZ_sw)
+#pragma omp parallel for default(none) schedule(static) shared(d, XYZ_sw)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -176,7 +176,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lowlight_data_t *d = (dt_iop_lowlight_data_t *)piece->data;
   dt_iop_lowlight_global_data_t *gd = (dt_iop_lowlight_global_data_t *)self->data;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -18,23 +18,24 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <string.h>
-#include <inttypes.h>
+#include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/opencl.h"
-#include "develop/develop.h"
-#include "control/control.h"
 #include "control/conf.h"
-#include "gui/accelerators.h"
+#include "control/control.h"
+#include "develop/develop.h"
 #include "dtgtk/drawingarea.h"
-#include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
 #include "gui/presets.h"
-#include "bauhaus/bauhaus.h"
+#include "iop/iop_api.h"
+#include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 DT_MODULE_INTROSPECTION(1, dt_iop_lowlight_params_t)
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -209,7 +209,7 @@ void connect_key_accels(dt_iop_module_t *self)
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lowpass_data_t *d = (dt_iop_lowpass_data_t *)piece->data;
   dt_iop_lowpass_global_data_t *gd = (dt_iop_lowpass_global_data_t *)self->data;
@@ -357,8 +357,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   return;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_lowpass_data_t *data = (dt_iop_lowpass_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -408,7 +408,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   const float *const Labminf = (float *)&Labmin;
   const float *const Labmaxf = (float *)&Labmax;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(in, out, data, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -33,6 +33,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <gtk/gtk.h>
 #include <math.h>

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -18,22 +18,23 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
-#include "common/colorspaces.h"
-#include "common/opencl.h"
+#include "bauhaus/bauhaus.h"
 #include "common/bilateral.h"
 #include "common/bilateralcl.h"
-#include "bauhaus/bauhaus.h"
-#include "develop/develop.h"
-#include "develop/tiling.h"
+#include "common/colorspaces.h"
+#include "common/opencl.h"
 #include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
+#include "develop/tiling.h"
 #include "dtgtk/drawingarea.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
-#include "develop/imageop.h"
+#include "iop/iop_api.h"
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 DT_MODULE_INTROSPECTION(2, dt_iop_monochrome_params_t)
 

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -143,14 +143,14 @@ static float envelope(const float L)
   }
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_monochrome_data_t *d = (dt_iop_monochrome_data_t *)piece->data;
   const float sigma2 = (d->size * 128.0) * (d->size * 128.0f);
 // first pass: evaluate color filter:
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, i, o, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -177,7 +177,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   dt_bilateral_free(b);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, i, o, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -195,7 +195,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_monochrome_data_t *d = (dt_iop_monochrome_data_t *)piece->data;
   dt_iop_monochrome_global_data_t *gd = (dt_iop_monochrome_global_data_t *)self->data;

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -169,7 +169,7 @@ static int bucket_next(unsigned int *state, unsigned int max)
 }
 
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_nlmeans_params_t *d = (dt_iop_nlmeans_params_t *)piece->data;
   dt_iop_nlmeans_global_data_t *gd = (dt_iop_nlmeans_global_data_t *)self->data;
@@ -375,8 +375,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
 #if defined(__SSE__)
 /** process, all real work is done here. */
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
@@ -415,8 +415,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 // do this in parallel with a little threading overhead. could parallelize the outer loops with a bit more
 // memory
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide)                           \
-    shared(kj, ki, roi_out, roi_in, ivoid, ovoid, Sa)
+#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide) shared(kj, ki, Sa)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {
@@ -548,7 +547,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   const __m128 weight = _mm_set_ps(1.0f, d->chroma, d->chroma, d->luma);
   const __m128 invert = _mm_sub_ps(_mm_set1_ps(1.0f), weight);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(ovoid, ivoid, roi_out, d)
+#pragma omp parallel for default(none) schedule(static) shared(d)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -26,6 +26,7 @@
 #include "develop/tiling.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <stdlib.h>
 

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -31,6 +31,7 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
+#include "iop/iop_api.h"
 
 DT_MODULE(3)
 

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -157,7 +157,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 #if defined(__SSE__)
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
-                  void *ovoid, const dt_iop_roi_t *roi_in, const dt_iop_roi_t *const roi_out)
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_develop_t *dev = self->dev;
 
@@ -173,7 +173,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const __m128 lower_color = _mm_load_ps(dt_iop_overexposed_colors[colorscheme][1]);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ovoid) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -207,7 +207,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_develop_t *dev = self->dev;
   dt_iop_overexposed_global_data_t *gd = (dt_iop_overexposed_global_data_t *)self->data;

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -25,6 +25,7 @@
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -88,7 +88,7 @@ void connect_key_accels(dt_iop_module_t *self)
 
 #ifdef HAVE_OPENCL
 int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_profilegamma_data_t *d = (dt_iop_profilegamma_data_t *)piece->data;
   dt_iop_profilegamma_global_data_t *gd = (dt_iop_profilegamma_global_data_t *)self->data;
@@ -134,15 +134,15 @@ error:
 }
 #endif
 
-void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_profilegamma_data_t *data = (dt_iop_profilegamma_data_t *)piece->data;
 
   const int ch = piece->colors;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, data) schedule(static)
+#pragma omp parallel for default(none) shared(data) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -349,8 +349,8 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
   free(fimg);
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_rawdenoise_data_t *d = (dt_iop_rawdenoise_data_t *)piece->data;
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -28,6 +28,7 @@
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -281,8 +281,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *ovoid,
-                  const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_rawprepare_data_t *const d = (dt_iop_rawprepare_data_t *)piece->data;
 
@@ -294,7 +294,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
     const int cx = d->x, cy = d->y;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(ovoid)
+#pragma omp parallel for default(none) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -356,7 +356,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
     const __m128 sub = _mm_load_ps(d->sub), div = _mm_load_ps(d->div);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(ovoid)
+#pragma omp parallel for default(none) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -444,7 +444,7 @@ error:
 }
 #endif
 
-void commit_params(dt_iop_module_t *self, const dt_iop_params_t *const params, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   const dt_iop_rawprepare_params_t *const p = (dt_iop_rawprepare_params_t *)params;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -18,12 +18,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "bauhaus/bauhaus.h"
+#include "common/opencl.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "bauhaus/bauhaus.h"
-#include "gui/gtk.h"
 #include "gui/accelerators.h"
-#include "common/opencl.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -24,16 +24,17 @@
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
-#include "develop/develop.h"
-#include "develop/imageop.h"
-#include "control/control.h"
 #include "common/debug.h"
 #include "common/opencl.h"
-#include "dtgtk/togglebutton.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop.h"
 #include "dtgtk/gradientslider.h"
+#include "dtgtk/togglebutton.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -113,8 +113,8 @@ void connect_key_accels(dt_iop_module_t *self)
 
 #define GAUSS(a, b, c, x) (a * pow(2.718281828, (-pow((x - b), 2) / (pow(c, 2)))))
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_relight_data_t *data = (dt_iop_relight_data_t *)piece->data;
   const int ch = piece->colors;
@@ -125,7 +125,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   const float c = (data->width / 10.0) / 2.0; // Width
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, data) schedule(static)
+#pragma omp parallel for default(none) shared(data) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -154,7 +154,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_relight_data_t *data = (dt_iop_relight_data_t *)piece->data;
   dt_iop_relight_global_data_t *gd = (dt_iop_relight_global_data_t *)self->data;

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -19,12 +19,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "bauhaus/bauhaus.h"
+#include "common/interpolation.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "common/interpolation.h"
-#include "bauhaus/bauhaus.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -235,8 +235,8 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
 
 // 3rd (final) pass: you get this input region (may be different from what was requested above),
 // do your best to fill the output region!
-void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, const void *const ivoid,
-             void *ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
@@ -248,7 +248,7 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
   const struct dt_interpolation *interpolation = dt_interpolation_new(DT_INTERPOLATION_USERPREF);
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ovoid, interpolation)
+#pragma omp parallel for schedule(static) default(none) shared(piece, interpolation)
 #endif
   // (slow) point-by-point transformation.
   // TODO: optimize with scanlines and linear steps between?

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -18,12 +18,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include "develop/imageop.h"
-#include "common/interpolation.h"
-#include "develop/tiling.h"
 #include "bauhaus/bauhaus.h"
-#include "gui/gtk.h"
+#include "common/interpolation.h"
+#include "develop/imageop.h"
+#include "develop/tiling.h"
 #include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -178,8 +178,8 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   roi_in->y = roi_out->y * d->y_scale;
 }
 
-void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, const void *const ivoid,
-             void *ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
@@ -187,7 +187,7 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
   const dt_iop_scalepixels_data_t * const d = piece->data;
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(ovoid, interpolation)
+#pragma omp parallel for schedule(static) default(none) shared(interpolation)
 #endif
   // (slow) point-by-point transformation.
   // TODO: optimize with scanlines and linear steps between?
@@ -205,7 +205,7 @@ void process(dt_iop_module_t *self, const dt_dev_pixelpipe_iop_t *const piece, c
   }
 }
 
-void commit_params(dt_iop_module_t *self, const dt_iop_params_t *const params, dt_dev_pixelpipe_t *pipe,
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
   const dt_iop_scalepixels_params_t *p = params;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -33,6 +33,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -315,8 +315,8 @@ static inline float sign(float x)
 }
 
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_shadhi_data_t *data = (dt_iop_shadhi_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -374,7 +374,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 // invert and desaturate
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(out, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(out) schedule(static)
 #endif
   for(size_t j = 0; j < (size_t)roi_out->width * roi_out->height * 4; j += 4)
   {
@@ -486,7 +486,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_shadhi_data_t *d = (dt_iop_shadhi_data_t *)piece->data;
   dt_iop_shadhi_global_data_t *gd = (dt_iop_shadhi_global_data_t *)self->data;

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -114,7 +114,7 @@ void connect_key_accels(dt_iop_module_t *self)
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_sharpen_data_t *d = (dt_iop_sharpen_data_t *)piece->data;
   dt_iop_sharpen_global_data_t *gd = (dt_iop_sharpen_global_data_t *)self->data;
@@ -455,8 +455,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_sharpen_data_t *data = (dt_iop_sharpen_data_t *)piece->data;
   const int ch = piece->colors;
@@ -498,7 +498,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 // gauss blur the image horizontally
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(mat, ivoid, ovoid, roi_out, roi_in) schedule(static)
+#pragma omp parallel for default(none) shared(mat) schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -539,7 +539,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 // gauss blur the image vertically
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(mat, ivoid, ovoid, roi_out, roi_in) schedule(static)
+#pragma omp parallel for default(none) shared(mat) schedule(static)
 #endif
   for(int j = rad; j < roi_out->height - wd4 * 4 + rad; j++)
   {
@@ -567,7 +567,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     }
   }
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(mat, ivoid, ovoid, roi_out, roi_in) schedule(static)
+#pragma omp parallel for default(none) shared(mat) schedule(static)
 #endif
   for(int j = roi_out->height - wd4 * 4 + rad; j < roi_out->height - rad; j++)
   {
@@ -600,7 +600,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   dt_free_align(tmp);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ivoid, ovoid, roi_out, roi_in) schedule(static)
+#pragma omp parallel for default(none) schedule(static)
 #endif
   for(int j = rad; j < roi_out->height - rad; j++)
   {
@@ -611,7 +611,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(data, ivoid, ovoid, roi_out, roi_in) schedule(static)
+#pragma omp parallel for default(none) shared(data) schedule(static)
 #endif
   // subtract blurred image, if diff > thrs, add *amount to original image
   for(int j = 0; j < roi_out->height; j++)

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -31,6 +31,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -268,8 +268,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_soften_data_t *data = (dt_iop_soften_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -280,7 +280,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   const float saturation = data->saturation / 100.0;
 /* create overexpose image and then blur */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(in, out, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(in, out) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -303,7 +303,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(out, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(out) schedule(static)
 #endif
     /* horizontal blur out into out */
     for(int y = 0; y < roi_out->height; y++)
@@ -336,7 +336,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     const int opoffs = -(radius + 1) * roi_out->width;
     const int npoffs = (radius)*roi_out->width;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(out, roi_out) schedule(static)
+#pragma omp parallel for default(none) shared(out) schedule(static)
 #endif
     for(int x = 0; x < roi_out->width; x++)
     {
@@ -372,7 +372,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   const __m128 amount = _mm_set1_ps(data->amount / 100.0);
   const __m128 amount_1 = _mm_set1_ps(1 - (data->amount) / 100.0);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, data) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {
@@ -385,7 +385,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_soften_data_t *d = (dt_iop_soften_data_t *)piece->data;
   dt_iop_soften_global_data_t *gd = (dt_iop_soften_global_data_t *)self->data;

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -26,15 +26,17 @@
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/tiling.h"
-#include "control/control.h"
 #include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
+
 #if defined(__SSE__)
 #include <xmmintrin.h>
 #endif

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -153,8 +153,8 @@ void init_presets(dt_iop_module_so_t *self)
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "commit", NULL, NULL, NULL);
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_splittoning_data_t *data = (dt_iop_splittoning_data_t *)piece->data;
   float *in;
@@ -163,7 +163,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
   const float compress = (data->compress / 110.0) / 2.0; // Dont allow 100% compression..
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(ivoid, ovoid, roi_out, data) private(in, out) schedule(static)
+#pragma omp parallel for default(none) shared(data) private(in, out) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -203,7 +203,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_splittoning_data_t *d = (dt_iop_splittoning_data_t *)piece->data;
   dt_iop_splittoning_global_data_t *gd = (dt_iop_splittoning_global_data_t *)self->data;

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -18,25 +18,26 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
 #include "bauhaus/bauhaus.h"
 #include "common/colorspaces.h"
 #include "common/debug.h"
 #include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
-#include "dtgtk/resetlabel.h"
-#include "dtgtk/gradientslider.h"
 #include "dtgtk/button.h"
+#include "dtgtk/gradientslider.h"
+#include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
+#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
 DT_MODULE_INTROSPECTION(1, dt_iop_splittoning_params_t)

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -18,13 +18,14 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "control/conf.h"
+#include "control/control.h"
+#include "develop/blend.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
-#include "develop/blend.h"
-#include "control/control.h"
-#include "control/conf.h"
-#include "gui/gtk.h"
 #include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <stdlib.h>
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -359,8 +359,8 @@ static int masks_get_delta(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   return res;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_spots_params_t *d = (dt_iop_spots_params_t *)piece->data;
   dt_develop_blend_params_t *bp = self->blend_params;
@@ -371,7 +371,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 // we don't modify most of the image:
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) shared(out, in, roi_in, roi_out)
+#pragma omp parallel for schedule(static) default(none) shared(out, in)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -461,8 +461,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_image_t *img = &self->dev->image_storage;
   const int filters = dt_image_filter(&piece->pipe->image);
@@ -471,7 +471,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters == 9u)
   { // xtrans float mosaiced
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -484,7 +484,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
   { // bayer float mosaiced
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
     for(int j = 0; j < roi_out->height; j++)
     {
@@ -537,7 +537,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
     const __m128 coeffs = _mm_set_ps(1.0f, d->coeffs[2], d->coeffs[1], d->coeffs[0]);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
     for(int k = 0; k < roi_out->height; k++)
     {
@@ -561,7 +561,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
   dt_iop_temperature_global_data_t *gd = (dt_iop_temperature_global_data_t *)self->data;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -40,6 +40,7 @@
 #include "external/wb_presets.c"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 // for Kelvin temperature and bogus WB
 #include "external/cie_colorimetric_tables.c"

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -680,7 +680,7 @@ static void pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *self)
 }
 
 
-static gboolean scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
+static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
@@ -777,7 +777,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "enter-notify-event", G_CALLBACK(dt_iop_tonecurve_enter_notify), self);
   g_signal_connect(G_OBJECT(c->area), "configure-event", G_CALLBACK(area_resized), self);
   g_signal_connect(G_OBJECT(tb), "toggled", G_CALLBACK(pick_toggled), self);
-  g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(scrolled), self);
+  g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_scrolled), self);
 
   c->autoscale_ab = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(c->autoscale_ab, NULL, _("scale chroma"));

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -35,6 +35,7 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 #include "libs/colorpicker.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -200,7 +200,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_tonecurve_data_t *d = (dt_iop_tonecurve_data_t *)piece->data;
   dt_iop_tonecurve_global_data_t *gd = (dt_iop_tonecurve_global_data_t *)self->data;
@@ -267,8 +267,8 @@ error:
 }
 #endif
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const int ch = piece->colors;
   dt_iop_tonecurve_data_t *d = (dt_iop_tonecurve_data_t *)(piece->data);
@@ -286,7 +286,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   const int unbound_ab = d->unbound_ab;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(i, o, d) schedule(static)
+#pragma omp parallel for default(none) shared(d) schedule(static)
 #endif
   for(int k = 0; k < height; k++)
   {

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -97,8 +97,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "spatial extent", GTK_WIDGET(g->Fsize));
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_tonemapping_data_t *data = (dt_iop_tonemapping_data_t *)piece->data;
   const int ch = piece->colors;

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -38,11 +38,12 @@ extern "C" {
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
 }

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -19,9 +19,10 @@
 #include "config.h"
 #endif
 // our includes go first:
-#include "develop/imageop.h"
 #include "bauhaus/bauhaus.h"
+#include "develop/imageop.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -98,8 +98,8 @@ output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_i
 // *roi_out, dt_iop_roi_t *roi_in);
 
 /** process, all real work is done here. */
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *i, void *o,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
@@ -112,7 +112,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 // iterate over all output pixels (same coordinates as input)
 #ifdef _OPENMP
 // optional: parallelize it!
-#pragma omp parallel for default(none) schedule(static) shared(i, o, roi_in, roi_out, d)
+#pragma omp parallel for default(none) schedule(static) shared(d)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -168,8 +168,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-                  const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+                  void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_velvia_data_t *data = (dt_iop_velvia_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -183,7 +183,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
   else
   {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out, data) schedule(static)
+#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
 #endif
     for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
     {
@@ -234,7 +234,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, v
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_velvia_data_t *data = (dt_iop_velvia_data_t *)piece->data;
   dt_iop_velvia_global_data_t *gd = (dt_iop_velvia_global_data_t *)self->data;

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -31,6 +31,7 @@
 #include "develop/imageop_math.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <inttypes.h>

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -24,12 +24,13 @@
 #include <string.h>
 
 #include "bauhaus/bauhaus.h"
+#include "common/opencl.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
-#include "common/opencl.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
 

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -87,8 +87,8 @@ void connect_key_accels(dt_iop_module_t *self)
 }
 #endif
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_vibrance_data_t *d = (dt_iop_vibrance_data_t *)piece->data;
   const float *in = (float *)ivoid;
@@ -98,7 +98,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   const float amount = (d->amount * 0.01);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, in, out) schedule(static)
+#pragma omp parallel for default(none) shared(in, out) schedule(static)
 #endif
   for(int k = 0; k < roi_out->height; k++)
   {
@@ -120,7 +120,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_vibrance_data_t *data = (dt_iop_vibrance_data_t *)piece->data;
   dt_iop_vibrance_global_data_t *gd = (dt_iop_vibrance_global_data_t *)self->data;

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -23,16 +23,17 @@
 #include <assert.h>
 #include <string.h>
 
+#include "bauhaus/bauhaus.h"
+#include "common/opencl.h"
+#include "control/control.h"
+#include "develop/blend.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "develop/blend.h"
-#include "control/control.h"
-#include "common/opencl.h"
-#include "bauhaus/bauhaus.h"
 #include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
-#include "gui/presets.h"
 #include "gui/gtk.h"
+#include "gui/presets.h"
+#include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <inttypes.h>
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -667,8 +667,8 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
   return 0;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_vignette_data_t *data = (dt_iop_vignette_data_t *)piece->data;
   const dt_iop_roi_t *buf_in = &piece->buf_in;
@@ -738,8 +738,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   memset(tea_states, 0, 2 * dt_get_num_threads() * sizeof(unsigned int));
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(roi_out, ivoid, ovoid, data, yscale, xscale, tea_states,       \
-                                              dither) schedule(static)
+#pragma omp parallel for default(none) shared(data, yscale, xscale, tea_states, dither) schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -812,7 +811,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_vignette_data_t *data = (dt_iop_vignette_data_t *)piece->data;
   dt_iop_vignette_global_data_t *gd = (dt_iop_vignette_global_data_t *)self->data;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -720,8 +720,8 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
   return svgdoc;
 }
 
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *ivoid, void *ovoid,
-             const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_watermark_data_t *data = (dt_iop_watermark_data_t *)piece->data;
   float *in = (float *)ivoid;
@@ -906,7 +906,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, void *
   float opacity = data->opacity / 100.0;
   /*
   #ifdef _OPENMP
-    #pragma omp parallel for default(none) shared(roi_out, in, out,sd,opacity) schedule(static)
+    #pragma omp parallel for default(none) shared(in, out,sd,opacity) schedule(static)
   #endif
   */
   for(int j = 0; j < roi_out->height; j++)

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -15,22 +15,23 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "version.h"
-#include <stdlib.h>
-#include <math.h>
-#include <assert.h>
-#include <string.h>
 #include "bauhaus/bauhaus.h"
+#include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
-#include "control/control.h"
 #include "dtgtk/button.h"
-#include "dtgtk/togglebutton.h"
 #include "dtgtk/resetlabel.h"
+#include "dtgtk/togglebutton.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "iop/iop_api.h"
+#include "version.h"
+#include <assert.h>
 #include <gtk/gtk.h>
 #include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <librsvg/rsvg.h>
 // ugh, ugly hack. why do people break stuff all the time?

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -36,6 +36,7 @@
 #include "dtgtk/togglebutton.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "iop/iop_api.h"
 
 #if defined(__SSE__)
 #include <xmmintrin.h>

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -335,7 +335,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
 #ifdef HAVE_OPENCL
 int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
-               const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out)
+               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_zonesystem_data_t *data = (dt_iop_zonesystem_data_t *)piece->data;
   dt_iop_zonesystem_global_data_t *gd = (dt_iop_zonesystem_global_data_t *)self->data;


### PR DESCRIPTION
This adds a header for our last type of libs - iops.
I have split it into several commits just because those are the logically separate changes, 
it is easier to read/review that way.

Also, as it was discussed with @hanatos, this adds some `const`s to `process*()` functions family.