### PR TITLE
print: fix image orientation handling

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -844,17 +844,17 @@ static void _set_orientation(dt_lib_print_settings_t *ps)
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, ps->image_id, DT_MIPMAP_3, DT_MIPMAP_BEST_EFFORT, 'r');
 
-  // FIXME: if there's no mipmap available, use width/height from EXIF data?
-  if (buf.width > buf.height)
-    ps->prt.page.landscape = TRUE;
-  else
-    ps->prt.page.landscape = FALSE;
+  // If there's a mipmap available, figure out orientation based upon
+  // its dimensions. Otherwise, don't touch orientation until the
+  // mipmap arrives.
+  if (buf.size != DT_MIPMAP_NONE)
+  {
+    ps->prt.page.landscape = (buf.width > buf.height);
+    dt_view_print_settings(darktable.view_manager, &ps->prt);
+    dt_bauhaus_combobox_set (ps->orientation, ps->prt.page.landscape==TRUE?1:0);
+  }
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-
-  dt_view_print_settings(darktable.view_manager, &ps->prt);
-
-  dt_bauhaus_combobox_set (ps->orientation, ps->prt.page.landscape==TRUE?1:0);
 }
 
 static void _image_update(void *data, gboolean new_image)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -842,7 +842,7 @@ static void _set_orientation(dt_lib_print_settings_t *ps)
     return;
 
   dt_mipmap_buffer_t buf;
-  dt_mipmap_cache_get(darktable.mipmap_cache, &buf, ps->image_id, DT_MIPMAP_3, DT_MIPMAP_BEST_EFFORT, 'r');
+  dt_mipmap_cache_get(darktable.mipmap_cache, &buf, ps->image_id, DT_MIPMAP_0, DT_MIPMAP_BEST_EFFORT, 'r');
 
   // If there's a mipmap available, figure out orientation based upon
   // its dimensions. Otherwise, don't touch orientation until the
@@ -940,7 +940,6 @@ void view_enter(struct dt_lib_module_t *self,struct dt_view_t *old_view,struct d
   // when an updated mipmap, we may have new orientation information
   // about the current image. This updates the image_id as well and
   // zeros out dimensions, but there should be no harm in that
-  // FIXME: This will fire multiple times as higher res mipmaps come in -- conceivably the user could have adjusted the orientation in the meantime and later signals will override the user's choice. Should only change the orientation if it has not previously been set for this image?
   dt_control_signal_connect(darktable.signals,
                             DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
                             G_CALLBACK(_print_settings_activate_or_update_callback),

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -853,6 +853,8 @@ static void _set_orientation(dt_lib_print_settings_t *ps)
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 
   dt_view_print_settings(darktable.view_manager, &ps->prt);
+
+  dt_bauhaus_combobox_set (ps->orientation, ps->prt.page.landscape==TRUE?1:0);
 }
 
 static void _image_update(void *data, gboolean new_image)
@@ -867,8 +869,6 @@ static void _image_update(void *data, gboolean new_image)
   }
 
   _set_orientation (ps);
-
-  dt_bauhaus_combobox_set (ps->orientation, ps->prt.page.landscape==TRUE?1:0);
 }
 
 static void _print_settings_filmstrip_activate_callback(gpointer instance,gpointer user_data)
@@ -999,19 +999,7 @@ gui_init (dt_lib_module_t *self)
 
   d->profiles = _get_profiles();
 
-  //  get orientation of the selectd image if possible
-
   d->image_id = -1;
-
-  GList *selected_images = dt_collection_get_selected(darktable.collection, 1);
-  if(selected_images)
-  {
-    int imgid = GPOINTER_TO_INT(selected_images->data);
-    d->image_id = imgid;
-  }
-  g_list_free(selected_images);
-
-  _set_orientation(d);
 
   //  create the spin-button now as values could be set when the printer has no hardware margin
 
@@ -1848,8 +1836,6 @@ gui_reset (dt_lib_module_t *self)
   // reset page orientation to fit the picture
 
   _set_orientation (ps);
-
-  dt_bauhaus_combobox_set (ps->orientation, ps->prt.page.landscape?1:0);
 }
 
 void init_key_accels(dt_lib_module_t *self)

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -280,7 +280,7 @@ void enter(dt_view_t *self)
   {
     int imgid = GPOINTER_TO_INT(selected_images->data);
     prt->image_id = imgid;
-    dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, FALSE);
+    dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, TRUE);
   }
   g_list_free(selected_images);
 

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -57,11 +57,6 @@ uint32_t view(const dt_view_t *self)
   return DT_VIEW_PRINT;
 }
 
-static void _print_mipmaps_updated_signal_callback(gpointer instance, gpointer user_data)
-{
-  dt_control_queue_redraw_center();
-}
-
 static void _set_orientation(dt_print_t *prt)
 {
   if (prt->image_id <= 0)
@@ -76,6 +71,14 @@ static void _set_orientation(dt_print_t *prt)
     prt->pinfo->page.landscape = FALSE;
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
+}
+
+static void _print_mipmaps_updated_signal_callback(gpointer instance, gpointer user_data)
+{
+  const dt_view_t *self = (dt_view_t *)user_data;
+  dt_print_t *prt=(dt_print_t*)self->data;
+  _set_orientation(prt);
+  dt_control_queue_redraw_center();
 }
 
 static void _film_strip_activated(const int imgid, void *data)


### PR DESCRIPTION
This catches the case when print view is entered from darkroom mode with an image of unknown width/height. Prior to this commit, the layout would default to portrait mode.

Fixes #11780.

A better fix may be to also have _set_orientation() fall back to the width/height in image metadata if there is no mipmap available.

Note that this does not fix the print settings orientation combobox, which can also be inaccurate.