### PR TITLE
properly disable color picker on reset

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1120,6 +1120,13 @@ static void apply_gain_auto(dt_iop_module_t *self)
 }
 #endif
 
+static void disable_colorpick(struct dt_iop_module_t *self)
+{
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  g->which_colorpicker = DT_PICKCOLBAL_NONE;
+}
+
 static int call_apply_picked_color(struct dt_iop_module_t *self, dt_iop_colorbalance_gui_data_t *g)
 {
   int handled = 1;
@@ -1250,9 +1257,8 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
   if(!in)
   {
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    disable_colorpick(self);
     g->apply_picked_color = 0;
-    g->which_colorpicker = DT_PICKCOLBAL_NONE;
     set_colorpick_state(g, g->which_colorpicker);
   }
 }
@@ -1437,10 +1443,11 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
 
-  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  disable_colorpick(self);
   self->color_picker_box[0] = self->color_picker_box[1] = .25f;
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;
   self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
+  set_colorpick_state(g, g->which_colorpicker);
 
   dt_bauhaus_combobox_set(g->mode, p->mode);
 
@@ -2600,7 +2607,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  disable_colorpick(self);
   // nothing else necessary, gtk will clean up the slider.
   free(self->gui_data);
   self->gui_data = NULL;

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -612,6 +612,13 @@ static void mode_callback(GtkWidget *combo, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
+static void disable_colorpick(struct dt_iop_module_t *self)
+{
+  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  g->which_colorpicker = DT_PICKPROFLOG_NONE;
+}
+
 static int call_apply_picked_color(struct dt_iop_module_t *self, dt_iop_profilegamma_gui_data_t *g)
 {
   int handled = 1;
@@ -720,9 +727,8 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
   if(!in)
   {
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    disable_colorpick(self);
     g->apply_picked_color = 0;
-    g->which_colorpicker = DT_PICKPROFLOG_NONE;
     set_colorpick_state(g, g->which_colorpicker);
   }
 }
@@ -838,7 +844,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)module->params;
 
-  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  disable_colorpick(self);
   self->color_picker_box[0] = self->color_picker_box[1] = .25f;
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;
   self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
@@ -915,10 +921,8 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
 
-  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-
+  disable_colorpick(self);
   g->apply_picked_color = 0;
-  g->which_colorpicker = DT_PICKPROFLOG_NONE;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
@@ -1032,7 +1036,7 @@ void gui_init(dt_iop_module_t *self)
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  disable_colorpick(self);
   free(self->gui_data);
   self->gui_data = NULL;
 }


### PR DESCRIPTION
This applies to "color balance" and "unbreak input profile" (log
mode).

Before this commit, a click on "reset parameters" was disabling the
colorpicker, but keeping the colorpicker icon active. The reason was
that self->request_color_pick was set to DT_REQUEST_COLORPICK_OFF but
g->which_colorpicker was kept to its former value.

Introduce disable_colorpick to reset both variables at the same time,
and add one missing set_colorpick_state call to propagate the
information to the GUI.