### PR TITLE
NIKON D3100: remove non available modes

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -2372,40 +2372,7 @@
 		<Crop x="0" y="0" width="-46" height="0"/>
 		<Sensor black="0" white="15892"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-compressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D3100">Nikon D3100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="8" y="2" width="-24" height="-2"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="14bit-uncompressed" decoder_version="2" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="D3100">Nikon D3100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="8" y="2" width="-24" height="-2"/>
-		<Sensor black="0" white="16383"/>
-	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="12bit-compressed" decoder_version="2">
-		<ID make="Nikon" model="D3100">Nikon D3100</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">GREEN</Color>
-			<Color x="1" y="0">BLUE</Color>
-			<Color x="0" y="1">RED</Color>
-			<Color x="1" y="1">GREEN</Color>
-		</CFA>
-		<Crop x="8" y="2" width="-24" height="-2"/>
-		<Sensor black="0" white="3880"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D3100" mode="12bit-uncompressed" decoder_version="2">
 		<ID make="Nikon" model="D3100">Nikon D3100</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">GREEN</Color>

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -41,6 +41,7 @@ IGNORE_ONLY_MODE = {
   ["NIKON CORPORATION", "NIKON D610"] => "compressed",
   ["NIKON CORPORATION", "NIKON D750"] => "compressed",
   ["NIKON CORPORATION", "NIKON D3000"] => "compressed",
+  ["NIKON CORPORATION", "NIKON D3100"] => "compressed",
   ["NIKON CORPORATION", "NIKON D3200"] => "compressed",
   ["NIKON CORPORATION", "NIKON D5100"] => "compressed",
   ["NIKON CORPORATION", "NIKON D5200"] => "compressed",


### PR DESCRIPTION
According to user manual only 12 Bit mode is supported. There is no
possiblity to change compression / non compression. Samples are compressed
raw.