### PR TITLE
x-trans cleanups

### DIFF
--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -198,7 +198,6 @@ static int process_xtrans(const void *const i, void *o, const dt_iop_roi_t *cons
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  const dt_image_t *img = &self->dev->image_storage;
   dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)self->gui_data;
   const dt_iop_hotpixels_data_t *data = (dt_iop_hotpixels_data_t *)piece->data;
   const float threshold = data->threshold;
@@ -214,7 +213,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   int fixed = 0;
 
-  if(img->filters == 9u)
+  if(piece->pipe->filters == 9u)
   {
     fixed = process_xtrans(i, o, roi_in, width, height, (const uint8_t(*const)[6])piece->pipe->xtrans, threshold,
                            multiplier, markfixed, min_neighbours);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -215,7 +215,7 @@ static void adjust_xtrans_filters(uint8_t (*xtrans)[6], uint32_t crop_x, uint32_
   {
     for(int j = 0; j < 6; ++j)
     {
-      xtrans[j][i] = tmp[j % 6][i % 6];
+      xtrans[j][i] = tmp[j][i];
     }
   }
 }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -199,23 +199,14 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   roi_in->height += (int)roundf((float)y * scale);
 }
 
-static void adjust_xtrans_filters(uint8_t (*xtrans)[6], uint32_t crop_x, uint32_t crop_y)
+static void adjust_xtrans_filters(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe,
+                                  uint32_t crop_x, uint32_t crop_y)
 {
-  uint8_t tmp[6][6];
-
   for(int i = 0; i < 6; ++i)
   {
     for(int j = 0; j < 6; ++j)
     {
-      tmp[j][i] = xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
-    }
-  }
-
-  for(int i = 0; i < 6; ++i)
-  {
-    for(int j = 0; j < 6; ++j)
-    {
-      xtrans[j][i] = tmp[j][i];
+      pipe->xtrans[j][i] = dev->image_storage.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
     }
   }
 }
@@ -259,8 +250,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
 
     piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
-    memcpy(piece->pipe->xtrans, self->dev->image_storage.xtrans, sizeof(self->dev->image_storage.xtrans));
-    adjust_xtrans_filters(piece->pipe->xtrans, csx, csy);
+    adjust_xtrans_filters(self->dev, piece->pipe, csx, csy);
   }
   else
   { // pre-downsampled buffer that needs black/white scaling
@@ -360,8 +350,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
     }
 
     piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
-    memcpy(piece->pipe->xtrans, self->dev->image_storage.xtrans, sizeof(self->dev->image_storage.xtrans));
-    adjust_xtrans_filters(piece->pipe->xtrans, csx, csy);
+    adjust_xtrans_filters(self->dev, piece->pipe, csx, csy);
   }
   else
   { // pre-downsampled buffer that needs black/white scaling
@@ -446,8 +435,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
   {
     piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
-    memcpy(piece->pipe->xtrans, self->dev->image_storage.xtrans, sizeof(self->dev->image_storage.xtrans));
-    adjust_xtrans_filters(piece->pipe->xtrans, csx, csy);
+    adjust_xtrans_filters(self->dev, piece->pipe, csx, csy);
   }
 
   return TRUE;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -199,14 +199,14 @@ void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const d
   roi_in->height += (int)roundf((float)y * scale);
 }
 
-static void adjust_xtrans_filters(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe,
+static void adjust_xtrans_filters(dt_dev_pixelpipe_t *pipe,
                                   uint32_t crop_x, uint32_t crop_y)
 {
   for(int i = 0; i < 6; ++i)
   {
     for(int j = 0; j < 6; ++j)
     {
-      pipe->xtrans[j][i] = dev->image_storage.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
+      pipe->xtrans[j][i] = pipe->image.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
     }
   }
 }
@@ -250,7 +250,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
 
     piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
-    adjust_xtrans_filters(self->dev, piece->pipe, csx, csy);
+    adjust_xtrans_filters(piece->pipe, csx, csy);
   }
   else
   { // pre-downsampled buffer that needs black/white scaling
@@ -350,7 +350,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
     }
 
     piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
-    adjust_xtrans_filters(self->dev, piece->pipe, csx, csy);
+    adjust_xtrans_filters(piece->pipe, csx, csy);
   }
   else
   { // pre-downsampled buffer that needs black/white scaling
@@ -435,7 +435,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
   {
     piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
-    adjust_xtrans_filters(self->dev, piece->pipe, csx, csy);
+    adjust_xtrans_filters(piece->pipe, csx, csy);
   }
 
   return TRUE;


### PR DESCRIPTION
This is a clean-up pass over recent changes to the x-trans code. The aim is to simplify the code while producing no changes to extant behavior.

The first commit removes no-longer used parameters to xtrans_markesteijn_interpolate() and vng_interpolate(). It also consistently uses the filters value from the pixelpipe struct rather than the image struct, and removes an unneeded modulo. None of these should have any functional change to the code.

The second commit is a follow-up to commit 8e859e9b890203eba7dae77bc9f61ab134c4d81e by @LebedevRI, and copies the x-trans CFA while shifting it.

The third commit uses the image struct from the pixelpipe rather than develop struct. These both should have the same data (unshifted x-trans CFA)? It is done in the name of simplifying parameters to adjust_xtrans_filters(). I see no discoloration/race on my testing here, but would very much regret if this went back to the behavior prior to 8e859e9b890203eba7dae77bc9f61ab134c4d81e.