### PR TITLE
[RFC] liquify: fix off-by-one access

### DIFF
--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -770,7 +770,7 @@ build_lookup_table (const int distance, const float control1, const float contro
 
   // reparameterize bezier by x and keep only y values
 
-  float *lookup = dt_alloc_align (16, (distance + 1) * sizeof (float));
+  float *lookup = dt_alloc_align(16, (distance + 2) * sizeof(float));
   float *ptr = lookup;
   float complex *cptr = clookup + 1;
   const float complex *cptr_end = cptr + distance;


### PR DESCRIPTION
Found with valgrind. When distance == 0, the code was doing 2 accesses in an array of 1 float.

This fixes the symptom, but I'm not sure whether `distance == 0` is supposed to happen. I guess it can't, and then a proper fix would be at the root of the issue to make sure `distance > 0`, and probably an `assert(distance > 0)` should be added here. @TurboGit, what do you think?