### PR TITLE
upgrade undo

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -799,6 +799,7 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
     memcpy(module->params, module->default_params, module->params_size);
     memcpy(module->blend_params, module->default_blendop_params, sizeof(dt_develop_blend_params_t));
     module->enabled = module->default_enabled;
+    module->multi_name[0] = '\0';
     modules = g_list_next(modules);
   }
   // go through history and set gui params
@@ -1638,8 +1639,8 @@ void dt_dev_module_remove(dt_develop_t *dev, dt_iop_module_t *module)
   if(dev->gui_attached && del)
   {
     /* signal that history has changed */
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE, module);
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_REMOVE, module);
     /* redraw */
     dt_control_queue_redraw_center();
   }

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -275,9 +275,9 @@ int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_versio
 
 /** we create a completely new form. */
 dt_masks_form_t *dt_masks_create(dt_masks_type_t type);
-/** retrieve form id from a list of forms */
+/** returns a form with formid == id from a list of forms */
 dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id);
-/** retrieve form id */
+/** returns a form with formid == id from dev->forms */
 dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id);
 
 /** read the forms from the db */


### PR DESCRIPTION
This modifies the history undo to use the same schema than PR  #1800

Now it works on the snapshot of dev->history and a copy of dev->iop, and when is done it replaces it.

It handles the delete of modules on dev->iop, that have to be done when the user undo a new multi-instance or redo a delete multi-instance, as there will be an extra module on dev->iop.
To do this I assume that any multi_priority > 0 must be in history and there must be only one multi_priority = 0 per operation.
If I find a multi_priority > 0 not in history, I delete it.
If I find two multi_priority = 0 for the same operation, one is in history and the other is not, I delete the one that is not in history.

It also handles the move up/down of a multi-instance, and fixes some small issues.
