### PR TITLE
slider popup: grab only keyboard events, fixes #11393

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -458,7 +458,7 @@ static void window_show(GtkWidget *w, gpointer user_data)
   gdk_seat_grab (
       gdk_display_get_default_seat(gtk_widget_get_display(w)),
       gtk_widget_get_window(w),
-      GDK_SEAT_CAPABILITY_ALL, TRUE, 0,0,0,0);
+      GDK_SEAT_CAPABILITY_KEYBOARD, FALSE, 0,0,0,0);
 #else
   GdkDisplay *display = gtk_widget_get_display(w);
   GdkDeviceManager *mgr = gdk_display_get_device_manager(display);


### PR DESCRIPTION
Previous attempt: #1409
After the introduction of a separate code path for GTK 3.20+, numerical input for sliders was broken on some platforms that used this code path. The old code path just grabbed for keyboard events, while the GTK 3.20+ code path grabbed all kinds of events. This commit adjusts the GTK 3.20+ code accordingly. Only keyboard events are grabbed and owner_events is set to FALSE. This fixes problems with numerical input to the slider popup on macOS and possibly other platforms where GTK 3.20+ is used.