### PR TITLE
Retouch GUI

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -684,6 +684,12 @@ int dt_control_key_pressed_override(guint key, guint state)
     gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
     return 1;
   }
+  // add an option to allow skip mouse events while editing masks
+  else if(key == accels->darkroom_skip_mouse_events.accel_key && state == accels->darkroom_skip_mouse_events.accel_mods)
+  {
+    darktable.develop->darkroom_skip_mouse_events = TRUE;
+    return 1;
+  }
   return 0;
 }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -105,8 +105,7 @@ typedef struct dt_control_accels_t
   GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right, lighttable_left,
       lighttable_center, lighttable_preview, lighttable_preview_display_focus, lighttable_preview_sticky,
       lighttable_preview_sticky_focus, lighttable_preview_sticky_exit, global_sideborders, global_header,
-      darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out;
-
+      darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out, darkroom_skip_mouse_events;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -251,6 +251,7 @@ typedef struct dt_develop_t
   } profile;
 
   int mask_form_selected_id; // select a mask inside an iop
+  gboolean darkroom_skip_mouse_events; // skip mouse events for masks
 } dt_develop_t;
 
 void dt_dev_init(dt_develop_t *dev, int32_t gui_attached);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1023,8 +1023,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     {
       float masks_hardness;
-      float amount = 1.25f;
-      if(up) amount = 0.8f;
+      float amount = 1.03f;
+      if(up) amount = 0.97f;
 
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
       {
@@ -1047,8 +1047,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
     {
       float masks_density;
-      float amount = 1.25f;
-      if(up) amount = 0.8f;
+      float amount = 1.03f;
+      if(up) amount = 0.97f;
 
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
       {
@@ -1078,7 +1078,7 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
       {
         masks_border = dt_conf_get_float("plugins/darkroom/spots/brush_border");
-        masks_border = MAX(0.005f, MIN(masks_border * amount, 0.5f));
+        masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
         dt_conf_set_float("plugins/darkroom/spots/brush_border", masks_border);
       }
       else
@@ -1113,7 +1113,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else
     {
       guint nb = g_list_length(form->points);
-      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      // resize don't care where the mouse is inside a shape
+      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
         float amount = 1.03f;
         if(up) amount = 0.97f;
@@ -1144,8 +1145,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       }
       else
       {
-        float amount = 1.25f;
-        if(up) amount = 0.8f;
+        float amount = 1.03f;
+        if(up) amount = 0.97f;
         for(int k = 0; k < nb; k++)
         {
           dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1023,8 +1023,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     {
       float masks_hardness;
-      float amount = 1.03f;
-      if(up) amount = 0.97f;
+      float amount = 1.25f;
+      if(up) amount = 0.8f;
 
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
       {
@@ -1047,8 +1047,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
     {
       float masks_density;
-      float amount = 1.03f;
-      if(up) amount = 0.97f;
+      float amount = 1.25f;
+      if(up) amount = 0.8f;
 
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
       {
@@ -1078,7 +1078,7 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
       {
         masks_border = dt_conf_get_float("plugins/darkroom/spots/brush_border");
-        masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
+        masks_border = MAX(0.005f, MIN(masks_border * amount, 0.5f));
         dt_conf_set_float("plugins/darkroom/spots/brush_border", masks_border);
       }
       else
@@ -1113,8 +1113,7 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
     else
     {
       guint nb = g_list_length(form->points);
-      // resize don't care where the mouse is inside a shape
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
         float amount = 1.03f;
         if(up) amount = 0.97f;
@@ -1145,8 +1144,8 @@ static int dt_brush_events_mouse_scrolled(struct dt_iop_module_t *module, float 
       }
       else
       {
-        float amount = 1.03f;
-        if(up) amount = 0.97f;
+        float amount = 1.25f;
+        if(up) amount = 0.8f;
         for(int k = 0; k < nb; k++)
         {
           dt_masks_point_brush_t *point = (dt_masks_point_brush_t *)g_list_nth_data(form->points, k);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -62,48 +62,45 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
   // add a preview when creating a circle
   if(gui->creation)
   {
-    if( ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) || state == 0)
+    if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     {
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
-      {
-        float masks_border;
+      float masks_border;
 
-        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
-          masks_border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
-        else
-          masks_border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
-
-        if(up && masks_border > 0.001f)
-          masks_border *= 0.97f;
-        else if(!up && masks_border < 1.0f)
-          masks_border *= 1.0f / 0.97f;
-
-        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
-          dt_conf_set_float("plugins/darkroom/spots/circle_border", masks_border);
-        else
-          dt_conf_set_float("plugins/darkroom/masks/circle/border", masks_border);
-      }
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+        masks_border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
       else
-      {
-        float masks_size;
+        masks_border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
 
-        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
-          masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
-        else
-          masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
+      if(up && masks_border > 0.001f)
+        masks_border *= 0.97f;
+      else if(!up && masks_border < 1.0f)
+        masks_border *= 1.0f / 0.97f;
 
-        if(up && masks_size > 0.001f)
-          masks_size *= 0.97f;
-        else if(!up && masks_size < 1.0f)
-          masks_size *= 1.0f / 0.97f;
-
-        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
-          dt_conf_set_float("plugins/darkroom/spots/circle_size", masks_size);
-        else
-          dt_conf_set_float("plugins/darkroom/masks/circle/size", masks_size);
-      }
-      return 1;
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+        dt_conf_set_float("plugins/darkroom/spots/circle_border", masks_border);
+      else
+        dt_conf_set_float("plugins/darkroom/masks/circle/border", masks_border);
     }
+    else if (state == 0)
+    {
+      float masks_size;
+
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+        masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
+      else
+        masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
+
+      if(up && masks_size > 0.001f)
+        masks_size *= 0.97f;
+      else if(!up && masks_size < 1.0f)
+        masks_size *= 1.0f / 0.97f;
+
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+        dt_conf_set_float("plugins/darkroom/spots/circle_size", masks_size);
+      else
+        dt_conf_set_float("plugins/darkroom/masks/circle/size", masks_size);
+    }
+    return 1;
   }
 
   if(gui->form_selected)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -66,7 +66,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     {
       float masks_border;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
         masks_border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
       else
         masks_border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
@@ -76,16 +76,16 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       else if(!up && masks_border < 1.0f)
         masks_border *= 1.0f / 0.97f;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
         dt_conf_set_float("plugins/darkroom/spots/circle_border", masks_border);
       else
         dt_conf_set_float("plugins/darkroom/masks/circle/border", masks_border);
     }
-    else if (state == 0)
+    else if(state == 0)
     {
       float masks_size;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
         masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
       else
         masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
@@ -95,7 +95,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       else if(!up && masks_size < 1.0f)
         masks_size *= 1.0f / 0.97f;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
         dt_conf_set_float("plugins/darkroom/spots/circle_size", masks_size);
       else
         dt_conf_set_float("plugins/darkroom/masks/circle/size", masks_size);
@@ -120,7 +120,8 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     {
       dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
       // resize don't care where the mouse is inside a shape
-      if (((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL) )
+      if(((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+         && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL))
       {
         if(up && circle->border > 0.001f)
           circle->border *= 0.97f;
@@ -445,11 +446,11 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
   {
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    
+
     dt_control_queue_redraw_center();
     return 1;
   }
-  
+
   return 0;
 }
 
@@ -460,7 +461,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   dashed[1] /= zoom_scale;
   int len = sizeof(dashed) / sizeof(dashed[0]);
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-  
+
   // add a preview when creating a circle
   // in creation mode
   if(gui->creation)
@@ -474,7 +475,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       if(!form) return;
 
       float radius1, radius2;
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
       {
         radius1 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_size"));
         radius2 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_border"));
@@ -487,7 +488,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       radius2 += radius1;
       radius1 *= MIN(wd, ht);
       radius2 *= MIN(wd, ht);
-      
+
       float xpos, ypos;
       if(gui->posx == 0 && gui->posy == 0)
       {
@@ -504,14 +505,14 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       }
 
       cairo_save(cr);
-      
+
       // draw circle
       cairo_set_dash(cr, dashed, 0, 0);
       cairo_set_line_width(cr, 3.0 / zoom_scale);
       cairo_set_source_rgba(cr, .3, .3, .3, .8);
-      
+
       cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
-      
+
       cairo_stroke_preserve(cr);
       cairo_set_line_width(cr, 1.0 / zoom_scale);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
@@ -523,7 +524,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_source_rgba(cr, .3, .3, .3, .8);
 
       cairo_arc(cr, xpos, ypos, radius2, 0, 2.0 * M_PI);
-      
+
       cairo_stroke_preserve(cr);
       cairo_set_line_width(cr, 1.0 / zoom_scale);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
@@ -535,7 +536,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
 
     return;
   }
-  
+
   if(!gpt) return;
   float dx = 0, dy = 0, dxs = 0, dys = 0;
   if((gui->group_selected == index) && gui->form_dragging)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -71,7 +71,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       else
         masks_border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
 
-      if(up && masks_border > 0.001f)
+      if(up && masks_border > 0.0005f)
         masks_border *= 0.97f;
       else if(!up && masks_border < 1.0f)
         masks_border *= 1.0f / 0.97f;
@@ -123,7 +123,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       if(((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
          && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL))
       {
-        if(up && circle->border > 0.001f)
+        if(up && circle->border > 0.0005f)
           circle->border *= 0.97f;
         else if(!up && circle->border < 1.0f)
           circle->border *= 1.0f / 0.97f;
@@ -228,8 +228,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     {
       const float circle_size = MIN(0.5f, dt_conf_get_float("plugins/darkroom/masks/circle/size"));
       const float circle_border = MIN(0.5f, dt_conf_get_float("plugins/darkroom/masks/circle/border"));
-      circle->radius = MAX(0.01f, circle_size);
-      circle->border = MAX(0.005f, circle_border);
+      circle->radius = MAX(0.001f, circle_size);
+      circle->border = MAX(0.0005f, circle_border);
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -59,6 +59,53 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
                                            uint32_t state, dt_masks_form_t *form, int parentid,
                                            dt_masks_form_gui_t *gui, int index)
 {
+  // add a preview when creating a circle
+  if(gui->creation)
+  {
+    if( ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) || state == 0)
+    {
+      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      {
+        float masks_border;
+
+        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+          masks_border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
+        else
+          masks_border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
+
+        if(up && masks_border > 0.001f)
+          masks_border *= 0.97f;
+        else if(!up && masks_border < 1.0f)
+          masks_border *= 1.0f / 0.97f;
+
+        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+          dt_conf_set_float("plugins/darkroom/spots/circle_border", masks_border);
+        else
+          dt_conf_set_float("plugins/darkroom/masks/circle/border", masks_border);
+      }
+      else
+      {
+        float masks_size;
+
+        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+          masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
+        else
+          masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
+
+        if(up && masks_size > 0.001f)
+          masks_size *= 0.97f;
+        else if(!up && masks_size < 1.0f)
+          masks_size *= 1.0f / 0.97f;
+
+        if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+          dt_conf_set_float("plugins/darkroom/spots/circle_size", masks_size);
+        else
+          dt_conf_set_float("plugins/darkroom/masks/circle/size", masks_size);
+      }
+      return 1;
+    }
+  }
+
   if(gui->form_selected)
   {
     // we register the current position
@@ -75,7 +122,8 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     else
     {
       dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
-      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      // resize don't care where the mouse is inside a shape
+      if (((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL) )
       {
         if(up && circle->border > 0.001f)
           circle->border *= 0.97f;
@@ -395,7 +443,16 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
     if(gui->edit_mode != DT_MASKS_EDIT_FULL) return 0;
     return 1;
   }
-
+  // add a preview when creating a circle
+  else if(gui->creation)
+  {
+    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
+    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    
+    dt_control_queue_redraw_center();
+    return 1;
+  }
+  
   return 0;
 }
 
@@ -406,6 +463,82 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   dashed[1] /= zoom_scale;
   int len = sizeof(dashed) / sizeof(dashed[0]);
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+  
+  // add a preview when creating a circle
+  // in creation mode
+  if(gui->creation)
+  {
+    float wd = darktable.develop->preview_pipe->iwidth;
+    float ht = darktable.develop->preview_pipe->iheight;
+
+    if(gui->guipoints_count == 0)
+    {
+      dt_masks_form_t *form = darktable.develop->form_visible;
+      if(!form) return;
+
+      float radius1, radius2;
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      {
+        radius1 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_size"));
+        radius2 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_border"));
+      }
+      else
+      {
+        radius1 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/masks/circle/size"));
+        radius2 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/masks/circle/border"));
+      }
+      radius2 += radius1;
+      radius1 *= MIN(wd, ht);
+      radius2 *= MIN(wd, ht);
+      
+      float xpos, ypos;
+      if(gui->posx == 0 && gui->posy == 0)
+      {
+        float zoom_x, zoom_y;
+        zoom_y = dt_control_get_dev_zoom_y();
+        zoom_x = dt_control_get_dev_zoom_x();
+        xpos = (.5f + zoom_x) * wd;
+        ypos = (.5f + zoom_y) * ht;
+      }
+      else
+      {
+        xpos = gui->posx;
+        ypos = gui->posy;
+      }
+
+      cairo_save(cr);
+      
+      // draw circle
+      cairo_set_dash(cr, dashed, 0, 0);
+      cairo_set_line_width(cr, 3.0 / zoom_scale);
+      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      
+      cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
+      
+      cairo_stroke_preserve(cr);
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      cairo_stroke(cr);
+
+      // draw border
+      cairo_set_dash(cr, dashed, len, 0);
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+
+      cairo_arc(cr, xpos, ypos, radius2, 0, 2.0 * M_PI);
+      
+      cairo_stroke_preserve(cr);
+      cairo_set_line_width(cr, 1.0 / zoom_scale);
+      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      cairo_set_dash(cr, dashed, len, 4);
+      cairo_stroke(cr);
+
+      cairo_restore(cr);
+    }
+
+    return;
+  }
+  
   if(!gpt) return;
   float dx = 0, dy = 0, dxs = 0, dys = 0;
   if((gui->group_selected == index) && gui->form_dragging)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -66,7 +66,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     {
       float masks_border;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         masks_border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
       else
         masks_border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
@@ -76,7 +76,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       else if(!up && masks_border < 1.0f)
         masks_border *= 1.0f / 0.97f;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         dt_conf_set_float("plugins/darkroom/spots/circle_border", masks_border);
       else
         dt_conf_set_float("plugins/darkroom/masks/circle/border", masks_border);
@@ -85,7 +85,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     {
       float masks_size;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
       else
         masks_size = dt_conf_get_float("plugins/darkroom/masks/circle/size");
@@ -95,7 +95,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       else if(!up && masks_size < 1.0f)
         masks_size *= 1.0f / 0.97f;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         dt_conf_set_float("plugins/darkroom/spots/circle_size", masks_size);
       else
         dt_conf_set_float("plugins/darkroom/masks/circle/size", masks_size);
@@ -475,7 +475,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       if(!form) return;
 
       float radius1, radius2;
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
         radius1 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_size"));
         radius2 = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_border"));

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -119,11 +119,9 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     else
     {
       dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
-      // resize don't care where the mouse is inside a shape
-      if(((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
-         && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL))
+      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
-        if(up && circle->border > 0.0005f)
+        if(up && circle->border > 0.001f)
           circle->border *= 0.97f;
         else if(!up && circle->border < 1.0f)
           circle->border *= 1.0f / 0.97f;
@@ -228,8 +226,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     {
       const float circle_size = MIN(0.5f, dt_conf_get_float("plugins/darkroom/masks/circle/size"));
       const float circle_border = MIN(0.5f, dt_conf_get_float("plugins/darkroom/masks/circle/border"));
-      circle->radius = MAX(0.001f, circle_size);
-      circle->border = MAX(0.0005f, circle_border);
+      circle->radius = MAX(0.01f, circle_size);
+      circle->border = MAX(0.005f, circle_border);
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -200,7 +200,8 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
     else
     {
       dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)(g_list_first(form->points)->data);
-      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      // resize don't care where the mouse is inside a shape
+      if (((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL) )
       {
         const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
         if(up && ellipse->border > 0.001f * reference)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -177,22 +177,20 @@ static void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_
   if(dt_ellipse_point_close_to_path(x, y, as, gpt->points + 10, gpt->points_count - 5)) *near = 1;
 }
 
-static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selected, const float zoom_scale, 
-                                  const float dx, const float dy,
-                                  const float xref, const float yref,
-                                  const float sinv, const float cosv,
-                                  const float scalea, const float scaleb,
+static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selected, const float zoom_scale,
+                                  const float dx, const float dy, const float xref, const float yref,
+                                  const float sinv, const float cosv, const float scalea, const float scaleb,
                                   float *points, const int points_count)
 {
   if(points_count <= 10) return;
-  
+
   const float r = atan2(points[3] - points[1], points[2] - points[0]);
   const float sinr = sin(r);
   const float cosr = cos(r);
 
   float x = 0.f;
   float y = 0.f;
-  
+
   cairo_set_dash(cr, dashed, 0, 0);
   if(selected)
     cairo_set_line_width(cr, 5.0 / zoom_scale);
@@ -200,17 +198,17 @@ static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selecte
     cairo_set_line_width(cr, 3.0 / zoom_scale);
   cairo_set_source_rgba(cr, .3, .3, .3, .8);
 
-  _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea,
-                           scaleb, sinv, cosv, &x, &y);
+  _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea, scaleb, sinv, cosv,
+                           &x, &y);
   cairo_move_to(cr, x, y);
   for(int i = 6; i < points_count; i++)
   {
-    _ellipse_point_transform(xref, yref, points[i * 2] + dx, points[i * 2 + 1] + dy, sinr, cosr,
-                             scalea, scaleb, sinv, cosv, &x, &y);
+    _ellipse_point_transform(xref, yref, points[i * 2] + dx, points[i * 2 + 1] + dy, sinr, cosr, scalea, scaleb,
+                             sinv, cosv, &x, &y);
     cairo_line_to(cr, x, y);
   }
-  _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea,
-                           scaleb, sinv, cosv, &x, &y);
+  _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea, scaleb, sinv, cosv,
+                           &x, &y);
   cairo_line_to(cr, x, y);
   cairo_stroke_preserve(cr);
   if(selected)
@@ -221,22 +219,20 @@ static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selecte
   cairo_stroke(cr);
 }
 
-static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len, const int selected, const float zoom_scale, 
-                                  const float dx, const float dy,
-                                  const float xref, const float yref,
-                                  const float sinv, const float cosv,
-                                  const float scaleab, const float scalebb,
-                                  float *border, const int border_count)
+static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len, const int selected,
+                                   const float zoom_scale, const float dx, const float dy, const float xref,
+                                   const float yref, const float sinv, const float cosv, const float scaleab,
+                                   const float scalebb, float *border, const int border_count)
 {
   if(border_count <= 10) return;
-  
+
   const float r = atan2(border[3] - border[1], border[2] - border[0]);
   const float sinr = sin(r);
   const float cosr = cos(r);
 
   float x = 0.f;
   float y = 0.f;
-  
+
   cairo_set_dash(cr, dashed, len, 0);
   if(selected)
     cairo_set_line_width(cr, 2.0 / zoom_scale);
@@ -244,17 +240,17 @@ static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len,
     cairo_set_line_width(cr, 1.0 / zoom_scale);
   cairo_set_source_rgba(cr, .3, .3, .3, .8);
 
-  _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab,
-                           scalebb, sinv, cosv, &x, &y);
+  _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab, scalebb, sinv, cosv,
+                           &x, &y);
   cairo_move_to(cr, x, y);
   for(int i = 6; i < border_count; i++)
   {
-    _ellipse_point_transform(xref, yref, border[i * 2] + dx, border[i * 2 + 1] + dy, sinr, cosr,
-                             scaleab, scalebb, sinv, cosv, &x, &y);
+    _ellipse_point_transform(xref, yref, border[i * 2] + dx, border[i * 2 + 1] + dy, sinr, cosr, scaleab, scalebb,
+                             sinv, cosv, &x, &y);
     cairo_line_to(cr, x, y);
   }
-  _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab,
-                           scalebb, sinv, cosv, &x, &y);
+  _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab, scalebb, sinv, cosv,
+                           &x, &y);
   cairo_line_to(cr, x, y);
 
   cairo_stroke_preserve(cr);
@@ -344,10 +340,10 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
   // add a preview when creating an ellipse
   if(gui->creation)
   {
-    if((state & (GDK_SHIFT_MASK|GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK|GDK_CONTROL_MASK))
+    if((state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     {
       float rotation;
-      
+
       if(form->type & DT_MASKS_CLONE)
         rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
       else
@@ -371,7 +367,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       float radius_a;
       float radius_b;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
       {
         masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
         flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
@@ -386,25 +382,26 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
       }
 
-      const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(radius_a, radius_b) : 1.0f);
+      const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
       if(up && masks_border > 0.001f * reference)
         masks_border *= 0.97f;
       else if(!up && masks_border < 1.0f * reference)
-        masks_border *= 1.0f/0.97f;
-      else return 1;
+        masks_border *= 1.0f / 0.97f;
+      else
+        return 1;
       masks_border = CLAMP(masks_border, 0.001f * reference, reference);
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
         dt_conf_set_float("plugins/darkroom/spots/ellipse_border", masks_border);
       else
         dt_conf_set_float("plugins/darkroom/masks/ellipse/border", masks_border);
     }
-    else if (state == 0)
+    else if(state == 0)
     {
       float radius_a;
       float radius_b;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
       {
         radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
         radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
@@ -421,14 +418,15 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         radius_a *= 0.97f;
       else if(!up && radius_a < 1.0f)
         radius_a *= 1.0f / 0.97f;
-      else return 1;
+      else
+        return 1;
 
       radius_a = CLAMP(radius_a, 0.001f, 1.0f);
 
       const float factor = radius_a / oldradius;
       radius_b *= factor;
 
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
       {
         dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", radius_a);
         dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", radius_b);
@@ -458,7 +456,8 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
     else
     {
       dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)(g_list_first(form->points)->data);
-      if((state & (GDK_SHIFT_MASK|GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK|GDK_CONTROL_MASK) && gui->edit_mode == DT_MASKS_EDIT_FULL)
+      if((state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK)
+         && gui->edit_mode == DT_MASKS_EDIT_FULL)
       {
         // we try to change the rotation
         if(up)
@@ -476,7 +475,8 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
           dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
       }
       // resize don't care where the mouse is inside a shape
-      else if (((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL) )
+      else if(((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+              && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL))
       {
         const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
         if(up && ellipse->border > 0.001f * reference)
@@ -1027,7 +1027,7 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
   {
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    
+
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1063,8 +1063,8 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       float radius_a;
       float radius_b;
       float rotation;
-  
-      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+
+      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
       {
         masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
         flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
@@ -1083,7 +1083,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
 
       float pzx = gui->posx;
       float pzy = gui->posy;
-      
+
       if(pzx == 0 && pzy == 0)
       {
         float zoom_x, zoom_y;
@@ -1092,68 +1092,61 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
         pzx = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
         pzy = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
       }
-      
+
       float pts[2] = { pzx, pzy };
       dt_dev_distort_backtransform(darktable.develop, pts, 1);
       x = pts[0] / darktable.develop->preview_pipe->iwidth;
       y = pts[1] / darktable.develop->preview_pipe->iheight;
-  
+
       float *points = NULL;
       int points_count = 0;
       float *border = NULL;
       int border_count = 0;
-      
+
       int draw = 0;
-      
+
       draw = dt_ellipse_get_points(darktable.develop, x, y, radius_a, radius_b, rotation, &points, &points_count);
-      if (draw && masks_border > 0.f)
+      if(draw && masks_border > 0.f)
       {
-        draw = dt_ellipse_get_points(darktable.develop, x, y,
+        draw = dt_ellipse_get_points(
+            darktable.develop, x, y,
             (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? radius_a * (1.0f + masks_border) : radius_a + masks_border),
             (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? radius_b * (1.0f + masks_border) : radius_b + masks_border),
             rotation, &border, &border_count);
       }
-    
-      if (draw && points_count >= 2)
+
+      if(draw && points_count >= 2)
       {
         xref = points[0];
         yref = points[1];
-        
-        dt_ellipse_draw_shape(cr, dashed, 0, zoom_scale, 
-            dx, dy, 
-            xref, yref,
-            sinv, cosv,
-            scalea, scaleb,
-            points, points_count);
+
+        dt_ellipse_draw_shape(cr, dashed, 0, zoom_scale, dx, dy, xref, yref, sinv, cosv, scalea, scaleb, points,
+                              points_count);
       }
-      if (draw && border_count >= 2)
+      if(draw && border_count >= 2)
       {
         xref = border[0];
         yref = border[1];
-        
-        dt_ellipse_draw_border(cr, dashed, len, 0, zoom_scale, 
-            dx, dy, 
-            xref, yref,
-            sinv, cosv,
-            scaleab, scalebb,
-            border, border_count);
+
+        dt_ellipse_draw_border(cr, dashed, len, 0, zoom_scale, dx, dy, xref, yref, sinv, cosv, scaleab, scalebb,
+                               border, border_count);
       }
-      
-      if (points) free(points);
-      if (border) free(border);
+
+      if(points) free(points);
+      if(border) free(border);
     }
     return;
   }
-  
+
   if(!gpt) return;
-  
+
   const float r = atan2(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
   const float sinr = sin(r);
   const float cosr = cos(r);
 
   xref = gpt->points[0];
   yref = gpt->points[1];
-  
+
   if(gpt->source_count > 10)
   {
     xrefs = gpt->source[0];

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -37,7 +37,6 @@ static inline void _ellipse_point_transform(const float xref, const float yref, 
   *ynew = yref + sinv * xtmp + cosv * ytmp;
 }
 
-
 // Jordan's point in polygon test
 static int dt_ellipse_cross_test(float x, float y, float *point_1, float *point_2)
 {
@@ -137,7 +136,6 @@ static int dt_ellipse_point_close_to_path(float x, float y, float as, float *poi
   return 0;
 }
 
-
 static void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_t *gui, int index,
                                     int *inside, int *inside_border, int *near, int *inside_source)
 {
@@ -179,11 +177,271 @@ static void dt_ellipse_get_distance(float x, int y, float as, dt_masks_form_gui_
   if(dt_ellipse_point_close_to_path(x, y, as, gpt->points + 10, gpt->points_count - 5)) *near = 1;
 }
 
+static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selected, const float zoom_scale, 
+                                  const float dx, const float dy,
+                                  const float xref, const float yref,
+                                  const float sinv, const float cosv,
+                                  const float scalea, const float scaleb,
+                                  float *points, const int points_count)
+{
+  if(points_count <= 10) return;
+  
+  const float r = atan2(points[3] - points[1], points[2] - points[0]);
+  const float sinr = sin(r);
+  const float cosr = cos(r);
+
+  float x = 0.f;
+  float y = 0.f;
+  
+  cairo_set_dash(cr, dashed, 0, 0);
+  if(selected)
+    cairo_set_line_width(cr, 5.0 / zoom_scale);
+  else
+    cairo_set_line_width(cr, 3.0 / zoom_scale);
+  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+
+  _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea,
+                           scaleb, sinv, cosv, &x, &y);
+  cairo_move_to(cr, x, y);
+  for(int i = 6; i < points_count; i++)
+  {
+    _ellipse_point_transform(xref, yref, points[i * 2] + dx, points[i * 2 + 1] + dy, sinr, cosr,
+                             scalea, scaleb, sinv, cosv, &x, &y);
+    cairo_line_to(cr, x, y);
+  }
+  _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea,
+                           scaleb, sinv, cosv, &x, &y);
+  cairo_line_to(cr, x, y);
+  cairo_stroke_preserve(cr);
+  if(selected)
+    cairo_set_line_width(cr, 2.0 / zoom_scale);
+  else
+    cairo_set_line_width(cr, 1.0 / zoom_scale);
+  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  cairo_stroke(cr);
+}
+
+static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len, const int selected, const float zoom_scale, 
+                                  const float dx, const float dy,
+                                  const float xref, const float yref,
+                                  const float sinv, const float cosv,
+                                  const float scaleab, const float scalebb,
+                                  float *border, const int border_count)
+{
+  if(border_count <= 10) return;
+  
+  const float r = atan2(border[3] - border[1], border[2] - border[0]);
+  const float sinr = sin(r);
+  const float cosr = cos(r);
+
+  float x = 0.f;
+  float y = 0.f;
+  
+  cairo_set_dash(cr, dashed, len, 0);
+  if(selected)
+    cairo_set_line_width(cr, 2.0 / zoom_scale);
+  else
+    cairo_set_line_width(cr, 1.0 / zoom_scale);
+  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+
+  _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab,
+                           scalebb, sinv, cosv, &x, &y);
+  cairo_move_to(cr, x, y);
+  for(int i = 6; i < border_count; i++)
+  {
+    _ellipse_point_transform(xref, yref, border[i * 2] + dx, border[i * 2 + 1] + dy, sinr, cosr,
+                             scaleab, scalebb, sinv, cosv, &x, &y);
+    cairo_line_to(cr, x, y);
+  }
+  _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab,
+                           scalebb, sinv, cosv, &x, &y);
+  cairo_line_to(cr, x, y);
+
+  cairo_stroke_preserve(cr);
+  if(selected)
+    cairo_set_line_width(cr, 2.0 / zoom_scale);
+  else
+    cairo_set_line_width(cr, 1.0 / zoom_scale);
+  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  cairo_set_dash(cr, dashed, len, 4);
+  cairo_stroke(cr);
+}
+
+static int dt_ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
+                                 float rotation, float **points, int *points_count)
+{
+  const float wd = dev->preview_pipe->iwidth;
+  const float ht = dev->preview_pipe->iheight;
+  const float v1 = (rotation / 180.0f) * M_PI;
+  const float v2 = (rotation - 90.0f) / 180.0f * M_PI;
+  float a, b, v;
+
+  if(radius_a >= radius_b)
+  {
+    a = radius_a * MIN(wd, ht);
+    b = radius_b * MIN(wd, ht);
+    v = v1;
+  }
+  else
+  {
+    a = radius_b * MIN(wd, ht);
+    b = radius_a * MIN(wd, ht);
+    v = v2;
+  }
+
+  const float sinv = sinf(v);
+  const float cosv = cosf(v);
+
+
+  // how many points do we need? we only take every nth point and rely on interpolation (only affecting GUI
+  // anyhow)
+  const int n = 10;
+  const float lambda = (a - b) / (a + b);
+  const int l = MAX(
+      100, (int)((M_PI * (a + b)
+                  * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda)))) / n));
+
+  // buffer allocations
+  *points = calloc(2 * (l + 5), sizeof(float));
+  *points_count = l + 5;
+
+  // now we set the points
+  const float x = (*points)[0] = xx * wd;
+  const float y = (*points)[1] = yy * ht;
+
+  (*points)[2] = x + a * cos(v);
+  (*points)[3] = y + a * sin(v);
+  (*points)[4] = x - a * cos(v);
+  (*points)[5] = y - a * sin(v);
+
+  (*points)[6] = x + b * cos(v - M_PI / 2.0f);
+  (*points)[7] = y + b * sin(v - M_PI / 2.0f);
+  (*points)[8] = x - b * cos(v - M_PI / 2.0f);
+  (*points)[9] = y - b * sin(v - M_PI / 2.0f);
+
+
+  for(int i = 5; i < l + 5; i++)
+  {
+    float alpha = (i - 5) * 2.0 * M_PI / (float)l;
+    (*points)[i * 2] = x + a * cosf(alpha) * cosv - b * sinf(alpha) * sinv;
+    (*points)[i * 2 + 1] = y + a * cosf(alpha) * sinv + b * sinf(alpha) * cosv;
+  }
+
+  // and we transform them with all distorted modules
+  if(dt_dev_distort_transform(dev, *points, l + 5)) return 1;
+
+  // if we failed, then free all and return
+  free(*points);
+  *points = NULL;
+  *points_count = 0;
+  return 0;
+}
 
 static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, float pzx, float pzy, int up,
                                             uint32_t state, dt_masks_form_t *form, int parentid,
                                             dt_masks_form_gui_t *gui, int index)
 {
+  // add a preview when creating an ellipse
+  if(gui->creation)
+  {
+    if((state & (GDK_SHIFT_MASK|GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK|GDK_CONTROL_MASK))
+    {
+      float rotation;
+      
+      if(form->type & DT_MASKS_CLONE)
+        rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
+      else
+        rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
+
+      if(up)
+        rotation -= 10.f;
+      else
+        rotation += 10.f;
+      rotation = fmodf(rotation, 360.0f);
+
+      if(form->type & DT_MASKS_CLONE)
+        dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", rotation);
+      else
+        dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", rotation);
+    }
+    else if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+    {
+      float masks_border;
+      int flags;
+      float radius_a;
+      float radius_b;
+
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      {
+        masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
+        flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
+        radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+        radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+      }
+      else
+      {
+        masks_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
+        flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
+        radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
+        radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+      }
+
+      const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(radius_a, radius_b) : 1.0f);
+      if(up && masks_border > 0.001f * reference)
+        masks_border *= 0.97f;
+      else if(!up && masks_border < 1.0f * reference)
+        masks_border *= 1.0f/0.97f;
+      else return 1;
+      masks_border = CLAMP(masks_border, 0.001f * reference, reference);
+
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+        dt_conf_set_float("plugins/darkroom/spots/ellipse_border", masks_border);
+      else
+        dt_conf_set_float("plugins/darkroom/masks/ellipse/border", masks_border);
+    }
+    else if (state == 0)
+    {
+      float radius_a;
+      float radius_b;
+
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      {
+        radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+        radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+      }
+      else
+      {
+        radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
+        radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+      }
+
+      const float oldradius = radius_a;
+
+      if(up && radius_a > 0.001f)
+        radius_a *= 0.97f;
+      else if(!up && radius_a < 1.0f)
+        radius_a *= 1.0f / 0.97f;
+      else return 1;
+
+      radius_a = CLAMP(radius_a, 0.001f, 1.0f);
+
+      const float factor = radius_a / oldradius;
+      radius_b *= factor;
+
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      {
+        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", radius_a);
+        dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", radius_b);
+      }
+      else
+      {
+        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_a", radius_a);
+        dt_conf_set_float("plugins/darkroom/masks/ellipse/radius_b", radius_b);
+      }
+    }
+    return 1;
+  }
+
   if(gui->form_selected)
   {
     // we register the current position
@@ -192,7 +450,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       gui->scrollx = pzx;
       gui->scrolly = pzy;
     }
-    if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+    if((state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK && !((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK))
     {
       // we try to change the opacity
       dt_masks_form_change_opacity(form, parentid, up);
@@ -200,8 +458,25 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
     else
     {
       dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)(g_list_first(form->points)->data);
+      if((state & (GDK_SHIFT_MASK|GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK|GDK_CONTROL_MASK) && gui->edit_mode == DT_MASKS_EDIT_FULL)
+      {
+        // we try to change the rotation
+        if(up)
+          ellipse->rotation -= 10.f;
+        else
+          ellipse->rotation += 10.f;
+        ellipse->rotation = fmodf(ellipse->rotation, 360.0f);
+
+        dt_masks_write_form(form, darktable.develop);
+        dt_masks_gui_form_remove(form, gui, index);
+        dt_masks_gui_form_create(form, gui, index);
+        if(form->type & DT_MASKS_CLONE)
+          dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", ellipse->rotation);
+        else
+          dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
+      }
       // resize don't care where the mouse is inside a shape
-      if (((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL) )
+      else if (((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK) && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL) )
       {
         const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
         if(up && ellipse->border > 0.001f * reference)
@@ -747,6 +1022,15 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
     if(gui->edit_mode != DT_MASKS_EDIT_FULL) return 0;
     return 1;
   }
+  // add a preview when creating an ellipse
+  else if(gui->creation)
+  {
+    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
+    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    
+    dt_control_queue_redraw_center();
+    return 1;
+  }
 
   return 0;
 }
@@ -758,17 +1042,118 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
   dashed[1] /= zoom_scale;
   int len = sizeof(dashed) / sizeof(dashed[0]);
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
-  if(!gpt) return;
 
-  const float r = atan2(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
-  const float sinr = sin(r);
-  const float cosr = cos(r);
-
-  float dx = 0.0f, dy = 0.0f, xref = gpt->points[0], yref = gpt->points[1];
+  float dx = 0.0f, dy = 0.0f, xref = 0.0f, yref = 0.0f;
   float dxs = 0.0f, dys = 0.0f, xrefs = 0.0f, yrefs = 0.0f;
   float sinv = 0.0f, cosv = 1.0f;
   float scalea = 1.0f, scaleb = 1.0f, scaleab = 1.0f, scalebb = 1.0f;
 
+  // add a preview when creating an ellipse
+  // in creation mode
+  if(gui->creation)
+  {
+    if(gui->guipoints_count == 0)
+    {
+      dt_masks_form_t *form = darktable.develop->form_visible;
+      if(!form) return;
+
+      float x, y;
+      float masks_border;
+      int flags;
+      float radius_a;
+      float radius_b;
+      float rotation;
+  
+      if(form->type & (DT_MASKS_CLONE/*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      {
+        masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
+        flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
+        radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+        radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+        rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
+      }
+      else
+      {
+        masks_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
+        flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
+        radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
+        radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+        rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
+      }
+
+      float pzx = gui->posx;
+      float pzy = gui->posy;
+      
+      if(pzx == 0 && pzy == 0)
+      {
+        float zoom_x, zoom_y;
+        zoom_y = dt_control_get_dev_zoom_y();
+        zoom_x = dt_control_get_dev_zoom_x();
+        pzx = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
+        pzy = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
+      }
+      
+      float pts[2] = { pzx, pzy };
+      dt_dev_distort_backtransform(darktable.develop, pts, 1);
+      x = pts[0] / darktable.develop->preview_pipe->iwidth;
+      y = pts[1] / darktable.develop->preview_pipe->iheight;
+  
+      float *points = NULL;
+      int points_count = 0;
+      float *border = NULL;
+      int border_count = 0;
+      
+      int draw = 0;
+      
+      draw = dt_ellipse_get_points(darktable.develop, x, y, radius_a, radius_b, rotation, &points, &points_count);
+      if (draw && masks_border > 0.f)
+      {
+        draw = dt_ellipse_get_points(darktable.develop, x, y,
+            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? radius_a * (1.0f + masks_border) : radius_a + masks_border),
+            (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? radius_b * (1.0f + masks_border) : radius_b + masks_border),
+            rotation, &border, &border_count);
+      }
+    
+      if (draw && points_count >= 2)
+      {
+        xref = points[0];
+        yref = points[1];
+        
+        dt_ellipse_draw_shape(cr, dashed, 0, zoom_scale, 
+            dx, dy, 
+            xref, yref,
+            sinv, cosv,
+            scalea, scaleb,
+            points, points_count);
+      }
+      if (draw && border_count >= 2)
+      {
+        xref = border[0];
+        yref = border[1];
+        
+        dt_ellipse_draw_border(cr, dashed, len, 0, zoom_scale, 
+            dx, dy, 
+            xref, yref,
+            sinv, cosv,
+            scaleab, scalebb,
+            border, border_count);
+      }
+      
+      if (points) free(points);
+      if (border) free(border);
+    }
+    return;
+  }
+  
+  if(!gpt) return;
+  
+  const float r = atan2(gpt->points[3] - gpt->points[1], gpt->points[2] - gpt->points[0]);
+  const float sinr = sin(r);
+  const float cosr = cos(r);
+
+  xref = gpt->points[0];
+  yref = gpt->points[1];
+  
   if(gpt->source_count > 10)
   {
     xrefs = gpt->source[0];
@@ -820,6 +1205,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
 
   float x, y;
 
+  // TODO: this can be replaced with a call to dt_ellipse_draw_shape()
   // draw shape
   if(gpt->points_count > 10)
   {
@@ -882,6 +1268,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
     }
   }
 
+  // TODO: this can be replaced with a call to dt_ellipse_draw_border()
   // draw border
   if((gui->group_selected == index) && gpt->border_count > 10)
   {
@@ -988,76 +1375,6 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
     cairo_set_source_rgba(cr, .8, .8, .8, .8);
     cairo_stroke(cr);
   }
-}
-
-static int dt_ellipse_get_points(dt_develop_t *dev, float xx, float yy, float radius_a, float radius_b,
-                                 float rotation, float **points, int *points_count)
-{
-  const float wd = dev->preview_pipe->iwidth;
-  const float ht = dev->preview_pipe->iheight;
-  const float v1 = (rotation / 180.0f) * M_PI;
-  const float v2 = (rotation - 90.0f) / 180.0f * M_PI;
-  float a, b, v;
-
-  if(radius_a >= radius_b)
-  {
-    a = radius_a * MIN(wd, ht);
-    b = radius_b * MIN(wd, ht);
-    v = v1;
-  }
-  else
-  {
-    a = radius_b * MIN(wd, ht);
-    b = radius_a * MIN(wd, ht);
-    v = v2;
-  }
-
-  const float sinv = sinf(v);
-  const float cosv = cosf(v);
-
-
-  // how many points do we need? we only take every nth point and rely on interpolation (only affecting GUI
-  // anyhow)
-  const int n = 10;
-  const float lambda = (a - b) / (a + b);
-  const int l = MAX(
-      100, (int)((M_PI * (a + b)
-                  * (1.0f + (3.0f * lambda * lambda) / (10.0f + sqrtf(4.0f - 3.0f * lambda * lambda)))) / n));
-
-  // buffer allocations
-  *points = calloc(2 * (l + 5), sizeof(float));
-  *points_count = l + 5;
-
-  // now we set the points
-  const float x = (*points)[0] = xx * wd;
-  const float y = (*points)[1] = yy * ht;
-
-  (*points)[2] = x + a * cos(v);
-  (*points)[3] = y + a * sin(v);
-  (*points)[4] = x - a * cos(v);
-  (*points)[5] = y - a * sin(v);
-
-  (*points)[6] = x + b * cos(v - M_PI / 2.0f);
-  (*points)[7] = y + b * sin(v - M_PI / 2.0f);
-  (*points)[8] = x - b * cos(v - M_PI / 2.0f);
-  (*points)[9] = y - b * sin(v - M_PI / 2.0f);
-
-
-  for(int i = 5; i < l + 5; i++)
-  {
-    float alpha = (i - 5) * 2.0 * M_PI / (float)l;
-    (*points)[i * 2] = x + a * cosf(alpha) * cosv - b * sinf(alpha) * sinv;
-    (*points)[i * 2 + 1] = y + a * cosf(alpha) * sinv + b * sinf(alpha) * cosv;
-  }
-
-  // and we transform them with all distorted modules
-  if(dt_dev_distort_transform(dev, *points, l + 5)) return 1;
-
-  // if we failed, then free all and return
-  free(*points);
-  *points = NULL;
-  *points_count = 0;
-  return 0;
 }
 
 static int dt_ellipse_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -474,9 +474,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         else
           dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
       }
-      // resize don't care where the mouse is inside a shape
-      else if(((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
-              && (gui->border_selected || gui->edit_mode == DT_MASKS_EDIT_FULL))
+      else if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
         const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
         if(up && ellipse->border > 0.001f * reference)

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -344,7 +344,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
     {
       float rotation;
 
-      if(form->type & DT_MASKS_CLONE)
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
       else
         rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
@@ -355,7 +355,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         rotation += 10.f;
       rotation = fmodf(rotation, 360.0f);
 
-      if(form->type & DT_MASKS_CLONE)
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", rotation);
       else
         dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", rotation);
@@ -367,7 +367,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       float radius_a;
       float radius_b;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
         masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
         flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
@@ -391,7 +391,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         return 1;
       masks_border = CLAMP(masks_border, 0.001f * reference, reference);
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         dt_conf_set_float("plugins/darkroom/spots/ellipse_border", masks_border);
       else
         dt_conf_set_float("plugins/darkroom/masks/ellipse/border", masks_border);
@@ -401,7 +401,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       float radius_a;
       float radius_b;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
         radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
         radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
@@ -426,7 +426,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       const float factor = radius_a / oldradius;
       radius_b *= factor;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
         dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_a", radius_a);
         dt_conf_set_float("plugins/darkroom/spots/ellipse_radius_b", radius_b);
@@ -469,7 +469,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         dt_masks_write_form(form, darktable.develop);
         dt_masks_gui_form_remove(form, gui, index);
         dt_masks_gui_form_create(form, gui, index);
-        if(form->type & DT_MASKS_CLONE)
+        if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
           dt_conf_set_float("plugins/darkroom/spots/ellipse_rotation", ellipse->rotation);
         else
           dt_conf_set_float("plugins/darkroom/masks/ellipse/rotation", ellipse->rotation);
@@ -1064,7 +1064,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       float radius_b;
       float rotation;
 
-      if(form->type & (DT_MASKS_CLONE /*|DT_MASKS_NON_CLONE*/)) // TODO: enable this when the option is created
+      if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
         masks_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
         flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1232,6 +1232,9 @@ void dt_masks_free_form(dt_masks_form_t *form)
 
 int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double y, double pressure, int which)
 {
+  // add an option to allow skip mouse events while editing masks
+  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
 
@@ -1278,6 +1281,9 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
 int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, double y, int which,
                                     uint32_t state)
 {
+  // add an option to allow skip mouse events while editing masks
+  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   float pzx, pzy;
@@ -1304,6 +1310,9 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
 int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, double y, double pressure,
                                    int which, int type, uint32_t state)
 {
+  // add an option to allow skip mouse events while editing masks
+  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   float pzx, pzy;
@@ -1349,6 +1358,9 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
 
 int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state)
 {
+  // add an option to allow skip mouse events while editing masks
+  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   float pzx, pzy;
@@ -1380,9 +1392,10 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   if(!gui) return;
   if(!form) return;
   // if it's a spot in creation, nothing to draw
-  if(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE) || (form->type & DT_MASKS_GRADIENT))
-     && gui->creation)
+  // add preview when creating a circle
+  if(((form->type & DT_MASKS_ELLIPSE) || (form->type & DT_MASKS_GRADIENT)) && gui->creation)
     return;
+  
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
   if(wd < 1.0 || ht < 1.0) return;
@@ -1406,7 +1419,9 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
   // we update the form if needed
-  dt_masks_gui_form_test_create(form, gui);
+  // add preview when creating a circle
+  if ( !((form->type & DT_MASKS_CIRCLE) && gui->creation) )
+    dt_masks_gui_form_test_create(form, gui);
 
   // draw form
   if(form->type & DT_MASKS_CIRCLE)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1233,7 +1233,7 @@ void dt_masks_free_form(dt_masks_form_t *form)
 int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double y, double pressure, int which)
 {
   // add an option to allow skip mouse events while editing masks
-  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(darktable.develop->darkroom_skip_mouse_events) return 0;
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1282,7 +1282,7 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
                                     uint32_t state)
 {
   // add an option to allow skip mouse events while editing masks
-  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(darktable.develop->darkroom_skip_mouse_events) return 0;
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1311,7 +1311,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
                                    int which, int type, uint32_t state)
 {
   // add an option to allow skip mouse events while editing masks
-  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(darktable.develop->darkroom_skip_mouse_events) return 0;
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1359,7 +1359,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
 int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state)
 {
   // add an option to allow skip mouse events while editing masks
-  if (darktable.develop->darkroom_skip_mouse_events) return 0;
+  if(darktable.develop->darkroom_skip_mouse_events) return 0;
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
@@ -1420,7 +1420,7 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
 
   // we update the form if needed
   // add preview when creating a circle or ellipse
-  if ( !(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE)) && gui->creation) )
+  if(!(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE)) && gui->creation))
     dt_masks_gui_form_test_create(form, gui);
 
   // draw form

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1392,8 +1392,8 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   if(!gui) return;
   if(!form) return;
   // if it's a spot in creation, nothing to draw
-  // add preview when creating a circle
-  if(((form->type & DT_MASKS_ELLIPSE) || (form->type & DT_MASKS_GRADIENT)) && gui->creation)
+  // add preview when creating a circle or ellipse
+  if((form->type & DT_MASKS_GRADIENT) && gui->creation)
     return;
   
   float wd = dev->preview_pipe->backbuf_width;
@@ -1419,8 +1419,8 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
   // we update the form if needed
-  // add preview when creating a circle
-  if ( !((form->type & DT_MASKS_CIRCLE) && gui->creation) )
+  // add preview when creating a circle or ellipse
+  if ( !(((form->type & DT_MASKS_CIRCLE) || (form->type & DT_MASKS_ELLIPSE)) && gui->creation) )
     dt_masks_gui_form_test_create(form, gui);
 
   // draw form

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -839,7 +839,8 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
                                          uint32_t state, dt_masks_form_t *form, int parentid,
                                          dt_masks_form_gui_t *gui, int index)
 {
-  if(gui->form_selected)
+  // resize a shape even if on a node or segment
+  if(gui->form_selected || gui->point_selected >= 0 || gui->feather_selected >= 0 || gui->seg_selected >= 0 || gui->point_border_selected >= 0)
   {
     // we register the current position
     if(gui->scrollx == 0.0f && gui->scrolly == 0.0f)
@@ -857,7 +858,8 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
       float amount = 1.03f;
       if(up) amount = 0.97f;
       guint nb = g_list_length(form->points);
-      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      // resize don't care where the mouse is inside a shape
+      if ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
         // do not exceed upper limit of 1.0
         for(int k = 0; k < nb; k++)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -840,7 +840,8 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
                                          dt_masks_form_gui_t *gui, int index)
 {
   // resize a shape even if on a node or segment
-  if(gui->form_selected || gui->point_selected >= 0 || gui->feather_selected >= 0 || gui->seg_selected >= 0 || gui->point_border_selected >= 0)
+  if(gui->form_selected || gui->point_selected >= 0 || gui->feather_selected >= 0 || gui->seg_selected >= 0
+     || gui->point_border_selected >= 0)
   {
     // we register the current position
     if(gui->scrollx == 0.0f && gui->scrolly == 0.0f)
@@ -859,7 +860,7 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
       if(up) amount = 0.97f;
       guint nb = g_list_length(form->points);
       // resize don't care where the mouse is inside a shape
-      if ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
         // do not exceed upper limit of 1.0
         for(int k = 0; k < nb; k++)

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -877,13 +877,13 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         {
           float masks_border = dt_conf_get_float("plugins/darkroom/spots/path_border");
-          masks_border = MAX(0.005f, MIN(masks_border * amount, 0.5f));
+          masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
           dt_conf_set_float("plugins/darkroom/spots/path_border", masks_border);
         }
         else
         {
           float masks_border = dt_conf_get_float("plugins/darkroom/masks/path/border");
-          masks_border = MAX(0.005f, MIN(masks_border * amount, 0.5f));
+          masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
           dt_conf_set_float("plugins/darkroom/masks/path/border", masks_border);
         }
       }
@@ -1054,7 +1054,7 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       bzpt->ctrl1[0] = bzpt->ctrl1[1] = bzpt->ctrl2[0] = bzpt->ctrl2[1] = -1.0;
       bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
-      bzpt->border[0] = bzpt->border[1] = MAX(0.005f, masks_border);
+      bzpt->border[0] = bzpt->border[1] = MAX(0.0005f, masks_border);
 
       // if that's the first point we should had another one as base point
       if(nb == 0)
@@ -1063,7 +1063,7 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
         bzpt2->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
         bzpt2->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
         bzpt2->ctrl1[0] = bzpt2->ctrl1[1] = bzpt2->ctrl2[0] = bzpt2->ctrl2[1] = -1.0;
-        bzpt2->border[0] = bzpt2->border[1] = MAX(0.005f, masks_border);
+        bzpt2->border[0] = bzpt2->border[1] = MAX(0.0005f, masks_border);
         bzpt2->state = DT_MASKS_POINT_STATE_NORMAL;
         form->points = g_list_append(form->points, bzpt2);
         form->source[0] = bzpt->corner[0] + 0.02f;
@@ -1190,8 +1190,8 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
         int right_index = gui->seg_selected == max_index ? 0 : gui->seg_selected + 1;
         dt_masks_point_path_t *left = (dt_masks_point_path_t *)g_list_nth_data(form->points, left_index);
         dt_masks_point_path_t *right = (dt_masks_point_path_t *)g_list_nth_data(form->points, right_index);
-        bzpt->border[0] = MAX(0.005f, (left->border[0] + right->border[0]) * 0.5);
-        bzpt->border[1] = MAX(0.005f, (left->border[1] + right->border[1]) * 0.5);
+        bzpt->border[0] = MAX(0.0005f, (left->border[0] + right->border[0]) * 0.5);
+        bzpt->border[1] = MAX(0.0005f, (left->border[1] + right->border[1]) * 0.5);
 
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _path_init_ctrl_points(form);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -859,8 +859,7 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
       float amount = 1.03f;
       if(up) amount = 0.97f;
       guint nb = g_list_length(form->points);
-      // resize don't care where the mouse is inside a shape
-      if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
+      if(gui->border_selected || (state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
       {
         // do not exceed upper limit of 1.0
         for(int k = 0; k < nb; k++)
@@ -877,13 +876,13 @@ static int dt_path_events_mouse_scrolled(struct dt_iop_module_t *module, float p
         if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         {
           float masks_border = dt_conf_get_float("plugins/darkroom/spots/path_border");
-          masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
+          masks_border = MAX(0.005f, MIN(masks_border * amount, 0.5f));
           dt_conf_set_float("plugins/darkroom/spots/path_border", masks_border);
         }
         else
         {
           float masks_border = dt_conf_get_float("plugins/darkroom/masks/path/border");
-          masks_border = MAX(0.0005f, MIN(masks_border * amount, 0.5f));
+          masks_border = MAX(0.005f, MIN(masks_border * amount, 0.5f));
           dt_conf_set_float("plugins/darkroom/masks/path/border", masks_border);
         }
       }
@@ -1054,7 +1053,7 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       bzpt->ctrl1[0] = bzpt->ctrl1[1] = bzpt->ctrl2[0] = bzpt->ctrl2[1] = -1.0;
       bzpt->state = DT_MASKS_POINT_STATE_NORMAL;
 
-      bzpt->border[0] = bzpt->border[1] = MAX(0.0005f, masks_border);
+      bzpt->border[0] = bzpt->border[1] = MAX(0.005f, masks_border);
 
       // if that's the first point we should had another one as base point
       if(nb == 0)
@@ -1063,7 +1062,7 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
         bzpt2->corner[0] = pts[0] / darktable.develop->preview_pipe->iwidth;
         bzpt2->corner[1] = pts[1] / darktable.develop->preview_pipe->iheight;
         bzpt2->ctrl1[0] = bzpt2->ctrl1[1] = bzpt2->ctrl2[0] = bzpt2->ctrl2[1] = -1.0;
-        bzpt2->border[0] = bzpt2->border[1] = MAX(0.0005f, masks_border);
+        bzpt2->border[0] = bzpt2->border[1] = MAX(0.005f, masks_border);
         bzpt2->state = DT_MASKS_POINT_STATE_NORMAL;
         form->points = g_list_append(form->points, bzpt2);
         form->source[0] = bzpt->corner[0] + 0.02f;
@@ -1190,8 +1189,8 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
         int right_index = gui->seg_selected == max_index ? 0 : gui->seg_selected + 1;
         dt_masks_point_path_t *left = (dt_masks_point_path_t *)g_list_nth_data(form->points, left_index);
         dt_masks_point_path_t *right = (dt_masks_point_path_t *)g_list_nth_data(form->points, right_index);
-        bzpt->border[0] = MAX(0.0005f, (left->border[0] + right->border[0]) * 0.5);
-        bzpt->border[1] = MAX(0.0005f, (left->border[1] + right->border[1]) * 0.5);
+        bzpt->border[0] = MAX(0.005f, (left->border[0] + right->border[0]) * 0.5);
+        bzpt->border[1] = MAX(0.005f, (left->border[1] + right->border[1]) * 0.5);
 
         form->points = g_list_insert(form->points, bzpt, gui->seg_selected + 1);
         _path_init_ctrl_points(form);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -163,7 +163,9 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   // darkroom
   dt_accel_path_view(path, sizeof(path), "darkroom", "full preview");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_preview);
-
+  // add an option to allow skip mouse events while editing masks
+  dt_accel_path_view(path, sizeof(path), "darkroom", "allow to pan & zoom while editing masks");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_skip_mouse_events);
 
   // Global
   dt_accel_path_global(path, sizeof(path), "toggle side borders");

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2186,6 +2186,11 @@ int key_released(dt_view_t *self, guint key, guint state)
     dt_dev_invalidate(darktable.develop);
     dt_control_queue_redraw_center();
   }
+  // add an option to allow skip mouse events while editing masks
+  if(key == accels->darkroom_skip_mouse_events.accel_key && state == accels->darkroom_skip_mouse_events.accel_mods)
+  {
+    darktable.develop->darkroom_skip_mouse_events = FALSE;
+  }
 
   return 1;
 }
@@ -2291,6 +2296,13 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     return 1;
   }
 
+  // add an option to allow skip mouse events while editing masks
+  if(key == accels->darkroom_skip_mouse_events.accel_key && state == accels->darkroom_skip_mouse_events.accel_mods)
+  {
+    darktable.develop->darkroom_skip_mouse_events = TRUE;
+    return 1;
+  }
+
   return 1;
 }
 
@@ -2349,6 +2361,8 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);
   dt_accel_register_view(self, NC_("accel", "redo"), GDK_KEY_y, GDK_CONTROL_MASK);
 
+  // add an option to allow skip mouse events while editing masks
+  dt_accel_register_view(self, NC_("accel", "allow to pan & zoom while editing masks"), GDK_KEY_a, 0);
 }
 
 static gboolean _darkroom_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,


### PR DESCRIPTION
This are GUI changes from PR#1548.

-add an option to allow skip mouse events while editing masks
can be found on preferences->shortcuts->views->darkroom->allow to pan & zoom while editing masks

-change resize step and minimum size of brush

-resize don't care where the mouse is inside a shape

-add a preview when creating a circle

-resize a path even if on a node or segment
