### PR TITLE
User manual typos

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -125,7 +125,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>whether to use pinned memory transfer during tiling</shortdescription>
-    <longdescription>during tiling huge amounts of memory need to be transfered between host and device. for some OpenCL implementations direct memory transfers give a drastic performance penalty. this can often be avoided by using indirect transfers via pinned memory. other devices have more efficient direct memory transfer implementations. AMD seems to belong to the first group, nvidia to the second.</longdescription>
+    <longdescription>during tiling huge amounts of memory need to be transferred between host and device. for some OpenCL implementations direct memory transfers give a drastic performance penalty. this can often be avoided by using indirect transfers via pinned memory. other devices have more efficient direct memory transfer implementations. AMD seems to belong to the first group, nvidia to the second.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_use_cpu_devices</name>

--- a/data/latex/photobook.cls
+++ b/data/latex/photobook.cls
@@ -144,7 +144,7 @@
 % PDF/X-3 files contain extra operators that define the bleed and trim area.
 % - The MediaBox defines the size of the entire document
 % - The ArtBox or TrimBox defines the extent of the printable area.
-% - If the file is to be printed with bleed, a BleedBox must be defined. It must be larger than  the TrimBox/ArtBox, but smaller than the MediaBox.
+% - If the file is to be printed with bleed, a BleedBox must be defined. It must be larger than the TrimBox/ArtBox, but smaller than the MediaBox.
 \ifthenelse{\isundefined{\draftmode}}{
 \pdfpageattr{/MediaBox [0 0 792.0 612.0]
 /TrimBox [49.4645668785 18.0 742.535433 594.0]}

--- a/data/noiseprofiles.json
+++ b/data/noiseprofiles.json
@@ -4530,7 +4530,7 @@
           ]
         },
         {
-          "comment": "k-3 ii contributed by zoltan. iso 25600+ graphs don't match well, but this is the same for K-3 ans seems camera model specific",
+          "comment": "k-3 ii contributed by zoltan. iso 25600+ graphs don't match well, but this is the same for K-3 and seems camera model specific",
           "model": "K-3 II",
           "profiles": [
             {"name": "K-3 II iso 100", "iso": 100, "a": [9.06110231252642e-06, 3.57419098087832e-06, 6.86083198118061e-06], "b": [2.81774050978302e-09, 3.15994036501297e-09, 4.22317452653176e-09]},

--- a/doc/doxygen.conf
+++ b/doc/doxygen.conf
@@ -281,7 +281,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # causing a significant performance penality.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
-# a logarithmic scale so increasing the size by one will rougly double the
+# a logarithmic scale so increasing the size by one will roughly double the
 # memory usage. The cache size is given by this formula:
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
 # corresponding to a cache size of 2^16 = 65536 symbols

--- a/doc/usermanual/darkroom/concepts/parametric_masks.xml
+++ b/doc/usermanual/darkroom/concepts/parametric_masks.xml
@@ -102,7 +102,7 @@
         graycale values or in false colors, depending on the corresponding preference setting in
         <quote>GUI options</quote> (see <xref linkend="gui_options"/>). You may additionally
         hold down the <emphasis>ctrl</emphasis> key which lets you see the resulting mask
-        overlayed to the image. When leaving the slider the image goes back to normal after a
+        overlaid to the image. When leaving the slider the image goes back to normal after a
         short delay.
       </para>
 

--- a/doc/usermanual/darkroom/modules/basic/crop_and_rotate.xml
+++ b/doc/usermanual/darkroom/modules/basic/crop_and_rotate.xml
@@ -62,7 +62,7 @@
 
     <para>
       Whenever the user interface of this module is in focus, you will see the full uncropped
-      image overlayed with handles and guiding lines.
+      image overlaid with handles and guiding lines.
     </para>
 
     <para>

--- a/doc/usermanual/darkroom/modules/correction/ashift.xml
+++ b/doc/usermanual/darkroom/modules/correction/ashift.xml
@@ -135,7 +135,7 @@
 
     <para>
       Clicking one of the <quote>automatic fit</quote> icons (see below) starts an optimization
-      process which finds the best suited parameters. The image and the overlayed lines are then
+      process which finds the best suited parameters. The image and the overlaid lines are then
       displayed with perspective corrections applied.
     </para>
 

--- a/doc/usermanual/darkroom/panels/snapshots.xml
+++ b/doc/usermanual/darkroom/panels/snapshots.xml
@@ -25,7 +25,7 @@
           <entry>
             You can take snapshots of images as you process them. A snapshot is stored as a
             bitmap of the current center view and is kept as long as you stay in the darkroom. A
-            snapshot can then be selected and overlayed in the current center view to help you
+            snapshot can then be selected and overlaid in the current center view to help you
             with a side by side comparison (left: snapshot, right: active) when you are tuning
             parameters of a module. This can also be combined with history (see
             <xref linkend="history"/>) to compare the snapshot against different stages of

--- a/doc/usermanual/lighttable/panels/export.xml
+++ b/doc/usermanual/lighttable/panels/export.xml
@@ -398,7 +398,7 @@
                 <code>$(var/pattern/replacement)</code>
               </entry>
               <entry>
-                Replace the first occurence of <code>pattern</code> in <code>var</code> with
+                Replace the first occurrence of <code>pattern</code> in <code>var</code> with
                 <code>replacement</code>. If <code>replacement</code> is empty then
                 <code>pattern</code> will be removed.
               </entry>
@@ -408,7 +408,7 @@
                 <code>$(var//pattern/replacement)</code>
               </entry>
               <entry>
-                Replace all occurences of <code>pattern</code> in <code>var</code> with
+                Replace all occurrences of <code>pattern</code> in <code>var</code> with
                 <code>replacement</code>. If <code>replacement</code> is empty then
                 <code>pattern</code> will be removed.
               </entry>

--- a/doc/usermanual/lua/lua.xml
+++ b/doc/usermanual/lua/lua.xml
@@ -819,7 +819,7 @@ end
         <function>:memory:</function>
         parameter to
         <function>--library</function>
-        is usefull here if you don't want to work on your personal library.
+        is useful here if you don't want to work on your personal library.
       </para>
 
     </sect2>

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -31,7 +31,7 @@
 <synopsis>function( 
 	<emphasis><link linkend="darktable_print_message">message</link></emphasis> : string
 )</synopsis>
-<para>Will print a string to the darktable control log (the long overlayed window that appears over the main panel).</para>
+<para>Will print a string to the darktable control log (the long overlaid window that appears over the main panel).</para>
 
 <variablelist>
 <varlistentry id="darktable_print_message"><term>message</term><listitem>
@@ -661,7 +661,7 @@
 <synopsis>table</synopsis>
 <para>A table of <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link> on which the user expects UI actions to happen.</para>
 <para>It is based on both the hovered image and the selection and is consistent with the way darktable works.</para>
-<para>It is recommended to use this table to implement Lua actions rather than <link linkend="darktable_gui_hovered">darktable.gui.hovered</link> or <link linkend="darktable_gui_selection">darktable.gui.selection</link> to be consistant with darktable's GUI.</para>
+<para>It is recommended to use this table to implement Lua actions rather than <link linkend="darktable_gui_hovered">darktable.gui.hovered</link> or <link linkend="darktable_gui_selection">darktable.gui.selection</link> to be consistent with darktable's GUI.</para>
 
 </section>
 
@@ -2698,7 +2698,7 @@ end</programlisting></para>
 
 <varlistentry id="darktable_preferences_register_default"><term>[default]</term><listitem>
 <synopsis>depends on type</synopsis>
-<para>Default value to use when not set explicitely or by the user.</para>
+<para>Default value to use when not set explicitly or by the user.</para>
 <para>For the enum type of pref, this is mandatory</para>
 
 </listitem></varlistentry>

--- a/tools/diff_lua_api.lua
+++ b/tools/diff_lua_api.lua
@@ -9,7 +9,7 @@ Takes two mandatory and one optiona argument
   nodes : also dump the content of added nodes
 
 This script will compare the two API and report any differences it sees
-optionnaly printing details of the difference
+optionally printing details of the difference
 
 Use this to quickly assess what has changed between two versions of DT
 

--- a/tools/dngmeta.sh
+++ b/tools/dngmeta.sh
@@ -165,10 +165,10 @@ echo -e "\t</Camera>"
 echo ""
 
 if [[ $MAKE == Panasonic ]]; then
-  echo "NOTE: Panasonic RW2s are different dependant on aspect ratio, please run this tool on RW2 for each of the camera's ratios (4:3,3:2,16:9,1:1)"
+  echo "NOTE: Panasonic RW2s are different dependent on aspect ratio, please run this tool on RW2 for each of the camera's ratios (4:3,3:2,16:9,1:1)"
   echo ""
 elif [[ $MAKE == "NIKON CORPORATION" ]]; then
-  echo "NOTE: NIKON NEFs are different dependant on mode, please run this tool on NEF for each of the camera's mode (14-bit, 12-bit; compressed, uncompressed)"
+  echo "NOTE: NIKON NEFs are different dependent on mode, please run this tool on NEF for each of the camera's mode (14-bit, 12-bit; compressed, uncompressed)"
   echo ""
 elif [[ $MAKE == "Canon" ]]; then
   echo "NOTE: CANON CR2 have different black/white levels per ISO, please run this tool on CR2 for each of the camera's ISO (including all the sub-iso 1/2 and 1/3)"

--- a/tools/lua_doc/content.lua
+++ b/tools/lua_doc/content.lua
@@ -81,7 +81,7 @@ code([[darktable = require "darktable"]])..
 --  DARKTABLE       --
 ----------------------
 darktable:set_text([[The darktable library is the main entry point for all access to the darktable internals.]])
-darktable.print:set_text([[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]])
+darktable.print:set_text([[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]])
 darktable.print:add_parameter("message","string",[[The string to display which should be a single line.]])
 
 darktable.print_log:set_text([[This function will print its parameter if the Lua logdomain is activated. Start darktable with the "-d lua" command line option to enable the Lua logdomain.]])
@@ -189,7 +189,7 @@ darktable.gui:set_text([[This subtable contains function and data to manipulate 
 
 darktable.gui.action_images:set_text([[A table of ]]..my_tostring(types.dt_lua_image_t)..[[ on which the user expects UI actions to happen.]]..para()..
 [[It is based on both the hovered image and the selection and is consistent with the way darktable works.]]..para()..
-[[It is recommended to use this table to implement Lua actions rather than ]]..my_tostring(darktable.gui.hovered)..[[ or ]]..my_tostring(darktable.gui.selection)..[[ to be consistant with darktable's GUI.]])
+[[It is recommended to use this table to implement Lua actions rather than ]]..my_tostring(darktable.gui.hovered)..[[ or ]]..my_tostring(darktable.gui.selection)..[[ to be consistent with darktable's GUI.]])
 
 remove_all_children(darktable.gui.action_images)
 
@@ -290,7 +290,7 @@ darktable.preferences.register:add_parameter("name","string",[[A unique name use
 darktable.preferences.register:add_parameter("type",types.lua_pref_type,[[The type of the preference - one of the string values described above.]])
 darktable.preferences.register:add_parameter("label","string",[[The label displayed in the preference screen.]])
 darktable.preferences.register:add_parameter("tooltip","string",[[The tooltip to display in the preference menu.]])
-darktable.preferences.register:add_parameter("default","depends on type",[[Default value to use when not set explicitely or by the user.]]..para().."For the enum type of pref, this is mandatory"):set_attribute("optional",true)
+darktable.preferences.register:add_parameter("default","depends on type",[[Default value to use when not set explicitly or by the user.]]..para().."For the enum type of pref, this is mandatory"):set_attribute("optional",true)
 darktable.preferences.register:add_parameter("min","int or float",[[Minimum value (integer and float preferences only).]]):set_attribute("optional",true)
 darktable.preferences.register:add_parameter("max","int or float",[[Maximum value (integer and float preferences only).]]):set_attribute("optional",true)
 darktable.preferences.register:add_parameter("step","float",[[Step of the spinner (float preferences only).]]):set_attribute("optional",true)

--- a/tools/lua_doc/old_api/dt_api202.lua
+++ b/tools/lua_doc/old_api/dt_api202.lua
@@ -1,5 +1,5 @@
 API = {
-["__text"] = [[This documentation is for the *developement* version of darktable. for the stable version, please visit the user manual
+["__text"] = [[This documentation is for the *development* version of darktable. for the stable version, please visit the user manual
 To access the darktable specific functions you must load the darktable environment:<code>darktable = require "darktable"</code>All functions and data are accessed through the darktable module.
 This documentation for API version 2.0.2.]],
 ["__attributes"] = {
@@ -11,7 +11,7 @@ This documentation for API version 2.0.2.]],
 ["reported_type"] = [[documentation node]],
 },
 ["print"] = {
-["__text"] = [[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]],
+["__text"] = [[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]],
 ["__attributes"] = {
 ["reported_type"] = [[function]],
 ["signature"] = {
@@ -617,7 +617,7 @@ Note that the parameter order is not relevant.]],
 ["copy_image"] = {
 ["__text"] = [[Physically copies an image to another film.
 This will copy the image file and the related XMP to the directory of the new film
-If there is already a file with the same name as the image file, it wil create a duplicate from that file instead
+If there is already a file with the same name as the image file, it will create a duplicate from that file instead
 Note that the parameter order is not relevant.]],
 ["__attributes"] = {
 ["is_attribute"] = true,
@@ -958,7 +958,7 @@ Note that the parameter order is not relevant.]],
 ["yellow"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["purple"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["reset"] = {
-["__text"] = [[Removes all processing from the image, reseting it back to its original state]],
+["__text"] = [[Removes all processing from the image, resetting it back to its original state]],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -1082,7 +1082,7 @@ Darktable will regenerate the thumbnail by itself when it is needed]],
 ["reported_type"] = [[function]],
 ["signature"] = {
 ["1"] = {
-["__text"] = [[The image whose cache must be droped.]],
+["__text"] = [[The image whose cache must be dropped.]],
 ["__attributes"] = {
 ["is_self"] = true,
 ["reported_type"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]]=],
@@ -1376,7 +1376,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -2433,7 +2433,7 @@ The snapshot file will be generated at the next redraw of the main window]],
 ["check_version"] = {
 ["__text"] = [[Check that a module is compatible with the running version of darktable
 Add the following line at the top of your module : <code>darktable.configuration.check(...,{M,m,p},{M2,m2,p2})</code>To document that your module has been tested with API version M.m.p and M2.m2.p2.
-This will raise an error if the user is running a released version of DT and a warning if he is running a developement version
+This will raise an error if the user is running a released version of DT and a warning if he is running a development version
 (the ... here will automatically expand to your module name if used at the top of your script]],
 ["__attributes"] = {
 ["reported_type"] = [[function]],
@@ -2506,13 +2506,13 @@ Note that the directory, enum and file type preferences are stored internally as
 },
 },
 ["5"] = {
-["__text"] = [[The tooltip to display in the preference menue.]],
+["__text"] = [[The tooltip to display in the preference menu.]],
 ["__attributes"] = {
 ["reported_type"] = [[string]],
 },
 },
 ["6"] = {
-["__text"] = [[Default value to use when not set explicitely or by the user.
+["__text"] = [[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]],
 ["__attributes"] = {
 ["optional"] = true,
@@ -3442,7 +3442,7 @@ defaults to darktable.debug.known if not set]],
 ["__text"] = [[Lua functions can yield at any point. The parameters and return types depend on why we want to yield.
 A callback that is yielding allows other Lua code to run.
 
-* wait_ms: one extra parameter; the execution will pause for that many miliseconds; yield returns nothing;
+* wait_ms: one extra parameter; the execution will pause for that many milliseconds; yield returns nothing;
 * file_readable: an opened file from a call to the OS library; will return when the file is readable; returns nothing;
 * run_command: a command to be run by "sh -c"; will return when the command terminates; returns the return code of the execution.
 ]],

--- a/tools/lua_doc/old_api/dt_api210dev.lua
+++ b/tools/lua_doc/old_api/dt_api210dev.lua
@@ -10,7 +10,7 @@ This documentation for API version 2.1.0-dev.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -983,7 +983,7 @@ Note that the parameter order is not relevant.]==],
 ["yellow"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["purple"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["reset"] = {
-["__text"] = [==[Removes all processing from the image, reseting it back to its original state]==],
+["__text"] = [==[Removes all processing from the image, resetting it back to its original state]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -1107,7 +1107,7 @@ Darktable will regenerate the thumbnail by itself when it is needed]==],
 ["reported_type"] = [==[function]==],
 ["signature"] = {
 ["1"] = {
-["__text"] = [==[The image whose cache must be droped.]==],
+["__text"] = [==[The image whose cache must be dropped.]==],
 ["__attributes"] = {
 ["is_self"] = true,
 ["reported_type"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]]=],
@@ -1768,7 +1768,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3376,7 +3376,7 @@ For more details of the member functions have a look at the cairo documentation 
 ["check_version"] = {
 ["__text"] = [==[Check that a module is compatible with the running version of darktable
 Add the following line at the top of your module : <code>darktable.configuration.check(...,{M,m,p},{M2,m2,p2})</code>To document that your module has been tested with API version M.m.p and M2.m2.p2.
-This will raise an error if the user is running a released version of DT and a warning if he is running a developement version
+This will raise an error if the user is running a released version of DT and a warning if he is running a development version
 (the ... here will automatically expand to your module name if used at the top of your script]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
@@ -3455,7 +3455,7 @@ Note that the directory, enum and file type preferences are stored internally as
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,
@@ -5348,7 +5348,7 @@ You can removes entries by setting them to nil]==],
 ["__text"] = [==[Lua functions can yield at any point. The parameters and return types depend on why we want to yield.
 A callback that is yielding allows other Lua code to run.
 
-* WAIT_MS: one extra parameter; the execution will pause for that many miliseconds; yield returns nothing;
+* WAIT_MS: one extra parameter; the execution will pause for that many milliseconds; yield returns nothing;
 * FILE_READABLE: an opened file from a call to the OS library; will return when the file is readable; returns nothing;
 * RUN_COMMAND: a command to be run by "sh -c"; will return when the command terminates; returns the return code of the execution.
 ]==],

--- a/tools/lua_doc/old_api/dt_api300.lua
+++ b/tools/lua_doc/old_api/dt_api300.lua
@@ -1,5 +1,5 @@
 API = {
-["__text"] = [==[This documentation is for the *developement* version of darktable. for the stable version, please visit the user manual
+["__text"] = [==[This documentation is for the *development* version of darktable. for the stable version, please visit the user manual
 To access the darktable specific functions you must load the darktable environment:<code>darktable = require "darktable"</code>All functions and data are accessed through the darktable module.
 This documentation for API version 3.0.0.]==],
 ["__attributes"] = {
@@ -11,7 +11,7 @@ This documentation for API version 3.0.0.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -984,7 +984,7 @@ Note that the parameter order is not relevant.]==],
 ["yellow"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["purple"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]["red"]]=],
 ["reset"] = {
-["__text"] = [==[Removes all processing from the image, reseting it back to its original state]==],
+["__text"] = [==[Removes all processing from the image, resetting it back to its original state]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -1108,7 +1108,7 @@ darktable will regenerate the thumbnail by itself when it is needed]==],
 ["reported_type"] = [==[function]==],
 ["signature"] = {
 ["1"] = {
-["__text"] = [==[The image whose cache must be droped.]==],
+["__text"] = [==[The image whose cache must be dropped.]==],
 ["__attributes"] = {
 ["is_self"] = true,
 ["reported_type"] = {} --[=[API["darktable"]["register_storage"].__attributes["signature"]["3"].__attributes["signature"]["1"].__attributes["reported_type"]["supports_format"].__attributes["signature"]["2"].__attributes["reported_type"]["write_image"].__attributes["signature"]["2"].__attributes["reported_type"]]=],
@@ -1769,7 +1769,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3353,7 +3353,7 @@ For more details of the member functions have a look at the cairo documentation 
 ["check_version"] = {
 ["__text"] = [==[Check that a module is compatible with the running version of darktable
 Add the following line at the top of your module : <code>darktable.configuration.check(...,{M,m,p},{M2,m2,p2})</code>To document that your module has been tested with API version M.m.p and M2.m2.p2.
-This will raise an error if the user is running a released version of DT and a warning if he is running a developement version
+This will raise an error if the user is running a released version of DT and a warning if he is running a development version
 (the ... here will automatically expand to your module name if used at the top of your script]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
@@ -3432,7 +3432,7 @@ Note that the directory, enum and file type preferences are stored internally as
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,
@@ -5344,7 +5344,7 @@ You can removes entries by setting them to nil]==],
 ["__text"] = [==[Lua functions can yield at any point. The parameters and return types depend on why we want to yield.
 A callback that is yielding allows other Lua code to run.
 
-* WAIT_MS: one extra parameter; the execution will pause for that many miliseconds; yield returns nothing;
+* WAIT_MS: one extra parameter; the execution will pause for that many milliseconds; yield returns nothing;
 * FILE_READABLE: an opened file from a call to the OS library; will return when the file is readable; returns nothing;
 * RUN_COMMAND: a command to be run by "sh -c"; will return when the command terminates; returns the return code of the execution.
 ]==],

--- a/tools/lua_doc/old_api/dt_api400.lua
+++ b/tools/lua_doc/old_api/dt_api400.lua
@@ -10,7 +10,7 @@ This documentation for API version 4.0.0.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -1769,7 +1769,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3457,7 +3457,7 @@ Note that the directory, enum, lua and file type preferences are stored internal
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,

--- a/tools/lua_doc/old_api/dt_api500.lua
+++ b/tools/lua_doc/old_api/dt_api500.lua
@@ -10,7 +10,7 @@ This documentation for API version 5.0.0.]==],
 ["reported_type"] = [==[documentation node]==],
 },
 ["print"] = {
-["__text"] = [==[Will print a string to the darktable control log (the long overlayed window that appears over the main panel).]==],
+["__text"] = [==[Will print a string to the darktable control log (the long overlaid window that appears over the main panel).]==],
 ["__attributes"] = {
 ["reported_type"] = [==[function]==],
 ["signature"] = {
@@ -1791,7 +1791,7 @@ Most of these function won't do anything if the GUI is not enabled (i.e you are 
 ["action_images"] = {
 ["__text"] = [==[A table of types.dt_lua_image_t on which the user expects UI actions to happen.
 It is based on both the hovered image and the selection and is consistent with the way darktable works.
-It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistant with darktable's GUI.]==],
+It is recommended to use this table to implement Lua actions rather than darktable.gui.hovered or darktable.gui.selection to be consistent with darktable's GUI.]==],
 ["__attributes"] = {
 ["is_attribute"] = true,
 ["read"] = true,
@@ -3481,7 +3481,7 @@ Note that the directory, enum, lua and file type preferences are stored internal
 },
 },
 ["6"] = {
-["__text"] = [==[Default value to use when not set explicitely or by the user.
+["__text"] = [==[Default value to use when not set explicitly or by the user.
 For the enum type of pref, this is mandatory]==],
 ["__attributes"] = {
 ["optional"] = true,


### PR DESCRIPTION
Found using `codespell -q 3 --skip="*.po,./src/external" -I ../darktable-whitelist.txt`
where whitelist consisted of:
```
cas
childs
ect
eacg
isnt
liquify
nd
nonexistant
substract
thru
```
This PR is actually split up from #1576