### PR TITLE
Display a warning message when there is too much exif data to be read…

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1378,6 +1378,7 @@ int dt_exif_read_blob(uint8_t *buf, const char *path, const int imgid, const int
       memcpy(buf + 6, &(blob[0]), length);
       return length + 6;
     }
+    fprintf(stderr, "[exif] Warning: too much data to store (%d bytes), Exif data will be discarded\n", length);
     return 6;
   }
   catch(Exiv2::AnyError &e)

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1122,7 +1122,7 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
   return 1;
 }
 
-int dt_exif_read_blob(uint8_t *buf, const char *path, const int imgid, const int sRGB, const int out_width,
+int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const int sRGB, const int out_width,
                       const int out_height, const int dng_mode)
 {
   try
@@ -1372,14 +1372,14 @@ int dt_exif_read_blob(uint8_t *buf, const char *path, const int imgid, const int
     Exiv2::Blob blob;
     Exiv2::ExifParser::encode(blob, Exiv2::bigEndian, exifData);
     const int length = blob.size();
-    memcpy(buf, "Exif\000\000", 6);
-    if(length > 0 && length < 65534)
+    *buf = (uint8_t *)malloc(length);
+    if (!*buf)
     {
-      memcpy(buf + 6, &(blob[0]), length);
-      return length + 6;
+      return 0;
     }
-    fprintf(stderr, "[exif] Warning: too much data to store (%d bytes), Exif data will be discarded\n", length);
-    return 6;
+    memcpy(*buf, "Exif\000\000", 6);
+    memcpy(*buf + 6, &(blob[0]), length);
+    return length + 6;
   }
   catch(Exiv2::AnyError &e)
   {

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1125,6 +1125,7 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
 int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const int sRGB, const int out_width,
                       const int out_height, const int dng_mode)
 {
+  *buf = NULL;
   try
   {
 #ifdef __APPLE__
@@ -1386,6 +1387,8 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
     // std::cerr.rdbuf(savecerr);
     std::string s(e.what());
     std::cerr << "[exiv2] " << path << ": " << s << std::endl;
+    free(*buf);
+    *buf = NULL;
     return 0;
   }
 }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1372,7 +1372,7 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
     Exiv2::Blob blob;
     Exiv2::ExifParser::encode(blob, Exiv2::bigEndian, exifData);
     const int length = blob.size();
-    *buf = (uint8_t *)malloc(length);
+    *buf = (uint8_t *)malloc(length+6);
     if (!*buf)
     {
       return 0;

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -34,9 +34,9 @@ int dt_exif_read(dt_image_t *img, const char *path);
 /** read exif data to image struct from given data blob, wherever you got it from. */
 int dt_exif_read_from_blob(dt_image_t *img, uint8_t *blob, const int size);
 
-/** write exif to blob, return length in bytes. blob needs to be as large at 65535 bytes. sRGB should be true
+/** write exif to blob, return length in bytes. blob will be allocated by the function. sRGB should be true
  * if sRGB colorspace is used as output. */
-int dt_exif_read_blob(uint8_t *blob, const char *path, const int imgid, const int sRGB, const int out_width,
+int dt_exif_read_blob(uint8_t **blob, const char *path, const int imgid, const int sRGB, const int out_width,
                       const int out_height, const int dng_mode);
 
 /** write blob to file exif. merges with existing exif information.*/

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -856,14 +856,18 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   if(!ignore_exif)
   {
     int length;
-    uint8_t exif_profile[65535]; // C++ alloc'ed buffer is uncool, so we waste some bits here.
+    uint8_t *exif_profile; // Exif data should be 65536 bytes max, but if original size is close to that,
+                           // adding new tags could make it go over that... so let it be and see what
+                           // happens when we write the image
     char pathname[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
     dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);
     // last param is dng mode, it's false here
-    length = dt_exif_read_blob(exif_profile, pathname, imgid, sRGB, processed_width, processed_height, 0);
+    length = dt_exif_read_blob(&exif_profile, pathname, imgid, sRGB, processed_width, processed_height, 0);
 
     res = format->write_image(format_params, filename, outbuf, exif_profile, length, imgid, num, total);
+
+    free(exif_profile);
   }
   else
   {

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -856,9 +856,9 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   if(!ignore_exif)
   {
     int length;
-    uint8_t *exif_profile; // Exif data should be 65536 bytes max, but if original size is close to that,
-                           // adding new tags could make it go over that... so let it be and see what
-                           // happens when we write the image
+    uint8_t *exif_profile = NULL; // Exif data should be 65536 bytes max, but if original size is close to that,
+                                  // adding new tags could make it go over that... so let it be and see what
+                                  // happens when we write the image
     char pathname[PATH_MAX] = { 0 };
     gboolean from_cache = TRUE;
     dt_image_full_path(imgid, pathname, sizeof(pathname), &from_cache);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -468,17 +468,18 @@ static int32_t dt_control_merge_hdr_job_run(dt_job_t *job)
   }
 
   // output hdr as digital negative with exif data.
-  uint8_t exif[65535];
+  uint8_t *exif = NULL;
   char pathname[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
   dt_image_full_path(d.first_imgid, pathname, sizeof(pathname), &from_cache);
 
   // last param is dng mode
-  const int exif_len = dt_exif_read_blob(exif, pathname, d.first_imgid, 0, d.wd, d.ht, 1);
+  const int exif_len = dt_exif_read_blob(&exif, pathname, d.first_imgid, 0, d.wd, d.ht, 1);
   char *c = pathname + strlen(pathname);
   while(*c != '.' && c > pathname) c--;
   g_strlcpy(c, "-hdr.dng", sizeof(pathname) - (c - pathname));
   dt_imageio_write_dng(pathname, d.pixels, d.wd, d.ht, exif, exif_len, d.first_filter, (const uint8_t (*)[6])d.first_xtrans, 1.0f);
+  free(exif);
 
   dt_control_job_set_progress(job, 1.0);
 

--- a/src/imageio/format/jpeg.c
+++ b/src/imageio/format/jpeg.c
@@ -395,8 +395,7 @@ int write_image(dt_imageio_module_data_t *jpg_tmp, const char *filename, const v
   jpeg_destroy_compress(&(jpg->cinfo));
   fclose(f);
 
-  if(exif && exif_len > 0 && exif_len < 65534)
-    dt_exif_write_blob(exif, exif_len, filename, 1);
+  dt_exif_write_blob(exif, exif_len, filename, 1);
 
   return 0;
 }


### PR DESCRIPTION
This is but a small band-aid, but at least display a message when added original (filtered) exif data + exif data added by darktable are too big and discarded.