### PR TITLE
Unbreak input profile : add log profile

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2192,14 +2192,14 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   float4 i = read_imagef(in, sampleri, (int2)(x, y));
   const float4 noise = pow((float4)2.0f, (float4)-dynamic_range);
   const float4 safety = pow((float4)2.0f, (float4)-14.0f);
-  const float4 Lognoise = log2(noise);
   const float4 dynamic4 = dynamic_range;
   const float4 shadows4 = shadows_range;
   const float4 grey4 = grey;
+  const float4 zero4 = (log( noise ) - shadows4) / dynamic4; 
+  const float4 safety_grey = safety / grey4;
   
   i = i / grey4;
-  i = (i > noise) ? log2(i + safety) : Lognoise;
-  i = (i - shadows4) / dynamic4 - safety;
+  i = (i >= noise) ? (log2(i + safety) - shadows4) / dynamic4 - safety_grey: zero4 - (dynamic4 / (i - zero4));
 
   write_imagef(out, (int2)(x, y), i);
 }

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2191,17 +2191,15 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
 
   float4 i = read_imagef(in, sampleri, (int2)(x, y));
   const float4 noise = pow((float4)2.0f, (float4)-dynamic_range);
-  const float4 safety = pow((float4)2.0f, (float4)-14.0f);
   const float4 dynamic4 = dynamic_range;
   const float4 shadows4 = shadows_range;
   const float4 grey4 = grey;
-  const float4 zero4 = (log( noise ) - shadows4) / dynamic4; 
-  const float4 safety_grey = safety / grey4;
   
-  i = i / grey4;
-  i = (i >= noise) ? (log2(i + safety) - shadows4) / dynamic4 - safety_grey: zero4 - (dynamic4 / (i - zero4));
+  float4 o;
+  
+  o = (log2(clamp(i, noise, (float4)9999.0f) / grey4) - shadows4) / dynamic4;
 
-  write_imagef(out, (int2)(x, y), i);
+  write_imagef(out, (int2)(x, y), o);
 }
 
 /* kernel for the interpolation resample helper */

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2190,15 +2190,16 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   if(x >= width || y >= height) return;
 
   float4 i = read_imagef(in, sampleri, (int2)(x, y));
-  const float4 noise = pow((float4)2.f, (float4)-dynamic_range);
+  const float4 noise = pow((float4)2.0f, (float4)-dynamic_range);
+  const float4 safety = pow((float4)2.0f, (float4)-14.0f);
   const float4 Lognoise = log2(noise);
   const float4 dynamic4 = dynamic_range;
   const float4 shadows4 = shadows_range;
   const float4 grey4 = grey;
   
   i = i / grey4;
-  i = (i > noise) ? log2(i) : Lognoise;
-  i = (i - shadows4) / dynamic4;
+  i = (i > noise) ? log2(i + safety) : Lognoise;
+  i = (i - shadows4) / dynamic4 - safety;
 
   write_imagef(out, (int2)(x, y), i);
 }

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2197,7 +2197,7 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   
   float4 o;
   
-  o = (log2(clamp(i, noise, (float4)9999.0f) / grey4) - shadows4) / dynamic4;
+  o = (log2(clamp(i / grey4, noise, (float4)9999.0f)) - shadows4) / dynamic4;
 
   write_imagef(out, (int2)(x, y), o);
 }

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2190,7 +2190,7 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   if(x >= width || y >= height) return;
 
   float4 i = read_imagef(in, sampleri, (int2)(x, y));
-  const float4 noise = pow((float4)2.0f, (float4)-dynamic_range);
+  const float4 noise = pow((float4)2.0f, (float4)-16.0f);
   const float4 dynamic4 = dynamic_range;
   const float4 shadows4 = shadows_range;
   const float4 grey4 = grey;

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2197,7 +2197,9 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   
   float4 o;
   
-  o = (log2(clamp(i / grey4, noise, (float4)9999.0f)) - shadows4) / dynamic4;
+  o = (i < noise) ? noise : i / grey4;
+  o = (log2(o) - shadows4) / dynamic4;
+  o = (o < (float4)0.0f) ? 0.0f : o;
 
   write_imagef(out, (int2)(x, y), o);
 }

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2199,7 +2199,7 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   
   o = (i < noise) ? noise : i / grey4;
   o = (log2(o) - shadows4) / dynamic4;
-  o = (o < (float4)0.0f) ? 0.0f : o;
+  o = (o < noise) ? noise : o;
 
   write_imagef(out, (int2)(x, y), o);
 }

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,16 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: darktable 1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-16 23:03+0200\n"
-"PO-Revision-Date: 2018-10-16 23:04+0200\n"
-"Last-Translator: Pascal Obry <pascal@obry.net>\n"
+"POT-Creation-Date: 2018-10-16 23:49-0400\n"
+"PO-Revision-Date: 2018-10-16 23:57-0400\n"
+"Last-Translator: Aurélien PIERRE <contact@aurelienpierre.com>\n"
 "Language-Team: \n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 2.2\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #: ../build/src/preferences_gen.h:1686
 msgid "GUI options"
@@ -1102,7 +1102,7 @@ msgstr ""
 
 #: ../src/common/collection.c:886 ../src/develop/lightroom.c:822
 #: ../src/iop/bilateral.cc:358 ../src/iop/channelmixer.c:451
-#: ../src/iop/channelmixer.c:462 ../src/iop/colorbalance.c:2155
+#: ../src/iop/channelmixer.c:462 ../src/iop/colorbalance.c:2160
 #: ../src/iop/temperature.c:1367 ../src/libs/collect.c:1183
 msgid "red"
 msgstr "rouge"
@@ -1114,7 +1114,7 @@ msgstr "jaune"
 
 #: ../src/common/collection.c:890 ../src/develop/lightroom.c:826
 #: ../src/iop/bilateral.cc:359 ../src/iop/channelmixer.c:452
-#: ../src/iop/channelmixer.c:468 ../src/iop/colorbalance.c:2162
+#: ../src/iop/channelmixer.c:468 ../src/iop/colorbalance.c:2167
 #: ../src/iop/temperature.c:1355 ../src/iop/temperature.c:1368
 #: ../src/libs/collect.c:1183
 msgid "green"
@@ -1122,7 +1122,7 @@ msgstr "vert"
 
 #: ../src/common/collection.c:892 ../src/develop/lightroom.c:828
 #: ../src/iop/bilateral.cc:360 ../src/iop/channelmixer.c:453
-#: ../src/iop/channelmixer.c:474 ../src/iop/colorbalance.c:2169
+#: ../src/iop/channelmixer.c:474 ../src/iop/colorbalance.c:2174
 #: ../src/iop/temperature.c:1369 ../src/libs/collect.c:1183
 msgid "blue"
 msgstr "bleu"
@@ -4925,12 +4925,12 @@ msgstr "abscisse : entrée, ordonnée : sortie. fonctionne sur les canaux RGB"
 msgid "scale"
 msgstr "échelle"
 
-#: ../src/iop/basecurve.c:1918 ../src/iop/profile_gamma.c:321
+#: ../src/iop/basecurve.c:1918 ../src/iop/profile_gamma.c:825
 #: ../src/iop/tonecurve.c:446
 msgid "linear"
 msgstr "linéaire"
 
-#: ../src/iop/basecurve.c:1919
+#: ../src/iop/basecurve.c:1919 ../src/iop/profile_gamma.c:809
 msgid "logarithmic"
 msgstr "logarithmique"
 
@@ -5002,11 +5002,12 @@ msgstr "contraste local"
 msgid "local laplacian: inconsistent output"
 msgstr "laplacien local: résultat incohérent"
 
-#: ../src/iop/bilat.c:516 ../src/iop/colorbalance.c:2012
+#: ../src/iop/bilat.c:516 ../src/iop/colorbalance.c:2017
 #: ../src/iop/denoiseprofile.c:2104 ../src/iop/exposure.c:849
 #: ../src/iop/lens.c:2233 ../src/iop/levels.c:569
-#: ../src/libs/copy_history.c:310 ../src/libs/export.c:644
-#: ../src/libs/print_settings.c:1508 ../src/views/darkroom.c:1454
+#: ../src/iop/profile_gamma.c:808 ../src/libs/copy_history.c:310
+#: ../src/libs/export.c:644 ../src/libs/print_settings.c:1508
+#: ../src/views/darkroom.c:1454
 msgid "mode"
 msgstr "mode"
 
@@ -5043,7 +5044,7 @@ msgid "feature size of local details (spatial sigma of bilateral filter)"
 msgstr "taille des détails locaux (sigma spatial du filtre bilatéral)"
 
 #: ../src/iop/bilat.c:537 ../src/iop/colisa.c:364
-#: ../src/iop/colorbalance.c:2054 ../src/iop/lowpass.c:671
+#: ../src/iop/colorbalance.c:2059 ../src/iop/lowpass.c:671
 msgid "contrast"
 msgstr "contraste"
 
@@ -5412,8 +5413,8 @@ msgid "destination"
 msgstr "canal de destination"
 
 #. dt_bauhaus_slider_set_format(g->gslider1, "");
-#: ../src/iop/channelmixer.c:448 ../src/iop/colorbalance.c:2135
-#: ../src/iop/colorbalance.c:2184 ../src/iop/colorbalance.c:2231
+#: ../src/iop/channelmixer.c:448 ../src/iop/colorbalance.c:2140
+#: ../src/iop/colorbalance.c:2189 ../src/iop/colorbalance.c:2236
 #: ../src/iop/colorize.c:427 ../src/iop/colorreconstruction.c:1363
 #: ../src/iop/colorreconstruction.c:1368 ../src/iop/colorzones.c:1076
 #: ../src/iop/colorzones.c:1107 ../src/iop/graduatednd.c:1168
@@ -5423,9 +5424,9 @@ msgstr "teinte"
 
 #. dt_bauhaus_slider_set_format(g->gslider2, "");
 #: ../src/iop/channelmixer.c:449 ../src/iop/colisa.c:366
-#: ../src/iop/colorbalance.c:2038 ../src/iop/colorbalance.c:2040
-#: ../src/iop/colorbalance.c:2056 ../src/iop/colorbalance.c:2147
-#: ../src/iop/colorbalance.c:2195 ../src/iop/colorbalance.c:2242
+#: ../src/iop/colorbalance.c:2043 ../src/iop/colorbalance.c:2045
+#: ../src/iop/colorbalance.c:2061 ../src/iop/colorbalance.c:2152
+#: ../src/iop/colorbalance.c:2200 ../src/iop/colorbalance.c:2247
 #: ../src/iop/colorchecker.c:1300 ../src/iop/colorcorrection.c:286
 #: ../src/iop/colorize.c:441 ../src/iop/colorzones.c:1074
 #: ../src/iop/colorzones.c:1108 ../src/iop/graduatednd.c:1182
@@ -5530,7 +5531,7 @@ msgid "flip"
 msgstr "symétrie miroir"
 
 #: ../src/iop/clipping.c:1867 ../src/iop/clipping.c:2052
-#: ../src/iop/colorbalance.c:2026 ../src/libs/live_view.c:377
+#: ../src/iop/colorbalance.c:2031 ../src/libs/live_view.c:377
 msgid "both"
 msgstr "les deux"
 
@@ -5705,176 +5706,179 @@ msgstr "ajustement de la luminosité"
 msgid "color saturation adjustment"
 msgstr "ajustement de la saturation"
 
-#: ../src/iop/colorbalance.c:139
+#: ../src/iop/colorbalance.c:140
 msgid "color balance"
 msgstr "balance couleur"
 
-#: ../src/iop/colorbalance.c:144
+#: ../src/iop/colorbalance.c:145
 msgid "lift/gamma/gain controls as seen in video editors"
 msgstr "contrôles lift/gamma/gain comme dans les éditeurs vidéos"
 
-#: ../src/iop/colorbalance.c:1464 ../src/iop/colorbalance.c:1525
-#: ../src/iop/colorbalance.c:1598 ../src/iop/colorbalance.c:1667
-#: ../src/iop/colorbalance.c:1842 ../src/iop/colorbalance.c:1886
-#: ../src/iop/colorbalance.c:1930
+#: ../src/iop/colorbalance.c:1469 ../src/iop/colorbalance.c:1530
+#: ../src/iop/colorbalance.c:1603 ../src/iop/colorbalance.c:1672
+#: ../src/iop/colorbalance.c:1847 ../src/iop/colorbalance.c:1891
+#: ../src/iop/colorbalance.c:1935 ../src/iop/profile_gamma.c:398
+#: ../src/iop/profile_gamma.c:436 ../src/iop/profile_gamma.c:484
+#: ../src/iop/profile_gamma.c:531
 msgid "wait for the preview to be updated."
 msgstr "attendez que la pré-visualisation soit mise à jour"
 
-#: ../src/iop/colorbalance.c:1727
+#: ../src/iop/colorbalance.c:1732
 msgid "you need to select 3 color samples first"
 msgstr "vous devez préalablement sélectionner 3 zones de couleur"
 
-#: ../src/iop/colorbalance.c:1965
+#: ../src/iop/colorbalance.c:1970
 msgid "you need to select 3 luma samples first"
 msgstr "vous devez préalablement sélectionner 3 zones de luminosité"
 
-#: ../src/iop/colorbalance.c:2013
+#: ../src/iop/colorbalance.c:2018
 msgid "lift / gamma / gain"
 msgstr "lift / gamma / gain"
 
-#: ../src/iop/colorbalance.c:2014
+#: ../src/iop/colorbalance.c:2019
 msgid "slope / offset / power"
 msgstr "slope / offset / power"
 
-#: ../src/iop/colorbalance.c:2016 ../src/iop/colorbalance.c:2029
+#: ../src/iop/colorbalance.c:2021 ../src/iop/colorbalance.c:2034
 msgid "color-grading mapping method"
 msgstr "méthode d'ajustement des couleurs"
 
-#: ../src/iop/colorbalance.c:2023
+#: ../src/iop/colorbalance.c:2028
 msgid "color control sliders"
 msgstr "contrôle des couleurs"
 
-#: ../src/iop/colorbalance.c:2024
+#: ../src/iop/colorbalance.c:2029
 msgid "HSL"
 msgstr "TSL"
 
-#: ../src/iop/colorbalance.c:2025
+#: ../src/iop/colorbalance.c:2030
 msgid "RGBL"
 msgstr "RGBL"
 
 #. master
-#: ../src/iop/colorbalance.c:2034
+#: ../src/iop/colorbalance.c:2039
 msgid "master"
 msgstr "maître"
 
-#: ../src/iop/colorbalance.c:2044
+#: ../src/iop/colorbalance.c:2049
 msgid "grey fulcrum"
 msgstr "gris pivot"
 
-#: ../src/iop/colorbalance.c:2047
+#: ../src/iop/colorbalance.c:2052
 msgid "adjust to match a neutral tone"
 msgstr "ajuste pour des tons neutres"
 
-#: ../src/iop/colorbalance.c:2112 ../src/iop/colorbalance.c:2122
+#: ../src/iop/colorbalance.c:2117 ../src/iop/colorbalance.c:2127
 msgid "factor of "
 msgstr "facteur de "
 
-#: ../src/iop/colorbalance.c:2113
+#: ../src/iop/colorbalance.c:2118
 msgid "factor"
 msgstr "facteur"
 
 #. lift
-#: ../src/iop/colorbalance.c:2128
+#: ../src/iop/colorbalance.c:2133
 msgid "shadows : lift / offset"
 msgstr "ombres : lift / offset"
 
-#: ../src/iop/colorbalance.c:2130
+#: ../src/iop/colorbalance.c:2135
 msgid "factor of lift"
 msgstr "facteur de lift"
 
-#: ../src/iop/colorbalance.c:2130
+#: ../src/iop/colorbalance.c:2135
 msgid "lift"
 msgstr "lift"
 
-#: ../src/iop/colorbalance.c:2137 ../src/iop/colorbalance.c:2186
-#: ../src/iop/colorbalance.c:2233
+#: ../src/iop/colorbalance.c:2142 ../src/iop/colorbalance.c:2191
+#: ../src/iop/colorbalance.c:2238
 msgid "select the hue"
 msgstr "sélectionne la teinte"
 
-#: ../src/iop/colorbalance.c:2150 ../src/iop/colorbalance.c:2198
-#: ../src/iop/colorbalance.c:2245
+#: ../src/iop/colorbalance.c:2155 ../src/iop/colorbalance.c:2203
+#: ../src/iop/colorbalance.c:2250
 msgid "select the saturation"
 msgstr "sélectionne la saturation"
 
-#: ../src/iop/colorbalance.c:2155
+#: ../src/iop/colorbalance.c:2160
 msgid "factor of red for lift"
 msgstr "facteur rouge du lift"
 
-#: ../src/iop/colorbalance.c:2162
+#: ../src/iop/colorbalance.c:2167
 msgid "factor of green for lift"
 msgstr "facteur vert du lift"
 
-#: ../src/iop/colorbalance.c:2169
+#: ../src/iop/colorbalance.c:2174
 msgid "factor of blue for lift"
 msgstr "facteur bleu du lift"
 
 #. gamma
-#: ../src/iop/colorbalance.c:2177
+#: ../src/iop/colorbalance.c:2182
 msgid "mid-tones : gamma / power"
 msgstr "tons moyens : gamma / power"
 
-#: ../src/iop/colorbalance.c:2179
+#: ../src/iop/colorbalance.c:2184
 msgid "factor of gamma"
 msgstr "facteur gamma"
 
-#: ../src/iop/colorbalance.c:2179 ../src/iop/profile_gamma.c:322
+#: ../src/iop/colorbalance.c:2184 ../src/iop/profile_gamma.c:810
+#: ../src/iop/profile_gamma.c:832
 msgid "gamma"
 msgstr "gamma"
 
-#: ../src/iop/colorbalance.c:2202
+#: ../src/iop/colorbalance.c:2207
 msgid "factor of red for gamma"
 msgstr "facteur rouge du gamma"
 
-#: ../src/iop/colorbalance.c:2209
+#: ../src/iop/colorbalance.c:2214
 msgid "factor of green for gamma"
 msgstr "facteur vert du gamma"
 
-#: ../src/iop/colorbalance.c:2216
+#: ../src/iop/colorbalance.c:2221
 msgid "factor of blue for gamma"
 msgstr "facteur bleu du gamma"
 
 #. gain
-#: ../src/iop/colorbalance.c:2224
+#: ../src/iop/colorbalance.c:2229
 msgid "highlights : gain / slope"
 msgstr "hautes lumières : gain / slope"
 
-#: ../src/iop/colorbalance.c:2226
+#: ../src/iop/colorbalance.c:2231
 msgid "factor of gain"
 msgstr "facteur du gain"
 
-#: ../src/iop/colorbalance.c:2226
+#: ../src/iop/colorbalance.c:2231
 msgid "gain"
 msgstr "gain"
 
-#: ../src/iop/colorbalance.c:2249
+#: ../src/iop/colorbalance.c:2254
 msgid "factor of red for gain"
 msgstr "facteur rouge du gain"
 
-#: ../src/iop/colorbalance.c:2256
+#: ../src/iop/colorbalance.c:2261
 msgid "factor of green for gain"
 msgstr "facteur vert du gain"
 
-#: ../src/iop/colorbalance.c:2263
+#: ../src/iop/colorbalance.c:2268
 msgid "factor of blue for gain"
 msgstr "facteur bleu du gain"
 
-#: ../src/iop/colorbalance.c:2271
+#: ../src/iop/colorbalance.c:2276
 msgid "auto optimizers"
 msgstr "optimiseurs automatiques"
 
-#: ../src/iop/colorbalance.c:2276
+#: ../src/iop/colorbalance.c:2282
 msgid "optimize luma"
 msgstr "optimiser luma"
 
-#: ../src/iop/colorbalance.c:2277
+#: ../src/iop/colorbalance.c:2283
 msgid "fit the whole histogram and center the average luma"
 msgstr "ajuste l'histogramme et centre la luminosité moyenne"
 
-#: ../src/iop/colorbalance.c:2281
+#: ../src/iop/colorbalance.c:2287
 msgid "neutralize colors"
 msgstr "neutraliser les couleurs"
 
-#: ../src/iop/colorbalance.c:2282
+#: ../src/iop/colorbalance.c:2288
 msgid "optimize the RGB curves to remove color casts"
 msgstr "optimise les courbes RGB et supprime les dérives de couleur"
 
@@ -6691,7 +6695,7 @@ msgstr ""
 "il apparaît afin que vous le désactiviez\n"
 "et utilisiez le nouvel égaliseur"
 
-#: ../src/iop/exposure.c:119
+#: ../src/iop/exposure.c:119 ../src/iop/profile_gamma.c:108
 msgctxt "accel"
 msgid "mode"
 msgstr "mode"
@@ -7742,27 +7746,104 @@ msgstr "force du flou pour les couleurs"
 msgid "overexposed"
 msgstr "sous- et sur-exposition"
 
-#: ../src/iop/profile_gamma.c:63
+#: ../src/iop/profile_gamma.c:92
 msgid "unbreak input profile"
 msgstr "correction du profil d'entrée"
 
-#: ../src/iop/profile_gamma.c:78
+#: ../src/iop/profile_gamma.c:109
 msgctxt "accel"
 msgid "linear"
 msgstr "linéaire"
 
-#: ../src/iop/profile_gamma.c:79
+#: ../src/iop/profile_gamma.c:110
 msgctxt "accel"
 msgid "gamma"
 msgstr "gamma"
 
-#: ../src/iop/profile_gamma.c:327
+#: ../src/iop/profile_gamma.c:111
+msgctxt "accel"
+msgid "dynamic_range"
+msgstr "plage dynamique"
+
+#: ../src/iop/profile_gamma.c:112
+msgctxt "accel"
+msgid "grey_point"
+msgstr "point gris"
+
+#: ../src/iop/profile_gamma.c:113
+#, fuzzy
+msgctxt "accel"
+msgid "shadows_range"
+msgstr "ombres"
+
+#: ../src/iop/profile_gamma.c:812
+msgid "tone mapping method"
+msgstr "méthode de mappage des tonalités"
+
+#: ../src/iop/profile_gamma.c:827
 msgid "linear part"
 msgstr "linéaire"
 
-#: ../src/iop/profile_gamma.c:328
+#: ../src/iop/profile_gamma.c:834
 msgid "gamma exponential factor"
 msgstr "facteur exponentiel gamma"
+
+#: ../src/iop/profile_gamma.c:847
+msgid "middle grey luma"
+msgstr "luma du gris moyen"
+
+#: ../src/iop/profile_gamma.c:850
+msgid "adjust to match the average luma of the subject"
+msgstr "ajuster pour faire correspondre à la luma moyenne du sujet"
+
+#: ../src/iop/profile_gamma.c:858
+msgid "black relative exposure"
+msgstr "exposition relative du noir"
+
+#: ../src/iop/profile_gamma.c:861
+msgid ""
+"number of stops between middle grey and pure black\n"
+"this is a reading a posemeter would give you on the scene"
+msgstr ""
+"nombre de stops entre le gris moyen et le noir pur\n"
+"ceci est une lecture que vous donnerait un posemètre sur la scène"
+
+#: ../src/iop/profile_gamma.c:869
+msgid "dynamic range"
+msgstr "plage dynamique"
+
+#: ../src/iop/profile_gamma.c:872
+msgid ""
+"number of stops between pure black and pure white\n"
+"this is a reading a posemeter would give you on the scene"
+msgstr ""
+"nombre de stops entre le noir pur et le blanc pur\n"
+"ceci est une lecture que vous donnerait un posemètre sur la scène"
+
+#. Auto tune slider
+#: ../src/iop/profile_gamma.c:878
+msgid "optimize automatically"
+msgstr "optimiser automatiquement"
+
+#: ../src/iop/profile_gamma.c:880
+msgid "security factor"
+msgstr "facteur de sécurité"
+
+#: ../src/iop/profile_gamma.c:883
+msgid ""
+"enlarge or shrink the computed dynamic range\n"
+"this is usefull when noise perturbates the measurements"
+msgstr ""
+"élargir ou rétrécir la plage dynamique calculée\n"
+"ceci est utile lorsque du bruit perturbe les mesures"
+
+#: ../src/iop/profile_gamma.c:886
+msgid "auto tune"
+msgstr "réglage auto"
+
+#: ../src/iop/profile_gamma.c:887
+msgid "make an optimization with some guessing"
+msgstr "faire une optimisation basée sur des suppositions"
 
 #: ../src/iop/rawdenoise.c:62
 msgid "raw denoise"

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -257,8 +257,9 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       const float grey = data->grey_point / 100.0f;
       const float noise = powf(2.0f, -data->dynamic_range);
-      const float Logmin = Log2(noise);
-      const float safety = powf(2.0f, -14.0f);
+      const float safety = powf(2.0f, -14.0f);  
+      const float safety_grey = safety / grey;
+      const float zero = (Log2( noise ) - data->shadows_range) / data->dynamic_range; 
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) shared(data) schedule(static)
@@ -276,11 +277,11 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
             if(lg2 < noise)
             {
-              out[i] = (Logmin - data->shadows_range) / (data->dynamic_range);
+              out[i] = zero - (data->dynamic_range / (lg2 - zero));
             }
             else
             {
-              out[i] = (Log2(lg2 + safety) - data->shadows_range) / (data->dynamic_range) - safety;
+              out[i] = (Log2(lg2 + safety) - data->shadows_range) / (data->dynamic_range) - safety_grey;
             }
           }
         }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -256,7 +256,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     case PROFILEGAMMA_LOG:
     {
       const float grey = data->grey_point / 100.0f;
-      const float noise = powf(2.0f, -data->dynamic_range);
+      const float noise = powf(2.0f, -16.0f);
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) shared(data) schedule(static)

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -372,14 +372,11 @@ static void optimize(dt_iop_module_t *self)
   dynamic_range = dynamic_range * ( 1. + (p->black_target / 100.));
 
   /* belt and suspenders sanitization */
-  if(dynamic_range > 0.5 && dynamic_range < 32.) p->dynamic_range = dynamic_range; else goto error;
+  if(dynamic_range > 0.5 && dynamic_range < 32.) p->dynamic_range = dynamic_range; else return;
 
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
   darktable.gui->reset = 0;
-  
-error:
-  return;
 }
 
 
@@ -411,8 +408,9 @@ static void measure_grey(dt_iop_module_t *self)
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
 
   if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f) return;
-  float const L[3] = { 0.2126f, 0.7152f, 0.0722f };
-  p->grey_point = 100.f * (self->picked_color[0] * L[0] + self->picked_color[1] * L[1] + self->picked_color[2] * L[2]);
+  float XYZ[3];
+  dt_prophotorgb_to_XYZ((const float *)self->picked_color, XYZ);
+  p->grey_point = 100.f * XYZ[1];
 }
 
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -421,13 +421,9 @@ static void black_target_callback(GtkWidget *slider, gpointer user_data)
   }
   
   dt_iop_request_focus(self);
-
-  if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
-    self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
-  else
-  {
-    optimize(self);
-  }
+  self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+  
+  optimize(self);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -518,6 +514,8 @@ static void shadows_pick_callback(GtkWidget *button, gpointer user_data)
     darktable.gui->reset = 1;
     dt_bauhaus_slider_set(g->shadows_range, p->shadows_range);
     darktable.gui->reset = 0;
+    
+    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   }
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -817,7 +815,7 @@ void gui_init(dt_iop_module_t *self)
 
   // grey_point slider
   g->grey_point = dt_bauhaus_slider_new_with_range(self, 0.1, 100., 0.5, p->grey_point, 2);
-  dt_bauhaus_widget_set_label(g->grey_point, NULL, _("middle grey target value"));
+  dt_bauhaus_widget_set_label(g->grey_point, NULL, _("input middle grey"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->grey_point, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->grey_point, "%.2f %%");
   gtk_widget_set_tooltip_text(
@@ -830,7 +828,7 @@ void gui_init(dt_iop_module_t *self)
   // Shadows range slider
   g->shadows_range = dt_bauhaus_slider_new_with_range(self, -16.0, -0.0, 0.1, p->shadows_range, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->shadows_range, -16., 16.0);
-  dt_bauhaus_widget_set_label(g->shadows_range, NULL, _("black relative exposure"));
+  dt_bauhaus_widget_set_label(g->shadows_range, NULL, _("output black exposure"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->shadows_range, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->shadows_range, "%.2f EV");
   gtk_widget_set_tooltip_text(g->shadows_range, _("number of stops between the new 50 % grey and 0 % black"));
@@ -841,18 +839,19 @@ void gui_init(dt_iop_module_t *self)
   // Dynamic range slider
   g->dynamic_range = dt_bauhaus_slider_new_with_range(self, 0.5, 16.0, 0.1, p->dynamic_range, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->dynamic_range, 0.01, 32.0);
-  dt_bauhaus_widget_set_label(g->dynamic_range, NULL, _("dynamic range"));
+  dt_bauhaus_widget_set_label(g->dynamic_range, NULL, _("output dynamic range"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->dynamic_range, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->dynamic_range, "%.2f EV");
   gtk_widget_set_tooltip_text(g->dynamic_range, _("number of stops between 0 % black and 100 % white"));
   g_signal_connect(G_OBJECT(g->dynamic_range), "value-changed", G_CALLBACK(dynamic_range_callback), self);
 
   // Auto tune slider
+   gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(_("optimize automatically")), FALSE, FALSE, 5); 
   g->black_target = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->black_target, 2);
-  dt_bauhaus_widget_set_label(g->black_target, NULL, _("contrast correction"));
+  dt_bauhaus_widget_set_label(g->black_target, NULL, _("dynamic range correction"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->black_target, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->black_target, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->black_target, _("resize the dynamic range to recover blacks"));
+  gtk_widget_set_tooltip_text(g->black_target, _("optimize the dynamic range and correct it"));
   g_signal_connect(G_OBJECT(g->black_target), "value-changed", G_CALLBACK(black_target_callback), self);
   dt_bauhaus_widget_set_quad_paint(g->black_target, dtgtk_cairo_paint_colorpicker, CPF_ACTIVE, NULL);
   g_signal_connect(G_OBJECT(g->black_target), "quad-pressed", G_CALLBACK(autofix_callback), self);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -1,28 +1,33 @@
 /*
-    This file is part of darktable,
-    copyright (c) 2009--2010 johannes hanika.
-    copyright (c) 2014 LebedevRI.
+   This file is part of darktable,
+   copyright (c) 2009--2010 johannes hanika.
+   copyright (c) 2014 LebedevRI.
+   copyright (c) 2018 Aurélien Pierre.
 
-    darktable is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
-    darktable is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/colorspaces_inline_conversions.h"
+#include "common/darktable.h"
+#include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop_math.h"
+#include "dtgtk/button.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
@@ -31,31 +36,54 @@
 #include <stdlib.h>
 #include <string.h>
 
-DT_MODULE_INTROSPECTION(1, dt_iop_profilegamma_params_t)
+DT_MODULE_INTROSPECTION(2, dt_iop_profilegamma_params_t)
+
+typedef enum dt_iop_profilegamma_mode_t
+{
+  PROFILEGAMMA_LOG = 0,
+  PROFILEGAMMA_GAMMA = 1
+} dt_iop_profilegamma_mode_t;
 
 typedef struct dt_iop_profilegamma_params_t
 {
+  dt_iop_profilegamma_mode_t mode;
   float linear;
   float gamma;
+  float dynamic_range;
+  float grey_point;
+  float shadows_range;
+  float black_target;
 } dt_iop_profilegamma_params_t;
 
 typedef struct dt_iop_profilegamma_gui_data_t
 {
+  GtkWidget *mode;
+  GtkWidget *mode_stack;
   GtkWidget *linear;
   GtkWidget *gamma;
+  GtkWidget *dynamic_range;
+  GtkWidget *grey_point;
+  GtkWidget *shadows_range;
+  GtkWidget *black_target;
 } dt_iop_profilegamma_gui_data_t;
 
 typedef struct dt_iop_profilegamma_data_t
 {
+  dt_iop_profilegamma_mode_t mode;
   float linear;
   float gamma;
   float table[0x10000];      // precomputed look-up table
   float unbounded_coeffs[3]; // approximation for extrapolation of curve
+  float dynamic_range;
+  float grey_point;
+  float shadows_range;
+  float black_target;
 } dt_iop_profilegamma_data_t;
 
 typedef struct dt_iop_profilegamma_global_data_t
 {
   int kernel_profilegamma;
+  int kernel_profilegamma_log;
 } dt_iop_profilegamma_global_data_t;
 
 const char *name()
@@ -70,25 +98,85 @@ int groups()
 
 int flags()
 {
-  return IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_ALLOW_TILING;
+  return IOP_FLAGS_ONE_INSTANCE | IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_INCLUDE_IN_STYLES
+         | IOP_FLAGS_SUPPORTS_BLENDING;
 }
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mode"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "linear"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gamma"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dynamic_range"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "grey_point"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows_range"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
 
+  dt_accel_connect_slider_iop(self, "mode", GTK_WIDGET(g->mode));
   dt_accel_connect_slider_iop(self, "linear", GTK_WIDGET(g->linear));
   dt_accel_connect_slider_iop(self, "gamma", GTK_WIDGET(g->gamma));
+  dt_accel_connect_slider_iop(self, "dynamic_range", GTK_WIDGET(g->dynamic_range));
+  dt_accel_connect_slider_iop(self, "grey_point", GTK_WIDGET(g->grey_point));
+  dt_accel_connect_slider_iop(self, "shadows_range", GTK_WIDGET(g->shadows_range));
 }
 
+
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
+                  const int new_version)
+{
+  if(old_version == 1 && new_version == 2)
+  {
+    typedef struct dt_iop_profilegamma_params_v1_t
+    {
+      float linear;
+      float gamma;
+    } dt_iop_profilegamma_params_v1_t;
+
+    dt_iop_profilegamma_params_v1_t *o = (dt_iop_profilegamma_params_v1_t *)old_params;
+    dt_iop_profilegamma_params_t *n = (dt_iop_profilegamma_params_t *)new_params;
+    dt_iop_profilegamma_params_t *d = (dt_iop_profilegamma_params_t *)self->default_params;
+
+    *n = *d; // start with a fresh copy of default parameters
+
+    n->linear = o->linear;
+    n->gamma = o->gamma;
+    n->mode = PROFILEGAMMA_GAMMA;
+    return 0;
+  }
+  return 1;
+}
+
+static inline float Log2(float x)
+{
+  if(x > 0.)
+  {
+    return logf(x) / logf(2.f);
+  }
+  else
+  {
+    return x;
+  }
+}
+
+static inline float Log2Thres(float x, float Thres)
+{
+  if(x > Thres)
+  {
+    return logf(x) / logf(2.f);
+  }
+  else
+  {
+    return logf(Thres) / logf(2.f);
+  }
+}
+
+
 #ifdef HAVE_OPENCL
-int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
+int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in, cl_mem dev_out,
                const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_profilegamma_data_t *d = (dt_iop_profilegamma_data_t *)piece->data;
@@ -96,36 +184,51 @@ int process_cl(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_mem dev_
 
   cl_int err = -999;
   const int devid = piece->pipe->devid;
-
   const int width = roi_in->width;
   const int height = roi_in->height;
-
   cl_mem dev_table = NULL;
   cl_mem dev_coeffs = NULL;
 
-  dev_table = dt_opencl_copy_host_to_device(devid, d->table, 256, 256, sizeof(float));
-  if(dev_table == NULL) goto error;
+  const float grey = d->grey_point / 100.;
 
-  dev_coeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs);
-  if(dev_coeffs == NULL) goto error;
+  size_t sizes[3] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
 
-  size_t sizes[3];
-  sizes[0] = ROUNDUPWD(width);
-  sizes[1] = ROUNDUPWD(height);
-  sizes[2] = 1;
-  dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 0, sizeof(cl_mem), (void *)&dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 1, sizeof(cl_mem), (void *)&dev_out);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 2, sizeof(int), (void *)&width);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 3, sizeof(int), (void *)&height);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 4, sizeof(cl_mem), (void *)&dev_table);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 5, sizeof(cl_mem), (void *)&dev_coeffs);
+  if(d->mode == PROFILEGAMMA_LOG)
+  {
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 0, sizeof(cl_mem), (void *)&dev_in);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 1, sizeof(cl_mem), (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 2, sizeof(int), (void *)&width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 3, sizeof(int), (void *)&height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 5, sizeof(float), (void *)&(d->dynamic_range));
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 7, sizeof(float), (void *)&(d->shadows_range));
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma_log, 8, sizeof(float), (void *)&grey);
 
-  err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma, sizes);
-  if(err != CL_SUCCESS) goto error;
+    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma_log, sizes);
+    if(err != CL_SUCCESS) goto error;
+    return TRUE;
+  }
+  else if(d->mode == PROFILEGAMMA_GAMMA)
+  {
+    dev_table = dt_opencl_copy_host_to_device(devid, d->table, 256, 256, sizeof(float));
+    if(dev_table == NULL) goto error;
 
-  dt_opencl_release_mem_object(dev_table);
-  dt_opencl_release_mem_object(dev_coeffs);
-  return TRUE;
+    dev_coeffs = dt_opencl_copy_host_to_device_constant(devid, sizeof(float) * 3, d->unbounded_coeffs);
+    if(dev_coeffs == NULL) goto error;
+
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 0, sizeof(cl_mem), (void *)&dev_in);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 1, sizeof(cl_mem), (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 2, sizeof(int), (void *)&width);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 3, sizeof(int), (void *)&height);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 4, sizeof(cl_mem), (void *)&dev_table);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_profilegamma, 5, sizeof(cl_mem), (void *)&dev_coeffs);
+
+    err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_profilegamma, sizes);
+    if(err != CL_SUCCESS) goto error;
+
+    dt_opencl_release_mem_object(dev_table);
+    dt_opencl_release_mem_object(dev_coeffs);
+    return TRUE;
+  }
 
 error:
   dt_opencl_release_mem_object(dev_table);
@@ -135,6 +238,7 @@ error:
 }
 #endif
 
+
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -142,28 +246,66 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   const int ch = piece->colors;
 
+  switch(data->mode)
+  {
+    case PROFILEGAMMA_LOG:
+    {
+      const float grey = (data->grey_point / 100.);
+      const float noise = powf(2, -data->dynamic_range);
+      const float Logmin = Log2(noise);
+
+#ifdef _OPENMP
+#pragma omp parallel for SIMD() default(none) shared(data) schedule(static)
+#endif
+      for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k++)
+      {
+        const float pixel = ((float *)ivoid)[k];
+        float lg2 = data->dynamic_range * ((pixel + noise)/ (grey + noise));
+
+        if(lg2 < noise)
+        {
+          lg2 = Logmin;
+        }
+        else
+        {
+          lg2 = Log2(lg2);
+        }
+
+        lg2 = ((lg2 - data->shadows_range) / (data->dynamic_range));
+        lg2 = (lg2 - noise) / (1. - noise);
+        ((float *)ovoid)[k] = lg2;
+      }
+      break;
+    }
+
+    case PROFILEGAMMA_GAMMA:
+    {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(data) schedule(static)
 #endif
-  for(int k = 0; k < roi_out->height; k++)
-  {
-    const float *in = ((float *)ivoid) + (size_t)ch * k * roi_out->width;
-    float *out = ((float *)ovoid) + (size_t)ch * k * roi_out->width;
-
-    for(int j = 0; j < roi_out->width; j++, in += ch, out += ch)
-    {
-      for(int i = 0; i < 3; i++)
+      for(int k = 0; k < roi_out->height; k++)
       {
-        // use base curve for values < 1, else use extrapolation.
-        if(in[i] < 1.0f)
-          out[i] = data->table[CLAMP((int)(in[i] * 0x10000ul), 0, 0xffff)];
-        else
-          out[i] = dt_iop_eval_exp(data->unbounded_coeffs, in[i]);
+        const float *in = ((float *)ivoid) + (size_t)ch * k * roi_out->width;
+        float *out = ((float *)ovoid) + (size_t)ch * k * roi_out->width;
+
+        for(int j = 0; j < roi_out->width; j++, in += ch, out += ch)
+        {
+          for(int i = 0; i < 3; i++)
+          {
+            // use base curve for values < 1, else use extrapolation.
+            if(in[i] < 1.0f)
+              out[i] = data->table[CLAMP((int)(in[i] * 0x10000ul), 0, 0xffff)];
+            else
+              out[i] = dt_iop_eval_exp(data->unbounded_coeffs, in[i]);
+          }
+        }
       }
+      break;
     }
   }
 
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
+    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 static void linear_callback(GtkWidget *slider, gpointer user_data)
@@ -183,6 +325,254 @@ static void gamma_callback(GtkWidget *slider, gpointer user_data)
   p->gamma = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
+
+static void optimize(dt_iop_module_t *self)
+{
+  /*******************
+
+  This section optimizes the camera parameters (black level correction and camera linearity factor) such that :
+    - the target dynamic range (of the color chart used to produce the ICC input profile) is matched,
+    - the input grey level is in the center of the histogram,
+    - the black point of the ICC profile / color chart is matched,
+    - the dynamic range is centered on 0 (black EV = - white EV).
+
+  It assumes that :
+    - the data will be color-corrected afterwards with an input ICC profile
+    - it is better to remap the data dynamic range to the color chart's before the ICC color correction
+    - a contrast + gamma curve will be applied at the end of the pixel pipe to recover a proper contrast and
+  saturation
+
+  IT 8 and data-color charts have L values between 17 % and 96 %, hence 2.5 EV of dynamic range.
+  ***********************/
+
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f) 
+  {
+    dt_control_log(_("wait for the preview to be updated before requesting an optimization."));
+    return;
+  }
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  
+  float grey = (p->grey_point /100.); 
+  float min = (self->picked_color_min[0] + self->picked_color_min[1] + self->picked_color_min[2]) / 3.;
+  float max = (self->picked_color_max[0] + self->picked_color_max[1] + self->picked_color_max[2]) / 3.;
+  
+  float dynamic_range = 32.;
+  float noise = powf(2., -dynamic_range);  
+  
+  const float RGBmin
+    = fmin(fmin(self->picked_color_min[0], self->picked_color_min[1]), self->picked_color_min[2]);
+  
+  if( RGBmin < noise ) {noise += fabsf(RGBmin);}
+  if ( min + noise <= 0.) {
+    dt_control_log(_("the black level is too low (negative). lift it in the exposure module."));
+    return;
+  }
+  
+  float EVmin, EVmax, temp;
+
+  // Recompute the real dynamic range in RGB
+  int i = 0;
+  while ( i < 200000) // TODO: write a stopping criterion
+  {
+    EVmin = Log2Thres( dynamic_range * (min + noise) / (grey + noise), noise );
+    EVmax = Log2Thres( dynamic_range * (max + noise) / (grey + noise), noise );
+    dynamic_range = fabsf(EVmax - EVmin);
+    temp = dynamic_range * powf(2., dynamic_range / 2.);
+    noise = (min * temp - grey) / (1. - temp);
+    ++i;
+  }
+  
+  /* Rescale the dynamic range with user input */
+  // at this point, we assume the camera factor has successfuly split the LAB dynamic range in 2 equal halfs
+  // so EVmin = -EVmax = 0.5 * (EVmin - EVmax)
+  float shadows_range = EVmin * ( 1. + (p->black_target / 100.));
+  dynamic_range = dynamic_range * ( 1. + (p->black_target / 100.));
+
+  /* belt and suspenders sanitization */
+  if(dynamic_range > 0.5 && dynamic_range < 32.) p->dynamic_range = dynamic_range; else goto error;
+  if(shadows_range < 0. && shadows_range > -16.) p->shadows_range = shadows_range; else goto error;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
+  dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
+  darktable.gui->reset = 0;
+  
+error:
+  dt_control_log(_("the optimization has returned inconsistent parameters. correct the exposure settings."));
+  return;
+}
+
+
+static void black_target_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+  p->black_target = dt_bauhaus_slider_get(slider);
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  {
+    dt_iop_request_focus(self);
+    dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+    dt_dev_reprocess_all(self->dev);
+  }
+  else
+  {
+    dt_control_queue_redraw();
+    return;
+  }
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
+    self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+  else
+  {
+    optimize(self);
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void measure_grey(dt_iop_module_t *self)
+{
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f) return;
+
+  const float RGBavg[3] = { self->picked_color[0], self->picked_color[1], self->picked_color[2] };
+  float LABavg[3];
+
+  dt_prophotorgb_to_Lab((const float *)RGBavg, (float *)LABavg);
+
+  p->grey_point = LABavg[0];
+}
+
+
+static void autogrey_point_callback(GtkWidget *button, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  {
+    dt_iop_request_focus(self);
+    dt_lib_colorpicker_set_area(darktable.lib, 0.9);
+    dt_dev_reprocess_all(self->dev);
+  }
+  else
+  {
+    dt_control_queue_redraw();
+  }
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
+    self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+  else
+  {
+    measure_grey(self);
+
+    dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+    dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->grey_point, p->grey_point);
+    darktable.gui->reset = 0;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void grey_point_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+  p->grey_point = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void dynamic_range_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+
+  float previous = p->dynamic_range;
+  p->dynamic_range = dt_bauhaus_slider_get(slider);
+  float ratio = (p->dynamic_range - previous) / previous;
+  p->shadows_range = p->shadows_range + p->shadows_range * ratio;
+
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
+  darktable.gui->reset = 0;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void shadows_range_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+  p->shadows_range = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void autofix_callback(GtkWidget *button, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  {
+    dt_iop_request_focus(self);
+    dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+    dt_dev_reprocess_all(self->dev);
+  }
+  else
+  {
+    dt_control_queue_redraw();
+  }
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
+    self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+  else
+  {
+    optimize(self);
+    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+
+static void mode_callback(GtkWidget *combo, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+  p->mode = dt_bauhaus_combobox_get(combo);
+
+  switch(p->mode)
+  {
+    case PROFILEGAMMA_LOG:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+    case PROFILEGAMMA_GAMMA:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "gamma");
+      break;
+    default:
+      p->mode = PROFILEGAMMA_LOG;
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
@@ -244,11 +634,22 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   // now the extrapolation stuff:
   const float x[4] = { 0.7f, 0.8f, 0.9f, 1.0f };
-  const float y[4] = { d->table[CLAMP((int)(x[0] * 0x10000ul), 0, 0xffff)],
-                       d->table[CLAMP((int)(x[1] * 0x10000ul), 0, 0xffff)],
-                       d->table[CLAMP((int)(x[2] * 0x10000ul), 0, 0xffff)],
-                       d->table[CLAMP((int)(x[3] * 0x10000ul), 0, 0xffff)] };
+  const float y[4]
+      = { d->table[CLAMP((int)(x[0] * 0x10000ul), 0, 0xffff)], d->table[CLAMP((int)(x[1] * 0x10000ul), 0, 0xffff)],
+          d->table[CLAMP((int)(x[2] * 0x10000ul), 0, 0xffff)],
+          d->table[CLAMP((int)(x[3] * 0x10000ul), 0, 0xffff)] };
   dt_iop_estimate_exp(x, y, 4, d->unbounded_coeffs);
+
+  d->dynamic_range = p->dynamic_range;
+  d->grey_point = p->grey_point;
+  d->shadows_range = p->shadows_range;
+  d->black_target = p->black_target;
+  d->mode = p->mode;
+
+  piece->process_cl_ready = 1;
+
+  // no OpenCL for log yet.
+  if(d->mode == PROFILEGAMMA_LOG) piece->process_cl_ready = 0;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -268,8 +669,30 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)module->params;
+
+  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+
+  switch(p->mode)
+  {
+    case PROFILEGAMMA_LOG:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+    case PROFILEGAMMA_GAMMA:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "gamma");
+      break;
+    default:
+      p->mode = PROFILEGAMMA_LOG;
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+  }
+  
+  dt_bauhaus_combobox_set(g->mode, p->mode);
   dt_bauhaus_slider_set(g->linear, p->linear);
   dt_bauhaus_slider_set(g->gamma, p->gamma);
+  dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
+  dt_bauhaus_slider_set_soft(g->grey_point, p->grey_point);
+  dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
+  dt_bauhaus_slider_set_soft(g->black_target, p->black_target);
 }
 
 void init(dt_iop_module_t *module)
@@ -280,7 +703,8 @@ void init(dt_iop_module_t *module)
   module->priority = 323; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_profilegamma_params_t);
   module->gui_data = NULL;
-  dt_iop_profilegamma_params_t tmp = (dt_iop_profilegamma_params_t){ 0.1, 0.45 };
+  dt_iop_profilegamma_params_t tmp
+      = (dt_iop_profilegamma_params_t){ 0, 0.1, 0.45, 8., 100., -4., 0. };
   memcpy(module->params, &tmp, sizeof(dt_iop_profilegamma_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_profilegamma_params_t));
 }
@@ -290,8 +714,10 @@ void init_global(dt_iop_module_so_t *module)
   const int program = 2; // basic.cl, from programs.conf
   dt_iop_profilegamma_global_data_t *gd
       = (dt_iop_profilegamma_global_data_t *)malloc(sizeof(dt_iop_profilegamma_global_data_t));
+
   module->data = gd;
   gd->kernel_profilegamma = dt_opencl_create_kernel(program, "profilegamma");
+  gd->kernel_profilegamma_log = dt_opencl_create_kernel(program, "profilegamma_log");
 }
 
 void cleanup(dt_iop_module_t *module)
@@ -304,32 +730,119 @@ void cleanup_global(dt_iop_module_so_t *module)
 {
   dt_iop_profilegamma_global_data_t *gd = (dt_iop_profilegamma_global_data_t *)module->data;
   dt_opencl_free_kernel(gd->kernel_profilegamma);
+  dt_opencl_free_kernel(gd->kernel_profilegamma_log);
   free(module->data);
   module->data = NULL;
 }
+
+
 void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_profilegamma_gui_data_t));
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
 
+  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
+  // mode choice
+  g->mode = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));
+  dt_bauhaus_combobox_add(g->mode, _("logarithmic"));
+  dt_bauhaus_combobox_add(g->mode, _("gamma"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->mode), TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->mode, _("tone mapping method"));
+  g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);
+
+  // prepare the modes widgets stack
+  g->mode_stack = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(g->mode_stack), FALSE);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
+
+
+  /**** GAMMA MODE ***/
+  GtkWidget *vbox_gamma = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  // linear slider
   g->linear = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.0001, p->linear, 4);
-  g->gamma = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.0001, p->gamma, 4);
-
   dt_bauhaus_widget_set_label(g->linear, NULL, _("linear"));
-  dt_bauhaus_widget_set_label(g->gamma, NULL, _("gamma"));
-
-  gtk_box_pack_start(GTK_BOX(self->widget), g->linear, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->gamma, TRUE, TRUE, 0);
-
+  gtk_box_pack_start(GTK_BOX(vbox_gamma), g->linear, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->linear, _("linear part"));
-  gtk_widget_set_tooltip_text(g->gamma, _("gamma exponential factor"));
-
   g_signal_connect(G_OBJECT(g->linear), "value-changed", G_CALLBACK(linear_callback), self);
+
+  // gamma slider
+  g->gamma = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.0001, p->gamma, 4);
+  dt_bauhaus_widget_set_label(g->gamma, NULL, _("gamma"));
+  gtk_box_pack_start(GTK_BOX(vbox_gamma), g->gamma, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->gamma, _("gamma exponential factor"));
   g_signal_connect(G_OBJECT(g->gamma), "value-changed", G_CALLBACK(gamma_callback), self);
+
+  gtk_widget_show_all(vbox_gamma);
+  gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_gamma, "gamma");
+
+
+  /**** LOG MODE ****/
+
+  GtkWidget *vbox_log = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+
+  // grey_point slider
+  g->grey_point = dt_bauhaus_slider_new_with_range(self, 0.1, 100., 0.5, p->grey_point, 2);
+  dt_bauhaus_widget_set_label(g->grey_point, NULL, _("middle grey target value"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->grey_point, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->grey_point, "%.2f %%");
+  gtk_widget_set_tooltip_text(
+      g->grey_point,
+      _("adjust to match a neutral tone\nthis will become the new 50 % grey after log correction\nuse 100 % to disable the tone-mapping"));
+  g_signal_connect(G_OBJECT(g->grey_point), "value-changed", G_CALLBACK(grey_point_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->grey_point, dtgtk_cairo_paint_colorpicker, CPF_ACTIVE, NULL);
+  g_signal_connect(G_OBJECT(g->grey_point), "quad-pressed", G_CALLBACK(autogrey_point_callback), self);
+
+  // Dynamic range slider
+  g->dynamic_range = dt_bauhaus_slider_new_with_range(self, 0.5, 16.0, 0.1, p->dynamic_range, 2);
+  dt_bauhaus_slider_enable_soft_boundaries(g->dynamic_range, 0.01, 32.0);
+  dt_bauhaus_widget_set_label(g->dynamic_range, NULL, _("dynamic range"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->dynamic_range, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->dynamic_range, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->dynamic_range, _("number of stops between 0 % black and 100 % white"));
+  g_signal_connect(G_OBJECT(g->dynamic_range), "value-changed", G_CALLBACK(dynamic_range_callback), self);
+
+  // Shadows range slider
+  g->shadows_range = dt_bauhaus_slider_new_with_range(self, -16.0, -0.0, 0.1, p->shadows_range, 2);
+  dt_bauhaus_slider_enable_soft_boundaries(g->shadows_range, -16., 16.0);
+  dt_bauhaus_widget_set_label(g->shadows_range, NULL, _("black relative exposure"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->shadows_range, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->shadows_range, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->shadows_range, _("number of stops between the new 50 % grey and 0 % black"));
+  g_signal_connect(G_OBJECT(g->shadows_range), "value-changed", G_CALLBACK(shadows_range_callback), self);
+
+  // Auto tune slider
+  g->black_target = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->black_target, 2);
+  dt_bauhaus_widget_set_label(g->black_target, NULL, _("contrast correction"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->black_target, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->black_target, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->black_target, _("resize the dynamic range to recover blacks"));
+  g_signal_connect(G_OBJECT(g->black_target), "value-changed", G_CALLBACK(black_target_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->black_target, dtgtk_cairo_paint_colorpicker, CPF_ACTIVE, NULL);
+  g_signal_connect(G_OBJECT(g->black_target), "quad-pressed", G_CALLBACK(autofix_callback), self);
+
+  gtk_widget_show_all(vbox_log);
+  gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_log, "log");
+
+  switch(p->mode)
+  {
+    case PROFILEGAMMA_LOG:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+    case PROFILEGAMMA_GAMMA:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "gamma");
+      break;
+    default:
+      p->mode = PROFILEGAMMA_LOG;
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+  }
 }
+
 
 void gui_cleanup(dt_iop_module_t *self)
 {

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -258,6 +258,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       const float grey = data->grey_point / 100.0f;
       const float noise = powf(2.0f, -data->dynamic_range);
       const float Logmin = Log2(noise);
+      const float safety = powf(2.0f, -14.0f);
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) shared(data) schedule(static)
@@ -279,7 +280,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
             }
             else
             {
-              out[i] = (Log2(lg2) - data->shadows_range) / (data->dynamic_range);
+              out[i] = (Log2(lg2 + safety) - data->shadows_range) / (data->dynamic_range) - safety;
             }
           }
         }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -271,7 +271,10 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
         {
           for(int i = 0; i < 3; i++)
           {
-            out[i] = (Log2(CLAMP(in[i] / grey, noise, 99999.0f)) - data->shadows_range) / (data->dynamic_range);
+            float tmp = in[i] / grey;
+            if (tmp < noise) tmp = noise;
+            out[i] = (Log2(tmp) - data->shadows_range) / (data->dynamic_range);
+            if (out[i] < 0.0f) out[i] = 0;
           }
         }
       }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -418,8 +418,9 @@ static void black_target_callback(GtkWidget *slider, gpointer user_data)
   else
   {
     dt_control_queue_redraw();
-    return;
   }
+  
+  dt_iop_request_focus(self);
 
   if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
     self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
@@ -461,6 +462,8 @@ static void autogrey_point_callback(GtkWidget *button, gpointer user_data)
   {
     dt_control_queue_redraw();
   }
+  
+  dt_iop_request_focus(self);
 
   if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
     self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
@@ -493,6 +496,8 @@ static void shadows_pick_callback(GtkWidget *button, gpointer user_data)
   {
     dt_control_queue_redraw();
   }
+  
+  dt_iop_request_focus(self);
 
   if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
     self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
@@ -500,7 +505,7 @@ static void shadows_pick_callback(GtkWidget *button, gpointer user_data)
   {
     if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f) return;
     
-      dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
+    dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
     dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
 
     const float RGBavg[3] = { self->picked_color[0], self->picked_color[1], self->picked_color[2] };
@@ -817,7 +822,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->grey_point, "%.2f %%");
   gtk_widget_set_tooltip_text(
       g->grey_point,
-      _("adjust to match a neutral tone\nthis will become the new 50 % grey after log correction\nuse 100 % to disable the tone-mapping"));
+      _("adjust to match a neutral tone\nuse 100 % to disable the tone-mapping"));
   g_signal_connect(G_OBJECT(g->grey_point), "value-changed", G_CALLBACK(grey_point_callback), self);
   dt_bauhaus_widget_set_quad_paint(g->grey_point, dtgtk_cairo_paint_colorpicker, CPF_ACTIVE, NULL);
   g_signal_connect(G_OBJECT(g->grey_point), "quad-pressed", G_CALLBACK(autogrey_point_callback), self);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -257,9 +257,6 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       const float grey = data->grey_point / 100.0f;
       const float noise = powf(2.0f, -data->dynamic_range);
-      const float safety = powf(2.0f, -14.0f);  
-      const float safety_grey = safety / grey;
-      const float zero = (Log2( noise ) - data->shadows_range) / data->dynamic_range; 
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) shared(data) schedule(static)
@@ -273,16 +270,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
         {
           for(int i = 0; i < 3; i++)
           {
-            const float lg2 = in[i]/ grey;
-
-            if(lg2 < noise)
-            {
-              out[i] = zero - (data->dynamic_range / (lg2 - zero));
-            }
-            else
-            {
-              out[i] = (Log2(lg2 + safety) - data->shadows_range) / (data->dynamic_range) - safety_grey;
-            }
+            out[i] = (Log2(CLAMP(in[i], noise, 99999.0f) / grey) - data->shadows_range) / (data->dynamic_range);
           }
         }
       }


### PR DESCRIPTION
_Warning : This is my first code contribution in dt and the first time I use C and work with GUIs._

This adds a new mode of tone-mapping before color profile correction, using the same approach as video encoding Log profiles (S-log, N-log, etc.). Details and example can be seen here : https://discuss.pixls.us/t/solving-dynamic-range-problems-in-a-linear-way/9006

It retains the previous gamma method and takes care of the legacy params.

It adds an auto solver to automatically compute the pest settings, namely the dynamic range, according to the target grey and the measurements from the color sampler.

It adds masking/blending options and the ability to add in styles.

The OpenCL code is given but does not work at this point. I need help to debug it. OpenCL is enabled for the gamma method and disabled for now on the log method. See https://www.mail-archive.com/darktable-dev@lists.darktable.org/msg03355.html
