### PR TITLE
use HW_PHYSMEM64 if available

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -471,6 +471,8 @@ static inline size_t dt_get_total_memory()
     || defined(__OpenBSD__)
 #if defined(__APPLE__)
   int mib[2] = { CTL_HW, HW_MEMSIZE };
+#elif defined(HW_PHYSMEM64)
+  int mib[2] = { CTL_HW, HW_PHYSMEM64 };
 #else
   int mib[2] = { CTL_HW, HW_PHYSMEM };
 #endif


### PR DESCRIPTION
At least on OpenBSD, HW_PHYSMEM is an int, HW_PHYSMEM64 needs to be used instead to return a 64-bit value. (It looks like NetBSD may also do this).