### PR TITLE
Sliders: input enhancement (keyboard arrows, modifiers)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1695,7 +1695,7 @@
     <type>float</type>
     <default>1.0</default>
     <shortdescription>the multiplier that is applied to any slider value change</shortdescription>
-    <longdescription>any slider value change will be multiplied by this number, when changing slider while NOT holding SHIFT modifier</longdescription>
+    <longdescription>any slider value change will be multiplied by this number, when changing slider while NOT holding SHIFT or CTRL modifiers</longdescription>
   </dtconfig>
   <dtconfig>
     <name>darkroom/ui/scale_rough_step_multiplier</name>
@@ -1703,5 +1703,12 @@
     <default>10.0</default>
     <shortdescription>the multiplier that is applied to any slider rough value change</shortdescription>
     <longdescription>any slider value change will be multiplied by this number, when changing slider while holding SHIFT modifier</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>darkroom/ui/scale_precise_step_multiplier</name>
+    <type>float</type>
+    <default>0.1</default>
+    <shortdescription>the multiplier that is applied to any slider precise value change</shortdescription>
+    <longdescription>any slider value change will be multiplied by this number, when changing slider while holding CTRL modifier</longdescription>
   </dtconfig>
 </dtconfiglist>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1689,4 +1689,19 @@
   </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
+
+  <dtconfig>
+    <name>darkroom/ui/scale_step_multiplier</name>
+    <type>float</type>
+    <default>1.0</default>
+    <shortdescription>the multiplier that is applied to any slider value change</shortdescription>
+    <longdescription>any slider value change will be multiplied by this number, when changing slider while NOT holding SHIFT modifier</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>darkroom/ui/scale_rough_step_multiplier</name>
+    <type>float</type>
+    <default>10.0</default>
+    <shortdescription>the multiplier that is applied to any slider rough value change</shortdescription>
+    <longdescription>any slider value change will be multiplied by this number, when changing slider while holding SHIFT modifier</longdescription>
+  </dtconfig>
 </dtconfiglist>

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1812,14 +1812,23 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
   }
   if(handled)
   {
-    if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    float multiplier;
+
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+    if((event->state & modifiers) == GDK_SHIFT_MASK)
     {
-      delta *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+      multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+    }
+    else if((event->state & modifiers) == GDK_CONTROL_MASK)
+    {
+      multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
     }
     else
     {
-      delta *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+      multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
     }
+
+    delta *= multiplier;
 
     if(w->module) dt_iop_request_focus(w->module);
     dt_bauhaus_slider_set_normalized(w, d->pos + delta);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -649,6 +649,7 @@ void dt_bauhaus_cleanup()
 static gboolean dt_bauhaus_slider_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
 static gboolean dt_bauhaus_slider_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
 static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer user_data);
+static gboolean dt_bauhaus_slider_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data);
 static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data);
 static gboolean dt_bauhaus_slider_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data);
 
@@ -945,11 +946,15 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
   d->timeout_handle = 0;
   d->callback = _default_linear_callback;
 
+  gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_PRESS_MASK);
+  gtk_widget_set_can_focus(GTK_WIDGET(w), TRUE);
+
   g_signal_connect(G_OBJECT(w), "button-press-event", G_CALLBACK(dt_bauhaus_slider_button_press),
                    (gpointer)NULL);
   g_signal_connect(G_OBJECT(w), "button-release-event", G_CALLBACK(dt_bauhaus_slider_button_release),
                    (gpointer)NULL);
   g_signal_connect(G_OBJECT(w), "scroll-event", G_CALLBACK(dt_bauhaus_slider_scroll), (gpointer)NULL);
+  g_signal_connect(G_OBJECT(w), "key-press-event", G_CALLBACK(dt_bauhaus_slider_key_press), (gpointer)NULL);
   g_signal_connect(G_OBJECT(w), "motion-notify-event", G_CALLBACK(dt_bauhaus_slider_motion_notify),
                    (gpointer)NULL);
   g_signal_connect(G_OBJECT(w), "leave-notify-event", G_CALLBACK(dt_bauhaus_slider_leave_notify),
@@ -1837,6 +1842,52 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
   return FALSE;
 }
 
+static gboolean dt_bauhaus_slider_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
+  if(w->type != DT_BAUHAUS_SLIDER) return FALSE;
+  dt_bauhaus_slider_data_t *d = &w->data.slider;
+  int handled = 0;
+  float delta = 0.0f;
+  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up || event->keyval == GDK_KEY_Right
+     || event->keyval == GDK_KEY_KP_Right)
+  {
+    handled = 1;
+    delta = d->scale / 5.0f;
+  }
+  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down || event->keyval == GDK_KEY_Left
+          || event->keyval == GDK_KEY_KP_Left)
+  {
+    handled = 1;
+    delta = -d->scale / 5.0f;
+  }
+  if(handled)
+  {
+    float multiplier;
+
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+    if((event->state & modifiers) == GDK_SHIFT_MASK)
+    {
+      multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+    }
+    else if((event->state & modifiers) == GDK_CONTROL_MASK)
+    {
+      multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
+    }
+    else
+    {
+      multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+    }
+
+    delta *= multiplier;
+
+    if(w->module) dt_iop_request_focus(w->module);
+    dt_bauhaus_slider_set_normalized(w, d->pos + delta);
+    return TRUE;
+  }
+  return FALSE;
+}
+
 
 static gboolean dt_bauhaus_combobox_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
@@ -2249,6 +2300,7 @@ static gboolean dt_bauhaus_slider_motion_notify(GtkWidget *widget, GdkEventMotio
     const float r = 1.0f - (tmp.height + 4.0f) / tmp.width;
     dt_bauhaus_slider_set_normalized(w, (event->x / tmp.width - l) / (r - l));
   }
+  gtk_widget_grab_focus(widget);
   // not sure if needed:
   // gdk_event_request_motions(event);
   return TRUE;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1798,16 +1798,31 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   if(w->type != DT_BAUHAUS_SLIDER) return FALSE;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+  int handled = 0;
+  float delta = 0.0f;
   if(event->direction == GDK_SCROLL_UP)
   {
-    if(w->module) dt_iop_request_focus(w->module);
-    dt_bauhaus_slider_set_normalized(w, d->pos + d->scale / 5.0f);
-    return TRUE;
+    handled = 1;
+    delta = d->scale / 5.0f;
   }
   else if(event->direction == GDK_SCROLL_DOWN)
   {
+    handled = 1;
+    delta = -d->scale / 5.0f;
+  }
+  if(handled)
+  {
+    if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    {
+      delta *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+    }
+    else
+    {
+      delta *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+    }
+
     if(w->module) dt_iop_request_focus(w->module);
-    dt_bauhaus_slider_set_normalized(w, d->pos - d->scale / 5.0f);
+    dt_bauhaus_slider_set_normalized(w, d->pos + delta);
     return TRUE;
   }
   return FALSE;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1798,11 +1798,42 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
   gtk_widget_grab_focus(darktable.bauhaus->popup_area);
 }
 
+static gboolean dt_bauhaus_slider_add_delta_internal(GtkWidget *widget, float delta, guint state)
+{
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
+  dt_bauhaus_slider_data_t *d = &w->data.slider;
+
+  float multiplier;
+
+  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  if((state & modifiers) == GDK_SHIFT_MASK)
+  {
+    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+  }
+  else if((state & modifiers) == GDK_CONTROL_MASK)
+  {
+    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
+  }
+  else
+  {
+    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+  }
+
+  delta *= multiplier;
+
+  if(w->module) dt_iop_request_focus(w->module);
+
+  dt_bauhaus_slider_set_normalized(w, d->pos + delta);
+
+  return TRUE;
+}
+
 static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   if(w->type != DT_BAUHAUS_SLIDER) return FALSE;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+
   int handled = 0;
   float delta = 0.0f;
   if(event->direction == GDK_SCROLL_UP)
@@ -1815,31 +1846,10 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
     handled = 1;
     delta = -d->scale / 5.0f;
   }
-  if(handled)
-  {
-    float multiplier;
 
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    if((event->state & modifiers) == GDK_SHIFT_MASK)
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-    }
-    else if((event->state & modifiers) == GDK_CONTROL_MASK)
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-    }
-    else
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-    }
+  if(!handled) return FALSE;
 
-    delta *= multiplier;
-
-    if(w->module) dt_iop_request_focus(w->module);
-    dt_bauhaus_slider_set_normalized(w, d->pos + delta);
-    return TRUE;
-  }
-  return FALSE;
+  return dt_bauhaus_slider_add_delta_internal(widget, delta, event->state);
 }
 
 static gboolean dt_bauhaus_slider_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
@@ -1847,6 +1857,7 @@ static gboolean dt_bauhaus_slider_key_press(GtkWidget *widget, GdkEventKey *even
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   if(w->type != DT_BAUHAUS_SLIDER) return FALSE;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+
   int handled = 0;
   float delta = 0.0f;
   if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up || event->keyval == GDK_KEY_Right
@@ -1861,31 +1872,10 @@ static gboolean dt_bauhaus_slider_key_press(GtkWidget *widget, GdkEventKey *even
     handled = 1;
     delta = -d->scale / 5.0f;
   }
-  if(handled)
-  {
-    float multiplier;
 
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    if((event->state & modifiers) == GDK_SHIFT_MASK)
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-    }
-    else if((event->state & modifiers) == GDK_CONTROL_MASK)
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-    }
-    else
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-    }
+  if(!handled) return FALSE;
 
-    delta *= multiplier;
-
-    if(w->module) dt_iop_request_focus(w->module);
-    dt_bauhaus_slider_set_normalized(w, d->pos + delta);
-    return TRUE;
-  }
-  return FALSE;
+  return dt_bauhaus_slider_add_delta_internal(widget, delta, event->state);
 }
 
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -867,16 +867,24 @@ static gboolean dt_iop_basecurve_key_press(GtkWidget *widget, GdkEventKey *event
 
     if(handled)
     {
-      if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      float multiplier;
+
+      GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+      if((event->state & modifiers) == GDK_SHIFT_MASK)
       {
-        dx *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-        dy *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+        multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+      }
+      else if((event->state & modifiers) == GDK_CONTROL_MASK)
+      {
+        multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
       }
       else
       {
-        dx *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-        dy *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+        multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
       }
+
+      dx *= multiplier;
+      dy *= multiplier;
 
       basecurve[c->selected].x = CLAMP(basecurve[c->selected].x + dx, 0.0f, 1.0f);
       basecurve[c->selected].y = CLAMP(basecurve[c->selected].y + dy, 0.0f, 1.0f);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -481,6 +481,8 @@ static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScrol
   return TRUE;
 }
 
+#define COLORCORRECTION_DEFAULT_STEP (0.5f)
+
 static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -493,35 +495,46 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
   if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
   {
     handled = 1;
-    dy = 0.5f;
+    dy = COLORCORRECTION_DEFAULT_STEP;
   }
   else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
   {
     handled = 1;
-    dy = -0.5f;
+    dy = -COLORCORRECTION_DEFAULT_STEP;
   }
   else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
   {
     handled = 1;
-    dx = 0.5f;
+    dx = COLORCORRECTION_DEFAULT_STEP;
   }
   else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
   {
     handled = 1;
-    dx = -0.5f;
+    dx = -COLORCORRECTION_DEFAULT_STEP;
   }
 
   if(handled)
   {
+    if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    {
+      dx *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+      dy *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+    }
+    else
+    {
+      dx *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+      dy *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+    }
+
     switch(g->selected)
     {
       case 1: // only set lo
-        p->loa += dx;
-        p->lob += dy;
+        p->loa = CLAMP(p->loa + dx, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
+        p->lob = CLAMP(p->lob + dy, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
         break;
       case 2: // only set hi
-        p->hia += dx;
-        p->hib += dy;
+        p->hia = CLAMP(p->hia + dx, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
+        p->hib = CLAMP(p->hib + dy, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
         break;
     }
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -515,16 +515,24 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
   if(handled)
   {
-    if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    float multiplier;
+
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+    if((event->state & modifiers) == GDK_SHIFT_MASK)
     {
-      dx *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-      dy *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+      multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+    }
+    else if((event->state & modifiers) == GDK_CONTROL_MASK)
+    {
+      multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
     }
     else
     {
-      dx *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-      dy *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+      multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
     }
+
+    dx *= multiplier;
+    dy *= multiplier;
 
     switch(g->selected)
     {

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -249,6 +249,7 @@ static gboolean dt_iop_colorcorrection_button_press(GtkWidget *widget, GdkEventB
 static gboolean dt_iop_colorcorrection_leave_notify(GtkWidget *widget, GdkEventCrossing *event,
                                                     gpointer user_data);
 static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data);
+static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data);
 
 void gui_init(struct dt_iop_module_t *self)
 {
@@ -265,8 +266,9 @@ void gui_init(struct dt_iop_module_t *self)
                                                      "use mouse wheel to change saturation."));
 
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
-                                             | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+                                                 | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
+                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK | GDK_KEY_PRESS_MASK);
+  gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_colorcorrection_draw), self);
   g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(dt_iop_colorcorrection_button_press),
                    self);
@@ -275,6 +277,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(dt_iop_colorcorrection_leave_notify),
                    self);
   g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(dt_iop_colorcorrection_scrolled), self);
+  g_signal_connect(G_OBJECT(g->area), "key-press-event", G_CALLBACK(dt_iop_colorcorrection_key_press), self);
 
   g->slider = dt_bauhaus_slider_new_with_range(self, -3.0f, 3.0f, 0.01f, 1.0f, 2);
   gtk_box_pack_start(GTK_BOX(self->widget), g->slider, TRUE, TRUE, 0);
@@ -422,6 +425,7 @@ static gboolean dt_iop_colorcorrection_motion_notify(GtkWidget *widget, GdkEvent
     else if(disthi < thrs * thrs && disthi <= distlo)
       g->selected = 2;
   }
+  if(g->selected > 0) gtk_widget_grab_focus(widget);
   gtk_widget_queue_draw(self->widget);
   return TRUE;
 }
@@ -474,6 +478,57 @@ static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScrol
   if(event->direction == GDK_SCROLL_DOWN && p->saturation < 3.0) p->saturation -= 0.1;
   dt_bauhaus_slider_set(g->slider, p->saturation);
   gtk_widget_queue_draw(widget);
+  return TRUE;
+}
+
+static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
+  if(g->selected < 1) return FALSE;
+
+  int handled = 0;
+  float dx = 0.0f, dy = 0.0f;
+  if(event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_KP_Up)
+  {
+    handled = 1;
+    dy = 0.5f;
+  }
+  else if(event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_KP_Down)
+  {
+    handled = 1;
+    dy = -0.5f;
+  }
+  else if(event->keyval == GDK_KEY_Right || event->keyval == GDK_KEY_KP_Right)
+  {
+    handled = 1;
+    dx = 0.5f;
+  }
+  else if(event->keyval == GDK_KEY_Left || event->keyval == GDK_KEY_KP_Left)
+  {
+    handled = 1;
+    dx = -0.5f;
+  }
+
+  if(handled)
+  {
+    switch(g->selected)
+    {
+      case 1: // only set lo
+        p->loa += dx;
+        p->lob += dy;
+        break;
+      case 2: // only set hi
+        p->hia += dx;
+        p->hib += dy;
+        break;
+    }
+
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+    gtk_widget_queue_draw(widget);
+  }
+
   return TRUE;
 }
 

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -513,42 +513,41 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
     dx = -COLORCORRECTION_DEFAULT_STEP;
   }
 
-  if(handled)
+  if(!handled) return TRUE;
+
+  float multiplier;
+
+  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  if((event->state & modifiers) == GDK_SHIFT_MASK)
   {
-    float multiplier;
-
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    if((event->state & modifiers) == GDK_SHIFT_MASK)
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-    }
-    else if((event->state & modifiers) == GDK_CONTROL_MASK)
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
-    }
-    else
-    {
-      multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-    }
-
-    dx *= multiplier;
-    dy *= multiplier;
-
-    switch(g->selected)
-    {
-      case 1: // only set lo
-        p->loa = CLAMP(p->loa + dx, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
-        p->lob = CLAMP(p->lob + dy, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
-        break;
-      case 2: // only set hi
-        p->hia = CLAMP(p->hia + dx, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
-        p->hib = CLAMP(p->hib + dy, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
-        break;
-    }
-
-    dt_dev_add_history_item(darktable.develop, self, TRUE);
-    gtk_widget_queue_draw(widget);
+    multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
   }
+  else if((event->state & modifiers) == GDK_CONTROL_MASK)
+  {
+    multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
+  }
+  else
+  {
+    multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+  }
+
+  dx *= multiplier;
+  dy *= multiplier;
+
+  switch(g->selected)
+  {
+    case 1: // only set lo
+      p->loa = CLAMP(p->loa + dx, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
+      p->lob = CLAMP(p->lob + dy, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
+      break;
+    case 2: // only set hi
+      p->hia = CLAMP(p->hia + dx, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
+      p->hib = CLAMP(p->hib + dy, -DT_COLORCORRECTION_MAX, DT_COLORCORRECTION_MAX);
+      break;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  gtk_widget_queue_draw(widget);
 
   return TRUE;
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -787,16 +787,24 @@ static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget, GdkEventKey *event
 
     if(handled)
     {
-      if((event->state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      float multiplier;
+
+      GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+      if((event->state & modifiers) == GDK_SHIFT_MASK)
       {
-        dx *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
-        dy *= dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+        multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+      }
+      else if((event->state & modifiers) == GDK_CONTROL_MASK)
+      {
+        multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
       }
       else
       {
-        dx *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
-        dy *= dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+        multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
       }
+
+      dx *= multiplier;
+      dy *= multiplier;
 
       tonecurve[c->selected].x = CLAMP(tonecurve[c->selected].x + dx, 0.0f, 1.0f);
       tonecurve[c->selected].y = CLAMP(tonecurve[c->selected].y + dy, 0.0f, 1.0f);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -737,12 +737,44 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 
   if(c->selected >= 0)
   {
+    int handled = 0;
+    float dy = 0.0f;
     if(event->direction == GDK_SCROLL_UP)
-      tonecurve[c->selected].y = MAX(0.0f, tonecurve[c->selected].y + TONECURVE_DEFAULT_STEP);
+    {
+      handled = 1;
+      dy = TONECURVE_DEFAULT_STEP;
+    }
     if(event->direction == GDK_SCROLL_DOWN)
-      tonecurve[c->selected].y = MIN(1.0f, tonecurve[c->selected].y - TONECURVE_DEFAULT_STEP);
-    dt_dev_add_history_item(darktable.develop, self, TRUE);
-    gtk_widget_queue_draw(widget);
+    {
+      handled = 1;
+      dy = -TONECURVE_DEFAULT_STEP;
+    }
+
+    if(handled)
+    {
+      float multiplier;
+
+      GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+      if((event->state & modifiers) == GDK_SHIFT_MASK)
+      {
+        multiplier = dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+      }
+      else if((event->state & modifiers) == GDK_CONTROL_MASK)
+      {
+        multiplier = dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
+      }
+      else
+      {
+        multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+      }
+
+      dy *= multiplier;
+
+      tonecurve[c->selected].y = CLAMP(tonecurve[c->selected].y + dy, 0.0f, 1.0f);
+
+      dt_dev_add_history_item(darktable.develop, self, TRUE);
+      gtk_widget_queue_draw(widget);
+    }
   }
   return TRUE;
 }


### PR DESCRIPTION
- Adds 3 config options: (config-only, not exposed in gui)
  - `darkroom/ui/scale_step_multiplier`, with default value of _1.0_
  - `darkroom/ui/scale_rough_step_multiplier`, default value of _10.0_
  - `darkroom/ui/scale_precise_step_multiplier`, with default value of _0.1_
- **Bauhaus slider**:
  - Allow to chage slider values with keyboard arrows [#11043](https://redmine.darktable.org/issues/11043)
    - up/right arrow == increase slider value
    - down/left arrow == decrease slider value
- **Tonecurve iop** / **Basecurve iop** /  **Color correction iop**:
  - Allow to move currently-selected curve point with keyboard arrows
    - up arrow == increase point's _y_ coordinate
    - down arrow == decrease point's _y_ coordinate
    - right arrow == increase point's _x_ coordinate
    - left arrow == decrease point's _x_ coordinate
- When changing values (either arrows, or scroll):
  - if `<SHIFT>` is pressed, multiply delta by `darkroom/ui/scale_rough_step_multiplier` - effectively increases slider's step
  - if `<CTRL>` is pressed, multiply delta by `darkroom/ui/scale_precise_step_multiplier` - effectively decreases slider's step
  - else, multiply delta by `darkroom/ui/scale_step_multiplier` - user-configurable multiplier for all bauhaus slider steps
  * FIXME(?): this only happens for **bauhaus slider**, **gradient slider (parametric mask)** and those 3 iop's. It probably should happen for some other widgets too...

* FIXME(?): additional, per-module (`view/module .so name/scale_multiplier`) ?


(arrows here mean both normal arrows, and arrows located on additional KB block (`GDK_KEY_Down` vs. `GDK_KEY_KP_Down`))