### PR TITLE
Change gtk-mac-bundler link in macosx/BUILD.txt to use HTTPS

### DIFF
--- a/packaging/macosx/BUILD.txt
+++ b/packaging/macosx/BUILD.txt
@@ -43,7 +43,7 @@ How to make disk image with darktable application bundle (64 bit Intel only):
 
 2). Download, patch and install gtk-mac-bundler (assuming darktable was cloned into ~/src directory):
      $ cd ~/src
-     $ curl -O http://ftp.gnome.org/pub/gnome/sources/gtk-mac-bundler/0.7/gtk-mac-bundler-0.7.4.tar.xz
+     $ curl -O https://ftp.gnome.org/pub/gnome/sources/gtk-mac-bundler/0.7/gtk-mac-bundler-0.7.4.tar.xz
      $ tar -xf gtk-mac-bundler-0.7.4.tar.xz
      $ cd gtk-mac-bundler-0.7.4
      $ patch -p1 < ../darktable/packaging/macosx/gtk-mac-bundler-0.7.4.patch


### PR DESCRIPTION
I've tested that this link https://ftp.gnome.org/pub/gnome/sources/gtk-mac-bundler/0.7/gtk-mac-bundler-0.7.4.tar.xz is also working.  
It should be preferred because http://… allows MitM to easily replace the contents with something else, which can be **FATAL** for executable code. (well at least it wasn't supposed to be run as root…)