### PR TITLE
clean up presentation of popup menus

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1533,6 +1533,7 @@ static void _preset_popup_position(GtkMenu *menu, gint *x, gint *y, gboolean *pu
 static void popup_callback(GtkButton *button, dt_iop_module_t *module)
 {
   dt_gui_presets_popup_menu_show_for_module(module);
+  gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
 #if GTK_CHECK_VERSION(3, 22, 0)
   gtk_menu_popup_at_widget(darktable.gui->presets_popup_menu,
@@ -1543,7 +1544,6 @@ static void popup_callback(GtkButton *button, dt_iop_module_t *module)
                  gtk_get_current_event_time());
 #endif
 
-  gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
   gtk_menu_reposition(GTK_MENU(darktable.gui->presets_popup_menu));
 }
 
@@ -1731,6 +1731,7 @@ static gboolean _iop_plugin_body_button_press(GtkWidget *w, GdkEventButton *e, g
   else if(e->button == 3)
   {
     dt_gui_presets_popup_menu_show_for_module(module);
+    gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
 #if GTK_CHECK_VERSION(3, 22, 0)
     gtk_menu_popup_at_pointer(darktable.gui->presets_popup_menu, (GdkEvent *)e);
@@ -1738,7 +1739,6 @@ static gboolean _iop_plugin_body_button_press(GtkWidget *w, GdkEventButton *e, g
     gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, NULL, NULL, e->button, e->time);
 #endif
 
-    gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
     return TRUE;
   }
   return FALSE;
@@ -1764,14 +1764,13 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
   else if(e->button == 3)
   {
     dt_gui_presets_popup_menu_show_for_module(module);
+    gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
 #if GTK_CHECK_VERSION(3, 22, 0)
     gtk_menu_popup_at_pointer(darktable.gui->presets_popup_menu, (GdkEvent *)e);
 #else
     gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, NULL, NULL, e->button, e->time);
 #endif
-
-    gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
     return TRUE;
   }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1542,9 +1542,8 @@ static void popup_callback(GtkButton *button, dt_iop_module_t *module)
 #else
   gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, _preset_popup_position, button, 0,
                  gtk_get_current_event_time());
-#endif
-
   gtk_menu_reposition(GTK_MENU(darktable.gui->presets_popup_menu));
+#endif
 }
 
 void dt_iop_request_focus(dt_iop_module_t *module)

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -367,7 +367,7 @@ static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, dt_lib_c
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
   g_signal_connect(menuitem, "activate", (GCallback)view_popup_menu_onRemove, treeview);
 
-  gtk_widget_show_all(menu);
+  gtk_widget_show_all(GTK_WIDGET(menu));
 
 #if GTK_CHECK_VERSION(3, 22, 0)
   gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
@@ -1638,13 +1638,13 @@ static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, 
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_change_and_not), d);
   }
 
+  gtk_widget_show_all(GTK_WIDGET(menu));
+
 #if GTK_CHECK_VERSION(3, 22, 0)
   gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 #else
   gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 #endif
-
-  gtk_widget_show_all(menu);
 
   return TRUE;
 }

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -810,6 +810,7 @@ static void popup_callback(GtkButton *button, dt_lib_module_t *module)
     fprintf(stderr, "something went wrong: &params=%p, size=%i\n", &params, size);
   }
   dt_lib_presets_popup_menu_show(&mi);
+  gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
 #if GTK_CHECK_VERSION(3, 22, 0)
   int c = module->container(module);
@@ -838,7 +839,6 @@ static void popup_callback(GtkButton *button, dt_lib_module_t *module)
                  gtk_get_current_event_time());
 #endif
 
-  gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
   gtk_menu_reposition(GTK_MENU(darktable.gui->presets_popup_menu));
 }
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -837,9 +837,8 @@ static void popup_callback(GtkButton *button, dt_lib_module_t *module)
 #else
   gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, _preset_popup_posistion, button, 0,
                  gtk_get_current_event_time());
-#endif
-
   gtk_menu_reposition(GTK_MENU(darktable.gui->presets_popup_menu));
+#endif
 }
 
 void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -810,6 +810,7 @@ static void popup_callback(GtkButton *button, dt_lib_module_t *module)
     fprintf(stderr, "something went wrong: &params=%p, size=%i\n", &params, size);
   }
   dt_lib_presets_popup_menu_show(&mi);
+
   gtk_widget_show_all(GTK_WIDGET(darktable.gui->presets_popup_menu));
 
 #if GTK_CHECK_VERSION(3, 22, 0)
@@ -820,9 +821,8 @@ static void popup_callback(GtkButton *button, dt_lib_module_t *module)
   if((c == DT_UI_CONTAINER_PANEL_LEFT_TOP) || (c == DT_UI_CONTAINER_PANEL_LEFT_CENTER)
      || (c == DT_UI_CONTAINER_PANEL_LEFT_BOTTOM))
   {
-    // FIXME: these should be _EAST, but then it goes out of the sidepanel...
-    widget_gravity = GDK_GRAVITY_SOUTH;
-    menu_gravity = GDK_GRAVITY_NORTH;
+    widget_gravity = GDK_GRAVITY_SOUTH_EAST;
+    menu_gravity = GDK_GRAVITY_NORTH_EAST;
   }
   else
   {
@@ -833,7 +833,6 @@ static void popup_callback(GtkButton *button, dt_lib_module_t *module)
   gtk_menu_popup_at_widget(darktable.gui->presets_popup_menu,
                            dtgtk_expander_get_header(DTGTK_EXPANDER(module->expander)), widget_gravity,
                            menu_gravity, NULL);
-
 #else
   gtk_menu_popup(darktable.gui->presets_popup_menu, NULL, NULL, _preset_popup_posistion, button, 0,
                  gtk_get_current_event_time());


### PR DESCRIPTION
This fixes the narrow windows bug when using the (currently disabled) Wayland backend to GDK. It also should be better practice regardless of the GDK backend. Also only manually reposition the menus for older versions of GTK.

This is a fix for problem 1 in https://redmine.darktable.org/issues/11535. I thought it should stand on its own as a PR, as a fix for at least the second problem looks to be pretty invasive.