### PR TITLE
Caches: poison

### DIFF
--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -134,6 +134,12 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache, const uint32_t key, char m
     if(end - start > 0.1)
       fprintf(stderr, "try+ wait time %.06fs mode %c \n", end - start, mode);
 
+    if(mode == 'w')
+    {
+      assert(entry->data_size);
+      ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);
+    }
+
     // WARNING: do *NOT* unpoison here. it must be done by the caller!
 
     return entry;
@@ -186,6 +192,12 @@ restart:
       assert(!pthread_equal(writer, pthread_self()));
     }
 #endif
+
+    if(mode == 'w')
+    {
+      assert(entry->data_size);
+      ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);
+    }
 
     // WARNING: do *NOT* unpoison here. it must be done by the caller!
 

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -126,6 +126,9 @@ dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache, const uint32_t key, char m
     double end = dt_get_wtime();
     if(end - start > 0.1)
       fprintf(stderr, "try+ wait time %.06fs mode %c \n", end - start, mode);
+
+    // WARNING: do *NOT* unpoison here. it must be done by the caller!
+
     return entry;
   }
   dt_pthread_mutex_unlock(&cache->lock);
@@ -177,6 +180,8 @@ restart:
     }
 #endif
 
+    // WARNING: do *NOT* unpoison here. it must be done by the caller!
+
     return entry;
   }
 
@@ -226,6 +231,9 @@ restart:
   double end = dt_get_wtime();
   if(end - start > 0.1)
     fprintf(stderr, "wait time %.06fs\n", end - start);
+
+  // WARNING: do *NOT* unpoison here. it must be done by the caller!
+
   return entry;
 }
 

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -312,7 +312,7 @@ void dt_cache_gc(dt_cache_t *cache, const float fill_ratio)
   }
 }
 
-void dt_cache_release(dt_cache_t *cache, dt_cache_entry_t *entry)
+void dt_cache_release_with_caller(dt_cache_t *cache, dt_cache_entry_t *entry, const char *file, int line)
 {
   dt_pthread_rwlock_unlock(&entry->lock);
 }

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -195,6 +195,7 @@ restart:
   int ret = dt_pthread_rwlock_init(&entry->lock, 0);
   if(ret) fprintf(stderr, "rwlock init: %d\n", ret);
   entry->data = 0;
+  entry->data_size = cache->entry_size;
   entry->cost = 1;
   entry->link = g_list_append(0, entry);
   entry->key = key;

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -222,6 +222,9 @@ restart:
   else
     entry->data = dt_alloc_align(16, entry->data_size);
 
+  assert(entry->data_size);
+  ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);
+
   // if allocate callback is given, always return a write lock
   const int write = ((mode == 'w') || cache->allocate);
 

--- a/src/common/cache.h
+++ b/src/common/cache.h
@@ -27,6 +27,7 @@
 typedef struct dt_cache_entry_t
 {
   void *data;
+  size_t data_size;
   size_t cost;
   GList *link;
   dt_pthread_rwlock_t lock;

--- a/src/common/cache.h
+++ b/src/common/cache.h
@@ -80,7 +80,8 @@ dt_cache_entry_t *dt_cache_get_with_caller(dt_cache_t *cache, const uint32_t key
 // same but returns 0 if not allocated yet (both will block and wait for entry rw locks to be released)
 dt_cache_entry_t *dt_cache_testget(dt_cache_t *cache, const uint32_t key, char mode);
 // release a lock on a cache entry. the cache knows which one you mean (r or w).
-void dt_cache_release(dt_cache_t *cache, dt_cache_entry_t *entry);
+#define dt_cache_release(A, B) dt_cache_release_with_caller(A, B, __FILE__, __LINE__)
+void dt_cache_release_with_caller(dt_cache_t *cache, dt_cache_entry_t *entry, const char *file, int line);
 
 // 0: not contained
 int32_t dt_cache_contains(dt_cache_t *cache, const uint32_t key);

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -180,6 +180,7 @@ dt_image_t *dt_image_cache_get(dt_image_cache_t *cache, const uint32_t imgid, ch
 {
   if(imgid <= 0) return NULL;
   dt_cache_entry_t *entry = dt_cache_get(&cache->cache, imgid, mode);
+  ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
   dt_image_t *img = (dt_image_t *)entry->data;
   img->cache_entry = entry;
   return img;
@@ -190,6 +191,7 @@ dt_image_t *dt_image_cache_testget(dt_image_cache_t *cache, const uint32_t imgid
   if(imgid <= 0) return 0;
   dt_cache_entry_t *entry = dt_cache_testget(&cache->cache, imgid, mode);
   if(!entry) return 0;
+  ASAN_UNPOISON_MEMORY_REGION(entry->data, sizeof(dt_image_t));
   dt_image_t *img = (dt_image_t *)entry->data;
   img->cache_entry = entry;
   return img;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -670,6 +670,7 @@ void dt_mipmap_cache_get_with_caller(
     buf->cache_entry = entry;
     if(entry)
     {
+      ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
       struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)entry->data;
       buf->width = dsc->width;
       buf->height = dsc->height;
@@ -715,6 +716,9 @@ void dt_mipmap_cache_get_with_caller(
   {
     // simple case: blocking get
     dt_cache_entry_t *entry =  dt_cache_get_with_caller(&_get_cache(cache, mip)->cache, key, mode, file, line);
+
+    ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
+
     struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)entry->data;
     buf->cache_entry = entry;
 
@@ -750,6 +754,7 @@ void dt_mipmap_cache_get_with_caller(
         buf->color_space = DT_COLORSPACE_NONE; // TODO: does the full buffer need to know this?
         dt_imageio_retval_t ret = dt_imageio_open(&buffered_image, filename, buf); // TODO: color_space?
         // might have been reallocated:
+        ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
         dsc = (struct dt_mipmap_buffer_dsc *)buf->cache_entry->data;
         if(ret != DT_IMAGEIO_OK)
         {
@@ -801,6 +806,7 @@ void dt_mipmap_cache_get_with_caller(
       dt_cache_release(&_get_cache(cache, mip)->cache, entry);
       // get a read lock
       buf->cache_entry = entry = dt_cache_get(&_get_cache(cache, mip)->cache, key, mode);
+      ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
       entry->_lock_demoting = 0;
       dsc = (struct dt_mipmap_buffer_dsc *)buf->cache_entry->data;
     }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1017,12 +1017,14 @@ static void _init_f(dt_mipmap_buffer_t *mipmap_buf, float *out, uint32_t *width,
     // downsample
     dt_iop_clip_and_zoom(out, (const float *)buf.buf, &roi_out, &roi_in, roi_out.width, roi_in.width);
   }
-  dt_image_cache_read_release(darktable.image_cache, image);
+
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 
   *width = roi_out.width;
   *height = roi_out.height;
   *iscale = (float)image->width / (float)roi_out.width;
+
+  dt_image_cache_read_release(darktable.image_cache, image);
 }
 
 

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -79,8 +79,23 @@ struct dt_mipmap_buffer_dsc
   size_t size;
   dt_mipmap_buffer_dsc_flags flags;
   dt_colorspaces_color_profile_type_t color_space;
+
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+  // do not touch!
+  // must be the last element.
+  // must be no less than 16bytes
+  char redzone[16];
+#endif
+
   /* NB: sizeof must be a multiple of 4*sizeof(float) */
 } __attribute__((packed, aligned(16)));
+
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+static const size_t dt_mipmap_buffer_dsc_size __attribute__((unused))
+= sizeof(struct dt_mipmap_buffer_dsc) - sizeof(((struct dt_mipmap_buffer_dsc *)0)->redzone);
+#else
+static const size_t dt_mipmap_buffer_dsc_size __attribute__((unused)) = sizeof(struct dt_mipmap_buffer_dsc);
+#endif
 
 // last resort mem alloc for dead images. sizeof(dt_mipmap_buffer_dsc) + dead image pixels (8x8)
 // Must be alignment to 4 * sizeof(float).

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -271,31 +271,37 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
   // for full image buffers
   struct dt_mipmap_buffer_dsc *dsc = entry->data;
   const dt_mipmap_size_t mip = get_size(entry->key);
+
   // alloc mere minimum for the header + broken image buffer:
   if(!dsc)
   {
     if(mip <= DT_MIPMAP_F)
     {
       // these are fixed-size:
-      entry->data = dt_alloc_align(16, cache->buffer_size[mip]);
+      entry->data_size = cache->buffer_size[mip];
     }
     else
     {
-      entry->data = dt_alloc_align(16, sizeof(*dsc) + sizeof(float) * 4 * 64);
+      entry->data_size = sizeof(*dsc) + sizeof(float) * 4 * 64;
     }
+
+    entry->data = dt_alloc_align(16, entry->data_size);
+
     // fprintf(stderr, "[mipmap cache] alloc dynamic for key %u %p\n", key, *buf);
     if(!(entry->data))
     {
       fprintf(stderr, "[mipmap cache] memory allocation failed!\n");
       exit(1);
     }
+
     dsc = entry->data;
+
     if(mip <= DT_MIPMAP_F)
     {
       dsc->width = cache->max_width[mip];
       dsc->height = cache->max_height[mip];
       dsc->iscale = 1.0f;
-      dsc->size = cache->buffer_size[mip];
+      dsc->size = entry->data_size;
       dsc->color_space = DT_COLORSPACE_NONE;
     }
     else
@@ -304,9 +310,10 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
       dsc->height = 0;
       dsc->iscale = 0.0f;
       dsc->color_space = DT_COLORSPACE_NONE;
-      dsc->size = sizeof(*dsc) + sizeof(float) * 4 * 64;
+      dsc->size = entry->data_size;
     }
   }
+
   assert(dsc->size >= sizeof(*dsc));
 
   int loaded_from_disk = 0;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -681,6 +681,8 @@ void dt_mipmap_cache_get_with_caller(
 
       // skip to next 8-byte alignment, for sse buffers.
       buf->buf = (uint8_t *)(dsc + 1);
+
+      ASAN_UNPOISON_MEMORY_REGION(buf->buf, dsc->size - sizeof(struct dt_mipmap_buffer_dsc));
     }
     else
     {
@@ -783,11 +785,13 @@ void dt_mipmap_cache_get_with_caller(
       }
       else if(mip == DT_MIPMAP_F)
       {
+        ASAN_UNPOISON_MEMORY_REGION(dsc + 1, dsc->size - sizeof(struct dt_mipmap_buffer_dsc));
         _init_f(buf, (float *)(dsc + 1), &dsc->width, &dsc->height, &dsc->iscale, imgid);
       }
       else
       {
         // 8-bit thumbs
+        ASAN_UNPOISON_MEMORY_REGION(dsc + 1, dsc->size - sizeof(struct dt_mipmap_buffer_dsc));
         _init_8((uint8_t *)(dsc + 1), &dsc->width, &dsc->height, &dsc->iscale, &buf->color_space, imgid, mip);
       }
       dsc->color_space = buf->color_space;
@@ -835,7 +839,10 @@ void dt_mipmap_cache_get_with_caller(
     buf->color_space = dsc->color_space;
     buf->imgid = imgid;
     buf->size = mip;
+
+    ASAN_UNPOISON_MEMORY_REGION(dsc + 1, dsc->size - sizeof(struct dt_mipmap_buffer_dsc));
     buf->buf = (uint8_t *)(dsc + 1);
+
     if(dsc->width == 0 || dsc->height == 0)
     {
       // fprintf(stderr, "[mipmap cache get] got a zero-sized image for img %u mip %d!\n", imgid, mip);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -287,6 +287,13 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
   // fprintf(stderr, "full buffer allocating img %u %d x %d = %u bytes (%p)\n", img->id, img->width,
   // img->height, buffer_size, *buf);
 
+  assert(entry->data_size);
+  assert(dsc->size);
+  assert(dsc->size <= entry->data_size);
+
+  ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);
+  ASAN_UNPOISON_MEMORY_REGION(dsc + 1, buffer_size - sizeof(struct dt_mipmap_buffer_dsc));
+
   // return pointer to start of payload
   return dsc + 1;
 }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -237,9 +237,11 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
 
   // buf might have been alloc'ed before,
   // so only check size and re-alloc if necessary:
-  if(!buf->buf || (dsc->size < buffer_size) || ((void *)dsc == (void *)dt_mipmap_cache_static_dead_image))
+  if(!buf->buf || ((void *)dsc == (void *)dt_mipmap_cache_static_dead_image) || (entry->data_size < buffer_size))
   {
     if((void *)dsc != (void *)dt_mipmap_cache_static_dead_image) dt_free_align(entry->data);
+
+    entry->data_size = 0;
 
     entry->data = dt_alloc_align(64, buffer_size);
 
@@ -252,10 +254,13 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
       return NULL;
     }
 
+    entry->data_size = buffer_size;
+
     // set buffer size only if we're making it larger.
     dsc = (struct dt_mipmap_buffer_dsc *)entry->data;
-    dsc->size = buffer_size;
   }
+
+  dsc->size = buffer_size;
 
   dsc->width = wd;
   dsc->height = ht;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -859,14 +859,15 @@ void dt_mipmap_cache_write_get_with_caller(dt_mipmap_cache_t *cache, dt_mipmap_b
   dt_mipmap_cache_get_with_caller(cache, buf, imgid, mip, DT_MIPMAP_BLOCKING, 'w', file, line);
 }
 
-void dt_mipmap_cache_release(dt_mipmap_cache_t *cache, dt_mipmap_buffer_t *buf)
+void dt_mipmap_cache_release_with_caller(dt_mipmap_cache_t *cache, dt_mipmap_buffer_t *buf, const char *file,
+                                         int line)
 {
   if(buf->size == DT_MIPMAP_NONE) return;
   assert(buf->imgid > 0);
   // assert(buf->size >= DT_MIPMAP_0); // breaks gcc-4.6/4.7 build
   assert(buf->size < DT_MIPMAP_NONE);
   assert(buf->cache_entry);
-  dt_cache_release(&_get_cache(cache, buf->size)->cache, buf->cache_entry);
+  dt_cache_release_with_caller(&_get_cache(cache, buf->size)->cache, buf->cache_entry, file, line);
   buf->size = DT_MIPMAP_NONE;
   buf->buf = NULL;
 }

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -947,6 +947,7 @@ void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid)
     dt_cache_entry_t *entry = dt_cache_testget(&_get_cache(cache, k)->cache, key, 'w');
     if(entry)
     {
+      ASAN_UNPOISON_MEMORY_REGION(entry->data, dt_mipmap_buffer_dsc_size);
       struct dt_mipmap_buffer_dsc *dsc = (struct dt_mipmap_buffer_dsc *)entry->data;
       dsc->flags |= DT_MIPMAP_BUFFER_DSC_FLAG_INVALIDATE;
       dt_cache_release(&_get_cache(cache, k)->cache, entry);

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -135,7 +135,9 @@ void dt_mipmap_cache_write_get_with_caller(
     int line);
 
 // drop a lock
-void dt_mipmap_cache_release(dt_mipmap_cache_t *cache, dt_mipmap_buffer_t *buf);
+#define dt_mipmap_cache_release(A, B) dt_mipmap_cache_release_with_caller(A, B, __FILE__, __LINE__)
+void dt_mipmap_cache_release_with_caller(dt_mipmap_cache_t *cache, dt_mipmap_buffer_t *buf, const char *file,
+                                         int line);
 
 // remove thumbnails, so they will be regenerated:
 void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1754,7 +1754,6 @@ void reload_defaults(dt_iop_module_t *module)
   }
   else
     use_eprofile = TRUE; // the image has a profile assigned
-  dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
   if(img->flags & DT_IMAGE_4BAYER) // 4Bayer images have been pre-converted to rec2020
     tmp.type = DT_COLORSPACE_LIN_REC709;
@@ -1768,6 +1767,8 @@ void reload_defaults(dt_iop_module_t *module)
     tmp.type = DT_COLORSPACE_SRGB;
   else if(!isnan(module->dev->image_storage.d65_color_matrix[0]))
     tmp.type = DT_COLORSPACE_EMBEDDED_MATRIX;
+
+  dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
 end:
   memcpy(module->params, &tmp, sizeof(dt_iop_colorin_params_t));


### PR DESCRIPTION
Since we have all this manual caches which maintain buffers, and the buffers can be bigger than the current request actually needs, we need to make sure to manually take care of all the asan abstraction.
In particular:
1. let each cache buffer know it's size
2. since `dt_mipmap_buffer_dsc` is prepended, we need to manually keep redzone between them, to detect buffer heap underflow.
3. when doing all the cache entries acquisition/unlock, we need to make sure to make avaliable only the size requested (via poisoning of the whole buf, and unpoisoning of the wanted size only)
4. also, this helps to detect the cases of usage of cache entries after unlocking them

Downside:
just look at this abomination in `cache.c` :)
```
void dt_cache_release_with_caller(dt_cache_t *cache, dt_cache_entry_t *entry, const char *file, int line)
{
#if((__has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)) && 1)
  // yes, this is *HIGHLY* unportable and is accessing implementation details.
#ifdef _DEBUG
  if(entry->lock.lock.__data.__nr_readers <= 1)
#else
  if(entry->lock.__data.__nr_readers <= 1)
#endif
  {
    // only if there are no other reades we may poison.
    assert(entry->data_size);
    ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);
  }
#endif

  dt_pthread_rwlock_unlock(&entry->lock);
}
```