### PR TITLE
lua get tagged images

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -2451,6 +2451,34 @@ end</programlisting></para>
 </variablelist>
 </section>
 
+<section status="final" id="darktable_tags_get_tagged_images">
+<title>darktable.tags.get_tagged_images</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>get_tagged_images</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_tags_get_tagged_images_tag">tag</link></emphasis> : <link linkend="types_dt_lua_tag_t">types.dt_lua_tag_t</link>
+) : table of <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>Gets all images with the attached tag.</para>
+
+<variablelist>
+<varlistentry id="darktable_tags_get_tagged_images_tag"><term>tag</term><listitem>
+<synopsis><link linkend="types_dt_lua_tag_t">types.dt_lua_tag_t</link></synopsis>
+<para>The tag to search images for.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis>table of <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>A table of images that have the tag attached.</para>
+
+</listitem></varlistentry>
+
+
+</variablelist>
+</section>
+
 </section>
 
 <section status="final" id="darktable_configuration">

--- a/src/lua/tags.h
+++ b/src/lua/tags.h
@@ -25,6 +25,7 @@ typedef unsigned int dt_lua_tag_t;
 int dt_lua_tag_attach(lua_State *L);
 int dt_lua_tag_detach(lua_State *L);
 int dt_lua_tag_get_attached(lua_State *L);
+int dt_lua_tag_get_tagged_images(lua_State *L);
 
 int dt_lua_init_tags(lua_State *L);
 


### PR DESCRIPTION
Added function to the lua api that returns a table of images containing a specified tag.  Updated the lua api manual to reflect the changes.

contrib/rename-tags.lua is very slow because it checks each image in the database for the tag that needs changed.  This function would return a list of images with the tag needing changed in one call, thus speeding the script up.