### PR TITLE
OpenCL: introduce drivers blacklist. Fixes #11358

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -128,6 +128,13 @@
     <longdescription>typically darktable's hand-optimized CPU code is much faster than any OpenCL-on-CPU code; therefore CPUs are excluded from being used as OpenCL devices by default. can be changed by setting this configuration option to TRUE (needs a restart).</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>opencl_disable_drivers_blacklist</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>whether to allow some partial opencl implementations to be used or not</shortdescription>
+    <longdescription>not all opencl implementations are fully-functional, there are at least two, which are not production-quality yet: pocl and beignet; therefore at this point in time, it is better to explicitly blacklist them by default. can be changed by setting this configuration option to TRUE (needs a restart).</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>opencl_checksum</name>
     <type>string</type>
     <default></default>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -26,6 +26,7 @@
 #include "common/gaussian.h"
 #include "common/interpolation.h"
 #include "common/nvidia_gpus.h"
+#include "common/opencl_drivers_blacklist.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/pixelpipe.h"
@@ -227,6 +228,14 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   if(((type & CL_DEVICE_TYPE_CPU) == CL_DEVICE_TYPE_CPU) && !dt_conf_get_bool("opencl_use_cpu_devices"))
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_init] discarding CPU device %d `%s'.\n", k, infostr);
+    res = -1;
+    goto end;
+  }
+
+  if(dt_opencl_check_driver_blacklist(deviceversion) && !dt_conf_get_bool("opencl_disable_drivers_blacklist"))
+  {
+    dt_print(DT_DEBUG_OPENCL, "[opencl_init] discarding device %d `%s' because the driver `%s' is blacklisted.\n",
+             k, infostr, deviceversion);
     res = -1;
     goto end;
   }

--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -1,0 +1,50 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Roman Lebedev.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+// FIXME: in the future, we may want to also take DRIVER_VERSION into account
+static const char *bad_opencl_drivers[] = {
+  // clang-format off
+
+  "beignet",
+  "pocl",
+  NULL
+
+  // clang-format on
+};
+
+// 0 - ok
+// else it is blacklisted
+int dt_opencl_check_driver_blacklist(const char *device_version)
+{
+  for(int i = 0; bad_opencl_drivers[i]; i++)
+  {
+    if(0 != strcasecmp(device_version, bad_opencl_drivers[i])) continue;
+
+    // oops, found in black list
+    return 1;
+  }
+
+  // did not find in the black list, guess it's ok.
+  return 0;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
Tested with pocl.
None of the strings here are translatable, so this does not affect string freeze.

According to the [clGetDeviceInfo docs](https://www.khronos.org/registry/cl/sdk/1.0/docs/man/xhtml/clGetDeviceInfo.html) about `CL_DRIVER_VERSION`,
```
This version string has the following format:
OpenCL<space><major_version.minor_version><space><vendor-specific information>
```
At least for pocl and beignet, the `<vendor-specific information>` is `pocl` and `beignet`, so we can use this field to detect them.