### PR TITLE
print: show filename in GUI/log message

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -547,9 +547,9 @@ void dt_print_file(const int32_t imgid, const char *filename, const dt_print_inf
   dt_image_cache_read_release(darktable.image_cache, img);
 
   if (job_id == 0)
-    dt_control_log(_("error while printing image %d on `%s'"), imgid, pinfo->printer.name);
+    dt_control_log(_("error while printing `%s' on `%s'"), job_title, pinfo->printer.name);
   else
-    dt_control_log(_("printing image %d on `%s'"), imgid, pinfo->printer.name);
+    dt_control_log(_("printing `%s' on `%s'"), job_title, pinfo->printer.name);
 
   cupsFreeOptions (num_options, options);
 }


### PR DESCRIPTION
As long as we have the filename, use it instead of image ID. This is more meaningful to the user than an internal dt-created id.

If can't retrieve the filename this will print a generic name ("darktable"), but in that case there are more problems than the print job failing.

This is a followup to #1626 which retrieves the filename for an image ID and uses that to name the print job.