### PR TITLE
Allow blending/masking in hot pixels module. 

### DIFF
--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -77,7 +77,7 @@ int groups()
 
 int flags()
 {
-  return IOP_FLAGS_ONE_INSTANCE;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_ONE_INSTANCE;
 }
 
 void init_key_accels(dt_iop_module_so_t *self)


### PR DESCRIPTION
Ref https://redmine.darktable.org/issues/11924

Tested locally, my local build works and allow to draw areas that include or exclude hot pixels.
