### PR TITLE
Windows: remove incorrect Atom detection & revised performance configuration

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1740,7 +1740,7 @@
     <name>performance_configuration_version_completed</name>
     <type>int</type>
     <default>0</default>
-    <shortdescription>latest version of performance configuration completed</shortdescription>
-    <longdescription>what was the latest version of performance configuration cycle which has been completed at last startup</longdescription>
+    <shortdescription>version of the last completed performance configuration</shortdescription>
+    <longdescription>what was the last performance configuration which has been completed</longdescription>
   </dtconfig>
 </dtconfiglist>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1736,4 +1736,11 @@
     <shortdescription>the multiplier that is applied to any slider precise value change</shortdescription>
     <longdescription>any slider value change will be multiplied by this number, when changing slider while holding CTRL modifier</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>performance_configuration_version_completed</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>latest version of performance configuration completed</shortdescription>
+    <longdescription>what was the latest version of performance configuration cycle which has been completed at last startup</longdescription>
+  </dtconfig>
 </dtconfiglist>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -774,21 +774,17 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   int last_configure_version = dt_conf_get_int("performance_configuration_version_completed");
   if(last_configure_version < DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION)
   {
-    // if this is the very first time -> run this configuration unconditionally
     bool run_configure = TRUE;
 
     // ask the user whether he/she would like
     // dt to make changes in the settings
-    char *label_text = g_markup_printf_escaped(
-        _("We have an updated performance configuration logic - executing that might improve the "
-          "performance of darktable.\nThis will potentially overwrite some your existing settings - escpecially in "
-          "case you have manually modified them to custom values.\n"
-          "Would you like to execute this performance configuration?\n"));
-
-    run_configure = dt_gui_show_standalone_yes_no_dialog(_("darktable - Run performance configuration?"),
-                                                        label_text, _("No"), _("Yes"));
-
-    g_free(label_text);
+    run_configure = dt_gui_show_standalone_yes_no_dialog(
+        _("darktable - Run performance configuration?"),
+        _("We have an updated performance configuration logic - executing that might improve the performance of "
+          "darktable.\nThis will potentially overwrite some of your existing settings - especially in case you "
+          "have manually modified them to custom values.\nWould you like to execute this update of the "
+          "performance configuration?\n"),
+        _("No"), _("Yes"));
 
     if(run_configure)
       dt_configure_performance();

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -777,31 +777,22 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     // if this is the very first time -> run this configuration unconditionally
     bool run_configure = TRUE;
 
-    // Don't ask if it is the very first run, eg. after a new install of dt
-    if (last_configure_version != 0)
-    {
-      // ask the user whether he/she would like
-      // dt to make changes in the settings
-      char *label_text = g_markup_printf_escaped(
-          _("We have an updated performance configuration logic - executing that might improve the "
-            "performance of darktable. This will potentially overwrite some your existing settings - escpecially in "
-            "case you have manually modified them to custom values.\n"
-            "Would you like to execute this performance configuration?\n"));
+    // ask the user whether he/she would like
+    // dt to make changes in the settings
+    char *label_text = g_markup_printf_escaped(
+        _("We have an updated performance configuration logic - executing that might improve the "
+          "performance of darktable.\nThis will potentially overwrite some your existing settings - escpecially in "
+          "case you have manually modified them to custom values.\n"
+          "Would you like to execute this performance configuration?\n"));
 
-      run_configure = dt_gui_show_standalone_yes_no_dialog(_("darktable - Run performance configuration?"),
-                                                          label_text, _("Yes"), _("No"));
+    run_configure = dt_gui_show_standalone_yes_no_dialog(_("darktable - Run performance configuration?"),
+                                                        label_text, _("No"), _("Yes"));
 
-      g_free(label_text);
-    }
+    g_free(label_text);
 
     if(run_configure)
       dt_configure_performance();
   }
-
-  // store the current performance configure version as the last completed
-  // that would prevent further execution of previous performance configuration run
-  // at subsequent startups
-  dt_conf_set_int("performance_configuration_version_completed", DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION);
 
   // detect cpu features and decide which codepaths to enable
   dt_codepaths_init();
@@ -1256,6 +1247,11 @@ void dt_configure_performance()
   }
 
   g_free(demosaic_quality);
+
+  // store the current performance configure version as the last completed
+  // that would prevent further execution of previous performance configuration run
+  // at subsequent startups
+  dt_conf_set_int("performance_configuration_version_completed", DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION);  
 }
 
 

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1171,6 +1171,7 @@ void dt_configure_performance()
   const int threads = dt_get_num_threads();
   const size_t mem = dt_get_total_memory();
   const int bits = (sizeof(void *) == 4) ? 32 : 64;
+  gchar *demosaic_quality = dt_conf_get_string("plugins/darkroom/demosaic/quality");
 
   fprintf(stderr, "[defaults] found a %d-bit system with %zu kb ram and %d cores (%d atom based)\n", bits, mem,
           threads, atom_cores);
@@ -1188,7 +1189,7 @@ void dt_configure_performance()
 
     if(dt_conf_get_int("singlebuffer_limit") < 16) dt_conf_set_int("singlebuffer_limit", 16);
 
-    if(!strcmp(dt_conf_get_string("plugins/darkroom/demosaic/quality"), "always bilinear (fast)"))
+    if(demosaic_quality == NULL || !strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
 
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
@@ -1205,7 +1206,7 @@ void dt_configure_performance()
 
     if(dt_conf_get_int("singlebuffer_limit") < 16) dt_conf_set_int("singlebuffer_limit", 16);
 
-    if(!strcmp(dt_conf_get_string("plugins/darkroom/demosaic/quality"), "always bilinear (fast)"))
+    if(demosaic_quality == NULL ||!strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
 
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
@@ -1232,6 +1233,8 @@ void dt_configure_performance()
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
   }
+
+  g_free(demosaic_quality);
 
   // store the current performance configure version as the last completed
   // that would prevent further execution of this performance configuration

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -87,6 +87,11 @@ typedef unsigned int u_int;
 
 #define DT_MODULE_VERSION 18 // version of dt's module interface
 
+// version of current performance configuration version
+// if you want to run an updated version of the performance configuration later
+// bump this number and make sure you have an updated logic in dt_configure_performance()
+#define DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION 1
+
 // every module has to define this:
 #ifdef _DEBUG
 #define DT_MODULE(MODVER)                                                                                    \
@@ -526,7 +531,7 @@ static inline size_t dt_get_total_memory()
 #endif
 }
 
-void dt_configure_defaults();
+void dt_configure_performance();
 
 // helper function which loads whatever image_to_load points to: single image files or whole directories
 // it tells you if it was a single image or a directory in single_image (when it's not NULL)

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -484,12 +484,6 @@ static inline int dt_get_num_atom_cores()
   }
 
   return hw_ncpu;
-#elif defined _WIN32
-
-  SYSTEM_INFO sysinfo;
-  GetSystemInfo(&sysinfo);
-  return sysinfo.dwNumberOfProcessors;
-
 #else
   return 0;
 #endif

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -251,6 +251,11 @@ static inline void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *ove
     fclose(f);
   }
 
+  // for the very first time after a fresh install
+  // execute performance configuration no matter what
+  if(defaults)
+    dt_configure_performance();
+
   if(override_entries)
   {
     GSList *p = override_entries;

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -250,7 +250,6 @@ static inline void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *ove
     }
     fclose(f);
   }
-  if(defaults) dt_configure_defaults();
 
   if(override_entries)
   {


### PR DESCRIPTION
This PR contains two changes:
* Windows: remove incorrect Atom detection - Fixes #11981
* Add more robust performance configuration 
So far performance configuration run only once on a naive machine, running darktable for the very first time. This change enables running performance configurations again when we see necessary by bumping DT_CURRENT_PERFORMANCE_CONFIGURE_VERSION. Also different performance configurations are better documented, and more structured.

Please help reviewing whether performance configuration is well balanced (ie we don't limit powerful machines/configurations with sub-optimal settings), and also whether additional settings might be needed to be added to performance config.