### PR TITLE
guided filter: add an additional parameter to adjust the effect of th…

### DIFF
--- a/src/common/guided_filter.h
+++ b/src/common/guided_filter.h
@@ -22,12 +22,10 @@
 
 struct dt_iop_roi_t;
 
-void guided_filter(const float * guide, const float * in, float * out,
-                   int width, int height, int ch, int w,
-                   float sqrt_eps, float min, float max);
+void guided_filter(const float *guide, const float *in, float *out, int width, int height, int ch, int w,
+                   float sqrt_eps, float guide_weight, float min, float max);
 
 #ifdef HAVE_OPENCL
-void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out,
-                      int width, int height, int ch, int w,
-                      float sqrt_eps, float min, float max);
+void guided_filter_cl(int devid, cl_mem guide, cl_mem in, cl_mem out, int width, int height, int ch, int w,
+                      float sqrt_eps, float guide_weight, float min, float max);
 #endif


### PR DESCRIPTION
…e guiding image for better feathering results in rgb mode

This pull request is to improve feathering results in rgb mode and to fix the issue https://redmine.darktable.org/issues/12429 . The result of the guided filter depends on the relative amplitudes of the input image (the mask) and the guiding image. In LAB mode pixel values are of the order of 100, in RGB mode, however, pixel values are in [0, 1]. Thus, an additional parameter was introduced to compensate this. Now, mask feathering should work in RGB mode as good as in LAB mode.  
