### PR TITLE
darktable-cli apply style to export

### DIFF
--- a/doc/man/darktable-cli.pod
+++ b/doc/man/darktable-cli.pod
@@ -14,6 +14,8 @@ Options:
     --bpp <bpp>
     --hq <0|1|true|false>
     --upscale <0|1|true|false>
+    --style <style name>
+    --overwrite
     --verbose
 
 =head1 DESCRIPTION
@@ -78,6 +80,18 @@ Defaults to true.
 
 A flag that defines whether to allow upscaling during export.
 Defaults to false.
+
+=item B<< --style <style name>  >>
+
+Specify the name of a style to be applied during export.  If a style
+is specified, the path to the darktable configuration directory must
+also be specified (i.e. --core --configdir ~/.config/darktable).
+Defaults to no style specified.
+
+=item B<< --overwrite  >>
+
+The specified style overwrites the history stack instead of being
+appended to it.
 
 =item B<< --verbose  >>
 

--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -427,6 +427,9 @@
               [--height &lt;max height&gt;]
               [--bpp &lt;bpp&gt;]
               [--hq &lt;0|1|true|false&gt;]
+              [--upscale &lt;0|1|true|false&gt;]
+              [--style &lt;style name&gt;]
+              [--overwrite]
               [--verbose]
               [--core &lt;darktable options&gt;]</synopsis>
 
@@ -520,6 +523,40 @@
             <listitem><para>
               A flag that defines whether to use high quality resampling during export (see
               <xref linkend="core_options"/>). Defaults to true.
+            </para></listitem>
+
+          </varlistentry>
+
+          <varlistentry>
+
+            <term>--upscale &lt;0|1|true|false&gt;</term>
+
+            <listitem><para>
+              A flag that defines whether allow upscaling during export. Defaults to false.
+            </para></listitem>
+
+          </varlistentry>
+
+          <varlistentry>
+
+            <term>--style &lt;style name&gt;</term>
+
+            <listitem><para>
+              Specify the name of a style to be applied during export.  If a style
+              is specified, the path to the darktable configuration directory must
+              also be specified (i.e. --core --configdir ~/.config/darktable).
+              Defaults to no style specified.
+            </para></listitem>
+
+          </varlistentry>
+
+          <varlistentry>
+
+            <term>--overwrite</term>
+
+            <listitem><para>
+              The specified style overwrites the history stack instead of being
+              appended to it.
             </para></listitem>
 
           </varlistentry>


### PR DESCRIPTION
Enabled the ability to specify a style to be applied on export with the option to overwrite the history stack instead of appending to it.  Fixes issue 12068.