### PR TITLE
Fix #11930: CSS themes: remove hard-coded font colors from bauhaus widgets

### DIFF
--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -90,6 +90,7 @@ combobox *:hover,
   border:0;
   margin:0;
   background-color: transparent;
+  color: @fg_color;
   outline-style:none;
 }
 /* buttons in plugins */

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -66,23 +66,24 @@ static float get_label_font_size()
 
 static void set_bg_normal(cairo_t *cr)
 {
-  cairo_set_source_rgb(cr, darktable.bauhaus->bg_normal, darktable.bauhaus->bg_normal,
-                       darktable.bauhaus->bg_normal);
+  cairo_set_source_rgb(cr, darktable.bauhaus->bg_normal->red, darktable.bauhaus->bg_normal->green,
+                       darktable.bauhaus->bg_normal->blue);
 }
 
 static void set_bg_focus(cairo_t *cr)
 {
-  cairo_set_source_rgb(cr, darktable.bauhaus->bg_focus, darktable.bauhaus->bg_focus,
-                       darktable.bauhaus->bg_focus);
+  cairo_set_source_rgb(cr, darktable.bauhaus->bg_focus->red, darktable.bauhaus->bg_focus->green,
+                       darktable.bauhaus->bg_focus->blue);
 }
 
 static void set_text_color(cairo_t *cr, int sensitive)
 {
   if(sensitive)
-    cairo_set_source_rgb(cr, darktable.bauhaus->text, darktable.bauhaus->text, darktable.bauhaus->text);
+    cairo_set_source_rgb(cr, darktable.bauhaus->text->red, darktable.bauhaus->text->green,
+                         darktable.bauhaus->text->blue);
   else
-    cairo_set_source_rgba(cr, darktable.bauhaus->text, darktable.bauhaus->text, darktable.bauhaus->text,
-                          darktable.bauhaus->insensitive);
+    cairo_set_source_rgba(cr, darktable.bauhaus->text->red, darktable.bauhaus->text->green,
+                          darktable.bauhaus->text->blue, darktable.bauhaus->insensitive);
 }
 
 static void set_grid_color(cairo_t *cr, int sensitive)
@@ -488,9 +489,6 @@ void dt_bauhaus_init()
   darktable.bauhaus->value_font_size = 0.6f;
   g_strlcpy(darktable.bauhaus->label_font, "sans", sizeof(darktable.bauhaus->label_font));
   g_strlcpy(darktable.bauhaus->value_font, "sans", sizeof(darktable.bauhaus->value_font));
-  darktable.bauhaus->bg_normal = 0.145098f;
-  darktable.bauhaus->bg_focus = 0.207843f;
-  darktable.bauhaus->text = .792f;
   darktable.bauhaus->grid = .1f;
   darktable.bauhaus->indicator = .6f;
   darktable.bauhaus->insensitive = 0.2f;
@@ -504,25 +502,31 @@ void dt_bauhaus_init()
   gtk_style_context_set_path(ctx, path);
   gtk_style_context_set_screen (ctx, gtk_widget_get_screen(root_window));
 
-  GdkRGBA color, selected_color, bg_color, selected_bg_color;
-  gtk_style_context_get_color(ctx, GTK_STATE_FLAG_NORMAL, &color);
-  {
-    GdkRGBA *bc;
-    gtk_style_context_get(ctx, GTK_STATE_FLAG_NORMAL, "background-color", &bc, NULL);
-    bg_color = *bc;
-    gdk_rgba_free(bc);
-  }
-  gtk_style_context_get_color(ctx, GTK_STATE_FLAG_SELECTED, &selected_color);
-  {
-    GdkRGBA *sbc;
-    gtk_style_context_get(ctx, GTK_STATE_FLAG_SELECTED, "background-color", &sbc, NULL);
-    selected_bg_color = *sbc;
-    gdk_rgba_free(sbc);
-  }
+  GdkRGBA *tmpcolor;
+
+  // Get the normal foreground color from the CSS stylesheet
+  tmpcolor = g_malloc0(sizeof(GdkRGBA));
+  gdk_rgba_parse(tmpcolor, "#3C3C3C"); // .792f;
+  gtk_style_context_get(ctx, GTK_STATE_FLAG_NORMAL, "color", &tmpcolor, NULL);
+  darktable.bauhaus->text = gdk_rgba_copy(tmpcolor);
+  gdk_rgba_free(tmpcolor);
+
+  // Get the normal background color from the CSS stylesheet
+  tmpcolor = g_malloc0(sizeof(GdkRGBA));
+  gdk_rgba_parse(tmpcolor, "#212121"); // 0.145098f;
+  gtk_style_context_get(ctx, GTK_STATE_FLAG_NORMAL, "background-color", &tmpcolor, NULL);
+  darktable.bauhaus->bg_normal = gdk_rgba_copy(tmpcolor);
+  gdk_rgba_free(tmpcolor);
+
+  // Get the selected background color from the CSS stylesheet
+  tmpcolor = g_malloc0(sizeof(GdkRGBA));
+  gdk_rgba_parse(tmpcolor, "#353535"); // 0.207843f;
+  gtk_style_context_get(ctx, GTK_STATE_FLAG_SELECTED, "background-color", &tmpcolor, NULL);
+  darktable.bauhaus->bg_focus = gdk_rgba_copy(tmpcolor);
+  gdk_rgba_free(tmpcolor);
+
   PangoFontDescription *pfont = 0;
   gtk_style_context_get(ctx, GTK_STATE_FLAG_NORMAL, "font", &pfont, NULL);
-  darktable.bauhaus->bg_normal = bg_color.red;
-  darktable.bauhaus->bg_focus = selected_bg_color.red;
   gtk_widget_path_free(path);
 
   darktable.bauhaus->pango_font_desc = pfont;
@@ -613,6 +617,10 @@ void dt_bauhaus_cleanup()
   // TODO: destroy keymap hash table!
   g_list_free_full(darktable.bauhaus->key_mod, (GDestroyNotify)g_free);
   g_list_free_full(darktable.bauhaus->key_val, (GDestroyNotify)g_free);
+
+  gdk_rgba_free(darktable.bauhaus->text);
+  gdk_rgba_free(darktable.bauhaus->bg_normal);
+  gdk_rgba_free(darktable.bauhaus->bg_focus);
 }
 
 // fwd declare a few callbacks

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -505,22 +505,16 @@ void dt_bauhaus_init()
   GdkRGBA *tmpcolor;
 
   // Get the normal foreground color from the CSS stylesheet
-  tmpcolor = g_malloc0(sizeof(GdkRGBA));
-  gdk_rgba_parse(tmpcolor, "#3C3C3C"); // .792f;
   gtk_style_context_get(ctx, GTK_STATE_FLAG_NORMAL, "color", &tmpcolor, NULL);
   darktable.bauhaus->text = gdk_rgba_copy(tmpcolor);
   gdk_rgba_free(tmpcolor);
 
   // Get the normal background color from the CSS stylesheet
-  tmpcolor = g_malloc0(sizeof(GdkRGBA));
-  gdk_rgba_parse(tmpcolor, "#212121"); // 0.145098f;
   gtk_style_context_get(ctx, GTK_STATE_FLAG_NORMAL, "background-color", &tmpcolor, NULL);
   darktable.bauhaus->bg_normal = gdk_rgba_copy(tmpcolor);
   gdk_rgba_free(tmpcolor);
 
   // Get the selected background color from the CSS stylesheet
-  tmpcolor = g_malloc0(sizeof(GdkRGBA));
-  gdk_rgba_parse(tmpcolor, "#353535"); // 0.207843f;
   gtk_style_context_get(ctx, GTK_STATE_FLAG_SELECTED, "background-color", &tmpcolor, NULL);
   darktable.bauhaus->bg_focus = gdk_rgba_copy(tmpcolor);
   gdk_rgba_free(tmpcolor);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -208,9 +208,9 @@ typedef struct dt_bauhaus_t
   int cursor_blink_counter;
 
   // colors:
-  float bg_normal;   // background without focus
-  float bg_focus;    // background with focus
-  float text;        // text color
+  GdkRGBA *bg_normal;   // background without focus
+  GdkRGBA *bg_focus;    // background with focus
+  GdkRGBA *text;        // text color
   float grid;        // background lines
   float indicator;   // meaningful lines
   float insensitive; // alpha for insensitive elements

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -109,8 +109,8 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(5));
 
-  d->compress_button = dtgtk_button_new(NULL, /*CPF_DO_NOT_USE_BORDER | CPF_STYLE_FLAT*/0, NULL);
-  gtk_button_set_label(GTK_BUTTON(d->compress_button), _("compress history stack"));
+  d->compress_button = gtk_button_new_with_label(_("compress history stack"));
+  gtk_label_set_xalign (GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->compress_button))), 0.0f);
   gtk_widget_set_tooltip_text(d->compress_button, _("create a minimal history stack which produces the same image"));
   g_signal_connect(G_OBJECT(d->compress_button), "clicked", G_CALLBACK(_lib_history_compress_clicked_callback), NULL);
 

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -185,6 +185,10 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget, cairo_t *cr, gpo
   gtk_widget_get_allocation(widget, &allocation);
   gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
 
+  // Get the normal foreground color from the CSS stylesheet
+  GdkRGBA *tmpcolor;
+  gtk_style_context_get(context, GTK_STATE_FLAG_NORMAL, "color", &tmpcolor, NULL);
+
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
 
   PangoFontDescription *font_desc = NULL;
@@ -207,7 +211,7 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget, cairo_t *cr, gpo
   pango_layout_set_font_description(layout, font_desc);
 
   pango_layout_set_text(layout, PACKAGE_NAME, -1);
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
+  cairo_set_source_rgba(cr, tmpcolor->red, tmpcolor->green, tmpcolor->blue, 0.7);
   cairo_move_to(cr, d->image_width + DT_PIXEL_APPLY_DPI(2.0), DT_PIXEL_APPLY_DPI(5.0));
   pango_cairo_show_layout(cr, layout);
 
@@ -216,10 +220,11 @@ static gboolean _lib_darktable_draw_callback(GtkWidget *widget, cairo_t *cr, gpo
   pango_layout_set_font_description(layout, font_desc);
   pango_layout_set_text(layout, darktable_package_version, -1);
   cairo_move_to(cr, d->image_width + DT_PIXEL_APPLY_DPI(4.0), DT_PIXEL_APPLY_DPI(30.0));
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.3);
+  cairo_set_source_rgba(cr, tmpcolor->red, tmpcolor->green, tmpcolor->blue, 0.3);
   pango_cairo_show_layout(cr, layout);
 
   /* cleanup */
+  gdk_rgba_free(tmpcolor);
   g_object_unref(layout);
   pango_font_description_free(font_desc);
 


### PR DESCRIPTION
Before this change, changing `@fg_color` in CSS had no effect on bauhaus widgets. See this example with `@fg_color=aqua;`
<img width="1280" alt="capture before" src="https://user-images.githubusercontent.com/7863452/35828211-f9e6a152-0abe-11e8-8b89-ccd8d36c6fd0.PNG">

After this change, the `@fg_color` is properly propagated to bauhaus labels:
<img width="1280" alt="capture - after" src="https://user-images.githubusercontent.com/7863452/35828240-1af603f6-0abf-11e8-87bd-fcdb0bbdc88f.PNG">
