### PR TITLE
Color picker fixes. Fixes #11163. Fixes #11164

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ FILE(GLOB SOURCE_FILES
   "common/cache.c"
   "common/calculator.c"
   "common/collection.c"
+  "common/color_picker.c"
   "common/colorlabels.c"
   "common/colorspaces.c"
   "common/curve_tools.c"

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -20,6 +20,7 @@
 #include "common/darktable.h"
 #include "develop/format.h"
 #include "develop/imageop.h"
+#include "develop/imageop_math.h"
 
 static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                     const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
@@ -112,12 +113,112 @@ static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float 
   }
 }
 
+static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
+                                      const dt_iop_roi_t *const roi, const int *const box,
+                                      float *const picked_color, float *const picked_color_min,
+                                      float *const picked_color_max)
+{
+  const int width = roi->width;
+  const uint32_t filters = dsc->filters;
+
+  const size_t size = ((box[3] - box[1]) * (box[2] - box[0]));
+
+  uint32_t weights[3] = { 0u, 0u, 0u };
+
+  if(size > 100) // avoid inefficient multi-threading in case of small region size (arbitrary limit)
+  {
+    const int numthreads = dt_get_num_threads();
+
+    float *msum = malloc((size_t)3 * numthreads * sizeof(float));
+    float *mmin = malloc((size_t)3 * numthreads * sizeof(float));
+    float *mmax = malloc((size_t)3 * numthreads * sizeof(float));
+    uint32_t *cnt = malloc((size_t)3 * numthreads * sizeof(uint32_t));
+
+    for(int n = 0; n < 3 * numthreads; n++)
+    {
+      msum[n] = 0.0f;
+      mmin[n] = INFINITY;
+      mmax[n] = -INFINITY;
+      cnt[n] = 0u;
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(msum, mmin, mmax, cnt) schedule(static) collapse(2)
+#endif
+    for(size_t j = box[1]; j < box[3]; j++)
+    {
+      for(size_t i = box[0]; i < box[2]; i++)
+      {
+        const int tnum = dt_get_thread_num();
+
+        float *tsum = msum + 3 * tnum;
+        float *tmmin = mmin + 3 * tnum;
+        float *tmmax = mmax + 3 * tnum;
+        uint32_t *tcnt = cnt + 3 * tnum;
+
+        const int c = FC(j + roi->y, i + roi->x, filters);
+        const size_t k = width * j + i;
+
+        const float v = pixel[k];
+
+        tsum[c] += v;
+        tmmin[c] = fminf(tmmin[c], v);
+        tmmax[c] = fmaxf(tmmax[c], v);
+        tcnt[c]++;
+      }
+    }
+
+    for(int n = 0; n < numthreads; n++)
+    {
+      for(int c = 0; c < 3; c++)
+      {
+        picked_color[c] += msum[3 * n + c];
+        picked_color_min[c] = fminf(picked_color_min[c], mmin[3 * n + c]);
+        picked_color_max[c] = fmaxf(picked_color_max[c], mmax[3 * n + c]);
+        weights[c] += cnt[3 * n + c];
+      }
+    }
+
+    free(cnt);
+    free(mmax);
+    free(mmin);
+    free(msum);
+  }
+  else
+  {
+    // code path for small region, especially for color picker point mode
+    for(size_t j = box[1]; j < box[3]; j++)
+    {
+      for(size_t i = box[0]; i < box[2]; i++)
+      {
+        const int c = FC(j + roi->y, i + roi->x, filters);
+        const size_t k = width * j + i;
+
+        const float v = pixel[k];
+
+        picked_color[c] += v;
+        picked_color_min[c] = fminf(picked_color_min[c], v);
+        picked_color_max[c] = fmaxf(picked_color_max[c], v);
+        weights[c]++;
+      }
+    }
+  }
+
+  // and finally normalize data. For bayer, there is twice as much green.
+  for(int c = 0; c < 3; c++)
+  {
+    picked_color[c] /= (float)weights[c];
+  }
+}
+
 void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
                             const int *const box, float *const picked_color, float *const picked_color_min,
                             float *const picked_color_max)
 {
   if(dsc->channels == 4u)
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+  else if(dsc->channels == 1u && dsc->filters && dsc->filters != 9u && !FILTERS_ARE_4BAYER(dsc->filters))
+    color_picker_helper_bayer(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
   else
     dt_unreachable_codepath();
 }

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -21,9 +21,9 @@
 #include "develop/format.h"
 #include "develop/imageop.h"
 
-void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
-                            const int *const box, float *const picked_color, float *const picked_color_min,
-                            float *const picked_color_max)
+static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
+                                    const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
+                                    float *const picked_color_min, float *const picked_color_max)
 {
   const int width = roi->width;
 
@@ -110,6 +110,16 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const p
       }
     }
   }
+}
+
+void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
+                            const int *const box, float *const picked_color, float *const picked_color_min,
+                            float *const picked_color_max)
+{
+  if(dsc->channels == 4u)
+    color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+  else
+    dt_unreachable_codepath();
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -1,0 +1,116 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/color_picker.h"
+#include "common/darktable.h"
+#include "develop/imageop.h"
+
+void dt_color_picker_helper(dt_iop_module_t *module, const float *const pixel, const dt_iop_roi_t *roi,
+                            const int *const box, float *const picked_color, float *const picked_color_min,
+                            float *const picked_color_max)
+{
+  const int width = roi->width;
+
+  const size_t size = ((box[3] - box[1]) * (box[2] - box[0]));
+
+  const float w = 1.0f / (float)size;
+
+  if(size > 100) // avoid inefficient multi-threading in case of small region size (arbitrary limit)
+  {
+    const int numthreads = dt_get_num_threads();
+
+    float *mean = malloc((size_t)3 * numthreads * sizeof(float));
+    float *mmin = malloc((size_t)3 * numthreads * sizeof(float));
+    float *mmax = malloc((size_t)3 * numthreads * sizeof(float));
+
+    for(int n = 0; n < 3 * numthreads; n++)
+    {
+      mean[n] = 0.0f;
+      mmin[n] = INFINITY;
+      mmax[n] = -INFINITY;
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(mean, mmin, mmax) schedule(static) collapse(2)
+#endif
+    for(size_t j = box[1]; j < box[3]; j++)
+    {
+      for(size_t i = box[0]; i < box[2]; i++)
+      {
+        const int tnum = dt_get_thread_num();
+        float *tmean = mean + 3 * tnum;
+        float *tmmin = mmin + 3 * tnum;
+        float *tmmax = mmax + 3 * tnum;
+        const size_t k = 4 * (width * j + i);
+        const float L = pixel[k];
+        const float a = pixel[k + 1];
+        const float b = pixel[k + 2];
+        tmean[0] += w * L;
+        tmean[1] += w * a;
+        tmean[2] += w * b;
+        tmmin[0] = fminf(tmmin[0], L);
+        tmmin[1] = fminf(tmmin[1], a);
+        tmmin[2] = fminf(tmmin[2], b);
+        tmmax[0] = fmaxf(tmmax[0], L);
+        tmmax[1] = fmaxf(tmmax[1], a);
+        tmmax[2] = fmaxf(tmmax[2], b);
+      }
+    }
+
+    for(int n = 0; n < numthreads; n++)
+    {
+      for(int k = 0; k < 3; k++)
+      {
+        picked_color[k] += mean[3 * n + k];
+        picked_color_min[k] = fminf(picked_color_min[k], mmin[3 * n + k]);
+        picked_color_max[k] = fmaxf(picked_color_max[k], mmax[3 * n + k]);
+      }
+    }
+
+    free(mmax);
+    free(mmin);
+    free(mean);
+  }
+  else
+  {
+    // code path for small region, especially for color picker point mode
+    for(size_t j = box[1]; j < box[3]; j++)
+    {
+      for(size_t i = box[0]; i < box[2]; i++)
+      {
+        const size_t k = 4 * (width * j + i);
+        const float L = pixel[k];
+        const float a = pixel[k + 1];
+        const float b = pixel[k + 2];
+        picked_color[0] += w * L;
+        picked_color[1] += w * a;
+        picked_color[2] += w * b;
+        picked_color_min[0] = fminf(picked_color_min[0], L);
+        picked_color_min[1] = fminf(picked_color_min[1], a);
+        picked_color_min[2] = fminf(picked_color_min[2], b);
+        picked_color_max[0] = fmaxf(picked_color_max[0], L);
+        picked_color_max[1] = fmaxf(picked_color_max[1], a);
+        picked_color_max[2] = fmaxf(picked_color_max[2], b);
+      }
+    }
+  }
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -18,9 +18,10 @@
 
 #include "common/color_picker.h"
 #include "common/darktable.h"
+#include "develop/format.h"
 #include "develop/imageop.h"
 
-void dt_color_picker_helper(dt_iop_module_t *module, const float *const pixel, const dt_iop_roi_t *roi,
+void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
                             const int *const box, float *const picked_color, float *const picked_color_min,
                             float *const picked_color_max)
 {

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -211,6 +211,103 @@ static void color_picker_helper_bayer(const dt_iop_buffer_dsc_t *const dsc, cons
   }
 }
 
+static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
+                                const dt_iop_roi_t *const roi, const int *const box, float *const picked_color,
+                                float *const picked_color_min, float *const picked_color_max)
+{
+  const int width = roi->width;
+  const uint8_t(*const xtrans)[6] = (const uint8_t(*const)[6])dsc->xtrans;
+
+  const size_t size = ((box[3] - box[1]) * (box[2] - box[0]));
+
+  uint32_t weights[3] = { 0u, 0u, 0u };
+
+  if(size > 100) // avoid inefficient multi-threading in case of small region size (arbitrary limit)
+  {
+    const int numthreads = dt_get_num_threads();
+
+    float *msum = malloc((size_t)3 * numthreads * sizeof(float));
+    float *mmin = malloc((size_t)3 * numthreads * sizeof(float));
+    float *mmax = malloc((size_t)3 * numthreads * sizeof(float));
+    uint32_t *cnt = malloc((size_t)3 * numthreads * sizeof(uint32_t));
+
+    for(int n = 0; n < 3 * numthreads; n++)
+    {
+      msum[n] = 0.0f;
+      mmin[n] = INFINITY;
+      mmax[n] = -INFINITY;
+      cnt[n] = 0u;
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(msum, mmin, mmax, cnt) schedule(static) collapse(2)
+#endif
+    for(size_t j = box[1]; j < box[3]; j++)
+    {
+      for(size_t i = box[0]; i < box[2]; i++)
+      {
+        const int tnum = dt_get_thread_num();
+
+        float *tsum = msum + 3 * tnum;
+        float *tmmin = mmin + 3 * tnum;
+        float *tmmax = mmax + 3 * tnum;
+        uint32_t *tcnt = cnt + 3 * tnum;
+
+        const int c = FCxtrans(j, i, roi, xtrans);
+        const size_t k = width * j + i;
+
+        const float v = pixel[k];
+
+        tsum[c] += v;
+        tmmin[c] = fminf(tmmin[c], v);
+        tmmax[c] = fmaxf(tmmax[c], v);
+        tcnt[c]++;
+      }
+    }
+
+    for(int n = 0; n < numthreads; n++)
+    {
+      for(int c = 0; c < 3; c++)
+      {
+        picked_color[c] += msum[3 * n + c];
+        picked_color_min[c] = fminf(picked_color_min[c], mmin[3 * n + c]);
+        picked_color_max[c] = fmaxf(picked_color_max[c], mmax[3 * n + c]);
+        weights[c] += cnt[3 * n + c];
+      }
+    }
+
+    free(cnt);
+    free(mmax);
+    free(mmin);
+    free(msum);
+  }
+  else
+  {
+    // code path for small region, especially for color picker point mode
+    for(size_t j = box[1]; j < box[3]; j++)
+    {
+      for(size_t i = box[0]; i < box[2]; i++)
+      {
+        const int c = FCxtrans(j, i, roi, xtrans);
+        const size_t k = width * j + i;
+
+        const float v = pixel[k];
+
+        picked_color[c] += v;
+        picked_color_min[c] = fminf(picked_color_min[c], v);
+        picked_color_max[c] = fmaxf(picked_color_max[c], v);
+        weights[c]++;
+      }
+    }
+  }
+
+  // and finally normalize data. For bayer, there is twice as much green.
+  for(int c = 0; c < 3; c++)
+  {
+    picked_color[c] /= (float)weights[c];
+  }
+}
+
 void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
                             const int *const box, float *const picked_color, float *const picked_color_min,
                             float *const picked_color_max)
@@ -219,6 +316,8 @@ void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const p
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
   else if(dsc->channels == 1u && dsc->filters && dsc->filters != 9u && !FILTERS_ARE_4BAYER(dsc->filters))
     color_picker_helper_bayer(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+  else if(dsc->channels == 1u && dsc->filters && dsc->filters == 9u)
+    color_picker_helper_xtrans(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
   else
     dt_unreachable_codepath();
 }

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -19,10 +19,10 @@
 #ifndef DT_COMMON_COLOR_PICKER_H
 #define DT_COMMON_COLOR_PICKER_H
 
-struct dt_iop_module_t;
+struct dt_iop_buffer_dsc_t;
 struct dt_iop_roi_t;
 
-void dt_color_picker_helper(struct dt_iop_module_t *module, const float *const pixel,
+void dt_color_picker_helper(const struct dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                             const struct dt_iop_roi_t *roi, const int *const box, float *const picked_color,
                             float *const picked_color_min, float *const picked_color_max);
 

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -1,0 +1,33 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DT_COMMON_COLOR_PICKER_H
+#define DT_COMMON_COLOR_PICKER_H
+
+struct dt_iop_module_t;
+struct dt_iop_roi_t;
+
+void dt_color_picker_helper(struct dt_iop_module_t *module, const float *const pixel,
+                            const struct dt_iop_roi_t *roi, const int *const box, float *const picked_color,
+                            float *const picked_color_min, float *const picked_color_max);
+
+#endif
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -267,9 +267,9 @@ typedef struct dt_iop_module_t
   /** single point to pick if in point mode */
   float color_picker_point[2];
   /** place to store the picked color of module input. */
-  float picked_color[3], picked_color_min[3], picked_color_max[3];
+  float picked_color[4], picked_color_min[4], picked_color_max[4];
   /** place to store the picked color of module output (before blending). */
-  float picked_output_color[3], picked_output_color_min[3], picked_output_color_max[3];
+  float picked_output_color[4], picked_output_color_min[4], picked_output_color_max[4];
   /** pointer to pre-module histogram data; if available: histogram_bins_count bins with 4 channels each */
   uint32_t *histogram;
   /** stats of captured histogram */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -520,17 +520,18 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
 
   const size_t size = region[0] * region[1];
 
+  const size_t bpp = dt_iop_buffer_dsc_to_bpp(dsc);
+
   // if a buffer is supplied and if size fits let's use it
-  if(buffer && bufsize >= size * 4 * sizeof(float))
+  if(buffer && bufsize >= size * bpp)
     pixel = buffer;
   else
-    pixel = tmpbuf = dt_alloc_align(64, size * 4 * sizeof(float));
+    pixel = tmpbuf = dt_alloc_align(64, size * bpp);
 
   if(pixel == NULL) return;
 
   // get the required part of the image from opencl device
-  cl_int err = dt_opencl_read_host_from_device_raw(devid, pixel, img, origin, region,
-                                                   region[0] * 4 * sizeof(float), CL_TRUE);
+  cl_int err = dt_opencl_read_host_from_device_raw(devid, pixel, img, origin, region, region[0] * bpp, CL_TRUE);
 
   if(err != CL_SUCCESS) goto error;
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -427,9 +427,9 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
 
   // initialize picker values. a positive value of picked_color_max[0] can later be used to check for validity
   // of data
-  for(int k = 0; k < 3; k++) picked_color_min[k] = INFINITY;
-  for(int k = 0; k < 3; k++) picked_color_max[k] = -INFINITY;
-  for(int k = 0; k < 3; k++) picked_color[k] = 0.0f;
+  for(int k = 0; k < 4; k++) picked_color_min[k] = INFINITY;
+  for(int k = 0; k < 4; k++) picked_color_max[k] = -INFINITY;
+  for(int k = 0; k < 4; k++) picked_color[k] = 0.0f;
 
   // do not continue if one of the point coordinates is set to a negative value indicating a not yet defined
   // position

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -540,7 +540,7 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
   box[2] = region[0];
   box[3] = region[1];
 
-  dt_iop_roi_t roi_copy = (dt_iop_roi_t){.x = 0, .y = 0, .width = region[0], .height = region[1] };
+  dt_iop_roi_t roi_copy = (dt_iop_roi_t){.x = roi->x, .y = roi->x, .width = region[0], .height = region[1] };
 
   dt_color_picker_helper(dsc, pixel, &roi_copy, box, picked_color, picked_color_min, picked_color_max);
 

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -172,9 +172,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
     color.blue = rgb[2];
   }
 
-  darktable.gui->reset = 1;
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
-  darktable.gui->reset = 0;
 }
 
 static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
@@ -194,7 +192,9 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   dt_iop_invert_params_t *p = self->params;
   for(int k = 0; k < 4; k++) p->color[k] = grayrgb[k];
 
+  darktable.gui->reset = 1;
   gui_update_from_coeffs(self);
+  darktable.gui->reset = 0;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   return FALSE;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -27,6 +27,7 @@
 #if defined(__SSE__)
 #include <xmmintrin.h>
 #endif
+#include "common/colorspaces.h"
 #include "control/control.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
@@ -36,11 +37,11 @@
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
-DT_MODULE_INTROSPECTION(1, dt_iop_invert_params_t)
+DT_MODULE_INTROSPECTION(2, dt_iop_invert_params_t)
 
 typedef struct dt_iop_invert_params_t
 {
-  float color[3]; // color of film material
+  float color[4]; // color of film material
 } dt_iop_invert_params_t;
 
 typedef struct dt_iop_invert_gui_data_t
@@ -49,6 +50,8 @@ typedef struct dt_iop_invert_gui_data_t
   GtkDarktableResetLabel *label;
   GtkBox *pickerbuttons;
   GtkWidget *picker;
+  double RGB_to_CAM[4][3];
+  double CAM_to_RGB[3][4];
 } dt_iop_invert_gui_data_t;
 
 typedef struct dt_iop_invert_global_data_t
@@ -61,6 +64,47 @@ typedef struct dt_iop_invert_data_t
 {
   float color[4]; // color of film material
 } dt_iop_invert_data_t;
+
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
+                  const int new_version)
+{
+  if(old_version == 1 && new_version == 2)
+  {
+    typedef struct dt_iop_invert_params_v1_t
+    {
+      float color[3]; // color of film material
+    } dt_iop_invert_params_v1_t;
+
+    dt_iop_invert_params_v1_t *o = (dt_iop_invert_params_v1_t *)old_params;
+    dt_iop_invert_params_t *n = (dt_iop_invert_params_t *)new_params;
+
+    n->color[0] = o->color[0];
+    n->color[1] = o->color[1];
+    n->color[2] = o->color[2];
+    n->color[3] = NAN;
+
+    if(self->dev && self->dev->image_storage.flags & DT_IMAGE_4BAYER)
+    {
+      const char *camera = self->dev->image_storage.camera_makermodel;
+
+      double RGB_to_CAM[4][3];
+
+      // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
+      if(!dt_colorspaces_conversion_matrices_rgb(camera, RGB_to_CAM, NULL, NULL))
+      {
+        fprintf(stderr, "[invert] `%s' color matrix not found for 4bayer image\n", camera);
+        dt_control_log(_("`%s' color matrix not found for 4bayer image"), camera);
+      }
+      else
+      {
+        dt_colorspaces_rgb_to_cygm(n->color, 1, RGB_to_CAM);
+      }
+    }
+
+    return 0;
+  }
+  return 1;
+}
 
 const char *name()
 {
@@ -108,27 +152,49 @@ static void request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t 
   dt_iop_request_focus(self);
 }
 
+static void gui_update_from_coeffs(dt_iop_module_t *self)
+{
+  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
+  dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
+
+  GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
+
+  const dt_image_t *img = &self->dev->image_storage;
+  if(img->flags & DT_IMAGE_4BAYER)
+  {
+    float rgb[4];
+    for(int k = 0; k < 4; k++) rgb[k] = p->color[k];
+
+    dt_colorspaces_cygm_to_rgb(rgb, 1, g->CAM_to_RGB);
+
+    color.red = rgb[0];
+    color.green = rgb[1];
+    color.blue = rgb[2];
+  }
+
+  darktable.gui->reset = 1;
+  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
+  darktable.gui->reset = 0;
+}
+
 static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return FALSE;
   if(self->picked_color_max[0] < 0.0f) return FALSE;
   if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF) return FALSE;
-  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
-  dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
-  if(fabsf(p->color[0] - self->picked_color[0]) < 0.0001f
-     && fabsf(p->color[1] - self->picked_color[1]) < 0.0001f
-     && fabsf(p->color[2] - self->picked_color[2]) < 0.0001f)
-  {
-    // interrupt infinite loops
-    return FALSE;
-  }
+  static float old[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
-  p->color[0] = self->picked_color[0];
-  p->color[1] = self->picked_color[1];
-  p->color[2] = self->picked_color[2];
-  GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
-  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
+  const float *grayrgb = self->picked_color;
+
+  if(grayrgb[0] == old[0] && grayrgb[1] == old[1] && grayrgb[2] == old[2] && grayrgb[3] == old[3]) return FALSE;
+
+  for(int k = 0; k < 4; k++) old[k] = grayrgb[k];
+
+  dt_iop_invert_params_t *p = self->params;
+  for(int k = 0; k < 4; k++) p->color[k] = grayrgb[k];
+
+  gui_update_from_coeffs(self);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   return FALSE;
@@ -148,6 +214,12 @@ static void colorpicker_callback(GtkColorButton *widget, dt_iop_module_t *self)
   p->color[0] = c.red;
   p->color[1] = c.green;
   p->color[2] = c.blue;
+
+  const dt_image_t *img = &self->dev->image_storage;
+  if(img->flags & DT_IMAGE_4BAYER)
+  {
+    dt_colorspaces_rgb_to_cygm(p->color, 1, g->RGB_to_CAM);
+  }
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -432,6 +504,20 @@ void reload_defaults(dt_iop_module_t *self)
   memcpy(self->default_params, &tmp, sizeof(dt_iop_invert_params_t));
 
   self->default_enabled = 0;
+
+  if(self->dev && self->dev->image_storage.flags & DT_IMAGE_4BAYER && self->gui_data)
+  {
+    dt_iop_invert_gui_data_t *g = self->gui_data;
+
+    const char *camera = self->dev->image_storage.camera_makermodel;
+
+    // Get and store the matrix to go from camera to RGB for 4Bayer images (used for spot WB)
+    if(!dt_colorspaces_conversion_matrices_rgb(camera, g->RGB_to_CAM, g->CAM_to_RGB, NULL))
+    {
+      fprintf(stderr, "[invert] `%s' color matrix not found for 4bayer image\n", camera);
+      dt_control_log(_("`%s' color matrix not found for 4bayer image"), camera);
+    }
+  }
 }
 
 void init_global(dt_iop_module_so_t *module)
@@ -475,35 +561,13 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)params;
   dt_iop_invert_data_t *d = (dt_iop_invert_data_t *)piece->data;
 
-  for(int k = 0; k < 3; k++)
-    d->color[k] = p->color[k];
-
-  d->color[3] = 0.0f;
+  for(int k = 0; k < 4; k++) d->color[k] = p->color[k];
 
   // x-trans images not implemented in OpenCL yet
   if(pipe->image.buf_dsc.filters == 9u) piece->process_cl_ready = 0;
 
   // 4Bayer images not implemented in OpenCL yet
   if(self->dev->image_storage.flags & DT_IMAGE_4BAYER) piece->process_cl_ready = 0;
-
-  // 4Bayer: convert the RGB color to CYGM
-  if(self->dev->image_storage.flags & DT_IMAGE_4BAYER)
-  {
-    double RGB_to_CAM[4][3];
-
-    char *camera = self->dev->image_storage.camera_makermodel;
-    if(!dt_colorspaces_conversion_matrices_rgb(camera, RGB_to_CAM, NULL, NULL))
-    {
-      fprintf(stderr, "[invert] `%s' color matrix not found for 4bayer image!\n", camera);
-      dt_control_log(_("`%s' color matrix not found for 4bayer image!"), camera);
-
-      // piece->enabled = 0; ???
-    }
-    else
-    {
-      dt_colorspaces_rgb_to_cygm(d->color, 1, RGB_to_CAM);
-    }
-  }
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -523,13 +587,11 @@ void gui_update(dt_iop_module_t *self)
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
   dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
-  dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   gtk_widget_set_visible(GTK_WIDGET(g->pickerbuttons), TRUE);
   dtgtk_reset_label_set_text(g->label, _("color of film material"));
 
-  GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
-  gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
+  gui_update_from_coeffs(self);
 }
 
 void gui_init(dt_iop_module_t *self)
@@ -540,7 +602,7 @@ void gui_init(dt_iop_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
 
-  g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, 3 * sizeof(float)));
+  g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, 4 * sizeof(float)));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);
 
   g->pickerbuttons = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5));


### PR DESCRIPTION
Aftermath of preview pipe going mosaiced.

Note that i have no ability to test opencl changes.

Also, no clue if invert iop does the right thing for 4bayer mosaic.