### PR TITLE
filmic: bugfix (UI)

### DIFF
--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -687,7 +687,7 @@ static void apply_auto_grey(dt_iop_module_t *self)
   const float prev_grey = p->grey_point_source;
   p->grey_point_source = 100.f * grey;
   const float grey_var = Log2(prev_grey / p->grey_point_source);
-  p->black_point_source = p->black_point_source + grey_var;
+  p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
 
   darktable.gui->reset = 1;
@@ -899,7 +899,7 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->grey_point_source = dt_bauhaus_slider_get(slider);
 
   float grey_var = Log2(prev_grey / p->grey_point_source);
-  p->black_point_source = p->black_point_source + grey_var;
+  p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
 
   darktable.gui->reset = 1;


### PR DESCRIPTION
Fix the black exposure correction in UI when the grey slider is modified, so that the mid-tones are affected accordingly.

Before, moving the grey did:

![image](https://user-images.githubusercontent.com/2779157/50176987-d6b1b600-02ce-11e9-9986-e3490c7df860.png)

So it was a no-op.

Now, it does:

![image](https://user-images.githubusercontent.com/2779157/50176577-c77e3880-02cd-11e9-87d6-a2bca0341c8f.png)
![image](https://user-images.githubusercontent.com/2779157/50176947-bc77d800-02ce-11e9-9726-19f59c72d9c6.png)

So the bounds are preserved, but the mid-tones are raised, which is expected from the grey value.