### PR TITLE
filmic: graph improvements

### DIFF
--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1338,15 +1338,15 @@ void init(dt_iop_module_t *module)
   dt_iop_filmic_params_t tmp
     = (dt_iop_filmic_params_t){
                                  .grey_point_source   = 18, // source grey
-                                 .black_point_source  = -10.0,  // source black
-                                 .white_point_source  = 3.0,  // source white
+                                 .black_point_source  = -8.64,  // source black
+                                 .white_point_source  = 2.45,  // source white
                                  .security_factor     = 0.0,  // security factor
                                  .grey_point_target   = 18.0, // target grey
                                  .black_point_target  = 0.0,  // target black
                                  .white_point_target  = 100.0,  // target white
                                  .output_power        = 2.2,  // target power (~ gamma)
                                  .latitude_stops      = 2.0,  // intent latitude
-                                 .contrast            = 1.618,  // intent contrast
+                                 .contrast            = 1.5,  // intent contrast
                                  .saturation          = 100.0,   // intent saturation
                                  .balance             = 0.0, // balance shadows/highlights
                                  .interpolator        = CUBIC_SPLINE, //interpolator

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1149,19 +1149,19 @@ void compute_curve_lut(dt_iop_filmic_params_t *p, float *table, float *table_tem
   else
   {
     // everything OK
-    nodes_data->nodes = 5;
+    nodes_data->nodes = 4;
 
     nodes_data->x[0] = black_log;
     nodes_data->x[1] = toe_log;
-    nodes_data->x[2] = grey_log,
-    nodes_data->x[3] = shoulder_log;
-    nodes_data->x[4] = white_log;
+    //nodes_data->x[2] = grey_log,
+    nodes_data->x[2] = shoulder_log;
+    nodes_data->x[3] = white_log;
 
     nodes_data->y[0] = black_display;
     nodes_data->y[1] = toe_display;
-    nodes_data->y[2] = grey_display,
-    nodes_data->y[3] = shoulder_display;
-    nodes_data->y[4] = white_display;
+    //nodes_data->y[2] = grey_display,
+    nodes_data->y[2] = shoulder_display;
+    nodes_data->y[3] = white_display;
 
     if(d)
     {


### PR DESCRIPTION
- remove the grey node to keep only 4 interpolations nodes: after going back and forth about this central node, I have come to the conclusion that it's better to give it up (at the expense of some precision on the grey point remapping) rather than having to deal with the cusps it produces.
- make a (big ?) improvement on the graph so now the grey is always remapped at (50, 50) % on the graph, no matter the parameters. This is only a scaling of the coordinates on the display, it does not change the actual parameters (similar in the logic to the log scaling in tone curve module, but using a different scaling equation). Since we give up the central node, the center of the graph can now be used anytime as a reference for the grey point and the S curve is now always symmetrical. It should give a better readability.

Sorry for the noise, with scattered last-minute PR, but ideas come to me as I use the tools and I believe it can help.