### PR TITLE
Better undo

### DIFF
--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -230,6 +230,7 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   {
     dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
+    if (!sel) return;
     if(sel->type & DT_MASKS_CIRCLE)
       dt_circle_events_post_expose(cr, zoom_scale, gui, pos);
     else if(sel->type & DT_MASKS_PATH)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -23,6 +23,7 @@
 #include "control/control.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
+#include "views/undo.h"
 
 #pragma GCC diagnostic ignored "-Wshadow"
 
@@ -34,6 +35,155 @@
 #include "develop/masks/ellipse.c"
 #include "develop/masks/group.c"
 // clang-format on
+
+typedef struct _masks_undo_data_t
+{
+  GList *forms;
+  dt_masks_form_t *form;
+} _masks_undo_data_t;
+
+static void _masks_write_form_db(dt_masks_form_t *form, dt_develop_t *dev);
+// write a form into the database
+
+static void _masks_write_forms_db(dt_develop_t *dev, gboolean undo);
+// write all masks form into the database. record an undo is undo is true
+
+static void _masks_free_form_list(GList *forms)
+{
+  GList *f = g_list_first(forms);
+  while(f)
+  {
+    dt_masks_free_form((dt_masks_form_t *)f->data);
+    f = g_list_next(f);
+  }
+  g_list_free(forms);
+}
+
+static dt_masks_form_t *_dup_masks_form(const dt_masks_form_t *form)
+{
+  dt_masks_form_t *new_form = malloc(sizeof(struct dt_masks_form_t));
+  memcpy(new_form, form, sizeof(struct dt_masks_form_t));
+
+  // then duplicate the GList *points
+
+  new_form->points = NULL;
+
+  if (form->points)
+  {
+    int size_item;
+
+    switch (form->type)
+    {
+    case DT_MASKS_CIRCLE:
+      size_item = sizeof(struct dt_masks_point_circle_t);
+      break;
+    case DT_MASKS_ELLIPSE:
+      size_item = sizeof(struct dt_masks_point_ellipse_t);
+      break;
+    case DT_MASKS_GRADIENT:
+      size_item = sizeof(struct dt_masks_point_gradient_t);
+      break;
+    case DT_MASKS_BRUSH:
+      size_item = sizeof(struct dt_masks_point_brush_t);
+      break;
+    case DT_MASKS_GROUP:
+      size_item = sizeof(struct dt_masks_point_group_t);
+      break;
+    case DT_MASKS_PATH:
+      size_item = sizeof(struct dt_masks_point_path_t);
+      break;
+    default:
+      size_item = 0;
+    }
+
+    if (size_item != 0)
+    {
+      GList *pt = g_list_first(form->points);
+      while (pt)
+      {
+        void *item = malloc(size_item);
+        memcpy(item, pt->data, size_item);
+        new_form->points = g_list_append(new_form->points, item);
+        pt = g_list_next(pt);
+      }
+    }
+  }
+
+  return new_form;
+}
+
+static void *_dup_masks_form_cb(const void *formdata, gpointer user_data)
+{
+  // duplicate the main form struct
+  dt_masks_form_t *form = (dt_masks_form_t *)formdata;
+  dt_masks_form_t *uform = (dt_masks_form_t *)user_data;
+  const dt_masks_form_t *f = uform == NULL || form->formid != uform->formid ? form : uform;
+  return (void *)_dup_masks_form(f);
+}
+
+// duplicate the list of forms, replace item in the list with form is the same formid
+static GList *_dup_masks_forms_deep(GList *forms, dt_masks_form_t *form)
+{
+  return (GList *)g_list_copy_deep(forms, _dup_masks_form_cb, (gpointer)form);
+}
+
+static _masks_undo_data_t *_create_snapshot(GList *forms, dt_masks_form_t *form, dt_develop_t *dev)
+{
+  _masks_undo_data_t *data = malloc(sizeof(struct _masks_undo_data_t));
+  data->forms = _dup_masks_forms_deep(forms, form);
+  data->form  = dev->form_visible ? _dup_masks_form(dev->form_visible) : NULL;
+  return data;
+}
+
+static unsigned long long _get_timestamp(void)
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  return (unsigned long long)(tv.tv_sec) * 1000 + (unsigned long long)(tv.tv_usec) / 1000;
+}
+
+static dt_undo_tag_t _get_tag(dt_masks_form_t *form)
+{
+  const unsigned long long ts = _get_timestamp() / 500;
+  return (dt_undo_tag_t)form->formid + ((dt_undo_tag_t)ts << 8);
+}
+
+void _masks_free_undo(gpointer data)
+{
+  _masks_undo_data_t *udata = (_masks_undo_data_t *)data;
+
+  _masks_free_form_list(udata->forms);
+  udata->forms = NULL;
+  dt_masks_free_form((dt_masks_form_t *)udata->form);
+  free(udata);
+}
+
+void _masks_do_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item)
+{
+  dt_develop_t *dev = (dt_develop_t *)user_data;
+  _masks_undo_data_t *udata = (_masks_undo_data_t *)item;
+
+  dev->forms = _dup_masks_forms_deep(udata->forms, NULL);
+  dev->form_gui->creation = FALSE;
+
+  dt_masks_clear_form_gui(dev);
+  dt_masks_change_form_gui(_dup_masks_form(udata->form));
+
+  _masks_write_forms_db(dev, FALSE);
+
+  // and we ensure that we are in edit mode
+  dt_masks_iop_update(darktable.develop->gui_module);
+  dt_dev_masks_list_change(dev);
+  dt_masks_set_edit_mode(darktable.develop->gui_module, DT_MASKS_EDIT_FULL);
+  dt_masks_update_image(dev);
+  dt_control_queue_redraw_center();
+}
+
+static void _do_record_undo(dt_develop_t *dev, dt_masks_form_t *form)
+{
+  dt_undo_record(darktable.undo, dev, DT_UNDO_MASK, (dt_undo_data_t *)_create_snapshot(dev->forms, form, dev),
+                 form ? _get_tag(form) : 0, _masks_do_undo, _masks_free_undo);
+}
 
 static void _set_hinter_message(dt_masks_form_gui_t *gui, dt_masks_type_t formtype)
 {
@@ -162,6 +312,7 @@ void dt_masks_gui_form_test_create(dt_masks_form_t *form, dt_masks_form_gui_t *g
       {
         dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
         dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
+        if (!sel) return;
         dt_masks_gui_form_create(sel, gui, pos);
         fpts = g_list_next(fpts);
         pos++;
@@ -243,6 +394,7 @@ void dt_masks_gui_form_save_creation(dt_iop_module_t *module, dt_masks_form_t *f
     dt_masks_write_form(grp, darktable.develop);
     // we update module gui
     if(gui) dt_masks_iop_update(module);
+    dt_dev_add_history_item(darktable.develop, module, TRUE);
   }
   // show the form if needed
   if(gui) darktable.develop->form_gui->formid = form->formid;
@@ -955,7 +1107,34 @@ void dt_masks_read_forms(dt_develop_t *dev)
   dt_dev_masks_list_change(dev);
 }
 
-static void _write_form_db(dt_masks_form_t *form, dt_develop_t *dev)
+static void _masks_write_forms_db(dt_develop_t *dev, gboolean undo)
+{
+  // we first erase all masks for the image present in the db
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.mask WHERE imgid = ?1", -1, &stmt,
+                              NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->image_storage.id);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  // and now we write each forms
+  GList *forms = g_list_first(dev->forms);
+  if (undo)
+  {
+    _do_record_undo(dev, NULL);
+  }
+
+  while(forms)
+  {
+    dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
+
+    if (form)
+      _masks_write_form_db(form, dev);
+
+    forms = g_list_next(forms);
+  }
+}
+static void _masks_write_form_db(dt_masks_form_t *form, dt_develop_t *dev)
 {
   sqlite3_stmt *stmt;
 
@@ -1052,6 +1231,8 @@ static void _write_form_db(dt_masks_form_t *form, dt_develop_t *dev)
 
 void dt_masks_write_form(dt_masks_form_t *form, dt_develop_t *dev)
 {
+  _do_record_undo(dev, form);
+
   // we first erase all masks for the image present in the db
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -1061,29 +1242,12 @@ void dt_masks_write_form(dt_masks_form_t *form, dt_develop_t *dev)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  _write_form_db (form, dev);
+  _masks_write_form_db(form, dev);
 }
 
 void dt_masks_write_forms(dt_develop_t *dev)
 {
-  // we first erase all masks for the image present in the db
-  sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.mask WHERE imgid = ?1", -1, &stmt,
-                              NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->image_storage.id);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-
-  // and now we write each forms
-  GList *forms = g_list_first(dev->forms);
-  while(forms)
-  {
-    dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
-
-    _write_form_db (form, dev);
-
-    forms = g_list_next(forms);
-  }
+  _masks_write_forms_db(dev, TRUE);
 }
 
 void dt_masks_free_form(dt_masks_form_t *form)
@@ -1264,6 +1428,7 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
     dt_ellipse_events_post_expose(cr, zoom_scale, gui, 0);
   else if(form->type & DT_MASKS_BRUSH)
     dt_brush_events_post_expose(cr, zoom_scale, gui, 0, g_list_length(form->points));
+
   cairo_restore(cr);
 }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -103,6 +103,7 @@ void gui_init(dt_lib_module_t *self)
 
   d->record_undo = TRUE;
   d->prev.snapshot = NULL;
+  d->prev.end = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
   gtk_widget_set_name(self->widget, "history-ui");

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -723,7 +723,7 @@ static void film_strip_activated(const int imgid, void *data)
   const dt_view_t *self = (dt_view_t *)data;
   dt_develop_t *dev = (dt_develop_t *)self->data;
   // clean the undo list
-  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_clear(darktable.undo, DT_UNDO_DEVELOP);
   dt_dev_change_image(dev, imgid);
   dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, FALSE);
   // record the imgid to display when going back to lighttable
@@ -1802,7 +1802,7 @@ void gui_init(dt_view_t *self)
 void enter(dt_view_t *self)
 {
   // clean the undo list
-  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_clear(darktable.undo, DT_UNDO_DEVELOP);
 
   /* connect to ui pipe finished signal for redraw */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
@@ -2426,14 +2426,14 @@ void init_key_accels(dt_view_t *self)
 static gboolean _darkroom_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                         GdkModifierType modifier, gpointer data)
 {
-  dt_undo_do_undo(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_do_undo(darktable.undo, DT_UNDO_DEVELOP);
   return TRUE;
 }
 
 static gboolean _darkroom_redo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                         GdkModifierType modifier, gpointer data)
 {
-  dt_undo_do_redo(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_do_redo(darktable.undo, DT_UNDO_DEVELOP);
   return TRUE;
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -722,14 +722,14 @@ static void film_strip_activated(const int imgid, void *data)
   // switch images in darkroom mode:
   const dt_view_t *self = (dt_view_t *)data;
   dt_develop_t *dev = (dt_develop_t *)self->data;
+  // clean the undo list
+  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
   dt_dev_change_image(dev, imgid);
   dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, FALSE);
   // record the imgid to display when going back to lighttable
   dt_view_lighttable_set_position(darktable.view_manager, dt_collection_image_offset(imgid));
   // force redraw
   dt_control_queue_redraw();
-  // clean the undo list
-  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
 }
 
 static void _view_darkroom_filmstrip_activate_callback(gpointer instance, gpointer user_data)
@@ -1801,6 +1801,8 @@ void gui_init(dt_view_t *self)
 
 void enter(dt_view_t *self)
 {
+  // clean the undo list
+  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
 
   /* connect to ui pipe finished signal for redraw */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
@@ -1909,9 +1911,6 @@ void enter(dt_view_t *self)
   dt_view_filmstrip_prefetch();
 
   dt_collection_hint_message(darktable.collection);
-
-  // clean the undo list
-  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
 }
 
 void leave(dt_view_t *self)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1177,8 +1177,16 @@ static void drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, g
       sqlite3_stmt *stmt;
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT DISTINCT imgid FROM main.selected_images",
                                   -1, &stmt, NULL);
+
+      // create an undo group for the set of change
+
+      dt_undo_start_group(darktable.undo, DT_UNDO_GEOTAG);
+
       while(sqlite3_step(stmt) == SQLITE_ROW)
         _view_map_add_image_to_map(self, sqlite3_column_int(stmt, 0), x, y);
+
+      dt_undo_end_group(darktable.undo);
+
       sqlite3_finalize(stmt);
       success = TRUE;
     }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1084,7 +1084,7 @@ static void _view_map_filmstrip_activate_callback(gpointer instance, gpointer us
   }
 }
 
-static void pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data)
 {
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
@@ -1115,7 +1115,7 @@ static void _push_position(dt_view_t *self, int imgid, float longitude, float la
   geotag->latitude = latitude;
   geotag->elevation = elevation;
 
-  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, &pop_undo, free);
+  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, 0, _pop_undo, free);
 }
 
 static void _get_image_location(dt_view_t *self, int imgid, float *longitude, float *latitude, float *elevation)

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -27,7 +27,9 @@ typedef enum dt_undo_type_t
 {
   DT_UNDO_GEOTAG = 1 << 0,
   DT_UNDO_HISTORY = 1 << 1,
-  DT_UNDO_ALL = DT_UNDO_GEOTAG | DT_UNDO_HISTORY
+  DT_UNDO_MASK = 1 << 2,
+  DT_UNDO_DEVELOP = DT_UNDO_HISTORY | DT_UNDO_MASK,
+  DT_UNDO_ALL = DT_UNDO_GEOTAG | DT_UNDO_HISTORY | DT_UNDO_MASK
 } dt_undo_type_t;
 
 typedef void *dt_undo_data_t;

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -32,6 +32,8 @@ typedef enum dt_undo_type_t
 
 typedef void *dt_undo_data_t;
 
+typedef unsigned long long dt_undo_tag_t;
+
 typedef struct dt_undo_t
 {
   GList *undo_list, *redo_list;
@@ -46,8 +48,8 @@ void dt_undo_cleanup(dt_undo_t *self);
 void dt_undo_start_group(dt_undo_t *self, dt_undo_type_t type);
 void dt_undo_end_group(dt_undo_t *self);
 
-// record a change that will be insered into the undo list
-void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
+// record a change that will be insered into the undo list. if tag is identical to the top item nothing is recorded
+void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_tag_t tag,
                     void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item),
                     void (*free_data)(gpointer data));
 

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -35,11 +35,16 @@ typedef void *dt_undo_data_t;
 typedef struct dt_undo_t
 {
   GList *undo_list, *redo_list;
+  dt_undo_type_t group;
   dt_pthread_mutex_t mutex;
 } dt_undo_t;
 
 dt_undo_t *dt_undo_init(void);
 void dt_undo_cleanup(dt_undo_t *self);
+
+// create a group of item to be handled together, a group
+void dt_undo_start_group(dt_undo_t *self, dt_undo_type_t type);
+void dt_undo_end_group(dt_undo_t *self);
 
 // record a change that will be insered into the undo list
 void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,


### PR DESCRIPTION
There is 3 new supports/fixes on the undo/redo circuitry:
1. support for group undo (used in map only at this stage)
2. support for avoiding some record (better than the smooth-undo-redo branch) used in history
3. support for undo/redo on forms/masks.