### PR TITLE
Nikon D5: reenable camera support after check, fixes #11236

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -2263,7 +2263,7 @@
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-compressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-compressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2272,12 +2272,12 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="400" white="4096"/>
+		<Sensor black="100" white="3880"/>
 		<Hints>
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-uncompressed" supported="no">
+	<Camera make="NIKON CORPORATION" model="NIKON D5" mode="12bit-uncompressed">
 		<ID make="Nikon" model="D5">Nikon D5</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -2286,7 +2286,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="400" white="4096"/>
+		<Sensor black="100" white="3880"/>
 		<Hints>
 			<Hint name="nikon_override_auto_black" value=""/>
 		</Hints>


### PR DESCRIPTION
Samples in ticket are all black, for D5_Uncompressed_12bit.NEF i get a
warning: {{{[rawspeed] (D5_Uncompressed_12bit.NEF) Skipped out of buffer
}}}

Samples from
http://www.photographyblog.com/reviews/nikon_d5_review/sample_images/
are ok.