### PR TITLE
cmake: Only set install RPATH for darktable binaries requiring it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,13 +285,6 @@ else(APPLE)
     set(RPATH_DT "$ORIGIN")
 endif(APPLE)
 
-if(NOT WIN32)
-  # Windows doesn't know the concept of RPATHs :(
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
-  set(CMAKE_INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
-endif(NOT WIN32)
-
 # we need some external programs for building darktable
 message(STATUS "Looking for external programs")
 set(EXTERNAL_PROGRAMS_FOUND 1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -841,6 +841,17 @@ if (WIN32)
   set_target_properties(darktable PROPERTIES LINK_FLAGS "-mconsole -mwindows -Wl,-subsystem,console")
   _detach_debuginfo (darktable bin)
   _detach_debuginfo (lib_darktable bin)
+else()
+    # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+    # The string "$ORIGIN" should end up in the executable as-is.
+    set(RPATH_DT "$ORIGIN")
+    if (APPLE)
+        # The string "@loader_path" should end up in the executable as-is.
+        set(RPATH_DT "@loader_path")
+    endif()
+    set_target_properties(darktable
+                          PROPERTIES
+                          INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
 endif(WIN32)
 
 install(TARGETS darktable DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT DTApplication)

--- a/src/chart/CMakeLists.txt
+++ b/src/chart/CMakeLists.txt
@@ -16,6 +16,17 @@ set_target_properties(darktable-chart PROPERTIES LINKER_LANGUAGE C)
 if (WIN32)
   set_target_properties(darktable-chart PROPERTIES LINK_FLAGS "-mwindows -Wl,-subsystem,windows")
   _detach_debuginfo (darktable-chart bin)
+else()
+    # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+    # The string "$ORIGIN" should end up in the executable as-is.
+    set(RPATH_DT "$ORIGIN")
+    if (APPLE)
+        # The string "@loader_path" should end up in the executable as-is.
+        set(RPATH_DT "@loader_path")
+    endif()
+    set_target_properties(darktable-chart
+                          PROPERTIES
+                          INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
 endif(WIN32)
 
 install(TARGETS darktable-chart DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT DTApplication)

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -7,6 +7,17 @@ target_link_libraries(darktable-cli lib_darktable)
 
 if (WIN32)
   _detach_debuginfo (darktable-cli bin)
+else()
+    # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+    # The string "$ORIGIN" should end up in the executable as-is.
+    set(RPATH_DT "$ORIGIN")
+    if (APPLE)
+        # The string "@loader_path" should end up in the executable as-is.
+        set(RPATH_DT "@loader_path")
+    endif()
+    set_target_properties(darktable-cli
+                          PROPERTIES
+                          INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
 endif(WIN32)
 
 install(TARGETS darktable-cli DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT DTApplication)

--- a/src/cltest/CMakeLists.txt
+++ b/src/cltest/CMakeLists.txt
@@ -7,6 +7,17 @@ target_link_libraries(darktable-cltest lib_darktable)
 
 if (WIN32)
   _detach_debuginfo (darktable-cltest bin)
+else()
+    # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+    # The string "$ORIGIN" should end up in the executable as-is.
+    set(RPATH_DT "$ORIGIN")
+    if (APPLE)
+        # The string "@loader_path" should end up in the executable as-is.
+        set(RPATH_DT "@loader_path")
+    endif()
+    set_target_properties(darktable-cltest
+                          PROPERTIES
+                          INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
 endif(WIN32)
 
 install(TARGETS darktable-cltest DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT DTApplication)

--- a/src/generate-cache/CMakeLists.txt
+++ b/src/generate-cache/CMakeLists.txt
@@ -7,6 +7,17 @@ target_link_libraries(darktable-generate-cache lib_darktable)
 
 if (WIN32)
   _detach_debuginfo (darktable-generate-cache bin)
+else()
+    # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+    # The string "$ORIGIN" should end up in the executable as-is.
+    set(RPATH_DT "$ORIGIN")
+    if (APPLE)
+        # The string "@loader_path" should end up in the executable as-is.
+        set(RPATH_DT "@loader_path")
+    endif()
+    set_target_properties(darktable-generate-cache
+                          PROPERTIES
+                          INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
 endif(WIN32)
 
 install(TARGETS darktable-generate-cache DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT DTApplication)

--- a/src/imageio/format/CMakeLists.txt
+++ b/src/imageio/format/CMakeLists.txt
@@ -32,9 +32,20 @@ if(OpenJPEG_FOUND)
 endif(OpenJPEG_FOUND)
 
 foreach(module ${MODULES})
-	target_link_libraries(${module} lib_darktable)
-  if (WIN32)
-    _detach_debuginfo (${module} ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/format)
-  endif(WIN32)
-  install(TARGETS  ${module} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/format COMPONENT DTApplication)
+    target_link_libraries(${module} lib_darktable)
+    if (WIN32)
+        _detach_debuginfo (${module} ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/format)
+    else()
+        # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+        # The string "$ORIGIN" should end up in the executable as-is.
+        set(RPATH_DT "$ORIGIN")
+        if (APPLE)
+            # The string "@loader_path" should end up in the executable as-is.
+            set(RPATH_DT "@loader_path")
+        endif()
+        set_target_properties(${module}
+                              PROPERTIES
+                              INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
+    endif(WIN32)
+    install(TARGETS  ${module} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/format COMPONENT DTApplication)
 endforeach(module)

--- a/src/imageio/storage/CMakeLists.txt
+++ b/src/imageio/storage/CMakeLists.txt
@@ -21,9 +21,20 @@ foreach(module ${MODULES})
 endforeach(module)
 
 foreach(module ${MODULES})
-	target_link_libraries(${module} lib_darktable)
-  if (WIN32)
-    _detach_debuginfo (${module} ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/storage)
-  endif(WIN32)
-  install(TARGETS  ${module} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/storage COMPONENT DTApplication)
+    target_link_libraries(${module} lib_darktable)
+    if (WIN32)
+        _detach_debuginfo (${module} ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/storage)
+    else()
+        # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+        # The string "$ORIGIN" should end up in the executable as-is.
+        set(RPATH_DT "$ORIGIN")
+        if (APPLE)
+            # The string "@loader_path" should end up in the executable as-is.
+            set(RPATH_DT "@loader_path")
+        endif()
+        set_target_properties(${module}
+                              PROPERTIES
+                              INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
+    endif(WIN32)
+    install(TARGETS  ${module} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/imageio/storage COMPONENT DTApplication)
 endforeach(module)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -41,6 +41,17 @@ macro (add_iop _lib _src)
 
   if (WIN32)
     _detach_debuginfo (${_lib} ${CMAKE_INSTALL_LIBDIR}/darktable/plugins)
+  else()
+      # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+      # The string "$ORIGIN" should end up in the executable as-is.
+      set(RPATH_DT "$ORIGIN")
+      if (APPLE)
+          # The string "@loader_path" should end up in the executable as-is.
+          set(RPATH_DT "@loader_path")
+      endif()
+      set_target_properties(${_lib}
+                            PROPERTIES
+                            INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
   endif(WIN32)
 
   install(TARGETS  ${_lib} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/plugins COMPONENT DTApplication)

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -117,6 +117,17 @@ endforeach(module)
 foreach(module ${MODULES})
     if (WIN32)
       _detach_debuginfo (${module} ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/lighttable)
-    endif(WIN32)
+    else()
+        # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+        # The string "$ORIGIN" should end up in the executable as-is.
+        set(RPATH_DT "$ORIGIN")
+        if (APPLE)
+            # The string "@loader_path" should end up in the executable as-is.
+            set(RPATH_DT "@loader_path")
+        endif()
+        set_target_properties(${module}
+                              PROPERTIES
+                              INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
+        endif(WIN32)
     install(TARGETS  ${module} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/plugins/lighttable COMPONENT DTApplication)
 endforeach(module)

--- a/src/views/CMakeLists.txt
+++ b/src/views/CMakeLists.txt
@@ -35,6 +35,17 @@ endforeach(module)
 foreach(module ${MODULES})
     if (WIN32)
       _detach_debuginfo (${module} ${CMAKE_INSTALL_LIBDIR}/darktable/views)
+    else()
+        # Note that $ORIGIN is not a variable but has a special meaning at runtime.
+        # The string "$ORIGIN" should end up in the executable as-is.
+        set(RPATH_DT "$ORIGIN")
+        if (APPLE)
+            # The string "@loader_path" should end up in the executable as-is.
+            set(RPATH_DT "@loader_path")
+        endif()
+        set_target_properties(${module}
+                              PROPERTIES
+                              INSTALL_RPATH ${RPATH_DT}/../${CMAKE_INSTALL_LIBDIR}/darktable)
     endif(WIN32)
 
     install(TARGETS  ${module} DESTINATION ${CMAKE_INSTALL_LIBDIR}/darktable/views COMPONENT DTApplication)


### PR DESCRIPTION
Hi,

it looks like this is only needed for the darktable executables and plugins.

A test build with this patch is at:
https://build.opensuse.org/package/show/home:gladiac:branches:graphics:darktable:master/darktable