### PR TITLE
imageop_math: fix Bayer downscale bounds

### DIFF
--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -195,13 +195,13 @@ void dt_iop_clip_and_zoom_mosaic_half_size_plain(uint16_t *const out, const uint
 
     const float fy = (y + roi_out->y) * px_footprint;
     const int miny = CLAMPS((int)floorf(fy - px_footprint), 0, roi_in->height-3);
-    const int maxy = MIN(roi_in->height-1, (int)ceilf(fy + px_footprint));
+    const int maxy = MIN(roi_in->height-2, (int)ceilf(fy + px_footprint));
 
     float fx = roi_out->x * px_footprint;
     for(int x = 0; x < roi_out->width; x++, fx += px_footprint, outc++)
     {
       const int minx = CLAMPS((int)floorf(fx - px_footprint), 0, roi_in->width-3);
-      const int maxx = MIN(roi_in->width-1, (int)ceilf(fx + px_footprint));
+      const int maxx = MIN(roi_in->width-2, (int)ceilf(fx + px_footprint));
 
       const int c = FC(y, x, filters);
       int num = 0;


### PR DESCRIPTION
Maximum x/y values for image downscale should be one less than # of image columns/rows, as downscale may look to following column/row.

This bug will only appear in certain images, depending on the downscale ratio.

This fixes the "unusual stability problem" as reported by David Vincent-Jones on the mailing list and narrowed down via Ulrich Pegelow's work with git bisect.