### PR TITLE
Define _NSIG via NSIG when available.

### DIFF
--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -37,6 +37,10 @@
 #include <string.h>      // for strerror
 #include <unistd.h>      // for STDOUT_FILENO, close, execlp, fork
 
+#if !defined(_NSIG) && defined(NSIG)
+# define _NSIG NSIG
+#endif
+
 #ifdef __linux__
 #include <sys/prctl.h> // for PR_SET_PTRACER, prctl
 #endif


### PR DESCRIPTION
Hi,

BSDs and SysVs systems used the NSIG macro to number signals, this will unbreak build on those.

Thanks,