### PR TITLE
print: export profile fixes

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -672,6 +672,7 @@ const dt_colorspaces_color_profile_t *dt_colorspaces_get_output_profile(const in
 
   const dt_colorspaces_color_profile_t *p = NULL;
 
+  // FIXME: this code is only useful for export, it would be helpful instead to pull the output profile from the pixelpipe or imageio data of the processed image
   int over_type = dt_conf_get_int("plugins/lighttable/export/icctype");
   gchar *over_filename = dt_conf_get_string("plugins/lighttable/export/iccprofile");
 

--- a/src/common/printprof.c
+++ b/src/common/printprof.c
@@ -38,24 +38,16 @@ static cmsUInt32Number ComputeFormatDescriptor (int OutColorSpace, int bps)
   return (FLOAT_SH(IsFlt)|COLORSPACE_SH(OutColorSpace)|PLANAR_SH(IsPlanar)|CHANNELS_SH(Channels)|BYTES_SH(bps));
 }
 
-int dt_apply_printer_profile(int imgid, void **in, uint32_t width, uint32_t height, int bpp,
-                             cmsHPROFILE hOutProfile, int intent, gboolean black_point_compensation)
+int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp,
+                             cmsHPROFILE hInProfile, cmsHPROFILE hOutProfile,
+                             int intent, gboolean black_point_compensation)
 {
-  cmsHPROFILE hInProfile;
   cmsHTRANSFORM hTransform;
   cmsUInt32Number wInput, wOutput;
   int OutputColorSpace;
 
-  if(!hOutProfile)
+  if(!(hInProfile && hOutProfile))
     return 1;
-
-  const dt_colorspaces_color_profile_t *in_profile = dt_colorspaces_get_output_profile(imgid);
-  if(!in_profile || !in_profile->profile)
-  {
-    fprintf(stderr, "error getting output profile for image %d\n", imgid);
-    return 1;
-  }
-  hInProfile = in_profile->profile;
 
   wInput = ComputeFormatDescriptor (PT_RGB, (bpp==8?1:2));
 

--- a/src/common/printprof.h
+++ b/src/common/printprof.h
@@ -23,8 +23,9 @@
 #include <lcms2.h>
 #include <stddef.h>
 
-int dt_apply_printer_profile(int imgid, void **in, uint32_t width, uint32_t height, int bpp,
-                             cmsHPROFILE hOutProfile, int intent, gboolean black_point_compensation);
+int dt_apply_printer_profile(void **in, uint32_t width, uint32_t height, int bpp,
+                             cmsHPROFILE hInProfile, cmsHPROFILE hOutProfile,
+                             int intent, gboolean black_point_compensation);
 // this routines takes as input an image of 8 or 16 bpp but always return a 8 bpp result. It is indeed better to
 // apply the profile to a 16bit input but we do not need this for printing.
 


### PR DESCRIPTION
- fixes a bug where once print exports an image via pixelpipe, it then arbitrarily assigns it to the profile as set in the export panel before converting it to the printer profile
- handle when the export intent is "image settings"
- use internal settings rather than conf values

The export profile bug is an unintended consequence of 1425e4f398ec2d7474ca9c3509d5931dd0d51ee4 which fixed #11787.