### PR TITLE
Fix string termination override on memmove.

### DIFF
--- a/src/chart/colorchart.c
+++ b/src/chart/colorchart.c
@@ -91,7 +91,7 @@ static int strinc(char *label, size_t buffer_size)
     else if(c == label)
     {
       if(label_len + 1 >= buffer_size) return 0;
-      memmove(c + 1, c, label_len);
+      memmove(c + 1, c, label_len + 1);
       *c = carry_over;
     }
     c--;
@@ -294,7 +294,7 @@ chart_t *parse_cht(const char *filename)
           size_t lxs_len = strlen(lxs), lxe_len = strlen(lxe), lys_len = strlen(lys), lye_len = strlen(lye);
           if(lxs_len > lxe_len || lys_len > lye_len) ERROR;
 
-          // make sure there is enough room to add another char in the beginning
+          // make sure there is enough space for the null character
           const size_t x_label_size = lxe_len + 1;
           const size_t y_label_size = lye_len + 1;
 

--- a/src/chart/colorchart.c
+++ b/src/chart/colorchart.c
@@ -294,7 +294,7 @@ chart_t *parse_cht(const char *filename)
           size_t lxs_len = strlen(lxs), lxe_len = strlen(lxe), lys_len = strlen(lys), lye_len = strlen(lye);
           if(lxs_len > lxe_len || lys_len > lye_len) ERROR;
 
-          // make sure there is enough space for the null character
+          // make sure there is enough room to add another char in the beginning
           const size_t x_label_size = lxe_len + 1;
           const size_t y_label_size = lye_len + 1;
 


### PR DESCRIPTION
strlen returns the number of characters excluding the null character. When shifting the string, that character has to be included to avoid undefined behaviour.

Also a small update to the comment to make it clear, that the extra character is required by the actual end label.