### PR TITLE
masks continuous add

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -302,6 +302,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
 int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, double y, int up, uint32_t state);
 void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery);
+void dt_masks_events_mouse_leave(struct dt_iop_module_t *module);
 
 /** functions used to manipulate gui datas */
 void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -339,8 +339,9 @@ void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel);
 void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const float x, const float y);
 void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
                                            const float pzy);
-void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float xpos,
-                                         const float ypos, float *px, float *py);
+void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float initial_xpos,
+                                         const float initial_ypos, const float xpos, const float ypos, float *px,
+                                         float *py, const int adding);
 
 /** code for dynamic handling of intermediate buffers */
 static inline

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -83,6 +83,13 @@ typedef enum dt_masks_ellipse_flags_t
   DT_MASKS_ELLIPSE_PROPORTIONAL = 1
 } dt_masks_ellipse_flags_t;
 
+typedef enum dt_masks_source_pos_type_t
+{
+  DT_MASKS_SOURCE_POS_RELATIVE = 0,
+  DT_MASKS_SOURCE_POS_RELATIVE_TEMP = 1,
+  DT_MASKS_SOURCE_POS_ABSOLUTE = 2
+} dt_masks_source_pos_type_t;
+
 /** structure used to store 1 point for a circle */
 typedef struct dt_masks_point_circle_t
 {
@@ -189,7 +196,7 @@ typedef struct dt_masks_form_gui_t
   int guipoints_count;
 
   // values for mouse positions, etc...
-  float posx, posy, dx, dy, scrollx, scrolly;
+  float posx, posy, dx, dy, scrollx, scrolly, posx_source, posy_source;
   gboolean form_selected;
   gboolean border_selected;
   gboolean source_selected;
@@ -200,6 +207,7 @@ typedef struct dt_masks_form_gui_t
   int feather_selected;
   int seg_selected;
   int point_border_selected;
+  int source_pos_type;
 
   gboolean form_dragging;
   gboolean source_dragging;
@@ -224,6 +232,9 @@ typedef struct dt_masks_form_gui_t
   int formid;
   uint64_t pipe_hash;
 } dt_masks_form_gui_t;
+
+/** init dt_masks_form_gui_t struct with default values */
+void dt_masks_init_form_gui(dt_masks_form_gui_t *gui);
 
 /** get points in real space with respect of distortion dx and dy are used to eventually move the center of
  * the circle */
@@ -317,7 +328,15 @@ int dt_masks_form_duplicate(dt_develop_t *dev, int formid);
 int dt_masks_point_in_form_exact(float x, float y, float *points, int points_start, int points_count);
 int dt_masks_point_in_form_near(float x, float y, float *points, int points_start, int points_count, float distance, int *near);
 
+/** allow to select a shape inside an iop */
 void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel);
+
+/** utils for selecting the source of a clone mask while creating it */
+void dt_masks_draw_clone_source_pos(cairo_t *cr, float zoom_scale, const float x, const float y);
+void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
+                                           const float pzy);
+void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float xpos,
+                                         const float ypos, float *px, float *py);
 
 /** code for dynamic handling of intermediate buffers */
 static inline

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -223,8 +223,10 @@ typedef struct dt_masks_form_gui_t
 
 
   gboolean creation;
+  gboolean creation_continuous;
   gboolean creation_closing_form;
   dt_iop_module_t *creation_module;
+  dt_iop_module_t *creation_continuous_module;
 
   dt_masks_pressure_sensitivity_t pressure_sensitivity;
 
@@ -313,6 +315,8 @@ dt_masks_point_group_t *dt_masks_group_add_form(dt_masks_form_t *grp, dt_masks_f
 void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton, struct dt_iop_module_t *module);
 void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module_t *module);
 void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t value);
+void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const int formid,
+                                        dt_masks_edit_mode_t value);
 void dt_masks_iop_update(struct dt_iop_module_t *module);
 void dt_masks_iop_combo_populate(GtkWidget *w, struct dt_iop_module_t **m);
 void dt_masks_iop_use_same_as(struct dt_iop_module_t *module, struct dt_iop_module_t *src);
@@ -332,7 +336,7 @@ int dt_masks_point_in_form_near(float x, float y, float *points, int points_star
 void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel);
 
 /** utils for selecting the source of a clone mask while creating it */
-void dt_masks_draw_clone_source_pos(cairo_t *cr, float zoom_scale, const float x, const float y);
+void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const float x, const float y);
 void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
                                            const float pzy);
 void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float xpos,

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2270,7 +2270,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       if(form->type & DT_MASKS_CLONE)
       {
         float x = 0.f, y = 0.f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, xpos, ypos, &x, &y);
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, xpos, ypos, xpos, ypos, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
 
@@ -2390,7 +2390,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       {
         const int i = gui->guipoints_count - 1;
         float x = 0.f, y = 0.f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, guipoints[i * 2], guipoints[i * 2 + 1], &x, &y);
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, guipoints[0], guipoints[1], guipoints[i * 2],
+                                            guipoints[i * 2 + 1], &x, &y, TRUE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1343,8 +1343,6 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
       if(!gpt) return 0;
       // we start the form dragging
       gui->source_dragging = TRUE;
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
       gui->dx = gpt->source[2] - gui->posx;
       gui->dy = gpt->source[3] - gui->posy;
       return 1;
@@ -1353,8 +1351,6 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
     {
       gui->form_dragging = TRUE;
       gui->point_edited = -1;
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
       gui->dx = gpt->points[2] - gui->posx;
       gui->dy = gpt->points[3] - gui->posy;
       return 1;
@@ -1454,8 +1450,6 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
       {
         // we move the entire segment
         gui->seg_dragging = gui->seg_selected;
-        gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-        gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
         gui->dx = gpt->points[gui->seg_selected * 6 + 2] - gui->posx;
         gui->dy = gpt->points[gui->seg_selected * 6 + 3] - gui->posy;
       }
@@ -1733,9 +1727,6 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
 
         darktable.develop->form_gui->creation = TRUE;
         darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
-
-        gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-        gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
       }
       else if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
@@ -1963,11 +1954,6 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
       dt_masks_dynbuf_add(gui->guipoints_payload, pressure);
       gui->guipoints_count++;
     }
-    else
-    {
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-    }
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -2093,8 +2079,6 @@ static int dt_brush_events_mouse_moved(struct dt_iop_module_t *module, float pzx
   }
   else if(gui->form_dragging || gui->source_dragging)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -2242,7 +2226,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       float radius2 = masks_border * MIN(wd, ht);
 
       float xpos, ypos;
-      if(gui->posx == 0 && gui->posy == 0)
+      if(gui->posx == -1.f && gui->posy == -1.f)
       {
         float zoom_x, zoom_y;
         zoom_y = dt_control_get_dev_zoom_y();

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -620,7 +620,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       if(form->type & DT_MASKS_CLONE)
       {
         float x = 0.f, y = 0.f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_CIRCLE, xpos, ypos, &x, &y);
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_CIRCLE, xpos, ypos, xpos, ypos, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
       

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -242,6 +242,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
   }
   else if(gui->creation && (which == 3))
   {
+    gui->creation_continuous = FALSE;
+    gui->creation_continuous_module = NULL;
     dt_masks_set_edit_mode(module, DT_MASKS_EDIT_FULL);
     dt_masks_iop_update(module);
     dt_control_queue_redraw_center();
@@ -303,7 +305,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       // we save the move
       dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
       // and we switch in edit mode to show all the forms
-      dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
+      if(gui->creation_continuous)
+        dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
+      else
+        dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
       gui->creation_module = NULL;
     }
@@ -413,6 +418,17 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     // we save the move
     dt_masks_update_image(darktable.develop);
 
+    if(gui->creation_continuous)
+    {
+      dt_masks_form_t *form_new = dt_masks_create(form->type);
+      dt_masks_change_form_gui(form_new);
+
+      darktable.develop->form_gui->creation = TRUE;
+      darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+
+      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
+      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    }
     return 1;
   }
   else if(gui->source_dragging)
@@ -422,10 +438,6 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     if(gui->scrollx != 0.0 || gui->scrolly != 0.0)
     {
       // if there's no dragging the source is calculated in dt_circle_events_button_pressed()
-      /* dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
-      form->source[0] = circle->center[0] + circle->radius;
-      form->source[1] = circle->center[1] - circle->radius;
-      gui->scrollx = gui->scrolly = 0.0; */
     }
     else
     {
@@ -448,6 +460,17 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
     // we save the move
     dt_masks_update_image(darktable.develop);
 
+    if(gui->creation_continuous)
+    {
+      dt_masks_form_t *form_new = dt_masks_create(form->type);
+      dt_masks_change_form_gui(form_new);
+
+      darktable.develop->form_gui->creation = TRUE;
+      darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+
+      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
+      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
+    }
     return 1;
   }
   return 0;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -222,8 +222,6 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     if(!gpt) return 0;
     // we start the form dragging
     gui->source_dragging = TRUE;
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     gui->dx = gpt->source[0] - gui->posx;
     gui->dy = gpt->source[1] - gui->posy;
     return 1;
@@ -234,8 +232,6 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     if(!gpt) return 0;
     // we start the form dragging
     gui->form_dragging = TRUE;
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -425,9 +421,6 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
 
       darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
-
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     }
     return 1;
   }
@@ -467,9 +460,6 @@ static int dt_circle_events_button_released(struct dt_iop_module_t *module, floa
 
       darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
-
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     }
     return 1;
   }
@@ -482,8 +472,6 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
 {
   if(gui->form_dragging || gui->source_dragging)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -529,9 +517,6 @@ static int dt_circle_events_mouse_moved(struct dt_iop_module_t *module, float pz
   // add a preview when creating a circle
   else if(gui->creation)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -575,7 +560,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       radius2 *= MIN(wd, ht);
 
       float xpos, ypos;
-      if(gui->posx == 0 && gui->posy == 0)
+      if(gui->posx == -1.f && gui->posy == -1.f)
       {
         float zoom_x, zoom_y;
         zoom_y = dt_control_get_dev_zoom_y();

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1210,7 +1210,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       if(form->type & DT_MASKS_CLONE)
       {
         float x = 0.f, y = 0.f;
-        dt_masks_calculate_source_pos_value(gui, DT_MASKS_ELLIPSE, pzx, pzy, &x, &y);
+        dt_masks_calculate_source_pos_value(gui, DT_MASKS_ELLIPSE, pzx, pzy, pzx, pzy, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
 

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -591,8 +591,6 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     if(!gpt) return 0;
     // we start the source dragging
     gui->source_dragging = TRUE;
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     gui->dx = gpt->source[0] - gui->posx;
     gui->dy = gpt->source[1] - gui->posy;
     return 1;
@@ -603,8 +601,6 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
     if(!gpt) return 0;
     gui->point_dragging = gui->point_selected;
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -619,8 +615,6 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -834,9 +828,6 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
 
       darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
-
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     }
     return 1;
   }
@@ -1018,9 +1009,6 @@ static int dt_ellipse_events_button_released(struct dt_iop_module_t *module, flo
 
       darktable.develop->form_gui->creation = TRUE;
       darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
-
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     }
     return 1;
   }
@@ -1033,8 +1021,6 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
 {
   if(gui->form_dragging || gui->form_rotating || gui->source_dragging || gui->point_dragging >= 1)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1099,9 +1085,6 @@ static int dt_ellipse_events_mouse_moved(struct dt_iop_module_t *module, float p
   // add a preview when creating an ellipse
   else if(gui->creation)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
-
     dt_control_queue_redraw_center();
     return 1;
   }
@@ -1158,7 +1141,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       float pzx = gui->posx;
       float pzy = gui->posy;
 
-      if(pzx == 0 && pzy == 0)
+      if(pzx == -1.f && pzy == -1.f)
       {
         float zoom_x, zoom_y;
         zoom_y = dt_control_get_dev_zoom_y();

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -128,8 +128,6 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
       gui->form_rotating = TRUE;
     else
       gui->form_dragging = TRUE;
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     gui->dx = gpt->points[0] - gui->posx;
     gui->dy = gpt->points[1] - gui->posy;
     return 1;
@@ -298,8 +296,6 @@ static int dt_gradient_events_mouse_moved(struct dt_iop_module_t *module, float 
 {
   if(gui->form_dragging || gui->form_rotating)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     dt_control_queue_redraw_center();
     return 1;
   }

--- a/src/develop/masks/group.c
+++ b/src/develop/masks/group.c
@@ -59,7 +59,8 @@ static int dt_group_events_button_pressed(struct dt_iop_module_t *module, float 
     // we set the selected form in edit mode
     gui->group_edited = gui->group_selected;
     // we initialise some variable
-    gui->posx = gui->posy = gui->dx = gui->dy = 0.0f;
+    gui->posx = gui->posy = -1.f;
+    gui->dx = gui->dy = 0.0f;
     gui->form_selected = gui->border_selected = gui->form_dragging = gui->form_rotating = FALSE;
     gui->pivot_selected = FALSE;
     gui->point_border_selected = gui->seg_selected = gui->point_selected = gui->feather_selected = -1;

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2517,8 +2517,9 @@ void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint3
 }
 
 // calculates the source position value for preview drawing, on cairo coordinates
-void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float xpos,
-                                         const float ypos, float *px, float *py)
+void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float initial_xpos,
+                                         const float initial_ypos, const float xpos, const float ypos, float *px,
+                                         float *py, const int adding)
 {
   float x = 0.f, y = 0.f;
 
@@ -2527,10 +2528,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
 
   if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
-    float pts_src[2] = { gui->posx_source * wd, gui->posy_source * ht };
-
-    x = xpos + pts_src[0];
-    y = ypos + pts_src[1];
+    x = xpos + gui->posx_source * wd;
+    y = ypos + gui->posy_source * ht;
   }
   else if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE_TEMP)
   {
@@ -2570,8 +2569,18 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   }
   else if(gui->source_pos_type == DT_MASKS_SOURCE_POS_ABSOLUTE)
   {
-    x = gui->posx_source;
-    y = gui->posy_source;
+    // if the user is actually adding the mask follow the cursor
+    if(adding)
+    {
+      x = xpos + gui->posx_source - initial_xpos;
+      y = ypos + gui->posy_source - initial_ypos;
+    }
+    else
+    {
+      // if not added yet set the start position
+      x = gui->posx_source;
+      y = gui->posy_source;
+    }
   }
   else
     fprintf(stderr, "unknown source position type for setting source position value\n");

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -202,6 +202,14 @@ static void _set_hinter_message(dt_masks_form_gui_t *gui, dt_masks_type_t formty
   dt_control_hinter_message(darktable.control, msg);
 }
 
+void dt_masks_init_form_gui(dt_masks_form_gui_t *gui)
+{
+  memset(gui, 0, sizeof(dt_masks_form_gui_t));
+
+  gui->posx_source = gui->posy_source = -1.0f;
+  gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
+}
+
 void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index)
 {
   if(g_list_length(gui->points) == index)
@@ -2429,6 +2437,114 @@ void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel)
         module->masks_selection_changed(module, darktable.develop->mask_form_selected_id);
     }
   }
+}
+
+// draw a cross where the source position of a clone mask will be created
+void dt_masks_draw_clone_source_pos(cairo_t *cr, float zoom_scale, const float x, const float y)
+{
+  const float dx = 5.f;
+  const float dy = 5.f;
+  
+  double dashed[] = { 4.0, 4.0 };
+  dashed[0] /= zoom_scale;
+  dashed[1] /= zoom_scale;
+  
+  cairo_set_dash(cr, dashed, 0, 0);
+  cairo_set_line_width(cr, 3.0 / zoom_scale);
+  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+  
+  cairo_move_to(cr, x + dx, y);
+  cairo_line_to(cr, x - dx, y);
+  cairo_move_to(cr, x, y + dy);
+  cairo_line_to(cr, x, y - dy);
+  cairo_stroke_preserve(cr);
+  
+  cairo_set_line_width(cr, 1.0 / zoom_scale);
+  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  cairo_stroke(cr);
+}
+
+// sets if the initial source position for a clone mask will be absolute or relative,
+// based on mouse position and key state
+void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
+                                           const float pzy)
+{
+  if(state & GDK_CONTROL_MASK)
+    gui->source_pos_type = DT_MASKS_SOURCE_POS_ABSOLUTE;
+  else if(state & GDK_SHIFT_MASK)
+    gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
+  else
+    fprintf(stderr, "unknown state for setting masks position type\n");
+
+  // both source types record an absolute position,
+  // for the relative type, the first time is used the position is recorded,
+  // the second time a relative position is calculated based on that one
+  gui->posx_source = pzx * darktable.develop->preview_pipe->backbuf_width;
+  gui->posy_source = pzy * darktable.develop->preview_pipe->backbuf_height;
+}
+
+// calculates the source position value for preview drawing, on cairo coordinates
+void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mask_type, const float xpos,
+                                         const float ypos, float *px, float *py)
+{
+  float x = 0.f, y = 0.f;
+
+  const float wd = darktable.develop->preview_pipe->iwidth;
+  const float ht = darktable.develop->preview_pipe->iheight;
+
+  if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
+  {
+    float pts_src[2] = { gui->posx_source * wd, gui->posy_source * ht };
+
+    x = xpos + pts_src[0];
+    y = ypos + pts_src[1];
+  }
+  else if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE_TEMP)
+  {
+    if(gui->posx_source == -1.f && gui->posy_source == -1.f)
+    {
+      if(mask_type & DT_MASKS_CIRCLE)
+      {
+        const float radius = MIN(0.5f, dt_conf_get_float("plugins/darkroom/spots/circle_size"));
+        x = xpos + radius * wd;
+        y = ypos - radius * ht;
+      }
+      else if(mask_type & DT_MASKS_ELLIPSE)
+      {
+        const float radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+        const float radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+        x = xpos + radius_a * wd;
+        y = ypos - radius_b * ht;
+      }
+      else if(mask_type & DT_MASKS_PATH)
+      {
+        x = xpos + 0.02f * wd;
+        y = ypos + 0.02f * ht;
+      }
+      else if(mask_type & DT_MASKS_BRUSH)
+      {
+        x = xpos + 0.01f * wd;
+        y = ypos + 0.01f * ht;
+      }
+      else
+        fprintf(stderr, "unsuported masks type when calculating source position value\n");
+    }
+    else
+    {
+      x = gui->posx_source;
+      y = gui->posy_source;
+    }
+  }
+  else if(gui->source_pos_type == DT_MASKS_SOURCE_POS_ABSOLUTE)
+  {
+    x = gui->posx_source;
+    y = gui->posy_source;
+  }
+  else
+    fprintf(stderr, "unknown source position type for setting source position value\n");
+
+  *px = x;
+  *py = y;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1544,6 +1544,39 @@ void dt_masks_set_edit_mode(struct dt_iop_module_t *module, dt_masks_edit_mode_t
   dt_control_queue_redraw_center();
 }
 
+void dt_masks_set_edit_mode_single_form(struct dt_iop_module_t *module, const int formid,
+                                        dt_masks_edit_mode_t value)
+{
+  if(!module) return;
+
+  dt_masks_form_t *grp = dt_masks_create(DT_MASKS_GROUP);
+
+  const int grid = module->blend_params->mask_id;
+  dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, formid);
+  if(form)
+  {
+    dt_masks_point_group_t *fpt = (dt_masks_point_group_t *)malloc(sizeof(dt_masks_point_group_t));
+    fpt->formid = formid;
+    fpt->parentid = grid;
+    fpt->state = DT_MASKS_STATE_USE;
+    fpt->opacity = 1.0f;
+    grp->points = g_list_append(grp->points, fpt);
+  }
+
+  dt_masks_form_t *grp2 = dt_masks_create(DT_MASKS_GROUP);
+  grp2->formid = 0;
+  dt_masks_group_ungroup(grp2, grp);
+  dt_masks_change_form_gui(grp2);
+  darktable.develop->form_gui->edit_mode = value;
+
+  if(value && form)
+    dt_dev_masks_selection_change(darktable.develop, formid, FALSE);
+  else
+    dt_dev_masks_selection_change(darktable.develop, 0, FALSE);
+
+  dt_control_queue_redraw_center();
+}
+
 void dt_masks_iop_edit_toggle_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
 {
   if(!module) return;
@@ -2440,11 +2473,11 @@ void dt_masks_select_form(struct dt_iop_module_t *module, dt_masks_form_t *sel)
 }
 
 // draw a cross where the source position of a clone mask will be created
-void dt_masks_draw_clone_source_pos(cairo_t *cr, float zoom_scale, const float x, const float y)
+void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const float x, const float y)
 {
-  const float dx = 5.f;
-  const float dy = 5.f;
-  
+  const float dx = 3.5f / zoom_scale;
+  const float dy = 3.5f / zoom_scale;
+
   double dashed[] = { 4.0, 4.0 };
   dashed[0] /= zoom_scale;
   dashed[1] /= zoom_scale;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2012,8 +2012,8 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
     if((k * 6 + 2) >= 0)
     {
       float x = 0.f, y = 0.f;
-      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, gpt->points[k * 6 + 2] + dx,
-                                          gpt->points[k * 6 + 3] + dy, &x, &y);
+      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, gpt->points[2] + dx, gpt->points[3] + dy,
+                                          gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy, &x, &y, TRUE);
       dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
     }
     else
@@ -2031,7 +2031,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       }
 
       float x = 0.f, y = 0.f;
-      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, xpos, ypos, &x, &y);
+      dt_masks_calculate_source_pos_value(gui, DT_MASKS_PATH, xpos, ypos, xpos, ypos, &x, &y, FALSE);
       dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
     }
   }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1078,9 +1078,6 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
 
         darktable.develop->form_gui->creation = TRUE;
         darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
-
-        gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-        gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
       }
       else if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
@@ -1179,8 +1176,6 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       if(!gpt) return 0;
       // we start the form dragging
       gui->source_dragging = TRUE;
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
       gui->dx = gpt->source[2] - gui->posx;
       gui->dy = gpt->source[3] - gui->posy;
       return 1;
@@ -1189,8 +1184,6 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
     {
       gui->form_dragging = TRUE;
       gui->point_edited = -1;
-      gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-      gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
       gui->dx = gpt->points[2] - gui->posx;
       gui->dy = gpt->points[3] - gui->posy;
       return 1;
@@ -1286,8 +1279,6 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       {
         // we move the entire segment
         gui->seg_dragging = gui->seg_selected;
-        gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-        gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
         gui->dx = gpt->points[gui->seg_selected * 6 + 2] - gui->posx;
         gui->dy = gpt->points[gui->seg_selected * 6 + 3] - gui->posy;
       }
@@ -1719,15 +1710,8 @@ static int dt_path_events_mouse_moved(struct dt_iop_module_t *module, float pzx,
   }
   else if(gui->form_dragging || gui->source_dragging)
   {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
     dt_control_queue_redraw_center();
     return 1;
-  }
-  else if(gui->creation)
-  {
-    gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
-    gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
   }
 
   gui->form_selected = FALSE;
@@ -2019,7 +2003,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
     else
     {
       float xpos, ypos;
-      if(gui->posx == 0 && gui->posy == 0)
+      if(gui->posx == -1.f && gui->posy == -1.f)
       {
         xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->iwidth;
         ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->iheight;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -523,6 +523,9 @@ static void rt_display_selected_fill_color(dt_iop_retouch_gui_data_t *g, dt_iop_
 static void rt_show_hide_controls(const dt_iop_module_t *self, const dt_iop_retouch_gui_data_t *d,
                                   dt_iop_retouch_params_t *p, dt_iop_retouch_gui_data_t *g)
 {
+  const int creation_continuous = (darktable.develop->form_gui && darktable.develop->form_gui->creation_continuous
+                                   && darktable.develop->form_gui->creation_continuous_module == self);
+
   switch(p->algorithm)
   {
     case dt_iop_retouch_heal:
@@ -554,7 +557,7 @@ static void rt_show_hide_controls(const dt_iop_module_t *self, const dt_iop_reto
     gtk_widget_hide(GTK_WIDGET(d->vbox_preview_scale));
 
   const dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, rt_get_selected_shape_id());
-  if(form)
+  if(form && !creation_continuous)
     gtk_widget_show(GTK_WIDGET(d->sl_mask_opacity));
   else
     gtk_widget_hide(GTK_WIDGET(d->sl_mask_opacity));
@@ -631,7 +634,10 @@ static void rt_shape_selection_changed(dt_iop_module_t *self)
 
   rt_display_selected_shapes_lbl(g);
 
-  if(index >= 0)
+  const int creation_continuous = (darktable.develop->form_gui && darktable.develop->form_gui->creation_continuous
+                                   && darktable.develop->form_gui->creation_continuous_module == self);
+
+  if(index >= 0 && !creation_continuous)
     gtk_widget_show(GTK_WIDGET(g->sl_mask_opacity));
   else
     gtk_widget_hide(GTK_WIDGET(g->sl_mask_opacity));
@@ -696,6 +702,8 @@ static void rt_reset_form_creation(GtkWidget *widget, dt_iop_module_t *self)
   {
     // we unset the creation mode
     dt_masks_change_form_gui(NULL);
+    darktable.develop->form_gui->creation_continuous = FALSE;
+    darktable.develop->form_gui->creation_continuous_module = NULL;
   }
 
   if(widget != g->bt_path) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
@@ -711,7 +719,9 @@ static void rt_reset_form_creation(GtkWidget *widget, dt_iop_module_t *self)
 
 static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
 {
-  if(!self->enabled || darktable.develop->gui_module != self) return;
+  if(!self->enabled || darktable.develop->gui_module != self || darktable.develop->form_gui->creation
+     || darktable.develop->form_gui->creation_continuous)
+    return;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
@@ -977,12 +987,87 @@ static int rt_shape_is_beign_added(dt_iop_module_t *self, const int shape_type)
 {
   int being_added = 0;
 
-  if(self->dev->form_gui && self->dev->form_visible && self->dev->form_gui->creation
-     && self->dev->form_gui->creation_module == self)
+  if(self->dev->form_gui && self->dev->form_visible
+     && ((self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
+         || (self->dev->form_gui->creation_continuous && self->dev->form_gui->creation_continuous_module == self)))
   {
-    being_added = (self->dev->form_visible->type & shape_type);
+    if(self->dev->form_visible->type & DT_MASKS_GROUP)
+    {
+      GList *forms = g_list_first(self->dev->form_visible->points);
+      if(forms)
+      {
+        dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)forms->data;
+        if(grpt)
+        {
+          const dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, grpt->formid);
+          if(form) being_added = (form->type & shape_type);
+        }
+      }
+    }
+    else
+      being_added = (self->dev->form_visible->type & shape_type);
   }
   return being_added;
+}
+
+static gboolean rt_add_shape(GtkWidget *widget, const int creation_continuous, dt_iop_module_t *self)
+{
+  const int allow = rt_allow_create_form(self);
+  if(allow)
+  {
+    rt_reset_form_creation(widget, self);
+
+    if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
+    {
+      rt_show_forms_for_current_scale(self);
+
+      return FALSE;
+    }
+
+    dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
+    dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+
+    // we want to be sure that the iop has focus
+    dt_iop_request_focus(self);
+
+    dt_masks_type_t type = DT_MASKS_CIRCLE;
+    if(widget == g->bt_path)
+      type = DT_MASKS_PATH;
+    else if(widget == g->bt_circle)
+      type = DT_MASKS_CIRCLE;
+    else if(widget == g->bt_ellipse)
+      type = DT_MASKS_ELLIPSE;
+    else if(widget == g->bt_brush)
+      type = DT_MASKS_BRUSH;
+
+    // we create the new form
+    dt_masks_form_t *spot = NULL;
+    if(p->algorithm == dt_iop_retouch_clone || p->algorithm == dt_iop_retouch_heal)
+      spot = dt_masks_create(type | DT_MASKS_CLONE);
+    else
+      spot = dt_masks_create(type | DT_MASKS_NON_CLONE);
+
+    dt_masks_change_form_gui(spot);
+    darktable.develop->form_gui->creation = TRUE;
+    darktable.develop->form_gui->creation_module = self;
+
+    if(creation_continuous)
+    {
+      darktable.develop->form_gui->creation_continuous = TRUE;
+      darktable.develop->form_gui->creation_continuous_module = self;
+    }
+    else
+    {
+      darktable.develop->form_gui->creation_continuous = FALSE;
+      darktable.develop->form_gui->creation_continuous_module = NULL;
+    }
+
+    dt_control_queue_redraw_center();
+  }
+  else
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
+
+  return !allow;
 }
 
 //---------------------------------------------------------------------------------
@@ -2036,50 +2121,10 @@ static gboolean rt_add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_i
 {
   if(darktable.gui->reset) return FALSE;
 
-  const int allow = rt_allow_create_form(self);
-  if(allow)
-  {
-    rt_reset_form_creation(widget, self);
+  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  const int creation_continuous = ((e->state & modifiers) == GDK_CONTROL_MASK);
 
-    if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
-    {
-      rt_show_forms_for_current_scale(self);
-
-      return FALSE;
-    }
-
-    dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
-    dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
-
-    // we want to be sure that the iop has focus
-    dt_iop_request_focus(self);
-
-    dt_masks_type_t type = DT_MASKS_CIRCLE;
-    if(widget == g->bt_path)
-      type = DT_MASKS_PATH;
-    else if(widget == g->bt_circle)
-      type = DT_MASKS_CIRCLE;
-    else if(widget == g->bt_ellipse)
-      type = DT_MASKS_ELLIPSE;
-    else if(widget == g->bt_brush)
-      type = DT_MASKS_BRUSH;
-
-    // we create the new form
-    dt_masks_form_t *spot = NULL;
-    if(p->algorithm == dt_iop_retouch_clone || p->algorithm == dt_iop_retouch_heal)
-      spot = dt_masks_create(type | DT_MASKS_CLONE);
-    else
-      spot = dt_masks_create(type | DT_MASKS_NON_CLONE);
-
-    dt_masks_change_form_gui(spot);
-    darktable.develop->form_gui->creation = TRUE;
-    darktable.develop->form_gui->creation_module = self;
-    dt_control_queue_redraw_center();
-  }
-  else
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), FALSE);
-
-  return !allow;
+  return rt_add_shape(widget, creation_continuous, self);
 }
 
 static void rt_select_algorithm_callback(GtkToggleButton *togglebutton, dt_iop_module_t *self)
@@ -2131,6 +2176,8 @@ static void rt_select_algorithm_callback(GtkToggleButton *togglebutton, dt_iop_m
 
     darktable.develop->form_gui->creation = TRUE;
     darktable.develop->form_gui->creation_module = self;
+    darktable.develop->form_gui->creation_continuous = TRUE;
+    darktable.develop->form_gui->creation_continuous_module = self;
     dt_control_queue_redraw_center();
   }
 
@@ -2425,6 +2472,14 @@ void gui_update(dt_iop_module_t *self)
 
   // check if there is new or deleted forms
   rt_resynch_params(self);
+
+  if(darktable.develop->form_gui->creation_continuous
+     && darktable.develop->form_gui->creation_continuous_module == self && !rt_allow_create_form(self))
+  {
+    dt_masks_change_form_gui(NULL);
+    darktable.develop->form_gui->creation_continuous = FALSE;
+    darktable.develop->form_gui->creation_continuous_module = NULL;
+  }
 
   // update clones count
   const dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, self->blend_params->mask_id);
@@ -3183,17 +3238,23 @@ void init_key_accels(dt_iop_module_so_t *module)
   dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool ellipse"), 0, 0);
   dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool path"), 0, 0);
   dt_accel_register_iop(module, TRUE, NC_("accel", "retouch tool brush"), 0, 0);
+
+  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add circle"), 0, 0);
+  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add ellipse"), 0, 0);
+  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add path"), 0, 0);
+  dt_accel_register_iop(module, TRUE, NC_("accel", "continuous add brush"), 0, 0);
 }
 
 static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                       GdkModifierType modifier, gpointer data)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-  rt_add_shape_callback(GTK_WIDGET(g->bt_circle), NULL, module);
-
   const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_circle), FALSE, module);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_beign_added(module, DT_MASKS_CIRCLE));
 
@@ -3205,12 +3266,13 @@ static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *accel
 static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                        GdkModifierType modifier, gpointer data)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-  rt_add_shape_callback(GTK_WIDGET(g->bt_ellipse), NULL, module);
-
   const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_ellipse), FALSE, module);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_beign_added(module, DT_MASKS_ELLIPSE));
 
@@ -3222,12 +3284,13 @@ static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acce
 static gboolean _add_brush_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-  rt_add_shape_callback(GTK_WIDGET(g->bt_brush), NULL, module);
-
   const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_brush), FALSE, module);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_beign_added(module, DT_MASKS_BRUSH));
 
@@ -3239,12 +3302,85 @@ static gboolean _add_brush_key_accel(GtkAccelGroup *accel_group, GObject *accele
 static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                     GdkModifierType modifier, gpointer data)
 {
-  dt_iop_module_t *module = (dt_iop_module_t *)data;
-  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
-  rt_add_shape_callback(GTK_WIDGET(g->bt_path), NULL, module);
-
   const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_path), FALSE, module);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_beign_added(module, DT_MASKS_PATH));
+
+  darktable.gui->reset = reset;
+
+  return TRUE;
+}
+
+static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                                 GdkModifierType modifier, gpointer data)
+{
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_circle), TRUE, module);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_beign_added(module, DT_MASKS_CIRCLE));
+
+  darktable.gui->reset = reset;
+
+  return TRUE;
+}
+
+static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                                  GdkModifierType modifier, gpointer data)
+{
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_ellipse), TRUE, module);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_beign_added(module, DT_MASKS_ELLIPSE));
+
+  darktable.gui->reset = reset;
+
+  return TRUE;
+}
+
+static gboolean _continuous_add_brush_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                                GdkModifierType modifier, gpointer data)
+{
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_brush), TRUE, module);
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_beign_added(module, DT_MASKS_BRUSH));
+
+  darktable.gui->reset = reset;
+
+  return TRUE;
+}
+
+static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                               GdkModifierType modifier, gpointer data)
+{
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
+
+  rt_add_shape(GTK_WIDGET(g->bt_path), TRUE, module);
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_beign_added(module, DT_MASKS_PATH));
 
@@ -3257,6 +3393,7 @@ void connect_key_accels(dt_iop_module_t *module)
 {
   GClosure *closure;
 
+  // single add
   closure = g_cclosure_new(G_CALLBACK(_add_circle_key_accel), (gpointer)module, NULL);
   dt_accel_connect_iop(module, "retouch tool circle", closure);
 
@@ -3268,6 +3405,19 @@ void connect_key_accels(dt_iop_module_t *module)
 
   closure = g_cclosure_new(G_CALLBACK(_add_path_key_accel), (gpointer)module, NULL);
   dt_accel_connect_iop(module, "retouch tool path", closure);
+
+  // continuous add
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_circle_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop(module, "continuous add circle", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_ellipse_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop(module, "continuous add ellipse", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_brush_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop(module, "continuous add brush", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_path_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop(module, "continuous add path", closure);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2176,8 +2176,6 @@ static void rt_select_algorithm_callback(GtkToggleButton *togglebutton, dt_iop_m
 
     darktable.develop->form_gui->creation = TRUE;
     darktable.develop->form_gui->creation_module = self;
-    darktable.develop->form_gui->creation_continuous = TRUE;
-    darktable.develop->form_gui->creation_continuous_module = self;
     dt_control_queue_redraw_center();
   }
 
@@ -2431,6 +2429,12 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       // lost focus, hide all shapes and free if some are in creation
       if(darktable.develop->form_gui->creation && darktable.develop->form_gui->creation_module == self)
         dt_masks_change_form_gui(NULL);
+
+      if(darktable.develop->form_gui->creation_continuous_module == self)
+      {
+        darktable.develop->form_gui->creation_continuous = FALSE;
+        darktable.develop->form_gui->creation_continuous_module = NULL;
+      }
 
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1885,6 +1885,9 @@ void mouse_leave(dt_view_t *self)
   dt_develop_t *dev = (dt_develop_t *)self->data;
   dt_control_set_mouse_over_id(dev->image_storage.id);
 
+  // masks
+  dt_masks_events_mouse_leave(dev->gui_module);
+
   // reset any changes the selected plugin might have made.
   dt_control_change_cursor(GDK_LEFT_PTR);
 }
@@ -1913,6 +1916,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   int handled = 0;
   x += offx;
   y += offy;
+
   if(dev->gui_module && dev->gui_module->request_color_pick != DT_REQUEST_COLORPICK_OFF && ctl->button_down
      && ctl->button_down_which == 1)
   {
@@ -1939,7 +1943,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     return;
   }
   // masks
-  if(dev->form_visible) handled = dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which);
+  handled = dt_masks_events_mouse_moved(dev->gui_module, x, y, pressure, which);
   if(handled) return;
   // module
   if(dev->gui_module && dev->gui_module->mouse_moved)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -559,6 +559,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   if(!dev->form_gui)
   {
     dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
+    dt_masks_init_form_gui(dev->form_gui);
   }
   dt_masks_change_form_gui(NULL);
 
@@ -1681,6 +1682,7 @@ void enter(dt_view_t *self)
   if(!dev->form_gui)
   {
     dev->form_gui = (dt_masks_form_gui_t *)calloc(1, sizeof(dt_masks_form_gui_t));
+    dt_masks_init_form_gui(dev->form_gui);
   }
   dt_masks_change_form_gui(NULL);
   dev->form_gui->pipe_hash = 0;


### PR DESCRIPTION
This PR allows to select the position of the source when adding a mask and also to keep adding masks without pressing the add button again.

When adding a clone mask a cross will be displayed on the position where the source will be created. To change the source position CNTRL+click sets an absolute position, that means next mask will have the source created at that position. SHIFT+click set a relative position, the first time the source will be created at the selected position but next mask will have the source at the same relative position of the previous one.

With CNTRL+click on the shapes toolbar on the retouch module the continuous add is activated. When a shape is added the module is still on add mode.
For the circle and ellipse is still available the possibility of dragging the source after the add and then keep adding.
New shortcuts are also added for this add type.

For now this only works with the retouch module.
 