### PR TITLE
Move crop & rotate to the linear part of the pixelpipe

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4215,7 +4215,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_ashift_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_ashift_params_t));
   module->default_enabled = 0;
-  module->priority = 205; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 217; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_ashift_params_t);
   module->gui_data = NULL;
   dt_iop_ashift_params_t tmp = (dt_iop_ashift_params_t){ 0.0f, 0.0f, 0.0f, 0.0f, DEFAULT_F_LENGTH, 1.0f, 100.0f, 1.0f, ASHIFT_MODE_GENERIC, 0,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -931,7 +931,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_atrous_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_atrous_params_t));
   module->default_enabled = 0;
-  module->priority = 565; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 579; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_atrous_params_t);
   module->gui_data = NULL;
   dt_iop_atrous_params_t tmp;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -931,7 +931,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_atrous_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_atrous_params_t));
   module->default_enabled = 0;
-  module->priority = 573; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 565; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_atrous_params_t);
   module->gui_data = NULL;
   dt_iop_atrous_params_t tmp;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1247,7 +1247,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_basecurve_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_basecurve_params_t));
   module->default_enabled = 0;
-  module->priority = 294; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 318; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_basecurve_params_t);
   module->gui_data = NULL;
   dt_iop_basecurve_params_t tmp = (dt_iop_basecurve_params_t){

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -387,7 +387,7 @@ void init(dt_iop_module_t *module)
   // by default:
   module->default_enabled = 0;
   // order has to be changed by editing the dependencies in tools/iop_dependencies.py
-  module->priority = 579; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 594; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bilat_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -387,7 +387,7 @@ void init(dt_iop_module_t *module)
   // by default:
   module->default_enabled = 0;
   // order has to be changed by editing the dependencies in tools/iop_dependencies.py
-  module->priority = 588; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 579; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bilat_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -323,7 +323,7 @@ void init(dt_iop_module_t *module)
   module->params = (dt_iop_params_t *)malloc(sizeof(dt_iop_bilateral_params_t));
   module->default_params = (dt_iop_params_t *)malloc(sizeof(dt_iop_bilateral_params_t));
   module->default_enabled = 0;
-  module->priority = 308; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 333; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bilateral_params_t);
   module->gui_data = NULL;
   dt_iop_bilateral_params_t tmp = (dt_iop_bilateral_params_t){ { 15.0, 15.0, 0.005, 0.005, 0.005 } };

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -486,7 +486,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_bloom_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_bloom_params_t));
   module->default_enabled = 0;
-  module->priority = 514; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 507; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bloom_params_t);
   module->gui_data = NULL;
   dt_iop_bloom_params_t tmp = (dt_iop_bloom_params_t){ 20, 90, 25 };

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -486,7 +486,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_bloom_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_bloom_params_t));
   module->default_enabled = 0;
-  module->priority = 507; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 521; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bloom_params_t);
   module->gui_data = NULL;
   dt_iop_bloom_params_t tmp = (dt_iop_bloom_params_t){ 20, 90, 25 };

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -897,7 +897,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_borders_params_t);
   module->gui_data = NULL;
-  module->priority = 955; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 956; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1520,7 +1520,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
 
   // we come just before demosaicing.
-  module->priority = 73; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 72; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_cacorrect_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -419,7 +419,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_channelmixer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_channelmixer_params_t));
   module->default_enabled = 0;
-  module->priority = 823; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 811; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_channelmixer_params_t);
   module->gui_data = NULL;
   dt_iop_channelmixer_params_t tmp = (dt_iop_channelmixer_params_t){ { 0, 0, 0, 1, 0, 0, 0 },

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -419,7 +419,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_channelmixer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_channelmixer_params_t));
   module->default_enabled = 0;
-  module->priority = 811; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 826; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_channelmixer_params_t);
   module->gui_data = NULL;
   dt_iop_channelmixer_params_t tmp = (dt_iop_channelmixer_params_t){ { 0, 0, 0, 1, 0, 0, 0 },

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -294,7 +294,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_rlce_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_rlce_params_t));
   module->default_enabled = 0;
-  module->priority = 897; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 898; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rlce_params_t);
   module->gui_data = NULL;
   dt_iop_rlce_params_t tmp = (dt_iop_rlce_params_t){ 64, 1.25 };

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -837,7 +837,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
 
-  //assert(ch == 4);
+  assert(ch == 4);
 
   // only crop, no rot fast and sharp path:
   if(!d->flags && d->angle == 0.0 && d->all_off && roi_in->width == roi_out->width

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -837,7 +837,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int ch = piece->colors;
   const int ch_width = ch * roi_in->width;
 
-  assert(ch == 4);
+  //assert(ch == 4);
 
   // only crop, no rot fast and sharp path:
   if(!d->flags && d->angle == 0.0 && d->all_off && roi_in->width == roi_out->width
@@ -1691,7 +1691,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_clipping_params_t);
   module->gui_data = NULL;
-  module->priority = 455; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 289; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -317,7 +317,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colisa_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colisa_params_t));
   module->default_enabled = 0;
-  module->priority = 647; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 637; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colisa_params_t);
   module->gui_data = NULL;
   dt_iop_colisa_params_t tmp = (dt_iop_colisa_params_t){ 0, 0, 0 };

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -317,7 +317,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colisa_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colisa_params_t));
   module->default_enabled = 0;
-  module->priority = 637; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 652; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colisa_params_t);
   module->gui_data = NULL;
   dt_iop_colisa_params_t tmp = (dt_iop_colisa_params_t){ 0, 0, 0 };

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1282,7 +1282,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorbalance_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorbalance_params_t));
   module->default_enabled = 0;
-  module->priority = 449; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 840; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorbalance_params_t);
   module->gui_data = NULL;
   dt_iop_colorbalance_params_t tmp = (dt_iop_colorbalance_params_t){ SLOPE_OFFSET_POWER,

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1282,7 +1282,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorbalance_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorbalance_params_t));
   module->default_enabled = 0;
-  module->priority = 840; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 463; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorbalance_params_t);
   module->gui_data = NULL;
   dt_iop_colorbalance_params_t tmp = (dt_iop_colorbalance_params_t){ SLOPE_OFFSET_POWER,

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -802,7 +802,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
   module->default_enabled = 0;
-  module->priority = 382; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 405; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorchecker_params_t);
   module->gui_data = NULL;
   dt_iop_colorchecker_params_t tmp;

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -305,7 +305,7 @@ void init(dt_iop_module_t *module)
   // our module is disabled by default
   module->default_enabled = 0;
   // we are pretty late in the pipe:
-  module->priority = 794; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 782; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorcontrast_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -305,7 +305,7 @@ void init(dt_iop_module_t *module)
   // our module is disabled by default
   module->default_enabled = 0;
   // we are pretty late in the pipe:
-  module->priority = 782; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 797; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorcontrast_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -228,7 +228,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorcorrection_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorcorrection_params_t));
   module->default_enabled = 0;
-  module->priority = 710; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 724; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorcorrection_params_t);
   module->gui_data = NULL;
   dt_iop_colorcorrection_params_t tmp = (dt_iop_colorcorrection_params_t){ 0., 0., 0., 0., 1.0 };

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -228,7 +228,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorcorrection_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorcorrection_params_t));
   module->default_enabled = 0;
-  module->priority = 720; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 710; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorcorrection_params_t);
   module->gui_data = NULL;
   dt_iop_colorcorrection_params_t tmp = (dt_iop_colorcorrection_params_t){ 0., 0., 0., 0., 1.0 };

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1699,7 +1699,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorin_params_t));
   module->params_size = sizeof(dt_iop_colorin_params_t);
   module->gui_data = NULL;
-  module->priority = 352; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 376; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->default_enabled = 1;
 }

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -400,7 +400,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorize_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorize_params_t));
   module->default_enabled = 0;
-  module->priority = 470; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 463; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorize_params_t);
   module->gui_data = NULL;
   dt_iop_colorize_params_t tmp = (dt_iop_colorize_params_t){ 0, 0.5, 50, 50, module->version() };

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -400,7 +400,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorize_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorize_params_t));
   module->default_enabled = 0;
-  module->priority = 463; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 478; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorize_params_t);
   module->gui_data = NULL;
   dt_iop_colorize_params_t tmp = (dt_iop_colorize_params_t){ 0, 0.5, 50, 50, module->version() };

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -869,7 +869,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colormapping_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colormapping_params_t));
   module->default_enabled = 0;
-  module->priority = 499; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 492; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colormapping_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -869,7 +869,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colormapping_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colormapping_params_t));
   module->default_enabled = 0;
-  module->priority = 492; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 507; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colormapping_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -727,7 +727,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorout_params_t));
   module->params_size = sizeof(dt_iop_colorout_params_t);
   module->gui_data = NULL;
-  module->priority = 797; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 811; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->default_enabled = 1;
   dt_iop_colorout_params_t tmp = (dt_iop_colorout_params_t){ DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL};

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -727,7 +727,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorout_params_t));
   module->params_size = sizeof(dt_iop_colorout_params_t);
   module->gui_data = NULL;
-  module->priority = 808; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 797; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->default_enabled = 1;
   dt_iop_colorout_params_t tmp = (dt_iop_colorout_params_t){ DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL};

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1302,7 +1302,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorreconstruct_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorreconstruct_params_t));
   module->default_enabled = 0;
-  module->priority = 367; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 391; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorreconstruct_params_t);
   module->gui_data = NULL;
   dt_iop_colorreconstruct_params_t tmp = (dt_iop_colorreconstruct_params_t){ 100.0f, 400.0f, 10.0f, 0.66f, COLORRECONSTRUCT_PRECEDENCE_NONE };

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -561,7 +561,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colortransfer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colortransfer_params_t));
   module->default_enabled = 0;
-  module->priority = 485; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 478; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colortransfer_params_t);
   module->gui_data = NULL;
   dt_iop_colortransfer_params_t tmp;

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -561,7 +561,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colortransfer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colortransfer_params_t));
   module->default_enabled = 0;
-  module->priority = 478; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 492; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colortransfer_params_t);
   module->gui_data = NULL;
   dt_iop_colortransfer_params_t tmp;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -382,7 +382,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 594; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 608; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorzones_params_t);
   module->gui_data = NULL;
   dt_iop_colorzones_params_t tmp;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -382,7 +382,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 602; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 594; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorzones_params_t);
   module->gui_data = NULL;
   dt_iop_colorzones_params_t tmp;

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -397,7 +397,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_defringe_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_defringe_params_t));
-  module->priority = 397; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 420; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_defringe_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -4657,7 +4657,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_demosaic_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_demosaic_params_t));
   module->default_enabled = 1;
-  module->priority = 117; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 115; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->params_size = sizeof(dt_iop_demosaic_params_t);
   module->gui_data = NULL;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2056,7 +2056,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_denoiseprofile_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_denoiseprofile_params_t));
-  module->priority = 132; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 130; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_denoiseprofile_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -267,7 +267,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_equalizer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_equalizer_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 411; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 434; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_equalizer_params_t);
   module->gui_data = NULL;
   dt_iop_equalizer_params_t tmp;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -542,7 +542,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_exposure_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_exposure_params_t));
   module->default_enabled = 0;
-  module->priority = 161; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 159; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_exposure_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -117,7 +117,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_finalscale_params_t));
   self->default_enabled = 1;
   self->hide_enable_button = 1;
-  self->priority = 911; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 913; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_finalscale_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -444,7 +444,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_flip_params_t);
   module->gui_data = NULL;
-  module->priority = 264; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 275; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -664,7 +664,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_global_tonemap_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_global_tonemap_params_t));
   module->default_enabled = 0;
-  module->priority = 544; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 536; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_global_tonemap_params_t);
   module->gui_data = NULL;
   dt_iop_global_tonemap_params_t tmp

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -664,7 +664,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_global_tonemap_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_global_tonemap_params_t));
   module->default_enabled = 0;
-  module->priority = 536; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 550; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_global_tonemap_params_t);
   module->gui_data = NULL;
   dt_iop_global_tonemap_params_t tmp

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1086,7 +1086,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_graduatednd_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_graduatednd_params_t));
   module->default_enabled = 0;
-  module->priority = 279; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 304; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_graduatednd_params_t);
   module->gui_data = NULL;
   dt_iop_graduatednd_params_t tmp = (dt_iop_graduatednd_params_t){ 1.0, 0, 0, 50, 0, 0 };

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -593,7 +593,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_grain_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_grain_params_t));
   module->default_enabled = 0;
-  module->priority = 768; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 782; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_grain_params_t);
   module->gui_data = NULL;
   dt_iop_grain_params_t tmp

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -593,7 +593,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_grain_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_grain_params_t));
   module->default_enabled = 0;
-  module->priority = 779; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 768; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_grain_params_t);
   module->gui_data = NULL;
   dt_iop_grain_params_t tmp

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -123,7 +123,7 @@ void init(dt_iop_module_t *self)
   self->params = calloc(1, sizeof(dt_iop_hazeremoval_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_hazeremoval_params_t));
   self->default_enabled = 0;
-  self->priority = 338; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 362; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_hazeremoval_params_t);
   self->gui_data = NULL;
   dt_iop_hazeremoval_params_t tmp = (dt_iop_hazeremoval_params_t){ 0.5f, 0.25f };

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1025,7 +1025,7 @@ void init(dt_iop_module_t *module)
   // module->data = malloc(sizeof(dt_iop_highlights_data_t));
   module->params = calloc(1, sizeof(dt_iop_highlights_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_highlights_params_t));
-  module->priority = 58; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 57; // module order created by iop_dependencies.py, do not edit!
   module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_highlights_params_t);
   module->gui_data = NULL;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -433,7 +433,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_highpass_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_highpass_params_t));
   module->default_enabled = 0;
-  module->priority = 764; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 753; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_highpass_params_t);
   module->gui_data = NULL;
   dt_iop_highpass_params_t tmp = (dt_iop_highpass_params_t){ 50, 50 };

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -433,7 +433,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_highpass_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_highpass_params_t));
   module->default_enabled = 0;
-  module->priority = 753; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 768; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_highpass_params_t);
   module->gui_data = NULL;
   dt_iop_highpass_params_t tmp = (dt_iop_highpass_params_t){ 50, 50 };

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -319,7 +319,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_hotpixels_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_hotpixels_params_t));
   module->default_enabled = 0;
-  module->priority = 88; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 86; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_hotpixels_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -544,7 +544,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_invert_params_t);
   module->gui_data = NULL;
-  module->priority = 29; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 28; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1243,7 +1243,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_lensfun_params_t);
   module->gui_data = NULL;
-  module->priority = 191; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 202; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -513,7 +513,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_levels_params_t));
   self->default_enabled = 0;
   self->request_histogram |= (DT_REQUEST_ON);
-  self->priority = 691; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 681; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_levels_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -513,7 +513,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_levels_params_t));
   self->default_enabled = 0;
   self->request_histogram |= (DT_REQUEST_ON);
-  self->priority = 681; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 695; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_levels_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1539,7 +1539,7 @@ void init (dt_iop_module_t *module)
 {
   // module is disabled by default
   module->default_enabled = 0;
-  module->priority = 220; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 231; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_liquify_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -289,7 +289,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_lowlight_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_lowlight_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 608; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 623; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_lowlight_params_t);
   module->gui_data = NULL;
   dt_iop_lowlight_params_t tmp;

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -289,7 +289,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_lowlight_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_lowlight_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 617; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 608; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_lowlight_params_t);
   module->gui_data = NULL;
   dt_iop_lowlight_params_t tmp;

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -599,7 +599,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_lowpass_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_lowpass_params_t));
   module->default_enabled = 0;
-  module->priority = 749; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 739; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_lowpass_params_t);
   module->gui_data = NULL;
   dt_iop_lowpass_params_t tmp = (dt_iop_lowpass_params_t){ 0, 10.0f, 1.0f, 0.0f, 1.0f, LOWPASS_ALGO_GAUSSIAN, 1 };

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -599,7 +599,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_lowpass_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_lowpass_params_t));
   module->default_enabled = 0;
-  module->priority = 739; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 753; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_lowpass_params_t);
   module->gui_data = NULL;
   dt_iop_lowpass_params_t tmp = (dt_iop_lowpass_params_t){ 0, 10.0f, 1.0f, 0.0f, 1.0f, LOWPASS_ALGO_GAUSSIAN, 1 };

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -338,7 +338,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_monochrome_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_monochrome_params_t));
   module->default_enabled = 0;
-  module->priority = 623; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 637; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_monochrome_params_t);
   module->gui_data = NULL;
   dt_iop_monochrome_params_t tmp = (dt_iop_monochrome_params_t){ 0., 0., 2., 0. };

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -338,7 +338,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_monochrome_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_monochrome_params_t));
   module->default_enabled = 0;
-  module->priority = 632; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 623; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_monochrome_params_t);
   module->gui_data = NULL;
   dt_iop_monochrome_params_t tmp = (dt_iop_monochrome_params_t){ 0., 0., 2., 0. };

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -724,7 +724,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_nlmeans_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_nlmeans_params_t));
   // about the first thing to do in Lab space:
-  module->priority = 529; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 521; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_nlmeans_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -724,7 +724,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_nlmeans_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_nlmeans_params_t));
   // about the first thing to do in Lab space:
-  module->priority = 521; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 536; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_nlmeans_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -286,7 +286,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_overexposed_t));
   module->hide_enable_button = 1;
   module->default_enabled = 1;
-  module->priority = 926; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 927; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_overexposed_t);
   module->gui_data = NULL;
 }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -879,7 +879,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_profilegamma_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_profilegamma_params_t));
   module->default_enabled = 0;
-  module->priority = 323; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 347; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_profilegamma_params_t);
   module->gui_data = NULL;
   dt_iop_profilegamma_params_t tmp

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -526,7 +526,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
 
   // raw denoise must come just before demosaicing.
-  module->priority = 102; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 101; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rawdenoise_params_t);
   module->gui_data = NULL;
   dt_iop_rawdenoise_params_t tmp;

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -499,7 +499,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
   module->hide_enable_button = 1;
   module->default_enabled = 1;
-  module->priority = 941; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 942; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rawoverexposed_t);
   module->gui_data = NULL;
 }

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -299,7 +299,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_relight_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_relight_params_t));
   module->default_enabled = 0;
-  module->priority = 705; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 695; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_relight_params_t);
   module->gui_data = NULL;
   dt_iop_relight_params_t tmp = (dt_iop_relight_params_t){ 0.33, 0, 4 };

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -299,7 +299,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_relight_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_relight_params_t));
   module->default_enabled = 0;
-  module->priority = 695; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 710; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_relight_params_t);
   module->gui_data = NULL;
   dt_iop_relight_params_t tmp = (dt_iop_relight_params_t){ 0.33, 0, 4 };

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2334,7 +2334,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_retouch_params_t));
   // our module is disabled by default
   module->default_enabled = 0;
-  module->priority = 180; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 188; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_retouch_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -343,7 +343,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_rotatepixels_params_t));
   self->params_size = sizeof(dt_iop_rotatepixels_params_t);
   self->gui_data = NULL;
-  self->priority = 235; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 246; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *self)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -268,7 +268,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_scalepixels_params_t));
   self->default_enabled = (!isnan(image->pixel_aspect_ratio) && image->pixel_aspect_ratio > 0.0f
                            && image->pixel_aspect_ratio != 1.0f);
-  self->priority = 249; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 260; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_scalepixels_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -770,7 +770,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_shadhi_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_shadhi_params_t));
   module->default_enabled = 0;
-  module->priority = 558; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 550; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_shadhi_params_t);
   module->gui_data = NULL;
   dt_iop_shadhi_params_t tmp

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -770,7 +770,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_shadhi_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_shadhi_params_t));
   module->default_enabled = 0;
-  module->priority = 550; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 565; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_shadhi_params_t);
   module->gui_data = NULL;
   dt_iop_shadhi_params_t tmp

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -713,7 +713,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_sharpen_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_sharpen_params_t));
   module->default_enabled = 0;
-  module->priority = 724; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 739; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_sharpen_params_t);
   module->gui_data = NULL;
   dt_iop_sharpen_params_t tmp = (dt_iop_sharpen_params_t){ 2.0, 0.5, 0.5 };

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -713,7 +713,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_sharpen_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_sharpen_params_t));
   module->default_enabled = 0;
-  module->priority = 735; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 724; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_sharpen_params_t);
   module->gui_data = NULL;
   dt_iop_sharpen_params_t tmp = (dt_iop_sharpen_params_t){ 2.0, 0.5, 0.5 };

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -680,7 +680,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_soften_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_soften_params_t));
   module->default_enabled = 0;
-  module->priority = 838; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 826; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_soften_params_t);
   module->gui_data = NULL;
   dt_iop_soften_params_t tmp = (dt_iop_soften_params_t){ 50, 100.0, 0.33, 50 };

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -680,7 +680,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_soften_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_soften_params_t));
   module->default_enabled = 0;
-  module->priority = 826; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 840; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_soften_params_t);
   module->gui_data = NULL;
   dt_iop_soften_params_t tmp = (dt_iop_soften_params_t){ 50, 100.0, 0.33, 50 };

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -455,7 +455,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_splittoning_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_splittoning_params_t));
   module->default_enabled = 0;
-  module->priority = 867; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 869; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_splittoning_params_t);
   module->gui_data = NULL;
   dt_iop_splittoning_params_t tmp = (dt_iop_splittoning_params_t){ 0, 0.5, 0.2, 0.5, 0.5, 33.0 };

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -540,7 +540,7 @@ void init(dt_iop_module_t *module)
   // our module is disabled by default
   // by default:
   module->default_enabled = 0;
-  module->priority = 176; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 173; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_spots_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1111,7 +1111,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_temperature_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_temperature_params_t));
-  module->priority = 44; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 43; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_temperature_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -649,7 +649,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_tonecurve_params_t));
   module->default_enabled = 0;
   module->request_histogram |= (DT_REQUEST_ON);
-  module->priority = 666; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 681; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_tonecurve_params_t);
   module->gui_data = NULL;
   dt_iop_tonecurve_params_t tmp = (dt_iop_tonecurve_params_t){

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -649,7 +649,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_tonecurve_params_t));
   module->default_enabled = 0;
   module->request_histogram |= (DT_REQUEST_ON);
-  module->priority = 676; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 666; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_tonecurve_params_t);
   module->gui_data = NULL;
   dt_iop_tonecurve_params_t tmp = (dt_iop_tonecurve_params_t){

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -267,7 +267,7 @@ void init(dt_iop_module_t *module)
   module->params = (dt_iop_params_t *)malloc(sizeof(dt_iop_tonemapping_params_t));
   module->default_params = (dt_iop_params_t *)malloc(sizeof(dt_iop_tonemapping_params_t));
   module->default_enabled = 0;
-  module->priority = 147; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 144; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_tonemapping_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -352,7 +352,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_velvia_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_velvia_params_t));
   module->default_enabled = 0;
-  module->priority = 882; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 884; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_velvia_params_t);
   module->gui_data = NULL;
   dt_iop_velvia_params_t tmp = (dt_iop_velvia_params_t){ 25, 1.0 };

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -216,7 +216,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_vibrance_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_vibrance_params_t));
   module->default_enabled = 0;
-  module->priority = 426; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 449; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_vibrance_params_t);
   module->gui_data = NULL;
   dt_iop_vibrance_params_t tmp = (dt_iop_vibrance_params_t){ 25 };

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1102,7 +1102,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_vignette_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_vignette_params_t));
   module->default_enabled = 0;
-  module->priority = 852; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 855; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_vignette_params_t);
   module->gui_data = NULL;
   dt_iop_vignette_params_t tmp

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1288,7 +1288,7 @@ void init(dt_iop_module_t *module)
   module->params_size = sizeof(dt_iop_watermark_params_t);
   module->default_params = calloc(1, sizeof(dt_iop_watermark_params_t));
   module->default_enabled = 0;
-  module->priority = 970; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 971; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_watermark_params_t);
   module->gui_data = NULL;
   dt_iop_watermark_params_t tmp = (dt_iop_watermark_params_t){

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -458,7 +458,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_zonesystem_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_zonesystem_params_t));
   module->default_enabled = 0;
-  module->priority = 661; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 652; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_zonesystem_params_t);
   module->gui_data = NULL;
   dt_iop_zonesystem_params_t tmp = (dt_iop_zonesystem_params_t){

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -458,7 +458,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_zonesystem_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_zonesystem_params_t));
   module->default_enabled = 0;
-  module->priority = 652; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 666; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_zonesystem_params_t);
   module->gui_data = NULL;
   dt_iop_zonesystem_params_t tmp = (dt_iop_zonesystem_params_t){

--- a/tools/iop_dependencies.py
+++ b/tools/iop_dependencies.py
@@ -460,6 +460,7 @@ def add_edges(gr):
   # colorbalance needs a Lab buffer and should be after clipping. probably.
   gr.add_edge(('colorbalance', 'colorin'))
   gr.add_edge(('colorout', 'colorbalance'))
+  gr.add_edge(('colorize', 'colorbalance'))
 
   # colorchecker should happen early in Lab mode, after
   # highlight colour reconstruction, but with the ability to mess with everything

--- a/tools/iop_dependencies.py
+++ b/tools/iop_dependencies.py
@@ -125,7 +125,15 @@ def add_edges(gr):
   gr.add_edge(('flip', 'retouch'))
   gr.add_edge(('flip', 'liquify'))
   gr.add_edge(('flip', 'ashift'))
-  
+
+  # clipping is a convolution operation and needs linear data to avoid messing-up edges
+  # therefore needs to go before any curve, gamma or contrast operation
+  gr.add_edge(('basecurve', 'clipping'))
+  gr.add_edge(('profile_gamma', 'clipping'))
+  gr.add_edge(('tonecurve', 'clipping'))
+  gr.add_edge(('graduatednd', 'clipping'))
+  gr.add_edge(('colisa', 'clipping'))
+
   # ashift wants a lens corrected image with straight lines.
   # therefore lens should come before and liquify should come after ashift
   gr.add_edge(('ashift', 'lens'))
@@ -450,8 +458,8 @@ def add_edges(gr):
   gr.add_edge(('equalizer', 'colorin'))
 
   # colorbalance needs a Lab buffer and should be after clipping. probably.
-  gr.add_edge(('clipping', 'colorbalance'))
   gr.add_edge(('colorbalance', 'colorin'))
+  gr.add_edge(('colorout', 'colorbalance'))
 
   # colorchecker should happen early in Lab mode, after
   # highlight colour reconstruction, but with the ability to mess with everything


### PR DESCRIPTION
Rotation is a convolution. Convolutions should happen in a linear space. 

This is what happens when we rotate a gamma-corrected image (classic sRGB gamma 2.4/2.2 depending how blows the wind):
![imagen 1](https://user-images.githubusercontent.com/2779157/47896666-f2f3b380-de44-11e8-8978-4cc441fbfbd6.png)
This what happens in a linear space:
![imagen](https://user-images.githubusercontent.com/2779157/47896678-fedf7580-de44-11e8-9af7-2fc09d965bc7.png)
Look at the edges…

For now, crop and rotate is done in the Lab part of the pixelpipe, just before colorbalance. First of all, Lab is by no mean a linear space (you convert from XYZ to Lab using a piece-wise x³ formula). Then, several aesthetic curves are applied in-between (gamma correction, colorchecker, colorbalance) that apply non-linear operation in a non-linear space. So this position makes no sense at all.

This PR moves the crop and rotate IOP just after the perspective correction and ensures the colorbalance  is properly positionned before the colorize IOP (where it was before). That is because the colorbalance position in the pixelpipe was defined according to the position of the crop and rotate IOP (which is a major case of rabbits + towers = fireworks) and not according to the position of other color-relative IOP.