### PR TITLE
Nikon P6000: reenable camera support, fixes #11227

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -3494,22 +3494,7 @@
 		<Crop x="0" y="0" width="-44" height="0"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-compressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="coolpixmangled" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -50,6 +50,7 @@ IGNORE_ONLY_MODE = {
   ["NIKON CORPORATION", "NIKON D7000"] => "compressed",
   ["NIKON CORPORATION", "NIKON D7100"] => "compressed",
   ["NIKON", "COOLPIX P330"] => "compressed",
+  ["NIKON", "COOLPIX P6000"] => "uncompressed",
   ["NIKON", "COOLPIX P7100"] => "uncompressed",
   ["NIKON", "COOLPIX P7700"] => "compressed",
   ["NIKON", "COOLPIX P7800"] => "compressed"
@@ -66,6 +67,7 @@ IGNORE_HIGH_WHITELEVEL = [
   ["NIKON CORPORATION", "NIKON D70"],
   ["NIKON CORPORATION", "NIKON D70s"],
   ["NIKON", "COOLPIX P330"],
+  ["NIKON", "COOLPIX P6000"],
   ["NIKON", "COOLPIX P7700"],
   ["NIKON", "COOLPIX P7800"]
 ]


### PR DESCRIPTION
Uncompressed 12 Bit is the only mode of this camera
according to user manual.