### PR TITLE
New module : Filmic

### DIFF
--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -22,3 +22,4 @@ basecurve.cl            18
 locallaplacian.cl       19
 dwt.cl                  20
 retouch.cl              21
+filmic.cl               22

--- a/src/common/sse.h
+++ b/src/common/sse.h
@@ -16,7 +16,7 @@
 
 #include <xmmintrin.h>
 
-/*
+/**
  * Fast SSE2 implementation of special math functions.
  */
 
@@ -120,6 +120,22 @@ static inline __m128 _mm_pow_ps(__m128 x, __m128 y)
 static inline __m128 _mm_pow_ps1(__m128 x, float y)
 {
   return _mm_exp2_ps(_mm_mul_ps(_mm_log2_ps(x), _mm_set1_ps(y)));
+}
+
+
+/**
+ * Allow access of the content of a SSE vector
+ **/
+
+static inline float _mm_vectorGetByIndex( __m128 V, unsigned int i)
+{
+  union {
+    __m128 v;
+    float a[4];
+  } converter;
+
+  converter.v = V;
+  return converter.a[i];
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -195,9 +195,19 @@ static inline void dt_draw_curve_calc_values(dt_draw_curve_t *c, const float min
   c->csample.m_outputRes = 0x10000;
   CurveDataSample(&c->c, &c->csample);
   if(x)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for SIMD() default(none) shared(x) schedule(static)
+#endif
     for(int k = 0; k < res; k++) x[k] = k * (1.0f / res);
+  }
   if(y)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for SIMD() default(none) shared(y, c) schedule(static)
+#endif
     for(int k = 0; k < res; k++) y[k] = min + (max - min) * c->csample.m_Samples[k] * (1.0f / 0x10000);
+  }
 }
 
 static inline float dt_draw_curve_calc_value(dt_draw_curve_t *c, const float x)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -123,7 +123,7 @@ add_iop(denoiseprofile "denoiseprofile.c")
 add_iop(defringe "defringe.c")
 add_iop(ashift "ashift.c")
 add_iop(hazeremoval "hazeremoval.c")
-add_iop(toneequalizer "filmic.c" DEFAULT_VISIBLE)
+add_iop(filmic "filmic.c" DEFAULT_VISIBLE)
 
 if(RSVG2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -123,7 +123,7 @@ add_iop(denoiseprofile "denoiseprofile.c")
 add_iop(defringe "defringe.c")
 add_iop(ashift "ashift.c")
 add_iop(hazeremoval "hazeremoval.c")
-add_iop(toneequalizer "toneequalizer.c" DEFAULT_VISIBLE)
+add_iop(toneequalizer "filmic.c" DEFAULT_VISIBLE)
 
 if(RSVG2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -123,6 +123,7 @@ add_iop(denoiseprofile "denoiseprofile.c")
 add_iop(defringe "defringe.c")
 add_iop(ashift "ashift.c")
 add_iop(hazeremoval "hazeremoval.c")
+add_iop(toneequalizer "toneequalizer.c" DEFAULT_VISIBLE)
 
 if(RSVG2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4311,7 +4311,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_ashift_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_ashift_params_t));
   module->default_enabled = 0;
-  module->priority = 205; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 214; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_ashift_params_t);
   module->gui_data = NULL;
   dt_iop_ashift_params_t tmp = (dt_iop_ashift_params_t){ 0.0f, 0.0f, 0.0f, 0.0f, DEFAULT_F_LENGTH, 1.0f, 100.0f, 1.0f, ASHIFT_MODE_GENERIC, 0,

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -931,7 +931,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_atrous_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_atrous_params_t));
   module->default_enabled = 0;
-  module->priority = 573; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 571; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_atrous_params_t);
   module->gui_data = NULL;
   dt_iop_atrous_params_t tmp;

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1247,7 +1247,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_basecurve_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_basecurve_params_t));
   module->default_enabled = 0;
-  module->priority = 294; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 299; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_basecurve_params_t);
   module->gui_data = NULL;
   dt_iop_basecurve_params_t tmp = (dt_iop_basecurve_params_t){

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -387,7 +387,7 @@ void init(dt_iop_module_t *module)
   // by default:
   module->default_enabled = 0;
   // order has to be changed by editing the dependencies in tools/iop_dependencies.py
-  module->priority = 588; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 585; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bilat_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -324,7 +324,7 @@ void init(dt_iop_module_t *module)
   module->params = (dt_iop_params_t *)malloc(sizeof(dt_iop_bilateral_params_t));
   module->default_params = (dt_iop_params_t *)malloc(sizeof(dt_iop_bilateral_params_t));
   module->default_enabled = 0;
-  module->priority = 308; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 314; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_bilateral_params_t);
   module->gui_data = NULL;
   dt_iop_bilateral_params_t tmp = (dt_iop_bilateral_params_t){ { 15.0, 15.0, 0.005, 0.005, 0.005 } };

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -911,7 +911,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_borders_params_t);
   module->gui_data = NULL;
-  module->priority = 955; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 957; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1520,7 +1520,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
 
   // we come just before demosaicing.
-  module->priority = 73; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 71; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_cacorrect_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -419,7 +419,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_channelmixer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_channelmixer_params_t));
   module->default_enabled = 0;
-  module->priority = 823; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 828; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_channelmixer_params_t);
   module->gui_data = NULL;
   dt_iop_channelmixer_params_t tmp = (dt_iop_channelmixer_params_t){ { 0, 0, 0, 1, 0, 0, 0 },

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -294,7 +294,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_rlce_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_rlce_params_t));
   module->default_enabled = 0;
-  module->priority = 897; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 899; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rlce_params_t);
   module->gui_data = NULL;
   dt_iop_rlce_params_t tmp = (dt_iop_rlce_params_t){ 64, 1.25 };

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1691,7 +1691,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_clipping_params_t);
   module->gui_data = NULL;
-  module->priority = 455; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 457; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -317,7 +317,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colisa_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colisa_params_t));
   module->default_enabled = 0;
-  module->priority = 647; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 657; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colisa_params_t);
   module->gui_data = NULL;
   dt_iop_colisa_params_t tmp = (dt_iop_colisa_params_t){ 0, 0, 0 };

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1301,7 +1301,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorbalance_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorbalance_params_t));
   module->default_enabled = 0;
-  module->priority = 449; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 442; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorbalance_params_t);
   module->gui_data = NULL;
   dt_iop_colorbalance_params_t tmp = (dt_iop_colorbalance_params_t){ SLOPE_OFFSET_POWER,

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -812,7 +812,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorchecker_params_t));
   module->default_enabled = 0;
-  module->priority = 382; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 385; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorchecker_params_t);
   module->gui_data = NULL;
   dt_iop_colorchecker_params_t tmp;

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -305,7 +305,7 @@ void init(dt_iop_module_t *module)
   // our module is disabled by default
   module->default_enabled = 0;
   // we are pretty late in the pipe:
-  module->priority = 794; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 799; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorcontrast_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -228,7 +228,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorcorrection_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorcorrection_params_t));
   module->default_enabled = 0;
-  module->priority = 720; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 728; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorcorrection_params_t);
   module->gui_data = NULL;
   dt_iop_colorcorrection_params_t tmp = (dt_iop_colorcorrection_params_t){ 0., 0., 0., 0., 1.0 };

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1699,7 +1699,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorin_params_t));
   module->params_size = sizeof(dt_iop_colorin_params_t);
   module->gui_data = NULL;
-  module->priority = 352; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 357; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->default_enabled = 1;
 }

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -400,7 +400,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorize_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorize_params_t));
   module->default_enabled = 0;
-  module->priority = 470; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 471; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorize_params_t);
   module->gui_data = NULL;
   dt_iop_colorize_params_t tmp = (dt_iop_colorize_params_t){ 0, 0.5, 50, 50, module->version() };

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -727,7 +727,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_colorout_params_t));
   module->params_size = sizeof(dt_iop_colorout_params_t);
   module->gui_data = NULL;
-  module->priority = 808; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 814; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->default_enabled = 1;
   dt_iop_colorout_params_t tmp = (dt_iop_colorout_params_t){ DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL};

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1302,7 +1302,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorreconstruct_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorreconstruct_params_t));
   module->default_enabled = 0;
-  module->priority = 367; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 371; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorreconstruct_params_t);
   module->gui_data = NULL;
   dt_iop_colorreconstruct_params_t tmp = (dt_iop_colorreconstruct_params_t){ 100.0f, 400.0f, 10.0f, 0.66f, COLORRECONSTRUCT_PRECEDENCE_NONE };

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -393,7 +393,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_colorzones_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 602; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 599; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_colorzones_params_t);
   module->gui_data = NULL;
   dt_iop_colorzones_params_t tmp;

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -397,7 +397,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_defringe_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_defringe_params_t));
-  module->priority = 397; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 399; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_defringe_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -4657,7 +4657,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_demosaic_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_demosaic_params_t));
   module->default_enabled = 1;
-  module->priority = 117; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 114; // module order created by iop_dependencies.py, do not edit!
   module->hide_enable_button = 1;
   module->params_size = sizeof(dt_iop_demosaic_params_t);
   module->gui_data = NULL;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2056,7 +2056,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_denoiseprofile_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_denoiseprofile_params_t));
-  module->priority = 132; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 128; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_denoiseprofile_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -267,7 +267,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_equalizer_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_equalizer_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 411; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 414; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_equalizer_params_t);
   module->gui_data = NULL;
   dt_iop_equalizer_params_t tmp;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -542,7 +542,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_exposure_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_exposure_params_t));
   module->default_enabled = 0;
-  module->priority = 161; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 157; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_exposure_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1,0 +1,732 @@
+/*
+   This file is part of darktable,
+   copyright (c) 2018 Aurélien Pierre, with guidance of Troy Sobotka.
+
+   darktable is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   darktable is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "bauhaus/bauhaus.h"
+#include "common/colorspaces_inline_conversions.h"
+#include "common/darktable.h"
+#include "common/opencl.h"
+#include "control/control.h"
+#include "develop/develop.h"
+#include "develop/imageop_math.h"
+#include "dtgtk/button.h"
+#include "gui/accelerators.h"
+#include "gui/gtk.h"
+#include "gui/presets.h"
+#include "iop/iop_api.h"
+#include "common/iop_group.h"
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+DT_MODULE_INTROSPECTION(2, dt_iop_filmic_params_t)
+
+typedef enum dt_iop_filmic_mode_t
+{
+  filmic_LOG = 0,
+  filmic_LINEAR = 1
+} dt_iop_filmic_mode_t;
+
+typedef enum dt_iop_filmic_pickcolor_type_t
+{
+  DT_PICKPROFLOG_NONE = 0,
+  DT_PICKPROFLOG_GREY_POINT = 1,
+  DT_PICKPROFLOG_BLACK_POINT = 2,
+  DT_PICKPROFLOG_white_point = 3
+} dt_iop_filmic_pickcolor_type_t;
+
+typedef struct dt_iop_filmic_params_t
+{
+  dt_iop_filmic_mode_t mode;
+  float white_point;
+  float grey_point;
+  float black_point;
+  float security_factor;
+} dt_iop_filmic_params_t;
+
+typedef struct dt_iop_filmic_gui_data_t
+{
+  int apply_picked_color;
+  int which_colorpicker;
+
+  GtkWidget *mode;
+  GtkWidget *mode_stack;
+  GtkWidget *white_point;
+  GtkWidget *grey_point;
+  GtkWidget *black_point;
+  GtkWidget *security_factor;
+  GtkWidget *auto_button;
+} dt_iop_filmic_gui_data_t;
+
+typedef struct dt_iop_filmic_data_t
+{
+  dt_iop_filmic_mode_t mode;
+  float linear;
+  float table[0x10000];      // precomputed look-up table
+  float unbounded_coeffs[3]; // approximation for extrapolation of curve
+  float white_point;
+  float grey_point;
+  float black_point;
+  float security_factor;
+} dt_iop_filmic_data_t;
+
+typedef struct dt_iop_filmic_global_data_t
+{
+  int kernel_filmic;
+  int kernel_filmic_log;
+} dt_iop_filmic_global_data_t;
+
+
+const char *name()
+{
+  return _("filmic");
+}
+
+int groups()
+{
+  return dt_iop_get_group("filmic", IOP_GROUP_COLOR);
+}
+
+int flags()
+{
+  return IOP_FLAGS_ALLOW_TILING | IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+static inline float Log2(float x)
+{
+  if(x > 0.0f)
+  {
+    return logf(x) / logf(2.0f);
+  }
+  else
+  {
+    return x;
+  }
+}
+
+static inline float Log2Thres(float x, float Thres)
+{
+  if(x > Thres)
+  {
+    return logf(x) / logf(2.f);
+  }
+  else
+  {
+    return logf(Thres) / logf(2.f);
+  }
+}
+
+
+// From data/kernels/extended.cl
+static inline float fastlog2(float x)
+{
+  union { float f; unsigned int i; } vx = { x };
+  union { unsigned int i; float f; } mx = { (vx.i & 0x007FFFFF) | 0x3f000000 };
+
+  float y = vx.i;
+
+  y *= 1.1920928955078125e-7f;
+
+  return y - 124.22551499f
+    - 1.498030302f * mx.f
+    - 1.72587999f / (0.3520887068f + mx.f);
+}
+
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_filmic_data_t *data = (dt_iop_filmic_data_t *)piece->data;
+
+  const int ch = piece->colors;
+
+  /** The log2(x) -> -INF when x -> 0
+  * thus very low values (noise) will get even lower, resulting in noise negative amplification,
+  * which leads to pepper noise in shadows. To avoid that, we need to clip values that are noise for sure.
+  * Using 16 bits RAW data, the black value (known by rawspeed for every manufacturer) could be used as a threshold.
+  * However, at this point of the pixelpipe, the RAW levels have already been corrected and everything can happen with black levels
+  * in the exposure module. So we define the threshold as the first non-null 16 bit integer
+  */
+
+  const float noise = powf(2.0f, -16.0f);
+  const float dynamic_range = data->white_point - data->black_point;
+  const float grey = data->grey_point / 100.0f;
+  const float black = data->black_point;
+  fprintf(stderr, "%f", grey);
+
+#ifdef _OPENMP
+#pragma omp parallel for SIMD() default(none) schedule(static)
+#endif
+  for(size_t j = 0; j < roi_out->height; j++)
+  {
+    const float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
+    float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
+    for(size_t i = 0; i < roi_out->width; i++)
+    {
+      // transform the pixel to sRGB:
+      // Lab -> XYZ
+      float XYZ[3] = { 0.0f };
+      dt_Lab_to_XYZ(in, XYZ);
+
+      // XYZ -> sRGB
+      float rgb[3] = { 0.0f };
+      dt_XYZ_to_prophotorgb(XYZ, rgb);
+
+      // do the calculation in RGB space
+      for(size_t c = 0; c < 3; c++)
+      {
+        float tmp = rgb[c] / grey;
+        if (tmp < noise) tmp = noise;
+        rgb[c] = (fastlog2(tmp) - black) / dynamic_range;
+      }
+
+      // transform the result back to Lab
+      // sRGB -> XYZ
+      dt_prophotorgb_to_XYZ(rgb, XYZ);
+
+      // XYZ -> Lab
+      dt_XYZ_to_Lab(XYZ, out);
+      out[3] = in[3];
+
+      in += ch;
+      out += ch;
+    }
+  }
+
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
+    dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
+}
+
+static void apply_auto_grey(dt_iop_module_t *self)
+{
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  float RGB[3] = { 0.0f };
+  dt_Lab_to_prophotorgb(self->picked_color, RGB);
+
+  float grey = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
+  p->grey_point = 100.f * grey;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set(g->grey_point, p->grey_point);
+  darktable.gui->reset = 0;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void apply_auto_black(dt_iop_module_t *self)
+{
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  float noise = powf(2.0f, -16.0f);
+
+  float RGB[3] = { 0.0f };
+  dt_Lab_to_prophotorgb(self->picked_color_min, RGB);
+
+  // Black
+  float black = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
+  float EVmin = Log2Thres(black / (p->grey_point / 100.0f), noise);
+  EVmin *= (1.0f + p->security_factor / 100.0f);
+
+  p->black_point = EVmin;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set(g->black_point, p->black_point);
+  darktable.gui->reset = 0;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void apply_auto_white_point(dt_iop_module_t *self)
+{
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  float noise = powf(2.0f, -16.0f);
+
+  float RGB[3] = { 0.0f };
+  dt_Lab_to_prophotorgb(self->picked_color_max, RGB);
+
+  // White
+  float white = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
+  float EVmax = Log2Thres(white / (p->grey_point / 100.0f), noise);
+  EVmax *= (1.0f + p->security_factor / 100.0f);
+
+  p->white_point = EVmax;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set(g->white_point, p->white_point);
+  darktable.gui->reset = 0;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  float previous = p->security_factor;
+  p->security_factor = dt_bauhaus_slider_get(slider);
+  float ratio = (p->security_factor - previous) / (previous + 100.0f);
+
+  float EVmin = p->black_point;
+  EVmin = EVmin + ratio * EVmin;
+
+  float EVmax = p->white_point;
+  EVmax = EVmax + ratio * EVmax;
+
+  p->white_point = EVmax;
+  p->black_point = EVmin;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set_soft(g->white_point, p->white_point);
+  dt_bauhaus_slider_set_soft(g->black_point, p->black_point);
+  darktable.gui->reset = 0;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void optimize_button_pressed_callback(GtkWidget *button, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+
+  dt_iop_request_focus(self);
+  dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+  dt_control_queue_redraw();
+  self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+  dt_dev_reprocess_all(self->dev);
+
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f)
+  {
+    dt_control_log(_("wait for the preview to be updated."));
+    return;
+  }
+
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  float noise = powf(2.0f, -16.0f);
+  float RGB[3] = { 0.0f };
+
+  // Grey
+  dt_Lab_to_prophotorgb(self->picked_color, RGB);
+  float grey = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
+  p->grey_point = 100.f * grey;
+
+  // Black
+  dt_Lab_to_prophotorgb(self->picked_color_min, RGB);
+  float black = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
+  float EVmin = Log2Thres(black / (p->grey_point / 100.0f), noise);
+  EVmin *= (1.0f + p->security_factor / 100.0f);
+
+  // White
+  dt_Lab_to_prophotorgb(self->picked_color_max, RGB);
+  float white = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
+  float EVmax = Log2Thres(white / (p->grey_point / 100.0f), noise);
+  EVmax *= (1.0f + p->security_factor / 100.0f);
+
+  p->black_point = EVmin;
+  p->white_point = EVmax;
+
+  darktable.gui->reset = 1;
+  dt_bauhaus_slider_set(g->grey_point, p->grey_point);
+  dt_bauhaus_slider_set(g->black_point, p->black_point);
+  dt_bauhaus_slider_set(g->white_point, p->white_point);
+  darktable.gui->reset = 0;
+
+  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+
+static void grey_point_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->grey_point = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void white_point_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->white_point = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void black_point_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->black_point = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+
+static void mode_callback(GtkWidget *combo, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->mode = dt_bauhaus_combobox_get(combo);
+
+  switch(p->mode)
+  {
+    case filmic_LOG:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+    case filmic_LINEAR:
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "linear");
+      break;
+    default:
+      p->mode = filmic_LOG;
+      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
+      break;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void disable_colorpick(struct dt_iop_module_t *self)
+{
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  g->which_colorpicker = DT_PICKPROFLOG_NONE;
+}
+
+static int call_apply_picked_color(struct dt_iop_module_t *self, dt_iop_filmic_gui_data_t *g)
+{
+  int handled = 1;
+  switch(g->which_colorpicker)
+  {
+     case DT_PICKPROFLOG_GREY_POINT:
+       apply_auto_grey(self);
+       break;
+     case DT_PICKPROFLOG_BLACK_POINT:
+       apply_auto_black(self);
+       break;
+     case DT_PICKPROFLOG_white_point:
+       apply_auto_white_point(self);
+       break;
+     default:
+       handled = 0;
+       break;
+  }
+  return handled;
+}
+
+static int get_colorpick_from_button(GtkWidget *button, dt_iop_filmic_gui_data_t *g)
+{
+  int which_colorpicker = DT_PICKPROFLOG_NONE;
+
+  if(button == g->grey_point)
+    which_colorpicker = DT_PICKPROFLOG_GREY_POINT;
+  else if(button == g->black_point)
+    which_colorpicker = DT_PICKPROFLOG_BLACK_POINT;
+  else if(button == g->white_point)
+    which_colorpicker = DT_PICKPROFLOG_white_point;
+
+  return which_colorpicker;
+}
+
+static void set_colorpick_state(dt_iop_filmic_gui_data_t *g, const int which_colorpicker)
+{
+  dt_bauhaus_widget_set_quad_active(g->grey_point, which_colorpicker == DT_PICKPROFLOG_GREY_POINT);
+  dt_bauhaus_widget_set_quad_active(g->black_point, which_colorpicker == DT_PICKPROFLOG_BLACK_POINT);
+  dt_bauhaus_widget_set_quad_active(g->white_point, which_colorpicker == DT_PICKPROFLOG_white_point);
+}
+
+static void color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
+{
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
+
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_OFF)
+  {
+    g->which_colorpicker = get_colorpick_from_button(button, g);
+
+    if(g->which_colorpicker != DT_PICKPROFLOG_NONE)
+    {
+      dt_iop_request_focus(self);
+      self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+
+      if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF) dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+
+      g->apply_picked_color = 1;
+
+      dt_dev_reprocess_all(self->dev);
+    }
+  }
+  else
+  {
+    if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f)
+    {
+      dt_control_log(_("wait for the preview to be updated."));
+      return;
+    }
+    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+
+    if(g->apply_picked_color)
+    {
+      call_apply_picked_color(self, g);
+      g->apply_picked_color = 0;
+    }
+
+    const int which_colorpicker = get_colorpick_from_button(button, g);
+    if(which_colorpicker != g->which_colorpicker && which_colorpicker != DT_PICKPROFLOG_NONE)
+    {
+      g->which_colorpicker = which_colorpicker;
+
+      self->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+
+      if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF) dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+
+      g->apply_picked_color = 1;
+
+      dt_dev_reprocess_all(self->dev);
+    }
+    else
+    {
+      g->which_colorpicker = DT_PICKPROFLOG_NONE;
+    }
+  }
+
+  set_colorpick_state(g, g->which_colorpicker);
+}
+
+void gui_focus(struct dt_iop_module_t *self, gboolean in)
+{
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  if(!in)
+  {
+    disable_colorpick(self);
+    g->apply_picked_color = 0;
+    set_colorpick_state(g, g->which_colorpicker);
+  }
+}
+
+int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state)
+{
+  int handled = 0;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF && which == 1)
+  {
+    handled = call_apply_picked_color(self, g);
+    g->apply_picked_color = 0;
+  }
+
+  return handled;
+}
+
+void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
+                   dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)p1;
+  dt_iop_filmic_data_t *d = (dt_iop_filmic_data_t *)piece->data;
+
+  d->white_point = p->white_point;
+  d->grey_point = p->grey_point;
+  d->black_point = p->black_point;
+  d->security_factor = p->security_factor;
+  d->mode = p->mode;
+}
+
+void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  piece->data = calloc(1, sizeof(dt_iop_filmic_data_t));
+  self->commit_params(self, self->default_params, pipe, piece);
+}
+
+void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  free(piece->data);
+  piece->data = NULL;
+}
+
+void gui_update(dt_iop_module_t *self)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)self;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)module->params;
+
+  disable_colorpick(self);
+
+  self->color_picker_box[0] = self->color_picker_box[1] = .25f;
+  self->color_picker_box[2] = self->color_picker_box[3] = .75f;
+  self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
+
+  dt_bauhaus_combobox_set(g->mode, p->mode);
+  dt_bauhaus_slider_set_soft(g->white_point, p->white_point);
+  dt_bauhaus_slider_set_soft(g->grey_point, p->grey_point);
+  dt_bauhaus_slider_set_soft(g->black_point, p->black_point);
+  dt_bauhaus_slider_set_soft(g->security_factor, p->security_factor);
+
+  set_colorpick_state(g, g->which_colorpicker);
+}
+
+void init(dt_iop_module_t *module)
+{
+  module->params = calloc(1, sizeof(dt_iop_filmic_params_t));
+  module->default_params = calloc(1, sizeof(dt_iop_filmic_params_t));
+  module->default_enabled = 0;
+  module->priority = 642; // module order created by iop_dependencies.py, do not edit!
+  module->params_size = sizeof(dt_iop_filmic_params_t);
+  module->gui_data = NULL;
+  dt_iop_filmic_params_t tmp = (dt_iop_filmic_params_t){ 0.18, -5., 10. };
+  memcpy(module->params, &tmp, sizeof(dt_iop_filmic_params_t));
+  memcpy(module->default_params, &tmp, sizeof(dt_iop_filmic_params_t));
+}
+
+void init_global(dt_iop_module_so_t *module)
+{
+  //const int program = 2; // basic.cl, from programs.conf
+  dt_iop_filmic_global_data_t *gd
+      = (dt_iop_filmic_global_data_t *)malloc(sizeof(dt_iop_filmic_global_data_t));
+
+  module->data = gd;
+}
+
+void cleanup(dt_iop_module_t *module)
+{
+  free(module->params);
+  module->params = NULL;
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  //dt_iop_filmic_global_data_t *gd = (dt_iop_filmic_global_data_t *)module->data;
+  free(module->data);
+  module->data = NULL;
+}
+
+
+void gui_init(dt_iop_module_t *self)
+{
+  self->gui_data = malloc(sizeof(dt_iop_filmic_gui_data_t));
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+
+  disable_colorpick(self);
+  g->apply_picked_color = 0;
+
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
+
+  // mode choice
+  g->mode = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));
+  dt_bauhaus_combobox_add(g->mode, _("logarithmic"));
+  dt_bauhaus_combobox_add(g->mode, _("linear"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->mode), TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->mode, _("tone mapping method"));
+  g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);
+
+  // prepare the modes widgets stack
+  g->mode_stack = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(g->mode_stack), FALSE);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
+
+  /**** LOG MODE ****/
+
+  GtkWidget *vbox_log = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+
+  // grey_point slider
+  g->grey_point = dt_bauhaus_slider_new_with_range(self, 0.1, 100., 0.5, p->grey_point, 2);
+  dt_bauhaus_widget_set_label(g->grey_point, NULL, _("middle grey luminance"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->grey_point, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->grey_point, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->grey_point, _("adjust to match the average luma of the subject"));
+  g_signal_connect(G_OBJECT(g->grey_point), "value-changed", G_CALLBACK(grey_point_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->grey_point, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->grey_point, TRUE);
+  g_signal_connect(G_OBJECT(g->grey_point), "quad-pressed", G_CALLBACK(color_picker_callback), self);
+
+  // Shadows range slider
+  g->black_point = dt_bauhaus_slider_new_with_range(self, -16.0, -0.0, 0.1, p->black_point, 2);
+  dt_bauhaus_slider_enable_soft_boundaries(g->black_point, -16., 16.0);
+  dt_bauhaus_widget_set_label(g->black_point, NULL, _("black relative exposure"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->black_point, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->black_point, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->black_point, _("number of stops between middle grey and pure black\nthis is a reading a posemeter would give you on the scene"));
+  g_signal_connect(G_OBJECT(g->black_point), "value-changed", G_CALLBACK(black_point_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->black_point, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->black_point, TRUE);
+  g_signal_connect(G_OBJECT(g->black_point), "quad-pressed", G_CALLBACK(color_picker_callback), self);
+
+  // Dynamic range slider
+  g->white_point = dt_bauhaus_slider_new_with_range(self, 0.5, 16.0, 0.1, p->white_point, 2);
+  dt_bauhaus_slider_enable_soft_boundaries(g->white_point, 0.01, 32.0);
+  dt_bauhaus_widget_set_label(g->white_point, NULL, _("white relative exposure"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->white_point, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->white_point, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->white_point, _("number of stops between pure black and pure white\nthis is a reading a posemeter would give you on the scene"));
+  g_signal_connect(G_OBJECT(g->white_point), "value-changed", G_CALLBACK(white_point_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->white_point, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->white_point, TRUE);
+  g_signal_connect(G_OBJECT(g->white_point), "quad-pressed", G_CALLBACK(color_picker_callback), self);
+
+  // Auto tune slider
+  gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(_("optimize automatically")), FALSE, FALSE, 5);
+  g->security_factor = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->security_factor, 2);
+  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("security factor"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->security_factor, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is usefull when noise perturbates the measurements"));
+  g_signal_connect(G_OBJECT(g->security_factor), "value-changed", G_CALLBACK(security_threshold_callback), self);
+
+  g->auto_button = gtk_button_new_with_label(_("auto tune"));
+  gtk_widget_set_tooltip_text(g->auto_button, _("make an optimization with some guessing"));
+  gtk_box_pack_start(GTK_BOX(vbox_log), g->auto_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->auto_button), "clicked", G_CALLBACK(optimize_button_pressed_callback), self);
+
+  gtk_widget_show_all(vbox_log);
+  gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_log, "log");
+}
+
+
+void gui_cleanup(dt_iop_module_t *self)
+{
+  disable_colorpick(self);
+  free(self->gui_data);
+  self->gui_data = NULL;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1,6 +1,6 @@
 /*
    This file is part of darktable,
-   copyright (c) 2018 Aurélien Pierre, with guidance of Troy Sobotka.
+   copyright (c) 2018 Aurélien Pierre, with guidance of Troy James Sobotka.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -36,55 +36,90 @@
 #include <stdlib.h>
 #include <string.h>
 
-DT_MODULE_INTROSPECTION(2, dt_iop_filmic_params_t)
+DT_MODULE_INTROSPECTION(1, dt_iop_filmic_params_t)
 
-typedef enum dt_iop_filmic_mode_t
-{
-  filmic_LOG = 0,
-  filmic_LINEAR = 1
-} dt_iop_filmic_mode_t;
+/**
+ * DOCUMENTATION
+ *
+ * This code ports :
+ * 1. Troy Sobotka's filmic curves for Blender (and other softs)
+ *      https://github.com/sobotka/OpenAgX/blob/master/lib/agx_colour.py
+ * 2. ACES camera logarithmic encoding
+ *        https://github.com/ampas/aces-dev/blob/master/transforms/ctl/utilities/ACESutil.Lin_to_Log2_param.ctl
+ *
+ * The ACES log implementation is taken from the profile_gamma.c IOP
+ * where it works in camera RGB space. Here, it works on an arbitrary RGB
+ * space. ProPhotoRGB has been choosen for its wide gamut coverage and
+ * for conveniency because it's already in darktable's libs. Any other
+ * RGB working space could work. This chouice could (should) also be
+ * exposed to the user.
+ *
+ * The filmic curves are tonecurves intended to simulate the luminance
+ * transfer function of film with "S" curves. These could be reproduced in
+ * the tonecurve.c IOP, however what we offer here is a parametric
+ * interface usefull to remap accurately and promptly the middle grey
+ * to any arbitrary value choosen accordingly to the destination space.
+ *
+ * The combined use of both define a modern way to deal with large
+ * dynamic range photographs by remapping the values with a comprehensive
+ * interface avoiding many of the back and forth adjustements darktable
+ * is prone to enforce.
+ *
+ * */
 
 typedef enum dt_iop_filmic_pickcolor_type_t
 {
   DT_PICKPROFLOG_NONE = 0,
   DT_PICKPROFLOG_GREY_POINT = 1,
   DT_PICKPROFLOG_BLACK_POINT = 2,
-  DT_PICKPROFLOG_white_point = 3
+  DT_PICKPROFLOG_WHITE_POINT = 3
 } dt_iop_filmic_pickcolor_type_t;
 
 typedef struct dt_iop_filmic_params_t
 {
-  dt_iop_filmic_mode_t mode;
-  float white_point;
-  float grey_point;
-  float black_point;
+  float grey_point_source;
+  float black_point_source;
+  float white_point_source;
   float security_factor;
+  float grey_point_target;
+  float black_point_target;
+  float white_point_target;
+  float output_power;
+  float latitude_stops;
+  float contrast;
+  float saturation;
+  float balance;
 } dt_iop_filmic_params_t;
 
 typedef struct dt_iop_filmic_gui_data_t
 {
   int apply_picked_color;
   int which_colorpicker;
-
-  GtkWidget *mode;
-  GtkWidget *mode_stack;
-  GtkWidget *white_point;
-  GtkWidget *grey_point;
-  GtkWidget *black_point;
+  GtkWidget *white_point_source;
+  GtkWidget *grey_point_source;
+  GtkWidget *black_point_source;
   GtkWidget *security_factor;
   GtkWidget *auto_button;
+  GtkWidget *grey_point_target;
+  GtkWidget *white_point_target;
+  GtkWidget *black_point_target;
+  GtkWidget *output_power;
+  GtkWidget *latitude_stops;
+  GtkWidget *contrast;
+  GtkWidget *saturation;
+  GtkWidget *balance;
 } dt_iop_filmic_gui_data_t;
 
 typedef struct dt_iop_filmic_data_t
 {
-  dt_iop_filmic_mode_t mode;
-  float linear;
+  dt_draw_curve_t *curve;
   float table[0x10000];      // precomputed look-up table
   float unbounded_coeffs[3]; // approximation for extrapolation of curve
-  float white_point;
-  float grey_point;
-  float black_point;
-  float security_factor;
+  float grey_source;
+  float black_source;
+  float dynamic_range;
+  float saturation;
+  float output_power;
 } dt_iop_filmic_data_t;
 
 typedef struct dt_iop_filmic_global_data_t
@@ -149,6 +184,18 @@ static inline float fastlog2(float x)
     - 1.72587999f / (0.3520887068f + mx.f);
 }
 
+
+static inline float average(const float *list, const size_t elements)
+{
+  float collect = 0;
+  for (size_t i = 0; i < elements; ++i)
+  {
+    collect += list[i];
+  }
+  return collect / elements;
+}
+
+
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -163,15 +210,10 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   * However, at this point of the pixelpipe, the RAW levels have already been corrected and everything can happen with black levels
   * in the exposure module. So we define the threshold as the first non-null 16 bit integer
   */
-
-  const float noise = powf(2.0f, -16.0f);
-  const float dynamic_range = data->white_point - data->black_point;
-  const float grey = data->grey_point / 100.0f;
-  const float black = data->black_point;
-  fprintf(stderr, "%f", grey);
+  const float EPS = powf(2.0f, -16);
 
 #ifdef _OPENMP
-#pragma omp parallel for SIMD() default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(data) schedule(static)
 #endif
   for(size_t j = 0; j < roi_out->height; j++)
   {
@@ -188,12 +230,27 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       float rgb[3] = { 0.0f };
       dt_XYZ_to_prophotorgb(XYZ, rgb);
 
-      // do the calculation in RGB space
       for(size_t c = 0; c < 3; c++)
       {
-        float tmp = rgb[c] / grey;
-        if (tmp < noise) tmp = noise;
-        rgb[c] = (fastlog2(tmp) - black) / dynamic_range;
+        // Log tone-mapping
+        rgb[c] = (rgb[c] > EPS) ? (Log2(rgb[c] / data->grey_source) - data->black_source) / data->dynamic_range : EPS;
+
+        // Filmic S curve
+        rgb[c] = data->table[CLAMP((int)(rgb[c] * 0x10000ul), 0, 0xffff)];
+
+        // Linearize for display transfor function (gamma)
+        // TODO: use the actual TRC from the ICC profile. That's just a quick fix.
+        // That means dealing with the utter shite that darktable's color management is first
+        rgb[c] = (rgb[c] <= 0.0f) ? rgb[c] : powf(rgb[c], data->output_power);
+      }
+
+      // Adjust the saturation
+      dt_prophotorgb_to_XYZ(rgb, XYZ);
+      const float Y = XYZ[1];
+
+      for(size_t c = 0; c < 3; c++)
+      {
+        rgb[c] = Y + data->saturation * (rgb[c] - Y);
       }
 
       // transform the result back to Lab
@@ -219,14 +276,14 @@ static void apply_auto_grey(dt_iop_module_t *self)
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
 
-  float RGB[3] = { 0.0f };
-  dt_Lab_to_prophotorgb(self->picked_color, RGB);
+  float XYZ[3] = { 0.0f };
+  dt_Lab_to_XYZ(self->picked_color, XYZ);
 
-  float grey = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
-  p->grey_point = 100.f * grey;
+  float grey = XYZ[1];
+  p->grey_point_source = 100.f * grey;
 
   darktable.gui->reset = 1;
-  dt_bauhaus_slider_set(g->grey_point, p->grey_point);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
   darktable.gui->reset = 0;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -240,24 +297,34 @@ static void apply_auto_black(dt_iop_module_t *self)
 
   float noise = powf(2.0f, -16.0f);
 
-  float RGB[3] = { 0.0f };
-  dt_Lab_to_prophotorgb(self->picked_color_min, RGB);
+  float XYZ[3] = { 0.0f };
+  dt_Lab_to_XYZ(self->picked_color_min, XYZ);
 
   // Black
-  float black = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
-  float EVmin = Log2Thres(black / (p->grey_point / 100.0f), noise);
+  float black = XYZ[1];
+  float EVmin = Log2Thres(black / (p->grey_point_source / 100.0f), noise);
   EVmin *= (1.0f + p->security_factor / 100.0f);
 
-  p->black_point = EVmin;
+  p->black_point_source = EVmin;
 
   darktable.gui->reset = 1;
-  dt_bauhaus_slider_set(g->black_point, p->black_point);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
   darktable.gui->reset = 0;
+
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
+  {
+    p->latitude_stops = 0.9f * (p->white_point_source - p->black_point_source);
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
+  }
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void apply_auto_white_point(dt_iop_module_t *self)
+static void apply_auto_white_point_source(dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
@@ -265,19 +332,29 @@ static void apply_auto_white_point(dt_iop_module_t *self)
 
   float noise = powf(2.0f, -16.0f);
 
-  float RGB[3] = { 0.0f };
-  dt_Lab_to_prophotorgb(self->picked_color_max, RGB);
+  float XYZ[3] = { 0.0f };
+  dt_Lab_to_XYZ(self->picked_color_max, XYZ);
 
   // White
-  float white = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
-  float EVmax = Log2Thres(white / (p->grey_point / 100.0f), noise);
+  float white = XYZ[1];
+  float EVmax = Log2Thres(white / (p->grey_point_source / 100.0f), noise);
   EVmax *= (1.0f + p->security_factor / 100.0f);
 
-  p->white_point = EVmax;
+  p->white_point_source = EVmax;
 
   darktable.gui->reset = 1;
-  dt_bauhaus_slider_set(g->white_point, p->white_point);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
   darktable.gui->reset = 0;
+
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
+  {
+    p->latitude_stops = 0.9f * (p->white_point_source - p->black_point_source);
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
+  }
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -293,19 +370,29 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->security_factor = dt_bauhaus_slider_get(slider);
   float ratio = (p->security_factor - previous) / (previous + 100.0f);
 
-  float EVmin = p->black_point;
+  float EVmin = p->black_point_source;
   EVmin = EVmin + ratio * EVmin;
 
-  float EVmax = p->white_point;
+  float EVmax = p->white_point_source;
   EVmax = EVmax + ratio * EVmax;
 
-  p->white_point = EVmax;
-  p->black_point = EVmin;
+  p->white_point_source = EVmax;
+  p->black_point_source = EVmin;
 
   darktable.gui->reset = 1;
-  dt_bauhaus_slider_set_soft(g->white_point, p->white_point);
-  dt_bauhaus_slider_set_soft(g->black_point, p->black_point);
+  dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   darktable.gui->reset = 0;
+
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
+  {
+    p->latitude_stops = 0.9f * (p->white_point_source - p->black_point_source);
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
+  }
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -332,33 +419,43 @@ static void optimize_button_pressed_callback(GtkWidget *button, gpointer user_da
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
 
   float noise = powf(2.0f, -16.0f);
-  float RGB[3] = { 0.0f };
+  float XYZ[3] = { 0.0f };
 
   // Grey
-  dt_Lab_to_prophotorgb(self->picked_color, RGB);
-  float grey = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
-  p->grey_point = 100.f * grey;
+  dt_Lab_to_XYZ(self->picked_color, XYZ);
+  float grey = XYZ[1];
+  p->grey_point_source = 100.f * grey;
 
   // Black
-  dt_Lab_to_prophotorgb(self->picked_color_min, RGB);
-  float black = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
-  float EVmin = Log2Thres(black / (p->grey_point / 100.0f), noise);
+  dt_Lab_to_XYZ(self->picked_color_min, XYZ);
+  float black = XYZ[1];
+  float EVmin = Log2Thres(black / (p->grey_point_source / 100.0f), noise);
   EVmin *= (1.0f + p->security_factor / 100.0f);
 
   // White
-  dt_Lab_to_prophotorgb(self->picked_color_max, RGB);
-  float white = fmax(fmax(RGB[0], RGB[1]), RGB[2]);
-  float EVmax = Log2Thres(white / (p->grey_point / 100.0f), noise);
+  dt_Lab_to_XYZ(self->picked_color_max, XYZ);
+  float white = XYZ[1];
+  float EVmax = Log2Thres(white / (p->grey_point_source / 100.0f), noise);
   EVmax *= (1.0f + p->security_factor / 100.0f);
 
-  p->black_point = EVmin;
-  p->white_point = EVmax;
+  p->black_point_source = EVmin;
+  p->white_point_source = EVmax;
 
   darktable.gui->reset = 1;
-  dt_bauhaus_slider_set(g->grey_point, p->grey_point);
-  dt_bauhaus_slider_set(g->black_point, p->black_point);
-  dt_bauhaus_slider_set(g->white_point, p->white_point);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
   darktable.gui->reset = 0;
+
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
+  {
+    p->latitude_stops = 0.9f * (p->white_point_source - p->black_point_source);
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
+  }
 
   self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
 
@@ -366,56 +463,139 @@ static void optimize_button_pressed_callback(GtkWidget *button, gpointer user_da
 }
 
 
-static void grey_point_callback(GtkWidget *slider, gpointer user_data)
+static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  p->grey_point = dt_bauhaus_slider_get(slider);
+  p->grey_point_source = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void white_point_callback(GtkWidget *slider, gpointer user_data)
+static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  p->white_point = dt_bauhaus_slider_get(slider);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void black_point_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(self->dt->gui->reset) return;
-  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  p->black_point = dt_bauhaus_slider_get(slider);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void mode_callback(GtkWidget *combo, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  p->mode = dt_bauhaus_combobox_get(combo);
+  p->white_point_source = dt_bauhaus_slider_get(slider);
 
-  switch(p->mode)
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
   {
-    case filmic_LOG:
-      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
-      break;
-    case filmic_LINEAR:
-      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "linear");
-      break;
-    default:
-      p->mode = filmic_LOG;
-      gtk_stack_set_visible_child_name(GTK_STACK(g->mode_stack), "log");
-      break;
+    p->latitude_stops = 0.9f * (p->white_point_source - p->black_point_source);
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
   }
 
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  p->black_point_source = dt_bauhaus_slider_get(slider);
+
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
+  {
+    p->latitude_stops = 0.9f * (p->white_point_source - p->black_point_source);
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void grey_point_target_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->grey_point_target = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void latitude_stops_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+
+  p->latitude_stops = dt_bauhaus_slider_get(slider);
+
+  // The film latitude is its linear part
+  // it can never be higher than the dynamic range
+  if (p->latitude_stops > p->white_point_source - p->black_point_source)
+  {
+    p->latitude_stops = p->white_point_source - p->black_point_source;
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+    darktable.gui->reset = 0;
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void contrast_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->contrast = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void saturation_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->saturation = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void white_point_target_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->white_point_target = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void black_point_target_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->black_point_target = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void output_power_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->output_power = dt_bauhaus_slider_get(slider);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void balance_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  p->balance = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -437,8 +617,8 @@ static int call_apply_picked_color(struct dt_iop_module_t *self, dt_iop_filmic_g
      case DT_PICKPROFLOG_BLACK_POINT:
        apply_auto_black(self);
        break;
-     case DT_PICKPROFLOG_white_point:
-       apply_auto_white_point(self);
+     case DT_PICKPROFLOG_WHITE_POINT:
+       apply_auto_white_point_source(self);
        break;
      default:
        handled = 0;
@@ -451,21 +631,21 @@ static int get_colorpick_from_button(GtkWidget *button, dt_iop_filmic_gui_data_t
 {
   int which_colorpicker = DT_PICKPROFLOG_NONE;
 
-  if(button == g->grey_point)
+  if(button == g->grey_point_source)
     which_colorpicker = DT_PICKPROFLOG_GREY_POINT;
-  else if(button == g->black_point)
+  else if(button == g->black_point_source)
     which_colorpicker = DT_PICKPROFLOG_BLACK_POINT;
-  else if(button == g->white_point)
-    which_colorpicker = DT_PICKPROFLOG_white_point;
+  else if(button == g->white_point_source)
+    which_colorpicker = DT_PICKPROFLOG_WHITE_POINT;
 
   return which_colorpicker;
 }
 
 static void set_colorpick_state(dt_iop_filmic_gui_data_t *g, const int which_colorpicker)
 {
-  dt_bauhaus_widget_set_quad_active(g->grey_point, which_colorpicker == DT_PICKPROFLOG_GREY_POINT);
-  dt_bauhaus_widget_set_quad_active(g->black_point, which_colorpicker == DT_PICKPROFLOG_BLACK_POINT);
-  dt_bauhaus_widget_set_quad_active(g->white_point, which_colorpicker == DT_PICKPROFLOG_white_point);
+  dt_bauhaus_widget_set_quad_active(g->grey_point_source, which_colorpicker == DT_PICKPROFLOG_GREY_POINT);
+  dt_bauhaus_widget_set_quad_active(g->black_point_source, which_colorpicker == DT_PICKPROFLOG_BLACK_POINT);
+  dt_bauhaus_widget_set_quad_active(g->white_point_source, which_colorpicker == DT_PICKPROFLOG_WHITE_POINT);
 }
 
 static void color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
@@ -560,21 +740,147 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)p1;
   dt_iop_filmic_data_t *d = (dt_iop_filmic_data_t *)piece->data;
 
-  d->white_point = p->white_point;
-  d->grey_point = p->grey_point;
-  d->black_point = p->black_point;
-  d->security_factor = p->security_factor;
-  d->mode = p->mode;
+  // source luminance - Used only in the log encoding
+  const float white_source = p->white_point_source;
+  const float grey_source = p->grey_point_source / 100.0f; // in %
+  const float black_source = p->black_point_source;
+  const float dynamic_range = white_source - black_source;
+
+  // commit
+  d->dynamic_range = dynamic_range;
+  d->black_source = black_source;
+  d->grey_source = grey_source;
+  d->output_power = p->output_power;
+  d->saturation = p->saturation;
+
+  // luminance after log encoding
+  const float black_log = 0.0f; // assumes user set log as in the autotuner
+  const float grey_log = fabsf(p->black_point_source) / dynamic_range;
+  const float white_log = 1.0f; // assumes user set log as in the autotuner
+
+  // target luminance desired after filmic curve
+  const float black_display = p->black_point_target / 100.0f; // in %
+  const float grey_display = powf(p->grey_point_target / 100.0f, 1.0f / p->output_power);
+  const float white_display = p->white_point_target / 100.0f; // in %
+
+  const float latitude = CLAMP(p->latitude_stops, 0.5f, dynamic_range);
+  const float balance = p->balance / 100.0f; // in %
+
+  float contrast = p->contrast;
+  if (contrast < grey_display / grey_log)
+  {
+    contrast = grey_display / grey_log;
+  }
+
+  // nodes for mapping from log encoding to desired target luminance
+  // Y coordinates
+  float toe_display = black_display +
+                        (
+                          (fabsf(black_source) / dynamic_range) *
+                          ((dynamic_range - latitude) / dynamic_range)
+                        ) * (1.0f - balance);
+  toe_display = CLAMP(toe_display, 0.0f, grey_display);
+  if (toe_display < 0.010f) toe_display = 0.0f;
+
+  float shoulder_display = white_display -
+                        (
+                          (white_source / dynamic_range) *
+                          ((dynamic_range - latitude) / dynamic_range)
+                        ) * (1.0f + balance);
+
+  shoulder_display = CLAMP(shoulder_display, grey_display, 1.0f);
+  if (shoulder_display > 0.990f) shoulder_display = 1.0f;
+
+  // interception
+  float linear_intercept = grey_display - (p->contrast * grey_log);
+
+  // X coordinates
+  float toe_log = (toe_display - linear_intercept) / p->contrast;
+  toe_log = CLAMP(toe_log, 0.0f, grey_log);
+  if (toe_log < 0.010f) toe_log = 0.0f;
+
+  float shoulder_log = (shoulder_display - linear_intercept) / p->contrast;
+  shoulder_log = CLAMP(shoulder_log, grey_log, 1.0f);
+  if (shoulder_log > 0.990f) shoulder_log = 1.0f;
+
+
+  // sanitize values
+  if (toe_log == grey_log)
+  {
+    toe_display = grey_display;
+  }
+  else if (toe_log == 0.0f)
+  {
+    toe_display = 0.0f;
+  }
+  if (toe_display == grey_display)
+  {
+    toe_log = grey_log;
+  }
+  else if (toe_display  == 0.0f)
+  {
+    toe_log = 0.0f;
+  }
+  if (shoulder_log == grey_log)
+  {
+    shoulder_display = grey_display;
+  }
+  else if (shoulder_log == 1.0f)
+  {
+    shoulder_display = 1.0f;
+  }
+  if (shoulder_display == grey_display)
+  {
+    shoulder_log = grey_log;
+  }
+  else if (shoulder_display == 1.0f)
+  {
+    shoulder_log = 1.0f;
+  }
+
+  /**
+   * Now we have 3 segments :
+   *  - x = [0.0 ; toe_log], curved part
+   *  - x = [toe_log ; shoulder_log], linear part
+   *  - x = [shoulder_log ; 1.0] curved part
+  **/
+
+  // Build the curve and LUT
+  const float x[5] = { black_log,
+                       toe_log,
+                       grey_log,
+                       shoulder_log,
+                       white_log };
+
+  const float y[5] = { black_display,
+                       toe_display,
+                       grey_display,
+                       shoulder_display,
+                       white_display };
+
+  dt_draw_curve_destroy(d->curve);
+  d->curve = dt_draw_curve_new(0.0, 1.0, MONOTONE_HERMITE);
+  for(int k = 0; k < 5; k++) (void)dt_draw_curve_add_point(d->curve, x[k], y[k]);
+  dt_draw_curve_calc_values(d->curve, 0.0f, 1.0f, 0x10000, NULL, d->table);
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = calloc(1, sizeof(dt_iop_filmic_data_t));
+  dt_iop_filmic_data_t *d = (dt_iop_filmic_data_t *)piece->data;
+
+  d->curve = dt_draw_curve_new(0.0, 1.0, CUBIC_SPLINE);
+
+  // Initialize the LUT with identity
+  for(int k = 0; k < 0x10000; k++) d->table[k] = k / 0x10000;
+
   self->commit_params(self, self->default_params, pipe, piece);
 }
 
 void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
+  dt_iop_filmic_data_t *d = (dt_iop_filmic_data_t *)piece->data;
+  dt_draw_curve_destroy(d->curve);
   free(piece->data);
   piece->data = NULL;
 }
@@ -591,11 +897,18 @@ void gui_update(dt_iop_module_t *self)
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;
   self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
 
-  dt_bauhaus_combobox_set(g->mode, p->mode);
-  dt_bauhaus_slider_set_soft(g->white_point, p->white_point);
-  dt_bauhaus_slider_set_soft(g->grey_point, p->grey_point);
-  dt_bauhaus_slider_set_soft(g->black_point, p->black_point);
-  dt_bauhaus_slider_set_soft(g->security_factor, p->security_factor);
+  dt_bauhaus_slider_set(g->white_point_source, p->white_point_source);
+  dt_bauhaus_slider_set(g->grey_point_source, p->grey_point_source);
+  dt_bauhaus_slider_set(g->black_point_source, p->black_point_source);
+  dt_bauhaus_slider_set(g->security_factor, p->security_factor);
+  dt_bauhaus_slider_set(g->white_point_target, p->white_point_target);
+  dt_bauhaus_slider_set(g->grey_point_target, p->grey_point_target);
+  dt_bauhaus_slider_set(g->black_point_target, p->black_point_target);
+  dt_bauhaus_slider_set(g->output_power, p->output_power);
+  dt_bauhaus_slider_set(g->latitude_stops, p->latitude_stops);
+  dt_bauhaus_slider_set(g->contrast, p->contrast);
+  dt_bauhaus_slider_set(g->saturation, p->saturation);
+  dt_bauhaus_slider_set(g->balance, p->balance);
 
   set_colorpick_state(g, g->which_colorpicker);
 }
@@ -608,7 +921,37 @@ void init(dt_iop_module_t *module)
   module->priority = 642; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_filmic_params_t);
   module->gui_data = NULL;
-  dt_iop_filmic_params_t tmp = (dt_iop_filmic_params_t){ 0.18, -5., 10. };
+
+  /** Param :
+    float grey_point_source;
+    float black_point_source;
+    float white_point_source;
+    float security_factor;
+    float grey_point_target;
+    float black_point_target;
+    float white_point_target;
+    float output_power;
+    float latitude_stops;
+    float contrast;
+    float saturation;
+    float balance;
+  **/
+
+  dt_iop_filmic_params_t tmp
+    = (dt_iop_filmic_params_t){
+                                 18, // source grey
+                                -7.0,  // source black
+                                 3.0,  // source white
+                                 0.0,  // security factor
+                                 18, // target grey
+                                 0.0,  // target black
+                                 100.0,  // target white
+                                 2.2,  // target power (~ gamma)
+                                 4.0,  // intent latitude
+                                 2.0,  // intent contrast
+                                 1.0,   // intent saturation
+                                 0.0, // balance shadows/highlights
+                              };
   memcpy(module->params, &tmp, sizeof(dt_iop_filmic_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_filmic_params_t));
 }
@@ -648,75 +991,119 @@ void gui_init(dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
-  // mode choice
-  g->mode = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));
-  dt_bauhaus_combobox_add(g->mode, _("logarithmic"));
-  dt_bauhaus_combobox_add(g->mode, _("linear"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->mode), TRUE, TRUE, 0);
-  gtk_widget_set_tooltip_text(g->mode, _("tone mapping method"));
-  g_signal_connect(G_OBJECT(g->mode), "value-changed", G_CALLBACK(mode_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("logarithmic tone-mapping")), FALSE, FALSE, 5);
 
-  // prepare the modes widgets stack
-  g->mode_stack = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(g->mode_stack), FALSE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
+  // grey_point_source slider
+  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.1, 100., 0.5, p->grey_point_source, 2);
+  dt_bauhaus_widget_set_label(g->grey_point_source, NULL, _("middle grey luminance"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_source, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luma of the subject"));
+  g_signal_connect(G_OBJECT(g->grey_point_source), "value-changed", G_CALLBACK(grey_point_source_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->grey_point_source, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->grey_point_source, TRUE);
+  g_signal_connect(G_OBJECT(g->grey_point_source), "quad-pressed", G_CALLBACK(color_picker_callback), self);
 
-  /**** LOG MODE ****/
+  // Black slider
+  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.5, 0.1, p->black_point_source, 2);
+  dt_bauhaus_widget_set_label(g->black_point_source, NULL, _("black relative exposure"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_source, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->black_point_source, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle grey and pure black\nthis is a reading a posemeter would give you on the scene"));
+  g_signal_connect(G_OBJECT(g->black_point_source), "value-changed", G_CALLBACK(black_point_source_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->black_point_source, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->black_point_source, TRUE);
+  g_signal_connect(G_OBJECT(g->black_point_source), "quad-pressed", G_CALLBACK(color_picker_callback), self);
 
-  GtkWidget *vbox_log = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
-
-  // grey_point slider
-  g->grey_point = dt_bauhaus_slider_new_with_range(self, 0.1, 100., 0.5, p->grey_point, 2);
-  dt_bauhaus_widget_set_label(g->grey_point, NULL, _("middle grey luminance"));
-  gtk_box_pack_start(GTK_BOX(vbox_log), g->grey_point, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->grey_point, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->grey_point, _("adjust to match the average luma of the subject"));
-  g_signal_connect(G_OBJECT(g->grey_point), "value-changed", G_CALLBACK(grey_point_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->grey_point, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->grey_point, TRUE);
-  g_signal_connect(G_OBJECT(g->grey_point), "quad-pressed", G_CALLBACK(color_picker_callback), self);
-
-  // Shadows range slider
-  g->black_point = dt_bauhaus_slider_new_with_range(self, -16.0, -0.0, 0.1, p->black_point, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->black_point, -16., 16.0);
-  dt_bauhaus_widget_set_label(g->black_point, NULL, _("black relative exposure"));
-  gtk_box_pack_start(GTK_BOX(vbox_log), g->black_point, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->black_point, "%.2f EV");
-  gtk_widget_set_tooltip_text(g->black_point, _("number of stops between middle grey and pure black\nthis is a reading a posemeter would give you on the scene"));
-  g_signal_connect(G_OBJECT(g->black_point), "value-changed", G_CALLBACK(black_point_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->black_point, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->black_point, TRUE);
-  g_signal_connect(G_OBJECT(g->black_point), "quad-pressed", G_CALLBACK(color_picker_callback), self);
-
-  // Dynamic range slider
-  g->white_point = dt_bauhaus_slider_new_with_range(self, 0.5, 16.0, 0.1, p->white_point, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->white_point, 0.01, 32.0);
-  dt_bauhaus_widget_set_label(g->white_point, NULL, _("white relative exposure"));
-  gtk_box_pack_start(GTK_BOX(vbox_log), g->white_point, TRUE, TRUE, 0);
-  dt_bauhaus_slider_set_format(g->white_point, "%.2f EV");
-  gtk_widget_set_tooltip_text(g->white_point, _("number of stops between pure black and pure white\nthis is a reading a posemeter would give you on the scene"));
-  g_signal_connect(G_OBJECT(g->white_point), "value-changed", G_CALLBACK(white_point_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->white_point, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->white_point, TRUE);
-  g_signal_connect(G_OBJECT(g->white_point), "quad-pressed", G_CALLBACK(color_picker_callback), self);
+  // White slider
+  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.5, 16.0, 0.1, p->white_point_source, 2);
+  dt_bauhaus_widget_set_label(g->white_point_source, NULL, _("white relative exposure"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_source, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->white_point_source, "%.2f EV");
+  gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between pure black and pure white\nthis is a reading a posemeter would give you on the scene"));
+  g_signal_connect(G_OBJECT(g->white_point_source), "value-changed", G_CALLBACK(white_point_source_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->white_point_source, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->white_point_source, TRUE);
+  g_signal_connect(G_OBJECT(g->white_point_source), "quad-pressed", G_CALLBACK(color_picker_callback), self);
 
   // Auto tune slider
-  gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(_("optimize automatically")), FALSE, FALSE, 5);
-  g->security_factor = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->security_factor, 2);
-  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("security factor"));
-  gtk_box_pack_start(GTK_BOX(vbox_log), g->security_factor, TRUE, TRUE, 0);
+  g->security_factor = dt_bauhaus_slider_new_with_range(self, -200., 200., 1.0, p->security_factor, 2);
+  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("auto tuning security factor"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is usefull when noise perturbates the measurements"));
   g_signal_connect(G_OBJECT(g->security_factor), "value-changed", G_CALLBACK(security_threshold_callback), self);
 
-  g->auto_button = gtk_button_new_with_label(_("auto tune"));
+  g->auto_button = gtk_button_new_with_label(_("auto tune source"));
   gtk_widget_set_tooltip_text(g->auto_button, _("make an optimization with some guessing"));
-  gtk_box_pack_start(GTK_BOX(vbox_log), g->auto_button, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->auto_button), "clicked", G_CALLBACK(optimize_button_pressed_callback), self);
 
-  gtk_widget_show_all(vbox_log);
-  gtk_stack_add_named(GTK_STACK(g->mode_stack), vbox_log, "log");
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("filmic S curve")), FALSE, FALSE, 5);
+
+  // Black slider
+  g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->black_point_target, 2);
+  dt_bauhaus_widget_set_label(g->black_point_target, NULL, _("black absolute luminance"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->black_point_target, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->black_point_target, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black"));
+  g_signal_connect(G_OBJECT(g->black_point_target), "value-changed", G_CALLBACK(black_point_target_callback), self);
+
+  // latitude slider
+  g->latitude_stops = dt_bauhaus_slider_new_with_range(self, 2.0, 12.0, 0.1, p->latitude_stops, 2);
+  dt_bauhaus_widget_set_label(g->latitude_stops, NULL, _("latitude of the film"));
+  dt_bauhaus_slider_set_format(g->latitude_stops, "%.2f EV");
+  gtk_box_pack_start(GTK_BOX(self->widget), g->latitude_stops, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->latitude_stops, _("linearity domain in the middle of the curve"));
+  g_signal_connect(G_OBJECT(g->latitude_stops), "value-changed", G_CALLBACK(latitude_stops_callback), self);
+
+  // White slider
+  g->white_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1., p->white_point_target, 2);
+  dt_bauhaus_widget_set_label(g->white_point_target, NULL, _("white absolute luminance"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->white_point_target, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->white_point_target, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white"));
+  g_signal_connect(G_OBJECT(g->white_point_target), "value-changed", G_CALLBACK(white_point_target_callback), self);
+
+  // contrast slider
+  g->contrast = dt_bauhaus_slider_new_with_range(self, 1., 5., 0.1, p->contrast, 2);
+  dt_bauhaus_widget_set_label(g->contrast, NULL, _("contrast"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->contrast, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve"));
+  g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
+
+  // balance slider
+  g->balance = dt_bauhaus_slider_new_with_range(self, -100., 100., 1.0, p->balance, 2);
+  dt_bauhaus_widget_set_label(g->balance, NULL, _("balance shadows/highlights"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->balance, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->balance, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->balance, _("gives more room to shadows or highlights, to protect the details"));
+  g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
+
+  // saturation slider
+  g->saturation = dt_bauhaus_slider_new_with_range(self, 0, 2., 0.1, p->saturation, 2);
+  dt_bauhaus_widget_set_label(g->saturation, NULL, _("saturation"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->saturation, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->saturation, _("correction of the output saturation"));
+  g_signal_connect(G_OBJECT(g->saturation), "value-changed", G_CALLBACK(saturation_callback), self);
+
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("destination/display")), FALSE, FALSE, 5);
+
+  // grey_point_source slider
+  g->grey_point_target = dt_bauhaus_slider_new_with_range(self, 0.1, 50., 0.5, p->grey_point_target, 2);
+  dt_bauhaus_widget_set_label(g->grey_point_target, NULL, _("middle grey destination"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->grey_point_target, TRUE, TRUE, 0);
+  dt_bauhaus_slider_set_format(g->grey_point_target, "%.2f %%");
+  gtk_widget_set_tooltip_text(g->grey_point_target, _("adjust to match the average luma of the subject"));
+  g_signal_connect(G_OBJECT(g->grey_point_target), "value-changed", G_CALLBACK(grey_point_target_callback), self);
+
+  // power/gamma slider
+  g->output_power = dt_bauhaus_slider_new_with_range(self, 1.8, 2.6, 0.1, p->output_power, 2);
+  dt_bauhaus_widget_set_label(g->output_power, NULL, _("destination power factor"));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->output_power, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->output_power, _("number of stops between pure black and pure white\nthis is a reading a posemeter would give you on the scene"));
+  g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
 }
 
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -894,6 +894,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   // interception
   float linear_intercept = grey_display - (contrast * grey_log);
+  if (linear_intercept > 0.0f) linear_intercept = -0.001f;
 
   // X coordinates
   float toe_log = (toe_display - linear_intercept) / p->contrast;

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -966,7 +966,7 @@ void init(dt_iop_module_t *module)
                                  100.0,  // target white
                                  2.2,  // target power (~ gamma)
                                  4.0,  // intent latitude
-                                 2.0,  // intent contrast
+                                 1.0,  // intent contrast
                                  90.,   // intent saturation
                                  0.0, // balance shadows/highlights
                               };

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -919,12 +919,18 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
   if (toe_log == grey_log || toe_log == 0.0f || toe_display  == 0.0f || toe_display == grey_display)
   {
-
     TOE_LOST = TRUE;
   }
   if (shoulder_log == grey_log || shoulder_log == 1.0f || shoulder_display == grey_display || shoulder_display == 1.0f)
   {
     SHOULDER_LOST = TRUE;
+  }
+
+  if (p->interpolator == CUBIC_SPLINE)
+  {
+    // the cubic spline is extra sensitive to close nodes : they will produce cusps
+    if (toe_log < 0.01f || toe_display < 0.01f) TOE_LOST = TRUE;
+    if (shoulder_log > 0.99f || shoulder_display > 0.99f) SHOULDER_LOST = TRUE;
   }
 
   // Build the curve from the nodes

--- a/src/iop/finalscale.c
+++ b/src/iop/finalscale.c
@@ -117,7 +117,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_finalscale_params_t));
   self->default_enabled = 1;
   self->hide_enable_button = 1;
-  self->priority = 911; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 914; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_finalscale_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -444,7 +444,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_flip_params_t);
   module->gui_data = NULL;
-  module->priority = 264; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 271; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -664,7 +664,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_global_tonemap_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_global_tonemap_params_t));
   module->default_enabled = 0;
-  module->priority = 544; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 542; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_global_tonemap_params_t);
   module->gui_data = NULL;
   dt_iop_global_tonemap_params_t tmp

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1086,7 +1086,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_graduatednd_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_graduatednd_params_t));
   module->default_enabled = 0;
-  module->priority = 279; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 285; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_graduatednd_params_t);
   module->gui_data = NULL;
   dt_iop_graduatednd_params_t tmp = (dt_iop_graduatednd_params_t){ 1.0, 0, 0, 50, 0, 0 };

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -593,7 +593,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_grain_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_grain_params_t));
   module->default_enabled = 0;
-  module->priority = 779; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 785; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_grain_params_t);
   module->gui_data = NULL;
   dt_iop_grain_params_t tmp

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -123,7 +123,7 @@ void init(dt_iop_module_t *self)
   self->params = calloc(1, sizeof(dt_iop_hazeremoval_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_hazeremoval_params_t));
   self->default_enabled = 0;
-  self->priority = 338; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 342; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_hazeremoval_params_t);
   self->gui_data = NULL;
   dt_iop_hazeremoval_params_t tmp = (dt_iop_hazeremoval_params_t){ 0.5f, 0.25f };

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1025,7 +1025,7 @@ void init(dt_iop_module_t *module)
   // module->data = malloc(sizeof(dt_iop_highlights_data_t));
   module->params = calloc(1, sizeof(dt_iop_highlights_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_highlights_params_t));
-  module->priority = 58; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 57; // module order created by iop_dependencies.py, do not edit!
   module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_highlights_params_t);
   module->gui_data = NULL;

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -433,7 +433,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_highpass_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_highpass_params_t));
   module->default_enabled = 0;
-  module->priority = 764; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 771; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_highpass_params_t);
   module->gui_data = NULL;
   dt_iop_highpass_params_t tmp = (dt_iop_highpass_params_t){ 50, 50 };

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -319,7 +319,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_hotpixels_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_hotpixels_params_t));
   module->default_enabled = 0;
-  module->priority = 88; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 85; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_hotpixels_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -544,7 +544,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_invert_params_t);
   module->gui_data = NULL;
-  module->priority = 29; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 28; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -1243,7 +1243,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_lensfun_params_t);
   module->gui_data = NULL;
-  module->priority = 191; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 199; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -530,7 +530,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_levels_params_t));
   self->default_enabled = 0;
   self->request_histogram |= (DT_REQUEST_ON);
-  self->priority = 691; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 699; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_levels_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1539,7 +1539,7 @@ void init (dt_iop_module_t *module)
 {
   // module is disabled by default
   module->default_enabled = 0;
-  module->priority = 220; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 228; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_liquify_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -289,7 +289,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_lowlight_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_lowlight_params_t));
   module->default_enabled = 0; // we're a rather slow and rare op.
-  module->priority = 617; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 614; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_lowlight_params_t);
   module->gui_data = NULL;
   dt_iop_lowlight_params_t tmp;

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -599,7 +599,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_lowpass_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_lowpass_params_t));
   module->default_enabled = 0;
-  module->priority = 749; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 757; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_lowpass_params_t);
   module->gui_data = NULL;
   dt_iop_lowpass_params_t tmp = (dt_iop_lowpass_params_t){ 0, 10.0f, 1.0f, 0.0f, 1.0f, LOWPASS_ALGO_GAUSSIAN, 1 };

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -346,7 +346,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_monochrome_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_monochrome_params_t));
   module->default_enabled = 0;
-  module->priority = 632; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 628; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_monochrome_params_t);
   module->gui_data = NULL;
   dt_iop_monochrome_params_t tmp = (dt_iop_monochrome_params_t){ 0., 0., 2., 0. };

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -724,7 +724,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_nlmeans_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_nlmeans_params_t));
   // about the first thing to do in Lab space:
-  module->priority = 529; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 528; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_nlmeans_params_t);
   module->gui_data = NULL;
   module->data = NULL;

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -286,7 +286,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_overexposed_t));
   module->hide_enable_button = 1;
   module->default_enabled = 1;
-  module->priority = 926; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 928; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_overexposed_t);
   module->gui_data = NULL;
 }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -863,7 +863,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_profilegamma_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_profilegamma_params_t));
   module->default_enabled = 0;
-  module->priority = 323; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 328; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_profilegamma_params_t);
   module->gui_data = NULL;
   dt_iop_profilegamma_params_t tmp

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -526,7 +526,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
 
   // raw denoise must come just before demosaicing.
-  module->priority = 102; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 99; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rawdenoise_params_t);
   module->gui_data = NULL;
   dt_iop_rawdenoise_params_t tmp;

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -499,7 +499,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_rawoverexposed_t));
   module->hide_enable_button = 1;
   module->default_enabled = 1;
-  module->priority = 941; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 942; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_rawoverexposed_t);
   module->gui_data = NULL;
 }

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -309,7 +309,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_relight_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_relight_params_t));
   module->default_enabled = 0;
-  module->priority = 705; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 714; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_relight_params_t);
   module->gui_data = NULL;
   dt_iop_relight_params_t tmp = (dt_iop_relight_params_t){ 0.33, 0, 4 };

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2334,7 +2334,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_retouch_params_t));
   // our module is disabled by default
   module->default_enabled = 0;
-  module->priority = 180; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 185; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_retouch_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -343,7 +343,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_rotatepixels_params_t));
   self->params_size = sizeof(dt_iop_rotatepixels_params_t);
   self->gui_data = NULL;
-  self->priority = 235; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 242; // module order created by iop_dependencies.py, do not edit!
 }
 
 void cleanup(dt_iop_module_t *self)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -268,7 +268,7 @@ void init(dt_iop_module_t *self)
   self->default_params = calloc(1, sizeof(dt_iop_scalepixels_params_t));
   self->default_enabled = (!isnan(image->pixel_aspect_ratio) && image->pixel_aspect_ratio > 0.0f
                            && image->pixel_aspect_ratio != 1.0f);
-  self->priority = 249; // module order created by iop_dependencies.py, do not edit!
+  self->priority = 257; // module order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_scalepixels_params_t);
   self->gui_data = NULL;
 }

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -770,7 +770,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_shadhi_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_shadhi_params_t));
   module->default_enabled = 0;
-  module->priority = 558; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 557; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_shadhi_params_t);
   module->gui_data = NULL;
   dt_iop_shadhi_params_t tmp

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -713,7 +713,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_sharpen_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_sharpen_params_t));
   module->default_enabled = 0;
-  module->priority = 735; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 742; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_sharpen_params_t);
   module->gui_data = NULL;
   dt_iop_sharpen_params_t tmp = (dt_iop_sharpen_params_t){ 2.0, 0.5, 0.5 };

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -680,7 +680,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_soften_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_soften_params_t));
   module->default_enabled = 0;
-  module->priority = 838; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 842; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_soften_params_t);
   module->gui_data = NULL;
   dt_iop_soften_params_t tmp = (dt_iop_soften_params_t){ 50, 100.0, 0.33, 50 };

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -455,7 +455,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_splittoning_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_splittoning_params_t));
   module->default_enabled = 0;
-  module->priority = 867; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 871; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_splittoning_params_t);
   module->gui_data = NULL;
   dt_iop_splittoning_params_t tmp = (dt_iop_splittoning_params_t){ 0, 0.5, 0.2, 0.5, 0.5, 33.0 };

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -540,7 +540,7 @@ void init(dt_iop_module_t *module)
   // our module is disabled by default
   // by default:
   module->default_enabled = 0;
-  module->priority = 176; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 171; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_spots_params_t);
   module->gui_data = NULL;
   // init defaults:

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1111,7 +1111,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_temperature_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_temperature_params_t));
-  module->priority = 44; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 42; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_temperature_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -660,7 +660,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_tonecurve_params_t));
   module->default_enabled = 0;
   module->request_histogram |= (DT_REQUEST_ON);
-  module->priority = 685; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 676; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_tonecurve_params_t);
   module->gui_data = NULL;
   dt_iop_tonecurve_params_t tmp = (dt_iop_tonecurve_params_t){

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -660,7 +660,7 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, sizeof(dt_iop_tonecurve_params_t));
   module->default_enabled = 0;
   module->request_histogram |= (DT_REQUEST_ON);
-  module->priority = 676; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 685; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_tonecurve_params_t);
   module->gui_data = NULL;
   dt_iop_tonecurve_params_t tmp = (dt_iop_tonecurve_params_t){

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -267,7 +267,7 @@ void init(dt_iop_module_t *module)
   module->params = (dt_iop_params_t *)malloc(sizeof(dt_iop_tonemapping_params_t));
   module->default_params = (dt_iop_params_t *)malloc(sizeof(dt_iop_tonemapping_params_t));
   module->default_enabled = 0;
-  module->priority = 147; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 142; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_tonemapping_params_t);
   module->gui_data = NULL;
 }

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -352,7 +352,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_velvia_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_velvia_params_t));
   module->default_enabled = 0;
-  module->priority = 882; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 885; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_velvia_params_t);
   module->gui_data = NULL;
   dt_iop_velvia_params_t tmp = (dt_iop_velvia_params_t){ 25, 1.0 };

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -216,7 +216,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_vibrance_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_vibrance_params_t));
   module->default_enabled = 0;
-  module->priority = 426; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 428; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_vibrance_params_t);
   module->gui_data = NULL;
   dt_iop_vibrance_params_t tmp = (dt_iop_vibrance_params_t){ 25 };

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1102,7 +1102,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_vignette_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_vignette_params_t));
   module->default_enabled = 0;
-  module->priority = 852; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 857; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_vignette_params_t);
   module->gui_data = NULL;
   dt_iop_vignette_params_t tmp

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1288,7 +1288,7 @@ void init(dt_iop_module_t *module)
   module->params_size = sizeof(dt_iop_watermark_params_t);
   module->default_params = calloc(1, sizeof(dt_iop_watermark_params_t));
   module->default_enabled = 0;
-  module->priority = 970; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 971; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_watermark_params_t);
   module->gui_data = NULL;
   dt_iop_watermark_params_t tmp = (dt_iop_watermark_params_t){

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -458,7 +458,7 @@ void init(dt_iop_module_t *module)
   module->params = calloc(1, sizeof(dt_iop_zonesystem_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_zonesystem_params_t));
   module->default_enabled = 0;
-  module->priority = 661; // module order created by iop_dependencies.py, do not edit!
+  module->priority = 671; // module order created by iop_dependencies.py, do not edit!
   module->params_size = sizeof(dt_iop_zonesystem_params_t);
   module->gui_data = NULL;
   dt_iop_zonesystem_params_t tmp = (dt_iop_zonesystem_params_t){

--- a/tools/iop_dependencies.py
+++ b/tools/iop_dependencies.py
@@ -268,6 +268,7 @@ def add_edges(gr):
   gr.add_edge(('colorcorrection', 'tonecurve'))
   gr.add_edge(('colorcorrection', 'levels'))
   gr.add_edge(('colorcorrection', 'relight'))
+  gr.add_edge(('colorcorrection', 'toneequalizer'))
   # want to split-tone monochrome images:
   gr.add_edge(('colorcorrection', 'monochrome'))
 
@@ -428,6 +429,11 @@ def add_edges(gr):
   gr.add_edge(('zonesystem', 'shadhi'))
   gr.add_edge(('relight', 'shadhi'))
   gr.add_edge(('colisa', 'shadhi'))
+  
+  # toneequalizer is a simple parametric filmic tonecurve
+  gr.add_edge(('colisa', 'toneequalizer'))
+  gr.add_edge(('tonecurve', 'toneequalizer'))
+  gr.add_edge(('levels', 'toneequalizer'))
 
   # the bilateral filter, in linear input rgb
   gr.add_edge(('colorin', 'bilateral'))
@@ -482,6 +488,7 @@ def add_edges(gr):
   gr.add_edge(('colorize', 'colorchecker'))
   gr.add_edge(('colisa', 'colorchecker'))
   gr.add_edge(('defringe', 'colorchecker'))
+  gr.add_edge(('toneequalizer', 'colorchecker'))
   gr.add_edge(('colorchecker', 'colorreconstruction'))
 
   # ugly hack: don't let vibrance drift any more
@@ -554,6 +561,7 @@ gr.add_nodes([
 'temperature',
 'tonecurve',
 'tonemap',
+'toneequalizer',
 'velvia',
 'vibrance',
 'vignette',

--- a/tools/iop_dependencies.py
+++ b/tools/iop_dependencies.py
@@ -125,7 +125,7 @@ def add_edges(gr):
   gr.add_edge(('flip', 'retouch'))
   gr.add_edge(('flip', 'liquify'))
   gr.add_edge(('flip', 'ashift'))
-  
+
   # ashift wants a lens corrected image with straight lines.
   # therefore lens should come before and liquify should come after ashift
   gr.add_edge(('ashift', 'lens'))
@@ -268,7 +268,7 @@ def add_edges(gr):
   gr.add_edge(('colorcorrection', 'tonecurve'))
   gr.add_edge(('colorcorrection', 'levels'))
   gr.add_edge(('colorcorrection', 'relight'))
-  gr.add_edge(('colorcorrection', 'toneequalizer'))
+  gr.add_edge(('colorcorrection', 'filmic'))
   # want to split-tone monochrome images:
   gr.add_edge(('colorcorrection', 'monochrome'))
 
@@ -429,11 +429,16 @@ def add_edges(gr):
   gr.add_edge(('zonesystem', 'shadhi'))
   gr.add_edge(('relight', 'shadhi'))
   gr.add_edge(('colisa', 'shadhi'))
-  
-  # toneequalizer is a simple parametric filmic tonecurve
-  gr.add_edge(('colisa', 'toneequalizer'))
-  gr.add_edge(('tonecurve', 'toneequalizer'))
-  gr.add_edge(('levels', 'toneequalizer'))
+
+  # filmic is a simple parametric tonecurve + log that simulates film
+  # we want it as the last step in the linear pipe
+  gr.add_edge(('colorout', 'filmic'))
+  gr.add_edge(('tonecurve', 'filmic'))
+  gr.add_edge(('levels', 'filmic'))
+  gr.add_edge(('zonesystem', 'filmic'))
+  gr.add_edge(('relight', 'filmic'))
+  gr.add_edge(('colisa', 'filmic'))
+  gr.add_edge(('filmic', 'colorbalance'))
 
   # the bilateral filter, in linear input rgb
   gr.add_edge(('colorin', 'bilateral'))
@@ -488,7 +493,7 @@ def add_edges(gr):
   gr.add_edge(('colorize', 'colorchecker'))
   gr.add_edge(('colisa', 'colorchecker'))
   gr.add_edge(('defringe', 'colorchecker'))
-  gr.add_edge(('toneequalizer', 'colorchecker'))
+  gr.add_edge(('filmic', 'colorchecker'))
   gr.add_edge(('colorchecker', 'colorreconstruction'))
 
   # ugly hack: don't let vibrance drift any more
@@ -528,6 +533,7 @@ gr.add_nodes([
 'equalizer', # deprecated
 'exposure',
 'finalscale',
+'filmic',
 'flip',
 'gamma',
 'globaltonemap',
@@ -561,7 +567,6 @@ gr.add_nodes([
 'temperature',
 'tonecurve',
 'tonemap',
-'toneequalizer',
 'velvia',
 'vibrance',
 'vignette',


### PR DESCRIPTION
This is based on the work of @sobotka who wrote the original Blender Filmic plugin and has been a great help for this work. Many thanks to him.

what ?
---

This new module is the log profile + tonecurve boundled at once in order to perform a quick, efficient and powerful dynamic-range compression with contrast addition, allowing to remap the middle grey value to a specified value.

![capture d ecran du 2018-11-08 23-36-33](https://user-images.githubusercontent.com/2779157/48243611-3a32f480-e3af-11e8-96a2-f8a0440c3577.png)

how ?
---

The settings are put in the same order they should be used.

The first group is directly issued from the unbreak profile module. It does a logarithmic remapping of the dynamic range, helped with auto-tuners. Auto-tune will do a good job 85 % of the time. You goal, setting this group, is not to enhance the picture, but adjust the bounds of the log. Don't strive for beauty in there.

The second group is the set of controls that will internally build an S-shaped "filmic curve". The controls are converted in nodes by which we create a curve using the same API as the tone curve module. The curves we try to create are shaped like that:

![capture d ecran du 2018-11-07 21-02-06](https://user-images.githubusercontent.com/2779157/48243745-e83e9e80-e3af-11e8-9648-32e1a014c063.png)

Good values for the contrast are usually between 1.5 and 2. The contrast is the slope of the linear middle part of the S. The latitude is the length of that linear part. More latitude will give more contrast at the extreme values of the histogram. The latitude is bounded between 25 % and 95 % of the dynamic range.

The balance shadows/highlights will translate the linear part toward the highlights or the shadows so one extreme has more room than the other. This allows to preserve the details in highligts or in shadows.

The main advantage of that module is that, no matter the contrast you set, the grey point will always be remaped to the input value, and the extreme values (black and white) are never affected once properly remapped through the log.

The saturation allows to desaturate if needed, to compensate for the artifacts that contrast manipulations can create in shadows (over-saturation). It can also be used to produce a pleasing black and white, based on the linear luminance.

The interpolation method is an emergency bypass for setups where the interpolation fails (you will see the contrast inverted). Cubic splines can give very pleasant but very unpredictible results, while monotonic splines are robust but sometimes too contrasty. Centripetal splines are good overall but can lack a bit of contrast.

The last group is related to the destination color-spaces. For classic Adobe RGB, sRGB etc. the defauts values work. They are usefull only for exotic gamma 1.8 color spaces and such. Grey and power function of the destination should never be touched in standard use, while the black and white luminance can be used to create a "retro" faded look if you like.

The suggested workflow is:

1. exposure
1. white balance
1. color profiles / LUT
1. filmic (tones)
1. color balance (colors)
1. denoising and enhancements as you please.

what's in ?
---

The modules comes before levels, tone curves, etc. to allow more precise control afterwards. The code comes mostly out of `src/iop/tonecurves.c` and `src//iop/profile_gamma.c`. The module has pure C, SSE and OpenCL versions.

why ?
---

The main benefit of this module is it's really easy and fast to setup. It can also be used with parametric blending and mask feathering as a better replacement than "shadows/highlights". It produces none to very little out-of-gamut colors.

It can replace (global) tonemap, base curves, shadows and highlights. It can be used in conjunction with tone curves, local contrast, etc.

screenshot or it didn't happen !
---

Before:
![capture d ecran du 2018-11-09 00-01-34](https://user-images.githubusercontent.com/2779157/48244214-a5ca9100-e3b2-11e8-822e-79410f433e48.png)

After:
![capture d ecran du 2018-11-09 00-02-36](https://user-images.githubusercontent.com/2779157/48244242-c85caa00-e3b2-11e8-9fbd-682b49e6e8de.png)

Before: (picture by @cryptomilk)
![capture d ecran du 2018-11-09 00-04-31](https://user-images.githubusercontent.com/2779157/48244349-4faa1d80-e3b3-11e8-9867-91dde232bd07.png)

After:
![capture d ecran du 2018-11-09 00-05-32](https://user-images.githubusercontent.com/2779157/48244355-55076800-e3b3-11e8-93b9-e2df4ce4c221.png)

After: (use with the awesome guided filter of @rabauke from #1809 )
![capture d ecran du 2018-11-09 00-15-20](https://user-images.githubusercontent.com/2779157/48244635-b67c0680-e3b4-11e8-8f7e-9203cdb049ff.png)

Before:
![capture d ecran du 2018-11-09 00-09-24](https://user-images.githubusercontent.com/2779157/48244434-bfb8a380-e3b3-11e8-8bdd-8a29f6eed039.png)

After : filmic + 2 instances of color balance with shipped orange/teal presets
![capture d ecran du 2018-11-09 00-09-07](https://user-images.githubusercontent.com/2779157/48244449-cfd08300-e3b3-11e8-9f5b-a58731789b26.png)

Note : the screenshots are produced on a screen with Adobe RGB profile, so colors might be desaturated.