### PR TITLE
fix combox and container lua widget behaviour

### DIFF
--- a/src/lua/widget/combobox.c
+++ b/src/lua/widget/combobox.c
@@ -67,9 +67,8 @@ static int combobox_numindex(lua_State*L)
     }
     return 0;
   }
-  if(key <= 0 || key > length) {
-    return luaL_error(L,"Invalid index for combo box : %d\n",key);
-  } else if (key > length) {
+  if(key <= 0 || key > length)
+  {
     lua_pushnil(L);
     return 1;
   }

--- a/src/lua/widget/container.c
+++ b/src/lua/widget/container.c
@@ -161,9 +161,7 @@ static int container_numindex(lua_State*L)
   } else {
     GtkWidget *searched_widget = g_list_nth_data(children,index);
     g_list_free(children);
-    lua_getuservalue(L,1);
-    lua_pushlightuserdata(L,searched_widget);
-    lua_gettable(L,-2);
+    luaA_push(L, lua_widget, &searched_widget);
     return 1;
   }
 }

--- a/src/lua/widget/container.c
+++ b/src/lua/widget/container.c
@@ -135,8 +135,8 @@ static int container_numindex(lua_State*L)
   luaA_to(L,lua_container,&container,1);
   GList * children = gtk_container_get_children(GTK_CONTAINER(container->widget));
   int index = lua_tointeger(L,2) -1;
+  int length = g_list_length(children);
   if(lua_gettop(L) >2) {
-    int length = g_list_length(children);
     if(!lua_isnil(L,3) &&  index == length) {
       lua_widget widget;
       luaA_to(L, lua_widget,&widget,3);
@@ -159,9 +159,16 @@ static int container_numindex(lua_State*L)
     g_list_free(children);
     return 0;
   } else {
-    GtkWidget *searched_widget = g_list_nth_data(children,index);
+    if(index < 0 || index >= length)
+    {
+      lua_pushnil(L);
+    }
+    else
+    {
+      GtkWidget *searched_widget = g_list_nth_data(children, index);
+      luaA_push(L, lua_widget, &searched_widget);
+    }
     g_list_free(children);
-    luaA_push(L, lua_widget, &searched_widget);
     return 1;
   }
 }


### PR DESCRIPTION
Generally speaking, comboboxes & containers now appears more like standard lua tables:
- access to numeric element out-of-bound return `nil`
- access to children of container by index is working (fix regression from 0edd2f429b905e86ce5dbc6cbd3db1beea5d4c1f)

After this changes:
- it is possible to get container (box, stack) element by index
- it is possible to use `for` with `pair` to list all attributes and children of containers & comboboxes
- it is possible to use `for` with `iparis` to list all children of containers & comboboxes

some examples of what this do: [tests.lua.txt](https://github.com/darktable-org/darktable/files/1066710/tests.lua.txt)
