### PR TITLE
cmake: Fix RPATH so that you can execute darktable in build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,10 +286,20 @@ else(APPLE)
 endif(APPLE)
 
 if(NOT WIN32)
-  # Windows doesn't know the concept of RPATHs :(
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
-  set(CMAKE_INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
+    # Windows doesn't know the concept of RPATHs :(
+
+    # use, i.e. don't skip the full RPATH for the build tree
+    set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+    # when building, don't use the install RPATH already
+    # (but later on when installing)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+    set(CMAKE_INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif(NOT WIN32)
 
 # we need some external programs for building darktable


### PR DESCRIPTION
This will allow that you can run darktable directly in the build directory:

./src/darktable

will just work! The binaries will be relinked during installation and the installation rpath set.