### PR TITLE
fix copy masks

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -814,7 +814,7 @@ static int _history_merge_module_into_history(dt_develop_t *dev_dest, dt_iop_mod
   if(module_added)
   {
     dt_dev_add_history_item_ext(dev_dest, module, FALSE, TRUE);
-    dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end, TRUE);
+    dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end);
     
     // we have added the module, now we need to make it last on the pipe
     // for this we increment 1 to all instances with multi_priority < than this one
@@ -910,8 +910,8 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   dt_dev_read_history_ext(dev_src, imgid, TRUE);
   dt_dev_read_history_ext(dev_dest, dest_imgid, TRUE);
 
-  dt_dev_pop_history_items_ext(dev_src, dev_src->history_end, TRUE);
-  dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end, TRUE);
+  dt_dev_pop_history_items_ext(dev_src, dev_src->history_end);
+  dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end);
 
   // we will copy only used forms
   guint nbf = g_list_length(dev_src->forms);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -974,19 +974,23 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   for(int i = 0; i < nbf && forms_used_replace[i] > 0; i++)
   {
     dt_masks_form_t *form = dt_masks_get_from_id_ext(dev_src->forms, forms_used_replace[i]);
-    
-    // check if the form already exists in dest image
-    // if so we'll remove it, so it is replaced 
-    dt_masks_form_t *form_dest = dt_masks_get_from_id_ext(dev_dest->forms, forms_used_replace[i]);
-    if(form_dest)
+    if(form)
     {
-      dev_dest->forms = g_list_remove(dev_dest->forms, form_dest);
+      // check if the form already exists in dest image
+      // if so we'll remove it, so it is replaced 
+      dt_masks_form_t *form_dest = dt_masks_get_from_id_ext(dev_dest->forms, forms_used_replace[i]);
+      if(form_dest)
+      {
+        dev_dest->forms = g_list_remove(dev_dest->forms, form_dest);
+      }
+      
+      // and add it to dest image
+      // we can do this because dev->allforms will take care of free() the form
+      // if that changes we'll have to duplicate the form
+      dev_dest->forms = g_list_append(dev_dest->forms, form);
     }
-    
-    // and add it to dest image
-    // we can do this because dev->allforms will take care of free() the form
-    // if that changes we'll have to duplicate the form
-    dev_dest->forms = g_list_append(dev_dest->forms, form);
+    else
+      fprintf(stderr, "[_history_copy_and_paste_on_image_merge] form %i not found in source image\n", forms_used_replace[i]);
   }
 
   // write history and forms to db

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -29,6 +29,8 @@
 #include "common/collection.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/blend.h"
+#include "develop/masks.h"
 
 void dt_history_item_free(gpointer data)
 {
@@ -51,6 +53,7 @@ static void remove_preset_flag(const int imgid)
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
 }
 
+#if 0
 static void _dt_history_cleanup_multi_instance()
 {
   /* as we let the user decide which history item to copy, we can end with some gaps in multi-instance
@@ -158,6 +161,7 @@ static void _dt_history_cleanup_multi_instance()
   g_free(req);
   g_list_free_full(hitems, free);
 }
+#endif
 
 static void _history_rebuild_multi_priority_append(const int dest_imgid)
 {
@@ -405,6 +409,7 @@ int dt_history_load_and_apply_on_selection(gchar *filename)
   return res;
 }
 
+#if 0
 int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboolean merge, GList *ops)
 {
   sqlite3_stmt *stmt;
@@ -585,6 +590,527 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
     dt_image_set_aspect_ratio(dest_imgid);
 
   return 0;
+}
+#endif
+
+// returns the first history item with hist->module == module
+static dt_dev_history_item_t *_search_history_by_module(dt_develop_t *dev, dt_iop_module_t *module)
+{
+  dt_dev_history_item_t *hist_mod = NULL;
+  GList *history = g_list_first(dev->history);
+  while(history)
+  {
+    dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
+
+    if(hist->module == module)
+    {
+      hist_mod = hist;
+      break;
+    }
+    history = g_list_next(history);
+  }
+  return hist_mod;
+}
+
+// returns the first history item with corresponding module->op 
+static dt_dev_history_item_t *_search_history_by_op(dt_develop_t *dev, dt_iop_module_t *module)
+{
+  dt_dev_history_item_t *hist_mod = NULL;
+  GList *history = g_list_first(dev->history);
+  while(history)
+  {
+    dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
+
+    if(strcmp(hist->module->op, module->op) == 0)
+    {
+      hist_mod = hist;
+      break;
+    }
+    history = g_list_next(history);
+  }
+  return hist_mod;
+}
+
+// returns the module on modules_list that is equal to module
+// used to check if module exists on the list
+static dt_iop_module_t *_search_list_iop_by_module(GList *modules_list, dt_iop_module_t *module)
+{
+  dt_iop_module_t *mod_ret = NULL;
+  GList *modules = g_list_first(modules_list);
+  while(modules)
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
+
+    if(mod == module)
+    {
+      mod_ret = mod;
+      break;
+    }
+    modules = g_list_next(modules);
+  }
+  return mod_ret;
+}
+
+// returns the first module on modules_list with operation = op_name
+static dt_iop_module_t *_search_list_iop_by_op(GList *modules_list, const char *op_name)
+{
+  dt_iop_module_t *mod_ret = NULL;
+  GList *modules = g_list_first(modules_list);
+  while(modules)
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
+
+    if(strcmp(mod->op, op_name) == 0)
+    {
+      mod_ret = mod;
+      break;
+    }
+    modules = g_list_next(modules);
+  }
+  return mod_ret;
+}
+
+// returns a new multi_priority number for op_name
+static int _get_new_iop_multi_priority(dt_develop_t *dev, const char *op_name)
+{
+  int multi_priority_new = -1;
+  GList *modules = g_list_first(dev->iop);
+  while(modules)
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
+
+    if(strcmp(mod->op, op_name) == 0)
+    {
+      multi_priority_new = MAX(multi_priority_new, mod->multi_priority);
+    }
+    modules = g_list_next(modules);
+  }
+  return (multi_priority_new + 1);
+}
+
+static int _history_merge_module_into_history(dt_develop_t *dev_dest, dt_iop_module_t *mod_src, GList **_modules_used,
+                                         const int append)
+{
+  int module_added = 1;
+  GList *modules_used = *_modules_used;
+  dt_iop_module_t *module = NULL;
+  dt_iop_module_t *mod_replace = NULL;
+  int multi_priority = mod_src->multi_priority;
+
+  // one-instance modules always replace the existing one
+  if(mod_src->flags() & IOP_FLAGS_ONE_INSTANCE)
+  {
+    mod_replace = _search_list_iop_by_op(dev_dest->iop, mod_src->op);
+    if(mod_replace)
+    {
+      multi_priority = mod_replace->multi_priority;
+    }
+    else
+    {
+      fprintf(stderr, "[_history_merge_module_into_history] can't find single instance module %s\n",
+              mod_src->op);
+      module_added = 0;
+    }
+  }
+
+  if(module_added && !append)
+  {
+    // we haven't found a module to replace
+    if(mod_replace == NULL)
+    {
+      // check if there's a module with the same (operation, multi_name) on dev->iop
+      GList *modules_dest = g_list_first(dev_dest->iop);
+      while(modules_dest)
+      {
+        dt_iop_module_t *mod_dest = (dt_iop_module_t *)(modules_dest->data);
+
+        if(strcmp(mod_src->op, mod_dest->op) == 0 && strcmp(mod_src->multi_name, mod_dest->multi_name) == 0)
+        {
+          // but only if it hasn't been used already
+          if(_search_list_iop_by_module(modules_used, mod_dest) == NULL)
+          {
+            // we will replace this module
+            modules_used = g_list_append(modules_used, mod_dest);
+            mod_replace = mod_dest;
+            multi_priority = mod_replace->multi_priority;
+            break;
+          }
+        }
+        modules_dest = g_list_next(modules_dest);
+      }
+    }
+  }
+
+  if(module_added)
+  {
+    // we haven't found a module to replace, so we will create a new instance
+    if(mod_replace == NULL)
+    {
+      // but if there's an un-used instance on dev->iop we will use that
+      if(_search_history_by_op(dev_dest, mod_src) == NULL)
+      {
+        // there should be only one instance of this iop (since is un-used)
+        mod_replace = _search_list_iop_by_op(dev_dest->iop, mod_src->op);
+        if(mod_replace)
+        {
+          multi_priority = mod_replace->multi_priority;
+        }
+        else
+        {
+          fprintf(stderr, "[_history_merge_module_into_history] can't find base instance module %s\n",
+                  mod_src->op);
+          module_added = 0;
+        }
+      }
+    }
+  }
+
+  if(module_added)
+  {
+    // change multi_priority so it replaces it
+    if(!mod_replace)
+    {
+      // otherwise generate a new multi_priority
+      multi_priority = _get_new_iop_multi_priority(dev_dest, mod_src->op);
+    }
+  }
+
+  if(module_added)
+  {
+    // if we are creating a new instance, create a new module
+    if(!mod_replace)
+    {
+      dt_iop_module_t *base = _search_list_iop_by_op(dev_dest->iop, mod_src->op);
+      module = (dt_iop_module_t *)calloc(1, sizeof(dt_iop_module_t));
+      if(dt_iop_load_module(module, base->so, dev_dest))
+      {
+        module_added = 0;
+      }
+      else
+      {
+        module->instance = mod_src->instance;
+        module->multi_priority = multi_priority;
+
+        dev_dest->iop = g_list_insert_sorted(dev_dest->iop, module, sort_plugins);
+      }
+    }
+    else
+    {
+      module = mod_replace;
+    }
+
+    module->enabled = mod_src->enabled;
+    snprintf(module->multi_name, sizeof(module->multi_name), "%s", mod_src->multi_name);
+
+    memcpy(module->params, mod_src->params, module->params_size);
+    if(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
+    {
+      memcpy(module->blend_params, mod_src->blend_params, sizeof(dt_develop_blend_params_t));
+      module->blend_params->mask_id = mod_src->blend_params->mask_id;
+    }
+  }
+
+  // and we add it to history
+  if(module_added)
+  {
+    dt_dev_add_history_item_ext(dev_dest, module, FALSE, TRUE);
+    dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end, TRUE);
+    
+    // we have added the module, now we need to make it last on the pipe
+    // for this we increment 1 to all instances with multi_priority < than this one
+    // and assign to it multi_priority = 0
+    if(module->multi_priority > 0)
+    {
+      multi_priority = module->multi_priority;
+      
+      GList *modules_dest = g_list_first(dev_dest->iop);
+      while(modules_dest)
+      {
+        dt_iop_module_t *mod_dest = (dt_iop_module_t *)(modules_dest->data);
+
+        if(mod_dest->instance == module->instance)
+        {
+          if(mod_dest->multi_priority < multi_priority)
+            mod_dest->multi_priority++;
+          else if(mod_dest == module)
+            mod_dest->multi_priority = 0;
+          
+          // also update the history
+          GList *history = g_list_first(dev_dest->history);
+          while(history)
+          {
+            dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
+
+            if(hist->module->instance == module->instance)
+              hist->multi_priority = hist->module->multi_priority;
+            
+            history = g_list_next(history);
+          }
+        }
+        
+        modules_dest = g_list_next(modules_dest);
+      }
+    }
+  }
+
+  *_modules_used = modules_used;
+
+  return module_added;
+}
+
+// fills used with formid, if it is a group it recurs and fill all sub-forms
+static void _fill_used_forms(GList *forms_list, int formid, int *used, int nb)
+{
+  // first, we search for the formid in used table
+  for(int i = 0; i < nb; i++)
+  {
+    if(used[i] == 0)
+    {
+      // we store the formid
+      used[i] = formid;
+      break;
+    }
+    if(used[i] == formid) break;
+  }
+
+  // if the form is a group, we iterate through the sub-forms
+  dt_masks_form_t *form = dt_masks_get_from_id_ext(forms_list, formid);
+  if(form && (form->type & DT_MASKS_GROUP))
+  {
+    GList *grpts = g_list_first(form->points);
+    while(grpts)
+    {
+      dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)grpts->data;
+      _fill_used_forms(forms_list, grpt->formid, used, nb);
+      grpts = g_list_next(grpts);
+    }
+  }
+}
+
+static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_imgid, GList *ops)
+{
+  GList *modules_used = NULL;
+
+  dt_develop_t _dev_src = { 0 };
+  dt_develop_t _dev_dest = { 0 };
+
+  dt_develop_t *dev_src = &_dev_src;
+  dt_develop_t *dev_dest = &_dev_dest;
+
+  // we will do the copy/paste on memory so we can deal with masks
+  dt_dev_init(dev_src, FALSE);
+  dt_dev_init(dev_dest, FALSE);
+
+  dev_src->iop = dt_iop_load_modules_ext(dev_src, TRUE);
+  dev_dest->iop = dt_iop_load_modules_ext(dev_dest, TRUE);
+
+  dt_masks_read_forms_ext(dev_src, imgid, TRUE);
+  dt_masks_read_forms_ext(dev_dest, dest_imgid, TRUE);
+  
+  dt_dev_read_history_ext(dev_src, imgid, TRUE);
+  dt_dev_read_history_ext(dev_dest, dest_imgid, TRUE);
+
+  dt_dev_pop_history_items_ext(dev_src, dev_src->history_end, TRUE);
+  dt_dev_pop_history_items_ext(dev_dest, dev_dest->history_end, TRUE);
+
+  // we will copy only used forms
+  guint nbf = g_list_length(dev_src->forms);
+  int *forms_used_replace = calloc(nbf, sizeof(int));
+
+  // the user have selected some history entries
+  if(ops)
+  {
+    // copy only selected history entries
+    GList *l = g_list_last(ops);
+    while(l)
+    {
+      unsigned int num = GPOINTER_TO_UINT(l->data);
+
+      dt_dev_history_item_t *hist = g_list_nth_data(dev_src->history, num);
+
+      if(hist)
+      {
+        // merge the entry
+        _history_merge_module_into_history(dev_dest, hist->module, &modules_used, FALSE);
+        
+        // record the masks used by this module
+        if(hist->module->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
+        {
+          if(hist->module->blend_params->mask_id > 0)
+            _fill_used_forms(dev_src->forms, hist->module->blend_params->mask_id, forms_used_replace, nbf);
+        }
+      }
+
+      l = g_list_previous(l);
+    }
+  }
+  else
+  {
+    // we will copy all modules
+    GList *modules_src = g_list_first(dev_src->iop);
+    while(modules_src)
+    {
+      dt_iop_module_t *mod_src = (dt_iop_module_t *)(modules_src->data);
+
+      // but only if module is in history in source image
+      if(_search_history_by_module(dev_src, mod_src) != NULL)
+      {
+        // merge the module into dest image
+        _history_merge_module_into_history(dev_dest, mod_src, &modules_used, FALSE);
+        
+        // record the masks used by this module
+        if(mod_src->flags() & IOP_FLAGS_SUPPORTS_BLENDING)
+        {
+          if(mod_src->blend_params->mask_id > 0)
+            _fill_used_forms(dev_src->forms, mod_src->blend_params->mask_id, forms_used_replace, nbf);
+        }
+      }
+
+      modules_src = g_list_next(modules_src);
+    }
+  }
+
+  // now copy masks
+  for(int i = 0; i < nbf && forms_used_replace[i] > 0; i++)
+  {
+    dt_masks_form_t *form = dt_masks_get_from_id_ext(dev_src->forms, forms_used_replace[i]);
+    
+    // check if the form already exists in dest image
+    // if so we'll remove it, so it is replaced 
+    dt_masks_form_t *form_dest = dt_masks_get_from_id_ext(dev_dest->forms, forms_used_replace[i]);
+    if(form_dest)
+    {
+      dev_dest->forms = g_list_remove(dev_dest->forms, form_dest);
+    }
+    
+    // and add it to dest image
+    // we can do this because dev->allforms will take care of free() the form
+    // if that changes we'll have to duplicate the form
+    dev_dest->forms = g_list_append(dev_dest->forms, form);
+  }
+
+  // write history and forms to db
+  dt_masks_write_forms_ext(dev_dest, dest_imgid, FALSE);
+  dt_dev_write_history_ext(dev_dest, dest_imgid);
+
+  dt_dev_cleanup(dev_src);
+  dt_dev_cleanup(dev_dest);
+
+  g_list_free(modules_used);
+  free(forms_used_replace);
+
+  return 0;
+}
+
+static int _history_copy_and_paste_on_image_overwrite(int32_t imgid, int32_t dest_imgid, GList *ops)
+{
+  int ret_val = 0;
+  sqlite3_stmt *stmt;
+
+  // replace history stack
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.history WHERE imgid = ?1", -1,
+                              &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dest_imgid);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  // and shapes
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.mask WHERE imgid = ?1", -1, &stmt,
+                              NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dest_imgid);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE main.images SET history_end = 0 WHERE id = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dest_imgid);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+  
+  // the user wants an exact duplicate of the history, so just copy the db
+  if(!ops)
+  {
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "INSERT INTO main.history "
+                                "(imgid,num,module,operation,op_params,enabled,blendop_params, "
+                                "blendop_version,multi_priority,multi_name) SELECT "
+                                "?1,num,module,operation,op_params,enabled,blendop_params, "
+                                "blendop_version,multi_priority,multi_name "
+                                "FROM main.history WHERE imgid=?2 ORDER BY num",
+                                -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dest_imgid);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "INSERT INTO main.mask "
+                                "(imgid, formid, form, name, version, points, points_count, source) SELECT "
+                                "?1, formid, form, name, version, points, points_count, source "
+                                "FROM main.mask WHERE imgid = ?2",
+                                -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dest_imgid);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "UPDATE main.images SET history_end = (SELECT history_end FROM main.images "
+                                "WHERE id = ?1) WHERE id = ?2",
+                                -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, dest_imgid);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+  }
+  else
+  {
+    // since the history and masks where deleted we can do a merge
+    ret_val = _history_copy_and_paste_on_image_merge(imgid, dest_imgid, ops);
+  }
+  
+  return ret_val;
+}
+
+int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboolean merge, GList *ops)
+{
+  if(imgid == dest_imgid) return 1;
+
+  if(imgid == -1)
+  {
+    dt_control_log(_("you need to copy history from an image before you paste it onto another"));
+    return 1;
+  }
+
+  // be sure the current history is written before pasting some other history data
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
+
+  int ret_val = 0;
+  if(merge)
+    ret_val = _history_copy_and_paste_on_image_merge(imgid, dest_imgid, ops);
+  else
+    ret_val = _history_copy_and_paste_on_image_overwrite(imgid, dest_imgid, ops);
+
+  /* if current image in develop reload history */
+  if(dt_dev_is_current_image(darktable.develop, dest_imgid))
+  {
+    dt_dev_reload_history_items(darktable.develop);
+    dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
+  }
+
+  /* update xmp file */
+  dt_image_synch_xmp(dest_imgid);
+
+  dt_mipmap_cache_remove(darktable.mipmap_cache, dest_imgid);
+
+  /* update the aspect ratio if the current sorting is based on aspect ratio, otherwise the aspect ratio will be
+     recalculated when the mimpap will be recreated */
+  if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+    dt_image_set_aspect_ratio(dest_imgid);
+
+  return ret_val;
 }
 
 GList *dt_history_get_items(int32_t imgid, gboolean enabled)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -803,14 +803,9 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
   dt_dev_pop_history_items(dev, dev->history_end);
 }
 
-void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt, gboolean no_image)
+void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt)
 {
   // printf("dev popping all history items >= %d\n", cnt);
-  if(!no_image)
-  {
-  dt_pthread_mutex_lock(&dev->history_mutex);
-  darktable.gui->reset = 1;
-  }
   dev->history_end = cnt;
   // reset gui params for all modules
   GList *modules = dev->iop;
@@ -836,10 +831,17 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt, gboolean no_im
 
     history = g_list_next(history);
   }
-  if(!no_image)
-  {
+}
+
+void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
+{
+  dt_pthread_mutex_lock(&dev->history_mutex);
+  darktable.gui->reset = 1;
+
+  dt_dev_pop_history_items_ext(dev, cnt);
+
   // update all gui modules
-  modules = dev->iop;
+  GList *modules = dev->iop;
   while(modules)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
@@ -852,12 +854,6 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt, gboolean no_im
   dt_dev_invalidate_all(dev);
   dt_pthread_mutex_unlock(&dev->history_mutex);
   dt_control_queue_redraw_center();
-  }
-}
-
-void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
-{
-  dt_dev_pop_history_items_ext(dev, cnt, FALSE);
 }
 
 void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -572,13 +572,6 @@ int dt_dev_write_history_item(const int imgid, dt_dev_history_item_t *h, int32_t
 
 void dt_dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable, gboolean no_image)
 {
-  if(!no_image)
-  {
-  if(!darktable.gui || darktable.gui->reset) return;
-  dt_pthread_mutex_lock(&dev->history_mutex);
-  }
-  if(dev->gui_attached || no_image)
-  {
     GList *history = g_list_nth(dev->history, dev->history_end);
     while(history)
     {
@@ -672,10 +665,17 @@ void dt_dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module, gbo
       dev->preview_pipe->changed |= DT_DEV_PIPE_TOP_CHANGED;
       }
     }
-  }
-  
-  if(!no_image)
+}
+
+void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable)
+{
+  if(!darktable.gui || darktable.gui->reset) return;
+  dt_pthread_mutex_lock(&dev->history_mutex);
+
+  if(dev->gui_attached)
   {
+    dt_dev_add_history_item_ext(dev, module, enable, FALSE);
+  }
 #if 0
   {
     // debug:
@@ -704,12 +704,6 @@ void dt_dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module, gbo
     /* redraw */
     dt_control_queue_redraw_center();
   }
-  }
-}
-
-void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable)
-{
-  dt_dev_add_history_item_ext(dev, module, enable, FALSE);
 }
 
 void dt_dev_free_history_item(gpointer data)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -270,10 +270,14 @@ void dt_dev_load_image(dt_develop_t *dev, const uint32_t imgid);
 void dt_dev_reload_image(dt_develop_t *dev, const uint32_t imgid);
 /** checks if provided imgid is the image currently in develop */
 int dt_dev_is_current_image(dt_develop_t *dev, uint32_t imgid);
+void dt_dev_add_history_item_ext(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable, gboolean no_image);
 void dt_dev_add_history_item(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable);
 void dt_dev_reload_history_items(dt_develop_t *dev);
+void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt, gboolean no_image);
 void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt);
+void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid);
 void dt_dev_write_history(dt_develop_t *dev);
+void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_image);
 void dt_dev_read_history(dt_develop_t *dev);
 void dt_dev_free_history_item(gpointer data);
 void dt_dev_invalidate_history_module(GList *list, struct dt_iop_module_t *module);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -273,7 +273,7 @@ int dt_dev_is_current_image(dt_develop_t *dev, uint32_t imgid);
 void dt_dev_add_history_item_ext(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable, gboolean no_image);
 void dt_dev_add_history_item(dt_develop_t *dev, struct dt_iop_module_t *module, gboolean enable);
 void dt_dev_reload_history_items(dt_develop_t *dev);
-void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt, gboolean no_image);
+void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt);
 void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt);
 void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid);
 void dt_dev_write_history(dt_develop_t *dev);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1437,7 +1437,7 @@ int dt_iop_load_module(dt_iop_module_t *module, dt_iop_module_so_t *module_so, d
   return 0;
 }
 
-GList *dt_iop_load_modules(dt_develop_t *dev)
+GList *dt_iop_load_modules_ext(dt_develop_t *dev, gboolean no_image)
 {
   GList *res = NULL;
   dt_iop_module_t *module;
@@ -1456,7 +1456,7 @@ GList *dt_iop_load_modules(dt_develop_t *dev)
     res = g_list_insert_sorted(res, module, sort_plugins);
     module->data = module_so->data;
     module->so = module_so;
-    dt_iop_reload_defaults(module);
+    if(!no_image) dt_iop_reload_defaults(module);
     iop = g_list_next(iop);
   }
 
@@ -1469,6 +1469,11 @@ GList *dt_iop_load_modules(dt_develop_t *dev)
     it = g_list_next(it);
   }
   return res;
+}
+
+GList *dt_iop_load_modules(dt_develop_t *dev)
+{
+  return dt_iop_load_modules_ext(dev, FALSE);
 }
 
 void dt_iop_cleanup_module(dt_iop_module_t *module)

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -467,6 +467,7 @@ void dt_iop_unload_modules_so();
 /** load a module for a given .so */
 int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, struct dt_develop_t *dev);
 /** returns a list of instances referencing stuff loaded in load_modules_so. */
+GList *dt_iop_load_modules_ext(struct dt_develop_t *dev, gboolean no_image);
 GList *dt_iop_load_modules(struct dt_develop_t *dev);
 int dt_iop_load_module(dt_iop_module_t *module, dt_iop_module_so_t *module_so, struct dt_develop_t *dev);
 gint sort_plugins(gconstpointer a, gconstpointer b);

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -281,8 +281,10 @@ dt_masks_form_t *dt_masks_get_from_id_ext(GList *forms, int id);
 dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id);
 
 /** read the forms from the db */
+void dt_masks_read_forms_ext(dt_develop_t *dev, const int imgid, gboolean no_image);
 void dt_masks_read_forms(dt_develop_t *dev);
 /** write the forms into the db */
+void dt_masks_write_forms_ext(dt_develop_t *dev, const int imgid, gboolean undo);
 void dt_masks_write_form(dt_masks_form_t *form, dt_develop_t *dev);
 void dt_masks_write_forms(dt_develop_t *dev);
 void dt_masks_free_form(dt_masks_form_t *form);

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -42,10 +42,10 @@ typedef struct _masks_undo_data_t
   dt_masks_form_t *form;
 } _masks_undo_data_t;
 
-static void _masks_write_form_db(dt_masks_form_t *form, dt_develop_t *dev);
+static void _masks_write_form_db(dt_masks_form_t *form, const int imgid, dt_develop_t *dev);
 // write a form into the database
 
-static void _masks_write_forms_db(dt_develop_t *dev, gboolean undo);
+static void _masks_write_forms_db(dt_develop_t *dev, const int imgid, gboolean undo);
 // write all masks form into the database. record an undo if undo is true
 
 static dt_masks_form_t *_dup_masks_form(const dt_masks_form_t *form)
@@ -136,7 +136,7 @@ static void _masks_do_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data
   dt_masks_clear_form_gui(dev);
   dt_masks_change_form_gui(_dup_masks_form(udata->form));
 
-  _masks_write_forms_db(dev, FALSE);
+  _masks_write_forms_db(dev, dev->image_storage.id, FALSE);
 
   // and we ensure that we are in edit mode
   dt_masks_iop_update(darktable.develop->gui_module);
@@ -981,20 +981,20 @@ dt_masks_form_t *dt_masks_get_from_id(dt_develop_t *dev, int id)
   return dt_masks_get_from_id_ext(dev->forms, id);
 }
 
-void dt_masks_read_forms(dt_develop_t *dev)
+void dt_masks_read_forms_ext(dt_develop_t *dev, const int imgid, gboolean no_image)
 {
   // first we have to reset the list
   g_list_free(dev->forms);
   dev->forms = NULL;
 
-  if(dev->image_storage.id <= 0) return;
+  if(imgid <= 0) return;
 
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get(darktable.db),
       "SELECT imgid, formid, form, name, version, points, points_count, source FROM main.mask WHERE imgid = ?1",
       -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->image_storage.id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
@@ -1076,7 +1076,7 @@ void dt_masks_read_forms(dt_develop_t *dev)
 
         fprintf(stderr,
                 "[dt_masks_read_forms] %s (imgid `%i'): mask version mismatch: history is %d, dt %d.\n",
-                fname, dev->image_storage.id, form->version, dt_masks_version());
+                fname, imgid, form->version, dt_masks_version());
         dt_control_log(_("%s: mask version mismatch: %d != %d"), fname, dt_masks_version(), form->version);
 
         continue;
@@ -1088,16 +1088,22 @@ void dt_masks_read_forms(dt_develop_t *dev)
   }
 
   sqlite3_finalize(stmt);
+  if(!no_image)
   dt_dev_masks_list_change(dev);
 }
 
-static void _masks_write_forms_db(dt_develop_t *dev, gboolean undo)
+void dt_masks_read_forms(dt_develop_t *dev)
+{
+  dt_masks_read_forms_ext(dev, dev->image_storage.id, FALSE);
+}
+
+static void _masks_write_forms_db(dt_develop_t *dev, const int imgid, gboolean undo)
 {
   // we first erase all masks for the image present in the db
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.mask WHERE imgid = ?1", -1, &stmt,
                               NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->image_storage.id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
@@ -1113,12 +1119,12 @@ static void _masks_write_forms_db(dt_develop_t *dev, gboolean undo)
     dt_masks_form_t *form = (dt_masks_form_t *)forms->data;
 
     if (form)
-      _masks_write_form_db(form, dev);
+      _masks_write_form_db(form, imgid, dev);
 
     forms = g_list_next(forms);
   }
 }
-static void _masks_write_form_db(dt_masks_form_t *form, dt_develop_t *dev)
+static void _masks_write_form_db(dt_masks_form_t *form, const int imgid, dt_develop_t *dev)
 {
   sqlite3_stmt *stmt;
 
@@ -1127,7 +1133,7 @@ static void _masks_write_form_db(dt_masks_form_t *form, dt_develop_t *dev)
                                                              "version, points, points_count,source) VALUES "
                                                              "(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                               -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->image_storage.id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, form->formid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, form->type);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, form->name, -1, SQLITE_TRANSIENT);
@@ -1230,12 +1236,17 @@ void dt_masks_write_form(dt_masks_form_t *form, dt_develop_t *dev)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  _masks_write_form_db(form, dev);
+  _masks_write_form_db(form, dev->image_storage.id, dev);
+}
+
+void dt_masks_write_forms_ext(dt_develop_t *dev, const int imgid, gboolean undo)
+{
+  _masks_write_forms_db(dev, imgid, undo);
 }
 
 void dt_masks_write_forms(dt_develop_t *dev)
 {
-  _masks_write_forms_db(dev, TRUE);
+  _masks_write_forms_db(dev, dev->image_storage.id, TRUE);
 }
 
 void dt_masks_free_form(dt_masks_form_t *form)


### PR DESCRIPTION
Copy / Paste history is not handling masks very well, in addition to always copy all the masks from the source image it doesn't check for duplicate forms, and when having duplicate forms on an edit they can only be removed by hand, the clear unused masks will not do it.

In order to fix it I'm doing the copy / paste in memory, so only the forms used by the modules being pasted are copied, and if a form already exists it is replaced.

This also will allow to fix the apply style on export.

As usual, I left some of the old code for a better reading on github.
