### PR TITLE
Add scrollbars to lighttable

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1071,6 +1071,19 @@
     <shortdescription>border around image in darkroom mode</shortdescription>
     <longdescription>process the image in darkroom mode with a small border. set to 0 if you don't want any border.</longdescription>
   </dtconfig>
+  <dtconfig prefs="gui">
+    <name>scrollbars</name>
+    <type>
+      <enum>
+        <option>no scrollbars</option>
+        <option>lighttable</option>
+        <option>lighttable + darkroom</option>
+      </enum>
+    </type>
+    <default>lighttable</default>
+    <shortdescription>show scrollbars for center view</shortdescription>
+    <longdescription>defines where scrollbars should be displayed</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>ui_last/expander_metadata</name>
     <type>int</type>

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -454,12 +454,18 @@ static gboolean draw_borders(GtkWidget *widget, cairo_t *crf, gpointer user_data
     {
       case 0:
       case 1: // left, right: vertical
-        cairo_rectangle(cr, 0.0, view->vscroll_pos / view->vscroll_size * height, width,
-                        MAX(DT_PIXEL_APPLY_DPI(5), view->vscroll_viewport_size / view->vscroll_size * height));
+        cairo_rectangle(cr, 0.0,
+                        (view->vscroll_pos - view->vscroll_lower) / (view->vscroll_size - view->vscroll_lower) * height,
+                        width,
+                        MAX(DT_PIXEL_APPLY_DPI(5),
+                            view->vscroll_viewport_size / (view->vscroll_size - view->vscroll_lower) * height));
         break;
       default: // bottom, top: horizontal
-        cairo_rectangle(cr, view->hscroll_pos / view->hscroll_size * width, 0.0,
-                        MAX(DT_PIXEL_APPLY_DPI(5), view->hscroll_viewport_size / view->hscroll_size * width), height);
+        cairo_rectangle(cr,
+                        (view->hscroll_pos - view->hscroll_lower) / (view->hscroll_size - view->hscroll_lower) * width,
+                        0.0,
+                        MAX(DT_PIXEL_APPLY_DPI(5),
+                            view->hscroll_viewport_size / (view->hscroll_size - view->hscroll_lower) * width), height);
         break;
     }
     cairo_fill(cr);
@@ -602,6 +608,33 @@ static gboolean borders_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoin
   g_signal_emit_by_name(G_OBJECT(user_data), "scroll-event", event, &res);
 
   return TRUE;
+}
+
+static gboolean scrollbar_changed(GtkWidget *widget, gpointer user_data)
+{
+  gdouble value_x, value_y;
+
+  GtkAdjustment *adjustment_x = gtk_range_get_adjustment(GTK_RANGE(darktable.gui->scrollbars.hscrollbar));
+  GtkAdjustment *adjustment_y = gtk_range_get_adjustment(GTK_RANGE(darktable.gui->scrollbars.vscrollbar));
+
+  value_x = gtk_adjustment_get_value (adjustment_x);
+  value_y = gtk_adjustment_get_value (adjustment_y);
+
+  dt_view_manager_scrollbar_changed(darktable.view_manager, value_x, value_y);
+
+  return TRUE;
+}
+
+static gboolean scrollbar_press_event(GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->scrollbars.dragging = TRUE;
+  return FALSE;
+}
+
+static gboolean scrollbar_release_event(GtkWidget *widget, gpointer user_data)
+{
+  darktable.gui->scrollbars.dragging = FALSE;
+  return FALSE;
 }
 
 int dt_gui_gtk_load_config()
@@ -1019,6 +1052,16 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // TODO: left, right, top, bottom:
   // leave-notify-event
 
+  widget = darktable.gui->scrollbars.vscrollbar;
+  g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(scrollbar_changed), NULL);
+  g_signal_connect(G_OBJECT(widget), "button-press-event", G_CALLBACK(scrollbar_press_event), NULL);
+  g_signal_connect(G_OBJECT(widget), "button-release-event", G_CALLBACK(scrollbar_release_event), NULL);
+
+  widget = darktable.gui->scrollbars.hscrollbar;
+  g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(scrollbar_changed), NULL);
+  g_signal_connect(G_OBJECT(widget), "button-press-event", G_CALLBACK(scrollbar_press_event), NULL);
+  g_signal_connect(G_OBJECT(widget), "button-release-event", G_CALLBACK(scrollbar_release_event), NULL);
+
   widget = darktable.gui->widgets.left_border;
   g_signal_connect(G_OBJECT(widget), "draw", G_CALLBACK(draw_borders), GINT_TO_POINTER(0));
   g_signal_connect(G_OBJECT(widget), "button-press-event", G_CALLBACK(borders_button_pressed),
@@ -1353,6 +1396,9 @@ static void init_widgets(dt_gui_gtk_t *gui)
 
     if(!dt_conf_get_bool(key)) gtk_widget_set_visible(gui->ui->panels[k], FALSE);
   }
+
+  gtk_widget_set_visible(gui->scrollbars.hscrollbar, FALSE);
+  gtk_widget_set_visible(gui->scrollbars.vscrollbar, FALSE);
 }
 
 static void init_main_table(GtkWidget *container)
@@ -1404,9 +1450,14 @@ static void init_main_table(GtkWidget *container)
   /* initiialize the center top panel */
   _ui_init_panel_center_top(darktable.gui->ui, widget);
 
+  GtkWidget *centergrid = gtk_grid_new();
+  gtk_box_pack_start(GTK_BOX(widget), centergrid, TRUE, TRUE, 0);
+
   /* setup center drawing area */
   GtkWidget *cda = gtk_drawing_area_new();
   gtk_widget_set_size_request(cda, DT_PIXEL_APPLY_DPI(50), DT_PIXEL_APPLY_DPI(200));
+  gtk_widget_set_hexpand(cda, TRUE);
+  gtk_widget_set_vexpand(cda, TRUE);
   gtk_widget_set_app_paintable(cda, TRUE);
   gtk_widget_set_events(cda, GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK
                              | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
@@ -1414,12 +1465,22 @@ static void init_main_table(GtkWidget *container)
   gtk_widget_set_can_focus(cda, TRUE);
   gtk_widget_set_visible(cda, TRUE);
 
-  gtk_box_pack_start(GTK_BOX(widget), cda, TRUE, TRUE, 0);
+  gtk_grid_attach(GTK_GRID(centergrid), cda, 0, 0, 1, 1);
   darktable.gui->ui->center = cda;
 
   /* center should redraw when signal redraw center is raised*/
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_CENTER,
                             G_CALLBACK(_ui_widget_redraw_callback), darktable.gui->ui->center);
+
+  // Adding the scrollbars
+  GtkWidget *vscrollBar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, NULL);
+  GtkWidget *hscrollBar = gtk_scrollbar_new(GTK_ORIENTATION_HORIZONTAL, NULL);
+
+  gtk_grid_attach_next_to(GTK_GRID(centergrid), vscrollBar, cda, GTK_POS_RIGHT, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(centergrid), hscrollBar, cda, GTK_POS_BOTTOM, 1, 1);
+
+  darktable.gui->scrollbars.vscrollbar = vscrollBar;
+  darktable.gui->scrollbars.hscrollbar = hscrollBar;
 
   /* initialize the center bottom panel */
   _ui_init_panel_center_bottom(darktable.gui->ui, widget);
@@ -1557,6 +1618,40 @@ void dt_ui_restore_panels(dt_ui_t *ui)
       else
         gtk_widget_set_visible(ui->panels[k], 1);
     }
+  }
+}
+
+void dt_ui_update_scrollbars(dt_ui_t *ui)
+{
+  if (!darktable.gui->scrollbars.visible) return;
+
+  /* update scrollbars for current view */
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+
+  gtk_adjustment_configure(gtk_range_get_adjustment(GTK_RANGE(darktable.gui->scrollbars.vscrollbar)),
+                           cv->vscroll_pos, cv->vscroll_lower, cv->vscroll_size, 0, cv->vscroll_viewport_size,
+                           cv->vscroll_viewport_size);
+
+  gtk_adjustment_configure(gtk_range_get_adjustment(GTK_RANGE(darktable.gui->scrollbars.hscrollbar)),
+                           cv->hscroll_pos, cv->hscroll_lower, cv->hscroll_size, 0, cv->hscroll_viewport_size,
+                           cv->hscroll_viewport_size);
+
+  gtk_widget_set_visible(darktable.gui->scrollbars.vscrollbar, cv->vscroll_size > cv->vscroll_viewport_size);
+  gtk_widget_set_visible(darktable.gui->scrollbars.hscrollbar, cv->hscroll_size > cv->hscroll_viewport_size);
+}
+
+void dt_ui_scrollbars_show(dt_ui_t *ui, gboolean show)
+{
+  darktable.gui->scrollbars.visible = show;
+
+  if (show)
+  {
+    dt_ui_update_scrollbars(ui);
+  }
+  else
+  {
+    gtk_widget_hide(darktable.gui->scrollbars.vscrollbar);
+    gtk_widget_hide(darktable.gui->scrollbars.hscrollbar);
   }
 }
 

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -44,6 +44,15 @@ typedef struct dt_gui_widgets_t
 
 } dt_gui_widgets_t;
 
+typedef struct dt_gui_scrollbars_t
+{
+    GtkWidget *vscrollbar;
+    GtkWidget *hscrollbar;
+
+    gboolean visible;
+    gboolean dragging;
+} dt_gui_scrollbars_t;
+
 typedef enum dt_gui_color_t {
   DT_GUI_COLOR_BG = 0,
   DT_GUI_COLOR_DARKROOM_BG,
@@ -61,6 +70,8 @@ typedef struct dt_gui_gtk_t
   struct dt_ui_t *ui;
 
   dt_gui_widgets_t widgets;
+
+  dt_gui_scrollbars_t scrollbars;
 
   cairo_surface_t *surface;
   GtkMenu *presets_popup_menu;
@@ -254,6 +265,10 @@ void dt_ui_panel_show(struct dt_ui_t *ui, const dt_ui_panel_t, gboolean show, gb
 void dt_ui_border_show(struct dt_ui_t *ui, gboolean show);
 /** \brief restore saved state of panel visibility for current view */
 void dt_ui_restore_panels(struct dt_ui_t *ui);
+/** \brief update scrollbars for current view */
+void dt_ui_update_scrollbars(struct dt_ui_t *ui);
+/** show or hide scrollbars */
+void dt_ui_scrollbars_show(struct dt_ui_t *ui, gboolean show);
 /** \brief toggle view of panels eg. collaps/expands to previous view state */
 void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
 /** \brief draw user's attention */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1777,6 +1777,18 @@ void enter(dt_view_t *self)
   dt_view_filmstrip_prefetch();
 
   dt_collection_hint_message(darktable.collection);
+
+  char *scrollbars_conf = dt_conf_get_string("scrollbars");
+
+  gboolean scrollbars_visible = FALSE;
+  if(scrollbars_conf)
+  {
+    if(!strcmp(scrollbars_conf, "lighttable + darkroom"))
+      scrollbars_visible = TRUE;
+    g_free(scrollbars_conf);
+  }
+
+  dt_ui_scrollbars_show(darktable.gui->ui, scrollbars_visible);
 }
 
 void leave(dt_view_t *self)
@@ -1870,6 +1882,8 @@ void leave(dt_view_t *self)
   if(dev->overexposed.timeout > 0) g_source_remove(dev->overexposed.timeout);
   gtk_widget_hide(dev->overexposed.floating_window);
   gtk_widget_hide(dev->profile.floating_window);
+
+  dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
 
   dt_print(DT_DEBUG_CONTROL, "[run_job-] 11 %f in darkroom mode\n", dt_get_wtime());
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -190,7 +190,7 @@ void expose(
   {
     float zx = zoom_x, zy = zoom_y, boxw = 1., boxh = 1.;
     dt_dev_check_zoom_bounds(dev, &zx, &zy, zoom, closeup, &boxw, &boxh);
-    dt_view_set_scrollbar(self, zx + .5 - boxw * .5, 1.0, boxw, zy + .5 - boxh * .5, 1.0, boxh);
+    dt_view_set_scrollbar(self, zx, -0.5 + boxw/2, 0.5, boxw/2, zy, -0.5+ boxh/2, 0.5, boxh/2);
   }
 
   if((dev->image_status == DT_DEV_PIXELPIPE_VALID)
@@ -2075,6 +2075,15 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
   return 0;
 }
 
+void scrollbar_changed(dt_view_t *self, double x, double y)
+{
+  dt_control_set_dev_zoom_x(x);
+  dt_control_set_dev_zoom_y(y);
+
+  /* redraw pipe */
+  dt_dev_invalidate(darktable.develop);
+  dt_control_queue_redraw();
+}
 
 void scrolled(dt_view_t *self, double x, double y, int up, int state)
 {

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1095,11 +1095,11 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
   }
   else
   {
-    if(zoom_x < -wd * DT_LIBRARY_MAX_ZOOM / 2) zoom_x = -wd * DT_LIBRARY_MAX_ZOOM / 2;
+    if(zoom_x < -width + wd) zoom_x = -width + wd;
     if(zoom_x > wd * DT_LIBRARY_MAX_ZOOM - wd) zoom_x = wd * DT_LIBRARY_MAX_ZOOM - wd;
     if(zoom_y < -height + ht) zoom_y = -height + ht;
-    if(zoom_y > ht * lib->collection_count / MIN(DT_LIBRARY_MAX_ZOOM, zoom) - ht)
-      zoom_y = ht * lib->collection_count / MIN(DT_LIBRARY_MAX_ZOOM, zoom) - ht;
+    if(zoom_y > ht * ceilf((float)lib->collection_count / DT_LIBRARY_MAX_ZOOM) - ht)
+      zoom_y = ht * ceilf((float)lib->collection_count / DT_LIBRARY_MAX_ZOOM) - ht;
   }
 
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1665,7 +1665,17 @@ void enter(dt_view_t *self)
     dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, FALSE);
   }
 
-  dt_ui_scrollbars_show(darktable.gui->ui, TRUE);
+  char *scrollbars_conf = dt_conf_get_string("scrollbars");
+
+  gboolean scrollbars_visible = FALSE;
+  if(scrollbars_conf)
+  {
+    if(strcmp(scrollbars_conf, "no scrollbars"))
+      scrollbars_visible = TRUE;
+    g_free(scrollbars_conf);
+  }
+
+  dt_ui_scrollbars_show(darktable.gui->ui, scrollbars_visible);
 }
 
 void leave(dt_view_t *self)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -587,7 +587,7 @@ static int expose_filemanager(dt_view_t *self, cairo_t *cr, int32_t width, int32
   /* update scroll borders */
   int shown_rows = ceilf((float)lib->collection_count / iir);
   if(iir > 1) shown_rows += max_rows - 2;
-  dt_view_set_scrollbar(self, 0, 1, 1, offset, shown_rows * iir, (max_rows - 1) * iir);
+  dt_view_set_scrollbar(self, 0, 0, 1, 1, offset, 0, shown_rows * iir, (max_rows - 1) * iir);
 
   /* let's reset and reuse the main_query statement */
   DT_DEBUG_SQLITE3_CLEAR_BINDINGS(lib->statements.main_query);
@@ -1137,8 +1137,10 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
 
   int id;
 
-  dt_view_set_scrollbar(self, MAX(0, offset_i), DT_LIBRARY_MAX_ZOOM, zoom, DT_LIBRARY_MAX_ZOOM * offset_j,
-                        lib->collection_count, DT_LIBRARY_MAX_ZOOM * max_cols);
+  dt_view_set_scrollbar(self,
+                        zoom_x, -width + wd, wd * DT_LIBRARY_MAX_ZOOM - wd + width, width,
+                        zoom_y,  -height + ht,
+                        ht * ceilf((float)lib->collection_count / DT_LIBRARY_MAX_ZOOM) - ht + height, height);
 
   cairo_translate(cr, -offset_x * wd, -offset_y * ht);
   cairo_translate(cr, -MIN(offset_i * wd, 0.0), 0.0);
@@ -1662,6 +1664,8 @@ void enter(dt_view_t *self)
     dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, FALSE, FALSE);
     dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, FALSE);
   }
+
+  dt_ui_scrollbars_show(darktable.gui->ui, TRUE);
 }
 
 void leave(dt_view_t *self)
@@ -1686,6 +1690,8 @@ void leave(dt_view_t *self)
     lib->full_preview = 0;
     lib->display_focus = 0;
   }
+
+  dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
 }
 
 void reset(dt_view_t *self)
@@ -1728,6 +1734,28 @@ void mouse_leave(dt_view_t *self)
 }
 
 
+void scrollbar_changed(dt_view_t *self, double x, double y)
+{
+  const int layout = dt_conf_get_int("plugins/lighttable/layout");
+
+  switch(layout)
+  {
+    case 1: // file manager
+    {
+      const int iir = dt_conf_get_int("plugins/lighttable/images_in_row");
+      _set_position(self, round(y/iir)*iir);
+      break;
+    }
+    default: // zoomable
+    {
+      dt_library_t *lib = (dt_library_t *) self->data;
+      lib->zoom_x = x;
+      lib->zoom_y = y;
+      dt_control_queue_redraw_center();
+      break;
+    }
+  }
+}
 
 void scrolled(dt_view_t *self, double x, double y, int up, int state)
 {

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -84,8 +84,8 @@ typedef struct dt_view_t
   // width and height of allocation
   uint32_t width, height;
   // scroll bar control
-  float vscroll_size, vscroll_viewport_size, vscroll_pos;
-  float hscroll_size, hscroll_viewport_size, hscroll_pos;
+  float vscroll_size, vscroll_lower, vscroll_viewport_size, vscroll_pos;
+  float hscroll_size, hscroll_lower, hscroll_viewport_size, hscroll_pos;
   const char *(*name)(struct dt_view_t *self);    // get translatable name
   uint32_t (*view)(const struct dt_view_t *self); // get the view type
   uint32_t (*flags)();                            // get the view flags
@@ -111,6 +111,7 @@ typedef struct dt_view_t
   int (*key_released)(struct dt_view_t *self, guint key, guint state);
   void (*configure)(struct dt_view_t *self, int width, int height);
   void (*scrolled)(struct dt_view_t *self, double x, double y, int up, int state); // mouse scrolled in view
+  void (*scrollbar_changed)(struct dt_view_t *self, double x, double y); // scrollbar changed in view
 
   // keyboard accel callbacks
   void (*init_key_accels)(struct dt_view_t *self);
@@ -314,6 +315,7 @@ int dt_view_manager_key_pressed(dt_view_manager_t *vm, guint key, guint state);
 int dt_view_manager_key_released(dt_view_manager_t *vm, guint key, guint state);
 void dt_view_manager_configure(dt_view_manager_t *vm, int width, int height);
 void dt_view_manager_scrolled(dt_view_manager_t *vm, double x, double y, int up, int state);
+void dt_view_manager_scrollbar_changed(dt_view_manager_t *vm, double x, double y);
 
 /** add widget to the current view toolbox */
 void dt_view_manager_view_toolbox_add(dt_view_manager_t *vm, GtkWidget *tool, dt_view_type_flags_t view);
@@ -322,8 +324,8 @@ void dt_view_manager_view_toolbox_add(dt_view_manager_t *vm, GtkWidget *tool, dt
 void dt_view_manager_module_toolbox_add(dt_view_manager_t *vm, GtkWidget *tool, dt_view_type_flags_t view);
 
 /** set scrollbar positions, gui method. */
-void dt_view_set_scrollbar(dt_view_t *view, float hpos, float hsize, float hwinsize, float vpos, float vsize,
-                           float vwinsize);
+void dt_view_set_scrollbar(dt_view_t *view, float hpos, float vscroll_lower, float hsize, float hwinsize,
+                           float vpos, float hscroll_lower, float vsize, float vwinsize);
 
 /*
  * Tethering View PROXY

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -59,6 +59,7 @@ int key_pressed(struct dt_view_t *self, guint key, guint state);
 int key_released(struct dt_view_t *self, guint key, guint state);
 void configure(struct dt_view_t *self, int width, int height);
 void scrolled(struct dt_view_t *self, double x, double y, int up, int state); // mouse scrolled in view
+void scrollbar_changed(struct dt_view_t *self, double x, double y); // scrollbars changed in view
 
 // keyboard accel callbacks
 void init_key_accels(struct dt_view_t *self);


### PR DESCRIPTION
Here is my attempt to add scrollbars for the center.
They show the current position like the previous indicators on the window border.
But you can also use them to change the position.

I have modified the clamping in the zoomable light table view to always show at least one column or row on the left and bottom side.