### PR TITLE
filmic: avoid "staircase function" effect when drawing the curve

### DIFF
--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1444,8 +1444,12 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   for(int k = 0; k < nodes_data->nodes; k++)
   {
-    const float x = powf(2.0f, a * nodes_data->x[k] + b) + d,
-                y = powf(nodes_data->y[k], 1.0f / gamma);
+    /*
+     * Use double precision locally to avoid cancellation effect on
+     * the "+ d" operation.
+     */
+    const float x = pow(2.0, (double)a * nodes_data->x[k] + b) + d;
+    const float y = powf(nodes_data->y[k], 1.0f / gamma);
 
     cairo_arc(cr, x * width, (1.0 - y) * (double)height, DT_PIXEL_APPLY_DPI(3), 0, 2. * M_PI);
     cairo_stroke_preserve(cr);
@@ -1462,8 +1466,12 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   for(int k = 1; k < 256; k++)
   {
-    const float x = powf(2.0f, a * k / 255.0f + b) + d,
-                y = powf(c->table[k], 1.0f / gamma);
+    /*
+     * Use double precision locally to avoid cancellation effect on
+     * the "+ d" operation.
+     */
+    const float x = pow(2.0, (double)a * k / 255.0 + b) + d;
+    const float y = powf(c->table[k], 1.0f / gamma);
     cairo_line_to(cr, x * width, (double)height * (1.0 - y));
   }
   cairo_stroke(cr);


### PR DESCRIPTION
The computation of x when drawing nodes and the curve itself was along
the lines of:

  powf(...) + d

where powf(...) and d were large numbers and the result small for low
middle grey values. As a result, using single precision floats were
resulting in cancellation effect where variatiations of k were not
propagated to x, resulting in points artificially grouped on at the
same abscissa on the graph, i.e. visually a staircase function, or
even all points squashed together at x=0:

![stair-multiple-stairs](https://user-images.githubusercontent.com/14709/49684300-95512780-fad2-11e8-808d-0322742ad1fd.png)
![stair-one-stair](https://user-images.githubusercontent.com/14709/49684301-95512780-fad2-11e8-80b0-61509fe791de.png)
![stair-vertical](https://user-images.githubusercontent.com/14709/49684302-95512780-fad2-11e8-8dc3-a47582c48070.png)

Fix this by using double precision locally. The effect on performance
is marginal since only a few hundreds of points are computed.

This only affects the way the curve is drawn, the processing of the
image was not affected.

While we're there, fix the coding style.