### PR TITLE
noise profile: read Hi/Lo iso values, refs #11580, fixes #11842

### DIFF
--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -339,6 +339,11 @@ get_image_iso() {
 			fi
 			if [ -z "$iso" -o "$iso" = "0" ]; then
 				iso=$(get_exif_key "$file" Exif.NikonIi.ISO)
+				# read hi/low iso setting
+				ciso=$(echo $iso | cut -d' ' -f2)
+				if [ "$ciso" = "Hi" -o "$ciso" = "Lo" ]; then
+					iso=$(echo $iso  | cut -d' '  -f1 )
+				fi
 			fi
 			;;
     [Cc][Aa][Nn][Oo][Nn]*)


### PR DESCRIPTION
This fixes "./gen-profile: 1: eval: Bad substitution" error
during noise profile calculation with same nikon images.
Tested with images from #11580, fix is copied from #11842.

exiv2 reports
{{{
$ exiv2  -g "Exif.NikonIi.ISO" -Pt DSC_1083.NEF
79
Lo 0.3
79
Lo 0.3
}}}
which can not be parsed correct with current script.

79 seems to be the correct iso value as it is reported from exiv2
without key argument.
{{{
$ exiv2 DSC_1083.NEF | grep ISO
ISO speed       : 79
}}}