### PR TITLE
Do not export default profile color tables

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1110,6 +1110,19 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
       dt_remove_exif_keys(imgExifData, keys, n_keys);
     }
 
+    // remove the profile tables
+    {
+      static const char *keys[] = {
+        "Exif.Image.ProfileLookTableDims",
+        "Exif.Image.ProfileLookTableData",
+        "Exif.Image.ProfileHueSatMapDims",
+        "Exif.Image.ProfileHueSatMapData1",
+        "Exif.Image.ProfileHueSatMapData2"
+      };
+      static const guint n_keys = G_N_ELEMENTS(keys);
+      dt_remove_exif_keys(imgExifData, keys, n_keys);
+    }
+
     imgExifData.sortByTag();
     image->writeMetadata();
   }


### PR DESCRIPTION
Hi, this pull request is a followup on the work on Exif data from the beginning of the week. In the cases reported, the main culprit for the size of the medata were embedded color profiles (120ko on a Pentax K-S1 DNG file).

These tags have no real purpose on exported images (unless we imagine complex/strange scenario where no curve is applied in darktable and the user want to still save the default for further processing); so maybe they should be filtered?

Note: other candidates for filtering would be the Exif.SubImage* tags.