### PR TITLE
Left from first image in zoomable LT --> no effect

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1077,7 +1077,7 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
   }
   else if(zoom < 1.01)
   {
-    if(zoom == 1 && zoom_x < 0) // full view, wrap around
+    if(zoom == 1 && zoom_x < 0 && zoom_y > 0) // full view, wrap around
     {
       zoom_x = wd * DT_LIBRARY_MAX_ZOOM - wd;
       zoom_y -= ht;


### PR DESCRIPTION
As a consequence of the movement logic, arrow keys can have a frustrating behavior in the following situation.

In zoomable light table, fully zoomed in, only a few images in the collection (e.g. five). The user is watching the first image and she hits the left arrow. Then the view is transfered to an empty slot (the last of the first row). Trying to go back from there with the right arrow brings her to a new empty slot (the first of the second row). Also trying to zoom out a little from that place does not bring any image into view. This can be very confusing.

In general, any action caused by hitting the left arrow should be undone by the right arrow, in particular when such action is an exception to the general rule, puzzling, and surely undesired. Considering that wrapping around has no reasonable use in that particular situation, it makes no sense for the left arrow on the first image of the collection to produce an action at all.

This little change simply inhibits wrap around when fully zoomed in on the first image in the first row.