### PR TITLE
fix custom shortcuts with <Shift> modifier

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -809,12 +809,12 @@ static gboolean key_pressed_override(GtkWidget *w, GdkEventKey *event, gpointer 
 
 static gboolean key_pressed(GtkWidget *w, GdkEventKey *event, gpointer user_data)
 {
-  return dt_control_key_pressed(event->keyval, event->state & KEY_STATE_MASK);
+  return dt_control_key_pressed(gdk_keyval_to_lower(event->keyval), event->state & KEY_STATE_MASK);
 }
 
 static gboolean key_released(GtkWidget *w, GdkEventKey *event, gpointer user_data)
 {
-  return dt_control_key_released(event->keyval, event->state & KEY_STATE_MASK);
+  return dt_control_key_released(gdk_keyval_to_lower(event->keyval), event->state & KEY_STATE_MASK);
 }
 
 static gboolean button_pressed(GtkWidget *w, GdkEventButton *event, gpointer user_data)

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -931,7 +931,7 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
   if(darktable.control->accel_remap_str)
   {
     // Change the accel map entry
-    if(gtk_accel_map_change_entry(darktable.control->accel_remap_str, event->keyval,
+    if(gtk_accel_map_change_entry(darktable.control->accel_remap_str, gdk_keyval_to_lower(event->keyval),
                                   event->state & KEY_STATE_MASK, TRUE))
     {
       // If it succeeded delete any conflicting accelerators


### PR DESCRIPTION
When I change the shortcut for e.g. sticky preview to '\<Shift\>z' it only works until restart of darktable.

The problem is that gtk_accel_map_save() and gtk_accel_map_load() are not symmretical.
gtk_accelerator_name(90, GDK_SHIFT_MASK) and gtk_accelerator_name(122, GDK_SHIFT_MASK) both return '\<Shift\>z'
But gtk_accelerator_parse() for '\<Shift\>z' gets 122 as accelerator_key.

In darktable after assigning the shortcut, accels->lighttable_preview_sticky.accel_key = 90 but after restart it is 122.
My solution is to use gdk_keyval_to_lower() for shortcut preferences assigment and the key_pressed()/key_released() functions where the keyval is compared later.