### PR TITLE
faster lighttable

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -727,7 +727,7 @@ end_query_cache:
                 while (loop_count--)
                 {
                   // ex shift + down toggle selection on images_in_row images
-                  to_toggle =  idx+(-1*lib->key_jump_offset/abs(lib->key_jump_offset)*loop_count);
+                  to_toggle = idx+(-1*lib->key_jump_offset/abs(lib->key_jump_offset)*loop_count);
                   if (query_ids[to_toggle])
                     dt_selection_toggle(darktable.selection, query_ids[to_toggle]);
                 }
@@ -1115,7 +1115,6 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
       zoom_y = ht * ceilf((float)lib->collection_count / DT_LIBRARY_MAX_ZOOM) - ht;
   }
 
-
   int offset_i = (int)(zoom_x / wd);
   int offset_j = (int)(zoom_y / ht);
   if(lib->first_visible_filemanager >= 0)
@@ -1420,7 +1419,6 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
      should be done in the place where the layout was actually changed. */
   const int new_layout = dt_conf_get_int("plugins/lighttable/layout");
   if(lib->layout != new_layout) switch_layout_to(lib, new_layout);
-
   int missing_thumbnails = 0;
 
   if(lib->full_preview_id != -1)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -129,6 +129,7 @@ typedef struct dt_library_t
 
   GtkWidget *profile_floating_window;
 
+  int32_t current_thumb_num;
 } dt_library_t;
 
 /* drag and drop callbacks to reorder picture sequence (dnd)*/
@@ -278,9 +279,11 @@ static void zoom_around_image(dt_library_t *lib, double pointerx, double pointer
 static void _view_lighttable_collection_listener_callback(gpointer instance, gpointer user_data)
 {
   dt_view_t *self = (dt_view_t *)user_data;
+  dt_library_t *lib = (dt_library_t *)self->data;
   _unregister_custom_image_order_drag_n_drop(self);
   _register_custom_image_order_drag_n_drop(self);
 
+  lib->current_thumb_num = -1;
   _update_collected_images(self);
 }
 
@@ -431,6 +434,7 @@ void init(dt_view_t *self)
   lib->full_res_thumb = 0;
   lib->full_res_thumb_id = -1;
   lib->audio_player_id = -1;
+  lib->current_thumb_num = -1;
 
   /* setup collection listener and initialize main_query statement */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
@@ -498,14 +502,19 @@ static int expose_filemanager(dt_view_t *self, cairo_t *cr, int32_t width, int32
   lib->image_over = DT_VIEW_DESERT;
   int32_t mouse_over_id = dt_control_get_mouse_over_id(), mouse_over_group = -1;
 
-  /* fill background */
-  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
-  cairo_paint(cr);
-
   offset_changed = lib->offset_changed;
 
   const float wd = width / (float)iir;
   const float ht = width / (float)iir;
+
+  const int32_t n = (int)(pointerx / wd) + (int)(pointery / ht) * iir;
+  if (lib->current_thumb_num != -1 && n == lib->current_thumb_num)
+    return 0;
+  lib->current_thumb_num = n;
+
+  /* fill background */
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
+  cairo_paint(cr);
 
   int pi = pointerx / (float)wd;
   int pj = pointery / (float)ht;
@@ -750,6 +759,7 @@ end_query_cache:
           // this single image.
           dt_selection_select_single(darktable.selection, id);
         }
+        dt_control_set_mouse_over_id(mouse_over_id);
         missing += dt_view_image_expose(&(lib->image_over), id, cr, wd, iir == 1 ? height : ht, iir, img_pointerx,
                              img_pointery, FALSE, FALSE);
 
@@ -989,9 +999,6 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
   lib->images_in_row = zoom;
   lib->image_over = DT_VIEW_DESERT;
 
-  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
-  cairo_paint(cr);
-
   const float wd = width / zoom;
   const float ht = width / zoom;
 
@@ -1077,11 +1084,6 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
     center = 0;
   }
 
-  // mouse left the area, but we leave mouse over as it was, especially during panning
-  // if(!pan && pointerx > 0 && pointerx < width && pointery > 0 && pointery < height)
-  // dt_control_set_mouse_over_id(-1);
-  if(!pan && zoom != 1) dt_control_set_mouse_over_id(-1);
-
   // set scrollbar positions, clamp zoom positions
 
   if(lib->collection_count == 0)
@@ -1127,6 +1129,20 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
   // arbitrary 1000 to avoid bug due to round towards zero using (int)
   int seli = zoom == 1 ? 0 : ((int)(1000 + (pointerx + zoom_x) / wd) - MAX(offset_i, 0) - 1000);
   int selj = zoom == 1 ? 0 : ((int)(1000 + (pointery + zoom_y) / ht) - offset_j - 1000);
+
+  const int32_t n = seli + selj * zoom;
+  if (lib->current_thumb_num != -1 && n == lib->current_thumb_num)
+    return 0;
+  lib->current_thumb_num = n;
+
+  // mouse left the area, but we leave mouse over as it was, especially during panning
+  // if(!pan && pointerx > 0 && pointerx < width && pointery > 0 && pointery < height)
+  // dt_control_set_mouse_over_id(-1);
+  if(!pan && zoom != 1) dt_control_set_mouse_over_id(-1);
+
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
+  cairo_paint(cr);
+
   float offset_x = (zoom == 1) ? 0.0 : (zoom_x / wd - (int)(zoom_x / wd));
   float offset_y = (zoom == 1) ? 0.0 : (zoom_y / ht - (int)(zoom_y / ht));
   const int max_rows = (zoom == 1) ? 1 : (2 + (int)((height) / ht + .5));
@@ -1441,7 +1457,10 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
   if(darktable.unmuted & DT_DEBUG_PERF)
     dt_print(DT_DEBUG_LIGHTTABLE, "[lighttable] expose took %0.04f sec\n", end - start);
   if(missing_thumbnails)
+  {
     g_timeout_add(500, _expose_again, 0);
+    lib->current_thumb_num = -1;
+  }
 }
 
 static gboolean go_up_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -1450,6 +1469,7 @@ static gboolean go_up_key_accel_callback(GtkAccelGroup *accel_group, GObject *ac
   const int layout = dt_conf_get_int("plugins/lighttable/layout");
   dt_view_t *self = (dt_view_t *)data;
   dt_library_t *lib = (dt_library_t *)self->data;
+  lib->current_thumb_num = -1;
 
   if(layout == 1)
     move_view(lib, DIRECTION_TOP);
@@ -1465,6 +1485,7 @@ static gboolean go_down_key_accel_callback(GtkAccelGroup *accel_group, GObject *
   const int layout = dt_conf_get_int("plugins/lighttable/layout");
   dt_view_t *self = (dt_view_t *)data;
   dt_library_t *lib = (dt_library_t *)self->data;
+  lib->current_thumb_num = -1;
 
   if(layout == 1)
     move_view(lib, DIRECTION_BOTTOM);
@@ -1480,6 +1501,7 @@ static gboolean go_pgup_key_accel_callback(GtkAccelGroup *accel_group, GObject *
   dt_view_t *self = (dt_view_t *)data;
   dt_library_t *lib = (dt_library_t *)self->data;
   const int layout = dt_conf_get_int("plugins/lighttable/layout");
+  lib->current_thumb_num = -1;
   if(layout == 1)
     move_view(lib, DIRECTION_PGUP);
   else
@@ -1499,6 +1521,7 @@ static gboolean go_pgdown_key_accel_callback(GtkAccelGroup *accel_group, GObject
   dt_view_t *self = (dt_view_t *)data;
   dt_library_t *lib = (dt_library_t *)self->data;
   const int layout = dt_conf_get_int("plugins/lighttable/layout");
+  lib->current_thumb_num = -1;
   if(layout == 1)
   {
     move_view(lib, DIRECTION_PGDOWN);
@@ -1519,6 +1542,7 @@ static gboolean realign_key_accel_callback(GtkAccelGroup *accel_group, GObject *
 {
   dt_view_t *self = (dt_view_t *)data;
   dt_library_t *lib = (dt_library_t *)self->data;
+  lib->current_thumb_num = -1;
   const int layout = dt_conf_get_int("plugins/lighttable/layout");
   if(layout == 1) move_view(lib, DIRECTION_CENTER);
   dt_control_queue_redraw_center();
@@ -1731,6 +1755,7 @@ void reset(dt_view_t *self)
   lib->offset = 0x7fffffff;
   lib->first_visible_zoomable = -1;
   lib->first_visible_filemanager = 0;
+  lib->current_thumb_num = -1;
   dt_control_set_mouse_over_id(-1);
 }
 
@@ -1739,6 +1764,7 @@ void mouse_enter(dt_view_t *self)
 {
   // TODO: In gtk.c the function center_leave return true. It is not needed when using arrows. the same for mouse_leave, mouse_move
   dt_library_t *lib = (dt_library_t *)self->data;
+  lib->current_thumb_num = -1;
   uint32_t id = dt_control_get_mouse_over_id();
   if (lib->using_arrows == 0)
   {
@@ -1751,12 +1777,14 @@ void mouse_enter(dt_view_t *self)
 void mouse_leave(dt_view_t *self)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
+  lib->current_thumb_num = -1;
   if (lib->using_arrows == 0)
   {
     lib->last_mouse_over_id = dt_control_get_mouse_over_id(); // see mouse_enter (re: fluxbox)
     if(!lib->pan && dt_conf_get_int("plugins/lighttable/images_in_row") != 1)
     {
       dt_control_set_mouse_over_id(-1);
+      lib->current_thumb_num = -1;
       dt_control_queue_redraw_center();
     }
   }
@@ -1790,6 +1818,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
   const int layout = dt_conf_get_int("plugins/lighttable/layout");
+  lib->current_thumb_num = -1;
   if(lib->full_preview_id > -1)
   {
     if(up)
@@ -1830,6 +1859,10 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
 void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which)
 {
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  /* ensure redraw when panning */
+  if (lib->pan) lib->current_thumb_num = -1;
   dt_control_queue_redraw_center();
 }
 
@@ -1838,6 +1871,7 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
 {
   dt_library_t *lib = (dt_library_t *)self->data;
   lib->pan = 0;
+  lib->current_thumb_num = -1;
   if(which == 1) dt_control_change_cursor(GDK_LEFT_PTR);
   return 1;
 }
@@ -1886,6 +1920,8 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
   {
     lib->pan = 1;
   }
+
+  lib->current_thumb_num = -1;
 
   if(which == 1) dt_control_change_cursor(GDK_HAND1);
   if(which == 1 && type == GDK_2BUTTON_PRESS) return 0;
@@ -2021,6 +2057,8 @@ int key_released(dt_view_t *self, guint key, guint state)
 
   if(!darktable.control->key_accelerators_on) return 0;
 
+  lib->current_thumb_num = -1;
+
   if(((key == accels->lighttable_preview.accel_key && state == accels->lighttable_preview.accel_mods)
       || (key == accels->lighttable_preview_display_focus.accel_key
           && state == accels->lighttable_preview_display_focus.accel_mods)) && lib->full_preview_id != -1)
@@ -2050,6 +2088,8 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   dt_control_accels_t *accels = &darktable.control->accels;
 
   if(!darktable.control->key_accelerators_on) return 0;
+
+  lib->current_thumb_num = -1;
 
   int zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
 
@@ -2177,7 +2217,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   {
     if(lib->full_preview_id > -1)
       lib->track = +DT_LIBRARY_MAX_ZOOM;
-    else if(layout == 1)
+    else if(layout == 1) 
     {
       if (zoom == 1)
       {


### PR DESCRIPTION
I'd like to have this re-discussed and tested.

The idea is to skip as much as possible event to make the lighttable faster on 4k (or more) screens. This is NOT a final solution as the best path would be to redesign and rewrite from scratch the lighttable. But this won't happen soon, and we have report that the lighttable is slow on large screen...

All in all I'm wondering if this should not go in for 2.6.

This needs lot of testing. And please if you have tested on 4k (or sup) screen can you tell if this improves the responsiveness of the lighttable or not. I don't have a 4k screen so cannot tell.