### PR TITLE
Avoid shading of selected location in map

### DIFF
--- a/src/views/map.c
+++ b/src/views/map.c
@@ -977,6 +977,7 @@ static OsmGpsMapPolygon *_view_map_add_polygon(const dt_view_t *view, GList *poi
 
   g_object_set(poly, "track", track, (gchar *)0);
   g_object_set(poly, "editable", FALSE, (gchar *)0);
+  g_object_set(poly, "shaded", FALSE, (gchar *)0);
 
   osm_gps_map_polygon_add(lib->map, poly);
 


### PR DESCRIPTION
Shading the selected location makes it harder to place images on the map by drag and drop.
Therefore only draw outline of the OsmGpsMapPolygon without shading.

The code works with the latest released OSM-GPS-Map widget, version 1.1.