### PR TITLE
Do not remove the accels from the module list.

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -533,11 +533,14 @@ void dt_accel_disconnect_locals_iop(dt_iop_module_t *module)
   while(l)
   {
     accel = (dt_accel_t *)l->data;
-    if(accel) gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
-    l = g_slist_delete_link(l, l);
+    if(accel)
+    {
+      g_closure_ref(accel->closure);
+      gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
+    }
+    l = g_slist_next(l);
   }
 
-  module->accel_closures_local = NULL;
   module->local_closures_connected = FALSE;
 }
 


### PR DESCRIPTION
We want to only disconnect the accels from the global accelerators.
This fixes an issue where after closing an IOP and opening it again
the accels where not working.
