### PR TITLE
print: properly restore export intent

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1277,7 +1277,7 @@ gui_init (dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->intent, _("absolute colorimetric"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->intent), TRUE, TRUE, 0);
 
-  dt_bauhaus_combobox_set(d->intent, 0);
+  dt_bauhaus_combobox_set(d->intent, dt_conf_get_int("plugins/print/print/iccintent") + 1);
 
   g_signal_connect (G_OBJECT (d->intent), "value-changed", G_CALLBACK (_intent_callback), (gpointer)self);
 
@@ -1789,7 +1789,7 @@ gui_reset (dt_lib_module_t *self)
   ps->prt.page.alignment = ALIGNMENT_CENTER;
   dt_bauhaus_combobox_set(ps->profile, 0);
   dt_bauhaus_combobox_set(ps->pprofile, 0);
-  dt_bauhaus_combobox_set(ps->pintent, dt_conf_get_int("plugins/print/print/iccintent") + 1);
+  dt_bauhaus_combobox_set(ps->pintent, 0);
   dt_bauhaus_combobox_set(ps->style, 0);
   dt_bauhaus_combobox_set(ps->intent, 0);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ps->black_point_compensation), TRUE);


### PR DESCRIPTION
Previously this always reverted to "image settings".

Also, on print settings reset, now set print intent to perceptual rather than an (off by one) value of export intent.

Fixes #11783.