### PR TITLE
force quick downscale MIP_F previews and refactor some demosaic choices into a single function

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1595,7 +1595,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing
       = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0) || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT
-        || uhq_thumb || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f)
+        || uhq_thumb
+        || ((roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f)) && (piece->pipe->type != DT_DEV_PIXELPIPE_PREVIEW))
         || (img->flags & DT_IMAGE_4BAYER); // half_size_f doesn't support 4bayer images
 
   // we check if we can stop at the linear interpolation step in VNG

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1502,6 +1502,15 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   // this op is disabled for preview pipe/filters == 0
 
   *roi_in = *roi_out;
+
+  if (piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+  {
+    // this is a MIP_F, and was given a larger buffer as
+    // 1-channel, but shrink to proper size now that it is
+    // 4-channel
+    roi_in->scale /= 2.0f;
+  }
+
   // need 1:1, demosaic and then sub-sample. or directly sample half-size
   roi_in->x /= roi_out->scale;
   roi_in->y /= roi_out->scale;
@@ -1705,12 +1714,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
       dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width, roi.width);
     else // sample half-size raw (Bayer) or 1/3-size raw (X-Trans)
-        if(piece->pipe->dsc.filters == 9u)
-      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
-                                                        xtrans);
-    else
-      dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
-                                                piece->pipe->dsc.filters);
+      if(piece->pipe->dsc.filters == 9u)
+        dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width, xtrans);
+      else
+        dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width, piece->pipe->dsc.filters);
   }
   if(data->color_smoothing) color_smoothing(o, roi_out, data->color_smoothing);
 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1586,15 +1586,13 @@ static int demosaic_op_flags(const dt_dev_pixelpipe_iop_t *const piece,
       if (qual > 1) flags |= DEMOSAIC_XTRANS_FULL_MARKESTEIJN;
       break;
     case DT_DEV_PIXELPIPE_EXPORT:
-      flags |= DEMOSAIC_FULL_SCALE;
-      flags |= DEMOSAIC_XTRANS_FULL_MARKESTEIJN;
+      flags |= DEMOSAIC_FULL_SCALE | DEMOSAIC_XTRANS_FULL_MARKESTEIJN;
       break;
     case DT_DEV_PIXELPIPE_THUMBNAIL:
       // we check if we need ultra-high quality thumbnail for this size
       if (get_thumb_quality(roi_out->width, roi_out->height))
       {
-        flags |= DEMOSAIC_FULL_SCALE;
-        flags |= DEMOSAIC_XTRANS_FULL_MARKESTEIJN;
+        flags |= DEMOSAIC_FULL_SCALE | DEMOSAIC_XTRANS_FULL_MARKESTEIJN;
       }
       break;
     default: // make C not complain about missing enum members
@@ -3390,8 +3388,6 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   const int op_flags = demosaic_op_flags(piece, &self->dev->image_storage,
                                          roi_out, qual);
   const int full_scale_demosaicing = op_flags & DEMOSAIC_FULL_SCALE;
-  // FIXME: this uses slightly differnet logic them demosaic_op_flags(), kept here to make code match prior behavior
-  const int xtrans_full_markesteijn_demosaicing = (op_flags & DEMOSAIC_XTRANS_FULL_MARKESTEIJN) || roi_out->scale > 0.8f;
 
   // check if output buffer has same dimension as input buffer (thus avoiding one
   // additional temporary buffer)
@@ -3419,7 +3415,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   }
   else if(((demosaicing_method ==  DT_IOP_DEMOSAIC_MARKESTEIJN) ||
            (demosaicing_method ==  DT_IOP_DEMOSAIC_MARKESTEIJN_3)) &&
-           xtrans_full_markesteijn_demosaicing)
+          (op_flags & DEMOSAIC_XTRANS_FULL_MARKESTEIJN))
   {
     // X-Trans pattern full Markesteijn processing
     const int ndir = (demosaicing_method == DT_IOP_DEMOSAIC_MARKESTEIJN_3) ? 8 : 4;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1884,7 +1884,7 @@ static int process_default_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
 
   if((piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0) || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT
-     || (uhq_thumb) || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : .5f))
+     || (uhq_thumb) || ((piece->pipe->type != DT_DEV_PIXELPIPE_PREVIEW) && (roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : .5f))))
   {
     // Full demosaic and then scaling if needed
     const int scaled = (roi_out->width != roi_in->width || roi_out->height != roi_in->height);
@@ -2162,7 +2162,7 @@ static int process_vng_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0)
                                      || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || uhq_thumb
-                                     || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f);
+                                     || ((piece->pipe->type != DT_DEV_PIXELPIPE_PREVIEW) && (roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f)));
 
   // check if we can stop at the linear interpolation step and
   // avoid full VNG
@@ -2588,7 +2588,7 @@ static int process_markesteijn_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0)
                                      || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || uhq_thumb
-                                     || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f);
+                                     || ((piece->pipe->type != DT_DEV_PIXELPIPE_PREVIEW) && (roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f)));
 
   cl_mem dev_tmp = NULL;
   cl_mem dev_tmptmp = NULL;
@@ -3388,7 +3388,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   // half scale or third scale interpolation instead
   const int full_scale_demosaicing = (piece->pipe->type == DT_DEV_PIXELPIPE_FULL && qual > 0)
                                      || piece->pipe->type == DT_DEV_PIXELPIPE_EXPORT || uhq_thumb
-                                     || roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f);
+                                     || ((piece->pipe->type != DT_DEV_PIXELPIPE_PREVIEW) && (roi_out->scale > (piece->pipe->dsc.filters == 9u ? 0.333f : 0.5f)));
 
   // we use full Markesteijn demosaicing on xtrans sensors only if
   // maximum quality is required

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1503,11 +1503,11 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
 
   *roi_in = *roi_out;
 
-  if (piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW)
+  if ((piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW) &&
+      self->dev->image_storage.buf_dsc.filters)
   {
-    // this is a MIP_F, and was given a larger buffer as
-    // 1-channel, but shrink to proper size now that it is
-    // 4-channel
+    // This is a mosaiced MIP_F, and was given a larger buffer as
+    // 1-channel. Shrink to proper size now that it is 4-channel.
     roi_in->scale /= 2.0f;
   }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -1502,15 +1502,6 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   // this op is disabled for preview pipe/filters == 0
 
   *roi_in = *roi_out;
-
-  if ((piece->pipe->type == DT_DEV_PIXELPIPE_PREVIEW) &&
-      self->dev->image_storage.buf_dsc.filters)
-  {
-    // This is a mosaiced MIP_F, and was given a larger buffer as
-    // 1-channel. Shrink to proper size now that it is 4-channel.
-    roi_in->scale /= 2.0f;
-  }
-
   // need 1:1, demosaic and then sub-sample. or directly sample half-size
   roi_in->x /= roi_out->scale;
   roi_in->y /= roi_out->scale;
@@ -1714,10 +1705,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
       dt_iop_clip_and_zoom_demosaic_passthrough_monochrome_f((float *)o, pixels, &roo, &roi, roo.width, roi.width);
     else // sample half-size raw (Bayer) or 1/3-size raw (X-Trans)
-      if(piece->pipe->dsc.filters == 9u)
-        dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width, xtrans);
-      else
-        dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width, piece->pipe->dsc.filters);
+        if(piece->pipe->dsc.filters == 9u)
+      dt_iop_clip_and_zoom_demosaic_third_size_xtrans_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
+                                                        xtrans);
+    else
+      dt_iop_clip_and_zoom_demosaic_half_size_f((float *)o, pixels, &roo, &roi, roo.width, roi.width,
+                                                piece->pipe->dsc.filters);
   }
   if(data->color_smoothing) color_smoothing(o, roi_out, data->color_smoothing);
 }


### PR DESCRIPTION
This addresses [bug #11340](https://redmine.darktable.org/issues/11340). When demosaicing MIP_Fs, this change makes previews always be quickly downscaled rather than going through a full demosaic. It also coalesces the logic behind determining whether how to perform the demosaic (whether to perform a full scale demosaic, only a linear interpolation, and a full Markesteijn demosaic) into a single function `demosaic_op_flags()` rather than repeating the same logic in several places in demosaic.c.

The first change appears to eliminate negative values from demosaic for both [Bayer](http://www.rawsamples.ch/raws/canon/RAW_CANON_EOS_5DS.CR2) and [X-Trans](https://dl.dropboxusercontent.com/u/2171814/_DSF1080.RAF) sample images.

It's not entirely clear why full demosaic algorithms fail for these images. A working theory is that when they are transformed in _init_f() from 1-channel full-size to 1-channel MIP_F-size, the noise in dark areas effectively increases frequency, and this leads a full demosaic to interpolate negative values.

NOTE: I updated PR title and description on 1/5/17 to reflect that it no longer addresses bug #11167 nor forces lower-resolution output from demosaic iop.