### PR TITLE
Bugfix: messed-up masks in OpenCL with colorbalance and profilegamma

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -2189,7 +2189,7 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
 
   if(x >= width || y >= height) return;
 
-  float4 i = read_imagef(in, sampleri, (int2)(x, y));
+  const float4 i = read_imagef(in, sampleri, (int2)(x, y));
   const float4 noise = pow((float4)2.0f, (float4)-16.0f);
   const float4 dynamic4 = dynamic_range;
   const float4 shadows4 = shadows_range;
@@ -2200,8 +2200,9 @@ profilegamma_log (read_only image2d_t in, write_only image2d_t out, int width, i
   o = (i < noise) ? noise : i / grey4;
   o = (log2(o) - shadows4) / dynamic4;
   o = (o < noise) ? noise : o;
+  i.xyz = o.xyz;
 
-  write_imagef(out, (int2)(x, y), o);
+  write_imagef(out, (int2)(x, y), i);
 }
 
 /* kernel for the interpolation resample helper */

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -594,9 +594,9 @@ colorbalance (read_only image2d_t in, write_only image2d_t out, const int width,
   sRGB = (sRGB <= (float4)0.0031308f) ? 12.92f * sRGB : (1.0f + 0.055f) * pow(sRGB, (float4)1.0f/2.4f) - (float4)0.055f;
   sRGB = pow(fmax(((sRGB - (float4)1.0f) * lift + (float4)1.0f) * gain, (float4)0.0f), gamma_inv);
   sRGB = (sRGB <= (float4)0.04045f) ? sRGB / 12.92f : pow((sRGB + (float4)0.055f) / (1.0f + 0.055f), (float4)2.4f);
-  sRGB = XYZ_to_Lab(sRGB_to_XYZ(sRGB));
+  Lab.xyz = XYZ_to_Lab(sRGB_to_XYZ(sRGB)).xyz;
 
-  write_imagef (out, (int2)(x, y), sRGB);
+  write_imagef (out, (int2)(x, y), Lab);
 }
 
 kernel void
@@ -633,9 +633,9 @@ colorbalance_lgg (read_only image2d_t in, write_only image2d_t out, const int wi
     RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB / grey4, contrast4) * grey4;
   }
 
-  RGB = prophotorgb_to_Lab(RGB);
+  Lab.xyz = prophotorgb_to_Lab(RGB).xyz;
 
-  write_imagef (out, (int2)(x, y), RGB);
+  write_imagef (out, (int2)(x, y), Lab);
 }
 
 kernel void
@@ -671,9 +671,9 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
     RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : pow(RGB / grey4, contrast4) * grey4;
   }
 
-  RGB = prophotorgb_to_Lab(RGB);
+  Lab.xyz = prophotorgb_to_Lab(RGB).xyz;
 
-  write_imagef (out, (int2)(x, y), RGB);
+  write_imagef (out, (int2)(x, y), Lab);
 }
 
 /* helpers and kernel for the colorchecker module */


### PR DESCRIPTION
Leaves the 4th channel of the picture untouched in OpenCL colorbalance and profilegamma modules. 

This avoids messing up the masks. I wasn't aware that the 4th channel was the alpha mask.

Solves the bug described in comments of #1767 by @edgardoh and the one I described in #1756.