### PR TITLE
collection: fix query string for folders

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -839,7 +839,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       break;
 
     case DT_COLLECTION_PROP_FOLDERS: // folders
-      query = dt_util_dstrcat(query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s%%'))",
+      query = dt_util_dstrcat(query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s'))",
                               escaped_text);
       break;
 


### PR DESCRIPTION
This commit fixes an issue with the display of relevant images from folders selected in "collect images".

Selecting a certain folder don't only show the pictures inside of it, but will also show pictures from folders that starts with the same name of the selected folder.
This is due to a wildcard at the end of the query string.

#### Example:
Assuming a directory structure like this is imported to Darktable:
* /home
  + ./Day1
  + ...
  + ./Day10
  + ./Day11

When the view of "collect images" (`lighttable` module) is set to `folders`,
selecting `Day1` folder will actually show images from `Day1`, `Day10` and `Day11`.
