### PR TITLE
Typo fix in crossprocessing.xml

### DIFF
--- a/doc/usermanual/darkroom/examples/crossprocessing.xml
+++ b/doc/usermanual/darkroom/examples/crossprocessing.xml
@@ -18,7 +18,7 @@
         <tbody>
           <row>
             <entry>
-              Cross-processing is a analog processing technique where slide film (normally
+              Cross-processing is an analog processing technique where slide film (normally
               developed thanks to an E6 solution) is processed in chemicals used for processing
               print film (C41). The resulting images get skewed colors usually a cyan hue and
               increased contrast and saturation.


### PR DESCRIPTION
"Cross-processing is a analog processing technique" should be "Cross-processing is an analog processing technique"