### PR TITLE
Misc trivial typo fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,7 +529,7 @@ endif(NOT WIN32)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME DTApplication)
 
 # lets continue into build directories
-include(data/supported_extensions.cmake) # this file needs to be included first as it gets ammended in src/
+include(data/supported_extensions.cmake) # this file needs to be included first as it gets amended in src/
 add_subdirectory(src) # src/ needs to be before data/ so that the correct CSS file gets installed
 add_subdirectory(data)
 add_subdirectory(doc)

--- a/cmake/modules/FindOpenCL.cmake.option2
+++ b/cmake/modules/FindOpenCL.cmake.option2
@@ -3,7 +3,7 @@
 # License: Public Domain
 # - Try to find OpenCL
 # This module tries to find an OpenCL implementation on your system. It supports
-# AMD / ATI, Apple and NVIDIA implementations, but shoudl work, too.
+# AMD / ATI, Apple and NVIDIA implementations, but should work, too.
 #
 # Once done this will define
 #  OPENCL_FOUND        - system has OpenCL

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -5,7 +5,7 @@ if(USE_OPENCL)
 endif(USE_OPENCL)
 
 #
-# Generate and instal darktable.css
+# Generate and install darktable.css
 #
 if ("${GTK3_VERSION}" VERSION_GREATER "3.19.0")
   if ("${GTK3_VERSION}" VERSION_GREATER "3.21.0")

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -125,7 +125,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>whether to use pinned memory transfer during tiling</shortdescription>
-    <longdescription>during tiling huge amounts of memory need to be transfered between host and device. for some OpenCL implementations direct memory transfers give a drastic performance penalty. this can often be avoided by using indirect transfers via pinned memory. other devices have more efficient direct memory transfer implementations. AMD seems to belong to the first group, nvidia to the second.</longdescription>
+    <longdescription>during tiling huge amounts of memory need to be transferred between host and device. for some OpenCL implementations direct memory transfers give a drastic performance penalty. this can often be avoided by using indirect transfers via pinned memory. other devices have more efficient direct memory transfer implementations. AMD seems to belong to the first group, nvidia to the second.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_use_cpu_devices</name>

--- a/data/latex/photobook.cls
+++ b/data/latex/photobook.cls
@@ -144,7 +144,7 @@
 % PDF/X-3 files contain extra operators that define the bleed and trim area.
 % - The MediaBox defines the size of the entire document
 % - The ArtBox or TrimBox defines the extent of the printable area.
-% - If the file is to be printed with bleed, a BleedBox must be defined. It must be larger than  the TrimBox/ArtBox, but smaller than the MediaBox.
+% - If the file is to be printed with bleed, a BleedBox must be defined. It must be larger than the TrimBox/ArtBox, but smaller than the MediaBox.
 \ifthenelse{\isundefined{\draftmode}}{
 \pdfpageattr{/MediaBox [0 0 792.0 612.0]
 /TrimBox [49.4645668785 18.0 742.535433 594.0]}

--- a/data/noiseprofiles.json
+++ b/data/noiseprofiles.json
@@ -4530,7 +4530,7 @@
           ]
         },
         {
-          "comment": "k-3 ii contributed by zoltan. iso 25600+ graphs don't match well, but this is the same for K-3 ans seems camera model specific",
+          "comment": "k-3 ii contributed by zoltan. iso 25600+ graphs don't match well, but this is the same for K-3 and seems camera model specific",
           "model": "K-3 II",
           "profiles": [
             {"name": "K-3 II iso 100", "iso": 100, "a": [9.06110231252642e-06, 3.57419098087832e-06, 6.86083198118061e-06], "b": [2.81774050978302e-09, 3.15994036501297e-09, 4.22317452653176e-09]},

--- a/data/pswp/photoswipe.js
+++ b/data/pswp/photoswipe.js
@@ -927,7 +927,7 @@ var publicMethods = {
 			if(_options.focus) {
 				// focus causes layout, 
 				// which causes lag during the animation, 
-				// that's why we delay it untill the initial zoom transition ends
+				// that's why we delay it until the initial zoom transition ends
 				template.focus();
 			}
 			 
@@ -1203,7 +1203,7 @@ var publicMethods = {
 		_shout('beforeResize'); // even may be used for example to switch image sources
 
 
-		// don't re-calculate size on inital size update
+		// don't re-calculate size on initial size update
 		if(_containerShiftIndex !== undefined) {
 
 			var holder,
@@ -3521,7 +3521,7 @@ var _historyUpdateTimeout,
 
 
 		if(_numAnimations || _isDragging) {
-			// changing browser URL forces layout/paint in some browsers, which causes noticable lag during animation
+			// changing browser URL forces layout/paint in some browsers, which causes noticeable lag during animation
 			// that's why we update hash only when no animations running
 			_hashAnimCheckTimeout = setTimeout(_updateHash, 500);
 			return;
@@ -3546,7 +3546,7 @@ var _historyUpdateTimeout,
 			if(_windowLoc.hash.indexOf(newHash) === -1) {
 				_urlChangedOnce = true;
 			}
-			// first time - add new hisory record, then just replace
+			// first time - add new history record, then just replace
 		}
 
 		var newURL = _windowLoc.href.split('#')[0] + '#' +  newHash;

--- a/doc/doxygen.conf
+++ b/doc/doxygen.conf
@@ -281,7 +281,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # causing a significant performance penality.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will rougly double the
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula:
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/doc/usermanual/darkroom/concepts/parametric_masks.xml
+++ b/doc/usermanual/darkroom/concepts/parametric_masks.xml
@@ -102,7 +102,7 @@
         graycale values or in false colors, depending on the corresponding preference setting in
         <quote>GUI options</quote> (see <xref linkend="gui_options"/>). You may additionally
         hold down the <emphasis>ctrl</emphasis> key which lets you see the resulting mask
-        overlayed to the image. When leaving the slider the image goes back to normal after a
+        overlaid to the image. When leaving the slider the image goes back to normal after a
         short delay.
       </para>
 

--- a/doc/usermanual/darkroom/modules/basic/crop_and_rotate.xml
+++ b/doc/usermanual/darkroom/modules/basic/crop_and_rotate.xml
@@ -62,7 +62,7 @@
 
     <para>
       Whenever the user interface of this module is in focus, you will see the full uncropped
-      image overlayed with handles and guiding lines.
+      image overlaid with handles and guiding lines.
     </para>
 
     <para>

--- a/doc/usermanual/darkroom/modules/correction/ashift.xml
+++ b/doc/usermanual/darkroom/modules/correction/ashift.xml
@@ -135,7 +135,7 @@
 
     <para>
       Clicking one of the <quote>automatic fit</quote> icons (see below) starts an optimization
-      process which finds the best suited parameters. The image and the overlayed lines are then
+      process which finds the best suited parameters. The image and the overlaid lines are then
       displayed with perspective corrections applied.
     </para>
 

--- a/doc/usermanual/darkroom/panels/snapshots.xml
+++ b/doc/usermanual/darkroom/panels/snapshots.xml
@@ -25,7 +25,7 @@
           <entry>
             You can take snapshots of images as you process them. A snapshot is stored as a
             bitmap of the current center view and is kept as long as you stay in the darkroom. A
-            snapshot can then be selected and overlayed in the current center view to help you
+            snapshot can then be selected and overlaid in the current center view to help you
             with a side by side comparison (left: snapshot, right: active) when you are tuning
             parameters of a module. This can also be combined with history (see
             <xref linkend="history"/>) to compare the snapshot against different stages of

--- a/doc/usermanual/lighttable/panels/export.xml
+++ b/doc/usermanual/lighttable/panels/export.xml
@@ -398,7 +398,7 @@
                 <code>$(var/pattern/replacement)</code>
               </entry>
               <entry>
-                Replace the first occurence of <code>pattern</code> in <code>var</code> with
+                Replace the first occurrence of <code>pattern</code> in <code>var</code> with
                 <code>replacement</code>. If <code>replacement</code> is empty then
                 <code>pattern</code> will be removed.
               </entry>
@@ -408,7 +408,7 @@
                 <code>$(var//pattern/replacement)</code>
               </entry>
               <entry>
-                Replace all occurences of <code>pattern</code> in <code>var</code> with
+                Replace all occurrences of <code>pattern</code> in <code>var</code> with
                 <code>replacement</code>. If <code>replacement</code> is empty then
                 <code>pattern</code> will be removed.
               </entry>

--- a/doc/usermanual/lua/lua.xml
+++ b/doc/usermanual/lua/lua.xml
@@ -819,7 +819,7 @@ end
         <function>:memory:</function>
         parameter to
         <function>--library</function>
-        is usefull here if you don't want to work on your personal library.
+        is useful here if you don't want to work on your personal library.
       </para>
 
     </sect2>

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -31,7 +31,7 @@
 <synopsis>function( 
 	<emphasis><link linkend="darktable_print_message">message</link></emphasis> : string
 )</synopsis>
-<para>Will print a string to the darktable control log (the long overlayed window that appears over the main panel).</para>
+<para>Will print a string to the darktable control log (the long overlaid window that appears over the main panel).</para>
 
 <variablelist>
 <varlistentry id="darktable_print_message"><term>message</term><listitem>
@@ -661,7 +661,7 @@
 <synopsis>table</synopsis>
 <para>A table of <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link> on which the user expects UI actions to happen.</para>
 <para>It is based on both the hovered image and the selection and is consistent with the way darktable works.</para>
-<para>It is recommended to use this table to implement Lua actions rather than <link linkend="darktable_gui_hovered">darktable.gui.hovered</link> or <link linkend="darktable_gui_selection">darktable.gui.selection</link> to be consistant with darktable's GUI.</para>
+<para>It is recommended to use this table to implement Lua actions rather than <link linkend="darktable_gui_hovered">darktable.gui.hovered</link> or <link linkend="darktable_gui_selection">darktable.gui.selection</link> to be consistent with darktable's GUI.</para>
 
 </section>
 
@@ -2698,7 +2698,7 @@ end</programlisting></para>
 
 <varlistentry id="darktable_preferences_register_default"><term>[default]</term><listitem>
 <synopsis>depends on type</synopsis>
-<para>Default value to use when not set explicitely or by the user.</para>
+<para>Default value to use when not set explicitly or by the user.</para>
 <para>For the enum type of pref, this is mandatory</para>
 
 </listitem></varlistentry>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -448,7 +448,7 @@ endif(WIN32)
 
 if(NOT CUSTOM_CFLAGS)
   if(BUILD_SSE2_CODEPATHS)
-    #we MUST always specify our requred instruction set, native might not detect it
+    #we MUST always specify our required instruction set, native might not detect it
     set(DT_REQ_INSTRUCTIONS "-msse2")
   endif()
 

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -567,7 +567,7 @@ void dt_bauhaus_init()
   // gtk_window_set_modal(GTK_WINDOW(c->popup_window), TRUE);
   // gtk_window_set_decorated(GTK_WINDOW(c->popup_window), FALSE);
 
-  // for pie menue:
+  // for pie menu:
   // gtk_window_set_position(GTK_WINDOW(c->popup_window), GTK_WIN_POS_MOUSE);// | GTK_WIN_POS_CENTER);
 
   // gtk_window_set_keep_above isn't enough on OS X

--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -47,7 +47,7 @@ typedef enum _camctl_camera_job_type_t
   _JOB_TYPE_SET_PROPERTY_CHOICE,
   /** For some reason stopping live view needs to pass an int, not a string. */
   _JOB_TYPE_SET_PROPERTY_INT,
-  /** get's a property from config cache. \todo This shouldn't be a job in jobqueue !?  */
+  /** gets a property from config cache. \todo This shouldn't be a job in jobqueue !?  */
   _JOB_TYPE_GET_PROPERTY
 } _camctl_camera_job_type_t;
 

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -161,7 +161,7 @@ typedef struct dt_camctl_t
 typedef struct dt_camctl_listener_t
 {
   void *data;
-  /** Invoked when a image is downloaded while in tethered mode or  by import. \see dt_camctl_status_t */
+  /** Invoked when a image is downloaded while in tethered mode or by import. \see dt_camctl_status_t */
   void (*control_status)(dt_camctl_status_t status, void *data);
 
   /** Invoked before images are fetched from camera and when tethered capture fetching an image. \note That
@@ -173,7 +173,7 @@ typedef struct dt_camctl_listener_t
   const char *(*request_image_filename)(const dt_camera_t *camera, const char *filename, time_t *exif_time,
                                         void *data);
 
-  /** Invoked when a image is downloaded while in tethered mode or  by import */
+  /** Invoked when a image is downloaded while in tethered mode or by import */
   void (*image_downloaded)(const dt_camera_t *camera, const char *filename, void *data);
 
   /** Invoked when a image is found on storage.. such as from dt_camctl_get_previews(), if 0 is returned the
@@ -202,7 +202,7 @@ typedef enum dt_camera_preview_flags_t
 {
   /** No image data */
   CAMCTL_IMAGE_NO_DATA = 0,
-  /**Get a image  preview. */
+  /**Get an image preview. */
   CAMCTL_IMAGE_PREVIEW_DATA = 1,
   /**Get the image exif */
   CAMCTL_IMAGE_EXIF_DATA = 2

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -134,7 +134,7 @@ typedef struct dt_collection_t
 } dt_collection_t;
 
 
-/** instansiates a collection context, if clone equals NULL default query is constructed. */
+/** instantiates a collection context, if clone equals NULL default query is constructed. */
 const dt_collection_t *dt_collection_new(const dt_collection_t *clone);
 /** frees a collection context. */
 void dt_collection_free(const dt_collection_t *collection);

--- a/src/common/curve_tools.c
+++ b/src/common/curve_tools.c
@@ -152,7 +152,7 @@ float *d3_np_fs(int n, float a[], float b[])
 
     The cubic spline is a piecewise cubic polynomial.  The intervals
     are determined by the "knots" or abscissas of the data to be
-    interpolated.  The cubic spline has continous first and second
+    interpolated.  The cubic spline has continuous first and second
     derivatives over the entire interval of interpolation.
 
     For any point T in the interval T(IVAL), T(IVAL+1), the form of
@@ -683,7 +683,7 @@ int CurveDataSample(CurveData *curve, CurveSample *sample)
   float y[20] = { 0 };
   float *ypp;
 
-  // The box points  are what the anchor points are relative
+  // The box points are what the anchor points are relative
   // to so...
 
   float box_width = curve->m_max_x - curve->m_min_x;
@@ -718,7 +718,7 @@ int CurveDataSample(CurveData *curve, CurveSample *sample)
   int minY = curve->m_min_y * (sample->m_outputRes - 1);
   // returns an array of second derivatives used to calculate the spline curve.
   // this is a malloc'd array that needs to be freed when done.
-  // The setings currently calculate the natural spline, which closely matches
+  // The settings currently calculate the natural spline, which closely matches
   // camera curve output in raw files.
   ypp = interpolate_set(n, x, y, curve->m_spline_type);
   if(ypp == NULL) return CT_ERROR;

--- a/src/common/curve_tools.h
+++ b/src/common/curve_tools.h
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 
-    part of this file is based on nikon_curve.h  from UFraw
+    part of this file is based on nikon_curve.h from UFraw
     Copyright 2004-2008 by Shawn Freeman, Udi Fuchs
 */
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -338,7 +338,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   int sse2_supported = 0;
 
 #ifdef HAVE_BUILTIN_CPU_SUPPORTS
-  // NOTE: _may_i_use_cpu_feature() looks better, but only avaliable in ICC
+  // NOTE: _may_i_use_cpu_feature() looks better, but only available in ICC
   __builtin_cpu_init();
   sse2_supported = __builtin_cpu_supports("sse2");
 #else

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -285,7 +285,7 @@ static gboolean _migrate_schema(dt_database_t *db, int version)
       i = 0;
     }
 
-    // find the next free ammended version of name
+    // find the next free amended version of name
     sqlite3_prepare_v2(db->handle, "SELECT name FROM main.presets  WHERE name = ?1 || ' (' || ?2 || ')' AND "
                                    "operation = ?3 AND op_version = ?4",
                        -1, &innerstmt, NULL);
@@ -1337,7 +1337,7 @@ void dt_database_show_error(const dt_database_t *db)
 {
   if(!db->lock_acquired)
   {
-    char *label_text = g_markup_printf_escaped(_("an error has occured while trying to open the database from\n"
+    char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
                                                   "\n"
                                                   "<span style=\"italic\">%s</span>\n"
                                                   "\n"
@@ -1646,7 +1646,7 @@ start:
       // oh, bad situation. the database is corrupt and can't be read!
       // we inform the user here and let him decide what to do: exit or delete and try again.
 
-      char *label_text = g_markup_printf_escaped(_("an error has occured while trying to open the database from\n"
+      char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
                                                    "\n"
                                                    "<span style=\"italic\">%s</span>\n"
                                                    "\n"
@@ -1722,7 +1722,7 @@ start:
     // oh, bad situation. the database is corrupt and can't be read!
     // we inform the user here and let him decide what to do: exit or delete and try again.
 
-    char *label_text = g_markup_printf_escaped(_("an error has occured while trying to open the database from\n"
+    char *label_text = g_markup_printf_escaped(_("an error has occurred while trying to open the database from\n"
                                                   "\n"
                                                   "<span style=\"italic\">%s</span>\n"
                                                   "\n"

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1912,7 +1912,7 @@ static GList *read_history_v2(Exiv2::XmpData &xmpData, const char *filename)
       {
         // AFAICT this can't happen with regular exiv2 parsed XMP data, but better safe than sorry.
         // it can happen though when constructing things in a unusual order and then passing it to us without
-        // serializing it inbetween
+        // serializing it in between
         current_entry = (history_entry_t *)g_list_nth_data(history_entries, n - 1); // XMP starts counting at 1!
       }
 
@@ -2858,7 +2858,7 @@ void dt_exif_init()
   Exiv2::LogMsg::setHandler(&dt_exif_log_handler);
 
   Exiv2::XmpParser::initialize();
-  // this has te stay with the old url (namespace already propagated outside dt)
+  // this has to stay with the old url (namespace already propagated outside dt)
   Exiv2::XmpProperties::registerNs("http://darktable.sf.net/", "darktable");
   Exiv2::XmpProperties::registerNs("http://ns.adobe.com/lightroom/1.0/", "lr");
   Exiv2::XmpProperties::registerNs("http://cipa.jp/exif/1.0/", "exifEX");

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -234,7 +234,7 @@ int dt_film_import(const char *dirname)
   if(sqlite3_step(stmt) == SQLITE_ROW) film->id = sqlite3_column_int(stmt, 0);
   sqlite3_finalize(stmt);
 
-  /* if we didn't find a id, lets instansiate a new filmroll */
+  /* if we didn't find an id, lets instantiate a new filmroll */
   if(film->id <= 0)
   {
     char datetime[20];

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -168,7 +168,7 @@ gboolean dt_image_safe_remove(const int32_t imgid)
 
   else
   {
-    // finaly check if we have a .xmp for the local copy. If no modification done on the local copy it is safe
+    // finally check if we have a .xmp for the local copy. If no modification done on the local copy it is safe
     // to remove.
     g_strlcat(pathname, ".xmp", sizeof(pathname));
     return !g_file_test(pathname, G_FILE_TEST_EXISTS);
@@ -721,7 +721,7 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
     }
     else
     {
-      // we need to derive the version number from the  filename
+      // we need to derive the version number from the filename
 
       gchar *c3 = xmpfilename + strlen(xmpfilename)
                   - 5; // skip over .xmp extension; position c3 at character before the '.'
@@ -1170,7 +1170,7 @@ int32_t dt_image_move(const int32_t imgid, const int32_t filmid)
       }
       g_list_free(dup_list);
 
-      // finaly, rename local copy if any
+      // finally, rename local copy if any
       if(g_file_test(copysrcpath, G_FILE_TEST_EXISTS))
       {
         // get new name

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -101,7 +101,7 @@ typedef struct dt_imageio_module_format_t
   size_t (*params_size)(struct dt_imageio_module_format_t *self);
   void *(*get_params)(struct dt_imageio_module_format_t *self);
   void (*free_params)(struct dt_imageio_module_format_t *self, dt_imageio_module_data_t *data);
-  /* resets the gui to the paramters as given here. return != 0 on fail. */
+  /* resets the gui to the parameters as given here. return != 0 on fail. */
   int (*set_params)(struct dt_imageio_module_format_t *self, const void *params, const int size);
 
   /* returns the mime type of the exported image. */

--- a/src/common/imageio_tiff.c
+++ b/src/common/imageio_tiff.c
@@ -218,7 +218,7 @@ dt_imageio_retval_t dt_imageio_open_tiff(dt_image_t *img, const char *filename, 
     return DT_IMAGEIO_CACHE_FULL;
   }
 
-  /* dont depend on planar config if spp == 1 */
+  /* don't depend on planar config if spp == 1 */
   if(t.spp > 1 && config != PLANARCONFIG_CONTIG)
   {
     fprintf(stderr, "[tiff_open] error: planar config other than contig is not supported.\n");

--- a/src/common/import_session.h
+++ b/src/common/import_session.h
@@ -45,7 +45,7 @@ void dt_import_session_set_time(struct dt_import_session_t *self, time_t time);
 /** \brief set the timestamp for EXIF variables */
 void dt_import_session_set_exif_time(struct dt_import_session_t *self, time_t exif_time);
 
-/** \brief set the orginal filename
+/** \brief set the original filename
     \remark This is used to expand $(FILE_X) variables. */
 void dt_import_session_set_filename(struct dt_import_session_t *self, const char *filename);
 

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -1133,7 +1133,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
 
 /** Prepares a 1D resampling plan
  *
- * This consists of the following informations
+ * This consists of the following information
  * <ul>
  * <li>A list of lengths that tell how many pixels are relevant for the
  *    next output</li>
@@ -1164,7 +1164,7 @@ const struct dt_interpolation *dt_interpolation_new(enum dt_interpolation_type t
  * done with the plan.
  * @param pkernel [out] Array of filter kernel taps
  * @param pindex [out] Array of sample indexes to be used for applying each kernel tap
- * arrays of informations
+ * arrays of information
  * @param pmeta [out] Array of int triplets (length, kernel, index) telling where to start for an arbitrary
  *out position meta[3*out]
  * @return 0 for success, !0 for failure

--- a/src/common/interpolation.h
+++ b/src/common/interpolation.h
@@ -63,7 +63,7 @@ struct dt_interpolation
  * This function computes a single interpolated sample. Implied costs are:
  * <ul>
  * <li>Horizontal filtering kernel computation</li>
- * <li>Vertical  filtering kernel computation</li>
+ * <li>Vertical filtering kernel computation</li>
  * <li>Sample computation</li>
  * </ul>
  *

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -717,7 +717,7 @@ void local_laplacian_internal(
       const float l1 = ll_laplacian(buf[hi][l+1], buf[hi][l], i, j, pw, ph);
       output[l][j*pw+i] += l0 * (1.0f-a) + l1 * a;
       // we could do this to save on memory (no need for finest buf[][]).
-      // unfortunately it results in a quite noticable loss of sharpness, i think
+      // unfortunately it results in a quite noticeable loss of sharpness, i think
       // the extra level is worth it.
       // else if(l == 0) // use finest scale from input to not amplify noise (and use less memory)
       //   output[l][j*pw+i] += ll_laplacian(padded[l+1], padded[l], i, j, pw, ph);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1124,7 +1124,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
   char filename[PATH_MAX] = { 0 };
   gboolean from_cache = TRUE;
 
-  /* do not even try to process file if it isnt available */
+  /* do not even try to process file if it isn't available */
   dt_image_full_path(imgid, filename, sizeof(filename), &from_cache);
   if(!*filename || !g_file_test(filename, G_FILE_TEST_EXISTS))
   {

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -221,7 +221,7 @@ int dt_opencl_get_max_work_item_sizes(const int dev, size_t *sizes);
 int dt_opencl_get_work_group_limits(const int dev, size_t *sizes, size_t *workgroupsize,
                                     unsigned long *localmemsize);
 
-/** return max workgroup size for a specifc kernel */
+/** return max workgroup size for a specific kernel */
 int dt_opencl_get_kernel_work_group_size(const int dev, const int kernel, size_t *kernelworkgroupsize);
 
 /** attach arg. */

--- a/src/common/pdf.h
+++ b/src/common/pdf.h
@@ -19,7 +19,7 @@
 /*
  *  this is a simple PDF writer, capable of creating multi page PDFs with embedded images.
  *  it is NOT meant to be a full fledged PDF library, and shall never turn into something like that!
- *  see the main() fucntion in pdf.c to see an example how to use this.
+ *  see the main() function in pdf.c to see an example how to use this.
  */
 
 #pragma once

--- a/src/common/points.h
+++ b/src/common/points.h
@@ -459,10 +459,10 @@ PRE_ALWAYS static __m128i mm_recursion(__m128i *a, __m128i *b, __m128i c, __m128
 
 /**
  * This function represents the recursion formula.
- * @param a a 128-bit part of the interal state array
- * @param b a 128-bit part of the interal state array
- * @param c a 128-bit part of the interal state array
- * @param d a 128-bit part of the interal state array
+ * @param a a 128-bit part of the internal state array
+ * @param b a 128-bit part of the internal state array
+ * @param c a 128-bit part of the internal state array
+ * @param d a 128-bit part of the internal state array
  * @param mask 128-bit mask
  * @return output
  */

--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -174,7 +174,7 @@ static LONG WINAPI dt_toplevel_exception_handler(PEXCEPTION_POINTERS pExceptionI
   }
   else
   {
-    gchar *exception_message = g_strdup_printf("An unhandled exception occured.\nBacktrace will be written to: %s "
+    gchar *exception_message = g_strdup_printf("An unhandled exception occurred.\nBacktrace will be written to: %s "
                                                "after you click on the OK button.\nIf you report this issue, "
                                                "please share this backtrace with the developers.\n",
                                                name_used);

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -40,11 +40,11 @@ gboolean dt_tag_new(const char *name, guint *tagid);
 gboolean dt_tag_new_from_gui(const char *name, guint *tagid);
 
 // read/import tags from a txt file as written by Lightroom. returns the number of imported tags
-// or -1 if an error occured.
+// or -1 if an error occurred.
 ssize_t dt_tag_import(const char *filename);
 
 // export all tags to a txt file as written by Lightroom. returns the number of exported tags
-// or -1 if an error occured.
+// or -1 if an error occurred.
 ssize_t dt_tag_export(const char *filename);
 
 /** get the name of specified id */

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -282,7 +282,7 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
 // See here for bash examples and documentation:
 // http://www.tldp.org/LDP/abs/html/parameter-substitution.html
 // https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
-// the descriptions in the comments are refering to the bash behaviour, dt doesn't do it 100% like that!
+// the descriptions in the comments are referring to the bash behaviour, dt doesn't do it 100% like that!
 static char *variable_get_value(dt_variables_params_t *params, char **variable)
 {
   // invariant: the variable starts with "$(" which we can skip

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -296,7 +296,7 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   struct dt_camera_shared_t *shared;
   shared = (dt_camera_shared_t *)data;
 
-  /* update import session with orginal filename so that $(FILE_EXTENSION)
+  /* update import session with original filename so that $(FILE_EXTENSION)
    *     and alikes can be expanded. */
   dt_import_session_set_filename(shared->session, filename);
   if(exif_time)

--- a/src/control/jobs/film_jobs.c
+++ b/src/control/jobs/film_jobs.c
@@ -214,7 +214,7 @@ static void dt_film_import1(dt_job_t *job, dt_film_t *film)
       if(cfr && cfr->dir)
       {
         /* check if we can find a gpx data file to be auto applied
-           to images in the jsut imported filmroll */
+           to images in the just imported filmroll */
         g_dir_rewind(cfr->dir);
         const gchar *dfn = NULL;
         while((dfn = g_dir_read_name(cfr->dir)) != NULL)

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -3378,7 +3378,7 @@ int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const ol
 
 {
   // first deal with all-zero parmameter sets, regardless of version number.
-  // these occured in previous
+  // these occurred in previous
   // darktable versions when modules
   // without blend support stored zero-initialized data in history stack. that's
   // no problem unless the module

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -374,7 +374,7 @@ gboolean dt_develop_blend_params_is_all_zero(const void *params, size_t length);
 /** update blendop params from older versions */
 int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const old_params,
                                    const int old_version, void *new_params, const int new_version,
-                                   const int lenght);
+                                   const int length);
 
 /** gui related stuff */
 void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1209,7 +1209,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
         bd->numberstops[6] = sizeof(_gradient_gray) / sizeof(dt_iop_gui_blendif_colorstop_t);
         break;
       default:
-        assert(FALSE); // blendif not supported for RAW, which is already catched upstream; we should not get
+        assert(FALSE); // blendif not supported for RAW, which is already caught upstream; we should not get
                        // here
     }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1503,7 +1503,7 @@ void dt_dev_average_delay_update(const dt_times_t *start, uint32_t *average_dela
 }
 
 
-/** duplicate a existant module */
+/** duplicate a existent module */
 dt_iop_module_t *dt_dev_module_duplicate(dt_develop_t *dev, dt_iop_module_t *base, int priority)
 {
   // we create the new module

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -343,9 +343,9 @@ void dt_dev_masks_selection_change(dt_develop_t *dev, int selectid, int throw_ev
 /*
  * multi instances
  */
-/** duplicate a existant module */
+/** duplicate a existent module */
 struct dt_iop_module_t *dt_dev_module_duplicate(dt_develop_t *dev, struct dt_iop_module_t *base, int priority);
-/** remove an existant module */
+/** remove an existent module */
 void dt_dev_module_remove(dt_develop_t *dev, struct dt_iop_module_t *module);
 /** update "show" values of the multi instance part (show_move, show_delete, ...) */
 void dt_dev_module_update_multishow(dt_develop_t *dev, struct dt_iop_module_t *module);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2031,7 +2031,7 @@ dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_f
 
   if(!(grp->type & DT_MASKS_GROUP)) return NULL;
   // either the form to add is not a group, so no risk
-  // or we go throught all points of form to see if we find a ref to grp->formid
+  // or we go through all points of form to see if we find a ref to grp->formid
   if(!(form->type & DT_MASKS_GROUP) || _find_in_group(form, grp->formid) == 0)
   {
     dt_masks_point_group_t *grpt = malloc(sizeof(dt_masks_point_group_t));
@@ -2217,7 +2217,7 @@ static void _cleanup_unused_recurs(dt_develop_t *dev, int formid, int *used, int
     if(used[i] == formid) break;
   }
 
-  // if the form is a group, we iterate throught the sub-forms
+  // if the form is a group, we iterate through the sub-forms
   dt_masks_form_t *form = dt_masks_get_from_id(dev, formid);
   if(form && (form->type & DT_MASKS_GROUP))
   {
@@ -2237,7 +2237,7 @@ void dt_masks_cleanup_unused(dt_develop_t *dev)
   guint nbf = g_list_length(dev->forms);
   int *used = calloc(nbf, sizeof(int));
 
-  // now we iterate throught all iop to find used forms
+  // now we iterate through all iop to find used forms
   GList *iops = g_list_first(dev->iop);
   while(iops)
   {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -399,9 +399,9 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
     return 0;
   }
 
-  // we'll iterate throught all border points, but we can't start at point[0]
+  // we'll iterate through all border points, but we can't start at point[0]
   // because it may be in a self-intersected section
-  // so we choose a point where we are sure there's no intersection :
+  // so we choose a point where we are sure there's no intersection:
   // one from border shape extrema (here x_max)
   int lastx = border[(posextr[1] - 1) * 2];
   int lasty = border[(posextr[1] - 1) * 2 + 1];
@@ -2199,8 +2199,8 @@ static int dt_path_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pie
       // we add the point
       if(just_change_dir && ii == i)
       {
-        // if we have changed the direction, we have to be carefull that point can be at the same place
-        // as the previous one , especially on sharp edges
+        // if we have changed the direction, we have to be careful that point can be at the same place
+        // as the previous one, especially on sharp edges
         const size_t idx = (size_t)(yy - (*posy)) * (*width) + xx - (*posx);
         assert(idx < bufsize);
         float v = (*buffer)[idx];

--- a/src/dtgtk/button.h
+++ b/src/dtgtk/button.h
@@ -47,7 +47,7 @@ typedef struct _GtkDarktableButtonClass
 
 GType dtgtk_button_get_type(void);
 
-/** Instansiate a new darktable button control passing paint function as content */
+/** instantiate a new darktable button control passing paint function as content */
 GtkWidget *dtgtk_button_new(DTGTKCairoPaintIconFunc paint, gint paintflags);
 /** set the paint function for a button */
 void dtgtk_button_set_paint(GtkDarktableButton *button, DTGTKCairoPaintIconFunc paint, gint paintflags);

--- a/src/dtgtk/gradientslider.h
+++ b/src/dtgtk/gradientslider.h
@@ -116,7 +116,7 @@ typedef struct _gradient_slider_stop_t
 GType dtgtk_gradient_slider_get_type(void);
 GType dtgtk_gradient_slider_multivalue_get_type(void);
 
-/** Instansiate a new darktable gradient slider control */
+/** instantiate a new darktable gradient slider control */
 GtkWidget *dtgtk_gradient_slider_new();
 GtkWidget *dtgtk_gradient_slider_new_with_color(GdkRGBA start, GdkRGBA end);
 
@@ -149,7 +149,7 @@ void dtgtk_gradient_slider_set_margins(GtkDarktableGradientSlider *gslider, gint
 void dtgtk_gradient_slider_set_increment(GtkDarktableGradientSlider *gslider, gdouble value);
 
 
-/** Instansiate a new darktable gradient slider multivalue control */
+/** instantiate a new darktable gradient slider multivalue control */
 GtkWidget *dtgtk_gradient_slider_multivalue_new(gint positions);
 GtkWidget *dtgtk_gradient_slider_multivalue_new_with_color(GdkRGBA start, GdkRGBA end, gint positions);
 

--- a/src/dtgtk/icon.h
+++ b/src/dtgtk/icon.h
@@ -40,7 +40,7 @@ typedef struct _GtkDarktableIconClass
 
 GType dtgtk_icon_get_type(void);
 
-/** Instansiate a new darktable icon control passing paint function as content */
+/** instantiate a new darktable icon control passing paint function as content */
 GtkWidget *dtgtk_icon_new(DTGTKCairoPaintIconFunc paint, gint paintflags);
 
 /** set the paint function for a icon */

--- a/src/dtgtk/togglebutton.h
+++ b/src/dtgtk/togglebutton.h
@@ -43,7 +43,7 @@ typedef struct _GtkDarktableToggleButtonClass
 
 GType dtgtk_togglebutton_get_type(void);
 
-/** Instansiate a new darktable toggle button */
+/** instantiate a new darktable toggle button */
 GtkWidget *dtgtk_togglebutton_new(DTGTKCairoPaintIconFunc paint, gint paintflag);
 
 /** Set the paint function and paint flags */

--- a/src/external/CL/cl.hpp
+++ b/src/external/CL/cl.hpp
@@ -1934,7 +1934,7 @@ public:
 };
 
 /*! \class Image
- * \brief Base class  interface for all images.
+ * \brief Base class interface for all images.
  */
 class Image : public Memory
 {

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -42,7 +42,7 @@ static GList *_gui_hist_get_active_items(dt_gui_hist_dialog_t *d)
 {
   GList *result = NULL;
 
-  /* run thru all items and add active ones to result */
+  /* run through all items and add active ones to result */
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->items));
   if(gtk_tree_model_get_iter_first(model, &iter))
@@ -61,7 +61,7 @@ static GList *_gui_hist_get_active_items(dt_gui_hist_dialog_t *d)
 
 static void _gui_hist_set_items(dt_gui_hist_dialog_t *d, gboolean active)
 {
-  /* run thru all items and set active status */
+  /* run through all items and set active status */
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->items));
   if(gtk_tree_model_get_iter_first(model, &iter))

--- a/src/gui/styles_dialog.c
+++ b/src/gui/styles_dialog.c
@@ -76,7 +76,7 @@ static int _single_selected_imgid()
 
 void _gui_styles_get_active_items(dt_gui_styles_dialog_t *sd, GList **enabled, GList **update)
 {
-  /* run thru all items and add active ones to result */
+  /* run through all items and add active ones to result */
   GtkTreeIter iter;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(sd->items));
   int num = 0, update_num = 0;

--- a/src/imageio/format/imageio_format_api.h
+++ b/src/imageio/format/imageio_format_api.h
@@ -61,7 +61,7 @@ void *legacy_params(struct dt_imageio_module_format_t *self, const void *const o
 size_t params_size(struct dt_imageio_module_format_t *self);
 void *get_params(struct dt_imageio_module_format_t *self);
 void free_params(struct dt_imageio_module_format_t *self, struct dt_imageio_module_data_t *data);
-/* resets the gui to the paramters as given here. return != 0 on fail. */
+/* resets the gui to the parameters as given here. return != 0 on fail. */
 int set_params(struct dt_imageio_module_format_t *self, const void *params, const int size);
 
 /* returns the mime type of the exported image. */

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -96,7 +96,7 @@ typedef enum FBAlbumPrivacyPolicy
 
 
 /**
- * Represents informations about an album
+ * Represents information about an album
  */
 typedef struct FBAlbum
 {
@@ -119,7 +119,7 @@ static void fb_album_destroy(FBAlbum *album)
 }
 
 /**
- * Represents informations about an account
+ * Represents information about an account
  */
 typedef struct FBAccountInfo
 {
@@ -552,7 +552,7 @@ static const gchar *fb_upload_photo_to_album(FBContext *ctx, gchar *albumid, gch
 
 /**
  * @see https://developers.facebook.com/docs/reference/api/user/
- * @return basic informations about the account
+ * @return basic information about the account
  */
 static FBAccountInfo *fb_get_account_info(FBContext *ctx)
 {

--- a/src/imageio/storage/picasa.c
+++ b/src/imageio/storage/picasa.c
@@ -82,7 +82,7 @@ typedef enum PicasaAlbumPrivacyPolicy
 } PicasaAlbumPrivacyPolicy;
 
 /**
- * Represents informations about an album
+ * Represents information about an album
  */
 typedef struct PicasaAlbum
 {
@@ -105,7 +105,7 @@ static void picasa_album_destroy(PicasaAlbum *album)
 }
 
 /**
- * Represents informations about an account
+ * Represents information about an account
  */
 typedef struct PicasaAccountInfo
 {
@@ -196,7 +196,7 @@ static gchar *picasa_get_user_refresh_token(PicasaContext *ctx);
 
 //////////////////////////// curl requests related functions
 
-/** Grow and fill _buffer_t with recieved data... */
+/** Grow and fill _buffer_t with received data... */
 static size_t _picasa_api_buffer_write_func(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   _buffer_t *buffer = (_buffer_t *)stream;
@@ -629,7 +629,7 @@ static const gchar *picasa_upload_photo_to_album(PicasaContext *ctx, gchar *albu
 
 /**
  * @see https://developers.google.com/accounts/docs/OAuth2InstalledApp#callinganapi
- * @return basic informations about the account
+ * @return basic information about the account
  */
 static PicasaAccountInfo *picasa_get_account_info(PicasaContext *ctx)
 {

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -52,8 +52,8 @@
 
 #define ROTATION_RANGE 10                   // allowed min/max default range for rotation parameter
 #define ROTATION_RANGE_SOFT 20              // allowed min/max range for rotation parameter with manual adjustment
-#define LENSSHIFT_RANGE 0.5                 // allowed min/max default range for lensshift paramters
-#define LENSSHIFT_RANGE_SOFT 1              // allowed min/max range for lensshift paramters with manual adjustment
+#define LENSSHIFT_RANGE 0.5                 // allowed min/max default range for lensshift parameters
+#define LENSSHIFT_RANGE_SOFT 1              // allowed min/max range for lensshift parameters with manual adjustment
 #define SHEAR_RANGE 0.2                     // allowed min/max range for shear parameter
 #define SHEAR_RANGE_SOFT 0.5                // allowed min/max range for shear parameter with manual adjustment
 #define MIN_LINE_LENGTH 5                   // the minimum length of a line in pixels to be regarded as relevant
@@ -67,7 +67,7 @@
 #define LSD_DENSITY_TH 0.7                  // LSD: minimal density of region points in rectangle
 #define LSD_N_BINS 1024                     // LSD: number of bins in pseudo-ordering of gradient modulus
 #define LSD_GAMMA 0.45                      // gamma correction to apply on raw images prior to line detection
-#define RANSAC_RUNS 400                     // how many interations to run in ransac
+#define RANSAC_RUNS 400                     // how many iterations to run in ransac
 #define RANSAC_EPSILON 2                    // starting value for ransac epsilon (in -log10 units)
 #define RANSAC_EPSILON_STEP 1               // step size of epsilon optimization (log10 units)
 #define RANSAC_ELIMINATION_RATIO 60         // percentage of lines we try to eliminate as outliers
@@ -2126,7 +2126,7 @@ static dt_iop_ashift_nmsresult_t nmsfit(dt_iop_module_t *module, dt_iop_ashift_p
   fit.lensshift_h = isnan(fit.lensshift_h) ? ilogit(params[pcount++], -fit.lensshift_h_range, fit.lensshift_h_range) : fit.lensshift_h;
   fit.shear = isnan(fit.shear) ? ilogit(params[pcount++], -fit.shear_range, fit.shear_range) : fit.shear;
 #ifdef ASHIFT_DEBUG
-  printf("params after optimization (%d interations): rotation %f, lensshift_v %f, lensshift_h %f, shear %f\n",
+  printf("params after optimization (%d iterations): rotation %f, lensshift_v %f, lensshift_h %f, shear %f\n",
          iter, fit.rotation, fit.lensshift_v, fit.lensshift_h, fit.shear);
 #endif
 
@@ -2456,7 +2456,7 @@ static void do_crop(dt_iop_module_t *module, dt_iop_ashift_params_t *p)
   if(A == 0.0f) goto failed;
 
   // we need the half diagonal of that rectangle (this is in output image dimensions);
-  // no need to check for division by zero here as this case implies A == 0.0f, catched above
+  // no need to check for division by zero here as this case implies A == 0.0f, caught above
   const float d = sqrt(A / (2.0f * sin(2.0f * cropfit.alpha)));
 
   // the rectangle's center in input image (homogeneous) coordinates
@@ -3170,7 +3170,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   int closeup = dt_control_get_dev_closeup();
   float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, closeup ? 2 : 1, 1);
 
-  // we draw the cropping area; we need x_off/y_off/width/height which is only availabe
+  // we draw the cropping area; we need x_off/y_off/width/height which is only available
   // after g->buf has been processed
   if(g->buf  && (p->cropmode != ASHIFT_CROP_OFF) && self->enabled)
   {

--- a/src/iop/ashift_nmsimplex.c
+++ b/src/iop/ashift_nmsimplex.c
@@ -22,7 +22,7 @@
  *      do not include "nmsimplex.h" (not needed)
  *      renamed configuration variables to NMS_*
  *      add additional argument to objfun for arbitrary parameters
- *      simplex() returns number of used interations intead of min value
+ *      simplex() returns number of used iterations instead of min value
  *      maximum number of iterations as function parameter
  *      make interface function simplex() static
  *      initialize i and j to avoid compiler warnings

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -211,7 +211,7 @@ static gboolean LinEqSolve(int nDim, double *pfMatr, double *pfVect, double *pfS
   // pfMatr - matrix with coefficients
   // pfVect - vector with free members
   // pfSolution - vector with system solution
-  // pfMatr becames trianglular after function call
+  // pfMatr becomes triangular after function call
   // pfVect changes after function call
   //
   // Developer: Henry Guennadi Levkin

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -71,7 +71,7 @@ static const float colorchecker_Lab[] =
 };
 
 // we came to the conclusion that more than 7x7 patches will not be
-// managable in the gui. the fitting experiments show however that you
+// manageable in the gui. the fitting experiments show however that you
 // can do significantly better with 49 than you can with 24 patches,
 // especially when considering max delta E.
 #define MAX_PATCHES 49
@@ -570,7 +570,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
       |       |  |   | = |   |
       \ P^t 0 /  \ d /   \ 0 /
 
-      for the coefficent vector (c d)^t.
+      for the coefficient vector (c d)^t.
 
       By design of the interpolation scheme the interpolation
       coefficients c for radial non-linear basis functions (the kernel)

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -445,7 +445,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->gslider2, TRUE, TRUE, 0);
 
-  // Additional paramters
+  // Additional parameters
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0.1, p->lightness * 100.0, 2);
   dt_bauhaus_slider_set_format(g->scale1, "%.2f%%");
   dt_bauhaus_widget_set_label(g->scale1, NULL, _("lightness"));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -109,7 +109,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     // autodetect current profile:
     if(!self->dev)
     {
-      // we are probably handling a style or preset, do nothing for them, we cant do anything to detect if
+      // we are probably handling a style or preset, do nothing for them, we can't do anything to detect if
       // autodetection was used or not
       return 0;
     }

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -310,7 +310,7 @@ static inline void box_mean_1d(int N, const float *x, float *y, size_t stride_y,
 }
 
 // calculate the two-dimensional moving average over a box of size (2*w+1) x (2*w+1)
-// does the calculation in-place if input and ouput images are identical
+// does the calculation in-place if input and output images are identical
 // this function is always called from a OpenMP thread, thus no parallelization
 static void box_mean(gray_image img1, gray_image img2, int w)
 {
@@ -357,7 +357,7 @@ static inline void box_max_1d(int N, const float *x, float *y, size_t stride_y, 
 }
 
 // calculate the two-dimensional moving maximum over a box of size (2*w+1) x (2*w+1)
-// does the calculation in-place if input and ouput images are identical
+// does the calculation in-place if input and output images are identical
 static void box_max(const gray_image img1, const gray_image img2, const int w)
 {
   gray_image img2_bak;
@@ -428,7 +428,7 @@ static inline void box_min_1d(int N, const float *x, float *y, size_t stride_y, 
 }
 
 // calculate the two-dimensional moving minimum over a box of size (2*w+1) x (2*w+1)
-// does the calculation in-place if input and ouput images are identical
+// does the calculation in-place if input and output images are identical
 static void box_min(const gray_image img1, const gray_image img2, const int w)
 {
   gray_image img2_bak;
@@ -737,8 +737,8 @@ void quick_select(float *first, float *nth, float *last)
 // reduced by the factor exp(-1)
 static float ambient_light(const const_rgb_image img, int w1, rgb_pixel *pA0)
 {
-  const float dark_channel_quantil = 0.95f; // quantil for determing the most hazy pixels
-  const float bright_quantil = 0.95f; // quantil for determing the brightest pixels among the most hazy pixels
+  const float dark_channel_quantil = 0.95f; // quantil for determining the most hazy pixels
+  const float bright_quantil = 0.95f; // quantil for determining the brightest pixels among the most hazy pixels
   int width = img.width;
   int height = img.height;
   const size_t size = (size_t)width * height;
@@ -788,7 +788,7 @@ static float ambient_light(const const_rgb_image img, int w1, rgb_pixel *pA0)
   (*pA0)[2] = A0_b / N_bright_hazy;
   free_gray_image(&dark_ch);
   // the critical haze level is at dark_channel_quantil (not 100%) to be insensitive
-  // to extrime outliners, compensate for that by some factor slighly larger than
+  // to extreme outliners, compensate for that by some factor slightly larger than
   // unity when calculating the maximal image depth
   return -1.125f * logf(crit_haze_level); // return the maximal depth
 }
@@ -803,7 +803,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int width = roi_in->width;
   const int height = roi_in->height;
   const size_t size = (size_t)width * height;
-  const int w1 = 6; // window size (positive integer) for determing the dark channel and the transition map
+  const int w1 = 6; // window size (positive integer) for determining the dark channel and the transition map
   const int w2 = 9; // window size (positive integer) for the guided filter
 
   // module parameters

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -289,7 +289,7 @@ static inline void interpolate_color_xtrans(const void *const ivoid, void *const
 {
   // In Bayer each row/col has only green/red or green/blue
   // transitions, hence can reconstruct color by single ratio per
-  // row. In x-trans there can be transitions between arbitary colors
+  // row. In x-trans there can be transitions between arbitrary colors
   // in a row/col (and 2x2 green blocks which provide no color
   // transition information). Hence calculate multiple color ratios
   // for each row/col.

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -160,7 +160,7 @@ void modify_roi_out(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, dt_iop
    * Think of input image as:
    * 1. Square, containing:
    * 3. 4x Right triangles (two pairs), located in the Edges of square
-   * 2. Rectangle (rotated 45 degrees), located inbetween triangles.
+   * 2. Rectangle (rotated 45 degrees), located in between triangles.
    *
    * Therefore, output image dimensions, that are sizes of inner Rectangle
    * can be found using Pythagorean theorem.

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -162,7 +162,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   float *out;
   const int ch = piece->colors;
 
-  const float compress = (data->compress / 110.0) / 2.0; // Dont allow 100% compression..
+  const float compress = (data->compress / 110.0) / 2.0; // Don't allow 100% compression..
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(data) private(in, out) schedule(static)
 #endif
@@ -215,7 +215,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int width = roi_out->width;
   const int height = roi_out->height;
 
-  const float compress = (d->compress / 110.0) / 2.0; // Dont allow 100% compression..
+  const float compress = (d->compress / 110.0) / 2.0; // Don't allow 100% compression..
   const float balance = d->balance;
   const float shadow_hue = d->shadow_hue;
   const float shadow_saturation = d->shadow_saturation;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -808,7 +808,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   /* create cairo context and setup transformation/scale */
   cairo_t *cr = cairo_create(surface);
 
-  // rsvg (or some part of cairo whic is used underneath) isn't thread safe, for example when handling fonts
+  // rsvg (or some part of cairo which is used underneath) isn't thread safe, for example when handling fonts
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
 
   /* create the rsvghandle from parsed svg data */

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -1006,7 +1006,7 @@ void *get_params(dt_lib_module_t *self, int *size)
   void *sdata = mstorage->get_params(mstorage);
   int32_t fversion = mformat->version();
   int32_t sversion = mstorage->version();
-  // we allow null pointers (plugin not ready for export in current state), and just dont copy back the
+  // we allow null pointers (plugin not ready for export in current state), and just don't copy back the
   // settings later:
   if(!sdata) ssize = 0;
   if(!fdata) fsize = 0;

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -56,7 +56,7 @@ DT_MODULE(1)
 
 
 #ifdef HAVE_GPHOTO2
-/** helper function to update ui with available cameras and ther actionbuttons */
+/** helper function to update ui with available cameras and their actionbuttons */
 static void _lib_import_ui_devices_update(dt_lib_module_t *self);
 #endif
 

--- a/src/libs/modulegroups.h
+++ b/src/libs/modulegroups.h
@@ -32,7 +32,7 @@ typedef enum dt_lib_modulegroup_t
   DT_MODULEGROUP_CORRECT,
   DT_MODULEGROUP_EFFECT,
 
-  /* dont touch the following */
+  /* don't touch the following */
   DT_MODULEGROUP_SIZE,
 
   DT_MODULEGROUP_NONE

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1212,7 +1212,7 @@ gui_init (dt_lib_module_t *self)
   const gboolean lock_active = dt_conf_get_bool("plugins/print/print/lock_borders");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->lock_button), lock_active);
 
-  // pack image dimention hbox here
+  // pack image dimension hbox here
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hboxdim), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hboxinfo), TRUE, TRUE, 0);

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -199,7 +199,7 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget, cairo_t *cr, gpo
     cairo_fill(cr);
   }
 
-  /* create a pango layout and print fancy  name/version string */
+  /* create a pango layout and print fancy name/version string */
   PangoLayout *layout;
   layout = gtk_widget_create_pango_layout(widget, NULL);
   pango_font_description_set_weight(font_desc, PANGO_WEIGHT_BOLD);

--- a/src/lua/call.c
+++ b/src/lua/call.c
@@ -59,7 +59,7 @@ int dt_lua_treated_pcall(lua_State*L, int nargs, int nresults)
    THREAD
    * threads are a way to store some work that will be done later
    * threads are saved in the table at REGISTRY_INDEX "dt_lua_bg_thread", that table is manipulated with save_thread, get_thread, drop_thread. They have a unique integer ID
-   * each thread is a lua_State with the folowing convention for its stack
+   * each thread is a lua_State with the following convention for its stack
       -- top of the stack --
       * args
       * lua function : function to call
@@ -73,7 +73,7 @@ int dt_lua_treated_pcall(lua_State*L, int nargs, int nresults)
   * must be called with the lua lock taken
   * find/create a new gtk thread
   * run that thread which is in charge of doing the job
-  * the ownership of the lock is transfered to the thread
+  * the ownership of the lock is transferred to the thread
   * wait for the thread to release the lock (the thread might not have finished
   * return to the caller
 
@@ -123,7 +123,7 @@ static void drop_thread(lua_State*L, int thread_num)
 
 static void run_async_thread_main(gpointer data,gpointer user_data)
 {
-  // lua lock ownership transfered from parent thread
+  // lua lock ownership transferred from parent thread
   int thread_num = GPOINTER_TO_INT(data);
   lua_State*L = darktable.lua_state.state;
   lua_State* thread = get_thread(L,thread_num);
@@ -152,7 +152,7 @@ static void run_async_thread_main(gpointer data,gpointer user_data)
 static void run_async_thread(lua_State* L, int thread_num)
 {
   g_thread_pool_push(darktable.lua_state.pool,GINT_TO_POINTER(thread_num),NULL);
-  // lock ownership is transfered to the new thread. We want to block until it is returned to us
+  // lock ownership is transferred to the new thread. We want to block until it is returned to us
   // either because the other thread finished or because it paused
   dt_lua_lock();
 }

--- a/src/lua/call.h
+++ b/src/lua/call.h
@@ -32,7 +32,7 @@ void dt_lua_gtk_wrap_internal(lua_State*L,const char* function, int line);
    */
 int dt_lua_treated_pcall(lua_State*L, int nargs, int nresults);
 /* 
-   deal wil lua_pcall calling convention
+   deal will lua_pcall calling convention
    * print the string on the top of L if result != LUA_OK
    * pop the error string
    * return result 
@@ -54,7 +54,7 @@ void dt_lua_async_call_internal(const char * function, int line,lua_State *L, in
 
 /*
    Call a lua function asynchronously, parameters are passed through varags,
-   and temporarly stored in a glist before pushing in the stack
+   and temporarily stored in a glist before pushing in the stack
 
    This function CAN be called with the gtk lock held.
    * function : the function to call

--- a/src/lua/lua.c
+++ b/src/lua/lua.c
@@ -30,7 +30,7 @@ void dt_lua_debug_stack_internal(lua_State *L, const char *function, int line)
   }
   else
   {
-    printf("(size %d),\n",lua_gettop(L)); //usefull to detect underflows
+    printf("(size %d),\n",lua_gettop(L)); //useful to detect underflows
   }
   for(int i = 1; i <= lua_gettop(L); i++)
   {
@@ -107,7 +107,7 @@ void dt_lua_goto_subtable(lua_State *L, const char *sub_name)
    is not protected against concurent access) so we need a mutex to cover us
 
    However there are cases in lua/call.c where we need to lock the lua access
-   from a thread and unlock it from another thread. This is done to guarentee
+   from a thread and unlock it from another thread. This is done to guarantee
    that the lua code from the first thread is followed from the lua code in the
    second thread with no other lua thread having a chance to run in the middle
 

--- a/src/lua/lua.h
+++ b/src/lua/lua.h
@@ -73,7 +73,7 @@ typedef struct
 
   bool ending;                       // true if we are in the process of terminating DT
 
-  GMainLoop *loop;                   // loop running  the lua context
+  GMainLoop *loop;                   // loop running the lua context
   GMainContext *context;             // the lua context responsible for dispatching tasks
   GThreadPool *pool;                 // pool of threads to run lua tasks on (should be one or two at most, unless lot of blocking lua threads
   GAsyncQueue * stacked_job_queue;   // queue of jobs whose arguments are on a lua stack

--- a/src/lua/modules.c
+++ b/src/lua/modules.c
@@ -107,7 +107,7 @@ luaA_Type dt_lua_module_get_preset_type(lua_State *L, const char *module_type_na
 void dt_lua_register_current_preset(lua_State *L, const char *module_type_name, const char *entry_name,
                                     lua_CFunction pusher, lua_CFunction getter)
 {
-  // stack usefull values
+  // stack useful values
   dt_lua_module_entry_push(L, module_type_name, entry_name);
   void *entry = *(void **)lua_touserdata(L, -1);
   luaA_Type entry_type = dt_lua_module_entry_get_type(L, module_type_name, entry_name);

--- a/src/lua/types.c
+++ b/src/lua/types.c
@@ -917,8 +917,8 @@ void dt_lua_type_setmetafield_type(lua_State*L,luaA_Type type_id,const char* met
     return;
   // whitelist for specific types
   } else if(
-      // if you add a type here, make sure it handles inheritence of metamethods itself
-      // typically, set the metamethod not for the parent type but just after inheritence
+      // if you add a type here, make sure it handles inheritance of metamethods itself
+      // typically, set the metamethod not for the parent type but just after inheritance
       ( !strcmp(method_name,"__associated_object")&& dt_lua_typeisa_type(L,type_id,luaA_type_find(L,"dt_imageio_module_format_t"))) ||
       ( !strcmp(method_name,"__associated_object")&& dt_lua_typeisa_type(L,type_id,luaA_type_find(L,"dt_imageio_module_storage_t"))) ||
       ( !strcmp(method_name,"__gc")&& dt_lua_typeisa_type(L,type_id,luaA_type_find(L,"dt_style_t"))) ||

--- a/src/lua/types.h
+++ b/src/lua/types.h
@@ -63,7 +63,7 @@ typedef PangoEllipsizeMode dt_lua_ellipsize_mode_t;
  * __luaA_Type : int, the associated luaA_Type
  * __pairs : will retun (__next,obj,nil)
  * __next : will iteratethrough the __get table of obj
- * __index : will look into the __get table to find a callback, then  raise an error
+ * __index : will look into the __get table to find a callback, then raise an error
  * __newindex : will look into the __set table to find a callback, then raise an error
  * __get : empty table, contains getters, similar API to __index
  * __set : empty table, contains setters, similar API to __newindex
@@ -105,7 +105,7 @@ void dt_lua_type_register_number_const_type(lua_State *L, luaA_Type type_id);
 
 /// register a type as a parent type
 /// the type will reuse all members and metafiels from the parent (unless it has its own)
-/// inheritence will be marked in __luaA_ParentMetatable
+/// inheritance will be marked in __luaA_ParentMetatable
 /// THIS FUNCTION MUST BE CALLED AFTER PARENT WAS COMPLETELY DEFINED
 #define dt_lua_type_register_parent(L, type_name, parent_type_name)                                          \
   dt_lua_type_register_parent_type(L, luaA_type_find(L, #type_name), luaA_type_find(L, #parent_type_name))
@@ -125,7 +125,7 @@ int dt_lua_type_member_luaautoc(lua_State *L);
 
 /**
   * similar to dt_lua_init_type but creates a type for int or gpointer singletons
-  * the type must match and will guarentee a singleton per value
+  * the type must match and will guarantee a singleton per value
   * i.e if you push the same int twice, you will push the same lua object
   * not recreate a different one each time
   * the singleton objects will still correctly be garbage collected
@@ -146,7 +146,7 @@ void dt_lua_type_gpointer_alias_type(lua_State*L,luaA_Type type_id,void* pointer
 
 /**
   * drop a gpointer. Pushing the pointer again will create a new object.
-  * We can't guarentee when the original object will be GC, but it will point to NULL
+  * We can't guarantee when the original object will be GC, but it will point to NULL
   * instead of its normal content. accessing it from the lua side will cause an error
   * luaA_to will also raise an error
   * NOTE : if the object had aliases, the aliases will return NULL too.

--- a/src/lua/widget/container.c
+++ b/src/lua/widget/container.c
@@ -141,7 +141,7 @@ static int container_numindex(lua_State*L)
       lua_widget widget;
       luaA_to(L, lua_widget,&widget,3);
       gtk_container_add(GTK_CONTAINER(container->widget),widget->widget);
-      // the following lines add the widget to the container's user_value to guarentee it's referenced on the lua side
+      // the following lines add the widget to the container's user_value to guarantee it's referenced on the lua side
       // they should be done by child_added, but 
       // there can be a race with lua's GC, so do it now.
       // child_added doing it a second time is harmless

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -509,7 +509,7 @@ static inline void _kill_mystery_ship(dt_knight_t *d)
 static inline void _add_mystery_ship(dt_knight_t *d)
 {
   d->mystery_ship_x = 0.0;
-  // only shoot once per occurence
+  // only shoot once per occurrence
   d->mystery_ship_potential_shot_x = (float)rand() / (float)RAND_MAX;
 }
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -114,7 +114,7 @@ typedef struct dt_library_t
   /* prepared and reusable statements */
   struct
   {
-    /* main query statment, should be update on listener signal of collection */
+    /* main query statement, should be update on listener signal of collection */
     sqlite3_stmt *main_query;
     /* select imgid from selected_images */
     sqlite3_stmt *select_imgid_in_selection;
@@ -348,7 +348,7 @@ static void _update_collected_images(dt_view_t *self)
     sqlite3_finalize(stmt);
   }
 
-  /* if we have a statment lets clean it */
+  /* if we have a statement lets clean it */
   if(lib->statements.main_query) sqlite3_finalize(lib->statements.main_query);
 
   /* prepare a new main query statement for collection */

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -231,7 +231,7 @@ static int zoom_member(lua_State *L)
   else
   {
     // we rely on osm to correctly clamp zoom (checked in osm source
-    // lua can have temporarly false values but it will fix itself when entering map
+    // lua can have temporarily false values but it will fix itself when entering map
     // unfortunately we can't get the min max when lib->map doesn't exist
     luaL_checktype(L, 3, LUA_TNUMBER);
     int zoom = luaL_checkinteger(L, 3);
@@ -567,7 +567,7 @@ static void _view_map_changed_callback(OsmGpsMap *map, dt_view_t *self)
     lib->images = NULL;
   }
 
-  /* add  all images to the map */
+  /* add all images to the map */
   gboolean needs_redraw = FALSE;
   const int _thumb_size = DT_PIXEL_APPLY_DPI(thumb_size);
   dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, _thumb_size, _thumb_size);

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -200,7 +200,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
     }
     dt_pthread_mutex_unlock(&cam->live_view_pixbuf_mutex);
   }
-  else if(lib->image_id >= 0) // First of all draw image if availble
+  else if(lib->image_id >= 0) // First of all draw image if available
   {
     cairo_translate(cr, MARGIN, MARGIN);
     dt_view_image_expose(&(lib->image_over), lib->image_id, cr, width - (MARGIN * 2.0f),
@@ -256,7 +256,7 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
 {
   struct dt_capture_t *lib = (dt_capture_t *)data;
 
-  /* update import session with orginal filename so that $(FILE_EXTENSION)
+  /* update import session with original filename so that $(FILE_EXTENSION)
    *     and alikes can be expanded. */
   dt_import_session_set_filename(lib->session, filename);
   const gchar *file = dt_import_session_filename(lib->session, FALSE);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1541,7 +1541,7 @@ void dt_view_filmstrip_scroll_relative(const int diff, int offset)
 
 void dt_view_filmstrip_scroll_to_image(dt_view_manager_t *vm, const int imgid, gboolean activate)
 {
-  // g_return_if_fail(vm->proxy.filmstrip.module!=NULL); // This can happend here for debugging
+  // g_return_if_fail(vm->proxy.filmstrip.module!=NULL); // This can happen here for debugging
   // g_return_if_fail(vm->proxy.filmstrip.scroll_to_image!=NULL);
 
   if(vm->proxy.filmstrip.module && vm->proxy.filmstrip.scroll_to_image)
@@ -1550,7 +1550,7 @@ void dt_view_filmstrip_scroll_to_image(dt_view_manager_t *vm, const int imgid, g
 
 int32_t dt_view_filmstrip_get_activated_imgid(dt_view_manager_t *vm)
 {
-  // g_return_val_if_fail(vm->proxy.filmstrip.module!=NULL, 0); // This can happend here for debugging
+  // g_return_val_if_fail(vm->proxy.filmstrip.module!=NULL, 0); // This can happen here for debugging
   // g_return_val_if_fail(vm->proxy.filmstrip.activated_image!=NULL, 0);
 
   if(vm->proxy.filmstrip.module && vm->proxy.filmstrip.activated_image)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -41,7 +41,7 @@
 #include "lua/view.h"
 #endif
 
-/** avilable views flags, a view should return it's type and
+/** available views flags, a view should return its type and
     is also used in modules flags available in src/libs to
     control which view the module should be available in also
     which placement in the panels the module have.
@@ -96,7 +96,7 @@ typedef struct dt_view_t
                  int32_t pointery);         // expose the module (gtk callback)
   int (*try_enter)(struct dt_view_t *self); // test if enter can succeed.
   void (*enter)(struct dt_view_t *self); // mode entered, this module got focus. return non-null on failure.
-  void (*leave)(struct dt_view_t *self); // mode left (is called after the new try_enter has succeded).
+  void (*leave)(struct dt_view_t *self); // mode left (is called after the new try_enter has succeeded).
   void (*reset)(struct dt_view_t *self); // reset default appearance
 
   // event callbacks:

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -44,7 +44,7 @@ void expose(struct dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, 
             int32_t pointery);         // expose the module (gtk callback)
 int try_enter(struct dt_view_t *self); // test if enter can succeed.
 void enter(struct dt_view_t *self);    // mode entered, this module got focus. return non-null on failure.
-void leave(struct dt_view_t *self);    // mode left (is called after the new try_enter has succeded).
+void leave(struct dt_view_t *self);    // mode left (is called after the new try_enter has succeeded).
 void reset(struct dt_view_t *self);    // reset default appearance
 
 // event callbacks:

--- a/tools/create_version_c.sh
+++ b/tools/create_version_c.sh
@@ -17,7 +17,7 @@ if echo "$NEW_VERSION" | grep -q Format; then
   NEW_VERSION="unknown-version"
 fi
 
-# version.c exists => check if it containts the up-to-date version
+# version.c exists => check if it contains the up-to-date version
 if [ -f "$C_FILE" ]; then
   OLD_VERSION=$(./tools/parse_version_c.sh "$C_FILE")
   if [ "${OLD_VERSION}" = "${NEW_VERSION}" ]; then

--- a/tools/diff_lua_api.lua
+++ b/tools/diff_lua_api.lua
@@ -9,7 +9,7 @@ Takes two mandatory and one optiona argument
   nodes : also dump the content of added nodes
 
 This script will compare the two API and report any differences it sees
-optionnaly printing details of the difference
+optionally printing details of the difference
 
 Use this to quickly assess what has changed between two versions of DT
 

--- a/tools/dngmeta.sh
+++ b/tools/dngmeta.sh
@@ -165,10 +165,10 @@ echo -e "\t</Camera>"
 echo ""
 
 if [[ $MAKE == Panasonic ]]; then
-  echo "NOTE: Panasonic RW2s are different dependant on aspect ratio, please run this tool on RW2 for each of the camera's ratios (4:3,3:2,16:9,1:1)"
+  echo "NOTE: Panasonic RW2s are different dependent on aspect ratio, please run this tool on RW2 for each of the camera's ratios (4:3,3:2,16:9,1:1)"
   echo ""
 elif [[ $MAKE == "NIKON CORPORATION" ]]; then
-  echo "NOTE: NIKON NEFs are different dependant on mode, please run this tool on NEF for each of the camera's mode (14-bit, 12-bit; compressed, uncompressed)"
+  echo "NOTE: NIKON NEFs are different dependent on mode, please run this tool on NEF for each of the camera's mode (14-bit, 12-bit; compressed, uncompressed)"
   echo ""
 elif [[ $MAKE == "Canon" ]]; then
   echo "NOTE: CANON CR2 have different black/white levels per ISO, please run this tool on CR2 for each of the camera's ISO (including all the sub-iso 1/2 and 1/3)"

--- a/tools/lua_doc/content.lua
+++ b/tools/lua_doc/content.lua
@@ -81,7 +81,7 @@ code([[darktable = require "darktable"]])..
 --  DARKTABLE       --
 ----------------------
 darktable:set_text([[The darktable library is the main entry point for all access to the darktable internals.]])
-darktable.print:set_text([[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]])
+darktable.print:set_text([[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]])
 darktable.print:add_parameter("message","string",[[The string to display which should be a single line.]])
 
 darktable.print_log:set_text([[This function will print its parameter if the Lua logdomain is activated. Start darktable with the "-d lua" command line option to enable the Lua logdomain.]])
@@ -189,7 +189,7 @@ darktable.gui:set_text([[This subtable contains function and data to manipulate 
 
 darktable.gui.action_images:set_text([[A table of ]]..my_tostring(types.dt_lua_image_t)..[[ on which the user expects UI actions to happen.]]..para()..
 [[It is based on both the hovered image and the selection and is consistent with the way darktable works.]]..para()..
-[[It is recommended to use this table to implement Lua actions rather than ]]..my_tostring(darktable.gui.hovered)..[[ or ]]..my_tostring(darktable.gui.selection)..[[ to be consistant with darktable's GUI.]])
+[[It is recommended to use this table to implement Lua actions rather than ]]..my_tostring(darktable.gui.hovered)..[[ or ]]..my_tostring(darktable.gui.selection)..[[ to be consistent with darktable's GUI.]])
 
 remove_all_children(darktable.gui.action_images)
 
@@ -290,7 +290,7 @@ darktable.preferences.register:add_parameter("name","string",[[A unique name use
 darktable.preferences.register:add_parameter("type",types.lua_pref_type,[[The type of the preference - one of the string values described above.]])
 darktable.preferences.register:add_parameter("label","string",[[The label displayed in the preference screen.]])
 darktable.preferences.register:add_parameter("tooltip","string",[[The tooltip to display in the preference menu.]])
-darktable.preferences.register:add_parameter("default","depends on type",[[Default value to use when not set explicitely or by the user.]]..para().."For the enum type of pref, this is mandatory"):set_attribute("optional",true)
+darktable.preferences.register:add_parameter("default","depends on type",[[Default value to use when not set explicitly or by the user.]]..para().."For the enum type of pref, this is mandatory"):set_attribute("optional",true)
 darktable.preferences.register:add_parameter("min","int or float",[[Minimum value (integer and float preferences only).]]):set_attribute("optional",true)
 darktable.preferences.register:add_parameter("max","int or float",[[Maximum value (integer and float preferences only).]]):set_attribute("optional",true)
 darktable.preferences.register:add_parameter("step","float",[[Step of the spinner (float preferences only).]]):set_attribute("optional",true)

--- a/tools/lua_doc/old_api/dt_api202.lua
+++ b/tools/lua_doc/old_api/dt_api202.lua
@@ -1,5 +1,5 @@
 API = {
-["__text"] = [[This documentation is for the *developement* version of darktable. for the stable version, please visit the user manual
+["__text"] = [[This documentation is for the *development* version of darktable. for the stable version, please visit the user manual
 To access the darktable specific functions you must load the darktable environment:<code>darktable = require "darktable"</code>All functions and data are accessed through the darktable module.
 This documentation for API version 2.0.2.]],
 ["__attributes"] = {
@@ -11,7 +11,7 @@ This documentation for API version 2.0.2.]],
 ["reported_type"] = [[documentation node]],
 },
 ["print"] = {
-["__text"] = [[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]],
+["__text"] = [[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]],
 ["__attributes"] = {
 ["reported_type"] = [[function]],
 ["signature"] = {
@@ -617,7 +617,7 @@ Note that the parameter order is not relevant.]],
 ["copy_image"] = {
 ["__text"] = [[Physically copies an image to another film.
 This will copy the image file and the related XMP to the directory of the new film
-If there is already a file with the same name as the image file, it wil create a duplicate from that file instead
+If there is already a file with the same name as the image file, it will create a duplicate from that file instead
 Note that the parameter order is not relevant.]],
 ["__attributes"] = {
 ["is_attribute"] = true,
@@ -958,7 +958,7 @@ Note that the parameter order is not relevant.]],
 ["yellow"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["purple"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["reset"] = {
-["__text"] = [[Removes all processing from the image, reseting it back to its original state]],
+["__text"] = [[Removes all processing from the image, resetting it back to its original state]],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -1082,7 +1082,7 @@ Darktable will regenerate the thumbnail by itself when it is needed]],
 ["reported_type"] = [[function]],
 ["signature"] = {
 ["1"] = {
-["__text"] = [[The image whose cache must be droped.]],
+["__text"] = [[The image whose cache must be dropped.]],
 ["__attributes"] = {
 ["is_self"] = true,
 ["reported_type"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]]=],
@@ -1376,7 +1376,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -2433,7 +2433,7 @@ The snapshot file will be generated at the next redraw of the main window]],
 ["check_version"] = {
 ["__text"] = [[Check that a module is compatible with the running version of darktable
 Add the following line at the top of your module : <code>darktable.configuration.check(...,{M,m,p},{M2,m2,p2})</code>To document that your module has been tested with API version M.m.p and M2.m2.p2.
-This will raise an error if the user is running a released version of DT and a warning if he is running a developement version
+This will raise an error if the user is running a released version of DT and a warning if he is running a development version
 (the ... here will automatically expand to your module name if used at the top of your script]],
 ["__attributes"] = {
 ["reported_type"] = [[function]],
@@ -2506,13 +2506,13 @@ Note that the directory, enum and file type preferences are stored internally as
 },
 },
 ["5"] = {
-["__text"] = [[The tooltip to display in the preference menue.]],
+["__text"] = [[The tooltip to display in the preference menu.]],
 ["__attributes"] = {
 ["reported_type"] = [[string]],
 },
 },
 ["6"] = {
-["__text"] = [[Default value to use when not set explicitely or by the user.
+["__text"] = [[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]],
 ["__attributes"] = {
 ["optional"] = true,
@@ -3442,7 +3442,7 @@ defaults to darktable.debug.known if not set]],
 ["__text"] = [[Lua functions can yield at any point. The parameters and return types depend on why we want to yield.
 A callback that is yielding allows other Lua code to run.
 
-* wait_ms: one extra parameter; the execution will pause for that many miliseconds; yield returns nothing;
+* wait_ms: one extra parameter; the execution will pause for that many milliseconds; yield returns nothing;
 * file_readable: an opened file from a call to the OS library; will return when the file is readable; returns nothing;
 * run_command: a command to be run by "sh -c"; will return when the command terminates; returns the return code of the execution.
 ]],

--- a/tools/lua_doc/old_api/dt_api210dev.lua
+++ b/tools/lua_doc/old_api/dt_api210dev.lua
@@ -10,7 +10,7 @@ This documentation for API version 2.1.0-dev.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -983,7 +983,7 @@ Note that the parameter order is not relevant.]==],
 ["yellow"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["purple"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["reset"] = {
-["__text"] = [==[Removes all processing from the image, reseting it back to its original state]==],
+["__text"] = [==[Removes all processing from the image, resetting it back to its original state]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -1107,7 +1107,7 @@ Darktable will regenerate the thumbnail by itself when it is needed]==],
 ["reported_type"] = [==[function]==],
 ["signature"] = {
 ["1"] = {
-["__text"] = [==[The image whose cache must be droped.]==],
+["__text"] = [==[The image whose cache must be dropped.]==],
 ["__attributes"] = {
 ["is_self"] = true,
 ["reported_type"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]]=],
@@ -1768,7 +1768,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3376,7 +3376,7 @@ For more details of the member functions have a look at the cairo documentation 
 ["check_version"] = {
 ["__text"] = [==[Check that a module is compatible with the running version of darktable
 Add the following line at the top of your module : <code>darktable.configuration.check(...,{M,m,p},{M2,m2,p2})</code>To document that your module has been tested with API version M.m.p and M2.m2.p2.
-This will raise an error if the user is running a released version of DT and a warning if he is running a developement version
+This will raise an error if the user is running a released version of DT and a warning if he is running a development version
 (the ... here will automatically expand to your module name if used at the top of your script]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
@@ -3455,7 +3455,7 @@ Note that the directory, enum and file type preferences are stored internally as
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,
@@ -5348,7 +5348,7 @@ You can removes entries by setting them to nil]==],
 ["__text"] = [==[Lua functions can yield at any point. The parameters and return types depend on why we want to yield.
 A callback that is yielding allows other Lua code to run.
 
-* WAIT_MS: one extra parameter; the execution will pause for that many miliseconds; yield returns nothing;
+* WAIT_MS: one extra parameter; the execution will pause for that many milliseconds; yield returns nothing;
 * FILE_READABLE: an opened file from a call to the OS library; will return when the file is readable; returns nothing;
 * RUN_COMMAND: a command to be run by "sh -c"; will return when the command terminates; returns the return code of the execution.
 ]==],

--- a/tools/lua_doc/old_api/dt_api300.lua
+++ b/tools/lua_doc/old_api/dt_api300.lua
@@ -1,5 +1,5 @@
 API = {
-["__text"] = [==[This documentation is for the *developement* version of darktable. for the stable version, please visit the user manual
+["__text"] = [==[This documentation is for the *development* version of darktable. for the stable version, please visit the user manual
 To access the darktable specific functions you must load the darktable environment:<code>darktable = require "darktable"</code>All functions and data are accessed through the darktable module.
 This documentation for API version 3.0.0.]==],
 ["__attributes"] = {
@@ -11,7 +11,7 @@ This documentation for API version 3.0.0.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -984,7 +984,7 @@ Note that the parameter order is not relevant.]==],
 ["yellow"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["purple"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["reset"] = {
-["__text"] = [==[Removes all processing from the image, reseting it back to its original state]==],
+["__text"] = [==[Removes all processing from the image, resetting it back to its original state]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -1108,7 +1108,7 @@ darktable will regenerate the thumbnail by itself when it is needed]==],
 ["reported_type"] = [==[function]==],
 ["signature"] = {
 ["1"] = {
-["__text"] = [==[The image whose cache must be droped.]==],
+["__text"] = [==[The image whose cache must be dropped.]==],
 ["__attributes"] = {
 ["is_self"] = true,
 ["reported_type"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]]=],
@@ -1769,7 +1769,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3353,7 +3353,7 @@ For more details of the member functions have a look at the cairo documentation 
 ["check_version"] = {
 ["__text"] = [==[Check that a module is compatible with the running version of darktable
 Add the following line at the top of your module : <code>darktable.configuration.check(...,{M,m,p},{M2,m2,p2})</code>To document that your module has been tested with API version M.m.p and M2.m2.p2.
-This will raise an error if the user is running a released version of DT and a warning if he is running a developement version
+This will raise an error if the user is running a released version of DT and a warning if he is running a development version
 (the ... here will automatically expand to your module name if used at the top of your script]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
@@ -3432,7 +3432,7 @@ Note that the directory, enum and file type preferences are stored internally as
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,
@@ -5344,7 +5344,7 @@ You can removes entries by setting them to nil]==],
 ["__text"] = [==[Lua functions can yield at any point. The parameters and return types depend on why we want to yield.
 A callback that is yielding allows other Lua code to run.
 
-* WAIT_MS: one extra parameter; the execution will pause for that many miliseconds; yield returns nothing;
+* WAIT_MS: one extra parameter; the execution will pause for that many milliseconds; yield returns nothing;
 * FILE_READABLE: an opened file from a call to the OS library; will return when the file is readable; returns nothing;
 * RUN_COMMAND: a command to be run by "sh -c"; will return when the command terminates; returns the return code of the execution.
 ]==],

--- a/tools/lua_doc/old_api/dt_api400.lua
+++ b/tools/lua_doc/old_api/dt_api400.lua
@@ -10,7 +10,7 @@ This documentation for API version 4.0.0.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -1769,7 +1769,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3457,7 +3457,7 @@ Note that the directory, enum, lua and file type preferences are stored internal
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,

--- a/tools/lua_doc/old_api/dt_api500.lua
+++ b/tools/lua_doc/old_api/dt_api500.lua
@@ -10,7 +10,7 @@ This documentation for API version 5.0.0.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -1791,7 +1791,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3481,7 +3481,7 @@ Note that the directory, enum, lua and file type preferences are stored internal
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,

--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -446,7 +446,7 @@ list_input_images() {
 		case "$image" in
 		*.[Jj][Pp][Gg]|*.[Jj][Pp][Ee][Gg])
 			# Skip jpeg files, if any. Other files don't
-			# have Exif and will be skept automatically.
+			# have Exif and will be skipped automatically.
 			continue
 			;;
 		esac

--- a/tools/parse_version_c.sh
+++ b/tools/parse_version_c.sh
@@ -4,7 +4,7 @@ set -e
 
 H_FILE="$1"
 
-# version.c exists => check if it containts the up-to-date version
+# version.c exists => check if it contains the up-to-date version
 if [ -f "$H_FILE" ]; then
   OLD_VERSION=$(tr '"' '\n' < "$H_FILE" | sed '8q;d')
   echo $OLD_VERSION


### PR DESCRIPTION
Many user-facing (incl. doxy) + many that are source code typos. Found using `codespell -q 3 --skip="*.po,./src/external" -I ../darktable-whitelist.txt`
where whitelist consisted of:
```
cas
childs
ect
eacg
isnt
liquify
nd
nonexistant
russian
substract
thru
```