### PR TITLE
basecurve: remove obsolete TODO

### DIFF
--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1156,7 +1156,6 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_basecurve_data_t *d = (dt_iop_basecurve_data_t *)(piece->data);
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)p1;
 
-  // TODO: implement opencl version:
   d->exposure_fusion = p->exposure_fusion;
   d->exposure_stops = p->exposure_stops;
   d->exposure_bias = p->exposure_bias;


### PR DESCRIPTION
The OpenCL version of exposure fusion is already implemented, but we
forgot to remove the corresponding TODO comment.

@hanatos confirmed that is was a leftover [here](https://github.com/darktable-org/darktable/pull/1429#issuecomment-277453598).