### PR TITLE
Add WB presets for Fujifilm X100F

### DIFF
--- a/src/external/wb_presets.c
+++ b/src/external/wb_presets.c
@@ -1912,6 +1912,14 @@ const wb_data wb_preset[] =
   { "Fujifilm", "X100T", WhiteFluorescent   , 0, { 2.013245, 1, 1.970199, 0 } },
   { "Fujifilm", "X100T", Underwater         , 0, { 1.927152, 1, 1.549669, 0 } },
 
+  { "Fujifilm", "X100F", Daylight, 0,            { 1.9503311258278146, 1, 1.8543046357615893, 0 } },
+  { "Fujifilm", "X100F", Cloudy, 0,              { 2.142384105960265, 1, 1.5927152317880795, 0 } },
+  { "Fujifilm", "X100F", DaylightFluorescent, 0, { 2.486754966887417, 1, 1.6291390728476822, 0 } },
+  { "Fujifilm", "X100F", DayWhiteFluorescent, 0, { 2.0827814569536423, 1, 1.9834437086092715, 0 } },
+  { "Fujifilm", "X100F", WhiteFluorescent, 0,    { 1.9569536423841059, 1, 2.5596026490066226, 0 } },
+  { "Fujifilm", "X100F", Incandescent, 0,        { 1.271523178807947, 1, 2.8311258278145695, 0 } },
+  { "Fujifilm", "X100F", Underwater, 0,          { 1.9503311258278146, 1, 1.8543046357615893, 0 } },
+
   { "Fujifilm", "X20", Daylight           , 0, { 1.688742, 1, 1.850993, 0 } },
   { "Fujifilm", "X20", Cloudy             , 0, { 1.827815, 1, 1.622517, 0 } },
   { "Fujifilm", "X20", Incandescent       , 0, { 1.066225, 1, 2.605960, 0 } },


### PR DESCRIPTION
-----

Note: because this is in `src/external`, I'm unsure about the exact protocol for adding new presets, I just hope this is good enough.

Note2: I would very much like to see this end up in darktable-2.2.x as well.  Will it be cherry-picked or should I create another PR against that branch for it?