### PR TITLE
Feature #8968: Actions are not applied to all grouped images when collapsed

### DIFF
--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -95,6 +95,7 @@ typedef enum dt_collection_properties_t
   DT_COLLECTION_PROP_ASPECT_RATIO,
   DT_COLLECTION_PROP_FILENAME,
   DT_COLLECTION_PROP_GEOTAGGING,
+  DT_COLLECTION_PROP_GROUPING,
   DT_COLLECTION_PROP_LOCAL_COPY
 } dt_collection_properties_t;
 
@@ -133,9 +134,9 @@ typedef struct dt_collection_params_t
 typedef struct dt_collection_t
 {
   int clone;
-  gchar *query;
+  gchar *query, *query_no_group;
   gchar **where_ext;
-  unsigned int count;
+  unsigned int count, count_no_group;
   dt_collection_params_t params;
   dt_collection_params_t store;
 } dt_collection_t;
@@ -153,6 +154,8 @@ void dt_collection_get_makermodels(const gchar *filter, GList **sanitized, GList
 gchar *dt_collection_get_makermodel(const char *exif_maker, const char *exif_model);
 /** get the generated query for collection */
 const gchar *dt_collection_get_query(const dt_collection_t *collection);
+/** get the generated query for collection including the images hidden in groups */
+const gchar *dt_collection_get_query_no_group(const dt_collection_t *collection);
 /** updates sql query for a collection. @return 1 if query changed. */
 int dt_collection_update(const dt_collection_t *collection);
 /** reset collection to default dummy selection */
@@ -195,6 +198,8 @@ gchar *dt_collection_get_sort_query(const dt_collection_t *collection);
 
 /** get the count of query */
 uint32_t dt_collection_get_count(const dt_collection_t *collection);
+/** get the count of query including the images hidden in groups */
+uint32_t dt_collection_get_count_no_group(const dt_collection_t *collection);
 /** get the nth image in the query */
 int dt_collection_get_nth(const dt_collection_t *collection, int nth);
 /** get all image ids order as current selection. no more than limit many images are returned, <0 ==

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -27,6 +27,9 @@ void dt_ratings_apply_to_selection(int rating);
 /** apply rating to the specified image */
 void dt_ratings_apply_to_image(int imgid, int rating);
 
+/** apply rating to the specified image, or any image in a collapsed group */
+void dt_ratings_apply_to_image_or_group(int imgid, int rating);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -30,6 +30,10 @@ void dt_selection_free(struct dt_selection_t *selection);
 void dt_selection_invert(struct dt_selection_t *selection);
 /** clears the selection */
 void dt_selection_clear(struct dt_selection_t *selection);
+/** adds imgid to the current selection */
+void dt_selection_select(struct dt_selection_t *selection, uint32_t imgid);
+/** removes imgid from the current selection */
+void dt_selection_deselect(struct dt_selection_t *selection, uint32_t imgid);
 /** clears current selection and adds imgid */
 void dt_selection_select_single(struct dt_selection_t *selection, uint32_t imgid);
 /** toggles selection of image in the current selection */

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1267,6 +1267,15 @@ static void list_view(dt_lib_collect_rule_t *dr)
                 "(SELECT id AS film_rolls_id, folder FROM main.film_rolls) ON film_id = film_rolls_id "
                 "WHERE %s GROUP BY folder ORDER BY folder DESC", where_ext);
         break;
+
+      case DT_COLLECTION_PROP_GROUPING: // Grouping, 2 hardcoded alternatives
+        g_snprintf(query, sizeof(query), "SELECT CASE "
+                           "WHEN id = group_id THEN '%s' ELSE '%s' END as group_leader, 1, "
+                           "COUNT(*) AS count "
+                           "FROM main.images "
+                           "WHERE %s GROUP BY group_leader ORDER BY group_leader ASC",
+                   _("group leaders"),  _("group followers"), where_ext);
+        break;
     }
 
     g_free(where_ext);
@@ -1516,7 +1525,8 @@ static void row_activated_with_event(GtkTreeView *view, GtkTreePath *path, GtkTr
   if(item == DT_COLLECTION_PROP_TAG || item == DT_COLLECTION_PROP_FOLDERS
      || item == DT_COLLECTION_PROP_DAY || item == DT_COLLECTION_PROP_TIME
      || item == DT_COLLECTION_PROP_COLORLABEL || item == DT_COLLECTION_PROP_GEOTAGGING
-     || item == DT_COLLECTION_PROP_HISTORY ||  item == DT_COLLECTION_PROP_LOCAL_COPY)
+     || item == DT_COLLECTION_PROP_HISTORY ||  item == DT_COLLECTION_PROP_LOCAL_COPY
+     || item == DT_COLLECTION_PROP_GROUPING)
     set_properties(d->rule + active); // we just have to set the selection
   else
     update_view(d->rule + active); // we have to update visible items too
@@ -2089,6 +2099,7 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_FILENAME);
   luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_GEOTAGGING);
   luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_LOCAL_COPY);
+  luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_GROUPING);
 
 }
 #endif

--- a/src/libs/collect.h
+++ b/src/libs/collect.h
@@ -36,7 +36,7 @@ const char *dt_lib_collect_string[] = { N_("film roll"),    N_("folders"),     N
                                         N_("rights"),       N_("lens"),        N_("focal length"),
                                         N_("ISO"),          N_("aperture"),    N_("exposure"),
                                         N_("aspect ratio"), N_("filename"),    N_("geotagging"),
-                                        N_("local copy") };
+                                        N_("grouping"),     N_("local copy") };
 const int dt_lib_collect_string_cnt = sizeof(dt_lib_collect_string) / sizeof(dt_lib_collect_string[0]);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -564,20 +564,7 @@ static gboolean _lib_filmstrip_button_press_callback(GtkWidget *w, GdkEventButto
           int offset = 0;
           if(mouse_over_id == strip->activated_image) offset = dt_collection_image_offset(mouse_over_id);
 
-          dt_image_t *image = dt_image_cache_get(darktable.image_cache, mouse_over_id, 'w');
-          if(strip->image_over == DT_VIEW_STAR_1 && ((image->flags & 0x7) == 1))
-            image->flags &= ~0x7;
-          else if(strip->image_over == DT_VIEW_REJECT && ((image->flags & 0x7) == 6))
-            image->flags &= ~0x7;
-          else
-          {
-            image->flags &= ~0x7;
-            image->flags |= strip->image_over;
-          }
-          dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
-
-
-          dt_collection_hint_message(darktable.collection); // More than this, we need to redraw all
+          dt_ratings_apply_to_image_or_group(mouse_over_id, strip->image_over);
 
           if(mouse_over_id == strip->activated_image)
             if(_lib_filmstrip_imgid_in_collection(darktable.collection, mouse_over_id) == 0)
@@ -943,7 +930,7 @@ static gboolean _lib_filmstrip_ratings_key_accel_callback(GtkAccelGroup *accel_g
       int offset = 0;
       if(mouse_over_id == activated_image) offset = dt_collection_image_offset(mouse_over_id);
 
-      dt_ratings_apply_to_image(mouse_over_id, num);
+      dt_ratings_apply_to_image_or_group(mouse_over_id, num);
 
       dt_collection_hint_message(darktable.collection); // More than this, we need to redraw all
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1587,7 +1587,7 @@ static gboolean star_key_accel_callback(GtkAccelGroup *accel_group, GObject *acc
   if(mouse_over_id <= 0)
     dt_ratings_apply_to_selection(num);
   else
-    dt_ratings_apply_to_image(mouse_over_id, num);
+    dt_ratings_apply_to_image_or_group(mouse_over_id, num);
   _update_collected_images(self);
 
   dt_collection_update_query(darktable.collection); // update the counter
@@ -1924,22 +1924,7 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
       case DT_VIEW_STAR_5:
       {
         int32_t mouse_over_id = dt_control_get_mouse_over_id();
-        dt_image_t *image = dt_image_cache_get(darktable.image_cache, mouse_over_id, 'w');
-        if(image)
-        {
-          if(lib->image_over == DT_VIEW_STAR_1 && ((image->flags & 0x7) == 1))
-            image->flags &= ~0x7;
-          else if(lib->image_over == DT_VIEW_REJECT && ((image->flags & 0x7) == 6))
-            image->flags &= ~0x7;
-          else
-          {
-            image->flags &= ~0x7;
-            image->flags |= lib->image_over;
-          }
-          dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
-        }
-        else
-          dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_RELAXED);
+        dt_ratings_apply_to_image_or_group(mouse_over_id, lib->image_over);
         _update_collected_images(self);
         break;
       }


### PR DESCRIPTION
Implements feature #8968: Actions are not applied to all grouped images when collapsed

See discussion here: https://redmine.darktable.org/issues/8968

This patch does a few things:
1) It allows you to click on a rating in a grouped image and apply that rating to the whole group.
2) When selecting grouped images, it selects all the images in that group, making it easier to do mass exports, etc.
3) It adds a new 'grouping' collection to filter group leaders or group followers. This allows you to access the old behaviour if you need it. For instance, if you want to do a mass export of just the representative images.
4) Fixed some minor bugs as I found them. The biggest was that if the group leader was filtered out by collection rules, the whole group was filtered out.