### PR TITLE
darktable.desktop is not needed on Windows platform

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -46,6 +46,7 @@ endif(USE_LUA)
 #
 # Install (and generate when necessary) other system shares
 #
+if(NOT WIN32)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/darktable.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/darktable.desktop.in)
 file(GLOB PO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../po/*.po")
 add_custom_command(
@@ -67,6 +68,7 @@ if(${VALIDATE_DESKTOP_FILE})
   add_dependencies(darktable.desktop_file validate_darktable_desktop)
 endif()
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/darktable.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications COMPONENT DTApplication)
+endif(NOT WIN32)
 
 if(${VALIDATE_APPDATA_FILE})
   add_custom_command(


### PR DESCRIPTION
If a user had an installed `mingw-w64-x86_64-desktop-file-utils` package it caused the build to stop as the generated .desktop file contained CRLFs, not just LFs - so I believe it's easier to remove that from the install from the Windows builds.