### PR TITLE
Mipmap MIP_F revamp

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -404,7 +404,7 @@ static void _get_image_dimension (int32_t imgid, int32_t *iwidth, int32_t *iheig
   if(res)
   {
     // set mem pointer to 0, won't be used.
-    dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f, 0);
+    dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f);
     dt_dev_pixelpipe_create_nodes(&pipe, &dev);
     dt_dev_pixelpipe_synch_all(&pipe, &dev);
     dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,

--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -258,7 +258,7 @@ static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid
     if(res)
     {
       // set mem pointer to 0, won't be used.
-      dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f, 0);
+      dt_dev_pixelpipe_set_input(&pipe, &dev, NULL, wd, ht, 1.0f);
       dt_dev_pixelpipe_create_nodes(&pipe, &dev);
       dt_dev_pixelpipe_synch_all(&pipe, &dev);
       dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -673,8 +673,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   }
 
   dt_dev_pixelpipe_set_input(&pipe, &dev, (float *)buf.buf, buf.width, buf.height,
-                             buf_is_downscaled ? dev.image_storage.width / (float)buf.width : 1.0f,
-                             buf.pre_monochrome_demosaiced);
+                             buf_is_downscaled ? dev.image_storage.width / (float)buf.width : 1.0f);
   dt_dev_pixelpipe_create_nodes(&pipe, &dev);
   dt_dev_pixelpipe_synch_all(&pipe, &dev);
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1104,6 +1104,12 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
       dt_iop_clip_and_zoom_mosaic_half_size((uint16_t * const)out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
                                             roi_out.width, roi_in.width, image->buf_dsc.filters);
     }
+    else if(image->buf_dsc.filters == 9u && image->buf_dsc.datatype == TYPE_UINT16)
+    {
+      dt_iop_clip_and_zoom_mosaic_third_size_xtrans((uint16_t * const)out, (const uint16_t *)buf.buf, &roi_out,
+                                                    &roi_in, roi_out.width, roi_in.width, image->buf_dsc.xtrans,
+                                                    image->raw_white_point);
+    }
     else if(image->buf_dsc.datatype == TYPE_FLOAT)
     {
       dt_iop_clip_and_zoom_pixel_binning_f((float *const)out, (const float *const)buf.buf, &roi_out, &roi_in,

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1053,7 +1053,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   unsigned int bin_blocks = 0;
 
   // now let's figure out the scaling...
-  if(pattern_size != 1)
+  if(image->buf_dsc.filters == 9u)
   {
     // ideal [inverse] scale, will result in same aspect ratio and
     // same or smaller area than requested.
@@ -1070,7 +1070,10 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   }
   else
   {
-    roi_out.scale = fminf(wd / (float)image->width, ht / (float)image->height);
+    // MIP_F is 4 channels, and we do not demosaic here
+    const float coeff = (image->buf_dsc.filters) ? 2.0f : 1.0f;
+
+    roi_out.scale = fminf((coeff * (float)wd) / (float)image->width, (coeff * (float)ht) / (float)image->height);
   }
 
   roi_out.width = roi_out.scale * roi_in.width;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1096,6 +1096,8 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
 #if 1
     if(image->buf_dsc.datatype == TYPE_FLOAT)
     {
+      dt_iop_clip_and_zoom_pixel_binning_f((float *const)out, (const float *const)buf.buf, &roi_out, &roi_in,
+                                           roi_out.width, roi_in.width, pattern_size, bin_blocks);
     }
     else
     {

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1088,7 +1088,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
         else
         {
           dt_iop_clip_and_zoom_demosaic_half_size(out, (const uint16_t *)buf.buf, &roi_out, &roi_in, roi_out.width,
-                                                  roi_in.width, image->buf_dsc.filters);
+                                                  roi_in.width, image->buf_dsc.filters, image->raw_white_point);
 
           // For four bayer images we'll need to convert to XYZ here as the pipe only carries 3 channels
           if(image->flags & DT_IMAGE_4BAYER)
@@ -1116,7 +1116,8 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
       else
       {
         dt_iop_clip_and_zoom_demosaic_third_size_xtrans(out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
-                                                        roi_out.width, roi_in.width, image->buf_dsc.xtrans);
+                                                        roi_out.width, roi_in.width, image->buf_dsc.xtrans,
+                                                        image->raw_white_point);
       }
     }
   }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1062,7 +1062,10 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   {
     // ideal [inverse] scale, will result in same aspect ratio and
     // same or smaller area than requested.
-    const float inv_scale = fmaxf((float)image->width / (float)wd, (float)image->height / (float)ht);
+    const float inv_scale
+        = fmaxf((float)image->width / ((float)2.0f * wd), (float)image->height / ((float)2.0f * ht));
+
+    // why "2*"? MIP_F is 4 channels, and we use only one channel => can increase area
 
     // this is how much blocks will be binned into 1
     // !!! we want to always round up, to never overflow out buffer !!!

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1091,7 +1091,12 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   if(image->buf_dsc.filters)
   {
 #if 1
-    if(image->buf_dsc.datatype == TYPE_FLOAT)
+    if(image->buf_dsc.filters != 9u && image->buf_dsc.datatype == TYPE_UINT16)
+    {
+      dt_iop_clip_and_zoom_mosaic_half_size((uint16_t * const)out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
+                                            roi_out.width, roi_in.width, image->buf_dsc.filters);
+    }
+    else if(image->buf_dsc.datatype == TYPE_FLOAT)
     {
       dt_iop_clip_and_zoom_pixel_binning_f((float *const)out, (const float *const)buf.buf, &roi_out, &roi_in,
                                            roi_out.width, roi_in.width, pattern_size, bin_blocks);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1091,7 +1091,12 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
   if(image->buf_dsc.filters)
   {
 #if 1
-    if(image->buf_dsc.filters != 9u && image->buf_dsc.datatype == TYPE_UINT16)
+    if(image->buf_dsc.filters != 9u && image->buf_dsc.datatype == TYPE_FLOAT)
+    {
+      dt_iop_clip_and_zoom_mosaic_half_size_f((float *const)out, (const float *const)buf.buf, &roi_out, &roi_in,
+                                              roi_out.width, roi_in.width, image->buf_dsc.filters);
+    }
+    else if(image->buf_dsc.filters != 9u && image->buf_dsc.datatype == TYPE_UINT16)
     {
       dt_iop_clip_and_zoom_mosaic_half_size((uint16_t * const)out, (const uint16_t *)buf.buf, &roi_out, &roi_in,
                                             roi_out.width, roi_in.width, image->buf_dsc.filters);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1075,7 +1075,7 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
         else
         {
           dt_iop_clip_and_zoom_demosaic_half_size_f(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width,
-                                                    roi_in.width, image->buf_dsc.filters, 1.0f);
+                                                    roi_in.width, image->buf_dsc.filters);
         }
       }
       else

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -67,8 +67,6 @@ typedef struct dt_mipmap_buffer_t
   int32_t width, height;
   uint8_t *buf;
   dt_colorspaces_color_profile_type_t color_space;
-  // buffer is pre-demosaiced and the demosaicing method is monochrome
-  int pre_monochrome_demosaiced;
   dt_cache_entry_t *cache_entry;
 } dt_mipmap_buffer_t;
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2782,7 +2782,6 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   }
 
   const dt_iop_colorspace_type_t cst = dt_iop_module_colorspace(self);
-  const int downsampled = dt_dev_pixelpipe_uses_downsampled_input(piece->pipe);
   int kernel_mask;
   int kernel;
   int kernel_set_mask = darktable.blendop->kernel_blendop_set_mask;
@@ -2790,14 +2789,8 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   switch(cst)
   {
     case iop_cs_RAW:
-      // special case handling: preview pipe uses downsampled rgb images instead
-      // of pre-demosaiced raw data.
-      // actually not used today as there currently exists no pre-demosaic module
-      // with blending *and* opencl support.
-      // only defined here for potential future additions.
-      kernel = (!downsampled) ? darktable.blendop->kernel_blendop_RAW : darktable.blendop->kernel_blendop_rgb;
-      kernel_mask = (!downsampled) ? darktable.blendop->kernel_blendop_mask_RAW
-                                   : darktable.blendop->kernel_blendop_mask_rgb;
+      kernel = darktable.blendop->kernel_blendop_RAW;
+      kernel_mask = darktable.blendop->kernel_blendop_mask_RAW;
       break;
 
     case iop_cs_rgb:

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -220,7 +220,7 @@ void dt_dev_process_preview_job(dt_develop_t *dev)
   }
   // init pixel pipeline for preview.
   dt_dev_pixelpipe_set_input(dev->preview_pipe, dev, (float *)buf.buf, buf.width, buf.height,
-                             dev->image_storage.width / (float)buf.width, buf.pre_monochrome_demosaiced);
+                             dev->image_storage.width / (float)buf.width);
 
   if(dev->preview_loading)
   {
@@ -310,8 +310,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
     return;
   }
 
-  dt_dev_pixelpipe_set_input(dev->pipe, dev, (float *)buf.buf, buf.width, buf.height, 1.0,
-                             buf.pre_monochrome_demosaiced);
+  dt_dev_pixelpipe_set_input(dev->pipe, dev, (float *)buf.buf, buf.width, buf.height, 1.0);
 
   if(dev->image_loading)
   {

--- a/src/develop/format.c
+++ b/src/develop/format.c
@@ -68,11 +68,11 @@ void default_input_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_de
 
   if(self->priority > _iop_module_demosaic) return;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW)) dsc->channels = 1;
+  if(pipe->image.flags & DT_IMAGE_RAW) dsc->channels = 1;
 
   if(self->priority > _iop_module_rawprepare) return;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
     dsc->datatype = TYPE_UINT16;
 }
 
@@ -86,11 +86,11 @@ void default_output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_d
 
   if(self->priority >= _iop_module_demosaic) return;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(pipe) && (pipe->image.flags & DT_IMAGE_RAW)) dsc->channels = 1;
+  if(pipe->image.flags & DT_IMAGE_RAW) dsc->channels = 1;
 
   if(self->priority >= _iop_module_rawprepare) return;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
     dsc->datatype = TYPE_UINT16;
 }
 

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -446,7 +446,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_plain(uint16_t *const out, const uint
         num = ((maxi - px) / 2 + 1 - dx) * ((maxj - py) / 2 + 1 - dy);
       }
 
-      const int c = (2 * (y % 2) + (x % 2));
+      const int c = (2 * ((y + rggby) % 2) + ((x + rggbx) % 2));
       *outc = (uint16_t)(col[c] / num);
       outc++;
     }
@@ -639,7 +639,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_sse2(uint16_t *const out, const uint1
       float fcol[4] __attribute__((aligned(16)));
       _mm_store_ps(fcol, col);
 
-      const int c = (2 * (y % 2) + (x % 2));
+      const int c = (2 * ((y + rggby) % 2) + ((x + rggbx) % 2));
       *outc = (uint16_t)(fcol[c]);
       outc++;
     }
@@ -842,7 +842,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f_plain(float *const out, const float
         num = ((maxi - px) / 2 + 1 - dx) * ((maxj - py) / 2 + 1 - dy);
       }
 
-      const int c = (2 * (y % 2) + (x % 2));
+      const int c = (2 * ((y + rggby) % 2) + ((x + rggbx) % 2));
       *outc = col[c] / num;
       outc++;
     }
@@ -1035,7 +1035,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f_sse2(float *const out, const float 
       float fcol[4] __attribute__((aligned(16)));
       _mm_store_ps(fcol, col);
 
-      const int c = (2 * (y % 2) + (x % 2));
+      const int c = (2 * ((y + rggby) % 2) + ((x + rggbx) % 2));
       *outc = fcol[c];
       outc++;
     }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -176,6 +176,51 @@ int dt_iop_clip_and_zoom_roi_cl(int devid, cl_mem dev_out, cl_mem dev_in, const 
 
 #endif
 
+void dt_iop_clip_and_zoom_pixel_binning(uint16_t *const ovoid, const uint16_t *const ivoid,
+                                        const struct dt_iop_roi_t *const roi_out,
+                                        const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                        const int32_t in_stride, const unsigned int pattern_size,
+                                        const unsigned int bin_blocks)
+{
+  const unsigned int pixel_stride = pattern_size * bin_blocks;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int y = 0; y < roi_out->height; y++)
+  {
+    uint16_t *in = (uint16_t *)ivoid;
+    uint16_t *out = (uint16_t *)ovoid + (size_t)out_stride * y;
+
+    const int py = pixel_stride * (y / pattern_size) + (y % pattern_size);
+
+    // needs to be bin_pixels or less.
+    const int maxj = MIN(roi_in->height, py + pixel_stride);
+
+    for(int x = 0; x < roi_out->width; x++, out++)
+    {
+      const int px = pixel_stride * (x / pattern_size) + (x % pattern_size);
+
+      // needs to be bin_pixels or less.
+      const int maxi = MIN(roi_in->width, px + pixel_stride);
+
+      size_t sum = 0, num = 0;
+      for(int j = py; j < maxj; j += pattern_size)
+      {
+        for(int i = px; i < maxi; i += pattern_size)
+        {
+          const uint16_t val = in[(size_t)in_stride * j + (size_t)i];
+
+          sum += val;
+          num++;
+        }
+      }
+
+      *out = (uint16_t)((float)sum / (float)num);
+    }
+  }
+}
+
 void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_plain(float *const out, const uint16_t *const in,
                                                                 const dt_iop_roi_t *const roi_out,
                                                                 const dt_iop_roi_t *const roi_in,

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -950,8 +950,7 @@ dt_iop_clip_and_zoom_demosaic_half_size_f(
 void dt_iop_clip_and_zoom_demosaic_half_size_f_plain(float *out, const float *const in,
                                                      const dt_iop_roi_t *const roi_out,
                                                      const dt_iop_roi_t *const roi_in, const int32_t out_stride,
-                                                     const int32_t in_stride, const uint32_t filters,
-                                                     const float clip)
+                                                     const int32_t in_stride, const uint32_t filters)
 {
   // adjust to pixel region and don't sample more than scale/2 nbs!
   // pixel footprint on input buffer, radius:
@@ -1127,8 +1126,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f_plain(float *out, const float *co
 void dt_iop_clip_and_zoom_demosaic_half_size_f_sse2(float *out, const float *const in,
                                                     const dt_iop_roi_t *const roi_out,
                                                     const dt_iop_roi_t *const roi_in, const int32_t out_stride,
-                                                    const int32_t in_stride, const uint32_t filters,
-                                                    const float clip)
+                                                    const int32_t in_stride, const uint32_t filters)
 {
   // adjust to pixel region and don't sample more than scale/2 nbs!
   // pixel footprint on input buffer, radius:
@@ -1305,15 +1303,14 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f_sse2(float *out, const float *con
 void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in,
                                                const dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in,
                                                const int32_t out_stride, const int32_t in_stride,
-                                               const uint32_t filters, const float clip)
+                                               const uint32_t filters)
 {
   if(darktable.codepath.OPENMP_SIMD)
     return dt_iop_clip_and_zoom_demosaic_half_size_f_plain(out, in, roi_out, roi_in, out_stride, in_stride,
-                                                           filters, clip);
+                                                           filters);
 #if defined(__SSE__)
   else if(darktable.codepath.SSE2)
-    return dt_iop_clip_and_zoom_demosaic_half_size_f_sse2(out, in, roi_out, roi_in, out_stride, in_stride,
-                                                          filters, clip);
+    return dt_iop_clip_and_zoom_demosaic_half_size_f_sse2(out, in, roi_out, roi_in, out_stride, in_stride, filters);
 #endif
   else
     dt_unreachable_codepath();

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -1122,6 +1122,57 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
   }
 }
 
+void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const float *const in,
+                                                     const dt_iop_roi_t *const roi_out,
+                                                     const dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                                     const int32_t in_stride, const uint8_t (*const xtrans)[6])
+{
+  const float px_footprint = 1.f / roi_out->scale;
+  const int samples = MAX(1, (int)floorf(px_footprint / 3));
+
+  // A slightly different algorithm than
+  // dt_iop_clip_and_zoom_demosaic_half_size_f() which aligns to 2x2
+  // Bayer grid and hence most pull additional data from all edges
+  // which don't align with CFA. Instead align to a 3x3 pattern (which
+  // is semi-regular in X-Trans CFA). If instead had aligned the
+  // samples to the full 6x6 X-Trans CFA, wouldn't need to perform a
+  // CFA lookup, but then would only work at 1/6 scale or less. This
+  // code doesn't worry about fractional pixel offset of top/left of
+  // pattern nor oversampling by non-integer number of samples.
+
+  // X-Trans RGB weighting averages to 2:5:2 for each 3x3 cell
+  static const float div[3] = { 2.0, 5.0, 2.0 };
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int y = 0; y < roi_out->height; y++)
+  {
+    float *outc = out + out_stride * y;
+    const int py = CLAMPS((int)round((y + roi_out->y - 0.5f) * px_footprint), 0, roi_in->height - 3);
+    const int ymax = MIN(roi_in->height - 3, py + 3 * samples);
+
+    for(int x = 0; x < roi_out->width; x++, outc++)
+    {
+      float col[3] = { 0.0f };
+      int num = 0;
+      const int px = CLAMPS((int)round((x + roi_out->x - 0.5f) * px_footprint), 0, roi_in->width - 3);
+      const int xmax = MIN(roi_in->width - 3, px + 3 * samples);
+      for(int yy = py; yy <= ymax; yy += 3)
+        for(int xx = px; xx <= xmax; xx += 3)
+        {
+          for(int j = 0; j < 3; ++j)
+            for(int i = 0; i < 3; ++i)
+              col[FCxtrans(yy + j, xx + i, roi_in, xtrans)] += in[xx + i + in_stride * (yy + j)];
+          num++;
+        }
+
+      const int c = FCxtrans(y, x, roi_out, xtrans);
+      *outc = col[c] / ((float)num * div[c]);
+    }
+  }
+}
+
 void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_plain(float *const out, const uint16_t *const in,
                                                                 const dt_iop_roi_t *const roi_out,
                                                                 const dt_iop_roi_t *const roi_in,

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -1059,6 +1059,69 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *cons
     dt_unreachable_codepath();
 }
 
+/**
+ * downscales and clips a Fujifilm X-Trans mosaiced buffer (in) to the given region of interest (r_*)
+ * and writes it to out.
+ */
+void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const uint16_t *const in,
+                                                   const dt_iop_roi_t *const roi_out,
+                                                   const dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                                   const int32_t in_stride, const uint8_t (*const xtrans)[6],
+                                                   const uint16_t whitelevel)
+{
+  const float px_footprint = 1.f / roi_out->scale;
+  const int samples = round(px_footprint / 3);
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int y = 0; y < roi_out->height; y++)
+  {
+    uint16_t *outc = out + out_stride * y;
+
+    int py = floorf((y + roi_out->y) * px_footprint);
+    py = MIN(roi_in->height - 4, py);
+    int maxj = MIN(roi_in->height - 3, py + 3 * samples);
+
+    float fx = roi_out->x * px_footprint;
+    for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
+    {
+      int px = floorf(fx);
+      px = MIN(roi_in->width - 4, px);
+      int maxi = MIN(roi_in->width - 3, px + 3 * samples);
+
+      uint16_t pc = 0;
+      for(int ii = 0; ii < 3; ++ii)
+        for(int jj = 0; jj < 3; ++jj) pc = MAX(pc, in[px + ii + in_stride * (py + jj)]);
+
+      uint8_t num[3] = { 0 };
+      uint32_t sum[3] = { 0 };
+
+      for(int j = py; j <= maxj; j += 3)
+        for(int i = px; i <= maxi; i += 3)
+        {
+          uint16_t lcl_max = 0;
+          for(int ii = 0; ii < 3; ++ii)
+            for(int jj = 0; jj < 3; ++jj) lcl_max = MAX(lcl_max, in[i + ii + in_stride * (j + jj)]);
+
+          if(!((pc >= whitelevel) ^ (lcl_max >= whitelevel)))
+          {
+            for(int ii = 0; ii < 3; ++ii)
+              for(int jj = 0; jj < 3; ++jj)
+              {
+                const uint8_t c = FCxtrans(j + jj, i + ii, roi_in, xtrans);
+                sum[c] += in[i + ii + in_stride * (j + jj)];
+                num[c]++;
+              }
+          }
+        }
+
+      const int c = FCxtrans(y, x, roi_out, xtrans);
+      *outc = (uint16_t)((float)(sum[c]) / (float)(num[c]));
+    }
+  }
+}
+
 void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_plain(float *const out, const uint16_t *const in,
                                                                 const dt_iop_roi_t *const roi_out,
                                                                 const dt_iop_roi_t *const roi_in,

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -393,7 +393,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_plain(uint16_t *const out, const uint
         // lower right 2x2 block
         p[0] = in[maxi + 2 + in_stride * (maxj + 2)];
         p[1] = in[maxi + 3 + in_stride * (maxj + 2)];
-        p[2] = in[maxi + in_stride * (maxj + 3)];
+        p[2] = in[maxi + 2 + in_stride * (maxj + 3)];
         p[3] = in[maxi + 3 + in_stride * (maxj + 3)];
         for(int c = 0; c < 4; c++) col[c] += (dx * dy) * p[c];
 
@@ -580,7 +580,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_sse2(uint16_t *const out, const uint1
         // lower right 2x2 block
         p1 = in[maxi + 2 + in_stride * (maxj + 2)];
         p2 = in[maxi + 3 + in_stride * (maxj + 2)];
-        p3 = in[maxi + in_stride * (maxj + 3)];
+        p3 = in[maxi + 2 + in_stride * (maxj + 3)];
         p4 = in[maxi + 3 + in_stride * (maxj + 3)];
         col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx * dy), _mm_set_ps(p4, p3, p2, p1)));
 
@@ -789,7 +789,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f_plain(float *const out, const float
         // lower right 2x2 block
         p[0] = in[maxi + 2 + in_stride * (maxj + 2)];
         p[1] = in[maxi + 3 + in_stride * (maxj + 2)];
-        p[2] = in[maxi + in_stride * (maxj + 3)];
+        p[2] = in[maxi + 2 + in_stride * (maxj + 3)];
         p[3] = in[maxi + 3 + in_stride * (maxj + 3)];
         for(int c = 0; c < 4; c++) col[c] += (dx * dy) * p[c];
 
@@ -976,7 +976,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f_sse2(float *const out, const float 
         // lower right 2x2 block
         p1 = in[maxi + 2 + in_stride * (maxj + 2)];
         p2 = in[maxi + 3 + in_stride * (maxj + 2)];
-        p3 = in[maxi + in_stride * (maxj + 3)];
+        p3 = in[maxi + 2 + in_stride * (maxj + 3)];
         p4 = in[maxi + 3 + in_stride * (maxj + 3)];
         col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx * dy), _mm_set_ps(p4, p3, p2, p1)));
 
@@ -1947,7 +1947,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f_plain(float *out, const float *co
 
         // lower right 2x2 block
         p[0] = in[maxi + 2 + in_stride * (maxj + 2)];
-        p[1] = in[maxi + 3 + in_stride * (maxj + 2)] + in[maxi + in_stride * (maxj + 3)];
+        p[1] = in[maxi + 3 + in_stride * (maxj + 2)] + in[maxi + 2 + in_stride * (maxj + 3)];
         p[2] = in[maxi + 3 + in_stride * (maxj + 3)];
         for(int c = 0; c < 3; c++) col[c] += (dx * dy) * p[c];
 
@@ -2123,7 +2123,7 @@ void dt_iop_clip_and_zoom_demosaic_half_size_f_sse2(float *out, const float *con
 
         // lower right 2x2 block
         p1 = in[maxi + 2 + in_stride * (maxj + 2)];
-        p2 = in[maxi + 3 + in_stride * (maxj + 2)] + in[maxi + in_stride * (maxj + 3)];
+        p2 = in[maxi + 3 + in_stride * (maxj + 2)] + in[maxi + 2 + in_stride * (maxj + 3)];
         p4 = in[maxi + 3 + in_stride * (maxj + 3)];
         col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx * dy), _mm_set_ps(0.0f, p4, p2, p1)));
 

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -663,6 +663,402 @@ void dt_iop_clip_and_zoom_mosaic_half_size(uint16_t *const out, const uint16_t *
     dt_unreachable_codepath();
 }
 
+void dt_iop_clip_and_zoom_mosaic_half_size_f_plain(float *const out, const float *const in,
+                                                   const dt_iop_roi_t *const roi_out,
+                                                   const dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                                   const int32_t in_stride, const uint32_t filters)
+{
+  // adjust to pixel region and don't sample more than scale/2 nbs!
+  // pixel footprint on input buffer, radius:
+  const float px_footprint = 1.f / roi_out->scale;
+  // how many 2x2 blocks can be sampled inside that area
+  const int samples = round(px_footprint / 2);
+
+  // move p to point to an rggb block:
+  int trggbx = 0, trggby = 0;
+  if(FC(trggby, trggbx + 1, filters) != 1) trggbx++;
+  if(FC(trggby, trggbx, filters) != 0)
+  {
+    trggbx = (trggbx + 1) & 1;
+    trggby++;
+  }
+  const int rggbx = trggbx, rggby = trggby;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int y = 0; y < roi_out->height; y++)
+  {
+    float *outc = out + out_stride * y;
+
+    float fy = (y + roi_out->y) * px_footprint;
+    int py = (int)fy & ~1;
+    const float dy = (fy - py) / 2;
+    py = MIN(((roi_in->height - 6) & ~1u), py) + rggby;
+
+    int maxj = MIN(((roi_in->height - 5) & ~1u) + rggby, py + 2 * samples);
+
+    for(int x = 0; x < roi_out->width; x++)
+    {
+      float col[4] = { 0, 0, 0, 0 };
+
+      float fx = (x + roi_out->x) * px_footprint;
+      int px = (int)fx & ~1;
+      const float dx = (fx - px) / 2;
+      px = MIN(((roi_in->width - 6) & ~1u), px) + rggbx;
+
+      int maxi = MIN(((roi_in->width - 5) & ~1u) + rggbx, px + 2 * samples);
+
+      float p[4];
+      float num = 0;
+
+      // upper left 2x2 block of sampling region
+      p[0] = in[px + in_stride * py];
+      p[1] = in[px + 1 + in_stride * py];
+      p[2] = in[px + in_stride * (py + 1)];
+      p[3] = in[px + 1 + in_stride * (py + 1)];
+      for(int c = 0; c < 4; c++) col[c] += ((1 - dx) * (1 - dy)) * p[c];
+
+      // left 2x2 block border of sampling region
+      for(int j = py + 2; j <= maxj; j += 2)
+      {
+        p[0] = in[px + in_stride * j];
+        p[1] = in[px + 1 + in_stride * j];
+        p[2] = in[px + in_stride * (j + 1)];
+        p[3] = in[px + 1 + in_stride * (j + 1)];
+        for(int c = 0; c < 4; c++) col[c] += (1 - dx) * p[c];
+      }
+
+      // upper 2x2 block border of sampling region
+      for(int i = px + 2; i <= maxi; i += 2)
+      {
+        p[0] = in[i + in_stride * py];
+        p[1] = in[i + 1 + in_stride * py];
+        p[2] = in[i + in_stride * (py + 1)];
+        p[3] = in[i + 1 + in_stride * (py + 1)];
+        for(int c = 0; c < 4; c++) col[c] += (1 - dy) * p[c];
+      }
+
+      // 2x2 blocks in the middle of sampling region
+      for(int j = py + 2; j <= maxj; j += 2)
+        for(int i = px + 2; i <= maxi; i += 2)
+        {
+          p[0] = in[i + in_stride * j];
+          p[1] = in[i + 1 + in_stride * j];
+          p[2] = in[i + in_stride * (j + 1)];
+          p[3] = in[i + 1 + in_stride * (j + 1)];
+          for(int c = 0; c < 4; c++) col[c] += p[c];
+        }
+
+      if(maxi == px + 2 * samples && maxj == py + 2 * samples)
+      {
+        // right border
+        for(int j = py + 2; j <= maxj; j += 2)
+        {
+          p[0] = in[maxi + 2 + in_stride * j];
+          p[1] = in[maxi + 3 + in_stride * j];
+          p[2] = in[maxi + 2 + in_stride * (j + 1)];
+          p[3] = in[maxi + 3 + in_stride * (j + 1)];
+          for(int c = 0; c < 4; c++) col[c] += dx * p[c];
+        }
+
+        // upper right
+        p[0] = in[maxi + 2 + in_stride * py];
+        p[1] = in[maxi + 3 + in_stride * py];
+        p[2] = in[maxi + 2 + in_stride * (py + 1)];
+        p[3] = in[maxi + 3 + in_stride * (py + 1)];
+        for(int c = 0; c < 4; c++) col[c] += (dx * (1 - dy)) * p[c];
+
+        // lower border
+        for(int i = px + 2; i <= maxi; i += 2)
+        {
+          p[0] = in[i + in_stride * (maxj + 2)];
+          p[1] = in[i + 1 + in_stride * (maxj + 2)];
+          p[2] = in[i + in_stride * (maxj + 3)];
+          p[3] = in[i + 1 + in_stride * (maxj + 3)];
+          for(int c = 0; c < 4; c++) col[c] += dy * p[c];
+        }
+
+        // lower left 2x2 block
+        p[0] = in[px + in_stride * (maxj + 2)];
+        p[1] = in[px + 1 + in_stride * (maxj + 2)];
+        p[2] = in[px + in_stride * (maxj + 3)];
+        p[3] = in[px + 1 + in_stride * (maxj + 3)];
+        for(int c = 0; c < 4; c++) col[c] += ((1 - dx) * dy) * p[c];
+
+        // lower right 2x2 block
+        p[0] = in[maxi + 2 + in_stride * (maxj + 2)];
+        p[1] = in[maxi + 3 + in_stride * (maxj + 2)];
+        p[2] = in[maxi + in_stride * (maxj + 3)];
+        p[3] = in[maxi + 3 + in_stride * (maxj + 3)];
+        for(int c = 0; c < 4; c++) col[c] += (dx * dy) * p[c];
+
+        num = (samples + 1) * (samples + 1);
+      }
+      else if(maxi == px + 2 * samples)
+      {
+        // right border
+        for(int j = py + 2; j <= maxj; j += 2)
+        {
+          p[0] = in[maxi + 2 + in_stride * j];
+          p[1] = in[maxi + 3 + in_stride * j];
+          p[2] = in[maxi + 2 + in_stride * (j + 1)];
+          p[3] = in[maxi + 3 + in_stride * (j + 1)];
+          for(int c = 0; c < 4; c++) col[c] += dx * p[c];
+        }
+
+        // upper right
+        p[0] = in[maxi + 2 + in_stride * py];
+        p[1] = in[maxi + 3 + in_stride * py];
+        p[2] = in[maxi + 2 + in_stride * (py + 1)];
+        p[3] = in[maxi + 3 + in_stride * (py + 1)];
+        for(int c = 0; c < 4; c++) col[c] += (dx * (1 - dy)) * p[c];
+
+        num = ((maxj - py) / 2 + 1 - dy) * (samples + 1);
+      }
+      else if(maxj == py + 2 * samples)
+      {
+        // lower border
+        for(int i = px + 2; i <= maxi; i += 2)
+        {
+          p[0] = in[i + in_stride * (maxj + 2)];
+          p[1] = in[i + 1 + in_stride * (maxj + 2)];
+          p[2] = in[i + in_stride * (maxj + 3)];
+          p[3] = in[i + 1 + in_stride * (maxj + 3)];
+          for(int c = 0; c < 4; c++) col[c] += dy * p[c];
+        }
+
+        // lower left 2x2 block
+        p[0] = in[px + in_stride * (maxj + 2)];
+        p[1] = in[px + 1 + in_stride * (maxj + 2)];
+        p[2] = in[px + in_stride * (maxj + 3)];
+        p[3] = in[px + 1 + in_stride * (maxj + 3)];
+        for(int c = 0; c < 4; c++) col[c] += ((1 - dx) * dy) * p[c];
+
+        num = ((maxi - px) / 2 + 1 - dx) * (samples + 1);
+      }
+      else
+      {
+        num = ((maxi - px) / 2 + 1 - dx) * ((maxj - py) / 2 + 1 - dy);
+      }
+
+      const int c = (2 * (y % 2) + (x % 2));
+      *outc = col[c] / num;
+      outc++;
+    }
+  }
+}
+
+#if defined(__SSE__)
+void dt_iop_clip_and_zoom_mosaic_half_size_f_sse2(float *const out, const float *const in,
+                                                  const dt_iop_roi_t *const roi_out,
+                                                  const dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                                  const int32_t in_stride, const uint32_t filters)
+{
+  // adjust to pixel region and don't sample more than scale/2 nbs!
+  // pixel footprint on input buffer, radius:
+  const float px_footprint = 1.f / roi_out->scale;
+  // how many 2x2 blocks can be sampled inside that area
+  const int samples = round(px_footprint / 2);
+
+  // move p to point to an rggb block:
+  int trggbx = 0, trggby = 0;
+  if(FC(trggby, trggbx + 1, filters) != 1) trggbx++;
+  if(FC(trggby, trggbx, filters) != 0)
+  {
+    trggbx = (trggbx + 1) & 1;
+    trggby++;
+  }
+  const int rggbx = trggbx, rggby = trggby;
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int y = 0; y < roi_out->height; y++)
+  {
+    float *outc = out + out_stride * y;
+
+    float fy = (y + roi_out->y) * px_footprint;
+    int py = (int)fy & ~1;
+    const float dy = (fy - py) / 2;
+    py = MIN(((roi_in->height - 6) & ~1u), py) + rggby;
+
+    int maxj = MIN(((roi_in->height - 5) & ~1u) + rggby, py + 2 * samples);
+
+    for(int x = 0; x < roi_out->width; x++)
+    {
+      __m128 col = _mm_setzero_ps();
+
+      float fx = (x + roi_out->x) * px_footprint;
+      int px = (int)fx & ~1;
+      const float dx = (fx - px) / 2;
+      px = MIN(((roi_in->width - 6) & ~1u), px) + rggbx;
+
+      int maxi = MIN(((roi_in->width - 5) & ~1u) + rggbx, px + 2 * samples);
+
+      float p1, p2, p3, p4;
+      float num = 0;
+
+      // upper left 2x2 block of sampling region
+      p1 = in[px + in_stride * py];
+      p2 = in[px + 1 + in_stride * py];
+      p3 = in[px + in_stride * (py + 1)];
+      p4 = in[px + 1 + in_stride * (py + 1)];
+      col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps((1 - dx) * (1 - dy)), _mm_set_ps(p4, p3, p2, p1)));
+
+      // left 2x2 block border of sampling region
+      for(int j = py + 2; j <= maxj; j += 2)
+      {
+        p1 = in[px + in_stride * j];
+        p2 = in[px + 1 + in_stride * j];
+        p3 = in[px + in_stride * (j + 1)];
+        p4 = in[px + 1 + in_stride * (j + 1)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(1 - dx), _mm_set_ps(p4, p3, p2, p1)));
+      }
+
+      // upper 2x2 block border of sampling region
+      for(int i = px + 2; i <= maxi; i += 2)
+      {
+        p1 = in[i + in_stride * py];
+        p2 = in[i + 1 + in_stride * py];
+        p3 = in[i + in_stride * (py + 1)];
+        p4 = in[i + 1 + in_stride * (py + 1)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(1 - dy), _mm_set_ps(p4, p3, p2, p1)));
+      }
+
+      // 2x2 blocks in the middle of sampling region
+      for(int j = py + 2; j <= maxj; j += 2)
+        for(int i = px + 2; i <= maxi; i += 2)
+        {
+          p1 = in[i + in_stride * j];
+          p2 = in[i + 1 + in_stride * j];
+          p3 = in[i + in_stride * (j + 1)];
+          p4 = in[i + 1 + in_stride * (j + 1)];
+          col = _mm_add_ps(col, _mm_set_ps(p4, p3, p2, p1));
+        }
+
+      if(maxi == px + 2 * samples && maxj == py + 2 * samples)
+      {
+        // right border
+        for(int j = py + 2; j <= maxj; j += 2)
+        {
+          p1 = in[maxi + 2 + in_stride * j];
+          p2 = in[maxi + 3 + in_stride * j];
+          p3 = in[maxi + 2 + in_stride * (j + 1)];
+          p4 = in[maxi + 3 + in_stride * (j + 1)];
+          col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx), _mm_set_ps(p4, p3, p2, p1)));
+        }
+
+        // upper right
+        p1 = in[maxi + 2 + in_stride * py];
+        p2 = in[maxi + 3 + in_stride * py];
+        p3 = in[maxi + 2 + in_stride * (py + 1)];
+        p4 = in[maxi + 3 + in_stride * (py + 1)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx * (1 - dy)), _mm_set_ps(p4, p3, p2, p1)));
+
+        // lower border
+        for(int i = px + 2; i <= maxi; i += 2)
+        {
+          p1 = in[i + in_stride * (maxj + 2)];
+          p2 = in[i + 1 + in_stride * (maxj + 2)];
+          p3 = in[i + in_stride * (maxj + 3)];
+          p4 = in[i + 1 + in_stride * (maxj + 3)];
+          col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dy), _mm_set_ps(p4, p3, p2, p1)));
+        }
+
+        // lower left 2x2 block
+        p1 = in[px + in_stride * (maxj + 2)];
+        p2 = in[px + 1 + in_stride * (maxj + 2)];
+        p3 = in[px + in_stride * (maxj + 3)];
+        p4 = in[px + 1 + in_stride * (maxj + 3)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps((1 - dx) * dy), _mm_set_ps(p4, p3, p2, p1)));
+
+        // lower right 2x2 block
+        p1 = in[maxi + 2 + in_stride * (maxj + 2)];
+        p2 = in[maxi + 3 + in_stride * (maxj + 2)];
+        p3 = in[maxi + in_stride * (maxj + 3)];
+        p4 = in[maxi + 3 + in_stride * (maxj + 3)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx * dy), _mm_set_ps(p4, p3, p2, p1)));
+
+        num = (samples + 1) * (samples + 1);
+      }
+      else if(maxi == px + 2 * samples)
+      {
+        // right border
+        for(int j = py + 2; j <= maxj; j += 2)
+        {
+          p1 = in[maxi + 2 + in_stride * j];
+          p2 = in[maxi + 3 + in_stride * j];
+          p3 = in[maxi + 2 + in_stride * (j + 1)];
+          p4 = in[maxi + 3 + in_stride * (j + 1)];
+          col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx), _mm_set_ps(p4, p3, p2, p1)));
+        }
+
+        // upper right
+        p1 = in[maxi + 2 + in_stride * py];
+        p2 = in[maxi + 3 + in_stride * py];
+        p3 = in[maxi + 2 + in_stride * (py + 1)];
+        p4 = in[maxi + 3 + in_stride * (py + 1)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dx * (1 - dy)), _mm_set_ps(p4, p3, p2, p1)));
+
+        num = ((maxj - py) / 2 + 1 - dy) * (samples + 1);
+      }
+      else if(maxj == py + 2 * samples)
+      {
+        // lower border
+        for(int i = px + 2; i <= maxi; i += 2)
+        {
+          p1 = in[i + in_stride * (maxj + 2)];
+          p2 = in[i + 1 + in_stride * (maxj + 2)];
+          p3 = in[i + in_stride * (maxj + 3)];
+          p4 = in[i + 1 + in_stride * (maxj + 3)];
+          col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps(dy), _mm_set_ps(p4, p3, p2, p1)));
+        }
+
+        // lower left 2x2 block
+        p1 = in[px + in_stride * (maxj + 2)];
+        p2 = in[px + 1 + in_stride * (maxj + 2)];
+        p3 = in[px + in_stride * (maxj + 3)];
+        p4 = in[px + 1 + in_stride * (maxj + 3)];
+        col = _mm_add_ps(col, _mm_mul_ps(_mm_set1_ps((1 - dx) * dy), _mm_set_ps(p4, p3, p2, p1)));
+
+        num = ((maxi - px) / 2 + 1 - dx) * (samples + 1);
+      }
+      else
+      {
+        num = ((maxi - px) / 2 + 1 - dx) * ((maxj - py) / 2 + 1 - dy);
+      }
+
+      num = 1.0f / num;
+      col = _mm_mul_ps(col, _mm_set1_ps(num));
+
+      float fcol[4] __attribute__((aligned(16)));
+      _mm_store_ps(fcol, col);
+
+      const int c = (2 * (y % 2) + (x % 2));
+      *outc = fcol[c];
+      outc++;
+    }
+  }
+  _mm_sfence();
+}
+#endif
+
+void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *const in,
+                                             const dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in,
+                                             const int32_t out_stride, const int32_t in_stride,
+                                             const uint32_t filters)
+{
+  if(darktable.codepath.OPENMP_SIMD)
+    return dt_iop_clip_and_zoom_mosaic_half_size_f_plain(out, in, roi_out, roi_in, out_stride, in_stride, filters);
+#if defined(__SSE__)
+  else if(darktable.codepath.SSE2)
+    return dt_iop_clip_and_zoom_mosaic_half_size_f_sse2(out, in, roi_out, roi_in, out_stride, in_stride, filters);
+#endif
+  else
+    dt_unreachable_codepath();
+}
+
 void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_plain(float *const out, const uint16_t *const in,
                                                                 const dt_iop_roi_t *const roi_out,
                                                                 const dt_iop_roi_t *const roi_in,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -51,6 +51,12 @@ int dt_iop_clip_and_zoom_roi_cl(int devid, cl_mem dev_out, cl_mem dev_in,
                                 const struct dt_iop_roi_t *const roi_in);
 #endif
 
+void dt_iop_clip_and_zoom_pixel_binning(uint16_t *const out, const uint16_t *const in,
+                                        const struct dt_iop_roi_t *const roi_out,
+                                        const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                        const int32_t in_stride, const unsigned int pattern_size,
+                                        const unsigned int bin_blocks);
+
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -54,9 +54,9 @@ int dt_iop_clip_and_zoom_roi_cl(int devid, cl_mem dev_out, cl_mem dev_in,
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,
-                                             const struct dt_iop_roi_t *const roi_in,
-                                             const int32_t out_stride, const int32_t in_stride,
-                                             const uint32_t filters);
+                                             const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                             const int32_t in_stride, const uint32_t filters,
+                                             const uint16_t whitelevel);
 
 void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome(float *out, const uint16_t *const in,
                                                           const struct dt_iop_roi_t *const roi_out,
@@ -80,7 +80,7 @@ void dt_iop_clip_and_zoom_demosaic_third_size_xtrans(float *out, const uint16_t 
                                                      const struct dt_iop_roi_t *const roi_out,
                                                      const struct dt_iop_roi_t *const roi_in,
                                                      const int32_t out_stride, const int32_t in_stride,
-                                                     const uint8_t (*const xtrans)[6]);
+                                                     const uint8_t (*const xtrans)[6], const uint16_t whitelevel);
 
 void dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f(float *out, const float *const in,
                                                        const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -63,6 +63,11 @@ void dt_iop_clip_and_zoom_pixel_binning_f(float *const out, const float *const i
                                           const int32_t in_stride, const unsigned int pattern_size,
                                           const unsigned int bin_blocks);
 
+void dt_iop_clip_and_zoom_mosaic_half_size(uint16_t *const out, const uint16_t *const in,
+                                           const dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in,
+                                           const int32_t out_stride, const int32_t in_stride,
+                                           const uint32_t filters);
+
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -73,6 +73,12 @@ void dt_iop_clip_and_zoom_mosaic_half_size(uint16_t *const out, const uint16_t *
                                            const int32_t out_stride, const int32_t in_stride,
                                            const uint32_t filters);
 
+void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const uint16_t *const in,
+                                                   const dt_iop_roi_t *const roi_out,
+                                                   const dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                                   const int32_t in_stride, const uint8_t (*const xtrans)[6],
+                                                   const uint16_t whitelevel);
+
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -63,6 +63,11 @@ void dt_iop_clip_and_zoom_pixel_binning_f(float *const out, const float *const i
                                           const int32_t in_stride, const unsigned int pattern_size,
                                           const unsigned int bin_blocks);
 
+void dt_iop_clip_and_zoom_mosaic_half_size_f(float *const out, const float *const in,
+                                             const dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in,
+                                             const int32_t out_stride, const int32_t in_stride,
+                                             const uint32_t filters);
+
 void dt_iop_clip_and_zoom_mosaic_half_size(uint16_t *const out, const uint16_t *const in,
                                            const dt_iop_roi_t *const roi_out, const dt_iop_roi_t *const roi_in,
                                            const int32_t out_stride, const int32_t in_stride,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -57,6 +57,12 @@ void dt_iop_clip_and_zoom_pixel_binning(uint16_t *const out, const uint16_t *con
                                         const int32_t in_stride, const unsigned int pattern_size,
                                         const unsigned int bin_blocks);
 
+void dt_iop_clip_and_zoom_pixel_binning_f(float *const out, const float *const in,
+                                          const struct dt_iop_roi_t *const roi_out,
+                                          const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                          const int32_t in_stride, const unsigned int pattern_size,
+                                          const unsigned int bin_blocks);
+
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -79,6 +79,11 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
                                                    const int32_t in_stride, const uint8_t (*const xtrans)[6],
                                                    const uint16_t whitelevel);
 
+void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const float *const in,
+                                                     const dt_iop_roi_t *const roi_out,
+                                                     const dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                                     const int32_t in_stride, const uint8_t (*const xtrans)[6]);
+
 /** clip and zoom mosaiced image without demosaicing it uint16_t -> float4 */
 void dt_iop_clip_and_zoom_demosaic_half_size(float *out, const uint16_t *const in,
                                              const struct dt_iop_roi_t *const roi_out,

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -71,9 +71,8 @@ void dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f(float *out, const fl
 
 void dt_iop_clip_and_zoom_demosaic_half_size_f(float *out, const float *const in,
                                                const struct dt_iop_roi_t *const roi_out,
-                                               const struct dt_iop_roi_t *const roi_in,
-                                               const int32_t out_stride, const int32_t in_stride,
-                                               const uint32_t filters, const float clip);
+                                               const struct dt_iop_roi_t *const roi_in, const int32_t out_stride,
+                                               const int32_t in_stride, const uint32_t filters);
 
 /** x-trans sensor downscaling */
 void dt_iop_clip_and_zoom_demosaic_third_size_xtrans(float *out, const uint16_t *const in,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -147,14 +147,13 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   return 1;
 }
 
-void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, float *input, int width,
-                                int height, float iscale, int pre_monochrome_demosaiced)
+void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, float *input, int width, int height,
+                                float iscale)
 {
   pipe->iwidth = width;
   pipe->iheight = height;
   pipe->iscale = iscale;
   pipe->input = input;
-  pipe->pre_monochrome_demosaiced = pre_monochrome_demosaiced;
   pipe->image = dev->image_storage;
   pipe->dsc = pipe->image.buf_dsc;
 

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -118,8 +118,6 @@ typedef struct dt_dev_pixelpipe_t
   int mask_display;
   // input data based on this timestamp:
   int input_timestamp;
-  // input data was pre-demosaiced and the demosaicing method is monochrome
-  int pre_monochrome_demosaiced;
   dt_dev_pixelpipe_type_t type;
   // the final output pixel format this pixelpipe will be converted to
   dt_imageio_levels_t levels;
@@ -147,7 +145,7 @@ int dt_dev_pixelpipe_init_dummy(dt_dev_pixelpipe_t *pipe, int32_t width, int32_t
 int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t entries);
 // constructs a new input buffer from given RGB float array.
 void dt_dev_pixelpipe_set_input(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, float *input, int width,
-                                int height, float iscale, int pre_monochrome_demosaiced);
+                                int height, float iscale);
 
 // returns the dimensions of the full image after processing.
 void dt_dev_pixelpipe_get_dimensions(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, int width_in,

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -192,10 +192,14 @@ void dt_dev_pixelpipe_remove_node(dt_dev_pixelpipe_t *pipe, struct dt_develop_t 
 // i.e. four floats per pixel already demosaiced/downsampled
 static inline int dt_dev_pixelpipe_uses_downsampled_input(dt_dev_pixelpipe_t *pipe)
 {
+#if 1
+  return 0;
+#else
   if(!dt_conf_get_bool("plugins/lighttable/low_quality_thumbnails"))
     return pipe->type == DT_DEV_PIXELPIPE_PREVIEW;
   else
     return (pipe->type == DT_DEV_PIXELPIPE_PREVIEW) || (pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);
+#endif
 }
 
 #endif

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -188,20 +188,6 @@ void dt_dev_pixelpipe_disable_before(dt_dev_pixelpipe_t *pipe, const char *op);
 void dt_dev_pixelpipe_add_node(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, int n);
 void dt_dev_pixelpipe_remove_node(dt_dev_pixelpipe_t *pipe, struct dt_develop_t *dev, int n);
 
-// signifies that this pipeline uses the MIP_F buffer instead of MIP_FULL
-// i.e. four floats per pixel already demosaiced/downsampled
-static inline int dt_dev_pixelpipe_uses_downsampled_input(dt_dev_pixelpipe_t *pipe)
-{
-#if 1
-  return 0;
-#else
-  if(!dt_conf_get_bool("plugins/lighttable/low_quality_thumbnails"))
-    return pipe->type == DT_DEV_PIXELPIPE_PREVIEW;
-  else
-    return (pipe->type == DT_DEV_PIXELPIPE_PREVIEW) || (pipe->type == DT_DEV_PIXELPIPE_THUMBNAIL);
-#endif
-}
-
 #endif
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1536,8 +1536,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 {
   // dt_iop_cacorrect_params_t *p = (dt_iop_cacorrect_params_t *)params;
   // dt_iop_cacorrect_data_t *d = (dt_iop_cacorrect_data_t *)piece->data;
-  // preview pipe doesn't have mosaiced data either:
-  if(!(pipe->image.flags & DT_IMAGE_RAW) || dt_dev_pixelpipe_uses_downsampled_input(pipe)) piece->enabled = 0;
+  if(!(pipe->image.flags & DT_IMAGE_RAW)) piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1686,8 +1686,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   else
   {
     // sample half-size raw (Bayer) or 1/3-size raw (X-Trans)
-    const float clip = fminf(piece->pipe->dsc.processed_maximum[0],
-                             fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
     if(piece->pipe->dsc.filters == 9u)
       dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
                                                         xtrans);
@@ -1698,7 +1696,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                                                roi.width);
       else
         dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
-                                                  piece->pipe->dsc.filters, clip);
+                                                  piece->pipe->dsc.filters);
     }
   }
   if(data->color_smoothing) color_smoothing(o, roi_out, data->color_smoothing);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -3584,7 +3584,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 {
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)params;
   dt_iop_demosaic_data_t *d = (dt_iop_demosaic_data_t *)piece->data;
-  if(!(pipe->image.flags & DT_IMAGE_RAW) || dt_dev_pixelpipe_uses_downsampled_input(pipe)) piece->enabled = 0;
+  if(!(pipe->image.flags & DT_IMAGE_RAW)) piece->enabled = 0;
   d->green_eq = p->green_eq;
   d->color_smoothing = p->color_smoothing;
   d->median_thrs = p->median_thrs;

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -111,11 +111,11 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int height = roi_in->height;
 
   size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-  const float clip
-      = d->clip * fminf(piece->pipe->dsc.processed_maximum[0],
-                        fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
+  const float clip = d->clip
+                     * fminf(piece->pipe->dsc.processed_maximum[0],
+                             fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
   const uint32_t filters = piece->pipe->dsc.filters;
-  if(dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) || !filters)
+  if(!filters)
   {
     dt_opencl_set_kernel_arg(devid, gd->kernel_highlights_4f_clip, 0, sizeof(cl_mem), (void *)&dev_in);
     dt_opencl_set_kernel_arg(devid, gd->kernel_highlights_4f_clip, 1, sizeof(cl_mem), (void *)&dev_out);
@@ -660,7 +660,7 @@ static void process_clip_plain(dt_dev_pixelpipe_iop_t *piece, const void *const 
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   { // raw mosaic
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) schedule(static)
@@ -689,7 +689,7 @@ static void process_clip_sse2(dt_dev_pixelpipe_iop_t *piece, const void *const i
                               const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out,
                               const float clip)
 {
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   { // raw mosaic
     const __m128 clipm = _mm_set1_ps(clip);
     const size_t n = (size_t)roi_out->height * roi_out->width;
@@ -749,7 +749,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       = data->clip * fminf(piece->pipe->dsc.processed_maximum[0],
                            fminf(piece->pipe->dsc.processed_maximum[1], piece->pipe->dsc.processed_maximum[2]));
   // const int ch = piece->colors;
-  if(dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) || !filters)
+  if(!filters)
   {
     process_clip(piece, ivoid, ovoid, roi_in, roi_out, clip);
     for(int k=0;k<3;k++)

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -341,9 +341,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   d->permissive = p->permissive;
   d->markfixed = p->markfixed && (pipe->type != DT_DEV_PIXELPIPE_EXPORT)
                  && (pipe->type != DT_DEV_PIXELPIPE_THUMBNAIL);
-  if(!(pipe->image.flags & DT_IMAGE_RAW) || dt_dev_pixelpipe_uses_downsampled_input(pipe)
-     || p->strength == 0.0)
-    piece->enabled = 0;
+  if(!(pipe->image.flags & DT_IMAGE_RAW) || p->strength == 0.0) piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -173,7 +173,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float *const in = (const float *const)ivoid;
   float *const out = (float *const)ovoid;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && (filters == 9u))
+  if(filters == 9u)
   { // xtrans float mosaiced
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) schedule(static) collapse(2)
@@ -189,7 +189,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
     for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   }
-  else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
+  else if(filters)
   { // bayer float mosaiced
 
 #ifdef _OPENMP
@@ -245,7 +245,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const uint32_t filters = piece->pipe->dsc.filters;
   const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])piece->pipe->dsc.xtrans;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && (filters == 9u))
+  if(filters == 9u)
   { // xtrans float mosaiced
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -260,7 +260,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
     for(int k = 0; k < 4; k++) piece->pipe->dsc.processed_maximum[k] = 1.0f;
   }
-  else if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
+  else if(filters)
   { // bayer float mosaiced
 
     const __m128 val_min = _mm_setzero_ps();
@@ -344,7 +344,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   float film_rgb_f[4] = { d->color[0], d->color[1], d->color[2], d->color[3] };
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && filters)
+  if(filters)
   {
     kernel = gd->kernel_invert_1f;
 
@@ -446,9 +446,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = 0;
 
-  // 4Bayer: convert the RGB color to CYGM only if we're not in the preview pipe (which is already RGB)
-  if((self->dev->image_storage.flags & DT_IMAGE_4BAYER)
-     && !dt_dev_pixelpipe_uses_downsampled_input(piece->pipe))
+  // 4Bayer: convert the RGB color to CYGM
+  if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)
   {
     double RGB_to_CAM[4][3];
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -22,7 +22,6 @@
 #endif
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
-#include "common/gaussian.h"
 #include "control/control.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
@@ -352,22 +351,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int width = roi_in->width;
   const int height = roi_in->height;
 
-  if (dt_dev_pixelpipe_uses_downsampled_input(piece->pipe))
-  {
-    const float radius = 30.0f*powf(fmax(0.0f, d->threshold), 0.7f);  // just a rough visual match
-    const float sigma = radius * roi_in->scale / piece ->iscale;
-    const int order = 0;
-    const int ch = 4;
-
-    const float RGBmax[] = { INFINITY, INFINITY, INFINITY, INFINITY };
-    const float RGBmin[] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
-
-    dt_gaussian_t *g = dt_gaussian_init(width, height, ch, RGBmax, RGBmin, sigma, order);
-    if(!g) return;
-    dt_gaussian_blur_4c(g, ivoid, ovoid);
-    dt_gaussian_free(g);
-  }
-  else if (!(d->threshold > 0.0f))
+  if(!(d->threshold > 0.0f))
   {
     memcpy(ovoid, ivoid, (size_t)sizeof(float)*width*height);
   }

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -269,7 +269,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float scale = roi_in->scale / piece->iscale;
   const int csx = (int)roundf((float)d->x * scale), csy = (int)roundf((float)d->y * scale);
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   { // raw mosaic
 
     const uint16_t *const in = (const uint16_t *const)ivoid;
@@ -334,7 +334,7 @@ void process_sse2(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const vo
   const float scale = roi_in->scale / piece->iscale;
   const int csx = (int)roundf((float)d->x * scale), csy = (int)roundf((float)d->y * scale);
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   { // raw mosaic
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -435,7 +435,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   int kernel = -1;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   {
     kernel = gd->kernel_rawprepare_1f;
   }
@@ -473,7 +473,7 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
   dt_opencl_release_mem_object(dev_sub);
   dt_opencl_release_mem_object(dev_div);
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   {
     piece->pipe->dsc.filters = dt_rawspeed_crop_dcraw_filters(self->dev->image_storage.buf_dsc.filters, csx, csy);
     adjust_xtrans_filters(piece->pipe, csx, csy);
@@ -500,7 +500,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   d->width = p->crop.named.width;
   d->height = p->crop.named.height;
 
-  if(!dt_dev_pixelpipe_uses_downsampled_input(piece->pipe) && piece->pipe->dsc.filters)
+  if(piece->pipe->dsc.filters)
   {
     const float white = (float)p->raw_white_point;
 

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -81,17 +81,6 @@ int groups()
   return IOP_GROUP_BASIC;
 }
 
-// implement this, if you have esoteric output bytes per pixel. default is 4*float
-/*
-int
-output_bpp(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(pipe->type != DT_DEV_PIXELPIPE_PREVIEW && module->dev->image->buf_dsc.filters) return sizeof(float);
-  else return 4*sizeof(float);
-}
-*/
-
-
 /** modify regions of interest (optional, per pixel ops don't need this) */
 // void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t
 // *roi_out, const dt_iop_roi_t *roi_in);


### PR DESCRIPTION
Newer and betterer :)

For raw images, **MIP_F** now contains only **downscaled** buffer, but **still mosaiced**.
I.e. the **darkroom preview pipe** will have to do **demosaicing** too.

The benefits are obvious:
- gets rid of a _lot_ of ugly/strange code
- **whitebalance** should be done before **demosaic**, now it is true for preview too
- **rawprepare** with extremely different black levels resulted in rather different preview
- fixes various bugs related to highlights in preview pipe, like
  - better histogram and color picker when there are clipped highlights

Also, will allow to sample the full buffer in an iop that is before **demosaic**.
I'm talking about stuff like this: https://github.com/darktable-org/darktable/blob/99cfcc9d2aa9644a5aac22f14e8f32d01b11b254/src/iop/colorreconstruction.c#L640-L647
I think that will be needed for proper **highlight in-painting iop**.

Downsides:
- preview pipe will have to do **demosaic** (=> slower)
- the downscaling algos are not best
  - **both** bayer and x-trans, uint16_t exhibit some **confetti colours along the edges**.
  - **xtrans (unlike bayer)** does not **sub-sample** => may have issues with aliasing? @dtorop 