### PR TITLE
Prophoto RGB support

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -38,6 +38,7 @@
 #endif
 
 static const cmsCIEXYZ d65 = {0.95045471, 1.00000000, 1.08905029};
+//static const cmsCIEXYZ d50 = {0.96422000, 1.00000000, 0.82490000};
 static const cmsCIEXYZTRIPLE rec709_primaries_pre_quantized = {
   {0.43603516, 0.22248840, 0.01391602},
   {0.38511658, 0.71690369, 0.09706116},
@@ -52,6 +53,11 @@ static const cmsCIEXYZTRIPLE adobe_primaries_prequantized = {
   {0.60974121, 0.31111145, 0.01947021},
   {0.20527649, 0.62567139, 0.06086731},
   {0.14918518, 0.06321716, 0.74456787}
+};
+static const cmsCIEXYZTRIPLE prophoto_primaries_prequantized = {
+    {0.7976749f, 0.1351917f, 0.0313534f},
+    {0.2880402f, 0.7118741f, 0.0000857f},
+    {0.0000000f, 0.0000000f, 0.8252100f}
 };
 
 #define generate_mat3inv_body(c_type, A, B)                                                                  \
@@ -333,6 +339,18 @@ static cmsHPROFILE dt_colorspaces_create_adobergb_profile(void)
 
   cmsHPROFILE profile = _create_lcms_profile("Adobe RGB (compatible)", "Adobe RGB",
                                              &adobe_primaries_prequantized, transferFunction, TRUE);
+
+  cmsFreeToneCurve(transferFunction);
+
+  return profile;
+}
+
+static cmsHPROFILE dt_colorspaces_create_prophotorgb_profile(void)
+{
+  cmsToneCurve *transferFunction = cmsBuildGamma(NULL, 1.8);
+
+  cmsHPROFILE profile = _create_lcms_profile("Prophoto RGB", "Prophoto RGB",
+                                             &prophoto_primaries_prequantized, transferFunction, TRUE);
 
   cmsFreeToneCurve(transferFunction);
 
@@ -945,7 +963,8 @@ static const char *_profile_names[] =
   N_("standard color matrix"),
   N_("enhanced color matrix"),
   N_("vendor color matrix"),
-  N_("alternate color matrix")
+  N_("alternate color matrix"),
+  N_("Prophoto RGB"),
 };
 
 static dt_colorspaces_color_profile_t *_create_profile(dt_colorspaces_color_profile_type_t type,
@@ -1188,6 +1207,11 @@ dt_colorspaces_t *dt_colorspaces_init()
   res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_BRG,
                                                                dt_colorspaces_create_brg_profile(),
                                                                _("BRG (for testing)"),
+                                                               ++in_pos, ++out_pos, ++display_pos));
+                                                               
+  res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_PROPHOTORGB,
+                                                               dt_colorspaces_create_prophotorgb_profile(),
+                                                               _("Prophoto RGB"),
                                                                ++in_pos, ++out_pos, ++display_pos));
 
   // temporary list of profiles to be added, we keep this separate to be able to sort it before adding

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -55,9 +55,9 @@ static const cmsCIEXYZTRIPLE adobe_primaries_prequantized = {
   {0.14918518, 0.06321716, 0.74456787}
 };
 static const cmsCIEXYZTRIPLE prophoto_primaries_prequantized = {
-    {0.7976749f, 0.1351917f, 0.0313534f},
-    {0.2880402f, 0.7118741f, 0.0000857f},
-    {0.0000000f, 0.0000000f, 0.8252100f}
+  {0.7976749f, 0.1351917f, 0.0313534f},
+  {0.2880402f, 0.7118741f, 0.0000857f},
+  {0.0000000f, 0.0000000f, 0.8252100f}
 };
 
 #define generate_mat3inv_body(c_type, A, B)                                                                  \
@@ -990,6 +990,9 @@ static void _update_display_transforms(dt_colorspaces_t *self)
 
   if(self->transform_adobe_rgb_to_display) cmsDeleteTransform(self->transform_adobe_rgb_to_display);
   self->transform_adobe_rgb_to_display = NULL;
+  
+  if(self->transform_prophoto_rgb_to_display) cmsDeleteTransform(self->transform_prophoto_rgb_to_display);
+  self->transform_prophoto_rgb_to_display = NULL;
 
   const dt_colorspaces_color_profile_t *display_dt_profile = _get_profile(self, self->display_type,
                                                                           self->display_filename,
@@ -1007,6 +1010,14 @@ static void _update_display_transforms(dt_colorspaces_t *self)
                                                        0);
 
   self->transform_adobe_rgb_to_display = cmsCreateTransform(_get_profile(self, DT_COLORSPACE_ADOBERGB, "",
+                                                                         DT_PROFILE_DIRECTION_DISPLAY)->profile,
+                                                            TYPE_RGBA_8,
+                                                            display_profile,
+                                                            TYPE_BGRA_8,
+                                                            self->display_intent,
+                                                            0);
+                                                            
+  self->transform_prophoto_rgb_to_display = cmsCreateTransform(_get_profile(self, DT_COLORSPACE_PROPHOTORGB, "",
                                                                          DT_PROFILE_DIRECTION_DISPLAY)->profile,
                                                             TYPE_RGBA_8,
                                                             display_profile,
@@ -1176,6 +1187,11 @@ dt_colorspaces_t *dt_colorspaces_init()
                                                                dt_colorspaces_create_adobergb_profile(),
                                                                _("Adobe RGB (compatible)"),
                                                                ++in_pos, ++out_pos, ++display_pos));
+                                                               
+  res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_PROPHOTORGB,
+                                                               dt_colorspaces_create_prophotorgb_profile(),
+                                                               _("Prophoto RGB"),
+                                                               ++in_pos, ++out_pos, ++display_pos));
 
   res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_LIN_REC709,
                                                                dt_colorspaces_create_linear_rec709_rgb_profile(),
@@ -1207,11 +1223,6 @@ dt_colorspaces_t *dt_colorspaces_init()
   res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_BRG,
                                                                dt_colorspaces_create_brg_profile(),
                                                                _("BRG (for testing)"),
-                                                               ++in_pos, ++out_pos, ++display_pos));
-                                                               
-  res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_PROPHOTORGB,
-                                                               dt_colorspaces_create_prophotorgb_profile(),
-                                                               _("Prophoto RGB"),
                                                                ++in_pos, ++out_pos, ++display_pos));
 
   // temporary list of profiles to be added, we keep this separate to be able to sort it before adding

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -96,7 +96,7 @@ typedef struct dt_colorspaces_t
 
   dt_colorspaces_color_mode_t mode;
 
-  cmsHTRANSFORM transform_srgb_to_display, transform_adobe_rgb_to_display;
+  cmsHTRANSFORM transform_srgb_to_display, transform_adobe_rgb_to_display, transform_prophoto_rgb_to_display;
 
 } dt_colorspaces_t;
 

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -57,7 +57,8 @@ typedef enum dt_colorspaces_color_profile_type_t
   DT_COLORSPACE_VENDOR_MATRIX = 13,
   DT_COLORSPACE_ALTERNATE_MATRIX = 14,
   DT_COLORSPACE_BRG = 15,
-  DT_COLORSPACE_LAST = 16
+  DT_COLORSPACE_LAST = 16,
+  DT_COLORSPACE_PROPHOTORGB = 17
 } dt_colorspaces_color_profile_type_t;
 
 typedef enum dt_colorspaces_color_mode_t

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -873,6 +873,8 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         img->colorspace = DT_IMAGE_COLORSPACE_SRGB;
       else if(colorspace == 0x02)
         img->colorspace = DT_IMAGE_COLORSPACE_ADOBE_RGB;
+      else if(colorspace == 0x03)
+        img->colorspace = DT_IMAGE_COLORSPACE_PROPHOTO_RGB;
       else if(colorspace == 0xffff)
       {
         if(FIND_EXIF_TAG("Exif.Iop.InteroperabilityIndex"))
@@ -2865,6 +2867,8 @@ dt_colorspaces_color_profile_type_t dt_exif_get_color_space(const uint8_t *data,
         return DT_COLORSPACE_SRGB;
       else if(colorspace == 0x02)
         return DT_COLORSPACE_ADOBERGB;
+      else if(colorspace == 0x03)
+        return DT_COLORSPACE_PROPHOTORGB;
       else if(colorspace == 0xffff)
       {
         if((pos = exifData.findKey(Exiv2::ExifKey("Exif.Iop.InteroperabilityIndex"))) != exifData.end()

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -76,7 +76,8 @@ typedef enum dt_image_colorspace_t
 {
   DT_IMAGE_COLORSPACE_NONE,
   DT_IMAGE_COLORSPACE_SRGB,
-  DT_IMAGE_COLORSPACE_ADOBE_RGB
+  DT_IMAGE_COLORSPACE_ADOBE_RGB,
+  DT_IMAGE_COLORSPACE_PROPHOTO_RGB
 } dt_image_colorspace_t;
 
 typedef struct dt_image_raw_parameters_t

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -62,6 +62,7 @@ typedef enum dt_iop_color_normalize_t
   DT_NORMALIZE_OFF,
   DT_NORMALIZE_SRGB,
   DT_NORMALIZE_ADOBE_RGB,
+  DT_NORMALIZE_PROPHOTO_RGB,
   DT_NORMALIZE_LINEAR_REC709_RGB,
   DT_NORMALIZE_LINEAR_REC2020_RGB
 } dt_iop_color_normalize_t;
@@ -1287,6 +1288,9 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     case DT_NORMALIZE_ADOBE_RGB:
       d->nrgb = dt_colorspaces_get_profile(DT_COLORSPACE_ADOBERGB, "", DT_PROFILE_DIRECTION_IN)->profile;
       break;
+    case DT_NORMALIZE_PROPHOTO_RGB:
+      d->nrgb = dt_colorspaces_get_profile(DT_COLORSPACE_PROPHOTORGB, "", DT_PROFILE_DIRECTION_IN)->profile;
+      break;
     case DT_NORMALIZE_LINEAR_REC709_RGB:
       d->nrgb = dt_colorspaces_get_profile(DT_COLORSPACE_LIN_REC709, "", DT_PROFILE_DIRECTION_IN)->profile;
       break;
@@ -1678,6 +1682,8 @@ void reload_defaults(dt_iop_module_t *module)
     tmp.type = DT_COLORSPACE_SRGB;
   else if(module->dev->image_storage.colorspace == DT_IMAGE_COLORSPACE_ADOBE_RGB)
     tmp.type = DT_COLORSPACE_ADOBERGB;
+  else if(module->dev->image_storage.colorspace == DT_IMAGE_COLORSPACE_PROPHOTO_RGB)
+    tmp.type = DT_COLORSPACE_PROPHOTORGB;
   else if(dt_image_is_ldr(&module->dev->image_storage))
     tmp.type = DT_COLORSPACE_SRGB;
   else if(!isnan(module->dev->image_storage.d65_color_matrix[0]))
@@ -1863,6 +1869,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->clipping_combobox, _("off"));
   dt_bauhaus_combobox_add(g->clipping_combobox, _("sRGB"));
   dt_bauhaus_combobox_add(g->clipping_combobox, _("Adobe RGB (compatible)"));
+  dt_bauhaus_combobox_add(g->clipping_combobox, _("Prophoto RGB"));
   dt_bauhaus_combobox_add(g->clipping_combobox, _("linear Rec709 RGB"));
   dt_bauhaus_combobox_add(g->clipping_combobox, _("linear Rec2020 RGB"));
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1021,6 +1021,11 @@ int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t imgid, cairo
           {
             transform = darktable.color_profiles->transform_adobe_rgb_to_display;
           }
+          else if(buf.color_space == DT_COLORSPACE_PROPHOTORGB &&
+                  darktable.color_profiles->transform_prophoto_rgb_to_display)
+          {
+            transform = darktable.color_profiles->transform_prophoto_rgb_to_display;
+          }
           else
           {
             pthread_rwlock_unlock(&darktable.color_profiles->xprofile_lock);


### PR DESCRIPTION
Add support for Prophoto RGB :

- as input profile and gamut clipping
- as output profile
- as a softproofing option
- as a display color management option.

It works in input, but in output, it produces magenta highlights and I can't figure out why.