### PR TITLE
retouch: fix computation of roi_in.

### DIFF
--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3031,7 +3031,7 @@ static void rt_compute_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelp
           // we get the area for the source
           int fl, ft, fw, fh;
 
-          if(!dt_masks_get_source_area(self, piece, form, &fw, &fh, &fl, &ft))
+          if(!dt_masks_get_area(self, piece, form, &fw, &fh, &fl, &ft))
           {
             forms = g_list_next(forms);
             continue;


### PR DESCRIPTION
for non clone we want the area and not the source area.

Fixes #12463.