### PR TITLE
Switching archetype printf to gnu_printf

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -236,7 +236,7 @@ extern const char dt_supported_extensions[];
 
 int dt_init(int argc, char *argv[], const int init_gui, lua_State *L);
 void dt_cleanup();
-void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(printf, 2, 3)));
+void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((format(gnu_printf, 2, 3)));
 void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 void *dt_alloc_align(size_t alignment, size_t size);

--- a/src/external/rawspeed/RawSpeed/CameraMetadataException.h
+++ b/src/external/rawspeed/RawSpeed/CameraMetadataException.h
@@ -25,7 +25,7 @@
 
 namespace RawSpeed {
 
-void ThrowCME(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void ThrowCME(const char* fmt, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 
 class CameraMetadataException :
   public std::runtime_error

--- a/src/external/rawspeed/RawSpeed/CiffParserException.h
+++ b/src/external/rawspeed/RawSpeed/CiffParserException.h
@@ -26,7 +26,7 @@
 
 namespace RawSpeed {
 
-void ThrowCPE(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void ThrowCPE(const char* fmt, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 
 class CiffParserException : public std::runtime_error
 {

--- a/src/external/rawspeed/RawSpeed/FileIOException.h
+++ b/src/external/rawspeed/RawSpeed/FileIOException.h
@@ -27,7 +27,7 @@
 
 namespace RawSpeed {
 
-void ThrowFIE(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void ThrowFIE(const char* fmt, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 
 class FileIOException: public RawDecoderException
 {

--- a/src/external/rawspeed/RawSpeed/IOException.h
+++ b/src/external/rawspeed/RawSpeed/IOException.h
@@ -27,7 +27,7 @@
 
 namespace RawSpeed {
 
-void ThrowIOE(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void ThrowIOE(const char* fmt, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 
 
 class IOException : public std::runtime_error

--- a/src/external/rawspeed/RawSpeed/RawDecoderException.h
+++ b/src/external/rawspeed/RawSpeed/RawDecoderException.h
@@ -25,7 +25,7 @@
 
 namespace RawSpeed {
 
-void ThrowRDE(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void ThrowRDE(const char* fmt, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 
 class RawDecoderException : public std::runtime_error
 {

--- a/src/external/rawspeed/RawSpeed/TiffParserException.h
+++ b/src/external/rawspeed/RawSpeed/TiffParserException.h
@@ -25,7 +25,7 @@
 
 namespace RawSpeed {
 
-void ThrowTPE(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+void ThrowTPE(const char* fmt, ...) __attribute__ ((format (gnu_printf, 1, 2)));
 
 class TiffParserException : public std::runtime_error
 {


### PR DESCRIPTION
Following our IRC discussion on the weekend.
Since version 4.4.x, gcc supports additional format archetypes. "printf" means "gnu_printf" when compiling for non-Windows and means "ms_printf" when compiling for Windows. Darktable code does seems to be assuming gnu_printf (judging by the use of %z and %l).