### PR TITLE
spots: add quick way to show/hide the spots masks.

### DIFF
--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -640,7 +640,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
   g->label = GTK_LABEL(gtk_label_new("-1"));
   gtk_widget_set_tooltip_text(hbox, _("click on a shape and drag on canvas.\nuse the mouse wheel "
-                                      "to adjust size.\nright click to remove a shape."));
+                                      "to adjust size.\nright click to remove a shape."
+                                      "\nmiddle click on image to show/hide masks"));
 
   g->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER);
   g_signal_connect(G_OBJECT(g->bt_path), "button-press-event", G_CALLBACK(_add_path), self);
@@ -689,6 +690,7 @@ void init_key_accels (dt_iop_module_so_t *module)
   dt_accel_register_iop (module, TRUE, NC_("accel", "spot circle tool"),   0, 0);
   dt_accel_register_iop (module, TRUE, NC_("accel", "spot elipse tool"),   0, 0);
   dt_accel_register_iop (module, TRUE, NC_("accel", "spot path tool"),     0, 0);
+  dt_accel_register_iop (module, TRUE, NC_("accel", "spot show or hide"),     0, 0);
 }
 
 static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -721,6 +723,30 @@ static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceler
   return TRUE;
 }
 
+static gboolean _show_hide_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                     GdkModifierType modifier, gpointer data)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  dt_masks_set_edit_mode(module, module->dev->form_gui->edit_mode == DT_MASKS_EDIT_FULL ? DT_MASKS_EDIT_OFF : DT_MASKS_EDIT_FULL);
+  return TRUE;
+}
+
+int button_pressed (struct dt_iop_module_t *self,
+                    double x,
+                    double y,
+                    double pressure,
+                    int which,
+                    int type,
+                    uint32_t state)
+{
+  if (which == 2)
+  {
+    dt_masks_set_edit_mode(self, self->dev->form_gui->edit_mode == DT_MASKS_EDIT_FULL ? DT_MASKS_EDIT_OFF : DT_MASKS_EDIT_FULL);
+    return 1;
+  }
+  return 0;
+}
+
 void connect_key_accels (dt_iop_module_t *module)
 {
   GClosure *closure;
@@ -733,6 +759,9 @@ void connect_key_accels (dt_iop_module_t *module)
 
   closure = g_cclosure_new(G_CALLBACK(_add_path_key_accel), (gpointer)module, NULL);
   dt_accel_connect_iop (module, "spot path tool", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_show_hide_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop (module, "spot show or hide", closure);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
To see the image without masks one need to go to the module gui and close
it. This needs moving out of the image away from the mask controls. This
commit add a quick way to show/hide the masks using the mouse button 3.