### PR TITLE
Fix map -> find location (Bug #12214)

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1726,6 +1726,13 @@
     <shortdescription>allow editing raw cropping boundaries</shortdescription>
     <longdescription>this is mainly useful for debugging and to add new camera support.</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/map/geotagging_search_url</name>
+    <type>string</type>
+    <default>https://nominatim.openstreetmap.org/search/%s?format=xml&amp;limit=%d&amp;polygon_text=1</default>
+    <shortdescription>Geotagging search URL</shortdescription>
+    <longdescription>this can be changed when the default OpenStreetMap search URL is broken</longdescription>
+  </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
 

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -389,6 +389,7 @@ bail_out:
 
   g_free(text);
   g_free(query);
+  g_free(search_url);
 
   if(ctx) g_markup_parse_context_free(ctx);
 

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -343,8 +343,8 @@ static gboolean _lib_location_search(gpointer user_data)
   clear_search(lib);
 
   /* build the query url */
-  query = dt_util_dstrcat(query, "https://nominatim.openstreetmap.org/search/%s?format=xml&limit=%d&polygon_text=1", text,
-                          LIMIT_RESULT);
+  gchar *search_url = dt_conf_get_string("plugins/map/geotagging_search_url");
+  query = dt_util_dstrcat(query, search_url, text, LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();
   if(!curl) goto bail_out;

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -332,7 +332,7 @@ static gboolean _lib_location_search(gpointer user_data)
 
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_location_t *lib = (dt_lib_location_t *)self->data;
-  gchar *query = NULL, *text = NULL;
+  gchar *query = NULL, *text = NULL, *search_url = NULL;
 
   /* get escaped search text */
   text = g_uri_escape_string(gtk_entry_get_text(lib->search), NULL, FALSE);
@@ -343,7 +343,7 @@ static gboolean _lib_location_search(gpointer user_data)
   clear_search(lib);
 
   /* build the query url */
-  gchar *search_url = dt_conf_get_string("plugins/map/geotagging_search_url");
+  search_url = dt_conf_get_string("plugins/map/geotagging_search_url");
   query = dt_util_dstrcat(query, search_url, text, LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -355,6 +355,7 @@ static gboolean _lib_location_search(gpointer user_data)
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _lib_location_curl_write_data);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, (char *)darktable_package_string);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 20L);
 
   res = curl_easy_perform(curl);
   if(res != 0) goto bail_out;

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -354,6 +354,7 @@ static gboolean _lib_location_search(gpointer user_data)
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, lib);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _lib_location_curl_write_data);
   curl_easy_setopt(curl, CURLOPT_USERAGENT, (char *)darktable_package_string);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
   res = curl_easy_perform(curl);
   if(res != 0) goto bail_out;

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -122,7 +122,7 @@ int position()
 }
 
 /*
-  http://nominatim.openstreetmap.org/search/norrköping?format=xml&limit=5
+  https://nominatim.openstreetmap.org/search/norrköping?format=xml&limit=5
  */
 void gui_init(dt_lib_module_t *self)
 {
@@ -343,7 +343,7 @@ static gboolean _lib_location_search(gpointer user_data)
   clear_search(lib);
 
   /* build the query url */
-  query = dt_util_dstrcat(query, "http://nominatim.openstreetmap.org/search/%s?format=xml&limit=%d&polygon_text=1", text,
+  query = dt_util_dstrcat(query, "https://nominatim.openstreetmap.org/search/%s?format=xml&limit=%d&polygon_text=1", text,
                           LIMIT_RESULT);
   /* load url */
   curl = curl_easy_init();


### PR DESCRIPTION
This fixes [Bug #12214](https://redmine.darktable.org/issues/12214) , the find location feature was broken because the openstreetmap search url is only accessible through https now.

```
Breakpoint 1 (location.c:364) pending.
(gdb) run
Starting program: /usr/bin/darktable 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
[...]

Thread 1 "darktable" hit Breakpoint 1, _lib_location_search (
    user_data=0x555557c8a1f0)
    at /home/trougnouf/uclouvain/Q4/lingi2402/dt/src/darktable/src/libs/location.c:364
364	  ctx = g_markup_parse_context_new(&_lib_location_parser, 0, lib, NULL);
(gdb) print lib->response
$5 = (gchar *) 0x555558229e20 "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>301 Moved Permanently</title>\n</head><body>\n<h1>Moved Permanently</h1>\n<p>The document has moved <a href=\"https://nominatim.opens"...
(gdb)
```