### PR TITLE
masks preview initial position

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2228,11 +2228,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        float zoom_x, zoom_y;
-        zoom_y = dt_control_get_dev_zoom_y();
-        zoom_x = dt_control_get_dev_zoom_x();
-        xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
-        ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
+        xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2228,11 +2228,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        float zoom_x, zoom_y;
-        zoom_y = dt_control_get_dev_zoom_y();
-        zoom_x = dt_control_get_dev_zoom_x();
-        xpos = (.5f + zoom_x) * wd;
-        ypos = (.5f + zoom_y) * ht;
+        xpos = darktable.develop->preview_pipe->backbuf_width / 2.f;
+        ypos = darktable.develop->preview_pipe->backbuf_height / 2.f;
       }
       else
       {

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2228,8 +2228,11 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        xpos = darktable.develop->preview_pipe->backbuf_width / 2.f;
-        ypos = darktable.develop->preview_pipe->backbuf_height / 2.f;
+        float zoom_x, zoom_y;
+        zoom_y = dt_control_get_dev_zoom_y();
+        zoom_x = dt_control_get_dev_zoom_x();
+        xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -562,11 +562,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        float zoom_x, zoom_y;
-        zoom_y = dt_control_get_dev_zoom_y();
-        zoom_x = dt_control_get_dev_zoom_x();
-        xpos = (.5f + zoom_x) * wd;
-        ypos = (.5f + zoom_y) * ht;
+        xpos = darktable.develop->preview_pipe->backbuf_width / 2.f;
+        ypos = darktable.develop->preview_pipe->backbuf_height / 2.f;
       }
       else
       {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -562,8 +562,11 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        xpos = darktable.develop->preview_pipe->backbuf_width / 2.f;
-        ypos = darktable.develop->preview_pipe->backbuf_height / 2.f;
+        float zoom_x, zoom_y;
+        zoom_y = dt_control_get_dev_zoom_y();
+        zoom_x = dt_control_get_dev_zoom_x();
+        xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -562,11 +562,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        float zoom_x, zoom_y;
-        zoom_y = dt_control_get_dev_zoom_y();
-        zoom_x = dt_control_get_dev_zoom_x();
-        xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
-        ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
+        xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1245,6 +1245,12 @@ int dt_masks_events_mouse_leave(struct dt_iop_module_t *module)
   if(darktable.develop->form_gui)
   {
     dt_masks_form_gui_t *gui = darktable.develop->form_gui;
+
+    // if masks are being created or edited don't reset the position
+    if(gui->creation || gui->form_dragging || gui->source_dragging || gui->point_dragging >= 0
+       || gui->feather_dragging >= 0 || gui->seg_dragging >= 0 || gui->point_border_dragging >= 0)
+      return 0;
+
     gui->posx = gui->posy = -1.f;
   }
   return 0;

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2005,8 +2005,11 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        xpos = darktable.develop->preview_pipe->backbuf_width / 2.f;
-        ypos = darktable.develop->preview_pipe->backbuf_height / 2.f;
+        float zoom_x, zoom_y;
+        zoom_y = dt_control_get_dev_zoom_y();
+        zoom_x = dt_control_get_dev_zoom_x();
+        xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2005,11 +2005,8 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        float zoom_x, zoom_y;
-        zoom_y = dt_control_get_dev_zoom_y();
-        zoom_x = dt_control_get_dev_zoom_x();
-        xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
-        ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
+        xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
+        ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;
       }
       else
       {

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -2005,8 +2005,8 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       float xpos, ypos;
       if(gui->posx == -1.f && gui->posy == -1.f)
       {
-        xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->iwidth;
-        ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->iheight;
+        xpos = darktable.develop->preview_pipe->backbuf_width / 2.f;
+        ypos = darktable.develop->preview_pipe->backbuf_height / 2.f;
       }
       else
       {


### PR DESCRIPTION
When an image has distortions applied (including rotation), the initial position of the preview mask for the circle, brush and path, if the mouse is not over the darkroom area, is not the middle of the darkroom area.
It should work the same as in an image with no distortions.

Also, do not reset posx, posy if a mask is being created/edited, to avoid strange behaviours.
(ie: drag a mask outside the darkroom area and it will be displayed at the top-left corner)
