### PR TITLE
Fixes 11505

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -996,7 +996,7 @@ int dt_exif_get_thumbnail(const char *path, uint8_t **buffer, size_t *size, char
     Exiv2::PreviewPropertiesList list = loader.getPreviewProperties();
     if(list.empty())
     {
-      std::cerr << "[exiv2] couldn't find thumbnail for " << path << std::endl;
+      dt_print(DT_DEBUG_LIGHTTABLE, "[exiv2] couldn't find thumbnail for %s", path);
       return 1;
     }
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -404,6 +404,11 @@ static void reset_child(GtkWidget* child, gpointer user_data)
 }
 #endif
 
+static void _check_button_callback(GtkWidget *widget, gpointer data)
+{
+    dt_conf_set_bool("ui_last/import_ignore_jpegs",
+                     gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+}
 
 static GtkWidget *_lib_import_get_extra_widget(dt_lib_module_t *self,dt_lib_import_metadata_t *data, gboolean import_folder)
 {
@@ -450,6 +455,8 @@ static GtkWidget *_lib_import_get_extra_widget(dt_lib_module_t *self,dt_lib_impo
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ignore_jpeg),
                                  dt_conf_get_bool("ui_last/import_ignore_jpegs"));
     gtk_box_pack_start(GTK_BOX(extra), ignore_jpeg, FALSE, FALSE, 0);
+    g_signal_connect(G_OBJECT(ignore_jpeg), "clicked",
+                   G_CALLBACK(_check_button_callback), ignore_jpeg);
   }
 
   // default metadata


### PR DESCRIPTION
This PR fixes the issue 11505: ignore jpg is treated differently in 
a) import->folder 
and
b) import->import from camera

The bug happened when

- insert SDcard with DCIM structure and jpgs 
- open dt

- import->folder->check ignore jpgs (ON) > open
- import->import from camera->select a JPG->import
-> you will see that it is being ignored in the collection (does not show up) but it is correctly copied to disk with the filename that is logged to the console

- import->folder->uncheck ignore jpgs (OFF) > open
- import->import from camera->select a JPG->import
-> import works as expected


- Also it fixes double '/' in path
- Also it removes the verbose thumbnail not found messages