### PR TITLE
Fix #12401: restore lighttable group preview image navigation (next, previous)

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1235,11 +1235,21 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
     /* If more than one image is selected, iterate over these. */
     /* If only one image is selected, scroll through all known images. */
     sqlite3_stmt *stmt;
-    int sel_img_count = 0;
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT COUNT(*) FROM main.selected_images", -1,
-                                &stmt, NULL);
-    if(sqlite3_step(stmt) == SQLITE_ROW) sel_img_count = sqlite3_column_int(stmt, 0);
+    int sel_group_count = 0;
+    int current_group = -1;
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1,
+        &stmt, NULL);
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      uint32_t imgid  = sqlite3_column_int(stmt, 0);
+      const dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
+      if (image->group_id != current_group) {
+        sel_group_count++;
+        current_group = image->group_id;
+      }
+      dt_image_cache_read_release(darktable.image_cache, image);
+    }
     sqlite3_finalize(stmt);
+    dt_print(DT_DEBUG_LIGHTTABLE, "[lighttable] selected group: %d\n", sel_group_count);
 
     /* How many images to preload in advance. */
     int preload_num = dt_conf_get_int("plugins/lighttable/preview/full_size_preload_count");
@@ -1248,7 +1258,7 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
 
     gchar *stmt_string = g_strdup_printf("SELECT col.imgid AS id, col.rowid FROM memory.collected_images AS col %s "
                                          "WHERE col.rowid %s %d ORDER BY col.rowid %s LIMIT %d",
-                                         (sel_img_count <= 1) ?
+                                         (sel_group_count <= 1) ?
                                            /* We want to operate on the currently collected images,
                                             * so there's no need to match against the selection */
                                            "" :


### PR DESCRIPTION
Since 20cd30b3c lighttable group preview navigation (previous, next) with only one group selected is stuck in the selected group picture.
This patch now uses group_id instead of image_id to count to number of selected groups.

ref: https://redmine.darktable.org/issues/12401