### PR TITLE
Fix: Custom image order only in view Lighttable

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1389,7 +1389,7 @@ void dt_collection_shift_image_positions(const unsigned int length, const int64_
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), update_image_pos_query, -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, length);
   DT_DEBUG_SQLITE3_BIND_INT64(stmt, 2, image_position);
-  DT_DEBUG_SQLITE3_BIND_INT64(stmt, 3, (image_position & 0xFFFFFFFF00000000) + (1l << 32));
+  DT_DEBUG_SQLITE3_BIND_INT64(stmt, 3, (image_position & 0xFFFFFFFF00000000) + (1ll << 32));
 
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -79,7 +79,7 @@ static int64_t create_next_image_position()
    * next image position
    * 0000 0003 0000 0000
    */
-  return (max_image_position() & 0xFFFFFFFF00000000) + (1l << 32);
+  return (max_image_position() & 0xFFFFFFFF00000000) + (1ll << 32);
 }
 
 static void _image_local_copy_full_path(const int imgid, char *pathname, size_t pathname_len);


### PR DESCRIPTION
Fixed crash in headless mode (no gui)

@edgardoh found that dragging the main image darktable view is also possible, if "custom sort" is selected.

This fix checks the current view and registers drag and drop only in lighttable view.