### PR TITLE
dt_dev_change_image(): reset mi name too. Fixes #10636

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -597,6 +597,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
     if(module->multi_priority == mp_base) // if the module is the "base" instance, we keep it
     {
       module->multi_priority = 0;
+      module->multi_name[0] = '\0';
       dt_iop_reload_defaults(module);
       dt_iop_gui_update(module);
     }


### PR DESCRIPTION
When image is changed in darkroom's strip, all module's instances except the "base" one are removed, remaining "base" instance gets its priority reset, and defaults loaded, however instance name (multi_name) is left as is from previous image. This pull request fixes that.