### PR TITLE
[RFC] bilat: don't grab data from preview pipe if hash==0, fixes #11872

### DIFF
--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -299,7 +299,11 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
         dt_pthread_mutex_lock(&g->lock);
         const uint64_t hash = g->hash;
         dt_pthread_mutex_unlock(&g->lock);
-        if(hash != 0 && !dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, 0, self->priority, &g->lock, &g->hash))
+        if(hash == 0)
+        {
+          // Don't try grabbing anything from preview pipe.
+        }
+        else if(!dt_dev_sync_pixelpipe_hash(self->dev, piece->pipe, 0, self->priority, &g->lock, &g->hash))
         {
           // TODO: remove this debug output at some point:
           dt_control_log(_("local laplacian: inconsistent output"));


### PR DESCRIPTION
_I don't fully understand the logic here (not familiar at all with this pixelpipe syncing mechanism), so I'm far from confident in the fact that this is the right fix. But it seems to make sense, and in practice it does fix the issue. A bit more details on the diagnosis is available on the [redmine bug](https://redmine.darktable.org/issues/11872). @hanatos, you're the author of the original code, can you have a look?_

When changing image in darkroom, and when both the previous and the new
image have local laplacian activated, the optimization grabing data from
the preview pixelpipe introduced in 911133c (local laplacian: make roi
aware in darkroom mode, 2017-10-15) was actually grabing data from the
previously selected image.

The guilty line was:

        if(hash != 0 && !dt_dev_sync_...)

in case hash == 0, the sync is not done, but the else branch still
does the grabbing. Change this to exhibit 3 cases: 1) don't try to
sync and grab, 2) sync failure, 3) sync success.