### PR TITLE
channelmixer: fix default for sliders w/ target != red

### DIFF
--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -361,8 +361,11 @@ static void output_callback(GtkComboBox *combo, gpointer user_data)
   if(combo1_index >= 0)
   {
     dt_bauhaus_slider_set(g->scale1, p->red[combo1_index]);
+    dt_bauhaus_slider_set_default(g->scale1, combo1_index == CHANNEL_RED ? 1.0 : 0.0);
     dt_bauhaus_slider_set(g->scale2, p->green[combo1_index]);
+    dt_bauhaus_slider_set_default(g->scale2, combo1_index == CHANNEL_GREEN ? 1.0 : 0.0);
     dt_bauhaus_slider_set(g->scale3, p->blue[combo1_index]);
+    dt_bauhaus_slider_set_default(g->scale3, combo1_index == CHANNEL_BLUE ? 1.0 : 0.0);
   }
   // dt_dev_add_history_item(darktable.develop, self, TRUE);
 }


### PR DESCRIPTION
The red/green/blue sliders had defaults 1.0/0.0/0.0, which was a good
default when targeting the red channel, but the defaults weren't
changed when changing the target.

Update the default when changing target: for red/green/blue targets, the
default is 1.0 for the current color and 0.0 for others. For other
targets, the default is 0.0.

Candidate for cherry-picking in stable branch.