### PR TITLE
Dither IOP: add non-SSE codepath

### DIFF
--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -47,6 +47,8 @@
 
 DT_MODULE_INTROSPECTION(1, dt_iop_dither_params_t)
 
+typedef void(_find_nearest_color)(float *val, float *err, const float f, const float rf);
+
 #if defined(__SSE__)
 typedef __m128(_find_nearest_color_sse)(float *val, const float f, const float rf);
 #endif
@@ -127,6 +129,23 @@ void init_presets(dt_iop_module_so_t *self)
 }
 
 
+// dither pixel into gray, with f=levels-1 and rf=1/f, return err=old-new
+static void _find_nearest_color_n_levels_gray(float *val, float *err, const float f, const float rf)
+{
+  const float in = 0.30f * val[0] + 0.59f * val[1] + 0.11f * val[2]; // RGB -> GRAY
+
+  float tmp = in * f;
+  int itmp = floorf(tmp);
+
+  float new = (tmp - itmp > 0.5f ? (float)(itmp + 1) : (float)itmp) * rf;
+
+  for(int c = 0; c < 4; c++)
+  {
+    err[c] = val[c] - new;
+    val[c] = new;
+  }
+}
+
 #if defined(__SSE__)
 // dither pixel into gray, with f=levels-1 and rf=1/f, return err=old-new
 static __m128 _find_nearest_color_n_levels_gray_sse(float *val, const float f, const float rf)
@@ -145,7 +164,24 @@ static __m128 _find_nearest_color_n_levels_gray_sse(float *val, const float f, c
 
   return err;
 }
+#endif
 
+// dither pixel into RGB, with f=levels-1 and rf=1/f, return err=old-new
+static void _find_nearest_color_n_levels_rgb(float *val, float *err, const float f, const float rf)
+{
+  for(int c = 0; c < 4; c++)
+  {
+    float old = val[c];
+    float tmp = old * f;
+    float itmp = floorf(tmp);
+    float new = (tmp - itmp > 0.5f ? itmp + 1 : itmp) * rf;
+
+    val[c] = new;
+    err[c] = old - new;
+  }
+}
+
+#if defined(__SSE__)
 // dither pixel into RGB, with f=levels-1 and rf=1/f, return err=old-new
 static __m128 _find_nearest_color_n_levels_rgb_sse(float *val, const float f, const float rf)
 {
@@ -163,13 +199,23 @@ static __m128 _find_nearest_color_n_levels_rgb_sse(float *val, const float f, co
 
   return _mm_sub_ps(old, new);
 }
+#endif
 
+static inline void _diffuse_error(float *val, const float *err, const float factor)
+{
+  for(int c = 0; c < 4; c++)
+  {
+    val[c] += err[c] * factor;
+  }
+}
 
+#if defined(__SSE__)
 static inline void _diffuse_error_sse(float *val, const __m128 err, const float factor)
 {
   _mm_store_ps(val,
                _mm_add_ps(_mm_load_ps(val), _mm_mul_ps(err, _mm_set1_ps(factor)))); // *val += err * factor
 }
+#endif
 
 static inline float clipnan(const float x)
 {
@@ -183,6 +229,172 @@ static inline float clipnan(const float x)
   return r;
 }
 
+void process_floyd_steinberg(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+                             const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
+                             const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_dither_data_t *data = (dt_iop_dither_data_t *)piece->data;
+
+  const int width = roi_in->width;
+  const int height = roi_in->height;
+  const int ch = piece->colors;
+  const float scale = roi_in->scale / piece->iscale;
+  const int l1 = floorf(1.0f + dt_log2f(1.0f / scale));
+
+  _find_nearest_color *nearest_color = NULL;
+  unsigned int levels = 1;
+  int bds = (piece->pipe->type != DT_DEV_PIXELPIPE_EXPORT) ? l1 * l1 : 1;
+
+  switch(data->dither_type)
+  {
+    case DITHER_FS1BIT:
+      nearest_color = _find_nearest_color_n_levels_gray;
+      levels = MAX(2, MIN(bds + 1, 256));
+      break;
+    case DITHER_FS4BIT_GRAY:
+      nearest_color = _find_nearest_color_n_levels_gray;
+      levels = MAX(16, MIN(15 * bds + 1, 256));
+      break;
+    case DITHER_FS8BIT:
+      nearest_color = _find_nearest_color_n_levels_rgb;
+      levels = 256;
+      break;
+    case DITHER_FS16BIT:
+      nearest_color = _find_nearest_color_n_levels_rgb;
+      levels = 65536;
+      break;
+    case DITHER_FSAUTO:
+      switch(piece->pipe->levels & IMAGEIO_CHANNEL_MASK)
+      {
+        case IMAGEIO_RGB:
+          nearest_color = _find_nearest_color_n_levels_rgb;
+          break;
+        case IMAGEIO_GRAY:
+          nearest_color = _find_nearest_color_n_levels_gray;
+          break;
+      }
+
+      switch(piece->pipe->levels & IMAGEIO_PREC_MASK)
+      {
+        case IMAGEIO_INT8:
+          levels = 256;
+          break;
+        case IMAGEIO_INT12:
+          levels = 4096;
+          break;
+        case IMAGEIO_INT16:
+          levels = 65536;
+          break;
+        case IMAGEIO_BW:
+          levels = 2;
+          break;
+        case IMAGEIO_INT32:
+        case IMAGEIO_FLOAT:
+        default:
+          nearest_color = NULL;
+          break;
+      }
+      // no automatic dithering for preview and thumbnail
+      if(piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW || piece->pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL)
+        nearest_color = NULL;
+      break;
+    case DITHER_RANDOM:
+      // this function won't ever be called for that type
+      // instead, process_random() will be called
+      __builtin_unreachable();
+      break;
+  }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int j = 0; j < height; j++)
+  {
+    const float *in = (const float *)ivoid + (size_t)ch * width * j;
+    float *out = (float *)ovoid + (size_t)ch * width * j;
+    for(int i = 0; i < width; i++, in += ch, out += ch)
+    {
+      out[0] = clipnan(in[0]);
+      out[1] = clipnan(in[1]);
+      out[2] = clipnan(in[2]);
+    }
+  }
+
+  if(nearest_color == NULL) return;
+
+  const float f = levels - 1;
+  const float rf = 1.0 / f;
+  float err[4];
+
+  // dither without error diffusion on very tiny images
+  if(width < 3 || height < 3)
+  {
+    for(int j = 0; j < height; j++)
+    {
+      float *out = ((float *)ovoid) + (size_t)ch * j * width;
+      for(int i = 0; i < width; i++) nearest_color(out + ch * i, err, f, rf);
+    }
+
+    if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+    return;
+  }
+
+  // floyd-steinberg dithering follows here
+
+  // first height-1 rows
+  for(int j = 0; j < height - 1; j++)
+  {
+    float *out = ((float *)ovoid) + (size_t)ch * j * width;
+
+    // first column
+    nearest_color(out, err, f, rf);
+    _diffuse_error(out + ch, err, 7.0f / 16.0f);
+    _diffuse_error(out + ch * width, err, 5.0f / 16.0f);
+    _diffuse_error(out + ch * (width + 1), err, 1.0f / 16.0f);
+
+
+    // main part of image
+    for(int i = 1; i < width - 1; i++)
+    {
+      nearest_color(out + ch * i, err, f, rf);
+      _diffuse_error(out + ch * (i + 1), err, 7.0f / 16.0f);
+      _diffuse_error(out + ch * (i - 1) + ch * width, err, 3.0f / 16.0f);
+      _diffuse_error(out + ch * i + ch * width, err, 5.0f / 16.0f);
+      _diffuse_error(out + ch * (i + 1) + ch * width, err, 1.0f / 16.0f);
+    }
+
+    // last column
+    nearest_color(out + ch * (width - 1), err, f, rf);
+    _diffuse_error(out + ch * (width - 2) + ch * width, err, 3.0f / 16.0f);
+    _diffuse_error(out + ch * (width - 1) + ch * width, err, 5.0f / 16.0f);
+  }
+
+  // last row
+  do
+  {
+    float *out = ((float *)ovoid) + (size_t)ch * (height - 1) * width;
+
+    // lower left pixel
+    nearest_color(out, err, f, rf);
+    _diffuse_error(out + ch, err, 7.0f / 16.0f);
+
+    // main part of last row
+    for(int i = 1; i < width - 1; i++)
+    {
+      nearest_color(out + ch * i, err, f, rf);
+      _diffuse_error(out + ch * (i + 1), err, 7.0f / 16.0f);
+    }
+
+    // lower right pixel
+    nearest_color(out + ch * (width - 1), err, f, rf);
+
+  } while(0);
+
+  // copy alpha channel if needed
+  if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+}
+
+#if defined(__SSE__)
 void process_floyd_steinberg_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                  const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
                                  const dt_iop_roi_t *const roi_out)
@@ -422,7 +634,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   if(data->dither_type == DITHER_RANDOM)
     process_random(self, piece, ivoid, ovoid, roi_in, roi_out);
   else
-    __builtin_unreachable();
+    process_floyd_steinberg(self, piece, ivoid, ovoid, roi_in, roi_out);
 }
 
 #if defined(__SSE__)

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -347,6 +347,7 @@ void process_floyd_steinberg(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   // copy alpha channel if needed
   if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
+#endif
 
 
 void encrypt_tea(unsigned int *arg)
@@ -413,6 +414,18 @@ void process_random(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
 }
 
 
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
+             void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_dither_data_t *data = (dt_iop_dither_data_t *)piece->data;
+
+  if(data->dither_type == DITHER_RANDOM)
+    process_random(self, piece, ivoid, ovoid, roi_in, roi_out);
+  else
+    __builtin_unreachable();
+}
+
+#if defined(__SSE__)
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {


### PR DESCRIPTION
This follows all the other non-sse work i've been doing.
This new code should produce the same output as the SSE version, but compile and work without SSE.

After this, there are only 3 places which are sse-only: atrous, nlmeans and denoiseprofile.

@upegelow did i miss anything?
Not sure there is anything here to review, but just to be sure...