### PR TITLE
OpenCL: dt_opencl_get_device_info() RFC

### DIFF
--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -135,6 +135,12 @@ typedef struct dt_opencl_t
   struct dt_interpolation_cl_global_t *interpolation;
 } dt_opencl_t;
 
+/** internally calls dt_clGetDeviceInfo, and takes care of memory allocation
+ * afterwards, *param_value will point to memory block of size at least *param_value
+ * which needs to be free()'d manually */
+int dt_opencl_get_device_info(dt_opencl_t *cl, cl_device_id device, cl_device_info param_name, void **param_value,
+                              size_t *param_value_size);
+
 /** inits the opencl subsystem. */
 void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics);
 


### PR DESCRIPTION
@upegelow 
So i would like to reduce stack usage even further.
Currently, `dt_opencl_init()` is the biggest one, with **~34Kb** of stack. (there may be others, but this is the one i know about)
```
/home/lebedevri/darktable/src/common/opencl.c: In function ‘dt_opencl_init’:
/home/lebedevri/darktable/src/common/opencl.c:93:6: error: stack usage might be 34064 bytes [-Werror=stack-usage=]
 void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboolean print_statistics)
      ^~~~~~~~~~~~~~
/home/lebedevri/darktable/src/common/opencl.c:666:1: error: the frame size of 33984 bytes is larger than 32768 bytes [-Werror=frame-larger-than=]
 }
 ^
```

I would like to replace all statically-sized arrays that are then used with **clGetDeviceInfo()** with this.
According to **clGetDeviceInfo()** docs, this seems to be the correct way to first get size, and then get values.

Pros/Cons:
- No more statically-sized arrays.
- Who says that hardcoded size of statically-sized arrays is always enough?
- Alas, in most cases they are bigger than needed.
- Need to actually take care of not leaking them.

Here, i have updated only one callsite, to just show the idea.

Thoughts?