### PR TITLE
Improved display of color labels inside the thumb

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -905,6 +905,10 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
     case 4:
       cairo_set_source_rgba(cr, 1, 0.0, 1.0, alpha);
       break; // purple
+    case 7:
+      // don't fill
+      cairo_set_source_rgba(cr, 0, 0, 0, 0);
+      break;
     default:
       cairo_set_source_rgba(cr, 1, 1, 1, alpha);
       def = TRUE;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1141,7 +1141,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
         for(int k = 0; k < 5; k++)
         {
           if(zoom != 1)
-            x = (0.41 + k * 0.12) * width;
+            x = (0.26 + k * 0.12) * width;
           else
             x = (.08 + k * 0.04) * fscale;
 
@@ -1169,7 +1169,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
 
       // Image rejected?
       if(zoom != 1)
-        x = 0.11 * width;
+        x = 0.08 * width;
       else
         x = .04 * fscale;
 
@@ -1292,8 +1292,15 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
     if(width > DECORATION_SIZE_LIMIT)
     {
       // color labels:
-      const float x = zoom == 1 ? (0.07) * fscale : .21 * width;
-      const float y = zoom == 1 ? 0.17 * fscale : 0.1 * height;
+      // const float x = zoom == 1 ? (0.07) * fscale : .21 * width;
+      // const float y = zoom == 1 ? 0.17 * fscale : 0.1 * height;
+      const float x[] = {0.84, 0.92, 0.88, 0.84, 0.92};
+      const float y[] = {0.84, 0.84, 0.88, 0.92, 0.92};
+      const float x_zoom[] = {0.27, 0.30, 0.285, 0.27, 0.30};
+      const float y_zoom[] = {0.095, 0.095, 0.11, 0.125, 0.125};
+      const int max_col = sizeof(x) / sizeof(x[0]);
+
+
       const float r = zoom == 1 ? 0.01 * fscale : 0.03 * width;
 
       /* clear and reset prepared statement */
@@ -1307,7 +1314,14 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
         cairo_save(cr);
         const int col = sqlite3_column_int(darktable.view_manager->statements.get_color, 0);
         // see src/dtgtk/paint.c
-        dtgtk_cairo_paint_label(cr, x + (3 * r * col) - 5 * r, y - r, r * 2, r * 2, col, NULL);
+        // dtgtk_cairo_paint_label(cr, x + (3 * r * col) - 5 * r, y - r, r * 2, r * 2, col, NULL);
+        if ( col < max_col )
+        {
+          if ( zoom != 1 )
+            dtgtk_cairo_paint_label(cr, x[col]  * width, y[col] * height, r * 2, r * 2, col, NULL);
+          else
+            dtgtk_cairo_paint_label(cr, x_zoom[col]  * fscale, y_zoom[col] * fscale, r * 2, r * 2, col, NULL);
+        }
         cairo_restore(cr);
       }
     }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1347,15 +1347,55 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
   {
     if(img && width > DECORATION_SIZE_LIMIT)
     {
-      // copy status:
-      const float x = zoom == 1 ? (0.07) * fscale : .21 * width;
-      const float y = zoom == 1 ? 0.17 * fscale : 0.1 * height;
-      const float r = zoom == 1 ? 0.01 * fscale : 0.03 * width;
-      const int xoffset = 6;
       const gboolean has_local_copy = (img && (img->flags & DT_IMAGE_LOCAL_COPY));
-      cairo_save(cr);
-      dtgtk_cairo_paint_local_copy(cr, x + (3 * r * xoffset) - 5 * r, y - r, r * 2, r * 2, has_local_copy, NULL);
-      cairo_restore(cr);
+
+      if (has_local_copy)
+      {
+        cairo_save(cr);
+
+        if (zoom != 1)
+        {
+          double x0 = DT_PIXEL_APPLY_DPI(1), y0 = DT_PIXEL_APPLY_DPI(1), rect_width = width - DT_PIXEL_APPLY_DPI(2),
+                radius = DT_PIXEL_APPLY_DPI(5);
+          double x1, off, off1;
+
+          x1 = x0 + rect_width;
+          off = radius * 0.666;
+          off1 = radius - off;
+
+          cairo_move_to(cr, x1 - width * 0.08, y0);
+          cairo_line_to(cr, x1 - radius, y0);
+          cairo_curve_to(cr, x1 - off1, y0, x1, y0 + off1, x1, y0 + radius);
+          cairo_line_to(cr, x1, y0 + height * 0.08);
+          cairo_close_path(cr);
+          cairo_set_source_rgb(cr, 1, 1, 1);
+          cairo_fill_preserve(cr);
+          cairo_set_line_width(cr, 0.005 * width);
+          cairo_set_source_rgb(cr, outlinecol, outlinecol, outlinecol);
+          cairo_stroke(cr);
+        }
+        else
+        {
+          const float x_zoom = 0.325;
+          const float y_zoom = 0.112;
+          const float edge_length = 0.016 * fscale;
+
+          cairo_rectangle(cr, x_zoom * fscale, y_zoom * fscale, edge_length, edge_length);
+          cairo_set_source_rgb(cr, 0.5, 0.5, 0.5);
+          cairo_set_line_width(cr, 0.002 * fscale);
+          cairo_stroke(cr);
+
+          cairo_move_to(cr, x_zoom * fscale + edge_length * 0.1, y_zoom * fscale);
+          cairo_line_to(cr, x_zoom * fscale + edge_length, y_zoom * fscale);
+          cairo_line_to(cr, x_zoom * fscale + edge_length, y_zoom * fscale + edge_length * 0.9);
+          cairo_close_path(cr);
+          cairo_set_source_rgb(cr, 1, 1, 1);
+          cairo_fill_preserve(cr);
+          cairo_set_source_rgb(cr, 0.5, 0.5, 0.5);
+          cairo_stroke(cr);
+        }
+        cairo_restore(cr);
+      }
     }
   }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1312,10 +1312,10 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
       {
         cairo_save(cr);
         const int col = sqlite3_column_int(darktable.view_manager->statements.get_color, 0);
-        if ( col < max_col )
+        if (col < max_col)
         {
           // see src/dtgtk/paint.c
-          if ( zoom != 1 )
+          if (zoom != 1)
             dtgtk_cairo_paint_label(cr, x[col]  * width, y[col] * height, r * 2, r * 2, col, NULL);
           else
             dtgtk_cairo_paint_label(cr, x_zoom[col]  * fscale, y_zoom[col] * fscale, r * 2, r * 2, col, NULL);
@@ -1332,7 +1332,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
           if (!painted_col[i])
           {
             cairo_save(cr);
-            if ( zoom != 1 )
+            if (zoom != 1)
               dtgtk_cairo_paint_label(cr, x[i]  * width, y[i] * height, r * 2, r * 2, dont_fill_col, NULL);
             else
               dtgtk_cairo_paint_label(cr, x_zoom[i]  * fscale, y_zoom[i] * fscale, r * 2, r * 2, dont_fill_col, NULL);


### PR DESCRIPTION
The display of the colorlabels has the following weak points.

- The image type is overwritten by the labels in landscape format.
- The image (and/or image type) is overwritten by the labels in portrait format.
- The position of the label seems oddly distributed.

This fix should fix the weak points. Since the labels are drawn like in a 5 in a dice, as soon as a label is set, the other labels are drawn as outlines. Without the outlines, it looks like the label is  out of position.

The preview mode has also been modified

**darktable 2.44** landscpe format
<img width="100" alt="labeldt244landscaoe" src="https://user-images.githubusercontent.com/41842524/44176500-5d207600-a0ea-11e8-89ff-e26e63cac41d.PNG">
**darktable 2.44** portrait format
<img width="100" alt="labeldt244portrait" src="https://user-images.githubusercontent.com/41842524/44176508-64478400-a0ea-11e8-8ecf-54780029728e.PNG">

**FIX** without color label --> just like darktable 2.44
<img width="100" alt="nonlabel" src="https://user-images.githubusercontent.com/41842524/44176523-70cbdc80-a0ea-11e8-91f2-323c4af486d2.PNG">
**FIX** one color label
<img width="100" alt="onelabel" src="https://user-images.githubusercontent.com/41842524/44176531-788b8100-a0ea-11e8-858b-6fc9716961d4.PNG">
**FIX** two color labels
<img width="100" alt="twolabels" src="https://user-images.githubusercontent.com/41842524/44176534-7aeddb00-a0ea-11e8-9e99-ebf4a9fee1e3.PNG">
**FIX** color labels and stars
<img width="100" alt="labelandstars" src="https://user-images.githubusercontent.com/41842524/44176538-804b2580-a0ea-11e8-9e26-43f976c3f88b.PNG">
'**FIX** portrait format
<img width="100" alt="portraitmode" src="https://user-images.githubusercontent.com/41842524/44176542-84774300-a0ea-11e8-82d7-27a0b5958954.PNG">
**FIX** preview
<img width="125" alt="preview" src="https://user-images.githubusercontent.com/41842524/44176544-86410680-a0ea-11e8-87ed-62823a4281dd.PNG">







