### PR TITLE
imageop_math: blur while downsample (x-trans)

### DIFF
--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -1031,20 +1031,8 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
                                                      const int32_t in_stride, const uint8_t (*const xtrans)[6])
 {
   const float px_footprint = 1.f / roi_out->scale;
-  const int samples = MAX(1, (int)floorf(px_footprint / 3));
-
-  // A slightly different algorithm than
-  // dt_iop_clip_and_zoom_demosaic_half_size_f() which aligns to 2x2
-  // Bayer grid and hence must pull additional data from all edges
-  // which don't align with CFA. Instead align to a 3x3 pattern (which
-  // is semi-regular in X-Trans CFA). If instead had aligned the
-  // samples to the full 6x6 X-Trans CFA, wouldn't need to perform a
-  // CFA lookup, but then would only work at 1/6 scale or less. This
-  // code doesn't worry about fractional pixel offset of top/left of
-  // pattern nor oversampling by non-integer number of samples.
-
-  // X-Trans RGB weighting averages to 2:5:2 for each 3x3 cell
-  static const float div[3] = { 2.0, 5.0, 2.0 };
+  assert((px_footprint / 3.f) >= 1.f);
+  const float px_antialias = px_footprint * 2.f/3.f;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -1052,26 +1040,30 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
   for(int y = 0; y < roi_out->height; y++)
   {
     float *outc = out + out_stride * y;
-    const int py = CLAMPS((int)round((y + roi_out->y - 0.5f) * px_footprint), 0, roi_in->height - 3);
-    const int ymax = MIN(roi_in->height - 3, py + 3 * samples);
 
-    for(int x = 0; x < roi_out->width; x++, outc++)
+    const float fy = (y + roi_out->y) * px_footprint;
+    const int py = MAX(0, (int)roundf(fy - px_antialias));
+    const int maxy = MIN(roi_in->height, (int)roundf(fy + px_footprint + px_antialias));
+
+    float fx = roi_out->x * px_footprint;
+    for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
-      float col[3] = { 0.0f };
-      int num = 0;
-      const int px = CLAMPS((int)round((x + roi_out->x - 0.5f) * px_footprint), 0, roi_in->width - 3);
-      const int xmax = MIN(roi_in->width - 3, px + 3 * samples);
-      for(int yy = py; yy <= ymax; yy += 3)
-        for(int xx = px; xx <= xmax; xx += 3)
-        {
-          for(int j = 0; j < 3; ++j)
-            for(int i = 0; i < 3; ++i)
-              col[FCxtrans(yy + j, xx + i, roi_in, xtrans)] += in[xx + i + in_stride * (yy + j)];
-          num++;
-        }
+      const int px = MAX(0, (int)roundf(fx - px_antialias));
+      const int maxx = MIN(roi_in->width, (int)roundf(fx + px_footprint + px_antialias));
 
       const int c = FCxtrans(y, x, roi_out, xtrans);
-      *outc = col[c] / ((float)num * div[c]);
+      int num = 0;
+      float col = 0;
+
+      for(int yy = py; yy < maxy; ++yy)
+        for(int xx = px; xx < maxx; ++xx)
+          if(FCxtrans(yy, xx, roi_in, xtrans) == c)
+          {
+            col += in[xx + in_stride * yy];
+            num++;
+          }
+      assert(num > 0);
+      *outc = col / (float)num;
     }
   }
 }

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -1045,8 +1045,8 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
       int num = 0;
       float col = 0;
 
-      for(int yy = miny; yy < maxy; ++yy)
-        for(int xx = minx; xx < maxx; ++xx)
+      for(int yy = miny; yy <= maxy; ++yy)
+        for(int xx = minx; xx <= maxx; ++xx)
           if(FCxtrans(yy, xx, roi_in, xtrans) == c)
           {
             col += in[xx + in_stride * yy];

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -983,7 +983,7 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
   // centered on current sample with edges rounded to nearest input
   // pixel. This seems to be the smallest filter which produces smooth
   // output in most cases.
-  const int kern_width = 3.5f;
+  const float kern_width = 3.5f;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -993,14 +993,14 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
     uint16_t *outc = out + out_stride * y;
 
     const float fy = (y + roi_out->y) * px_footprint;
-    const int miny = MAX(0, (int)(roundf(fy) - kern_width));
-    const int maxy = MIN(roi_in->height-1, (int)(roundf(fy) + kern_width));
+    const int miny = MAX(0, (int)roundf(fy - kern_width));
+    const int maxy = MIN(roi_in->height-1, (int)roundf(fy + kern_width));
 
     float fx = roi_out->x * px_footprint;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
-      const int minx = MAX(0, (int)(roundf(fx) - kern_width));
-      const int maxx = MIN(roi_in->width-1, (int)(roundf(fx) + kern_width));
+      const int minx = MAX(0, (int)roundf(fx - kern_width));
+      const int maxx = MIN(roi_in->width-1, (int)roundf(fx + kern_width));
 
       const int c = FCxtrans(y, x, roi_out, xtrans);
       int num = 0;
@@ -1024,7 +1024,7 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
                                                      const int32_t in_stride, const uint8_t (*const xtrans)[6])
 {
   const float px_footprint = 1.f / roi_out->scale;
-  const int kern_width = 3.5f;
+  const float kern_width = 3.5f;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -1034,14 +1034,14 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
     float *outc = out + out_stride * y;
 
     const float fy = (y + roi_out->y) * px_footprint;
-    const int miny = MAX(0, (int)(roundf(fy) - kern_width));
-    const int maxy = MIN(roi_in->height-1, (int)(roundf(fy) + kern_width));
+    const int miny = MAX(0, (int)roundf(fy - kern_width));
+    const int maxy = MIN(roi_in->height-1, (int)roundf(fy + kern_width));
 
     float fx = roi_out->x * px_footprint;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
-      const int minx = MAX(0, (int)(roundf(fx) - kern_width));
-      const int maxx = MIN(roi_in->width-1, (int)(roundf(fx) + kern_width));
+      const int minx = MAX(0, (int)roundf(fx - kern_width));
+      const int maxx = MIN(roi_in->width-1, (int)roundf(fx + kern_width));
 
       const int c = FCxtrans(y, x, roi_out, xtrans);
       int num = 0;

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -979,8 +979,11 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
                                                    const int32_t in_stride, const uint8_t (*const xtrans)[6])
 {
   const float px_footprint = 1.f / roi_out->scale;
-  // 9x9 box filter to anti-alias
-  const int kern_width = 4;
+  // Use box filter to anti-alias, each side (kern_width*2)+1,
+  // centered on current sample with edges rounded to nearest input
+  // pixel. This seems to be the smallest filter which produces smooth
+  // output in most cases.
+  const int kern_width = 3.5f;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -990,20 +993,19 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
     uint16_t *outc = out + out_stride * y;
 
     const float fy = (y + roi_out->y) * px_footprint;
-    const int miny = MAX(0, (int)roundf(fy) - kern_width);
-    const int maxy = MIN(roi_in->height-1, (int)roundf(fy) + kern_width);
+    const int miny = MAX(0, (int)(roundf(fy) - kern_width));
+    const int maxy = MIN(roi_in->height-1, (int)(roundf(fy) + kern_width));
 
     float fx = roi_out->x * px_footprint;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
-      const int minx = MAX(0, (int)roundf(fx) - kern_width);
-      const int maxx = MIN(roi_in->width-1, (int)roundf(fx) + kern_width);
+      const int minx = MAX(0, (int)(roundf(fx) - kern_width));
+      const int maxx = MIN(roi_in->width-1, (int)(roundf(fx) + kern_width));
 
       const int c = FCxtrans(y, x, roi_out, xtrans);
       int num = 0;
       uint32_t col = 0;
 
-      // FIXME: could speed up with ring buffer or lookup of offsets/weight per CFA position
       for(int yy = miny; yy <= maxy; ++yy)
         for(int xx = minx; xx <= maxx; ++xx)
           if(FCxtrans(yy, xx, roi_in, xtrans) == c)
@@ -1022,7 +1024,7 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
                                                      const int32_t in_stride, const uint8_t (*const xtrans)[6])
 {
   const float px_footprint = 1.f / roi_out->scale;
-  const int kern_width = 4;
+  const int kern_width = 3.5f;
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -1032,18 +1034,18 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans_f(float *const out, const flo
     float *outc = out + out_stride * y;
 
     const float fy = (y + roi_out->y) * px_footprint;
-    const int miny = MAX(0, (int)roundf(fy) - kern_width);
-    const int maxy = MIN(roi_in->height-1, (int)roundf(fy) + kern_width);
+    const int miny = MAX(0, (int)(roundf(fy) - kern_width));
+    const int maxy = MIN(roi_in->height-1, (int)(roundf(fy) + kern_width));
 
     float fx = roi_out->x * px_footprint;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
-      const int minx = MAX(0, (int)roundf(fx) - kern_width);
-      const int maxx = MIN(roi_in->width-1, (int)roundf(fx) + kern_width);
+      const int minx = MAX(0, (int)(roundf(fx) - kern_width));
+      const int maxx = MIN(roi_in->width-1, (int)(roundf(fx) + kern_width));
 
       const int c = FCxtrans(y, x, roi_out, xtrans);
       int num = 0;
-      float col = 0;
+      float col = 0.f;
 
       for(int yy = miny; yy <= maxy; ++yy)
         for(int xx = minx; xx <= maxx; ++xx)

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -996,14 +996,14 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
     uint16_t *outc = out + out_stride * y;
 
     const float fy = (y + roi_out->y) * px_footprint;
-    const int py = MAX(0, (int) roundf(fy - px_antialias));
-    const int maxy = MIN(roi_in->height, (int) roundf(fy + px_footprint + px_antialias));
+    const int py = MAX(0, (int)roundf(fy - px_antialias));
+    const int maxy = MIN(roi_in->height, (int)roundf(fy + px_footprint + px_antialias));
 
     float fx = roi_out->x * px_footprint;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
-      const int px = MAX(0, (int) roundf(fx - px_antialias));
-      const int maxx = MIN(roi_in->width, (int) roundf(fx + px_footprint + px_antialias));
+      const int px = MAX(0, (int)roundf(fx - px_antialias));
+      const int maxx = MIN(roi_in->width, (int)roundf(fx + px_footprint + px_antialias));
 
       const int c = FCxtrans(y, x, roi_out, xtrans);
       int num = 0;
@@ -1011,16 +1011,13 @@ void dt_iop_clip_and_zoom_mosaic_third_size_xtrans(uint16_t *const out, const ui
 
       for(int yy = py; yy < maxy; ++yy)
         for(int xx = px; xx < maxx; ++xx)
-        {
-          if(FCxtrans(yy, xx, roi_in, xtrans) != c) continue;
-
-          col += in[xx + in_stride * yy];
-          num++;
-        }
-
+          if(FCxtrans(yy, xx, roi_in, xtrans) == c)
+          {
+            col += in[xx + in_stride * yy];
+            num++;
+          }
       assert(num > 0);
-
-      *outc = (uint16_t)((float)col / (float)num);
+      *outc = col / num;
     }
   }
 }


### PR DESCRIPTION
For the x-trans int path, do a simple blur while downsampling mosaiced images. This gets rid of color fringes (confetti). See redmine bug 11167.

Notes:

- I still see a bit of color fringing in very fine detail, e.g. closely spaced vertical lines.
- The leftmost column of the image is black (but prior to this, the rightmost column was gray).
- As [noted in 11167](https://redmine.darktable.org/issues/11167#note-19), the blurring factor is chosen by experimentation. As @LebedevRI suggests, perhaps @hanatos could have insight as to this?
- PR #1382 still has problems, but if the image is downscaled by 50% at the demosaic step, this would make the blurriness of the preview less apparent?
- I'd be curious if there is a smarter but still fast way to anti-alias, if aliasing is indeed the root of the confetti artifacts.
- It may be possible to optimize the blurring code with a lookup of which pixels to look at, based on knowledge of the CFA (rather than arbitrarily expanding width/height of the sample), though this would add complexity.

I will work on something similar for the X-Trans float codepath, and could work similarly on the Bayer paths if this is useful. Part of this work would include simplifying downsampling, as in cf20f38765fa31d7546ffe6786699dced802751f and b9e780969e3b32495e714a01c1bfd5fa2c784e62. As the X-Trans code path is so much simpler, an SSE2 variant would not be too difficult as well.