### PR TITLE
CYGM preview fix

### DIFF
--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -201,7 +201,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_plain(uint16_t *const out, const uint
   // offsets from start of a 2x2 block at which to find that
   // color. First index is color, second is to the list of offsets,
   // preceded by the number of offsets.
-  int clut[4][3] = {0};
+  int clut[4][3] = {{0}};
   for(int y = 0; y < 2; ++y)
     for(int x = 0; x < 2; ++x)
     {


### PR DESCRIPTION
This fixes bug #11495 and restores the ability of the integer downscale path to handle a CYGM matrix. The code is now agnostic as to the color make-up of the CFA, so long as no color occurs more than twice.

It now also more closely matches the prior Bayer downscale code in how it moves to the start of each CFA block.

The code in this PR should be as fast, or nearly as fast, as the code currently in master, and should produce nearly identical output.

I still haven't gotten to a proper bandlimited subsampliming implementation, which could further reduce the confetti/artifacts at edges.