### PR TITLE
Pipe: format callbacks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,7 @@ FILE(GLOB SOURCE_FILES
   "develop/blend_gui.c"
   "develop/tiling.c"
   "develop/masks/masks.c"
+  "develop/format.c"
   "dtgtk/button.c"
   "dtgtk/drawingarea.c"
   "dtgtk/expander.c"

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -81,7 +81,7 @@ typedef unsigned int u_int;
 #include "common/poison.h"
 #endif
 
-#define DT_MODULE_VERSION 15 // version of dt's module interface
+#define DT_MODULE_VERSION 16 // version of dt's module interface
 
 // every module has to define this:
 #ifdef _DEBUG

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -972,7 +972,7 @@ void dt_image_init(dt_image_t *img)
   img->legacy_flip.legacy = 0;
   img->legacy_flip.user_flip = 0;
 
-  img->filters = 0u;
+  img->buf_dsc.filters = 0u;
   img->buf_dsc = (dt_iop_buffer_dsc_t){.channels = 0, .datatype = TYPE_UNKNOWN };
   img->film_id = -1;
   img->group_id = -1;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -973,7 +973,7 @@ void dt_image_init(dt_image_t *img)
   img->legacy_flip.user_flip = 0;
 
   img->filters = 0u;
-  img->bpp = 0;
+  img->buf_dsc = (dt_iop_buffer_dsc_t){.channels = 0, .datatype = TYPE_UNKNOWN };
   img->film_id = -1;
   img->group_id = -1;
   img->flags = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -23,6 +23,7 @@
 
 #include "common/darktable.h"
 #include "common/dtpthread.h"
+#include "develop/format.h"
 #include <glib.h>
 #include <inttypes.h>
 
@@ -153,8 +154,7 @@ typedef struct dt_image_t
   dt_image_loader_t loader;
 
   uint32_t filters;          // Bayer demosaic pattern
-  int32_t bpp;               // bytes per pixel
-  int32_t cpp;               // components per pixel
+  dt_iop_buffer_dsc_t buf_dsc;
   float d65_color_matrix[9]; // the 3x3 matrix embedded in some DNGs
   uint8_t *profile;          // embedded profile, for example from JPEGs
   uint32_t profile_size;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -153,8 +153,8 @@ typedef struct dt_image_t
   int32_t num, flags, film_id, id, group_id, version;
   dt_image_loader_t loader;
 
-  uint32_t filters;          // Bayer demosaic pattern
   dt_iop_buffer_dsc_t buf_dsc;
+
   float d65_color_matrix[9]; // the 3x3 matrix embedded in some DNGs
   uint8_t *profile;          // embedded profile, for example from JPEGs
   uint32_t profile_size;
@@ -175,9 +175,6 @@ typedef struct dt_image_t
   /* needed to fix some manufacturers madness */
   uint32_t fuji_rotation_pos;
   float pixel_aspect_ratio;
-
-  /* filter for Fuji X-Trans images, only used if filters == 9u */
-  uint8_t xtrans[6][6];
 
   /* White balance coeffs from the raw */
   float wb_coeffs[4];

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -104,16 +104,29 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
 
     // buffer size?
     if(img->flags & DT_IMAGE_LDR)
-      img->bpp = 4 * sizeof(float);
+    {
+      img->buf_dsc.channels = 4;
+      img->buf_dsc.datatype = TYPE_FLOAT;
+    }
     else if(img->flags & DT_IMAGE_HDR)
     {
       if(img->flags & DT_IMAGE_RAW)
-        img->bpp = sizeof(float);
+      {
+        img->buf_dsc.channels = 1;
+        img->buf_dsc.datatype = TYPE_FLOAT;
+      }
       else
-        img->bpp = 4 * sizeof(float);
+      {
+        img->buf_dsc.channels = 4;
+        img->buf_dsc.datatype = TYPE_FLOAT;
+      }
     }
-    else // raw
-      img->bpp = sizeof(uint16_t);
+    else
+    {
+      // raw
+      img->buf_dsc.channels = 1;
+      img->buf_dsc.datatype = TYPE_UINT16;
+    }
   }
   else
   {

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -354,7 +354,7 @@ dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, d
 return_label:
   if(ret == DT_IMAGEIO_OK)
   {
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_LDR;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags |= DT_IMAGE_HDR;
@@ -463,7 +463,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_tiff(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
@@ -474,7 +474,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_png(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
@@ -486,7 +486,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_j2k(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
@@ -498,7 +498,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
   ret = dt_imageio_open_jpeg(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
@@ -913,7 +913,7 @@ dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename
   dt_imageio_retval_t ret = dt_imageio_open_gm(img, filename, buf);
   if(ret == DT_IMAGEIO_OK || ret == DT_IMAGEIO_CACHE_FULL)
   {
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -336,7 +336,8 @@ size_t dt_imageio_write_pos(int i, int j, int wd, int ht, float fwd, float fht,
 dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf)
 {
   // needed to alloc correct buffer size:
-  img->bpp = 4 * sizeof(float);
+  img->buf_dsc.channels = 4;
+  img->buf_dsc.datatype = TYPE_FLOAT;
   dt_imageio_retval_t ret;
   dt_image_loader_t loader;
 #ifdef HAVE_OPENEXR

--- a/src/common/imageio_exr.cc
+++ b/src/common/imageio_exr.cc
@@ -130,7 +130,8 @@ dt_imageio_retval_t dt_imageio_open_exr(dt_image_t *img, const char *filename, d
   img->height = dw.max.y - dw.min.y + 1;
 
   // Try to allocate image data
-  img->bpp = 4 * sizeof(float);
+  img->buf_dsc.channels = 4;
+  img->buf_dsc.datatype = TYPE_FLOAT;
   float *buf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!buf)
   {

--- a/src/common/imageio_gm.c
+++ b/src/common/imageio_gm.c
@@ -116,7 +116,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   if(image_info) DestroyImageInfo(image_info);
   DestroyExceptionInfo(&exception);
 
-  img->filters = 0u;
+  img->buf_dsc.filters = 0u;
   img->flags &= ~DT_IMAGE_RAW;
   img->flags &= ~DT_IMAGE_HDR;
   img->flags |= DT_IMAGE_LDR;

--- a/src/common/imageio_gm.c
+++ b/src/common/imageio_gm.c
@@ -88,7 +88,8 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   img->width = width;
   img->height = height;
 
-  img->bpp = 4 * sizeof(float);
+  img->buf_dsc.channels = 4;
+  img->buf_dsc.datatype = TYPE_FLOAT;
 
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!mipbuf)

--- a/src/common/imageio_j2k.c
+++ b/src/common/imageio_j2k.c
@@ -258,7 +258,9 @@ dt_imageio_retval_t dt_imageio_open_j2k(dt_image_t *img, const char *filename, d
 
   img->width = image->x1;
   img->height = image->y1;
-  img->bpp = 4 * sizeof(float);
+
+  img->buf_dsc.channels = 4;
+  img->buf_dsc.datatype = TYPE_FLOAT;
 
   float *buf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!buf)

--- a/src/common/imageio_jpeg.c
+++ b/src/common/imageio_jpeg.c
@@ -741,7 +741,8 @@ dt_imageio_retval_t dt_imageio_open_jpeg(dt_image_t *img, const char *filename, 
     return DT_IMAGEIO_FILE_CORRUPTED;
   }
 
-  img->bpp = 4 * sizeof(float);
+  img->buf_dsc.channels = 4;
+  img->buf_dsc.datatype = TYPE_FLOAT;
   void *buf = dt_mipmap_cache_alloc(mbuf, img);
   if(!buf)
   {

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -172,7 +172,8 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
   height = img->height = image.height;
   bpp = image.bit_depth;
 
-  img->bpp = 4 * sizeof(float);
+  img->buf_dsc.channels = 4;
+  img->buf_dsc.datatype = TYPE_FLOAT;
 
   float *mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, img);
   if(!mipbuf)

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -248,7 +248,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     // Grab the WB
     for(int i = 0; i < 4; i++) img->wb_coeffs[i] = r->metadata.wbCoeffs[i];
 
-    img->filters = 0u;
+    img->buf_dsc.filters = 0u;
     if(!r->isCFA)
     {
       dt_imageio_retval_t ret = dt_imageio_open_rawspeed_sraw(img, r, mbuf);
@@ -298,18 +298,17 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     // as the X-Trans filters comments later on states, these are for
     // cropped image, so we need to uncrop them.
-    img->filters = dt_rawspeed_crop_dcraw_filters(r->cfa.getDcrawFilter(), cropTL.x, cropTL.y);
+    img->buf_dsc.filters = dt_rawspeed_crop_dcraw_filters(r->cfa.getDcrawFilter(), cropTL.x, cropTL.y);
 
-    if(FILTERS_ARE_4BAYER(img->filters))
-      img->flags |= DT_IMAGE_4BAYER;
+    if(FILTERS_ARE_4BAYER(img->buf_dsc.filters)) img->flags |= DT_IMAGE_4BAYER;
 
-    if(img->filters)
+    if(img->buf_dsc.filters)
     {
       img->flags &= ~DT_IMAGE_LDR;
       img->flags |= DT_IMAGE_RAW;
       if(r->getDataType() == TYPE_FLOAT32) img->flags |= DT_IMAGE_HDR;
       // special handling for x-trans sensors
-      if(img->filters == 9u)
+      if(img->buf_dsc.filters == 9u)
       {
         // get 6x6 CFA offset from top left of cropped image
         // NOTE: This is different from how things are done with Bayer
@@ -320,7 +319,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
         for(int i = 0; i < 6; ++i)
           for(int j = 0; j < 6; ++j)
           {
-            img->xtrans[j][i] = r->cfa.getColorAt(i % 6, j % 6);
+            img->buf_dsc.xtrans[j][i] = r->cfa.getColorAt(i % 6, j % 6);
           }
       }
     }

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -185,7 +185,8 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
   t.image->width = t.width;
   t.image->height = t.height;
 
-  t.image->bpp = 4 * sizeof(float);
+  t.image->buf_dsc.channels = 4;
+  t.image->buf_dsc.datatype = TYPE_FLOAT;
 
   t.mipbuf = (float *)dt_mipmap_cache_alloc(mbuf, t.image);
   if(!t.mipbuf)

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -226,7 +226,9 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
   const int wd = img->width;
   const int ht = img->height;
   struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)buf->cache_entry->data;
-  const size_t buffer_size = (size_t)wd*ht*img->bpp + sizeof(*dsc);
+
+  const size_t bpp = dt_iop_buffer_dsc_to_bpp(&img->buf_dsc);
+  const size_t buffer_size = (size_t)wd * ht * bpp + sizeof(*dsc);
 
   // buf might have been alloc'ed before,
   // so only check size and re-alloc if necessary:
@@ -1063,7 +1065,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
              && (method_name && !strcmp(method_name, "DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME")));
 
       // Bayer
-      if(image->bpp == sizeof(float))
+      if(image->buf_dsc.datatype == TYPE_FLOAT)
       {
         if(mipmap_buf->pre_monochrome_demosaiced)
         {
@@ -1106,7 +1108,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
     else
     {
       // X-Trans
-      if(image->bpp == sizeof(float))
+      if(image->buf_dsc.datatype == TYPE_FLOAT)
       {
         dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(out, (const float *)buf.buf, &roi_out, &roi_in,
                                                           roi_out.width, roi_in.width, image->xtrans);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1053,10 +1053,10 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   mipmap_buf->pre_monochrome_demosaiced = 0;
   mipmap_buf->color_space = DT_COLORSPACE_NONE; // TODO: do we need that information in this buffer?
 
-  if(image->filters)
+  if(image->buf_dsc.filters)
   {
     // demosaic during downsample
-    if(image->filters != 9u)
+    if(image->buf_dsc.filters != 9u)
     {
       const char *method_name = NULL;
       const int method = dt_image_get_demosaic_method(imgid, &(method_name));
@@ -1075,7 +1075,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
         else
         {
           dt_iop_clip_and_zoom_demosaic_half_size_f(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width,
-                                                    roi_in.width, image->filters, 1.0f);
+                                                    roi_in.width, image->buf_dsc.filters, 1.0f);
         }
       }
       else
@@ -1088,7 +1088,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
         else
         {
           dt_iop_clip_and_zoom_demosaic_half_size(out, (const uint16_t *)buf.buf, &roi_out, &roi_in, roi_out.width,
-                                                  roi_in.width, image->filters);
+                                                  roi_in.width, image->buf_dsc.filters);
 
           // For four bayer images we'll need to convert to XYZ here as the pipe only carries 3 channels
           if(image->flags & DT_IMAGE_4BAYER)
@@ -1111,12 +1111,12 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
       if(image->buf_dsc.datatype == TYPE_FLOAT)
       {
         dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(out, (const float *)buf.buf, &roi_out, &roi_in,
-                                                          roi_out.width, roi_in.width, image->xtrans);
+                                                          roi_out.width, roi_in.width, image->buf_dsc.xtrans);
       }
       else
       {
         dt_iop_clip_and_zoom_demosaic_third_size_xtrans(out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
-                                                        roi_out.width, roi_in.width, image->xtrans);
+                                                        roi_out.width, roi_in.width, image->buf_dsc.xtrans);
       }
     }
   }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -304,7 +304,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
   if(!d->pixels)
   {
     d->first_imgid = imgid;
-    d->first_filter = image.filters;
+    d->first_filter = image.buf_dsc.filters;
     // sensor layout is just passed on to be written to dng.
     // we offset it to the crop of the image here, so we don't
     // need to load in the FCxtrans dependency into the dng writer.
@@ -314,7 +314,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
     roi.x = image.crop_x;
     roi.y = image.crop_y;
     for(int j=0;j<6;j++)
-      for(int i=0;i<6;i++) d->first_xtrans[j][i] = FCxtrans(j, i, &roi, image.xtrans);
+      for(int i = 0; i < 6; i++) d->first_xtrans[j][i] = FCxtrans(j, i, &roi, image.buf_dsc.xtrans);
     d->pixels = calloc(datai->width * datai->height, sizeof(float));
     d->weight = calloc(datai->width * datai->height, sizeof(float));
     d->wd = datai->width;
@@ -322,13 +322,13 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
     d->orientation = image.orientation;
   }
 
-  if(image.filters == 0u || image.buf_dsc.channels != 1 || image.buf_dsc.datatype != TYPE_UINT16)
+  if(image.buf_dsc.filters == 0u || image.buf_dsc.channels != 1 || image.buf_dsc.datatype != TYPE_UINT16)
   {
     dt_control_log(_("exposure bracketing only works on raw images."));
     d->abort = TRUE;
     return 1;
   }
-  else if(datai->width != d->wd || datai->height != d->ht || d->first_filter != image.filters
+  else if(datai->width != d->wd || datai->height != d->ht || d->first_filter != image.buf_dsc.filters
           || d->orientation != image.orientation)
   {
     dt_control_log(_("images have to be of same size and orientation!"));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -322,7 +322,7 @@ static int dt_control_merge_hdr_process(dt_imageio_module_data_t *datai, const c
     d->orientation = image.orientation;
   }
 
-  if(image.filters == 0u || image.bpp != sizeof(uint16_t))
+  if(image.filters == 0u || image.buf_dsc.channels != 1 || image.buf_dsc.datatype != TYPE_UINT16)
   {
     dt_control_log(_("exposure bracketing only works on raw images."));
     d->abort = TRUE;

--- a/src/develop/format.c
+++ b/src/develop/format.c
@@ -1,0 +1,97 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/format.h"
+#include "develop/imageop.h"
+
+size_t dt_iop_buffer_dsc_to_bpp(const struct dt_iop_buffer_dsc_t *dsc)
+{
+  size_t bpp = dsc->channels;
+
+  switch(dsc->datatype)
+  {
+    case TYPE_FLOAT:
+      bpp *= sizeof(float);
+      break;
+    case TYPE_UINT16:
+      bpp *= sizeof(uint16_t);
+      break;
+    default:
+      dt_unreachable_codepath();
+      break;
+  }
+
+  return bpp;
+}
+
+static int _iop_module_rawprepare = 0, _iop_module_demosaic = 0;
+static inline void _get_iop_priorities(const dt_iop_module_t *module)
+{
+  if(_iop_module_rawprepare && _iop_module_demosaic) return;
+
+  GList *iop = module->dev->iop;
+  while(iop)
+  {
+    dt_iop_module_t *m = (dt_iop_module_t *)iop->data;
+
+    if(!strcmp(m->op, "rawprepare")) _iop_module_rawprepare = m->priority;
+    if(!strcmp(m->op, "demosaic")) _iop_module_demosaic = m->priority;
+
+    if(_iop_module_rawprepare && _iop_module_demosaic) break;
+
+    iop = g_list_next(iop);
+  }
+}
+
+void default_input_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece,
+                          dt_iop_buffer_dsc_t *dsc)
+{
+  _get_iop_priorities(self);
+
+  dsc->channels = 4;
+  dsc->datatype = TYPE_FLOAT;
+
+  if(self->priority > _iop_module_demosaic) return;
+
+  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW)) dsc->channels = 1;
+
+  if(self->priority > _iop_module_rawprepare) return;
+
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters) dsc->datatype = TYPE_UINT16;
+}
+
+void default_output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece,
+                           dt_iop_buffer_dsc_t *dsc)
+{
+  _get_iop_priorities(self);
+
+  dsc->channels = 4;
+  dsc->datatype = TYPE_FLOAT;
+
+  if(self->priority >= _iop_module_demosaic) return;
+
+  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW)) dsc->channels = 1;
+
+  if(self->priority >= _iop_module_rawprepare) return;
+
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters) dsc->datatype = TYPE_UINT16;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/format.c
+++ b/src/develop/format.c
@@ -72,7 +72,8 @@ void default_input_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_de
 
   if(self->priority > _iop_module_rawprepare) return;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters) dsc->datatype = TYPE_UINT16;
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+    dsc->datatype = TYPE_UINT16;
 }
 
 void default_output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece,
@@ -89,7 +90,8 @@ void default_output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_d
 
   if(self->priority >= _iop_module_rawprepare) return;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters) dsc->datatype = TYPE_UINT16;
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+    dsc->datatype = TYPE_UINT16;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/format.h
+++ b/src/develop/format.h
@@ -42,6 +42,8 @@ typedef struct dt_iop_buffer_dsc_t
   uint32_t filters;
   /** filter for Fuji X-Trans images, only used if filters == 9u */
   uint8_t xtrans[6][6];
+  /** sensor saturation, propagated through the operations */
+  float processed_maximum[4];
 } dt_iop_buffer_dsc_t;
 
 size_t dt_iop_buffer_dsc_to_bpp(const struct dt_iop_buffer_dsc_t *dsc);

--- a/src/develop/format.h
+++ b/src/develop/format.h
@@ -42,6 +42,13 @@ typedef struct dt_iop_buffer_dsc_t
   uint32_t filters;
   /** filter for Fuji X-Trans images, only used if filters == 9u */
   uint8_t xtrans[6][6];
+
+  struct
+  {
+    uint16_t raw_black_level;
+    uint16_t raw_white_point;
+  } rawprepare;
+
   /** sensor saturation, propagated through the operations */
   float processed_maximum[4];
 } dt_iop_buffer_dsc_t;

--- a/src/develop/format.h
+++ b/src/develop/format.h
@@ -1,0 +1,54 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_DEVELOP_FORMAT_H
+#define DT_DEVELOP_FORMAT_H
+
+#include <stddef.h>
+
+struct dt_dev_pixelpipe_iop_t;
+struct dt_dev_pixelpipe_t;
+struct dt_iop_module_t;
+
+typedef enum dt_iop_buffer_type_t {
+  TYPE_UNKNOWN,
+  TYPE_FLOAT,
+  TYPE_UINT16,
+} dt_iop_buffer_type_t;
+
+typedef struct dt_iop_buffer_dsc_t
+{
+  /** how many channels the data has? 1 or 4 */
+  unsigned int channels;
+  /** what is the datatype? */
+  dt_iop_buffer_type_t datatype;
+} dt_iop_buffer_dsc_t;
+
+size_t dt_iop_buffer_dsc_to_bpp(const struct dt_iop_buffer_dsc_t *dsc);
+
+void default_input_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                          struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+
+void default_output_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                           struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+
+#endif
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/format.h
+++ b/src/develop/format.h
@@ -20,6 +20,7 @@
 #define DT_DEVELOP_FORMAT_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct dt_dev_pixelpipe_iop_t;
 struct dt_dev_pixelpipe_t;
@@ -37,6 +38,10 @@ typedef struct dt_iop_buffer_dsc_t
   unsigned int channels;
   /** what is the datatype? */
   dt_iop_buffer_type_t datatype;
+  /** Bayer demosaic pattern */
+  uint32_t filters;
+  /** filter for Fuji X-Trans images, only used if filters == 9u */
+  uint8_t xtrans[6][6];
 } dt_iop_buffer_dsc_t;
 
 size_t dt_iop_buffer_dsc_to_bpp(const struct dt_iop_buffer_dsc_t *dsc);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -38,6 +38,7 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "libs/modulegroups.h"
+#include "develop/format.h"
 
 #include <assert.h>
 #include <gmodule.h>
@@ -121,13 +122,6 @@ static int default_operation_tags()
 static int default_operation_tags_filter()
 {
   return 0;
-}
-
-/* default bytes per pixel: 4*sizeof(float). */
-static int default_output_bpp(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                              struct dt_dev_pixelpipe_iop_t *piece)
-{
-  return 4 * sizeof(float);
 }
 
 static void default_commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params,
@@ -237,8 +231,10 @@ int dt_iop_load_module_so(dt_iop_module_so_t *module, const char *libname, const
     module->operation_tags = default_operation_tags;
   if(!g_module_symbol(module->module, "operation_tags_filter", (gpointer) & (module->operation_tags_filter)))
     module->operation_tags_filter = default_operation_tags_filter;
-  if(!g_module_symbol(module->module, "output_bpp", (gpointer) & (module->output_bpp)))
-    module->output_bpp = default_output_bpp;
+  if(!g_module_symbol(module->module, "input_format", (gpointer) & (module->input_format)))
+    module->input_format = default_input_format;
+  if(!g_module_symbol(module->module, "output_format", (gpointer) & (module->output_format)))
+    module->output_format = default_output_format;
   if(!g_module_symbol(module->module, "tiling_callback", (gpointer) & (module->tiling_callback)))
     module->tiling_callback = default_tiling_callback;
   if(!g_module_symbol(module->module, "gui_reset", (gpointer) & (module->gui_reset)))
@@ -389,7 +385,8 @@ static int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t 
   module->description = so->description;
   module->operation_tags = so->operation_tags;
   module->operation_tags_filter = so->operation_tags_filter;
-  module->output_bpp = so->output_bpp;
+  module->input_format = so->input_format;
+  module->output_format = so->output_format;
   module->tiling_callback = so->tiling_callback;
   module->gui_update = so->gui_update;
   module->gui_reset = so->gui_reset;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -157,8 +157,13 @@ typedef struct dt_iop_module_so_t
   int (*operation_tags)();
   int (*operation_tags_filter)();
 
-  int (*output_bpp)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece);
+  /** what do the iop want as an input? */
+  void (*input_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                       struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+  /** what will it output? */
+  void (*output_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                        struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+
   void (*tiling_callback)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                           const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,
                           struct dt_develop_tiling_t *tiling);
@@ -336,9 +341,11 @@ typedef struct dt_iop_module_t
   int (*operation_tags)();
 
   int (*operation_tags_filter)();
-  /** how many bytes per pixel in the output. */
-  int (*output_bpp)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-                    struct dt_dev_pixelpipe_iop_t *piece);
+  void (*input_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                       struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+  /** what will it output? */
+  void (*output_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                        struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
   /** report back info for tiling: memory usage and overlap. Memory usage: factor * input_size + overhead */
   void (*tiling_callback)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                           const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -18,6 +18,7 @@
 
 #include "develop/pixelpipe_cache.h"
 #include "develop/pixelpipe_hb.h"
+#include "develop/format.h"
 #include "libs/lib.h"
 #include <stdlib.h>
 
@@ -36,6 +37,10 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
   cache->entries = entries;
   cache->data = (void **)calloc(entries, sizeof(void *));
   cache->size = (size_t *)calloc(entries, sizeof(size_t));
+  cache->dsc = (dt_iop_buffer_dsc_t *)calloc(entries, sizeof(dt_iop_buffer_dsc_t));
+#ifdef _DEBUG
+  memset(cache->dsc, 0x2c, sizeof(dt_iop_buffer_dsc_t) * entries);
+#endif
   cache->hash = (uint64_t *)calloc(entries, sizeof(uint64_t));
   cache->used = (int32_t *)calloc(entries, sizeof(int32_t));
   for(int k = 0; k < entries; k++)
@@ -57,16 +62,7 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
   return 1;
 
 alloc_memory_fail:
-  for(int k = 0; k < entries; k++)
-  {
-    if(cache->data[k]) dt_free_align(cache->data[k]);
-  }
-
-  free(cache->data);
-  free(cache->size);
-  free(cache->hash);
-  free(cache->used);
-
+  dt_dev_pixelpipe_cache_cleanup(cache);
   return 0;
 }
 
@@ -74,6 +70,7 @@ void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache)
 {
   for(int k = 0; k < cache->entries; k++) dt_free_align(cache->data[k]);
   free(cache->data);
+  free(cache->dsc);
   free(cache->hash);
   free(cache->used);
   free(cache->size);
@@ -122,20 +119,20 @@ int dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint
   return 0;
 }
 
-int dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash,
-                                         const size_t size, void **data)
+int dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size,
+                                         void **data, dt_iop_buffer_dsc_t **dsc)
 {
-  return dt_dev_pixelpipe_cache_get_weighted(cache, hash, size, data, -cache->entries);
+  return dt_dev_pixelpipe_cache_get_weighted(cache, hash, size, data, dsc, -cache->entries);
 }
 
 int dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size,
-                               void **data)
+                               void **data, dt_iop_buffer_dsc_t **dsc)
 {
-  return dt_dev_pixelpipe_cache_get_weighted(cache, hash, size, data, 0);
+  return dt_dev_pixelpipe_cache_get_weighted(cache, hash, size, data, dsc, 0);
 }
 
-int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash,
-                                        const size_t size, void **data, int weight)
+int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size,
+                                        void **data, dt_iop_buffer_dsc_t **dsc, int weight)
 {
   cache->queries++;
   *data = NULL;
@@ -153,6 +150,7 @@ int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const u
     if(cache->hash[k] == hash)
     {
       *data = cache->data[k];
+      *dsc = &cache->dsc[k];
       sz = cache->size[k];
       cache->used[k] = weight; // this is the MRU entry
     }
@@ -170,6 +168,11 @@ int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const u
       cache->size[max] = size;
     }
     *data = cache->data[max];
+
+    // first, update our copy, then update the pointer to point at our copy
+    cache->dsc[max] = **dsc;
+    *dsc = &cache->dsc[max];
+
     cache->hash[max] = hash;
     cache->used[max] = weight;
     cache->misses++;

--- a/src/develop/pixelpipe_cache.h
+++ b/src/develop/pixelpipe_cache.h
@@ -19,17 +19,23 @@
 #define DT_PIXELPIPE_CACHE_H
 
 #include <inttypes.h>
+
+struct dt_dev_pixelpipe_t;
+struct dt_iop_buffer_dsc_t;
+struct dt_iop_roi_t;
+
 /**
  * implements a simple pixel cache suitable for caching float images
  * corresponding to history items and zoom/pan settings in the develop module.
  * it is optimized for very few entries (~5), so most operations are O(N).
  */
-struct dt_dev_pixelpipe_t;
+
 typedef struct dt_dev_pixelpipe_cache_t
 {
   int32_t entries;
   void **data;
   size_t *size;
+  struct dt_iop_buffer_dsc_t *dsc;
   uint64_t *hash;
   int32_t *used;
 #ifdef HAVE_OPENCL
@@ -46,7 +52,6 @@ typedef struct dt_dev_pixelpipe_cache_t
 int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, size_t size);
 void dt_dev_pixelpipe_cache_cleanup(dt_dev_pixelpipe_cache_t *cache);
 
-struct dt_iop_roi_t;
 /** creates a hopefully unique hash from the complete module stack up to the module-th. */
 uint64_t dt_dev_pixelpipe_cache_hash(int imgid, const struct dt_iop_roi_t *roi,
                                      struct dt_dev_pixelpipe_t *pipe, int module);
@@ -55,11 +60,11 @@ uint64_t dt_dev_pixelpipe_cache_hash(int imgid, const struct dt_iop_roi_t *roi,
   * cache line, the least recently used cache line will be cleared and an empty buffer is returned
   * together with a non-zero return value. */
 int dt_dev_pixelpipe_cache_get(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size,
-                               void **data);
-int dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash,
-                                         const size_t size, void **data);
-int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash,
-                                        const size_t size, void **data, int weight);
+                               void **data, struct dt_iop_buffer_dsc_t **dsc);
+int dt_dev_pixelpipe_cache_get_important(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size,
+                                         void **data, struct dt_iop_buffer_dsc_t **dsc);
+int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash, const size_t size,
+                                        void **data, struct dt_iop_buffer_dsc_t **dsc, int weight);
 
 /** test availability of a cache line without destroying another, if it is not found. */
 int dt_dev_pixelpipe_cache_available(dt_dev_pixelpipe_cache_t *cache, const uint64_t hash);
@@ -77,6 +82,7 @@ void dt_dev_pixelpipe_cache_invalidate(dt_dev_pixelpipe_cache_t *cache, void *da
 void dt_dev_pixelpipe_cache_print(dt_dev_pixelpipe_cache_t *cache);
 
 #endif
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -156,8 +156,8 @@ void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, flo
   pipe->pre_monochrome_demosaiced = pre_monochrome_demosaiced;
   pipe->image = dev->image_storage;
 
-  pipe->filters = pipe->image.filters;
-  memcpy(pipe->xtrans, pipe->image.xtrans, sizeof(pipe->xtrans));
+  pipe->filters = pipe->image.buf_dsc.filters;
+  memcpy(pipe->xtrans, pipe->image.buf_dsc.xtrans, sizeof(pipe->xtrans));
 }
 
 void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -158,8 +158,8 @@ void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, flo
   pipe->image = dev->image_storage;
   pipe->dsc = pipe->image.buf_dsc;
 
-  pipe->filters = pipe->image.buf_dsc.filters;
-  memcpy(pipe->xtrans, pipe->image.buf_dsc.xtrans, sizeof(pipe->xtrans));
+  pipe->dsc.filters = pipe->image.buf_dsc.filters;
+  memcpy(pipe->dsc.xtrans, pipe->image.buf_dsc.xtrans, sizeof(pipe->dsc.xtrans));
 }
 
 void dt_dev_pixelpipe_cleanup(dt_dev_pixelpipe_t *pipe)
@@ -764,19 +764,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     // dev->preview_pipe ? "[preview]" : "", hash);
     // copy over cached info:
     if(piece)
-    {
-      pipe->filters = piece->filters;
-
-      for(int i = 0; i < 6; ++i)
-      {
-        for(int j = 0; j < 6; ++j)
-        {
-          pipe->xtrans[j][i] = piece->xtrans[j % 6][i % 6];
-        }
-      }
-
       for(int k = 0; k < 4; k++) pipe->processed_maximum[k] = piece->processed_maximum[k];
-    }
     else
       for(int k = 0; k < 4; k++) pipe->processed_maximum[k] = 1.0f;
 
@@ -1879,16 +1867,6 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
     // in case we get this buffer from the cache in the future, cache some stuff:
     **out_format = piece->dsc_out = pipe->dsc;
-
-    piece->filters = pipe->filters;
-
-    for(int i = 0; i < 6; ++i)
-    {
-      for(int j = 0; j < 6; ++j)
-      {
-        piece->xtrans[j][i] = pipe->xtrans[j % 6][i % 6];
-      }
-    }
 
     for(int k = 0; k < 4; k++) piece->processed_maximum[k] = pipe->processed_maximum[k];
     dt_pthread_mutex_unlock(&pipe->busy_mutex);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -338,6 +338,9 @@ static void get_output_format(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
   {
     dsc->channels = 4;
     dsc->datatype = TYPE_FLOAT;
+
+    // image max is normalized before
+    for(int k = 0; k < 4; k++) dsc->processed_maximum[k] = 1.0f;
   }
   else
   {
@@ -2405,7 +2408,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, int x,
 restart:
 
   // image max is normalized before
-  for(int k = 0; k < 4; k++) pipe->dsc.processed_maximum[k] = 1.0f; // dev->image->maximum;
+  for(int k = 0; k < 4; k++) pipe->dsc.processed_maximum[k] = 1.0f;
 
   // check if we should obsolete caches
   if(pipe->cache_obsolete) dt_dev_pixelpipe_cache_flush(&(pipe->cache));

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -335,7 +335,7 @@ static int get_output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_
     if(dt_dev_pixelpipe_uses_downsampled_input(pipe) || !(pipe->image.flags & DT_IMAGE_RAW))
       return 4 * sizeof(float);
     else
-      return pipe->image.bpp;
+      return dt_iop_buffer_dsc_to_bpp(&pipe->image.buf_dsc);
   }
   return module->output_bpp(module, pipe, piece);
 }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -762,11 +762,6 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
   {
     // if(module) printf("found valid buf pos %d in cache for module %s %s %lu\n", pos, module->op, pipe ==
     // dev->preview_pipe ? "[preview]" : "", hash);
-    // copy over cached info:
-    if(piece)
-      for(int k = 0; k < 4; k++) pipe->processed_maximum[k] = piece->processed_maximum[k];
-    else
-      for(int k = 0; k < 4; k++) pipe->processed_maximum[k] = 1.0f;
 
     (void)dt_dev_pixelpipe_cache_get(&(pipe->cache), hash, bufsize, output, out_format);
 
@@ -1868,7 +1863,6 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     // in case we get this buffer from the cache in the future, cache some stuff:
     **out_format = piece->dsc_out = pipe->dsc;
 
-    for(int k = 0; k < 4; k++) piece->processed_maximum[k] = pipe->processed_maximum[k];
     dt_pthread_mutex_unlock(&pipe->busy_mutex);
     if(module == darktable.develop->gui_module)
     {
@@ -2411,7 +2405,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, int x,
 restart:
 
   // image max is normalized before
-  for(int k = 0; k < 4; k++) pipe->processed_maximum[k] = 1.0f; // dev->image->maximum;
+  for(int k = 0; k < 4; k++) pipe->dsc.processed_maximum[k] = 1.0f; // dev->image->maximum;
 
   // check if we should obsolete caches
   if(pipe->cache_obsolete) dt_dev_pixelpipe_cache_flush(&(pipe->cache));

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -56,6 +56,7 @@ typedef struct dt_dev_pixelpipe_iop_t
   int process_cl_ready;       // set this to 0 in commit_params to temporarily disable the use of process_cl
 
   // the following are used  internally for caching:
+  dt_iop_buffer_dsc_t dsc_in, dsc_out;
   float processed_maximum[4]; // sensor saturation after this iop
   // sensor pattern aka filters, propagated through the operations:
   uint32_t filters; // Bayer demosaic pattern
@@ -96,6 +97,7 @@ typedef struct dt_dev_pixelpipe_t
   // sensor saturation, propagated through the operations:
   float processed_maximum[4];
 
+  dt_iop_buffer_dsc_t dsc;
   // sensor pattern aka filters, propagated through the operations:
   uint32_t filters; // Bayer demosaic pattern
   /* filter for Fuji X-Trans images, only used if filters == 9u */

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -57,8 +57,6 @@ typedef struct dt_dev_pixelpipe_iop_t
 
   // the following are used  internally for caching:
   dt_iop_buffer_dsc_t dsc_in, dsc_out;
-
-  float processed_maximum[4]; // sensor saturation after this iop
 } dt_dev_pixelpipe_iop_t;
 
 typedef enum dt_dev_pixelpipe_change_t
@@ -91,8 +89,6 @@ typedef struct dt_dev_pixelpipe_t
   float iscale;
   // dimensions of processed buffer
   int processed_width, processed_height;
-  // sensor saturation, propagated through the operations:
-  float processed_maximum[4];
 
   // this one actually contains the expected output format,
   // and should be modified by process*(), if necessary.

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -57,11 +57,8 @@ typedef struct dt_dev_pixelpipe_iop_t
 
   // the following are used  internally for caching:
   dt_iop_buffer_dsc_t dsc_in, dsc_out;
+
   float processed_maximum[4]; // sensor saturation after this iop
-  // sensor pattern aka filters, propagated through the operations:
-  uint32_t filters; // Bayer demosaic pattern
-  /* filter for Fuji X-Trans images, only used if filters == 9u */
-  uint8_t xtrans[6][6];
 } dt_dev_pixelpipe_iop_t;
 
 typedef enum dt_dev_pixelpipe_change_t
@@ -100,11 +97,6 @@ typedef struct dt_dev_pixelpipe_t
   // this one actually contains the expected output format,
   // and should be modified by process*(), if necessary.
   dt_iop_buffer_dsc_t dsc;
-
-  // sensor pattern aka filters, propagated through the operations:
-  uint32_t filters; // Bayer demosaic pattern
-  /* filter for Fuji X-Trans images, only used if filters == 9u */
-  uint8_t xtrans[6][6];
 
   // instances of pixelpipe, stored in GList of dt_dev_pixelpipe_iop_t
   GList *nodes;

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -97,7 +97,10 @@ typedef struct dt_dev_pixelpipe_t
   // sensor saturation, propagated through the operations:
   float processed_maximum[4];
 
+  // this one actually contains the expected output format,
+  // and should be modified by process*(), if necessary.
   dt_iop_buffer_dsc_t dsc;
+
   // sensor pattern aka filters, propagated through the operations:
   uint32_t filters; // Bayer demosaic pattern
   /* filter for Fuji X-Trans images, only used if filters == 9u */

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -587,8 +587,10 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
 {
   void *input = NULL;
   void *output = NULL;
+  dt_iop_buffer_dsc_t dsc;
+  self->output_format(self, piece->pipe, piece, &dsc);
+  const int out_bpp = dt_iop_buffer_dsc_to_bpp(&dsc);
 
-  const int out_bpp = self->output_bpp(self, piece->pipe, piece);
   const int ipitch = roi_in->width * in_bpp;
   const int opitch = roi_out->width * out_bpp;
   const int max_bpp = _max(in_bpp, out_bpp);
@@ -835,7 +837,10 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   //_print_roi(roi_in, "module roi_in");
   //_print_roi(roi_out, "module roi_out");
 
-  const int out_bpp = self->output_bpp(self, piece->pipe, piece);
+  dt_iop_buffer_dsc_t dsc;
+  self->output_format(self, piece->pipe, piece, &dsc);
+  const int out_bpp = dt_iop_buffer_dsc_to_bpp(&dsc);
+
   const int ipitch = roi_in->width * in_bpp;
   const int opitch = roi_out->width * out_bpp;
   const int max_bpp = _max(in_bpp, out_bpp);
@@ -1187,8 +1192,11 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   void *input_buffer = NULL;
   void *output_buffer = NULL;
 
+  dt_iop_buffer_dsc_t dsc;
+  self->output_format(self, piece->pipe, piece, &dsc);
+  const int out_bpp = dt_iop_buffer_dsc_to_bpp(&dsc);
+
   const int devid = piece->pipe->devid;
-  const int out_bpp = self->output_bpp(self, piece->pipe, piece);
   const int ipitch = roi_in->width * in_bpp;
   const int opitch = roi_out->width * out_bpp;
   const int max_bpp = _max(in_bpp, out_bpp);
@@ -1539,8 +1547,11 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   //_print_roi(roi_in, "module roi_in");
   //_print_roi(roi_out, "module roi_out");
 
+  dt_iop_buffer_dsc_t dsc;
+  self->output_format(self, piece->pipe, piece, &dsc);
+  const int out_bpp = dt_iop_buffer_dsc_to_bpp(&dsc);
+
   const int devid = piece->pipe->devid;
-  const int out_bpp = self->output_bpp(self, piece->pipe, piece);
   const int ipitch = roi_in->width * in_bpp;
   const int opitch = roi_out->width * out_bpp;
   const int max_bpp = _max(in_bpp, out_bpp);

--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -719,7 +719,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
   /* store processed_maximum to be re-used and aggregated */
   float processed_maximum_saved[4];
   float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->processed_maximum[k];
+  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
 
   /* iterate over tiles */
@@ -758,7 +758,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
         memcpy((char *)input + j * wd * in_bpp, (char *)ivoid + ioffs + j * ipitch, (size_t)wd * in_bpp);
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_saved[k];
+      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
 
       /* call process() of module */
       self->process(self, piece, input, output, &iroi, &oroi);
@@ -768,12 +768,12 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
                appropriate action (calculate minimum, maximum, average, ...?) */
       for(int k = 0; k < 4; k++)
       {
-        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->processed_maximum[k]) > 1.0e-6f)
+        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(
               DT_DEBUG_DEV,
               "[default_process_tiling_ptp] processed_maximum[%d] differs between tiles in module '%s'\n", k,
               self->op);
-        processed_maximum_new[k] = piece->pipe->processed_maximum[k];
+        processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
       /* correct origin and region of tile for overlap.
@@ -801,7 +801,7 @@ static void _default_process_tiling_ptp(struct dt_iop_module_t *self, struct dt_
     }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_new[k];
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
 
   if(input != NULL) dt_free_align(input);
   if(output != NULL) dt_free_align(output);
@@ -978,7 +978,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
   /* store processed_maximum to be re-used and aggregated */
   float processed_maximum_saved[4];
   float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->processed_maximum[k];
+  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* iterate over tiles */
   for(size_t tx = 0; tx < tiles_x; tx++)
@@ -1101,7 +1101,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
                (size_t)iroi_full.width * in_bpp);
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_saved[k];
+      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
 
       /* call process() of module */
       self->process(self, piece, input, output, &iroi_full, &oroi_full);
@@ -1111,12 +1111,12 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
                appropriate action (calculate minimum, maximum, average, ...?) */
       for(int k = 0; k < 4; k++)
       {
-        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->processed_maximum[k]) > 1.0e-6f)
+        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(
               DT_DEBUG_DEV,
               "[default_process_tiling_roi] processed_maximum[%d] differs between tiles in module '%s'\n", k,
               self->op);
-        processed_maximum_new[k] = piece->pipe->processed_maximum[k];
+        processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
       /* copy "good" part of tile to output buffer */
@@ -1136,7 +1136,7 @@ static void _default_process_tiling_roi(struct dt_iop_module_t *self, struct dt_
     }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_new[k];
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
 
   if(input != NULL) dt_free_align(input);
   if(output != NULL) dt_free_align(output);
@@ -1308,7 +1308,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
   /* store processed_maximum to be re-used and aggregated */
   float processed_maximum_saved[4];
   float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->processed_maximum[k];
+  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* reserve pinned input and output memory for host<->device data transfer */
   if(use_pinned_memory)
@@ -1426,7 +1426,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
       }
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_saved[k];
+      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
 
       /* call process_cl of module */
       if(!self->process_cl(self, piece, input, output, &iroi, &oroi)) goto error;
@@ -1436,12 +1436,12 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
                appropriate action (calculate minimum, maximum, average, ...?) */
       for(int k = 0; k < 4; k++)
       {
-        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->processed_maximum[k]) > 1.0e-6f)
+        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(
               DT_DEBUG_OPENCL,
               "[default_process_tiling_cl_ptp] processed_maximum[%d] differs between tiles in module '%s'\n",
               k, self->op);
-        processed_maximum_new[k] = piece->pipe->processed_maximum[k];
+        processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
       if(use_pinned_memory)
@@ -1499,7 +1499,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
     }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_new[k];
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
 
   if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
   if(pinned_input != NULL) dt_opencl_release_mem_object(pinned_input);
@@ -1512,7 +1512,7 @@ static int _default_process_tiling_cl_ptp(struct dt_iop_module_t *self, struct d
 
 error:
   /* copy back stored processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_saved[k];
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
   if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
   if(pinned_input != NULL) dt_opencl_release_mem_object(pinned_input);
   if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);
@@ -1684,7 +1684,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
   /* store processed_maximum to be re-used and aggregated */
   float processed_maximum_saved[4];
   float processed_maximum_new[4] = { 1.0f };
-  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->processed_maximum[k];
+  for(int k = 0; k < 4; k++) processed_maximum_saved[k] = piece->pipe->dsc.processed_maximum[k];
 
   /* reserve pinned input and output memory for host<->device data transfer */
   if(use_pinned_memory)
@@ -1881,7 +1881,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
       }
 
       /* take original processed_maximum as starting point */
-      for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_saved[k];
+      for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
 
       /* call process_cl of module */
       if(!self->process_cl(self, piece, input, output, &iroi_full, &oroi_full)) goto error;
@@ -1891,12 +1891,12 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
                appropriate action (calculate minimum, maximum, average, ...?) */
       for(int k = 0; k < 4; k++)
       {
-        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->processed_maximum[k]) > 1.0e-6f)
+        if(tx + ty > 0 && fabs(processed_maximum_new[k] - piece->pipe->dsc.processed_maximum[k]) > 1.0e-6f)
           dt_print(
               DT_DEBUG_OPENCL,
               "[default_process_tiling_cl_roi] processed_maximum[%d] differs between tiles in module '%s'\n",
               k, self->op);
-        processed_maximum_new[k] = piece->pipe->processed_maximum[k];
+        processed_maximum_new[k] = piece->pipe->dsc.processed_maximum[k];
       }
 
       if(use_pinned_memory)
@@ -1936,7 +1936,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
     }
 
   /* copy back final processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_new[k];
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_new[k];
   if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
   if(pinned_input != NULL) dt_opencl_release_mem_object(pinned_input);
   if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);
@@ -1948,7 +1948,7 @@ static int _default_process_tiling_cl_roi(struct dt_iop_module_t *self, struct d
 
 error:
   /* copy back stored processed_maximum */
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = processed_maximum_saved[k];
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = processed_maximum_saved[k];
   if(input_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_input, input_buffer);
   if(pinned_input != NULL) dt_opencl_release_mem_object(pinned_input);
   if(output_buffer != NULL) dt_opencl_unmap_mem_object(devid, pinned_output, output_buffer);

--- a/src/iop/amaze_demosaic_RT.cc
+++ b/src/iop/amaze_demosaic_RT.cc
@@ -325,8 +325,8 @@ void amaze_demosaic_RT(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
   const int width = winw, height = winh;
   //   const float clip_pt = 1.0 / initialGain;
   //   const float clip_pt8 = 0.8 / initialGain;
-  const float clip_pt = fminf(piece->pipe->processed_maximum[0],
-                              fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
+  const float clip_pt = fminf(piece->pipe->dsc.processed_maximum[0],
+                              fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
   const float clip_pt8 = 0.8f * clip_pt;
 
 // this allows to pass AMAZETS to the code. On some machines larger AMAZETS is faster

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1500,7 +1500,7 @@ void reload_defaults(dt_iop_module_t *module)
   if(!module->dev) goto end;
 
   // can't be switched on for non-raw or x-trans images:
-  if(dt_image_is_raw(&module->dev->image_storage) && (module->dev->image_storage.filters != 9u))
+  if(dt_image_is_raw(&module->dev->image_storage) && (module->dev->image_storage.buf_dsc.filters != 9u))
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
@@ -1561,7 +1561,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(dt_iop_module_t *self)
 {
   if(dt_image_is_raw(&self->dev->image_storage))
-    if(self->dev->image_storage.filters != 9u)
+    if(self->dev->image_storage.buf_dsc.filters != 9u)
       gtk_label_set_text(GTK_LABEL(self->widget), _("automatic chromatic aberration correction"));
     else
       gtk_label_set_text(GTK_LABEL(self->widget),

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -306,7 +306,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 {
   const int width = roi_in->width;
   const int height = roi_in->height;
-  const uint32_t filters = piece->pipe->filters;
+  const uint32_t filters = piece->pipe->dsc.filters;
   memcpy(out, in2, width * height * sizeof(float));
   const float *const in = out;
   const double cared = 0, cablue = 0;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -67,12 +67,6 @@ int flags()
   return IOP_FLAGS_ONE_INSTANCE;
 }
 
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  return sizeof(float);
-}
-
-
 /** modify regions of interest (optional, per pixel ops don't need this) */
 // void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t
 // *roi_out, const dt_iop_roi_t *roi_in);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1664,7 +1664,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         if (img->flags & DT_IMAGE_4BAYER)
         {
           dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, data->CAM_to_RGB);
-          dt_colorspaces_cygm_to_rgb(piece->pipe->processed_maximum, 1, data->CAM_to_RGB);
+          dt_colorspaces_cygm_to_rgb(piece->pipe->dsc.processed_maximum, 1, data->CAM_to_RGB);
         }
       }
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
@@ -1686,8 +1686,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   else
   {
     // sample half-size raw (Bayer) or 1/3-size raw (X-Trans)
-    const float clip = fminf(piece->pipe->processed_maximum[0],
-                             fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
+    const float clip = fminf(piece->pipe->dsc.processed_maximum[0],
+                             fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
     if(piece->pipe->dsc.filters == 9u)
       dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                         xtrans);
@@ -2092,10 +2092,9 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   const int devid = piece->pipe->devid;
   const int qual = get_quality();
 
-  const float processed_maximum[4] = { piece->pipe->processed_maximum[0],
-                                       piece->pipe->processed_maximum[1],
-                                       piece->pipe->processed_maximum[2],
-                                       1.0f };
+  const float processed_maximum[4]
+      = { piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1],
+          piece->pipe->dsc.processed_maximum[2], 1.0f };
 
   // we check if we need ultra-high quality thumbnail for this size
   int uhq_thumb = 0;
@@ -2512,10 +2511,9 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
   const int qual = get_quality();
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
-  const float processed_maximum[4] = { piece->pipe->processed_maximum[0],
-                                       piece->pipe->processed_maximum[1],
-                                       piece->pipe->processed_maximum[2],
-                                       1.0f };
+  const float processed_maximum[4]
+      = { piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1],
+          piece->pipe->dsc.processed_maximum[2], 1.0f };
 
   // we check if we need ultra-high quality thumbnail for this size
   int uhq_thumb = 0;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1502,7 +1502,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   roi_in->height /= roi_out->scale;
   roi_in->scale = 1.0f;
   // clamp to even x/y, to make demosaic pattern still hold..
-  if(piece->pipe->filters != 9u)
+  if(piece->pipe->dsc.filters != 9u)
   {
     roi_in->x = MAX(0, roi_in->x & ~1);
     roi_in->y = MAX(0, roi_in->y & ~1);
@@ -1568,7 +1568,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   roo.x = roo.y = 0;
   // roi_out->scale = global scale: (iscale == 1.0, always when demosaic is on)
 
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
   dt_iop_demosaic_data_t *data = (dt_iop_demosaic_data_t *)piece->data;
 
@@ -1576,8 +1576,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   int demosaicing_method = data->demosaicing_method;
   if(piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual < 2 && roi_out->scale <= .99999f
      && // only overwrite setting if quality << requested and in dr mode
-     ((piece->pipe->filters != 9u) && (demosaicing_method != DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)))
-    demosaicing_method = (piece->pipe->filters != 9u) ? DT_IOP_DEMOSAIC_PPG : DT_IOP_DEMOSAIC_MARKESTEIJN;
+     ((piece->pipe->dsc.filters != 9u) && (demosaicing_method != DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)))
+    demosaicing_method = (piece->pipe->dsc.filters != 9u) ? DT_IOP_DEMOSAIC_PPG : DT_IOP_DEMOSAIC_MARKESTEIJN;
 
   // we check if we need ultra-high quality thumbnail for this size
   int uhq_thumb = 0;
@@ -1588,13 +1588,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing
       = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0) || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT
-        || uhq_thumb || roi_out->scale > (piece->pipe->filters == 9u ? 0.333f : 0.5f)
+        || uhq_thumb || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f)
         || (img->flags & DT_IMAGE_4BAYER); // half_size_f doesn't support 4bayer images
 
   // we check if we can stop at the linear interpolation step in VNG
   // instead of going the full way
   const int only_vng_linear
-      = full_scale_demosaicing && roi_out->scale < (piece->pipe->filters == 9u ? 0.5f : 0.667f);
+      = full_scale_demosaicing && roi_out->scale < (piece->pipe->dsc.filters == 9u ? 0.5f : 0.667f);
 
   // we use full Markesteijn demosaicing on xtrans sensors only if
   // maximum quality is required
@@ -1622,14 +1622,13 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       tmp = (float *)dt_alloc_align(16, (size_t)roo.width * roo.height * 4 * sizeof(float));
     }
 
-    if(piece->pipe->filters == 9u)
+    if(piece->pipe->dsc.filters == 9u)
     {
       if(demosaicing_method >= DT_IOP_DEMOSAIC_MARKESTEIJN && xtrans_full_markesteijn_demosaicing)
         xtrans_markesteijn_interpolate(tmp, pixels, &roo, &roi, xtrans,
                                        1 + (demosaicing_method - DT_IOP_DEMOSAIC_MARKESTEIJN) * 2);
       else
-        vng_interpolate(tmp, pixels, &roo, &roi, piece->pipe->filters, xtrans,
-                        only_vng_linear);
+        vng_interpolate(tmp, pixels, &roo, &roi, piece->pipe->dsc.filters, xtrans, only_vng_linear);
     }
     else
     {
@@ -1641,17 +1640,17 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         switch(data->green_eq)
         {
           case DT_IOP_GREEN_EQ_FULL:
-            green_equilibration_favg(in, pixels, roi_in->width, roi_in->height, piece->pipe->filters, roi_in->x,
-                                     roi_in->y);
+            green_equilibration_favg(in, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
+                                     roi_in->x, roi_in->y);
             break;
           case DT_IOP_GREEN_EQ_LOCAL:
-            green_equilibration_lavg(in, pixels, roi_in->width, roi_in->height, piece->pipe->filters, roi_in->x,
-                                     roi_in->y, 0, threshold);
+            green_equilibration_lavg(in, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
+                                     roi_in->x, roi_in->y, 0, threshold);
             break;
           case DT_IOP_GREEN_EQ_BOTH:
-            green_equilibration_favg(in, pixels, roi_in->width, roi_in->height, piece->pipe->filters, roi_in->x,
-                                     roi_in->y);
-            green_equilibration_lavg(in, in, roi_in->width, roi_in->height, piece->pipe->filters, roi_in->x,
+            green_equilibration_favg(in, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
+                                     roi_in->x, roi_in->y);
+            green_equilibration_lavg(in, in, roi_in->width, roi_in->height, piece->pipe->dsc.filters, roi_in->x,
                                      roi_in->y, 1, threshold);
             break;
         }
@@ -1661,8 +1660,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         passthrough_monochrome(tmp, in, &roo, &roi);
       else if(demosaicing_method == DT_IOP_DEMOSAIC_VNG4 || (img->flags & DT_IMAGE_4BAYER))
       {
-        vng_interpolate(tmp, in, &roo, &roi, piece->pipe->filters, xtrans,
-                        only_vng_linear);
+        vng_interpolate(tmp, in, &roo, &roi, piece->pipe->dsc.filters, xtrans, only_vng_linear);
         if (img->flags & DT_IMAGE_4BAYER)
         {
           dt_colorspaces_cygm_to_rgb(tmp, roo.width*roo.height, data->CAM_to_RGB);
@@ -1670,10 +1668,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         }
       }
       else if(demosaicing_method != DT_IOP_DEMOSAIC_AMAZE)
-        demosaic_ppg(tmp, in, &roo, &roi, piece->pipe->filters,
+        demosaic_ppg(tmp, in, &roo, &roi, piece->pipe->dsc.filters,
                      data->median_thrs); // wanted ppg or zoomed out a lot and quality is limited to 1
       else
-        amaze_demosaic_RT(self, piece, in, tmp, &roi, &roo, piece->pipe->filters);
+        amaze_demosaic_RT(self, piece, in, tmp, &roi, &roo, piece->pipe->dsc.filters);
 
       if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO) dt_free_align(in);
     }
@@ -1690,7 +1688,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // sample half-size raw (Bayer) or 1/3-size raw (X-Trans)
     const float clip = fminf(piece->pipe->processed_maximum[0],
                              fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
-    if(piece->pipe->filters == 9u)
+    if(piece->pipe->dsc.filters == 9u)
       dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                         xtrans);
     else
@@ -1700,7 +1698,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                                                roi.width);
       else
         dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
-                                                  piece->pipe->filters, clip);
+                                                  piece->pipe->dsc.filters, clip);
     }
   }
   if(data->color_smoothing) color_smoothing(o, roi_out, data->color_smoothing);
@@ -1877,9 +1875,8 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   cl_mem dev_green_eq = NULL;
   cl_int err = -999;
 
-  if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0) ||
-      piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || (uhq_thumb) ||
-      roi_out->scale > (piece->pipe->filters == 9u ? 0.333f : .5f))
+  if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0) || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT
+     || (uhq_thumb) || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : .5f))
   {
     // Full demosaic and then scaling if needed
     const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
@@ -1913,7 +1910,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 1, sizeof(cl_mem), &dev_green_eq);
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 2, sizeof(int), &width);
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 3, sizeof(int), &height);
-      dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 4, sizeof(uint32_t), (void *)&piece->pipe->filters);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 5, sizeof(float), (void *)&threshold);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_green_eq, sizes);
       if(err != CL_SUCCESS) goto error;
@@ -1938,7 +1935,8 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 1, sizeof(cl_mem), &dev_aux);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 2, sizeof(int), &width);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 3, sizeof(int), &height);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 4, sizeof(uint32_t), (void *)&piece->pipe->filters);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 4, sizeof(uint32_t),
+                                 (void *)&piece->pipe->dsc.filters);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 5, sizeof(float), (void *)&data->median_thrs);
         dt_opencl_set_kernel_arg(devid, gd->kernel_pre_median, 6, sizeof(int), (void *)&one);
         err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_pre_median, sizes);
@@ -1949,7 +1947,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green_median, 2, sizeof(int), &width);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green_median, 3, sizeof(int), &height);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green_median, 4, sizeof(uint32_t),
-                                 (void *)&piece->pipe->filters);
+                                 (void *)&piece->pipe->dsc.filters);
         err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_ppg_green_median, sizes);
         if(err != CL_SUCCESS) goto error;
       }
@@ -1959,7 +1957,8 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 1, sizeof(cl_mem), &dev_tmp);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 2, sizeof(int), &width);
         dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 3, sizeof(int), &height);
-        dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 4, sizeof(uint32_t), (void *)&piece->pipe->filters);
+        dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_green, 4, sizeof(uint32_t),
+                                 (void *)&piece->pipe->dsc.filters);
         err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_ppg_green, sizes);
         if(err != CL_SUCCESS) goto error;
       }
@@ -1968,7 +1967,8 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_redblue, 1, sizeof(cl_mem), &dev_aux);
       dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_redblue, 2, sizeof(int), &width);
       dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_redblue, 3, sizeof(int), &height);
-      dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_redblue, 4, sizeof(uint32_t), (void *)&piece->pipe->filters);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_ppg_redblue, 4, sizeof(uint32_t),
+                               (void *)&piece->pipe->dsc.filters);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_ppg_redblue, sizes);
       if(err != CL_SUCCESS) goto error;
 
@@ -1978,7 +1978,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 2, sizeof(int), (void *)&width);
       dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 3, sizeof(int), (void *)&height);
       dt_opencl_set_kernel_arg(devid, gd->kernel_border_interpolate, 4, sizeof(uint32_t),
-                               (void *)&piece->pipe->filters);
+                               (void *)&piece->pipe->dsc.filters);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_border_interpolate, sizes);
       if(err != CL_SUCCESS) goto error;
     }
@@ -2014,7 +2014,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_passthrough_monochrome, 8, sizeof(float),
                                (void *)&roi_out->scale);
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_passthrough_monochrome, 9, sizeof(uint32_t),
-                               (void *)&piece->pipe->filters);
+                               (void *)&piece->pipe->dsc.filters);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_zoom_passthrough_monochrome, sizes);
       if(err != CL_SUCCESS) goto error;
     }
@@ -2037,7 +2037,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 7, sizeof(int), (void *)&roi_in->height);
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 8, sizeof(float), (void *)&roi_out->scale);
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 9, sizeof(uint32_t),
-                               (void *)&piece->pipe->filters);
+                               (void *)&piece->pipe->dsc.filters);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_zoom_half_size, sizes);
       if(err != CL_SUCCESS) goto error;
     }
@@ -2074,16 +2074,16 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   const dt_image_t *img = &self->dev->image_storage;
   const float threshold = 0.0001f * img->exif_iso;
 
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
   // separate out G1 and G2 in Bayer patterns
   uint32_t filters4;
-  if(piece->pipe->filters == 9u)
-    filters4 = piece->pipe->filters;
-  else if((piece->pipe->filters & 3) == 1)
-    filters4 = piece->pipe->filters | 0x03030303u;
+  if(piece->pipe->dsc.filters == 9u)
+    filters4 = piece->pipe->dsc.filters;
+  else if((piece->pipe->dsc.filters & 3) == 1)
+    filters4 = piece->pipe->dsc.filters | 0x03030303u;
   else
-    filters4 = piece->pipe->filters | 0x0c0c0c0cu;
+    filters4 = piece->pipe->dsc.filters | 0x0c0c0c0cu;
 
   const int size = (filters4 == 9u) ? 6 : 16;
   const int colors = (filters4 == 9u) ? 3 : 4;
@@ -2106,12 +2106,12 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0)
                                      || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || uhq_thumb
-                                     || roi_out->scale > (piece->pipe->filters == 9u ? 0.333f : 0.5f);
+                                     || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f);
 
   // check if we can stop at the linear interpolation step and
   // avoid full VNG
   const int only_vng_linear
-      = full_scale_demosaicing && roi_out->scale < (piece->pipe->filters == 9u ? 0.5f : 0.667f);
+      = full_scale_demosaicing && roi_out->scale < (piece->pipe->dsc.filters == 9u ? 0.5f : 0.667f);
 
   cl_mem dev_tmp = NULL;
   cl_mem dev_aux = NULL;
@@ -2122,9 +2122,10 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   cl_mem dev_green_eq = NULL;
   cl_int err = -999;
 
-  if(piece->pipe->filters == 9u)
+  if(piece->pipe->dsc.filters == 9u)
   {
-    dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->xtrans), piece->pipe->xtrans);
+    dev_xtrans
+        = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->dsc.xtrans), piece->pipe->dsc.xtrans);
     if(dev_xtrans == NULL) goto error;
   }
 
@@ -2277,7 +2278,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
     dev_ips = dt_opencl_copy_host_to_device_constant(devid, sizeof(ips), ips);
     if(dev_ips == NULL) goto error;
 
-    if(piece->pipe->filters != 9u && data->green_eq != DT_IOP_GREEN_EQ_NO)
+    if(piece->pipe->dsc.filters != 9u && data->green_eq != DT_IOP_GREEN_EQ_NO)
     {
       // green equilibration for Bayer sensors
       dev_green_eq = dt_opencl_alloc_device(devid, roi_in->width, roi_in->height, sizeof(float));
@@ -2290,7 +2291,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 1, sizeof(cl_mem), (void *)&dev_green_eq);
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 2, sizeof(int), (void *)&width);
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 3, sizeof(int), (void *)&height);
-      dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 4, sizeof(uint32_t), (void *)&piece->pipe->filters);
+      dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 4, sizeof(uint32_t), (void *)&piece->pipe->dsc.filters);
       dt_opencl_set_kernel_arg(devid, gd->kernel_green_eq, 5, sizeof(float), (void *)&threshold);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_green_eq, sizes);
       if(err != CL_SUCCESS) goto error;
@@ -2415,7 +2416,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   else
   {
     // sample half-size or third-size image
-    if(piece->pipe->filters == 9u)
+    if(piece->pipe->dsc.filters == 9u)
     {
       const int width = roi_out->width;
       const int height = roi_out->height;
@@ -2451,7 +2452,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 7, sizeof(int), (void *)&roi_in->height);
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 8, sizeof(float), (void *)&roi_out->scale);
       dt_opencl_set_kernel_arg(devid, gd->kernel_zoom_half_size, 9, sizeof(uint32_t),
-                               (void *)&piece->pipe->filters);
+                               (void *)&piece->pipe->dsc.filters);
       err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_zoom_half_size, sizes);
       if(err != CL_SUCCESS) goto error;
     }
@@ -2509,7 +2510,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
 
   const int devid = piece->pipe->devid;
   const int qual = get_quality();
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
   const float processed_maximum[4] = { piece->pipe->processed_maximum[0],
                                        piece->pipe->processed_maximum[1],
@@ -2525,7 +2526,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0)
                                      || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || uhq_thumb
-                                     || roi_out->scale > (piece->pipe->filters == 9u ? 0.333f : 0.5f);
+                                     || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f);
 
   cl_mem dev_tmp = NULL;
   cl_mem dev_tmptmp = NULL;
@@ -2544,7 +2545,8 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
 
   cl_mem *dev_rgb = dev_rgbv;
 
-  dev_xtrans = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->xtrans), piece->pipe->xtrans);
+  dev_xtrans
+      = dt_opencl_copy_host_to_device_constant(devid, sizeof(piece->pipe->dsc.xtrans), piece->pipe->dsc.xtrans);
   if(dev_xtrans == NULL) goto error;
 
   if(full_scale_demosaicing)
@@ -3378,7 +3380,8 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int qual = get_quality();
   const float ioratio = (float)roi_out->width * roi_out->height / ((float)roi_in->width * roi_in->height);
   const float smooth = data->color_smoothing ? ioratio : 0.0f;
-  const float greeneq = ((piece->pipe->filters != 9u) && (data->green_eq != DT_IOP_GREEN_EQ_NO)) ? 0.25f : 0.0f;
+  const float greeneq
+      = ((piece->pipe->dsc.filters != 9u) && (data->green_eq != DT_IOP_GREEN_EQ_NO)) ? 0.25f : 0.0f;
   const dt_iop_demosaic_method_t demosaicing_method = data->demosaicing_method;
 
   // we check if we need ultra-high quality thumbnail for this size
@@ -3389,7 +3392,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0)
                                      || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || uhq_thumb
-                                     || roi_out->scale > (piece->pipe->filters == 9u ? 0.333f : 0.5f);
+                                     || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f);
 
   // we use full Markesteijn demosaicing on xtrans sensors only if
   // maximum quality is required

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3666,7 +3666,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)self->params;
 
-  if(self->dev->image_storage.filters != 9u)
+  if(self->dev->image_storage.buf_dsc.filters != 9u)
   {
     gtk_widget_show(g->demosaic_method_bayer);
     gtk_widget_hide(g->demosaic_method_xtrans);
@@ -3729,7 +3729,7 @@ void reload_defaults(dt_iop_module_t *module)
   else
     module->default_enabled = 0;
 
-  if(module->dev->image_storage.filters == 9u) tmp.demosaicing_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
+  if(module->dev->image_storage.buf_dsc.filters == 9u) tmp.demosaicing_method = DT_IOP_DEMOSAIC_MARKESTEIJN;
 
 end:
   memcpy(module->params, &tmp, sizeof(dt_iop_demosaic_params_t));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -776,9 +776,9 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   tmp = dt_alloc_align(64, (size_t)4 * sizeof(float) * npixels);
 
   const float wb[3] = { // twice as many samples in green channel:
-                        2.0f * piece->pipe->processed_maximum[0] * d->strength * (in_scale * in_scale),
-                        piece->pipe->processed_maximum[1] * d->strength * (in_scale * in_scale),
-                        2.0f * piece->pipe->processed_maximum[2] * d->strength * (in_scale * in_scale)
+                        2.0f * piece->pipe->dsc.processed_maximum[0] * d->strength * (in_scale * in_scale),
+                        piece->pipe->dsc.processed_maximum[1] * d->strength * (in_scale * in_scale),
+                        2.0f * piece->pipe->dsc.processed_maximum[2] * d->strength * (in_scale * in_scale)
   };
   // only use green channel + wb for now:
   const float aa[3] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2] };
@@ -902,9 +902,9 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   memset(ovoid, 0x0, (size_t)sizeof(float) * roi_out->width * roi_out->height * 4);
   float *in = dt_alloc_align(64, (size_t)4 * sizeof(float) * roi_in->width * roi_in->height);
 
-  const float wb[3] = { piece->pipe->processed_maximum[0] * d->strength * (scale * scale),
-                        piece->pipe->processed_maximum[1] * d->strength * (scale * scale),
-                        piece->pipe->processed_maximum[2] * d->strength * (scale * scale) };
+  const float wb[3] = { piece->pipe->dsc.processed_maximum[0] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[1] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[2] * d->strength * (scale * scale) };
   const float aa[3] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2] };
   const float bb[3] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2] };
   precondition((float *)ivoid, in, roi_in->width, roi_in->height, aa, bb);
@@ -1050,9 +1050,9 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   memset(ovoid, 0x0, (size_t)sizeof(float) * roi_out->width * roi_out->height * 4);
   float *in = dt_alloc_align(64, (size_t)4 * sizeof(float) * roi_in->width * roi_in->height);
 
-  const float wb[3] = { piece->pipe->processed_maximum[0] * d->strength * (scale * scale),
-                        piece->pipe->processed_maximum[1] * d->strength * (scale * scale),
-                        piece->pipe->processed_maximum[2] * d->strength * (scale * scale) };
+  const float wb[3] = { piece->pipe->dsc.processed_maximum[0] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[1] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[2] * d->strength * (scale * scale) };
   const float aa[3] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2] };
   const float bb[3] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2] };
   precondition((float *)ivoid, in, roi_in->width, roi_in->height, aa, bb);
@@ -1266,11 +1266,9 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   const float norm = 0.015f / (2 * P + 1);
 
 
-  const float wb[4]
-      = { piece->pipe->processed_maximum[0] * d->strength * (scale * scale),
-          piece->pipe->processed_maximum[1] * d->strength * (scale * scale),
-          piece->pipe->processed_maximum[2] * d->strength * (scale * scale),
-          0.0f };
+  const float wb[4] = { piece->pipe->dsc.processed_maximum[0] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[1] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[2] * d->strength * (scale * scale), 0.0f };
   const float aa[4] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2], 1.0f };
   const float bb[4] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2], 1.0f };
   const float sigma2[4] = { (bb[0] / aa[0]) * (bb[0] / aa[0]), (bb[1] / aa[1]) * (bb[1] / aa[1]),
@@ -1555,9 +1553,9 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     if(dev_detail[k] == NULL) goto error;
   }
 
-  const float wb[4] = { 2.0f * piece->pipe->processed_maximum[0] * d->strength * (scale * scale),
-                        piece->pipe->processed_maximum[1] * d->strength * (scale * scale),
-                        2.0f * piece->pipe->processed_maximum[2] * d->strength * (scale * scale), 0.0f };
+  const float wb[4] = { 2.0f * piece->pipe->dsc.processed_maximum[0] * d->strength * (scale * scale),
+                        piece->pipe->dsc.processed_maximum[1] * d->strength * (scale * scale),
+                        2.0f * piece->pipe->dsc.processed_maximum[2] * d->strength * (scale * scale), 0.0f };
   const float aa[4] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2], 1.0f };
   const float bb[4] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2], 1.0f };
   const float sigma2[4] = { (bb[0] / aa[0]) * (bb[0] / aa[0]), (bb[1] / aa[1]) * (bb[1] / aa[1]),

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -343,7 +343,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_set_kernel_arg(devid, gd->kernel_exposure, 5, sizeof(float), (void *)&(d->scale));
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_exposure, sizes);
   if(err != CL_SUCCESS) goto error;
-  for(int k = 0; k < 3; k++) piece->pipe->processed_maximum[k] *= d->scale;
+  for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] *= d->scale;
 
   return TRUE;
 
@@ -370,7 +370,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(piece->pipe->mask_display) dt_iop_alpha_copy(i, o, roi_out->width, roi_out->height);
 
-  for(int k = 0; k < 3; k++) piece->pipe->processed_maximum[k] *= d->scale;
+  for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] *= d->scale;
 }
 
 #if defined(__SSE__)
@@ -396,7 +396,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   if(piece->pipe->mask_display) dt_iop_alpha_copy(i, o, roi_out->width, roi_out->height);
 
-  for(int k = 0; k < 3; k++) piece->pipe->processed_maximum[k] *= d->scale;
+  for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] *= d->scale;
 }
 #endif
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -237,7 +237,7 @@ static void deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histog
   dt_image_t image = *img;
   dt_image_cache_read_release(darktable.image_cache, img);
 
-  if(image.bpp != sizeof(uint16_t)) return;
+  if(image.buf_dsc.channels != 1 || image.buf_dsc.datatype != TYPE_UINT16) return;
 
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, self->dev->image_storage.id, DT_MIPMAP_FULL,
@@ -417,7 +417,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   float exposure = p->exposure;
 
   if(p->mode == EXPOSURE_MODE_DEFLICKER && dt_image_is_raw(&self->dev->image_storage)
-     && self->dev->image_storage.bpp == sizeof(uint16_t))
+     && self->dev->image_storage.buf_dsc.channels == 1 && self->dev->image_storage.buf_dsc.datatype == TYPE_UINT16)
   {
     // first, compute correction.
     if(g)
@@ -471,7 +471,8 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
   dt_iop_exposure_params_t *p = (dt_iop_exposure_params_t *)self->params;
 
-  if(!dt_image_is_raw(&self->dev->image_storage) || self->dev->image_storage.bpp != sizeof(uint16_t))
+  if(!dt_image_is_raw(&self->dev->image_storage) || self->dev->image_storage.buf_dsc.channels != 1
+     || self->dev->image_storage.buf_dsc.datatype != TYPE_UINT16)
   {
     gtk_widget_hide(GTK_WIDGET(g->mode));
     p->mode = EXPOSURE_MODE_MANUAL;
@@ -589,7 +590,8 @@ static void mode_callback(GtkWidget *combo, gpointer user_data)
   {
     case EXPOSURE_MODE_DEFLICKER:
       autoexp_disable(self);
-      if(!dt_image_is_raw(&self->dev->image_storage) || self->dev->image_storage.bpp != sizeof(uint16_t))
+      if(!dt_image_is_raw(&self->dev->image_storage) || self->dev->image_storage.buf_dsc.channels != 1
+         || self->dev->image_storage.buf_dsc.datatype != TYPE_UINT16)
       {
         dt_bauhaus_combobox_set(g->mode, g_list_index(g->modes, GUINT_TO_POINTER(EXPOSURE_MODE_MANUAL)));
         gtk_widget_hide(GTK_WIDGET(g->mode));
@@ -738,7 +740,9 @@ static void deflicker_params_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
 
-  if(!dt_image_is_raw(&self->dev->image_storage) || self->dev->image_storage.bpp != sizeof(uint16_t)) return;
+  if(!dt_image_is_raw(&self->dev->image_storage) || self->dev->image_storage.buf_dsc.channels != 1
+     || self->dev->image_storage.buf_dsc.datatype != TYPE_UINT16)
+    return;
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
   dt_iop_exposure_params_t *p = (dt_iop_exposure_params_t *)self->params;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -134,11 +134,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "target level", GTK_WIDGET(g->deflicker_target_level));
 }
 
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  return 4 * sizeof(float);
-}
-
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -49,11 +49,6 @@ int groups()
   return IOP_GROUP_BASIC;
 }
 
-int output_bpp(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  return 4 * sizeof(float);
-}
-
 void modify_roi_in(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_out,
                    dt_iop_roi_t *roi_in)
 {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -867,7 +867,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   piece->process_cl_ready = 1;
 
   // x-trans images not implemented in OpenCL yet
-  if(pipe->image.filters == 9u) piece->process_cl_ready = 0;
+  if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = 0;
 
   // no OpenCL for DT_IOP_HIGHLIGHTS_INPAINT yet.
   if(d->mode == DT_IOP_HIGHLIGHTS_INPAINT) piece->process_cl_ready = 0;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -111,9 +111,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int height = roi_in->height;
 
   size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-  const float clip = d->clip
-                     * fminf(piece->pipe->processed_maximum[0],
-                             fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
+  const float clip
+      = d->clip * fminf(piece->pipe->dsc.processed_maximum[0],
+                        fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
   const uint32_t filters = piece->pipe->dsc.filters;
   if(dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) || !filters)
   {
@@ -144,11 +144,9 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   }
 
   // update processed maximum
-  const float m = fmaxf(fmaxf(
-        piece->pipe->processed_maximum[0],
-        piece->pipe->processed_maximum[1]),
-      piece->pipe->processed_maximum[2]);
-  for(int k=0;k<3;k++) piece->pipe->processed_maximum[k] = m;
+  const float m = fmaxf(fmaxf(piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1]),
+                        piece->pipe->dsc.processed_maximum[2]);
+  for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] = m;
 
   return TRUE;
 
@@ -748,15 +746,16 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   dt_iop_highlights_data_t *data = (dt_iop_highlights_data_t *)piece->data;
 
   const float clip
-      = data->clip * fminf(piece->pipe->processed_maximum[0],
-                           fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
+      = data->clip * fminf(piece->pipe->dsc.processed_maximum[0],
+                           fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
   // const int ch = piece->colors;
   if(dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) || !filters)
   {
     process_clip(piece, ivoid, ovoid, roi_in, roi_out, clip);
     for(int k=0;k<3;k++)
-      piece->pipe->processed_maximum[k] = fminf(piece->pipe->processed_maximum[0],
-          fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
+      piece->pipe->dsc.processed_maximum[k]
+          = fminf(piece->pipe->dsc.processed_maximum[0],
+                  fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
     return;
   }
 
@@ -764,9 +763,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     case DT_IOP_HIGHLIGHTS_INPAINT: // a1ex's (magiclantern) idea of color inpainting:
     {
-      const float clips[4] = { 0.987 * data->clip * piece->pipe->processed_maximum[0],
-                               0.987 * data->clip * piece->pipe->processed_maximum[1],
-                               0.987 * data->clip * piece->pipe->processed_maximum[2], clip };
+      const float clips[4] = { 0.987 * data->clip * piece->pipe->dsc.processed_maximum[0],
+                               0.987 * data->clip * piece->pipe->dsc.processed_maximum[1],
+                               0.987 * data->clip * piece->pipe->dsc.processed_maximum[2], clip };
 
       if(filters == 9u)
       {
@@ -824,11 +823,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 
   // update processed maximum
-  const float m = fmaxf(fmaxf(
-        piece->pipe->processed_maximum[0],
-        piece->pipe->processed_maximum[1]),
-      piece->pipe->processed_maximum[2]);
-  for(int k=0;k<3;k++) piece->pipe->processed_maximum[k] = m;
+  const float m = fmaxf(fmaxf(piece->pipe->dsc.processed_maximum[0], piece->pipe->dsc.processed_maximum[1]),
+                        piece->pipe->dsc.processed_maximum[2]);
+  for(int k = 0; k < 3; k++) piece->pipe->dsc.processed_maximum[k] = m;
 
   if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -114,7 +114,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const float clip = d->clip
                      * fminf(piece->pipe->processed_maximum[0],
                              fminf(piece->pipe->processed_maximum[1], piece->pipe->processed_maximum[2]));
-  const uint32_t filters = piece->pipe->filters;
+  const uint32_t filters = piece->pipe->dsc.filters;
   if(dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) || !filters)
   {
     dt_opencl_set_kernel_arg(devid, gd->kernel_highlights_4f_clip, 0, sizeof(cl_mem), (void *)&dev_in);
@@ -428,7 +428,7 @@ static void process_lch_bayer(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
                               void *const ovoid, const dt_iop_roi_t *const roi_in,
                               const dt_iop_roi_t *const roi_out, const float clip)
 {
-  const uint32_t filters = piece->pipe->filters;
+  const uint32_t filters = piece->pipe->dsc.filters;
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic) default(none)
@@ -527,7 +527,7 @@ static void process_lch_xtrans(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
                                void *const ovoid, const dt_iop_roi_t *const roi_in,
                                const dt_iop_roi_t *const roi_out, const float clip)
 {
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic) default(none)
@@ -662,7 +662,7 @@ static void process_clip_plain(dt_dev_pixelpipe_iop_t *piece, const void *const 
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   { // raw mosaic
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) schedule(static)
@@ -691,7 +691,7 @@ static void process_clip_sse2(dt_dev_pixelpipe_iop_t *piece, const void *const i
                               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                               const float clip)
 {
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   { // raw mosaic
     const __m128 clipm = _mm_set1_ps(clip);
     const size_t n = (size_t)roi_out->height * roi_out->width;
@@ -744,7 +744,7 @@ static void process_clip(dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  const uint32_t filters = piece->pipe->filters;
+  const uint32_t filters = piece->pipe->dsc.filters;
   dt_iop_highlights_data_t *data = (dt_iop_highlights_data_t *)piece->data;
 
   const float clip
@@ -770,7 +770,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
       if(filters == 9u)
       {
-        const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+        const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic) default(none)
 #endif

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -158,14 +158,6 @@ error:
 }
 #endif
 
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW))
-    return sizeof(float);
-  else
-    return 4 * sizeof(float);
-}
-
 /* interpolate value for a pixel, ideal via ratio to nearby pixel */
 static inline float interp_pix_xtrans(const int ratio_next,
                                       const ssize_t offset_next,

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -94,11 +94,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
 }
 
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  return sizeof(float);
-}
-
 /* Detect hot sensor pixels based on the 4 surrounding sites. Pixels
  * having 3 or 4 (depending on permissive setting) surrounding pixels that
  * than value*multiplier are considered "hot", and are replaced by the maximum of

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -277,9 +277,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   memcpy(ovoid, ivoid, (size_t)roi_out->width * roi_out->height * sizeof(float));
 
   int fixed;
-  if(piece->pipe->filters == 9u)
+  if(piece->pipe->dsc.filters == 9u)
   {
-    fixed = process_xtrans(data, ivoid, ovoid, roi_out, (const uint8_t(*const)[6])piece->pipe->xtrans);
+    fixed = process_xtrans(data, ivoid, ovoid, roi_out, (const uint8_t(*const)[6])piece->pipe->dsc.xtrans);
   }
   else
   {
@@ -335,7 +335,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 {
   dt_iop_hotpixels_params_t *p = (dt_iop_hotpixels_params_t *)params;
   dt_iop_hotpixels_data_t *d = (dt_iop_hotpixels_data_t *)piece->data;
-  d->filters = piece->pipe->filters;
+  d->filters = piece->pipe->dsc.filters;
   d->multiplier = p->strength / 2.0;
   d->threshold = p->threshold;
   d->permissive = p->permissive;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -157,7 +157,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 {
   const dt_iop_invert_data_t *const d = (dt_iop_invert_data_t *)piece->data;
 
-  const float *const m = piece->pipe->processed_maximum;
+  const float *const m = piece->pipe->dsc.processed_maximum;
 
   const float film_rgb_f[4]
       = { d->color[0] * m[0], d->color[1] * m[1], d->color[2] * m[2], d->color[3] * m[3] };
@@ -187,7 +187,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
 
-    for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = 1.0f;
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   }
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
   { // bayer float mosaiced
@@ -204,7 +204,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
 
-    for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = 1.0f;
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   }
   else
   { // non-mosaiced
@@ -232,7 +232,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 {
   dt_iop_invert_data_t *d = (dt_iop_invert_data_t *)piece->data;
 
-  const float *const m = piece->pipe->processed_maximum;
+  const float *const m = piece->pipe->dsc.processed_maximum;
 
   const float film_rgb_f[4]
       = { d->color[0] * m[0], d->color[1] * m[1], d->color[2] * m[2], d->color[3] * m[3] };
@@ -258,7 +258,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
         *out = CLAMP(film_rgb_f[FCxtrans(j, i, roi_out, xtrans)] - *in, 0.0f, 1.0f);
     }
 
-    for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = 1.0f;
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   }
   else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
   { // bayer float mosaiced
@@ -300,7 +300,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     }
     _mm_sfence();
 
-    for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = 1.0f;
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   }
   else
   { // non-mosaiced
@@ -348,7 +348,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   {
     kernel = gd->kernel_invert_1f;
 
-    const float *const m = piece->pipe->processed_maximum;
+    const float *const m = piece->pipe->dsc.processed_maximum;
     for(int c = 0; c < 4; c++) film_rgb_f[c] *= m[c];
   }
   else
@@ -375,7 +375,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   if(err != CL_SUCCESS) goto error;
 
   dt_opencl_release_mem_object(dev_color);
-  for(int k = 0; k < 4; k++) piece->pipe->processed_maximum[k] = 1.0f;
+  for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   return TRUE;
 
 error:

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -89,13 +89,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_button_iop(self, "pick color of film material from image", GTK_WIDGET(g->colorpicker));
 }
 
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW))
-    return sizeof(float);
-  return 4 * sizeof(float);
-}
-
 static void request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -167,8 +167,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // do nothing
   //   }
 
-  const uint32_t filters = piece->pipe->filters;
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint32_t filters = piece->pipe->dsc.filters;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
@@ -242,8 +242,8 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   // do nothing
   //   }
 
-  const uint32_t filters = piece->pipe->filters;
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint32_t filters = piece->pipe->dsc.filters;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && (filters == 9u))
   { // xtrans float mosaiced
@@ -337,7 +337,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_invert_global_data_t *gd = (dt_iop_invert_global_data_t *)self->data;
 
   const int devid = piece->pipe->devid;
-  const uint32_t filters = piece->pipe->filters;
+  const uint32_t filters = piece->pipe->dsc.filters;
   cl_mem dev_color = NULL;
   cl_int err = -999;
   int kernel = -1;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -448,7 +448,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   d->color[3] = 0.0f;
 
   // x-trans images not implemented in OpenCL yet
-  if(pipe->image.filters == 9u) piece->process_cl_ready = 0;
+  if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = 0;
 
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = 0;

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -42,6 +42,7 @@ struct dt_dev_pixelpipe_t;
 struct dt_dev_pixelpipe_iop_t;
 struct dt_iop_roi_t;
 struct dt_develop_tiling_t;
+struct dt_iop_buffer_dsc_t;
 
 #ifndef DT_IOP_PARAMS_T
 #define DT_IOP_PARAMS_T
@@ -76,9 +77,13 @@ const char *description();
 int operation_tags();
 int operation_tags_filter();
 
-/** how many bytes per pixel in the output. */
-int output_bpp(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
-               struct dt_dev_pixelpipe_iop_t *piece);
+/** what do the iop want as an input? */
+void input_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                  struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+/** what will it output? */
+void output_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
+                   struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
+
 /** report back info for tiling: memory usage and overlap. Memory usage: factor * input_size + overhead */
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const struct dt_iop_roi_t *roi_in, const struct dt_iop_roi_t *roi_out,

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -373,8 +373,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else
   {
-    const uint32_t filters = piece->pipe->filters;
-    const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+    const uint32_t filters = piece->pipe->dsc.filters;
+    const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
     if (filters != 9u)
       wavelet_denoise(ivoid, ovoid, roi_in, d->threshold, filters);
     else

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -73,12 +73,6 @@ int groups()
   return IOP_GROUP_CORRECT;
 }
 
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW)) return sizeof(float);
-  return 4*sizeof(float);
-}
-
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "noise threshold"));

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -237,7 +237,7 @@ static void adjust_xtrans_filters(dt_dev_pixelpipe_t *pipe,
   {
     for(int j = 0; j < 6; ++j)
     {
-      pipe->xtrans[j][i] = pipe->image.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
+      pipe->xtrans[j][i] = pipe->image.buf_dsc.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
     }
   }
 }
@@ -280,7 +280,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
 
-    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
+    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
   }
   else
@@ -380,7 +380,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
       }
     }
 
-    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
+    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
   }
   else
@@ -465,7 +465,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
   {
-    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.filters, csx, csy);
+    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
   }
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -517,7 +517,9 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
     }
   }
 
-  if(!dt_image_is_raw(&piece->pipe->image) || piece->pipe->image.bpp == sizeof(float)) piece->enabled = 0;
+  if(!dt_image_is_raw(&piece->pipe->image)
+     || (piece->pipe->image.buf_dsc.channels == 1 && piece->pipe->image.buf_dsc.datatype == TYPE_FLOAT))
+    piece->enabled = 0;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -551,7 +553,8 @@ void reload_defaults(dt_iop_module_t *self)
                                      .raw_black_level_separate[3] = image->raw_black_level_separate[3],
                                      .raw_white_point = image->raw_white_point };
 
-  self->default_enabled = dt_image_is_raw(image) && image->bpp != sizeof(float);
+  self->default_enabled
+      = dt_image_is_raw(image) && !(image->buf_dsc.channels == 1 && image->buf_dsc.datatype == TYPE_FLOAT);
 
 end:
   memcpy(self->params, &tmp, sizeof(dt_iop_rawprepare_params_t));
@@ -575,7 +578,8 @@ void init(dt_iop_module_t *self)
   self->params = calloc(1, sizeof(dt_iop_rawprepare_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_rawprepare_params_t));
   self->hide_enable_button = 1;
-  self->default_enabled = dt_image_is_raw(image) && image->bpp != sizeof(float);
+  self->default_enabled
+      = dt_image_is_raw(image) && !(image->buf_dsc.channels == 1 && image->buf_dsc.datatype == TYPE_FLOAT);
   self->priority = 10; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_rawprepare_params_t);
   self->gui_data = NULL;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -229,7 +229,7 @@ static void adjust_xtrans_filters(dt_dev_pixelpipe_t *pipe,
   {
     for(int j = 0; j < 6; ++j)
     {
-      pipe->xtrans[j][i] = pipe->image.buf_dsc.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
+      pipe->dsc.xtrans[j][i] = pipe->image.buf_dsc.xtrans[(j + crop_y) % 6][(i + crop_x) % 6];
     }
   }
 }
@@ -251,7 +251,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float scale = roi_in->scale / piece->iscale;
   const int csx = (int)roundf((float)d->x * scale), csy = (int)roundf((float)d->y * scale);
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   { // raw mosaic
 
     const uint16_t *const in = (const uint16_t *const)ivoid;
@@ -272,7 +272,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       }
     }
 
-    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
+    piece->pipe->dsc.filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
   }
   else
@@ -316,7 +316,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
   const float scale = roi_in->scale / piece->iscale;
   const int csx = (int)roundf((float)d->x * scale), csy = (int)roundf((float)d->y * scale);
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   { // raw mosaic
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -372,7 +372,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
       }
     }
 
-    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
+    piece->pipe->dsc.filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
   }
   else
@@ -417,7 +417,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   int kernel = -1;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   {
     kernel = gd->kernel_rawprepare_1f;
   }
@@ -455,9 +455,9 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dt_opencl_release_mem_object(dev_sub);
   dt_opencl_release_mem_object(dev_div);
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   {
-    piece->pipe->filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
+    piece->pipe->dsc.filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
   }
 
@@ -482,7 +482,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   d->width = p->crop.named.width;
   d->height = p->crop.named.height;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->filters)
+  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
   {
     const float white = (float)p->raw_white_point;
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -158,14 +158,6 @@ void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const
   return;
 }
 
-int output_bpp(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW))
-    return sizeof(float);
-  else
-    return 4 * sizeof(float);
-}
-
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
 {
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -70,11 +70,6 @@ int operation_tags()
   return IOP_TAG_DISTORT;
 }
 
-int output_bpp(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  return 4 * sizeof(float);
-}
-
 static void transform(const dt_dev_pixelpipe_iop_t *const piece, float *p)
 {
   dt_iop_scalepixels_data_t *d = piece->data;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -393,8 +393,8 @@ static void dt_wb_preset_interpolate(const wb_data *const p1, // the smaller tun
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-  const uint32_t filters = piece->pipe->filters;
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint32_t filters = piece->pipe->dsc.filters;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   const dt_iop_temperature_data_t *const d = (dt_iop_temperature_data_t *)piece->data;
 
   const float *const in = (const float *const)ivoid;
@@ -468,8 +468,8 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_image_t *img = &self->dev->image_storage;
-  const uint32_t filters = piece->pipe->filters;
-  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->xtrans;
+  const uint32_t filters = piece->pipe->dsc.filters;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
   if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters == 9u)
   { // xtrans float mosaiced
@@ -570,7 +570,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_iop_temperature_global_data_t *gd = (dt_iop_temperature_global_data_t *)self->data;
 
   const int devid = piece->pipe->devid;
-  const uint32_t filters = piece->pipe->filters;
+  const uint32_t filters = piece->pipe->dsc.filters;
   cl_mem dev_coeffs = NULL;
   cl_int err = -999;
   int kernel = -1;
@@ -634,7 +634,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
   for(int k = 0; k < 4; k++) d->coeffs[k] = p->coeffs[k];
 
-  if(piece->pipe->filters && dt_dev_pixelpipe_uses_downsampled_input(piece->pipe)
+  if(piece->pipe->dsc.filters && dt_dev_pixelpipe_uses_downsampled_input(piece->pipe)
      && pipe->pre_monochrome_demosaiced)
   {
     // piece->process_cl_ready = 0;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -436,10 +436,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                             roi_out->width * roi_out->height, d2->RGB_to_CAM, d2->CAM_to_RGB,
                                             d2->coeffs);
     float new_maximum[4] = {1.0f};
-    dt_colorspaces_cygm_apply_coeffs_to_rgb(new_maximum, piece->pipe->processed_maximum, 1, d2->RGB_to_CAM,
+    dt_colorspaces_cygm_apply_coeffs_to_rgb(new_maximum, piece->pipe->dsc.processed_maximum, 1, d2->RGB_to_CAM,
                                             d2->CAM_to_RGB, d2->coeffs);
-    for(int k = 0; k < 4; k++)
-      piece->pipe->processed_maximum[k] = new_maximum[k];
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = new_maximum[k];
   }
   else
   { // non-mosaiced
@@ -460,7 +459,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
   }
   for(int k = 0; k < 4; k++)
-    piece->pipe->processed_maximum[k] = d->coeffs[k] * piece->pipe->processed_maximum[k];
+    piece->pipe->dsc.processed_maximum[k] = d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
 }
 
 #if defined(__SSE__)
@@ -528,10 +527,9 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                                             roi_out->width*roi_out->height,
                                             d->RGB_to_CAM, d->CAM_to_RGB, d->coeffs);
     float new_maximum[4] = {1.0f};
-    dt_colorspaces_cygm_apply_coeffs_to_rgb(new_maximum, piece->pipe->processed_maximum,
-                                            1, d->RGB_to_CAM, d->CAM_to_RGB, d->coeffs);
-    for(int k = 0; k < 4; k++)
-      piece->pipe->processed_maximum[k] = new_maximum[k];
+    dt_colorspaces_cygm_apply_coeffs_to_rgb(new_maximum, piece->pipe->dsc.processed_maximum, 1, d->RGB_to_CAM,
+                                            d->CAM_to_RGB, d->coeffs);
+    for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = new_maximum[k];
   }
   else
   { // non-mosaiced
@@ -558,7 +556,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     if(piece->pipe->mask_display) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
   }
   for(int k = 0; k < 4; k++)
-    piece->pipe->processed_maximum[k] = d->coeffs[k] * piece->pipe->processed_maximum[k];
+    piece->pipe->dsc.processed_maximum[k] = d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
 }
 #endif
 
@@ -604,7 +602,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   dt_opencl_release_mem_object(dev_coeffs);
   for(int k = 0; k < 3; k++)
-    piece->pipe->processed_maximum[k] = d->coeffs[k] * piece->pipe->processed_maximum[k];
+    piece->pipe->dsc.processed_maximum[k] = d->coeffs[k] * piece->pipe->dsc.processed_maximum[k];
   return TRUE;
 
 error:

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -651,7 +651,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
 
   // x-trans images not implemented in OpenCL yet
-  if(pipe->image.filters == 9u) piece->process_cl_ready = 0;
+  if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = 0;
 
   if (self->dev->image_storage.flags & DT_IMAGE_4BAYER)
   {
@@ -1295,7 +1295,7 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
   const dt_image_t *img = &self->dev->image_storage;
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
 
-  if(FILTERS_ARE_CYGM(img->filters))
+  if(FILTERS_ARE_CYGM(img->buf_dsc.filters))
   {
     dt_bauhaus_widget_set_label(g->scale_r, NULL, _("green"));
     dt_bauhaus_widget_set_label(g->scale_g, NULL, _("magenta"));

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -184,15 +184,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "green2", GTK_WIDGET(g->scale_g2));
 }
 
-
-int output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW))
-    return sizeof(float);
-  else
-    return 4 * sizeof(float);
-}
-
 /*
  * Spectral power distribution functions
  * https://en.wikipedia.org/wiki/Spectral_power_distribution

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -194,7 +194,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   // also process the clipping point, as good as we can without knowing
   // the local environment (i.e. assuming detail == 0)
-  float *pmax = piece->pipe->processed_maximum;
+  float *pmax = piece->pipe->dsc.processed_maximum;
   float L = 0.2126 * pmax[0] + 0.7152 * pmax[1] + 0.0722 * pmax[2];
   if(L <= 0.0) L = 1e-6;
   L = logf(L);

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -86,7 +86,7 @@ int groups()
 int
 output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  if(pipe->type != DT_DEV_PIXELPIPE_PREVIEW && module->dev->image->filters) return sizeof(float);
+  if(pipe->type != DT_DEV_PIXELPIPE_PREVIEW && module->dev->image->buf_dsc.filters) return sizeof(float);
   else return 4*sizeof(float);
 }
 */


### PR DESCRIPTION
Prerequisite for #1241

The idea is to have some struct, that would contain the description of the buffer, and cache/process/pass it along with the buffer.

Also, given that output_bpp is no longer an integer, it should be easier for opencl codepath to allocate proper buffers.