### PR TITLE
New copy history

### DIFF
--- a/src/common/history.h
+++ b/src/common/history.h
@@ -25,6 +25,9 @@
 /** helper function to free a GList of dt_history_item_t */
 void dt_history_item_free(gpointer data);
 
+/** adds to memory.style_items instances of operations that shoudn't be modified by the copy/paste or style */
+void dt_history_rebuild_multi_priority_merge(const int dest_imgid);
+
 /** copy history from imgid and pasts on dest_imgid, merge or overwrite... */
 int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboolean merge, GList *ops);
 

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -558,6 +558,9 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 
+    // rebuild multi-priority
+    if(!duplicate) dt_history_rebuild_multi_priority_merge(newimgid);
+
     /* copy the style items into the history */
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                 "INSERT INTO main.history "


### PR DESCRIPTION
This changes copy/paste history and apply styles so, when a (operation, multi_name) is added to an image:

-if (operation, multi_name) already exists on dest image, it replaces it
-if do not exists, it creates a new instance
-not replaced instances must be kept
-all added entries are placed last on the pipe
-the user must be able to go back in history to the state before the paste, except for the order of the multi-instances, that can't be undone going back to history

There's a change in behaviour:
-copy all/paste all with mode append copies the last entry in history for each (operation, multi_priority) in the source image, same as copy/paste, the only way of having an exact duplicate of the history is to use copy all/paste all with mode override
