### PR TITLE
undo: add support for masks.

### DIFF
--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -230,6 +230,7 @@ static void dt_group_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   {
     dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)fpts->data;
     dt_masks_form_t *sel = dt_masks_get_from_id(darktable.develop, fpt->formid);
+    if (!sel) return;
     if(sel->type & DT_MASKS_CIRCLE)
       dt_circle_events_post_expose(cr, zoom_scale, gui, pos);
     else if(sel->type & DT_MASKS_PATH)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -50,6 +50,8 @@ static void _masks_write_forms_db(dt_develop_t *dev, gboolean undo);
 
 static dt_masks_form_t *_dup_masks_form(const dt_masks_form_t *form)
 {
+  if (!form) return NULL;
+
   dt_masks_form_t *new_form = malloc(sizeof(struct dt_masks_form_t));
   memcpy(new_form, form, sizeof(struct dt_masks_form_t));
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -737,7 +737,7 @@ static void film_strip_activated(const int imgid, void *data)
   const dt_view_t *self = (dt_view_t *)data;
   dt_develop_t *dev = (dt_develop_t *)self->data;
   // clean the undo list
-  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_clear(darktable.undo, DT_UNDO_DEVELOP);
   dt_dev_change_image(dev, imgid);
   dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, FALSE);
   // record the imgid to display when going back to lighttable
@@ -1663,7 +1663,7 @@ void gui_init(dt_view_t *self)
 void enter(dt_view_t *self)
 {
   // clean the undo list
-  dt_undo_clear(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_clear(darktable.undo, DT_UNDO_DEVELOP);
 
   /* connect to ui pipe finished signal for redraw */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
@@ -2287,14 +2287,14 @@ void init_key_accels(dt_view_t *self)
 static gboolean _darkroom_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                         GdkModifierType modifier, gpointer data)
 {
-  dt_undo_do_undo(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_do_undo(darktable.undo, DT_UNDO_DEVELOP);
   return TRUE;
 }
 
 static gboolean _darkroom_redo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                         GdkModifierType modifier, gpointer data)
 {
-  dt_undo_do_redo(darktable.undo, DT_UNDO_HISTORY);
+  dt_undo_do_redo(darktable.undo, DT_UNDO_DEVELOP);
   return TRUE;
 }
 

--- a/src/views/undo.h
+++ b/src/views/undo.h
@@ -27,7 +27,9 @@ typedef enum dt_undo_type_t
 {
   DT_UNDO_GEOTAG = 1 << 0,
   DT_UNDO_HISTORY = 1 << 1,
-  DT_UNDO_ALL = DT_UNDO_GEOTAG | DT_UNDO_HISTORY
+  DT_UNDO_MASK = 1 << 2,
+  DT_UNDO_DEVELOP = DT_UNDO_HISTORY | DT_UNDO_MASK,
+  DT_UNDO_ALL = DT_UNDO_GEOTAG | DT_UNDO_HISTORY | DT_UNDO_MASK
 } dt_undo_type_t;
 
 typedef void *dt_undo_data_t;


### PR DESCRIPTION
Masks are now supported by the undo/redo circuitry as done for the
development data.