### PR TITLE
Undo memory leak

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -545,15 +545,6 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
     dt_iop_gui_cleanup_module(module);
   }
 
-  // we remove all references in the history stack and dev->iop
-  dt_dev_module_remove(dev, module);
-
-  // we recreate the pipe
-  dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
-  dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
-  dt_dev_pixelpipe_create_nodes(dev->pipe, dev);
-  dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
-
   // if module was priority 0, then we set next to priority 0
   if(is_zero)
   {
@@ -569,6 +560,15 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
       history = g_list_next(history);
     }
   }
+
+  // we remove all references in the history stack and dev->iop
+  dt_dev_module_remove(dev, module);
+
+  // we recreate the pipe
+  dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
+  dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
+  dt_dev_pixelpipe_create_nodes(dev->pipe, dev);
+  dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
 
   // we cleanup the module
   dt_accel_disconnect_list(module->accel_closures);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -440,8 +440,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *d
         // if not already done, set the module to all others same instance
         if (!done)
         {
-          GList *h = (dev->history);
-          _reset_module_instance(h, module, hitem->multi_priority);
+          _reset_module_instance(dev->history, module, hitem->multi_priority);
 
           // and do that also in the undo/redo lists
           struct _cb_data udata = { module, hitem->multi_priority };


### PR DESCRIPTION
This fixes the undo of a deleted base instance, that was not working, and a memory leak on every undo-delete, to confirm build with asan.

The redo of a deleted instance and undo of a new one still have funny effects, but that is even more tricky than this one, so better to handle it on a new PR.

There's still a memory leak on the undo, but it doesn't seem to be related to this. I'll check that later.