### PR TITLE
Cleanup all Gtk3.22 deprecations

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1413,6 +1413,23 @@ static void dt_colorspaces_get_display_profile_colord_callback(GObject *source, 
 }
 #endif
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+static int _gtk_get_monitor_num(GdkMonitor *monitor)
+{
+  GdkDisplay *display;
+  int n_monitors, i;
+
+  display = gdk_monitor_get_display(monitor);
+  n_monitors = gdk_display_get_n_monitors(display);
+  for(i = 0; i < n_monitors; i++)
+  {
+    if(gdk_display_get_monitor(display, i) == monitor) return i;
+  }
+
+  return -1;
+}
+#endif
+
 // Get the display ICC profile of the monitor associated with the widget.
 // For X display, uses the ICC profile specifications version 0.2 from
 // http://burtonini.com/blog/computers/xicc
@@ -1452,9 +1469,17 @@ void dt_colorspaces_set_display_profile()
   if(use_xatom)
   {
     GtkWidget *widget = dt_ui_center(darktable.gui->ui);
+    GdkWindow *window = gtk_widget_get_window(widget);
     GdkScreen *screen = gtk_widget_get_screen(widget);
     if(screen == NULL) screen = gdk_screen_get_default();
-    int monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(widget));
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+    GdkDisplay *display = gtk_widget_get_display(widget);
+    int monitor = _gtk_get_monitor_num(gdk_display_get_monitor_at_window(display, window));
+#else
+    int monitor = gdk_screen_get_monitor_at_window(screen, window);
+#endif
+
     char *atom_name;
     if(monitor > 0)
       atom_name = g_strdup_printf("_ICC_PROFILE_%d", monitor);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1503,7 +1503,7 @@ static void dt_iop_gui_reset_callback(GtkButton *button, dt_iop_module_t *module
   dt_dev_add_history_item(module->dev, module, TRUE);
 }
 
-
+#if !GTK_CHECK_VERSION(3, 22, 0)
 static void _preset_popup_position(GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gpointer data)
 {
   GtkRequisition requisition = { 0 };
@@ -1514,12 +1514,21 @@ static void _preset_popup_position(GtkMenu *menu, gint *x, gint *y, gboolean *pu
   gtk_widget_get_allocation(GTK_WIDGET(data), &allocation);
   (*y) += allocation.height;
 }
+#endif
 
 static void popup_callback(GtkButton *button, dt_iop_module_t *module)
 {
   dt_gui_presets_popup_menu_show_for_module(module);
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_widget(darktable.gui->presets_popup_menu,
+                           dtgtk_expander_get_header(DTGTK_EXPANDER(module->expander)), GDK_GRAVITY_SOUTH_WEST,
+                           GDK_GRAVITY_NORTH_WEST, NULL);
+#else
   gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, _preset_popup_position, button, 0,
                  gtk_get_current_event_time());
+#endif
+
   gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
   gtk_menu_reposition(GTK_MENU(darktable.gui->presets_popup_menu));
 }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1741,7 +1741,13 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
   else if(e->button == 3)
   {
     dt_gui_presets_popup_menu_show_for_module(module);
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(darktable.gui->presets_popup_menu, (GdkEvent *)e);
+#else
     gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, NULL, NULL, e->button, e->time);
+#endif
+
     gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
     return TRUE;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -893,8 +893,13 @@ static void dt_iop_gui_multimenu_callback(GtkButton *button, gpointer user_data)
   gtk_menu_shell_append(menu, item);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
+
   // popup
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+#else
   gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user_data)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1708,7 +1708,13 @@ static gboolean _iop_plugin_body_button_press(GtkWidget *w, GdkEventButton *e, g
   else if(e->button == 3)
   {
     dt_gui_presets_popup_menu_show_for_module(module);
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(darktable.gui->presets_popup_menu, (GdkEvent *)e);
+#else
     gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, NULL, NULL, e->button, e->time);
+#endif
+
     gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
     return TRUE;
   }

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1885,7 +1885,11 @@ static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
   lens_menu_fill(self, lenslist);
   lf_free(lenslist);
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(g->lens_menu), NULL);
+#else
   gtk_menu_popup(GTK_MENU(g->lens_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 /* -- end lens -- */

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1507,7 +1507,12 @@ static void camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   if(!camlist) return;
   camera_menu_fill(self, camlist);
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(g->camera_menu), NULL);
+#else
   gtk_menu_popup(GTK_MENU(g->camera_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1857,7 +1857,11 @@ static void lens_menusearch_clicked(GtkWidget *button, gpointer user_data)
   lens_menu_fill(self, lenslist);
   lf_free(lenslist);
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(g->lens_menu), NULL);
+#else
   gtk_menu_popup(GTK_MENU(g->lens_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1546,7 +1546,11 @@ static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
     lf_free(camlist);
   }
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(g->camera_menu), NULL);
+#else
   gtk_menu_popup(GTK_MENU(g->camera_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 }
 
 /* -- end camera -- */

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -262,7 +262,12 @@ static void _property_choice_callback(GtkMenuItem *item, gpointer user_data)
 static void _show_property_popupmenu_clicked(GtkWidget *widget, gpointer user_data)
 {
   dt_lib_camera_t *lib = (dt_lib_camera_t *)user_data;
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(lib->gui.properties_menu, NULL);
+#else
   gtk_menu_popup(lib->gui.properties_menu, NULL, NULL, NULL, NULL, 1, gtk_get_current_event_time());
+#endif
 }
 
 static void _lib_property_add_to_gui(dt_lib_camera_property_t *prop, dt_lib_camera_t *lib)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -360,10 +360,14 @@ static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, dt_lib_c
 
   gtk_widget_show_all(menu);
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
+#else
   /* Note: event can be NULL here when called from view_onPopupMenu;
    *  gdk_event_get_time() accepts a NULL argument */
   gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, (event != NULL) ? event->button : 0,
                  gdk_event_get_time((GdkEvent *)event));
+#endif
 }
 
 static gboolean view_onButtonPressed(GtkWidget *treeview, GdkEventButton *event, dt_lib_collect_t *d)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1623,7 +1623,12 @@ static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, 
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_change_and_not), d);
   }
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+  gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
+#else
   gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
+#endif
+
   gtk_widget_show_all(menu);
 
   return TRUE;

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1166,7 +1166,12 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
     gtk_menu_shell_append(menu, item);
 
     gtk_widget_show_all(GTK_WIDGET(menu));
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
+#else
     gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, 0, gdk_event_get_time((GdkEvent *)event));
+#endif
 
     return 1;
   }

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -515,7 +515,12 @@ static gboolean _lib_navigation_button_press_callback(GtkWidget *widget, GdkEven
     gtk_menu_shell_append(menu, item);
 
     gtk_widget_show_all(GTK_WIDGET(menu));
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
+#else
     gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+#endif
 
     return TRUE;
   }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -885,7 +885,12 @@ static void _darkroom_ui_favorite_presets_popupmenu(GtkWidget *w, gpointer user_
   if(darktable.gui->presets_popup_menu)
   {
     gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(darktable.gui->presets_popup_menu, NULL);
+#else
     gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, NULL, NULL, 0, 0);
+#endif
   }
   else
     dt_control_log(_("no userdefined presets for favorite modules were found"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -950,7 +950,11 @@ static void _darkroom_ui_apply_style_popupmenu(GtkWidget *w, gpointer user_data)
   /* if we got any styles, lets popup menu for selection */
   if(menu)
   {
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+#else
     gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, 0, 0);
+#endif
   }
   else
     dt_control_log(_("no styles have been created yet"));

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -357,12 +357,21 @@ void enter(dt_view_t *self)
 
   // alloc screen-size double buffer
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+  GdkRectangle rect;
+
+#if GTK_CHECK_VERSION(3, 22, 0)
+  GdkDisplay *display = gtk_widget_get_display(window);
+  GdkMonitor *mon = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(window));
+  gdk_monitor_get_geometry(mon, &rect);
+#else
   GdkScreen *screen = gtk_widget_get_screen(window);
   if(!screen) screen = gdk_screen_get_default();
   int monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(window));
-  GdkRectangle rect;
   gdk_screen_get_monitor_geometry(screen, monitor, &rect);
+#endif
+
   dt_pthread_mutex_lock(&d->lock);
+
   d->width = rect.width * darktable.gui->ppd;
   d->height = rect.height * darktable.gui->ppd;
   d->buf1 = dt_alloc_align(64, sizeof(uint32_t) * d->width * d->height);


### PR DESCRIPTION
Good news is, Gtk3.22 is, finally, the last one in  Gtk3 series!

@houz could you please look at the first commit, at `dt_colorspaces_set_display_profile()`