### PR TITLE
Brush colors/transparency configurable through CSS

### DIFF
--- a/data/darktable-3.18.css.in
+++ b/data/darktable-3.18.css.in
@@ -12,6 +12,8 @@
 @define-color darkroom_preview_bg_color shade(@darkroom_bg_color, .5);
 @define-color lighttable_bg_color @darkroom_bg_color;
 @define-color lighttable_preview_bg_color shade(@lighttable_bg_color, .5);
+@define-color brush_cursor alpha(white, .5);
+@define-color brush_trace alpha(black, .8);
 
 @define-color dark_bg_color #350000;
 

--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -12,6 +12,8 @@
 @define-color darkroom_preview_bg_color shade(@darkroom_bg_color, .5);
 @define-color lighttable_bg_color @darkroom_bg_color;
 @define-color lighttable_preview_bg_color shade(@lighttable_bg_color, .5);
+@define-color brush_cursor alpha(white, .5);
+@define-color brush_trace alpha(black, .8);
 
 @define-color dark_bg_color #350000;
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -24,6 +24,11 @@
 #include "develop/imageop.h"
 #include "develop/masks.h"
 
+#define CREATE_MAX_BRUSH_OPACITY 0.5f
+// the maximum opacity when drawing a mask, this is to let see through it for better control
+#define CREATE_MAX_TRACE_OPACITY 0.8f
+// like above but for the trace
+
 /** get squared distance of indexed point to line segment, taking weighted payload data into account */
 static float _brush_point_line_distance2(int index, int pointscount, const float *points, const float *payload)
 {
@@ -2089,7 +2094,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       }
 
       cairo_save(cr);
-      cairo_set_source_rgba(cr, .8, .8, .8, masks_density);
+      cairo_set_source_rgba(cr, .8, .8, .8, masks_density * CREATE_MAX_BRUSH_OPACITY);
       cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
@@ -2144,7 +2149,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       opacity = oldopacity = masks_density;
 
       cairo_set_line_width(cr, 2 * radius);
-      cairo_set_source_rgba(cr, .1, .1, .1, opacity);
+      cairo_set_source_rgba(cr, .1, .1, .1, opacity * CREATE_MAX_TRACE_OPACITY);
 
       cairo_move_to(cr, guipoints[0], guipoints[1]);
       for(int i = 1; i < gui->guipoints_count; i++)
@@ -2187,7 +2192,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
           cairo_stroke(cr);
           stroked = 1;
           cairo_set_line_width(cr, 2 * radius);
-          cairo_set_source_rgba(cr, .1, .1, .1, opacity);
+          cairo_set_source_rgba(cr, .1, .1, .1, opacity * CREATE_MAX_TRACE_OPACITY);
           oldradius = radius;
           oldopacity = opacity;
           cairo_move_to(cr, guipoints[i * 2], guipoints[i * 2 + 1]);
@@ -2196,7 +2201,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       if(!stroked) cairo_stroke(cr);
 
       cairo_set_line_width(cr, linewidth);
-      cairo_set_source_rgba(cr, .8, .8, .8, opacity);
+      cairo_set_source_rgba(cr, .8, .8, .8, opacity * CREATE_MAX_BRUSH_OPACITY);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
                 guipoints[2 * (gui->guipoints_count - 1) + 1], radius, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -24,11 +24,6 @@
 #include "develop/imageop.h"
 #include "develop/masks.h"
 
-#define CREATE_MAX_BRUSH_OPACITY 0.5f
-// the maximum opacity when drawing a mask, this is to let see through it for better control
-#define CREATE_MAX_TRACE_OPACITY 0.8f
-// like above but for the trace
-
 /** get squared distance of indexed point to line segment, taking weighted payload data into account */
 static float _brush_point_line_distance2(int index, int pointscount, const float *points, const float *payload)
 {
@@ -2094,7 +2089,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       }
 
       cairo_save(cr);
-      cairo_set_source_rgba(cr, .8, .8, .8, masks_density * CREATE_MAX_BRUSH_OPACITY);
+      dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_CURSOR, masks_density);
       cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
@@ -2149,7 +2144,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       opacity = oldopacity = masks_density;
 
       cairo_set_line_width(cr, 2 * radius);
-      cairo_set_source_rgba(cr, .1, .1, .1, opacity * CREATE_MAX_TRACE_OPACITY);
+      dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_TRACE, opacity);
 
       cairo_move_to(cr, guipoints[0], guipoints[1]);
       for(int i = 1; i < gui->guipoints_count; i++)
@@ -2192,7 +2187,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
           cairo_stroke(cr);
           stroked = 1;
           cairo_set_line_width(cr, 2 * radius);
-          cairo_set_source_rgba(cr, .1, .1, .1, opacity * CREATE_MAX_TRACE_OPACITY);
+          dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_TRACE, opacity);
           oldradius = radius;
           oldopacity = opacity;
           cairo_move_to(cr, guipoints[i * 2], guipoints[i * 2 + 1]);
@@ -2201,7 +2196,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       if(!stroked) cairo_stroke(cr);
 
       cairo_set_line_width(cr, linewidth);
-      cairo_set_source_rgba(cr, .8, .8, .8, opacity * CREATE_MAX_BRUSH_OPACITY);
+      dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_CURSOR, opacity);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
                 guipoints[2 * (gui->guipoints_count - 1) + 1], radius, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2090,6 +2090,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
       cairo_save(cr);
       dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_CURSOR, masks_density);
+      if(masks_density < 1.0) cairo_set_line_width(cr, cairo_get_line_width(cr) * .8);
       cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
@@ -2197,6 +2198,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
       cairo_set_line_width(cr, linewidth);
       dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_CURSOR, opacity);
+      if(opacity < 1.0) cairo_set_line_width(cr, cairo_get_line_width(cr) * .8);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
                 guipoints[2 * (gui->guipoints_count - 1) + 1], radius, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -527,6 +527,12 @@ void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t color)
   cairo_set_source_rgb(cr, bc.red, bc.green, bc.blue);
 }
 
+void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t color, float opacity_coef)
+{
+  GdkRGBA bc = darktable.gui->colors[color];
+  cairo_set_source_rgba(cr, bc.red, bc.green, bc.blue, bc.alpha * opacity_coef);
+}
+
 void dt_gui_gtk_quit()
 {
   GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
@@ -992,6 +998,12 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   c[DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG] = (GdkRGBA){ .1, .1, .1, 1.0 };
   gtk_style_context_lookup_color(ctx, "lighttable_preview_bg_color", &c[DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG]);
+
+  c[DT_GUI_COLOR_BRUSH_CURSOR] = (GdkRGBA){ 1., 1., 1., 0.5 };
+  gtk_style_context_lookup_color(ctx, "brush_cursor", &c[DT_GUI_COLOR_BRUSH_CURSOR]);
+
+  c[DT_GUI_COLOR_BRUSH_TRACE] = (GdkRGBA){ 0., 0., 0., 0.8 };
+  gtk_style_context_lookup_color(ctx, "brush_trace", &c[DT_GUI_COLOR_BRUSH_TRACE]);
 
   // let's try to support pressure sensitive input devices like tablets for mask drawing
   dt_print(DT_DEBUG_INPUT, "[input device] Input devices found:\n\n");

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -60,6 +60,8 @@ typedef enum dt_gui_color_t {
   DT_GUI_COLOR_DARKROOM_PREVIEW_BG,
   DT_GUI_COLOR_LIGHTTABLE_BG,
   DT_GUI_COLOR_LIGHTTABLE_PREVIEW_BG,
+  DT_GUI_COLOR_BRUSH_CURSOR,
+  DT_GUI_COLOR_BRUSH_TRACE,
   DT_GUI_COLOR_LAST
 } dt_gui_color_t;
 
@@ -147,6 +149,7 @@ void dt_gui_store_last_preset(const char *name);
 int dt_gui_gtk_load_config();
 int dt_gui_gtk_write_config();
 void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t);
+void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t, float opacity_coef);
 
 /** block any keyaccelerators when widget have focus, block is released when widget lose focus. */
 void dt_gui_key_accel_block_on_focus_connect(GtkWidget *w);


### PR DESCRIPTION
This comes on top of #1417 and adds CSS configurability.

I've kept @TurboGit 's commit to avoid getting all the credit and to let him check my changes on top of his, but it probably makes sense to squash them while merging. I've just rebased it to get edcfc91 (make brush color configurable through CSS, 2017-02-14) and build on it.