### PR TITLE
toolbox: put a battery indicator widget in the top panel

### DIFF
--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -106,6 +106,8 @@ void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);
 /** paint the preferences wheel. */
 void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);
+/** paint a battery indicator. */
+void dtgtk_cairo_paint_battery(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);
 /** paint the "show ovelays" icon. */
 void dtgtk_cairo_paint_overlays(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags);
 /** paint and */

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -75,6 +75,17 @@ void gui_init(dt_lib_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
 
+  /* battery indicator */
+  FILE *fd = g_fopen("/sys/class/power_supply/BAT0/energy_now", "r");
+  if(fd)
+  {
+    fclose(fd);
+    GtkWidget *w = dtgtk_button_new(dtgtk_cairo_paint_battery, CPF_STYLE_FLAT|CPF_DO_NOT_USE_BORDER);
+    gtk_widget_set_size_request(w, DT_PIXEL_APPLY_DPI(18), DT_PIXEL_APPLY_DPI(18));
+    gtk_box_pack_start(GTK_BOX(self->widget), w, FALSE, FALSE, 2);
+    gtk_widget_set_tooltip_text(w, _("battery indicator"));
+  }
+
   /* create the grouping button */
   d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, CPF_STYLE_FLAT);
   gtk_widget_set_size_request(d->grouping_button, DT_PIXEL_APPLY_DPI(18), DT_PIXEL_APPLY_DPI(18));


### PR DESCRIPTION
i'm creating a pull request because this has a few controversial points:

* not sure if a feature. but this is the only reason i sometimes switch from fullscreen back to dwm such that i can see the battery indicator on my laptop
* bloatware and a clear sign of being overly feature complete
* code quality: i was so happy that the poison.h header didn't get included that i used plain fopen() wherever i could
* completely non-portable code to find out battery status (sys interface)

oh, here's a screenshot:
![2018-01-26-232151_2560x1440_scrot](https://user-images.githubusercontent.com/1574185/35435515-d85dcab4-02ef-11e8-8901-7783218b2a38.png)