### PR TITLE
Bug fix #12390 : broken HQ export

### DIFF
--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2154,7 +2154,7 @@ int dt_dev_pixelpipe_process_no_gamma(dt_dev_pixelpipe_t *pipe, dt_develop_t *de
   // temporarily disable gamma mapping.
   GList *gammap = g_list_last(pipe->nodes);
   dt_dev_pixelpipe_iop_t *gamma = (dt_dev_pixelpipe_iop_t *)gammap->data;
-  while(strcmp(gamma->module->op, "colorout"))
+  while(strcmp(gamma->module->op, "gamma"))
   {
     gamma = NULL;
     gammap = g_list_previous(gammap);


### PR DESCRIPTION
The fix I introduced for the color picker broke the HQ export. This revert it. Anyway, it didn't work with LittleCMS, so it was probably not a real fix