### PR TITLE
Fix mouse action transfer in lighttable view (when use_arrows is active) (bug #11317)

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -739,8 +739,10 @@ end_query_cache:
           // this single image.
           dt_selection_select_single(darktable.selection, id);
         }
-        missing += dt_view_image_expose(&(lib->image_over), id, cr, wd, iir == 1 ? height : ht, iir, img_pointerx,
-                             img_pointery, FALSE, FALSE);
+        missing += dt_view_image_expose(
+            &(lib->image_over), id, cr, wd, iir == 1 ? height : ht, iir,
+            pi == col && pj == row ? img_pointerx : -1,
+            pi == col && pj == row ? img_pointery : -1, FALSE, FALSE);
 
         cairo_restore(cr);
       }


### PR DESCRIPTION
Redmine: https://redmine.darktable.org/issues/11317

Change to only forward relative mouse pointer positions if they are within the current frame. 

The existing behavior does not appear to be needed as when multiple images are selected, current behavior is to have batch rating occur using the bottom bar or keyboard only and not via a single image.