### PR TITLE
Nikon E5700: reenable camera support after check, fixes #11229

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -3365,21 +3365,7 @@
 			<Hint name="coolpixsplit" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON" model="E5700" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="E5700">Nikon E5700</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">FUJI_GREEN</Color>
-			<Color x="1" y="0">MAGENTA</Color>
-			<Color x="0" y="1">YELLOW</Color>
-			<Color x="1" y="1">CYAN</Color>
-		</CFA>
-		<Crop x="0" y="0" width="2576" height="1924"/>
-		<Sensor black="0" white="4095"/>
-		<Hints>
-			<Hint name="coolpixsplit" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON" model="E5700" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON" model="E5700" mode="12bit-uncompressed" decoder_version="4">
 		<ID make="Nikon" model="E5700">Nikon E5700</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">FUJI_GREEN</Color>

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -54,7 +54,8 @@ IGNORE_ONLY_MODE = {
   ["NIKON", "COOLPIX P7100"] => "uncompressed",
   ["NIKON", "COOLPIX P7700"] => "compressed",
   ["NIKON", "COOLPIX P7800"] => "compressed",
-  ["NIKON", "E5400"] => "uncompressed"
+  ["NIKON", "E5400"] => "uncompressed",
+  ["NIKON", "E5700"] => "uncompressed"
 }
 
 IGNORE_HIGH_WHITELEVEL = [
@@ -71,7 +72,8 @@ IGNORE_HIGH_WHITELEVEL = [
   ["NIKON", "COOLPIX P6000"],
   ["NIKON", "COOLPIX P7700"],
   ["NIKON", "COOLPIX P7800"],
-  ["NIKON", "E5400"]
+  ["NIKON", "E5400"],
+  ["NIKON", "E5700"]
 ]
 
 require 'nokogiri'


### PR DESCRIPTION
User manual:
{{{
Uncompressed: NEF (RAW-quality images), and
TIFF-RGB (HI-quality images)
}}}