### PR TITLE
Simplify histogram exposure string

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -279,8 +279,20 @@ void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len)
     else
       snprintf(line, line_len, "%.1f″ f/%.1f %dmm iso %d", img->exif_exposure, img->exif_aperture,
                (int)img->exif_focal_length, (int)img->exif_iso);
-  else
+  /* want to catch everything below 0.3 seconds */
+  else if(img->exif_exposure < 0.29f)
     snprintf(line, line_len, "1/%.0f f/%.1f %dmm iso %d", 1.0 / img->exif_exposure, img->exif_aperture,
+             (int)img->exif_focal_length, (int)img->exif_iso);
+  /* catch 1/2, 1/3 */
+  else if(nearbyintf(1.0f / img->exif_exposure) == 1.0f / img->exif_exposure)
+    snprintf(line, line_len, "1/%.0f f/%.1f %dmm iso %d", 1.0 / img->exif_exposure, img->exif_aperture,
+             (int)img->exif_focal_length, (int)img->exif_iso);
+  /* catch 1/1.3, 1/1.6, etc. */
+  else if(10 * nearbyintf(10.0f / img->exif_exposure) == nearbyintf(100.0f / img->exif_exposure))
+    snprintf(line, line_len, "1/%.1f f/%.1f %dmm iso %d", 1.0 / img->exif_exposure, img->exif_aperture,
+             (int)img->exif_focal_length, (int)img->exif_iso);
+  else
+    snprintf(line, line_len, "%.1f″ f/%.1f %dmm iso %d", img->exif_exposure, img->exif_aperture,
              (int)img->exif_focal_length, (int)img->exif_iso);
 }
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -272,21 +272,16 @@ void dt_image_path_append_version(int imgid, char *pathname, size_t pathname_len
 
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len)
 {
-  if(img->exif_exposure >= 4.0f) // Use whole seconds (e.g., 5" for exposures >= 4s)
-    snprintf(line, line_len, "%.0f″ f/%.1f %dmm iso %d", img->exif_exposure, img->exif_aperture,
-             (int)img->exif_focal_length, (int)img->exif_iso);
-  else if(img->exif_exposure < 0.35f) // Use fractions (e.g., 1/200 all the way up to 1/3)
+  if(img->exif_exposure >= 1.0f)
+    if(nearbyintf(img->exif_exposure) == img->exif_exposure)
+      snprintf(line, line_len, "%.0f″ f/%.1f %dmm iso %d", img->exif_exposure, img->exif_aperture,
+               (int)img->exif_focal_length, (int)img->exif_iso);
+    else
+      snprintf(line, line_len, "%.1f″ f/%.1f %dmm iso %d", img->exif_exposure, img->exif_aperture,
+               (int)img->exif_focal_length, (int)img->exif_iso);
+  else
     snprintf(line, line_len, "1/%.0f f/%.1f %dmm iso %d", 1.0 / img->exif_exposure, img->exif_aperture,
              (int)img->exif_focal_length, (int)img->exif_iso);
-  else // Use seconds and tenths (e.g., 1"2 for 1.2s exposure)
-  {
-    // Round first so we don't end up showing 0"10 instead of 1"0
-    float exposure = roundf(img->exif_exposure*10.0f)/10.0f;
-    float integral = 0.0f;
-    float fractional = modff(exposure, &integral) * 10.0f;
-    snprintf(line, line_len, "%.0f″%.0f f/%.1f %dmm iso %d", integral, fractional, img->exif_aperture,
-             (int)img->exif_focal_length, (int)img->exif_iso);
-  }
 }
 
 void dt_image_set_location(const int32_t imgid, double lon, double lat)


### PR DESCRIPTION
Display shutter speeds as
  ... 2″, 1.6″, 1.3″, 1″, 1/1.3, 1/1.6, 1/2, etc.

Fixes #11154

P.S. to reiterate from https://redmine.darktable.org/issues/11154
the previous code showed some wrong values; e.g. displaying a 1/2 exposure as 0″4 instead of 0″5.  I have been using the patch for a couple weeks now, and tested looking at files 1/320, 1.3″, 1″, 4″, etc. at both image information on the left and the histogram are in agreement.

P.P.S. Now reading the contrib guidelines, I wonder if I'm missing braces ;)  In any case, I'd appreciate commentary and hope this regression can be fixed for the next release.