### PR TITLE
blend changes lost

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1380,6 +1380,10 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
 {
   uint64_t hash = 5381;
   piece->hash = 0;
+
+  // this should be redundant! (but is not)
+  memcpy(module->blend_params, blendop_params, sizeof(dt_develop_blend_params_t));
+
   if(piece->enabled)
   {
     /* construct module params data for hash calc */
@@ -1398,8 +1402,6 @@ void dt_iop_commit_params(dt_iop_module_t *module, dt_iop_params_t *params,
       pos += sizeof(dt_develop_blend_params_t);
     }
     memcpy(piece->blendop_data, blendop_params, sizeof(dt_develop_blend_params_t));
-    // this should be redundant! (but is not)
-    memcpy(module->blend_params, blendop_params, sizeof(dt_develop_blend_params_t));
     /* and we add masks */
     dt_masks_group_get_hash_buffer(grp, str + pos);
 


### PR DESCRIPTION
When the last entry of a module in the history is disabled and has changes on the blend module, if the edit is re-visited, the changes are lost.

Steps to duplicate:

-enable exposure and set some parametric mask
-enable any other module
-change the parametric mask on the exposure
-disable exposure
-go to lighttable
-go back to darkroom, changes on the blend module are lost
