### PR TITLE
colorbalance: BUGFIX

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -718,6 +718,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
       break;
     }
   }
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -364,8 +364,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
         // XYZ -> Lab
         dt_XYZ_to_Lab(XYZ, out);
-
-        out[3] = in[3];
       }
       break;
     }
@@ -432,9 +430,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
         // XYZ -> Lab
         dt_XYZ_to_Lab(XYZ, out);
-
-        out[3] = in[3];
-
       }
       break;
    }
@@ -495,12 +490,11 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
         // XYZ -> Lab
         dt_XYZ_to_Lab(XYZ, out);
-
-        out[3] = in[3];
       }
       break;
     }
   }
+  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -306,12 +306,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   dt_iop_colorbalance_data_t *d = (dt_iop_colorbalance_data_t *)piece->data;
   const int ch = piece->colors;
 
- // these are RGB values!
-    const float gain[3] = { d->gain[CHANNEL_RED] * d->gain[CHANNEL_FACTOR],
-                            d->gain[CHANNEL_GREEN] * d->gain[CHANNEL_FACTOR],
-                            d->gain[CHANNEL_BLUE] * d->gain[CHANNEL_FACTOR] },
-                contrast = (d->contrast != 0.0f) ? 1.0f / d->contrast : 1000000.0f,
-                grey = d->grey / 100.0f;
+  // these are RGB values!
+  const float gain[3] = { d->gain[CHANNEL_RED] * d->gain[CHANNEL_FACTOR],
+                          d->gain[CHANNEL_GREEN] * d->gain[CHANNEL_FACTOR],
+                          d->gain[CHANNEL_BLUE] * d->gain[CHANNEL_FACTOR] },
+              contrast = (d->contrast != 0.0f) ? 1.0f / d->contrast : 1000000.0f,
+              grey = d->grey / 100.0f;
 
   // For neutral parameters, skip the computations doing x^1 or (x-a)*1 + a to save time
   const int run_contrast = (d->contrast == 1.0f) ? 0 : 1;
@@ -322,7 +322,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     case LEGACY:
     {
-       // these are RGB values!
+      // these are RGB values!
       const float lift[3] = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
@@ -334,49 +334,44 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                               (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        float XYZ[3] = { 0.0f };
+        dt_Lab_to_XYZ(in, XYZ);
+
+        // XYZ -> sRGB
+        float rgb[3] = { 0.0f };
+        dt_XYZ_to_sRGB(XYZ, rgb);
+
+        // do the calculation in RGB space
+        for(int c = 0; c < 3; c++)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          float XYZ[3] = { 0.0f };
-          dt_Lab_to_XYZ(in, XYZ);
-
-          // XYZ -> sRGB
-          float rgb[3] = { 0.0f };
-          dt_XYZ_to_sRGB(XYZ, rgb);
-
-          // do the calculation in RGB space
-          for(int c = 0; c < 3; c++)
-          {
-            // lift gamma gain
-            rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
-            rgb[c] = (rgb[c] < 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c]);
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          dt_sRGB_to_XYZ(rgb, XYZ);
-
-          // XYZ -> Lab
-          dt_XYZ_to_Lab(XYZ, out);
-          out[3] = in[3];
-
-          in += ch;
-          out += ch;
+          // lift gamma gain
+          rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
+          rgb[c] = (rgb[c] < 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c]);
         }
-      }
 
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        dt_sRGB_to_XYZ(rgb, XYZ);
+
+        // XYZ -> Lab
+        dt_XYZ_to_Lab(XYZ, out);
+
+        out[3] = in[3];
+      }
       break;
     }
     case LIFT_GAMMA_GAIN:
     {
-       // these are RGB values!
+      // these are RGB values!
       const float lift[3] = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
@@ -388,62 +383,60 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                               (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        float XYZ[3] = { 0.0f };
+        dt_Lab_to_XYZ(in, XYZ);
+
+        // XYZ -> sRGB
+        float rgb[3] = { 0.0f };
+        dt_XYZ_to_prophotorgb(XYZ, rgb);
+
+        float luma = XYZ[1]; // the Y channel is the relative luminance
+
+        // do the calculation in RGB space
+        for(int c = 0; c < 3; c++)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          float XYZ[3] = { 0.0f };
-          dt_Lab_to_XYZ(in, XYZ);
+          // main saturation input
+          if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
 
-          // XYZ -> sRGB
-          float rgb[3] = { 0.0f };
-          dt_XYZ_to_prophotorgb(XYZ, rgb);
+          // RGB gamma correction
+          rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], 1.0f/2.2f);
 
-          float luma = XYZ[1]; // the Y channel is the relative luminance
-
-          // do the calculation in RGB space
-          for(int c = 0; c < 3; c++)
-          {
-            // main saturation input
-            if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
-
-            // RGB gamma correction
-            rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], 1.0f/2.2f);
-
-            // lift gamma gain
-            rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
-            rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c] * 2.2f);
-
-            // main saturation output
-            dt_prophotorgb_to_XYZ(rgb, XYZ);
-            luma = XYZ[1];
-            if (run_saturation_out) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
-
-            // contrast
-            if (run_contrast) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          dt_prophotorgb_to_XYZ(rgb, XYZ);
-
-          // XYZ -> Lab
-          dt_XYZ_to_Lab(XYZ, out);
-          out[3] = in[3];
-
-          in += ch;
-          out += ch;
+          // lift gamma gain
+          rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
+          rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c] * 2.2f);
         }
+
+        // main saturation output
+        if (run_saturation_out)
+        {
+          dt_prophotorgb_to_XYZ(rgb, XYZ);
+          luma = XYZ[1];
+          for(int c = 0; c < 3; c++) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
+        }
+
+        // fulcrum contrat
+        if (run_contrast) for(int c = 0; c < 3; c++) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        dt_prophotorgb_to_XYZ(rgb, XYZ);
+
+        // XYZ -> Lab
+        dt_XYZ_to_Lab(XYZ, out);
+
+        out[3] = in[3];
+
       }
-
       break;
-
    }
     case SLOPE_OFFSET_POWER:
     {
@@ -457,59 +450,57 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                               (2.0f - d->gamma[CHANNEL_BLUE]) * (2.0f - d->gamma[CHANNEL_FACTOR])};
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to RGB:
+        // Lab -> XYZ
+        float XYZ[3];
+        dt_Lab_to_XYZ(in, XYZ);
+
+        // XYZ -> RGB
+        float rgb[3];
+        dt_XYZ_to_prophotorgb(XYZ, rgb);
+
+        float luma = XYZ[1]; // the Y channel is the RGB luminance
+
+        // do the calculation in RGB space
+        for(int c = 0; c < 3; c++)
         {
-          // transform the pixel to RGB:
-          // Lab -> XYZ
-          float XYZ[3];
-          dt_Lab_to_XYZ(in, XYZ);
+          // main saturation input
+          if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
 
-          // XYZ -> RGB
-          float rgb[3];
-          dt_XYZ_to_prophotorgb(XYZ, rgb);
-
-          float luma = XYZ[1]; // the Y channel is the RGB luminance
-
-          // do the calculation in RGB space
-          for(int c = 0; c < 3; c++)
-          {
-            // main saturation input
-            if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
-
-            // channel CDL
-            rgb[c] = CDL(rgb[c], gain[c], lift[c], gamma[c]);
-
-            // main saturation output
-            dt_prophotorgb_to_XYZ(rgb, XYZ);
-            luma = XYZ[1];
-            if (run_saturation_out) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
-
-            // fulcrum contrat
-            if (run_contrast) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          dt_prophotorgb_to_XYZ(rgb , XYZ);
-
-          // XYZ -> Lab
-          dt_XYZ_to_Lab(XYZ, out);
-          out[3] = in[3];
-
-          in += ch;
-          out += ch;
+          // channel CDL
+          rgb[c] = CDL(rgb[c], gain[c], lift[c], gamma[c]);
         }
+
+        // main saturation output
+        if (run_saturation_out)
+        {
+          dt_prophotorgb_to_XYZ(rgb, XYZ);
+          luma = XYZ[1];
+          for(int c = 0; c < 3; c++) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
+        }
+
+        // fulcrum contrat
+        if (run_contrast) for(int c = 0; c < 3; c++) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        dt_prophotorgb_to_XYZ(rgb , XYZ);
+
+        // XYZ -> Lab
+        dt_XYZ_to_Lab(XYZ, out);
+
+        out[3] = in[3];
       }
       break;
     }
   }
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)
@@ -558,34 +549,31 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                                        0.0f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
-        {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-          // XYZ -> sRGB
-          __m128 rgb = dt_XYZ_to_sRGB_sse2(XYZ);
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
 
-          // do the calculation in RGB space
-          // regular lift gamma gain
-          rgb = ((rgb - one) * lift + one) * gain;
-          rgb = _mm_max_ps(rgb, zero);
-          rgb = _mm_pow_ps(rgb, gamma_inv);
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
+        // XYZ -> sRGB
+        __m128 rgb = dt_XYZ_to_sRGB_sse2(XYZ);
 
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          XYZ = dt_sRGB_to_XYZ_sse2(rgb);
-          // XYZ -> Lab
-          _mm_store_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
-        }
+        // do the calculation in RGB space
+        // regular lift gamma gain
+        rgb = ((rgb - one) * lift + one) * gain;
+        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_pow_ps(rgb, gamma_inv);
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        XYZ = dt_sRGB_to_XYZ_sse2(rgb);
+        // XYZ -> Lab
+        _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
       }
-
       break;
     }
 
@@ -609,58 +597,56 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
       const __m128 gamma_inv_RGB = _mm_set1_ps(1.0f/2.2f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD()default(none) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
+        // XYZ -> sRGB
+        __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
+
+        __m128 luma;
+
+        // adjust main saturation input
+        if (run_saturation)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-          // XYZ -> sRGB
-          __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
-
-          __m128 luma;
-
-          // adjust main saturation input
-          if (run_saturation)
-          {
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation * (rgb - luma);
-          }
-
-          // RGB gamma adjustement
-          rgb = _mm_pow_ps(_mm_max_ps(rgb, zero), gamma_inv_RGB);
-
-          // regular lift gamma gain
-          rgb = ((rgb - one) * lift + one) * gain;
-          rgb = _mm_max_ps(rgb, zero);
-          rgb = _mm_pow_ps(rgb, gamma_inv * gamma_RGB);
-
-          // adjust main saturation output
-          if (run_saturation_out)
-          {
-            XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation_out * (rgb - luma);
-          }
-
-          // fulcrum contrast
-          if (run_contrast)
-          {
-            rgb = _mm_max_ps(rgb, zero);
-            rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-          // XYZ -> Lab
-          _mm_store_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation * (rgb - luma);
         }
+
+        // RGB gamma adjustement
+        rgb = _mm_pow_ps(_mm_max_ps(rgb, zero), gamma_inv_RGB);
+
+        // regular lift gamma gain
+        rgb = ((rgb - one) * lift + one) * gain;
+        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_pow_ps(rgb, gamma_inv * gamma_RGB);
+
+        // adjust main saturation output
+        if (run_saturation_out)
+        {
+          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation_out * (rgb - luma);
+        }
+
+        // fulcrum contrast
+        if (run_contrast)
+        {
+          rgb = _mm_max_ps(rgb, zero);
+          rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
+        }
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+        // XYZ -> Lab
+        _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
       }
 
       break;
@@ -679,63 +665,59 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                                       0.0f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
+        // XYZ -> sRGB
+        __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
+
+        __m128 luma;
+
+        // adjust main saturation
+        if (run_saturation)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-          // XYZ -> sRGB
-          __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
-
-          __m128 luma;
-
-          // adjust main saturation
-          if (run_saturation)
-          {
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation * (rgb - luma);
-          }
-
-          // slope offset
-          rgb = rgb * gain + lift;
-
-          //power
-          rgb = _mm_max_ps(rgb, zero);
-          rgb = _mm_pow_ps(rgb, gamma);
-
-          // adjust main saturation output
-          if (run_saturation_out)
-          {
-            XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation_out * (rgb - luma);
-          }
-
-          // fulcrum contrast
-          if (run_contrast)
-          {
-            rgb = _mm_max_ps(rgb, zero);
-            rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-          // XYZ -> Lab
-          _mm_store_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation * (rgb - luma);
         }
+
+        // slope offset
+        rgb = rgb * gain + lift;
+
+        //power
+        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_pow_ps(rgb, gamma);
+
+        // adjust main saturation output
+        if (run_saturation_out)
+        {
+          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation_out * (rgb - luma);
+        }
+
+        // fulcrum contrast
+        if (run_contrast)
+        {
+          rgb = _mm_max_ps(rgb, zero);
+          rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
+        }
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+        // XYZ -> Lab
+        _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
       }
       break;
     }
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 


### PR DESCRIPTION
In pure C version, the output saturation was corrected while CDL was applied. Now, CDL is applied, then the output luminance is computed, and finally the saturation is corrected.

Also, some perf optimizations : 
* perform checks out of inner loops 
* combine (i, j) loops to (k) loops improve auto-vectorization
* replace `_mm_store_ps` with `_mm_stream_ps` for better cache management

Now, the auto-vectorized OpenMP SIMD codepath runs roughly at the same speed as the pure SSE2.