### PR TITLE
Nikon Coolpix A: Reenable camera support after check, fixes #11187

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -3468,7 +3468,7 @@
 		<Crop x="0" y="0" width="0" height="0"/>
 		<Sensor black="200" white="3800"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-compressed" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="14bit-compressed">
 		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3477,18 +3477,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="-44" height="0"/>
-		<Sensor black="0" white="4095"/>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="COOLPIX A" mode="12bit-uncompressed" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="Coolpix A">Nikon Coolpix A</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="-44" height="0"/>
-		<Sensor black="0" white="4095"/>
+		<Sensor black="0" white="15892"/>
 	</Camera>
 	<Camera make="NIKON" model="COOLPIX P6000" mode="12bit-uncompressed" decoder_version="1">
 		<ID make="Nikon" model="Coolpix P6000">Nikon Coolpix P6000</ID>

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -24,7 +24,8 @@
 
 IGNORE_ONLY_14BIT = [
   ["NIKON CORPORATION", "NIKON D5100"],
-  ["NIKON CORPORATION", "NIKON D5200"]
+  ["NIKON CORPORATION", "NIKON D5200"],
+  ["NIKON CORPORATION", "COOLPIX A"]
 ]
 
 IGNORE_ONLY_MODE = {
@@ -50,6 +51,7 @@ IGNORE_ONLY_MODE = {
   ["NIKON CORPORATION", "NIKON D5200"] => "compressed",
   ["NIKON CORPORATION", "NIKON D7000"] => "compressed",
   ["NIKON CORPORATION", "NIKON D7100"] => "compressed",
+  ["NIKON CORPORATION", "COOLPIX A"] => "compressed",
   ["NIKON", "COOLPIX P330"] => "compressed",
   ["NIKON", "COOLPIX P6000"] => "uncompressed",
   ["NIKON", "COOLPIX P7100"] => "uncompressed",


### PR DESCRIPTION
only 14Bit compressed is supported