### PR TITLE
use GtkPopover for toolbar floating windows

### DIFF
--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -209,12 +209,22 @@ table
   background-color: transparent;
 }
 
+popover {
+  opacity: 0.9;
+  border: 0;
+  border-radius: 0;
+  box-shadow: 0 0 0 2pt #111111;
+  background-color: @selected_bg_color;
+  padding: 1pt;
+}
+
 frame {
   border: 1pt solid #111111;
   background-color: @selected_bg_color;
   color: @selected_fg_color;
 }
 
+popover *,
 frame * {
   background-color: transparent;
   color: @selected_fg_color;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -37,8 +37,6 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *cr, gpointer u
 static gboolean dt_bauhaus_popup_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data);
 static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w);
 static void dt_bauhaus_widget_reject(dt_bauhaus_widget_t *w);
-static gboolean dt_bauhaus_root_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data);
-static gboolean dt_bauhaus_root_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data);
 
 
 static int get_line_space()
@@ -232,46 +230,38 @@ static void draw_slider_line(cairo_t *cr, float pos, float off, float scale, con
 }
 // -------------------------------
 
-// handlers on the root window, to close popup:
-static gboolean dt_bauhaus_root_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
+// handlers on the popup window, to close popup:
+static gboolean dt_bauhaus_window_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
-  if(darktable.bauhaus->current)
+  const float tol = 50;
+  gint wx, wy;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  gdk_window_get_origin(gtk_widget_get_window(widget), &wx, &wy);
+  if(event->x_root > wx + allocation.width + tol || event->y_root > wy + allocation.height + tol
+     || event->x_root < (int)wx - tol || event->y_root < (int)wy - tol)
   {
-    const float tol = 50;
-    gint wx, wy;
-    widget = darktable.bauhaus->popup_window;
-    GtkAllocation allocation;
-    gtk_widget_get_allocation(widget, &allocation);
-    gdk_window_get_origin(gtk_widget_get_window(widget), &wx, &wy);
-    if(event->x_root > wx + allocation.width + tol || event->y_root > wy + allocation.height + tol
-       || event->x_root < (int)wx - tol || event->y_root < (int)wy - tol)
-    {
-      dt_bauhaus_widget_reject(darktable.bauhaus->current);
-      dt_bauhaus_hide_popup();
-    }
+    dt_bauhaus_widget_reject(darktable.bauhaus->current);
+    dt_bauhaus_hide_popup();
     return TRUE;
   }
   // make sure to propagate the event further
   return FALSE;
 }
 
-static gboolean dt_bauhaus_root_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+static gboolean dt_bauhaus_window_button_press(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
-  if(darktable.bauhaus->current)
+  const float tol = 0;
+  gint wx, wy;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  gdk_window_get_origin(gtk_widget_get_window(widget), &wx, &wy);
+  if((event->x_root > wx + allocation.width + tol || event->y_root > wy + allocation.height + tol
+      || event->x_root < (int)wx - tol || event->y_root < (int)wy - tol))
   {
-    const float tol = 0;
-    gint wx, wy;
-    widget = darktable.bauhaus->popup_window;
-    GtkAllocation allocation;
-    gtk_widget_get_allocation(widget, &allocation);
-    gdk_window_get_origin(gtk_widget_get_window(widget), &wx, &wy);
-    if((event->x_root > wx + allocation.width + tol || event->y_root > wy + allocation.height + tol
-        || event->x_root < (int)wx - tol || event->y_root < (int)wy - tol))
-    {
-      dt_bauhaus_widget_reject(darktable.bauhaus->current);
-      dt_bauhaus_hide_popup();
-      return TRUE;
-    }
+    dt_bauhaus_widget_reject(darktable.bauhaus->current);
+    dt_bauhaus_hide_popup();
+    return TRUE;
   }
   // make sure to propagate the event further
   return FALSE;
@@ -451,30 +441,14 @@ static gboolean dt_bauhaus_popup_button_press(GtkWidget *widget, GdkEventButton 
   return TRUE;
 }
 
-static void window_show(GtkWidget *w, gpointer user_data)
+static void dt_bauhaus_window_show(GtkWidget *w, gpointer user_data)
 {
-#if GTK_CHECK_VERSION(3, 20, 0)
-  gdk_seat_grab (
-      gdk_display_get_default_seat(gtk_widget_get_display(w)),
-      gtk_widget_get_window(w),
-      GDK_SEAT_CAPABILITY_KEYBOARD, FALSE, 0,0,0,0);
-#else
-  GdkDisplay *display = gtk_widget_get_display(w);
-  GdkDeviceManager *mgr = gdk_display_get_device_manager(display);
-  GList *devices = gdk_device_manager_list_devices(mgr, GDK_DEVICE_TYPE_MASTER);
-  GList *tmp = devices;
-  while(tmp)
-  {
-    GdkDevice *dev = tmp->data;
-    if(gdk_device_get_source(dev) == GDK_SOURCE_KEYBOARD)
-    {
-      gdk_device_grab(dev, gtk_widget_get_window(w), GDK_OWNERSHIP_NONE, FALSE,
-                      GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK, NULL, GDK_CURRENT_TIME);
-    }
-    tmp = tmp->next;
-  }
-  g_list_free(devices);
-#endif
+  // Could grab the popup_area rather than popup_window, but if so
+  // then popup_area would get all motion events including those
+  // outside of the popup. This way the popup_area gets motion events
+  // related to updating the popup, and popup_window gets all others
+  // which would be the ones telling it to close the popup.
+  gtk_grab_add(w);
 }
 
 static void dt_bh_init(DtBauhausWidget *class)
@@ -505,13 +479,6 @@ void dt_bauhaus_init()
   darktable.bauhaus->current = NULL;
   darktable.bauhaus->popup_area = gtk_drawing_area_new();
 
-  // connect signal to eventually clean up our popup if we go too far away and such:
-  GtkWidget *root_window = dt_ui_main_window(darktable.gui->ui);
-  g_signal_connect(G_OBJECT(root_window), "motion-notify-event", G_CALLBACK(dt_bauhaus_root_motion_notify),
-                   (gpointer)NULL);
-  g_signal_connect(G_OBJECT(root_window), "button-press-event", G_CALLBACK(dt_bauhaus_root_button_press),
-                   (gpointer)NULL);
-
   darktable.bauhaus->line_space = 2;
   darktable.bauhaus->line_height = 11;
   darktable.bauhaus->marker_size = 0.3f;
@@ -526,6 +493,7 @@ void dt_bauhaus_init()
   darktable.bauhaus->indicator = .6f;
   darktable.bauhaus->insensitive = 0.2f;
 
+  GtkWidget *root_window = dt_ui_main_window(darktable.gui->ui);
   GtkStyleContext *ctx = gtk_style_context_new();
   GtkWidgetPath *path;
   path = gtk_widget_path_new ();
@@ -611,8 +579,12 @@ void dt_bauhaus_init()
                                                        | GDK_KEY_PRESS_MASK | GDK_LEAVE_NOTIFY_MASK
                                                        | GDK_SCROLL_MASK | GDK_SMOOTH_SCROLL_MASK);
 
-  g_signal_connect(G_OBJECT(darktable.bauhaus->popup_window), "show", G_CALLBACK(window_show), (gpointer)NULL);
+  g_signal_connect(G_OBJECT(darktable.bauhaus->popup_window), "show", G_CALLBACK(dt_bauhaus_window_show), (gpointer)NULL);
   g_signal_connect(G_OBJECT(darktable.bauhaus->popup_area), "draw", G_CALLBACK(dt_bauhaus_popup_draw),
+                   (gpointer)NULL);
+  g_signal_connect(G_OBJECT(darktable.bauhaus->popup_window), "motion-notify-event",
+                   G_CALLBACK(dt_bauhaus_window_motion_notify), (gpointer)NULL);
+  g_signal_connect(G_OBJECT(darktable.bauhaus->popup_window), "button-press-event", G_CALLBACK(dt_bauhaus_window_button_press),
                    (gpointer)NULL);
   g_signal_connect(G_OBJECT(darktable.bauhaus->popup_area), "motion-notify-event",
                    G_CALLBACK(dt_bauhaus_popup_motion_notify), (gpointer)NULL);
@@ -1741,25 +1713,7 @@ void dt_bauhaus_hide_popup()
 {
   if(darktable.bauhaus->current)
   {
-#if GTK_CHECK_VERSION(3, 20, 0)
-    gdk_seat_ungrab(
-      gdk_display_get_default_seat(gtk_widget_get_display(GTK_WIDGET(darktable.bauhaus->current))));
-#else
-    GdkDisplay *display = gdk_display_get_default();
-    GdkDeviceManager *mgr = gdk_display_get_device_manager(display);
-    GList *devices = gdk_device_manager_list_devices(mgr, GDK_DEVICE_TYPE_MASTER);
-    GList *tmp = devices;
-    while(tmp)
-    {
-      GdkDevice *dev = tmp->data;
-      if(gdk_device_get_source(dev) == GDK_SOURCE_KEYBOARD)
-      {
-        gdk_device_ungrab(dev, GDK_CURRENT_TIME);
-      }
-      tmp = tmp->next;
-    }
-    g_list_free(devices);
-#endif
+    gtk_grab_remove(darktable.bauhaus->popup_window);
     gtk_widget_hide(darktable.bauhaus->popup_window);
     darktable.bauhaus->current = NULL;
     // TODO: give focus to center view? do in accept() as well?

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -976,36 +976,10 @@ static void _overexposed_quickbutton_clicked(GtkWidget *w, gpointer user_data)
   dt_dev_reprocess_all(d);
 }
 
-static gboolean _overexposed_close_popup(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  dt_develop_t *d = (dt_develop_t *)user_data;
-  if(!gtk_widget_is_visible(darktable.bauhaus->popup_window))
-    gtk_widget_hide(d->overexposed.floating_window);
-  return FALSE;
-}
-
 static gboolean _overexposed_show_popup(gpointer user_data)
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
-  /** finally move the window next to the button */
-  gint x, y, wx, wy;
-  gint px, py, window_w, window_h;
-  GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
   gtk_widget_show_all(d->overexposed.floating_window);
-  gdk_window_get_origin(gtk_widget_get_window(d->overexposed.button), &px, &py);
-
-  window_w = gdk_window_get_width(gtk_widget_get_window(d->overexposed.floating_window));
-  window_h = gdk_window_get_height(gtk_widget_get_window(d->overexposed.floating_window));
-
-  gtk_widget_translate_coordinates(d->overexposed.button, window, 0, 0, &wx, &wy);
-  x = px + wx - window_w + DT_PIXEL_APPLY_DPI(5);
-  y = py + wy - window_h - DT_PIXEL_APPLY_DPI(5);
-  gtk_window_move(GTK_WINDOW(d->overexposed.floating_window), x, y);
-
-  gtk_window_present(GTK_WINDOW(d->overexposed.floating_window));
-
-  // when the mouse moves back over the main window we close the popup.
-  g_signal_connect(d->overexposed.floating_window, "focus-out-event", G_CALLBACK(_overexposed_close_popup), user_data);
 
   return FALSE;
 }
@@ -1076,36 +1050,10 @@ static void _rawoverexposed_quickbutton_clicked(GtkWidget *w, gpointer user_data
   dt_dev_reprocess_all(d);
 }
 
-static gboolean _rawoverexposed_close_popup(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  dt_develop_t *d = (dt_develop_t *)user_data;
-  if(!gtk_widget_is_visible(darktable.bauhaus->popup_window)) gtk_widget_hide(d->rawoverexposed.floating_window);
-  return FALSE;
-}
-
 static gboolean _rawoverexposed_show_popup(gpointer user_data)
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
-  /** finally move the window next to the button */
-  gint x, y, wx, wy;
-  gint px, py, window_w, window_h;
-  GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
   gtk_widget_show_all(d->rawoverexposed.floating_window);
-  gdk_window_get_origin(gtk_widget_get_window(d->rawoverexposed.button), &px, &py);
-
-  window_w = gdk_window_get_width(gtk_widget_get_window(d->rawoverexposed.floating_window));
-  window_h = gdk_window_get_height(gtk_widget_get_window(d->rawoverexposed.floating_window));
-
-  gtk_widget_translate_coordinates(d->rawoverexposed.button, window, 0, 0, &wx, &wy);
-  x = px + wx - window_w + DT_PIXEL_APPLY_DPI(5);
-  y = py + wy - window_h - DT_PIXEL_APPLY_DPI(5);
-  gtk_window_move(GTK_WINDOW(d->rawoverexposed.floating_window), x, y);
-
-  gtk_window_present(GTK_WINDOW(d->rawoverexposed.floating_window));
-
-  // when the mouse moves back over the main window we close the popup.
-  g_signal_connect(d->rawoverexposed.floating_window, "focus-out-event", G_CALLBACK(_rawoverexposed_close_popup),
-                   user_data);
 
   return FALSE;
 }
@@ -1188,36 +1136,11 @@ static void _softproof_quickbutton_clicked(GtkWidget *w, gpointer user_data)
   dt_dev_reprocess_all(d);
 }
 
-static gboolean _profile_close_popup(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  dt_develop_t *d = (dt_develop_t *)user_data;
-  if(!gtk_widget_is_visible(darktable.bauhaus->popup_window))
-    gtk_widget_hide(d->profile.floating_window);
-  return FALSE;
-}
-
 static gboolean _softproof_show_popup(gpointer user_data)
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
-  /** finally move the window next to the button */
-  gint x, y, wx, wy;
-  gint px, py, window_w, window_h;
-  GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+  gtk_popover_set_relative_to(GTK_POPOVER(d->profile.floating_window), d->profile.softproof_button);
   gtk_widget_show_all(d->profile.floating_window);
-  gdk_window_get_origin(gtk_widget_get_window(d->profile.softproof_button), &px, &py);
-
-  window_w = gdk_window_get_width(gtk_widget_get_window(d->profile.floating_window));
-  window_h = gdk_window_get_height(gtk_widget_get_window(d->profile.floating_window));
-
-  gtk_widget_translate_coordinates(d->profile.softproof_button, window, 0, 0, &wx, &wy);
-  x = px + wx - window_w + DT_PIXEL_APPLY_DPI(5);
-  y = py + wy - window_h - DT_PIXEL_APPLY_DPI(5);
-  gtk_window_move(GTK_WINDOW(d->profile.floating_window), x, y);
-
-  gtk_window_present(GTK_WINDOW(d->profile.floating_window));
-
-  // when the mouse moves back over the main window we close the popup.
-  g_signal_connect(d->profile.floating_window, "focus-out-event", G_CALLBACK(_profile_close_popup), user_data);
 
   return FALSE;
 }
@@ -1263,25 +1186,8 @@ static void _gamut_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 static gboolean _gamut_show_popup(gpointer user_data)
 {
   dt_develop_t *d = (dt_develop_t *)user_data;
-  /** finally move the window next to the button */
-  gint x, y, wx, wy;
-  gint px, py, window_w, window_h;
-  GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+  gtk_popover_set_relative_to(GTK_POPOVER(d->profile.floating_window), d->profile.gamut_button);
   gtk_widget_show_all(d->profile.floating_window);
-  gdk_window_get_origin(gtk_widget_get_window(d->profile.gamut_button), &px, &py);
-
-  window_w = gdk_window_get_width(gtk_widget_get_window(d->profile.floating_window));
-  window_h = gdk_window_get_height(gtk_widget_get_window(d->profile.floating_window));
-
-  gtk_widget_translate_coordinates(d->profile.gamut_button, window, 0, 0, &wx, &wy);
-  x = px + wx - window_w + DT_PIXEL_APPLY_DPI(5);
-  y = py + wy - window_h - DT_PIXEL_APPLY_DPI(5);
-  gtk_window_move(GTK_WINDOW(d->profile.floating_window), x, y);
-
-  gtk_window_present(GTK_WINDOW(d->profile.floating_window));
-
-  // when the mouse moves back over the main window we close the popup.
-  g_signal_connect(d->profile.floating_window, "focus-out-event", G_CALLBACK(_profile_close_popup), user_data);
 
   return FALSE;
 }
@@ -1511,6 +1417,8 @@ void gui_init(dt_view_t *self)
   gtk_widget_set_tooltip_text(styles, _("quick access for applying any of your styles"));
   dt_view_manager_view_toolbox_add(darktable.view_manager, styles, DT_VIEW_DARKROOM);
 
+  const int panel_width = dt_conf_get_int("panel_width");
+
   /* create rawoverexposed popup tool */
   {
     // the button
@@ -1527,33 +1435,19 @@ void gui_init(dt_view_t *self)
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->rawoverexposed.button, DT_VIEW_DARKROOM);
 
     // and the popup window
-    const int panel_width = dt_conf_get_int("panel_width");
+    dev->rawoverexposed.floating_window = gtk_popover_new(dev->rawoverexposed.button);
+    gtk_widget_set_size_request(GTK_WIDGET(dev->rawoverexposed.floating_window), panel_width, -1);
+#if GTK_CHECK_VERSION(3, 16, 0)
+    g_object_set(G_OBJECT(dev->rawoverexposed.floating_window), "transitions-enabled", FALSE, NULL);
+#endif
 
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-
-    dev->rawoverexposed.floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_default_size(GTK_WINDOW(dev->rawoverexposed.floating_window), panel_width, -1);
-    GtkWidget *frame = gtk_frame_new(NULL);
-    GtkWidget *event_box = gtk_event_box_new();
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
     gtk_widget_set_margin_start(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_end(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_top(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_bottom(vbox, DT_PIXEL_APPLY_DPI(8));
 
-    gtk_widget_set_can_focus(dev->rawoverexposed.floating_window, TRUE);
-    gtk_window_set_decorated(GTK_WINDOW(dev->rawoverexposed.floating_window), FALSE);
-    gtk_window_set_type_hint(GTK_WINDOW(dev->rawoverexposed.floating_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);
-    gtk_window_set_transient_for(GTK_WINDOW(dev->rawoverexposed.floating_window), GTK_WINDOW(window));
-    gtk_widget_set_opacity(dev->rawoverexposed.floating_window, 0.9);
-
-    gtk_widget_set_state_flags(frame, GTK_STATE_FLAG_SELECTED, TRUE);
-    gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_OUT);
-
-
-    gtk_container_add(GTK_CONTAINER(dev->rawoverexposed.floating_window), frame);
-    gtk_container_add(GTK_CONTAINER(frame), event_box);
-    gtk_container_add(GTK_CONTAINER(event_box), vbox);
+    gtk_container_add(GTK_CONTAINER(dev->rawoverexposed.floating_window), vbox);
 
     /** let's fill the encapsulating widgets */
     /* mode of operation */
@@ -1609,33 +1503,19 @@ void gui_init(dt_view_t *self)
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->overexposed.button, DT_VIEW_DARKROOM);
 
     // and the popup window
-    const int panel_width = dt_conf_get_int("panel_width");
+    dev->overexposed.floating_window = gtk_popover_new(dev->overexposed.button);
+    gtk_widget_set_size_request(GTK_WIDGET(dev->overexposed.floating_window), panel_width, -1);
+#if GTK_CHECK_VERSION(3, 16, 0)
+    g_object_set(G_OBJECT(dev->overexposed.floating_window), "transitions-enabled", FALSE, NULL);
+#endif
 
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-
-    dev->overexposed.floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_default_size(GTK_WINDOW(dev->overexposed.floating_window), panel_width, -1);
-    GtkWidget *frame = gtk_frame_new(NULL);
-    GtkWidget *event_box = gtk_event_box_new();
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
     gtk_widget_set_margin_start(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_end(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_top(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_bottom(vbox, DT_PIXEL_APPLY_DPI(8));
 
-    gtk_widget_set_can_focus(dev->overexposed.floating_window, TRUE);
-    gtk_window_set_decorated(GTK_WINDOW(dev->overexposed.floating_window), FALSE);
-    gtk_window_set_type_hint(GTK_WINDOW(dev->overexposed.floating_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);
-    gtk_window_set_transient_for(GTK_WINDOW(dev->overexposed.floating_window), GTK_WINDOW(window));
-    gtk_widget_set_opacity(dev->overexposed.floating_window, 0.9);
-
-    gtk_widget_set_state_flags(frame, GTK_STATE_FLAG_SELECTED, TRUE);
-    gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_OUT);
-
-
-    gtk_container_add(GTK_CONTAINER(dev->overexposed.floating_window), frame);
-    gtk_container_add(GTK_CONTAINER(frame), event_box);
-    gtk_container_add(GTK_CONTAINER(event_box), vbox);
+    gtk_container_add(GTK_CONTAINER(dev->overexposed.floating_window), vbox);
 
     /** let's fill the encapsulating widgets */
     /* color scheme */
@@ -1697,33 +1577,21 @@ void gui_init(dt_view_t *self)
                      G_CALLBACK(_profile_quickbutton_released), dev);
     dt_view_manager_module_toolbox_add(darktable.view_manager, dev->profile.gamut_button, DT_VIEW_DARKROOM);
 
-    // and the popup window
-    const int panel_width = dt_conf_get_int("panel_width");
+    // and the popup window, which is shared between the profile two buttons
+    // FIXME: can set this to NULL as relative-to is determined later?
+    dev->profile.floating_window = gtk_popover_new(dev->profile.softproof_button);
+    gtk_widget_set_size_request(GTK_WIDGET(dev->profile.floating_window), panel_width, -1);
+#if GTK_CHECK_VERSION(3, 16, 0)
+    g_object_set(G_OBJECT(dev->profile.floating_window), "transitions-enabled", FALSE, NULL);
+#endif
 
-    GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-
-    dev->profile.floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-    gtk_window_set_default_size(GTK_WINDOW(dev->profile.floating_window), panel_width, -1);
-    GtkWidget *frame = gtk_frame_new(NULL);
-    GtkWidget *event_box = gtk_event_box_new();
     GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
     gtk_widget_set_margin_start(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_end(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_top(vbox, DT_PIXEL_APPLY_DPI(8));
     gtk_widget_set_margin_bottom(vbox, DT_PIXEL_APPLY_DPI(8));
 
-    gtk_widget_set_can_focus(dev->profile.floating_window, TRUE);
-    gtk_window_set_decorated(GTK_WINDOW(dev->profile.floating_window), FALSE);
-    gtk_window_set_type_hint(GTK_WINDOW(dev->profile.floating_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);
-    gtk_window_set_transient_for(GTK_WINDOW(dev->profile.floating_window), GTK_WINDOW(window));
-    gtk_widget_set_opacity(dev->profile.floating_window, 0.9);
-
-    gtk_widget_set_state_flags(frame, GTK_STATE_FLAG_SELECTED, TRUE);
-    gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_OUT);
-
-    gtk_container_add(GTK_CONTAINER(dev->profile.floating_window), frame);
-    gtk_container_add(GTK_CONTAINER(frame), event_box);
-    gtk_container_add(GTK_CONTAINER(event_box), vbox);
+    gtk_container_add(GTK_CONTAINER(dev->profile.floating_window), vbox);
 
     /** let's fill the encapsulating widgets */
     char datadir[PATH_MAX] = { 0 };

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2271,14 +2271,6 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "realign images to grid", closure);
 }
 
-static gboolean _profile_quickbutton_pressed(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  dt_library_t *lib = (dt_library_t *)user_data;
-
-  gtk_widget_show_all(lib->profile_floating_window);
-  return TRUE;
-}
-
 static void display_intent_callback(GtkWidget *combo, gpointer user_data)
 {
   const int pos = dt_bauhaus_combobox_get(combo);
@@ -2357,7 +2349,6 @@ void gui_init(dt_view_t *self)
   // create display profile button
   GtkWidget *const profile_button = dtgtk_button_new(dtgtk_cairo_paint_display, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER);
   gtk_widget_set_tooltip_text(profile_button, _("set display profile"));
-  g_signal_connect(G_OBJECT(profile_button), "button-press-event", G_CALLBACK(_profile_quickbutton_pressed), lib);
   dt_view_manager_module_toolbox_add(darktable.view_manager, profile_button, DT_VIEW_LIGHTTABLE);
 
   // and the popup window
@@ -2367,6 +2358,7 @@ void gui_init(dt_view_t *self)
 #if GTK_CHECK_VERSION(3, 16, 0)
   g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
 #endif
+  g_signal_connect_swapped(G_OBJECT(profile_button), "button-press-event", G_CALLBACK(gtk_widget_show_all), lib->profile_floating_window);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
   gtk_widget_set_margin_start(vbox, DT_PIXEL_APPLY_DPI(8));

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2271,14 +2271,6 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "realign images to grid", closure);
 }
 
-static gboolean _profile_popover_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
-{
-  // hack to draw popover children but not the popover widget's outline/tail
-  // FIXME: could make popover not point to anything via gtk_popover_set_relative_to(), but then need to give it another owner so it doesn't get destroyed
-  gtk_container_propagate_draw(GTK_CONTAINER(widget), gtk_bin_get_child(GTK_BIN(widget)), cr);
-  return TRUE;
-}
-
 static gboolean _profile_quickbutton_pressed(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
   dt_library_t *lib = (dt_library_t *)user_data;
@@ -2287,7 +2279,6 @@ static gboolean _profile_quickbutton_pressed(GtkWidget *widget, GdkEvent *event,
   // 1 when closing the widget
   gtk_widget_set_opacity(lib->profile_floating_window, 0.9);
   gtk_widget_show_all(lib->profile_floating_window);
-  g_signal_connect(lib->profile_floating_window, "draw", G_CALLBACK(_profile_popover_draw), user_data);
   return TRUE;
 }
 
@@ -2373,18 +2364,12 @@ void gui_init(dt_view_t *self)
   dt_view_manager_module_toolbox_add(darktable.view_manager, profile_button, DT_VIEW_LIGHTTABLE);
 
   // and the popup window
-  // FIXME: if have to roll it by hand based on gtkpopover then move popover setup code to src/dtgtk, as it gets used a few times in darkroom mode as well
   const int panel_width = dt_conf_get_int("panel_width");
-
   lib->profile_floating_window = gtk_popover_new(profile_button);
   gtk_widget_set_size_request(GTK_WIDGET(lib->profile_floating_window), panel_width, -1);
 #if GTK_CHECK_VERSION(3, 16, 0)
   g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
 #endif
-  // FIXME: this is a hack to make the popover SE corner be near the button, but it's unclear if it'll work in general
-  // y is based on TAIL_HEIGHT from gtkpopover.c
-  const GdkRectangle r = { .x = DT_PIXEL_APPLY_DPI(19)-panel_width/2, .y = DT_PIXEL_APPLY_DPI(9), .width = 0, .height = 0 };
-  gtk_popover_set_pointing_to(GTK_POPOVER(lib->profile_floating_window), &r);
 
   GtkWidget *frame = gtk_frame_new(NULL);
   GtkWidget *event_box = gtk_event_box_new();

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2275,9 +2275,6 @@ static gboolean _profile_quickbutton_pressed(GtkWidget *widget, GdkEvent *event,
 {
   dt_library_t *lib = (dt_library_t *)user_data;
 
-  // set opacity before showing the widget, as GtkPopover sets opacity
-  // 1 when closing the widget
-  gtk_widget_set_opacity(lib->profile_floating_window, 0.9);
   gtk_widget_show_all(lib->profile_floating_window);
   return TRUE;
 }
@@ -2371,20 +2368,13 @@ void gui_init(dt_view_t *self)
   g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
 #endif
 
-  GtkWidget *frame = gtk_frame_new(NULL);
-  GtkWidget *event_box = gtk_event_box_new();
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
   gtk_widget_set_margin_start(vbox, DT_PIXEL_APPLY_DPI(8));
   gtk_widget_set_margin_end(vbox, DT_PIXEL_APPLY_DPI(8));
   gtk_widget_set_margin_top(vbox, DT_PIXEL_APPLY_DPI(8));
   gtk_widget_set_margin_bottom(vbox, DT_PIXEL_APPLY_DPI(8));
 
-  gtk_widget_set_state_flags(frame, GTK_STATE_FLAG_SELECTED, TRUE);
-  gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_OUT);
-
-  gtk_container_add(GTK_CONTAINER(lib->profile_floating_window), frame);
-  gtk_container_add(GTK_CONTAINER(frame), event_box);
-  gtk_container_add(GTK_CONTAINER(event_box), vbox);
+  gtk_container_add(GTK_CONTAINER(lib->profile_floating_window), vbox);
 
   /** let's fill the encapsulating widgets */
   char datadir[PATH_MAX] = { 0 };

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -124,10 +124,7 @@ typedef struct dt_library_t
     sqlite3_stmt *is_grouped;
   } statements;
 
-  struct
-  {
-    GtkWidget *button, *floating_window;
-  } profile;
+  GtkWidget *profile_floating_window;
 
 } dt_library_t;
 
@@ -2274,39 +2271,23 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "realign images to grid", closure);
 }
 
-
-
-// ugly hack. we lose focus when moving the mouse over the main window, but also when opening the bauhaus popup
-static gboolean _profile_close_popup(GtkWidget *widget, GdkEvent *event, gpointer user_data)
+static gboolean _profile_popover_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
-  dt_library_t *lib = (dt_library_t *)user_data;
-  if(!gtk_widget_is_visible(darktable.bauhaus->popup_window))
-    gtk_widget_hide(lib->profile.floating_window);
-  return FALSE;
+  // hack to draw popover children but not the popover widget's outline/tail
+  // FIXME: could make popover not point to anything via gtk_popover_set_relative_to(), but then need to give it another owner so it doesn't get destroyed
+  gtk_container_propagate_draw(GTK_CONTAINER(widget), gtk_bin_get_child(GTK_BIN(widget)), cr);
+  return TRUE;
 }
 
 static gboolean _profile_quickbutton_pressed(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
   dt_library_t *lib = (dt_library_t *)user_data;
-  /** finally move the window next to the button */
-  gint x, y, wx, wy;
-  gint px, py, window_w, window_h;
-  GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
-  gtk_widget_show_all(lib->profile.floating_window);
-  gdk_window_get_origin(gtk_widget_get_window(lib->profile.button), &px, &py);
 
-  window_w = gdk_window_get_width(gtk_widget_get_window(lib->profile.floating_window));
-  window_h = gdk_window_get_height(gtk_widget_get_window(lib->profile.floating_window));
-
-  gtk_widget_translate_coordinates(lib->profile.button, window, 0, 0, &wx, &wy);
-  x = px + wx - window_w + DT_PIXEL_APPLY_DPI(5);
-  y = py + wy - window_h - DT_PIXEL_APPLY_DPI(5);
-  gtk_window_move(GTK_WINDOW(lib->profile.floating_window), x, y);
-
-  gtk_window_present(GTK_WINDOW(lib->profile.floating_window));
-
-  // when the mouse moves back over the main window we close the popup.
-  g_signal_connect(lib->profile.floating_window, "focus-out-event", G_CALLBACK(_profile_close_popup), user_data);
+  // set opacity before showing the widget, as GtkPopover sets opacity
+  // 1 when closing the widget
+  gtk_widget_set_opacity(lib->profile_floating_window, 0.9);
+  gtk_widget_show_all(lib->profile_floating_window);
+  g_signal_connect(lib->profile_floating_window, "draw", G_CALLBACK(_profile_popover_draw), user_data);
   return TRUE;
 }
 
@@ -2386,18 +2367,25 @@ void gui_init(dt_view_t *self)
   dt_library_t *lib = (dt_library_t *)self->data;
 
   // create display profile button
-  lib->profile.button = dtgtk_button_new(dtgtk_cairo_paint_display, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER);
-  gtk_widget_set_tooltip_text(lib->profile.button, _("set display profile"));
-  g_signal_connect(G_OBJECT(lib->profile.button), "button-press-event", G_CALLBACK(_profile_quickbutton_pressed), lib);
-  dt_view_manager_module_toolbox_add(darktable.view_manager, lib->profile.button, DT_VIEW_LIGHTTABLE);
+  GtkWidget *const profile_button = dtgtk_button_new(dtgtk_cairo_paint_display, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER);
+  gtk_widget_set_tooltip_text(profile_button, _("set display profile"));
+  g_signal_connect(G_OBJECT(profile_button), "button-press-event", G_CALLBACK(_profile_quickbutton_pressed), lib);
+  dt_view_manager_module_toolbox_add(darktable.view_manager, profile_button, DT_VIEW_LIGHTTABLE);
 
   // and the popup window
+  // FIXME: if have to roll it by hand based on gtkpopover then move popover setup code to src/dtgtk, as it gets used a few times in darkroom mode as well
   const int panel_width = dt_conf_get_int("panel_width");
 
-  GtkWidget *window = dt_ui_main_window(darktable.gui->ui);
+  lib->profile_floating_window = gtk_popover_new(profile_button);
+  gtk_widget_set_size_request(GTK_WIDGET(lib->profile_floating_window), panel_width, -1);
+#if GTK_CHECK_VERSION(3, 16, 0)
+  g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
+#endif
+  // FIXME: this is a hack to make the popover SE corner be near the button, but it's unclear if it'll work in general
+  // y is based on TAIL_HEIGHT from gtkpopover.c
+  const GdkRectangle r = { .x = DT_PIXEL_APPLY_DPI(19)-panel_width/2, .y = DT_PIXEL_APPLY_DPI(9), .width = 0, .height = 0 };
+  gtk_popover_set_pointing_to(GTK_POPOVER(lib->profile_floating_window), &r);
 
-  lib->profile.floating_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  gtk_window_set_default_size(GTK_WINDOW(lib->profile.floating_window), panel_width, -1);
   GtkWidget *frame = gtk_frame_new(NULL);
   GtkWidget *event_box = gtk_event_box_new();
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
@@ -2406,16 +2394,10 @@ void gui_init(dt_view_t *self)
   gtk_widget_set_margin_top(vbox, DT_PIXEL_APPLY_DPI(8));
   gtk_widget_set_margin_bottom(vbox, DT_PIXEL_APPLY_DPI(8));
 
-  gtk_widget_set_can_focus(lib->profile.floating_window, TRUE);
-  gtk_window_set_decorated(GTK_WINDOW(lib->profile.floating_window), FALSE);
-  gtk_window_set_type_hint(GTK_WINDOW(lib->profile.floating_window), GDK_WINDOW_TYPE_HINT_POPUP_MENU);
-  gtk_window_set_transient_for(GTK_WINDOW(lib->profile.floating_window), GTK_WINDOW(window));
-  gtk_widget_set_opacity(lib->profile.floating_window, 0.9);
-
   gtk_widget_set_state_flags(frame, GTK_STATE_FLAG_SELECTED, TRUE);
   gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_OUT);
 
-  gtk_container_add(GTK_CONTAINER(lib->profile.floating_window), frame);
+  gtk_container_add(GTK_CONTAINER(lib->profile_floating_window), frame);
   gtk_container_add(GTK_CONTAINER(frame), event_box);
   gtk_container_add(GTK_CONTAINER(event_box), vbox);
 


### PR DESCRIPTION
This simplifies code and makes the toolbar floating windows Wayland compatible (see bug 11535). It also fixes a subtle bug in mouse grab behavior for bauhaus comboboxes.

In order to make things work with Wayland without jumping through too many hoops, this PR uses more GTK interfaces in lieu of low-level GDK work. But this results in UI changes:

- The floating windows are now drawn centered over the button they correspond to, and with a tail pointing to that button.
- Pressing `ESCAPE` now closes the floating window.
- On GTK+ < 3.16, there will be a close transition for the floating window
- Clicks outside of a bauhaus combobox will close the combobox. Previously they were ignored, and if the combobox was in a floating window, that floating window would not close until its toolbar button was pressed again then the user clicked outside of the re-presented floating window.
- Moving the mouse slightly outside of a bauhaus combobox previously generated "prelight" events on widgets, and those widgets would respond to mouse clicks even though a combobox and floating window was also open. Now other widgets are not sensitive to mouse clicks until after the combobox and floating window are closed. Tooltips will still appear, though.

Questions:

- GtkPopovers make the code cleaner, and push the hairy floating window implementation onto GTK. But the floating windows now look GTK-ish, rather than bauhaus-ish. Is this a good thing? (There should be ways to draw floating windows without tails, at the expense of more code complexity and being more subject to future changes in GTK/GDK).
- Should the popover implementation (now quite minimal, but it'd grow more elaborate if it goes back to using GDK) end up in src/dtgtk, rather than having the same boilerplate code repeated in multiple places?
