### PR TITLE
Add new build option: BUILD_MSYS2_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ option(BUILD_SSE2_CODEPATHS "(EXPERIMENTAL OPTION, DO NOT DISABLE) Building SSE2
 option(VALIDATE_APPDATA_FILE "Use appstream-util (if found) to validate the .appdata file" OFF)
 option(BUILD_TESTS "Build tests in src/tests/, runnable from the build/ directory" OFF)
 option(BUILD_BATTERY_INDICATOR "Add an icon to the top toolbar showing the state of a laptop battery" OFF)
+option(BUILD_MSYS2_INSTALL "Build an MSYS2 version of the install, aka for Windows platform, but without dependency installs" OFF)
 
 if(USE_OPENCL)
   option(TESTBUILD_OPENCL_PROGRAMS "Test-compile opencl programs (needs llvm and clang 3.9+)" ON)
@@ -168,6 +169,9 @@ if(WIN32)
   set(BUILD_CMSTEST OFF)
   set(BUILD_PRINT OFF)
   set(TESTBUILD_OPENCL_PROGRAMS OFF)
+  if(BUILD_MSYS2_INSTALL)
+    add_definitions(-DMSYS2_INSTALL)
+  endif()
 endif(WIN32)
 
 

--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -29,7 +29,7 @@ endmacro()
 
 function(InstallDependencyFiles)
 
-if (WIN32)
+if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
   # Dependency files (files which needs to be installed alongside the darktable binaries)
   # Please note these are ONLY the files which are not geing detected by fixup_bundle()
   # must be in the bin directory
@@ -198,6 +198,6 @@ if (WIN32)
     endforeach()
   endif(ISO_CODES_FOUND)
 
-endif(WIN32)
+endif(WIN32 AND NOT BUILD_MSYS2_INSTALL)
 
 endfunction()

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-IF(WIN32)
+IF(WIN32 AND NOT BUILD_MSYS2_INSTALL)
 
   set(plugin_dest_dir lib/darktable/plugins)
   set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/darktable.exe")  # paths to executables
@@ -59,4 +59,4 @@ IF(WIN32)
 
   endif()
 
-ENDIF(WIN32)
+ENDIF(WIN32 AND NOT BUILD_MSYS2_INSTALL)

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -65,7 +65,7 @@ static void get_language_names(GList *languages)
   JsonParser *parser = NULL;
   GError *error = NULL;
 
-#ifdef _WIN32 // TODO: add osx?
+#if defined(_WIN32) && !defined(MSYS2_INSTALL) // TODO: add osx?
   char datadir[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
   char *filename = g_build_filename(datadir, "..",  "iso-codes", "json", "iso_639-2.json", NULL);
@@ -80,7 +80,7 @@ static void get_language_names(GList *languages)
     goto end;
   }
 
-#ifdef _WIN32 // TODO: add osx?
+#if defined(_WIN32) && !defined(MSYS2_INSTALL) // TODO: add osx?
   // on windows we are shipping the translations of iso-codes along ours
   char *localedir = g_build_filename(datadir, "..", "locale", NULL);
   bindtextdomain("iso_639", localedir);

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1079,12 +1079,14 @@ void init_global(dt_iop_module_so_t *module)
   if(lf_db_load(dt_iop_lensfun_db) != LF_NO_ERROR)
 #endif
   {
-    char path[PATH_MAX] = { 0 };
-    dt_loc_get_datadir(path, sizeof(path));
-    char *c = path + strlen(path);
-    for(; c > path && *c != G_DIR_SEPARATOR; c--)
-      ;
-    *c = '\0';
+    char datadir[PATH_MAX] = { 0 };
+    dt_loc_get_datadir(datadir, sizeof(datadir));
+
+    // get parent directory
+    GFile *file = g_file_parse_name(datadir);
+    gchar *path = g_file_get_path(g_file_get_parent(file));
+    g_object_unref(file);
+
 #ifdef LF_MAX_DATABASE_VERSION
     g_free(dt_iop_lensfun_db->HomeDataDir);
     dt_iop_lensfun_db->HomeDataDir = g_build_filename(path, "lensfun", "version_" STR(LF_MAX_DATABASE_VERSION), NULL);
@@ -1099,6 +1101,8 @@ void init_global(dt_iop_module_so_t *module)
 #ifdef LF_MAX_DATABASE_VERSION
     }
 #endif
+
+    g_free(path);
   }
 }
 


### PR DESCRIPTION
This option simply skips installing dependencies. By default this option is OFF.
While I was at it and checking how directories behave, I have found a not very robust way to get a parent directory in the lensfun initialization. I have replaced that with a more robust glib code. 