### PR TITLE
WIP: Fix segfault when drawing a path for a mask

### DIFF
--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -340,11 +340,18 @@ static void _path_points_recurs(float *p1, float *p2, double tmin, double tmax, 
 }
 
 /** find all self intersections in a path */
-static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners, float *border, int border_count)
+static size_t _path_find_self_intersection(dt_masks_dynbuf_t *inter,
+                                           size_t nb_corners,
+                                           float *border,
+                                           size_t border_count)
 {
   if(nb_corners == 0 || border_count == 0) return 0;
 
-  int inter_count = 0;
+  if (nb_corners * 3 < nb_corners) {
+      return 0;
+  }
+
+  size_t inter_count = 0;
 
   // we search extreme points in x and y
   int xmin, xmax, ymin, ymax;
@@ -352,8 +359,11 @@ static int _path_find_self_intersection(dt_masks_dynbuf_t *inter, int nb_corners
   xmax = ymax = INT_MIN;
   int posextr[4] = { -1 }; // xmin,xmax,ymin,ymax
 
-  for(int i = nb_corners * 3; i < border_count; i++)
+  for(size_t i = nb_corners * 3; i < border_count; i++)
   {
+    if (i * 2 < i) {
+        return 0;
+    }
     if(isnan(border[i * 2]) || isnan(border[i * 2 + 1]))
     {
       border[i * 2] = border[i * 2 - 2];

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -354,10 +354,10 @@ static size_t _path_find_self_intersection(dt_masks_dynbuf_t *inter,
   size_t inter_count = 0;
 
   // we search extreme points in x and y
-  int xmin, xmax, ymin, ymax;
+  size_t xmin, xmax, ymin, ymax;
   xmin = ymin = INT_MAX;
-  xmax = ymax = INT_MIN;
-  int posextr[4] = { -1 }; // xmin,xmax,ymin,ymax
+  xmax = ymax = 0;
+  size_t posextr[4] = { 0 }; // xmin,xmax,ymin,ymax
 
   for(size_t i = nb_corners * 3; i < border_count; i++)
   {
@@ -390,13 +390,30 @@ static size_t _path_find_self_intersection(dt_masks_dynbuf_t *inter,
       posextr[3] = i;
     }
   }
+  if (xmin == 0 || ymin == 0) {
+      return 0;
+  }
   xmin -= 1, ymin -= 1;
-  xmax += 1, ymax += 1;
-  const int hb = ymax - ymin;
-  const int wb = xmax - xmin;
 
+  if (xmax == INT_MAX || ymax == INT_MAX) {
+      return 0;
+  }
+  xmax += 1, ymax += 1;
+
+  if (ymax == INT_MAX || ymin > ymax) {
+      return 0;
+  }
+  const size_t hb = ymax - ymin;
+  if (xmax == INT_MAX || xmin > xmax) {
+      return 0;
+  }
+  const size_t wb = xmax - xmin;
+
+  if (hb * wb > hb) {
+      return 0;
+  }
   // we allocate the buffer
-  const size_t ss = (size_t)hb * wb;
+  const size_t ss = hb * wb;
   if(ss < 10) return 0;
 
   int *binter = calloc(ss, sizeof(int));
@@ -416,10 +433,10 @@ static size_t _path_find_self_intersection(dt_masks_dynbuf_t *inter,
   int lastx = border[(posextr[1] - 1) * 2];
   int lasty = border[(posextr[1] - 1) * 2 + 1];
 
-  for(int ii = nb_corners * 3; ii < border_count; ii++)
+  for(size_t ii = nb_corners * 3; ii < border_count; ii++)
   {
     // we want to loop from one border extremity
-    int i = ii - nb_corners * 3 + posextr[1];
+    size_t i = ii - nb_corners * 3 + posextr[1];
     if(i >= border_count) i = i - border_count + nb_corners * 3;
 
     if(inter_count >= nb_corners * 4) break;
@@ -432,8 +449,8 @@ static size_t _path_find_self_intersection(dt_masks_dynbuf_t *inter,
     // and "register" them in binter
     for(int j = dt_masks_dynbuf_position(extra) / 2 - 1; j >= 0; j--)
     {
-      int xx = (dt_masks_dynbuf_buffer(extra))[j * 2];
-      int yy = (dt_masks_dynbuf_buffer(extra))[j * 2 + 1];
+      size_t xx = (dt_masks_dynbuf_buffer(extra))[j * 2];
+      size_t yy = (dt_masks_dynbuf_buffer(extra))[j * 2 + 1];
 
       // we check also 2 points around to be sure catching intersection
       int v[3] = { 0 };


### PR DESCRIPTION
I'm trying to address the segfault which is attached at the end. I see several problems here. The code uses `int` instead of `size_t` for array access and allocating memory. This could be a problem as signed integer overflows are undefined in the C specification. For size calculations an unsigned integer should be use, also that the optimize will understand the code better.

```
Thread 1 (Thread 0x7fcf14e19c80 (LWP 25895)):
#0  0x00007fcf1f1b38da in __waitpid (pid=pid@entry=32301, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
        resultvar = 18446744073709551104
        sc_cancel_oldtype = 0
#1  0x00007fcf1f4d2e60 in _dt_sigsegv_handler (param=11) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/common/system_signal_handling.c:118
        pid = 32301
        name_used = 0x55ceca05bc90 "/tmp/darktable_bt_VU5KRZ.txt"
        fout = <optimized out>
        delete_file = 0
        datadir = "/usr/share/darktable", '\000' <repeats 4075 times>
        pid_arg = 0x55ceca4e41a0 "25895"
        comm_arg = 0x55ceca45ef30 "/usr/share/darktable/gdb_commands"
        log_arg = 0x55ceca4adac0 "set logging on /tmp/darktable_bt_VU5KRZ.txt"
#2  0x00007fcf1f1b3f70 in <signal handler called> () at /lib64/libpthread.so.0
#3  0x00007fcf1f5320db in _path_find_self_intersection (border_count=8567, border=0x7fcdd4b0d010, nb_corners=3, inter=0x55cec98cb610) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/path.c:430
        xx = <optimized out>
        yy = <optimized out>
        v = {<optimized out>, 0, 0}
        j = 435
        i = 9
        ii = 9
        inter_count = 0
        xmax = <optimized out>
        wb = 719
        xmin = 163
        ymax = <optimized out>
        ss = <optimized out>
        binter = 0x7fce18b81010
        lastx = <optimized out>
        ymin = 402
        posextr = {4142, 9, 21, 4446}
        extra = 0x55cec992d430
        lasty = <optimized out>
        start2 = 250145551.227718
        wd = <optimized out>
        ht = <optimized out>
        nb = 3
        dpoints = <optimized out>
        dborder = <optimized out>
        intersections = 0x55cec98cb610
        dx = <optimized out>
        dy = <optimized out>
        border_init = 0x55cec98c0e00
        cw = <optimized out>
        inter_count = 0
#4  0x00007fcf1f5320db in _path_get_points_border (dev=dev@entry=0x55cec7b54fe0, form=form@entry=0x55cec9e48e40, prio_max=prio_max@entry=999999, pipe=0x55cec7b55df0, points=points@entry=0x55cec90a3810, points_count=points_count@entry=0x55cec90a3818, border=0x55cec90a3820, border_count=0x55cec90a3828, source=0) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/path.c:681
        start2 = 250145551.227718
        wd = <optimized out>
        ht = <optimized out>
        nb = 3
        dpoints = <optimized out>
        dborder = <optimized out>
        intersections = 0x55cec98cb610
        dx = <optimized out>
        dy = <optimized out>
        border_init = 0x55cec98c0e00
        cw = <optimized out>
        inter_count = 0
#5  0x00007fcf1f5345b4 in dt_path_get_points_border (source=0, border_count=0x55cec90a3828, border=0x55cec90a3820, points_count=0x55cec90a3818, points=0x55cec90a3810, form=0x55cec9e48e40, dev=0x55cec7b54fe0) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/path.c:834
#6  0x00007fcf1f5345b4 in dt_masks_get_points_border (dev=0x55cec7b54fe0, form=form@entry=0x55cec9e48e40, points=points@entry=0x55cec90a3810, points_count=points_count@entry=0x55cec90a3818, border=border@entry=0x55cec90a3820, border_count=border_count@entry=0x55cec90a3828, source=0) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/masks.c:507
#7  0x00007fcf1f5347f0 in dt_masks_gui_form_create (form=form@entry=0x55cec9e48e40, gui=gui@entry=0x55cec8bd7800, index=index@entry=0) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/masks.c:232
        gpt = 0x55cec90a3810
#8  0x00007fcf1f54464d in dt_path_events_mouse_moved (pzx=<optimized out>, pzy=<optimized out>, form=form@entry=0x55cec9e48e40, gui=gui@entry=0x55cec8bd7800, index=index@entry=0, parentid=0, which=0, pressure=1, module=<optimized out>) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/path.c:1651
        pos2 = <optimized out>
        point2 = <optimized out>
        ht = <optimized out>
        pts = {351.299561, 561.158325}
        dx = <optimized out>
        point = <optimized out>
        wd = <optimized out>
        dy = <optimized out>
        zoom = <optimized out>
        closeup = <optimized out>
        zoom_scale = 1.78666663
        gpt = <optimized out>
        nb = <optimized out>
        in = -944418848
        inb = 21966
        near = 525376325
        ins = 32719
#9  0x00007fcf1f5455cd in dt_masks_events_mouse_moved (module=<optimized out>, x=x@entry=730.38671875, y=y@entry=1003.7430419921875, pressure=pressure@entry=1, which=which@entry=0) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/develop/masks/masks.c:1290
        gui = 0x55cec8bd7800
        form = 0x55cec9e48e40
        pzx = 0.258517683
        pzy = 0.624218285
        rep = 0
#10 0x00007fcf0c032bea in mouse_moved (self=0x55cec7b539c0, x=<optimized out>, y=<optimized out>, pressure=1, which=0) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/views/darkroom.c:1972
        capwd = <optimized out>
        capht = <optimized out>
        dev = 0x55cec7b54fe0
        mouse_over_id = <optimized out>
        ctl = 0x55cec6ca4ae0
        width_i = <optimized out>
        height_i = <optimized out>
        offx = <optimized out>
        offy = <optimized out>
        handled = 0
#11 0x00007fcf1f56fa2d in mouse_moved (w=w@entry=0x55cec78fb450 [GtkDrawingArea], event=0x55cec943ac70, user_data=<optimized out>) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/gui/gtk.c:894
        pressure = 1
        device = <optimized out>
        x = 120
        y = 0
#16 0x00007fcf1df0233f in <emit signal ??? on instance 0x55cec78fb450 [GtkDrawingArea]> (instance=instance@entry=0x55cec78fb450, signal_id=<optimized out>, detail=detail@entry=0) at gsignal.c:3447
        var_args = {{gp_offset = 32, fp_offset = 48, overflow_arg_area = 0x7fff57b15530, reg_save_area = 0x7fff57b15470}}
    #12 0x00007fcf1e6df6fb in _gtk_marshal_BOOLEAN__BOXED (closure=0x55cec7b14970, return_value=0x7fff57b15210, n_param_values=<optimized out>, param_values=0x7fff57b15270, invocation_hint=<optimized out>, marshal_data=<optimized out>) at gtkmarshalers.c:83
                cc = 0x55cec7b14970
                data1 = 0x55cec78fb450
                data2 = <optimized out>
                callback = 0x7fcf1f56f9d0 <mouse_moved>
                v_return = <optimized out>
                __func__ = "_gtk_marshal_BOOLEAN__BOXED"
    #13 0x00007fcf1dee5b6d in g_closure_invoke (closure=0x55cec7b14970, return_value=0x7fff57b15210, n_param_values=2, param_values=0x7fff57b15270, invocation_hint=0x7fff57b151f0) at gclosure.c:810
                marshal = 0x7fcf1e6df690 <_gtk_marshal_BOOLEAN__BOXED>
                marshal_data = 0x0
                in_marshal = 0
                real_closure = 0x55cec7b14950
                __func__ = "g_closure_invoke"
    #14 0x00007fcf1def8cb3 in signal_emit_unlocked_R (node=node@entry=0x55cec6e13320, detail=detail@entry=0, instance=instance@entry=0x55cec78fb450, emission_return=emission_return@entry=0x7fff57b153a0, instance_and_params=instance_and_params@entry=0x7fff57b15270) at gsignal.c:3635
                tmp = <optimized out>
                handler = 0x55cec7afc8c0
                accumulator = 0x55cec6e42680
                emission = {next = 0x0, instance = 0x55cec78fb450, ihint = {signal_id = 98, detail = 0, run_type = G_SIGNAL_RUN_FIRST}, state = EMISSION_RUN, chain_type = 0x4 [void]}
                class_closure = 0x55cec6e40b40
                hlist = <optimized out>
                handler_list = 0x55cec7afc8c0
                return_accu = 0x7fff57b15210
                accu = {g_type = 0x14 [gboolean], data = {{v_int = 0, v_uint = 0, v_long = 0, v_ulong = 0, v_int64 = 0, v_uint64 = 0, v_float = 0, v_double = 0, v_pointer = 0x0}, {v_int = 0, v_uint = 0, v_long = 0, v_ulong = 0, v_int64 = 0, v_uint64 = 0, v_float = 0, v_double = 0, v_pointer = 0x0}}}
                signal_id = 98
                max_sequential_handler_number = 383454
                return_value_altered = 0
    #15 0x00007fcf1df013d3 in g_signal_emit_valist (instance=<optimized out>, signal_id=<optimized out>, detail=<optimized out>, var_args=var_args@entry=0x7fff57b15450) at gsignal.c:3401
                return_value = {g_type = 0x14 [gboolean], data = {{v_int = 0, v_uint = 0, v_long = 0, v_ulong = 0, v_int64 = 0, v_uint64 = 0, v_float = 0, v_double = 0, v_pointer = 0x0}, {v_int = 0, v_uint = 0, v_long = 0, v_ulong = 0, v_int64 = 0, v_uint64 = 0, v_float = 0, v_double = 0, v_pointer = 0x0}}}
                error = 0x0
                rtype = 0x14 [gboolean]
                static_scope = 0
                instance_and_params = 0x7fff57b15270
                signal_return_type = <optimized out>
                param_values = 0x7fff57b15288
                node = <optimized out>
                i = <optimized out>
                n_params = <optimized out>
                __func__ = "g_signal_emit_valist"
#17 0x00007fcf1e68d924 in gtk_widget_event_internal (widget=widget@entry=0x55cec78fb450 [GtkDrawingArea], event=event@entry=0x55cec943ac70) at gtkwidget.c:7744
        signal_num = <optimized out>
        return_val = <optimized out>
        handled = 0
        __func__ = "gtk_widget_event_internal"
#18 0x00007fcf1e68fa3a in gtk_widget_event (widget=widget@entry=0x55cec78fb450 [GtkDrawingArea], event=event@entry=0x55cec943ac70) at gtkwidget.c:7314
        __func__ = "gtk_widget_event"
#19 0x00007fcf1e54e5d6 in propagate_event_up (topmost=<optimized out>, event=<optimized out>, widget=0x55cec78fb450 [GtkDrawingArea]) at gtkmain.c:2582
        tmp = <optimized out>
        handled_event = <optimized out>
        handled_event = 0
#20 0x00007fcf1e54e5d6 in propagate_event (widget=<optimized out>, event=0x55cec943ac70, captured=<optimized out>, topmost=0x0) at gtkmain.c:2685
        handled_event = 0
#21 0x00007fcf1e550693 in gtk_main_do_event (event=<optimized out>) at gtkmain.c:1915
        grab_widget = <optimized out>
        window_group = <optimized out>
        rewritten_event = <optimized out>
        device = <optimized out>
        tmp_list = <optimized out>
        event_widget = <optimized out>
        topmost_widget = <optimized out>
        event = 0x55cec943ac70
        __func__ = "gtk_main_do_event"
        __func__ = "gtk_main_do_event"
#22 0x00007fcf1e2462a5 in _gdk_event_emit (event=event@entry=0x55cec943ac70) at gdkevents.c:73
#23 0x00007fcf1e276d62 in gdk_event_source_dispatch (source=<optimized out>, callback=<optimized out>, user_data=<optimized out>) at gdkeventsource.c:367
        display = <optimized out>
        event = 0x55cec943ac70
#24 0x00007fcf1f824c15 in g_main_dispatch (context=0x55cec6ca7b10) at gmain.c:3182
        dispatch = 0x7fcf1e276d40 <gdk_event_source_dispatch>
        prev_source = 0x0
        was_in_call = 0
        user_data = 0x0
        callback = 0x0
        cb_funcs = 0x0
        cb_data = 0x0
        need_destroy = <optimized out>
        source = 0x55cec6d6d560
        current = 0x55cec6c6c890
        i = 0
        __func__ = "g_main_dispatch"
#25 0x00007fcf1f824c15 in g_main_context_dispatch (context=context@entry=0x55cec6ca7b10) at gmain.c:3847
#26 0x00007fcf1f824fd8 in g_main_context_iterate (context=0x55cec6ca7b10, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at gmain.c:3920
        max_priority = 0
        timeout = 0
        some_ready = 1
        nfds = <optimized out>
        allocated_nfds = 3
        fds = 0x55cec813e970
#27 0x00007fcf1f8252d2 in g_main_loop_run (loop=0x55cec7bf7100) at gmain.c:4116
        __func__ = "g_main_loop_run"
#28 0x00007fcf1e54f775 in gtk_main () at gtkmain.c:1323
        loop = 0x55cec7bf7100
#29 0x00007fcf1f5727aa in dt_gui_gtk_run (gui=<optimized out>) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/gui/gtk.c:1242
        widget = <optimized out>
        allocation = {x = 574, y = 24, width = 190, height = 690}
#30 0x000055cec53060a2 in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/darktable-ivybridge-2.5.0~git710.f0ad51b33-606.1.x86_64/src/main.c:83
[Inferior 1 (process 25895) detached]
```