### PR TITLE
fix masks and new module crash

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2908,7 +2908,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
     /* we blend with a drawn and/or parametric mask */
 
     /* get the drawn mask if there is one */
-    dt_masks_form_t *form = dt_masks_get_from_id(self->dev, d->mask_id);
+    dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, d->mask_id);
 
     if(form && (!(self->flags() & IOP_FLAGS_NO_MASKS)) && (d->mask_mode & DEVELOP_MASK_MASK))
     {
@@ -3164,7 +3164,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     /* we blend with a drawn and/or parametric mask */
 
     /* apply masks if there's some */
-    dt_masks_form_t *form = dt_masks_get_from_id(self->dev, d->mask_id);
+    dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, d->mask_id);
     if(form && (!(self->flags() & IOP_FLAGS_NO_MASKS)) && (d->mask_mode & DEVELOP_MASK_MASK))
     {
       dt_masks_group_render_roi(self, piece, form, roi_out, mask);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -113,6 +113,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 
   dev->iop_instance = 0;
   dev->iop = NULL;
+  dev->alliop = NULL;
 
   dev->proxy.exposure = NULL;
 
@@ -154,6 +155,12 @@ void dt_dev_cleanup(dt_develop_t *dev)
     dt_iop_cleanup_module((dt_iop_module_t *)dev->iop->data);
     free(dev->iop->data);
     dev->iop = g_list_delete_link(dev->iop, dev->iop);
+  }
+  while(dev->alliop)
+  {
+    dt_iop_cleanup_module((dt_iop_module_t *)dev->alliop->data);
+    free(dev->alliop->data);
+    dev->alliop = g_list_delete_link(dev->alliop, dev->alliop);
   }
   dt_pthread_mutex_destroy(&dev->history_mutex);
   free(dev->histogram);
@@ -1712,7 +1719,7 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, i
                                   float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
-  GList *modules = g_list_first(dev->iop);
+  GList *modules = g_list_first(pipe->iop);
   GList *pieces = g_list_first(pipe->nodes);
   while(modules)
   {
@@ -1739,7 +1746,7 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
                                       float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
-  GList *modules = g_list_last(dev->iop);
+  GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
   while(modules)
   {
@@ -1787,7 +1794,7 @@ uint64_t dt_dev_hash_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, in
 {
   uint64_t hash = 5381;
   dt_pthread_mutex_lock(&dev->history_mutex);
-  GList *modules = g_list_last(dev->iop);
+  GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
   while(modules)
   {
@@ -1881,7 +1888,7 @@ uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *
 {
   uint64_t hash = 5381;
   dt_pthread_mutex_lock(&dev->history_mutex);
-  GList *modules = g_list_last(dev->iop);
+  GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
   while(modules)
   {

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -151,6 +151,8 @@ typedef struct dt_develop_t
   // operations pipeline
   int32_t iop_instance;
   GList *iop;
+  // iop's to be deleted
+  GList *alliop;
 
   // histogram for display.
   uint32_t *histogram, *histogram_pre_tonecurve, *histogram_pre_levels;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -564,18 +564,12 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   // we remove all references in the history stack and dev->iop
   dt_dev_module_remove(dev, module);
 
-  // we recreate the pipe
-  dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
-  dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
-  dt_dev_pixelpipe_create_nodes(dev->pipe, dev);
-  dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
-
   // we cleanup the module
   dt_accel_disconnect_list(module->accel_closures);
   dt_accel_cleanup_locals_iop(module);
   module->accel_closures = NULL;
-  dt_iop_cleanup_module(module);
-  free(module);
+  // don't delete the module, a pipe may still need it
+  dev->alliop = g_list_append(dev->alliop, module);
   module = NULL;
 
   // we update show params for multi-instances for each other instances

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -275,6 +275,8 @@ int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_versio
 
 /** we create a completely new form. */
 dt_masks_form_t *dt_masks_create(dt_masks_type_t type);
+/** retrieve a form from a list of forms with is id */
+dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id);
 /** retrieve a form with is id */
 dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id);
 
@@ -328,6 +330,8 @@ void dt_masks_form_remove(struct dt_iop_module_t *module, dt_masks_form_t *grp, 
 void dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up);
 void dt_masks_form_move(dt_masks_form_t *grp, int formid, int up);
 int dt_masks_form_duplicate(dt_develop_t *dev, int formid);
+/* duplicate the list of forms, replace item in the list with form is the same formid */
+GList *dt_masks_dup_forms_deep(GList *forms, dt_masks_form_t *form);
 
 /** utils functions */
 int dt_masks_point_in_form_exact(float x, float y, float *points, int points_start, int points_count);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -102,7 +102,7 @@ static void *_dup_masks_form_cb(const void *formdata, gpointer user_data)
 }
 
 // duplicate the list of forms, replace item in the list with form is the same formid
-static GList *_dup_masks_forms_deep(GList *forms, dt_masks_form_t *form)
+GList *dt_masks_dup_forms_deep(GList *forms, dt_masks_form_t *form)
 {
   return (GList *)g_list_copy_deep(forms, _dup_masks_form_cb, (gpointer)form);
 }
@@ -110,7 +110,7 @@ static GList *_dup_masks_forms_deep(GList *forms, dt_masks_form_t *form)
 static _masks_undo_data_t *_create_snapshot(GList *forms, dt_masks_form_t *form, dt_develop_t *dev)
 {
   _masks_undo_data_t *data = malloc(sizeof(struct _masks_undo_data_t));
-  data->forms = _dup_masks_forms_deep(forms, form);
+  data->forms = dt_masks_dup_forms_deep(forms, form);
   data->form  = dev->form_visible ? _dup_masks_form(dev->form_visible) : NULL;
   return data;
 }
@@ -130,7 +130,7 @@ static void _masks_do_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data
   dt_develop_t *dev = (dt_develop_t *)user_data;
   _masks_undo_data_t *udata = (_masks_undo_data_t *)item;
 
-  dev->forms = _dup_masks_forms_deep(udata->forms, NULL);
+  dev->forms = dt_masks_dup_forms_deep(udata->forms, NULL);
   dev->form_gui->creation = FALSE;
 
   dt_masks_clear_form_gui(dev);
@@ -965,9 +965,8 @@ dt_masks_form_t *dt_masks_create(dt_masks_type_t type)
   return form;
 }
 
-dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id)
+dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id)
 {
-  GList *forms = g_list_first(dev->forms);
   while(forms)
   {
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
@@ -977,6 +976,10 @@ dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id)
   return NULL;
 }
 
+dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id)
+{
+  return dt_masks_get_from_id_ext(dev->forms, id);
+}
 
 void dt_masks_read_forms(dt_develop_t *dev)
 {

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -130,6 +130,10 @@ typedef struct dt_dev_pixelpipe_t
   dt_colorspaces_color_profile_type_t icc_type;
   gchar *icc_filename;
   dt_iop_color_intent_t icc_intent;
+  // snapshot of modules
+  GList *iop;
+  // snapshot of mask list
+  GList *forms;
 } dt_dev_pixelpipe_t;
 
 struct dt_develop_t;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2980,7 +2980,7 @@ static void rt_compute_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelp
   int roiy = *_roiy;
 
   // We iterate through all forms
-  const dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, bp->mask_id);
+  const dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
   if(grp && (grp->type & DT_MASKS_GROUP))
   {
     GList *forms = g_list_first(grp->points);
@@ -2992,7 +2992,7 @@ static void rt_compute_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelp
         const int formid = grpt->formid;
 
         // we get the spot
-        dt_masks_form_t *form = dt_masks_get_from_id(self->dev, formid);
+        dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form)
         {
           // if the form is outside the roi, we just skip it
@@ -3060,7 +3060,7 @@ static void rt_extend_roi_in_from_source_clones(struct dt_iop_module_t *self, st
   int roiy = *_roiy;
 
   // We iterate through all forms
-  const dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, bp->mask_id);
+  const dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
   if(grp && (grp->type & DT_MASKS_GROUP))
   {
     GList *forms = g_list_first(grp->points);
@@ -3084,7 +3084,7 @@ static void rt_extend_roi_in_from_source_clones(struct dt_iop_module_t *self, st
         }
 
         // we get the spot
-        dt_masks_form_t *form = dt_masks_get_from_id(self->dev, formid);
+        dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form)
         {
           // we get the source area
@@ -3152,7 +3152,7 @@ static void rt_extend_roi_in_for_clone(struct dt_iop_module_t *self, struct dt_d
   int roiy = *_roiy;
 
   // go through all clone and heal forms
-  const dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, bp->mask_id);
+  const dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
   if(grp && (grp->type & DT_MASKS_GROUP))
   {
     GList *forms = g_list_first(grp->points);
@@ -3171,7 +3171,7 @@ static void rt_extend_roi_in_for_clone(struct dt_iop_module_t *self, struct dt_d
         }
 
         // we get the spot
-        dt_masks_form_t *form = dt_masks_get_from_id(self->dev, formid);
+        dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form == NULL)
         {
           forms = g_list_next(forms);
@@ -4047,7 +4047,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
   // iterate through all forms
   if(!usr_d->suppress_mask)
   {
-    const dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, bp->mask_id);
+    const dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP))
     {
       GList *forms = g_list_first(grp->points);
@@ -4088,7 +4088,7 @@ static void rt_process_forms(float *layer, dwt_params_t *const wt_p, const int s
         }
 
         // get the spot
-        dt_masks_form_t *form = dt_masks_get_from_id(self->dev, formid);
+        dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form == NULL)
         {
           fprintf(stderr, "rt_process_forms: missing form=%i from masks\n", formid);
@@ -4855,7 +4855,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
   // iterate through all forms
   if(!usr_d->suppress_mask)
   {
-    dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, bp->mask_id);
+    dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP))
     {
       GList *forms = g_list_first(grp->points);
@@ -4896,7 +4896,7 @@ static cl_int rt_process_forms_cl(cl_mem dev_layer, dwt_params_cl_t *const wt_p,
         }
 
         // get the spot
-        dt_masks_form_t *form = dt_masks_get_from_id(self->dev, formid);
+        dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, formid);
         if(form == NULL)
         {
           fprintf(stderr, "rt_process_forms: missing form=%i from masks\n", formid);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -258,7 +258,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   dt_develop_blend_params_t *bp = self->blend_params;
 
   // We iterate through all spots or polygons
-  dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, bp->mask_id);
+  dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
   if(grp && (grp->type & DT_MASKS_GROUP))
   {
     GList *forms = g_list_first(grp->points);
@@ -266,7 +266,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     {
       dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)forms->data;
       // we get the spot
-      dt_masks_form_t *form = dt_masks_get_from_id(self->dev, grpt->formid);
+      dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, grpt->formid);
       if(form)
       {
         // if the form is outside the roi, we just skip it
@@ -383,7 +383,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 
   // iterate through all forms
-  dt_masks_form_t *grp = dt_masks_get_from_id(self->dev, bp->mask_id);
+  dt_masks_form_t *grp = dt_masks_get_from_id_ext(piece->pipe->forms, bp->mask_id);
   int pos = 0;
   if(grp && (grp->type & DT_MASKS_GROUP))
   {
@@ -392,7 +392,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     {
       dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)forms->data;
       // we get the spot
-      dt_masks_form_t *form = dt_masks_get_from_id(self->dev, grpt->formid);
+      dt_masks_form_t *form = dt_masks_get_from_id_ext(piece->pipe->forms, grpt->formid);
       if(!form)
       {
         forms = g_list_next(forms);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -622,6 +622,15 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
       free(module);
     }
   }
+  
+  // we also clear the saved modules
+  while(dev->alliop)
+  {
+    dt_iop_cleanup_module((dt_iop_module_t *)dev->alliop->data);
+    free(dev->alliop->data);
+    dev->alliop = g_list_delete_link(dev->alliop, dev->alliop);
+  }
+  
   dt_dev_pixelpipe_create_nodes(dev->pipe, dev);
   dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
   dt_masks_read_forms(dev);
@@ -1886,6 +1895,12 @@ void leave(dt_view_t *self)
     dt_iop_cleanup_module(module);
     free(module);
     dev->iop = g_list_delete_link(dev->iop, dev->iop);
+  }
+  while(dev->alliop)
+  {
+    dt_iop_cleanup_module((dt_iop_module_t *)dev->alliop->data);
+    free(dev->alliop->data);
+    dev->alliop = g_list_delete_link(dev->alliop, dev->alliop);
   }
 
   dt_pthread_mutex_unlock(&dev->history_mutex);


### PR DESCRIPTION
This fixes Bug #11956 and some random crashes when using masks.
https://redmine.darktable.org/issues/11956

Basically it makes dev->iop and dev-forms thread-safe inside the pipe.

To duplicate the masks issue add several heavy masks on retouch and delete them while dt is still processing.
