### PR TITLE
Nikon P7100: reenable camera support after check, fixes #11218

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -3641,7 +3641,7 @@
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3650,27 +3650,10 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Sensor black="250" white="4095" iso_min="400" iso_max="0"/>
+		<Sensor black="0" white="3800"/>
+		<Sensor black="250" white="3800" iso_min="400" iso_max="0"/>
 		<!-- In usual Nikon style, ISO 6400 is marked as ISO 0 -->
-		<Sensor black="260" white="4095" iso_min="0" iso_max="1"/>
-		<Hints>
-			<Hint name="coolpixmangled" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="COOLPIX P7100" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix P7100">Nikon Coolpix P7100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Sensor black="250" white="4095" iso_min="400" iso_max="0"/>
-		<!-- In usual Nikon style, ISO 6400 is marked as ISO 0 -->
-		<Sensor black="260" white="4095" iso_min="0" iso_max="1"/>
+		<Sensor black="260" white="3800" iso_min="0" iso_max="1"/>
 		<Hints>
 			<Hint name="coolpixmangled" value=""/>
 		</Hints>

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -45,6 +45,7 @@ IGNORE_ONLY_MODE = {
   ["NIKON CORPORATION", "NIKON D7000"] => "compressed",
   ["NIKON CORPORATION", "NIKON D7100"] => "compressed",
   ["NIKON", "COOLPIX P330"] => "compressed",
+  ["NIKON", "COOLPIX P7100"] => "uncompressed",
   ["NIKON", "COOLPIX P7700"] => "compressed",
   ["NIKON", "COOLPIX P7800"] => "compressed"
 }


### PR DESCRIPTION
Manul does not say anything about more modes than the provides sampel,
so compressed mode is deleted