### PR TITLE
tools/extract_wb: only use the "White Point" values if there are at least four

### DIFF
--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -100,7 +100,7 @@ ARGV.each do |filename|
         red = values[1].to_f/green
         blue = values[2].to_f/green
         green = 1
-      elsif tag == "White Point"
+      elsif tag == "White Point" && values.length > 3
         green = (values[1].to_f+values[2].to_f)/2.0
         red = values[0].to_f/green
         blue = values[3].to_f/green


### PR DESCRIPTION
It turns out that the Fujifilm X100F gives both "WB GRB Levels" and
"White Point", in that order.  Unfortunately, the latter has the exact
same values in any image, and only two values, which makes them
unsuitable to figure out the white balance values.  So we avoid using
them by requiring that there be at least four "White Point" values.