### PR TITLE
darktable.c: prefer XWayland

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -721,7 +721,15 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
   // we need this REALLY early so that error messages can be shown
   if(init_gui)
+  {
+#ifdef GDK_WINDOWING_WAYLAND
+    // There are currently bad interactions with Wayland (drop-downs
+    // are very narrow, scroll events lost). Until this is fixed, give
+    // priority to the XWayland backend for Wayland users.
+    gdk_set_allowed_backends("x11,*");
+#endif
     gtk_init(&argc, &argv);
+  }
 
 #ifdef _OPENMP
   omp_set_num_threads(darktable.num_openmp_threads);


### PR DESCRIPTION
Currently darktable has bad interaction with Wayland (drop-downs too narrow, scroll events lost, keyboard input ignored). This is an attempt to prefer XWayland when running under Wayland. The intent is to not alter behavior for systems running X11 or Quartz.

I have tested this under X11 and Wayland, but not on OS X. The `gdk_set_allowed_backends("x11,*");` should prefer XWayland in the case of systems with both Wayland and X11, but the `*` should ensure that Quartz is still tried. Enclosing in `#ifdef GDK_WINDOWING_WAYLAND` may be overkill.

Bug reported by Hajo Schatz, who then found that starting darktable:

`GDK_BACKEND=x11 && darktable`

forces use of XWayland.