### PR TITLE
Update context sensitive help

### DIFF
--- a/doc/usermanual/darkroom/modules/color/colorbalance.xml
+++ b/doc/usermanual/darkroom/modules/color/colorbalance.xml
@@ -3,7 +3,7 @@
 		<!ENTITY % darktable_dtd SYSTEM "../../../dtd/darktable.dtd">
 		%darktable_dtd;
 		]>
-<sect3 status="final">
+<sect3 status="final" id="color_balance">
 
   <title>Color balance</title>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ FILE(GLOB SOURCE_FILES
   "common/resource_limits.c"
   "common/histogram.c"
   "common/undo.c"
+  "common/usermanual_url.c"
   "control/control.c"
   "control/crawler.c"
   "control/jobs.c"

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -85,6 +85,8 @@ typedef unsigned int u_int;
 #include "common/poison.h"
 #endif
 
+#include "common/usermanual_url.h"
+
 #define DT_MODULE_VERSION 18 // version of dt's module interface
 
 // version of current performance configuration version

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -89,7 +89,7 @@ char *dt_get_help_url(char *name)
   if(!strcmp(name, "colortransfer")) return NULL;
   if(!strcmp(name, "colorize")) return "effect_group.html#colorize";
   if(!strcmp(name, "clipping")) return "modules.html#crop_and_rotate";
-  if(!strcmp(name, "colorbalance")) return "color_group.html#d0e8958";
+  if(!strcmp(name, "colorbalance")) return "color_group.html#color_balance";
   if(!strcmp(name, "vibrance")) return "color_group.html#vibrance";
   if(!strcmp(name, "equalizer")) return "correction_group.html#equalizer";
   if(!strcmp(name, "defringe")) return "correction_group.html#defringe";

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -1,0 +1,225 @@
+/*
+    This file is part of darktable,
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/usermanual_url.h"
+
+char* dt_get_help_url(char* name)
+{
+  if(!strcmp(name,"ratings"))
+    return "star_ratings_and_color_labels.html";
+  if(!strcmp(name,"filter"))
+    return "filtering_and_sort_order.html";
+  if(!strcmp(name,"colorlabels"))
+    return "star_ratings_and_color_labels.html";
+  if(!strcmp(name,"import"))
+    return "lighttable_panels.html#import";
+  if(!strcmp(name,"select"))
+    return "select.html";
+  if(!strcmp(name,"image"))
+    return "selected_images.html";
+  if(!strcmp(name,"copy_history"))
+    return "history_stack.html";
+  if(!strcmp(name,"styles"))
+    return "styles.html";
+  if(!strcmp(name,"metadata"))
+    return "metadata_editor.html";
+  if(!strcmp(name,"tagging"))
+    return "tagging.html";
+  if(!strcmp(name,"geotagging"))
+    return "geotagging.html";
+  if(!strcmp(name,"collect"))
+    return "collect_images.html";
+  if(!strcmp(name,"recentcollect"))
+    return "recently_used_collections.html";
+  if(!strcmp(name,"metadata_view"))
+    return "image_information.html";
+  if(!strcmp(name,"export"))
+    return "export_selected.html";
+  if(!strcmp(name,"histogram"))
+    return "histogram.html";
+  if(!strcmp(name,"navigation"))
+    return "darkroom_panels.html#navigation";
+  if(!strcmp(name,"snapshots"))
+    return "snapshots.html";
+  if(!strcmp(name,"modulegroups"))
+    return "module_groups.html";
+  if(!strcmp(name,"history"))
+    return "history.html";
+  if(!strcmp(name,"colorpicker"))
+    return "global_color_picker.html";
+  if(!strcmp(name,"masks"))
+    return "mask_manager.html";
+  if(!strcmp(name,"modulelist"))
+    return "more_modules.html";
+  if(!strcmp(name,"location"))
+    return "find_location.html";
+  if(!strcmp(name,"map_settings"))
+    return "map_settings.html";
+  if(!strcmp(name,"print_settings"))
+    return "print_settings.html";
+  if(!strcmp(name,"global_toolbox"))
+    return NULL;
+  if(!strcmp(name,"lighttable_mode"))
+    return NULL;
+  if(!strcmp(name,"module_toolbox"))
+    return NULL;
+  if(!strcmp(name,"view_toolbox"))
+    return NULL;
+  if(!strcmp(name,"backgroundjobs"))
+    return NULL;
+  if(!strcmp(name,"hinter"))
+    return NULL;
+  if(!strcmp(name,"filter"))
+    return NULL;
+  if(!strcmp(name,"filmstrip"))
+    return NULL;
+  if(!strcmp(name,"viewswitcher"))
+    return NULL;
+
+  if(!strcmp(name,"dither"))
+    return "correction_group.html#dithering";
+  if(!strcmp(name,"watermark"))
+    return "effect_group.html#watermark";
+  if(!strcmp(name,"borders"))
+    return "effect_group.html#framing";
+  if(!strcmp(name,"clahe"))
+    return "tone_group.html#local_contrast";
+  if(!strcmp(name,"velvia"))
+    return "color_group.html#velvia";
+  if(!strcmp(name,"splittoning"))
+    return "effect_group.html#splittoning";
+  if(!strcmp(name,"vignette"))
+    return "effect_group.html#vignetting";
+  if(!strcmp(name,"soften"))
+    return "effect_group.html#soften";
+  if(!strcmp(name,"channelmixer"))
+    return "color_group.html#channel_mixer";
+  if(!strcmp(name,"colorout"))
+    return "color_group.html#output_color_profile";
+  if(!strcmp(name,"colorcontrast"))
+    return "color_group.html#color_contrast";
+  if(!strcmp(name,"grain"))
+    return "effect_group.html#grain";
+  if(!strcmp(name,"highpass"))
+    return "effect_group.html#highpass";
+  if(!strcmp(name,"lowpass"))
+    return "effect_group.html#lowpass";
+  if(!strcmp(name,"sharpen"))
+    return "correction_group.html#sharpen";
+  if(!strcmp(name,"colorcorrection"))
+    return "color_group.html#color_correction";
+  if(!strcmp(name,"relight"))
+    return "tone_group.html#fill_light";
+  if(!strcmp(name,"levels"))
+    return "tone_group.html#levels";
+  if(!strcmp(name,"tonecurve"))
+    return "tone_group.html#tone_curve";
+  if(!strcmp(name,"zonesystem"))
+    return "tone_group.html#zone_system";
+  if(!strcmp(name,"colisa"))
+    return "modules.html#contrast_brightness_saturation";
+  if(!strcmp(name,"monochrome"))
+    return "color_group.html#monochrome";
+  if(!strcmp(name,"lowlight"))
+    return "effect_group.html#low_light";
+  if(!strcmp(name,"colorzones"))
+    return "color_group.html#color_zones";
+  if(!strcmp(name,"bilat"))
+    return "tone_group.html#local_contrast";
+  if(!strcmp(name,"atrous"))
+    return "correction_group.html#equalizer";
+  if(!strcmp(name,"shadhi"))
+    return "modules.html#shadows_and_highlights";
+  if(!strcmp(name,"globaltonemap"))
+    return "tone_group.html#global_tonemap";
+  if(!strcmp(name,"nlmeans"))
+    return "correction_group.html#denoise_non_local_means";
+  if(!strcmp(name,"bloom"))
+    return "effect_group.html#bloom";
+  if(!strcmp(name,"colormapping"))
+    return "effect_group.html#color_mapping";
+  if(!strcmp(name,"colortransfer"))
+    return NULL;//TODO
+  if(!strcmp(name,"colorize"))
+    return "effect_group.html#colorize";
+  if(!strcmp(name,"clipping"))
+    return "modules.html#crop_and_rotate";
+  if(!strcmp(name,"colorbalance"))
+    return "color_group.html#d0e8958";
+  if(!strcmp(name,"vibrance"))
+    return "color_group.html#vibrance";
+  if(!strcmp(name,"equalizer"))
+    return "correction_group.html#equalizer";
+  if(!strcmp(name,"defringe"))
+    return "correction_group.html#defringe";
+  if(!strcmp(name,"colorchecker"))
+    return "color_group.html#color_look_up_table";
+  if(!strcmp(name,"colorreconstruct"))
+    return "modules.html#color_reconstruction";
+  if(!strcmp(name,"colorin"))
+    return "color_group.html#input_color_profile";
+  if(!strcmp(name,"hazeremoval"))
+    return "correction_group.html#haze_removal";
+  if(!strcmp(name,"profile_gamma"))
+    return "color_group.html#unbreak_input_profile";
+  if(!strcmp(name,"bilateral"))
+    return "correction_group.html#denoise_bilateral";
+  if(!strcmp(name,"basecurve"))
+    return "modules.html#base_curve";
+  if(!strcmp(name,"graduatednd"))
+    return "effect_group.html#graduated_density";
+  if(!strcmp(name,"flip"))
+    return "modules.html#orientation";
+  if(!strcmp(name,"scalepixels"))
+    return "correction_group.html#scale_pixels";
+  if(!strcmp(name,"rotatepixels"))
+    return "correction_group.html#rotate_pixels";
+  if(!strcmp(name,"liquify"))
+    return "correction_group.html#liquify";
+  if(!strcmp(name,"ashift"))
+    return "correction_group.html#perspective_correction";
+  if(!strcmp(name,"lens"))
+    return "correction_group.html#lens_correction";
+  if(!strcmp(name,"retouch"))
+    return NULL;//TODO
+  if(!strcmp(name,"spots"))
+    return "correction_group.html#spot_removal";
+  if(!strcmp(name,"exposure"))
+    return "modules.html#exposure";
+  if(!strcmp(name,"tonemap"))
+    return "tone_group.html#tonemapping";
+  if(!strcmp(name,"denoiseprofile"))
+    return "correction_group.html#denoise_profiled";
+  if(!strcmp(name,"demosaic"))
+    return "modules.html#demosaic";
+  if(!strcmp(name,"rawdenoise"))
+    return "correction_group.html#raw_denoise";
+  if(!strcmp(name,"hotpixels"))
+    return "correction_group.html#hotpixels";
+  if(!strcmp(name,"cacorrect"))
+    return "correction_group.html#chromatic_aberrations";
+  if(!strcmp(name,"highlights"))
+    return "modules.html#highlight_reconstruction";
+  if(!strcmp(name,"temperature"))
+    return "modules.html#whitebalance";
+  if(!strcmp(name,"invert"))
+    return "modules.html#invert";
+  if(!strcmp(name,"rawprepare"))
+    return "modules.html#raw_black_white_point";
+
+  return NULL;
+}

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -153,7 +153,7 @@ char* dt_get_help_url(char* name)
   if(!strcmp(name,"colormapping"))
     return "effect_group.html#color_mapping";
   if(!strcmp(name,"colortransfer"))
-    return NULL;//TODO
+    return NULL;
   if(!strcmp(name,"colorize"))
     return "effect_group.html#colorize";
   if(!strcmp(name,"clipping"))

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -17,209 +17,109 @@
 
 #include "common/usermanual_url.h"
 
-char* dt_get_help_url(char* name)
+char *dt_get_help_url(char *name)
 {
-  if(!strcmp(name,"ratings"))
-    return "star_ratings_and_color_labels.html";
-  if(!strcmp(name,"filter"))
-    return "filtering_and_sort_order.html";
-  if(!strcmp(name,"colorlabels"))
-    return "star_ratings_and_color_labels.html";
-  if(!strcmp(name,"import"))
-    return "lighttable_panels.html#import";
-  if(!strcmp(name,"select"))
-    return "select.html";
-  if(!strcmp(name,"image"))
-    return "selected_images.html";
-  if(!strcmp(name,"copy_history"))
-    return "history_stack.html";
-  if(!strcmp(name,"styles"))
-    return "styles.html";
-  if(!strcmp(name,"metadata"))
-    return "metadata_editor.html";
-  if(!strcmp(name,"tagging"))
-    return "tagging.html";
-  if(!strcmp(name,"geotagging"))
-    return "geotagging.html";
-  if(!strcmp(name,"collect"))
-    return "collect_images.html";
-  if(!strcmp(name,"recentcollect"))
-    return "recently_used_collections.html";
-  if(!strcmp(name,"metadata_view"))
-    return "image_information.html";
-  if(!strcmp(name,"export"))
-    return "export_selected.html";
-  if(!strcmp(name,"histogram"))
-    return "histogram.html";
-  if(!strcmp(name,"navigation"))
-    return "darkroom_panels.html#navigation";
-  if(!strcmp(name,"snapshots"))
-    return "snapshots.html";
-  if(!strcmp(name,"modulegroups"))
-    return "module_groups.html";
-  if(!strcmp(name,"history"))
-    return "history.html";
-  if(!strcmp(name,"colorpicker"))
-    return "global_color_picker.html";
-  if(!strcmp(name,"masks"))
-    return "mask_manager.html";
-  if(!strcmp(name,"modulelist"))
-    return "more_modules.html";
-  if(!strcmp(name,"location"))
-    return "find_location.html";
-  if(!strcmp(name,"map_settings"))
-    return "map_settings.html";
-  if(!strcmp(name,"print_settings"))
-    return "print_settings.html";
-  if(!strcmp(name,"global_toolbox"))
-    return NULL;
-  if(!strcmp(name,"lighttable_mode"))
-    return NULL;
-  if(!strcmp(name,"module_toolbox"))
-    return NULL;
-  if(!strcmp(name,"view_toolbox"))
-    return NULL;
-  if(!strcmp(name,"backgroundjobs"))
-    return NULL;
-  if(!strcmp(name,"hinter"))
-    return NULL;
-  if(!strcmp(name,"filter"))
-    return NULL;
-  if(!strcmp(name,"filmstrip"))
-    return NULL;
-  if(!strcmp(name,"viewswitcher"))
-    return NULL;
+  if(!strcmp(name, "ratings")) return "star_ratings_and_color_labels.html";
+  if(!strcmp(name, "filter")) return "filtering_and_sort_order.html";
+  if(!strcmp(name, "colorlabels")) return "star_ratings_and_color_labels.html";
+  if(!strcmp(name, "import")) return "lighttable_panels.html#import";
+  if(!strcmp(name, "select")) return "select.html";
+  if(!strcmp(name, "image")) return "selected_images.html";
+  if(!strcmp(name, "copy_history")) return "history_stack.html";
+  if(!strcmp(name, "styles")) return "styles.html";
+  if(!strcmp(name, "metadata")) return "metadata_editor.html";
+  if(!strcmp(name, "tagging")) return "tagging.html";
+  if(!strcmp(name, "geotagging")) return "geotagging.html";
+  if(!strcmp(name, "collect")) return "collect_images.html";
+  if(!strcmp(name, "recentcollect")) return "recently_used_collections.html";
+  if(!strcmp(name, "metadata_view")) return "image_information.html";
+  if(!strcmp(name, "export")) return "export_selected.html";
+  if(!strcmp(name, "histogram")) return "histogram.html";
+  if(!strcmp(name, "navigation")) return "darkroom_panels.html#navigation";
+  if(!strcmp(name, "snapshots")) return "snapshots.html";
+  if(!strcmp(name, "modulegroups")) return "module_groups.html";
+  if(!strcmp(name, "history")) return "history.html";
+  if(!strcmp(name, "colorpicker")) return "global_color_picker.html";
+  if(!strcmp(name, "masks")) return "mask_manager.html";
+  if(!strcmp(name, "modulelist")) return "more_modules.html";
+  if(!strcmp(name, "location")) return "find_location.html";
+  if(!strcmp(name, "map_settings")) return "map_settings.html";
+  if(!strcmp(name, "print_settings")) return "print_settings.html";
+  if(!strcmp(name, "global_toolbox")) return NULL;
+  if(!strcmp(name, "lighttable_mode")) return NULL;
+  if(!strcmp(name, "module_toolbox")) return NULL;
+  if(!strcmp(name, "view_toolbox")) return NULL;
+  if(!strcmp(name, "backgroundjobs")) return NULL;
+  if(!strcmp(name, "hinter")) return NULL;
+  if(!strcmp(name, "filter")) return NULL;
+  if(!strcmp(name, "filmstrip")) return NULL;
+  if(!strcmp(name, "viewswitcher")) return NULL;
 
-  if(!strcmp(name,"dither"))
-    return "correction_group.html#dithering";
-  if(!strcmp(name,"watermark"))
-    return "effect_group.html#watermark";
-  if(!strcmp(name,"borders"))
-    return "effect_group.html#framing";
-  if(!strcmp(name,"clahe"))
-    return "tone_group.html#local_contrast";
-  if(!strcmp(name,"velvia"))
-    return "color_group.html#velvia";
-  if(!strcmp(name,"splittoning"))
-    return "effect_group.html#splittoning";
-  if(!strcmp(name,"vignette"))
-    return "effect_group.html#vignetting";
-  if(!strcmp(name,"soften"))
-    return "effect_group.html#soften";
-  if(!strcmp(name,"channelmixer"))
-    return "color_group.html#channel_mixer";
-  if(!strcmp(name,"colorout"))
-    return "color_group.html#output_color_profile";
-  if(!strcmp(name,"colorcontrast"))
-    return "color_group.html#color_contrast";
-  if(!strcmp(name,"grain"))
-    return "effect_group.html#grain";
-  if(!strcmp(name,"highpass"))
-    return "effect_group.html#highpass";
-  if(!strcmp(name,"lowpass"))
-    return "effect_group.html#lowpass";
-  if(!strcmp(name,"sharpen"))
-    return "correction_group.html#sharpen";
-  if(!strcmp(name,"colorcorrection"))
-    return "color_group.html#color_correction";
-  if(!strcmp(name,"relight"))
-    return "tone_group.html#fill_light";
-  if(!strcmp(name,"levels"))
-    return "tone_group.html#levels";
-  if(!strcmp(name,"tonecurve"))
-    return "tone_group.html#tone_curve";
-  if(!strcmp(name,"zonesystem"))
-    return "tone_group.html#zone_system";
-  if(!strcmp(name,"colisa"))
-    return "modules.html#contrast_brightness_saturation";
-  if(!strcmp(name,"monochrome"))
-    return "color_group.html#monochrome";
-  if(!strcmp(name,"lowlight"))
-    return "effect_group.html#low_light";
-  if(!strcmp(name,"colorzones"))
-    return "color_group.html#color_zones";
-  if(!strcmp(name,"bilat"))
-    return "tone_group.html#local_contrast";
-  if(!strcmp(name,"atrous"))
-    return "correction_group.html#equalizer";
-  if(!strcmp(name,"shadhi"))
-    return "modules.html#shadows_and_highlights";
-  if(!strcmp(name,"globaltonemap"))
-    return "tone_group.html#global_tonemap";
-  if(!strcmp(name,"nlmeans"))
-    return "correction_group.html#denoise_non_local_means";
-  if(!strcmp(name,"bloom"))
-    return "effect_group.html#bloom";
-  if(!strcmp(name,"colormapping"))
-    return "effect_group.html#color_mapping";
-  if(!strcmp(name,"colortransfer"))
-    return NULL;
-  if(!strcmp(name,"colorize"))
-    return "effect_group.html#colorize";
-  if(!strcmp(name,"clipping"))
-    return "modules.html#crop_and_rotate";
-  if(!strcmp(name,"colorbalance"))
-    return "color_group.html#d0e8958";
-  if(!strcmp(name,"vibrance"))
-    return "color_group.html#vibrance";
-  if(!strcmp(name,"equalizer"))
-    return "correction_group.html#equalizer";
-  if(!strcmp(name,"defringe"))
-    return "correction_group.html#defringe";
-  if(!strcmp(name,"colorchecker"))
-    return "color_group.html#color_look_up_table";
-  if(!strcmp(name,"colorreconstruct"))
-    return "modules.html#color_reconstruction";
-  if(!strcmp(name,"colorin"))
-    return "color_group.html#input_color_profile";
-  if(!strcmp(name,"hazeremoval"))
-    return "correction_group.html#haze_removal";
-  if(!strcmp(name,"profile_gamma"))
-    return "color_group.html#unbreak_input_profile";
-  if(!strcmp(name,"bilateral"))
-    return "correction_group.html#denoise_bilateral";
-  if(!strcmp(name,"basecurve"))
-    return "modules.html#base_curve";
-  if(!strcmp(name,"graduatednd"))
-    return "effect_group.html#graduated_density";
-  if(!strcmp(name,"flip"))
-    return "modules.html#orientation";
-  if(!strcmp(name,"scalepixels"))
-    return "correction_group.html#scale_pixels";
-  if(!strcmp(name,"rotatepixels"))
-    return "correction_group.html#rotate_pixels";
-  if(!strcmp(name,"liquify"))
-    return "correction_group.html#liquify";
-  if(!strcmp(name,"ashift"))
-    return "correction_group.html#perspective_correction";
-  if(!strcmp(name,"lens"))
-    return "correction_group.html#lens_correction";
-  if(!strcmp(name,"retouch"))
-    return NULL;//TODO
-  if(!strcmp(name,"spots"))
-    return "correction_group.html#spot_removal";
-  if(!strcmp(name,"exposure"))
-    return "modules.html#exposure";
-  if(!strcmp(name,"tonemap"))
-    return "tone_group.html#tonemapping";
-  if(!strcmp(name,"denoiseprofile"))
-    return "correction_group.html#denoise_profiled";
-  if(!strcmp(name,"demosaic"))
-    return "modules.html#demosaic";
-  if(!strcmp(name,"rawdenoise"))
-    return "correction_group.html#raw_denoise";
-  if(!strcmp(name,"hotpixels"))
-    return "correction_group.html#hotpixels";
-  if(!strcmp(name,"cacorrect"))
-    return "correction_group.html#chromatic_aberrations";
-  if(!strcmp(name,"highlights"))
-    return "modules.html#highlight_reconstruction";
-  if(!strcmp(name,"temperature"))
-    return "modules.html#whitebalance";
-  if(!strcmp(name,"invert"))
-    return "modules.html#invert";
-  if(!strcmp(name,"rawprepare"))
-    return "modules.html#raw_black_white_point";
+  if(!strcmp(name, "dither")) return "correction_group.html#dithering";
+  if(!strcmp(name, "watermark")) return "effect_group.html#watermark";
+  if(!strcmp(name, "borders")) return "effect_group.html#framing";
+  if(!strcmp(name, "clahe")) return "tone_group.html#local_contrast";
+  if(!strcmp(name, "velvia")) return "color_group.html#velvia";
+  if(!strcmp(name, "splittoning")) return "effect_group.html#splittoning";
+  if(!strcmp(name, "vignette")) return "effect_group.html#vignetting";
+  if(!strcmp(name, "soften")) return "effect_group.html#soften";
+  if(!strcmp(name, "channelmixer")) return "color_group.html#channel_mixer";
+  if(!strcmp(name, "colorout")) return "color_group.html#output_color_profile";
+  if(!strcmp(name, "colorcontrast")) return "color_group.html#color_contrast";
+  if(!strcmp(name, "grain")) return "effect_group.html#grain";
+  if(!strcmp(name, "highpass")) return "effect_group.html#highpass";
+  if(!strcmp(name, "lowpass")) return "effect_group.html#lowpass";
+  if(!strcmp(name, "sharpen")) return "correction_group.html#sharpen";
+  if(!strcmp(name, "colorcorrection")) return "color_group.html#color_correction";
+  if(!strcmp(name, "relight")) return "tone_group.html#fill_light";
+  if(!strcmp(name, "levels")) return "tone_group.html#levels";
+  if(!strcmp(name, "tonecurve")) return "tone_group.html#tone_curve";
+  if(!strcmp(name, "zonesystem")) return "tone_group.html#zone_system";
+  if(!strcmp(name, "colisa")) return "modules.html#contrast_brightness_saturation";
+  if(!strcmp(name, "monochrome")) return "color_group.html#monochrome";
+  if(!strcmp(name, "lowlight")) return "effect_group.html#low_light";
+  if(!strcmp(name, "colorzones")) return "color_group.html#color_zones";
+  if(!strcmp(name, "bilat")) return "tone_group.html#local_contrast";
+  if(!strcmp(name, "atrous")) return "correction_group.html#equalizer";
+  if(!strcmp(name, "shadhi")) return "modules.html#shadows_and_highlights";
+  if(!strcmp(name, "globaltonemap")) return "tone_group.html#global_tonemap";
+  if(!strcmp(name, "nlmeans")) return "correction_group.html#denoise_non_local_means";
+  if(!strcmp(name, "bloom")) return "effect_group.html#bloom";
+  if(!strcmp(name, "colormapping")) return "effect_group.html#color_mapping";
+  if(!strcmp(name, "colortransfer")) return NULL;
+  if(!strcmp(name, "colorize")) return "effect_group.html#colorize";
+  if(!strcmp(name, "clipping")) return "modules.html#crop_and_rotate";
+  if(!strcmp(name, "colorbalance")) return "color_group.html#d0e8958";
+  if(!strcmp(name, "vibrance")) return "color_group.html#vibrance";
+  if(!strcmp(name, "equalizer")) return "correction_group.html#equalizer";
+  if(!strcmp(name, "defringe")) return "correction_group.html#defringe";
+  if(!strcmp(name, "colorchecker")) return "color_group.html#color_look_up_table";
+  if(!strcmp(name, "colorreconstruct")) return "modules.html#color_reconstruction";
+  if(!strcmp(name, "colorin")) return "color_group.html#input_color_profile";
+  if(!strcmp(name, "hazeremoval")) return "correction_group.html#haze_removal";
+  if(!strcmp(name, "profile_gamma")) return "color_group.html#unbreak_input_profile";
+  if(!strcmp(name, "bilateral")) return "correction_group.html#denoise_bilateral";
+  if(!strcmp(name, "basecurve")) return "modules.html#base_curve";
+  if(!strcmp(name, "graduatednd")) return "effect_group.html#graduated_density";
+  if(!strcmp(name, "flip")) return "modules.html#orientation";
+  if(!strcmp(name, "scalepixels")) return "correction_group.html#scale_pixels";
+  if(!strcmp(name, "rotatepixels")) return "correction_group.html#rotate_pixels";
+  if(!strcmp(name, "liquify")) return "correction_group.html#liquify";
+  if(!strcmp(name, "ashift")) return "correction_group.html#perspective_correction";
+  if(!strcmp(name, "lens")) return "correction_group.html#lens_correction";
+  if(!strcmp(name, "retouch")) return NULL; // TODO
+  if(!strcmp(name, "spots")) return "correction_group.html#spot_removal";
+  if(!strcmp(name, "exposure")) return "modules.html#exposure";
+  if(!strcmp(name, "tonemap")) return "tone_group.html#tonemapping";
+  if(!strcmp(name, "denoiseprofile")) return "correction_group.html#denoise_profiled";
+  if(!strcmp(name, "demosaic")) return "modules.html#demosaic";
+  if(!strcmp(name, "rawdenoise")) return "correction_group.html#raw_denoise";
+  if(!strcmp(name, "hotpixels")) return "correction_group.html#hotpixels";
+  if(!strcmp(name, "cacorrect")) return "correction_group.html#chromatic_aberrations";
+  if(!strcmp(name, "highlights")) return "modules.html#highlight_reconstruction";
+  if(!strcmp(name, "temperature")) return "modules.html#whitebalance";
+  if(!strcmp(name, "invert")) return "modules.html#invert";
+  if(!strcmp(name, "rawprepare")) return "modules.html#raw_black_white_point";
 
   return NULL;
 }

--- a/src/common/usermanual_url.h
+++ b/src/common/usermanual_url.h
@@ -1,0 +1,22 @@
+/*
+    This file is part of darktable,
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <string.h>
+
+char* dt_get_help_url(char* name);

--- a/src/common/usermanual_url.h
+++ b/src/common/usermanual_url.h
@@ -19,4 +19,4 @@
 
 #include <string.h>
 
-char* dt_get_help_url(char* name);
+char *dt_get_help_url(char *name);

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -42,7 +42,6 @@
 #include <string.h>
 #include <strings.h>
 
-
 void dt_control_init(dt_control_t *s)
 {
   memset(s->vimkey, 0, sizeof(s->vimkey));
@@ -76,6 +75,7 @@ void dt_control_init(dt_control_t *s)
   s->dev_zoom_x = 0;
   s->dev_zoom_y = 0;
   s->dev_zoom = DT_ZOOM_FIT;
+  s->lock_cursor_shape = false;
 }
 
 void dt_control_key_accelerators_on(struct dt_control_t *s)
@@ -98,12 +98,25 @@ int dt_control_is_key_accelerators_on(struct dt_control_t *s)
   return s->key_accelerators_on;
 }
 
+void dt_control_forbid_change_cursor()
+{
+  darktable.control->lock_cursor_shape = true;
+}
+
+void dt_control_allow_change_cursor()
+{
+  darktable.control->lock_cursor_shape = false;
+}
+
 void dt_control_change_cursor(dt_cursor_t curs)
 {
-  GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
-  GdkCursor *cursor = gdk_cursor_new_for_display(gdk_display_get_default(), curs);
-  gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
-  g_object_unref(cursor);
+  if (!darktable.control->lock_cursor_shape)
+  {
+    GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
+    GdkCursor *cursor = gdk_cursor_new_for_display(gdk_display_get_default(), curs);
+    gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
+    g_object_unref(cursor);
+  }
 }
 
 int dt_control_running()

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -60,6 +60,10 @@ gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer 
 void dt_control_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void dt_control_log_busy_enter();
 void dt_control_log_busy_leave();
+// disable the possibility to change the cursor shape with dt_control_change_cursor
+void dt_control_forbid_change_cursor();
+// enable the possibility to change the cursor shape with dt_control_change_cursor
+void dt_control_allow_change_cursor();
 void dt_control_change_cursor(dt_cursor_t cursor);
 void dt_control_write_sidecar_files();
 void dt_control_delete_images();
@@ -142,6 +146,7 @@ typedef struct dt_control_t
   double button_x, button_y;
   int history_start;
   int32_t mouse_over_id;
+  bool lock_cursor_shape;
 
   // TODO: move these to some darkroom struct
   // synchronized navigation

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1835,8 +1835,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                                                         "parametric mask, or combination of both"));
     g_signal_connect(G_OBJECT(bd->masks_modes_combo), "value-changed",
                      G_CALLBACK(_blendop_masks_mode_callback), bd);
-
-
+    dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_combo), "blending.html");
 
     bd->blend_modes_combo = dt_bauhaus_combobox_new(module);
     dt_bauhaus_widget_set_label(bd->blend_modes_combo, _("blend"), _("blend mode"));
@@ -1993,6 +1992,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     dt_bauhaus_combobox_set(bd->blend_modes_combo, 0);
     g_signal_connect(G_OBJECT(bd->blend_modes_combo), "value-changed",
                      G_CALLBACK(_blendop_blend_mode_callback), bd);
+    dt_gui_add_help_link(GTK_WIDGET(bd->blend_modes_combo), "blending_operators.html");
 
 
     bd->opacity_slider = dt_bauhaus_slider_new_with_range(module, 0.0, 100.0, 1, 100.0, 0);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1084,6 +1084,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->blendif_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  dt_gui_add_help_link(GTK_WIDGET(bd->blendif_box), "parametric_mask.html");
 
   /* create and add blendif support if module supports it */
   if(bd->blendif_support)
@@ -1416,6 +1417,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->masks_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  dt_gui_add_help_link(GTK_WIDGET(bd->masks_box), "drawn_mask.html");
 
   /* create and add masks support if module supports it */
   if(bd->masks_support)
@@ -2083,6 +2085,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), GTK_WIDGET(bd->masks_invert_combo), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->bottom_box), hbox, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(bd->bottom_box), TRUE, TRUE, 0);
+    dt_gui_add_help_link(GTK_WIDGET(bd->bottom_box), "combined_masks.html");
 
     bd->blend_inited = 1;
     gtk_widget_queue_draw(GTK_WIDGET(iopw));

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1084,7 +1084,10 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->blendif_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-  dt_gui_add_help_link(GTK_WIDGET(bd->blendif_box), "parametric_mask.html");
+  // add event box so that one can click into the area to get help for parametric masks
+  GtkWidget* event_box = gtk_event_box_new();
+  dt_gui_add_help_link(GTK_WIDGET(event_box), "parametric_mask.html");
+  gtk_container_add(GTK_CONTAINER(blendw), event_box);
 
   /* create and add blendif support if module supports it */
   if(bd->blendif_support)
@@ -1356,7 +1359,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     bd->blendif_inited = 1;
   }
 
-  gtk_box_pack_start(GTK_BOX(blendw), GTK_WIDGET(bd->blendif_box), TRUE, TRUE, 0);
+  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->blendif_box));
 }
 
 void dt_iop_gui_update_masks(dt_iop_module_t *module)
@@ -1417,7 +1420,10 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
 
   bd->masks_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-  dt_gui_add_help_link(GTK_WIDGET(bd->masks_box), "drawn_mask.html");
+  // add event box so that one can click into the area to get help for drawn masks
+  GtkWidget* event_box = gtk_event_box_new();
+  dt_gui_add_help_link(GTK_WIDGET(event_box), "drawn_mask.html");
+  gtk_container_add(GTK_CONTAINER(blendw), event_box);
 
   /* create and add masks support if module supports it */
   if(bd->masks_support)
@@ -1508,8 +1514,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->masks_inited = 1;
   }
-
-  gtk_box_pack_start(GTK_BOX(blendw), GTK_WIDGET(bd->masks_box), TRUE, TRUE, 0);
+  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->masks_box));
 }
 
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -428,7 +428,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->legacy_params = so->legacy_params;
   // allow to select a shape inside an iop
   module->masks_selection_changed = so->masks_selection_changed;
-  
+
   module->connect_key_accels = so->connect_key_accels;
   module->disconnect_key_accels = so->disconnect_key_accels;
 
@@ -1886,6 +1886,141 @@ static GdkPixbuf *load_image(const char *filename, int size)
   return pixbuf;
 }
 
+static char* dt_iop_get_help_url(dt_iop_module_t *module)
+{
+  if(!strcmp(module->op,"dither"))
+    return "correction_group.html#dithering";
+  if(!strcmp(module->op,"watermark"))
+    return "effect_group.html#watermark";
+  if(!strcmp(module->op,"borders"))
+    return "effect_group.html#framing";
+  if(!strcmp(module->op,"clahe"))
+    return "tone_group.html#local_contrast";
+  if(!strcmp(module->op,"velvia"))
+    return "color_group.html#velvia";
+  if(!strcmp(module->op,"splittoning"))
+    return "effect_group.html#splittoning";
+  if(!strcmp(module->op,"vignette"))
+    return "effect_group.html#vignetting";
+  if(!strcmp(module->op,"soften"))
+    return "effect_group.html#soften";
+  if(!strcmp(module->op,"channelmixer"))
+    return "color_group.html#channel_mixer";
+  if(!strcmp(module->op,"colorout"))
+    return "color_group.html#output_color_profile";
+  if(!strcmp(module->op,"colorcontrast"))
+    return "color_group.html#color_contrast";
+  if(!strcmp(module->op,"grain"))
+    return "effect_group.html#grain";
+  if(!strcmp(module->op,"highpass"))
+    return "effect_group.html#highpass";
+  if(!strcmp(module->op,"lowpass"))
+    return "effect_group.html#lowpass";
+  if(!strcmp(module->op,"sharpen"))
+    return "correction_group.html#sharpen";
+  if(!strcmp(module->op,"colorcorrection"))
+    return "color_group.html#color_correction";
+  if(!strcmp(module->op,"relight"))
+    return "tone_group.html#fill_light";
+  if(!strcmp(module->op,"levels"))
+    return "tone_group.html#levels";
+  if(!strcmp(module->op,"tonecurve"))
+    return "tone_group.html#tone_curve";
+  if(!strcmp(module->op,"zonesystem"))
+    return "tone_group.html#zone_system";
+  if(!strcmp(module->op,"colisa"))
+    return "modules.html#contrast_brightness_saturation";
+  if(!strcmp(module->op,"monochrome"))
+    return "color_group.html#monochrome";
+  if(!strcmp(module->op,"lowlight"))
+    return "effect_group.html#low_light";
+  if(!strcmp(module->op,"colorzones"))
+    return "color_group.html#color_zones";
+  if(!strcmp(module->op,"bilat"))
+    return "tone_group.html#local_contrast";
+  if(!strcmp(module->op,"atrous"))
+    return "correction_group.html#equalizer";
+  if(!strcmp(module->op,"shadhi"))
+    return "modules.html#shadows_and_highlights";
+  if(!strcmp(module->op,"globaltonemap"))
+    return "tone_group.html#global_tonemap";
+  if(!strcmp(module->op,"nlmeans"))
+    return "correction_group.html#denoise_non_local_means";
+  if(!strcmp(module->op,"bloom"))
+    return "effect_group.html#bloom";
+  if(!strcmp(module->op,"colormapping"))
+    return "effect_group.html#color_mapping";
+  if(!strcmp(module->op,"colortransfer"))
+    return NULL;//TODO
+  if(!strcmp(module->op,"colorize"))
+    return "effect_group.html#colorize";
+  if(!strcmp(module->op,"clipping"))
+    return "modules.html#crop_and_rotate";
+  if(!strcmp(module->op,"colorbalance"))
+    return "color_group.html#d0e8958";
+  if(!strcmp(module->op,"vibrance"))
+    return "color_group.html#vibrance";
+  if(!strcmp(module->op,"equalizer"))
+    return "correction_group.html#equalizer";
+  if(!strcmp(module->op,"defringe"))
+    return "correction_group.html#defringe";
+  if(!strcmp(module->op,"colorchecker"))
+    return "color_group.html#color_look_up_table";
+  if(!strcmp(module->op,"colorreconstruct"))
+    return "modules.html#color_reconstruction";
+  if(!strcmp(module->op,"colorin"))
+    return "color_group.html#input_color_profile";
+  if(!strcmp(module->op,"hazeremoval"))
+    return "correction_group.html#haze_removal";
+  if(!strcmp(module->op,"profile_gamma"))
+    return "color_group.html#unbreak_input_profile";
+  if(!strcmp(module->op,"bilateral"))
+    return "correction_group.html#denoise_bilateral";
+  if(!strcmp(module->op,"basecurve"))
+    return "modules.html#base_curve";
+  if(!strcmp(module->op,"graduatednd"))
+    return "effect_group.html#graduated_density";
+  if(!strcmp(module->op,"flip"))
+    return "modules.html#orientation";
+  if(!strcmp(module->op,"scalepixels"))
+    return "correction_group.html#scale_pixels";
+  if(!strcmp(module->op,"rotatepixels"))
+    return "correction_group.html#rotate_pixels";
+  if(!strcmp(module->op,"liquify"))
+    return "correction_group.html#liquify";
+  if(!strcmp(module->op,"ashift"))
+    return "correction_group.html#perspective_correction";
+  if(!strcmp(module->op,"lens"))
+    return "correction_group.html#lens_correction";
+  if(!strcmp(module->op,"retouch"))
+    return NULL;//TODO
+  if(!strcmp(module->op,"spots"))
+    return "correction_group.html#spot_removal";
+  if(!strcmp(module->op,"exposure"))
+    return "modules.html#exposure";
+  if(!strcmp(module->op,"tonemap"))
+    return "tone_group.html#tonemapping";
+  if(!strcmp(module->op,"denoiseprofile"))
+    return "correction_group.html#denoise_profiled";
+  if(!strcmp(module->op,"demosaic"))
+    return "modules.html#demosaic";
+  if(!strcmp(module->op,"rawdenoise"))
+    return "correction_group.html#raw_denoise";
+  if(!strcmp(module->op,"hotpixels"))
+    return "correction_group.html#hotpixels";
+  if(!strcmp(module->op,"cacorrect"))
+    return "correction_group.html#chromatic_aberrations";
+  if(!strcmp(module->op,"highlights"))
+    return "modules.html#highlight_reconstruction";
+  if(!strcmp(module->op,"temperature"))
+    return "modules.html#whitebalance";
+  if(!strcmp(module->op,"invert"))
+    return "modules.html#invert";
+  if(!strcmp(module->op,"rawprepare"))
+    return "modules.html#raw_black_white_point";
+  return NULL;
+}
+
 static const uint8_t fallback_pixel[4] = { 0, 0, 0, 0 };
 
 GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
@@ -1992,6 +2127,8 @@ got_image:
     gtk_widget_set_size_request(GTK_WIDGET(hw[idx++]), bs, bs);
   }
 
+  dt_gui_add_help_link(expander, dt_iop_get_help_url(module));
+
   /* add reset button */
   hw[idx] = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   module->reset_button = GTK_WIDGET(hw[idx]);
@@ -2028,6 +2165,7 @@ got_image:
   /* reorder header, for now, iop are always in the right panel */
   for(int i = 7; i >= 0; i--)
     if(hw[i]) gtk_box_pack_start(GTK_BOX(header), hw[i], i == 2 ? TRUE : FALSE, i == 2 ? TRUE : FALSE, 2);
+  dt_gui_add_help_link(header, "interacting.html");
 
   gtk_widget_set_halign(hw[2], GTK_ALIGN_END);
   dtgtk_icon_set_paint(hw[0], dtgtk_cairo_paint_solid_arrow, CPF_DIRECTION_LEFT, NULL);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -26,6 +26,7 @@
 #include "common/interpolation.h"
 #include "common/module.h"
 #include "common/opencl.h"
+#include "common/usermanual_url.h"
 #include "control/control.h"
 #include "develop/blend.h"
 #include "develop/develop.h"
@@ -1886,141 +1887,6 @@ static GdkPixbuf *load_image(const char *filename, int size)
   return pixbuf;
 }
 
-static char* dt_iop_get_help_url(dt_iop_module_t *module)
-{
-  if(!strcmp(module->op,"dither"))
-    return "correction_group.html#dithering";
-  if(!strcmp(module->op,"watermark"))
-    return "effect_group.html#watermark";
-  if(!strcmp(module->op,"borders"))
-    return "effect_group.html#framing";
-  if(!strcmp(module->op,"clahe"))
-    return "tone_group.html#local_contrast";
-  if(!strcmp(module->op,"velvia"))
-    return "color_group.html#velvia";
-  if(!strcmp(module->op,"splittoning"))
-    return "effect_group.html#splittoning";
-  if(!strcmp(module->op,"vignette"))
-    return "effect_group.html#vignetting";
-  if(!strcmp(module->op,"soften"))
-    return "effect_group.html#soften";
-  if(!strcmp(module->op,"channelmixer"))
-    return "color_group.html#channel_mixer";
-  if(!strcmp(module->op,"colorout"))
-    return "color_group.html#output_color_profile";
-  if(!strcmp(module->op,"colorcontrast"))
-    return "color_group.html#color_contrast";
-  if(!strcmp(module->op,"grain"))
-    return "effect_group.html#grain";
-  if(!strcmp(module->op,"highpass"))
-    return "effect_group.html#highpass";
-  if(!strcmp(module->op,"lowpass"))
-    return "effect_group.html#lowpass";
-  if(!strcmp(module->op,"sharpen"))
-    return "correction_group.html#sharpen";
-  if(!strcmp(module->op,"colorcorrection"))
-    return "color_group.html#color_correction";
-  if(!strcmp(module->op,"relight"))
-    return "tone_group.html#fill_light";
-  if(!strcmp(module->op,"levels"))
-    return "tone_group.html#levels";
-  if(!strcmp(module->op,"tonecurve"))
-    return "tone_group.html#tone_curve";
-  if(!strcmp(module->op,"zonesystem"))
-    return "tone_group.html#zone_system";
-  if(!strcmp(module->op,"colisa"))
-    return "modules.html#contrast_brightness_saturation";
-  if(!strcmp(module->op,"monochrome"))
-    return "color_group.html#monochrome";
-  if(!strcmp(module->op,"lowlight"))
-    return "effect_group.html#low_light";
-  if(!strcmp(module->op,"colorzones"))
-    return "color_group.html#color_zones";
-  if(!strcmp(module->op,"bilat"))
-    return "tone_group.html#local_contrast";
-  if(!strcmp(module->op,"atrous"))
-    return "correction_group.html#equalizer";
-  if(!strcmp(module->op,"shadhi"))
-    return "modules.html#shadows_and_highlights";
-  if(!strcmp(module->op,"globaltonemap"))
-    return "tone_group.html#global_tonemap";
-  if(!strcmp(module->op,"nlmeans"))
-    return "correction_group.html#denoise_non_local_means";
-  if(!strcmp(module->op,"bloom"))
-    return "effect_group.html#bloom";
-  if(!strcmp(module->op,"colormapping"))
-    return "effect_group.html#color_mapping";
-  if(!strcmp(module->op,"colortransfer"))
-    return NULL;//TODO
-  if(!strcmp(module->op,"colorize"))
-    return "effect_group.html#colorize";
-  if(!strcmp(module->op,"clipping"))
-    return "modules.html#crop_and_rotate";
-  if(!strcmp(module->op,"colorbalance"))
-    return "color_group.html#d0e8958";
-  if(!strcmp(module->op,"vibrance"))
-    return "color_group.html#vibrance";
-  if(!strcmp(module->op,"equalizer"))
-    return "correction_group.html#equalizer";
-  if(!strcmp(module->op,"defringe"))
-    return "correction_group.html#defringe";
-  if(!strcmp(module->op,"colorchecker"))
-    return "color_group.html#color_look_up_table";
-  if(!strcmp(module->op,"colorreconstruct"))
-    return "modules.html#color_reconstruction";
-  if(!strcmp(module->op,"colorin"))
-    return "color_group.html#input_color_profile";
-  if(!strcmp(module->op,"hazeremoval"))
-    return "correction_group.html#haze_removal";
-  if(!strcmp(module->op,"profile_gamma"))
-    return "color_group.html#unbreak_input_profile";
-  if(!strcmp(module->op,"bilateral"))
-    return "correction_group.html#denoise_bilateral";
-  if(!strcmp(module->op,"basecurve"))
-    return "modules.html#base_curve";
-  if(!strcmp(module->op,"graduatednd"))
-    return "effect_group.html#graduated_density";
-  if(!strcmp(module->op,"flip"))
-    return "modules.html#orientation";
-  if(!strcmp(module->op,"scalepixels"))
-    return "correction_group.html#scale_pixels";
-  if(!strcmp(module->op,"rotatepixels"))
-    return "correction_group.html#rotate_pixels";
-  if(!strcmp(module->op,"liquify"))
-    return "correction_group.html#liquify";
-  if(!strcmp(module->op,"ashift"))
-    return "correction_group.html#perspective_correction";
-  if(!strcmp(module->op,"lens"))
-    return "correction_group.html#lens_correction";
-  if(!strcmp(module->op,"retouch"))
-    return NULL;//TODO
-  if(!strcmp(module->op,"spots"))
-    return "correction_group.html#spot_removal";
-  if(!strcmp(module->op,"exposure"))
-    return "modules.html#exposure";
-  if(!strcmp(module->op,"tonemap"))
-    return "tone_group.html#tonemapping";
-  if(!strcmp(module->op,"denoiseprofile"))
-    return "correction_group.html#denoise_profiled";
-  if(!strcmp(module->op,"demosaic"))
-    return "modules.html#demosaic";
-  if(!strcmp(module->op,"rawdenoise"))
-    return "correction_group.html#raw_denoise";
-  if(!strcmp(module->op,"hotpixels"))
-    return "correction_group.html#hotpixels";
-  if(!strcmp(module->op,"cacorrect"))
-    return "correction_group.html#chromatic_aberrations";
-  if(!strcmp(module->op,"highlights"))
-    return "modules.html#highlight_reconstruction";
-  if(!strcmp(module->op,"temperature"))
-    return "modules.html#whitebalance";
-  if(!strcmp(module->op,"invert"))
-    return "modules.html#invert";
-  if(!strcmp(module->op,"rawprepare"))
-    return "modules.html#raw_black_white_point";
-  return NULL;
-}
-
 static const uint8_t fallback_pixel[4] = { 0, 0, 0, 0 };
 
 GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
@@ -2127,7 +1993,7 @@ got_image:
     gtk_widget_set_size_request(GTK_WIDGET(hw[idx++]), bs, bs);
   }
 
-  dt_gui_add_help_link(expander, dt_iop_get_help_url(module));
+  dt_gui_add_help_link(expander, dt_get_help_url(module->op));
 
   /* add reset button */
   hw[idx] = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -3055,7 +3055,7 @@ static int get_points(struct dt_iop_module_t *self, const dt_iop_ashift_line_t *
   for(int n = 0; n < lines_count; n++)
   {
     const int length = lines[n].length;
-    
+
     total_points += length;
 
     my_points_idx[n].length = length;
@@ -4119,7 +4119,7 @@ static void process_after_preview_callback(gpointer instance, gpointer user_data
       }
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       break;
-      
+
     case ASHIFT_JOBCODE_NONE:
     default:
       break;
@@ -4464,7 +4464,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#perspective_correction");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->rotation = dt_bauhaus_slider_new_with_range(self, -ROTATION_RANGE, ROTATION_RANGE, 0.01*ROTATION_RANGE, p->rotation, 2);
   dt_bauhaus_widget_set_label(g->rotation, NULL, _("rotation"));

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4464,6 +4464,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#perspective_correction");
 
   g->rotation = dt_bauhaus_slider_new_with_range(self, -ROTATION_RANGE, ROTATION_RANGE, 0.01*ROTATION_RANGE, p->rotation, 2);
   dt_bauhaus_widget_set_label(g->rotation, NULL, _("rotation"));

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1652,7 +1652,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->x_move = -1;
   c->mouse_radius = 1.0 / BANDS;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#equalizer");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1652,6 +1652,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->x_move = -1;
   c->mouse_radius = 1.0 / BANDS;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#equalizer");
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1921,7 +1921,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->loglogscale = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#base_curve");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_widget_set_tooltip_text(GTK_WIDGET(c->area), _("abscissa: input, ordinate: output. works on RGB channels"));
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1921,6 +1921,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->loglogscale = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#base_curve");
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_widget_set_tooltip_text(GTK_WIDGET(c->area), _("abscissa: input, ordinate: output. works on RGB channels"));
 

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -511,7 +511,7 @@ void gui_init(dt_iop_module_t *self)
   dt_pthread_mutex_init(&g->lock, NULL);
   g->hash = 0;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "tone_group.html#local_contrast");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -511,6 +511,7 @@ void gui_init(dt_iop_module_t *self)
   dt_pthread_mutex_init(&g->lock, NULL);
   g->hash = 0;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "tone_group.html#local_contrast");
 
   g->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -344,7 +344,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_bilateral_params_t *p = (dt_iop_bilateral_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#denoise_bilateral");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 1.0, 30.0, 1.0, p->sigma[0], 1);
   g->scale3 = dt_bauhaus_slider_new_with_range(self, 0.0001, .1, 0.001, p->sigma[2], 4);

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -344,6 +344,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_bilateral_params_t *p = (dt_iop_bilateral_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#denoise_bilateral");
 
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 1.0, 30.0, 1.0, p->sigma[0], 1);
   g->scale3 = dt_bauhaus_slider_new_with_range(self, 0.0001, .1, 0.001, p->sigma[2], 4);

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -507,7 +507,7 @@ void gui_init(struct dt_iop_module_t *self)
   const dt_iop_bloom_params_t *p = (dt_iop_bloom_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#bloom");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* size */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1.0, p->size, 0);

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -507,6 +507,7 @@ void gui_init(struct dt_iop_module_t *self)
   const dt_iop_bloom_params_t *p = (dt_iop_bloom_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#bloom");
 
   /* size */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1.0, p->size, 0);

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -972,7 +972,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#framing");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->size = dt_bauhaus_slider_new_with_range(self, 0.0, 50.0, 0.5, p->size * 100.0, 2);
   dt_bauhaus_widget_set_label(g->size, NULL, _("border size"));

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -972,6 +972,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#framing");
 
   g->size = dt_bauhaus_slider_new_with_range(self, 0.0, 50.0, 0.5, p->size * 100.0, 2);
   dt_bauhaus_widget_set_label(g->size, NULL, _("border size"));

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1571,7 +1571,7 @@ void gui_init(dt_iop_module_t *self)
   self->gui_data = NULL;
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  dt_gui_add_help_link(self->widget, "correction_group.html#chromatic_aberrations");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1571,6 +1571,7 @@ void gui_init(dt_iop_module_t *self)
   self->gui_data = NULL;
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+  dt_gui_add_help_link(self->widget, "correction_group.html#chromatic_aberrations");
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -441,7 +441,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#channel_mixer");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* output */
   g->combo1 = dt_bauhaus_combobox_new(self);

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -441,6 +441,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#channel_mixer");
 
   /* output */
   g->combo1 = dt_bauhaus_combobox_new(self);

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -313,7 +313,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)self->params;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  dt_gui_add_help_link(self->widget, "tone_group.html#local_contrast");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->vbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING));
   g->vbox2 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->vbox1), FALSE, FALSE, 5);

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -313,6 +313,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)self->params;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+  dt_gui_add_help_link(self->widget, "tone_group.html#local_contrast");
   g->vbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING));
   g->vbox2 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->vbox1), FALSE, FALSE, 5);

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1859,7 +1859,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->old_width = g->old_height = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#crop_and_rotate");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->hvflip = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->hvflip, NULL, _("flip"));
   dt_bauhaus_combobox_add(g->hvflip, _("none"));

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1859,6 +1859,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->old_width = g->old_height = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#crop_and_rotate");
   g->hvflip = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->hvflip, NULL, _("flip"));
   dt_bauhaus_combobox_add(g->hvflip, _("none"));

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -356,7 +356,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colisa_params_t *p = (dt_iop_colisa_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#contrast_brightness_saturation");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->contrast = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->contrast, 2);
   g->brightness = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->brightness, 2);

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -356,6 +356,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colisa_params_t *p = (dt_iop_colisa_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#contrast_brightness_saturation");
 
   g->contrast = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->contrast, 2);
   g->brightness = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->brightness, 2);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -2233,7 +2233,7 @@ void gui_init(dt_iop_module_t *self)
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#d0e8958");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // mode choice
   g->mode = dt_bauhaus_combobox_new(self);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -2233,6 +2233,7 @@ void gui_init(dt_iop_module_t *self)
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#d0e8958");
 
   // mode choice
   g->mode = dt_bauhaus_combobox_new(self);

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -49,13 +49,13 @@ static const float colorchecker_Lab[] =
  49.93,   -4.88, -21.93, // blue sky
  43.14,  -13.10,  21.91, // foliage
  55.11,    8.84, -25.40, // blue flower
- 70.72,  -33.40, -0.20 , // bluish green  
+ 70.72,  -33.40, -0.20 , // bluish green
  62.66,   36.07,  57.10, // orange
  40.02,   10.41, -45.96, // purple red
- 51.12,   48.24,  16.25, // moderate red  
+ 51.12,   48.24,  16.25, // moderate red
  30.33,   22.98, -21.59, // purple
- 72.53,  -23.71,  57.26, // yellow green  
- 71.94,  19.36 ,  67.86, // orange yellow 
+ 72.53,  -23.71,  57.26, // yellow green
+ 71.94,  19.36 ,  67.86, // orange yellow
  28.78,  14.18 , -50.30, // blue
  55.26,  -38.34,  31.37, // green
  42.10,  53.38 ,  28.19, // red
@@ -305,7 +305,7 @@ vfastlog2 (v4sf x)
   const v4sf c_0_3520087068 = v4sfl (0.3520887068f);
 
   return y - c_124_22551499
-    - c_1_498030302 * mx.f 
+    - c_1_498030302 * mx.f
     - c_1_725877999 / (c_0_3520087068 + mx.f);
 }
 
@@ -319,7 +319,7 @@ vfastlog (v4sf x)
 // thinplate spline kernel \phi(r) = 2 r^2 ln(r)
 static inline v4sf kerneldist4(const float *x, const float *y)
 {
-  const float r2 = 
+  const float r2 =
       (x[0]-y[0])*(x[0]-y[0])+
       (x[1]-y[1])*(x[1]-y[1])+
       (x[2]-y[2])*(x[2]-y[2]);
@@ -327,7 +327,7 @@ static inline v4sf kerneldist4(const float *x, const float *y)
 }
 #endif
 
-static inline float 
+static inline float
 fastlog2 (float x)
 {
   union { float f; uint32_t i; } vx = { x };
@@ -336,7 +336,7 @@ fastlog2 (float x)
   y *= 1.1920928955078125e-7f;
 
   return y - 124.22551499f
-    - 1.498030302f * mx.f 
+    - 1.498030302f * mx.f
     - 1.72587999f / (0.3520887068f + mx.f);
 }
 
@@ -365,7 +365,7 @@ static inline float kernel(const float *x, const float *y)
   // well damnit, this speedup thing unfortunately shows severe artifacts.
   // return r*r*fasterlog(MAX(1e-8f,r));
   // this one seems to be a lot better, let's see how it goes:
-  const float r2 = 
+  const float r2 =
       (x[0]-y[0])*(x[0]-y[0])+
       (x[1]-y[1])*(x[1]-y[1])+
       (x[2]-y[2])*(x[2]-y[2]);
@@ -1250,7 +1250,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#color_look_up_table");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // custom 24-patch widget in addition to combo box
   g->area = dtgtk_drawing_area_new_with_aspect_ratio(4.0/6.0);

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1250,6 +1250,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#color_look_up_table");
 
   // custom 24-patch widget in addition to combo box
   g->area = dtgtk_drawing_area_new_with_aspect_ratio(4.0/6.0);

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -384,7 +384,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_colorcontrast_params_t *p = (dt_iop_colorcontrast_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#color_contrast");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* a scale */
   g->a_scale = dt_bauhaus_slider_new_with_range(self, 0.0, 5.0, 0.01, p->a_steepness, 2);

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -384,6 +384,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_colorcontrast_params_t *p = (dt_iop_colorcontrast_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#color_contrast");
 
   /* a scale */
   g->a_scale = dt_bauhaus_slider_new_with_range(self, 0.0, 5.0, 0.01, p->a_steepness, 2);

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -259,7 +259,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->selected = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#color_correction");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag the line for split toning. "

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -259,6 +259,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->selected = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#color_correction");
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag the line for split toning. "

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1838,7 +1838,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#input_color_profile");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->profile_combobox = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->profile_combobox, NULL, _("profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile_combobox, TRUE, TRUE, 0);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1838,6 +1838,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#input_color_profile");
   g->profile_combobox = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->profile_combobox, NULL, _("profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile_combobox, TRUE, TRUE, 0);

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -419,7 +419,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#colorize");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* hue slider */
   g->gslider1 = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 1.0f, 0.01f, 0.0f, 2, 0);

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -419,6 +419,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#colorize");
 
   /* hue slider */
   g->gslider1 = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 1.0f, 0.01f, 0.0f, 2, 0);

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1090,7 +1090,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_pthread_mutex_init(&g->lock, NULL);
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-  dt_gui_add_help_link(self->widget, "effect_group.html#color_mapping");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   GtkBox *hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   GtkWidget *source = gtk_label_new(_("source clusters:"));

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1090,6 +1090,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_pthread_mutex_init(&g->lock, NULL);
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  dt_gui_add_help_link(self->widget, "effect_group.html#color_mapping");
 
   GtkBox *hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   GtkWidget *source = gtk_label_new(_("source clusters:"));

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -771,7 +771,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#output_color_profile");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // TODO:
   g->output_intent = dt_bauhaus_combobox_new(self);

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -771,6 +771,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_user_config_dir(confdir, sizeof(confdir));
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#output_color_profile");
 
   // TODO:
   g->output_intent = dt_bauhaus_combobox_new(self);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -641,7 +641,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 
   if(!b) goto error;
-  
+
   dt_iop_colorreconstruct_bilateral_slice(b, in, out, data->threshold, roi_in, piece->iscale);
 
   // here is where we generate the canned bilateral grid of the preview pipe for later use
@@ -887,7 +887,7 @@ static dt_iop_colorreconstruct_bilateral_cl_t *dt_iop_colorreconstruct_bilateral
   b->sigma_r = bf->sigma_r;
   b->dev_grid = NULL;
   b->dev_grid_tmp = NULL;
-  
+
   // alloc grid buffer:
   b->dev_grid
       = dt_opencl_alloc_device_buffer(b->devid, (size_t)b->size_x * b->size_y * b->size_z * 4 * sizeof(float));
@@ -1350,7 +1350,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->hash = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#color_reconstruction");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->threshold = dt_bauhaus_slider_new_with_range(self, 50.0f, 150.0f, 0.1f, p->threshold, 2);
   g->spatial = dt_bauhaus_slider_new_with_range(self, 0.0f, 1000.0f, 1.0f, p->spatial, 2);

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1350,6 +1350,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->hash = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#color_reconstruction");
 
   g->threshold = dt_bauhaus_slider_new_with_range(self, 50.0f, 150.0f, 0.1f, p->threshold, 2);
   g->spatial = dt_bauhaus_slider_new_with_range(self, 0.0f, 1000.0f, 1.0f, p->spatial, 2);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1058,7 +1058,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_radius = 1.0 / DT_IOP_COLORZONES_BANDS;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#color_zones");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // tabs
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1058,6 +1058,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_radius = 1.0 / DT_IOP_COLORZONES_BANDS;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#color_zones");
 
   // tabs
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -437,7 +437,7 @@ void gui_init(dt_iop_module_t *module)
   dt_iop_defringe_params_t *p = (dt_iop_defringe_params_t *)module->params;
 
   module->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(module->widget, "correction_group.html#defringe");
+  dt_gui_add_help_link(module->widget, dt_get_help_url(module->op));
 
   /* mode selection */
   g->mode_select = dt_bauhaus_combobox_new(module);

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -437,6 +437,7 @@ void gui_init(dt_iop_module_t *module)
   dt_iop_defringe_params_t *p = (dt_iop_defringe_params_t *)module->params;
 
   module->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(module->widget, "correction_group.html#defringe");
 
   /* mode selection */
   g->mode_select = dt_bauhaus_combobox_new(module);

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5029,7 +5029,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#demosaic");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5029,6 +5029,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#demosaic");
 
   g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2565,7 +2565,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#denoise_profiled");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->profiles = NULL;
   g->profile = dt_bauhaus_combobox_new(self);
   g->mode = dt_bauhaus_combobox_new(self);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2565,6 +2565,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#denoise_profiled");
   g->profiles = NULL;
   g->profile = dt_bauhaus_combobox_new(self);
   g->mode = dt_bauhaus_combobox_new(self);

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -780,7 +780,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#dithering");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->random = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->dither_type = dt_bauhaus_combobox_new(self);

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -780,6 +780,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_dither_params_t *p = (dt_iop_dither_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#dithering");
   g->random = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   g->dither_type = dt_bauhaus_combobox_new(self);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -844,7 +844,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-  dt_gui_add_help_link(self->widget, "modules.html#exposure");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -844,6 +844,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+  dt_gui_add_help_link(self->widget, "modules.html#exposure");
 
   g->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -504,7 +504,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_flip_params_t *p = (dt_iop_flip_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-  dt_gui_add_help_link(self->widget, "modules.html#orientation");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   GtkWidget *label = dtgtk_reset_label_new(_("rotate"), self, &p->orientation, sizeof(int32_t));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -504,6 +504,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_flip_params_t *p = (dt_iop_flip_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+  dt_gui_add_help_link(self->widget, "modules.html#orientation");
 
   GtkWidget *label = dtgtk_reset_label_new(_("rotate"), self, &p->orientation, sizeof(int32_t));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -688,7 +688,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->hash = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "tone_group.html#global_tonemap");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* operator */
   g->operator= dt_bauhaus_combobox_new(self);

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -688,6 +688,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->hash = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "tone_group.html#global_tonemap");
 
   /* operator */
   g->operator= dt_bauhaus_combobox_new(self);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1133,7 +1133,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#graduated_density");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* density */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, -8.0, 8.0, 0.1, p->density, 2);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1133,6 +1133,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#graduated_density");
 
   /* density */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, -8.0, 8.0, 0.1, p->density, 2);

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -613,7 +613,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_grain_params_t *p = (dt_iop_grain_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#grain");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* courseness */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 20.0, 6400.0, 20.0, p->scale * GRAIN_SCALE_FACTOR, 0);

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -613,6 +613,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_grain_params_t *p = (dt_iop_grain_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#grain");
 
   /* courseness */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 20.0, 6400.0, 20.0, p->scale * GRAIN_SCALE_FACTOR, 0);

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -181,7 +181,7 @@ void gui_init(dt_iop_module_t *self)
   g->hash = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#haze_removal");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->strength = dt_bauhaus_slider_new_with_range(self, -1, 1, 0.01, p->strength, 2);
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -181,6 +181,7 @@ void gui_init(dt_iop_module_t *self)
   g->hash = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#haze_removal");
 
   g->strength = dt_bauhaus_slider_new_with_range(self, -1, 1, 0.01, p->strength, 2);
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1042,7 +1042,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#highlight_reconstruction");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->mode = dt_bauhaus_combobox_new(self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->mode, TRUE, TRUE, 0);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1042,6 +1042,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_highlights_params_t *p = (dt_iop_highlights_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#highlight_reconstruction");
 
   g->mode = dt_bauhaus_combobox_new(self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->mode, TRUE, TRUE, 0);

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -478,7 +478,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_highpass_params_t *p = (dt_iop_highpass_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#highpass");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* sharpness */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0.5, p->sharpness, 2);

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -478,6 +478,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_highpass_params_t *p = (dt_iop_highpass_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#highpass");
 
   /* sharpness */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0.5, p->sharpness, 2);

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -442,7 +442,7 @@ void gui_init(dt_iop_module_t *self)
   g->pixels_fixed = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#hotpixels");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   g_signal_connect(G_OBJECT(g->box_raw), "draw", G_CALLBACK(draw), self);

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -442,6 +442,7 @@ void gui_init(dt_iop_module_t *self)
   g->pixels_fixed = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#hotpixels");
 
   g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   g_signal_connect(G_OBJECT(g->box_raw), "draw", G_CALLBACK(draw), self);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -615,7 +615,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-  dt_gui_add_help_link(self->widget, "modules.html#invert");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, 4 * sizeof(float)));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -615,6 +615,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+  dt_gui_add_help_link(self->widget, "modules.html#invert");
 
   g->label = DTGTK_RESET_LABEL(dtgtk_reset_label_new("", self, &p->color, 4 * sizeof(float)));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->label), TRUE, TRUE, 0);

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -2132,7 +2132,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *button;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#lens_correction");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -2132,6 +2132,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *button;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#lens_correction");
 
   // camera selector
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -564,7 +564,7 @@ void gui_init(dt_iop_module_t *self)
   for(int i = 0; i < 3; i++)
     for(int j = 0; j < 2; j++) c->pick_xy_positions[i][j] = -1;
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 5));
-  dt_gui_add_help_link(self->widget, "tone_group.html#levels");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   c->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(c->mode, NULL, _("mode"));

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -564,6 +564,7 @@ void gui_init(dt_iop_module_t *self)
   for(int i = 0; i < 3; i++)
     for(int j = 0; j < 2; j++) c->pick_xy_positions[i][j] = -1;
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 5));
+  dt_gui_add_help_link(self->widget, "tone_group.html#levels");
 
   c->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(c->mode, NULL, _("mode"));

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3364,7 +3364,7 @@ void gui_init (dt_iop_module_t *module)
   g->node_index = 0;
 
   module->widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(module->widget, "correction_group.html#liquify");
+  dt_gui_add_help_link(module->widget, dt_get_help_url(module->op));
 
   GtkWidget *hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3365,7 +3365,7 @@ void gui_init (dt_iop_module_t *module)
 
   module->widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
   dt_gui_add_help_link(module->widget, "correction_group.html#liquify");
-  
+
   GtkWidget *hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3364,7 +3364,8 @@ void gui_init (dt_iop_module_t *module)
   g->node_index = 0;
 
   module->widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
-
+  dt_gui_add_help_link(module->widget, "correction_group.html#liquify");
+  
   GtkWidget *hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -833,7 +833,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_radius = 1.0 / DT_IOP_LOWLIGHT_BANDS;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#low_light");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.75));
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -833,6 +833,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_radius = 1.0 / DT_IOP_LOWLIGHT_BANDS;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#low_light");
 
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.75));
 

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -648,7 +648,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_lowpass_params_t *p = (dt_iop_lowpass_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#lowpass");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
 #if 0 // gaussian is order not user selectable here, as it does not make much sense for a lowpass filter
   GtkBox *hbox  = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5));

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -648,6 +648,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_lowpass_params_t *p = (dt_iop_lowpass_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#lowpass");
 
 #if 0 // gaussian is order not user selectable here, as it does not make much sense for a lowpass filter
   GtkBox *hbox  = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5));

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -586,7 +586,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->dragging = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#monochrome");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag and scroll mouse wheel to adjust the virtual color filter"));

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -586,6 +586,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->dragging = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#monochrome");
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("drag and scroll mouse wheel to adjust the virtual color filter"));

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -836,7 +836,7 @@ void gui_init(dt_iop_module_t *self)
   self->gui_data = malloc(sizeof(dt_iop_nlmeans_gui_data_t));
   dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#denoise_non_local_means");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->radius = dt_bauhaus_slider_new_with_range(self, 1.0f, 4.0f, 1., 2.f, 0);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 50.f, 0);
   g->luma = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 50.f, 0);

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -836,6 +836,7 @@ void gui_init(dt_iop_module_t *self)
   self->gui_data = malloc(sizeof(dt_iop_nlmeans_gui_data_t));
   dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#denoise_non_local_means");
   g->radius = dt_bauhaus_slider_new_with_range(self, 1.0f, 4.0f, 1., 2.f, 0);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 50.f, 0);
   g->luma = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 50.f, 0);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -882,7 +882,7 @@ void gui_init(dt_iop_module_t *self)
   g->which_colorpicker = DT_PICKPROFLOG_NONE;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#unbreak_input_profile");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // mode choice
   g->mode = dt_bauhaus_combobox_new(self);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -882,6 +882,7 @@ void gui_init(dt_iop_module_t *self)
   g->which_colorpicker = DT_PICKPROFLOG_NONE;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#unbreak_input_profile");
 
   // mode choice
   g->mode = dt_bauhaus_combobox_new(self);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -940,7 +940,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  dt_gui_add_help_link(self->widget, "correction_group.html#raw_denoise");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   c->stack = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(c->stack), FALSE);
   gtk_box_pack_start(GTK_BOX(self->widget), c->stack, TRUE, TRUE, 0);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -940,6 +940,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  dt_gui_add_help_link(self->widget, "correction_group.html#raw_denoise");
   c->stack = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(c->stack), FALSE);
   gtk_box_pack_start(GTK_BOX(self->widget), c->stack, TRUE, TRUE, 0);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -804,7 +804,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#raw_black_white_point");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -804,6 +804,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#raw_black_white_point");
 
   g->box_raw = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -345,7 +345,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "tone_group.html#fill_light");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -345,6 +345,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "tone_group.html#fill_light");
 
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
 

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -354,7 +354,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  dt_gui_add_help_link(self->widget, "correction_group.html#rotate_pixels");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -354,6 +354,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+  dt_gui_add_help_link(self->widget, "correction_group.html#rotate_pixels");
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -281,7 +281,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  dt_gui_add_help_link(self->widget, "correction_group.html#scale_pixels");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -281,6 +281,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+  dt_gui_add_help_link(self->widget, "correction_group.html#scale_pixels");
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -811,7 +811,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_shadhi_params_t *p = (dt_iop_shadhi_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "modules.html#shadows_and_highlights");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->shadows = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->shadows, 2);
   g->highlights = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->highlights, 2);

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -811,6 +811,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_shadhi_params_t *p = (dt_iop_shadhi_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "modules.html#shadows_and_highlights");
 
   g->shadows = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->shadows, 2);
   g->highlights = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->highlights, 2);

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -755,7 +755,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_sharpen_params_t *p = (dt_iop_sharpen_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "correction_group.html#sharpen");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 8.0000, 0.100, p->radius, 3);
   gtk_widget_set_tooltip_text(g->scale1, _("spatial extent of the unblurring"));

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -755,6 +755,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_sharpen_params_t *p = (dt_iop_sharpen_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "correction_group.html#sharpen");
 
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 8.0000, 0.100, p->radius, 3);
   gtk_widget_set_tooltip_text(g->scale1, _("spatial extent of the unblurring"));

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -700,7 +700,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_soften_params_t *p = (dt_iop_soften_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#soften");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* size */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 2, p->size, 2);

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -700,6 +700,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_soften_params_t *p = (dt_iop_soften_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#soften");
 
   /* size */
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 2, p->size, 2);

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -523,7 +523,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_set_row_spacing(grid, DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(grid, DT_BAUHAUS_SPACE);
   gtk_grid_set_column_homogeneous(grid, FALSE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#splittoning");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   float rgb[3];
 

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -523,6 +523,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_set_row_spacing(grid, DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(grid, DT_BAUHAUS_SPACE);
   gtk_grid_set_column_homogeneous(grid, FALSE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#splittoning");
 
   float rgb[3];
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -635,7 +635,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget, "correction_group.html#spot_removal");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
   GtkWidget *label = gtk_label_new(_("number of strokes:"));
   gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -635,6 +635,7 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget, "correction_group.html#spot_removal");
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
   GtkWidget *label = gtk_label_new(_("number of strokes:"));
   gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -773,7 +773,7 @@ void gui_update(struct dt_iop_module_t *self)
     for(int i = 0; i < wb_preset_count; i++)
     {
       if(g->preset_cnt >= 50) break;
-      if(!strcmp(wb_preset[i].make, self->dev->image_storage.camera_maker) 
+      if(!strcmp(wb_preset[i].make, self->dev->image_storage.camera_maker)
          && !strcmp(wb_preset[i].model, self->dev->image_storage.camera_model))
       {
         if(!wb_name || strcmp(wb_name, wb_preset[i].name))
@@ -810,7 +810,7 @@ void gui_update(struct dt_iop_module_t *self)
     for(int j = DT_IOP_NUM_OF_STD_TEMP_PRESETS; !found && (j < g->preset_cnt); j++)
     {
       // look through all variants of this preset, with different tuning
-      for(int i = g->preset_num[j]; !found && (i < wb_preset_count) 
+      for(int i = g->preset_num[j]; !found && (i < wb_preset_count)
                                     && !strcmp(wb_preset[i].make, self->dev->image_storage.camera_maker)
                                     && !strcmp(wb_preset[i].model, self->dev->image_storage.camera_model)
                                     && !strcmp(wb_preset[i].name, wb_preset[g->preset_num[j]].name);
@@ -1064,7 +1064,7 @@ gui:
       // we're normalizing that to be D65
       for(int i = 0; i < wb_preset_count; i++)
       {
-        if(!strcmp(wb_preset[i].make, module->dev->image_storage.camera_maker) 
+        if(!strcmp(wb_preset[i].make, module->dev->image_storage.camera_maker)
            && !strcmp(wb_preset[i].model, module->dev->image_storage.camera_model)
            && !strcmp(wb_preset[i].name, Daylight) && wb_preset[i].tuning == 0)
         {
@@ -1277,7 +1277,7 @@ static void apply_preset(dt_iop_module_t *self)
     {
       gboolean found = FALSE;
       // look through all variants of this preset, with different tuning
-      for(int i = g->preset_num[pos]; (i < wb_preset_count) 
+      for(int i = g->preset_num[pos]; (i < wb_preset_count)
                                       && !strcmp(wb_preset[i].make, self->dev->image_storage.camera_maker)
                                       && !strcmp(wb_preset[i].model, self->dev->image_storage.camera_model)
                                       && !strcmp(wb_preset[i].name, wb_preset[g->preset_num[pos]].name);
@@ -1385,7 +1385,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  dt_gui_add_help_link(self->widget, "modules.html#whitebalance");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
 
   g->stack = gtk_stack_new();

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1385,6 +1385,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  dt_gui_add_help_link(self->widget, "modules.html#whitebalance");
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
 
   g->stack = gtk_stack_new();

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -907,7 +907,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->selected = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "tone_group.html#tone_curve");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   // tabs
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -907,6 +907,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->selected = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "tone_group.html#tone_curve");
 
   // tabs
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -284,7 +284,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_tonemapping_params_t *p = (dt_iop_tonemapping_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "tone_group.html#tonemapping");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* contrast */
   g->contrast = dt_bauhaus_slider_new_with_range(self, 1.0, 5.0000, 0.1, p->contrast, 3);

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -284,6 +284,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_tonemapping_params_t *p = (dt_iop_tonemapping_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "tone_group.html#tonemapping");
 
   /* contrast */
   g->contrast = dt_bauhaus_slider_new_with_range(self, 1.0, 5.0000, 0.1, p->contrast, 3);

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -371,7 +371,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_velvia_params_t *p = (dt_iop_velvia_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#velvia");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   /* strength */
   g->strength_scale = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->strength, 0);

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -371,6 +371,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_velvia_params_t *p = (dt_iop_velvia_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#velvia");
 
   /* strength */
   g->strength_scale = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->strength, 0);

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -235,7 +235,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_vibrance_params_t *p = (dt_iop_vibrance_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "color_group.html#vibrance");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   ;
 
   /* vibrance */

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -235,6 +235,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_iop_vibrance_params_t *p = (dt_iop_vibrance_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "color_group.html#vibrance");
   ;
 
   /* vibrance */

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1123,7 +1123,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *hbox, *label1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  dt_gui_add_help_link(self->widget, "effect_group.html#vignetting");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   label1 = dtgtk_reset_label_new(_("automatic ratio"), self, &p->autoratio, sizeof p->autoratio);
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1123,6 +1123,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *hbox, *label1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, "effect_group.html#vignetting");
 
   label1 = dtgtk_reset_label_new(_("automatic ratio"), self, &p->autoratio, sizeof p->autoratio);
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1312,7 +1312,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_grid_new();
   gtk_grid_set_row_spacing(GTK_GRID(self->widget), DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(10));
-  dt_gui_add_help_link(self->widget, "effect_group.html#watermark");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   gtk_grid_attach(GTK_GRID(self->widget), dt_ui_section_label_new(_("content")), 0, line++, 3, 1);
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1312,6 +1312,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_grid_new();
   gtk_grid_set_row_spacing(GTK_GRID(self->widget), DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(10));
+  dt_gui_add_help_link(self->widget, "effect_group.html#watermark");
 
   gtk_grid_attach(GTK_GRID(self->widget), dt_ui_section_label_new(_("content")), 0, line++, 3, 1);
 

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -528,7 +528,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_pthread_mutex_init(&g->lock, NULL);
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING);
-  dt_gui_add_help_link(self->widget, "tone_group.html#zone_system");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->preview = dtgtk_drawing_area_new_with_aspect_ratio(1.0);
   g_signal_connect(G_OBJECT(g->preview), "size-allocate", G_CALLBACK(size_allocate_callback), self);

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -528,6 +528,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_pthread_mutex_init(&g->lock, NULL);
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_GUI_IOP_MODULE_CONTROL_SPACING);
+  dt_gui_add_help_link(self->widget, "tone_group.html#zone_system");
 
   g->preview = dtgtk_drawing_area_new_with_aspect_ratio(1.0);
   g_signal_connect(G_OBJECT(g->preview), "size-allocate", G_CALLBACK(size_allocate_callback), self);

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -439,6 +439,7 @@ void gui_init(dt_lib_module_t *self)
   // Camera control
   GtkWidget *label = dt_ui_section_label_new(_("camera control"));
   gtk_grid_attach(GTK_GRID(self->widget), label, lib->gui.rows++, 0, 2, 1);
+  dt_gui_add_help_link(self->widget, "camera_settings.html#camera_settings");
 
   GtkWidget *modes_label = gtk_label_new(_("modes"));
   GtkWidget *timer_label = gtk_label_new(_("timer (s)"));
@@ -515,6 +516,7 @@ void gui_init(dt_lib_module_t *self)
   // Camera settings
   label = dt_ui_section_label_new(_("properties"));
   gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(label), 0, lib->gui.rows++, 2, 1);
+  dt_gui_add_help_link(self->widget, "camera_settings.html#camera_settings");
 
   lib->gui.prop_start = lib->gui.rows -1;
   lib->gui.prop_end = lib->gui.rows;
@@ -523,6 +525,7 @@ void gui_init(dt_lib_module_t *self)
   // user specified properties
   label = dt_ui_section_label_new(_("additional properties"));
   gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(label), 0, lib->gui.rows++, 2, 1);
+  dt_gui_add_help_link(self->widget, "camera_settings.html#camera_settings");
 
   label = gtk_label_new(_("label"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1784,7 +1784,7 @@ void gui_init(dt_lib_module_t *self)
 
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget, "collect_images.html#collect_images_usage");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   d->active_rule = 0;
   d->nb_rules = 0;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1790,6 +1790,7 @@ void gui_init(dt_lib_module_t *self)
 
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget, "collect_images.html#collect_images_usage");
   
   d->active_rule = 0;
   d->nb_rules = 0;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -221,7 +221,7 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
   GtkTreeView *treeview = GTK_TREE_VIEW(userdata);
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *filechooser;
-
+  
   GtkTreeSelection *selection;
   GtkTreeIter iter, child;
   GtkTreeModel *model;
@@ -246,7 +246,6 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
 #endif
 
   gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
-
   if(tree_path != NULL)
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), tree_path);
   else
@@ -377,7 +376,7 @@ static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, dt_lib_c
   g_signal_connect(menuitem, "activate", (GCallback)view_popup_menu_onRemove, treeview);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
-
+  
 #if GTK_CHECK_VERSION(3, 22, 0)
   gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 #else
@@ -1098,7 +1097,6 @@ static void list_view(dt_lib_collect_rule_t *dr)
   set_properties(dr);
 
   GtkTreeModel *model = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(d->listfilter));
-
   if(d->view_rule != property)
   {
     sqlite3_stmt *stmt;
@@ -1394,11 +1392,13 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
       // only clear
       button->icon = dtgtk_cairo_paint_cancel;
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule"));
+      dt_gui_add_help_link(GTK_WIDGET(button), "collect_images.html#collect_images_usage");
     }
     else if(i == active)
     {
       button->icon = dtgtk_cairo_paint_dropdown;
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule or add new rules"));
+      dt_gui_add_help_link(GTK_WIDGET(button), "collect_images.html#collect_images_usage");
     }
     else
     {
@@ -1408,6 +1408,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
       if(mode == DT_LIB_COLLECT_MODE_OR) button->icon = dtgtk_cairo_paint_or;
       if(mode == DT_LIB_COLLECT_MODE_AND_NOT) button->icon = dtgtk_cairo_paint_andnot;
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule"));
+      dt_gui_add_help_link(GTK_WIDGET(button), "collect_images.html#collect_images_usage");
     }
   }
 
@@ -1452,17 +1453,20 @@ static void combo_changed(GtkComboBox *combo, dt_lib_collect_rule_t *d)
      || property == DT_COLLECTION_PROP_EXPOSURE)
   {
     gtk_widget_set_tooltip_text(d->text, _("type your query, use <, <=, >, >=, <>, =, [;] as operators"));
+    dt_gui_add_help_link(d->text, "collect_images.html#collect_images_usage");
   }
   else if(property == DT_COLLECTION_PROP_DAY || property == DT_COLLECTION_PROP_TIME)
   {
     gtk_widget_set_tooltip_text(d->text,
                                 _("type your query, use <, <=, >, >=, <>, =, [;] as operators, type dates in "
                                   "the form : YYYY:MM:DD HH:MM:SS (only the year is mandatory)"));
+    dt_gui_add_help_link(d->text, "collect_images.html#collect_images_usage");
   }
   else
   {
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(d->text, _("type your query, use `%' as wildcard"));
+    dt_gui_add_help_link(d->text, "collect_images.html#collect_images_usage");
   }
 
   set_properties(d);
@@ -1786,7 +1790,7 @@ void gui_init(dt_lib_module_t *self)
 
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-
+  
   d->active_rule = 0;
   d->nb_rules = 0;
   d->params = (dt_lib_collect_params_t *)malloc(sizeof(dt_lib_collect_params_t));
@@ -1816,6 +1820,7 @@ void gui_init(dt_lib_module_t *self)
 
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(w, _("type your query, use `%' as wildcard"));
+    dt_gui_add_help_link(w, "collect_images.html#collect_images_usage");
     gtk_widget_add_events(w, GDK_KEY_PRESS_MASK);
     g_signal_connect(G_OBJECT(w), "insert-text", G_CALLBACK(entry_insert_text), d->rule + i);
     g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(entry_changed), d->rule + i);
@@ -1866,14 +1871,14 @@ void gui_init(dt_lib_module_t *self)
   g_object_unref(treemodel);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sw), TRUE, TRUE, 0);
-
+  
   GtkWidget *sw2 = gtk_scrolled_window_new(NULL, NULL);
   d->sw2 = GTK_SCROLLED_WINDOW(sw2);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw2), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw2), DT_PIXEL_APPLY_DPI(300));
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sw2), TRUE, TRUE, 0);
-
+  
   /* setup proxy */
   darktable.view_manager->proxy.module_collect.module = self;
   darktable.view_manager->proxy.module_collect.update = _lib_collect_gui_update;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -221,7 +221,7 @@ static void view_popup_menu_onSearchFilmroll(GtkWidget *menuitem, gpointer userd
   GtkTreeView *treeview = GTK_TREE_VIEW(userdata);
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *filechooser;
-  
+
   GtkTreeSelection *selection;
   GtkTreeIter iter, child;
   GtkTreeModel *model;
@@ -376,7 +376,7 @@ static void view_popup_menu(GtkWidget *treeview, GdkEventButton *event, dt_lib_c
   g_signal_connect(menuitem, "activate", (GCallback)view_popup_menu_onRemove, treeview);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
-  
+
 #if GTK_CHECK_VERSION(3, 22, 0)
   gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *)event);
 #else
@@ -1785,7 +1785,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
   dt_gui_add_help_link(self->widget, "collect_images.html#collect_images_usage");
-  
+
   d->active_rule = 0;
   d->nb_rules = 0;
   d->params = (dt_lib_collect_params_t *)malloc(sizeof(dt_lib_collect_params_t));
@@ -1865,14 +1865,14 @@ void gui_init(dt_lib_module_t *self)
   g_object_unref(treemodel);
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sw), TRUE, TRUE, 0);
-  
+
   GtkWidget *sw2 = gtk_scrolled_window_new(NULL, NULL);
   d->sw2 = GTK_SCROLLED_WINDOW(sw2);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw2), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
   gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw2), DT_PIXEL_APPLY_DPI(300));
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(sw2), TRUE, TRUE, 0);
-  
+
   /* setup proxy */
   darktable.view_manager->proxy.module_collect.module = self;
   darktable.view_manager->proxy.module_collect.update = _lib_collect_gui_update;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1392,13 +1392,11 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
       // only clear
       button->icon = dtgtk_cairo_paint_cancel;
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule"));
-      dt_gui_add_help_link(GTK_WIDGET(button), "collect_images.html#collect_images_usage");
     }
     else if(i == active)
     {
       button->icon = dtgtk_cairo_paint_dropdown;
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule or add new rules"));
-      dt_gui_add_help_link(GTK_WIDGET(button), "collect_images.html#collect_images_usage");
     }
     else
     {
@@ -1408,7 +1406,6 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
       if(mode == DT_LIB_COLLECT_MODE_OR) button->icon = dtgtk_cairo_paint_or;
       if(mode == DT_LIB_COLLECT_MODE_AND_NOT) button->icon = dtgtk_cairo_paint_andnot;
       gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("clear this rule"));
-      dt_gui_add_help_link(GTK_WIDGET(button), "collect_images.html#collect_images_usage");
     }
   }
 
@@ -1453,20 +1450,17 @@ static void combo_changed(GtkComboBox *combo, dt_lib_collect_rule_t *d)
      || property == DT_COLLECTION_PROP_EXPOSURE)
   {
     gtk_widget_set_tooltip_text(d->text, _("type your query, use <, <=, >, >=, <>, =, [;] as operators"));
-    dt_gui_add_help_link(d->text, "collect_images.html#collect_images_usage");
   }
   else if(property == DT_COLLECTION_PROP_DAY || property == DT_COLLECTION_PROP_TIME)
   {
     gtk_widget_set_tooltip_text(d->text,
                                 _("type your query, use <, <=, >, >=, <>, =, [;] as operators, type dates in "
                                   "the form : YYYY:MM:DD HH:MM:SS (only the year is mandatory)"));
-    dt_gui_add_help_link(d->text, "collect_images.html#collect_images_usage");
   }
   else
   {
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(d->text, _("type your query, use `%' as wildcard"));
-    dt_gui_add_help_link(d->text, "collect_images.html#collect_images_usage");
   }
 
   set_properties(d);
@@ -1821,7 +1815,6 @@ void gui_init(dt_lib_module_t *self)
 
     /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(w, _("type your query, use `%' as wildcard"));
-    dt_gui_add_help_link(w, "collect_images.html#collect_images_usage");
     gtk_widget_add_events(w, GDK_KEY_PRESS_MASK);
     g_signal_connect(G_OBJECT(w), "insert-text", G_CALLBACK(entry_insert_text), d->rule + i);
     g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(entry_changed), d->rule + i);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -501,7 +501,7 @@ void gui_init(dt_lib_module_t *self)
   // Setting up the GUI
   self->widget = container;
   gtk_box_pack_start(GTK_BOX(container), output_row, TRUE, TRUE, 0);
-  dt_gui_add_help_link(self->widget, "global_color_picker.html#global_color_picker");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   // The color patch
   data->color_patch = gtk_drawing_area_new();

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -142,6 +142,7 @@ static void _update_picker_output(dt_lib_module_t *self)
     darktable.gui->reset = 1;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->picker_button),
                                  module->request_color_pick != DT_REQUEST_COLORPICK_OFF);
+    dt_gui_add_help_link(data->picker_button, "global_color_picker.html#global_color_picker");
     darktable.gui->reset = 0;
 
     int input_color = dt_conf_get_int("ui_last/colorpicker_model");
@@ -362,6 +363,7 @@ static void _add_sample(GtkButton *widget, gpointer self)
   gtk_widget_set_events(sample->color_patch, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_BUTTON_PRESS_MASK);
   gtk_widget_set_tooltip_text(sample->color_patch, _("hover to highlight sample on canvas, "
                                                        "click to lock sample"));
+  dt_gui_add_help_link(sample->color_patch, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(sample->container), sample->color_patch, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(sample->color_patch), "enter-notify-event", G_CALLBACK(_live_sample_enter),
@@ -376,6 +378,7 @@ static void _add_sample(GtkButton *widget, gpointer self)
   gtk_box_pack_start(GTK_BOX(sample->container), sample->output_label, TRUE, TRUE, 0);
 
   sample->delete_button = gtk_button_new_with_label(_("remove"));
+  dt_gui_add_help_link(sample->delete_button, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(sample->container), sample->delete_button, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(sample->delete_button), "clicked", G_CALLBACK(_remove_sample), sample);
@@ -513,7 +516,9 @@ void gui_init(dt_lib_module_t *self)
 
   data->size_selector = gtk_combo_box_text_new();
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->size_selector), _("point"));
+  dt_gui_add_help_link(data->size_selector, "global_color_picker.html#global_color_picker");
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->size_selector), _("area"));
+  dt_gui_add_help_link(data->size_selector, "global_color_picker.html#global_color_picker");
   gtk_combo_box_set_active(GTK_COMBO_BOX(data->size_selector), dt_conf_get_int("ui_last/colorpicker_size"));
   gtk_widget_set_size_request(data->size_selector, DT_PIXEL_APPLY_DPI(30), -1);
   gtk_box_pack_start(GTK_BOX(picker_subrow), data->size_selector, TRUE, TRUE, 0);
@@ -525,6 +530,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(picker_subrow), data->picker_button, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), self);
+  dt_gui_add_help_link(data->picker_button, "global_color_picker.html#global_color_picker");
 
   gtk_box_pack_start(GTK_BOX(output_options), picker_subrow, TRUE, TRUE, 0);
 
@@ -538,6 +544,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(output_options), data->statistic_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->statistic_selector), "changed", G_CALLBACK(_statistic_changed), self);
+  dt_gui_add_help_link(data->statistic_selector, "global_color_picker.html#global_color_picker");
 
   data->color_mode_selector = gtk_combo_box_text_new();
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->color_mode_selector), _("RGB"));
@@ -547,6 +554,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(output_options), data->color_mode_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->color_mode_selector), "changed", G_CALLBACK(_color_mode_changed), self);
+  dt_gui_add_help_link(data->color_mode_selector, "global_color_picker.html#global_color_picker");
 
   data->output_label = gtk_label_new("");
   gtk_label_set_justify(GTK_LABEL(data->output_label), GTK_JUSTIFY_CENTER);
@@ -559,7 +567,7 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.restrict_histogram
       = dt_conf_get_int("ui_last/colorpicker_restrict_histogram");
   gtk_box_pack_start(GTK_BOX(container), restrict_button, TRUE, TRUE, 0);
-
+  dt_gui_add_help_link(restrict_button, "global_color_picker.html#global_color_picker");
   g_signal_connect(G_OBJECT(restrict_button), "toggled", G_CALLBACK(_restrict_histogram_changed), NULL);
 
   // Adding the live samples section
@@ -572,6 +580,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_statistic_selector), _("max"));
   gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_statistic_selector),
                            dt_conf_get_int("ui_last/colorsamples_mode"));
+  dt_gui_add_help_link(data->samples_statistic_selector, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->samples_statistic_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->samples_statistic_selector), "changed",
@@ -582,12 +591,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_mode_selector), _("Lab"));
   gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_mode_selector),
                            dt_conf_get_int("ui_last/colorsamples_model"));
+  dt_gui_add_help_link(data->samples_mode_selector, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->samples_mode_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->samples_mode_selector), "changed", G_CALLBACK(_samples_mode_changed), self);
 
   data->add_sample_button = gtk_button_new_with_label(_("add"));
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
+  dt_gui_add_help_link(data->add_sample_button, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->add_sample_button, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(data->add_sample_button), "clicked", G_CALLBACK(_add_sample), self);
@@ -596,6 +607,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(container), data->samples_container, TRUE, TRUE, 0);
 
   data->display_samples_check_box = gtk_check_button_new_with_label(_("display sample areas on image"));
+  dt_gui_add_help_link(data->display_samples_check_box, "global_color_picker.html#global_color_picker");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box),
                                dt_conf_get_int("ui_last/colorpicker_display_samples"));
   gtk_box_pack_start(GTK_BOX(container), data->display_samples_check_box, TRUE, TRUE, 0);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -142,7 +142,6 @@ static void _update_picker_output(dt_lib_module_t *self)
     darktable.gui->reset = 1;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->picker_button),
                                  module->request_color_pick != DT_REQUEST_COLORPICK_OFF);
-    dt_gui_add_help_link(data->picker_button, "global_color_picker.html#global_color_picker");
     darktable.gui->reset = 0;
 
     int input_color = dt_conf_get_int("ui_last/colorpicker_model");
@@ -363,7 +362,6 @@ static void _add_sample(GtkButton *widget, gpointer self)
   gtk_widget_set_events(sample->color_patch, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_BUTTON_PRESS_MASK);
   gtk_widget_set_tooltip_text(sample->color_patch, _("hover to highlight sample on canvas, "
                                                        "click to lock sample"));
-  dt_gui_add_help_link(sample->color_patch, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(sample->container), sample->color_patch, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(sample->color_patch), "enter-notify-event", G_CALLBACK(_live_sample_enter),
@@ -378,7 +376,6 @@ static void _add_sample(GtkButton *widget, gpointer self)
   gtk_box_pack_start(GTK_BOX(sample->container), sample->output_label, TRUE, TRUE, 0);
 
   sample->delete_button = gtk_button_new_with_label(_("remove"));
-  dt_gui_add_help_link(sample->delete_button, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(sample->container), sample->delete_button, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(sample->delete_button), "clicked", G_CALLBACK(_remove_sample), sample);
@@ -504,6 +501,7 @@ void gui_init(dt_lib_module_t *self)
   // Setting up the GUI
   self->widget = container;
   gtk_box_pack_start(GTK_BOX(container), output_row, TRUE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, "global_color_picker.html#global_color_picker");
 
   // The color patch
   data->color_patch = gtk_drawing_area_new();
@@ -516,9 +514,7 @@ void gui_init(dt_lib_module_t *self)
 
   data->size_selector = gtk_combo_box_text_new();
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->size_selector), _("point"));
-  dt_gui_add_help_link(data->size_selector, "global_color_picker.html#global_color_picker");
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->size_selector), _("area"));
-  dt_gui_add_help_link(data->size_selector, "global_color_picker.html#global_color_picker");
   gtk_combo_box_set_active(GTK_COMBO_BOX(data->size_selector), dt_conf_get_int("ui_last/colorpicker_size"));
   gtk_widget_set_size_request(data->size_selector, DT_PIXEL_APPLY_DPI(30), -1);
   gtk_box_pack_start(GTK_BOX(picker_subrow), data->size_selector, TRUE, TRUE, 0);
@@ -530,7 +526,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(picker_subrow), data->picker_button, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), self);
-  dt_gui_add_help_link(data->picker_button, "global_color_picker.html#global_color_picker");
 
   gtk_box_pack_start(GTK_BOX(output_options), picker_subrow, TRUE, TRUE, 0);
 
@@ -544,7 +539,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(output_options), data->statistic_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->statistic_selector), "changed", G_CALLBACK(_statistic_changed), self);
-  dt_gui_add_help_link(data->statistic_selector, "global_color_picker.html#global_color_picker");
 
   data->color_mode_selector = gtk_combo_box_text_new();
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->color_mode_selector), _("RGB"));
@@ -554,7 +548,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(output_options), data->color_mode_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->color_mode_selector), "changed", G_CALLBACK(_color_mode_changed), self);
-  dt_gui_add_help_link(data->color_mode_selector, "global_color_picker.html#global_color_picker");
 
   data->output_label = gtk_label_new("");
   gtk_label_set_justify(GTK_LABEL(data->output_label), GTK_JUSTIFY_CENTER);
@@ -567,7 +560,6 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.restrict_histogram
       = dt_conf_get_int("ui_last/colorpicker_restrict_histogram");
   gtk_box_pack_start(GTK_BOX(container), restrict_button, TRUE, TRUE, 0);
-  dt_gui_add_help_link(restrict_button, "global_color_picker.html#global_color_picker");
   g_signal_connect(G_OBJECT(restrict_button), "toggled", G_CALLBACK(_restrict_histogram_changed), NULL);
 
   // Adding the live samples section
@@ -580,7 +572,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_statistic_selector), _("max"));
   gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_statistic_selector),
                            dt_conf_get_int("ui_last/colorsamples_mode"));
-  dt_gui_add_help_link(data->samples_statistic_selector, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->samples_statistic_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->samples_statistic_selector), "changed",
@@ -591,14 +582,12 @@ void gui_init(dt_lib_module_t *self)
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_mode_selector), _("Lab"));
   gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_mode_selector),
                            dt_conf_get_int("ui_last/colorsamples_model"));
-  dt_gui_add_help_link(data->samples_mode_selector, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->samples_mode_selector, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(data->samples_mode_selector), "changed", G_CALLBACK(_samples_mode_changed), self);
 
   data->add_sample_button = gtk_button_new_with_label(_("add"));
   gtk_widget_set_sensitive(data->add_sample_button, FALSE);
-  dt_gui_add_help_link(data->add_sample_button, "global_color_picker.html#global_color_picker");
   gtk_box_pack_start(GTK_BOX(samples_options_row), data->add_sample_button, FALSE, FALSE, 0);
 
   g_signal_connect(G_OBJECT(data->add_sample_button), "clicked", G_CALLBACK(_add_sample), self);
@@ -607,7 +596,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(container), data->samples_container, TRUE, TRUE, 0);
 
   data->display_samples_check_box = gtk_check_button_new_with_label(_("display sample areas on image"));
-  dt_gui_add_help_link(data->display_samples_check_box, "global_color_picker.html#global_color_picker");
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box),
                                dt_conf_get_int("ui_last/colorpicker_display_samples"));
   gtk_box_pack_start(GTK_BOX(container), data->display_samples_check_box, TRUE, TRUE, 0);

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -279,28 +279,28 @@ void gui_init(dt_lib_module_t *self)
   ellipsize_button(copy_parts);
   d->copy_parts_button = copy_parts;
   gtk_widget_set_tooltip_text(copy_parts, _("copy part history stack of\nfirst selected image"));
-  dt_gui_add_help_link(copy_parts,"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(copy_parts, "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, copy_parts, 0, line, 2, 1);
 
   GtkWidget *copy = gtk_button_new_with_label(_("copy all"));
   ellipsize_button(copy);
   d->copy_button = copy;
   gtk_widget_set_tooltip_text(copy, _("copy history stack of\nfirst selected image"));
-  dt_gui_add_help_link(copy,"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(copy, "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, copy, 2, line, 2, 1);
 
   GtkWidget *delete = gtk_button_new_with_label(_("discard"));
   ellipsize_button(delete);
   d->delete_button = delete;
   gtk_widget_set_tooltip_text(delete, _("discard history stack of\nall selected images"));
-  dt_gui_add_help_link(delete,"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(delete, "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, delete, 4, line++, 2, 1);
 
 
   d->paste_parts = GTK_BUTTON(gtk_button_new_with_label(_("paste")));
   ellipsize_button(d->paste_parts);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->paste_parts), _("paste part history stack to\nall selected images"));
-  dt_gui_add_help_link(GTK_WIDGET(d->paste_parts),"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(GTK_WIDGET(d->paste_parts), "history_stack.html#history_stack_usage");
   d->imageid = -1;
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste_parts), FALSE);
   gtk_grid_attach(grid, GTK_WIDGET(d->paste_parts), 0, line, 3, 1);
@@ -308,7 +308,7 @@ void gui_init(dt_lib_module_t *self)
   d->paste = GTK_BUTTON(gtk_button_new_with_label(_("paste all")));
   ellipsize_button(d->paste);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->paste), _("paste history stack to\nall selected images"));
-  dt_gui_add_help_link(GTK_WIDGET(d->paste),"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(GTK_WIDGET(d->paste), "history_stack.html#history_stack_usage");
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste), FALSE);
   gtk_grid_attach(grid, GTK_WIDGET(d->paste), 3, line++, 3, 1);
 
@@ -317,7 +317,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->pastemode, _("append"));
   dt_bauhaus_combobox_add(d->pastemode, _("overwrite"));
   gtk_widget_set_tooltip_text(d->pastemode, _("how to handle existing history"));
-  dt_gui_add_help_link(d->pastemode,"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(d->pastemode, "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, d->pastemode, 0, line++, 6, 1);
   dt_bauhaus_combobox_set(d->pastemode, dt_conf_get_int("plugins/lighttable/copy_history/pastemode"));
 
@@ -326,14 +326,14 @@ void gui_init(dt_lib_module_t *self)
   ellipsize_button(loadbutton);
   d->load_button = loadbutton;
   gtk_widget_set_tooltip_text(loadbutton, _("open an XMP sidecar file\nand apply it to selected images"));
-  dt_gui_add_help_link(loadbutton,"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(loadbutton, "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, loadbutton, 0, line, 3, 1);
 
   GtkWidget *button = gtk_button_new_with_label(_("write sidecar files"));
   ellipsize_button(button);
   d->write_button = button;
   gtk_widget_set_tooltip_text(button, _("write history stack and tags to XMP sidecar files"));
-  dt_gui_add_help_link(button,"history_stack.html#history_stack_usage");
+  dt_gui_add_help_link(button, "history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, button, 3, line, 3, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(write_button_clicked), (gpointer)self);
 

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -267,7 +267,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   self->widget = gtk_grid_new();
   GtkGrid *grid = GTK_GRID(self->widget);
-  dt_gui_add_help_link(self->widget,"history_stack.html#history_stack");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_homogeneous(grid, TRUE);

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -267,6 +267,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   self->widget = gtk_grid_new();
   GtkGrid *grid = GTK_GRID(self->widget);
+  dt_gui_add_help_link(self->widget,"history_stack.html#history_stack");
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_homogeneous(grid, TRUE);
@@ -278,24 +279,28 @@ void gui_init(dt_lib_module_t *self)
   ellipsize_button(copy_parts);
   d->copy_parts_button = copy_parts;
   gtk_widget_set_tooltip_text(copy_parts, _("copy part history stack of\nfirst selected image"));
+  dt_gui_add_help_link(copy_parts,"history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, copy_parts, 0, line, 2, 1);
 
   GtkWidget *copy = gtk_button_new_with_label(_("copy all"));
   ellipsize_button(copy);
   d->copy_button = copy;
   gtk_widget_set_tooltip_text(copy, _("copy history stack of\nfirst selected image"));
+  dt_gui_add_help_link(copy,"history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, copy, 2, line, 2, 1);
 
   GtkWidget *delete = gtk_button_new_with_label(_("discard"));
   ellipsize_button(delete);
   d->delete_button = delete;
   gtk_widget_set_tooltip_text(delete, _("discard history stack of\nall selected images"));
+  dt_gui_add_help_link(delete,"history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, delete, 4, line++, 2, 1);
 
 
   d->paste_parts = GTK_BUTTON(gtk_button_new_with_label(_("paste")));
   ellipsize_button(d->paste_parts);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->paste_parts), _("paste part history stack to\nall selected images"));
+  dt_gui_add_help_link(GTK_WIDGET(d->paste_parts),"history_stack.html#history_stack_usage");
   d->imageid = -1;
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste_parts), FALSE);
   gtk_grid_attach(grid, GTK_WIDGET(d->paste_parts), 0, line, 3, 1);
@@ -303,6 +308,7 @@ void gui_init(dt_lib_module_t *self)
   d->paste = GTK_BUTTON(gtk_button_new_with_label(_("paste all")));
   ellipsize_button(d->paste);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->paste), _("paste history stack to\nall selected images"));
+  dt_gui_add_help_link(GTK_WIDGET(d->paste),"history_stack.html#history_stack_usage");
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste), FALSE);
   gtk_grid_attach(grid, GTK_WIDGET(d->paste), 3, line++, 3, 1);
 
@@ -311,6 +317,7 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_add(d->pastemode, _("append"));
   dt_bauhaus_combobox_add(d->pastemode, _("overwrite"));
   gtk_widget_set_tooltip_text(d->pastemode, _("how to handle existing history"));
+  dt_gui_add_help_link(d->pastemode,"history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, d->pastemode, 0, line++, 6, 1);
   dt_bauhaus_combobox_set(d->pastemode, dt_conf_get_int("plugins/lighttable/copy_history/pastemode"));
 
@@ -319,12 +326,14 @@ void gui_init(dt_lib_module_t *self)
   ellipsize_button(loadbutton);
   d->load_button = loadbutton;
   gtk_widget_set_tooltip_text(loadbutton, _("open an XMP sidecar file\nand apply it to selected images"));
+  dt_gui_add_help_link(loadbutton,"history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, loadbutton, 0, line, 3, 1);
 
   GtkWidget *button = gtk_button_new_with_label(_("write sidecar files"));
   ellipsize_button(button);
   d->write_button = button;
   gtk_widget_set_tooltip_text(button, _("write history stack and tags to XMP sidecar files"));
+  dt_gui_add_help_link(button,"history_stack.html#history_stack_usage");
   gtk_grid_attach(grid, button, 3, line, 3, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(write_button_clicked), (gpointer)self);
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -508,7 +508,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_export_t *d = (dt_lib_export_t *)malloc(sizeof(dt_lib_export_t));
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   GtkWidget *label;
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -508,7 +508,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_export_t *d = (dt_lib_export_t *)malloc(sizeof(dt_lib_export_t));
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,"export_selected.html#export_selected");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
 
   GtkWidget *label;
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -508,11 +508,13 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_export_t *d = (dt_lib_export_t *)malloc(sizeof(dt_lib_export_t));
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
+  dt_gui_add_help_link(self->widget,"export_selected.html#export_selected");
 
   GtkWidget *label;
 
   label = dt_ui_section_label_new(_("storage options"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 
   d->storage = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(d->storage, NULL, _("target storage"));
@@ -541,6 +543,7 @@ void gui_init(dt_lib_module_t *self)
   label = dt_ui_section_label_new(_("format options"));
   gtk_widget_set_margin_top(label, DT_PIXEL_APPLY_DPI(20));
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 
   d->format = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(d->format, NULL, _("file format"));
@@ -564,6 +567,7 @@ void gui_init(dt_lib_module_t *self)
   label = dt_ui_section_label_new(_("global options"));
   gtk_widget_set_margin_top(label, DT_PIXEL_APPLY_DPI(20));
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 
   d->width = GTK_SPIN_BUTTON(gtk_spin_button_new_with_range(0, EXPORT_MAX_IMAGE_SIZE, 1));
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->width), _("maximum output width\nset to 0 for no scaling"));

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -775,7 +775,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   d->timezones = _lib_geotagging_get_timezones();
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,"geotagging.html#geotagging");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
   GtkBox *hbox;
   GtkWidget *button, *label;
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -775,7 +775,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   d->timezones = _lib_geotagging_get_timezones();
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   GtkBox *hbox;
   GtkWidget *button, *label;
 

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -775,6 +775,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   d->timezones = _lib_geotagging_get_timezones();
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
+  dt_gui_add_help_link(self->widget,"geotagging.html#geotagging");
   GtkBox *hbox;
   GtkWidget *button, *label;
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -125,7 +125,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   gtk_widget_add_events(self->widget, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK |

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -125,7 +125,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
-  dt_gui_add_help_link(self->widget,"histogram.html#histogram");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
 
   gtk_widget_add_events(self->widget, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK |

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -125,6 +125,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
+  dt_gui_add_help_link(self->widget,"histogram.html#histogram");
 
   gtk_widget_add_events(self->widget, GDK_LEAVE_NOTIFY_MASK | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK |

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -104,7 +104,7 @@ void gui_init(dt_lib_module_t *self)
   d->record_undo = TRUE;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget, "history.html#history");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_widget_set_name(self->widget, "history-ui");
   d->history_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -112,6 +112,7 @@ void gui_init(dt_lib_module_t *self)
   d->compress_button = gtk_button_new_with_label(_("compress history stack"));
   gtk_label_set_xalign (GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->compress_button))), 0.0f);
   gtk_widget_set_tooltip_text(d->compress_button, _("create a minimal history stack which produces the same image"));
+  dt_gui_add_help_link(d->compress_button, "history.html#history");
   g_signal_connect(G_OBJECT(d->compress_button), "clicked", G_CALLBACK(_lib_history_compress_clicked_callback), NULL);
 
   /* add toolbar button for creating style */
@@ -120,6 +121,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->create_button), "clicked",
                    G_CALLBACK(_lib_history_create_style_button_clicked_callback), NULL);
   gtk_widget_set_tooltip_text(d->create_button, _("create a style from the current history stack"));
+  dt_gui_add_help_link(d->create_button, "history.html#history");
 
   /* add buttons to buttonbox */
   gtk_box_pack_start(GTK_BOX(hhbox), d->compress_button, TRUE, TRUE, 0);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -104,6 +104,7 @@ void gui_init(dt_lib_module_t *self)
   d->record_undo = TRUE;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
+  dt_gui_add_help_link(self->widget, "history.html#history");
   gtk_widget_set_name(self->widget, "history-ui");
   d->history_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -112,7 +113,6 @@ void gui_init(dt_lib_module_t *self)
   d->compress_button = gtk_button_new_with_label(_("compress history stack"));
   gtk_label_set_xalign (GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->compress_button))), 0.0f);
   gtk_widget_set_tooltip_text(d->compress_button, _("create a minimal history stack which produces the same image"));
-  dt_gui_add_help_link(d->compress_button, "history.html#history");
   g_signal_connect(G_OBJECT(d->compress_button), "clicked", G_CALLBACK(_lib_history_compress_clicked_callback), NULL);
 
   /* add toolbar button for creating style */
@@ -121,7 +121,6 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->create_button), "clicked",
                    G_CALLBACK(_lib_history_create_style_button_clicked_callback), NULL);
   gtk_widget_set_tooltip_text(d->create_button, _("create a style from the current history stack"));
-  dt_gui_add_help_link(d->create_button, "history.html#history");
 
   /* add buttons to buttonbox */
   gtk_box_pack_start(GTK_BOX(hhbox), d->compress_button, TRUE, TRUE, 0);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -170,7 +170,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_image_t *d = (dt_lib_image_t *)malloc(sizeof(dt_lib_image_t));
   self->data = (void *)d;
   self->widget = gtk_grid_new();
-  dt_gui_add_help_link(self->widget,"selected_images.html#selected_images_usage");
+  dt_gui_add_help_link(self->widget, "selected_images.html#selected_images_usage");
   GtkGrid *grid = GTK_GRID(self->widget);
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -170,6 +170,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_image_t *d = (dt_lib_image_t *)malloc(sizeof(dt_lib_image_t));
   self->data = (void *)d;
   self->widget = gtk_grid_new();
+  dt_gui_add_help_link(self->widget,"selected_images.html#selected_images_usage");
   GtkGrid *grid = GTK_GRID(self->widget);
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -270,6 +270,7 @@ void gui_init(dt_lib_module_t *self)
 
   // Setup gui
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget, "live_view.html#live_view");
   GtkWidget *box;
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -130,7 +130,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_location_t *lib = self->data;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,"find_location.html#find_location");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
 
   /* add search box */
   lib->search = GTK_ENTRY(gtk_entry_new());

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -130,7 +130,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_location_t *lib = self->data;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   /* add search box */
   lib->search = GTK_ENTRY(gtk_entry_new());

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -130,6 +130,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_location_t *lib = self->data;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
+  dt_gui_add_help_link(self->widget,"find_location.html#find_location");
 
   /* add search box */
   lib->search = GTK_ENTRY(gtk_entry_new());

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -87,7 +87,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)malloc(sizeof(dt_lib_map_settings_t));
   self->data = d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget,"map_settings.html#map_settings");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
   GtkBox *hbox;
   GtkWidget *label;
 

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -87,7 +87,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)malloc(sizeof(dt_lib_map_settings_t));
   self->data = d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   GtkBox *hbox;
   GtkWidget *label;
 

--- a/src/libs/map_settings.c
+++ b/src/libs/map_settings.c
@@ -87,6 +87,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_map_settings_t *d = (dt_lib_map_settings_t *)malloc(sizeof(dt_lib_map_settings_t));
   self->data = d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget,"map_settings.html#map_settings");
   GtkBox *hbox;
   GtkWidget *label;
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1629,7 +1629,7 @@ void gui_init(dt_lib_module_t *self)
 
   // initialise widgets
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
-  dt_gui_add_help_link(self->widget, "mask_manager.html#mask_manager");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkWidget *label = gtk_label_new(_("created shapes"));

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1629,6 +1629,7 @@ void gui_init(dt_lib_module_t *self)
 
   // initialise widgets
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
+  dt_gui_add_help_link(self->widget, "mask_manager.html#mask_manager");
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkWidget *label = gtk_label_new(_("created shapes"));

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -321,7 +321,7 @@ void gui_init(dt_lib_module_t *self)
   d->imgsel = -1;
 
   self->widget = gtk_grid_new();
-  dt_gui_add_help_link(self->widget,"metadata_editor.html#metadata_editor_usage");
+  dt_gui_add_help_link(self->widget, "metadata_editor.html#metadata_editor_usage");
   gtk_grid_set_row_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(10));
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -321,6 +321,7 @@ void gui_init(dt_lib_module_t *self)
   d->imgsel = -1;
 
   self->widget = gtk_grid_new();
+  dt_gui_add_help_link(self->widget,"metadata_editor.html#metadata_editor_usage");
   gtk_grid_set_row_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(10));
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -660,7 +660,7 @@ void gui_init(dt_lib_module_t *self)
   _lib_metatdata_view_init_labels();
 
   self->widget = gtk_grid_new();
-  dt_gui_add_help_link(self->widget,"image_information.html#image_information");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(5));
 //   GtkWidget *last = NULL;
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -660,7 +660,7 @@ void gui_init(dt_lib_module_t *self)
   _lib_metatdata_view_init_labels();
 
   self->widget = gtk_grid_new();
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(5));
 //   GtkWidget *last = NULL;
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -660,6 +660,7 @@ void gui_init(dt_lib_module_t *self)
   _lib_metatdata_view_init_labels();
 
   self->widget = gtk_grid_new();
+  dt_gui_add_help_link(self->widget,"image_information.html#image_information");
   gtk_grid_set_column_spacing(GTK_GRID(self->widget), DT_PIXEL_APPLY_DPI(5));
 //   GtkWidget *last = NULL;
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -99,7 +99,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
-  dt_gui_add_help_link(self->widget, "module_groups.html#module_groups");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   dtgtk_cairo_paint_flags_t pf = CPF_STYLE_FLAT;
 

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -99,6 +99,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
+  dt_gui_add_help_link(self->widget, "module_groups.html#module_groups");
 
   dtgtk_cairo_paint_flags_t pf = CPF_STYLE_FLAT;
 

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -81,7 +81,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_scrolled_window_new(
       NULL, NULL); // GTK_ADJUSTMENT(gtk_adjustment_new(200, 100, 200, 10, 100, 100))
   gtk_widget_set_size_request(self->widget, -1, DT_PIXEL_APPLY_DPI(208));
-  dt_gui_add_help_link(self->widget, "more_modules.html#more_modules");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self->widget), GTK_POLICY_AUTOMATIC, GTK_POLICY_ALWAYS);
   d->tree = GTK_TREE_VIEW(gtk_tree_view_new());
   gtk_widget_set_size_request(GTK_WIDGET(d->tree), DT_PIXEL_APPLY_DPI(50), -1);

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -81,6 +81,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_scrolled_window_new(
       NULL, NULL); // GTK_ADJUSTMENT(gtk_adjustment_new(200, 100, 200, 10, 100, 100))
   gtk_widget_set_size_request(self->widget, -1, DT_PIXEL_APPLY_DPI(208));
+  dt_gui_add_help_link(self->widget, "more_modules.html#more_modules");
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(self->widget), GTK_POLICY_AUTOMATIC, GTK_POLICY_ALWAYS);
   d->tree = GTK_TREE_VIEW(gtk_tree_view_new());
   gtk_widget_set_size_request(GTK_WIDGET(d->tree), DT_PIXEL_APPLY_DPI(50), -1);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -106,7 +106,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
-  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_widget_set_events(self->widget, GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK
                                       | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -106,7 +106,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
-  dt_gui_add_help_link(self->widget,"darkroom_panels.html#navigation");
+  dt_gui_add_help_link(self->widget,dt_get_help_url(self->plugin_name));
   gtk_widget_set_events(self->widget, GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK
                                       | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -106,6 +106,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
+  dt_gui_add_help_link(self->widget,"darkroom_panels.html#navigation");
   gtk_widget_set_events(self->widget, GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK
                                       | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK
                                       | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK);

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1112,7 +1112,7 @@ gui_init (dt_lib_module_t *self)
   dt_lib_print_settings_t *d = (dt_lib_print_settings_t*)malloc(sizeof(dt_lib_print_settings_t));
   self->data = d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget,"print_chapter.html#print_overview");
+  dt_gui_add_help_link(self->widget, "print_chapter.html#print_overview");
 
   char datadir[PATH_MAX] = { 0 };
   char confdir[PATH_MAX] = { 0 };

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -1112,6 +1112,7 @@ gui_init (dt_lib_module_t *self)
   dt_lib_print_settings_t *d = (dt_lib_print_settings_t*)malloc(sizeof(dt_lib_print_settings_t));
   self->data = d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget,"print_chapter.html#print_overview");
 
   char datadir[PATH_MAX] = { 0 };
   char confdir[PATH_MAX] = { 0 };
@@ -1162,7 +1163,7 @@ gui_init (dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(_("printer"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
-
+  dt_gui_add_help_link(self->widget, "print_usage.html#print_printer_section");
   d->printers = dt_bauhaus_combobox_new(NULL);
 
   gtk_box_pack_start(GTK_BOX(self->widget), d->printers, TRUE, TRUE, 0);
@@ -1264,6 +1265,7 @@ gui_init (dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(_("page"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, "print_page_section.html#print_page_section");
 
   //// papers
 
@@ -1394,6 +1396,7 @@ gui_init (dt_lib_module_t *self)
 
   label = dt_ui_section_label_new(_("print settings"));
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
+  dt_gui_add_help_link(self->widget, "print_settings.html#print_settings");
 
   //  Add export profile combo
 
@@ -1527,6 +1530,7 @@ gui_init (dt_lib_module_t *self)
   d->print_button = button;
   gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("print with current settings"));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(button), TRUE, TRUE, 0);
+  dt_gui_add_help_link(GTK_WIDGET(button), "print_button.html#print_button");
 
   g_signal_connect (G_OBJECT (button), "clicked",
                     G_CALLBACK (_print_button_clicked),

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -301,7 +301,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_recentcollect_t *d = (dt_lib_recentcollect_t *)calloc(1, sizeof(dt_lib_recentcollect_t));
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  dt_gui_add_help_link(self->widget, "recently_used_collections.html#recently_used_collections");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   d->inited = 0;
 
   gtk_widget_set_name(self->widget, "recent-collection-ui");

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -301,6 +301,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_recentcollect_t *d = (dt_lib_recentcollect_t *)calloc(1, sizeof(dt_lib_recentcollect_t));
   self->data = (void *)d;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  dt_gui_add_help_link(self->widget, "recently_used_collections.html#recently_used_collections");
   d->inited = 0;
 
   gtk_widget_set_name(self->widget, "recent-collection-ui");

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -91,7 +91,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_select_t *d = (dt_lib_select_t *)malloc(sizeof(dt_lib_select_t));
   self->data = d;
   self->widget = gtk_grid_new();
-  dt_gui_add_help_link(self->widget,"select.html#select_usage");
+  dt_gui_add_help_link(self->widget, "select.html#select_usage");
   GtkGrid *grid = GTK_GRID(self->widget);
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -91,6 +91,7 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_select_t *d = (dt_lib_select_t *)malloc(sizeof(dt_lib_select_t));
   self->data = d;
   self->widget = gtk_grid_new();
+  dt_gui_add_help_link(self->widget,"select.html#select_usage");
   GtkGrid *grid = GTK_GRID(self->widget);
   gtk_grid_set_row_spacing(grid, DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(5));

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -82,7 +82,7 @@ static void create_callback(GtkButton *button, gpointer user_data)
 void gui_init(dt_lib_module_t *self)
 {
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
-  dt_gui_add_help_link(self->widget,"tethering_panels.html#session");
+  dt_gui_add_help_link(self->widget, "tethering_panels.html#session");
   self->data = calloc(1, sizeof(dt_lib_session_t));
 
   // Setup lib data

--- a/src/libs/session.c
+++ b/src/libs/session.c
@@ -82,6 +82,7 @@ static void create_callback(GtkButton *button, gpointer user_data)
 void gui_init(dt_lib_module_t *self)
 {
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_PIXEL_APPLY_DPI(5));
+  dt_gui_add_help_link(self->widget,"tethering_panels.html#session");
   self->data = calloc(1, sizeof(dt_lib_session_t));
 
   // Setup lib data

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -271,6 +271,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_lib_snapshots_add_button_clicked_callback), self);
   gtk_widget_set_tooltip_text(button, _("take snapshot to compare with another image "
                                         "or the same image at another stage of development"));
+  dt_gui_add_help_link(button, "snapshots.html#snapshots");
 
   /*
    * initialize snapshots

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -263,6 +263,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* initialize ui containers */
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
+  dt_gui_add_help_link(self->widget, "snapshots.html#snapshots");
   d->snapshots_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   /* create take snapshot button */

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -303,7 +303,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   d->edit_button = NULL;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget,"styles.html#styles_usage");
+  dt_gui_add_help_link(self->widget, "styles.html#styles_usage");
   GtkWidget *w;
   GtkWidget *scrolled;
 

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -303,6 +303,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
   d->edit_button = NULL;
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget,"styles.html#styles_usage");
   GtkWidget *w;
   GtkWidget *scrolled;
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -474,7 +474,7 @@ void gui_init(dt_lib_module_t *self)
   d->imgsel = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-  dt_gui_add_help_link(self->widget, "tagging.html#tagging");
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   //   gtk_widget_set_size_request(self->widget, DT_PIXEL_APPLY_DPI(100), -1);
 
   GtkBox *box, *hbox;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -474,6 +474,7 @@ void gui_init(dt_lib_module_t *self)
   d->imgsel = -1;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  dt_gui_add_help_link(self->widget, "tagging.html#tagging");
   //   gtk_widget_set_size_request(self->widget, DT_PIXEL_APPLY_DPI(100), -1);
 
   GtkBox *box, *hbox;
@@ -501,6 +502,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_set_model(d->current, GTK_TREE_MODEL(liststore));
   g_object_unref(liststore);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->current), _("attached tags,\ndoubleclick to detach"));
+  dt_gui_add_help_link(GTK_WIDGET(d->current), "tagging.html#tagging_usage");
   g_signal_connect(G_OBJECT(d->current), "row-activated", G_CALLBACK(detach_activated), (gpointer)self);
   gtk_container_add(GTK_CONTAINER(w), GTK_WIDGET(d->current));
 
@@ -510,12 +512,14 @@ void gui_init(dt_lib_module_t *self)
   button = gtk_button_new_with_label(_("attach"));
   d->attach_button = button;
   gtk_widget_set_tooltip_text(button, _("attach tag to all selected images"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(attach_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(_("detach"));
   d->detach_button = button;
   gtk_widget_set_tooltip_text(button, _("detach tag from all selected images"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(detach_button_clicked), (gpointer)self);
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
 
@@ -528,6 +532,7 @@ void gui_init(dt_lib_module_t *self)
   // text entry and new button
   w = gtk_entry_new();
   gtk_widget_set_tooltip_text(w, _("enter tag name"));
+  dt_gui_add_help_link(w, "tagging.html#tagging_usage");
   gtk_box_pack_start(box, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   // g_signal_connect(G_OBJECT(w), "key-release-event",
@@ -553,6 +558,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_set_model(d->related, GTK_TREE_MODEL(liststore));
   g_object_unref(liststore);
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->related), _("related tags,\ndoubleclick to attach"));
+  dt_gui_add_help_link(GTK_WIDGET(d->related), "tagging.html#tagging_usage");
   g_signal_connect(G_OBJECT(d->related), "row-activated", G_CALLBACK(attach_activated), (gpointer)self);
   gtk_container_add(GTK_CONTAINER(w), GTK_WIDGET(d->related));
 
@@ -562,24 +568,28 @@ void gui_init(dt_lib_module_t *self)
   button = gtk_button_new_with_label(_("new"));
   d->new_button = button;
   gtk_widget_set_tooltip_text(button, _("create a new tag with the\nname you entered"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(new_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(_("delete"));
   d->delete_button = button;
   gtk_widget_set_tooltip_text(button, _("delete selected tag"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(delete_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(C_("verb", "import"));
   d->import_button = button;
   gtk_widget_set_tooltip_text(button, _("import tags from a Lightroom keyword file"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(import_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(C_("verb", "export"));
   d->export_button = button;
   gtk_widget_set_tooltip_text(button, _("export all tags to a Lightroom keyword file"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(export_button_clicked), (gpointer)self);
 

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -240,21 +240,21 @@ static void _main_do_event(GdkEvent *event, gpointer data)
           }
           if(base_url)
           {
-            dt_l10n_language_t *language = (dt_l10n_language_t *)g_list_nth(darktable.l10n->languages, darktable.l10n->selected)->data;
+            dt_l10n_language_t *language
+                = (dt_l10n_language_t *)g_list_nth(darktable.l10n->languages, darktable.l10n->selected)->data;
             char *lang = language->code;
             const int number_of_supported_languages = 4;
-            const char* supported_languages[4] = {"en", "fr", "it", "es"};
+            const char *supported_languages[4] = { "en", "fr", "it", "es" };
             bool is_language_supported = false;
-            for (int i = 0; i < number_of_supported_languages; i++)
+            for(int i = 0; i < number_of_supported_languages; i++)
             {
-              if (0 == strcmp(lang, supported_languages[i]))
+              if(0 == strcmp(lang, supported_languages[i]))
               {
                 is_language_supported = true;
                 break;
               }
             }
-            if (!is_language_supported)
-              lang = "en";
+            if(!is_language_supported) lang = "en";
             char *url = g_build_path("/", base_url, lang, help_url, NULL);
             // TODO: call the web browser directly so that file:// style base for local installs works
 #if GTK_CHECK_VERSION(3, 22, 0)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -264,6 +264,7 @@ static void _main_do_event(GdkEvent *event, gpointer data)
 #endif
             g_free(base_url);
             g_free(url);
+            dt_control_log(_("Help url opened in web brower"));
           }
         }
         else

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -18,6 +18,7 @@
 
 #include "common/collection.h"
 #include "common/darktable.h"
+#include "common/l10n.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "dtgtk/button.h"
@@ -239,8 +240,21 @@ static void _main_do_event(GdkEvent *event, gpointer data)
           }
           if(base_url)
           {
-            // TODO: try to use the currently set language
-            char *lang = "en";
+            dt_l10n_language_t *language = (dt_l10n_language_t *)g_list_nth(darktable.l10n->languages, darktable.l10n->selected)->data;
+            char *lang = language->code;
+            const int number_of_supported_languages = 4;
+            const char* supported_languages[4] = {"en", "fr", "it", "es"};
+            bool is_language_supported = false;
+            for (int i = 0; i < number_of_supported_languages; i++)
+            {
+              if (0 == strcmp(lang, supported_languages[i]))
+              {
+                is_language_supported = true;
+                break;
+              }
+            }
+            if (!is_language_supported)
+              lang = "en";
             char *url = g_build_path("/", base_url, lang, help_url, NULL);
             // TODO: call the web browser directly so that file:// style base for local installs works
 #if GTK_CHECK_VERSION(3, 22, 0)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -243,16 +243,19 @@ static void _main_do_event(GdkEvent *event, gpointer data)
             dt_l10n_language_t *language
                 = (dt_l10n_language_t *)g_list_nth(darktable.l10n->languages, darktable.l10n->selected)->data;
             char *lang = language->code;
-            const int number_of_supported_languages = 4;
-            const char *supported_languages[4] = { "en", "fr", "it", "es" };
-            bool is_language_supported = false;
-            for(int i = 0; i < number_of_supported_languages; i++)
+            // array of languages the usermanual supports.
+            // "\0" MUST remain the last element of the array
+            const char *supported_languages[5] = { "en", "fr", "it", "es", "\0" };
+            gboolean is_language_supported = false;
+            int i = 0;
+            while(supported_languages[i][0] != '\0')
             {
               if(0 == strcmp(lang, supported_languages[i]))
               {
                 is_language_supported = true;
                 break;
               }
+              i++;
             }
             if(!is_language_supported) lang = "en";
             char *url = g_build_path("/", base_url, lang, help_url, NULL);
@@ -264,12 +267,12 @@ static void _main_do_event(GdkEvent *event, gpointer data)
 #endif
             g_free(base_url);
             g_free(url);
-            dt_control_log(_("Help url opened in web brower"));
+            dt_control_log(_("help url opened in web brower"));
           }
         }
         else
         {
-          dt_control_log(_("There is no help available for this element"));
+          dt_control_log(_("there is no help available for this element"));
         }
       }
       handled = TRUE;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -201,6 +201,7 @@ static void _main_do_event(GdkEvent *event, gpointer data)
     case GDK_BUTTON_PRESS:
     {
       // reset GTK to normal behaviour
+      dt_control_allow_change_cursor();
       dt_control_change_cursor(GDK_LEFT_PTR);
       gdk_event_handler_set((GdkEventFunc)gtk_main_do_event, NULL, NULL);
       g_signal_handlers_block_by_func(d->help_button, _lib_help_button_clicked, d);
@@ -251,6 +252,10 @@ static void _main_do_event(GdkEvent *event, gpointer data)
             g_free(url);
           }
         }
+        else
+        {
+          dt_control_log(_("There is no help available for this element"));
+        }
       }
       handled = TRUE;
       break;
@@ -265,8 +270,10 @@ static void _main_do_event(GdkEvent *event, gpointer data)
         if(help_url)
         {
           // TODO: find a better way to tell the user that the hovered widget has a help link
-          dt_cursor_t cursor = event->type == GDK_ENTER_NOTIFY ? GDK_HAND1 : GDK_QUESTION_ARROW;
+          dt_cursor_t cursor = event->type == GDK_ENTER_NOTIFY ? GDK_QUESTION_ARROW : GDK_X_CURSOR;
+          dt_control_allow_change_cursor();
           dt_control_change_cursor(cursor);
+          dt_control_forbid_change_cursor();
         }
       }
       break;
@@ -280,7 +287,8 @@ static void _main_do_event(GdkEvent *event, gpointer data)
 
 static void _lib_help_button_clicked(GtkWidget *widget, gpointer user_data)
 {
-  dt_control_change_cursor(GDK_QUESTION_ARROW);
+  dt_control_change_cursor(GDK_X_CURSOR);
+  dt_control_forbid_change_cursor();
   gdk_event_handler_set(_main_do_event, user_data, NULL);
 }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -310,6 +310,75 @@ int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name)
   return dt_view_manager_switch_by_view(vm, new_view);
 }
 
+static char* dt_lib_get_help_url(dt_lib_module_t *plugin)
+{
+  if(!strcmp(plugin->plugin_name,"ratings"))
+    return "star_ratings_and_color_labels.html";
+  if(!strcmp(plugin->plugin_name,"filter"))
+    return "filtering_and_sort_order.html";
+  if(!strcmp(plugin->plugin_name,"colorlabels"))
+    return "star_ratings_and_color_labels.html";
+  if(!strcmp(plugin->plugin_name,"import"))
+    return "lighttable_panels.html#import";
+  if(!strcmp(plugin->plugin_name,"select"))
+    return "select.html";
+  if(!strcmp(plugin->plugin_name,"image"))
+    return "selected_images.html";
+  if(!strcmp(plugin->plugin_name,"copy_history"))
+    return "history_stack.html";
+  if(!strcmp(plugin->plugin_name,"styles"))
+    return "styles.html";
+  if(!strcmp(plugin->plugin_name,"metadata"))
+    return "metadata_editor.html";
+  if(!strcmp(plugin->plugin_name,"tagging"))
+    return "tagging.html";
+  if(!strcmp(plugin->plugin_name,"geotagging"))
+    return "geotagging.html";
+  if(!strcmp(plugin->plugin_name,"collect"))
+    return "collect_images.html";
+  if(!strcmp(plugin->plugin_name,"recentcollect"))
+    return "recently_used_collections.html";
+  if(!strcmp(plugin->plugin_name,"metadata_view"))
+    return "image_information.html";
+  if(!strcmp(plugin->plugin_name,"export"))
+    return "export_selected.html";
+  if(!strcmp(plugin->plugin_name,"histogram"))
+    return "histogram.html";
+  if(!strcmp(plugin->plugin_name,"navigation"))
+    return "darkroom_panels.html#navigation";
+  if(!strcmp(plugin->plugin_name,"snapshots"))
+    return "snapshots.html";
+  if(!strcmp(plugin->plugin_name,"modulegroups"))
+    return "module_groups.html";
+  if(!strcmp(plugin->plugin_name,"history"))
+    return "history.html";
+  if(!strcmp(plugin->plugin_name,"colorpicker"))
+    return "global_color_picker.html";
+  if(!strcmp(plugin->plugin_name,"masks"))
+    return "mask_manager.html";
+  if(!strcmp(plugin->plugin_name,"modulelist"))
+    return "more_modules.html";
+  if(!strcmp(plugin->plugin_name,"global_toolbox"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"lighttable_mode"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"module_toolbox"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"view_toolbox"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"backgroundjobs"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"hinter"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"filter"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"filmstrip"))
+    return NULL;
+  if(!strcmp(plugin->plugin_name,"viewswitcher"))
+    return NULL;
+  return NULL;
+}
+
 int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 {
   dt_view_t *old_view = vm->current_view;
@@ -426,6 +495,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
       /* if we didn't get an expander let's add the widget */
       if(!w) w = plugin->widget;
+      dt_gui_add_help_link(w, dt_lib_get_help_url(plugin));
 
       /* add module to its container */
       dt_ui_container_add_widget(darktable.gui->ui, plugin->container(plugin), w);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -28,6 +28,7 @@
 #include "common/mipmap_cache.h"
 #include "common/module.h"
 #include "common/undo.h"
+#include "common/usermanual_url.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -310,82 +311,6 @@ int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name)
   return dt_view_manager_switch_by_view(vm, new_view);
 }
 
-static char* dt_lib_get_help_url(dt_lib_module_t *plugin)
-{
-  if(!strcmp(plugin->plugin_name,"ratings"))
-    return "star_ratings_and_color_labels.html";
-  if(!strcmp(plugin->plugin_name,"filter"))
-    return "filtering_and_sort_order.html";
-  if(!strcmp(plugin->plugin_name,"colorlabels"))
-    return "star_ratings_and_color_labels.html";
-  if(!strcmp(plugin->plugin_name,"import"))
-    return "lighttable_panels.html#import";
-  if(!strcmp(plugin->plugin_name,"select"))
-    return "select.html";
-  if(!strcmp(plugin->plugin_name,"image"))
-    return "selected_images.html";
-  if(!strcmp(plugin->plugin_name,"copy_history"))
-    return "history_stack.html";
-  if(!strcmp(plugin->plugin_name,"styles"))
-    return "styles.html";
-  if(!strcmp(plugin->plugin_name,"metadata"))
-    return "metadata_editor.html";
-  if(!strcmp(plugin->plugin_name,"tagging"))
-    return "tagging.html";
-  if(!strcmp(plugin->plugin_name,"geotagging"))
-    return "geotagging.html";
-  if(!strcmp(plugin->plugin_name,"collect"))
-    return "collect_images.html";
-  if(!strcmp(plugin->plugin_name,"recentcollect"))
-    return "recently_used_collections.html";
-  if(!strcmp(plugin->plugin_name,"metadata_view"))
-    return "image_information.html";
-  if(!strcmp(plugin->plugin_name,"export"))
-    return "export_selected.html";
-  if(!strcmp(plugin->plugin_name,"histogram"))
-    return "histogram.html";
-  if(!strcmp(plugin->plugin_name,"navigation"))
-    return "darkroom_panels.html#navigation";
-  if(!strcmp(plugin->plugin_name,"snapshots"))
-    return "snapshots.html";
-  if(!strcmp(plugin->plugin_name,"modulegroups"))
-    return "module_groups.html";
-  if(!strcmp(plugin->plugin_name,"history"))
-    return "history.html";
-  if(!strcmp(plugin->plugin_name,"colorpicker"))
-    return "global_color_picker.html";
-  if(!strcmp(plugin->plugin_name,"masks"))
-    return "mask_manager.html";
-  if(!strcmp(plugin->plugin_name,"modulelist"))
-    return "more_modules.html";
-  if(!strcmp(plugin->plugin_name,"location"))
-    return "find_location.html";
-  if(!strcmp(plugin->plugin_name,"map_settings"))
-    return "map_settings.html";
-  if(!strcmp(plugin->plugin_name,"print_settings"))
-    return "print_settings.html";
-  if(!strcmp(plugin->plugin_name,"global_toolbox"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"lighttable_mode"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"module_toolbox"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"view_toolbox"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"backgroundjobs"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"hinter"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"filter"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"filmstrip"))
-    return NULL;
-  if(!strcmp(plugin->plugin_name,"viewswitcher"))
-    return NULL;
-  printf("%s\n",plugin->plugin_name);
-  return NULL;
-}
-
 int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 {
   dt_view_t *old_view = vm->current_view;
@@ -502,7 +427,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
       /* if we didn't get an expander let's add the widget */
       if(!w) w = plugin->widget;
-      dt_gui_add_help_link(w, dt_lib_get_help_url(plugin));
+      dt_gui_add_help_link(w, dt_get_help_url(plugin->plugin_name));
 
       /* add module to its container */
       dt_ui_container_add_widget(darktable.gui->ui, plugin->container(plugin), w);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -358,6 +358,12 @@ static char* dt_lib_get_help_url(dt_lib_module_t *plugin)
     return "mask_manager.html";
   if(!strcmp(plugin->plugin_name,"modulelist"))
     return "more_modules.html";
+  if(!strcmp(plugin->plugin_name,"location"))
+    return "find_location.html";
+  if(!strcmp(plugin->plugin_name,"map_settings"))
+    return "map_settings.html";
+  if(!strcmp(plugin->plugin_name,"print_settings"))
+    return "print_settings.html";
   if(!strcmp(plugin->plugin_name,"global_toolbox"))
     return NULL;
   if(!strcmp(plugin->plugin_name,"lighttable_mode"))
@@ -376,6 +382,7 @@ static char* dt_lib_get_help_url(dt_lib_module_t *plugin)
     return NULL;
   if(!strcmp(plugin->plugin_name,"viewswitcher"))
     return NULL;
+  printf("%s\n",plugin->plugin_name);
   return NULL;
 }
 


### PR DESCRIPTION
This pull request update the context sensitive help in the following ways:
- it adds the urls that @mpaglia0 put in https://github.com/darktable-org/darktable/pull/1656 (I had to do a rebase as one of the commits of that pull request was unrelated to this, so I removed it and kept the others). Thanks @mpaglia0 for all this work
- it change the way the cursor behaves. Before: it was a question mark, and became a hand when there was a help link. But in darktable, when going other the right panel, the shape was overrided. Now: it is a cross, and becomes a question mark on widgets that have a link (I think it is clearer like this), and the shape is no more changed by other events.
- a message is displayed to the user if he clicks on something for which we do not have any url
- the expanders have now help urls too. Previously, we had to click inside a module to get help, now we can click on its expander.
- the code gets the ui language, and checks if the usermanual is available in this language.

This PR solves the issue https://redmine.darktable.org/issues/8660

The only problem that remains, and I think it requires a huge GUI code change (at least, I do not see how to solve it without such a change), is that on some elements the cursor is a cross whereas they do have a help url, and the url open successfully on click.
I personally think we can live with that, as this behavior is only here for a small number of the widgets, and considering the amount of changes this may require in the code I do not know if it really is worth it (I already spent quite a lot on time on this, but did not find any solution).