### PR TITLE
modifiy the range of the blur radius sliders

### DIFF
--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -662,7 +662,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(hbox, GTK_WIDGET(g->order), TRUE, TRUE, 0);
 #endif
 
-  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 200.0, 0.1, p->radius, 2);
+  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 500.0, 0.1, p->radius, 2);
   g->contrast = dt_bauhaus_slider_new_with_range(self, -3.0, 3.0, 0.01, p->contrast, 2);
   g->brightness = dt_bauhaus_slider_new_with_range(self, -3.0, 3.0, 0.01, p->brightness, 2);
   g->saturation = dt_bauhaus_slider_new_with_range(self, -3.0, 3.0, 0.01, p->saturation, 2);

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -819,7 +819,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->shadhi_algo, NULL, _("soften with"));
   dt_bauhaus_combobox_add(g->shadhi_algo, _("gaussian"));
   dt_bauhaus_combobox_add(g->shadhi_algo, _("bilateral filter"));
-  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 200.0, 2., p->radius, 2);
+  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 500.0, 2., p->radius, 2);
   g->compress = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->compress, 2);
   g->shadows_ccorrect = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->shadows_ccorrect, 2);
   g->highlights_ccorrect = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->highlights_ccorrect, 2);


### PR DESCRIPTION
Minor change : modify the range of the blur radius slider from 0-200 to 0-500 in shadows/highlights and lowpass modules. This is usefull sometimes when pushing the highlights gain below -50, to avoid dark spots.