### PR TITLE
hotpixels for x-trans bugfix and misc. fixups

### DIFF
--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -179,10 +179,21 @@ static int process_xtrans(const void *const ivoid, void *const ovoid,
           fixed++;
           if(markfixed)
           {
-            // cheat and mark all colors of pixels
-            // FIXME: use offsets
-            for(int i = -2; i >= -10 && i >= -col; --i) out[i] = *in;
-            for(int i = 2; i <= 10 && i < width - col; ++i) out[i] = *in;
+            const uint8_t c = FCxtrans(row, col, roi_out, xtrans);
+            for(int i = -2; i >= -10 && i >= -col; --i)
+            {
+              if(c == FCxtrans(row, col+i, roi_out, xtrans))
+              {
+                out[i] = *in;
+              }
+            }
+            for(int i = 2; i <= 10 && i < width - col; ++i)
+            {
+              if(c == FCxtrans(row, col+i, roi_out, xtrans))
+              {
+                out[i] = *in;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This fixes a bug reported by Marc Cousin which causes the hotpixels iop to erroneously alter non-hot pixels in areas of saturated color. Note that, as a commit message states, this may alter the behavior of the iop for given threshold/strength values. This bug was present from the initial x-trans implementation of hotpixels.

The PR also contains some other misc. code fixups/clarifications, and makes the marking of fixed x-trans pixels be less visually noisy.