### PR TITLE
Handling stdout on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -817,7 +817,7 @@ endif(APPLE)
 target_link_libraries(darktable lib_darktable)
 
 if (WIN32)
-  set_target_properties(darktable PROPERTIES LINK_FLAGS "-mwindows -Wl,-subsystem,windows")
+  set_target_properties(darktable PROPERTIES LINK_FLAGS "-mconsole -mwindows -Wl,-subsystem,console")
   _detach_debuginfo (darktable bin)
   _detach_debuginfo (lib_darktable bin)
 endif(WIN32)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -103,6 +103,11 @@ darktable_t darktable;
 
 static int usage(const char *argv0)
 {
+#ifdef _WIN32
+  char *logdir = g_build_filename(g_get_user_cache_dir(), "darktable", NULL);
+  char *logfile = g_build_filename(logdir, "darktable-log.txt", NULL);
+#endif
+
   printf("usage: %s [options] [IMG_1234.{RAW,..}|image_folder/]\n", argv0);
   printf("\n");
   printf("options:\n");
@@ -112,6 +117,9 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch, input,lighttable,\n");
   printf("      lua, masks,memory,nan,opencl, perf,pwstorage,print,sql}\n");
+#ifdef _WIN32
+  printf("     Note: debug log will be written to this file: %s\n", logfile);
+#endif
   printf("  --datadir <data directory>\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
@@ -127,6 +135,11 @@ static int usage(const char *argv0)
   printf("  -t <num openmp threads>\n");
   printf("  --tmpdir <tmp directory>\n");
   printf("  --version\n");
+
+#ifdef _WIN32
+  g_free(logdir);
+  g_free(logfile);
+#endif
 
   return 1;
 }

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -117,9 +117,6 @@ static int usage(const char *argv0)
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch, input,lighttable,\n");
   printf("      lua, masks,memory,nan,opencl, perf,pwstorage,print,sql}\n");
-#ifdef _WIN32
-  printf("     Note: debug log will be written to this file: %s\n", logfile);
-#endif
   printf("  --datadir <data directory>\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
@@ -135,6 +132,9 @@ static int usage(const char *argv0)
   printf("  -t <num openmp threads>\n");
   printf("  --tmpdir <tmp directory>\n");
   printf("  --version\n");
+#ifdef _WIN32
+  printf("  Note: debug log and output will be written to this file: %s\n", logfile);
+#endif
 
 #ifdef _WIN32
   g_free(logdir);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -104,8 +104,7 @@ darktable_t darktable;
 static int usage(const char *argv0)
 {
 #ifdef _WIN32
-  char *logdir = g_build_filename(g_get_user_cache_dir(), "darktable", NULL);
-  char *logfile = g_build_filename(logdir, "darktable-log.txt", NULL);
+  char *logfile = g_build_filename(g_get_user_cache_dir(), "darktable", "darktable-log.txt", NULL);
 #endif
 
   printf("usage: %s [options] [IMG_1234.{RAW,..}|image_folder/]\n", argv0);
@@ -137,7 +136,6 @@ static int usage(const char *argv0)
 #endif
 
 #ifdef _WIN32
-  g_free(logdir);
   g_free(logfile);
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,10 @@ int main(int argc, char *argv[])
     g_freopen(logfile, "a", stdout);
     dup2(fileno(stdout), fileno(stderr));
 
+    // We don't need the console window anymore, free it
+    // This ensures that only darktable's main window will be visible
+    FreeConsole();
+
     g_free(logdir);
     g_free(logfile);
 

--- a/src/main.c
+++ b/src/main.c
@@ -37,6 +37,16 @@ int main(int argc, char *argv[])
   gboolean redirect_output = ((out_type != FILE_TYPE_DISK && out_type != FILE_TYPE_PIPE) &&
                               (err_type != FILE_TYPE_DISK && err_type != FILE_TYPE_PIPE));
 
+  for(int k = 1; k < argc; k++)
+  {
+    if(argv[k][0] == '-')
+    {
+      // For simple arguments do not redirect stdout
+      if(!strcmp(argv[k], "--help") || !strcmp(argv[k], "-h") || !strcmp(argv[k], "--version"))
+        redirect_output = FALSE;
+    }
+  }
+
   if(redirect_output)
   {
     // something like C:\Users\username\AppData\Local\Microsoft\Windows\Temporary Internet Files\darktable\darktable-log.txt


### PR DESCRIPTION
This PR is aiming to solve the small problem we had with `stdout` on Windows, namely that even simple command line arguments like `--help` or `--version` did not show anything on the command line console /command prompt as all `stdout` was already redirected to a log file, hence the user did not see the result.

This change is adding back the console subsystem to the compiler and linker flags, (while keeping the `-mwindows`) and adds a simple logic at startup, that for simple command line arguments, like `-h`, `--help` and `--version` the `stdout` won't be redirected, so the user would see the output, while for other cases the existing redirection to the log file is still working.

Also I have extended the `--help`, with showing the location of the debug log file to help the users to find this if its needed.

This way both file logging and console output is working.