### PR TITLE
NIKON D5200: remove unavailable mode settings, fixes #11202

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -2560,39 +2560,6 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="14bit-uncompressed">
-		<ID make="Nikon" model="D5200">Nikon D5200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="15892"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D5200">Nikon D5200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5200" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D5200">Nikon D5200</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4096"/>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D5300" mode="12bit-compressed">
 		<ID make="Nikon" model="D5300">Nikon D5300</ID>
 		<CFA width="2" height="2">

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -23,7 +23,8 @@
 # SOFTWARE.
 
 IGNORE_ONLY_14BIT = [
-  ["NIKON CORPORATION", "NIKON D5100"]
+  ["NIKON CORPORATION", "NIKON D5100"],
+  ["NIKON CORPORATION", "NIKON D5200"]
 ]
 
 IGNORE_ONLY_MODE = {
@@ -40,6 +41,7 @@ IGNORE_ONLY_MODE = {
   ["NIKON CORPORATION", "NIKON D3000"] => "compressed",
   ["NIKON CORPORATION", "NIKON D3200"] => "compressed",
   ["NIKON CORPORATION", "NIKON D5100"] => "compressed",
+  ["NIKON CORPORATION", "NIKON D5200"] => "compressed",
   ["NIKON CORPORATION", "NIKON D7000"] => "compressed",
   ["NIKON CORPORATION", "NIKON D7100"] => "compressed",
   ["NIKON", "COOLPIX P330"] => "compressed",


### PR DESCRIPTION
Only 14 bit compressed mode is availiable according to user manual.