### PR TITLE
background colors from CSS instead of hardcoded

### DIFF
--- a/data/darktable-3.18.css.in
+++ b/data/darktable-3.18.css.in
@@ -8,6 +8,10 @@
 @define-color tooltip_bg_color #000000;
 @define-color tooltip_fg_color #ffffff;
 @define-color really_dark_bg_color #111;
+@define-color darkroom_bg_color #333333;
+@define-color darkroom_preview_bg_color shade(@darkroom_bg_color, .5);
+@define-color lighttable_bg_color @darkroom_bg_color;
+@define-color lighttable_preview_bg_color shade(@lighttable_bg_color, .5);
 
 @define-color dark_bg_color #350000;
 

--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -8,6 +8,10 @@
 @define-color tooltip_bg_color #000000;
 @define-color tooltip_fg_color #ffffff;
 @define-color really_dark_bg_color #111;
+@define-color darkroom_bg_color #333333;
+@define-color darkroom_preview_bg_color shade(@darkroom_bg_color, .5);
+@define-color lighttable_bg_color @darkroom_bg_color;
+@define-color lighttable_preview_bg_color shade(@lighttable_bg_color, .5);
 
 @define-color dark_bg_color #350000;
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -974,11 +974,12 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                           g_cclosure_new(G_CALLBACK(view_switch_key_accel_callback), NULL, NULL));
 
   darktable.gui->reset = 0;
-  for(int i = 0; i < 3; i++) darktable.gui->bgcolor[i] = 0.1333;
 
   GdkRGBA *c = darktable.gui->colors;
   GtkWidget *main_window = dt_ui_main_window(darktable.gui->ui);
   GtkStyleContext *ctx = gtk_widget_get_style_context(main_window);
+
+  c[DT_GUI_COLOR_BG] = (GdkRGBA){ 0.1333, 0.1333, 0.1333, 1.0 };
 
   c[DT_GUI_COLOR_DARKROOM_BG] = (GdkRGBA){ .2, .2, .2, 1.0 };
   gtk_style_context_lookup_color(ctx, "darkroom_bg_color", &c[DT_GUI_COLOR_DARKROOM_BG]);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -521,6 +521,12 @@ int dt_gui_gtk_write_config()
   return 0;
 }
 
+void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t color)
+{
+  GdkRGBA bc = darktable.gui->colors[color];
+  cairo_set_source_rgb(cr, bc.red, bc.green, bc.blue);
+}
+
 void dt_gui_gtk_quit()
 {
   GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
@@ -969,6 +975,22 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   darktable.gui->reset = 0;
   for(int i = 0; i < 3; i++) darktable.gui->bgcolor[i] = 0.1333;
+
+  GdkRGBA *c = darktable.gui->colors;
+  GtkWidget *main_window = dt_ui_main_window(darktable.gui->ui);
+  GtkStyleContext *ctx = gtk_widget_get_style_context(main_window);
+
+  c[DT_GUI_COLOR_DARKROOM_BG] = (GdkRGBA){ .2, .2, .2, 1.0 };
+  gtk_style_context_lookup_color(ctx, "darkroom_bg_color", &c[DT_GUI_COLOR_DARKROOM_BG]);
+
+  c[DT_GUI_COLOR_DARKROOM_PREVIEW_BG] = (GdkRGBA){ .1, .1, .1, 1.0 };
+  gtk_style_context_lookup_color(ctx, "darkroom_preview_bg_color", &c[DT_GUI_COLOR_DARKROOM_PREVIEW_BG]);
+
+  c[DT_GUI_COLOR_LIGHTTABLE_BG] = (GdkRGBA){ .2, .2, .2, 1.0 };
+  gtk_style_context_lookup_color(ctx, "lighttable_bg_color", &c[DT_GUI_COLOR_LIGHTTABLE_BG]);
+
+  c[DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG] = (GdkRGBA){ .1, .1, .1, 1.0 };
+  gtk_style_context_lookup_color(ctx, "lighttable_preview_bg_color", &c[DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG]);
 
   // let's try to support pressure sensitive input devices like tablets for mask drawing
   dt_print(DT_DEBUG_INPUT, "[input device] Input devices found:\n\n");

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -55,7 +55,8 @@ typedef struct dt_gui_widgets_t
 } dt_gui_widgets_t;
 
 typedef enum dt_gui_color_t {
-  DT_GUI_COLOR_DARKROOM_BG = 0,
+  DT_GUI_COLOR_BG = 0,
+  DT_GUI_COLOR_DARKROOM_BG,
   DT_GUI_COLOR_DARKROOM_PREVIEW_BG,
   DT_GUI_COLOR_LIGHTTABLE_BG,
   DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG,
@@ -74,7 +75,6 @@ typedef struct dt_gui_gtk_t
   char *last_preset;
 
   int32_t reset;
-  float bgcolor[3];
   GdkRGBA colors[DT_GUI_COLOR_LAST];
 
   int32_t center_tooltip; // 0 = no tooltip, 1 = new tooltip, 2 = old tooltip

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -54,6 +54,14 @@ typedef struct dt_gui_widgets_t
 
 } dt_gui_widgets_t;
 
+typedef enum dt_gui_color_t {
+  DT_GUI_COLOR_DARKROOM_BG = 0,
+  DT_GUI_COLOR_DARKROOM_PREVIEW_BG,
+  DT_GUI_COLOR_LIGHTTABLE_BG,
+  DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG,
+  DT_GUI_COLOR_LAST
+} dt_gui_color_t;
+
 typedef struct dt_gui_gtk_t
 {
 
@@ -67,6 +75,7 @@ typedef struct dt_gui_gtk_t
 
   int32_t reset;
   float bgcolor[3];
+  GdkRGBA colors[DT_GUI_COLOR_LAST];
 
   int32_t center_tooltip; // 0 = no tooltip, 1 = new tooltip, 2 = old tooltip
 
@@ -137,6 +146,7 @@ void dt_gui_gtk_quit();
 void dt_gui_store_last_preset(const char *name);
 int dt_gui_gtk_load_config();
 int dt_gui_gtk_write_config();
+void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t);
 
 /** block any keyaccelerators when widget have focus, block is released when widget lose focus. */
 void dt_gui_key_accel_block_on_focus_connect(GtkWidget *w);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -195,9 +195,9 @@ void expose(
     wd /= darktable.gui->ppd;
     ht /= darktable.gui->ppd;
     if(dev->full_preview)
-      cairo_set_source_rgb(cr, .1, .1, .1);
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_PREVIEW_BG);
     else
-      cairo_set_source_rgb(cr, .2, .2, .2);
+      dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
     cairo_translate(cr, .5f * (width - wd), .5f * (height - ht));
     if(closeup)
@@ -226,7 +226,7 @@ void expose(
     const float wd = dev->preview_pipe->backbuf_width;
     const float ht = dev->preview_pipe->backbuf_height;
     const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, closeup ? 2 : 1, 1);
-    cairo_set_source_rgb(cr, .2, .2, .2);
+    dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
     cairo_rectangle(cr, tb, tb, width-2*tb, height-2*tb);
     cairo_clip(cr);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -488,7 +488,7 @@ static int expose_filemanager(dt_view_t *self, cairo_t *cr, int32_t width, int32
   int32_t mouse_over_id = dt_control_get_mouse_over_id(), mouse_over_group = -1;
 
   /* fill background */
-  cairo_set_source_rgb(cr, .2, .2, .2);
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
   cairo_paint(cr);
 
   offset_changed = lib->offset_changed;
@@ -979,7 +979,7 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
   lib->images_in_row = zoom;
   lib->image_over = DT_VIEW_DESERT;
 
-  cairo_set_source_rgb(cr, .2, .2, .2);
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
   cairo_paint(cr);
 
   const float wd = width / zoom;
@@ -1291,7 +1291,7 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
   }
 
   lib->image_over = DT_VIEW_DESERT;
-  cairo_set_source_rgb(cr, .1, .1, .1);
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG);
   cairo_paint(cr);
 
   const int frows = 5, fcols = 5;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -497,7 +497,7 @@ void dt_view_manager_expose(dt_view_manager_t *vm, cairo_t *cr, int32_t width, i
 {
   if(vm->current_view < 0)
   {
-    cairo_set_source_rgb(cr, darktable.gui->bgcolor[0], darktable.gui->bgcolor[1], darktable.gui->bgcolor[2]);
+    dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_BG);
     cairo_paint(cr);
     return;
   }


### PR DESCRIPTION
Most of dt's UI is themeable using CSS, and it is tempting to use this
to create a neutral grey or a white theme (see e.g.
https://redmine.darktable.org/issues/11173). Unfortunately, a few color
values are still hardcoded in the source code, hence a full light theme
is only possible by patching the C files and recompiling.

This patch replaces the hardcoded values with code that fetches them
from @define-color definitions in darktable.css. For example, a neutral
grey theme can use:

```CSS
@define-color darkroom_bg_color #777777;
@define-color darkroom_preview_bg_color shade(@darkroom_bg_color, .8);
@define-color lighttable_bg_color @darkroom_bg_color;
@define-color lighttable_preview_bg_color shade(@lighttable_bg_color, .8);
```

The colors are unchanged by default.

@aurelienpierre: I wrote the patch after seeing your message on the mailing list (I can't find the link anymore). Your feedback is welcome.