### PR TITLE
smooth scrolling

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2238,11 +2238,11 @@ static gboolean dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event
       }
       else if(event->keyval == GDK_KEY_Up)
       {
-        combobox_popup_scroll(1);
+        combobox_popup_scroll(-1);
       }
       else if(event->keyval == GDK_KEY_Down)
       {
-        combobox_popup_scroll(-1);
+        combobox_popup_scroll(1);
       }
       else if(event->keyval == GDK_KEY_Return || event->keyval == GDK_KEY_KP_Enter)
       {

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1900,6 +1900,11 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
     handled = 1;
     delta = -d->scale / 5.0f;
   }
+  else if(event->direction == GDK_SCROLL_SMOOTH)
+  {
+    handled = 1;
+    delta = -event->delta_y * d->scale / 5.0f;
+  }
 
   if(!handled) return FALSE;
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -100,7 +100,6 @@ typedef struct dt_bauhaus_combobox_data_t
   int active;        // currently active element
   int defpos;        // default position
   int editable;      // 1 if arbitrary text may be typed
-  gdouble scrollacc; // for smooth scrolling
   char text[180];    // roughly as much as a slider
   GList *labels;     // list of elements
   GList *alignments; // alignments of the labels. we keep this extra to make it easy to pass the labels around

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -100,6 +100,7 @@ typedef struct dt_bauhaus_combobox_data_t
   int active;        // currently active element
   int defpos;        // default position
   int editable;      // 1 if arbitrary text may be typed
+  gdouble scrollacc; // for smooth scrolling
   char text[180];    // roughly as much as a slider
   GList *labels;     // list of elements
   GList *alignments; // alignments of the labels. we keep this extra to make it easy to pass the labels around

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -295,7 +295,7 @@ static gboolean _gradient_slider_button_release(GtkWidget *widget, GdkEventButto
   return TRUE;
 }
 
-static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, float delta, guint state)
+static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble delta, guint state)
 {
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
 
@@ -336,17 +336,24 @@ static gboolean _gradient_slider_scroll_event(GtkWidget *widget, GdkEventScroll 
   if(gslider->selected == -1) return TRUE;
 
   int handled = 0;
-  float delta = 0.0f;
+  gdouble delta = 0.0;
 
-  if(event->direction == GDK_SCROLL_UP)
+  switch(event->direction)
   {
-    handled = 1;
-    delta = gslider->increment;
-  }
-  else if(event->direction == GDK_SCROLL_DOWN)
-  {
-    handled = 1;
-    delta = -gslider->increment;
+    case GDK_SCROLL_UP:
+      handled = 1;
+      delta = gslider->increment;
+      break;
+    case GDK_SCROLL_DOWN:
+      handled = 1;
+      delta = -gslider->increment;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      handled = 1;
+      delta = -event->delta_y * gslider->increment;
+      break;
+    default:
+      break;
   }
 
   if(!handled) return TRUE;
@@ -429,7 +436,8 @@ static void _gradient_slider_realize(GtkWidget *widget)
   attributes.wclass = GDK_INPUT_OUTPUT;
   attributes.event_mask = gtk_widget_get_events(widget) | GDK_EXPOSURE_MASK | GDK_BUTTON_PRESS_MASK
                           | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
-                          | GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK | GDK_POINTER_MOTION_MASK | GDK_SCROLL_MASK;
+                          | GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK | GDK_POINTER_MOTION_MASK
+                          | GDK_SCROLL_MASK | GDK_SMOOTH_SCROLL_MASK;
   attributes_mask = GDK_WA_X | GDK_WA_Y;
 
   gtk_widget_set_can_focus(GTK_WIDGET(widget), TRUE);

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -335,30 +335,14 @@ static gboolean _gradient_slider_scroll_event(GtkWidget *widget, GdkEventScroll 
 
   if(gslider->selected == -1) return TRUE;
 
-  int handled = 0;
-  gdouble delta = 0.0;
-
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      handled = 1;
-      delta = gslider->increment;
-      break;
-    case GDK_SCROLL_DOWN:
-      handled = 1;
-      delta = -gslider->increment;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      handled = 1;
-      delta = -event->delta_y * gslider->increment;
-      break;
-    default:
-      break;
+    delta_y *= -gslider->increment;
+    return _gradient_slider_add_delta_internal(widget, delta_y, event->state);
   }
 
-  if(!handled) return TRUE;
-
-  return _gradient_slider_add_delta_internal(widget, delta, event->state);
+  return TRUE;
 }
 
 static gboolean _gradient_slider_key_press_event(GtkWidget *widget, GdkEventKey *event)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -151,6 +151,17 @@ int dt_gui_gtk_write_config();
 void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t);
 void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t, float opacity_coef);
 
+/* Return requested scroll delta(s) from event. If delta_x or delta_y
+ * is NULL, do not return that delta. Return TRUE if requested deltas
+ * can be retrieved. Handles both GDK_SCROLL_UP/DOWN/LEFT/RIGHT and
+ * GDK_SCROLL_SMOOTH style scroll events. */
+gboolean dt_gui_get_scroll_deltas(const GdkEventScroll *event, gdouble *delta_x, gdouble *delta_y);
+/* Same as above, except accumulate smooth scrolls deltas of < 1 and
+ * only set deltas and return TRUE once scrolls accumulate to >= 1.
+ * Effectively makes smooth scroll events act like old-style unit
+ * scroll events. */
+gboolean dt_gui_get_scroll_unit_deltas(const GdkEventScroll *event, int *delta_x, int *delta_y);
+
 /** block any keyaccelerators when widget have focus, block is released when widget lose focus. */
 void dt_gui_key_accel_block_on_focus_connect(GtkWidget *w);
 /** clean up connected signal handlers before destroying your widget: */

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1598,24 +1598,33 @@ static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+
+  int handled = FALSE;
+  double delta = 0.0;
   switch(event->direction)
   {
     case GDK_SCROLL_UP:
-      if(c->mouse_radius > 0.25 / BANDS) c->mouse_radius *= 0.9; // 0.7;
+      delta = -1.0;
+      handled = TRUE;
+      break;
       break;
     case GDK_SCROLL_DOWN:
-      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      delta = 1.0;
+      handled = TRUE;
       break;
     case GDK_SCROLL_SMOOTH:
-      if((event->delta_y < 0) && (c->mouse_radius > 0.25 / BANDS))
-        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
-      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
-        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      delta = event->delta_y;
+      handled = TRUE;
       break;
     default:
       break;
   }
-  gtk_widget_queue_draw(widget);
+
+  if(handled)
+  {
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.25 / BANDS, 1.0);
+    gtk_widget_queue_draw(widget);
+  }
   return TRUE;
 }
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1599,30 +1599,10 @@ static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
 
-  int handled = FALSE;
-  double delta = 0.0;
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      delta = -1.0;
-      handled = TRUE;
-      break;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = 1.0;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      delta = event->delta_y;
-      handled = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(handled)
-  {
-    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.25 / BANDS, 1.0);
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.25 / BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
   return TRUE;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1598,8 +1598,23 @@ static gboolean area_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
-  if(event->direction == GDK_SCROLL_UP && c->mouse_radius > 0.25 / BANDS) c->mouse_radius *= 0.9; // 0.7;
-  if(event->direction == GDK_SCROLL_DOWN && c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+  switch(event->direction)
+  {
+    case GDK_SCROLL_UP:
+      if(c->mouse_radius > 0.25 / BANDS) c->mouse_radius *= 0.9; // 0.7;
+      break;
+    case GDK_SCROLL_DOWN:
+      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      if((event->delta_y < 0) && (c->mouse_radius > 0.25 / BANDS))
+        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
+      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
+        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      break;
+    default:
+      break;
+  }
   gtk_widget_queue_draw(widget);
   return TRUE;
 }
@@ -1680,7 +1695,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                              | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                             | GDK_SMOOTH_SCROLL_MASK);
   g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(area_draw), self);
   g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(area_button_press), self);
   g_signal_connect(G_OBJECT(c->area), "button-release-event", G_CALLBACK(area_button_release), self);

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1796,7 +1796,21 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
   if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
     delta_x *= -BASECURVE_DEFAULT_STEP;
-    delta_y *= BASECURVE_DEFAULT_STEP;
+    delta_y *= -BASECURVE_DEFAULT_STEP;
+
+    GdkDevice *source_device = gdk_event_get_source_device((GdkEvent*)event);
+    GdkInputSource source = gdk_device_get_source(source_device);
+    // For touch and trackpoint events, move the pointer in the
+    // direction of the scroll if the event type is available. Never
+    // flip mousewheel deltas. Note that GDK's Wayland backend
+    // identifies touchpad/trackpoint events, but under XWayland, the
+    // Wayland backend reports touchpad/trackpoint events as
+    // GDK_SOURCE_MOUSE. GDK's X11 backend identifies trackpoint
+    // events but reports touchpad events as being GDK_SOURCE_MOUSE.
+    if((source == GDK_SOURCE_TOUCHPAD) || (source == GDK_SOURCE_TRACKPOINT) ||
+       (source == GDK_SOURCE_TOUCHSCREEN))
+      delta_y = -delta_y;
+
     return _move_point_internal(self, widget, delta_x, delta_y, event->state);
   }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1792,12 +1792,11 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 
   if(c->selected < 0) return TRUE;
 
-  gdouble delta_x, delta_y;
-  if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    delta_x *= BASECURVE_DEFAULT_STEP;
     delta_y *= -BASECURVE_DEFAULT_STEP;
-    return _move_point_internal(self, widget, delta_x, delta_y, event->state);
+    return _move_point_internal(self, widget, 0.0, delta_y, event->state);
   }
 
   return TRUE;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1795,22 +1795,8 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
   gdouble delta_x, delta_y;
   if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
-    delta_x *= -BASECURVE_DEFAULT_STEP;
+    delta_x *= BASECURVE_DEFAULT_STEP;
     delta_y *= -BASECURVE_DEFAULT_STEP;
-
-    GdkDevice *source_device = gdk_event_get_source_device((GdkEvent*)event);
-    GdkInputSource source = gdk_device_get_source(source_device);
-    // For touch and trackpoint events, move the pointer in the
-    // direction of the scroll if the event type is available. Never
-    // flip mousewheel deltas. Note that GDK's Wayland backend
-    // identifies touchpad/trackpoint events, but under XWayland, the
-    // Wayland backend reports touchpad/trackpoint events as
-    // GDK_SOURCE_MOUSE. GDK's X11 backend identifies trackpoint
-    // events but reports touchpad events as being GDK_SOURCE_MOUSE.
-    if((source == GDK_SOURCE_TOUCHPAD) || (source == GDK_SOURCE_TRACKPOINT) ||
-       (source == GDK_SOURCE_TOUCHSCREEN))
-      delta_y = -delta_y;
-
     return _move_point_internal(self, widget, delta_x, delta_y, event->state);
   }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1792,38 +1792,15 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 
   if(c->selected < 0) return TRUE;
 
-  int handled = 0;
-  float dx = 0.0f, dy = 0.0f;
-  switch(event->direction)
+  gdouble delta_x, delta_y;
+  if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      handled = 1;
-      dy = -BASECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_DOWN:
-      handled = 1;
-      dy = BASECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_LEFT:
-      handled = 1;
-      dx = BASECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_RIGHT:
-      handled = 1;
-      dx = -BASECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      handled = 1;
-      dx = -BASECURVE_DEFAULT_STEP * event->delta_x;
-      dy = BASECURVE_DEFAULT_STEP * event->delta_y;
-      break;
-    default:
-      break;
+    delta_x *= -BASECURVE_DEFAULT_STEP;
+    delta_y *= BASECURVE_DEFAULT_STEP;
+    return _move_point_internal(self, widget, delta_x, delta_y, event->state);
   }
 
-  if(!handled) return TRUE;
-
-  return _move_point_internal(self, widget, dx, dy, event->state);
+  return TRUE;
 }
 
 static gboolean dt_iop_basecurve_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1793,21 +1793,37 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
   if(c->selected < 0) return TRUE;
 
   int handled = 0;
-  float dy = 0.0f;
-  if(event->direction == GDK_SCROLL_UP)
+  float dx = 0.0f, dy = 0.0f;
+  switch(event->direction)
   {
-    handled = 1;
-    dy = BASECURVE_DEFAULT_STEP;
-  }
-  if(event->direction == GDK_SCROLL_DOWN)
-  {
-    handled = 1;
-    dy = -BASECURVE_DEFAULT_STEP;
+    case GDK_SCROLL_UP:
+      handled = 1;
+      dy = -BASECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_DOWN:
+      handled = 1;
+      dy = BASECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_LEFT:
+      handled = 1;
+      dx = BASECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_RIGHT:
+      handled = 1;
+      dx = -BASECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      handled = 1;
+      dx = -BASECURVE_DEFAULT_STEP * event->delta_x;
+      dy = BASECURVE_DEFAULT_STEP * event->delta_y;
+      break;
+    default:
+      break;
   }
 
   if(!handled) return TRUE;
 
-  return _move_point_internal(self, widget, 0.0, dy, event->state);
+  return _move_point_internal(self, widget, dx, dy, event->state);
 }
 
 static gboolean dt_iop_basecurve_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
@@ -1953,7 +1969,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                  | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK | GDK_KEY_PRESS_MASK);
+                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                                 | GDK_SMOOTH_SCROLL_MASK | GDK_KEY_PRESS_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(c->area), TRUE);
   g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(dt_iop_basecurve_draw), self);
   g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(dt_iop_basecurve_button_press), self);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -267,7 +267,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                  | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK | GDK_KEY_PRESS_MASK);
+                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                                 | GDK_SMOOTH_SCROLL_MASK | GDK_KEY_PRESS_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_colorcorrection_draw), self);
   g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(dt_iop_colorcorrection_button_press),
@@ -474,8 +475,23 @@ static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScrol
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
-  if(event->direction == GDK_SCROLL_UP && p->saturation > -3.0) p->saturation += 0.1;
-  if(event->direction == GDK_SCROLL_DOWN && p->saturation < 3.0) p->saturation -= 0.1;
+
+  float s = p->saturation;
+  switch(event->direction)
+  {
+    case GDK_SCROLL_UP:
+      s += 0.1;
+      break;
+    case GDK_SCROLL_DOWN:
+      s -= 0.1;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      s -= 0.1 * event->delta_y;
+      break;
+    default:
+      break;
+  }
+  p->saturation = CLAMP(s, -3.0, 3.0);
   dt_bauhaus_slider_set(g->slider, p->saturation);
   gtk_widget_queue_draw(widget);
   return TRUE;

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -476,24 +476,14 @@ static gboolean dt_iop_colorcorrection_scrolled(GtkWidget *widget, GdkEventScrol
   dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
   dt_iop_colorcorrection_params_t *p = (dt_iop_colorcorrection_params_t *)self->params;
 
-  float s = p->saturation;
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      s += 0.1;
-      break;
-    case GDK_SCROLL_DOWN:
-      s -= 0.1;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      s -= 0.1 * event->delta_y;
-      break;
-    default:
-      break;
+     p->saturation = CLAMP(p->saturation - 0.1 * delta_y, -3.0, 3.0);
+     dt_bauhaus_slider_set(g->slider, p->saturation);
+     gtk_widget_queue_draw(widget);
   }
-  p->saturation = CLAMP(s, -3.0, 3.0);
-  dt_bauhaus_slider_set(g->slider, p->saturation);
-  gtk_widget_queue_draw(widget);
+
   return TRUE;
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -979,32 +979,13 @@ static gboolean colorzones_scrolled(GtkWidget *widget, GdkEventScroll *event, gp
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
 
-  int handled = FALSE;
-  double delta = 0.0;
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      delta = -1.0;
-      handled = TRUE;
-      break;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = 1.0;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      delta = event->delta_y;
-      handled = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(handled)
-  {
-    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.2 / DT_IOP_COLORZONES_BANDS, 1.0);
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_COLORZONES_BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
+
   return TRUE;
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -978,24 +978,33 @@ static gboolean colorzones_scrolled(GtkWidget *widget, GdkEventScroll *event, gp
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+
+  int handled = FALSE;
+  double delta = 0.0;
   switch(event->direction)
   {
     case GDK_SCROLL_UP:
-      if(c->mouse_radius > 0.2 / DT_IOP_COLORZONES_BANDS) c->mouse_radius *= 0.9; // 0.7;
+      delta = -1.0;
+      handled = TRUE;
+      break;
       break;
     case GDK_SCROLL_DOWN:
-      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      delta = 1.0;
+      handled = TRUE;
       break;
     case GDK_SCROLL_SMOOTH:
-      if((event->delta_y < 0) && (c->mouse_radius > 0.2 / DT_IOP_COLORZONES_BANDS))
-        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
-      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
-        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      delta = event->delta_y;
+      handled = TRUE;
       break;
     default:
       break;
   }
-  gtk_widget_queue_draw(widget);
+
+  if(handled)
+  {
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.2 / DT_IOP_COLORZONES_BANDS, 1.0);
+    gtk_widget_queue_draw(widget);
+  }
   return TRUE;
 }
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -369,7 +369,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->area), TRUE, TRUE, 0);
   gtk_widget_set_size_request(GTK_WIDGET(c->area), 195, 195);
 
-  gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+  gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK | GDK_SMOOTH_SCROLL_MASK);
   g_signal_connect (G_OBJECT (c->area), "draw",
                     G_CALLBACK (dt_iop_equalizer_expose), self);
   g_signal_connect (G_OBJECT (c->area), "button-press-event",
@@ -674,8 +674,23 @@ static gboolean dt_iop_equalizer_scrolled(GtkWidget *widget, GdkEventScroll *eve
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_equalizer_gui_data_t *c = (dt_iop_equalizer_gui_data_t *)self->gui_data;
-  if(event->direction == GDK_SCROLL_UP   && c->mouse_radius > 0.25/DT_IOP_EQUALIZER_BANDS) c->mouse_radius *= 0.9; //0.7;
-  if(event->direction == GDK_SCROLL_DOWN && c->mouse_radius < 1.0) c->mouse_radius *= (1.0/0.9); //1.42;
+  switch(event->direction)
+  {
+    case GDK_SCROLL_UP:
+      if(c->mouse_radius > 0.25 / DT_IOP_EQUALIZER_BANDS) c->mouse_radius *= 0.9; // 0.7;
+      break;
+    case GDK_SCROLL_DOWN:
+      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      if((event->delta_y < 0) && (c->mouse_radius > 0.25 / DT_IOP_EQUALIZER_BANDS))
+        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
+      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
+        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      break;
+    default:
+      break;
+  }
   gtk_widget_queue_draw(widget);
   return TRUE;
 }

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -674,24 +674,33 @@ static gboolean dt_iop_equalizer_scrolled(GtkWidget *widget, GdkEventScroll *eve
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_equalizer_gui_data_t *c = (dt_iop_equalizer_gui_data_t *)self->gui_data;
+
+  int handled = FALSE;
+  double delta = 0.0;
   switch(event->direction)
   {
     case GDK_SCROLL_UP:
-      if(c->mouse_radius > 0.25 / DT_IOP_EQUALIZER_BANDS) c->mouse_radius *= 0.9; // 0.7;
+      delta = -1.0;
+      handled = TRUE;
+      break;
       break;
     case GDK_SCROLL_DOWN:
-      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      delta = 1.0;
+      handled = TRUE;
       break;
     case GDK_SCROLL_SMOOTH:
-      if((event->delta_y < 0) && (c->mouse_radius > 0.25 / DT_IOP_EQUALIZER_BANDS))
-        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
-      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
-        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      delta = event->delta_y;
+      handled = TRUE;
       break;
     default:
       break;
   }
-  gtk_widget_queue_draw(widget);
+
+  if(handled)
+  {
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.25 / DT_IOP_EQUALIZER_BANDS, 1.0);
+    gtk_widget_queue_draw(widget);
+  }
   return TRUE;
 }
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -675,32 +675,13 @@ static gboolean dt_iop_equalizer_scrolled(GtkWidget *widget, GdkEventScroll *eve
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_equalizer_gui_data_t *c = (dt_iop_equalizer_gui_data_t *)self->gui_data;
 
-  int handled = FALSE;
-  double delta = 0.0;
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      delta = -1.0;
-      handled = TRUE;
-      break;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = 1.0;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      delta = event->delta_y;
-      handled = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(handled)
-  {
-    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.25 / DT_IOP_EQUALIZER_BANDS, 1.0);
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.25 / DT_IOP_EQUALIZER_BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
+
   return TRUE;
 }
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -588,7 +588,8 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                              | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                             | GDK_SMOOTH_SCROLL_MASK);
   g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(dt_iop_levels_area_draw), self);
   g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(dt_iop_levels_button_press), self);
   g_signal_connect(G_OBJECT(c->area), "button-release-event", G_CALLBACK(dt_iop_levels_button_release), self);
@@ -1038,15 +1039,22 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
     return FALSE;
   }
 
-  if(event->direction == GDK_SCROLL_UP)
+  switch(event->direction)
   {
-    new_position = p->levels[c->handle_move] + interval;
-    updated = TRUE;
-  }
-  else if(event->direction == GDK_SCROLL_DOWN)
-  {
-    new_position = p->levels[c->handle_move] - interval;
-    updated = TRUE;
+    case GDK_SCROLL_UP:
+      new_position = p->levels[c->handle_move] + interval;
+      updated = TRUE;
+      break;
+    case GDK_SCROLL_DOWN:
+      new_position = p->levels[c->handle_move] - interval;
+      updated = TRUE;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      new_position = p->levels[c->handle_move] - interval * event->delta_y;
+      updated = TRUE;
+      break;
+    default:
+      break;
   }
 
   if(updated)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1030,35 +1030,16 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
-  const float interval = 0.002; // Distance moved for each scroll event
-  gboolean updated = FALSE;
-  float new_position = 0;
-
   if(c->dragging)
   {
     return FALSE;
   }
 
-  switch(event->direction)
+  const float interval = 0.002; // Distance moved for each scroll event
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      new_position = p->levels[c->handle_move] + interval;
-      updated = TRUE;
-      break;
-    case GDK_SCROLL_DOWN:
-      new_position = p->levels[c->handle_move] - interval;
-      updated = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      new_position = p->levels[c->handle_move] - interval * event->delta_y;
-      updated = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(updated)
-  {
+    float new_position = p->levels[c->handle_move] - interval * delta_y;
     dt_iop_levels_move_handle(self, c->handle_move, new_position, p->levels, c->drag_start_percentage);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     return TRUE;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -794,24 +794,33 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+
+  int handled = FALSE;
+  double delta = 0.0;
   switch(event->direction)
   {
     case GDK_SCROLL_UP:
-      if(c->mouse_radius > 0.2 / DT_IOP_LOWLIGHT_BANDS) c->mouse_radius *= 0.9; // 0.7;
+      delta = -1.0;
+      handled = TRUE;
+      break;
       break;
     case GDK_SCROLL_DOWN:
-      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      delta = 1.0;
+      handled = TRUE;
       break;
     case GDK_SCROLL_SMOOTH:
-      if((event->delta_y < 0) && (c->mouse_radius > 0.2 / DT_IOP_LOWLIGHT_BANDS))
-        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
-      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
-        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      delta = event->delta_y;
+      handled = TRUE;
       break;
     default:
       break;
   }
-  gtk_widget_queue_draw(widget);
+
+  if(handled)
+  {
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
+    gtk_widget_queue_draw(widget);
+  }
   return TRUE;
 }
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -795,32 +795,13 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
 
-  int handled = FALSE;
-  double delta = 0.0;
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      delta = -1.0;
-      handled = TRUE;
-      break;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = 1.0;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      delta = event->delta_y;
-      handled = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(handled)
-  {
-    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_LOWLIGHT_BANDS, 1.0);
     gtk_widget_queue_draw(widget);
   }
+
   return TRUE;
 }
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -794,9 +794,23 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
-  if(event->direction == GDK_SCROLL_UP && c->mouse_radius > 0.2 / DT_IOP_LOWLIGHT_BANDS)
-    c->mouse_radius *= 0.9; // 0.7;
-  if(event->direction == GDK_SCROLL_DOWN && c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+  switch(event->direction)
+  {
+    case GDK_SCROLL_UP:
+      if(c->mouse_radius > 0.2 / DT_IOP_LOWLIGHT_BANDS) c->mouse_radius *= 0.9; // 0.7;
+      break;
+    case GDK_SCROLL_DOWN:
+      if(c->mouse_radius < 1.0) c->mouse_radius *= (1.0 / 0.9); // 1.42;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      if((event->delta_y < 0) && (c->mouse_radius > 0.2 / DT_IOP_LOWLIGHT_BANDS))
+        c->mouse_radius *= 1.0 + 0.1 * event->delta_y;
+      else if((event->delta_y > 0) && (c->mouse_radius < 1.0))
+        c->mouse_radius *= 1.0 + (0.1 / 0.9) * event->delta_y;
+      break;
+    default:
+      break;
+  }
   gtk_widget_queue_draw(widget);
   return TRUE;
 }
@@ -836,7 +850,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                              | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                             | GDK_SMOOTH_SCROLL_MASK);
   g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(lowlight_draw), self);
   g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(lowlight_button_press), self);
   g_signal_connect(G_OBJECT(c->area), "button-release-event", G_CALLBACK(lowlight_button_release), self);

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -534,10 +534,33 @@ static gboolean dt_iop_monochrome_scrolled(GtkWidget *widget, GdkEventScroll *ev
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-  if(event->direction == GDK_SCROLL_UP && p->size > .5) p->size -= 0.1;
-  if(event->direction == GDK_SCROLL_DOWN && p->size < 3.0) p->size += 0.1;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-  gtk_widget_queue_draw(widget);
+
+  int handled = FALSE;
+  float delta = 0.0;
+  switch(event->direction)
+  {
+    case GDK_SCROLL_UP:
+      delta = -0.1f;
+      handled = TRUE;
+      break;
+    case GDK_SCROLL_DOWN:
+      delta = 0.1f;
+      handled = TRUE;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      delta = 0.1f * event->delta_y;
+      handled = TRUE;
+      break;
+    default:
+      break;
+  }
+
+  if(handled)
+  {
+    p->size = CLAMP(p->size + delta, 0.5f, 3.0f);
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+    gtk_widget_queue_draw(widget);
+  }
   return TRUE;
 }
 
@@ -587,7 +610,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                              | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+                                             | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                             | GDK_SMOOTH_SCROLL_MASK);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_monochrome_draw), self);
   g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(dt_iop_monochrome_button_press), self);
   g_signal_connect(G_OBJECT(g->area), "button-release-event", G_CALLBACK(dt_iop_monochrome_button_release),

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -535,32 +535,14 @@ static gboolean dt_iop_monochrome_scrolled(GtkWidget *widget, GdkEventScroll *ev
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
-  int handled = FALSE;
-  float delta = 0.0;
-  switch(event->direction)
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      delta = -0.1f;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = 0.1f;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      delta = 0.1f * event->delta_y;
-      handled = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(handled)
-  {
-    p->size = CLAMP(p->size + delta, 0.5f, 3.0f);
+    p->size = CLAMP(p->size + delta_y * 0.1, 0.5f, 3.0f);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     gtk_widget_queue_draw(widget);
   }
+
   return TRUE;
 }
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -807,12 +807,11 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 
   if(c->selected < 0) return TRUE;
 
-  gdouble delta_x, delta_y;
-  if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {
-    delta_x *= TONECURVE_DEFAULT_STEP;
     delta_y *= -TONECURVE_DEFAULT_STEP;
-    return _move_point_internal(self, widget, delta_x, delta_y, event->state);
+    return _move_point_internal(self, widget, 0.0, delta_y, event->state);
   }
 
   return TRUE;

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -811,7 +811,21 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
   if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
     delta_x *= -TONECURVE_DEFAULT_STEP;
-    delta_y *= TONECURVE_DEFAULT_STEP;
+    delta_y *= -TONECURVE_DEFAULT_STEP;
+
+    GdkDevice *source_device = gdk_event_get_source_device((GdkEvent*)event);
+    GdkInputSource source = gdk_device_get_source(source_device);
+    // For touch and trackpoint events, move the pointer in the
+    // direction of the scroll if the event type is available. Never
+    // flip mousewheel deltas. Note that GDK's Wayland backend
+    // identifies touchpad/trackpoint events, but under XWayland, the
+    // Wayland backend reports touchpad/trackpoint events as
+    // GDK_SOURCE_MOUSE. GDK's X11 backend identifies trackpoint
+    // events but reports touchpad events as being GDK_SOURCE_MOUSE.
+    if((source == GDK_SOURCE_TOUCHPAD) || (source == GDK_SOURCE_TRACKPOINT) ||
+       (source == GDK_SOURCE_TOUCHSCREEN))
+      delta_y = -delta_y;
+
     return _move_point_internal(self, widget, delta_x, delta_y, event->state);
   }
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -810,22 +810,8 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
   gdouble delta_x, delta_y;
   if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
-    delta_x *= -TONECURVE_DEFAULT_STEP;
+    delta_x *= TONECURVE_DEFAULT_STEP;
     delta_y *= -TONECURVE_DEFAULT_STEP;
-
-    GdkDevice *source_device = gdk_event_get_source_device((GdkEvent*)event);
-    GdkInputSource source = gdk_device_get_source(source_device);
-    // For touch and trackpoint events, move the pointer in the
-    // direction of the scroll if the event type is available. Never
-    // flip mousewheel deltas. Note that GDK's Wayland backend
-    // identifies touchpad/trackpoint events, but under XWayland, the
-    // Wayland backend reports touchpad/trackpoint events as
-    // GDK_SOURCE_MOUSE. GDK's X11 backend identifies trackpoint
-    // events but reports touchpad events as being GDK_SOURCE_MOUSE.
-    if((source == GDK_SOURCE_TOUCHPAD) || (source == GDK_SOURCE_TRACKPOINT) ||
-       (source == GDK_SOURCE_TOUCHSCREEN))
-      delta_y = -delta_y;
-
     return _move_point_internal(self, widget, delta_x, delta_y, event->state);
   }
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -807,38 +807,15 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
 
   if(c->selected < 0) return TRUE;
 
-  int handled = 0;
-  float dx = 0.0f, dy = 0.0f;
-  switch(event->direction)
+  gdouble delta_x, delta_y;
+  if(dt_gui_get_scroll_deltas(event, &delta_x, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      handled = 1;
-      dy = -TONECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_DOWN:
-      handled = 1;
-      dy = TONECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_LEFT:
-      handled = 1;
-      dx = TONECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_RIGHT:
-      handled = 1;
-      dx = -TONECURVE_DEFAULT_STEP;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      handled = 1;
-      dx = -TONECURVE_DEFAULT_STEP * event->delta_x;
-      dy = TONECURVE_DEFAULT_STEP * event->delta_y;
-      break;
-    default:
-      break;
+    delta_x *= -TONECURVE_DEFAULT_STEP;
+    delta_y *= TONECURVE_DEFAULT_STEP;
+    return _move_point_internal(self, widget, delta_x, delta_y, event->state);
   }
 
-  if(!handled) return TRUE;
-
-  return _move_point_internal(self, widget, dx, dy, event->state);
+  return TRUE;
 }
 
 static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -808,21 +808,37 @@ static gboolean _scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer use
   if(c->selected < 0) return TRUE;
 
   int handled = 0;
-  float dy = 0.0f;
-  if(event->direction == GDK_SCROLL_UP)
+  float dx = 0.0f, dy = 0.0f;
+  switch(event->direction)
   {
-    handled = 1;
-    dy = TONECURVE_DEFAULT_STEP;
-  }
-  if(event->direction == GDK_SCROLL_DOWN)
-  {
-    handled = 1;
-    dy = -TONECURVE_DEFAULT_STEP;
+    case GDK_SCROLL_UP:
+      handled = 1;
+      dy = -TONECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_DOWN:
+      handled = 1;
+      dy = TONECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_LEFT:
+      handled = 1;
+      dx = TONECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_RIGHT:
+      handled = 1;
+      dx = -TONECURVE_DEFAULT_STEP;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      handled = 1;
+      dx = -TONECURVE_DEFAULT_STEP * event->delta_x;
+      dy = TONECURVE_DEFAULT_STEP * event->delta_y;
+      break;
+    default:
+      break;
   }
 
   if(!handled) return TRUE;
 
-  return _move_point_internal(self, widget, 0.0, dy, event->state);
+  return _move_point_internal(self, widget, dx, dy, event->state);
 }
 
 static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
@@ -929,7 +945,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                  | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK | GDK_KEY_PRESS_MASK);
+                                                 | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                                 | GDK_SMOOTH_SCROLL_MASK | GDK_KEY_PRESS_MASK);
   gtk_widget_set_can_focus(GTK_WIDGET(c->area), TRUE);
   g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
   g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(dt_iop_tonecurve_button_press), self);

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -589,7 +589,8 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->zones), "scroll-event", G_CALLBACK(dt_iop_zonesystem_bar_scrolled), self);
   gtk_widget_add_events(GTK_WIDGET(g->zones), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                               | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
-                                              | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK);
+                                              | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
+                                              | GDK_SMOOTH_SCROLL_MASK);
   gtk_widget_set_size_request(g->zones, -1, DT_PIXEL_APPLY_DPI(40));
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->preview, TRUE, TRUE, 0);
@@ -772,18 +773,38 @@ static gboolean dt_iop_zonesystem_bar_scrolled(GtkWidget *widget, GdkEventScroll
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
   int cs = CLAMP(p->size, 4, MAX_ZONE_SYSTEM_SIZE);
 
-  if(event->direction == GDK_SCROLL_UP)
-    p->size += 1;
-  else if(event->direction == GDK_SCROLL_DOWN)
-    p->size -= 1;
+  static double acc = 0.0;
+  int delta = 0;
+  switch(event->direction)
+  {
+    case GDK_SCROLL_UP:
+      delta = 1;
+      break;
+    case GDK_SCROLL_DOWN:
+      delta = -1;
+      break;
+    case GDK_SCROLL_SMOOTH:
+      acc += event->delta_y;
+      if(fabs(acc) >= 1.0)
+      {
+        delta = -trunc(acc);
+        acc -= trunc(acc);
+      }
+#if GTK_CHECK_VERSION(3, 20, 0)
+      if(gdk_event_is_scroll_stop_event((GdkEvent*)event)) acc = 0.0;
+#endif
+      break;
+    default:
+      break;
+  }
 
-  /* sanity checks */
-  p->size = CLAMP(p->size, 4, MAX_ZONE_SYSTEM_SIZE);
-
-  p->zone[cs] = -1;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-
-  gtk_widget_queue_draw(widget);
+  if(delta)
+  {
+    p->size = CLAMP(p->size + delta, 4, MAX_ZONE_SYSTEM_SIZE);
+    p->zone[cs] = -1;
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+    gtk_widget_queue_draw(widget);
+  }
 
   return TRUE;
 }

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -773,34 +773,10 @@ static gboolean dt_iop_zonesystem_bar_scrolled(GtkWidget *widget, GdkEventScroll
   dt_iop_zonesystem_params_t *p = (dt_iop_zonesystem_params_t *)self->params;
   int cs = CLAMP(p->size, 4, MAX_ZONE_SYSTEM_SIZE);
 
-  static double acc = 0.0;
-  int delta = 0;
-  switch(event->direction)
+  int delta_y;
+  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
   {
-    case GDK_SCROLL_UP:
-      delta = 1;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = -1;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      acc += event->delta_y;
-      if(fabs(acc) >= 1.0)
-      {
-        delta = -trunc(acc);
-        acc -= trunc(acc);
-      }
-#if GTK_CHECK_VERSION(3, 20, 0)
-      if(gdk_event_is_scroll_stop_event((GdkEvent*)event)) acc = 0.0;
-#endif
-      break;
-    default:
-      break;
-  }
-
-  if(delta)
-  {
-    p->size = CLAMP(p->size + delta, 4, MAX_ZONE_SYSTEM_SIZE);
+    p->size = CLAMP(p->size - delta_y, 4, MAX_ZONE_SYSTEM_SIZE);
     p->zone[cs] = -1;
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     gtk_widget_queue_draw(widget);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -606,32 +606,16 @@ static gboolean _lib_histogram_scroll_callback(GtkWidget *widget, GdkEventScroll
   float ce = dt_dev_exposure_get_exposure(darktable.develop);
   float cb = dt_dev_exposure_get_black(darktable.develop);
 
-  int handled = FALSE;
-  double delta = 0.0;
-  switch(event->direction)
-  {
-    case GDK_SCROLL_UP:
-      delta = -1.0;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_DOWN:
-      delta = 1.0;
-      handled = TRUE;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      delta = event->delta_y;
-      handled = TRUE;
-      break;
-    default:
-      break;
-  }
-
-  if(handled)
+  int delta_y;
+  // note are using unit rather than smooth scroll events, as
+  // exposure changes can get laggy if handling a multitude of smooth
+  // scroll events
+  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
   {
     if(d->highlight == 2)
-      dt_dev_exposure_set_exposure(darktable.develop, ce - 0.15 * delta);
+      dt_dev_exposure_set_exposure(darktable.develop, ce - 0.15f * delta_y);
     else if(d->highlight == 1)
-      dt_dev_exposure_set_black(darktable.develop, cb + 0.001 * delta);
+      dt_dev_exposure_set_black(darktable.develop, cb + 0.001f * delta_y);
   }
 
   return TRUE;

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -486,37 +486,14 @@ static gboolean _lib_filmstrip_motion_notify_callback(GtkWidget *w, GdkEventMoti
 
 static gboolean _lib_filmstrip_scroll_callback(GtkWidget *w, GdkEventScroll *e, gpointer user_data)
 {
-  static double acc = 0.0;
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
 
   /* change the offset */
-  int delta = 0;
-  switch(e->direction)
+  int delta_x, delta_y;
+  if(dt_gui_get_scroll_unit_deltas(e, &delta_x, &delta_y))
   {
-    case GDK_SCROLL_UP:
-    case GDK_SCROLL_LEFT:
-      delta = -1;
-      break;
-    case GDK_SCROLL_DOWN:
-    case GDK_SCROLL_RIGHT:
-      delta = 1;
-      break;
-    case GDK_SCROLL_SMOOTH:
-      acc += e->delta_y + e->delta_x;
-      delta = trunc(acc);
-      acc -= delta;
-#if GTK_CHECK_VERSION(3, 20, 0)
-      if(gdk_event_is_scroll_stop_event((GdkEvent*)e)) acc = 0.0;
-#endif
-      break;
-    default:
-      break;
-  }
-
-  if(delta)
-  {
-    strip->offset = CLAMP(strip->offset + delta, 0, strip->collection_count-1);
+    strip->offset = CLAMP(strip->offset + delta_x + delta_y, 0, strip->collection_count-1);
     gtk_widget_queue_draw(self->widget);
   }
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -302,27 +302,9 @@ static void _lib_filter_compare_button_changed(GtkDarktableToggleButton *widget,
 
 static gboolean _comparator_scolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
-  static double acc = 0.0;
-  switch(event->direction)
-  {
-    case GDK_SCROLL_UP:
-      _change_comparator(GTK_WIDGET(widget), user_data, -1);
-      break;
-    case GDK_SCROLL_DOWN:
-      _change_comparator(GTK_WIDGET(widget), user_data, 1);
-      break;
-    case GDK_SCROLL_SMOOTH:
-      acc += event->delta_y;
-      if(fabs(acc) >= 1.0)
-      {
-        int change = trunc(acc);
-        acc -= change;
-        _change_comparator(GTK_WIDGET(widget), user_data, change);
-      }
-      break;
-    default:
-      break;
-  }
+  int delta_y;
+  if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
+    _change_comparator(GTK_WIDGET(widget), user_data, delta_y);
   return TRUE;
 }
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -113,7 +113,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), widget, FALSE, FALSE, 4);
   g_signal_connect(G_OBJECT(widget), "toggled", G_CALLBACK(_lib_filter_compare_button_changed),
                    (gpointer)self);
-  gtk_widget_add_events(widget, GDK_SCROLL_MASK);
+  gtk_widget_add_events(widget, GDK_SCROLL_MASK | GDK_SMOOTH_SCROLL_MASK);
   g_signal_connect(G_OBJECT(widget), "scroll-event", G_CALLBACK(_comparator_scolled), self);
 
   /* create the filter combobox */
@@ -302,15 +302,26 @@ static void _lib_filter_compare_button_changed(GtkDarktableToggleButton *widget,
 
 static gboolean _comparator_scolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
-  if(event->direction == 0)
+  static double acc = 0.0;
+  switch(event->direction)
   {
-    // scrollled up
-    _change_comparator(GTK_WIDGET(widget), user_data, -1);
-  }
-  else
-  {
-    // scrolled down
-    _change_comparator(GTK_WIDGET(widget), user_data, 1);
+    case GDK_SCROLL_UP:
+      _change_comparator(GTK_WIDGET(widget), user_data, -1);
+      break;
+    case GDK_SCROLL_DOWN:
+      _change_comparator(GTK_WIDGET(widget), user_data, 1);
+      break;
+    case GDK_SCROLL_SMOOTH:
+      acc += event->delta_y;
+      if(fabs(acc) >= 1.0)
+      {
+        int change = trunc(acc);
+        acc -= change;
+        _change_comparator(GTK_WIDGET(widget), user_data, change);
+      }
+      break;
+    default:
+      break;
   }
   return TRUE;
 }


### PR DESCRIPTION
Allow smooth scrolling for the majority of the UI components. The rationale is twofold:

1. Smooth scrolling can make things nicer for trackpad users. It has been supported since GTK+ 3.4, and it seems worth taking advantage of these events.
2. GDK's Wayland backend will only generate smooth scroll events for trackpads. Therefore this is a step towards re-enabling the Wayland backend. See bug #11535.

Some things are still not smooth-scrolled:
1. GtkComboBox does not implement smooth scrolling, even though it is widely used in the UI. I'm not clear if this is a bug or a decision. The very-similar bauhaus comboboxes do now allow smooth scrolling to change their values. Does it make sense to disable the latter, for consistency? Or wrap the former to allow smooth scrolling?
2. The view's center container still gets up-or-not-up rather than a smooth scroll delta. Smooth scrolling actually looks great in the center container, but the events also have to be routed to masks and possibly iops. For now am keeping things integral and these changes contained.

I found and fixed a few minor bugs along the way, as noted in commit messages. I had to make some calls where the original implementation seemed off when clamping ranges. I changed the behavior of scrolling on control points of basecurve and tone curve (flipped up/down, added left/right), I hope for the better.