### PR TITLE
darktable-cli: exit with error if xmp file not readable

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -255,7 +255,13 @@ int main(int argc, char *arg[])
     {
       int id = GPOINTER_TO_INT(iter->data);
       dt_image_t *image = dt_image_cache_get(darktable.image_cache, id, 'w');
-      dt_exif_xmp_read(image, xmp_filename, 1);
+      if(dt_exif_xmp_read(image, xmp_filename, 1) != 0)
+      {
+        fprintf(stderr, _("error: can't open xmp file %s"), xmp_filename);
+        fprintf(stderr, "\n");
+        free(m_arg);
+        exit(1);
+      }
       // don't write new xmp:
       dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_RELAXED);
     }


### PR DESCRIPTION
I think `darktable-cli` should raise an error if an xmp file is specified which cannot be read. This would help to debug batch-processing problems.

I do not fully understand what `dt_image_cache_write_release` does. It might be necessary to actually call this function for clean-up before exiting. 