### PR TITLE
dt_dev_distort_[back]transform_plus add exception for module.

### DIFF
--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -263,7 +263,7 @@ static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid
       dt_dev_pixelpipe_synch_all(&pipe, &dev);
       dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,
                                       &pipe.processed_height);
-      dt_dev_distort_transform_plus(&dev, &pipe, 0, 99999, pos, fs * 3);
+      dt_dev_distort_transform_plus(&dev, &pipe, 0, 99999, NULL, pos, fs * 3);
       dt_dev_pixelpipe_cleanup(&pipe);
       wd = pipe.processed_width;
       ht = pipe.processed_height;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1661,15 +1661,15 @@ gchar *dt_history_item_get_name_html(struct dt_iop_module_t *module)
 
 int dt_dev_distort_transform(dt_develop_t *dev, float *points, size_t points_count)
 {
-  return dt_dev_distort_transform_plus(dev, dev->preview_pipe, 0, 99999, points, points_count);
+  return dt_dev_distort_transform_plus(dev, dev->preview_pipe, 0, 99999, NULL, points, points_count);
 }
 int dt_dev_distort_backtransform(dt_develop_t *dev, float *points, size_t points_count)
 {
-  return dt_dev_distort_backtransform_plus(dev, dev->preview_pipe, 0, 99999, points, points_count);
+  return dt_dev_distort_backtransform_plus(dev, dev->preview_pipe, 0, 99999, NULL, points, points_count);
 }
 
 int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
-                                  float *points, size_t points_count)
+                                  struct dt_iop_module_t *except, float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_first(dev->iop);
@@ -1683,7 +1683,7 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, i
     }
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
-    if(piece->enabled && module->priority <= pmax && module->priority >= pmin &&
+    if(piece->enabled && module->priority <= pmax && module->priority >= pmin && module != except &&
       !(dev->gui_module && dev->gui_module->operation_tags_filter() & module->operation_tags()))
     {
       module->distort_transform(module, piece, points, points_count);
@@ -1696,7 +1696,7 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, i
 }
 
 int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
-                                      float *points, size_t points_count)
+                                      struct dt_iop_module_t *except, float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(dev->iop);
@@ -1710,7 +1710,7 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
     }
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)(pieces->data);
-    if(piece->enabled && module->priority <= pmax && module->priority >= pmin &&
+    if(piece->enabled && module->priority <= pmax && module->priority >= pmin && module != except &&
       !(dev->gui_module && dev->gui_module->operation_tags_filter() & module->operation_tags()))
     {
       module->distort_backtransform(module, piece, points, points_count);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -312,11 +312,11 @@ gchar *dt_history_item_get_name_html(struct dt_iop_module_t *module);
 int dt_dev_distort_transform(dt_develop_t *dev, float *points, size_t points_count);
 /** reverse apply all transforms to the specified points (in preview pipe space) */
 int dt_dev_distort_backtransform(dt_develop_t *dev, float *points, size_t points_count);
-/** same fct, but we can specify iop with priority between pmin and pmax */
+/** same fct, but we can specify iop with priority between pmin and pmax, skip module except */
 int dt_dev_distort_transform_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
-                                  float *points, size_t points_count);
+                                  struct dt_iop_module_t *except, float *points, size_t points_count);
 int dt_dev_distort_backtransform_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, int pmin, int pmax,
-                                      float *points, size_t points_count);
+                                      struct dt_iop_module_t *except, float *points, size_t points_count);
 /** get the iop_pixelpipe instance corresponding to the iop in the given pipe */
 struct dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe,
                                                            struct dt_iop_module_t *module);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -847,9 +847,9 @@ static int _brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, in
   start2 = dt_get_wtime();
 
   // and we transform them with all distorted modules
-  if(dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, *points, *points_count))
+  if(dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, NULL, *points, *points_count))
   {
-    if(!border || dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, *border, *border_count))
+    if(!border || dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, NULL, *border, *border_count))
     {
       if(darktable.unmuted & DT_DEBUG_PERF)
         dt_print(DT_DEBUG_MASKS, "[masks %s] brush_points transform took %0.04f sec\n", form->name,

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -593,7 +593,7 @@ static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_i
   }
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe, 0, module->priority, points, l + 1))
+  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe, 0, module->priority, NULL, points, l + 1))
   {
     free(points);
     return 0;
@@ -642,7 +642,7 @@ static int dt_circle_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   }
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, 0, module->priority, points, l + 1))
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points, l + 1))
   {
     free(points);
     return 0;
@@ -699,7 +699,7 @@ static int dt_circle_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   start2 = dt_get_wtime();
 
   // we back transform all this points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, points, w * h))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points, w * h))
   {
     free(points);
     return 0;
@@ -786,7 +786,7 @@ static int dt_circle_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_
   start2 = dt_get_wtime();
 
   // we back transform all these points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, points,
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points,
                                         (size_t)mw * mh))
   {
     free(points);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1103,7 +1103,7 @@ static int dt_ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_
   }
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe, 0, module->priority, points, l + 5))
+  if(!dt_dev_distort_transform_plus(darktable.develop, piece->pipe, 0, module->priority, NULL, points, l + 5))
   {
     free(points);
     return 0;
@@ -1189,7 +1189,7 @@ static int dt_ellipse_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
   }
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, 0, module->priority, points, l + 5))
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points, l + 5))
   {
     free(points);
     return 0;
@@ -1246,7 +1246,7 @@ static int dt_ellipse_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *
   start2 = dt_get_wtime();
 
   // we back transform all this points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, points, w * h))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points, w * h))
   {
     free(points);
     return 0;
@@ -1359,7 +1359,7 @@ static int dt_ellipse_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop
   start2 = dt_get_wtime();
 
   // we back transform all these points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, points,
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points,
                                         (size_t)mw * mh))
   {
     free(points);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -755,7 +755,7 @@ static int dt_gradient_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   points[7] = ht;
 
   // and we transform them with all distorted modules
-  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, 0, module->priority, points, 4)) return 0;
+  if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points, 4)) return 0;
 
   // now we search min and max
   float xmin, xmax, ymin, ymax;
@@ -826,7 +826,7 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   start2 = dt_get_wtime();
 
   // we backtransform all these points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, points, mw * mh))
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points, mw * mh))
   {
     free(points);
     return 0;
@@ -955,7 +955,7 @@ static int dt_gradient_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_io
   start2 = dt_get_wtime();
 
   // we backtransform all these points
-  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, points,
+  if(!dt_dev_distort_backtransform_plus(module->dev, piece->pipe, 0, module->priority, NULL, points,
                                         (size_t)mw * mh))
   {
     free(points);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -606,7 +606,7 @@ static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, int
 
     dt_masks_dynbuf_add(dpoints, rc[0]);
     dt_masks_dynbuf_add(dpoints, rc[1]);
-    
+
     border_init[k * 6 + 4] = dborder ? -dt_masks_dynbuf_position(dborder) : 0;
 
     if(dborder)
@@ -677,9 +677,9 @@ static int _path_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, int
   }
 
   // and we transform them with all distorted modules
-  if(dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, *points, *points_count))
+  if(dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, NULL, *points, *points_count))
   {
-    if(!border || dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, *border, *border_count))
+    if(!border || dt_dev_distort_transform_plus(dev, pipe, 0, prio_max, NULL, *border, *border_count))
     {
       if(darktable.unmuted & DT_DEBUG_PERF)
         dt_print(DT_DEBUG_MASKS, "[masks %s] path_points transform took %0.04f sec\n", form->name,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -444,7 +444,7 @@ static void pixelpipe_picker(dt_iop_module_t *module, const float *img, const dt
     // transform back to current module coordinates
     dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
                                       module->priority + (picker_source == PIXELPIPE_PICKER_INPUT ? 0 : 1),
-                                      99999, fbox, 2);
+                                      99999, NULL, fbox, 2);
 
     fbox[0] -= roi->x;
     fbox[1] -= roi->y;
@@ -528,7 +528,7 @@ static void pixelpipe_picker(dt_iop_module_t *module, const float *img, const dt
     // transform back to current module coordinates
     dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
                                       module->priority  + (picker_source == PIXELPIPE_PICKER_INPUT ? 0 : 1),
-                                      99999, fpoint, 1);
+                                      99999, NULL, fpoint, 1);
 
     point[0] = fpoint[0] - roi->x;
     point[1] = fpoint[1] - roi->y;
@@ -587,7 +587,7 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, cl_mem img, 
   // transform back to current module coordinates
   dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
                                     module->priority  + (picker_source == PIXELPIPE_PICKER_INPUT ? 0 : 1),
-                                    99999, fbox, 2);
+                                    99999, NULL, fbox, 2);
 
   fbox[0] -= roi->x;
   fbox[1] -= roi->y;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1989,7 +1989,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     float ivecl = sqrt(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
     // where do they go?
-    dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, points,
+    dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, NULL, points,
                                       2);
 
     float ovec[2] = { points[2] - points[0], points[3] - points[1] };
@@ -2119,7 +2119,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     float ivecl = sqrt(ivec[0] * ivec[0] + ivec[1] * ivec[1]);
 
     // where do they go?
-    dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, points,
+    dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, NULL, points,
                                       2);
 
     float ovec[2] = { points[2] - points[0], points[3] - points[1] };
@@ -2299,7 +2299,7 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   for(int n = 0; n < lines_count; n++)
   {
     const int length = lines[n].length;
-    
+
     total_points += length;
 
     my_points_idx[n].length = length;
@@ -2350,7 +2350,7 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   }
 
   // third step: transform all points
-  if(!dt_dev_distort_transform_plus(dev, dev->preview_pipe, self->priority, 9999999, my_points, total_points))
+  if(!dt_dev_distort_transform_plus(dev, dev->preview_pipe, self->priority, 9999999, NULL, my_points, total_points))
     goto error;
 
   // fourth step: get bounding box in final coordinates (used later for checking "near"-ness to mouse pointer)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -509,7 +509,7 @@ static int _iop_clipping_set_max_clip(struct dt_iop_module_t *self)
 
   float wp = piece->buf_out.width, hp = piece->buf_out.height;
   float points[8] = { 0.0, 0.0, wp, hp, p->cx * wp, p->cy * hp, fabsf(p->cw) * wp, fabsf(p->ch) * hp };
-  if(!dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, points, 4))
+  if(!dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, NULL, points, 4))
     return 0;
 
   g->clip_max_x = points[0] / self->dev->preview_pipe->backbuf_width;
@@ -2312,7 +2312,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     float wp = piece->buf_out.width, hp = piece->buf_out.height;
     float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                      p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
-    if(dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, pts, 4))
+    if(dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, NULL, pts, 4))
     {
       if(p->k_type == 3)
       {
@@ -2580,7 +2580,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     if(g->k_drag == TRUE && g->k_selected >= 0)
     {
       float pts[2] = { pzx * wd, pzy * ht };
-      dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, pts,
+      dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, NULL, pts,
                                         1);
       dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
       float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
@@ -2765,7 +2765,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
       float points[4]
           = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
       if(dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999,
-                                           points, 2))
+                                           NULL, points, 2))
       {
         dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
         if(piece)
@@ -2817,7 +2817,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     if(g->k_show == 1 && g->k_drag == FALSE)
     {
       float pts[2] = { pzx * wd, pzy * ht };
-      dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, pts,
+      dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, NULL, pts,
                                         1);
       dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
       float xx = pts[0] / (float)piece->buf_out.width, yy = pts[1] / (float)piece->buf_out.height;
@@ -2877,7 +2877,7 @@ static void commit_box(dt_iop_module_t *self, dt_iop_clipping_gui_data_t *g, dt_
   float points[4]
       = { g->clip_x * wd, g->clip_y * ht, (g->clip_x + g->clip_w) * wd, (g->clip_y + g->clip_h) * ht };
   if(dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999,
-                                       points, 2))
+                                       NULL, points, 2))
   {
     dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
     if(piece)
@@ -2978,7 +2978,7 @@ int button_pressed(struct dt_iop_module_t *self, double x, double y, double pres
         float wp = piece->buf_out.width, hp = piece->buf_out.height;
         float pts[8] = { p->kxa * wp, p->kya * hp, p->kxb * wp, p->kyb * hp,
                          p->kxc * wp, p->kyc * hp, p->kxd * wp, p->kyd * hp };
-        dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, pts, 4);
+        dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, NULL, pts, 4);
 
         float xx = pzx * self->dev->preview_pipe->backbuf_width,
               yy = pzy * self->dev->preview_pipe->backbuf_height;

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -204,7 +204,7 @@ static int set_grad_from_points(struct dt_iop_module_t *self, float xa, float ya
   float pts[4]
       = { xa * self->dev->preview_pipe->backbuf_width, ya * self->dev->preview_pipe->backbuf_height,
           xb * self->dev->preview_pipe->backbuf_width, yb * self->dev->preview_pipe->backbuf_height };
-  dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, pts, 2);
+  dt_dev_distort_backtransform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 9999999, NULL, pts, 2);
   dt_dev_pixelpipe_iop_t *piece = dt_dev_distort_get_iop_pipe(self->dev, self->dev->preview_pipe, self);
   pts[0] /= (float)piece->buf_out.width;
   pts[2] /= (float)piece->buf_out.width;
@@ -380,7 +380,7 @@ static int set_points_from_grad(struct dt_iop_module_t *self, float *xa, float *
   }
   // now we want that points to take care of distort modules
 
-  if(!dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, pts, 2))
+  if(!dt_dev_distort_transform_plus(self->dev, self->dev->preview_pipe, self->priority + 1, 999999, NULL, pts, 2))
     return 0;
   *xa = pts[0] / self->dev->preview_pipe->backbuf_width;
   *ya = pts[1] / self->dev->preview_pipe->backbuf_height;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -324,7 +324,7 @@ static int masks_point_calc_delta(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t 
   masks_point_denormalize(piece, roi, target, 1, points);
   masks_point_denormalize(piece, roi, source, 1, points + 2);
 
-  int res = dt_dev_distort_transform_plus(self->dev, piece->pipe, 0, self->priority, points, 2);
+  int res = dt_dev_distort_transform_plus(self->dev, piece->pipe, 0, self->priority, NULL, points, 2);
   if(!res) return res;
 
   *dx = points[0] - points[2];
@@ -416,7 +416,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         masks_point_denormalize(piece, roi_in, circle->center, 1, points);
         masks_point_denormalize(piece, roi_in, form->source, 1, points + 2);
 
-        if(!dt_dev_distort_transform_plus(self->dev, piece->pipe, 0, self->priority, points, 2))
+        if(!dt_dev_distort_transform_plus(self->dev, piece->pipe, 0, self->priority, NULL, points, 2))
         {
           forms = g_list_next(forms);
           pos++;


### PR DESCRIPTION
In these routines we had a way to select the range of module priority
to use to apply the distortion. A new parameter except is introduced
to be able to add an exception for a module to skip during the
computation. If the parameter is NULL there is no exception and
the routines are behaving as before.

This is needed and used in liquify as the distortion for the control
elements must be computed for the whole pipe (before liquify we have
lens and ashift to take into account, and after roration and crop)
except liquify itself which must not modify the control point.

Proper fix for #10939.