### PR TITLE
exif: canon subject distance is in cm.

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -648,15 +648,23 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     }
     else if(Exiv2::testVersion(0,25,0) && FIND_EXIF_TAG("Exif.CanonFi.FocusDistanceUpper"))
     {
-      float FocusDistanceUpper = pos->toFloat();
-      if(FocusDistanceUpper <= 0.0f || FocusDistanceUpper >= 0xffff)
+      const float FocusDistanceUpper = pos->toFloat();
+      if(FocusDistanceUpper <= 0.0f || (int)FocusDistanceUpper >= 0xffff)
       {
         img->exif_focus_distance = 0.0f;
       }
-      else if(FIND_EXIF_TAG("Exif.CanonFi.FocusDistanceLower"))
+      else
       {
-        float FocusDistanceLower = pos->toFloat();
-        img->exif_focus_distance = (FocusDistanceLower + FocusDistanceUpper) / 200;
+        img->exif_focus_distance = FocusDistanceUpper / 100.0;
+        if(FIND_EXIF_TAG("Exif.CanonFi.FocusDistanceLower"))
+        {
+          const float FocusDistanceLower = pos->toFloat();
+          if(FocusDistanceLower > 0.0f && (int)FocusDistanceLower < 0xffff)
+          {
+            img->exif_focus_distance += FocusDistanceLower / 100.0;
+            img->exif_focus_distance /= 2.0;
+          }
+        }
       }
     }
     else if(FIND_EXIF_TAG("Exif.CanonSi.SubjectDistance"))

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -659,6 +659,10 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         img->exif_focus_distance = (FocusDistanceLower + FocusDistanceUpper) / 200;
       }
     }
+    else if(FIND_EXIF_TAG("Exif.CanonSi.SubjectDistance"))
+    {
+      img->exif_focus_distance = pos->toFloat() / 100.0;
+    }
     else if((pos = Exiv2::subjectDistance(exifData)) != exifData.end() && pos->size())
     {
       img->exif_focus_distance = pos->toFloat();


### PR DESCRIPTION
This fixes https://redmine.darktable.org/issues/12432

But I'm not sure it is ok for all Canon camera. Better this to be double checked by someone else I'm using Nikon.