### PR TITLE
temperature: properly deal with NaN coefficients

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -409,7 +409,7 @@ static cmsCIEXYZ mul2xyz(dt_iop_module_t *self, const float coeffs[4])
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
 
   double CAM[4];
-  for(int k = 0; k < 4; k++) coeffs[k] > 0.0f ? CAM[k] = 1.0 / coeffs[k] : 0.0f;
+  for(int k = 0; k < 4; k++) CAM[k] = coeffs[k] > 0.0f ? 1.0 / coeffs[k] : 0.0f;
 
   double XYZ[3];
   for(int k = 0; k < 3; k++)


### PR DESCRIPTION
Before this patch, the call to mul2temp at the end of reoad_defaults()
was returning

  TempK = 24999.647537
  tint = -nan

The visible effect was that the tint slider was not properly colored
(white to green instead of magenta to white to green).

The expression computing CAM[k] was clearly wrong. Not only the
assignment within the "then" branch of ?: was misleading, but the
"else" branch was just a no-op: return 0.0f and throw it away.

Fix the expression to make it what the initial author probably
intended, i.e. an assignment of a conditional expression to CAM[k].
With this patch, I get:

  TempK = 6244.398697
  tint = 1.002153

and the slider is properly colored.