### PR TITLE
opencl: do not alias readonly with writeonly image buffers

### DIFF
--- a/data/kernels/bilateral.cl
+++ b/data/kernels/bilateral.cl
@@ -281,7 +281,7 @@ blur_line(
 kernel void
 slice_to_output(
     read_only  image2d_t in,
-    read_only  image2d_t output,
+    read_only  image2d_t target,
     write_only image2d_t out,
     global float        *grid,
     const int            width,
@@ -307,7 +307,7 @@ slice_to_output(
   float4 sigma = (float4)(sigma_s, sigma_s, sigma_r, 0);
 
   float4 pixel  = read_imagef (in,   samplerc, (int2)(x, y));
-  float4 pixel2 = read_imagef (output, samplerc, (int2)(x, y));
+  float4 pixel2 = read_imagef (target, samplerc, (int2)(x, y));
   float L = pixel.x;
   float4 p = (float4)(x, y, L, 0);
   float4 gridp = image_to_grid(p, size, sigma);

--- a/data/kernels/bilateral.cl
+++ b/data/kernels/bilateral.cl
@@ -281,8 +281,8 @@ blur_line(
 kernel void
 slice_to_output(
     read_only  image2d_t in,
+    read_only  image2d_t output,
     write_only image2d_t out,
-    read_only  image2d_t out2,  // alias.
     global float        *grid,
     const int            width,
     const int            height,
@@ -307,7 +307,7 @@ slice_to_output(
   float4 sigma = (float4)(sigma_s, sigma_s, sigma_r, 0);
 
   float4 pixel  = read_imagef (in,   samplerc, (int2)(x, y));
-  float4 pixel2 = read_imagef (out2, samplerc, (int2)(x, y));
+  float4 pixel2 = read_imagef (output, samplerc, (int2)(x, y));
   float L = pixel.x;
   float4 p = (float4)(x, y, L, 0);
   float4 gridp = image_to_grid(p, size, sigma);

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -326,7 +326,7 @@ denoiseprofile_decompose(read_only image2d_t in, write_only image2d_t coarse, wr
 
 
 kernel void
-denoiseprofile_synthesize(write_only image2d_t out, read_only image2d_t coarse, read_only image2d_t detail,
+denoiseprofile_synthesize(read_only image2d_t coarse, read_only image2d_t detail, write_only image2d_t out, 
      const int width, const int height,
      const float t0, const float t1, const float t2, const float t3,
      const float b0, const float b1, const float b2, const float b3)

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -47,6 +47,14 @@ size_t dt_bilateral_memory_use(const int width,     // width of input image
   return size_x * size_y * size_z * sizeof(float);
 }
 
+// for the CPU path this is just an alias as no additional temp buffer is needed
+size_t dt_bilateral_memory_use2(const int width,
+                                const int height,
+                                const float sigma_s,
+                                const float sigma_r)
+{
+  return dt_bilateral_memory_use(width, height, sigma_s, sigma_r);
+}
 
 size_t dt_bilateral_singlebuffer_size(const int width,     // width of input image
                                       const int height,    // height of input image
@@ -61,6 +69,15 @@ size_t dt_bilateral_singlebuffer_size(const int width,     // width of input ima
   size_t size_z = CLAMPS((int)_z, 4, DT_COMMON_BILATERAL_MAX_RES_R) + 1;
 
   return size_x * size_y * size_z * sizeof(float);
+}
+
+// for the CPU path this is just an alias as no additional temp buffer is needed
+size_t dt_bilateral_singlebuffer_size2(const int width,
+                                       const int height,
+                                       const float sigma_s,
+                                       const float sigma_r)
+{
+  return dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r);
 }
 #endif
 

--- a/src/common/bilateral.h
+++ b/src/common/bilateral.h
@@ -34,10 +34,20 @@ size_t dt_bilateral_memory_use(const int width,      // width of input image
                                const float sigma_s,  // spatial sigma (blur pixel coords)
                                const float sigma_r); // range sigma (blur luma values)
 
+size_t dt_bilateral_memory_use2(const int width,      // width of input image
+                                const int height,     // height of input image
+                                const float sigma_s,  // spatial sigma (blur pixel coords)
+                                const float sigma_r); // range sigma (blur luma values)
+
 size_t dt_bilateral_singlebuffer_size(const int width,      // width of input image
                                       const int height,     // height of input image
                                       const float sigma_s,  // spatial sigma (blur pixel coords)
                                       const float sigma_r); // range sigma (blur luma values)
+
+size_t dt_bilateral_singlebuffer_size2(const int width,      // width of input image
+                                       const int height,     // height of input image
+                                       const float sigma_s,  // spatial sigma (blur pixel coords)
+                                       const float sigma_r); // range sigma (blur luma values)
 
 dt_bilateral_t *dt_bilateral_init(const int width,      // width of input image
                                   const int height,     // height of input image

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -282,7 +282,6 @@ typedef struct dt_blendop_t
   int kernel_blendop_Lab;
   int kernel_blendop_RAW;
   int kernel_blendop_rgb;
-  int kernel_blendop_copy_alpha;
   int kernel_blendop_set_mask;
 } dt_blendop_t;
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -955,19 +955,22 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
     dt_pixelpipe_flow_t pixelpipe_flow = (PIXELPIPE_FLOW_NONE | PIXELPIPE_FLOW_HISTOGRAM_NONE);
 
-    dt_develop_tiling_t tiling = { 0 };
-    dt_develop_tiling_t tiling_blendop = { 0 };
-
     /* get tiling requirement of module */
+    dt_develop_tiling_t tiling = { 0 };
     module->tiling_callback(module, piece, &roi_in, roi_out, &tiling);
 
-    /* get specific requirement for blending */
-    tiling_callback_blendop(module, piece, &roi_in, roi_out, &tiling_blendop);
+    /* does this module involve blending? */
+    if(piece->blendop_data && (dt_develop_blend_params_t *)piece->blendop_data != DEVELOP_MASK_DISABLED)
+    {
+      /* get specific memory requirement for blending */
+      dt_develop_tiling_t tiling_blendop = { 0 };
+      tiling_callback_blendop(module, piece, &roi_in, roi_out, &tiling_blendop);
 
-    /* aggregate in structure tiling */
-    tiling.factor = fmax(tiling.factor, tiling_blendop.factor);
-    tiling.maxbuf = fmax(tiling.maxbuf, tiling_blendop.maxbuf);
-    tiling.overhead = fmax(tiling.overhead, tiling_blendop.overhead);
+      /* aggregate in structure tiling */
+      tiling.factor = fmax(tiling.factor, tiling_blendop.factor);
+      tiling.maxbuf = fmax(tiling.maxbuf, tiling_blendop.maxbuf);
+      tiling.overhead = fmax(tiling.overhead, tiling_blendop.overhead);
+    }
 
     /* remark: we do not do tiling for blendop step, neither in opencl nor on cpu. if overall tiling
        requirements (maximum of module and blendop) require tiling for opencl path, then following blend

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -506,9 +506,9 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
   const size_t basebuffer = width * height * channels * sizeof(float);
 
-  tiling->factor = 2.0f + (float)dt_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer;
+  tiling->factor = 2.0f + (float)dt_bilateral_memory_use2(width, height, sigma_s, sigma_r) / basebuffer;
   tiling->maxbuf
-      = fmax(1.0f, (float)dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r) / basebuffer);
+      = fmax(1.0f, (float)dt_bilateral_singlebuffer_size2(width, height, sigma_s, sigma_r) / basebuffer);
   tiling->overhead = 0;
   tiling->overlap = ceilf(4 * sigma_s);
   tiling->xalign = 1;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -205,7 +205,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   sizes[1] = ROUNDUPHT(height);
   sizes[2] = 1;
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_invert, 0, sizeof(cl_mem), (void *)&dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_invert, 1, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_invert, 1, sizeof(cl_mem), (void *)&dev_tmp);
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_invert, 2, sizeof(int), (void *)&width);
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_invert, 3, sizeof(int), (void *)&height);
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_highpass_invert, sizes);
@@ -220,8 +220,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     local[0] = blocksize;
     local[1] = 1;
     local[2] = 1;
-    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 0, sizeof(cl_mem), (void *)&dev_out);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 1, sizeof(cl_mem), (void *)&dev_tmp);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 0, sizeof(cl_mem), (void *)&dev_tmp);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 1, sizeof(cl_mem), (void *)&dev_out);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 2, sizeof(cl_mem), (void *)&dev_m);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 3, sizeof(int), (void *)&wdh);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_hblur, 4, sizeof(int), (void *)&width);
@@ -239,8 +239,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     local[0] = 1;
     local[1] = blocksize;
     local[2] = 1;
-    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 0, sizeof(cl_mem), (void *)&dev_tmp);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 1, sizeof(cl_mem), (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 0, sizeof(cl_mem), (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 1, sizeof(cl_mem), (void *)&dev_tmp);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 2, sizeof(cl_mem), (void *)&dev_m);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 3, sizeof(int), (void *)&wdh);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_vblur, 4, sizeof(int), (void *)&width);
@@ -251,12 +251,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(err != CL_SUCCESS) goto error;
   }
 
-  /* mixing out and in -> out */
+  /* mixing tmp and in -> out */
   sizes[0] = ROUNDUPWD(width);
   sizes[1] = ROUNDUPHT(height);
   sizes[2] = 1;
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_mix, 0, sizeof(cl_mem), (void *)&dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_mix, 1, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_mix, 1, sizeof(cl_mem), (void *)&dev_tmp);
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_mix, 2, sizeof(cl_mem), (void *)&dev_out);
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_mix, 3, sizeof(int), (void *)&width);
   dt_opencl_set_kernel_arg(devid, gd->kernel_highpass_mix, 4, sizeof(int), (void *)&height);

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -234,6 +234,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   cl_mem dev_ccoeffs = NULL;
   cl_mem dev_lm = NULL;
   cl_mem dev_lcoeffs = NULL;
+  cl_mem dev_tmp = NULL;
 
   dt_gaussian_cl_t *g = NULL;
   dt_bilateral_cl_t *b = NULL;
@@ -274,20 +275,30 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     b = NULL; // make sure we don't clean it up twice
   }
 
+  dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
+  if(dev_tmp == NULL) goto error;
+
   dev_cm = dt_opencl_copy_host_to_device(devid, d->ctable, 256, 256, sizeof(float));
   if(dev_cm == NULL) goto error;
+
   dev_ccoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->cunbounded_coeffs);
   if(dev_ccoeffs == NULL) goto error;
+
   dev_lm = dt_opencl_copy_host_to_device(devid, d->ltable, 256, 256, sizeof(float));
   if(dev_lm == NULL) goto error;
+
   dev_lcoeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->lunbounded_coeffs);
   if(dev_lcoeffs == NULL) goto error;
 
+  size_t origin[] = { 0, 0, 0 };
+  size_t region[] = { width, height, 1 };
+  err = dt_opencl_enqueue_copy_image(devid, dev_out, dev_tmp, origin, origin, region);
+  if(err != CL_SUCCESS) goto error;
 
   sizes[0] = ROUNDUPWD(width);
   sizes[1] = ROUNDUPWD(height);
   sizes[2] = 1;
-  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 0, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 0, sizeof(cl_mem), (void *)&dev_tmp);
   dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 1, sizeof(cl_mem), (void *)&dev_out);
   dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 2, sizeof(int), (void *)&width);
   dt_opencl_set_kernel_arg(devid, gd->kernel_lowpass_mix, 3, sizeof(int), (void *)&height);
@@ -301,10 +312,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_lowpass_mix, sizes);
   if(err != CL_SUCCESS) goto error;
 
-  if(dev_lcoeffs != NULL) dt_opencl_release_mem_object(dev_lcoeffs);
-  if(dev_lm != NULL) dt_opencl_release_mem_object(dev_lm);
-  if(dev_ccoeffs != NULL) dt_opencl_release_mem_object(dev_ccoeffs);
-  if(dev_cm != NULL) dt_opencl_release_mem_object(dev_cm);
+  dt_opencl_release_mem_object(dev_tmp);
+  dt_opencl_release_mem_object(dev_lcoeffs);
+  dt_opencl_release_mem_object(dev_lm);
+  dt_opencl_release_mem_object(dev_ccoeffs);
+  dt_opencl_release_mem_object(dev_cm);
 
   return TRUE;
 
@@ -312,6 +324,7 @@ error:
   if(g) dt_gaussian_free_cl(g);
   if(b) dt_bilateral_free_cl(b);
 
+  if(dev_tmp != NULL) dt_opencl_release_mem_object(dev_tmp);
   if(dev_lcoeffs != NULL) dt_opencl_release_mem_object(dev_lcoeffs);
   if(dev_lm != NULL) dt_opencl_release_mem_object(dev_lm);
   if(dev_ccoeffs != NULL) dt_opencl_release_mem_object(dev_ccoeffs);
@@ -341,14 +354,14 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   if(d->lowpass_algo == LOWPASS_ALGO_BILATERAL)
   {
     // bilateral filter
-    tiling->factor = 2.0f + (float)dt_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer;
+    tiling->factor = 2.0f + fmax(1.0f, (float)dt_bilateral_memory_use(width, height, sigma_s, sigma_r) / basebuffer);
     tiling->maxbuf
         = fmax(1.0f, (float)dt_bilateral_singlebuffer_size(width, height, sigma_s, sigma_r) / basebuffer);
   }
   else
   {
     // gaussian blur
-    tiling->factor = 2.0f + (float)dt_gaussian_memory_use(width, height, channels) / basebuffer;
+    tiling->factor = 2.0f + fmax(1.0f, (float)dt_gaussian_memory_use(width, height, channels) / basebuffer);
     tiling->maxbuf = fmax(1.0f, (float)dt_gaussian_singlebuffer_size(width, height, channels) / basebuffer);
   }
   tiling->overhead = 0;

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -222,7 +222,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   size_t sizes[2] = { ROUNDUPWD(width), ROUNDUPHT(height) };
   dt_opencl_set_kernel_arg(devid, gd->kernel_monochrome_filter, 0, sizeof(cl_mem), &dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_monochrome_filter, 1, sizeof(cl_mem), &dev_tmp);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_monochrome_filter, 1, sizeof(cl_mem), &dev_out);
   dt_opencl_set_kernel_arg(devid, gd->kernel_monochrome_filter, 2, sizeof(int), &width);
   dt_opencl_set_kernel_arg(devid, gd->kernel_monochrome_filter, 3, sizeof(int), &height);
   dt_opencl_set_kernel_arg(devid, gd->kernel_monochrome_filter, 4, sizeof(float), &d->a);
@@ -231,11 +231,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_monochrome_filter, sizes);
   if(err != CL_SUCCESS) goto error;
 
-  err = dt_bilateral_splat_cl(b, dev_tmp);
+  err = dt_bilateral_splat_cl(b, dev_out);
   if(err != CL_SUCCESS) goto error;
   err = dt_bilateral_blur_cl(b);
   if(err != CL_SUCCESS) goto error;
-  err = dt_bilateral_slice_cl(b, dev_tmp, dev_tmp, detail);
+  err = dt_bilateral_slice_cl(b, dev_out, dev_tmp, detail);
   if(err != CL_SUCCESS) goto error;
   dt_bilateral_free_cl(b);
   b = NULL; // make sure we don't do double cleanup in case the next few lines err out

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -469,7 +469,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   sizes[1] = ROUNDUPHT(height);
   sizes[2] = 1;
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_overexposed, 0, sizeof(cl_mem), (void *)&dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_soften_overexposed, 1, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_soften_overexposed, 1, sizeof(cl_mem), (void *)&dev_tmp);
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_overexposed, 2, sizeof(int), (void *)&width);
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_overexposed, 3, sizeof(int), (void *)&height);
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_overexposed, 4, sizeof(float), (void *)&saturation);
@@ -486,8 +486,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     local[0] = blocksize;
     local[1] = 1;
     local[2] = 1;
-    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 0, sizeof(cl_mem), (void *)&dev_out);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 1, sizeof(cl_mem), (void *)&dev_tmp);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 0, sizeof(cl_mem), (void *)&dev_tmp);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 1, sizeof(cl_mem), (void *)&dev_out);
     dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 2, sizeof(cl_mem), (void *)&dev_m);
     dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 3, sizeof(int), (void *)&wdh);
     dt_opencl_set_kernel_arg(devid, gd->kernel_soften_hblur, 4, sizeof(int), (void *)&width);
@@ -506,8 +506,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     local[0] = 1;
     local[1] = blocksize;
     local[2] = 1;
-    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 0, sizeof(cl_mem), (void *)&dev_tmp);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 1, sizeof(cl_mem), (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 0, sizeof(cl_mem), (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 1, sizeof(cl_mem), (void *)&dev_tmp);
     dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 2, sizeof(cl_mem), (void *)&dev_m);
     dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 3, sizeof(int), (void *)&wdh);
     dt_opencl_set_kernel_arg(devid, gd->kernel_soften_vblur, 4, sizeof(int), (void *)&width);
@@ -519,12 +519,12 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(err != CL_SUCCESS) goto error;
   }
 
-  /* mixing out and in -> out */
+  /* mixing tmp and in -> out */
   sizes[0] = ROUNDUPWD(width);
   sizes[1] = ROUNDUPHT(height);
   sizes[2] = 1;
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_mix, 0, sizeof(cl_mem), (void *)&dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_soften_mix, 1, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_soften_mix, 1, sizeof(cl_mem), (void *)&dev_tmp);
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_mix, 2, sizeof(cl_mem), (void *)&dev_out);
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_mix, 3, sizeof(int), (void *)&width);
   dt_opencl_set_kernel_arg(devid, gd->kernel_soften_mix, 4, sizeof(int), (void *)&height);


### PR DESCRIPTION
in several places we circumvent the ocl-1.x limitation to offer only
readonly and writeonly image objects by using aliases for the same buffer.
according to the ocl-1.2 standard this is no longer allowed and effectively
seems to lead to corrupted output in some opencl implementations (namely not in
NVIDIA and AMD drivers).
