### PR TITLE
Default tiling_callback() changes.

### DIFF
--- a/src/develop/tiling.c
+++ b/src/develop/tiling.c
@@ -1989,6 +1989,24 @@ int default_process_tiling_cl(struct dt_iop_module_t *self, struct dt_dev_pixelp
 
 
 
+static int _iop_module_demosaic = 0;
+static inline void _get_iop_priorities(const dt_iop_module_t *module)
+{
+  if(_iop_module_demosaic) return;
+
+  GList *iop = module->dev->iop;
+  while(iop)
+  {
+    dt_iop_module_t *m = (dt_iop_module_t *)iop->data;
+
+    if(!strcmp(m->op, "demosaic")) _iop_module_demosaic = m->priority;
+
+    if(_iop_module_demosaic) break;
+
+    iop = g_list_next(iop);
+  }
+}
+
 /* If a module does not implement tiling_callback() by itself, this function is called instead.
    Default is an image size factor of 2 (i.e. input + output buffer needed), no overhead (1),
    no overlap between tiles, and an pixel alignment of 1 in x and y direction, i.e. no special
@@ -1999,12 +2017,39 @@ void default_tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpi
                              const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                              struct dt_develop_tiling_t *tiling)
 {
-  tiling->factor = 2.0f;
+  _get_iop_priorities(self);
+
+  const float ioratio
+      = ((float)roi_out->width * (float)roi_out->height) / ((float)roi_in->width * (float)roi_in->height);
+
+  tiling->factor = 1.0f + ioratio;
   tiling->maxbuf = 1.0f;
   tiling->overhead = 0;
   tiling->overlap = 0;
   tiling->xalign = 1;
   tiling->yalign = 1;
+
+  if((self->flags() & IOP_FLAGS_TILING_FULL_ROI) == IOP_FLAGS_TILING_FULL_ROI) tiling->overlap = 4;
+
+  if(self->priority > _iop_module_demosaic) return;
+
+  // all operations that work with mosaiced data should respect pattern size!
+
+  if(!piece->pipe->dsc.filters) return;
+
+  if(piece->pipe->dsc.filters == 9u)
+  {
+    // X-Trans, sensor is 6x6
+    tiling->xalign = 6;
+    tiling->yalign = 6;
+  }
+  else
+  {
+    // Bayer, good old 2x2
+    tiling->xalign = 2;
+    tiling->yalign = 2;
+  }
+
   return;
 }
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -2881,20 +2881,6 @@ error:
 }
 #endif
 
-
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
-{
-  tiling->factor = 2.0f;
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 3; // accounts for interpolation width
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
-}
-
 // gather information about "near"-ness in g->points_idx
 static void get_near(const float *points, dt_iop_ashift_points_idx_t *points_idx, const int lines_count,
                      float pzx, float pzy, float delta)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -988,22 +988,6 @@ error:
 }
 #endif
 
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
-{
-  float ioratio = (float)roi_out->width * roi_out->height / ((float)roi_in->width * roi_in->height);
-
-  tiling->factor = 1.0f + ioratio; // in + out, no temp
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
-}
-
-
 void init_global(dt_iop_module_so_t *module)
 {
   const int program = 2; // basic.cl from programs.conf

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -99,20 +99,6 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   if(piece->pipe->type != DT_DEV_PIXELPIPE_EXPORT) piece->enabled = 0;
 }
 
-void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_in,
-                     const dt_iop_roi_t *const roi_out, dt_develop_tiling_t *tiling)
-{
-  float ioratio = ((float)roi_out->width * roi_out->height) / ((float)roi_in->width * roi_in->height);
-
-  tiling->factor = 1.0f + ioratio; // in + out, no temp
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
-}
-
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_finalscale_data_t));

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -151,20 +151,6 @@ void connect_key_accels(dt_iop_module_t *self)
   }
 }
 
-void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_in,
-                     const dt_iop_roi_t *const roi_out, dt_develop_tiling_t *tiling)
-{
-  float ioratio = (float)roi_out->width * roi_out->height / ((float)roi_in->width * roi_in->height);
-
-  tiling->factor = 1.0f + ioratio; // in + out, no temp
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 0;
-  tiling->xalign = 2; // Bayer pattern
-  tiling->yalign = 2; // Bayer pattern
-  return;
-}
-
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
 {
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -274,20 +274,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   }
 }
 
-void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_in,
-                     const dt_iop_roi_t *const roi_out, dt_develop_tiling_t *tiling)
-{
-  float ioratio = ((float)roi_out->width * roi_out->height) / ((float)roi_in->width * roi_in->height);
-
-  tiling->factor = 1.0f + ioratio; // in + out, no temp
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
-}
-
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -215,20 +215,6 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
     piece->enabled = 0;
 }
 
-void tiling_callback(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const dt_iop_roi_t *const roi_in,
-                     const dt_iop_roi_t *const roi_out, dt_develop_tiling_t *tiling)
-{
-  float ioratio = ((float)roi_out->width * roi_out->height) / ((float)roi_in->width * roi_in->height);
-
-  tiling->factor = 1.0f + ioratio; // in + out, no temp
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 4;
-  tiling->xalign = 1;
-  tiling->yalign = 1;
-  return;
-}
-
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_scalepixels_data_t));

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -646,19 +646,6 @@ error:
 }
 #endif
 
-void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                     const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
-                     struct dt_develop_tiling_t *tiling)
-{
-  tiling->factor = 2.0f; // in + out
-  tiling->maxbuf = 1.0f;
-  tiling->overhead = 0;
-  tiling->overlap = 0;
-  tiling->xalign = 2; // Bayer pattern
-  tiling->yalign = 2; // Bayer pattern
-  return;
-}
-
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {


### PR DESCRIPTION
1. All operations that work with **mosaiced** data should respect **patter size**!

2. Also attempt to **automatically** handle simple case of **buffer size change**.

     NOTE: this does not attempt to guess additional required buffer sizes.
3. Attempt to set **overlap** (to 4) based on flag **IOP_FLAGS_TILING_FULL_ROI**

     I'm not too sure about this, but all the iop's that set **IOP_FLAGS_TILING_FULL_ROI** flag, also have non-zero `tiling->overlap`.