### PR TITLE
BUGFIX : color picker wrong readings

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2154,7 +2154,7 @@ int dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe, dt_develop_t *de
   // temporarily disable gamma mapping.
   GList *gammap = g_list_last(pipe->nodes);
   dt_dev_pixelpipe_iop_t *gamma = (dt_dev_pixelpipe_iop_t *)gammap->data;
-  while(strcmp(gamma->module->op, "gamma"))
+  while(strcmp(gamma->module->op, "colorout"))
   {
     gamma = NULL;
     gammap = g_list_previous(gammap);


### PR DESCRIPTION
what was done
---

When using local and global color pickers, the pixelpipe was redirected to a special processing function that disabled the gamma.c IOP to avoid messing up the readings.

problem
---

For some time, the gamma.c IOP does nothing else than converting RGB output to `uint8`. Now the gamma correction is done in the colorout.c IOP. See #1794 

Consequently, the readings of the color picker Lab were always off.

fix
---

In the special processing function without gamma, we select and disable the colorout.c IOP instead of the gamma.c.

warning
---

It does not fix the bug when LittleCMS is used.