### PR TITLE
Update non local means in denoise profiled

### DIFF
--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -229,7 +229,7 @@ denoiseprofile_accu(read_only image2d_t in, global float4* U2, global float* U4,
 
 
 kernel void
-denoiseprofile_finish(read_only image2d_t in, global float4* U2, write_only image2d_t out, const int width, const int height,
+denoiseprofile_finish(read_only image2d_t in, read_only image2d_t in2, global float4* U2, write_only image2d_t out, const int width, const int height,
                              const float4 a, const float4 sigma2)
 {
   const int x = get_global_id(0);
@@ -240,8 +240,11 @@ denoiseprofile_finish(read_only image2d_t in, global float4* U2, write_only imag
 
   float4 u2   = U2[gidx];
   float alpha = read_imagef(in, sampleri, (int2)(x, y)).w;
+  /* in2 is the image after the precondition
+     orig is the pixel value from this (undenoised) image */
+  float4 orig = read_imagef(in2, sampleri, (int2)(x, y));
 
-  float4 px = ((float4)u2.w > (float4)0.0f ? u2/u2.w : (float4)0.0f);
+  float4 px = ((float4)u2.w > (float4)0.0f ? u2/u2.w : orig;
 
   px = (px < (float4)0.5f ? (float4)0.0f : 
     0.25f*px*px + 0.25f*sqrt(1.5f)/px - 1.375f/(px*px) + 0.625f*sqrt(1.5f)/(px*px*px) - 0.125f - sigma2);

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -244,7 +244,7 @@ denoiseprofile_finish(read_only image2d_t in, read_only image2d_t in2, global fl
      orig is the pixel value from this (undenoised) image */
   float4 orig = read_imagef(in2, sampleri, (int2)(x, y));
 
-  float4 px = ((float4)u2.w > (float4)0.0f ? u2/u2.w : orig;
+  float4 px = ((float4)u2.w > (float4)0.0f ? u2/u2.w : orig);
 
   px = (px < (float4)0.5f ? (float4)0.0f : 
     0.25f*px*px + 0.25f*sqrt(1.5f)/px - 1.375f/(px*px) + 0.625f*sqrt(1.5f)/(px*px*px) - 0.125f - sigma2);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -299,11 +299,11 @@ void init_presets(dt_iop_module_so_t *self)
 {
   // these blobs were exported as dtstyle and copied from there:
   add_preset(self, _("chroma (use on 1st instance)"),
-             "gz04eJxjYGiwZ2B44MAAphv2b4vdb1mnYGTFLcZomryXxzRr910TRgYYaLADEkB1DvYQ9RSJURUDAIFFGLo=", 5,
+             "gz03eJxjYGiwZ2B44MAAphv2b4vdb1mnYGTFLcZomryXxzRr910TRgYYaLADEkB1DvYQ9eSLiUf9s+te/s/OjJPV/sA7Y3vZI/X2EHnyMAB8fx/c", 5,
              "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
   add_preset(self, _("luma (use on 2nd instance)"),
-             "gz04eJxjYGhwYGB4AMQM9gwMDfu3xe63rFMwsuIWYzRN3stjmrX7rgkDHDTYQdQ5gNTaUyhGVQwAImYYOg==", 5,
-             "gz12eJxjZGBgEGAAgWlODESDBnsIHll8AJKaGMo=", 7);
+             "gz03eJxjYGiwZ4AAIN2w388ywNJ97j7LS3qqpokcz03CM61NGRlgoMEOos4BpNaeQjF7zi3/7XJef7QLvPPUbnHHXag8eRgAb44fKg==", 5,
+             "gz12eJxjZGBgEABiRoYCJwaiQYM9BI8sPgBoshil", 7);
 }
 
 typedef union floatint_t

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -302,8 +302,8 @@ void init_presets(dt_iop_module_so_t *self)
              "gz03eJxjYGiwZ2B44MAAphv2b4vdb1mnYGTFLcZomryXxzRr910TRgYYaLADEkB1DvYQ9eSLiUf9s+te/s/OjJPV/sA7Y3vZI/X2EHnyMAB8fx/c", 5,
              "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
   add_preset(self, _("luma (use on 2nd instance)"),
-             "gz03eJxjYGiwZ4AAIN2w388ywNJ97j7LS3qqpokcz03CM61NGRlgoMEOos4BpNaeQjF7zi3/7XJef7QLvPPUbnHHXag8eRgAb44fKg==", 5,
-             "gz12eJxjZGBgEABiRoYCJwaiQYM9BI8sPgBoshil", 7);
+             "gz03eJxjYGiwZwCCWTNn2jEwNOz3swywdJ+7z/KSnqppIsdzk/BMa1NGBhhoAKphAKp3AGKIPnLF/B78sT2hqm33u3yhnWH2D7vC1qVQefIwAPd8IVk=", 5,
+             "gz12eJxjZGBgEGAAgR4nBqJBgz0Ejyw+AIdGGMA=", 7);
 }
 
 typedef union floatint_t

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2744,7 +2744,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));
   dt_bauhaus_widget_set_label(g->radius, NULL, _("patch size"));
   dt_bauhaus_slider_set_format(g->radius, "%.0f");
-  dt_bauhaus_widget_set_label(g->nbhood, NULL, _("coarse noise elimination"));
+  dt_bauhaus_widget_set_label(g->nbhood, NULL, _("coarse-grain noise reduction"));
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means"));
   dt_bauhaus_combobox_add(g->mode, _("wavelets"));
@@ -2754,7 +2754,7 @@ void gui_init(dt_iop_module_t *self)
                                          "wavelets work best for `color' blending"));
   gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match. increase for more sharpness"));
   gtk_widget_set_tooltip_text(g->nbhood, _("size of the zone around the pixel to search for similar patches. "
-                                           "increase if you see coarse grain noise. "
+                                           "increase if you see coarse-grain noise. "
                                            "reduce if you see grid artefacts."));
   gtk_widget_set_tooltip_text(g->strength, _("finetune denoising strength"));
   g_signal_connect(G_OBJECT(g->profile), "value-changed", G_CALLBACK(profile_callback), self);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -151,6 +151,13 @@ typedef struct dt_iop_denoiseprofile_global_data_t
   int kernel_denoiseprofile_reduce_second;
 } dt_iop_denoiseprofile_global_data_t;
 
+static int sign(int a)
+{
+  return (a > 0) - (a < 0);
+}
+
+#define DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE 7
+
 static dt_noiseprofile_t dt_iop_denoiseprofile_get_auto_profile(dt_iop_module_t *self);
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
@@ -1062,13 +1069,6 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 #undef MAX_MAX_SCALE
 }
 
-static int sign(int a)
-{
-  return (a > 0) - (a < 0);
-}
-
-#define DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE 7
-
 static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                             const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
                             const dt_iop_roi_t *const roi_out)
@@ -1112,6 +1112,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
     for(int ki_index = -K; ki_index <= K; ki_index++)
     {
       int ki = coordinate_offsets[abs(ki_index)] * sign(ki_index);
+      if(ki == 0 && kj == 0) continue;
       // TODO: adaptive K tests here!
       // TODO: expf eval for real bilateral experience :)
 
@@ -1266,6 +1267,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
     for(int ki_index = -K; ki_index <= K; ki_index++)
     {
       int ki = coordinate_offsets[abs(ki_index)] * sign(ki_index);
+      if(ki == 0 && kj == 0) continue;
       int inited_slide = 0;
 // don't construct summed area tables but use sliding window! (applies to cpu version res < 1k only, or else
 // we will add up errors)
@@ -1545,6 +1547,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
     for(int ki_index = -K; ki_index <= K; ki_index++)
     {
       int i = coordinate_offsets[abs(ki_index)] * sign(ki_index);
+      if(i == 0 && j == 0) continue;
       int q[2] = { i, j };
 
       dev_U4 = buckets[bucket_next(&state, NUM_BUCKETS)];

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1208,14 +1208,23 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
 
 // normalize
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for default(none) schedule(static) firstprivate(in)
 #endif
   for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
   {
-    if(out[k + 3] <= 0.0f) continue;
-    for(size_t c = 0; c < 4; c++)
+    if(out[k + 3] <= 0.0f)
     {
-      out[k + c] *= (1.0f / out[k + 3]);
+      for(size_t c = 0; c < 4; c++)
+      {
+        out[k + c] = in[k + c];
+      }
+    }
+    else
+    {
+      for(size_t c = 0; c < 4; c++)
+      {
+        out[k + c] *= (1.0f / out[k + 3]);
+      }
     }
   }
 
@@ -1407,17 +1416,21 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   }
 // normalize
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static) shared(d)
+#pragma omp parallel for default(none) schedule(static) shared(d) firstprivate(in)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
     float *out = ((float *)ovoid) + (size_t)4 * roi_out->width * j;
+    float *inp = ((float *)in) + (size_t)4 * roi_out->width * j;
     for(int i = 0; i < roi_out->width; i++)
     {
       if(out[3] > 0.0f) _mm_store_ps(out, _mm_mul_ps(_mm_load_ps(out), _mm_set1_ps(1.0f / out[3])));
+      else
+        _mm_store_ps(out, _mm_load_ps(inp));
       // DEBUG show weights
       // _mm_store_ps(out, _mm_set1_ps(1.0f/out[3]));
       out += 4;
+      inp += 4;
     }
   }
   // free shared tmp memory:
@@ -1616,12 +1629,13 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   }
 
   dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 0, sizeof(cl_mem), (void *)&dev_in);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 1, sizeof(cl_mem), (void *)&dev_U2);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 2, sizeof(cl_mem), (void *)&dev_out);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 3, sizeof(int), (void *)&width);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 4, sizeof(int), (void *)&height);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 5, 4 * sizeof(float), (void *)&aa);
-  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 6, 4 * sizeof(float), (void *)&sigma2);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 1, sizeof(cl_mem), (void *)&dev_tmp);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 2, sizeof(cl_mem), (void *)&dev_U2);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 3, sizeof(cl_mem), (void *)&dev_out);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 4, sizeof(int), (void *)&width);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 5, sizeof(int), (void *)&height);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 6, 4 * sizeof(float), (void *)&aa);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 7, 4 * sizeof(float), (void *)&sigma2);
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_denoiseprofile_finish, sizes);
   if(err != CL_SUCCESS) goto error;
 
@@ -2659,7 +2673,7 @@ void gui_init(dt_iop_module_t *self)
   g->profile = dt_bauhaus_combobox_new(self);
   g->mode = dt_bauhaus_combobox_new(self);
   g->radius = dt_bauhaus_slider_new_with_range(self, 0.0f, 4.0f, 1., 1.f, 0);
-  g->nbhood = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01, 0.0f, 2);
+  g->nbhood = dt_bauhaus_slider_new_with_range(self, 0.0f, 0.99f, 0.01, 0.0f, 2);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
   g->channel = dt_conf_get_int("plugins/darkroom/denoiseprofile/gui_channel");
 
@@ -2740,7 +2754,8 @@ void gui_init(dt_iop_module_t *self)
                                          "wavelets work best for `color' blending"));
   gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match. increase for more sharpness"));
   gtk_widget_set_tooltip_text(g->nbhood, _("size of the zone around the pixel to search for similar patches. "
-                                           "increase if you see coarse grain noise"));
+                                           "increase if you see coarse grain noise. "
+                                           "reduce if you see grid artefacts."));
   gtk_widget_set_tooltip_text(g->strength, _("finetune denoising strength"));
   g_signal_connect(G_OBJECT(g->profile), "value-changed", G_CALLBACK(profile_callback), self);
   g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -227,7 +227,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
         v5->y[c][b] = v4.y[c][b];
       }
     }
-    v5->nbhood = 7; // set to old hardcoded default
+    v5->nbhood = 0.0; // set to old hardcoded default
     return 0;
   }
   return 1;
@@ -326,12 +326,13 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   {
     const int P
         = ceilf(d->radius * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f)); // pixel filter size
-    const int K = ceilf(d->nbhood * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f)); // nbhood
+    const int K = ceilf(7 * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f)); // nbhood
+    const int max_K = ceilf(d->nbhood * K * K + K);
 
     tiling->factor = 4.0f + 0.25f * NUM_BUCKETS; // in + out + (2 + NUM_BUCKETS * 0.25) tmp
     tiling->maxbuf = 1.0f;
     tiling->overhead = 0;
-    tiling->overlap = P + K;
+    tiling->overlap = P + max_K;
     tiling->xalign = 1;
     tiling->yalign = 1;
   }
@@ -1061,6 +1062,13 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 #undef MAX_MAX_SCALE
 }
 
+static int sign(int a)
+{
+  return (a > 0) - (a < 0);
+}
+
+#define DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE 7
+
 static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                             const void *const ivoid, void *const ovoid, const dt_iop_roi_t *const roi_in,
                             const dt_iop_roi_t *const roi_out)
@@ -1075,7 +1083,13 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   // adjust to zoom size:
   const float scale = fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f);
   const int P = ceilf(d->radius * scale); // pixel filter size
-  const int K = ceilf(d->nbhood * scale); // nbhood
+  const int K = ceilf(DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE * scale);
+
+  int coordinate_offsets[DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE];
+  for(int i = 0; i < DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE; i++)
+  {
+    coordinate_offsets[i] = i * i * d->nbhood + i;
+  }
 
   // P == 0 : this will degenerate to a (fast) bilateral filter.
 
@@ -1092,10 +1106,12 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   precondition((float *)ivoid, in, roi_in->width, roi_in->height, aa, bb);
 
   // for each shift vector
-  for(int kj = -K; kj <= K; kj++)
+  for(int kj_index = -K; kj_index <= K; kj_index++)
   {
-    for(int ki = -K; ki <= K; ki++)
+    int kj = coordinate_offsets[abs(kj_index)] * sign(kj_index);
+    for(int ki_index = -K; ki_index <= K; ki_index++)
     {
+      int ki = coordinate_offsets[abs(ki_index)] * sign(ki_index);
       // TODO: adaptive K tests here!
       // TODO: expf eval for real bilateral experience :)
 
@@ -1217,13 +1233,18 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
-  dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
+  dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)piece->data;
 
   // adjust to zoom size:
   const float scale = fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f);
   const int P = ceilf(d->radius * scale); // pixel filter size
-  const int K = ceilf(d->nbhood * scale); // nbhood
+  const int K = ceilf(DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE * scale);
 
+  int coordinate_offsets[DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE];
+  for(int i = 0; i < DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE; i++)
+  {
+    coordinate_offsets[i] = i * i * d->nbhood + i;
+  }
   // P == 0 : this will degenerate to a (fast) bilateral filter.
 
   float *Sa = dt_alloc_align(64, (size_t)sizeof(float) * roi_out->width * dt_get_num_threads());
@@ -1239,10 +1260,12 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   precondition((float *)ivoid, in, roi_in->width, roi_in->height, aa, bb);
 
   // for each shift vector
-  for(int kj = -K; kj <= K; kj++)
+  for(int kj_index = -K; kj_index <= K; kj_index++)
   {
-    for(int ki = -K; ki <= K; ki++)
+    int kj = coordinate_offsets[abs(kj_index)] * sign(kj_index);
+    for(int ki_index = -K; ki_index <= K; ki_index++)
     {
+      int ki = coordinate_offsets[abs(ki_index)] * sign(ki_index);
       int inited_slide = 0;
 // don't construct summed area tables but use sliding window! (applies to cpu version res < 1k only, or else
 // we will add up errors)
@@ -1419,7 +1442,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
                               cl_mem dev_out, const dt_iop_roi_t *const roi_in,
                               const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
+  dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)piece->data;
   dt_iop_denoiseprofile_global_data_t *gd = (dt_iop_denoiseprofile_global_data_t *)self->data;
 
   const int devid = piece->pipe->devid;
@@ -1440,7 +1463,12 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
 
   const float scale = fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f);
   const int P = ceilf(d->radius * scale); // pixel filter size
-  const int K = ceilf(d->nbhood * scale); // nbhood
+  const int K = ceilf(DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE * scale);
+  int coordinate_offsets[DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE];
+  for(int i = 0; i < DT_DENOISE_PROFILE_NBHOOD_NORMAL_SIZE; i++)
+  {
+    coordinate_offsets[i] = i * i * d->nbhood + i;
+  }
   const float norm = 0.015f / (2 * P + 1);
 
 
@@ -1511,10 +1539,12 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_denoiseprofile_init, sizes);
   if(err != CL_SUCCESS) goto error;
 
-
-  for(int j = -K; j <= 0; j++)
-    for(int i = -K; i <= K; i++)
+  for(int kj_index = -K; kj_index <= 0; kj_index++)
+  {
+    int j = coordinate_offsets[abs(kj_index)] * sign(kj_index);
+    for(int ki_index = -K; ki_index <= K; ki_index++)
     {
+      int i = coordinate_offsets[abs(ki_index)] * sign(ki_index);
       int q[2] = { i, j };
 
       dev_U4 = buckets[bucket_next(&state, NUM_BUCKETS)];
@@ -1580,6 +1610,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
       // indirectly give gpu some air to breathe (and to do display related stuff)
       dt_iop_nap(darktable.opencl->micro_nap);
     }
+  }
 
   dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 0, sizeof(cl_mem), (void *)&dev_in);
   dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 1, sizeof(cl_mem), (void *)&dev_U2);
@@ -2039,7 +2070,7 @@ void reload_defaults(dt_iop_module_t *module)
     }
 
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius = 1.0f;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->nbhood = 7.0f;
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->nbhood = 0.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->strength = 1.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->mode = MODE_NLMEANS;
     for(int k = 0; k < 3; k++)
@@ -2247,7 +2278,7 @@ static void radius_callback(GtkWidget *w, dt_iop_module_t *self)
 static void nbhood_callback(GtkWidget *w, dt_iop_module_t *self)
 {
   dt_iop_denoiseprofile_params_t *p = self->params;
-  p->nbhood = (int)dt_bauhaus_slider_get(w);
+  p->nbhood = dt_bauhaus_slider_get(w);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2625,7 +2656,7 @@ void gui_init(dt_iop_module_t *self)
   g->profile = dt_bauhaus_combobox_new(self);
   g->mode = dt_bauhaus_combobox_new(self);
   g->radius = dt_bauhaus_slider_new_with_range(self, 0.0f, 4.0f, 1., 1.f, 0);
-  g->nbhood = dt_bauhaus_slider_new_with_range(self, 1.0f, 30.0f, 1., 7.f, 0);
+  g->nbhood = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01, 0.0f, 2);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
   g->channel = dt_conf_get_int("plugins/darkroom/denoiseprofile/gui_channel");
 
@@ -2696,8 +2727,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));
   dt_bauhaus_widget_set_label(g->radius, NULL, _("patch size"));
   dt_bauhaus_slider_set_format(g->radius, "%.0f");
-  dt_bauhaus_widget_set_label(g->nbhood, NULL, _("search radius"));
-  dt_bauhaus_slider_set_format(g->nbhood, "%.0f");
+  dt_bauhaus_widget_set_label(g->nbhood, NULL, _("coarse noise elimination"));
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means"));
   dt_bauhaus_combobox_add(g->mode, _("wavelets"));
@@ -2706,7 +2736,8 @@ void gui_init(dt_iop_module_t *self)
                                          "non-local means works best for `lightness' blending, "
                                          "wavelets work best for `color' blending"));
   gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match. increase for more sharpness"));
-  gtk_widget_set_tooltip_text(g->nbhood, _("emergency use only: radius of the neighbourhood to search patches in. increase for better denoising performance, but watch the long runtimes! large radii can be very slow. you have been warned"));
+  gtk_widget_set_tooltip_text(g->nbhood, _("size of the zone around the pixel to search for similar patches. "
+                                           "increase if you see coarse grain noise"));
   gtk_widget_set_tooltip_text(g->strength, _("finetune denoising strength"));
   g_signal_connect(G_OBJECT(g->profile), "value-changed", G_CALLBACK(profile_callback), self);
   g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);


### PR DESCRIPTION
This pull request contains several changes for the non local means algorithm:
(1) a replacement for the slider "radius" (added recently by @hanatos ), which impacts a lot the performance. Time of execution depends on the square of the radius. The replacement allows to have a similar visual effect without impacting performance by looking at patches more "wide-spread" without changing the number of patches. So there is no more performance issue, and the slider is much more usable in practice.
(2) a change in the algorithm's core that make it possible to use smaller force without having too much "unchanged" pixels. Previously, the central patch was used to denoise itself (which is absurd), thus it had a weight of 1, and smaller weights of other patches were not able to be considered correctly. Now, the central patch is not used. This affects the output little, so it should not be an issue for backward compatibility, but gives a wider "visually usable" range for the force slider.
(3) a change for the presets. I personally think using the non local means in the luminance preset is a bad idea, as non local means is not very consistent: sometimes it gives great outputs, but sometimes a lot of ugly artifacts. Thus, I put a wavelet instead, with a curve fitting the use in "lightness mode" (smooth a little bit less the fine grain noise). In addition, I changed the wavelet in color mode, in order to have a curve to better remove the fine-grain color noise. I think these presets will show the users that playing with the curve can allow them to tune the denoising.

Please note:
I tested the opencl code on CPU, as I don't have a GPU. It should work, but please try to test it on GPU anyway.
Code tested under linux mint 18 and in a docker based on fedora.

Here are some comparisons:
For point (1) (left is with these changes, right is with radius). See the outputs are very similar, whereas with these changes the code was 5 times faster
![comparison_radius](https://user-images.githubusercontent.com/34063828/47930108-47da0d00-decb-11e8-9350-edb3527db859.png)
For point (2) (left is old, right is new). Some pixels are left undenoised on the left.
![comparison_central_patch](https://user-images.githubusercontent.com/34063828/47929962-d5692d00-deca-11e8-82bf-6df5913d96c3.jpg)
For point (3) (left is old, right is new). Output with new presets has less artifacts, and a noise more pleasing to look at.
![comparaison_presets](https://user-images.githubusercontent.com/34063828/47929965-d7cb8700-deca-11e8-91c8-66bc6937b8a0.jpg)