### PR TITLE
misc. typos

### DIFF
--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -116,7 +116,7 @@ if (WIN32)
 
   install(PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION bin COMPONENT DTApplication)
 
-  # TODO: Add auxilliary files for openssl?
+  # TODO: Add auxiliary files for openssl?
 
   # Add pixbuf loader libraries
   # FILE(GLOB_RECURSE GDK_PIXBUF "${MINGW_PATH}/../lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll"  )

--- a/doc/doxygen.conf
+++ b/doc/doxygen.conf
@@ -278,7 +278,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # For small to medium size projects (<1000 input files) the default value is
 # probably good enough. For larger projects a too small cache size can cause
 # doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
+# causing a significant performance penalty.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
 # a logarithmic scale so increasing the size by one will roughly double the

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -341,7 +341,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
           int dy = *tmp++;
           int x = MAX(0, MIN(width - 1, t + dx));
           int y = MAX(0, MIN(height - 1, v + dy));
-          // inverse chroma weighted average of neigbouring pixels inside window
+          // inverse chroma weighted average of neighbouring pixels inside window
           // also taking average edge chromaticity into account (either global or local average)
           weight = 1.0 / (out[(size_t)y * width * ch + x * ch + 3] + avg_edge_chroma);
           atot += weight * in[(size_t)y * width * ch + x * ch + 1];

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -21,8 +21,8 @@
 #include <lua/lua.h>
 
 /*
- * LUA API VERSIONNING
- * This API versionning follows semantic versionning as defined in
+ * LUA API VERSIONING
+ * This API versioning follows semantic versioning as defined in
  * http://semver.org
  * only stable releases are considered "released"
  *   => no need to increase API version with every commit,

--- a/tools/lua_doc/old_api/dt_api202.lua
+++ b/tools/lua_doc/old_api/dt_api202.lua
@@ -256,7 +256,7 @@ A storage is a module that is responsible for handling images once they have bee
 ["__text"] = [[The image object to export.]],
 ["__attributes"] = {
 ["reported_type"] = {
-["__text"] = [[Image objects represent an image in the database. This is slightly different from a file on disk since a file can have multiple developements.
+["__text"] = [[Image objects represent an image in the database. This is slightly different from a file on disk since a file can have multiple developments.
 
 	Note that this is the real image object; changing the value of a field will immediately change it in darktable and will be reflected on any copy of that image object you may have kept.]],
 ["__attributes"] = {

--- a/tools/lua_doc/old_api/dt_api210dev.lua
+++ b/tools/lua_doc/old_api/dt_api210dev.lua
@@ -255,7 +255,7 @@ A storage is a module that is responsible for handling images once they have bee
 ["__text"] = [==[The image object to export.]==],
 ["__attributes"] = {
 ["reported_type"] = {
-["__text"] = [==[Image objects represent an image in the database. This is slightly different from a file on disk since a file can have multiple developements.
+["__text"] = [==[Image objects represent an image in the database. This is slightly different from a file on disk since a file can have multiple developments.
 
 	Note that this is the real image object; changing the value of a field will immediately change it in darktable and will be reflected on any copy of that image object you may have kept.]==],
 ["__attributes"] = {

--- a/tools/lua_doc/old_api/dt_api300.lua
+++ b/tools/lua_doc/old_api/dt_api300.lua
@@ -256,7 +256,7 @@ A storage is a module that is responsible for handling images once they have bee
 ["__text"] = [==[The image object to export.]==],
 ["__attributes"] = {
 ["reported_type"] = {
-["__text"] = [==[Image objects represent an image in the database. This is slightly different from a file on disk since a file can have multiple developements.
+["__text"] = [==[Image objects represent an image in the database. This is slightly different from a file on disk since a file can have multiple developments.
 
 	Note that this is the real image object; changing the value of a field will immediately change it in darktable and will be reflected on any copy of that image object you may have kept.]==],
 ["__attributes"] = {


### PR DESCRIPTION
Found via `codespell` 
FYI, doxygen.conf fix was fixed upstream.