### PR TITLE
Correct type for XResolution and YResolution

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1270,8 +1270,8 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
     int resolution = dt_conf_get_int("metadata/resolution");
     if(resolution > 0)
     {
-      exifData["Exif.Image.XResolution"] = resolution;
-      exifData["Exif.Image.YResolution"] = resolution;
+      exifData["Exif.Image.XResolution"] = Exiv2::Rational(resolution, 1);
+      exifData["Exif.Image.YResolution"] = Exiv2::Rational(resolution, 1);
       exifData["Exif.Image.ResolutionUnit"] = uint16_t(2); /* inches */
     }
     else


### PR DESCRIPTION
The datatype for XResolution and YResolution that darktable writes is not compliant to the Exif standard (see http://www.exiv2.org/tags.html). Even though most readers might ignore this issue and are tolerant, things become a problem when writing tags with a different tool, such as piexif (http://piexif.readthedocs.io/en/latest/). Piexif expects the correct datatype and therefore refuses to write changed exif tags that have been read from a darktable-exported image.

Also - being standard-compliant is usually a good thing.