### PR TITLE
Support test-compiling OpenCL kernels when there is {LLVM,clang}-3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(BUILD_PRINT "Build the print module" ON)
 option(BUILD_RS_IDENTIFY "Build the darktable-rs-identify debug aid" ON)
 option(BUILD_SSE2_CODEPATHS "(EXPERIMENTAL OPTION, DO NOT DISABLE) Building SSE2-optimized codepaths" ON)
 option(VALIDATE_APPDATA_FILE "Use appstream-util (if found) to validate the .appdata file" OFF)
+option(TESTBUILD_OPENCL_PROGRAMS "Test-compile opencl programs (needs llvm and clang 3.9+)" ON)
 
 if(BUILD_SSE2_CODEPATHS)
   CHECK_C_COMPILER_FLAG("-msse2" _MSSE2)
@@ -310,6 +311,50 @@ if(VALIDATE_APPDATA_FILE)
     message(STATUS "Found appstream-util")
   endif(${appstream_util_BIN} STREQUAL "appstream_util_BIN-NOTFOUND")
 endif(VALIDATE_APPDATA_FILE)
+
+if(TESTBUILD_OPENCL_PROGRAMS)
+  set(TESTBUILD_OPENCL_PROGRAMS OFF)
+
+  # 3.9 is the first version with which this works.
+  find_package(LLVM 3.9 CONFIG)
+  if (LLVM_FOUND)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+
+    find_program(CLANG_OPENCL_COMPILER
+      NAMES clang-${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} clang-${LLVM_PACKAGE_VERSION}
+    )
+
+    if (NOT ${CLANG_OPENCL_COMPILER} STREQUAL "CLANG_OPENCL_COMPILER-NOTFOUND")
+      message(STATUS "Found clang compiler - ${CLANG_OPENCL_COMPILER}")
+
+      find_path(CLANG_OPENCL_INCLUDE_DIR opencl-c.h
+        HINTS ${LLVM_INSTALL_PREFIX}/lib/clang
+        PATH_SUFFIXES include ${LLVM_PACKAGE_VERSION}/include
+        NO_DEFAULT_PATH
+      )
+
+      if (NOT ${CLANG_OPENCL_INCLUDE_DIR} STREQUAL "CLANG_OPENCL_INCLUDE_DIR-NOTFOUND")
+        message(STATUS "Found clang opencl-c.h header in ${CLANG_OPENCL_INCLUDE_DIR}")
+        set(TESTBUILD_OPENCL_PROGRAMS ON)
+      else()
+        message(WARNING "Could not find clang opencl-c.h header include dir")
+        message(WARNING "Test-compilation of OpenCL programs can not be done.")
+      endif()
+    else()
+      message(WARNING "Could not find appropriate clang compiler")
+      message(WARNING "Test-compilation of OpenCL programs can not be done.")
+    endif()
+  else()
+    message(WARNING "Could not find LLVM 3.9+")
+    message(WARNING "Test-compilation of OpenCL programs can not be done.")
+  endif()
+endif()
+
+if(TESTBUILD_OPENCL_PROGRAMS)
+  message(STATUS "Will be able to test-compile OpenCL programs. Nice.")
+else()
+  message(STATUS "Test-compilation of OpenCL programs is disabled.")
+endif()
 
 # we need jsonschema to check noiseprofiles.json
 find_program(jsonschema_BIN jsonschema)

--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -1,5 +1,40 @@
 #
 # install opencl kernel source files
 #
-FILE(GLOB DT_OPENCL_KERNELS "*.cl" "programs.conf" "common.h")
+FILE(GLOB DT_OPENCL_KERNELS "*.cl" "common.h")
+FILE(GLOB DT_OPENCL_EXTRA "programs.conf")
+
+add_custom_target(testcompile_opencl_kernels ALL)
+
+macro (testcompile_opencl_kernel IN)
+  get_filename_component(KERNAME ${IN} NAME)
+
+  set(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/${KERNAME}.touch")
+
+  set(KERNAME_OUT "opencl-program-${KERNAME}")
+
+  add_custom_command(
+    OUTPUT  ${TOUCH}
+    COMMAND ${CLANG_OPENCL_COMPILER} -cc1 -cl-std=CL1.1 -isystem ${CLANG_OPENCL_INCLUDE_DIR} -finclude-default-header -I${CMAKE_CURRENT_SOURCE_DIR} ${IN}
+    COMMAND ${CMAKE_COMMAND} -E touch ${TOUCH} # will be empty!
+    DEPENDS ${IN}
+    COMMENT "Test-compiling OpenCL program ${KERNAME}"
+  )
+
+  add_custom_target(
+    ${KERNAME_OUT}
+    DEPENDS ${TOUCH} # will be empty!
+    DEPENDS ${IN}
+  )
+
+  add_dependencies(testcompile_opencl_kernels ${KERNAME_OUT})
+endmacro (testcompile_opencl_kernel)
+
+if (TESTBUILD_OPENCL_PROGRAMS)
+  foreach(IN ${DT_OPENCL_KERNELS})
+    testcompile_opencl_kernel(${IN})
+  endforeach()
+endif()
+
 install(FILES ${DT_OPENCL_KERNELS} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable/kernels)
+install(FILES ${DT_OPENCL_EXTRA} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/darktable/kernels)

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2035,7 +2035,7 @@ rawoverexposed_falsecolor (
   float p[4];
   vstore4(pixel, 0, p);
   // falsecolor
-  p[c] = 0.0;
+  p[c] = 0.0f;
   pixel = vload4(0, p);
 
   write_imagef (out, (int2)(x, y), pixel);


### PR DESCRIPTION
As PR to not break build if it does not work the first time.

CC @upegelow 