### PR TITLE
usermanual: note on liquify's feathering modes

### DIFF
--- a/doc/usermanual/darkroom/modules/correction/liquify.xml
+++ b/doc/usermanual/darkroom/modules/correction/liquify.xml
@@ -175,7 +175,9 @@
                 </entry>
                 <entry>
                   Two control circles are displayed and can be modified independently to feather
-                  the strength of the effect.
+                  the strength of the effect. Note that clicking again
+                  the center of the circle only hides the feathering
+                  controls but does not return to the default.
                 </entry>
                 <entry>
                   <graphic fileref="darkroom/modules/images/liquify_ex2.png" scalefit="1" width="80%" align="center" />


### PR DESCRIPTION
This is a complement to a667bca (liquify: fix hint message for the
feathring controls., 2017-01-03), to make it clear that linear/feathered
are not really two "modes", but just two views on the same thing.