### PR TITLE
Global zoom accelerators & keyboard navigation for zoomed photos in darkroom view

### DIFF
--- a/doc/usermanual/preferences/keymappings.xml
+++ b/doc/usermanual/preferences/keymappings.xml
@@ -104,7 +104,7 @@
           global/zoom in
         </entry>
         <entry>
-        &lt;Primary&gt;KP_Add
+        &lt;Primary&gt;KP_plus
         </entry>
       </row>
       <row>
@@ -112,7 +112,7 @@
           global/zoom out
         </entry>
         <entry>
-        &lt;Primary&gt;KP_Subtract
+        &lt;Primary&gt;KP_minus
         </entry>
       </row>
       <row>

--- a/doc/usermanual/preferences/keymappings.xml
+++ b/doc/usermanual/preferences/keymappings.xml
@@ -101,6 +101,22 @@
       </row>
       <row>
         <entry>
+          global/zoom in
+        </entry>
+        <entry>
+        &lt;Primary&gt;KP_Add
+        </entry>
+      </row>
+      <row>
+        <entry>
+          global/zoom out
+        </entry>
+        <entry>
+        &lt;Primary&gt;KP_Subtract
+        </entry>
+      </row>
+      <row>
+        <entry>
           image operations/clipping/commit
         </entry>
         <entry>

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -102,10 +102,10 @@ int dt_control_is_key_accelerators_on(struct dt_control_t *s);
 // All the accelerator keys for the key_pressed style shortcuts
 typedef struct dt_control_accels_t
 {
-  GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right,
-      lighttable_left, lighttable_center, lighttable_preview, lighttable_preview_display_focus,
-      lighttable_preview_sticky, lighttable_preview_sticky_focus, lighttable_preview_sticky_exit,
-      global_sideborders, global_header, darkroom_preview, slideshow_start;
+  GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right, lighttable_left,
+      lighttable_center, lighttable_preview, lighttable_preview_display_focus, lighttable_preview_sticky,
+      lighttable_preview_sticky_focus, lighttable_preview_sticky_exit, global_sideborders, global_header,
+      darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out;
 
 } dt_control_accels_t;
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -168,6 +168,12 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
 
   dt_accel_path_global(path, sizeof(path), "toggle header");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_header);
+
+  dt_accel_path_global(path, sizeof(path), "zoom in");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_zoom_in);
+
+  dt_accel_path_global(path, sizeof(path), "zoom out");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_zoom_out);
 }
 
 static gboolean fullscreen_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
@@ -1091,6 +1097,10 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   dt_accel_connect_global("switch view",
                           g_cclosure_new(G_CALLBACK(view_switch_key_accel_callback), NULL, NULL));
+
+  // Global zoom in & zoom out
+  dt_accel_register_global(NC_("accel", "zoom in"), GDK_KEY_KP_Add, GDK_CONTROL_MASK);
+  dt_accel_register_global(NC_("accel", "zoom out"), GDK_KEY_KP_Subtract, GDK_CONTROL_MASK);
 
   darktable.gui->reset = 0;
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1099,8 +1099,8 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
                           g_cclosure_new(G_CALLBACK(view_switch_key_accel_callback), NULL, NULL));
 
   // Global zoom in & zoom out
-  dt_accel_register_global(NC_("accel", "zoom in"), GDK_KEY_KP_Add, GDK_CONTROL_MASK);
-  dt_accel_register_global(NC_("accel", "zoom out"), GDK_KEY_KP_Subtract, GDK_CONTROL_MASK);
+  dt_accel_register_global(NC_("accel", "zoom in"), GDK_KEY_plus, GDK_CONTROL_MASK);
+  dt_accel_register_global(NC_("accel", "zoom out"), GDK_KEY_minus, GDK_CONTROL_MASK);
 
   darktable.gui->reset = 0;
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2234,7 +2234,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   {
     dt_develop_t *dev = (dt_develop_t *)self->data;
 
-    scrolled(self, dev->width / 2, dev->height / 2, 1, 0);
+    scrolled(self, dev->width / 2, dev->height / 2, 1, state);
     return 1;
   }
 
@@ -2242,7 +2242,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   {
     dt_develop_t *dev = (dt_develop_t *)self->data;
 
-    scrolled(self, dev->width / 2, dev->height / 2, 0, 0);
+    scrolled(self, dev->width / 2, dev->height / 2, 0, state);
     return 1;
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2229,6 +2229,54 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     else
       return 0;
   }
+
+  if(key == accels->global_zoom_in.accel_key && state == accels->global_zoom_in.accel_mods)
+  {
+    dt_develop_t *dev = (dt_develop_t *)self->data;
+
+    scrolled(self, dev->width / 2, dev->height / 2, 1, 0);
+    return 1;
+  }
+
+  if(key == accels->global_zoom_out.accel_key && state == accels->global_zoom_out.accel_mods)
+  {
+    dt_develop_t *dev = (dt_develop_t *)self->data;
+
+    scrolled(self, dev->width / 2, dev->height / 2, 0, 0);
+    return 1;
+  }
+
+  if(key == GDK_KEY_Left || key == GDK_KEY_Right || key == GDK_KEY_Up || key == GDK_KEY_Down)
+  {
+    dt_develop_t *dev = (dt_develop_t *)self->data;
+    dt_dev_zoom_t zoom;
+
+    zoom = dt_control_get_dev_zoom();
+
+    const int closeup = dt_control_get_dev_closeup();
+    float old_zoom_x, old_zoom_y;
+
+    old_zoom_x = dt_control_get_dev_zoom_x();
+    old_zoom_y = dt_control_get_dev_zoom_y();
+
+    float zx = old_zoom_x;
+    float zy = old_zoom_y;
+
+    if(key == GDK_KEY_Left) zx = zx - 0.1f;
+    if(key == GDK_KEY_Right) zx = zx + 0.1f;
+    if(key == GDK_KEY_Up) zy = zy - 0.1f;
+    if(key == GDK_KEY_Down) zy = zy + 0.1f;
+
+    dt_dev_check_zoom_bounds(dev, &zx, &zy, zoom, closeup, NULL, NULL);
+    dt_control_set_dev_zoom_x(zx);
+    dt_control_set_dev_zoom_y(zy);
+
+    dt_dev_invalidate(dev);
+    dt_control_queue_redraw();
+
+    return 1;
+  }
+
   return 1;
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2261,10 +2261,10 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     // For each cursor press, move one screen by default
     float step_changex = dev->width / (procw * scale);
     float step_changey = dev->height / (proch * scale);
-    float factor = 1;
+    float factor = 0.2f;
 
-    if((state & modifiers) == GDK_MOD1_MASK) factor = 0.1f;
-    if((state & modifiers) == GDK_CONTROL_MASK) factor = 10.0f;
+    if((state & modifiers) == GDK_MOD1_MASK) factor = 0.02f;
+    if((state & modifiers) == GDK_CONTROL_MASK) factor = 1.0f;
 
     float old_zoom_x, old_zoom_y;
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2197,6 +2197,25 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     lib->center = 1;
     return 1;
   }
+
+  if(key == accels->global_zoom_in.accel_key && state == accels->global_zoom_in.accel_mods)
+  {
+    zoom--;
+    if(zoom < 1) zoom = 1;
+
+    dt_view_lighttable_set_zoom(darktable.view_manager, zoom);
+    return 1;
+  }
+
+  if(key == accels->global_zoom_out.accel_key && state == accels->global_zoom_out.accel_mods)
+  {
+    zoom++;
+    if(zoom > 2 * DT_LIBRARY_MAX_ZOOM) zoom = 2 * DT_LIBRARY_MAX_ZOOM;
+
+    dt_view_lighttable_set_zoom(darktable.view_manager, zoom);
+    return 1;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
This PR is about two changes:
1. Adding global zoom keyboard accelerators with default values CTRL++ (zoom in) and CTRL+- (zoom out). These work currently parallel to the existing seprate lighttable entries (`modules->lighttable->zoom in` and `modules->lighttable->zoom out`) and somewhat similar darkroom entries (`views->darkroom->zoom close-up` etc), however I believe it would be good to settle to one global zoom in and zoom out accelerator on a longer run.

    So these keyboard accelerators can be used to zoom in/out when using lighttable view, but also works when using darkroom view as well to zoom in and out the image.

    This is related to feature #8850 and feautre #11031

2. Adding keyboard navigation when you are using a zoomed in darkroom view.
Using cursor keys you can move the zoomed in image, without using your mouse. I was thinking to add these as well as configurable accelerators, but first check what is the public opinion first on the usability of such features.

    This is related to feature #11500