### PR TITLE
usermanual: exposure shift's default is 1, not 3

### DIFF
--- a/doc/usermanual/darkroom/modules/basic/basecurve.xml
+++ b/doc/usermanual/darkroom/modules/basic/basecurve.xml
@@ -105,7 +105,7 @@
       <para>
         This slider is only visible if the <emphasis>exposure fusion</emphasis> feature is
         activated. It allows you to set the exposure difference between the merged images in ev
-        units (default 3).
+        units (default 1).
       </para>
     </sect5>
 


### PR DESCRIPTION
Since e7f1f8e (basecurve: fix exposure fusion offset stops glitch in
presets, 2016-11-08), the default is 1.0, not 3. Reflect this in the
usermanual.

This is a candidate to be merged in branch darktable-2.2.x.