### PR TITLE
control: Use gboolean instead of C99 stdbool

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -75,7 +75,7 @@ void dt_control_init(dt_control_t *s)
   s->dev_zoom_x = 0;
   s->dev_zoom_y = 0;
   s->dev_zoom = DT_ZOOM_FIT;
-  s->lock_cursor_shape = false;
+  s->lock_cursor_shape = FALSE;
 }
 
 void dt_control_key_accelerators_on(struct dt_control_t *s)
@@ -100,12 +100,12 @@ int dt_control_is_key_accelerators_on(struct dt_control_t *s)
 
 void dt_control_forbid_change_cursor()
 {
-  darktable.control->lock_cursor_shape = true;
+  darktable.control->lock_cursor_shape = TRUE;
 }
 
 void dt_control_allow_change_cursor()
 {
-  darktable.control->lock_cursor_shape = false;
+  darktable.control->lock_cursor_shape = FALSE;
 }
 
 void dt_control_change_cursor(dt_cursor_t curs)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -146,7 +146,7 @@ typedef struct dt_control_t
   double button_x, button_y;
   int history_start;
   int32_t mouse_over_id;
-  bool lock_cursor_shape;
+  gboolean lock_cursor_shape;
 
   // TODO: move these to some darkroom struct
   // synchronized navigation

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -246,13 +246,13 @@ static void _main_do_event(GdkEvent *event, gpointer data)
             // array of languages the usermanual supports.
             // NULL MUST remain the last element of the array
             const char *supported_languages[] = { "en", "fr", "it", "es", NULL };
-            gboolean is_language_supported = false;
+            gboolean is_language_supported = FALSE;
             int i = 0;
             while(supported_languages[i])
             {
               if(!strcmp(lang, supported_languages[i]))
               {
-                is_language_supported = true;
+                is_language_supported = TRUE;
                 break;
               }
               i++;


### PR DESCRIPTION
Looks like this fails on some Fedora systems as stdbool.h is not included. May also depend on some special CFLAGS. However the code uses gboolean everywhere else.