### PR TITLE
Smarter "Collect images" filter

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -842,12 +842,18 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     break;
 
     case DT_COLLECTION_PROP_HISTORY: // history
-      query = dt_util_dstrcat(query, "(id %s IN (SELECT imgid FROM main.history WHERE imgid=images.id)) ",
+      if (!text || text[0] == '\0') // Optimize away the empty case
+        query = dt_util_dstrcat(query, "(1=1)");
+      else
+        query = dt_util_dstrcat(query, "(id %s IN (SELECT imgid FROM main.history WHERE imgid=images.id)) ",
                               (strcmp(escaped_text, _("altered")) == 0) ? "" : "not");
       break;
 
     case DT_COLLECTION_PROP_GEOTAGGING: // geotagging
-      query = dt_util_dstrcat(query, "(id %s IN (SELECT id AS imgid FROM main.images WHERE "
+      if (!text || text[0] == '\0') // Optimize away the empty case
+        query = dt_util_dstrcat(query, "(1=1)");
+      else
+        query = dt_util_dstrcat(query, "(id %s IN (SELECT id AS imgid FROM main.images WHERE "
                                      "(longitude IS NOT NULL AND latitude IS NOT NULL))) ",
                               (strcmp(escaped_text, _("tagged")) == 0) ? "" : "not");
       break;
@@ -887,7 +893,10 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       }
       break;
     case DT_COLLECTION_PROP_TAG: // tag
-      query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
+      if (!text || text[0] == '\0') // Optimize away the empty case
+        query = dt_util_dstrcat(query, "(1=1)");
+      else
+        query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
                                      "data.tags AS b ON a.tagid = b.id WHERE name LIKE '%1$s' OR name like '%1$s|%%'))",
                               escaped_text);
       break;

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -520,7 +520,7 @@ GList *dt_collection_get(const dt_collection_t *collection, int limit, gboolean 
 
 GList *dt_collection_get_all(const dt_collection_t *collection, int limit)
 {
-  return dt_collection_get(collection,limit,FALSE);
+  return dt_collection_get(collection, limit, FALSE);
 }
 
 int dt_collection_get_nth(const dt_collection_t *collection, int nth)
@@ -547,7 +547,7 @@ int dt_collection_get_nth(const dt_collection_t *collection, int nth)
 
 GList *dt_collection_get_selected(const dt_collection_t *collection, int limit)
 {
-  return dt_collection_get(collection,limit,TRUE);
+  return dt_collection_get(collection, limit, TRUE);
 }
 
 /* splits an input string into a number part and an optional operator part.

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -277,10 +277,11 @@ gchar *dt_collection_get_extended_where(const dt_collection_t *collection, int e
     char confname[200];
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", exclude);
     const int mode = dt_conf_get_int(confname);
-    if (mode != 1)
+    if (mode != 1) // don't limit the collection for OR
     {
-      for(int i = 0; collection->where_ext[i] != NULL; i++) {
-        // exclude rule from extended where
+      for(int i = 0; collection->where_ext[i] != NULL; i++)
+      {
+        // exclude the one rule from extended where
         if (i != exclude)
           complete_string = dt_util_dstrcat(complete_string, "%s", collection->where_ext[i]);
       }

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -142,7 +142,9 @@ void dt_collection_free(const dt_collection_t *collection);
 /** fetch params for collection for storing. */
 const dt_collection_params_t *dt_collection_params(const dt_collection_t *collection);
 /** get the filtered map between sanitized makermodel and exif maker/model **/
-void dt_collection_get_makermodel(const gchar *filter, GList **sanitized, GList **exif);
+void dt_collection_get_makermodels(const gchar *filter, GList **sanitized, GList **exif);
+/** get the sanitized makermodel for exif maker/model **/
+gchar *dt_collection_get_makermodel(const char *exif_maker, const char *exif_model);
 /** get the generated query for collection */
 const gchar *dt_collection_get_query(const dt_collection_t *collection);
 /** updates sql query for a collection. @return 1 if query changed. */

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -128,7 +128,7 @@ typedef struct dt_collection_t
 {
   int clone;
   gchar *query;
-  gchar *where_ext;
+  gchar **where_ext;
   unsigned int count;
   dt_collection_params_t params;
   dt_collection_params_t store;
@@ -151,8 +151,10 @@ const gchar *dt_collection_get_query(const dt_collection_t *collection);
 int dt_collection_update(const dt_collection_t *collection);
 /** reset collection to default dummy selection */
 void dt_collection_reset(const dt_collection_t *collection);
+/** gets an extended where part */
+gchar *dt_collection_get_extended_where(const dt_collection_t *collection, int exclude);
 /** sets an extended where part */
-void dt_collection_set_extended_where(const dt_collection_t *collection, gchar *extended_where);
+void dt_collection_set_extended_where(const dt_collection_t *collection, gchar **extended_where);
 
 /** get filter flags for collection */
 uint32_t dt_collection_get_filter_flags(const dt_collection_t *collection);

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -271,6 +271,16 @@ void dt_control_signal_disconnect(const struct dt_control_signal_t *ctlsig, GCal
                                        0, NULL, cb, user_data);
 }
 
+void dt_control_signal_block_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data)
+{
+  g_signal_handlers_block_by_func(G_OBJECT(ctlsig->sink), cb, user_data);
+}
+
+void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data)
+{
+  g_signal_handlers_unblock_by_func(G_OBJECT(ctlsig->sink), cb, user_data);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -173,6 +173,10 @@ void dt_control_signal_connect(const struct dt_control_signal_t *ctlsig, const d
                                GCallback cb, gpointer user_data);
 /* disconnects a callback from a sink */
 void dt_control_signal_disconnect(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data);
+/* blocks a callback */
+void dt_control_signal_block_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data);
+/* unblocks a callback */
+void dt_control_signal_unblock_by_func(const struct dt_control_signal_t *ctlsig, GCallback cb, gpointer user_data);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -857,21 +857,25 @@ gboolean tree_count_childsum (GtkTreeModel *model, GtkTreePath *path, GtkTreeIte
   return FALSE;
 }
 
-gboolean tree_count_show (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+void tree_count_show(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model, GtkTreeIter *iter,
+                     gpointer data)
 {
   gchar *name;
-  guint  count;
+  guint count;
 
-  gtk_tree_model_get (model, iter, DT_LIB_COLLECT_COL_TEXT, &name, DT_LIB_COLLECT_COL_COUNT, &count, -1);
-  if(!count) return FALSE;
-
-  gchar *coltext = g_strdup_printf("%s (%d)", name, count);
-  gtk_tree_store_set (GTK_TREE_STORE(model), iter, DT_LIB_COLLECT_COL_TEXT, coltext, -1);
+  gtk_tree_model_get(model, iter, DT_LIB_COLLECT_COL_TEXT, &name, DT_LIB_COLLECT_COL_COUNT, &count, -1);
+  if (!count)
+  {
+    g_object_set(renderer, "text", name, NULL);
+  }
+  else
+  {
+    gchar *coltext = g_strdup_printf("%s (%d)", name, count);
+    g_object_set(renderer, "text", coltext, NULL);
+    g_free(coltext);
+  }
 
   g_free(name);
-  g_free(coltext);
-
-  return FALSE;
 }
 
 static const char *UNCATEGORIZED_TAG = N_("uncategorized");
@@ -1067,7 +1071,6 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     g_list_free_full(sorted_names, free_tuple);
 
     if(folders || days || times)  gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc)tree_count_childsum, NULL);
-    gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc)tree_count_show, NULL);
 
     gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(d->view), DT_LIB_COLLECT_COL_TOOLTIP);
 
@@ -1840,7 +1843,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_append_column(view, col);
   GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
   gtk_tree_view_column_pack_start(col, renderer, TRUE);
-  gtk_tree_view_column_add_attribute(col, renderer, "text", DT_LIB_COLLECT_COL_TEXT);
+  gtk_tree_view_column_set_cell_data_func(col, renderer, tree_count_show, NULL, NULL);
   g_object_set(renderer, "strikethrough", TRUE, (gchar *)0);
   gtk_tree_view_column_add_attribute(col, renderer, "strikethrough-set", DT_LIB_COLLECT_COL_UNREACHABLE);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -446,6 +446,7 @@ static gboolean list_select(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   if(strcmp(haystack, needle) == 0)
   {
     gtk_tree_selection_select_path(gtk_tree_view_get_selection(d->view), path);
+    gtk_tree_view_scroll_to_cell(d->view, path, NULL, FALSE, 0.2, 0);
   }
 
   g_free(haystack);
@@ -502,6 +503,7 @@ static gboolean tree_expand(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter 
   {
     gtk_tree_view_expand_to_path(d->view, path);
     gtk_tree_selection_select_path(gtk_tree_view_get_selection(d->view), path);
+    gtk_tree_view_scroll_to_cell(d->view, path, NULL, FALSE, 0.2, 0);
   }
   else if(startwildcard && g_strrstr(haystack, needle+1) != NULL)
   {

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1467,13 +1467,7 @@ static void row_activated(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColum
   d->rule[active].typing = FALSE;
 
   const int item = gtk_combo_box_get_active(GTK_COMBO_BOX(d->rule[active].combo));
-  if(item == DT_COLLECTION_PROP_FILMROLL || // get full path for film rolls
-     item == DT_COLLECTION_PROP_TAG ||      // or tags
-     item == DT_COLLECTION_PROP_FOLDERS ||  // or folders
-     item == DT_COLLECTION_PROP_DAY)        // or days
-    gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
-  else
-    gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
+  gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
 
   g_signal_handlers_block_matched(d->rule[active].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_insert_text, NULL);
   g_signal_handlers_block_matched(d->rule[active].text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);
@@ -1520,14 +1514,7 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
       if(gtk_tree_model_get_iter_first(model, &iter))
       {
         gchar *text;
-        const int item = gtk_combo_box_get_active(GTK_COMBO_BOX(d->combo));
-        if(item == DT_COLLECTION_PROP_FILMROLL || // get full path for film rolls
-           item == DT_COLLECTION_PROP_TAG ||      // or tags
-           item == DT_COLLECTION_PROP_FOLDERS ||  // or folders
-           item == DT_COLLECTION_PROP_DAY)        // or days
-          gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
-        else
-          gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
+        gtk_tree_model_get(model, &iter, DT_LIB_COLLECT_COL_PATH, &text, -1);
 
         g_signal_handlers_block_matched(d->text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_insert_text, NULL);
         g_signal_handlers_block_matched(d->text, G_SIGNAL_MATCH_FUNC, 0, 0, NULL, entry_changed, NULL);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -109,6 +109,7 @@ static void entry_insert_text(GtkWidget *entry, gchar *new_text, gint new_length
                           dt_lib_collect_rule_t *d);
 static void entry_changed(GtkEntry *entry, dt_lib_collect_rule_t *dr);
 static void row_activated(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColumn *col, dt_lib_collect_t *d);
+static void collection_updated(gpointer instance, gpointer self);
 
 const char *name(dt_lib_module_t *self)
 {
@@ -1493,7 +1494,11 @@ static void row_activated(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColum
   else
     update_view(d->rule + active); // we have to update visible items too
 
+  dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
+                                  darktable.view_manager->proxy.module_collect.module);
   dt_collection_update_query(darktable.collection);
+  dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
+                                    darktable.view_manager->proxy.module_collect.module);
   dt_control_queue_redraw_center();
 }
 
@@ -1536,7 +1541,11 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
       }
     }
   }
+  dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated),
+                                  darktable.view_manager->proxy.module_collect.module);
   dt_collection_update_query(darktable.collection);
+  dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated),
+                                    darktable.view_manager->proxy.module_collect.module);
 }
 
 static void entry_insert_text(GtkWidget *entry, gchar *new_text, gint new_length, gpointer *position,

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1619,6 +1619,12 @@ static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d
 
 static void collection_updated(gpointer instance, gpointer self)
 {
+  dt_lib_module_t *dm = (dt_lib_module_t *)self;
+  dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
+
+  // update tree
+  d->view_rule = -1;
+  d->rule[d->active_rule].typing = FALSE;
   _lib_collect_gui_update(self);
 }
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1170,14 +1170,12 @@ static void list_view(dt_lib_collect_rule_t *dr)
         break;
 
       case DT_COLLECTION_PROP_LOCAL_COPY: // local copy, 2 hardcoded alternatives
-        gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-        gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, _("copied locally"),
-                           DT_LIB_COLLECT_COL_ID, 0, DT_LIB_COLLECT_COL_TOOLTIP, _("copied locally"),
-                           DT_LIB_COLLECT_COL_VISIBLE, TRUE, DT_LIB_COLLECT_COL_PATH, _("copied locally"), -1);
-        gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-        gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, _("not copied locally"),
-                           DT_LIB_COLLECT_COL_ID, 1, DT_LIB_COLLECT_COL_TOOLTIP, _("not copied locally"),
-                           DT_LIB_COLLECT_COL_VISIBLE, TRUE, DT_LIB_COLLECT_COL_PATH, _("not copied locally"), -1);
+        g_snprintf(query, sizeof(query), "SELECT CASE "
+                           "WHEN (flags & %d) THEN '%s' ELSE '%s' END as lcp, 1, "
+                           "COUNT(*) AS count "
+                           "FROM main.images "
+                           "WHERE %s GROUP BY lcp ORDER BY lcp ASC",
+                   DT_IMAGE_LOCAL_COPY, _("copied locally"),  _("not copied locally"), where_ext);
         break;
 
       case DT_COLLECTION_PROP_COLORLABEL: // colorlabels

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1416,6 +1416,7 @@ void gui_reset(dt_lib_module_t *self)
   dt_conf_set_string("plugins/lighttable/collect/string0", "");
   dt_lib_collect_t *d = (dt_lib_collect_t *)self->data;
   d->active_rule = 0;
+  d->view_rule = -1;
   dt_collection_set_query_flags(darktable.collection, COLLECTION_QUERY_FULL);
   dt_collection_update_query(darktable.collection);
 }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -877,10 +877,10 @@ static void tree_view(dt_lib_collect_rule_t *dr)
   // update related list
   dt_lib_collect_t *d = get_collect(dr);
   int property = gtk_combo_box_get_active(dr->combo);
-  gboolean folders = (property == DT_COLLECTION_PROP_FOLDERS);
-  gboolean tags = (property == DT_COLLECTION_PROP_TAG);
-  gboolean days = (property == DT_COLLECTION_PROP_DAY);
-  gboolean times = (property == DT_COLLECTION_PROP_TIME);
+  const gboolean folders = (property == DT_COLLECTION_PROP_FOLDERS);
+  const gboolean tags = (property == DT_COLLECTION_PROP_TAG);
+  const gboolean days = (property == DT_COLLECTION_PROP_DAY);
+  const gboolean times = (property == DT_COLLECTION_PROP_TIME);
   const char *format_separator = folders ? "%s" G_DIR_SEPARATOR_S :
   days || times ? "%s:" : "%s|";
   int insert_position = tags ? 0 : -1;
@@ -935,7 +935,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       char *name_folded = g_utf8_casefold(name, -1);
       gchar *collate_key = NULL;
 
-      int count = sqlite3_column_int(stmt, 2);
+      const int count = sqlite3_column_int(stmt, 2);
 
       if(folders)
       {
@@ -966,7 +966,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     {
       name_key_tuple_t *tuple = (name_key_tuple_t *)names->data;
       char *name = tuple->name;
-      int count = tuple->count;
+      const int count = tuple->count;
       if(name == NULL) continue; // safeguard against degenerated db entries
 
       if(tags && strchr(name, '|') == 0 && (last_tokens_length == 0 || strcmp(name, *last_tokens)))
@@ -1128,7 +1128,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
         {
           char *exif_maker = (char *)sqlite3_column_text(stmt, 0);
           char *exif_model = (char *)sqlite3_column_text(stmt, 1);
-          int count = sqlite3_column_int(stmt, 2);
+          const int count = sqlite3_column_int(stmt, 2);
 
           gchar *makermodel =  dt_collection_get_makermodel(exif_maker, exif_model);
 
@@ -1276,7 +1276,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
           folder = dt_image_film_roll_name(folder);
         }
         gchar *value = (gchar *)sqlite3_column_text(stmt, 0);
-        int count = sqlite3_column_int(stmt, 2);
+        const int count = sqlite3_column_int(stmt, 2);
 
         // replace invalid utf8 characters if any
         gchar *text = g_strdup(value);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1242,13 +1242,6 @@ static void list_view(dt_lib_collect_rule_t *dr)
                 "FROM main.images WHERE %s GROUP BY filename ORDER BY filename", darktable.collection->where_ext);
         break;
 
-//      case DT_COLLECTION_PROP_DAY:
-//        g_snprintf(query, sizeof(query),
-//                  "SELECT SUBSTR(datetime_taken, 1, 10), 1, COUNT(*) AS count "
-//                          "FROM main.images WHERE %s GROUP BY SUBSTR(datetime_taken, 1, 10) "
-//                          "ORDER BY datetime_taken DESC",
-//                   darktable.collection->where_ext);
-//        break;
 
       case DT_COLLECTION_PROP_TIME:
         g_snprintf(query, sizeof(query), "SELECT datetime_taken, 1, COUNT(*) AS count "

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1576,7 +1576,7 @@ static void entry_focus_in_callback(GtkWidget *w, GdkEventFocus *event, dt_lib_c
   }
 }
 
-static void menuitem_and(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
+static void menuitem_mode(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
 {
   // add next row with and operator
   const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules");
@@ -1585,7 +1585,15 @@ static void menuitem_and(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   {
     char confname[200] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", active);
-    dt_conf_set_int(confname, DT_LIB_COLLECT_MODE_AND);
+    dt_lib_collect_mode_t mode = 0;
+    const gchar *label = gtk_menu_item_get_label (menuitem);
+    if(strcmp(label, _("narrow down search")) == 0)
+      mode = DT_LIB_COLLECT_MODE_AND;
+    else if(strcmp(label, _("add more images")) == 0)
+      mode = DT_LIB_COLLECT_MODE_OR;
+    else if(strcmp(label, _("exclude images")) == 0)
+      mode = DT_LIB_COLLECT_MODE_AND_NOT;
+    dt_conf_set_int(confname, mode);
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", active);
     dt_conf_set_string(confname, "");
     dt_conf_set_int("plugins/lighttable/collect/num_rules", active + 1);
@@ -1596,47 +1604,7 @@ static void menuitem_and(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   dt_collection_update_query(darktable.collection);
 }
 
-static void menuitem_or(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
-{
-  // add next row with or operator
-  const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules");
-  const int active = CLAMP(_a, 1, MAX_RULES);
-  if(active < MAX_RULES)
-  {
-    char confname[200] = { 0 };
-    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", active);
-    dt_conf_set_int(confname, DT_LIB_COLLECT_MODE_OR);
-    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", active);
-    dt_conf_set_string(confname, "");
-    dt_conf_set_int("plugins/lighttable/collect/num_rules", active + 1);
-    dt_lib_collect_t *c = get_collect(d);
-    c->active_rule = active;
-    c->view_rule = -1;
-  }
-  dt_collection_update_query(darktable.collection);
-}
-
-static void menuitem_and_not(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
-{
-  // add next row with and not operator
-  const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules");
-  const int active = CLAMP(_a, 1, MAX_RULES);
-  if(active < MAX_RULES)
-  {
-    char confname[200] = { 0 };
-    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", active);
-    dt_conf_set_int(confname, DT_LIB_COLLECT_MODE_AND_NOT);
-    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", active);
-    dt_conf_set_string(confname, "");
-    dt_conf_set_int("plugins/lighttable/collect/num_rules", active + 1);
-    dt_lib_collect_t *c = get_collect(d);
-    c->active_rule = active;
-    c->view_rule = -1;
-  }
-  dt_collection_update_query(darktable.collection);
-}
-
-static void menuitem_change_and(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
+static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
 {
   // add next row with and operator
   const int num = d->num + 1;
@@ -1644,37 +1612,15 @@ static void menuitem_change_and(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   {
     char confname[200] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", num);
-    dt_conf_set_int(confname, DT_LIB_COLLECT_MODE_AND);
-  }
-  dt_lib_collect_t *c = get_collect(d);
-  c->view_rule = -1;
-  dt_collection_update_query(darktable.collection);
-}
-
-static void menuitem_change_or(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
-{
-  // add next row with or operator
-  const int num = d->num + 1;
-  if(num < MAX_RULES && num > 0)
-  {
-    char confname[200] = { 0 };
-    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", num);
-    dt_conf_set_int(confname, DT_LIB_COLLECT_MODE_OR);
-  }
-  dt_lib_collect_t *c = get_collect(d);
-  c->view_rule = -1;
-  dt_collection_update_query(darktable.collection);
-}
-
-static void menuitem_change_and_not(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
-{
-  // add next row with and not operator
-  const int num = d->num + 1;
-  if(num < MAX_RULES && num > 0)
-  {
-    char confname[200] = { 0 };
-    snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", num);
-    dt_conf_set_int(confname, DT_LIB_COLLECT_MODE_AND_NOT);
+    dt_lib_collect_mode_t mode = 0;
+    const gchar *label = gtk_menu_item_get_label (menuitem);
+    if(strcmp(label, _("change to: and")) == 0)
+      mode = DT_LIB_COLLECT_MODE_AND;
+    else if(strcmp(label, _("change to: or")) == 0)
+      mode = DT_LIB_COLLECT_MODE_OR;
+    else if(strcmp(label, _("change to: except")) == 0)
+      mode = DT_LIB_COLLECT_MODE_AND_NOT;
+    dt_conf_set_int(confname, mode);
   }
   dt_lib_collect_t *c = get_collect(d);
   c->view_rule = -1;
@@ -1793,29 +1739,29 @@ static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, 
   {
     mi = gtk_menu_item_new_with_label(_("narrow down search"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_and), d);
+    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("add more images"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_or), d);
+    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("exclude images"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_and_not), d);
+    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
   }
   else if(d->num < active - 1)
   {
     mi = gtk_menu_item_new_with_label(_("change to: and"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_change_and), d);
+    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: or"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_change_or), d);
+    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: except"));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
-    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_change_and_not), d);
+    g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
   }
 
   gtk_widget_show_all(GTK_WIDGET(menu));

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -59,6 +59,7 @@ typedef struct dt_lib_collect_t
 
   GtkTreeView *view;
   int view_rule;
+  gboolean skipnextupdate;
 
   GtkTreeModel *treefilter;
   GtkTreeModel *listfilter;
@@ -1497,6 +1498,7 @@ static void row_activated(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColum
   else
     update_view(d->rule + active); // we have to update visible items too
 
+  d->skipnextupdate = TRUE;
   dt_collection_update_query(darktable.collection);
   dt_control_queue_redraw_center();
 }
@@ -1540,6 +1542,7 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
       }
     }
   }
+  c->skipnextupdate = TRUE;
   dt_collection_update_query(darktable.collection);
 }
 
@@ -1626,6 +1629,11 @@ static void collection_updated(gpointer instance, gpointer self)
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
 
   // update tree
+  if (d->skipnextupdate)
+  {
+    d->skipnextupdate = FALSE;
+    return;
+  }
   d->view_rule = -1;
   d->rule[d->active_rule].typing = FALSE;
   _lib_collect_gui_update(self);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1579,14 +1579,7 @@ static void menuitem_mode(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d)
   {
     char confname[200] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", active);
-    dt_lib_collect_mode_t mode = 0;
-    const gchar *label = gtk_menu_item_get_label (menuitem);
-    if(strcmp(label, _("narrow down search")) == 0)
-      mode = DT_LIB_COLLECT_MODE_AND;
-    else if(strcmp(label, _("add more images")) == 0)
-      mode = DT_LIB_COLLECT_MODE_OR;
-    else if(strcmp(label, _("exclude images")) == 0)
-      mode = DT_LIB_COLLECT_MODE_AND_NOT;
+    const dt_lib_collect_mode_t mode = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "menuitem_mode"));
     dt_conf_set_int(confname, mode);
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/string%1d", active);
     dt_conf_set_string(confname, "");
@@ -1606,14 +1599,7 @@ static void menuitem_mode_change(GtkMenuItem *menuitem, dt_lib_collect_rule_t *d
   {
     char confname[200] = { 0 };
     snprintf(confname, sizeof(confname), "plugins/lighttable/collect/mode%1d", num);
-    dt_lib_collect_mode_t mode = 0;
-    const gchar *label = gtk_menu_item_get_label (menuitem);
-    if(strcmp(label, _("change to: and")) == 0)
-      mode = DT_LIB_COLLECT_MODE_AND;
-    else if(strcmp(label, _("change to: or")) == 0)
-      mode = DT_LIB_COLLECT_MODE_OR;
-    else if(strcmp(label, _("change to: except")) == 0)
-      mode = DT_LIB_COLLECT_MODE_AND_NOT;
+    const dt_lib_collect_mode_t mode = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(menuitem), "menuitem_mode"));
     dt_conf_set_int(confname, mode);
   }
   dt_lib_collect_t *c = get_collect(d);
@@ -1743,28 +1729,34 @@ static gboolean popup_button_callback(GtkWidget *widget, GdkEventButton *event, 
   if(d->num == active - 1)
   {
     mi = gtk_menu_item_new_with_label(_("narrow down search"));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("add more images"));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
 
     mi = gtk_menu_item_new_with_label(_("exclude images"));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode), d);
   }
   else if(d->num < active - 1)
   {
     mi = gtk_menu_item_new_with_label(_("change to: and"));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: or"));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_OR));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
 
     mi = gtk_menu_item_new_with_label(_("change to: except"));
+    g_object_set_data(G_OBJECT(mi), "menuitem_mode", GINT_TO_POINTER(DT_LIB_COLLECT_MODE_AND_NOT));
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
     g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_mode_change), d);
   }

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1312,13 +1312,14 @@ static void list_view(dt_lib_collect_rule_t *dr)
   }
 
   // if needed, we restrict the tree to matching entries
-  if(property == DT_COLLECTION_PROP_CAMERA || property == DT_COLLECTION_PROP_CREATOR
+  if (dr->typing
+     &&(property == DT_COLLECTION_PROP_CAMERA || property == DT_COLLECTION_PROP_CREATOR
      || property == DT_COLLECTION_PROP_DAY || property == DT_COLLECTION_PROP_DESCRIPTION
      || property == DT_COLLECTION_PROP_FILENAME || property == DT_COLLECTION_PROP_FILMROLL
      || property == DT_COLLECTION_PROP_LENS || property == DT_COLLECTION_PROP_PUBLISHER
      || property == DT_COLLECTION_PROP_RIGHTS || property == DT_COLLECTION_PROP_TIME
      || property == DT_COLLECTION_PROP_TITLE || property == DT_COLLECTION_PROP_APERTURE
-     || property == DT_COLLECTION_PROP_FOCAL_LENGTH || property == DT_COLLECTION_PROP_ISO)
+     || property == DT_COLLECTION_PROP_FOCAL_LENGTH || property == DT_COLLECTION_PROP_ISO))
     gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc)list_match_string, dr);
   // we update list selection
   gtk_tree_selection_unselect_all(gtk_tree_view_get_selection(d->view));

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -59,7 +59,6 @@ typedef struct dt_lib_collect_t
 
   GtkTreeView *view;
   int view_rule;
-  gboolean skipnextupdate;
 
   GtkTreeModel *treefilter;
   GtkTreeModel *listfilter;
@@ -1494,7 +1493,6 @@ static void row_activated(GtkTreeView *view, GtkTreePath *path, GtkTreeViewColum
   else
     update_view(d->rule + active); // we have to update visible items too
 
-  d->skipnextupdate = TRUE;
   dt_collection_update_query(darktable.collection);
   dt_control_queue_redraw_center();
 }
@@ -1538,7 +1536,6 @@ static void entry_activated(GtkWidget *entry, dt_lib_collect_rule_t *d)
       }
     }
   }
-  c->skipnextupdate = TRUE;
   dt_collection_update_query(darktable.collection);
 }
 
@@ -1611,11 +1608,6 @@ static void collection_updated(gpointer instance, gpointer self)
   dt_lib_collect_t *d = (dt_lib_collect_t *)dm->data;
 
   // update tree
-  if (d->skipnextupdate)
-  {
-    d->skipnextupdate = FALSE;
-    return;
-  }
   d->view_rule = -1;
   d->rule[d->active_rule].typing = FALSE;
   _lib_collect_gui_update(self);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1136,19 +1136,16 @@ static void list_view(dt_lib_collect_rule_t *dr)
           char *exif_model = (char *)sqlite3_column_text(stmt, 1);
           const int count = sqlite3_column_int(stmt, 2);
 
-          gchar *makermodel =  dt_collection_get_makermodel(exif_maker, exif_model);
-
-          gchar *coltext = g_strdup_printf("%s (%d)", makermodel, count);
+          gchar *value =  dt_collection_get_makermodel(exif_maker, exif_model);
 
           gtk_list_store_append(GTK_LIST_STORE(model), &iter);
-          gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, coltext,
-                             DT_LIB_COLLECT_COL_ID, index, DT_LIB_COLLECT_COL_TOOLTIP, makermodel,
-                             DT_LIB_COLLECT_COL_PATH, makermodel, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
+          gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, value,
+                             DT_LIB_COLLECT_COL_ID, index, DT_LIB_COLLECT_COL_TOOLTIP, value,
+                             DT_LIB_COLLECT_COL_PATH, value, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
                              DT_LIB_COLLECT_COL_COUNT, count,
                              -1);
 
-          g_free(makermodel);
-          g_free(coltext);
+          g_free(value);
           index++;
         }
         g_free(makermodel_query);
@@ -1284,18 +1281,16 @@ static void list_view(dt_lib_collect_rule_t *dr)
 
         // replace invalid utf8 characters if any
         gchar *text = g_strdup(value);
-        gchar *coltext = g_strdup_printf("%s (%d)", folder, count);
         gchar *ptr = text;
         while(!g_utf8_validate(ptr, -1, (const gchar **)&ptr)) ptr[0] = '?';
 
         gchar *escaped_text = g_markup_escape_text(text, -1);
 
-        gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, coltext,
+        gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_COLLECT_COL_TEXT, folder,
                            DT_LIB_COLLECT_COL_ID, sqlite3_column_int(stmt, 1), DT_LIB_COLLECT_COL_TOOLTIP,
                            escaped_text, DT_LIB_COLLECT_COL_PATH, value, DT_LIB_COLLECT_COL_VISIBLE, TRUE,
                            DT_LIB_COLLECT_COL_COUNT, count,
                            -1);
-        g_free(coltext);
         g_free(text);
         g_free(escaped_text);
       }


### PR DESCRIPTION
Here are some changes to the collect images panel
- collect options depend on other rules
- show image count for the option
- hierarchical dates
- selecting "AND NOT" does not clear collection until something is selected
But since I don't have a large collection, I don't know whether it will be fast enough, as multiple tables are joined.