### PR TITLE
Use platform dependent folder separator in SQL statements

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -179,7 +179,7 @@ void dt_image_full_path(const int imgid, char *pathname, size_t pathname_len, gb
 {
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT folder || '/' || filename FROM main.images i, main.film_rolls f WHERE "
+                              "SELECT folder || '" G_DIR_SEPARATOR_S "' || filename FROM main.images i, main.film_rolls f WHERE "
                               "i.film_id = f.id and i.id = ?1",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
@@ -207,7 +207,7 @@ static void _image_local_copy_full_path(const int imgid, char *pathname, size_t 
 
   *pathname = '\0';
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT folder || '/' || filename FROM main.images i, main.film_rolls f "
+                              "SELECT folder || '" G_DIR_SEPARATOR_S "' || filename FROM main.images i, main.film_rolls f "
                               "WHERE i.film_id = f.id AND i.id = ?1",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);

--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -61,7 +61,7 @@ GList *dt_control_crawler_run()
   gboolean look_for_xmp = dt_conf_get_bool("write_sidecar_files");
 
   sqlite3_prepare_v2(dt_database_get(darktable.db),
-                     "SELECT i.id, write_timestamp, version, folder || '/' || filename, flags "
+                     "SELECT i.id, write_timestamp, version, folder || '" G_DIR_SEPARATOR_S "' || filename, flags "
                      "FROM main.images i, main.film_rolls f ON i.film_id = f.id ORDER BY f.id, filename",
                      -1, &stmt, NULL);
   sqlite3_prepare_v2(dt_database_get(darktable.db), "UPDATE main.images SET flags = ?1 WHERE id = ?2", -1,

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -591,7 +591,7 @@ static GList *_get_full_pathname(char *imgs)
   sqlite3_stmt *stmt = NULL;
   GList *list = NULL;
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT DISTINCT folder || '/' || filename FROM "
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT DISTINCT folder || '" G_DIR_SEPARATOR_S "' || filename FROM "
                                                              "main.images i, main.film_rolls f "
                                                              "ON i.film_id = f.id WHERE i.id IN (?1)",
                               -1, &stmt, NULL);


### PR DESCRIPTION
Fixes the cosmetic issue that in the image information module the "Full path" field always contained [path]/[filename.ext] even on Windows.
While I was there I have realized there are a few other places where SQL statements were using hard coded '/' path delimiters.
