### PR TITLE
Set the sqlite threading mode to serialized

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1555,6 +1555,9 @@ start:
     return db;
   }
 
+  /*  set the threading mode to Serialized */
+  sqlite3_config(SQLITE_CONFIG_SERIALIZED);
+
   /* opening / creating database */
   if(sqlite3_open(db->dbfilename_library, &db->handle))
   {


### PR DESCRIPTION
This should be the default when SQLite is compiled with SQLITE_THREADSAFE=1 (default)

But on my mac sqlite3 is compiled with THREADSAFE=2 (according to `echo 'PRAGMA compile_options;' | sqlite3`) and I get frequent crashes (EXC_BAD_ACCESS).