### PR TITLE
opencl: fix cpu/gpu differences in rawprepare

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -38,15 +38,14 @@ rawprepare_1f(read_only image2d_t in, write_only image2d_t out,
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
-  if(x < cx || y < cy) return;
-  if(x >= width + cx || y >= height + cy) return;
+  if(x >= width || y >= height) return;
 
-  const float pixel = read_imageui(in, sampleri, (int2)(x, y)).x;
+  const float pixel = read_imageui(in, sampleri, (int2)(x + cx, y + cy)).x;
 
   const int id = BL(ry+cy+y, rx+cx+x);
   const float pixel_scaled = (pixel - sub[id]) / div[id];
 
-  write_imagef(out, (int2)(x-cx, y-cy), (float4)(pixel_scaled, 0.0f, 0.0f, 0.0f));
+  write_imagef(out, (int2)(x, y), (float4)(pixel_scaled, 0.0f, 0.0f, 0.0f));
 }
 
 kernel void
@@ -59,15 +58,14 @@ rawprepare_1f_unnormalized(read_only image2d_t in, write_only image2d_t out,
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
-  if(x < cx || y < cy) return;
-  if(x >= width + cx || y >= height + cy) return;
+  if(x >= width  || y >= height) return;
 
-  const float pixel = read_imagef(in, sampleri, (int2)(x, y)).x;
+  const float pixel = read_imagef(in, sampleri, (int2)(x + cx, y + cy)).x;
 
   const int id = BL(ry+cy+y, rx+cx+x);
   const float pixel_scaled = (pixel - sub[id]) / div[id];
 
-  write_imagef(out, (int2)(x-cx, y-cy), (float4)(pixel_scaled, 0.0f, 0.0f, 0.0f));
+  write_imagef(out, (int2)(x, y), (float4)(pixel_scaled, 0.0f, 0.0f, 0.0f));
 }
 
 kernel void
@@ -79,13 +77,12 @@ rawprepare_4f(read_only image2d_t in, write_only image2d_t out,
   const int x = get_global_id(0);
   const int y = get_global_id(1);
 
-  if(x < cx || y < cy) return;
-  if(x >= width + cx || y >= height + cy) return;
+  if(x >= width || y >= height) return;
 
-  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel = read_imagef(in, sampleri, (int2)(x + cx, y + cy));
   pixel.xyz = (pixel.xyz - black[0]) / div[0];
 
-  write_imagef(out, (int2)(x-cx, y-cy), pixel);
+  write_imagef(out, (int2)(x, y), pixel);
 }
 
 kernel void


### PR DESCRIPTION
This fixes a difference (shift by a few pixels) between OpenCL and CPU codepath. While this is not a big deal in itself it's still better to fix in an effort to detect cpu/gpu differences in other modules by image comparison.

Rationale: the OpenCL kernels get called with the image dimensions of the output image (roi_out->width/height). Therefore we ought to use the get_global_id() coordinates x/y for writing to output and apply the needed offsets cx/cy when reading from the input image. The old code would apply the offset in reading and not in writing.