### PR TITLE
Denoise profile wavelets: change force by frequency and channel

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -953,22 +953,22 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     // zoom level, it does NOT corresponds to the the maximum number of scales.
     // in other words, max_scale is the maximum number of VISIBLE scales.
     // That is why we have this "scale+offset_scale"
-    float band_force_exp_2 = d->force[denoiseprofile_all][scale + offset_scale];
+    float band_force_exp_2 = d->force[denoiseprofile_all][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     for (int ch = 0; ch < 3; ch++)
     {
       adjt[ch] *= band_force_exp_2;
     }
-    band_force_exp_2 = d->force[denoiseprofile_R][scale + offset_scale];
+    band_force_exp_2 = d->force[denoiseprofile_R][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[0] *= band_force_exp_2;
-    band_force_exp_2 = d->force[denoiseprofile_G][scale + offset_scale];
+    band_force_exp_2 = d->force[denoiseprofile_G][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[1] *= band_force_exp_2;
-    band_force_exp_2 = d->force[denoiseprofile_B][scale + offset_scale];
+    band_force_exp_2 = d->force[denoiseprofile_B][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[2] *= band_force_exp_2;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -231,7 +231,6 @@ static void add_preset(dt_iop_module_so_t *self, const char *name, const char *p
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  // TODO update these
   // these blobs were exported as dtstyle and copied from there:
   add_preset(self, _("chroma (use on 1st instance)"),
              "gz04eJxjYGiwZ4Dg/dti91vWKRhZcYsxmibv5THN2n3XhJEBBhrsgARQnQNUPUViVMUApDYXmg==",
@@ -2197,7 +2196,6 @@ static void strength_callback(GtkWidget *w, dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  // TODO use a stack
   // let gui slider match current parameters:
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -898,7 +898,15 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     const float std_x[3] = { sqrtf(MAX(1e-6f, var_y[0] - sb2)), sqrtf(MAX(1e-6f, var_y[1] - sb2)),
                              sqrtf(MAX(1e-6f, var_y[2] - sb2)) };
     // add 8.0 here because it seemed a little weak
-    const float adjt = 8.0f;
+    float adjt = 8.0f;
+
+    //TODO make adjt multiplied by a number in [0,4] on scales 0 -> 4
+    // yet, scale 4 does not give much change.
+    // max_scale -1 always corresponds to the largest scale.
+    // small scales are ignored by the algorithm  when zoomed out,
+    // so if max_scale < 5, pay attention to which multiplier to use
+    // so that the fine scale multipliers are not used on large scales
+
     const float thrs[4] = { adjt * sb2 / std_x[0], adjt * sb2 / std_x[1], adjt * sb2 / std_x[2], 0.0f };
 // const float std = (std_x[0] + std_x[1] + std_x[2])/3.0f;
 // const float thrs[4] = { adjt*sigma*sigma/std, adjt*sigma*sigma/std, adjt*sigma*sigma/std, 0.0f};

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -145,6 +145,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     }
     n->radius = o->radius;
     n->strength = o->strength;
+    memcpy(n->a, o->a, sizeof(float) * 3);
+    memcpy(n->b, o->b, sizeof(float) * 3);
     // autodetect current profile:
     if(!self->dev)
     {

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2125,9 +2125,17 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   p->mode = dt_bauhaus_combobox_get(w);
   if(p->mode == MODE_WAVELETS)
+  {
     gtk_widget_set_visible(g->radius, FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs), TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->area), TRUE);
+  }
   else
+  {
     gtk_widget_set_visible(g->radius, TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs), FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(g->area), FALSE);
+  }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2156,9 +2164,17 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->mode, p->mode);
   dt_bauhaus_combobox_set(g->profile, -1);
   if(p->mode == MODE_WAVELETS)
+  {
     gtk_widget_set_visible(g->radius, FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs), TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->area), TRUE);
+  }
   else
+  {
     gtk_widget_set_visible(g->radius, TRUE);
+    gtk_widget_set_visible(GTK_WIDGET(g->channel_tabs), FALSE);
+    gtk_widget_set_visible(GTK_WIDGET(g->area), FALSE);
+  }
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -231,11 +231,11 @@ void init_presets(dt_iop_module_so_t *self)
   // these blobs were exported as dtstyle and copied from there:
   add_preset(self,
              _("chroma (use on 1st instance)"),
-             "0000803f0000803f000080bf05a32a3636106236c01b58341f1609b446faddb301000000",
+             "gz04eJxjYGiwZ4Dg/dti91vWKRhZcYsxmibv5THN2n3XhJEBBhrsgARQnQNUPUViVMUApDYXmg==",
              "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
   add_preset(self,
              _("luma (use on 2nd instance)"),
-             "000080400000003f000080bf38c54438c0d7b83828ff8934230e0c344a216d3400000000",
+             "gz04eJxjYGhwYGBgsGdgaNi/LXa/ZZ2CkRW3GKNp8l4e06zdd00Y4KDBDqLOAaTWnkIxqmIARVMXGg==",
              "gz12eJxjZGBgEGAAgWlODESDBnsIHll8AJKaGMo=", 7);
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2175,13 +2175,9 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   p->mode = dt_bauhaus_combobox_get(w);
   if(p->mode == MODE_WAVELETS)
-  {
     gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "wavelets");
-  }
   else
-  {
     gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "nlm");
-  }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2210,13 +2206,9 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->mode, p->mode);
   dt_bauhaus_combobox_set(g->profile, -1);
   if(p->mode == MODE_WAVELETS)
-  {
     gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "wavelets");
-  }
   else
-  {
     gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "nlm");
-  }
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -19,9 +19,9 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
+#include "common/exif.h"
 #include "common/noiseprofiles.h"
 #include "common/opencl.h"
-#include "common/exif.h"
 #include "control/control.h"
 #include "develop/blend.h"
 #include "develop/imageop.h"
@@ -54,8 +54,7 @@ typedef enum dt_iop_denoiseprofile_mode_t
   MODE_WAVELETS = 1
 } dt_iop_denoiseprofile_mode_t;
 
-typedef enum dt_iop_denoiseprofile_channel_t
-{
+typedef enum dt_iop_denoiseprofile_channel_t {
   denoiseprofile_all = 0,
   denoiseprofile_R = 1,
   denoiseprofile_G = 2,
@@ -73,7 +72,8 @@ typedef struct dt_iop_denoiseprofile_params_t
   float strength;   // noise level after equalization
   float a[3], b[3]; // fit for poissonian-gaussian noise per color channel.
   dt_iop_denoiseprofile_mode_t mode; // switch between nlmeans and wavelets
-  float x[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS], y[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS]; // values to change wavelet force by frequency
+  float x[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS],
+      y[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS]; // values to change wavelet force by frequency
 } dt_iop_denoiseprofile_params_t;
 
 typedef struct dt_iop_denoiseprofile_gui_data_t
@@ -84,7 +84,7 @@ typedef struct dt_iop_denoiseprofile_gui_data_t
   GtkWidget *strength;
   dt_noiseprofile_t interpolated; // don't use name, maker or model, they may point to garbage
   GList *profiles;
-  //TODO add stack?
+  // TODO add stack?
   dt_draw_curve_t *transition_curve; // curve for gui to draw
   GtkDrawingArea *area;
   GtkNotebook *channel_tabs;
@@ -101,9 +101,9 @@ typedef struct dt_iop_denoiseprofile_gui_data_t
 
 typedef struct dt_iop_denoiseprofile_data_t
 {
-  float radius;     // search radius
-  float strength;   // noise level after equalization
-  float a[3], b[3]; // fit for poissonian-gaussian noise per color channel.
+  float radius;                      // search radius
+  float strength;                    // noise level after equalization
+  float a[3], b[3];                  // fit for poissonian-gaussian noise per color channel.
   dt_iop_denoiseprofile_mode_t mode; // switch between nlmeans and wavelets
   dt_draw_curve_t *curve[denoiseprofile_none];
   dt_iop_denoiseprofile_channel_t channel;
@@ -229,14 +229,12 @@ static void add_preset(dt_iop_module_so_t *self, const char *name, const char *p
 
 void init_presets(dt_iop_module_so_t *self)
 {
-  //TODO update these
+  // TODO update these
   // these blobs were exported as dtstyle and copied from there:
-  add_preset(self,
-             _("chroma (use on 1st instance)"),
+  add_preset(self, _("chroma (use on 1st instance)"),
              "gz04eJxjYGiwZ4Dg/dti91vWKRhZcYsxmibv5THN2n3XhJEBBhrsgARQnQNUPUViVMUApDYXmg==",
              "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
-  add_preset(self,
-             _("luma (use on 2nd instance)"),
+  add_preset(self, _("luma (use on 2nd instance)"),
              "gz04eJxjYGhwYGBgsGdgaNi/LXa/ZZ2CkRW3GKNp8l4e06zdd00Y4KDBDqLOAaTWnkIxqmIARVMXGg==",
              "gz12eJxjZGBgEGAAgWlODESDBnsIHll8AJKaGMo=", 7);
 }
@@ -946,7 +944,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     const float std_x[3] = { sqrtf(MAX(1e-6f, var_y[0] - sb2)), sqrtf(MAX(1e-6f, var_y[1] - sb2)),
                              sqrtf(MAX(1e-6f, var_y[2] - sb2)) };
     // add 8.0 here because it seemed a little weak
-    float adjt[3] = {8.0f, 8.0f, 8.0f};
+    float adjt[3] = { 8.0f, 8.0f, 8.0f };
 
     int offset_scale = DT_IOP_DENOISE_PROFILE_BANDS - max_scale;
     // current scale number is scale+offset_scale
@@ -955,10 +953,11 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     // zoom level, it does NOT corresponds to the the maximum number of scales.
     // in other words, max_scale is the maximum number of VISIBLE scales.
     // That is why we have this "scale+offset_scale"
-    float band_force_exp_2 = d->force[denoiseprofile_all][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
+    float band_force_exp_2
+        = d->force[denoiseprofile_all][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
-    for (int ch = 0; ch < 3; ch++)
+    for(int ch = 0; ch < 3; ch++)
     {
       adjt[ch] *= band_force_exp_2;
     }
@@ -2005,10 +2004,10 @@ void init(dt_iop_module_t *module)
   module->gui_data = NULL;
   module->data = NULL;
   dt_iop_denoiseprofile_params_t tmp;
-  memset(&tmp,0,sizeof(dt_iop_denoiseprofile_params_t));
+  memset(&tmp, 0, sizeof(dt_iop_denoiseprofile_params_t));
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
   {
-    for (int ch = 0; ch < denoiseprofile_none; ch++)
+    for(int ch = 0; ch < denoiseprofile_none; ch++)
     {
       tmp.x[ch][k] = k / (DT_IOP_DENOISE_PROFILE_BANDS - 1.0);
       tmp.y[ch][k] = 0.5f;
@@ -2098,7 +2097,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 
   d->radius = p->radius;
   d->strength = p->strength;
-  for (int i = 0; i < 3; i++)
+  for(int i = 0; i < 3; i++)
   {
     d->a[i] = p->a[i];
     d->b[i] = p->b[i];
@@ -2119,7 +2118,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
     }
   }
 
-  for (int ch = 0; ch < denoiseprofile_none; ch++)
+  for(int ch = 0; ch < denoiseprofile_none; ch++)
   {
     dt_draw_curve_set_point(d->curve[ch], 0, p->x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0, p->y[ch][0]);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
@@ -2136,7 +2135,7 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_denoiseprofile_params_t *default_params = (dt_iop_denoiseprofile_params_t *)self->default_params;
 
   piece->data = (void *)d;
-  for (int ch = 0; ch < denoiseprofile_none; ch++)
+  for(int ch = 0; ch < denoiseprofile_none; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
@@ -2204,7 +2203,7 @@ static void strength_callback(GtkWidget *w, dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-  //TODO use a stack
+  // TODO use a stack
   // let gui slider match current parameters:
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
@@ -2244,8 +2243,8 @@ void gui_update(dt_iop_module_t *self)
   }
 }
 
-static void dt_iop_denoiseprofile_get_params(dt_iop_denoiseprofile_params_t *p, const int ch, const double mouse_x, const double mouse_y,
-                                         const float rad)
+static void dt_iop_denoiseprofile_get_params(dt_iop_denoiseprofile_params_t *p, const int ch, const double mouse_x,
+                                             const double mouse_y, const float rad)
 {
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
   {
@@ -2261,8 +2260,7 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
   dt_iop_denoiseprofile_params_t p = *(dt_iop_denoiseprofile_params_t *)self->params;
 
   int ch = (int)c->channel;
-  dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0,
-                          p.y[ch][0]);
+  dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0, p.y[ch][0]);
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
     dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
   dt_draw_curve_set_point(c->transition_curve, DT_IOP_DENOISE_PROFILE_BANDS + 1, p.x[ch][1] + 1.0,
@@ -2300,23 +2298,23 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
   {
     // draw min/max curves:
     dt_iop_denoiseprofile_get_params(&p, c->channel, c->mouse_x, 1., c->mouse_radius);
-    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0,
-                            p.y[ch][0]);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0, p.y[ch][0]);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
       dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
     dt_draw_curve_set_point(c->transition_curve, DT_IOP_DENOISE_PROFILE_BANDS + 1, p.x[ch][1] + 1.0,
                             p.y[ch][DT_IOP_DENOISE_PROFILE_BANDS - 1]);
-    dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_DENOISE_PROFILE_RES, c->draw_min_xs, c->draw_min_ys);
+    dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_DENOISE_PROFILE_RES, c->draw_min_xs,
+                              c->draw_min_ys);
 
     p = *(dt_iop_denoiseprofile_params_t *)self->params;
     dt_iop_denoiseprofile_get_params(&p, c->channel, c->mouse_x, .0, c->mouse_radius);
-    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0,
-                            p.y[ch][0]);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0, p.y[ch][0]);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
       dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
     dt_draw_curve_set_point(c->transition_curve, DT_IOP_DENOISE_PROFILE_BANDS + 1, p.x[ch][1] + 1.0,
                             p.y[ch][DT_IOP_DENOISE_PROFILE_BANDS - 1]);
-    dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_DENOISE_PROFILE_RES, c->draw_max_xs, c->draw_max_ys);
+    dt_draw_curve_calc_values(c->transition_curve, 0.0, 1.0, DT_IOP_DENOISE_PROFILE_RES, c->draw_max_xs,
+                              c->draw_max_ys);
   }
 
   cairo_save(cr);
@@ -2327,14 +2325,14 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
 
-  for (int i = 0; i < denoiseprofile_none; i++)
+  for(int i = 0; i < denoiseprofile_none; i++)
   {
     // draw curves, selected last
     ch = ((int)c->channel + i + 1) % denoiseprofile_none;
     float alpha = 0.3;
-    if (i == denoiseprofile_none-1)
-      alpha = 1.0;
-    switch (ch) {
+    if(i == denoiseprofile_none - 1) alpha = 1.0;
+    switch(ch)
+    {
       case 0:
         cairo_set_source_rgba(cr, .7, .7, .7, alpha);
         break;
@@ -2350,8 +2348,7 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
     }
 
     p = *(dt_iop_denoiseprofile_params_t *)self->params;
-    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0,
-                            p.y[ch][0]);
+    dt_draw_curve_set_point(c->transition_curve, 0, p.x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0, p.y[ch][0]);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
       dt_draw_curve_set_point(c->transition_curve, k + 1, p.x[ch][k], p.y[ch][k]);
     dt_draw_curve_set_point(c->transition_curve, DT_IOP_DENOISE_PROFILE_BANDS + 1, p.x[ch][1] + 1.0,
@@ -2585,17 +2582,13 @@ void gui_init(dt_iop_module_t *self)
 
   g->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
 
-  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("all")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("R")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("G")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs),
-                           GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
+  gtk_notebook_append_page(GTK_NOTEBOOK(g->channel_tabs), GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0)),
                            gtk_label_new(_("B")));
 
   gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->channel_tabs, g->channel)));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -54,12 +54,13 @@ typedef enum dt_iop_denoiseprofile_mode_t
   MODE_WAVELETS = 1
 } dt_iop_denoiseprofile_mode_t;
 
-typedef enum dt_iop_denoiseprofile_channel_t {
-  denoiseprofile_all = 0,
-  denoiseprofile_R = 1,
-  denoiseprofile_G = 2,
-  denoiseprofile_B = 3,
-  denoiseprofile_none = 4
+typedef enum dt_iop_denoiseprofile_channel_t
+{
+  DT_DENOISE_PROFILE_ALL = 0,
+  DT_DENOISE_PROFILE_R = 1,
+  DT_DENOISE_PROFILE_G = 2,
+  DT_DENOISE_PROFILE_B = 3,
+  DT_DENOISE_PROFILE_NONE = 4
 } dt_iop_denoiseprofile_channel_t;
 
 // this is the version of the modules parameters,
@@ -72,8 +73,8 @@ typedef struct dt_iop_denoiseprofile_params_t
   float strength;   // noise level after equalization
   float a[3], b[3]; // fit for poissonian-gaussian noise per color channel.
   dt_iop_denoiseprofile_mode_t mode; // switch between nlmeans and wavelets
-  float x[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS],
-      y[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS]; // values to change wavelet force by frequency
+  float x[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS];
+  float y[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS]; // values to change wavelet force by frequency
 } dt_iop_denoiseprofile_params_t;
 
 typedef struct dt_iop_denoiseprofile_gui_data_t
@@ -107,9 +108,9 @@ typedef struct dt_iop_denoiseprofile_data_t
   float strength;                    // noise level after equalization
   float a[3], b[3];                  // fit for poissonian-gaussian noise per color channel.
   dt_iop_denoiseprofile_mode_t mode; // switch between nlmeans and wavelets
-  dt_draw_curve_t *curve[denoiseprofile_none];
+  dt_draw_curve_t *curve[DT_DENOISE_PROFILE_NONE];
   dt_iop_denoiseprofile_channel_t channel;
-  float force[denoiseprofile_none][DT_IOP_DENOISE_PROFILE_BANDS];
+  float force[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS];
 } dt_iop_denoiseprofile_data_t;
 
 typedef struct dt_iop_denoiseprofile_global_data_t
@@ -955,22 +956,22 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     // in other words, max_scale is the maximum number of VISIBLE scales.
     // That is why we have this "scale+offset_scale"
     float band_force_exp_2
-        = d->force[denoiseprofile_all][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
+        = d->force[DT_DENOISE_PROFILE_ALL][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     for(int ch = 0; ch < 3; ch++)
     {
       adjt[ch] *= band_force_exp_2;
     }
-    band_force_exp_2 = d->force[denoiseprofile_R][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
+    band_force_exp_2 = d->force[DT_DENOISE_PROFILE_R][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[0] *= band_force_exp_2;
-    band_force_exp_2 = d->force[denoiseprofile_G][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
+    band_force_exp_2 = d->force[DT_DENOISE_PROFILE_G][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[1] *= band_force_exp_2;
-    band_force_exp_2 = d->force[denoiseprofile_B][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
+    band_force_exp_2 = d->force[DT_DENOISE_PROFILE_B][DT_IOP_DENOISE_PROFILE_BANDS - (scale + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[2] *= band_force_exp_2;
@@ -1790,22 +1791,22 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     // zoom level, it does NOT corresponds to the the maximum number of scales.
     // in other words, max_scale is the maximum number of VISIBLE scales.
     // That is why we have this "s+offset_scale"
-    float band_force_exp_2 = d->force[denoiseprofile_all][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
+    float band_force_exp_2 = d->force[DT_DENOISE_PROFILE_ALL][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     for(int ch = 0; ch < 3; ch++)
     {
       adjt[ch] *= band_force_exp_2;
     }
-    band_force_exp_2 = d->force[denoiseprofile_R][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
+    band_force_exp_2 = d->force[DT_DENOISE_PROFILE_R][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[0] *= band_force_exp_2;
-    band_force_exp_2 = d->force[denoiseprofile_G][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
+    band_force_exp_2 = d->force[DT_DENOISE_PROFILE_G][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[1] *= band_force_exp_2;
-    band_force_exp_2 = d->force[denoiseprofile_B][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
+    band_force_exp_2 = d->force[DT_DENOISE_PROFILE_B][DT_IOP_DENOISE_PROFILE_BANDS - (s + offset_scale + 1)];
     band_force_exp_2 *= band_force_exp_2;
     band_force_exp_2 *= 4; // scale to [0,4]. 1 is the neutral curve point
     adjt[2] *= band_force_exp_2;
@@ -2008,7 +2009,7 @@ void init(dt_iop_module_t *module)
   memset(&tmp, 0, sizeof(dt_iop_denoiseprofile_params_t));
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
   {
-    for(int ch = 0; ch < denoiseprofile_none; ch++)
+    for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++)
     {
       tmp.x[ch][k] = k / (DT_IOP_DENOISE_PROFILE_BANDS - 1.0);
       tmp.y[ch][k] = 0.5f;
@@ -2119,7 +2120,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
     }
   }
 
-  for(int ch = 0; ch < denoiseprofile_none; ch++)
+  for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++)
   {
     dt_draw_curve_set_point(d->curve[ch], 0, p->x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0, p->y[ch][0]);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
@@ -2136,7 +2137,7 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_denoiseprofile_params_t *default_params = (dt_iop_denoiseprofile_params_t *)self->default_params;
 
   piece->data = (void *)d;
-  for(int ch = 0; ch < denoiseprofile_none; ch++)
+  for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++)
   {
     d->curve[ch] = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
     for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
@@ -2148,7 +2149,7 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
 void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)(piece->data);
-  for(int ch = 0; ch < denoiseprofile_none; ch++) dt_draw_curve_destroy(d->curve[ch]);
+  for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++) dt_draw_curve_destroy(d->curve[ch]);
   free(piece->data);
   piece->data = NULL;
 }
@@ -2309,12 +2310,12 @@ static gboolean denoiseprofile_draw(GtkWidget *widget, cairo_t *crf, gpointer us
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));
 
-  for(int i = 0; i < denoiseprofile_none; i++)
+  for(int i = 0; i < DT_DENOISE_PROFILE_NONE; i++)
   {
     // draw curves, selected last
-    ch = ((int)c->channel + i + 1) % denoiseprofile_none;
+    ch = ((int)c->channel + i + 1) % DT_DENOISE_PROFILE_NONE;
     float alpha = 0.3;
-    if(i == denoiseprofile_none - 1) alpha = 1.0;
+    if(i == DT_DENOISE_PROFILE_NONE - 1) alpha = 1.0;
     switch(ch)
     {
       case 0:

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2482,7 +2482,7 @@ static gboolean denoiseprofile_button_press(GtkWidget *widget, GdkEventButton *e
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-  int ch = c->channel;
+  const int ch = c->channel;
   if(event->button == 1 && event->type == GDK_2BUTTON_PRESS)
   {
     // reset current curve
@@ -2595,7 +2595,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(denoiseprofile_tab_switch), self);
 
   g->channel = dt_conf_get_int("plugins/darkroom/denoiseprofile/gui_channel");
-  int ch = (int)g->channel;
+  const int ch = (int)g->channel;
   g->transition_curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
   (void)dt_draw_curve_add_point(g->transition_curve, p->x[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2] - 1.0,
                                 p->y[ch][DT_IOP_DENOISE_PROFILE_BANDS - 2]);


### PR DESCRIPTION
This pull request adds a GUI for the wavelets of denoise profile that is similar to equalizer.
The GUI is the same as in https://github.com/darktable-org/darktable/pull/1752

This does not change the underlying algorithm, but allows the user to finely control the denoising:
  - the user can change the force band by band. For instance, this is useful if user wants to preserve fine-grain noise
  - the user can change the force band by band for each channel. As in raw files there are less "red" and "blue" pixels than "green" pixels before demosaic, noise in red and blue channel has usually a coarser grain than in the green channel after demosaic, as the errors are "spread" by demosaic. The changes proposed here allow to take this into account in the denoising, but increasing the force for red and blue without changing the green channel.

I choosed to use a gtk stack for the GUI to solve the issue we had before:
When duplicating an instance that is in wavelet mode, the "patch size" slider was appearing.
![bug_denoise_profile](https://user-images.githubusercontent.com/34063828/47013541-da4a8480-d147-11e8-8b50-602cc400949d.jpg)
With a stack, this is fixed.

How to get better denoising with this change?
There are plenty of ways:
- You can use the "all" curve to preserve the fine details more in case of coarse grain noise, but lowering the curve on the right.
- You can use the gray channel of channel mixer module to see only R, G or B channel, and then tune the denoising channel per channel. Then disable the channel mixer to see the result, and add another instance in color blend mode if needed.
- Sometimes in color blend mode, some small green pixels are not corrected, which forces to push the force slider a lot. With this change, the fix is easy: take the green curve and push it toward the top on finest scale:
Before (please look at 100% zoom level, as we are talking about pixel-level changes here):
![capture du 2018-10-16 13-39-48](https://user-images.githubusercontent.com/34063828/47014091-7fb22800-d149-11e8-9992-680b2aa6a7ba.png)
After:
![capture du 2018-10-16 13-40-03](https://user-images.githubusercontent.com/34063828/47014092-817beb80-d149-11e8-9c65-46a49ca181ae.png)

Finally, in order to control easily the force with the curve, you should set the force slider around 0.3, which gives much more flexibility than 1.