### PR TITLE
Windows: make trashing of the files silent

### DIFF
--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -45,6 +45,9 @@
 #ifdef __APPLE__
 #include "osx/osx.h"
 #endif
+#ifdef _WIN32
+#include "win/dtwin.h"
+#endif
 
 typedef struct dt_control_time_offset_t
 {
@@ -779,11 +782,13 @@ static enum _dt_delete_status delete_file_from_disk(const char *filename)
     GError *gerror = NULL;
     if (send_to_trash)
     {
-      #ifdef __APPLE__
+#ifdef __APPLE__
       delete_success = dt_osx_file_trash(filename, &gerror);
-      #else
+#elif defined(_WIN32)
+      delete_success = dt_win_file_trash(gfile, NULL /*cancellable*/, &gerror);
+#else
       delete_success = g_file_trash(gfile, NULL /*cancellable*/, &gerror);
-      #endif
+#endif
     }
     else
     {

--- a/src/win/dtwin.c
+++ b/src/win/dtwin.c
@@ -336,6 +336,40 @@ void dtwin_set_thread_name(DWORD dwThreadID, const char *threadName)
   RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(DWORD), (const ULONG_PTR *)&info);
 }
 
+
+boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error)
+{
+  SHFILEOPSTRUCTW op = { 0 };
+  gboolean success;
+  wchar_t *wfilename;
+  long len;
+
+  wfilename = g_utf8_to_utf16(g_file_get_parse_name(file), -1, NULL, &len, NULL);
+  /* SHFILEOPSTRUCT.pFrom is double-zero-terminated */
+  wfilename = g_renew(wchar_t, wfilename, len + 2);
+  wfilename[len + 1] = 0;
+
+  op.wFunc = FO_DELETE;
+  op.pFrom = wfilename;
+  op.fFlags = FOF_ALLOWUNDO | FOF_SILENT | FOF_NOCONFIRMATION;
+
+  success = SHFileOperationW(&op) == 0;
+
+  if(success && op.fAnyOperationsAborted)
+  {
+    if(cancellable && !g_cancellable_is_cancelled(cancellable)) g_cancellable_cancel(cancellable);
+    g_set_error(error, G_IO_ERROR, g_io_error_from_errno(ECANCELED),
+                g_strdup_printf("Unable to trash file %s: %s", file, ECANCELED), g_file_get_parse_name(file),
+                g_strerror(ECANCELED));
+    success = FALSE;
+  }
+  else if(!success)
+    g_set_error(error, G_IO_ERROR, g_io_error_from_errno(0), g_strdup_printf("Unable to trash file %s", file),
+                g_file_get_parse_name(file), g_strerror(0));
+
+  g_free(wfilename);
+  return success;
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/win/dtwin.c
+++ b/src/win/dtwin.c
@@ -336,7 +336,10 @@ void dtwin_set_thread_name(DWORD dwThreadID, const char *threadName)
   RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(DWORD), (const ULONG_PTR *)&info);
 }
 
-
+// This is taken from: https://git.gnome.org/browse/glib/tree/gio/glocalfile.c#n2269
+// The glib version of this function unfortunately shows always confirmation dialog boxes
+// This version does thrashing silently, without dialog boxes: FOF_SILENT | FOF_NOCONFIRMATION
+// When glib version on Windows will do silent trashing we can remove this function
 boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error)
 {
   SHFILEOPSTRUCTW op = { 0 };

--- a/src/win/dtwin.h
+++ b/src/win/dtwin.h
@@ -19,10 +19,12 @@
 
 #pragma once
 
+#include <gtk/gtk.h>
 #include <windows.h>
 
 const wchar_t *dtwin_get_locale();
 void dtwin_set_thread_name(DWORD dwThreadID, const char *threadName);
+boolean dt_win_file_trash(GFile *file, GCancellable *cancellable, GError **error);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Current g_file_trash() on Widnows still displays confirmation dialogs, this change makes trashing silent using a local implementation. When g_file_trash() in glib wil be updated we can remove this workaround.

Fixes 11919