### PR TITLE
dt_image_import(): sync call lua post-import-image event. Fixes  #11674

### DIFF
--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -217,14 +217,6 @@ static void on_film_imported(gpointer instance, uint32_t id, gpointer user_data)
       LUA_ASYNC_DONE);
 }
 
-static void on_image_imported(gpointer instance, uint32_t id, gpointer user_data)
-{
-  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper,
-      0,NULL,NULL,
-      LUA_ASYNC_TYPENAME,"const char*","post-import-image",
-      LUA_ASYNC_TYPENAME,"dt_lua_image_t",GINT_TO_POINTER(id),
-      LUA_ASYNC_DONE);
-}
 int dt_lua_init_database(lua_State *L)
 {
 
@@ -272,7 +264,7 @@ int dt_lua_init_database(lua_State *L)
   lua_pushcfunction(L, dt_lua_event_multiinstance_register);
   lua_pushcfunction(L, dt_lua_event_multiinstance_trigger);
   dt_lua_event_add(L, "post-import-image");
-  dt_control_signal_connect(darktable.signals, DT_SIGNAL_IMAGE_IMPORT, G_CALLBACK(on_image_imported), NULL);
+
   return 0;
 }
 

--- a/tools/lua_doc/content.lua
+++ b/tools/lua_doc/content.lua
@@ -1027,7 +1027,7 @@ local widget = dt.new_widget("button"){
 
 	events["post-import-image"]:set_text([[This event is triggered whenever a new image is imported into the database.
 
-	This event can be registered multiple times, all callbacks will be called.]])
+	This event can be registered multiple times, all callbacks will be called. The call is blocking.]])
 	events["post-import-image"].callback:add_parameter("event","string",[[The name of the event that triggered the callback.]])
 	events["post-import-image"].callback:add_parameter("image",types.dt_lua_image_t,[[The image object that has been imported.]])
 	events["post-import-image"].extra_registration_parameters:set_text([[This event has no extra registration parameters.]])


### PR DESCRIPTION
Change makes LUA post-import-image event being called synchronously in dt_image_import() just after successfully importing the image. This  avoids race conditions between event code and darkroom, which were possible when mentioned event was called asynchronously. For further information look here: https://redmine.darktable.org/issues/11674