### PR TITLE
bauhaus: default colors consistent with CSS

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -460,30 +460,30 @@ void dt_bauhaus_init()
 
   if(!gtk_style_context_lookup_color(ctx, "bauhaus_fg", &darktable.bauhaus->color_fg))
   {
-    darktable.bauhaus->color_fg.red = 0.0;
-    darktable.bauhaus->color_fg.green = 1.0;
-    darktable.bauhaus->color_fg.blue = 0.0;
+    darktable.bauhaus->color_fg.red = 0x99 / 255.0;
+    darktable.bauhaus->color_fg.green = 0x99 / 255.0;
+    darktable.bauhaus->color_fg.blue = 0x99 / 255.0;
     darktable.bauhaus->color_fg.alpha = 1.0;
   }
   if(!gtk_style_context_lookup_color(ctx, "bauhaus_fg_insensitive", &darktable.bauhaus->color_fg_insensitive))
   {
-    darktable.bauhaus->color_fg_insensitive.red = 1.0;
-    darktable.bauhaus->color_fg_insensitive.green = 0.0;
-    darktable.bauhaus->color_fg_insensitive.blue = 1.0;
-    darktable.bauhaus->color_fg_insensitive.alpha = 1.0;
+    darktable.bauhaus->color_fg_insensitive.red = 0x19 / 255.0;
+    darktable.bauhaus->color_fg_insensitive.green = 0x19 / 255.0;
+    darktable.bauhaus->color_fg_insensitive.blue = 0x19 / 255.0;
+    darktable.bauhaus->color_fg_insensitive.alpha = .5;
   }
   if(!gtk_style_context_lookup_color(ctx, "bauhaus_bg", &darktable.bauhaus->color_bg))
   {
-    darktable.bauhaus->color_bg.red = 1.0;
-    darktable.bauhaus->color_bg.green = 0.0;
-    darktable.bauhaus->color_bg.blue = 0.0;
-    darktable.bauhaus->color_bg.alpha = 1.0;
+    darktable.bauhaus->color_bg.red = 0x99 / 255.0;
+    darktable.bauhaus->color_bg.green = 0x99 / 255.0;
+    darktable.bauhaus->color_bg.blue = 0x99 / 255.0;
+    darktable.bauhaus->color_bg.alpha = .2;
   }
   if(!gtk_style_context_lookup_color(ctx, "bauhaus_border", &darktable.bauhaus->color_border))
   {
-    darktable.bauhaus->color_border.red = 0.0;
-    darktable.bauhaus->color_border.green = 0.0;
-    darktable.bauhaus->color_border.blue = 1.0;
+    darktable.bauhaus->color_border.red = 0x19 / 255.0;
+    darktable.bauhaus->color_border.green = 0x19 / 255.0;
+    darktable.bauhaus->color_border.blue = 0x19 / 255.0;
     darktable.bauhaus->color_border.alpha = 1.0;
   }
 


### PR DESCRIPTION
When configurable colors were not found in the CSS file, hardcoded
defaults are used instead. It does happen in practice for users who
copied a darktable.css in their ~/.config/darktable/ directory with dt
2.4, and then upgraded to 2.6. Before this patch, a missing colors was
resulting in magenta sliders for these users for example.

Should be really harmless, and the effect without the fix is rather disturbing for users (remember the complaints about the red frames following a gtk upgrade ...), so I think this should go in 2.6.

Unfortunately, this doesn't fix all issues for people who copied their 2.4's CSS. The selected entry in a dropdown menu is not properly highlighted until one adds this to the CSS:

```
#bauhaus-popup:selected
{
  /* SELECTED */
  color: shade(@fg_color, 1.5);
}
#bauhaus-popup:hover
{
  /* PRELIGHT */
  color: shade(@fg_color, 0.7);
}

#bauhaus-popup:disabled
{
  /* insensitive */
  color: black;
}
```