### PR TITLE
Tonecurve presets & GUI improvements

### DIFF
--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -287,7 +287,7 @@ static inline void dt_draw_histogram_8_log(cairo_t *cr, uint32_t *hist, int32_t 
 static inline void dt_draw_histogram_8_log_base(cairo_t *cr, uint32_t *hist, int32_t channels, int32_t channel, float base_log)
 {
   cairo_move_to(cr, 0, 0);
-  for(int k = 0; k < 256; k++) cairo_line_to(cr, CLAMP((int)255.0 * logf(k/255.0 * (base_log - 1.0f) + 1.0f), 0, 255) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
+  for(int k = 0; k < 256; k++) cairo_line_to(cr, CLAMP((int)(255.0 * logf(k/255.0 * (base_log - 1.0f) + 1.0f)), 0, 255) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
   cairo_fill(cr);

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -287,7 +287,12 @@ static inline void dt_draw_histogram_8_log(cairo_t *cr, uint32_t *hist, int32_t 
 static inline void dt_draw_histogram_8_log_base(cairo_t *cr, uint32_t *hist, int32_t channels, int32_t channel, float base_log)
 {
   cairo_move_to(cr, 0, 0);
-  for(int k = 0; k < 256; k++) cairo_line_to(cr, CLAMP((int)(255.0 * logf(k/255.0 * (base_log - 1.0f) + 1.0f)), 0, 255) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
+  for(int k = 0; k < 256; k++)
+  {
+    const float x = (float)k / 255.0f;
+    cairo_line_to(cr, logf(x * (base_log - 1.0f) + 1.0f) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
+  }
+
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
   cairo_fill(cr);

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -83,7 +83,7 @@ static inline void dt_draw_grid(cairo_t *cr, const int num, const int left, cons
 }
 
 static inline void dt_draw_loglog_grid(cairo_t *cr, const int num, const int left, const int top,
-                                       const int right, const int bottom, const int base)
+                                       const int right, const int bottom, const float base)
 {
   float width = right - left;
   float height = bottom - top;
@@ -92,6 +92,38 @@ static inline void dt_draw_loglog_grid(cairo_t *cr, const int num, const int lef
   {
     const float x = logf(k / (float)num * (base - 1.0f) + 1) / logf(base);
     dt_draw_line(cr, left + x * width, top, left + x * width, bottom);
+    cairo_stroke(cr);
+    dt_draw_line(cr, left, top + x * height, right, top + x * height);
+    cairo_stroke(cr);
+  }
+}
+
+static inline void dt_draw_semilog_x_grid(cairo_t *cr, const int num, const int left, const int top,
+                                       const int right, const int bottom, const float base)
+{
+  float width = right - left;
+  float height = bottom - top;
+
+  for(int k = 1; k < num; k++)
+  {
+    const float x = logf(k / (float)num * (base - 1.0f) + 1) / logf(base);
+    dt_draw_line(cr, left + x * width, top, left + x * width, bottom);
+    cairo_stroke(cr);
+    dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
+    cairo_stroke(cr);
+  }
+}
+
+static inline void dt_draw_semilog_y_grid(cairo_t *cr, const int num, const int left, const int top,
+                                       const int right, const int bottom, const float base)
+{
+  float width = right - left;
+  float height = bottom - top;
+
+  for(int k = 1; k < num; k++)
+  {
+    const float x = logf(k / (float)num * (base - 1.0f) + 1) / logf(base);
+    dt_draw_line(cr, left + k / (float)num * width, top, left + k / (float)num * width, bottom);
     cairo_stroke(cr);
     dt_draw_line(cr, left, top + x * height, right, top + x * height);
     cairo_stroke(cr);
@@ -247,6 +279,15 @@ static inline void dt_draw_histogram_8_log(cairo_t *cr, uint32_t *hist, int32_t 
 {
   cairo_move_to(cr, 0, 0);
   for(int k = 0; k < 256; k++) cairo_line_to(cr, k, logf(1.0 + hist[channels * k + channel]));
+  cairo_line_to(cr, 255, 0);
+  cairo_close_path(cr);
+  cairo_fill(cr);
+}
+
+static inline void dt_draw_histogram_8_log_base(cairo_t *cr, uint32_t *hist, int32_t channels, int32_t channel, float base_log)
+{
+  cairo_move_to(cr, 0, 0);
+  for(int k = 0; k < 256; k++) cairo_line_to(cr, CLAMP((int)logf(k * (base_log - 1.0f) + 1.0f), 0, 255) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
   cairo_fill(cr);

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -287,7 +287,7 @@ static inline void dt_draw_histogram_8_log(cairo_t *cr, uint32_t *hist, int32_t 
 static inline void dt_draw_histogram_8_log_base(cairo_t *cr, uint32_t *hist, int32_t channels, int32_t channel, float base_log)
 {
   cairo_move_to(cr, 0, 0);
-  for(int k = 0; k < 256; k++) cairo_line_to(cr, CLAMP((int)logf(k * (base_log - 1.0f) + 1.0f), 0, 255) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
+  for(int k = 0; k < 256; k++) cairo_line_to(cr, CLAMP((int)255.0 * logf(k/255.0 * (base_log - 1.0f) + 1.0f), 0, 255) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
   cairo_fill(cr);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -492,27 +492,6 @@ void init_presets(dt_iop_module_so_t *self)
   for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = powf(p.tonecurve[ch_L][k].y, 2.2f);
   dt_gui_presets_add_generic(_("contrast - high (gamma 2.2)"), self->op, self->version(), &p, sizeof(p), 1);
 
-  // Log contrast
-  for(int k = 0; k < 7; k++) p.tonecurve[ch_L][k].x = linear_L[k];
-  for(int k = 0; k < 7; k++) p.tonecurve[ch_L][k].y = linear_L[k];
-  p.tonecurve[ch_L][1].y -= 0.020;
-  p.tonecurve[ch_L][2].y -= 0.030;
-  p.tonecurve[ch_L][4].y += 0.030;
-  p.tonecurve[ch_L][5].y += 0.020;
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].x = ((logf(p.tonecurve[ch_L][k].x) / logf(2.0f)) + 8.0f) / 8.0f;
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = ((logf(p.tonecurve[ch_L][k].y) / logf(2.0f)) + 8.0f) / 8.0f;
-  dt_gui_presets_add_generic(_("contrast - med (log 8 EV)"), self->op, self->version(), &p, sizeof(p), 1);
-
-  for(int k = 0; k < 7; k++) p.tonecurve[ch_L][k].x = linear_L[k];
-  for(int k = 0; k < 7; k++) p.tonecurve[ch_L][k].y = linear_L[k];
-  p.tonecurve[ch_L][1].y -= 0.040;
-  p.tonecurve[ch_L][2].y -= 0.060;
-  p.tonecurve[ch_L][4].y += 0.060;
-  p.tonecurve[ch_L][5].y += 0.040;
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].x = ((logf(p.tonecurve[ch_L][k].x) / logf(2.0f)) + 8.0f) / 8.0f;
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = ((logf(p.tonecurve[ch_L][k].y) / logf(2.0f)) + 8.0f) / 8.0f;
-  dt_gui_presets_add_generic(_("contrast - high (log 8 EV)"), self->op, self->version(), &p, sizeof(p), 1);
-
   /** for pure power-like functions, we need more nodes close to the bounds**/
 
   p.tonecurve_type[ch_L] = MONOTONE_HERMITE;
@@ -535,14 +514,6 @@ void init_presets(dt_iop_module_so_t *self)
   // Exp2 - no contrast
   for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = powf(2.0f, linear_L[k]) - 1.0f;
   dt_gui_presets_add_generic(_("exponential (base 2)"), self->op, self->version(), &p, sizeof(p), 1);
-
-   // Log10 - no contrast
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = logf(linear_L[k] * 9.0f + 1.0f) / logf(9.0f);
-  dt_gui_presets_add_generic(_("logarithm (base 10)"), self->op, self->version(), &p, sizeof(p), 1);
-
-  // Exp10 - no contrast
-  for(int k = 1; k < 6; k++) p.tonecurve[ch_L][k].y = (powf(10.0f, linear_L[k]) - 1.0f) / 9.0f;
-  dt_gui_presets_add_generic(_("exponential (base 10)"), self->op, self->version(), &p, sizeof(p), 1);
 
   for (int k=0; k<sizeof(preset_camera_curves)/sizeof(preset_camera_curves[0]); k++)
   {

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1154,10 +1154,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   c->autoscale_ab = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(c->autoscale_ab, NULL, _("color space"));
-  dt_bauhaus_combobox_add(c->autoscale_ab, _("Lab, bounded channels"));
+  dt_bauhaus_combobox_add(c->autoscale_ab, _("Lab, linked channels"));
   dt_bauhaus_combobox_add(c->autoscale_ab, _("Lab, independant channels"));
-  dt_bauhaus_combobox_add(c->autoscale_ab, _("XYZ, bounded channels"));
-  dt_bauhaus_combobox_add(c->autoscale_ab, _("RGB, bounded channels"));
+  dt_bauhaus_combobox_add(c->autoscale_ab, _("XYZ, linked channels"));
+  dt_bauhaus_combobox_add(c->autoscale_ab, _("RGB, linked channels"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->autoscale_ab, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(c->autoscale_ab, _("if set to auto, a and b curves have no effect and are "
                                                  "not displayed. chroma values (a and b) of each pixel are "

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -650,8 +650,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 static float eval_grey(float x)
 {
-  // estimate the log base to remap
-  //return (100.0f / x + 1.0f - 1.0f / 0.18f) / 2.0f;
+  // estimate the log base to remap the grey x to 0.5
   return x;
 }
 
@@ -1250,9 +1249,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 
   c->logbase = dt_bauhaus_slider_new_with_range(self, 2.0f, 64.f, 0.5f, 2.0f, 2);
-  dt_bauhaus_widget_set_label(c->logbase, NULL, _("logarithmic middle grey reference"));
-  gtk_widget_set_tooltip_text(c->logbase, _("select the middle grey luma (as in the unbreak profile) "
-                                             "to set the base of the logaritm in the graph display"));
+  dt_bauhaus_widget_set_label(c->logbase, NULL, _("base of the logarithm"));
   gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 
@@ -1396,6 +1393,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   // draw grid
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(.4));
   cairo_set_source_rgb(cr, .1, .1, .1);
+
   if (c->loglogscale > 0.0f && ch == ch_L )
   {
     if (c->semilog == 0)
@@ -1474,12 +1472,19 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_save(cr);
       cairo_scale(cr, width / 255.0, -(height - DT_PIXEL_APPLY_DPI(5)) / hist_max);
       cairo_set_source_rgba(cr, .2, .2, .2, 0.5);
+
       if (ch == ch_L && c->loglogscale > 0.0f && c->semilog != -1)
-        dt_draw_histogram_8_log_base(cr, hist, 4, ch, c->loglogscale);
+      {
+        // not working
+        // dt_draw_histogram_8_log_base(cr, hist, 4, ch, c->loglogscale);
+      }
       else
+      {
+        // the histogram shows linear Lab so we hide it for RGB, XYZ and log scales
         dt_draw_histogram_8(cr, hist, 4, ch, dev->histogram_type == DT_DEV_HISTOGRAM_LINEAR); // TODO: make draw
-                                                                                         // handle waveform
+                                                                                       // handle waveform
                                                                                          // histograms
+      }
       cairo_restore(cr);
     }
 


### PR DESCRIPTION
_WIP, help welcomed_

screenshot
---
![capture d ecran du 2018-11-03 03-53-46](https://user-images.githubusercontent.com/2779157/47949599-66b4bf80-df1c-11e8-946d-21267f9b22ee.png)

tl; dr
---

This PR is intended to enable further the logaritmic workflow introduced with the unbreak profile module. It only affects the GUI. No internal data changes.

New features
---

- Add presets for generic image-processing functions such as Log2, Exp2, Gamma 2, Gamma 0.5
- Rename existing presets with more explicit names describing the actual operations (contrast high becomes contrast - high (gamma))
- Existing presets get 7 nodes instead of 5. That will allow to use the curve the same way as the Lightroom equalizer (with blacks, shadows, mid-tones, highlights and whites), with the presets as a base and define filmic curves easily.
- Port the log-log scaling from the basecurve module, and enable semi-log scales. The benefit is, in semi-log (y) mode, when you draw a line, it's actually an exponential (good to revert partially the log profile). The other way around, in semi-log (x), when you draw a line, it's actually a log. The log-log mode is usefull to zoom closer on the shadows. This only affects the display.
- Let the user choose the base of the log scaling, to match the grey level set in unbreak profile. This means you can center the graph to whatever grey level you want, to help you see what you are doing.
- Rename the modes : automatic, manual, auto XYZ and auto RGB were not super explicit. They are renamed "color space" : Lab (bounded channels), Lab (independant channels), RGB (bounded channels), XYZ (ibounded channels)
- Expose the interpolation method : previously, this was implicitely set by applying presets. Now user can choose between 3 splines with different fitting properties.
- Hide the 3 Lab tabs when bounded channels mode are used. They are useless in this setup, and it's misleading to have Lab tabs when you work in RGB or XYZ anyway.
- In RGB and XYZ mode, convert the luminance values of the color samplers to XYZ, so they are properly remapped on the graph. Previously, in RGB and XYZ, you still got Lab luminance values. Again, misleading.
- Remap the color samplers accordingly to the log scale.
- Remap the inset histogram accordingly to the log scale.

What does not work (yet)
---

- global color pickers values conversion to XYZ fails, I don't know why (this Lab -> XYZ conversion is used successfully several times in the 2 other modules I hacked)
- after setting up color pickers, when the cursor leaves and enter back the graph zone, color pickers disappear (GUI glitch)
- the histogram in log-log or semi-log (x) sometimes disappear and values are wrong anyway.