### PR TITLE
Update grain.c: grain blending using photographic-paper response. Fixes #11335

### DIFF
--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -364,15 +364,15 @@ static double _simplex_2d_noise(double x, double y, uint32_t octaves, double per
 static float paper_resp(float exposure, float mb, float gp)
 {
   float density;
-  float delta = GRAIN_LUT_DELTA_MAX * dt_fast_expf((mb / 100.0f) * logf(GRAIN_LUT_DELTA_MIN));
-  density = (1.0f + 2.0f * delta) / (1.0f + dt_fast_expf( (4.0f * gp * (0.5f - exposure)) / (1.0f + 2.0f * delta) )) - delta;
+  float delta = GRAIN_LUT_DELTA_MAX * expf((mb / 100.0f) * logf(GRAIN_LUT_DELTA_MIN));
+  density = (1.0f + 2.0f * delta) / (1.0f + expf( (4.0f * gp * (0.5f - exposure)) / (1.0f + 2.0f * delta) )) - delta;
   return density;
 }
 
 static float paper_resp_inverse(float density, float mb, float gp)
 {
   float exposure;
-  float delta = GRAIN_LUT_DELTA_MAX * dt_fast_expf((mb / 100.0f) * logf(GRAIN_LUT_DELTA_MIN));
+  float delta = GRAIN_LUT_DELTA_MAX * expf((mb / 100.0f) * logf(GRAIN_LUT_DELTA_MIN));
   exposure = -logf((1.0f + 2.0f * delta) / (density + delta) - 1.0f) * (1.0f + 2.0f * delta) / (4.0f * gp) + 0.5f;
   return exposure;
 }

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -364,20 +364,20 @@ static double _simplex_2d_noise(double x, double y, uint32_t octaves, double per
 static float paper_resp(float exposure, float mb, float gp)
 {
   float density;
-  float delta = GRAIN_LUT_DELTA_MAX * exp(mb * logf(GRAIN_LUT_DELTA_MIN));
-  density = (1.0f + 2.0f * delta) / (1.0f + exp( (4.0f * gp * (0.5f - exposure)) / (1.0f + 2.0f * delta) )) - delta;
+  float delta = GRAIN_LUT_DELTA_MAX * dt_fast_expf((mb / 100.0f) * logf(GRAIN_LUT_DELTA_MIN));
+  density = (1.0f + 2.0f * delta) / (1.0f + dt_fast_expf( (4.0f * gp * (0.5f - exposure)) / (1.0f + 2.0f * delta) )) - delta;
   return density;
 }
 
 static float paper_resp_inverse(float density, float mb, float gp)
 {
   float exposure;
-  float delta = GRAIN_LUT_DELTA_MAX * exp(mb * logf(GRAIN_LUT_DELTA_MIN));
+  float delta = GRAIN_LUT_DELTA_MAX * dt_fast_expf((mb / 100.0f) * logf(GRAIN_LUT_DELTA_MIN));
   exposure = -logf((1.0f + 2.0f * delta) / (density + delta) - 1.0f) * (1.0f + 2.0f * delta) / (4.0f * gp) + 0.5f;
   return exposure;
 }
 
-static void evaluate_grain_lut(float * grain_lut, const float mb)
+static void evaluate_grain_lut(float *grain_lut, const float mb)
 {
   for(int i = 0; i < GRAIN_LUT_SIZE; i++)
   {
@@ -385,7 +385,7 @@ static void evaluate_grain_lut(float * grain_lut, const float mb)
     {
       float gu = (float)i / (GRAIN_LUT_SIZE - 1) - 0.5;
       float l = (float)j / (GRAIN_LUT_SIZE - 1);
-      grain_lut[j * GRAIN_LUT_SIZE + i]= paper_resp(gu + paper_resp_inverse(l, mb, GRAIN_LUT_PAPER_GAMMA), mb, GRAIN_LUT_PAPER_GAMMA) - l;
+      grain_lut[j * GRAIN_LUT_SIZE + i] = 100.0f * (paper_resp(gu + paper_resp_inverse(l, mb, GRAIN_LUT_PAPER_GAMMA), mb, GRAIN_LUT_PAPER_GAMMA) - l);
     }
   }
 }
@@ -509,7 +509,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         noise = _simplex_2d_noise(x + hash, y, octaves, 1.0, zoom);
       }
 
-      out[0] = in[0] + (100.0 * dt_lut_lookup_2d_1c(data->grain_lut, (noise * strength) * GRAIN_LIGHTNESS_STRENGTH_SCALE, in[0] / 100.0));
+      out[0] = in[0] + dt_lut_lookup_2d_1c(data->grain_lut, (noise * strength) * GRAIN_LIGHTNESS_STRENGTH_SCALE, in[0] / 100.0f);
       out[1] = in[1];
       out[2] = in[2];
       out[3] = in[3];
@@ -556,7 +556,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->channel = p->channel;
   d->scale = p->scale;
   d->strength = p->strength;
-  d->midtones_bias = p->midtones_bias / 100.0f;
+  d->midtones_bias = p->midtones_bias;
   
   evaluate_grain_lut(d->grain_lut, d->midtones_bias);
 }
@@ -630,11 +630,11 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->scale2), "value-changed", G_CALLBACK(strength_callback), self);
 
   /* midtones bias */
-  g->scale3 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1.0, p->midtones_bias * 100, 2);
+  g->scale3 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1.0, p->midtones_bias, 2);
   dt_bauhaus_widget_set_label(g->scale3, NULL, _("midtones bias"));
   dt_bauhaus_slider_set_format(g->scale3, "%.0f%%");
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale3), TRUE, TRUE, 0);
-  gtk_widget_set_tooltip_text(g->scale3, _("amount of midtones bias from the photographic paper response modeling"));
+  gtk_widget_set_tooltip_text(g->scale3, _("amount of midtones bias from the photographic paper response modeling. the greater the bias, the more pronounced the fall off of the grain in shadows and highlights"));
   g_signal_connect(G_OBJECT(g->scale3), "value-changed", G_CALLBACK(midtones_bias_callback), self);
 }
 


### PR DESCRIPTION
A sigmoidal function is used to model a the exposure-density characteristic curve of photographic paper, and the lightness channel is used to modulate the grain accordingly to the characteristic curve. A LUT is used for computational efficiency. The main effect is a fall off of the grain in shadows and highlights accompanied by the skewing of grain distribution (for further info see the discussion on discuss.pixls.us: https://discuss.pixls.us/t/lets-improve-grain/2709/22). A "midtones bias" slider has been added, at 0% the added grain is indistinguishable from the old implementation.