### PR TITLE
collections: add sort by full path

### DIFF
--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -64,7 +64,8 @@ typedef enum dt_collection_sort_t
   DT_COLLECTION_SORT_RATING,
   DT_COLLECTION_SORT_ID,
   DT_COLLECTION_SORT_COLOR,
-  DT_COLLECTION_SORT_GROUP
+  DT_COLLECTION_SORT_GROUP,
+  DT_COLLECTION_SORT_PATH
 } dt_collection_sort_t;
 
 typedef enum dt_collection_properties_t

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -143,6 +143,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("id"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("color label"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("group"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), _("full path"));
 
   /* select the last selected value */
   gtk_combo_box_set_active(GTK_COMBO_BOX(widget), dt_collection_get_sort_field(darktable.collection));


### PR DESCRIPTION
This is needed if you collect multiple film_rolls and image names doesn't sort by themselves. Example : 
/home/me/photos/01 Paris/PIC_01254.cr2
/home/me/photos/02 London/IMG_2597.cr2