### PR TITLE
Markesteijn interp rb for solitary g fixup

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -819,13 +819,13 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
               // use that color interpolation instead
               if((d > 1) && (d & 1) && (diff[d - 1] < diff[d]))
               {
-                //for(int c = 0; c < 2; c++) color[c * 2][d] = color[c * 2][d - 1];
                 color[0][d] = color[0][d - 1];
                 color[1][d] = color[1][d - 1];
               }
               if(d < 2 || (d & 1))
               {
-                for(int c = 0; c < 2; c++) rfx[0][c * 2] = color[c][d] / 2.f;
+                rfx[0][0] = color[0][d] / 2.f;
+                rfx[0][2] = color[1][d] / 2.f;
                 rfx += TS * TS;
               }
             }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -777,8 +777,8 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
             float(*rfx)[3] = &rgb[0][row - top][col - left];
             int h = FCxtrans(row, col + 1, roi_in, xtrans);
             float diff[6] = { 0.0f };
-            // FIXME: why is color[3][8] if only up to color[3][6] is used?
-            float color[3][8];
+            // FIXME: only using color[0] and color[2], not color[0], so can get rid of that and make 12 element array (vs. 24 as it was before) though will that make offsets harder, better to keep 6 dummy elements?
+            float color[3][6];
             // six passes, alternating interpolating from x or y axis
             // (i), starting with R or B (h) depending on which is
             // closest pixel

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -778,8 +778,8 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
             int h = FCxtrans(row, col + 1, roi_in, xtrans);
             float diff[6] = { 0.0f };
             // interplated color: first index is red/blue, second is
-            // x/y, is double actual results, halved on assignment
-            float color[2][2];
+            // pass, is double actual results, halved on assignment
+            float color[2][6];
             // Six passes, alternating interpolating from x or y axis
             // (i), starting with R or B (h) depending on which is
             // closest pixel.  Passes 0,1 produce output to rgb[0],
@@ -803,7 +803,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
                 // color is halved before being stored in rgb, hence
                 // this becomes green rate of change plus the average
                 // of the near red or blue pixels on current axis
-                color[h != 0][d & 1] = g + rfx[i << c][h] + rfx[-(i << c)][h];
+                color[h != 0][d] = g + rfx[i << c][h] + rfx[-(i << c)][h];
                 // Note that diff will become the slope for both red
                 // and blue differentials in the current direction.
                 // For 2nd and 3rd hori+vert passes, create a sum of
@@ -815,7 +815,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
               if((d < 2) || (d & 1))
               { // output for passes 0, 1, 3, 5
                 // for 0, 1 just use hori/vert, for 3, 5 use best of x/y dir
-                const int d_out = (d < 2) ? d : (diff[d] < diff[d-1]);
+                const int d_out = d - ((d > 1) && (diff[d-1] < diff[d]));
                 rfx[0][0] = color[0][d_out] / 2.f;
                 rfx[0][2] = color[1][d_out] / 2.f;
                 rfx += TS * TS;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -776,8 +776,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           {
             float(*rfx)[3] = &rgb[0][row - top][col - left];
             int h = FCxtrans(row, col + 1, roi_in, xtrans);
-            // most recent x/y differentials
-            float diff[2] = { 0.0f };
+            float diff[6] = { 0.0f };
             // interplated color: first index is red/blue, second is
             // x/y, is double actual results, halved on assignment
             float color[2][2];
@@ -810,17 +809,16 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
                 // For 2nd and 3rd hori+vert passes, create a sum of
                 // steepness for both cardinal directions.
                 if(d > 1)
-                  diff[d & 1] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
-                                 + SQR(g);
+                  diff[d] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
+                             + SQR(g);
               }
               if((d < 2) || (d & 1))
               { // output for passes 0, 1, 3, 5
                 // for 0, 1 just use hori/vert, for 3, 5 use best of x/y dir
-                const int d_out = (d < 2) ? d : (diff[0] >= diff[1]);
+                const int d_out = (d < 2) ? d : (diff[d] < diff[d-1]);
                 rfx[0][0] = color[0][d_out] / 2.f;
                 rfx[0][2] = color[1][d_out] / 2.f;
                 rfx += TS * TS;
-                if (d == 3) diff[0] = diff[1] = 0.f;
               }
             }
           }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -776,20 +776,19 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           {
             float(*rfx)[3] = &rgb[0][row - top][col - left];
             int h = FCxtrans(row, col + 1, roi_in, xtrans);
-            // FIXME: could do diff[2], colors[2][2], as only need to remember current and prior pass results?
-            float diff[6] = { 0.0f };
-            // red/blue results for each pass, color[0][]=red,
-            // color[1][]=blue, are double actual results, halved on
-            // assignment
-            float color[2][6];
+            // most recent x/y differentials
+            float diff[2] = { 0.0f };
+            // interplated color: first index is red/blue, second is
+            // x/y, is double actual results, halved on assignment
+            float color[2][2];
             // Six passes, alternating interpolating from x or y axis
             // (i), starting with R or B (h) depending on which is
             // closest pixel.  Passes 0,1 produce output to rgb[0],
             // rgb[1] respectively of interpolated hori/vert results.
             // Pass 3,5 produces output to rgb[2], rgb[3] respectively
             // of best of interpolated hori/vert results.  Each pass
-            // which outputs to rgb then moves on to the next rgb[]
-            // for its input of interpolated greens.
+            // which outputs moves on to the next rgb[] for input of
+            // interpolated greens.
             for(int i = 1, d = 0; d < 6; d++, i ^= TS ^ 1, h ^= 2)
             {
               // look 1 and 2 pixels distance from solitary green, red
@@ -805,28 +804,23 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
                 // color is halved before being stored in rgb, hence
                 // this becomes green rate of change plus the average
                 // of the near red or blue pixels on current axis
-                color[h != 0][d] = g + rfx[i << c][h] + rfx[-(i << c)][h];
+                color[h != 0][d & 1] = g + rfx[i << c][h] + rfx[-(i << c)][h];
                 // Note that diff will become the slope for both red
-                // and blue differentals in the current direction.
+                // and blue differentials in the current direction.
                 // For 2nd and 3rd hori+vert passes, create a sum of
                 // steepness for both cardinal directions.
                 if(d > 1)
-                  diff[d] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
-                             + SQR(g);
+                  diff[d & 1] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
+                                 + SQR(g);
               }
-              // if on 2nd or 3rd pass of y direction, and the
-              // previously-calculated x-direction has a smaller diff,
-              // use that color interpolation instead
-              if((d > 1) && (d & 1) && (diff[d - 1] < diff[d]))
-              {
-                color[0][d] = color[0][d - 1];
-                color[1][d] = color[1][d - 1];
-              }
-              if(d < 2 || (d & 1))
-              {
-                rfx[0][0] = color[0][d] / 2.f;
-                rfx[0][2] = color[1][d] / 2.f;
+              if((d < 2) || (d & 1))
+              { // output for passes 0, 1, 3, 5
+                // for 0, 1 just use hori/vert, for 3, 5 use best of x/y dir
+                const int d_out = (d < 2) ? d : (diff[0] >= diff[1]);
+                rfx[0][0] = color[0][d_out] / 2.f;
+                rfx[0][2] = color[1][d_out] / 2.f;
                 rfx += TS * TS;
+                if (d == 3) diff[0] = diff[1] = 0.f;
               }
             }
           }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -776,39 +776,44 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
           {
             float(*rfx)[3] = &rgb[0][row - top][col - left];
             int h = FCxtrans(row, col + 1, roi_in, xtrans);
+            // FIXME: could do diff[2], colors[2][2], as only need to remember current and prior pass results?
             float diff[6] = { 0.0f };
-            // FIXME: only using color[0] and color[2], not color[0], so can get rid of that and make 12 element array (vs. 24 as it was before) though will that make offsets harder, better to keep 6 dummy elements?
+            // red/blue results for each pass, color[0][]=red,
+            // color[1][]=blue, are double actual results, halved on
+            // assignment
             float color[3][6];
-            // six passes, alternating interpolating from x or y axis
+            // Six passes, alternating interpolating from x or y axis
             // (i), starting with R or B (h) depending on which is
-            // closest pixel
-            //
-            // pass   direction
-            // 0      x
-            // 1      y
-            // 2      x
-            // 3      y
-            // 4      x
-            // 5      y
-            //
-            // passes 0,1 produce output to rgb[0], rgb[1] respectively of interpolated hori/vert results
-            // pass 3,5 produces output to rgb[2], rgb[3] respectively of best of interpolated hori/vert results
-
-            // FIXME: each pass may use the prior pass data, but none before that, so could use a ring array with just x/y data instead of array of all 6 passes
-            // QUESTION: does pass 0/1, 2/3, and 4/5 produce the same color/diff results??? if not why not?
+            // closest pixel.  Passes 0,1 produce output to rgb[0],
+            // rgb[1] respectively of interpolated hori/vert results.
+            // Pass 3,5 produces output to rgb[2], rgb[3] respectively
+            // of best of interpolated hori/vert results.  Each pass
+            // which outputs to rgb then moves on to the next rgb[]
+            // for its input of interpolated greens.
             for(int i = 1, d = 0; d < 6; d++, i ^= TS ^ 1, h ^= 2)
             {
+              // look 1 and 2 pixels distance from solitary green, red
+              // then blue or blue then red
               for(int c = 0; c < 2; c++, h ^= 2)
               {
-                // gradient between solitary green pixel and interpolated greens 1 or 2 pixels away
+                // rate of change in greens between current pixel and
+                // interpolated pixels 1 or 2 distant: a quick
+                // derivative which will be divided by two later to be
+                // rate of luminance change for red/blue between known
+                // red/blue neighbors and the current unknown pixel
                 float g = 2 * rfx[0][1] - rfx[i << c][1] - rfx[-(i << c)][1];
-                // gradient plus mosaic values for red or blue at 1 or 2 pixels away
+                // color is halved before being stored in rgb, hence
+                // this becomes green rate of change plus the average
+                // of the near red or blue pixels on current axis
                 color[h][d] = g + rfx[i << c][h] + rfx[-(i << c)][h];
+                // Note that diff will become the slope for both red
+                // and blue differentals in the current direction.
+                // For 2nd and 3rd hori+vert passes, create a sum of
+                // steepness for both cardinal directions.
                 if(d > 1)
                   diff[d] += SQR(rfx[i << c][1] - rfx[-(i << c)][1] - rfx[i << c][h] + rfx[-(i << c)][h])
                              + SQR(g);
               }
-
               // if on 2nd or 3rd pass of y direction, and the
               // previously-calculated x-direction has a smaller diff,
               // use that color interpolation instead
@@ -818,9 +823,6 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
                 color[0][d] = color[0][d - 1];
                 color[2][d] = color[2][d - 1];
               }
-
-              // output one pixel each for the 4 layers of rgb for
-              // pass 0, 1, 3, 5
               if(d < 2 || (d & 1))
               {
                 for(int c = 0; c < 2; c++) rfx[0][c * 2] = color[c * 2][d] / 2.f;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -781,7 +781,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
             // red/blue results for each pass, color[0][]=red,
             // color[1][]=blue, are double actual results, halved on
             // assignment
-            float color[3][6];
+            float color[2][6];
             // Six passes, alternating interpolating from x or y axis
             // (i), starting with R or B (h) depending on which is
             // closest pixel.  Passes 0,1 produce output to rgb[0],
@@ -805,7 +805,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
                 // color is halved before being stored in rgb, hence
                 // this becomes green rate of change plus the average
                 // of the near red or blue pixels on current axis
-                color[h][d] = g + rfx[i << c][h] + rfx[-(i << c)][h];
+                color[h != 0][d] = g + rfx[i << c][h] + rfx[-(i << c)][h];
                 // Note that diff will become the slope for both red
                 // and blue differentals in the current direction.
                 // For 2nd and 3rd hori+vert passes, create a sum of
@@ -821,11 +821,11 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
               {
                 //for(int c = 0; c < 2; c++) color[c * 2][d] = color[c * 2][d - 1];
                 color[0][d] = color[0][d - 1];
-                color[2][d] = color[2][d - 1];
+                color[1][d] = color[1][d - 1];
               }
               if(d < 2 || (d & 1))
               {
-                for(int c = 0; c < 2; c++) rfx[0][c * 2] = color[c * 2][d] / 2.f;
+                for(int c = 0; c < 2; c++) rfx[0][c * 2] = color[c][d] / 2.f;
                 rfx += TS * TS;
               }
             }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -778,20 +778,18 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
             int h = FCxtrans(row, col + 1, roi_in, xtrans);
             float diff[6] = { 0.0f };
             // interplated color: first index is red/blue, second is
-            // pass, is double actual results, halved on assignment
+            // pass, is double actual result
             float color[2][6];
-            // Six passes, alternating interpolating from x or y axis
-            // (i), starting with R or B (h) depending on which is
-            // closest pixel.  Passes 0,1 produce output to rgb[0],
-            // rgb[1] respectively of interpolated hori/vert results.
-            // Pass 3,5 produces output to rgb[2], rgb[3] respectively
-            // of best of interpolated hori/vert results.  Each pass
-            // which outputs moves on to the next rgb[] for input of
-            // interpolated greens.
+            // Six passes, alternating hori/vert interp (i),
+            // starting with R or B (h) depending on which is closest.
+            // Passes 0,1 to rgb[0], rgb[1] of hori/vert interp. Pass
+            // 3,5 to rgb[2], rgb[3] of best of interp hori/vert
+            // results. Each pass which outputs moves on to the next
+            // rgb[] for input of interp greens.
             for(int i = 1, d = 0; d < 6; d++, i ^= TS ^ 1, h ^= 2)
             {
-              // look 1 and 2 pixels distance from solitary green, red
-              // then blue or blue then red
+              // look 1 and 2 pixels distance from solitary green to
+              // red then blue or blue then red
               for(int c = 0; c < 2; c++, h ^= 2)
               {
                 // rate of change in greens between current pixel and


### PR DESCRIPTION
This PR should produce identical output to the extant code, but not allocate unused memory. It also adds some comments and, for clarity, slightly refactors how the interpolation step generates output and unrolls a two-iteration loop.

In the original Markesteijn demosaic code from dcraw, the `color[][]` array is used in two interpolation steps, but neither step uses all the elements of the array. As `color` is locally declared within each interpolation step in the dt variant, it seems sloppy to declare a larger array than is actually used, hence this PR.

As this PR shouldn't change the actual output, there is no attempt to alter the OpenCL path, which, regardless, works with `color` storage differently.

I do understand that this PR makes the Markesteijn code diverge yet more from what is in dcraw, plus it is odd to comment extensively on one step while so many others are left obscure.