### PR TITLE
filmic: rename "auto tuning security factor" to "security factor"

### DIFF
--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1279,9 +1279,11 @@ void gui_init(dt_iop_module_t *self)
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -200., 200., 1.0, p->security_factor, 2);
   dt_bauhaus_widget_set_label(g->security_factor, NULL, _("auto tuning safety factor"));
+  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("safety factor"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range"));
+  gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\n"
+                                                    "useful in conjunction with \"auto tune levels\""));
   g_signal_connect(G_OBJECT(g->security_factor), "value-changed", G_CALLBACK(security_threshold_callback), self);
 
   // Auto tune slider

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1278,7 +1278,7 @@ void gui_init(dt_iop_module_t *self)
 
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -200., 200., 1.0, p->security_factor, 2);
-  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("auto tuning security factor"));
+  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("auto tuning safety factor"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range"));

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -922,7 +922,7 @@ void gui_init(dt_iop_module_t *self)
   // Security factor
   gtk_box_pack_start(GTK_BOX(vbox_log), dt_ui_section_label_new(_("optimize automatically")), FALSE, FALSE, 5);
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->security_factor, 2);
-  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("security factor"));
+  dt_bauhaus_widget_set_label(g->security_factor, NULL, _("safety factor"));
   gtk_box_pack_start(GTK_BOX(vbox_log), g->security_factor, TRUE, TRUE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%.2f %%");
   gtk_widget_set_tooltip_text(g->security_factor, _("enlarge or shrink the computed dynamic range\nthis is usefull when noise perturbates the measurements"));


### PR DESCRIPTION
It's misleading to include "auto tuning" in the name, since the slider
acts also when auto-tuning isn't enabled. Mention auto-tuning in the
tooltip text.

I'm not a native but I think we should also `s/security/safety/` here and in profile_gamma.

Cc: @aurelienpierre 