### PR TITLE
Highlights iop: X-Trans 'Reconstruct in LCh' algo rewrite

### DIFF
--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -573,7 +573,7 @@ static void process_lch_xtrans(dt_iop_module_t *self, const void *const ivoid,
                 {
                   for(int ii = offset_i; ii <= offset_i + 2; ii++)
                   {
-                    const float val = in[(size_t)jj * roi_in->width + ii];
+                    const float val = in[(ssize_t)jj * roi_in->width + ii];
                     clipped = (clipped || (val > clip));
                   }
                 }
@@ -592,7 +592,7 @@ static void process_lch_xtrans(dt_iop_module_t *self, const void *const ivoid,
           {
             for(int ii = -1; ii <= 1; ii++)
             {
-              const float val = in[(size_t)jj * roi_in->width + ii];
+              const float val = in[(ssize_t)jj * roi_in->width + ii];
               const int c = FCxtrans(j+jj, i+ii, roi_in, xtrans);
               mean[c] += val;
               cnt[c]++;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -538,7 +538,7 @@ static void process_lch_xtrans(dt_iop_module_t *self, const void *const ivoid,
   const uint8_t (*const xtrans)[6] = self->dev->image_storage.xtrans;
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none)
+#pragma omp parallel for schedule(dynamic) default(none)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -567,7 +567,8 @@ static void process_lch_xtrans(dt_iop_module_t *self, const void *const ivoid,
           {
             for(int offset_i = -2; offset_i <= 0; offset_i++)
             {
-              if (clipped) {
+              if (clipped)
+              {
                 clipped = 0;
                 for(int jj = offset_j; jj <= offset_j + 2; jj++)
                 {
@@ -623,18 +624,13 @@ static void process_lch_xtrans(dt_iop_module_t *self, const void *const ivoid,
             H *= ratio;
           }
 
-          switch(FCxtrans(j, i, roi_out, xtrans))
-          {
-            case 0:
-              out[0] = L - H / 6.0f + C / SQRT12;
-              break;
-            case 1:
-              out[0] = L - H / 6.0f - C / SQRT12;
-              break;
-            case 2:
-              out[0] = L + H / 3.0f;
-              break;
-          }
+          float RGB[3] = { 0.0f, 0.0f, 0.0f };
+
+          RGB[0] = L - H / 6.0f + C / SQRT12;
+          RGB[1] = L - H / 6.0f - C / SQRT12;
+          RGB[2] = L + H / 3.0f;
+
+          out[0] = RGB[FCxtrans(j, i, roi_out, xtrans)];
         }
         else
           out[0] = in[0];


### PR DESCRIPTION
This follows up on #1188 by rewriting X-Trans 'Reconstruct in LCh' to match the algorithm @LebedevRI wrote for the Bayer variant. It is also allows for an approx. 3x speed increase.

Note that the initial commit uses a 3x3 sample for reconstruction, and the following one changes this to a 2x2 sample. The 2x2 sample seems to be an improvement, as it provides for more detail, though it also results in more artifacts at edges.

See https://imgur.com/a/cZXa1. First image compares X-Trans LCh in master with the rewrite. The second image is details processed by: 1) master, 2) PR code with 2x2 sample, and 3) the intermediate commit with a 3x3 sample.