### PR TITLE
ashift4: fourth version of the ashift module

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -888,7 +888,7 @@ void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t 
       pin[1] /= roi_in->scale;
       pin[2] = 1.0f;
 
-      // apply hompgraph
+      // apply homograph
       mat3mulv(pout, (float *)homograph, pin);
 
       // convert to output image coordinates
@@ -1383,7 +1383,7 @@ static int fact(const int n)
 // combined with the highest total weight wins.
 // Disadvantage: compared to the original RANSAC we don't get any model parameters that
 // we could use for the following NMS fit.
-// Self optimization: we optimize "epsilon", the hurdle line to reject a line as an outlier,
+// Self optimization: we optimize "epsilon", the hurdle rate to reject a line as an outlier,
 // by a number of dry runs first. The target average percentage value of lines to eliminate as
 // outliers (without judging on the quality of the model) is given by RANSAC_ELIMINATION_RATIO,
 // note: the actual percentage of outliers removed in the final run will be lower because we
@@ -1552,7 +1552,7 @@ static int remove_outliers(dt_iop_module_t *module)
   // holds the result of ransac
   int inout_set[g->lines_count];
 
-  // some counting variables
+  // some accounting variables
   int vnb = 0, vcount = 0;
   int hnb = 0, hcount = 0;
 
@@ -1911,7 +1911,7 @@ static dt_iop_ashift_nmsresult_t nmsfit(dt_iop_module_t *module, dt_iop_ashift_p
   p->shear = isnan(fit.shear) ? ilogit(params[pcount++], -fit.shear_range, fit.shear_range) : fit.shear;
 #ifdef ASHIFT_DEBUG
   printf("params after optimization (%d interations): rotation %f, lensshift_v %f, lensshift_h %f, shear %f\n",
-         iter, p->rotation, p->lensshift_v, p->lensshift_h, shear);
+         iter, p->rotation, p->lensshift_v, p->lensshift_h, p->shear);
 #endif
 
   return NMS_SUCCESS;
@@ -1988,7 +1988,7 @@ static void model_probe(dt_iop_module_t *module, dt_iop_ashift_params_t *p, dt_i
   double quality = model_fitness(params, (void *)&fit);
 
   printf("model fitness: %.8f (rotation %f, lensshift_v %f, lensshift_h %f, shear %f)\n",
-         quality, p->rotation, p->lensshift_v, p->lensshift_h, shear);
+         quality, p->rotation, p->lensshift_v, p->lensshift_h, p->shear);
 }
 #endif
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -53,7 +53,8 @@
 #define ROTATION_RANGE_SOFT 20              // allowed min/max range for rotation parameter with manual adjustment
 #define LENSSHIFT_RANGE 0.5                 // allowed min/max default range for lensshift paramters
 #define LENSSHIFT_RANGE_SOFT 1              // allowed min/max range for lensshift paramters with manual adjustment
-#define SHEAR_RANGE 0.5                     // allowed min/max range for shdar parameter
+#define SHEAR_RANGE 0.2                     // allowed min/max range for shear parameter
+#define SHEAR_RANGE_SOFT 0.5                // allowed min/max range for shear parameter with manual adjustment
 #define MIN_LINE_LENGTH 10                  // the minimum length of a line in pixels to be regarded as relevant
 #define MAX_TANGENTIAL_DEVIATION 15         // by how many degrees a line may deviate from the +/-180 and +/-90 to be regarded as relevant
 #define POINTS_NEAR_DELTA 4                 // distance of mouse pointer to line for "near" detection
@@ -3345,7 +3346,7 @@ static int fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
       dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
       dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
       dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-      dt_bauhaus_slider_set(g->shear, p->shear);
+      dt_bauhaus_slider_set_soft(g->shear, p->shear);
       darktable.gui->reset = 0;
     }
     g->lastfit = fitaxis;
@@ -3390,7 +3391,7 @@ static int fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
       dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
       dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
       dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-      dt_bauhaus_slider_set(g->shear, p->shear);
+      dt_bauhaus_slider_set_soft(g->shear, p->shear);
       darktable.gui->reset = 0;
     }
     g->lastfit = fitaxis;
@@ -3437,7 +3438,7 @@ static int fit_both_button_clicked(GtkWidget *widget, GdkEventButton *event, gpo
       dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
       dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
       dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-      dt_bauhaus_slider_set(g->shear, p->shear);
+      dt_bauhaus_slider_set_soft(g->shear, p->shear);
       darktable.gui->reset = 0;
     }
     g->lastfit = fitaxis;
@@ -3557,7 +3558,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
   dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
   dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
-  dt_bauhaus_slider_set(g->shear, p->shear);
+  dt_bauhaus_slider_set_soft(g->shear, p->shear);
   dt_bauhaus_slider_set_soft(g->f_length, p->f_length);
   dt_bauhaus_slider_set_soft(g->crop_factor, p->crop_factor);
   dt_bauhaus_slider_set(g->orthocorr, p->orthocorr);
@@ -3673,7 +3674,7 @@ void reload_defaults(dt_iop_module_t *module)
     g->rotation_range = ROTATION_RANGE_SOFT;
     g->lensshift_v_range = LENSSHIFT_RANGE_SOFT;
     g->lensshift_h_range = LENSSHIFT_RANGE_SOFT;
-    g->shear_range = SHEAR_RANGE;
+    g->shear_range = SHEAR_RANGE_SOFT;
     g->lines_suppressed = 0;
     g->lines_version = 0;
     g->show_guides = 0;
@@ -3823,7 +3824,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->rotation_range = ROTATION_RANGE_SOFT;
   g->lensshift_v_range = LENSSHIFT_RANGE_SOFT;
   g->lensshift_h_range = LENSSHIFT_RANGE_SOFT;
-  g->shear_range = SHEAR_RANGE;
+  g->shear_range = SHEAR_RANGE_SOFT;
   g->show_guides = 0;
   g->isselecting = 0;
   g->isdeselecting = 0;
@@ -3849,7 +3850,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->shear = dt_bauhaus_slider_new_with_range(self, -SHEAR_RANGE, SHEAR_RANGE, 0.01*SHEAR_RANGE, p->shear, 3);
   dt_bauhaus_widget_set_label(g->shear, NULL, _("shear"));
-  //dt_bauhaus_slider_enable_soft_boundaries(g->shear, -SHEAR_RANGE_SOFT, SHEAR_RANGE_SOFT);
+  dt_bauhaus_slider_enable_soft_boundaries(g->shear, -SHEAR_RANGE_SOFT, SHEAR_RANGE_SOFT);
   gtk_box_pack_start(GTK_BOX(self->widget), g->shear, TRUE, TRUE, 0);
 
   g->guide_lines = dt_bauhaus_combobox_new(self);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -478,6 +478,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "rotation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lens shift (v)"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lens shift (h)"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shear"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -487,6 +488,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "rotation", GTK_WIDGET(g->rotation));
   dt_accel_connect_slider_iop(self, "lens shift (v)", GTK_WIDGET(g->lensshift_v));
   dt_accel_connect_slider_iop(self, "lens shift (h)", GTK_WIDGET(g->lensshift_h));
+  dt_accel_connect_slider_iop(self, "shear", GTK_WIDGET(g->shear));
 }
 
 // multiply 3x3 matrix with 3x1 vector

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -69,7 +69,7 @@
 #define MINIMUM_FITLINES 4                  // minimum number of lines needed for automatic parameter fit
 #define NMS_EPSILON 1e-3                    // break criterion for Nelder-Mead simplex
 #define NMS_SCALE 1.0                       // scaling factor for Nelder-Mead simplex
-#define NMS_ITERATIONS 200                  // number of iterations for Nelder-Mead simplex
+#define NMS_ITERATIONS 400                  // number of iterations for Nelder-Mead simplex
 #define NMS_CROP_EPSILON 100.0              // break criterion for Nelder-Mead simplex on crop fitting
 #define NMS_CROP_SCALE 0.5                  // scaling factor for Nelder-Mead simplex on crop fitting
 #define NMS_CROP_ITERATIONS 100             // number of iterations for Nelder-Mead simplex on crop fitting

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3998,7 +3998,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->fit_both, _("automatically correct for vertical and "
                                              "horizontal perspective distortions\n"
                                              "ctrl-click to only fit rotation\n"
-                                             "shift-click to only fit lens shift"
+                                             "shift-click to only fit lens shift\n"
                                              "shift-ctrl-click to also fit shear"));
   gtk_widget_set_tooltip_text(g->structure, _("analyse line structure in image\n"
                                               "ctrl-click for an additional edge enhancement"));


### PR DESCRIPTION
Adds a further "shear" parameter to allow perfect fitting results for both directions also in extreme cases. You can fit "shear" by shift-ctrl-clicking on the "fit both" icon. Extreme perspective corrections often lead to poor image quality as massive interpolation is needed.

TODO: check if can we get a more natural adjustment of aspect ratio in this case.