### PR TITLE
Updates to manual & doxygen

### DIFF
--- a/doc/doxygen.conf
+++ b/doc/doxygen.conf
@@ -307,7 +307,7 @@ EXTRACT_PRIVATE        = NO
 # If the EXTRACT_STATIC tag is set to YES all static members of a file
 # will be included in the documentation.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES classes (and structs)
 # defined locally in source files will be included in the documentation.

--- a/doc/usermanual/lighttable/panels/export.xml
+++ b/doc/usermanual/lighttable/panels/export.xml
@@ -320,7 +320,7 @@
       <para>
         <emphasis>Caution: for various reasons embedding XMP tags into output files may fail
         without notice, eg. if certain size limits are exceeded. Users are therefore advised to
-        not rely their backup strategy on this feature. To backup your data make sure to save
+        not rely their backup strategy on this feature. To back up your data make sure to save
         your input (raw) file as well as all of darktable's XMP sidecar files.</emphasis>
       </para>
 
@@ -405,7 +405,7 @@
         darktable combines with the existing history stack to generate the output image. These
         history items are only added temporarily; the original history stack is not overwritten.
         You can use this feature to add processing steps and parameters that you want to be
-        applied specifically to exported images, e.g. you may define a style that adds a
+        applied specifically to images before export, e.g. you may define a style that adds a
         stronger level of sharpening when you produce scaled-down JPEG files for the internet or
         add a certain level of exposure compensation to all of your output images. Learn more
         about styles in <xref linkend="styles"/>, and <xref linkend="history"/>.

--- a/doc/usermanual/lighttable/panels/metadata_editor.xml
+++ b/doc/usermanual/lighttable/panels/metadata_editor.xml
@@ -21,7 +21,7 @@
             Edit metadata of an image, like <emphasis>title</emphasis>,
             <emphasis>description</emphasis>, <emphasis>creator</emphasis>,
             <emphasis>publisher</emphasis>, or <emphasis>rights</emphasis>. You can define your
-            own presets, if you want to apply specific settings frequently.
+            own presets if you want to apply specific settings frequently.
           </entry>
           <entry>
             <graphic fileref="lighttable/images/panel_metadata_editor.png" scalefit="1" width="80%" align="center" />

--- a/doc/usermanual/lighttable/panels/tagging.xml
+++ b/doc/usermanual/lighttable/panels/tagging.xml
@@ -18,10 +18,10 @@
       <tbody>
         <row>
           <entry>
-            This panel is for managing tags on images. Tags are stored in both, sidecar files
-            (.xmp), and within the darktable database for a faster access. The panel is divided
+            This panel is for managing tags on images. Tags are stored in both sidecar files
+            (.xmp) and within the darktable database for a faster access. The panel is divided
             into two parts: the upper part contains the tag(s) currently attached to the image
-            under the cursor, or the selected image(s) if the mouse is outside the lighttable.
+            under the cursor or the selected image(s) if the mouse is outside the lighttable.
             The lower part contains a list of all available tags in the database, which can be
             filtered in the text box above.
           </entry>
@@ -97,7 +97,7 @@
 
       <para>
         Delete a tag from the list and from all images. A warning will be displayed on how many
-        images have this tag attached. Take this warning serious as there is no way to recover
+        images have this tag attached. Take this warning seriously as there is no way to recover
         or later find the affected images.
       </para>
 

--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -1181,7 +1181,7 @@
           Sometimes you will need to remove spots caused by sensor dirt. The
           <link linkend="spot_removal"><emphasis>spot removal</emphasis></link> module is at
           hand and can also correct other disturbing elements like skin blemishes. If your
-          camera has stuck pixels or tends to produce hot pixels at high ISO values, or longer
+          camera has stuck pixels or tends to produce hot pixels at high ISO values or longer
           exposure times, have a look at the <link linkend="hotpixels"><emphasis>hot
           pixels</emphasis></link> module for automatic correction.
         </para>
@@ -1254,7 +1254,7 @@
           used, it can give your photograph the right pop. darktable offers several modules for
           this task. The <link linkend="local_contrast"><emphasis>local
           contrast</emphasis></link> module is easy to handle, with just a few parameters. A
-          much more versatile, but also more complex technique, is offered by the
+          much more versatile, but also more complex, technique is offered by the
           <link linkend="equalizer"><emphasis>equalizer</emphasis></link> module. Have a look at
           its presets, to get a feeling for how it works. Equalizer is darktable's "Swiss Army
           Knife" for many adjustments where spatial dimension plays a role.
@@ -1351,7 +1351,7 @@
         Select images on the lighttable, choose the target storage and format, and set the
         maximum width and height image restraints. This means that none of the images will be
         bigger than any of the width/height restraints and hit the export button. Leave the
-        width and height restraints at zero, if you want the original resolution.
+        width and height restraints at zero if you want the original resolution.
       </para>
 
     </sect2>

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -160,7 +160,7 @@ int dt_imageio_large_thumbnail(const char *filename, uint8_t **buffer, int32_t *
   {
     fprintf(
         stderr,
-        "[dt_imageio_large_thumbnail] error: Not an supported thumbnail image format or broken thumbnail: %s\n",
+        "[dt_imageio_large_thumbnail] error: Not a supported thumbnail image format or broken thumbnail: %s\n",
         mime_type);
     goto error;
   }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2198,9 +2198,10 @@ static float find_nearest_on_line_t (const float complex p0, const float complex
  * solver. Use the GSL?)
  *
  * Here is an article that explains the math:
- * http://www.particleincell.com/blog/2012/bezier-splines/ Basically
- * we find all the ctrl1 points when we solve the linear system, then
- * we calculate each ctrl2 from the ctrl1.
+ * http://www.particleincell.com/blog/2012/bezier-splines/
+ *
+ * Basically we find all the ctrl1 points when we solve the linear
+ * system, then we calculate each ctrl2 from the ctrl1.
  *
  * We build the linear system choosing for each segment of the path an
  * equation among following 9 equations.  "Straight" is a path that
@@ -2210,34 +2211,31 @@ static float find_nearest_on_line_t (const float complex p0, const float complex
  * knot (1st and 2nd derivatives are constant around the knot.)
  * "Keep" means to keep the control point as the user set it.
  *
- *      start     end of path
- *
- *   1: straight  smooth
- *   2: smooth    smooth
- *   3: smooth    straight
- *   4: keep      smooth
- *   5: keep      keep
- *   6: smooth    keep
- *   7: keep      straight
- *   8: straight  straight  (yields a line)
- *   9: straight  keep
+ * |    | start       |   end of path
+ * | -- | ----------- | ---------------
+ * | 1  | straight    | smooth
+ * | 2  | smooth      | smooth
+ * | 3  | smooth      | straight
+ * | 4  | keep        | smooth
+ * | 5  | keep        | keep
+ * | 6  | smooth      | keep
+ * | 7  | keep        | straight
+ * | 8  | straight    | straight  (yields a line)
+ * | 9  | straight    | keep
  *
  * The equations are (close your eyes):
  *
  * \f{eqnarray}{
- *                2P_{1,i} + P_{1,i+1} &=&  K_i + 2K_{i+1}  \eqno(1) \\
- *    P_{1,i-1} + 4P_{1,i} + P_{1,i+1} &=& 4K_i + 2K_{i+1}  \eqno(2) \\
- *   2P_{1,i-1} + 7P_{1,i}             &=& 8K_i +  K_{i+1}  \eqno(3) \\
- *                 P_{1,i}             &=& C1_i             \eqno(4) \\
- *                 P_{1,i}             &=& C1_i             \eqno(5) \\
- *    P_{1,i-1} + 4P_{1,i}             &=& C2_i + 4K_i      \eqno(6) \\
- *                 P_{1,i}             &=& C1_i             \eqno(7) \\
- *                3P_{1,i}             &=& 2K_i +  K_{i+1}  \eqno(8) \\
- *                2P_{1,i}             &=&  K_i +  C2_i     \eqno(9)
+ *                2P_{1,i} + P_{1,i+1} &=&  K_i + 2K_{i+1}  \label{1} \\
+ *    P_{1,i-1} + 4P_{1,i} + P_{1,i+1} &=& 4K_i + 2K_{i+1}  \label{2} \\
+ *   2P_{1,i-1} + 7P_{1,i}             &=& 8K_i +  K_{i+1}  \label{3} \\
+ *                 P_{1,i}             &=& C1_i             \label{4} \\
+ *                 P_{1,i}             &=& C1_i             \label{5} \\
+ *    P_{1,i-1} + 4P_{1,i}             &=& C2_i + 4K_i      \label{6} \\
+ *                 P_{1,i}             &=& C1_i             \label{7} \\
+ *                3P_{1,i}             &=& 2K_i +  K_{i+1}  \label{8} \\
+ *                2P_{1,i}             &=&  K_i +  C2_i     \label{9}
  * \f}
- *
- * FIXME (hodapp): Above causes an error with doxygen:
- * ! You can't use `\eqno' in math mode.
  *
  * Some of these are the same and differ only in the way we calculate
  * c2. (You may open your eyes again.)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2236,6 +2236,9 @@ static float find_nearest_on_line_t (const float complex p0, const float complex
  *                2P_{1,i}             &=&  K_i +  C2_i     \eqno(9)
  * \f}
  *
+ * FIXME (hodapp): Above causes an error with doxygen:
+ * ! You can't use `\eqno' in math mode.
+ *
  * Some of these are the same and differ only in the way we calculate
  * c2. (You may open your eyes again.)
  */


### PR DESCRIPTION
This includes a handful of little updates (mostly grammer/syntax) to the manual. It also fixes doxygen, which was producing a LaTeX error about eqno and math mode. While I've been told that doxygen is rarely used here, I have been using it in order to try to understand the codebase (which is also why I've enabled EXTRACT_STATIC: it seemed a little silly to fix LaTeX that doesn't even appear to be present because it's on a static function, and also a lot of darktable's functionality resides in static functions).

The "applied specifically to images before export" wording change is because "applied specifically to exported images" is a bit ambiguous. It can be taken to mean that styles are applied to images after they are exported, which is not the case: they're applied to images before they are exported.