### PR TITLE
temperature: allow wb iop for non-raw non-monochrome

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -730,7 +730,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)module->params;
   dt_iop_temperature_params_t *fp = (dt_iop_temperature_params_t *)module->default_params;
 
-  if(!self->default_enabled)
+  if(self->hide_enable_button)
   {
     gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "disabled");
     return;
@@ -962,7 +962,6 @@ void reload_defaults(dt_iop_module_t *module)
   {
     // raw images need wb:
     module->default_enabled = 1;
-    module->hide_enable_button = 0;
 
     int found = 1;
 


### PR DESCRIPTION
Fixes 15d1bf52998b90444af1a92739349de2b306566a from PR #1621 which disabled temperature iop for JPEGs.

Don't bother to set `hide_enable_button` to 0 if is a raw, as that is the default value.

Behavior of temperature iop:

- monochrome raw: do not allow iop
- JPEG: allow iop, disable by default
- non-monochrome raw: allow iop, enable by default