### PR TITLE
Added optional drawing styles for module sliders

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -22,6 +22,26 @@
     <shortdescription>width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
+  <dtconfig prefs="gui">
+    <name>alt_module_style</name>
+    <type>
+      <enum>
+        <option>default</option>
+        <option>slider between label and value</option>
+        <option>increase vertical gap between text and slider</option>
+      </enum>
+    </type>
+    <default>default</default>
+    <shortdescription>Alternativ module slider style</shortdescription>
+    <longdescription>default - standard darktable style, slider between label and value - requires wider right panel (see next option), increase vertical gap between text and slider - slightly enlarges the gap between label/value and the slider (needs a restart)</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui">
+    <name>wider_right_panel</name>
+    <type min="0" max="500">int</type>
+    <default>0</default>
+    <shortdescription>enlarge right panel width in pixel</shortdescription>
+    <longdescription>enlarge right panel width in lighttable and darkroom (needs a restart)</longdescription>
+  </dtconfig>
   <dtconfig prefs="core">
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -32,7 +32,7 @@
       </enum>
     </type>
     <default>default</default>
-    <shortdescription>Alternativ module slider style</shortdescription>
+    <shortdescription>alternative module slider style</shortdescription>
     <longdescription>default - standard darktable style, slider between label and value - requires wider right panel (see next option), increase vertical gap between text and slider - slightly enlarges the gap between label/value and the slider (needs a restart)</longdescription>
   </dtconfig>
   <dtconfig prefs="gui">

--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -20,6 +20,8 @@
 #include "develop/imageop.h"
 
 #include <gtk/gtk.h>
+#include <string.h>
+
 
 G_DEFINE_TYPE(GtkDarktableSidePanel, dtgtk_side_panel, GTK_TYPE_BOX);
 
@@ -27,8 +29,12 @@ static void dtgtk_side_panel_get_preferred_width(GtkWidget *widget, gint *minimu
 {
   GtkDarktableSidePanelClass *class = DTGTK_SIDE_PANEL_GET_CLASS(widget);
 
-  *minimum_size = *natural_size = class->width;
+  if ( strcmp(gtk_widget_get_name(widget), "right") == 0 )
+    *minimum_size = *natural_size = class->right_width;
+  else
+    *minimum_size = *natural_size = class->width;
 }
+
 
 static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
 {
@@ -37,6 +43,11 @@ static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
   widget_class->get_preferred_width = dtgtk_side_panel_get_preferred_width;
 
   class->width = dt_conf_get_int("panel_width");
+  class->right_width = class->width + dt_conf_get_int("wider_right_panel");
+  if (class->right_width > 1000 )
+  {
+    class->right_width = 1000;
+  }
 }
 
 static void dtgtk_side_panel_init(GtkDarktableSidePanel *panel)

--- a/src/dtgtk/sidepanel.h
+++ b/src/dtgtk/sidepanel.h
@@ -44,6 +44,7 @@ typedef struct _GtkDarktableSidePanelClass
 
   /*< private >*/
   gint width;
+  gint right_width;
 } GtkDarktableSidePanelClass;
 
 GType dtgtk_side_panel_get_type(void);


### PR DESCRIPTION
**This extension does not change anything on the darktable standard unless the user selects it through the new options.**

This extension includes 3 options and may be useful for users with large monitors:

1. a different rendering of the module slider (slider between label and value) 
2. a less compact standard rendering of the module slider in the height. 
3. an option to enlarge the right panel independently of the left one (_useful for option 1_).

**New options**  --> _Oops just seen: the typo in_ 'alternativ**e**' and fixed
 
<img width="568" alt="gui-options" src="https://user-images.githubusercontent.com/41842524/44618999-7bbc0500-a880-11e8-9586-ab8b45aebcf4.PNG">

**Slider styles**  --> _Oops just seen: the typo in_ 'alternativ**e**' and fixed

![slider-styles](https://user-images.githubusercontent.com/41842524/44619007-8aa2b780-a880-11e8-905d-ab89de5e68e8.png)

===============================================================

_**Option 1**_ : „a different rendering of the module slider (slider between label and value) “
Please note: This mode is only activated if the width is at least 250 pixels at 96 dpi and it scales with the dpi (400 pix at 144 dpi …).

The width of the label and slider scales with the right panel width.

**Examples:**  different right panel width

<img width="243" alt="new-style" src="https://user-images.githubusercontent.com/41842524/44619020-ac9c3a00-a880-11e8-8786-01a3aad1f3a5.PNG">

<img width="295" alt="new-style-wider" src="https://user-images.githubusercontent.com/41842524/44619023-b1f98480-a880-11e8-99de-1b835fe4de76.PNG">

Pros:
- Needs less height.
- Less vertical scrolling needed.
- Mouse click on the left of the slider sets the minimal value.
- Mouse click on the right side  of the slider sets the maximum value.

Cons:
- Needs more panel width.
- Reduced slider width.
- Long labels are displayed shortend (ellipsized).

===============================================================

_**Option 2**_ : „a less compact standard rendering of the module slider in the height“
This option fixes 3 tiny issues of the default drawing.
1. Characters with descenders (like g, j, p...) overwrite the slider line. 
2. The slider indicator is overwritten by characters with descenders. 
3. The bottom black outline of the indicator is missing. 

**darktable default**
![slider-issues](https://user-images.githubusercontent.com/41842524/44619041-dbb2ab80-a880-11e8-9933-12bf085a5b41.PNG)

**Option**
![slider-issues-fix](https://user-images.githubusercontent.com/41842524/44619258-d2770e00-a883-11e8-8943-483e4894059d.PNG)


===============================================================

_**Option 3**_ : "an option to enlarge the right panel independently of the left one"
This option allows you to increase the width of the right panel compared to the left panel. This is useful for the darkroom module panel, but has the disadvantage that the lighttable panel is also enlarged. This is a weakness of the current darktable design..


