### PR TITLE
Checking for empty mask list. Fixes #11758

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1129,11 +1129,15 @@ static void _masks_write_form_db(dt_masks_form_t *form, dt_develop_t *dev)
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 5, form->version);
   if(form->type & DT_MASKS_CIRCLE)
   {
-    dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
-    DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 6, circle, sizeof(dt_masks_point_circle_t), SQLITE_TRANSIENT);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 7, 1);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+    GList *points = g_list_first(form->points);
+    if(points)
+    {
+      dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(points->data);
+      DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 6, circle, sizeof(dt_masks_point_circle_t), SQLITE_TRANSIENT);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 7, 1);
+      sqlite3_step(stmt);
+      sqlite3_finalize(stmt);
+    }
   }
   else if(form->type & DT_MASKS_PATH)
   {


### PR DESCRIPTION
This prevents crash, but mask undo still behaves strange: if you have a few spot removal circles, and push undo, it will remove all of them. Somebody with more knowledge about undo should loook into that.