### PR TITLE
Rawdenoise: change force by frequency and channel

### DIFF
--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -25,6 +25,7 @@
 #include "control/control.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
+#include "dtgtk/drawingarea.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
@@ -33,24 +34,42 @@
 #include <stdlib.h>
 #include <strings.h>
 
-DT_MODULE_INTROSPECTION(1, dt_iop_rawdenoise_params_t)
+DT_MODULE_INTROSPECTION(2, dt_iop_rawdenoise_params_t)
+
+#define DT_IOP_RAWDENOISE_INSET DT_PIXEL_APPLY_DPI(5)
+#define DT_IOP_RAWDENOISE_RES 64
+#define DT_IOP_RAWDENOISE_BANDS 5
+#define DT_IOP_RAWDENOISE_LUT_RES 0x10000
 
 typedef struct dt_iop_rawdenoise_params_t
 {
   float threshold;
+  float transition_x[DT_IOP_RAWDENOISE_BANDS], transition_y[DT_IOP_RAWDENOISE_BANDS];
 } dt_iop_rawdenoise_params_t;
 
 typedef struct dt_iop_rawdenoise_gui_data_t
 {
-  GtkWidget *stack;
+  dt_draw_curve_t *transition_curve; // curve for gui to draw
+
   GtkWidget *box_raw;
   GtkWidget *threshold;
   GtkWidget *label_non_raw;
+  GtkDrawingArea *area;
+  double mouse_x, mouse_y, mouse_pick;
+  float mouse_radius;
+  dt_iop_rawdenoise_params_t drag_params;
+  int dragging;
+  int x_move;
+  float draw_xs[DT_IOP_RAWDENOISE_RES], draw_ys[DT_IOP_RAWDENOISE_RES];
+  float draw_min_xs[DT_IOP_RAWDENOISE_RES], draw_min_ys[DT_IOP_RAWDENOISE_RES];
+  float draw_max_xs[DT_IOP_RAWDENOISE_RES], draw_max_ys[DT_IOP_RAWDENOISE_RES];
 } dt_iop_rawdenoise_gui_data_t;
 
 typedef struct dt_iop_rawdenoise_data_t
 {
   float threshold;
+  dt_draw_curve_t *curve;
+  float lut[DT_IOP_RAWDENOISE_LUT_RES];
 } dt_iop_rawdenoise_data_t;
 
 typedef struct dt_iop_rawdenoise_global_data_t
@@ -368,11 +387,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 void reload_defaults(dt_iop_module_t *module)
 {
-  // init defaults:
-  dt_iop_rawdenoise_params_t tmp = (dt_iop_rawdenoise_params_t){ .threshold = 0.01 };
-
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) goto end;
+  if(!module->dev) return;
 
   // can't be switched on for non-raw images:
   if(dt_image_is_raw(&module->dev->image_storage))
@@ -380,10 +396,6 @@ void reload_defaults(dt_iop_module_t *module)
   else
     module->hide_enable_button = 1;
   module->default_enabled = 0;
-
-end:
-  memcpy(module->params, &tmp, sizeof(dt_iop_rawdenoise_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_rawdenoise_params_t));
 }
 
 void init(dt_iop_module_t *module)
@@ -397,6 +409,12 @@ void init(dt_iop_module_t *module)
   module->priority = 102; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rawdenoise_params_t);
   module->gui_data = NULL;
+  dt_iop_rawdenoise_params_t tmp;
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++) tmp.transition_x[k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++) tmp.transition_y[k] = 0.5f;
+  tmp.threshold = 0.01f;
+  memcpy(module->params, &tmp, sizeof(dt_iop_rawdenoise_params_t));
+  memcpy(module->default_params, &tmp, sizeof(dt_iop_rawdenoise_params_t));
 }
 
 void cleanup(dt_iop_module_t *module)
@@ -415,18 +433,36 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 
   d->threshold = p->threshold;
 
+  dt_draw_curve_set_point(d->curve, 0, p->transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p->transition_y[0]);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    dt_draw_curve_set_point(d->curve, k + 1, p->transition_x[k], p->transition_y[k]);
+  dt_draw_curve_set_point(d->curve, DT_IOP_RAWDENOISE_BANDS + 1, p->transition_x[1] + 1.0,
+                          p->transition_y[DT_IOP_RAWDENOISE_BANDS - 1]);
+  dt_draw_curve_calc_values(d->curve, 0.0, 1.0, DT_IOP_RAWDENOISE_LUT_RES, NULL, d->lut);
+
   if (!(pipe->image.flags & DT_IMAGE_RAW))
     piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-  piece->data = malloc(sizeof(dt_iop_rawdenoise_data_t));
-  self->commit_params(self, self->default_params, pipe, piece);
+  dt_iop_rawdenoise_data_t *d = (dt_iop_rawdenoise_data_t *)malloc(sizeof(dt_iop_rawdenoise_data_t));
+  dt_iop_rawdenoise_params_t *default_params = (dt_iop_rawdenoise_params_t *)self->default_params;
+
+  piece->data = (void *)d;
+  d->curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
+  (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
+                                default_params->transition_y[DT_IOP_RAWDENOISE_BANDS - 2]);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[k], default_params->transition_y[k]);
+  (void)dt_draw_curve_add_point(d->curve, default_params->transition_x[1] + 1.0, default_params->transition_y[1]);
+  self->commit_params(self, self->default_params, pipe, piece); // TODO necessary?
 }
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  dt_iop_rawdenoise_data_t *d = (dt_iop_rawdenoise_data_t *)(piece->data);
+  dt_draw_curve_destroy(d->curve);
   free(piece->data);
   piece->data = NULL;
 }
@@ -437,8 +473,18 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
 
   dt_bauhaus_slider_set(g->threshold, p->threshold);
+  gtk_widget_queue_draw(self->widget);
 
-  gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "non_raw" : "raw");
+  if(self->hide_enable_button)
+  {
+    gtk_widget_set_visible(g->label_non_raw, TRUE);
+    gtk_widget_set_visible(self->widget, FALSE);
+  }
+  else
+  {
+    gtk_widget_set_visible(g->label_non_raw, FALSE);
+    gtk_widget_set_visible(self->widget, TRUE);
+  }
 }
 
 static void threshold_callback(GtkWidget *slider, gpointer user_data)
@@ -450,40 +496,403 @@ static void threshold_callback(GtkWidget *slider, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
+// FIXME update to fit our needs
+// fills in new parameters based on mouse position (in 0,1)
+static void dt_iop_rawdenoise_get_params(dt_iop_rawdenoise_params_t *p, const double mouse_x, const double mouse_y,
+                                         const float rad)
+{
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+  {
+    const float f = expf(-(mouse_x - p->transition_x[k]) * (mouse_x - p->transition_x[k]) / (rad * rad));
+    p->transition_y[k] = (1 - f) * p->transition_y[k] + f * mouse_y;
+  }
+}
+
+static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_params_t p = *(dt_iop_rawdenoise_params_t *)self->params;
+
+  dt_draw_curve_set_point(c->transition_curve, 0, p.transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
+                          p.transition_y[0]);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    dt_draw_curve_set_point(c->transition_curve, k + 1, p.transition_x[k], p.transition_y[k]);
+  dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.transition_x[1] + 1.0,
+                          p.transition_y[DT_IOP_RAWDENOISE_BANDS - 1]);
+
+  const int inset = DT_IOP_RAWDENOISE_INSET;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int width = allocation.width, height = allocation.height;
+  cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+  cairo_t *cr = cairo_create(cst);
+
+  cairo_set_source_rgb(cr, .2, .2, .2);
+  cairo_paint(cr);
+
+  cairo_translate(cr, inset, inset);
+  width -= 2 * inset;
+  height -= 2 * inset;
+
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0));
+  cairo_set_source_rgb(cr, .1, .1, .1);
+  cairo_rectangle(cr, 0, 0, width, height);
+  cairo_stroke(cr);
+
+  cairo_set_source_rgb(cr, .3, .3, .3);
+  cairo_rectangle(cr, 0, 0, width, height);
+  cairo_fill(cr);
+
+  // draw grid
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(.4));
+  cairo_set_source_rgb(cr, .1, .1, .1);
+  dt_draw_grid(cr, 8, 0, 0, width, height);
+
+
+  if(c->mouse_y > 0 || c->dragging)
+  {
+    // draw min/max curves:
+    dt_iop_rawdenoise_get_params(&p, c->mouse_x, 1., c->mouse_radius);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
+                            p.transition_y[0]);
+    for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+      dt_draw_curve_set_point(c->transition_curve, k + 1, p.transition_x[k], p.transition_y[k]);
+    dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.transition_x[1] + 1.0,
+                            p.transition_y[DT_IOP_RAWDENOISE_BANDS - 1]);
+    dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_RAWDENOISE_RES, c->draw_min_xs, c->draw_min_ys);
+
+    p = *(dt_iop_rawdenoise_params_t *)self->params;
+    dt_iop_rawdenoise_get_params(&p, c->mouse_x, .0, c->mouse_radius);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
+                            p.transition_y[0]);
+    for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+      dt_draw_curve_set_point(c->transition_curve, k + 1, p.transition_x[k], p.transition_y[k]);
+    dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.transition_x[1] + 1.0,
+                            p.transition_y[DT_IOP_RAWDENOISE_BANDS - 1]);
+    dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_RAWDENOISE_RES, c->draw_max_xs, c->draw_max_ys);
+  }
+
+  cairo_save(cr);
+
+  // draw x positions
+  cairo_set_source_rgb(cr, 0.6, 0.6, 0.6);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
+  const float arrw = DT_PIXEL_APPLY_DPI(7.0f);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+  {
+    cairo_move_to(cr, width * p.transition_x[k], height + inset - DT_PIXEL_APPLY_DPI(1));
+    cairo_rel_line_to(cr, -arrw * .5f, 0);
+    cairo_rel_line_to(cr, arrw * .5f, -arrw);
+    cairo_rel_line_to(cr, arrw * .5f, arrw);
+    cairo_close_path(cr);
+    if(c->x_move == k)
+      cairo_fill(cr);
+    else
+      cairo_stroke(cr);
+  }
+
+  // draw selected cursor
+  cairo_translate(cr, 0, height);
+
+  // cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
+  // cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
+  cairo_set_source_rgba(cr, .7, .7, .7, 1.0);
+
+  p = *(dt_iop_rawdenoise_params_t *)self->params;
+  dt_draw_curve_set_point(c->transition_curve, 0, p.transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
+                          p.transition_y[0]);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    dt_draw_curve_set_point(c->transition_curve, k + 1, p.transition_x[k], p.transition_y[k]);
+  dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.transition_x[1] + 1.0,
+                          p.transition_y[DT_IOP_RAWDENOISE_BANDS - 1]);
+  dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_RAWDENOISE_RES, c->draw_xs, c->draw_ys);
+  cairo_move_to(cr, 0 * width / (float)(DT_IOP_RAWDENOISE_RES - 1), -height * c->draw_ys[0]);
+  for(int k = 1; k < DT_IOP_RAWDENOISE_RES; k++)
+    cairo_line_to(cr, k * width / (float)(DT_IOP_RAWDENOISE_RES - 1), -height * c->draw_ys[k]);
+  cairo_stroke(cr);
+
+  // draw dots on knots
+  cairo_set_source_rgb(cr, 0.7, 0.7, 0.7);
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+  {
+    cairo_arc(cr, width * p.transition_x[k], -height * p.transition_y[k], DT_PIXEL_APPLY_DPI(3.0), 0.0, 2.0 * M_PI);
+    if(c->x_move == k)
+      cairo_fill(cr);
+    else
+      cairo_stroke(cr);
+  }
+
+  if(c->mouse_y > 0 || c->dragging)
+  {
+    // draw min/max, if selected
+    cairo_set_source_rgba(cr, .7, .7, .7, .6);
+    cairo_move_to(cr, 0, -height * c->draw_min_ys[0]);
+    for(int k = 1; k < DT_IOP_RAWDENOISE_RES; k++)
+      cairo_line_to(cr, k * width / (float)(DT_IOP_RAWDENOISE_RES - 1), -height * c->draw_min_ys[k]);
+    for(int k = DT_IOP_RAWDENOISE_RES - 1; k >= 0; k--)
+      cairo_line_to(cr, k * width / (float)(DT_IOP_RAWDENOISE_RES - 1), -height * c->draw_max_ys[k]);
+    cairo_close_path(cr);
+    cairo_fill(cr);
+    // draw mouse focus circle
+    cairo_set_source_rgba(cr, .9, .9, .9, .5);
+    const float pos = DT_IOP_RAWDENOISE_RES * c->mouse_x;
+    int k = (int)pos;
+    const float f = k - pos;
+    if(k >= DT_IOP_RAWDENOISE_RES - 1) k = DT_IOP_RAWDENOISE_RES - 2;
+    float ht = -height * (f * c->draw_ys[k] + (1 - f) * c->draw_ys[k + 1]);
+    cairo_arc(cr, c->mouse_x * width, ht, c->mouse_radius * width, 0, 2. * M_PI);
+    cairo_stroke(cr);
+  }
+
+  cairo_restore(cr);
+
+  cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+
+  // draw labels:
+  PangoLayout *layout;
+  PangoRectangle ink;
+  PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
+  pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
+  pango_font_description_set_absolute_size(desc, (.06 * height) * PANGO_SCALE);
+  layout = pango_cairo_create_layout(cr);
+  pango_layout_set_font_description(layout, desc);
+  cairo_set_source_rgb(cr, .1, .1, .1);
+
+  pango_layout_set_text(layout, _("dark"), -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, .02 * width - ink.y, .5 * (height + ink.width));
+  cairo_save(cr);
+  cairo_rotate(cr, -M_PI * .5f);
+  pango_cairo_show_layout(cr, layout);
+  cairo_restore(cr);
+
+  pango_layout_set_text(layout, _("bright"), -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, .98 * width - ink.height, .5 * (height + ink.width));
+  cairo_save(cr);
+  cairo_rotate(cr, -M_PI * .5f);
+  pango_cairo_show_layout(cr, layout);
+  cairo_restore(cr);
+
+
+  pango_layout_set_text(layout, _("day vision"), -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, .5 * (width - ink.width), .08 * height - ink.height);
+  pango_cairo_show_layout(cr, layout);
+
+  pango_layout_set_text(layout, _("night vision"), -1);
+  pango_layout_get_pixel_extents(layout, &ink, NULL);
+  cairo_move_to(cr, .5 * (width - ink.width), .97 * height - ink.height);
+  pango_cairo_show_layout(cr, layout);
+
+  pango_font_description_free(desc);
+  g_object_unref(layout);
+  cairo_destroy(cr);
+  cairo_set_source_surface(crf, cst, 0, 0);
+  cairo_paint(crf);
+  cairo_surface_destroy(cst);
+  return TRUE;
+}
+
+static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
+  const int inset = DT_IOP_RAWDENOISE_INSET;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
+  if(!c->dragging) c->mouse_x = CLAMP(event->x - inset, 0, width) / (float)width;
+  c->mouse_y = 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+  if(c->dragging)
+  {
+    *p = c->drag_params;
+    if(c->x_move >= 0)
+    {
+      const float mx = CLAMP(event->x - inset, 0, width) / (float)width;
+      if(c->x_move > 0 && c->x_move < DT_IOP_RAWDENOISE_BANDS - 1)
+      {
+        const float minx = p->transition_x[c->x_move - 1] + 0.001f;
+        const float maxx = p->transition_x[c->x_move + 1] - 0.001f;
+        p->transition_x[c->x_move] = fminf(maxx, fmaxf(minx, mx));
+      }
+    }
+    else
+    {
+      dt_iop_rawdenoise_get_params(p, c->mouse_x, c->mouse_y + c->mouse_pick, c->mouse_radius);
+    }
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+  }
+  else if(event->y > height)
+  {
+    c->x_move = 0;
+    float dist = fabs(p->transition_x[0] - c->mouse_x);
+    for(int k = 1; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    {
+      float d2 = fabs(p->transition_x[k] - c->mouse_x);
+      if(d2 < dist)
+      {
+        c->x_move = k;
+        dist = d2;
+      }
+    }
+  }
+  else
+  {
+    c->x_move = -1;
+  }
+  gtk_widget_queue_draw(widget);
+  gint x, y;
+#if GTK_CHECK_VERSION(3, 20, 0)
+  gdk_window_get_device_position(
+      event->window, gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_window_get_display(event->window))), &x,
+      &y, 0);
+#else
+  gdk_window_get_device_position(
+      event->window,
+      gdk_device_manager_get_client_pointer(gdk_display_get_device_manager(gdk_window_get_display(event->window))),
+      &x, &y, NULL);
+#endif
+  return TRUE;
+}
+
+static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
+  {
+    // reset current curve
+    dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
+    dt_iop_rawdenoise_params_t *d = (dt_iop_rawdenoise_params_t *)self->default_params;
+    /*   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data; */
+    for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    {
+      p->transition_x[k] = d->transition_x[k];
+      p->transition_y[k] = d->transition_y[k];
+    }
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+    gtk_widget_queue_draw(self->widget);
+  }
+  else if(event->button == 1)
+  {
+    dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+    c->drag_params = *(dt_iop_rawdenoise_params_t *)self->params;
+    const int inset = DT_IOP_RAWDENOISE_INSET;
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(widget, &allocation);
+    int height = allocation.height - 2 * inset, width = allocation.width - 2 * inset;
+    c->mouse_pick
+        = dt_draw_curve_calc_value(c->transition_curve, CLAMP(event->x - inset, 0, width) / (float)width);
+    c->mouse_pick -= 1.0 - CLAMP(event->y - inset, 0, height) / (float)height;
+    c->dragging = 1;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static gboolean rawdenoise_button_release(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
+{
+  if(event->button == 1)
+  {
+    dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+    dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+    c->dragging = 0;
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static gboolean rawdenoise_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  if(!c->dragging) c->mouse_y = -1.0;
+  gtk_widget_queue_draw(widget);
+  return TRUE;
+}
+
+static gboolean rawdenoise_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+
+  gdouble delta_y;
+  if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
+  {
+    c->mouse_radius = CLAMP(c->mouse_radius * (1.0 + 0.1 * delta_y), 0.2 / DT_IOP_RAWDENOISE_BANDS, 1.0);
+    gtk_widget_queue_draw(widget);
+  }
+
+  return TRUE;
+}
+
 void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_rawdenoise_gui_data_t));
   dt_iop_rawdenoise_gui_data_t *g = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = g; // FIXME
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
 
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  c->transition_curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
+  (void)dt_draw_curve_add_point(c->transition_curve, p->transition_x[DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
+                                p->transition_y[DT_IOP_RAWDENOISE_BANDS - 2]);
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    (void)dt_draw_curve_add_point(c->transition_curve, p->transition_x[k], p->transition_y[k]);
+  (void)dt_draw_curve_add_point(c->transition_curve, p->transition_x[1] + 1.0, p->transition_y[1]);
 
-  g->stack = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(g->stack), FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->stack, TRUE, TRUE, 0);
+  c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
+  c->dragging = 0;
+  c->x_move = -1;
+  c->mouse_radius = 1.0 / DT_IOP_RAWDENOISE_BANDS;
 
-  g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  /* threshold */
+  c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.75));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->area), FALSE, FALSE, 0);
+
+  gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
+                                                 | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
+                                                 | GDK_LEAVE_NOTIFY_MASK | darktable.gui->scroll_mask);
+  g_signal_connect(G_OBJECT(c->area), "draw", G_CALLBACK(rawdenoise_draw), self);
+  g_signal_connect(G_OBJECT(c->area), "button-press-event", G_CALLBACK(rawdenoise_button_press), self);
+  g_signal_connect(G_OBJECT(c->area), "button-release-event", G_CALLBACK(rawdenoise_button_release), self);
+  g_signal_connect(G_OBJECT(c->area), "motion-notify-event", G_CALLBACK(rawdenoise_motion_notify), self);
+  g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(rawdenoise_leave_notify), self);
+  g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(rawdenoise_scrolled), self);
+
   g->threshold = dt_bauhaus_slider_new_with_range(self, 0.0, 0.1, 0.001, p->threshold, 3);
-  gtk_box_pack_start(GTK_BOX(g->box_raw), GTK_WIDGET(g->threshold), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->threshold), TRUE, TRUE, 0);
   dt_bauhaus_widget_set_label(g->threshold, NULL, _("noise threshold"));
   g_signal_connect(G_OBJECT(g->threshold), "value-changed", G_CALLBACK(threshold_callback), self);
 
-  gtk_widget_show_all(g->box_raw);
-  gtk_stack_add_named(GTK_STACK(g->stack), g->box_raw, "raw");
+  gtk_widget_show_all(self->widget);
 
   g->label_non_raw = gtk_label_new(_("raw denoising\nonly works for raw images."));
   gtk_widget_set_halign(g->label_non_raw, GTK_ALIGN_START);
 
   gtk_widget_show_all(g->label_non_raw);
-  gtk_stack_add_named(GTK_STACK(g->stack), g->label_non_raw, "non_raw");
 
-  gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "non_raw" : "raw");
+  if(self->hide_enable_button)
+  {
+    gtk_widget_set_visible(g->label_non_raw, TRUE);
+    gtk_widget_set_visible(self->widget, FALSE);
+  }
+  else
+  {
+    gtk_widget_set_visible(g->label_non_raw, FALSE);
+    gtk_widget_set_visible(self->widget, TRUE);
+  }
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
+  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_draw_curve_destroy(c->transition_curve);
   free(self->gui_data);
   self->gui_data = NULL;
 }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -40,8 +40,7 @@ DT_MODULE_INTROSPECTION(2, dt_iop_rawdenoise_params_t)
 #define DT_IOP_RAWDENOISE_RES 64
 #define DT_IOP_RAWDENOISE_BANDS 5
 
-typedef enum dt_iop_rawdenoise_channel_t
-{
+typedef enum dt_iop_rawdenoise_channel_t {
   rawdenoise_all = 0,
   rawdenoise_R = 1,
   rawdenoise_G = 2,
@@ -144,12 +143,12 @@ static void hat_transform(float *temp, const float *const base, int stride, int 
 #define BIT16 65536.0
 
 static void wavelet_denoise(const float *const in, float *const out, const dt_iop_roi_t *const roi,
-                            dt_iop_rawdenoise_data_t* data, uint32_t filters)
+                            dt_iop_rawdenoise_data_t *data, uint32_t filters)
 {
   float threshold = data->threshold;
   int lev;
   float noise_all[] = { 0.8002, 0.2735, 0.1202, 0.0585, 0.0291, 0.0152, 0.0080, 0.0044 };
-  for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
+  for(int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
   {
     // scale the value from [0,1] to [0,16],
     // and makes the "0.5" neutral value become 1
@@ -175,10 +174,11 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
   for(int c = 0; c < nc; c++) /* denoise R,G1,B,G3 individually */
   {
     float noise[DT_IOP_RAWDENOISE_BANDS];
-    for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
+    for(int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
     {
       float threshold_exp_4;
-      switch (c) {
+      switch(c)
+      {
         case 0:
           threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
@@ -310,14 +310,14 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
 }
 
 static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_iop_roi_t *const roi,
-                                   dt_iop_rawdenoise_data_t* data, const uint8_t (*const xtrans)[6])
+                                   dt_iop_rawdenoise_data_t *data, const uint8_t (*const xtrans)[6])
 {
   float threshold = data->threshold;
   // note that these constants are the same for X-Trans and Bayer, as
   // they are proportional to image detail on each channel, not the
   // sensor pattern
   float noise_all[] = { 0.8002, 0.2735, 0.1202, 0.0585, 0.0291, 0.0152, 0.0080, 0.0044 };
-  for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
+  for(int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
   {
     // scale the value from [0,1] to [0,16],
     // and makes the "0.5" neutral value become 1
@@ -335,10 +335,11 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
   for(int c = 0; c < 3; c++)
   {
     float noise[DT_IOP_RAWDENOISE_BANDS];
-    for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
+    for(int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
     {
       float threshold_exp_4;
-      switch (c) {
+      switch(c)
+      {
         case 0:
           threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
@@ -483,7 +484,7 @@ void init(dt_iop_module_t *module)
   dt_iop_rawdenoise_params_t tmp;
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
   {
-    for (int ch = 0; ch < rawdenoise_none; ch++)
+    for(int ch = 0; ch < rawdenoise_none; ch++)
     {
       tmp.x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
       tmp.y[ch][k] = 0.5f;
@@ -510,7 +511,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 
   d->threshold = p->threshold;
 
-  for (int ch = 0; ch < rawdenoise_none; ch++)
+  for(int ch = 0; ch < rawdenoise_none; ch++)
   {
     dt_draw_curve_set_point(d->curve[ch], 0, p->x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p->y[ch][0]);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
@@ -530,7 +531,7 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_rawdenoise_params_t *default_params = (dt_iop_rawdenoise_params_t *)self->default_params;
 
   piece->data = (void *)d;
-  for (int ch = 0; ch < rawdenoise_none; ch++)
+  for(int ch = 0; ch < rawdenoise_none; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
@@ -566,8 +567,8 @@ static void threshold_callback(GtkWidget *slider, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void dt_iop_rawdenoise_get_params(dt_iop_rawdenoise_params_t *p, const int ch, const double mouse_x, const double mouse_y,
-                                         const float rad)
+static void dt_iop_rawdenoise_get_params(dt_iop_rawdenoise_params_t *p, const int ch, const double mouse_x,
+                                         const double mouse_y, const float rad)
 {
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
   {
@@ -583,8 +584,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   dt_iop_rawdenoise_params_t p = *(dt_iop_rawdenoise_params_t *)self->params;
 
   int ch = (int)c->channel;
-  dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
-                          p.y[ch][0]);
+  dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p.y[ch][0]);
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
     dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
   dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.x[ch][1] + 1.0,
@@ -622,8 +622,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   {
     // draw min/max curves:
     dt_iop_rawdenoise_get_params(&p, c->channel, c->mouse_x, 1., c->mouse_radius);
-    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
-                            p.y[ch][0]);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p.y[ch][0]);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
       dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
     dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.x[ch][1] + 1.0,
@@ -632,8 +631,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
 
     p = *(dt_iop_rawdenoise_params_t *)self->params;
     dt_iop_rawdenoise_get_params(&p, c->channel, c->mouse_x, .0, c->mouse_radius);
-    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
-                            p.y[ch][0]);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p.y[ch][0]);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
       dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
     dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.x[ch][1] + 1.0,
@@ -649,14 +647,14 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
 
-  for (int i = 0; i < rawdenoise_none; i++)
+  for(int i = 0; i < rawdenoise_none; i++)
   {
     // draw curves, selected last
     ch = ((int)c->channel + i + 1) % rawdenoise_none;
     float alpha = 0.3;
-    if (i == rawdenoise_none-1)
-      alpha = 1.0;
-    switch (ch) {
+    if(i == rawdenoise_none - 1) alpha = 1.0;
+    switch(ch)
+    {
       case 0:
         cairo_set_source_rgba(cr, .7, .7, .7, alpha);
         break;
@@ -672,8 +670,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
     }
 
     p = *(dt_iop_rawdenoise_params_t *)self->params;
-    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
-                            p.y[ch][0]);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p.y[ch][0]);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
       dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
     dt_draw_curve_set_point(c->transition_curve, DT_IOP_RAWDENOISE_BANDS + 1, p.x[ch][1] + 1.0,
@@ -902,17 +899,13 @@ void gui_init(dt_iop_module_t *self)
 
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
 
-  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("all")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("R")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("G")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(c->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("B")));
 
   gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
@@ -963,7 +956,7 @@ void gui_init(dt_iop_module_t *self)
   // In other words, if the original one is in "non_raw" mode, we have to put
   // "non_raw" in the stack first, so that when we add a new instance, we see
   // the label_non_raw
-  if (self->hide_enable_button)
+  if(self->hide_enable_button)
   {
     gtk_stack_add_named(GTK_STACK(c->stack), c->label_non_raw, "non_raw");
     gtk_stack_add_named(GTK_STACK(c->stack), c->box_raw, "raw");

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -834,7 +834,7 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
-  int ch = c->channel;
+  const int ch = c->channel;
   if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
   {
     // reset current curve
@@ -937,7 +937,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(rawdenoise_tab_switch), self);
 
   c->channel = dt_conf_get_int("plugins/darkroom/rawdenoise/gui_channel");
-  int ch = (int)c->channel;
+  const int ch = (int)c->channel;
   c->transition_curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
   (void)dt_draw_curve_add_point(c->transition_curve, p->x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,
                                 p->y[ch][DT_IOP_RAWDENOISE_BANDS - 2]);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -148,7 +148,7 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
 {
   float threshold = data->threshold;
   int lev;
-  float noise[] = { 0.8002, 0.2735, 0.1202, 0.0585, 0.0291, 0.0152, 0.0080, 0.0044 };
+  float noise_all[] = { 0.8002, 0.2735, 0.1202, 0.0585, 0.0291, 0.0152, 0.0080, 0.0044 };
   for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
   {
     // scale the value from [0,1] to [0,16],
@@ -156,7 +156,7 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
     float threshold_exp_4 = data->force[rawdenoise_all][DT_IOP_RAWDENOISE_BANDS - i - 1];
     threshold_exp_4 *= threshold_exp_4;
     threshold_exp_4 *= threshold_exp_4;
-    noise[i] = noise[i] * threshold_exp_4 * 16.0;
+    noise_all[i] = noise_all[i] * threshold_exp_4 * 16.0;
   }
 
   const size_t size = (size_t)(roi->width / 2 + 1) * (roi->height / 2 + 1);
@@ -174,6 +174,26 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
   const int nc = 4;
   for(int c = 0; c < nc; c++) /* denoise R,G1,B,G3 individually */
   {
+    float noise[DT_IOP_RAWDENOISE_BANDS];
+    for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
+    {
+      float threshold_exp_4;
+      switch (c) {
+        case 0:
+          threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          break;
+        case 3:
+          threshold_exp_4 = data->force[rawdenoise_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          break;
+        default:
+          threshold_exp_4 = data->force[rawdenoise_G][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          break;
+      }
+      threshold_exp_4 *= threshold_exp_4;
+      threshold_exp_4 *= threshold_exp_4;
+      noise[i] = noise_all[i] * threshold_exp_4 * 16.0;
+    }
+
     // zero lowest quarter part
     memset(fimg, 0, size * sizeof(float));
 
@@ -296,7 +316,7 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
   // note that these constants are the same for X-Trans and Bayer, as
   // they are proportional to image detail on each channel, not the
   // sensor pattern
-  float noise[] = { 0.8002, 0.2735, 0.1202, 0.0585, 0.0291, 0.0152, 0.0080, 0.0044 };
+  float noise_all[] = { 0.8002, 0.2735, 0.1202, 0.0585, 0.0291, 0.0152, 0.0080, 0.0044 };
   for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
   {
     // scale the value from [0,1] to [0,16],
@@ -304,7 +324,7 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
     float threshold_exp_4 = data->force[rawdenoise_all][DT_IOP_RAWDENOISE_BANDS - i - 1];
     threshold_exp_4 *= threshold_exp_4;
     threshold_exp_4 *= threshold_exp_4;
-    noise[i] = noise[i] * threshold_exp_4 * 16.0;
+    noise_all[i] = noise_all[i] * threshold_exp_4 * 16.0;
   }
 
   const int width = roi->width;
@@ -314,6 +334,25 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
 
   for(int c = 0; c < 3; c++)
   {
+    float noise[DT_IOP_RAWDENOISE_BANDS];
+    for (int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
+    {
+      float threshold_exp_4;
+      switch (c) {
+        case 0:
+          threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          break;
+        case 2:
+          threshold_exp_4 = data->force[rawdenoise_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          break;
+        default:
+          threshold_exp_4 = data->force[rawdenoise_G][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          break;
+      }
+      threshold_exp_4 *= threshold_exp_4;
+      threshold_exp_4 *= threshold_exp_4;
+      noise[i] = noise_all[i] * threshold_exp_4 * 16.0;
+    }
     memset(fimg, 0, size * sizeof(float));
 
 #ifdef _OPENMP

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -662,7 +662,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   pango_layout_set_font_description(layout, desc);
   cairo_set_source_rgb(cr, .1, .1, .1);
 
-  pango_layout_set_text(layout, _("dark"), -1);
+  pango_layout_set_text(layout, _("coarse"), -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   cairo_move_to(cr, .02 * width - ink.y, .5 * (height + ink.width));
   cairo_save(cr);
@@ -670,7 +670,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   pango_cairo_show_layout(cr, layout);
   cairo_restore(cr);
 
-  pango_layout_set_text(layout, _("bright"), -1);
+  pango_layout_set_text(layout, _("fine"), -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   cairo_move_to(cr, .98 * width - ink.height, .5 * (height + ink.width));
   cairo_save(cr);
@@ -679,12 +679,12 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   cairo_restore(cr);
 
 
-  pango_layout_set_text(layout, _("day vision"), -1);
+  pango_layout_set_text(layout, _("smooth"), -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   cairo_move_to(cr, .5 * (width - ink.width), .08 * height - ink.height);
   pango_cairo_show_layout(cr, layout);
 
-  pango_layout_set_text(layout, _("night vision"), -1);
+  pango_layout_set_text(layout, _("noisy"), -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   cairo_move_to(cr, .5 * (width - ink.width), .97 * height - ink.height);
   pango_cairo_show_layout(cr, layout);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -40,18 +40,19 @@ DT_MODULE_INTROSPECTION(2, dt_iop_rawdenoise_params_t)
 #define DT_IOP_RAWDENOISE_RES 64
 #define DT_IOP_RAWDENOISE_BANDS 5
 
-typedef enum dt_iop_rawdenoise_channel_t {
-  rawdenoise_all = 0,
-  rawdenoise_R = 1,
-  rawdenoise_G = 2,
-  rawdenoise_B = 3,
-  rawdenoise_none = 4
+typedef enum dt_iop_rawdenoise_channel_t
+{
+  DT_RAWDENOISE_ALL = 0,
+  DT_RAWDENOISE_R = 1,
+  DT_RAWDENOISE_G = 2,
+  DT_RAWDENOISE_B = 3,
+  DT_RAWDENOISE_NONE = 4
 } dt_iop_rawdenoise_channel_t;
 
 typedef struct dt_iop_rawdenoise_params_t
 {
   float threshold;
-  float x[rawdenoise_none][DT_IOP_RAWDENOISE_BANDS], y[rawdenoise_none][DT_IOP_RAWDENOISE_BANDS];
+  float x[DT_RAWDENOISE_NONE][DT_IOP_RAWDENOISE_BANDS], y[DT_RAWDENOISE_NONE][DT_IOP_RAWDENOISE_BANDS];
 } dt_iop_rawdenoise_params_t;
 
 typedef struct dt_iop_rawdenoise_gui_data_t
@@ -78,9 +79,9 @@ typedef struct dt_iop_rawdenoise_gui_data_t
 typedef struct dt_iop_rawdenoise_data_t
 {
   float threshold;
-  dt_draw_curve_t *curve[rawdenoise_none];
+  dt_draw_curve_t *curve[DT_RAWDENOISE_NONE];
   dt_iop_rawdenoise_channel_t channel;
-  float force[rawdenoise_none][DT_IOP_RAWDENOISE_BANDS];
+  float force[DT_RAWDENOISE_NONE][DT_IOP_RAWDENOISE_BANDS];
 } dt_iop_rawdenoise_data_t;
 
 typedef struct dt_iop_rawdenoise_global_data_t
@@ -97,7 +98,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->threshold = o->threshold;
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
     {
-      for(int ch = 0; ch < rawdenoise_none; ch++)
+      for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
       {
         n->x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
         n->y[ch][k] = 0.5f;
@@ -174,7 +175,7 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
   {
     // scale the value from [0,1] to [0,16],
     // and makes the "0.5" neutral value become 1
-    float threshold_exp_4 = data->force[rawdenoise_all][DT_IOP_RAWDENOISE_BANDS - i - 1];
+    float threshold_exp_4 = data->force[DT_RAWDENOISE_ALL][DT_IOP_RAWDENOISE_BANDS - i - 1];
     threshold_exp_4 *= threshold_exp_4;
     threshold_exp_4 *= threshold_exp_4;
     noise_all[i] = noise_all[i] * threshold_exp_4 * 16.0;
@@ -203,13 +204,13 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
       switch(color)
       {
         case 0:
-          threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          threshold_exp_4 = data->force[DT_RAWDENOISE_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
         case 2:
-          threshold_exp_4 = data->force[rawdenoise_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          threshold_exp_4 = data->force[DT_RAWDENOISE_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
         default:
-          threshold_exp_4 = data->force[rawdenoise_G][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          threshold_exp_4 = data->force[DT_RAWDENOISE_G][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
       }
       threshold_exp_4 *= threshold_exp_4;
@@ -344,7 +345,7 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
   {
     // scale the value from [0,1] to [0,16],
     // and makes the "0.5" neutral value become 1
-    float threshold_exp_4 = data->force[rawdenoise_all][DT_IOP_RAWDENOISE_BANDS - i - 1];
+    float threshold_exp_4 = data->force[DT_RAWDENOISE_ALL][DT_IOP_RAWDENOISE_BANDS - i - 1];
     threshold_exp_4 *= threshold_exp_4;
     threshold_exp_4 *= threshold_exp_4;
     noise_all[i] = noise_all[i] * threshold_exp_4 * 16.0;
@@ -364,13 +365,13 @@ static void wavelet_denoise_xtrans(const float *const in, float *out, const dt_i
       switch(c)
       {
         case 0:
-          threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          threshold_exp_4 = data->force[DT_RAWDENOISE_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
         case 2:
-          threshold_exp_4 = data->force[rawdenoise_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          threshold_exp_4 = data->force[DT_RAWDENOISE_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
         default:
-          threshold_exp_4 = data->force[rawdenoise_G][DT_IOP_RAWDENOISE_BANDS - i - 1];
+          threshold_exp_4 = data->force[DT_RAWDENOISE_G][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
       }
       threshold_exp_4 *= threshold_exp_4;
@@ -507,7 +508,7 @@ void init(dt_iop_module_t *module)
   dt_iop_rawdenoise_params_t tmp;
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
   {
-    for(int ch = 0; ch < rawdenoise_none; ch++)
+    for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
     {
       tmp.x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
       tmp.y[ch][k] = 0.5f;
@@ -534,7 +535,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 
   d->threshold = p->threshold;
 
-  for(int ch = 0; ch < rawdenoise_none; ch++)
+  for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
   {
     dt_draw_curve_set_point(d->curve[ch], 0, p->x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0, p->y[ch][0]);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
@@ -554,19 +555,19 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_rawdenoise_params_t *default_params = (dt_iop_rawdenoise_params_t *)self->default_params;
 
   piece->data = (void *)d;
-  for(int ch = 0; ch < rawdenoise_none; ch++)
+  for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
       (void)dt_draw_curve_add_point(d->curve[ch], default_params->x[ch][k], default_params->y[ch][k]);
   }
-  self->commit_params(self, self->default_params, pipe, piece); // TODO necessary?
+  self->commit_params(self, self->default_params, pipe, piece);
 }
 
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rawdenoise_data_t *d = (dt_iop_rawdenoise_data_t *)(piece->data);
-  for(int ch = 0; ch < rawdenoise_none; ch++) dt_draw_curve_destroy(d->curve[ch]);
+  for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++) dt_draw_curve_destroy(d->curve[ch]);
   free(piece->data);
   piece->data = NULL;
 }
@@ -670,12 +671,12 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
 
-  for(int i = 0; i < rawdenoise_none; i++)
+  for(int i = 0; i < DT_RAWDENOISE_NONE; i++)
   {
     // draw curves, selected last
-    ch = ((int)c->channel + i + 1) % rawdenoise_none;
+    ch = ((int)c->channel + i + 1) % DT_RAWDENOISE_NONE;
     float alpha = 0.3;
-    if(i == rawdenoise_none - 1) alpha = 1.0;
+    if(i == DT_RAWDENOISE_NONE - 1) alpha = 1.0;
     switch(ch)
     {
       case 0:

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -643,27 +643,9 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
 
   cairo_save(cr);
 
-  // draw x positions
-  cairo_set_source_rgb(cr, 0.6, 0.6, 0.6);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
-  const float arrw = DT_PIXEL_APPLY_DPI(7.0f);
-  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
-  {
-    cairo_move_to(cr, width * p.x[ch][k], height + inset - DT_PIXEL_APPLY_DPI(1));
-    cairo_rel_line_to(cr, -arrw * .5f, 0);
-    cairo_rel_line_to(cr, arrw * .5f, -arrw);
-    cairo_rel_line_to(cr, arrw * .5f, arrw);
-    cairo_close_path(cr);
-    if(c->x_move == k)
-      cairo_fill(cr);
-    else
-      cairo_stroke(cr);
-  }
-
   // draw selected cursor
   cairo_translate(cr, 0, height);
 
-  // cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -87,6 +87,28 @@ typedef struct dt_iop_rawdenoise_global_data_t
 {
 } dt_iop_rawdenoise_global_data_t;
 
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
+                  const int new_version)
+{
+  if(old_version == 1 && new_version == 2)
+  {
+    dt_iop_rawdenoise_params_t *o = (dt_iop_rawdenoise_params_t *)old_params;
+    dt_iop_rawdenoise_params_t *n = (dt_iop_rawdenoise_params_t *)new_params;
+    n->threshold = o->threshold;
+    for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+    {
+      for(int ch = 0; ch < rawdenoise_none; ch++)
+      {
+        n->x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
+        n->y[ch][k] = 0.5f;
+      }
+    }
+    return 0;
+  }
+  return 1;
+}
+
+
 const char *name()
 {
   return _("raw denoise");

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -712,35 +712,11 @@ static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *even
   if(c->dragging)
   {
     *p = c->drag_params;
-    if(c->x_move >= 0)
-    {
-      const float mx = CLAMP(event->x - inset, 0, width) / (float)width;
-      if(c->x_move > 0 && c->x_move < DT_IOP_RAWDENOISE_BANDS - 1)
-      {
-        const float minx = p->transition_x[c->x_move - 1] + 0.001f;
-        const float maxx = p->transition_x[c->x_move + 1] - 0.001f;
-        p->transition_x[c->x_move] = fminf(maxx, fmaxf(minx, mx));
-      }
-    }
-    else
+    if(c->x_move < 0)
     {
       dt_iop_rawdenoise_get_params(p, c->mouse_x, c->mouse_y + c->mouse_pick, c->mouse_radius);
     }
     dt_dev_add_history_item(darktable.develop, self, TRUE);
-  }
-  else if(event->y > height)
-  {
-    c->x_move = 0;
-    float dist = fabs(p->transition_x[0] - c->mouse_x);
-    for(int k = 1; k < DT_IOP_RAWDENOISE_BANDS; k++)
-    {
-      float d2 = fabs(p->transition_x[k] - c->mouse_x);
-      if(d2 < dist)
-      {
-        c->x_move = k;
-        dist = d2;
-      }
-    }
   }
   else
   {

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -557,21 +557,7 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   int width = allocation.width, height = allocation.height;
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
-
-  switch (ch) { //TODO not really best thing. Color the curve instead.
-    case 1:
-      cairo_set_source_rgb(cr, 1, 0, 0);
-      break;
-    case 2:
-      cairo_set_source_rgb(cr, 0, 1, 0);
-      break;
-    case 3:
-      cairo_set_source_rgb(cr, 0, 0, 1);
-      break;
-    default:
-      cairo_set_source_rgb(cr, .2, .2, .2);
-      break;
-  }
+  cairo_set_source_rgb(cr, .2, .2, .2);
 
   cairo_paint(cr);
 
@@ -592,7 +578,6 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(.4));
   cairo_set_source_rgb(cr, .1, .1, .1);
   dt_draw_grid(cr, 8, 0, 0, width, height);
-
 
   if(c->mouse_y > 0 || c->dragging)
   {
@@ -647,10 +632,23 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   {
     // draw curves, selected last
     ch = ((int)c->channel + i + 1) % rawdenoise_none;
+    float alpha = 0.3;
     if (i == rawdenoise_none-1)
-      cairo_set_source_rgba(cr, .7, .7, .7, 1.0);
-    else
-      cairo_set_source_rgba(cr, .7, .7, .7, 0.3);
+      alpha = 1.0;
+    switch (ch) {
+      case 0:
+        cairo_set_source_rgba(cr, .7, .7, .7, alpha);
+        break;
+      case 1:
+        cairo_set_source_rgba(cr, .7, .1, .1, alpha);
+        break;
+      case 2:
+        cairo_set_source_rgba(cr, .1, .7, .1, alpha);
+        break;
+      case 3:
+        cairo_set_source_rgba(cr, .1, .1, .7, alpha);
+        break;
+    }
 
     p = *(dt_iop_rawdenoise_params_t *)self->params;
     dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_RAWDENOISE_BANDS - 2] - 1.0,

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -93,6 +93,14 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 {
   if(old_version == 1 && new_version == 2)
   {
+    // Since first version, the dt_iop_params_t struct have new members
+    // at the end of the struct.
+    // Yet, the beginning of the struct is exactly the same:
+    // threshold is still the first member of the struct.
+    // This allows to define the variable o with dt_iop_rawdenoise_params_t
+    // as long as we don't try to access new members on o.
+    // In other words, o can be seen as a dt_iop_rawdenoise_params_t
+    // with no allocated space for the new member.
     dt_iop_rawdenoise_params_t *o = (dt_iop_rawdenoise_params_t *)old_params;
     dt_iop_rawdenoise_params_t *n = (dt_iop_rawdenoise_params_t *)new_params;
     n->threshold = o->threshold;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -473,18 +473,19 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
 
   dt_bauhaus_slider_set(g->threshold, p->threshold);
-  gtk_widget_queue_draw(self->widget);
-
   if(self->hide_enable_button)
   {
-    gtk_widget_set_visible(g->label_non_raw, TRUE);
     gtk_widget_set_visible(self->widget, FALSE);
+    self->widget = g->label_non_raw;
+    gtk_widget_set_visible(self->widget, TRUE);
   }
   else
   {
-    gtk_widget_set_visible(g->label_non_raw, FALSE);
+    gtk_widget_set_visible(self->widget, FALSE);
+    self->widget = g->box_raw;
     gtk_widget_set_visible(self->widget, TRUE);
   }
+  gtk_widget_queue_draw(self->widget);
 }
 
 static void threshold_callback(GtkWidget *slider, gpointer user_data)
@@ -849,11 +850,11 @@ void gui_init(dt_iop_module_t *self)
   c->x_move = -1;
   c->mouse_radius = 1.0 / DT_IOP_RAWDENOISE_BANDS;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.75));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->area), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_raw), GTK_WIDGET(c->area), FALSE, FALSE, 0);
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                  | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
@@ -866,11 +867,11 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(rawdenoise_scrolled), self);
 
   g->threshold = dt_bauhaus_slider_new_with_range(self, 0.0, 0.1, 0.001, p->threshold, 3);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->threshold), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_raw), GTK_WIDGET(g->threshold), TRUE, TRUE, 0);
   dt_bauhaus_widget_set_label(g->threshold, NULL, _("noise threshold"));
   g_signal_connect(G_OBJECT(g->threshold), "value-changed", G_CALLBACK(threshold_callback), self);
 
-  gtk_widget_show_all(self->widget);
+  gtk_widget_show_all(g->box_raw);
 
   g->label_non_raw = gtk_label_new(_("raw denoising\nonly works for raw images."));
   gtk_widget_set_halign(g->label_non_raw, GTK_ALIGN_START);
@@ -879,14 +880,17 @@ void gui_init(dt_iop_module_t *self)
 
   if(self->hide_enable_button)
   {
-    gtk_widget_set_visible(g->label_non_raw, TRUE);
     gtk_widget_set_visible(self->widget, FALSE);
+    self->widget = g->label_non_raw;
+    gtk_widget_set_visible(self->widget, TRUE);
   }
   else
   {
-    gtk_widget_set_visible(g->label_non_raw, FALSE);
+    gtk_widget_set_visible(self->widget, FALSE);
+    self->widget = g->box_raw;
     gtk_widget_set_visible(self->widget, TRUE);
   }
+  gtk_widget_show_all(self->widget);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -195,16 +195,17 @@ static void wavelet_denoise(const float *const in, float *const out, const dt_io
   const int nc = 4;
   for(int c = 0; c < nc; c++) /* denoise R,G1,B,G3 individually */
   {
+    int color = FC(c % 2, c / 2, filters);
     float noise[DT_IOP_RAWDENOISE_BANDS];
     for(int i = 0; i < DT_IOP_RAWDENOISE_BANDS; i++)
     {
       float threshold_exp_4;
-      switch(c)
+      switch(color)
       {
         case 0:
           threshold_exp_4 = data->force[rawdenoise_R][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
-        case 3:
+        case 2:
           threshold_exp_4 = data->force[rawdenoise_B][DT_IOP_RAWDENOISE_BANDS - i - 1];
           break;
         default:

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -475,15 +475,15 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->threshold, p->threshold);
   if(self->hide_enable_button)
   {
-    gtk_widget_set_visible(self->widget, FALSE);
-    self->widget = g->label_non_raw;
-    gtk_widget_set_visible(self->widget, TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->area), FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(g->threshold), FALSE);
+    gtk_widget_set_visible(g->label_non_raw, TRUE);
   }
   else
   {
-    gtk_widget_set_visible(self->widget, FALSE);
-    self->widget = g->box_raw;
-    gtk_widget_set_visible(self->widget, TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->area), TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->threshold), TRUE);
+    gtk_widget_set_visible(g->label_non_raw, FALSE);
   }
   gtk_widget_queue_draw(self->widget);
 }
@@ -871,25 +871,13 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->threshold, NULL, _("noise threshold"));
   g_signal_connect(G_OBJECT(g->threshold), "value-changed", G_CALLBACK(threshold_callback), self);
 
-  gtk_widget_show_all(g->box_raw);
-
   g->label_non_raw = gtk_label_new(_("raw denoising\nonly works for raw images."));
   gtk_widget_set_halign(g->label_non_raw, GTK_ALIGN_START);
+  gtk_box_pack_start(GTK_BOX(g->box_raw), GTK_WIDGET(g->label_non_raw), TRUE, TRUE, 0);
 
-  gtk_widget_show_all(g->label_non_raw);
+  // gtk_widget_show_all(g->box_raw);
 
-  if(self->hide_enable_button)
-  {
-    gtk_widget_set_visible(self->widget, FALSE);
-    self->widget = g->label_non_raw;
-    gtk_widget_set_visible(self->widget, TRUE);
-  }
-  else
-  {
-    gtk_widget_set_visible(self->widget, FALSE);
-    self->widget = g->box_raw;
-    gtk_widget_set_visible(self->widget, TRUE);
-  }
+  self->widget = g->box_raw;
   gtk_widget_show_all(self->widget);
 }
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -483,8 +483,19 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 void reload_defaults(dt_iop_module_t *module)
 {
+  // init defaults:
+  dt_iop_rawdenoise_params_t tmp;
+  tmp.threshold = 0.01;
+  for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
+  {
+    for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
+    {
+      tmp.x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
+      tmp.y[ch][k] = 0.5f;
+    }
+  }
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) return;
+  if(!module->dev) goto end;
 
   // can't be switched on for non-raw images:
   if(dt_image_is_raw(&module->dev->image_storage))
@@ -492,6 +503,10 @@ void reload_defaults(dt_iop_module_t *module)
   else
     module->hide_enable_button = 1;
   module->default_enabled = 0;
+
+end:
+ memcpy(module->params, &tmp, sizeof(dt_iop_rawdenoise_params_t));
+ memcpy(module->default_params, &tmp, sizeof(dt_iop_rawdenoise_params_t));
 }
 
 void init(dt_iop_module_t *module)

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -844,7 +844,7 @@ void gui_init(dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
   c->x_move = -1;
-  c->mouse_radius = 1.0 / DT_IOP_RAWDENOISE_BANDS;
+  c->mouse_radius = 1.0 / (DT_IOP_RAWDENOISE_BANDS * 2);
 
   c->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 


### PR DESCRIPTION
This pull request adds a GUI to rawdenoise similar to the one of the equalizer.

It does NOT change the underlying algorithm, but allows the user to finely control the denoising:
- the user can change the force band by band. For instance, this is useful if user wants to preserve fine-grain noise
- the user can change the force band by band for each channel. As color channels are usually not noisy in the same way (coarseness of the noise and amount of noise), this allows the user to adjust the denoising accordingly (this may produce an image with some pixels of wrong color, but it is easily fixed with a denoiseprofile instance with wavelet mode and blendmode color).

I think this gives much more power to the user, without adding complexity in the algorithm.
(almost all the code change in this pull request are for the GUI.)