### PR TITLE
opencl: add option to force-use opencl for a specific pixelpipe

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -114,6 +114,13 @@
     <longdescription>defines priorities on how (multiple) OpenCL devices are allocated to the different types of pixelpipe (full, preview, export, thumbnail). for more details visit our usermanual (needs a restart).</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>opencl_mandatory_timeout</name>
+    <type min="0">int</type>
+    <default>200</default>
+    <shortdescription>timeout period for locking mandatory opencl device</shortdescription>
+    <longdescription>time period (in units of 5ms) after which we give up try-locking an opencl device for mandatory use. defaults to 200.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>opencl_use_pinned_memory</name>
     <type>bool</type>
     <default>false</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -196,6 +196,19 @@
     <shortdescription>activate OpenCL support</shortdescription>
     <longdescription>if found, use OpenCL runtime on your system for improved processing speed. can be switched on and off at any time.</longdescription>
   </dtconfig>
+  <dtconfig prefs="core" capability="opencl">
+    <name>opencl_scheduling_profile</name>
+    <type>
+      <enum>
+        <option>default</option>
+        <option>multiple GPUs</option>
+        <option>very fast GPU</option>
+      </enum>
+    </type>
+    <default>default</default>
+    <shortdescription>OpenCL scheduling profile</shortdescription>
+    <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems. default - GPU processes full and CPU processes preview pipe (adaptable by config parameters); multiple GPUs - process both pixelpipes in parallel on two different GPUs; very fast GPU - process both pixelipes sequentially on the GPU.</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>opencl_library</name>
     <type>string</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -157,7 +157,7 @@
   </dtconfig>
   <dtconfig>
     <name>pixelpipe_synchronization_timeout</name>
-    <type min="0">int</type>
+    <type>int</type>
     <default>200</default>
     <shortdescription>timeout period of pixelpipe synchronization</shortdescription>
     <longdescription>time period (in units of 5ms) after which synchronization of preview and full pixelpipe is assumed to have failed. set to zero to omit pixelpipe synchronization. defaults to 200.</longdescription>

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -497,6 +497,7 @@ void dt_opencl_init(dt_opencl_t *cl, const gboolean exclude_opencl, const gboole
   cl->synch_cache = dt_conf_get_bool("opencl_synch_cache");
   cl->micro_nap = dt_conf_get_int("opencl_micro_nap");
   cl->enable_markesteijn = dt_conf_get_bool("opencl_enable_markesteijn");
+  cl->opencl_synchronization_timeout = dt_conf_get_int("pixelpipe_synchronization_timeout");
   cl->crc = 0;
   cl->dlocl = NULL;
   cl->dev_priority_image = NULL;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -125,6 +125,7 @@ typedef struct dt_opencl_t
   int stopped;
   int num_devs;
   int error_count;
+  int opencl_synchronization_timeout;
   uint32_t crc;
   int mandatory[4];
   int *dev_priority_image;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -126,6 +126,7 @@ typedef struct dt_opencl_t
   int num_devs;
   int error_count;
   uint32_t crc;
+  int mandatory[4];
   int *dev_priority_image;
   int *dev_priority_preview;
   int *dev_priority_export;

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -53,6 +53,13 @@ typedef enum dt_opencl_memory_t
   OPENCL_MEMORY_SUB
 } dt_opencl_memory_t;
 
+typedef enum dt_opencl_scheduling_profile_t
+{
+  OPENCL_PROFILE_DEFAULT,
+  OPENCL_PROFILE_MULTIPLE_GPUS,
+  OPENCL_PROFILE_VERYFAST_GPU
+} dt_opencl_scheduling_profile_t;
+
 /**
  * Accounting information used for OpenCL events.
  */
@@ -126,6 +133,7 @@ typedef struct dt_opencl_t
   int num_devs;
   int error_count;
   int opencl_synchronization_timeout;
+  dt_opencl_scheduling_profile_t scheduling_profile;
   uint32_t crc;
   int mandatory[4];
   int *dev_priority_image;
@@ -219,8 +227,8 @@ int dt_opencl_is_enabled(void);
 /** disable opencl */
 void dt_opencl_disable(void);
 
-/** update enabled flag with value from preferences */
-int dt_opencl_update_enabled(void);
+/** update enabled flag and profile with value from preferences, returns enabled flag */
+int dt_opencl_update_settings(void);
 
 /** HAVE_OPENCL mode only: copy and alloc buffers. */
 int dt_opencl_copy_device_to_host(const int devid, void *host, void *device, const int width,
@@ -423,7 +431,7 @@ static inline int dt_opencl_is_enabled(void)
 static inline void dt_opencl_disable(void)
 {
 }
-static inline int dt_opencl_update_enabled(void)
+static inline int dt_opencl_update_settings(void)
 {
   return 0;
 }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -29,6 +29,7 @@
 #include "common/image_cache.h"
 #include "common/imageio.h"
 #include "common/mipmap_cache.h"
+#include "common/opencl.h"
 #include "common/tags.h"
 #include "control/conf.h"
 #include "control/control.h"
@@ -1816,7 +1817,17 @@ int dt_dev_wait_hash(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, int pmi
                      const volatile uint64_t *const hash)
 {
   const int usec = 5000;
-  const int nloop = dt_conf_get_int("pixelpipe_synchronization_timeout");
+  int nloop;
+
+#ifdef HAVE_OPENCL
+  if(pipe->devid >= 0)
+    nloop = darktable.opencl->opencl_synchronization_timeout;
+  else
+    nloop = dt_conf_get_int("pixelpipe_synchronization_timeout");
+#else
+  nloop = dt_conf_get_int("pixelpipe_synchronization_timeout");
+#endif
+
   if(nloop <= 0) return TRUE;  // non-positive values omit pixelpipe synchronization
 
   for(int n = 0; n < nloop; n++)
@@ -1894,7 +1905,17 @@ int dt_dev_wait_hash_distort(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe,
                      const volatile uint64_t *const hash)
 {
   const int usec = 5000;
-  const int nloop = dt_conf_get_int("pixelpipe_synchronization_timeout");
+  int nloop;
+
+#ifdef HAVE_OPENCL
+  if(pipe->devid >= 0)
+    nloop = darktable.opencl->opencl_synchronization_timeout;
+  else
+    nloop = dt_conf_get_int("pixelpipe_synchronization_timeout");
+#else
+  nloop = dt_conf_get_int("pixelpipe_synchronization_timeout");
+#endif
+
   if(nloop <= 0) return TRUE;  // non-positive values omit pixelpipe synchronization
 
   for(int n = 0; n < nloop; n++)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2229,7 +2229,7 @@ int dt_dev_pixelpipe_process(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, int x,
                              float scale)
 {
   pipe->processing = 1;
-  pipe->opencl_enabled = dt_opencl_update_enabled(); // update enabled flag from preferences
+  pipe->opencl_enabled = dt_opencl_update_settings(); // update enabled flag and profile from preferences
   pipe->devid = (pipe->opencl_enabled) ? dt_opencl_lock_device(pipe->type)
                                        : -1; // try to get/lock opencl resource
 


### PR DESCRIPTION
prefixing with a '+' the corresponding entry in the opencl_device_priority parameter causes darktable to compulsorily use one of the given opencl devices rather than falling back to the CPU; if no free device is found the pixelpipe is forced to wait; maximum waiting time is given by the opencl_mandatory_timeout parameter in units of 5ms; use this option if you have a very fast GPU (compared to your CPU) and sequential processing of full and preview pixelpipe on GPU is better than parallel processing on GPU+CPU.

a typical setting would be

`opencl_device_priority=+*/+*/*/*`

beware that activating this feature might cause some hickups (intermittent slow pixelpipe processing) if modules are activated which require pixelpipe synchronization (e.g. global tonemap). one needs to play with the opencl_mandatory_timeout and pixelpipe_synchronization_timout parameters to optimize for best results (feedback welcome). in case of really fast GPUs this should not be a major issue.