### PR TITLE
Configure sqlite3 before initialization

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1535,6 +1535,9 @@ static gboolean _lock_databases(dt_database_t *db)
 
 dt_database_t *dt_database_init(const char *alternative, const gboolean load_data)
 {
+  /*  set the threading mode to Serialized */
+  sqlite3_config(SQLITE_CONFIG_SERIALIZED);
+
   sqlite3_initialize();
 
 start:
@@ -1603,8 +1606,6 @@ start:
     return db;
   }
 
-  /*  set the threading mode to Serialized */
-  sqlite3_config(SQLITE_CONFIG_SERIALIZED);
 
   /* opening / creating database */
   if(sqlite3_open(db->dbfilename_library, &db->handle))


### PR DESCRIPTION
This is a follow-up to #1594.

After I got some EXC_BAD_ACCESS exceptions (and a "[logging] misuse at line 153876 of [95fbac39ba] log message") on macOS i found c2b64379014575bf8095cc6219aa3b89fd40bc57 as the cause.

According to https://www.sqlite.org/c3ref/config.html
"The sqlite3_config() interface may only be invoked prior to library
initialization using sqlite3_initialize() or after shutdown by sqlite3_shutdown()"