### PR TITLE
Imageop: make presence of process() required.

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -298,23 +298,7 @@ int dt_iop_load_module_so(dt_iop_module_so_t *module, const char *libname, const
   if(!g_module_symbol(module->module, "process_sse2", (gpointer) & (module->process_sse2)))
     module->process_sse2 = NULL;
 
-  if(!g_module_symbol(module->module, "process", (gpointer) & (module->process_plain)))
-  {
-    if(darktable.codepath._no_intrinsics || (
-#if defined(__SSE__)
-                                                (darktable.codepath.SSE2 && !(module->process_sse2))
-#else
-                                                1
-#endif
-                                                    ))
-    {
-      goto error;
-    }
-    else
-    {
-      module->process_plain = NULL;
-    }
-  }
+  if(!g_module_symbol(module->module, "process", (gpointer) & (module->process_plain))) goto error;
 
   if(!darktable.opencl->inited
      || !g_module_symbol(module->module, "process_cl", (gpointer) & (module->process_cl)))

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -145,6 +145,7 @@ int legacy_params(struct dt_iop_module_t *self, const void *const old_params, co
   * scaled to the same size width*height and contain a max of 3 floats. other color
   * formats may be filled by this callback, if the pipeline can handle it. */
 /** the simplest variant of process(). you can only use OpenMP SIMD here, no intrinsics */
+/** must be provided by each IOP. */
 void process(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
              void *const o, const struct dt_iop_roi_t *const roi_in,
              const struct dt_iop_roi_t *const roi_out);
@@ -155,6 +156,7 @@ void process_tiling(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t 
 
 #if defined(__SSE2__)
 /** a variant process(), that can contain SSE2 intrinsics. */
+/** can be provided by each IOP. */
 void process_sse2(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, const void *const i,
                   void *const o, const struct dt_iop_roi_t *const roi_in,
                   const struct dt_iop_roi_t *const roi_out);


### PR DESCRIPTION
This is to make sure that no new code is added that is SSE2-only.