### PR TITLE
Reverse change that crippled collect-by-tag.

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -919,7 +919,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       break;
     case DT_COLLECTION_PROP_TAG: // tag
       query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.tagged_images AS a JOIN "
-                                     "data.tags AS b ON a.tagid = b.id WHERE name LIKE '%1$s' OR name like '%1$s|%%'))",
+                                     "data.tags AS b ON a.tagid = b.id WHERE name LIKE '%s'))",
                               escaped_text);
       break;
 


### PR DESCRIPTION
This reverses a change to the behavior of the "tag" query in the collect module. Previously, when the name of a tag (e.g., `foo`) was entered into the collect module, it collected only images with that exact tag. Now it also collects images with _any_ of the tag's subtags (e.g., `foo|bar`).

The change was made in commit 71da7aaa as part of the resolution of bug #11817. It was not documented anywhere that I could find except in the Redmine comments.

I am requesting that this change be reversed on the grounds that it makes some reasonable queries outright impossible to formulate; two obvious examples:

* Images with the exact tag `foo` (could previously be collected with `tag "foo"`)
* Images with the tag `foo|bar` but not the tag `foo` (could previously be collected with `tag "foo|bar" BUT NOT tag "foo"`)