### PR TITLE
Hybrid fdc with crossover iso configurable in darktablerc

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1203,6 +1203,13 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/demosaic/fdc_xover_iso</name>
+    <type>int</type>
+    <default>1600</default>
+    <shortdescription>crossover iso for X-Trans fdc demosaicing</shortdescription>
+    <longdescription>up to, and including, this iso, X-Trans frequency domain chroma demosaicing uses the hybrid mode for determining chroma; for all higher iso values the pure fdc is used.</longdescription>
+  </dtconfig>
   <dtconfig prefs="core" section="quality">
     <name>plugins/darkroom/demosaic/quality</name>
     <type>


### PR DESCRIPTION
Further improvement of fdc demosaicing, which addresses the colour bleeding into black and into dark image areas. For doing this, chroma from Markesteijn is selectively used. This gives very clean images for lower iso. For higher iso, the original fdc is still delivering better results with respect to chroma noise. The highest iso that is treated with the new hybrid approach can be configured in darktablerc. 1600 appears to be a very good compromise. Configuration also allows for new approach only or pure fdc (i.e. old approach) only by setting the crossover iso accordingly.