### PR TITLE
Make clang build work on Windows Appveyor as well

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -13,6 +13,16 @@
 #    You should have received a copy of the GNU General Public License
 #    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 
+environment:
+  matrix:
+    - CC:  cc
+      CXX: c++
+    - CC:  clang
+      CXX: clang++
+
+matrix:
+  fast_finish: true
+
 init:
   - git config --global core.autocrlf input
 

--- a/.ci/ci-script-windows.sh
+++ b/.ci/ci-script-windows.sh
@@ -81,7 +81,7 @@ cat > "$FONTCONFIG_FILE" <<EOF
 <fontconfig><dir>$(cygpath -aw fonts)</dir></fontconfig>
 EOF
 
-execute 'Installing base-devel and toolchain'  pacman -S --noconfirm mingw-w64-x86_64-{toolchain,cmake}
+execute 'Installing base-devel and toolchain'  pacman -S --noconfirm mingw-w64-x86_64-{toolchain,clang,cmake}
 execute 'Installing dependencies' pacman -S --noconfirm  mingw-w64-x86_64-{exiv2,lcms2,lensfun,dbus-glib,openexr,sqlite3,libxslt,libsoup,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes}
 execute 'Updating lensfun databse' lensfun-update-data
 execute 'Building darktable' build_darktable

--- a/cmake/compiler-warnings.cmake
+++ b/cmake/compiler-warnings.cmake
@@ -9,8 +9,6 @@ CHECK_COMPILER_FLAG_AND_ENABLE_IT(-fno-strict-aliasing)
 if(WIN32)
   # MSYS2 gcc compiler gives false positive warnings for (format (printf, 1, 2) - need to turn off for the time being
   CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wno-format)
-
-  CHECK_COMPILER_FLAG_AND_ENABLE_IT(-mms-bitfields)
 else()
   CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wformat)
   CHECK_COMPILER_FLAG_AND_ENABLE_IT(-Wformat-security)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -317,7 +317,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 {
   double start_wtime = dt_get_wtime();
 
-#ifndef __WIN32__
+#ifndef _WIN32
   if(getuid() == 0 || geteuid() == 0)
     printf(
         "WARNING: either your user id or the effective user id are 0. are you running darktable as root?\n");
@@ -1102,7 +1102,7 @@ void *dt_alloc_align(size_t alignment, size_t size)
 {
 #if defined(__FreeBSD_version) && __FreeBSD_version < 700013
   return malloc(size);
-#elif defined(__WIN32__)
+#elif defined(_WIN32)
   return _aligned_malloc(size, alignment);
 #else
   void *ptr = NULL;
@@ -1111,7 +1111,7 @@ void *dt_alloc_align(size_t alignment, size_t size)
 #endif
 }
 
-#ifdef __WIN32__
+#ifdef _WIN32
 void dt_free_align(void *mem)
 {
   _aligned_free(mem);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -23,14 +23,14 @@
 #if defined __DragonFly__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 #define _WITH_DPRINTF
 #define _WITH_GETLINE
-#elif !defined _XOPEN_SOURCE && !defined __WIN32__
+#elif !defined _XOPEN_SOURCE && !defined _WIN32
 #define _XOPEN_SOURCE 700 // for localtime_r and dprintf
 #endif
 
 // needs to be defined before any system header includes for control/conf.h to work in C++ code
 #define __STDC_FORMAT_MACROS
 
-#if defined __WIN32__
+#if defined _WIN32
 #include "win/win.h"
 #endif
 
@@ -41,7 +41,7 @@
 #include "common/dtpthread.h"
 #include "common/utility.h"
 #include <time.h>
-#ifdef __WIN32__
+#ifdef _WIN32
 #include "win/getrusage.h"
 #else
 #include <sys/resource.h>
@@ -247,7 +247,7 @@ void dt_print(dt_debug_thread_t thread, const char *msg, ...) __attribute__((for
 void dt_gettime_t(char *datetime, size_t datetime_len, time_t t);
 void dt_gettime(char *datetime, size_t datetime_len);
 void *dt_alloc_align(size_t alignment, size_t size);
-#ifdef __WIN32__
+#ifdef _WIN32
 void dt_free_align(void *mem);
 #else
 #define dt_free_align(A) free(A)

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1360,7 +1360,7 @@ static gboolean pid_is_alive(int pid)
 {
   gboolean pid_is_alive;
 
-#ifdef __WIN32__
+#ifdef _WIN32
   pid_is_alive = FALSE;
   HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
   if(h)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -41,7 +41,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#ifndef __WIN32__
+#ifndef _WIN32
 #include <glob.h>
 #endif
 #include <glib/gstdio.h>
@@ -675,7 +675,7 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
     while(*c2 != '.' && c2 > filename) c2--;
     snprintf(c1 + strlen(*glob_pattern), pattern + sizeof(pattern) - c1 - strlen(*glob_pattern), "%s.xmp", c2);
 
-#ifdef __WIN32__
+#ifdef _WIN32
     wchar_t *wpattern = g_utf8_to_utf16(pattern, -1, NULL, NULL, NULL);
     WIN32_FIND_DATAW data;
     HANDLE handle = FindFirstFileW(wpattern, &data);

--- a/src/common/points.h
+++ b/src/common/points.h
@@ -22,7 +22,7 @@
 #ifndef __SSE2__
 
 #if !defined _XOPEN_SOURCE && !defined(__DragonFly__) && !defined(__FreeBSD__) && !defined(__NetBSD__)       \
-    && !defined(__OpenBSD__) && !defined(__WIN32__)
+    && !defined(__OpenBSD__) && !defined(_WIN32)
 #define _XOPEN_SOURCE
 #endif
 

--- a/src/common/system_signal_handling.c
+++ b/src/common/system_signal_handling.c
@@ -41,7 +41,7 @@
 #include <sys/prctl.h> // for PR_SET_PTRACER, prctl
 #endif
 
-#ifndef __WIN32__
+#ifndef _WIN32
 #include <sys/wait.h> // for waitpid
 #endif
 
@@ -55,19 +55,19 @@
 
 typedef void(dt_signal_handler_t)(int);
 
-#if !defined(__APPLE__) && !defined(__WIN32__)
+#if !defined(__APPLE__) && !defined(_WIN32)
 static dt_signal_handler_t *_dt_sigsegv_old_handler = NULL;
 #endif
 
 // deer graphicsmagick, please stop messing with the stuff that you should not be touching at all.
 // based on GM's InitializeMagickSignalHandlers() and MagickSignalHandlerMessage()
-#if !defined(__WIN32__)
+#if !defined(_WIN32)
 static const int _signals_to_preserve[] = { SIGHUP,  SIGINT,  SIGQUIT, SIGILL,  SIGABRT, SIGBUS, SIGFPE,
                                             SIGPIPE, SIGALRM, SIGTERM, SIGCHLD, SIGXCPU, SIGXFSZ };
 #else
 static const int _signals_to_preserve[] = { SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM };
 static LPTOP_LEVEL_EXCEPTION_FILTER _dt_exceptionfilter_old_handler = NULL;
-#endif //! defined (__WIN32__)
+#endif //! defined (_WIN32)
 
 #define _NUM_SIGNALS_TO_PRESERVE (sizeof(_signals_to_preserve) / sizeof(_signals_to_preserve[0]))
 static dt_signal_handler_t *_orig_sig_handlers[_NUM_SIGNALS_TO_PRESERVE] = { NULL };
@@ -86,7 +86,7 @@ static int dprintf(int fd, const char *fmt, ...) __attribute__((format(printf, 2
 }
 #endif
 
-#if !defined(__APPLE__) && !defined(__WIN32__)
+#if !defined(__APPLE__) && !defined(_WIN32)
 static void _dt_sigsegv_handler(int param)
 {
   pid_t pid;

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -278,7 +278,7 @@ size_t dt_utf8_strlcpy(char *dest, const char *src, size_t n)
 
 off_t dt_util_get_file_size(const char *filename)
 {
-#ifdef __WIN32__
+#ifdef _WIN32
   struct _stati64 st;
   if(_stati64(filename, &st) == 0) return st.st_size;
 #else
@@ -371,7 +371,7 @@ dt_logo_season_t dt_util_get_logo_season(void)
     easter_sunday.tm_isdst = -1;
     time_t easter_sunday_sec = mktime(&easter_sunday);
     // we start at midnight, so it's basically +- 2 days
-    if(labs(easter_sunday_sec - now) <= 2 * 24 * 60 * 60) return DT_LOGO_SEASON_EASTER;
+    if(llabs(easter_sunday_sec - now) <= 2 * 24 * 60 * 60) return DT_LOGO_SEASON_EASTER;
   }
 
   return DT_LOGO_SEASON_NONE;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -940,7 +940,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
           do
           {
             char *xmp_filename = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-            files = g_list_append(files, g_build_filename(dirname, xmp_filename));
+            files = g_list_append(files, g_build_filename(dirname, xmp_filename, NULL));
             g_free(xmp_filename);
           }
           while(FindNextFileW(handle, &data));

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1799,9 +1799,9 @@ static void _stop_audio(dt_library_t *lib)
   if(lib->audio_player_id == -1) return;
   // we don't want to trigger the callback due to a possible race condition
   g_source_remove(lib->audio_player_event_source);
-#ifdef __WIN32__
+#ifdef _WIN32
 // TODO: add Windows code to actually kill the process
-#else  // __WIN32__
+#else  // _WIN32
   if(lib->audio_player_id != -1)
   {
     if(getpgid(0) != getpgid(lib->audio_player_pid))
@@ -1809,7 +1809,7 @@ static void _stop_audio(dt_library_t *lib)
     else
       kill(lib->audio_player_pid, SIGKILL);
   }
-#endif // __WIN32__
+#endif // _WIN32
   g_spawn_close_pid(lib->audio_player_pid);
   lib->audio_player_id = -1;
 }


### PR DESCRIPTION
3 items were needed:
* `__WIN32__` is not defined with clang builds, I have replaced them with `_WIN32`
* `mms_bitfields` flag resulted compile errors in RS:  `ms_struct may not produce Microsoft-compatible layouts for classes with base classes or virtual functions`. Removing `mms_bitfields` solved the problem, and seems that normal gcc builds behave normally after removing this flag. Interestingly [gcc documentation](https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html#x86-Options) says this field is enabled by default for windows targets, but this is apparently not the case for MINGW gcc (I have checked with `gcc -v`. I have found only [this discussion](http://mingw-users.1079350.n2.nabble.com/mms-bitfields-td2288523.html) on this subject. I'd appreciate your views.
* I had to replace `labs()` with `llabs()` in one instance

@LebedevRI please have a look at it 
  