### PR TITLE
temperature: fix reload_defaults

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -946,12 +946,14 @@ void reload_defaults(dt_iop_module_t *module)
 
   const int is_raw = dt_image_is_raw(&module->dev->image_storage);
 
+  module->default_enabled = 0;
+  module->hide_enable_button = 0;
+
   // White balance module doesn't need to be enabled for monochrome raws (like
   // for leica monochrom cameras). prepare_matrices is a noop as well, as there
   // isn't a color matrix, so we can skip that as well.
   if(is_raw && dt_image_is_monochrome(&(module->dev->image_storage)))
   {
-    module->default_enabled = 0;
     module->hide_enable_button = 1;
     goto gui;
   }


### PR DESCRIPTION
Make sure that `reload_defaults()` initializes `default_enabled` and `hide_enable_button` to sane values before changing them as necessary for (monochrome or color) raw images.

This fixes 330af2428f968f696730c0c8d6f304ac577fd96e which resulted in the temperature iop remaining disabled when switching from monochrome to non-monochrome raw files.

Bug pointed out by Kelvie Wong, fix provided by Roman Lebedev. See PR #1631.