### PR TITLE
fix module reaming UI issues

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -934,12 +934,6 @@ static gboolean _rename_module_key_press(GtkWidget *entry, GdkEventKey *event, d
   return FALSE; /* event not handled */
 }
 
-static gboolean _rename_module_destroy(GtkWidget *widget, GdkEvent *event, gpointer user_data)
-{
-  gtk_widget_destroy(GTK_WIDGET(user_data));
-  return FALSE;
-}
-
 static void _iop_gui_rename_module(dt_iop_module_t *module)
 {
   const int bs = DT_PIXEL_APPLY_DPI(12);
@@ -972,16 +966,17 @@ static void _iop_gui_rename_module(dt_iop_module_t *module)
 
   GtkWidget *entry = gtk_entry_new();
   gtk_widget_set_size_request(entry, w, h);
-  gtk_widget_add_events(entry, GDK_FOCUS_CHANGE_MASK);
 
   gtk_editable_select_region(GTK_EDITABLE(entry), 0, -1);
   gtk_container_add(GTK_CONTAINER(d->floating_window), entry);
-  g_signal_connect(entry, "focus-out-event", G_CALLBACK(_rename_module_destroy), d->floating_window);
   g_signal_connect(entry, "key-press-event", G_CALLBACK(_rename_module_key_press), d);
 
   gtk_entry_set_text(GTK_ENTRY(entry), module->multi_name);
 
-  gtk_widget_show_all(d->floating_window);
+  gtk_widget_show(d->floating_window);
+  gtk_widget_show(entry);
+  gtk_window_resize(GTK_WINDOW(d->floating_window), w, h + 4);
+  gtk_window_set_modal(GTK_WINDOW(d->floating_window), TRUE);
   gtk_widget_grab_focus(entry);
   gtk_window_present(GTK_WINDOW(d->floating_window));
 }


### PR DESCRIPTION
Currently module renaming does not work in some desktop environments. No UI element to enter the new name shows up.  To fix this
```
gtk_widget_show_all(d->floating_window);
```
was replaced by
```
gtk_widget_show(d->floating_window);
gtk_widget_show(entry);
```

Other code changes are to _not_ to destroy the window as soon as it loses focus. This is necessary because  the desktop environment may be configured to give focus to the window below the mouse cursor without clicking into the window. In this case, the window with the input field would immediately disappear unless it is created under the current position of the mouse cursor (which is normally not the case). Side effect of the chance: Input dialog can only be canceled via ESC key.