### PR TITLE
Fix opencl of nlmeans (borders were oversmoothed)

### DIFF
--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -86,7 +86,10 @@ denoiseprofile_dist(read_only image2d_t in, global float* U4, const int width, c
   const int y = get_global_id(1);
   const int gidx = mad24(y, width, x);
 
+  // Reminder: q.x and q.y can be negative
   if(x >= width || y >= height) return;
+  if(x+q.x >= width || y+q.y >= height) return;
+  if(x+q.x < 0 || y+q.y < 0) return;
 
   float4 p1 = read_imagef(in, sampleri, (int2)(x, y));
   float4 p2 = read_imagef(in, sampleri, (int2)(x, y) + q);
@@ -211,7 +214,22 @@ denoiseprofile_accu(read_only image2d_t in, global float4* U2, global float* U4,
   const int y = get_global_id(1);
   const int gidx = mad24(y, width, x);
 
-  if(x >= width || y >= height) return;
+  if(q.x<0)
+  {
+    if(x-q.x >= width || x<-q.x) return;
+  }
+  else
+  {
+    if(x+q.x >= width || x<q.x) return;
+  }
+  if(q.y<0)
+  {
+    if(y-q.y >= height || y<-q.y) return;
+  }
+  else
+  {
+    if(y+q.y >= height || y<q.y) return;
+  }
 
   float4 u1_pq = read_imagef(in, sampleri, (int2)(x, y) + q);
   float4 u1_mq = read_imagef(in, sampleri, (int2)(x, y) - q);

--- a/data/kernels/nlmeans.cl
+++ b/data/kernels/nlmeans.cl
@@ -70,7 +70,10 @@ nlmeans_dist(read_only image2d_t in, global float *U4, const int width, const in
   const int gidx = mad24(y, width, x);
   const float4 norm2 = (float4)(nL2, nC2, nC2, 1.0f);
 
+  // Reminder: q.x and q.y can be negative
   if(x >= width || y >= height) return;
+  if(x+q.x >= width || y+q.y >= height) return;
+  if(x+q.x < 0 || y+q.y < 0) return;
 
   float4 p1 = read_imagef(in, sampleri, (int2)(x, y));
   float4 p2 = read_imagef(in, sampleri, (int2)(x, y) + q);
@@ -195,7 +198,22 @@ nlmeans_accu(read_only image2d_t in, global float4* U2, global float* U4,
   const int y = get_global_id(1);
   const int gidx = mad24(y, width, x);
 
-  if(x >= width || y >= height) return;
+  if(q.x<0)
+  {
+    if(x-q.x >= width || x<-q.x) return;
+  }
+  else
+  {
+    if(x+q.x >= width || x<q.x) return;
+  }
+  if(q.y<0)
+  {
+    if(y-q.y >= height || y<-q.y) return;
+  }
+  else
+  {
+    if(y+q.y >= height || y<q.y) return;
+  }
 
   float4 u1_pq = read_imagef(in, sampleri, (int2)(x, y) + q);
   float4 u1_mq = read_imagef(in, sampleri, (int2)(x, y) - q);


### PR DESCRIPTION
Before:
    output was very different than with CPU version of nlmeans on borders:
    they were oversmoothed (very visible with high radius).
Now:
    output much closer, and borders are not oversmoothed anymore.

Important warning: I do not have a GPU. I tested this opencl code on CPU. Please, test it on a GPU

Exemple:
With this test image:
![black](https://user-images.githubusercontent.com/34063828/48579263-3efe2800-e91c-11e8-995a-f3b562e1019e.jpg)

Using denoise profile in non local means mode with patch size = 0, radius = 30, and force = 4
CPU output:
![black_profile_cpu](https://user-images.githubusercontent.com/34063828/48579335-7a005b80-e91c-11e8-860a-4c044ce1ca91.jpg)

old opencl output:
![black_profile_gpu_old](https://user-images.githubusercontent.com/34063828/48579346-7ec50f80-e91c-11e8-9ff4-ddb04b5ce0fb.jpg)

new opencl output:
![black_profile_gpu_new](https://user-images.githubusercontent.com/34063828/48579358-88e70e00-e91c-11e8-856d-2499a66915e3.jpg)

There is still a very small difference between opencl output and CPU output, but it is much less visible and is probably due to rounding error (thanks @upegelow for pointing me the fact that rounding errors could result in small differences)

This resolves this issue: https://redmine.darktable.org/issues/12400
