### PR TITLE
Modules: only export those symbols which are listed in API headers

### DIFF
--- a/src/imageio/format/CMakeLists.txt
+++ b/src/imageio/format/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 2.6)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../" "${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories(SYSTEM "${PNG_PNG_INCLUDE_DIR}")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+add_definitions(-include module_api.h)
 add_definitions(-include imageio/format/imageio_format_api.h)
 
 set(MODULES copy jpeg pdf png ppm pfm tiff )

--- a/src/imageio/format/imageio_format_api.h
+++ b/src/imageio/format/imageio_format_api.h
@@ -34,6 +34,8 @@ struct dt_imageio_module_data_t;
 
 // !!! MUST BE KEPT IN SYNC WITH dt_imageio_module_format_t defined in src/common/imageio_module.h !!!
 
+#pragma GCC visibility push(default)
+
 // gui and management:
 /** version */
 int version();
@@ -82,6 +84,8 @@ int levels(struct dt_imageio_module_data_t *data);
 int flags(struct dt_imageio_module_data_t *data);
 
 int read_image(struct dt_imageio_module_data_t *data, uint8_t *out);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/src/imageio/storage/CMakeLists.txt
+++ b/src/imageio/storage/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.6)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../" "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+add_definitions(-include module_api.h)
 add_definitions(-include imageio/storage/imageio_storage_api.h)
 
 set(MODULES disk email gallery latex)

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -35,6 +35,8 @@ struct dt_imageio_module_data_t;
 
 // !!! MUST BE KEPT IN SYNC WITH dt_imageio_module_storage_t defined in src/common/imageio_module.h !!!
 
+#pragma GCC visibility push(default)
+
 int version();
 /* get translated module name */
 const char *name(const struct dt_imageio_module_storage_t *self);
@@ -77,6 +79,8 @@ void free_params(struct dt_imageio_module_storage_t *self, struct dt_imageio_mod
 int set_params(struct dt_imageio_module_storage_t *self, const void *params, const int size);
 
 void export_dispatched(struct dt_imageio_module_storage_t *self);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.6)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+add_definitions(-include module_api.h)
 add_definitions(-include iop/iop_api.h)
 
 macro (add_iop _lib _src)

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -52,6 +52,8 @@ typedef void dt_iop_params_t;
 
 // !!! MUST BE KEPT IN SYNC WITH dt_iop_module_so_t and dt_iop_module_t defined in src/develop/imageop.h !!!
 
+#pragma GCC visibility push(default)
+
 /** this initializes static, hardcoded presets for this module and is called only once per run of dt. */
 void init_presets(struct dt_iop_module_so_t *self);
 /** called once per module, at startup. */
@@ -186,6 +188,8 @@ dt_introspection_t *get_introspection();
 dt_introspection_field_t *get_introspection_linear();
 void *get_p(const void *param, const char *name);
 dt_introspection_field_t *get_f(const char *name);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+#include "common/introspection.h"
+
 #include <cairo/cairo.h>
 #include <glib.h>
 #include <stdint.h>
@@ -177,7 +179,13 @@ int distort_transform(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_
 int distort_backtransform(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, float *points,
                           size_t points_count);
 
-// FIXME: introspection?
+
+// introspection related callbacks, will be auto-implemented if DT_MODULE_INTROSPECTION() is used,
+int introspection_init(struct dt_iop_module_so_t *self, int api_version);
+dt_introspection_t *get_introspection();
+dt_introspection_field_t *get_introspection_linear();
+void *get_p(const void *param, const char *name);
+dt_introspection_field_t *get_f(const char *name);
 
 #ifdef __cplusplus
 }

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 2.6)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+add_definitions(-include module_api.h)
 add_definitions(-include libs/lib_api.h)
 
 # The modules

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -36,6 +36,8 @@ struct dt_view_t;
 
 // !!! MUST BE KEPT IN SYNC WITH dt_lib_module_t defined in src/libs/lib.h !!!
 
+#pragma GCC visibility push(default)
+
 /** version */
 int version();
 /** get name of the module, to be translated. */
@@ -89,6 +91,8 @@ void init_presets(struct dt_lib_module_t *self);
 /** Optional callbacks for keyboard accelerators */
 void init_key_accels(struct dt_lib_module_t *self);
 void connect_key_accels(struct dt_lib_module_t *self);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/src/module_api.h
+++ b/src/module_api.h
@@ -1,0 +1,46 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_MODULE_API_H
+#define DT_MODULE_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// these 2 functions are defined by DT_MODULE() macro.
+
+#pragma GCC visibility push(default)
+
+// returns the version of dt's module interface at the time this module was build
+int dt_module_dt_version();
+
+// returns the version of this module
+int dt_module_mod_version();
+
+#pragma GCC visibility pop
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-space on;

--- a/src/views/CMakeLists.txt
+++ b/src/views/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DI
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
+add_definitions(-include module_api.h)
 add_definitions(-include views/view_api.h)
 
 set(MODULES darkroom lighttable slideshow)

--- a/src/views/CMakeLists.txt
+++ b/src/views/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.6)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
 add_definitions(-include views/view_api.h)
 
 set(MODULES darkroom lighttable slideshow)

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -33,6 +33,8 @@ struct dt_view_t;
 
 // !!! MUST BE KEPT IN SYNC WITH dt_view_t defined in src/views/view.h !!!
 
+#pragma GCC visibility push(default)
+
 const char *name(struct dt_view_t *self);    // get translatable name
 uint32_t view(const struct dt_view_t *self); // get the view type
 void init(struct dt_view_t *self);           // init *data
@@ -61,6 +63,8 @@ void scrolled(struct dt_view_t *self, double x, double y, int up, int state); //
 // keyboard accel callbacks
 void init_key_accels(struct dt_view_t *self);
 void connect_key_accels(struct dt_view_t *self);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This also adds API for introspection for iops into header file.
And fixes a few small issues.

There are at least several reasons why it is good:
1. This will help to keep those api headers up-to-date.
2. Shared objects probably shouldn't export symbols which are not part of their public API.
Luckily, for us that public api is pretty well-defined (for libs, not libdarktable.so...)