### PR TITLE
rawspeed: add 16:9 and 3:2 mode to Panasonic DMC-FZ18 (fix #10856)

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -5005,6 +5005,28 @@
 		<Crop x="10" y="0" width="-30" height="-1"/>
 		<Sensor black="0" white="3986"/>
 	</Camera>
+	<Camera make="Panasonic" model="DMC-FZ18" mode="16:9">
+		<ID make="Panasonic" model="DMC-FZ18">Panasonic DMC-FZ18</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="9" y="0" width="-31" height="0"/>
+		<Sensor black="0" white="3986"/>
+	</Camera>
+	<Camera make="Panasonic" model="DMC-FZ18" mode="3:2">
+		<ID make="Panasonic" model="DMC-FZ18">Panasonic DMC-FZ18</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">BLUE</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">RED</Color>
+		</CFA>
+		<Crop x="9" y="0" width="-31" height="0"/>
+		<Sensor black="0" white="3986"/>
+	</Camera>
 	<Camera make="Panasonic" model="DMC-L1" decoder_version="2">
 		<ID make="Panasonic" model="DMC-L1">Panasonic DMC-L1</ID>
 		<CFA width="2" height="2">


### PR DESCRIPTION
https://redmine.darktable.org/issues/10856

Mode 1:1 is missing as there is no sample provided

tools/dngmeta.sh would create
> 	<Camera make="Panasonic" model="DMC-FZ18" mode="3:2">
> 		<ID make="Panasonic" model="DMC-FZ18">Panasonic DMC-FZ18</ID>
> 		<CFA width="2" height="2">
> 			<Color x="0" y="0">GREEN</Color>
> 			<Color x="1" y="0">BLUE</Color>
> 			<Color x="0" y="1">RED</Color>
> 			<Color x="1" y="1">GREEN</Color>
> 		</CFA>
> 		<Crop x="0" y="0" width="0" height="0"/>
> 		<Sensor black="0" white="3986"/>
> 	</Camera>
but this results in a magenta image. Correcting the colors like they were in 4:3 the image is ok.

1) Why does dngmeta.sh give a wrong color order? 
2) do you want to merge also 1:1 is missing?