### PR TITLE
Manual section 3.4.4.2: Fix spelling error and clarify slightly

### DIFF
--- a/doc/usermanual/darkroom/modules/correction/equalizer.xml
+++ b/doc/usermanual/darkroom/modules/correction/equalizer.xml
@@ -61,9 +61,10 @@
     <title>Usage</title>
 
     <para>
-      Each frequence band can be tweaked independently. In particular, you can adjust contrast
-      boost and denoise threshold splines for both lightness and chromaticity, as well as the
-      acuteness (<quote>edge</quote>) of the wavelet basis on each frequency scale.
+      Each frequency band can be tweaked independently. In particular, you can adjust contrast
+      boost and denoise threshold splines for both lightness and chromaticity (<quote>luma</quote>
+      and <quote>chroma</quote>), as well as the acuteness (<quote>edges</quote>) of the wavelet basis
+      on each frequency scale.
     </para>
 
     <informaltable frame="none">


### PR DESCRIPTION
"frequence band" should be "frequency band".

Also, the paragraph in question appears to be referring to the three
tabs, but it only refers to the final tab by its name ("edges"), while
the first two it refers to as lightness and chromaticity, which is not
how the UI refers to them. So, I added a reference to them as
"luma" and "chroma" to hopefully clarify this.