### PR TITLE
fix set clone masks source position

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1280,7 +1280,9 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
   else
     masks_density = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/density"), 1.0f);
 
-  if(gui->creation && which == 1 && (state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
+  if(gui->creation && which == 1
+     && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+         || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -246,7 +246,9 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     dt_control_queue_redraw_center();
     return 1;
   }
-  else if(gui->creation && (state & (GDK_CONTROL_MASK|GDK_SHIFT_MASK)))
+  else if(gui->creation && which == 1
+          && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+              || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -638,7 +638,9 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     dt_control_queue_redraw_center();
     return 1;
   }
-  else if(gui->creation && (state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
+  else if(gui->creation && which == 1
+          && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+              || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2530,9 +2530,9 @@ void dt_masks_draw_clone_source_pos(cairo_t *cr, const float zoom_scale, const f
 void dt_masks_set_source_pos_initial_state(dt_masks_form_gui_t *gui, const uint32_t state, const float pzx,
                                            const float pzy)
 {
-  if(state & GDK_CONTROL_MASK)
+  if((state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == (GDK_SHIFT_MASK | GDK_CONTROL_MASK))
     gui->source_pos_type = DT_MASKS_SOURCE_POS_ABSOLUTE;
-  else if(state & GDK_SHIFT_MASK)
+  else if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
   else
     fprintf(stderr, "unknown state for setting masks position type\n");

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1020,7 +1020,9 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
   else
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/path/border"), 0.5f);
 
-  if(gui->creation && which == 1 && (state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)))
+  if(gui->creation && which == 1 && g_list_length(form->points) == 0
+     && (((state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) == (GDK_CONTROL_MASK | GDK_SHIFT_MASK))
+         || ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)))
   {
     // set some absolute or relative position for the source of the clone mask
     if(form->type & DT_MASKS_CLONE) dt_masks_set_source_pos_initial_state(gui, state, pzx, pzy);


### PR DESCRIPTION
As @TurboGit  reported, the cntrl-click gets in the way when creating a path, that uses it to create sharp edges.
Now to set an absolute position on a clone mask source shift+cntrl-click is used.
