### PR TITLE
Make dual action of one star rating a config option

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1074,6 +1074,13 @@
     <shortdescription>do high quality resampling during export</shortdescription>
     <longdescription>the image will first be processed in full resolution, and downscaled at the very end. this can result in better quality sometimes, but will always be slower.</longdescription>
   </dtconfig>
+ <dtconfig prefs="gui">
+    <name>rating_one_double_tap</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>rating an image one star twice will not zero out the rating</shortdescription>
+    <longdescription>do not have the rating of one star behave as documented in the manual--an image rated one star twice will result in a zero star rating.</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>darkroom/ui/rawoverexposed/mode</name>
     <type>int</type>

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -28,7 +28,11 @@ void dt_ratings_apply_to_image(int imgid, int rating)
 {
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
   // one star is a toggle, so you can easily reject images by removing the last star:
-  if(((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap") && (rating == 1)) rating = 0;
+  if(((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap") && (rating == 1))
+  {
+    rating = 0;
+  }
+
   image->flags = (image->flags & ~0x7) | (0x7 & rating);
   // synch through:
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -28,7 +28,7 @@ void dt_ratings_apply_to_image(int imgid, int rating)
 {
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
   // one star is a toggle, so you can easily reject images by removing the last star:
-  if(((image->flags & 0x7) == 1) && (rating == 1)) rating = 0;
+  if(((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap") && (rating == 1)) rating = 0;
   image->flags = (image->flags & ~0x7) | (0x7 & rating);
   // synch through:
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -23,6 +23,7 @@
 #include "common/history.h"
 #include "common/image_cache.h"
 #include "common/mipmap_cache.h"
+#include "common/ratings.h"
 #include "common/selection.h"
 #include "control/conf.h"
 #include "control/control.h"
@@ -949,21 +950,7 @@ static gboolean _lib_filmstrip_ratings_key_accel_callback(GtkAccelGroup *accel_g
       int offset = 0;
       if(mouse_over_id == activated_image) offset = dt_collection_image_offset(mouse_over_id);
 
-      dt_image_t *image = dt_image_cache_get(darktable.image_cache, mouse_over_id, 'w');
-      if(num == 666)
-        image->flags &= ~0xf;
-      else if(num == DT_VIEW_STAR_1 && ((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap"))
-      {
-        image->flags &= ~0x7;
-      }
-      else if(num == DT_VIEW_REJECT && ((image->flags & 0x7) == 6))
-        image->flags &= ~0x7;
-      else
-      {
-        image->flags &= ~0x7;
-        image->flags |= num;
-      }
-      dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+      dt_ratings_apply_to_image(mouse_over_id, num);
 
       dt_collection_hint_message(darktable.collection); // More than this, we need to redraw all
 

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -952,7 +952,7 @@ static gboolean _lib_filmstrip_ratings_key_accel_callback(GtkAccelGroup *accel_g
       dt_image_t *image = dt_image_cache_get(darktable.image_cache, mouse_over_id, 'w');
       if(num == 666)
         image->flags &= ~0xf;
-      else if(num == DT_VIEW_STAR_1 && ((image->flags & 0x7) == 1))
+      else if(num == DT_VIEW_STAR_1 && ((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap"))
         image->flags &= ~0x7;
       else if(num == DT_VIEW_REJECT && ((image->flags & 0x7) == 6))
         image->flags &= ~0x7;

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -953,7 +953,9 @@ static gboolean _lib_filmstrip_ratings_key_accel_callback(GtkAccelGroup *accel_g
       if(num == 666)
         image->flags &= ~0xf;
       else if(num == DT_VIEW_STAR_1 && ((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap"))
+      {
         image->flags &= ~0x7;
+      }
       else if(num == DT_VIEW_REJECT && ((image->flags & 0x7) == 6))
         image->flags &= ~0x7;
       else


### PR DESCRIPTION
Bug tracker: https://redmine.darktable.org/issues/9959

Per https://www.darktable.org/usermanual/ch02s02s04.html.php, "Clicking ... the first star for a second time resets the image rating to unranked, or zero stars." 

While documented, the default behavior is problematic as attempting to re-rate an image one star (e.g., by reflex) will, instead, clear the star rating for that image. Similar note from mailing list: https://www.mail-archive.com/darktable-user@lists.darktable.org/msg01249.html.

A config option to enable/disable this behavior would be preferable.

(Separately, it appears that the code for processing ratings for the lighttable and darkroom views is different. Is any background available?)