### PR TITLE
WB Presets for Leaf Credo 40 and Olymus E-M1 Mark II

### DIFF
--- a/src/external/wb_presets.c
+++ b/src/external/wb_presets.c
@@ -7428,6 +7428,12 @@ const wb_data wb_preset[] =
   { "Sony", "SLT-A99", DaylightFluorescent, 0,	{ 2.63671875, 1, 1.37890625, 0 } },
   { "Sony", "SLT-A99", Flash, 0,		{ 2.70703125, 1, 1.32031250, 0 } },
 
+  // Firmware version 4.01.2
+  { "Leaf", "Credo 40", Daylight, 0,		{ 1.31208002567291, 1, 1.40452003479004, 0 } },
+  { "Leaf", "Credo 40", Fluorescent, 0,		{ 0.9466667343775486, 1, 2.272152602270239, 0 } },
+  { "Leaf", "Credo 40", Incandescent, 0,	{ 0.8719298739795124, 1, 2.202473677432417, 0 } },
+  { "Leaf", "Credo 40", Flash, 0,		{ 1.26238000392914, 1, 1.48148000240326, 0 } },
+
 };
 
 const int wb_preset_count = sizeof(wb_preset) / sizeof(wb_data);

--- a/src/external/wb_presets.c
+++ b/src/external/wb_presets.c
@@ -4491,6 +4491,15 @@ const wb_data wb_preset[] =
   { "Olympus", "E-M1", Underwater, 0,		{ 1.3984, 1, 2.2813, 0 } },
   { "Olympus", "E-M1", Flash, 0,		{ 2.3437, 1, 1.4219, 0 } },
 
+  // Firmware version 1.1
+  { "Olympus", "E-M1MarkII", Daylight, 0,       { 1.8203125, 1, 1.9140625, 0 } },
+  { "Olympus", "E-M1MarkII", Shade, 0,		{ 2.1328125, 1, 1.484375, 0 } },
+  { "Olympus", "E-M1MarkII", Cloudy, 0,		{ 1.953125, 1, 1.7265625, 0 } },
+  { "Olympus", "E-M1MarkII", Tungsten, 0,       { 1.1328125, 1, 3.546875, 0 } },
+  { "Olympus", "E-M1MarkII", Fluorescent, 0,    { 1.75, 1, 2.734375, 0 } },
+  { "Olympus", "E-M1MarkII", Underwater, 0,     { 1.828125, 1, 1.921875, 0 } },
+  { "Olympus", "E-M1MarkII", Flash, 0,		{ 2.0703125, 1, 1.6328125, 0 } },
+
   /* -7/+7 fine tuning is -7/+7 in amber-blue and zero in green-magenta */
   { "Olympus", "E-M5", Daylight, -7,		{ 1.8047, 1, 2.0547, 0 } },
   { "Olympus", "E-M5", Daylight, 0,		{ 2.1016, 1, 1.8047, 0 } },


### PR DESCRIPTION
This adds WB presets for two cameras I have that don't currently have them: the Leaf Credo 40 and the Olympus E-M1 Mark II.  All generated with the extraction script in tools/.  Apologies if the indentation isn't correct, none of the editors I view it in seem to agree on how mid-line tab stops should work, so I just lined it up in gedit and prayed that would work