### PR TITLE
Nikon 1 J4: Reenable camera support after check, fixes #11252

### DIFF
--- a/src/external/rawspeed/data/cameras.xml
+++ b/src/external/rawspeed/data/cameras.xml
@@ -3222,7 +3222,7 @@
 		<Crop x="0" y="0" width="0" height="-2"/>
 		<Sensor black="0" white="4095"/>
 	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
+	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-compressed" decoder_version="4">
 		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
 		<CFA width="2" height="2">
 			<Color x="0" y="0">RED</Color>
@@ -3231,24 +3231,7 @@
 			<Color x="1" y="1">BLUE</Color>
 		</CFA>
 		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="200" white="4095"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
-	</Camera>
-	<Camera make="NIKON CORPORATION" model="NIKON 1 J4" mode="12bit-uncompressed" decoder_version="4" supported="no"> <!-- need raw sample for whitelevel -->
-		<ID make="Nikon" model="1 J4">Nikon 1 J4</ID>
-		<CFA width="2" height="2">
-			<Color x="0" y="0">RED</Color>
-			<Color x="1" y="0">GREEN</Color>
-			<Color x="0" y="1">GREEN</Color>
-			<Color x="1" y="1">BLUE</Color>
-		</CFA>
-		<Crop x="0" y="0" width="0" height="0"/>
-		<Sensor black="200" white="4095"/>
-		<Hints>
-			<Hint name="nikon_override_auto_black" value=""/>
-		</Hints>
+		<Sensor black="200" white="4000"/>
 	</Camera>
 	<Camera make="NIKON CORPORATION" model="NIKON 1 J5" mode="12bit-compressed">
 		<ID make="Nikon" model="1 J5">Nikon 1 J5</ID>

--- a/tools/rawspeed-check-nikon-modes.rb
+++ b/tools/rawspeed-check-nikon-modes.rb
@@ -31,6 +31,7 @@ IGNORE_ONLY_MODE = {
   ["NIKON CORPORATION", "NIKON 1 J1"] => "compressed",
   ["NIKON CORPORATION", "NIKON 1 J2"] => "compressed",
   ["NIKON CORPORATION", "NIKON 1 J3"] => "compressed",
+  ["NIKON CORPORATION", "NIKON 1 J4"] => "compressed",
   ["NIKON CORPORATION", "NIKON 1 S1"] => "compressed",
   ["NIKON CORPORATION", "NIKON 1 S2"] => "compressed",
   ["NIKON CORPORATION", "NIKON 1 V1"] => "compressed",


### PR DESCRIPTION
camera supports only 12 bit compressed mode according to manual.
Samples can be found at
http://www.photographyblog.com/reviews/nikon_1_j4_review/sample_images/

nikon_override_auto_black is ignored for this camera (checked with debug output in NefDecoder.c:577), so remove it.