### PR TITLE
dt_image_import(): refactoring for optional LUA locking

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -745,7 +745,7 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
 }
 
 
-uint32_t dt_image_import_internal(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs, gboolean lua_locking)
+static uint32_t dt_image_import_internal(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs, gboolean lua_locking)
 {
   if(!g_file_test(filename, G_FILE_TEST_IS_REGULAR) || dt_util_get_file_size(filename) == 0) return 0;
   const char *cc = filename + strlen(filename);
@@ -987,6 +987,16 @@ uint32_t dt_image_import_internal(const int32_t film_id, const char *filename, g
   // keywords side pane when trying to use it, which can lock up the whole dt GUI ..
   // if (new_tags_set) dt_control_signal_raise(darktable.signals,DT_SIGNAL_TAG_CHANGED);
   return id;
+}
+
+uint32_t dt_image_import(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs)
+{
+  return dt_image_import_internal(film_id, filename, override_ignore_jpegs, true);
+}
+
+uint32_t dt_image_import_lua(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs)
+{
+  return dt_image_import_internal(film_id, filename, override_ignore_jpegs, false);
 }
 
 void dt_image_init(dt_image_t *img)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -745,7 +745,7 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
 }
 
 
-uint32_t dt_image_import(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs)
+uint32_t dt_image_import_internal(const int32_t film_id, const char *filename, gboolean override_ignore_jpegs, gboolean lua_locking)
 {
   if(!g_file_test(filename, G_FILE_TEST_IS_REGULAR) || dt_util_get_file_size(filename) == 0) return 0;
   const char *cc = filename + strlen(filename);
@@ -969,14 +969,16 @@ uint32_t dt_image_import(const int32_t film_id, const char *filename, gboolean o
 
   #ifdef USE_LUA
   //Synchronous calling of lua post-import-image events
-  dt_lua_lock();
+  if (lua_locking)
+    dt_lua_lock();
 
   lua_State *L = darktable.lua_state.state;
 
   luaA_push(L, dt_lua_image_t, &id);
   dt_lua_event_trigger(L, "post-import-image", 1);
 
-  dt_lua_unlock();
+  if (lua_locking)
+    dt_lua_unlock();
   #endif  
 
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_IMAGE_IMPORT, id);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -211,8 +211,12 @@ void dt_image_path_append_version(int imgid, char *pathname, size_t pathname_len
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len);
 /** look for duplicate's xmp files and read them. */
 void dt_image_read_duplicates(uint32_t id, const char *filename);
-/** imports a new image from raw/etc file and adds it to the data base and image cache. */
-uint32_t dt_image_import(int32_t film_id, const char *filename, gboolean override_ignore_jpegs);
+/** imports a new image from raw/etc file and adds it to the data base and image cache. Don't call directly, use wrapper functions below.*/
+uint32_t dt_image_import_internal(int32_t film_id, const char *filename, gboolean override_ignore_jpegs, gboolean lua_locking);
+/** imports a new image from raw/etc file and adds it to the data base and image cache. Use from threads other than lua.*/
+#define dt_image_import(film_id,filename,override_ignore_jpegs) dt_image_import_internal(film_id,filename,override_ignore_jpegs,true)
+/** imports a new image from raw/etc file and adds it to the data base and image cache. Use from lua thread.*/
+#define dt_image_import_lua(film_id,filename,override_ignore_jpegs) dt_image_import_internal(film_id,filename,override_ignore_jpegs,false)
 /** removes the given image from the database. */
 void dt_image_remove(const int32_t imgid);
 /** duplicates the given image in the database with the duplicate getting the supplied version number. if that

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -211,12 +211,10 @@ void dt_image_path_append_version(int imgid, char *pathname, size_t pathname_len
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len);
 /** look for duplicate's xmp files and read them. */
 void dt_image_read_duplicates(uint32_t id, const char *filename);
-/** imports a new image from raw/etc file and adds it to the data base and image cache. Don't call directly, use wrapper functions below.*/
-uint32_t dt_image_import_internal(int32_t film_id, const char *filename, gboolean override_ignore_jpegs, gboolean lua_locking);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from threads other than lua.*/
-#define dt_image_import(film_id,filename,override_ignore_jpegs) dt_image_import_internal(film_id,filename,override_ignore_jpegs,true)
+uint32_t dt_image_import(int32_t film_id, const char *filename, gboolean override_ignore_jpegs);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from lua thread.*/
-#define dt_image_import_lua(film_id,filename,override_ignore_jpegs) dt_image_import_internal(film_id,filename,override_ignore_jpegs,false)
+uint32_t dt_image_import_lua(int32_t film_id, const char *filename, gboolean override_ignore_jpegs);
 /** removes the given image from the database. */
 void dt_image_remove(const int32_t imgid);
 /** duplicates the given image in the database with the duplicate getting the supplied version number. if that

--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -132,7 +132,7 @@ static int import_images(lua_State *L)
       return luaL_error(L, "error while importing");
     }
 
-    result = dt_image_import(new_film.id, full_name, TRUE);
+    result = dt_image_import_lua(new_film.id, full_name, TRUE);
     if(dt_film_is_empty(new_film.id)) dt_film_remove(new_film.id);
     dt_film_cleanup(&new_film);
     if(result == 0)


### PR DESCRIPTION
dt_image_import() was refactored into dt_image_import_internal()
and 2 wrapper functions: dt_image_import() and dt_image_import_lua().

The former keeps the old functionality (does lua locking) and is
intended to be called from threads other than ones executing lua.
The later does not do lua locking, and hence is intended to be called
from threads executing lua code.

Change is required for avoiding deadlock in dt_image_import() when image is imported from LUA code (using darktable.database.import) like it is done i.e. in gimp.lua.