### PR TITLE
colorzones: don't reset strength (aka mix) on double-click

### DIFF
--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -922,7 +922,6 @@ static gboolean colorzones_button_press(GtkWidget *widget, GdkEventButton *event
       p->equalizer_x[c->channel][k] = d->equalizer_x[c->channel][k];
       p->equalizer_y[c->channel][k] = d->equalizer_y[c->channel][k];
     }
-    p->strength = d->strength;
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     gtk_widget_queue_draw(self->widget);
   }


### PR DESCRIPTION
When double-clicking on a curve within the color zones module, the
module was internally reseting the "strength" parameter (displayed as
"mix" slider in the ui), but not moving the cursor, resulting in an
inconsistancy between what's shown in the GUI and what is applied to the
picture.

One way to fix this would be to update the GUI after the reset. However,
this "reset the mix slider on double-click" is undocumented and
confusing: a double-click on a curve panel should only reset the curve
being clicked, not other parameters. There's a reset button like on
every modules to do a global reset, and reseting the "mix" cursor can
still be done by double-clicking on the cursor itself.