### PR TITLE
Reference views by name, not a number

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ FILE(GLOB SOURCE_FILES
   "common/locallaplaciancl.c"
   "common/metadata.c"
   "common/mipmap_cache.c"
+  "common/module.c"
   "common/noiseprofiles.c"
   "common/pdf.c"
   "common/styles.c"

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -270,7 +270,7 @@ int dt_load_from_string(const gchar *input, gboolean open_image_in_dr, gboolean 
     if(id)
     {
       dt_film_open(id);
-      dt_ctl_switch_mode_to(DT_LIBRARY);
+      dt_ctl_switch_mode_to("lighttable");
     }
     else
     {
@@ -304,7 +304,7 @@ int dt_load_from_string(const gchar *input, gboolean open_image_in_dr, gboolean 
         if(open_image_in_dr)
         {
           dt_control_set_mouse_over_id(id);
-          dt_ctl_switch_mode_to(DT_DEVELOP);
+          dt_ctl_switch_mode_to("darkroom");
         }
       }
     }
@@ -965,13 +965,13 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     dt_gui_gtk_load_config();
   }
 
-  dt_control_gui_mode_t mode = DT_LIBRARY;
+  const char *mode = "lighttable";
   // april 1st: you have to earn using dt first! or know that you can switch views with keyboard shortcuts
   time_t now;
   time(&now);
   struct tm lt;
   localtime_r(&now, &lt);
-  if(lt.tm_mon == 3 && lt.tm_mday == 1) mode = DT_KNIGHT;
+  if(lt.tm_mon == 3 && lt.tm_mday == 1) mode = "knight";
   if(init_gui)
   {
     // init the gui part of views
@@ -1022,7 +1022,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     if(loaded_images == 1 && only_single_images)
     {
       dt_control_set_mouse_over_id(last_id);
-      mode = DT_DEVELOP;
+      mode = "darkroom";
     }
 #endif
   }
@@ -1065,7 +1065,7 @@ void dt_cleanup()
 #endif
   if(init_gui)
   {
-    dt_ctl_switch_mode_to(DT_MODE_NONE);
+    dt_ctl_switch_mode_to("");
     dt_dbus_destroy(darktable.dbus);
 
     dt_control_shutdown(darktable.control);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -82,7 +82,7 @@ typedef unsigned int u_int;
 #include "common/poison.h"
 #endif
 
-#define DT_MODULE_VERSION 16 // version of dt's module interface
+#define DT_MODULE_VERSION 17 // version of dt's module interface
 
 // every module has to define this:
 #ifdef _DEBUG

--- a/src/common/module.c
+++ b/src/common/module.c
@@ -1,0 +1,70 @@
+/*
+ *    This file is part of darktable,
+ *    copyright (c) 2017 tobias ellinghaus.
+ *
+ *    darktable is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    darktable is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <gmodule.h>
+
+#include "config.h"
+#include "common/file_location.h"
+#include "common/module.h"
+
+GList *dt_module_load_modules(const char *subdir, size_t module_size,
+                              int (*load_module_so)(void *module, const char *libname, const char *plugin_name),
+                              void (*init_module)(void *module),
+                              gint (*sort_modules)(gconstpointer a, gconstpointer b))
+{
+  GList *plugin_list = NULL;
+  char plugindir[PATH_MAX] = { 0 };
+  const gchar *dir_name;
+  dt_loc_get_plugindir(plugindir, sizeof(plugindir));
+  g_strlcat(plugindir, subdir, sizeof(plugindir));
+  GDir *dir = g_dir_open(plugindir, 0, NULL);
+  if(!dir) return NULL;
+  const int name_offset = strlen(SHARED_MODULE_PREFIX),
+            name_end = strlen(SHARED_MODULE_PREFIX) + strlen(SHARED_MODULE_SUFFIX);
+  while((dir_name = g_dir_read_name(dir)))
+  {
+    // get lib*.so
+    if(!g_str_has_prefix(dir_name, SHARED_MODULE_PREFIX)) continue;
+    if(!g_str_has_suffix(dir_name, SHARED_MODULE_SUFFIX)) continue;
+    char *plugin_name = g_strndup(dir_name + name_offset, strlen(dir_name) - name_end);
+    void *module = calloc(1, module_size);
+    gchar *libname = g_module_build_path(plugindir, plugin_name);
+    int res = load_module_so(module, libname, plugin_name);
+    g_free(libname);
+    g_free(plugin_name);
+    if(res)
+    {
+      free(module);
+      continue;
+    }
+    plugin_list = g_list_append(plugin_list, module);
+
+    if(init_module) init_module(module);
+  }
+  g_dir_close(dir);
+
+  if(sort_modules) plugin_list = g_list_sort(plugin_list, sort_modules);
+
+ return plugin_list;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/module.h
+++ b/src/common/module.h
@@ -1,0 +1,30 @@
+/*
+ *    This file is part of darktable,
+ *    copyright (c) 2017 tobias ellinghaus.
+ *
+ *    darktable is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    darktable is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+GList *dt_module_load_modules(const char *subdir, size_t module_size,
+                              int (*load_module_so)(void *module, const char *libname, const char *plugin_name),
+                              void (*init_module)(void *module),
+                              gint (*sort_modules)(gconstpointer a, gconstpointer b));
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -58,8 +58,6 @@ void dt_control_init(dt_control_t *s)
   s->log_message_timeout_id = 0;
   dt_pthread_mutex_init(&(s->log_mutex), NULL);
 
-  dt_conf_set_int("ui_last/view", DT_MODE_NONE);
-
   pthread_cond_init(&s->cond, NULL);
   dt_pthread_mutex_init(&s->cond_mutex, NULL);
   dt_pthread_mutex_init(&s->queue_mutex, NULL);
@@ -393,37 +391,49 @@ void dt_control_button_released(double x, double y, int which, uint32_t state)
   dt_view_manager_button_released(darktable.view_manager, x - tb, y - tb, which, state);
 }
 
-static gboolean _dt_ctl_switch_mode_to(gpointer user_data)
+static void _dt_ctl_switch_mode_prepare()
 {
-  dt_control_gui_mode_t mode = GPOINTER_TO_INT(user_data);
-
   darktable.control->button_down = 0;
   darktable.control->button_down_which = 0;
   darktable.gui->center_tooltip = 0;
   GtkWidget *widget = dt_ui_center(darktable.gui->ui);
   gtk_widget_set_tooltip_text(widget, "");
+}
 
-  if(!dt_view_manager_switch(darktable.view_manager, mode))
-    dt_conf_set_int("ui_last/view", mode);
-
+static gboolean _dt_ctl_switch_mode_to(gpointer user_data)
+{
+  const char *mode = (const char*)user_data;
+  _dt_ctl_switch_mode_prepare();
+  dt_view_manager_switch(darktable.view_manager, mode);
   return FALSE;
 }
 
-void dt_ctl_switch_mode_to(dt_control_gui_mode_t mode)
+static gboolean _dt_ctl_switch_mode_to_by_view(gpointer user_data)
 {
-  dt_control_gui_mode_t oldmode = dt_conf_get_int("ui_last/view");
-  if(oldmode == mode) return;
+  const dt_view_t *view = (const dt_view_t*)user_data;
+  _dt_ctl_switch_mode_prepare();
+  dt_view_manager_switch_by_view(darktable.view_manager, view);
+  return FALSE;
+}
 
-  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, GINT_TO_POINTER(mode));
+void dt_ctl_switch_mode_to(const char *mode)
+{
+  const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
+  if(current_view && !strcmp(mode, current_view->module_name)) return;
+
+  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to, (gpointer)mode);
+}
+
+void dt_ctl_switch_mode_to_by_view(const dt_view_t *view)
+{
+  if(view == dt_view_manager_get_current_view(darktable.view_manager)) return;
+  g_main_context_invoke(NULL, _dt_ctl_switch_mode_to_by_view, (gpointer)view);
 }
 
 void dt_ctl_switch_mode()
 {
-  dt_control_gui_mode_t mode = dt_conf_get_int("ui_last/view");
-  if(mode == DT_LIBRARY)
-    mode = DT_DEVELOP;
-  else
-    mode = DT_LIBRARY;
+  const dt_view_t *view = dt_view_manager_get_current_view(darktable.view_manager);
+  const char *mode = (view && !strcmp(view->module_name, "lighttable")) ? "darkroom" : "lighttable";
   dt_ctl_switch_mode_to(mode);
 }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -39,24 +39,6 @@
 
 struct dt_lib_backgroundjob_element_t;
 
-typedef enum dt_control_gui_mode_t
-{
-  DT_LIBRARY = 0,
-  DT_DEVELOP,
-#ifdef HAVE_GPHOTO2
-  DT_CAPTURE,
-#endif
-#ifdef HAVE_MAP
-  DT_MAP,
-#endif
-  DT_SLIDESHOW,
-#ifdef HAVE_PRINT
-  DT_PRINT,
-#endif
-  DT_KNIGHT,
-  DT_MODE_NONE
-} dt_control_gui_mode_t;
-
 typedef GdkCursorType dt_cursor_t;
 
 // called from gui
@@ -98,7 +80,8 @@ void dt_control_queue_redraw_center();
 void dt_control_queue_redraw_widget(GtkWidget *widget);
 
 void dt_ctl_switch_mode();
-void dt_ctl_switch_mode_to(dt_control_gui_mode_t mode);
+void dt_ctl_switch_mode_to(const char *mode);
+void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);
 
 struct dt_control_t;
 

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -336,7 +336,7 @@ static int32_t dt_camera_import_job_run(dt_job_t *job)
 
   // Switch to new filmroll
   dt_film_open(dt_import_session_film_id(params->shared.session));
-  dt_ctl_switch_mode_to(DT_LIBRARY);
+  dt_ctl_switch_mode_to("lighttable");
 
   // register listener
   dt_camctl_listener_t listener = { 0 };

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -118,7 +118,6 @@ void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierTyp
   g_strlcpy(accel->translated_path, accel_path, sizeof(accel->translated_path));
 
   *(accel->module) = '\0';
-  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
   accel->local = FALSE;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
@@ -136,7 +135,6 @@ void dt_accel_register_view(dt_view_t *self, const gchar *path, guint accel_key,
   g_strlcpy(accel->translated_path, accel_path, sizeof(accel->translated_path));
 
   g_strlcpy(accel->module, self->module_name, sizeof(accel->module));
-  accel->views = self->view(self);
   accel->local = FALSE;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
@@ -156,7 +154,6 @@ void dt_accel_register_iop(dt_iop_module_so_t *so, gboolean local, const gchar *
 
   g_strlcpy(accel->module, so->op, sizeof(accel->module));
   accel->local = local;
-  accel->views = DT_VIEW_DARKROOM;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -173,7 +170,6 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
 
   g_strlcpy(accel->module, self->plugin_name, sizeof(accel->module));
   accel->local = FALSE;
-  accel->views = self->views(self);
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -206,7 +202,6 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
     g_strlcpy(accel->translated_path, paths_trans[i], sizeof(accel->translated_path));
     g_strlcpy(accel->module, so->op, sizeof(accel->module));
     accel->local = local;
-    accel->views = DT_VIEW_DARKROOM;
 
     darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
   }
@@ -225,7 +220,6 @@ void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType m
   g_strlcpy(accel->translated_path, accel_path, sizeof(accel->translated_path));
 
   *(accel->module) = '\0';
-  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
   accel->local = FALSE;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -30,7 +30,6 @@ typedef struct dt_accel_t
   gchar path[256];
   gchar translated_path[256];
   gchar module[256];
-  guint views;
   gboolean local;
   GClosure *closure;
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -60,6 +60,16 @@
 
 #define DT_UI_PANEL_MODULE_SPACING 3
 
+typedef enum dt_gui_view_switch_t
+{
+  DT_GUI_VIEW_SWITCH_TO_TETHERING = 1,
+  DT_GUI_VIEW_SWITCH_TO_LIGHTTABLE,
+  DT_GUI_VIEW_SWITCH_TO_DARKROOM,
+  DT_GUI_VIEW_SWITCH_TO_MAP,
+  DT_GUI_VIEW_SWITCH_TO_SLIDESHOW,
+  DT_GUI_VIEW_SWITCH_TO_PRINT
+} dt_gui_view_switch_to_t;
+
 const char *_ui_panel_config_names[]
     = { "header", "toolbar_top", "toolbar_bottom", "left", "right", "bottom" };
 
@@ -416,9 +426,7 @@ static gboolean draw_borders(GtkWidget *widget, cairo_t *crf, gpointer user_data
   cairo_paint(cr);
 
   // draw scrollbar indicators
-  int v = darktable.view_manager->current_view;
-  dt_view_t *view = NULL;
-  if(v >= 0 && v < darktable.view_manager->num_views) view = darktable.view_manager->view + v;
+  const dt_view_t *view = dt_view_manager_get_current_view(darktable.view_manager);
   color_found = gtk_style_context_lookup_color (context, "bg_color", &color);
   if(!color_found)
   {
@@ -590,7 +598,6 @@ static gboolean borders_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoin
 int dt_gui_gtk_load_config()
 {
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-  dt_conf_set_int("ui_last/view", DT_MODE_NONE);
   int width = dt_conf_get_int("ui_last/window_w");
   int height = dt_conf_get_int("ui_last/window_h");
   gint x = MAX(0, dt_conf_get_int("ui_last/window_x"));
@@ -678,41 +685,37 @@ static gboolean _gui_switch_view_key_accel_callback(GtkAccelGroup *accel_group, 
                                                     guint keyval, GdkModifierType modifier, gpointer p)
 {
   int view = GPOINTER_TO_INT(p);
-  dt_control_gui_mode_t mode = DT_MODE_NONE;
+  const char *mode = "";
   /* do some setup before switch view*/
   switch(view)
   {
-#ifdef HAVE_GPHOTO2
     case DT_GUI_VIEW_SWITCH_TO_TETHERING:
-      mode = DT_CAPTURE;
+      mode = "tethering";
       break;
-#endif
 
     case DT_GUI_VIEW_SWITCH_TO_DARKROOM:
-      mode = DT_DEVELOP;
+      mode = "darkroom";
       break;
 
-    case DT_GUI_VIEW_SWITCH_TO_LIBRARY:
-      mode = DT_LIBRARY;
+    case DT_GUI_VIEW_SWITCH_TO_LIGHTTABLE:
+      mode = "lighttable";
       break;
 
-#ifdef HAVE_MAP
     case DT_GUI_VIEW_SWITCH_TO_MAP:
-      mode = DT_MAP;
+      mode = "map";
       break;
-#endif
+
     case DT_GUI_VIEW_SWITCH_TO_SLIDESHOW:
-      mode = DT_SLIDESHOW;
+      mode = "slideshow";
       break;
-#ifdef HAVE_PRINT
+
     case DT_GUI_VIEW_SWITCH_TO_PRINT:
-      mode = DT_PRINT;
+      mode = "print";
       break;
-#endif
   }
 
   /* try switch to mode */
-  if(mode != DT_MODE_NONE) dt_ctl_switch_mode_to(mode);
+  if(*mode) dt_ctl_switch_mode_to(mode);
   return TRUE;
 }
 
@@ -1048,7 +1051,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                                          GINT_TO_POINTER(DT_GUI_VIEW_SWITCH_TO_TETHERING), NULL));
   dt_accel_connect_global("lighttable view",
                           g_cclosure_new(G_CALLBACK(_gui_switch_view_key_accel_callback),
-                                         GINT_TO_POINTER(DT_GUI_VIEW_SWITCH_TO_LIBRARY), NULL));
+                                         GINT_TO_POINTER(DT_GUI_VIEW_SWITCH_TO_LIGHTTABLE), NULL));
   dt_accel_connect_global("darkroom view",
                           g_cclosure_new(G_CALLBACK(_gui_switch_view_key_accel_callback),
                                          GINT_TO_POINTER(DT_GUI_VIEW_SWITCH_TO_DARKROOM), NULL));

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -29,16 +29,6 @@
  * DPI */
 #define DT_PIXEL_APPLY_DPI(value) ((value) * darktable.gui->dpi_factor)
 
-typedef enum dt_gui_view_switch_t
-{
-  DT_GUI_VIEW_SWITCH_TO_TETHERING = 1,
-  DT_GUI_VIEW_SWITCH_TO_LIBRARY,
-  DT_GUI_VIEW_SWITCH_TO_DARKROOM,
-  DT_GUI_VIEW_SWITCH_TO_MAP,
-  DT_GUI_VIEW_SWITCH_TO_SLIDESHOW,
-  DT_GUI_VIEW_SWITCH_TO_PRINT
-} dt_gui_view_switch_to_t;
-
 typedef struct dt_gui_widgets_t
 {
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -785,7 +785,6 @@ static void delete_matching_accels(gpointer current, gpointer mapped)
 
   if(current_key.accel_key == mapped_key.accel_key                 // Key code matches
      && current_key.accel_mods == mapped_key.accel_mods            // Key state matches
-     && current_accel->views & mapped_accel->views                 // Conflicting views
      && !(current_accel->local && mapped_accel->local              // Not both local to
           && strcmp(current_accel->module, mapped_accel->module))) // diff mods
     gtk_accel_map_change_entry(current_accel->path, 0, 0, TRUE);

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -53,9 +53,10 @@ const char *name(dt_lib_module_t *self)
   return _("background jobs");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_DARKROOM | DT_VIEW_MAP | DT_VIEW_PRINT;
+  static const char *v[] = {"*", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -78,9 +78,10 @@ const char *name(dt_lib_module_t *self)
   return _("camera settings");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_TETHERING;
+  static const char *v[] = {"tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)
@@ -210,7 +211,7 @@ static gboolean _bailout_of_tethering(gpointer user_data)
   dt_camctl_unregister_listener(darktable.camctl, lib->data.listener);
 
   /* switch back to library mode */
-  dt_ctl_switch_mode_to(DT_LIBRARY);
+  dt_ctl_switch_mode_to("lighttable");
 
   return FALSE;
 }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -200,9 +200,10 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 }
 
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP | DT_VIEW_PRINT;
+  static const char *v[] = {"lighttable", "map", "print", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -52,9 +52,10 @@ const char *name(dt_lib_module_t *self)
   return _("color picker");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -51,9 +51,10 @@ const char *name(dt_lib_module_t *self)
   return _("history stack");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -64,9 +64,10 @@ const char *name(dt_lib_module_t *self)
   return _("export selected");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -44,9 +44,10 @@ const char *name(dt_lib_module_t *self)
   return _("geotagging");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -62,9 +62,10 @@ const char *name(dt_lib_module_t *self)
   return _("histogram");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM | DT_VIEW_TETHERING;
+  static const char *v[] = {"darkroom", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -63,9 +63,10 @@ const char *name(dt_lib_module_t *self)
   return _("history");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -51,9 +51,10 @@ const char *name(dt_lib_module_t *self)
   return _("selected image[s]");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -104,9 +104,10 @@ const char *name(dt_lib_module_t *self)
 }
 
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)
@@ -175,7 +176,7 @@ static void _lib_import_tethered_callback(GtkToggleButton *button, gpointer data
 {
   /* select camera to work with before switching mode */
   dt_camctl_select_camera(darktable.camctl, (dt_camera_t *)data);
-  dt_ctl_switch_mode_to(DT_CAPTURE);
+  dt_ctl_switch_mode_to("tethering");
 }
 
 
@@ -863,7 +864,7 @@ static void _lib_import_single_image_callback(GtkWidget *widget, gpointer user_d
       else
       {
         dt_control_set_mouse_over_id(id);
-        dt_ctl_switch_mode_to(DT_DEVELOP);
+        dt_ctl_switch_mode_to("darkroom");
       }
     }
   }

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -89,7 +89,7 @@ typedef struct dt_lib_module_t
   /** get name of the module, to be translated. */
   const char *(*name)(struct dt_lib_module_t *self);
   /** get the views which the module should be loaded in. */
-  uint32_t (*views)(struct dt_lib_module_t *self);
+  const char **(*views)(struct dt_lib_module_t *self);
   /** get the container which the module should be placed in */
   uint32_t (*container)(struct dt_lib_module_t *self);
   /** check if module should use a expander or not, default implementation
@@ -143,10 +143,6 @@ typedef struct dt_lib_module_t
 void dt_lib_init(dt_lib_t *lib);
 void dt_lib_cleanup(dt_lib_t *lib);
 
-/** loads and inits the modules in the libs/ directory. */
-int dt_lib_load_modules();
-/** calls module->cleanup and closes the dl connection. */
-void dt_lib_unload_module(dt_lib_module_t *module);
 /** creates a label widget for the expander, with callback to enable/disable this module. */
 GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module);
 /** set a expand/collaps plugin expander */
@@ -161,6 +157,8 @@ void dt_lib_connect_common_accels(dt_lib_module_t *module);
 gboolean dt_lib_is_visible(dt_lib_module_t *module);
 /** set the visible state of a plugin */
 void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible);
+/** check if a plugin is to be shown in a given view */
+gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module, const dt_view_t *view);
 
 /** returns the localized plugin name for a given plugin_name. must not be freed. */
 gchar *dt_lib_get_localized_name(const gchar *plugin_name);

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -43,7 +43,7 @@ int version();
 const char *name(struct dt_lib_module_t *self);
 
 /** get the views which the module should be loaded in. */
-uint32_t views(struct dt_lib_module_t *self);
+const char **views(struct dt_lib_module_t *self);
 /** get the container which the module should be placed in */
 uint32_t container(struct dt_lib_module_t *self);
 /** check if module should use a expander or not, default implementation

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -140,9 +140,10 @@ const char *name(dt_lib_module_t *self)
   return _("live view");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_TETHERING;
+  static const char *v[] = {"tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -93,9 +93,10 @@ const char *name(dt_lib_module_t *self)
   return _("find location");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_MAP;
+  static const char *v[] = {"map", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -37,9 +37,10 @@ const char *name(dt_lib_module_t *self)
   return _("map settings");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_MAP;
+  static const char *v[] = {"map", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -56,9 +56,10 @@ const char *name(dt_lib_module_t *self)
   return _("mask manager");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -56,9 +56,10 @@ const char *name(dt_lib_module_t *self)
   return _("metadata editor");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  static const char *v[] = {"lighttable", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -133,10 +133,10 @@ const char *name(dt_lib_module_t *self)
   return _("image information");
 }
 
-/* show module in left panel in all views */
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_ALL;
+  static const char *v[] = {"*", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -69,9 +69,10 @@ const char *name(dt_lib_module_t *self)
   return _("modulegroups");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -56,9 +56,10 @@ const char *name(dt_lib_module_t *self)
   return _("more modules");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -65,9 +65,10 @@ const char *name(dt_lib_module_t *self)
   return _("navigation");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -43,9 +43,10 @@ const char *name(dt_lib_module_t *self)
   return _("print settings");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_PRINT;
+  static const char *v[] = {"print", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -51,9 +51,10 @@ const char *name(dt_lib_module_t *self)
   return _("recently used collections");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_MAP;
+  static const char *v[] = {"lighttable", "map", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -40,9 +40,10 @@ const char *name(dt_lib_module_t *self)
   return _("select");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -47,9 +47,10 @@ const char *name(dt_lib_module_t *self)
   return _("session");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_TETHERING;
+  static const char *v[] = {"tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -79,9 +79,10 @@ const char *name(dt_lib_module_t *self)
   return _("snapshots");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM;
+  static const char *v[] = {"darkroom", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -46,9 +46,10 @@ const char *name(dt_lib_module_t *self)
   return _("styles");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -63,11 +63,15 @@ const char *name(dt_lib_module_t *self)
   return _("tagging");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  uint32_t v = DT_VIEW_LIGHTTABLE | DT_VIEW_MAP | DT_VIEW_TETHERING;
-  if(dt_conf_get_bool("plugins/darkroom/tagging/visible")) v |= DT_VIEW_DARKROOM;
-  return v;
+  static const char *v1[] = {"lighttable", "darkroom", "map", "tethering", NULL};
+  static const char *v2[] = {"lighttable", "map", "tethering", NULL};
+
+  if(dt_conf_get_bool("plugins/darkroom/tagging/visible"))
+    return v1;
+  else
+    return v2;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -40,9 +40,10 @@ const char *name(dt_lib_module_t *self)
   return _("colorlabels");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  static const char *v[] = {"lighttable", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -56,9 +56,10 @@ const char *name(dt_lib_module_t *self)
   return _("darktable");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_ALL;
+  static const char *v[] = {"*", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -143,9 +143,10 @@ const char *name(dt_lib_module_t *self)
   return _("filmstrip");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT;
+  static const char *v[] = {"darkroom", "tethering", "map", "print", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -68,7 +68,7 @@ const char *name(dt_lib_module_t *self)
   return _("filter");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
   /* for now, show in all view due this affects filmroll too
 
@@ -76,7 +76,8 @@ uint32_t views(dt_lib_module_t *self)
            unloading/loading a module while switching views.
 
    */
-  return DT_VIEW_ALL;
+  static const char *v[] = {"*", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -46,9 +46,10 @@ const char *name(dt_lib_module_t *self)
   return _("preferences");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT;
+  static const char *v[] = {"*", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/hinter.c
+++ b/src/libs/tools/hinter.c
@@ -42,9 +42,10 @@ const char *name(dt_lib_module_t *self)
   return _("hinter");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING;
+  static const char *v[] = {"lighttable", "darkroom", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -64,9 +64,10 @@ const char *name(dt_lib_module_t *self)
   return _("lighttable");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE;
+  static const char *v[] = {"lighttable", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/module_toolbox.c
+++ b/src/libs/tools/module_toolbox.c
@@ -46,9 +46,10 @@ const char *name(dt_lib_module_t *self)
   return _("module toolbox");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  static const char *v[] = {"darkroom", "lighttable", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -54,9 +54,10 @@ const char *name(dt_lib_module_t *self)
   return _("ratings");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  static const char *v[] = {"lighttable", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/view_toolbox.c
+++ b/src/libs/tools/view_toolbox.c
@@ -46,9 +46,10 @@ const char *name(dt_lib_module_t *self)
   return _("view toolbox");
 }
 
-uint32_t views(dt_lib_module_t *self)
+const char **views(dt_lib_module_t *self)
 {
-  return DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING;
+  static const char *v[] = {"darkroom", "lighttable", "tethering", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -104,13 +104,9 @@ static int current_view_cb(lua_State *L)
 {
   if(lua_gettop(L) > 0)
   {
-    dt_view_t *module;
-    luaA_to(L,dt_lua_view_t,&module,1);
-    int i = 0;
-    while(i < darktable.view_manager->num_views && module != &darktable.view_manager->view[i]) i++;
-    if(i == darktable.view_manager->num_views)
-      return luaL_error(L, "should never happen : %s %d\n", __FILE__, __LINE__);
-    dt_ctl_switch_mode_to(i);
+    dt_view_t *view;
+    luaA_to(L, dt_lua_view_t, &view, 1);
+    dt_ctl_switch_mode_to_by_view(view);
   }
   const dt_view_t *current_view = dt_view_manager_get_current_view(darktable.view_manager);
   dt_lua_module_entry_push(L, "view", current_view->module_name);

--- a/src/lua/lib.c
+++ b/src/lua/lib.c
@@ -103,11 +103,13 @@ static int container_member(lua_State*L) {
 
 static int views_member(lua_State*L) {
   dt_lib_module_t * module = *(dt_lib_module_t**)lua_touserdata(L,1);
-  int i;
   lua_newtable(L);
-  for(i=0; i<  darktable.view_manager->num_views ; i++) {
-    if(darktable.view_manager->view[i].view(&darktable.view_manager->view[i]) & module->views(module)){
-      dt_lua_module_entry_push(L,"view",(darktable.view_manager->view[i].module_name));
+  for(GList *iter = darktable.view_manager->views; iter; iter = g_list_next(iter))
+  {
+    const dt_view_t *view = (const dt_view_t *)iter->data;
+    if(dt_lib_is_visible_in_view(module, view))
+    {
+      dt_lua_module_entry_push(L,"view",(view->module_name));
       luaL_ref(L,-2);
     }
   }

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -1333,7 +1333,7 @@ static void _expose_intro(dt_knight_t *d, cairo_t *cr, int32_t w, int32_t h)
       cairo_rectangle(cr, 0, 0, wipe_progress * w, h);
       cairo_fill(cr);
     }
-    if(d->animation_loop > wipe_start + wipe_duration * 2) dt_ctl_switch_mode_to(DT_LIBRARY);
+    if(d->animation_loop > wipe_start + wipe_duration * 2) dt_ctl_switch_mode_to("lighttable");
   }
   else if(d->game_state == WIN)
   {
@@ -1353,7 +1353,7 @@ static void _expose_intro(dt_knight_t *d, cairo_t *cr, int32_t w, int32_t h)
       cairo_rectangle(cr, 0, 0, wipe_progress * w, h);
       cairo_fill(cr);
     }
-    if(d->animation_loop > wipe_start + wipe_duration * 2) dt_ctl_switch_mode_to(DT_LIBRARY);
+    if(d->animation_loop > wipe_start + wipe_duration * 2) dt_ctl_switch_mode_to("lighttable");
   }
 }
 

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -754,7 +754,7 @@ static gboolean _view_map_button_press_callback(GtkWidget *w, GdkEventButton *e,
       {
         // open the image in darkroom
         dt_control_set_mouse_over_id(lib->selected_image);
-        dt_ctl_switch_mode_to(DT_DEVELOP);
+        dt_ctl_switch_mode_to("darkroom");
         return TRUE;
       }
       else

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -509,7 +509,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     return 0;
   }
   // go back to lt mode
-  dt_ctl_switch_mode_to(DT_LIBRARY);
+  dt_ctl_switch_mode_to("lighttable");
   return 0;
 }
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -229,7 +229,7 @@ void expose(dt_view_t *self, cairo_t *cri, int32_t width, int32_t height, int32_
   while(modules)
   {
     dt_lib_module_t *module = (dt_lib_module_t *)(modules->data);
-    if((module->views(module) & self->view(self)) && module->gui_post_expose)
+    if(module->gui_post_expose && dt_lib_is_visible_in_view(module, self))
       module->gui_post_expose(module, cri, width, height, pointerx, pointery);
     modules = g_list_next(modules);
   }

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -165,8 +165,8 @@ void dt_view_toggle_selection(int imgid);
  */
 typedef struct dt_view_manager_t
 {
-  dt_view_t view[DT_VIEW_MAX_MODULES];
-  int32_t current_view, num_views;
+  GList *views;
+  dt_view_t *current_view;
 
   /* reusable db statements
    * TODO: reconsider creating a common/database helper API
@@ -295,7 +295,8 @@ void dt_view_manager_cleanup(dt_view_manager_t *vm);
 /** return translated name. */
 const char *dt_view_manager_name(dt_view_manager_t *vm);
 /** switch to this module. returns non-null if the module fails to change. */
-int dt_view_manager_switch(dt_view_manager_t *vm, int k);
+int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name);
+int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *new_view);
 /** expose current module. */
 void dt_view_manager_expose(dt_view_manager_t *vm, cairo_t *cr, int32_t width, int32_t height,
                             int32_t pointerx, int32_t pointery);
@@ -321,12 +322,6 @@ void dt_view_manager_view_toolbox_add(dt_view_manager_t *vm, GtkWidget *tool, dt
 /** add widget to the current module toolbox */
 void dt_view_manager_module_toolbox_add(dt_view_manager_t *vm, GtkWidget *tool, dt_view_type_flags_t view);
 
-/** load module to view managers list, if still space. return slot number on success. */
-int dt_view_manager_load_module(dt_view_manager_t *vm, const char *mod);
-/** load a view module */
-int dt_view_load_module(dt_view_t *view, const char *module);
-/** unload, cleanup */
-void dt_view_unload_module(dt_view_t *view);
 /** set scrollbar positions, gui method. */
 void dt_view_set_scrollbar(dt_view_t *view, float hpos, float hsize, float hwinsize, float vpos, float vsize,
                            float vwinsize);


### PR DESCRIPTION
This removes (almost) all knowledge about existing views from dt's core
code. Instead of hardcoding the list of available views we just load
whatever we find in the corresponding directory and allow libs to
reference them by name. That also fixes bugs when loading a view failed
(for example map when osmgpsmap isn't installed), resulting in wrong
views being loaded in some cases.