### PR TITLE
Remove more superfluous metadata when writting images

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1201,11 +1201,13 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
 
       {
         static const char *keys[] = {
-          // Color profile info
+          // Embedded color profile info
+          "Exif.Image.BaselineExposureOffset",
           "Exif.Image.CalibrationIlluminant1",
           "Exif.Image.CalibrationIlluminant2",
           "Exif.Image.ColorMatrix1",
           "Exif.Image.ColorMatrix2",
+          "Exif.Image.DefaultBlackRender",
           "Exif.Image.ForwardMatrix1",
           "Exif.Image.ForwardMatrix2",
           "Exif.Image.ProfileCalibrationSignature",
@@ -1214,17 +1216,14 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
           "Exif.Image.ProfileHueSatMapData1",
           "Exif.Image.ProfileHueSatMapData2",
           "Exif.Image.ProfileHueSatMapDims",
+          "Exif.Image.ProfileHueSatMapEncoding",
           "Exif.Image.ProfileLookTableData",
           "Exif.Image.ProfileLookTableDims",
+          "Exif.Image.ProfileLookTableEncoding",
           "Exif.Image.ProfileName",
           "Exif.Image.ProfileToneCurve",
           "Exif.Image.ReductionMatrix1",
           "Exif.Image.ReductionMatrix2",
-          // Some DNG tags not yet registered in exiv2
-          //"Exif.Image.BaselineExposureOffset", // 0xc7a5
-          //"Exif.Image.DefaultBlackRender", // 0xc7a6
-          //"Exif.Image.ProfileHueSatMapEncoding", // 0xc7a3
-          //"Exif.Image.ProfileLookTableEncoding", // 0xc7a4
 
           // Canon color space info
           "Exif.Canon.ColorSpace",

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -205,8 +205,16 @@ static void dt_remove_exif_keys(Exiv2::ExifData &exif, const char *keys[], unsig
 {
   for(unsigned int i = 0; i < n_keys; i++)
   {
-    Exiv2::ExifData::iterator pos = exif.findKey(Exiv2::ExifKey(keys[i]));
-    if(pos != exif.end()) exif.erase(pos);
+    try
+    {
+      Exiv2::ExifData::iterator pos = exif.findKey(Exiv2::ExifKey(keys[i]));
+      if(pos != exif.end()) exif.erase(pos);
+    }
+    catch(Exiv2::AnyError &e)
+    {
+      std::string s(e.what());
+      std::cerr << "[exiv2] " << s << std::endl;
+    }
   }
 }
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1110,6 +1110,16 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
       dt_remove_exif_keys(imgExifData, keys, n_keys);
     }
 
+    // remove subimage* trees, related to thumbnails or HDR usually
+    for(Exiv2::ExifData::iterator i = imgExifData.begin(); i != imgExifData.end();)
+    {
+      const char *keystr = (i->key()).c_str();
+      if(strstr(keystr, "Exif.SubImage") == keystr)
+        i = imgExifData.erase(i);
+      else
+        ++i;
+    }
+
     // only compressed images may set PixelXDimension and PixelYDimension
     if(!compressed)
     {
@@ -1124,11 +1134,33 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
     // remove the profile tables
     {
       static const char *keys[] = {
-        "Exif.Image.ProfileLookTableDims",
-        "Exif.Image.ProfileLookTableData",
-        "Exif.Image.ProfileHueSatMapDims",
+        "Exif.Image.CalibrationIlluminant1",
+        "Exif.Image.CalibrationIlluminant2",
+        "Exif.Image.ColorMatrix1",
+        "Exif.Image.ColorMatrix2",
+        "Exif.Image.ForwardMatrix1",
+        "Exif.Image.ForwardMatrix2",
+        "Exif.Image.ProfileCalibrationSignature",
+        "Exif.Image.ProfileCopyright",
+        "Exif.Image.ProfileEmbedPolicy",
         "Exif.Image.ProfileHueSatMapData1",
-        "Exif.Image.ProfileHueSatMapData2"
+        "Exif.Image.ProfileHueSatMapData2",
+        "Exif.Image.ProfileHueSatMapDims",
+        "Exif.Image.ProfileLookTableData",
+        "Exif.Image.ProfileLookTableDims",
+        "Exif.Image.ProfileName",
+        "Exif.Image.ProfileToneCurve",
+        "Exif.Image.ReductionMatrix1",
+        "Exif.Image.ReductionMatrix2",
+        // Some DNG tags not yet registered in exiv2
+        //"Exif.Image.BaselineExposureOffset", // 0xc7a5
+        //"Exif.Image.DefaultBlackRender", // 0xc7a6
+        //"Exif.Image.ProfileHueSatMapEncoding", // 0xc7a3
+        //"Exif.Image.ProfileLookTableEncoding", // 0xc7a4
+
+        "Exif.Canon.ColorData",
+
+        "Exif.PentaxDng.ColorInfo"
       };
       static const guint n_keys = G_N_ELEMENTS(keys);
       dt_remove_exif_keys(imgExifData, keys, n_keys);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -207,8 +207,9 @@ static void dt_remove_exif_keys(Exiv2::ExifData &exif, const char *keys[], unsig
   {
     try
     {
-      Exiv2::ExifData::iterator pos = exif.findKey(Exiv2::ExifKey(keys[i]));
-      if(pos != exif.end()) exif.erase(pos);
+      Exiv2::ExifData::iterator pos;
+      while((pos = exif.findKey(Exiv2::ExifKey(keys[i]))) != exif.end())
+        exif.erase(pos);
     }
     catch(Exiv2::AnyError &e)
     {
@@ -1259,7 +1260,7 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
       // remove subimage* trees, related to thumbnails or HDR usually
       for(Exiv2::ExifData::iterator i = exifData.begin(); i != exifData.end();)
       {
-        std::string needle = "Exif.SubImage";
+        static const std::string needle = "Exif.SubImage";
         if(i->key().compare(0, needle.length(), needle) == 0)
           i = exifData.erase(i);
         else

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1113,8 +1113,8 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
     // remove subimage* trees, related to thumbnails or HDR usually
     for(Exiv2::ExifData::iterator i = imgExifData.begin(); i != imgExifData.end();)
     {
-      const char *keystr = (i->key()).c_str();
-      if(strstr(keystr, "Exif.SubImage") == keystr)
+      std::string needle = "Exif.SubImage";
+      if(i->key().compare(0, needle.length(), needle) == 0)
         i = imgExifData.erase(i);
       else
         ++i;

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1131,41 +1131,6 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
       dt_remove_exif_keys(imgExifData, keys, n_keys);
     }
 
-    // remove the profile tables
-    {
-      static const char *keys[] = {
-        "Exif.Image.CalibrationIlluminant1",
-        "Exif.Image.CalibrationIlluminant2",
-        "Exif.Image.ColorMatrix1",
-        "Exif.Image.ColorMatrix2",
-        "Exif.Image.ForwardMatrix1",
-        "Exif.Image.ForwardMatrix2",
-        "Exif.Image.ProfileCalibrationSignature",
-        "Exif.Image.ProfileCopyright",
-        "Exif.Image.ProfileEmbedPolicy",
-        "Exif.Image.ProfileHueSatMapData1",
-        "Exif.Image.ProfileHueSatMapData2",
-        "Exif.Image.ProfileHueSatMapDims",
-        "Exif.Image.ProfileLookTableData",
-        "Exif.Image.ProfileLookTableDims",
-        "Exif.Image.ProfileName",
-        "Exif.Image.ProfileToneCurve",
-        "Exif.Image.ReductionMatrix1",
-        "Exif.Image.ReductionMatrix2",
-        // Some DNG tags not yet registered in exiv2
-        //"Exif.Image.BaselineExposureOffset", // 0xc7a5
-        //"Exif.Image.DefaultBlackRender", // 0xc7a6
-        //"Exif.Image.ProfileHueSatMapEncoding", // 0xc7a3
-        //"Exif.Image.ProfileLookTableEncoding", // 0xc7a4
-
-        "Exif.Canon.ColorData",
-
-        "Exif.PentaxDng.ColorInfo"
-      };
-      static const guint n_keys = G_N_ELEMENTS(keys);
-      dt_remove_exif_keys(imgExifData, keys, n_keys);
-    }
-
     imgExifData.sortByTag();
     image->writeMetadata();
   }
@@ -1228,8 +1193,34 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
 
       {
         static const char *keys[] = {
+          // Color profile info
+          "Exif.Image.CalibrationIlluminant1",
+          "Exif.Image.CalibrationIlluminant2",
+          "Exif.Image.ColorMatrix1",
+          "Exif.Image.ColorMatrix2",
+          "Exif.Image.ForwardMatrix1",
+          "Exif.Image.ForwardMatrix2",
+          "Exif.Image.ProfileCalibrationSignature",
+          "Exif.Image.ProfileCopyright",
+          "Exif.Image.ProfileEmbedPolicy",
+          "Exif.Image.ProfileHueSatMapData1",
+          "Exif.Image.ProfileHueSatMapData2",
+          "Exif.Image.ProfileHueSatMapDims",
+          "Exif.Image.ProfileLookTableData",
+          "Exif.Image.ProfileLookTableDims",
+          "Exif.Image.ProfileName",
+          "Exif.Image.ProfileToneCurve",
+          "Exif.Image.ReductionMatrix1",
+          "Exif.Image.ReductionMatrix2",
+          // Some DNG tags not yet registered in exiv2
+          //"Exif.Image.BaselineExposureOffset", // 0xc7a5
+          //"Exif.Image.DefaultBlackRender", // 0xc7a6
+          //"Exif.Image.ProfileHueSatMapEncoding", // 0xc7a3
+          //"Exif.Image.ProfileLookTableEncoding", // 0xc7a4
+
           // Canon color space info
           "Exif.Canon.ColorSpace",
+          "Exif.Canon.ColorData",
 
           // Nikon thumbnail data
           "Exif.Nikon3.Preview",
@@ -1245,6 +1236,8 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
           "Exif.PentaxDng.PreviewResolution",
           "Exif.PentaxDng.PreviewLength",
           "Exif.PentaxDng.PreviewOffset",
+          // Pentax color info
+          "Exif.PentaxDng.ColorInfo",
 
           // Minolta thumbnail data
           "Exif.Minolta.Thumbnail",

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -212,8 +212,10 @@ static void dt_remove_exif_keys(Exiv2::ExifData &exif, const char *keys[], unsig
     }
     catch(Exiv2::AnyError &e)
     {
-      std::string s(e.what());
-      std::cerr << "[exiv2] " << s << std::endl;
+      // the only exception we may get is "invalid" tag, which is not
+      // important enough to either stop the function, or even display
+      // a message (it's probably the tag is not implemented in the
+      // exiv2 version used)
     }
   }
 }

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1120,16 +1120,6 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
       dt_remove_exif_keys(imgExifData, keys, n_keys);
     }
 
-    // remove subimage* trees, related to thumbnails or HDR usually
-    for(Exiv2::ExifData::iterator i = imgExifData.begin(); i != imgExifData.end();)
-    {
-      std::string needle = "Exif.SubImage";
-      if(i->key().compare(0, needle.length(), needle) == 0)
-        i = imgExifData.erase(i);
-      else
-        ++i;
-    }
-
     // only compressed images may set PixelXDimension and PixelYDimension
     if(!compressed)
     {
@@ -1264,6 +1254,16 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
         };
         static const guint n_keys = G_N_ELEMENTS(keys);
         dt_remove_exif_keys(exifData, keys, n_keys);
+      }
+
+      // remove subimage* trees, related to thumbnails or HDR usually
+      for(Exiv2::ExifData::iterator i = exifData.begin(); i != exifData.end();)
+      {
+        std::string needle = "Exif.SubImage";
+        if(i->key().compare(0, needle.length(), needle) == 0)
+          i = exifData.erase(i);
+        else
+          ++i;
       }
 
 #if EXIV2_MINOR_VERSION >= 23


### PR DESCRIPTION
Followup of https://github.com/darktable-org/darktable/pull/1256, this request removes more metadata:
- subimage info (thumbnails, hdr, pixelshift, etc)
- more colorspace related tags

More work could be done regarding proprietary tags probably. I looked at raws from Canon, Nikon, Leica, Pentax to see if there were similar tags, but it was no exhaustive study.