### PR TITLE
gen-profile:profile_image: quote directory path

### DIFF
--- a/tools/noise/gen-profile
+++ b/tools/noise/gen-profile
@@ -133,7 +133,7 @@ profile_image() {
 
 	echo "--> Run noiseprofile"
 	dat="${pfm%.pfm}.dat"
-	$noiseprofile "$pfm" > "$dat"
+	"$noiseprofile" "$pfm" > "$dat"
 
 	echo "--> Plotting $pfm"
 	title="$maker, $model, $iso ISO ($(basename "${pfm%.pfm}"))"


### PR DESCRIPTION
Quote the full path stored in $noiseprofile to prevent errors caused by special characters in the path name (like white spaces).