### PR TITLE
collection: fix folder query string once again

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -839,8 +839,9 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       break;
 
     case DT_COLLECTION_PROP_FOLDERS: // folders
-      query = dt_util_dstrcat(query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%s'))",
-                              escaped_text);
+      query = dt_util_dstrcat(
+          query, "(film_id IN (SELECT id FROM main.film_rolls WHERE folder LIKE '%1$s' OR folder LIKE '%1$s/%%'))",
+          escaped_text);
       break;
 
     case DT_COLLECTION_PROP_COLORLABEL: // colorlabel


### PR DESCRIPTION
This commit fixes an issue with the display of relevant images from folders selected in "collect images".
It improve changes from PR #1458:
 - it make sure that if on the same level we have multiple folders with the same name prefix
   only the selected one will be used
 - it will also select all children of selected folder

**Example:**
For directory folder structure:
- images/
  - day1/
    - a/
        - aa/
    - b/
  - day10/
  - day11/
  - day2/

before this PR, when _day1_ was selected, images from _a_, _aa_ and _b_ were not visible. Now, darktable will show union of  _day1_, _a_, _aa_ and _b_ 