### PR TITLE
limit resampling scale to 1 for darkroom

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -384,6 +384,15 @@ restart:
   scale = dt_dev_get_zoom_scale(dev, zoom, 1.0f, 0) * darktable.gui->ppd;
   window_width = dev->width * darktable.gui->ppd;
   window_height = dev->height * darktable.gui->ppd;
+
+  if (scale > 1)
+  {
+    float closeup2 = scale;
+    scale = 1;
+    window_width /= closeup2;
+    window_height /= closeup2;
+  }
+
   if(closeup)
   {
     window_width /= 2;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -211,7 +211,21 @@ void expose(
     else
       dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
-    cairo_translate(cr, .5f * (width - wd), .5f * (height - ht));
+
+    float closeup2 = 1.0;
+    const float scale = dt_dev_get_zoom_scale(dev, zoom, 1.0f, 0) * darktable.gui->ppd;
+
+    if (scale > 1)
+    {
+      closeup2 = scale;
+    }
+
+    cairo_translate(cr, .5f * (width - wd*closeup2), .5f * (height - ht*closeup2));
+    if(closeup2 > 1)
+    {
+      cairo_scale(cr, closeup2, closeup2);
+    }
+
     if(closeup)
     {
       cairo_scale(cr, 2.0, 2.0);
@@ -221,7 +235,7 @@ void expose(
     cairo_set_source_surface(cr, surface, 0, 0);
     cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
     cairo_fill_preserve(cr);
-    cairo_set_line_width(cr, 1.0);
+    cairo_set_line_width(cr, 1.0/closeup2);
     cairo_set_source_rgb(cr, .3, .3, .3);
     cairo_stroke(cr);
     cairo_surface_destroy(surface);


### PR DESCRIPTION
I noticed that especially on HiDPI screens, pictures get resampled with scale >1 in darkroom mode.
I don't think this brings any benefits, but slows down the pixel pipeline. 
e.g. panning around a 200% zoomed image with denoise module activated:

```
resampling_cl 0x7fb42fd18240 (379x293@0x0 scale 1,000000) -> 0x7fb42990a600 (1518x1172@0x0 scale 4,000000)
[dev_process_image]` pixel pipeline processing took 1,648 secs (1,945 CPU)
```


with my code the scale is limited to <=1
```
[dev_process_image] pixel pipeline processing took 0,215 secs (0,615 CPU)
```

I think dev_closeup was perhaps meant for something similar, but it is a bit buggy e.g. different behaviour from 200% zoom by navigation module and when zooming by scrolling.

If my PR makes sense, I would try to fix dev_closeup also, as it would not be needed in most cases.