### PR TITLE
Expand quick-tag autocomplete to handle multiple tags.

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -656,10 +656,51 @@ static gboolean _lib_tagging_tag_destroy(GtkWidget *widget, GdkEvent *event, gpo
   return FALSE;
 }
 
+static gboolean _match_selected_func(GtkEntryCompletion *completion, GtkTreeModel *model, GtkTreeIter *iter, gpointer user_data)
+{
+  char *tag = NULL;
+  int column = gtk_entry_completion_get_text_column(completion);
+
+  if(gtk_tree_model_get_column_type(model, column) != G_TYPE_STRING) return TRUE;
+
+  gtk_tree_model_get(model, iter, column, &tag, -1);
+  
+  GtkEditable *e = (GtkEditable *)gtk_entry_completion_get_entry(completion);
+  gint cut_off, cur_pos = gtk_editable_get_position(e);
+
+  gchar *currentText = gtk_editable_get_chars(e, 0, -1);
+  const gchar *lastTag = g_strrstr(currentText, ",");
+  if(lastTag == NULL)
+  {
+    cut_off = 0;
+  }
+  else
+  {
+    cut_off = (int)(g_utf8_strlen(currentText, -1) - g_utf8_strlen(lastTag, -1))+1;
+  }
+  free(currentText);
+
+  gtk_editable_delete_text(e, cut_off, cur_pos);
+  cur_pos = cut_off;
+  gtk_editable_insert_text(e, tag, -1, &cur_pos);
+  gtk_editable_set_position(e, cur_pos);
+  return TRUE;
+}      
+
 static gboolean _completion_match_func(GtkEntryCompletion *completion, const gchar *key, GtkTreeIter *iter,
                                        gpointer user_data)
 {
   gboolean res = FALSE;
+
+  GtkEditable *e = (GtkEditable *)gtk_entry_completion_get_entry(completion);
+  gint cur_pos = gtk_editable_get_position(e);
+  gboolean onLastTag = (g_strstr_len(&key[cur_pos], -1, ",") == NULL);
+  if(!onLastTag)
+  {
+    return FALSE;
+  }
+  
+  
   char *tag = NULL;
   GtkTreeModel *model = gtk_entry_completion_get_model(completion);
   int column = gtk_entry_completion_get_text_column(completion);
@@ -667,6 +708,20 @@ static gboolean _completion_match_func(GtkEntryCompletion *completion, const gch
   if(gtk_tree_model_get_column_type(model, column) != G_TYPE_STRING) return FALSE;
 
   gtk_tree_model_get(model, iter, column, &tag, -1);
+
+  const gchar *lastTag = g_strrstr(key, ",");
+  if(lastTag != NULL)
+  {
+    lastTag++;
+  }
+  else
+  {
+    lastTag = key;
+  }
+  if(lastTag[0] == '\0' && key[0] != '\0')
+  {
+    return FALSE;
+  }
 
   if(tag)
   {
@@ -676,7 +731,7 @@ static gboolean _completion_match_func(GtkEntryCompletion *completion, const gch
       char *casefold = g_utf8_casefold(normalized, -1);
       if(casefold)
       {
-        res = g_strstr_len(casefold, -1, key) != NULL;
+        res = g_strstr_len(casefold, -1, lastTag) != NULL;
       }
       g_free(casefold);
     }
@@ -749,6 +804,7 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
   gtk_entry_completion_set_text_column(completion, 0);
   gtk_entry_completion_set_inline_completion(completion, TRUE);
   gtk_entry_completion_set_popup_set_width(completion, FALSE);
+  g_signal_connect(G_OBJECT(completion), "match-selected", G_CALLBACK(_match_selected_func), self);
   gtk_entry_completion_set_match_func(completion, _completion_match_func, NULL, NULL);
   gtk_entry_set_completion(GTK_ENTRY(entry), completion);
 


### PR DESCRIPTION
Currently, the autocompletion feature in the quick-tag (Ctrl+T) text box works only for the first tag entered. If you are entering a comma-separated list of tags, for each one past the first you have to type out the name in full, with no help from the autocomplete.

This pull request modifies the tagging module so that when the quick-tag box contains a comma-separated list of tags, only the last element in the list is passed to the autocomplete, thus letting you use it for every tag you type in.