### PR TITLE
FCxtrans rework

### DIFF
--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -210,9 +210,7 @@ static inline int fcol(const int row, const int col, const unsigned int filters,
                        const uint8_t (*const xtrans)[6])
 {
   if(filters == 9)
-    // There are a few cases in VNG demosaic in which row or col is -1
-    // or -2. The +6 ensures a non-negative array index.
-    return FCxtrans(row + 6, col + 6, NULL, xtrans);
+    return FCxtrans(row, col, NULL, xtrans);
   else
     return FC(row, col, filters);
 }

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -186,27 +186,25 @@ static inline int FC(const size_t row, const size_t col, const unsigned int filt
   return filters >> (((row << 1 & 14) + (col & 1)) << 1) & 3;
 }
 
-/** Calculate modulo with a positive result regardless of sign of a **/
-static inline int umod(const int a, const int n)
-{
-  // note that this does not produce a useful result if n is negative
-  const int r = a % n;
-  return (r >= 0) ? r : n + r;
-}
-
 /** Calculate the xtrans pattern color from the row and column **/
-static inline int FCxtrans(int row, int col, const dt_iop_roi_t *const roi,
+static inline int FCxtrans(const int row, const int col, const dt_iop_roi_t *const roi,
                            const uint8_t (*const xtrans)[6])
 {
+  // Add +600 (which must be a multiple of CFA width 6) as offset can
+  // be negative and need to ensure a non-negative array index. The
+  // negative offsets in current code come from the demosaic iop:
+  // Markesteijn 1-pass (-12), Markesteijn 3-pass (-17), and VNG (-2).
+  int irow = row + 600;
+  int icol = col + 600;
+  assert(irow >= 0 && icol >= 0);
+
   if(roi)
   {
-    row += roi->y;
-    col += roi->x;
+    irow += roi->y;
+    icol += roi->x;
   }
 
-  // use unsigned modulo as offsets from demosaic iop may be negative
-  // but need to assure a non-negative array index
-  return xtrans[umod(row,6)][umod(col,6)];
+  return xtrans[irow % 6][icol % 6];
 }
 
 static inline int fcol(const int row, const int col, const unsigned int filters,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -187,7 +187,7 @@ static inline int FC(const size_t row, const size_t col, const unsigned int filt
 }
 
 /** Calculate the xtrans pattern color from the row and column **/
-static inline int FCxtrans(const size_t row, const size_t col, const dt_iop_roi_t *const roi,
+static inline int FCxtrans(const int row, const int col, const dt_iop_roi_t *const roi,
                            const uint8_t (*const xtrans)[6])
 {
   // Add +18 (which must be a multiple of CFA width 6) as offset can

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -186,24 +186,27 @@ static inline int FC(const size_t row, const size_t col, const unsigned int filt
   return filters >> (((row << 1 & 14) + (col & 1)) << 1) & 3;
 }
 
+/** Calculate modulo with a positive result regardless of sign of a **/
+static inline int umod(const int a, const int n)
+{
+  // note that this does not produce a useful result if n is negative
+  const int r = a % n;
+  return (r >= 0) ? r : n + r;
+}
+
 /** Calculate the xtrans pattern color from the row and column **/
-static inline int FCxtrans(const int row, const int col, const dt_iop_roi_t *const roi,
+static inline int FCxtrans(int row, int col, const dt_iop_roi_t *const roi,
                            const uint8_t (*const xtrans)[6])
 {
-  // Add +18 (which must be a multiple of CFA width 6) as offset can
-  // be negative and need to ensure a non-negative array index. This
-  // offest is enough to handle negative offsets from both Markesteijn
-  // and VNG demosaic.
-  int irow = row + 18;
-  int icol = col + 18;
-
   if(roi)
   {
-    irow += roi->y;
-    icol += roi->x;
+    row += roi->y;
+    col += roi->x;
   }
 
-  return xtrans[irow % 6][icol % 6];
+  // use unsigned modulo as offsets from demosaic iop may be negative
+  // but need to assure a non-negative array index
+  return xtrans[umod(row,6)][umod(col,6)];
 }
 
 static inline int fcol(const int row, const int col, const unsigned int filters,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -190,10 +190,12 @@ static inline int FC(const size_t row, const size_t col, const unsigned int filt
 static inline int FCxtrans(const size_t row, const size_t col, const dt_iop_roi_t *const roi,
                            const uint8_t (*const xtrans)[6])
 {
-  // add +6 to as offset can be -1 or -2 and need to ensure a
-  // non-negative array index.
-  int irow = row + 6;
-  int icol = col + 6;
+  // Add +18 (which must be a multiple of CFA width 6) as offset can
+  // be negative and need to ensure a non-negative array index. This
+  // offest is enough to handle negative offsets from both Markesteijn
+  // and VNG demosaic.
+  int irow = row + 18;
+  int icol = col + 18;
 
   if(roi)
   {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -597,7 +597,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           else
           {
             // mirror a border pixel if beyond image edge
-            const int c = FCxtrans(row + 12, col + 12, roi_in, xtrans);
+            const int c = FCxtrans(row, col, roi_in, xtrans);
             for(int cc = 0; cc < 3; cc++)
               if(cc != c)
                 pix[cc] = 0.0f;
@@ -653,7 +653,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           // if in row of horizontal red & blue pairs (or processing
           // vertical red & blue pairs near image bottom), reset min/max
           // between each pair
-          if(FCxtrans(row + 12, col + 12, roi_in, xtrans) == 1)
+          if(FCxtrans(row, col, roi_in, xtrans) == 1)
           {
             min = FLT_MAX, max = 0.0f;
             continue;
@@ -699,7 +699,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
         for(int col = left + pad_g_interp; col < mcol - pad_g_interp; col++)
         {
           float color[8];
-          int f = FCxtrans(row + 12, col + 12, roi_in, xtrans);
+          int f = FCxtrans(row, col, roi_in, xtrans);
           if(f == 1) continue;
           float (*const pix)[3] = &rgb[0][row - top][col - left];
           short *hex = allhex[(row + 15) % 3][(col + 15) % 3];
@@ -734,7 +734,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           for(int row = top + pad_g_recalc; row < mrow - pad_g_recalc; row++)
             for(int col = left + pad_g_recalc; col < mcol - pad_g_recalc; col++)
             {
-              int f = FCxtrans(row + 12, col + 12, roi_in, xtrans);
+              int f = FCxtrans(row, col, roi_in, xtrans);
               if(f == 1) continue;
               short *hex = allhex[(row + 18) % 3][(col + 18) % 3];
               for(int d = 3; d < 6; d++)
@@ -753,7 +753,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           for(int col = (left - sgcol + pad_rb_g + 2) / 3 * 3 + sgcol; col < mcol - pad_rb_g; col += 3)
           {
             float(*rfx)[3] = &rgb[0][row - top][col - left];
-            int h = FCxtrans(row + 12, col + 13, roi_in, xtrans);
+            int h = FCxtrans(row, col + 1, roi_in, xtrans);
             float diff[6] = { 0.0f };
             float color[3][8];
             for(int i = 1, d = 0; d < 6; d++, i ^= TS ^ 1, h ^= 2)
@@ -782,7 +782,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
         for(int row = top + pad_rb_br; row < mrow - pad_rb_br; row++)
           for(int col = left + pad_rb_br; col < mcol - pad_rb_br; col++)
           {
-            int f = 2 - FCxtrans(row + 12, col + 12, roi_in, xtrans);
+            int f = 2 - FCxtrans(row, col, roi_in, xtrans);
             if(f == 1) continue;
             float(*rfx)[3] = &rgb[0][row - top][col - left];
             int c = (row - sgrow) % 3 ? TS : 1;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -549,6 +549,9 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           }
       }
 
+// succinct lookup for allhex[], making sure that row/col aren't negative
+#define HEXMAP(y,x) allhex[((y) + 18) % 3][((x) + 18) % 3]
+
   // extra passes propagates out errors at edges, hence need more padding
   const int pad_tile = (passes == 1) ? 12 : 17;
 #ifdef _OPENMP
@@ -666,7 +669,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           if(max == 0.0f)
           {
             float (*const pix)[3] = &rgb[0][row - top][col - left];
-            const short *const hex = allhex[(row + 18) % 3][(col + 18) % 3];
+            const short *const hex = HEXMAP(row,col);
             for(int c = 0; c < 6; c++)
             {
               const float val = pix[hex[c]][1];
@@ -702,7 +705,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           int f = FCxtrans(row, col, roi_in, xtrans);
           if(f == 1) continue;
           float (*const pix)[3] = &rgb[0][row - top][col - left];
-          short *hex = allhex[(row + 15) % 3][(col + 15) % 3];
+          short *hex = HEXMAP(row,col);
           // TODO: these constants come from integer math constants in
           // dcraw -- calculate them instead from interpolation math
           color[0] = 0.6796875f * (pix[hex[1]][1] + pix[hex[0]][1])
@@ -736,7 +739,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
             {
               int f = FCxtrans(row, col, roi_in, xtrans);
               if(f == 1) continue;
-              short *hex = allhex[(row + 18) % 3][(col + 18) % 3];
+              short *hex = HEXMAP(row,col);
               for(int d = 3; d < 6; d++)
               {
                 float(*rfx)[3] = &rgb[(d - 2) ^ !((row - sgrow) % 3)][row - top][col - left];
@@ -804,7 +807,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
               if((col - sgcol) % 3)
               {
                 float(*rfx)[3] = &rgb[0][row - top][col - left];
-                short *hex = allhex[(row + 18) % 3][(col + 18) % 3];
+                short *hex = HEXMAP(row,col);
                 for(int d = 0; d < ndir; d += 2, rfx += TS * TS)
                   if(hex[d] + hex[d + 1])
                   {

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -494,7 +494,7 @@ static void green_equilibration_favg(float *out, const float *const in, const in
 
 /** Lookup for allhex[], making sure that row/col aren't negative **/
 static inline const short *const hexmap(const int row, const int col,
-                                        const short (*const allhex)[3][8])
+                                        short (*const allhex)[3][8])
 {
   // Row and column offsets may be negative, but C's modulo function
   // is not useful here with a negative dividend. To be safe, add a

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -550,7 +550,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
       }
 
 // succinct lookup for allhex[], making sure that row/col aren't negative
-#define HEXMAP(y,x) allhex[((y) + 18) % 3][((x) + 18) % 3]
+#define HEXMAP(y,x) allhex[umod((y),3)][umod((x),3)]
 
   // extra passes propagates out errors at edges, hence need more padding
   const int pad_tile = (passes == 1) ? 12 : 17;


### PR DESCRIPTION
This overlaps with (and is a superset of) PR #1155 but am putting it up for the sake of discussion/comparison. I'd been sitting on this until PR #1123 went up, but should have put it out there earlier, so as not to duplicate @pedrocr's work. I'd be happy to modify it appropriately to do make it complement PR1155, as mentioned.

Changes:

- as with #1155, use a higher negative guard in FCxtrans() so caller doesn't have to do same (+18 is high enough for all current code, though as pedrocr says, this may be famous last words)
- take advantage of pedrocr adding roi to FCxtrans() to simplify calls to it in xtrans_markesteijn_interpolate()
- fcol() doesn't need a negative guard, as FCxtrans() handles this
- inspired by the useful FCxtrans(), make a macro internal to xtrans_markesteijn_interpolate() which does something similar for allhex[] lookups