### PR TITLE
Add OARS metadata

### DIFF
--- a/data/darktable.appdata.xml.in
+++ b/data/darktable.appdata.xml.in
@@ -47,6 +47,7 @@
       <_caption>Print your images</_caption>
     </screenshot>
   </screenshots>
+  <content_rating type="oars-1.1" />
   <url type="homepage">https://www.darktable.org/</url>
   <url type="bugtracker">https://redmine.darktable.org/projects/darktable/issues</url>
   <url type="help">https://www.darktable.org/usermanual/</url>


### PR DESCRIPTION
OARS (https://hughsie.github.io/oars/) is a content labelling system used by software stores like GNOME Software. It's a flathub requirement and increasingly supported. This policy indicates that Darktable doesn't do anything dubious.