### PR TITLE
Thumb overlay (stars display) improved and expanded

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -572,6 +572,13 @@
     <longdescription>if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).</longdescription>
   </dtconfig>
   <dtconfig prefs="gui">
+    <name>plugins/lighttable/extended_thumb_overlay</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>enable extended thumb overlay</shortdescription>
+    <longdescription>if set to true, thumb overlay shows filename and some exif data.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui">
     <name>pressure_sensitivity</name>
     <type>
       <enum>

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1139,7 +1139,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
 
       if(img)
       {
-        if ( zoom != 1 && (!darktable.gui->show_overlays || imgsel == imgid) )
+        if (zoom != 1 && (!darktable.gui->show_overlays || imgsel == imgid))
         {
           const double overlay_height = 0.33 * height;
           const int exif_offset = DT_PIXEL_APPLY_DPI(5);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1139,7 +1139,7 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
 
       if(img)
       {
-        if ( zoom != 1)
+        if ( zoom != 1 && (!darktable.gui->show_overlays || imgsel == imgid) )
         {
           const double overlay_height = 0.33 * height;
           const int exif_offset = DT_PIXEL_APPLY_DPI(5);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1130,21 +1130,22 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
         r2 = 0.007 * fscale;
       }
 
+      const gboolean extended_thumb_overlay = dt_conf_get_bool("plugins/lighttable/extended_thumb_overlay");
       float x, y;
       if(zoom != 1)
-        y = 0.90 * height;
+        y = (extended_thumb_overlay ? 0.93 : 0.9) * height;
       else
         y = .12 * fscale;
       const gboolean image_is_rejected = (img && ((img->flags & 0x7) == 6));
 
       if(img)
       {
-        if (zoom != 1 && (!darktable.gui->show_overlays || imgsel == imgid))
+        if (zoom != 1 && (!darktable.gui->show_overlays || imgsel == imgid) && extended_thumb_overlay)
         {
-          const double overlay_height = 0.33 * height;
-          const int exif_offset = DT_PIXEL_APPLY_DPI(5);
-          const int fontsize = 0.17 * overlay_height;
-          const double line_offs = 1.2 * fontsize;
+          const double overlay_height = 0.26 * height;
+          const int exif_offset = DT_PIXEL_APPLY_DPI(3);
+          const int fontsize = 0.18 * overlay_height;
+          const double line_offs = 1.15 * fontsize;
 
 
           double x0 = DT_PIXEL_APPLY_DPI(1);


### PR DESCRIPTION
The overlay display which shows the stars inside the thumb, when the mouse hovers the thumb, is hardly recognizable with images in portrait format (depending on the image content). 

It also makes the work easier if the filename and some exif data are displayed, because you don't always have to switch the view direction between the exif data on the left side of the window and the thumb or because the image information on the left side is hidden.

**This fix is only visible when the mouse hovers the thumb**.

**darktable 2.4.4**
<img width="100" alt="overlaydt244" src="https://user-images.githubusercontent.com/41842524/44178954-ed63b880-a0f4-11e8-9291-40a35634ecbc.PNG">

**FIX** landscape format and mouse hovering thumb
<img width="100" alt="overlaylandscape" src="https://user-images.githubusercontent.com/41842524/44178979-079d9680-a0f5-11e8-8474-efb131b1b6ff.PNG">

**FIX**  portrait format and mouse hovering thumb
<img width="100" alt="overlayportrait" src="https://user-images.githubusercontent.com/41842524/44179001-213ede00-a0f5-11e8-89f2-84df794b8199.PNG">


