### PR TITLE
gen-profile: read exiv.image for possible iso setting

### DIFF
--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -299,6 +299,9 @@ get_image_iso() {
 	if [ -z "$iso" -o "$iso" = "65535" ]; then
 		iso=$(get_exif_key "$file" Exif.Photo.StandardOutputSensitivity)
 	fi
+	if [ -z "$iso" -o "$iso" = "65535" ]; then
+		iso=$(get_exif_key "$file" Exif.Image.ISOSpeedRatings)
+	fi
 
 	# Then try some brand specific values if still not found.
 


### PR DESCRIPTION
Nexus 5 only writes Exif.Image.ISOSpeedRatings instead of Exif.Photo.ISOSpeedRatings