### PR TITLE
Highlights iop: 'Reconstruct in LCh' algo rewrite

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -436,7 +436,7 @@ static void process_lch_bayer(
     float *in = (float *)ivoid + (size_t)width * j;
     for(int i = 0; i < width; i++)
     {
-      if(i == 0 || i == width - 1 || j == 0 || j == height - 1)
+      if(i == roi_out->width - 1 || j == roi_out->height - 1)
       {
         // fast path for border
         out[0] = MIN(clip, in[0]);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -436,7 +436,7 @@ static void process_lch_bayer(
       if(i == 0 || i == width - 1 || j == 0 || j == height - 1)
       {
         // fast path for border
-        out[0] = in[0];
+        out[0] = MIN(clip, in[0]);
       }
       else
       {


### PR DESCRIPTION
4 sample images (exported using the same history stack): http://imgur.com/a/uKMtR
Old - git master; new - pr;

Results in much more gradual transition from clipped to non-clipped pixels,
with no (or at least much less) banding.
And clipped pixels are now more white than gray.

That being said, this 'Reconstruct in LCh' mode still produces pretty bad results, but much better than what we currently have in git master.

I believe this algo is also applicable to X-Trans. @dtorop 

Opencl kernel was not completely obvious to me this time, so i just disabled opencl in `commit_params()` for that mode for now... @upegelow 

This looks like a bugfix. @hanatos thinks that `legacy_params()` is not needed here.