### PR TITLE
Improve monochrome raw handling #11912

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -96,6 +96,18 @@ int dt_image_is_raw(const dt_image_t *img)
   return !isnonraw;
 }
 
+int dt_image_is_monochrome(const dt_image_t *img)
+{
+  if(strncmp(img->exif_maker, "Leica Camera AG", 15) != 0) return 0;
+
+  gchar *tmp_model = g_ascii_strdown(img->exif_model, -1);
+
+  const int res = strstr(tmp_model, "monochrom") != NULL;
+  g_free(tmp_model);
+
+  return res;
+}
+
 const char *dt_image_film_roll_name(const char *path)
 {
   const char *folder = path + strlen(path);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -194,6 +194,8 @@ int dt_image_is_ldr(const dt_image_t *img);
 int dt_image_is_raw(const dt_image_t *img);
 /** returns non-zero if the image contains float data. */
 int dt_image_is_hdr(const dt_image_t *img);
+/** returns non-zero if this image was taken using a monochrome camera */
+int dt_image_is_monochrome(const dt_image_t *img);
 /** returns the full path name where the image was imported from. from_cache=TRUE check and return local
  * cached filename if any. */
 void dt_image_full_path(const int imgid, char *pathname, size_t pathname_len, gboolean *from_cache);

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -225,7 +225,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
     for(int i = 0; i < 4; i++) img->wb_coeffs[i] = r->metadata.wbCoeffs[i];
 
     img->buf_dsc.filters = 0u;
-    if(!r->isCFA)
+    if(!r->isCFA && !dt_image_is_monochrome(img))
     {
       dt_imageio_retval_t ret = dt_imageio_open_rawspeed_sraw(img, r, mbuf);
       return ret;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1493,8 +1493,9 @@ void reload_defaults(dt_iop_module_t *module)
   // we might be called from presets update infrastructure => there is no image
   if(!module->dev) goto end;
 
+  dt_image_t *img = &module->dev->image_storage;
   // can't be switched on for non-raw or x-trans images:
-  if(dt_image_is_raw(&module->dev->image_storage) && (module->dev->image_storage.buf_dsc.filters != 9u))
+  if(dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !dt_image_is_monochrome(img))
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
@@ -1536,7 +1537,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 {
   // dt_iop_cacorrect_params_t *p = (dt_iop_cacorrect_params_t *)params;
   // dt_iop_cacorrect_data_t *d = (dt_iop_cacorrect_data_t *)piece->data;
-  if(!(pipe->image.flags & DT_IMAGE_RAW)) piece->enabled = 0;
+  dt_image_t *img = &pipe->image;
+  if(!(img->flags & DT_IMAGE_RAW) || dt_image_is_monochrome(img)) piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -1554,7 +1556,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(dt_iop_module_t *self)
 {
   if(dt_image_is_raw(&self->dev->image_storage))
-    if(self->dev->image_storage.buf_dsc.filters != 9u)
+    if(self->dev->image_storage.buf_dsc.filters != 9u && !dt_image_is_monochrome(&self->dev->image_storage))
       gtk_label_set_text(GTK_LABEL(self->widget), _("automatic chromatic aberration correction"));
     else
       gtk_label_set_text(GTK_LABEL(self->widget),

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1262,19 +1262,6 @@ static void mat3mul(float *dst, const float *const m1, const float *const m2)
   }
 }
 
-
-static int is_leica_monochrom(dt_image_t *img)
-{
-  if(strncmp(img->exif_maker, "Leica Camera AG", 15) != 0) return 0;
-
-  gchar *tmp_model = g_ascii_strdown(img->exif_model, -1);
-
-  const int res = strstr(tmp_model, "monochrom") != NULL;
-  g_free(tmp_model);
-
-  return res;
-}
-
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
@@ -1400,7 +1387,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
     if(isnan(cam_xyz[0]))
     {
-      if(dt_image_is_raw(&pipe->image) && !is_leica_monochrom(&pipe->image))
+      if(dt_image_is_raw(&pipe->image) && !dt_image_is_monochrome(&pipe->image))
       {
         fprintf(stderr, "[colorin] `%s' color matrix not found!\n", pipe->image.camera_makermodel);
         dt_control_log(_("`%s' color matrix not found!"), pipe->image.camera_makermodel);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -4909,6 +4909,9 @@ void reload_defaults(dt_iop_module_t *module)
   // we might be called from presets update infrastructure => there is no image
   if(!module->dev) goto end;
 
+  if(dt_image_is_monochrome(&module->dev->image_storage))
+    tmp.demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
+
   // only on for raw images:
   if(dt_image_is_raw(&module->dev->image_storage))
     module->default_enabled = 1;

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1134,6 +1134,8 @@ void reload_defaults(dt_iop_module_t *module)
   tmp.tca_b = 1.0;
   tmp.modified = 0;
 
+  if(dt_image_is_monochrome(img)) tmp.modify_flags &= ~LF_MODIFY_TCA;
+
   // init crop from db:
   char model[100]; // truncate often complex descriptions.
   g_strlcpy(model, img->exif_model, sizeof(model));

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -72,6 +72,9 @@ typedef struct dt_iop_temperature_gui_data_t
   GtkWidget *scale_k, *scale_tint, *coeff_widgets, *scale_r, *scale_g, *scale_b, *scale_g2;
   GtkWidget *presets;
   GtkWidget *finetune;
+  GtkWidget *box_enabled;
+  GtkWidget *label_disabled;
+  GtkWidget *stack;
   int preset_cnt;
   int preset_num[50];
   double daylight_wb[4];
@@ -695,6 +698,13 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 {
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)p1;
   dt_iop_temperature_data_t *d = (dt_iop_temperature_data_t *)piece->data;
+
+  if(self->hide_enable_button)
+  {
+    piece->enabled = 0;
+    return;
+  }
+
   for(int k = 0; k < 4; k++) d->coeffs[k] = p->coeffs[k];
 
   // 4Bayer images not implemented in OpenCL yet
@@ -716,13 +726,21 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)self;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)module->params;
+  dt_iop_temperature_params_t *fp = (dt_iop_temperature_params_t *)module->default_params;
+
+  if(!self->default_enabled)
+  {
+    gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "disabled");
+    return;
+  }
+  gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "enabled");
+
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   self->color_picker_box[0] = self->color_picker_box[1] = .25f;
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;
   self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)module->params;
-  dt_iop_temperature_params_t *fp = (dt_iop_temperature_params_t *)module->default_params;
 
   double TempK, tint;
   mul2temp(self, p->coeffs, &TempK, &tint);
@@ -931,8 +949,12 @@ void reload_defaults(dt_iop_module_t *module)
   // White balance module doesn't need to be enabled for monochrome raws (like
   // for leica monochrom cameras). prepare_matrices is a noop as well, as there
   // isn't a color matrix, so we can skip that as well.
-  if(is_raw && dt_image_is_monochrome(&(module->dev->image_storage))) goto gui;
-
+  if(is_raw && dt_image_is_monochrome(&(module->dev->image_storage)))
+  {
+    module->default_enabled = 0;
+    module->hide_enable_button = 1;
+    goto gui;
+  }
   if(module->gui_data) prepare_matrices(module);
 
   /* check if file is raw / hdr */
@@ -940,6 +962,7 @@ void reload_defaults(dt_iop_module_t *module)
   {
     // raw images need wb:
     module->default_enabled = 1;
+    module->hide_enable_button = 0;
 
     int found = 1;
 
@@ -1354,8 +1377,14 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->default_params;
 
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
+
+  g->stack = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(g->stack), FALSE);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->stack, TRUE, TRUE, 0);
+
+  g->box_enabled = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   for(int k = 0; k < 4; k++) g->daylight_wb[k] = 1.0;
   g->scale_tint
@@ -1398,20 +1427,20 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->scale_tint, NULL, _("tint"));
   dt_bauhaus_widget_set_label(g->scale_k, NULL, _("temperature"));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->scale_tint, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->scale_k, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_tint, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_k, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_r, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_g, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_b, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_g2, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->coeff_widgets, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->coeff_widgets, TRUE, TRUE, 0);
   gtk_widget_set_no_show_all(g->scale_g2, TRUE);
 
   gui_sliders_update(self);
 
   g->presets = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->presets, NULL, _("preset"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->presets, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->presets, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->presets, _("choose white balance preset from camera"));
 
   g->finetune = dt_bauhaus_slider_new_with_range(self, -9.0, 9.0, 1.0, 0.0, 0);
@@ -1419,8 +1448,19 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->finetune, _("%.0f mired"));
   // initially doesn't have fine tuning stuff (camera wb)
   gtk_widget_set_sensitive(g->finetune, FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->finetune, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->finetune, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->finetune, _("fine tune white balance preset"));
+
+  gtk_widget_show_all(g->box_enabled);
+  gtk_stack_add_named(GTK_STACK(g->stack), g->box_enabled, "enabled");
+
+  g->label_disabled = gtk_label_new(_("white balance disabled for camera"));
+  gtk_widget_set_halign(g->label_disabled, GTK_ALIGN_START);
+
+  gtk_widget_show_all(g->label_disabled);
+  gtk_stack_add_named(GTK_STACK(g->stack), g->label_disabled, "disabled");
+
+  gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "disabled" : "enabled");
 
   self->gui_update(self);
 


### PR DESCRIPTION
This does the following automatically for monochrome raws (namely, the ones
coming out of a Leica Monochrom camera):

1. Disable TCA for lens correction by default, as the corrections sometimes
   introduce colour onto a monochrome image (!)
2. Re-enable normal raw processing for monochrome raws; previously it processed
   them as sraws, which disabled auto-exposure
3. Use the passthrough demosaic method, as demosaicing isn't necessary
4. Turn off the white balance module, which in turn disables an error message in
   prepare_matrices, which is a noop for monochrome raws
  