### PR TITLE
fix gui modules order

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -234,11 +234,13 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
         case DT_MODULEGROUP_ACTIVE_PIPE:
         {
           if(module->enabled)
-            gtk_widget_show(w);
+          {
+            if(w) gtk_widget_show(w);
+          }
           else
           {
             if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
-            gtk_widget_hide(w);
+            if(w) gtk_widget_hide(w);
           }
         }
         break;
@@ -246,11 +248,13 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
         case DT_MODULEGROUP_FAVORITES:
         {
           if(module->so->state == dt_iop_state_FAVORITE)
-            gtk_widget_show(w);
+          {
+            if(w) gtk_widget_show(w);
+          }
           else
           {
             if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
-            gtk_widget_hide(w);
+            if(w) gtk_widget_hide(w);
           }
         }
         break;
@@ -260,11 +264,13 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
           /* show all except hidden ones */
           if((module->so->state != dt_iop_state_HIDDEN || module->enabled)
              && (!(module->flags() & IOP_FLAGS_DEPRECATED)))
-            gtk_widget_show(w);
+          {
+            if(w) gtk_widget_show(w);
+          }
           else
           {
             if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
-            gtk_widget_hide(w);
+            if(w) gtk_widget_hide(w);
           }
         }
         break;
@@ -274,11 +280,13 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
           if(_lib_modulegroups_test(self, d->current, module->groups())
              && module->so->state != dt_iop_state_HIDDEN
              && (!(module->flags() & IOP_FLAGS_DEPRECATED) || module->enabled))
-            gtk_widget_show(w);
+          {
+            if(w) gtk_widget_show(w);
+          }
           else
           {
             if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
-            gtk_widget_hide(w);
+            if(w) gtk_widget_hide(w);
           }
         }
       }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -628,7 +628,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   dt_dev_read_history(dev);
 
   // we have to init all module instances other than "base" instance
-  GList *modules = dev->iop;
+  GList *modules = g_list_last(dev->iop);
   while(modules)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
@@ -669,7 +669,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
             base->expander, "position", &gv);
         gtk_box_reorder_child(dt_ui_get_container(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER),
                               expander, g_value_get_int(&gv) + pos_base - pos_module);
-        dt_iop_gui_set_expanded(module, TRUE, FALSE);
+        dt_iop_gui_set_expanded(module, FALSE, FALSE);
         dt_iop_gui_update_blending(module);
       }
 
@@ -687,7 +687,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
       if(!dt_iop_is_hidden(module)) dt_iop_gui_update_header(module);
     }
 
-    modules = g_list_next(modules);
+    modules = g_list_previous(modules);
   }
 
   dt_dev_pop_history_items(dev, dev->history_end);


### PR DESCRIPTION
When moving from one image to another within the darkroom, if the new image has multiple instances of a module, the order of the modules on the module list is not correct.
This is a gui issue only, the dev->iop list is correct.
This PR fixes this, and display multi-instance modules collapsed instead of expanded.

This also fixes some gtk assertions on the same scenario.
