### PR TITLE
Fix #11393: Numerical input for sliders not working

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -592,7 +592,7 @@ void dt_bauhaus_init()
   gtk_widget_set_size_request(darktable.bauhaus->popup_area, DT_PIXEL_APPLY_DPI(300), DT_PIXEL_APPLY_DPI(300));
   gtk_window_set_resizable(GTK_WINDOW(darktable.bauhaus->popup_window), FALSE);
   gtk_window_set_default_size(GTK_WINDOW(darktable.bauhaus->popup_window), 260, 260);
-  // gtk_window_set_modal(GTK_WINDOW(c->popup_window), TRUE);
+  gtk_window_set_modal(GTK_WINDOW(darktable.bauhaus->popup_window), TRUE);
   // gtk_window_set_decorated(GTK_WINDOW(c->popup_window), FALSE);
 
   // for pie menue:


### PR DESCRIPTION
This is supposed to fix https://redmine.darktable.org/issues/11393. Without making the slider popup modal, keyboard events are still send to the main window and trigger various actions (e.g. numerical input changes star rating).

This is only tested on macOS+homebrew. If changing the modality harms other platforms, it should be guarded via `#if defined(__APPLE__) || defined(__MACOSX)`.