### PR TITLE
Color balance : optimizations and corrections

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -588,27 +588,54 @@ colorbalance (read_only image2d_t in, write_only image2d_t out, const int width,
   if(x >= width || y >= height) return;
 
   const float4 Lab = read_imagef(in, sampleri, (int2)(x, y));
-  const float4 XYZ = Lab_to_XYZ(Lab);
-  float4 sRGB = XYZ_to_sRGB(XYZ);
-  const float4 luma = XYZ.y;
-  const float4 saturation4 = saturation;
-  const float4 contrast4 = contrast;
-  const float4 grey4 = grey;
-
- // saturation
-  sRGB = luma + saturation4 * (sRGB - luma);
+  float4 sRGB = XYZ_to_sRGB(Lab_to_XYZ(Lab));
 
   // Lift gamma gain
   sRGB = (sRGB <= (float4)0.0031308f) ? 12.92f * sRGB : (1.0f + 0.055f) * pow(sRGB, (float4)1.0f/2.4f) - (float4)0.055f;
   sRGB = pow(fmax(((sRGB - (float4)1.0f) * lift + (float4)1.0f) * gain, (float4)0.0f), gamma_inv);
   sRGB = (sRGB <= (float4)0.04045f) ? sRGB / 12.92f : pow((sRGB + (float4)0.055f) / (1.0f + 0.055f), (float4)2.4f);
-  
-  // fulcrum contrast
-  sRGB = pow(fmax(sRGB, (float4)0.0f) / grey4, contrast4) * grey4;
-
   sRGB = XYZ_to_Lab(sRGB_to_XYZ(sRGB));
 
   write_imagef (out, (int2)(x, y), sRGB);
+}
+
+kernel void
+colorbalance_lgg (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+              const float4 lift, const float4 gain, const float4 gamma_inv, const float saturation, const float contrast, const float grey)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  const float4 Lab = read_imagef(in, sampleri, (int2)(x, y));
+  const float4 XYZ = Lab_to_XYZ(Lab);
+  float4 RGB = XYZ_to_prophotorgb(XYZ);
+
+  // saturation
+  if (saturation != 1.0f) 
+  {
+    const float4 luma = XYZ.y;
+    const float4 saturation4 = saturation;
+    RGB = luma + saturation4 * (RGB - luma);
+  }
+
+  // Lift gamma gain
+  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB, (float4)1.0f/2.2f);
+  RGB = ((RGB - (float4)1.0f) * lift + (float4)1.0f) * gain;
+  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB, gamma_inv * (float4)2.2f);
+  
+  // fulcrum contrast
+  if (contrast != 1.0f) 
+  {
+    const float4 contrast4 = contrast;
+    const float4 grey4 = grey;
+    RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB / grey4, contrast4) * grey4;
+  }
+
+  RGB = prophotorgb_to_Lab(RGB);
+
+  write_imagef (out, (int2)(x, y), RGB);
 }
 
 kernel void
@@ -623,19 +650,26 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
   const float4 Lab = read_imagef(in, sampleri, (int2)(x, y));
   const float4 XYZ = Lab_to_XYZ(Lab);
   float4 RGB = XYZ_to_prophotorgb(XYZ);
-  const float4 luma = XYZ.y;
-  const float4 saturation4 = saturation;
-  const float4 contrast4 = contrast;
-  const float4 grey4 = grey;
-  
+
   // saturation
-  RGB = luma + saturation4 * (RGB - luma);
+  if (saturation != 1.0f) 
+  {
+    const float4 luma = XYZ.y;
+    const float4 saturation4 = saturation;
+    RGB = luma + saturation4 * (RGB - luma);
+  }
  
   // lift power slope
-  RGB = pow(fmax((RGB * gain + lift), (float4)0.0f), gamma_inv);
+  RGB = RGB * gain + lift;
+  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB, gamma_inv);
   
   // fulcrum contrast
-  RGB = pow(fmax(RGB, (float4)0.0f) / grey4, contrast4) * grey4;
+  if (contrast != 1.0f) 
+  {
+    const float4 contrast4 = contrast;
+    const float4 grey4 = grey;
+    RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB / grey4, contrast4) * grey4;
+  }
 
   RGB = prophotorgb_to_Lab(RGB);
 


### PR DESCRIPTION
Sorry for noise, but I found an error on the lift/gamma/gain.

In C/SSE2, the sequence for lift/gamma/gain was:
---

1. **convert to sRGB and correct sRGB gamma** (from the lib `common/colorspaces_inline_conversions.h`)
1. adjust saturation
1. do lift/gamma/gain
1. adjust contrast
1. **revert sRGB gamma & convert to Lab** (from the lib `common/colorspaces_inline_conversions.h`)

In OpenCL, the sequence for lift/gamma/gain was:
---

1. **convert to sRGB** (from the lib `kernels/colorspaces.cl`)
1. adjust saturation
1. **correct sRGB gamma**
1. do lift/gamma/gain
1. **revert sRGB gamma***
1. adjust contrast
1. convert to Lab (from the lib `kernels/colorspaces.cl`)

So, no solution for this except tweaking the lib and breaking compatibility.

Solution
---

The sRGB lift/gamma/gain is bumped as a third mode called "legacy", with no saturation and contrast adjustements. It's exactly the same mode as in 2.4, with some performance optimizations (see previous PR).

The new lift/gamma/gain mode uses ProphotoRGB space, with the same RGB gamma correction as before (RGB gamma = 2.4), but this correction is directly in the IOP (not in the lib), allowing to merge the gamma correction from the user input and the one from the RGB space (`(x^a)^b) = x^(a * b)`) and divide the running time by 2.

The new sequence in C/SSE2/OpenCL is:

1. **convert to ProphotoRGB** (from the lib `kernels/colorspaces.cl`)
1. adjust saturation
1. **correct RGB gamma**
1. do lift/gamma/gain & **revert RGB gamma**
1. adjust contrast
1. convert to Lab (from the lib `kernels/colorspaces.cl`)

Other optimizations
---

When the contrast and saturation settings are neutral ( == 0.0 in the UI, == 1.0 in the IOP params), the contrast and saturation computations are skipped to avoid computing `x^1` or `(x-a)*1+a`. It speed-up the computations by 1.25× to 1.33×.

Previously, to avoid taking the root of a negative number, the sequence was:
```
if (x < 0) x = 0;
x = powf(x, gamma);
```

But `0^gamma = 0`, so it's costly and useless. Now, before every power function, we do instead:
```
x = (x <= 0) ? 0 : powf(x, gamma);
```

With all these optimizations, the colorbalance module runs now in OpenCL between 1× to 5× as fast as the exposure module. Before, it was up to 10× as fast.