### PR TITLE
Replacing free() with dt_free_align() for buffers

### DIFF
--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -204,7 +204,7 @@ static inline void gauss_reduce_sse2(
     for(int i=cw&~7;i<cw-1;i++)
       out[i] = (6*row2[i] + 4*(row1[i] + row3[i]) + row0[i] + row4[i])*(1.0f/256.0f);
   }
-  free(ringbuf);
+  dt_free_align(ringbuf);
   ll_fill_boundary1(coarse, cw, ch);
 }
 #endif
@@ -576,10 +576,9 @@ void local_laplacian_internal(
   // free all buffers!
   for(int l=0;l<max_levels;l++)
   {
-    free(padded[l]);
-    free(output[l]);
-    for(int k=0;k<num_gamma;k++)
-      free(buf[k][l]);
+    dt_free_align(padded[l]);
+    dt_free_align(output[l]);
+    for(int k = 0; k < num_gamma; k++) dt_free_align(buf[k][l]);
   }
 #undef num_levels
 #undef num_gamma


### PR DESCRIPTION
which were allocated using dt_alloc_align. Fixes #11592