### PR TITLE
Two Windows specific build fixes

### DIFF
--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -721,7 +721,7 @@ Section "-Core installation"
    ; set variable for local machine
    WriteRegExpandStr ${env_hklm} CAMLIBS "$INSTDIR\lib\libgphoto2\@CPACK_NSIS_GPHOTO2_VERSION@"
    WriteRegExpandStr ${env_hklm} IOLIBS $INSTDIR\lib\libgphoto2_port\0.12.0
-   WriteRegExpandStr ${env_hklm} MAGICK_HOME $INSTDIR\lib\GraphicsMagick-1.3.29\modules-Q8\coders
+   WriteRegExpandStr ${env_hklm} MAGICK_HOME $INSTDIR\lib\GraphicsMagick-@CPACK_NSIS_GRAPHICSMAGICK_VERSION@\modules-Q8\coders
 
   !insertmacro MUI_STARTMENU_WRITE_END
 

--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -160,8 +160,8 @@ if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
 
   # Add GraphicsMagick libraries
   install(DIRECTORY
-      "${MINGW_PATH}/../lib/GraphicsMagick-1.3.29/modules-Q8/coders"
-      DESTINATION lib/GraphicsMagick-1.3.29/modules-Q8/
+      "${MINGW_PATH}/../lib/GraphicsMagick-${GraphicsMagick_PKGCONF_VERSION}/modules-Q8/coders"
+      DESTINATION lib/GraphicsMagick-${GraphicsMagick_PKGCONF_VERSION}/modules-Q8/
       COMPONENT DTApplication
       FILES_MATCHING PATTERN "*"
       PATTERN "*.a" EXCLUDE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -430,7 +430,8 @@ if(GPHOTO2_FOUND)
   # CPack ignores variables you define in your CMakeLists.txt file,
   # and only variables ${CPACK_*} are correctly used.
   # so this needs to be saved by adding another variable with a name beginning with CPACK
-  set( CPACK_NSIS_GPHOTO2_VERSION ${GPHOTO2_VERSION_STRING} CACHE STRING "GPHOT2 version string")
+  set( CPACK_NSIS_GPHOTO2_VERSION ${GPHOTO2_VERSION_STRING} CACHE STRING "GPHOTO2 version string")
+  set( CPACK_NSIS_GRAPHICSMAGICK_VERSION ${GraphicsMagick_PKGCONF_VERSION} CACHE STRING "GM version string")
 endif(GPHOTO2_FOUND)
 
 # Check for __builtin_cpu_supports here due to a bug in clang/llvm. LLVM uses

--- a/tools/create_metadata.sh
+++ b/tools/create_metadata.sh
@@ -40,7 +40,7 @@ grep -v "^#" "$inputfile" | while IFS= read -r line; do
     first=1
 
     cat >> "$outputdir/$outputbody" << EOF
-    if(strncmp(key, "$line", $length) == 0)
+    if(strncmp(key, "$(echo $line |tr -d '\r')", $length) == 0)
         return $enum;
 EOF
 


### PR DESCRIPTION
* create_metadata.sh: remove CR from $line in the generated metadata file - I think it should not influence the *nix shell script, but pls check
* Replace hard-coded Graphicsmagick versions with variables 