### PR TITLE
lens: re-enable tiling in the lens correction module

### DIFF
--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -919,7 +919,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(buf) reduction(min : xm, ym) reduction(max : xM, yM)
+#pragma omp parallel for default(none) shared(buf) reduction(min : xm, ym) reduction(max : xM, yM)
 #endif
     for(int k = 0; k < nbpoints; k++)
     {

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -144,7 +144,7 @@ int operation_tags()
 
 int flags()
 {
-  return /* IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | */ IOP_FLAGS_ONE_INSTANCE;
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_TILING_FULL_ROI | IOP_FLAGS_ONE_INSTANCE;
 }
 
 void init_key_accels(dt_iop_module_so_t *self)
@@ -780,7 +780,6 @@ error:
 }
 #endif
 
-#if 0
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,
                      struct dt_develop_tiling_t *tiling)
@@ -793,7 +792,6 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   tiling->yalign = 1;
   return;
 }
-#endif
 
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)
 {

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -883,10 +883,10 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
     const size_t nbpoints = 2 * awidth + 2 * aheight;
 
-    float *buf = dt_alloc_align(16, nbpoints * 2 * 3 * sizeof(float));
+    float *const buf = dt_alloc_align(16, nbpoints * 2 * 3 * sizeof(float));
 
 #ifdef _OPENMP
-#pragma omp parallel default(none) shared(modifier, buf) reduction(min : xm, ym) reduction(max : xM, yM)
+#pragma omp parallel default(none) shared(modifier) reduction(min : xm, ym) reduction(max : xM, yM)
 #endif
     {
 #ifdef _OPENMP

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -914,14 +914,20 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
         lf_modifier_apply_subpixel_geometry_distortion(modifier, xoff + (width - 1), yoff + j * ystep, 1, 1, buf + 6 * (2 * awidth + aheight + j));
 
 #ifdef _OPENMP
+#pragma omp barrier
+#endif
+
+#ifdef _OPENMP
 #pragma omp for schedule(static)
 #endif
       for(int k = 0; k < nbpoints; k++)
       {
-        xm = fminf(xm, buf[6 * k + 0]);
-        xM = fmaxf(xM, buf[6 * k + 0]);
-        ym = fminf(ym, buf[6 * k + 3]);
-        yM = fmaxf(yM, buf[6 * k + 3]);
+        const float x = buf[6 * k + 0];
+        const float y = buf[6 * k + 3];
+        xm = isnan(x) ? xm : MIN(xm, x);
+        xM = isnan(x) ? xM : MAX(xM, x);
+        ym = isnan(y) ? ym : MIN(ym, y);
+        yM = isnan(y) ? yM : MAX(yM, y);
       }
     }
 


### PR DESCRIPTION
In order to process modify_roi_in() there is no need to distort-process all image
coordinates. It's sufficient to handle only the circumference pixels. This way we
can formulate the problem in a more generic way that will also nicely deal with
unbound roi values. These unbound values (e.g. negative or zero width/height) may
be presented to modify_roi_in() by the tiling mechanism when it comes to fitting
a roi_out to a given roi_in.

Note: this needs intensive testing and is only meant to be merged in the 2.3 branch