### PR TITLE
Color picker: IOP modules respect last selected colorpicker size (poi…

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -527,7 +527,7 @@ static void _blendop_blendif_pick_toggled(GtkToggleButton *togglebutton, dt_iop_
   /* set the area sample size */
   if(module->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+    dt_lib_colorpicker_set(darktable.lib, 0.5, 0.5);
     dt_dev_reprocess_all(module->dev);
   }
   else

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -567,7 +567,7 @@ static void request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t 
   /* use point sample */
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+    dt_lib_colorpicker_set(darktable.lib, 0.5, 0.5);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1019,7 +1019,7 @@ static void request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t 
   /* set the area sample size */
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+    dt_lib_colorpicker_set(darktable.lib, 0.5, 0.5);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -723,7 +723,7 @@ static void autoexp_callback(GtkWidget *button, gpointer user_data)
 
   if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
   {
-    dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+    dt_lib_colorpicker_set(darktable.lib, 0.99, 0);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -142,7 +142,7 @@ static void request_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t 
 
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+    dt_lib_colorpicker_set(darktable.lib, 0.99, 0);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1064,7 +1064,7 @@ static void dt_iop_levels_pick_general_handler(GtkToggleButton *togglebutton, dt
   if(TRUE == toggle)
   {
     self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
-    dt_lib_colorpicker_set_point(darktable.lib, xpick, ypick);
+    dt_lib_colorpicker_set(darktable.lib, xpick, ypick);
     c->activeToggleButton = togglebutton;
     c->current_pick = picklevel;
     dt_dev_reprocess_all(self->dev);

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -569,7 +569,7 @@ static void picker_callback(GtkWidget *button, gpointer user_data)
 
   if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
   {
-    dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+    dt_lib_colorpicker_set(darktable.lib, 0.99, 0);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -217,7 +217,7 @@ static void picker_callback(GtkDarktableToggleButton *button, gpointer user_data
   /* set the area sample size*/
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+    dt_lib_colorpicker_set(darktable.lib, 0.5, 0.5);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1231,8 +1231,7 @@ static void apply_preset(dt_iop_module_t *self)
       self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
       /* set the area sample size*/
-      if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
-        dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+      if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF) dt_lib_colorpicker_set(darktable.lib, 0.99, 0);
 
       break;
     default: // camera WB presets

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -735,7 +735,7 @@ static void pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *self)
   /* set the area sample size */
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
+    dt_lib_colorpicker_set(darktable.lib, 0.5, 0.5);
     dt_dev_reprocess_all(self->dev);
   }
   else

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -26,6 +26,7 @@
 #include "dtgtk/icon.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
+#include "libs/colorpicker.h"
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -1202,6 +1203,14 @@ void dt_lib_colorpicker_set_point(dt_lib_t *lib, float x, float y)
 {
   if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_point) return;
   lib->proxy.colorpicker.set_sample_point(lib->proxy.colorpicker.module, x, y);
+}
+
+void dt_lib_colorpicker_set(dt_lib_t *lib, float sizex, float y)
+{
+  if(dt_conf_get_int("ui_last/colorpicker_size") == DT_COLORPICKER_SIZE_POINT)
+    dt_lib_colorpicker_set_point(lib, sizex, y);
+  else
+    dt_lib_colorpicker_set_area(lib, sizex);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -179,6 +179,9 @@ void dt_lib_colorpicker_set_area(dt_lib_t *lib, float size);
 /** set the colorpicker point selection tool and position */
 void dt_lib_colorpicker_set_point(dt_lib_t *lib, float x, float y);
 
+/** set the colorpicker selection either area or point, depending on preference */
+void dt_lib_colorpicker_set(dt_lib_t *lib, float sizex, float y);
+
 /** sorter callback to add a lib in the list of libs after init */
 gint dt_lib_sort_plugins(gconstpointer a, gconstpointer b);
 /** init presets for a newly created lib */


### PR DESCRIPTION
…nt or area) Fixes #11512

Before that some IOP modules were _always_ initiated to use point type color picker others were _always_ initiated to use area type color picker. The user had to change color picker size if it was not matching his/her preference.

This change makes all IOPs handle the same way the color picker, using the last selected color picker size.