### PR TITLE
Colorpicker: fix "restrict histogram" bounding box. Fixes #10654

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2115,7 +2115,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             box[k] = MIN(roi_out->width - 1,
                          MAX(0, dev->gui_module->color_picker_box[k] * (roi_out->width - 1)));
           for(int k = 1; k < 4; k += 2)
-            box[k] = MIN(roi_out->height - 1, MAX(0, module->color_picker_box[k] * (roi_out->height - 1)));
+            box[k] = MIN(roi_out->height - 1,
+                         MAX(0, dev->gui_module->color_picker_box[k] * (roi_out->height - 1)));
         }
         else
         {
@@ -2123,7 +2124,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
             box[k] = MIN(roi_out->width - 1,
                          MAX(0, dev->gui_module->color_picker_point[0] * (roi_out->width - 1)));
           for(int k = 1; k < 4; k += 2)
-            box[k] = MIN(roi_out->height - 1, MAX(0, module->color_picker_point[1] * (roi_out->height - 1)));
+            box[k] = MIN(roi_out->height - 1,
+                         MAX(0, dev->gui_module->color_picker_point[1] * (roi_out->height - 1)));
         }
       }
       else


### PR DESCRIPTION
This is an attempt to fix http://redmine.darktable.org/issues/10654

I'm not familiar enough with the code to be sure I'm doing the right fix, but the previous code really looks wrong: it takes `dev->gui_module` on the x axis and `module` on the y axis.

At least, I'm getting the expected behavior with the patch, and it was wrong before.

Can anyone check my code?

Thanks a lot!