### PR TITLE
[WIP] add support for target clones compilation

### DIFF
--- a/src/common/gaussian.c
+++ b/src/common/gaussian.c
@@ -154,7 +154,7 @@ error:
   return NULL;
 }
 
-
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 {
 
@@ -173,7 +173,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 
 // vertical blur column by column
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,           \
+#pragma omp parallel for SIMD() default(none) shared(temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,           \
                                               coefn) schedule(static)
 #endif
   for(int i = 0; i < width; i++)
@@ -245,7 +245,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 
 // horizontal blur line by line
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,           \
+#pragma omp parallel for SIMD() default(none) shared(temp, Labmin, Labmax, a0, a1, a2, a3, b1, b2, coefp,           \
                                               coefn) schedule(static)
 #endif
   for(int j = 0; j < height; j++)
@@ -319,6 +319,7 @@ void dt_gaussian_blur(dt_gaussian_t *g, const float *const in, float *const out)
 
 
 #if defined(__SSE__)
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, const float *const in, float *const out)
 {
 
@@ -340,7 +341,7 @@ static void dt_gaussian_blur_4c_sse(dt_gaussian_t *g, const float *const in, flo
 
 // vertical blur column by column
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(temp, a0, a1, a2, a3, b1, b2, coefp, coefn) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(temp, a0, a1, a2, a3, b1, b2, coefp, coefn) schedule(static)
 #endif
   for(int i = 0; i < width; i++)
   {

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -300,18 +300,19 @@ static inline float CDL(float x, float slope, float offset, float power)
 }
 
 // see http://www.brucelindbloom.com/Eqn_RGB_XYZ_Matrix.html for the transformation matrices
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   dt_iop_colorbalance_data_t *d = (dt_iop_colorbalance_data_t *)piece->data;
   const int ch = piece->colors;
 
- // these are RGB values!
-    const float gain[3] = { d->gain[CHANNEL_RED] * d->gain[CHANNEL_FACTOR],
-                            d->gain[CHANNEL_GREEN] * d->gain[CHANNEL_FACTOR],
-                            d->gain[CHANNEL_BLUE] * d->gain[CHANNEL_FACTOR] },
-                contrast = (d->contrast != 0.0f) ? 1.0f / d->contrast : 1000000.0f,
-                grey = d->grey / 100.0f;
+  // these are RGB values!
+  const float gain[3] = { d->gain[CHANNEL_RED] * d->gain[CHANNEL_FACTOR],
+                          d->gain[CHANNEL_GREEN] * d->gain[CHANNEL_FACTOR],
+                          d->gain[CHANNEL_BLUE] * d->gain[CHANNEL_FACTOR] },
+              contrast = (d->contrast != 0.0f) ? 1.0f / d->contrast : 1000000.0f,
+              grey = d->grey / 100.0f;
 
   // For neutral parameters, skip the computations doing x^1 or (x-a)*1 + a to save time
   const int run_contrast = (d->contrast == 1.0f) ? 0 : 1;
@@ -322,7 +323,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     case LEGACY:
     {
-       // these are RGB values!
+      // these are RGB values!
       const float lift[3] = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
@@ -334,49 +335,44 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                               (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        float XYZ[3] = { 0.0f };
+        dt_Lab_to_XYZ(in, XYZ);
+
+        // XYZ -> sRGB
+        float rgb[3] = { 0.0f };
+        dt_XYZ_to_sRGB(XYZ, rgb);
+
+        // do the calculation in RGB space
+        for(int c = 0; c < 3; c++)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          float XYZ[3] = { 0.0f };
-          dt_Lab_to_XYZ(in, XYZ);
-
-          // XYZ -> sRGB
-          float rgb[3] = { 0.0f };
-          dt_XYZ_to_sRGB(XYZ, rgb);
-
-          // do the calculation in RGB space
-          for(int c = 0; c < 3; c++)
-          {
-            // lift gamma gain
-            rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
-            rgb[c] = (rgb[c] < 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c]);
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          dt_sRGB_to_XYZ(rgb, XYZ);
-
-          // XYZ -> Lab
-          dt_XYZ_to_Lab(XYZ, out);
-          out[3] = in[3];
-
-          in += ch;
-          out += ch;
+          // lift gamma gain
+          rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
+          rgb[c] = (rgb[c] < 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c]);
         }
-      }
 
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        dt_sRGB_to_XYZ(rgb, XYZ);
+
+        // XYZ -> Lab
+        dt_XYZ_to_Lab(XYZ, out);
+
+        out[3] = in[3];
+      }
       break;
     }
     case LIFT_GAMMA_GAIN:
     {
-       // these are RGB values!
+      // these are RGB values!
       const float lift[3] = { 2.0 - (d->lift[CHANNEL_RED] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_GREEN] * d->lift[CHANNEL_FACTOR]),
                               2.0 - (d->lift[CHANNEL_BLUE] * d->lift[CHANNEL_FACTOR]) },
@@ -388,62 +384,60 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                               (gamma[2] != 0.0) ? 1.0 / gamma[2] : 1000000.0 };
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        float XYZ[3] = { 0.0f };
+        dt_Lab_to_XYZ(in, XYZ);
+
+        // XYZ -> sRGB
+        float rgb[3] = { 0.0f };
+        dt_XYZ_to_prophotorgb(XYZ, rgb);
+
+        float luma = XYZ[1]; // the Y channel is the relative luminance
+
+        // do the calculation in RGB space
+        for(int c = 0; c < 3; c++)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          float XYZ[3] = { 0.0f };
-          dt_Lab_to_XYZ(in, XYZ);
+          // main saturation input
+          if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
 
-          // XYZ -> sRGB
-          float rgb[3] = { 0.0f };
-          dt_XYZ_to_prophotorgb(XYZ, rgb);
+          // RGB gamma correction
+          rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], 1.0f/2.2f);
 
-          float luma = XYZ[1]; // the Y channel is the relative luminance
-
-          // do the calculation in RGB space
-          for(int c = 0; c < 3; c++)
-          {
-            // main saturation input
-            if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
-
-            // RGB gamma correction
-            rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], 1.0f/2.2f);
-
-            // lift gamma gain
-            rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
-            rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c] * 2.2f);
-
-            // main saturation output
-            dt_prophotorgb_to_XYZ(rgb, XYZ);
-            luma = XYZ[1];
-            if (run_saturation_out) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
-
-            // contrast
-            if (run_contrast) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          dt_prophotorgb_to_XYZ(rgb, XYZ);
-
-          // XYZ -> Lab
-          dt_XYZ_to_Lab(XYZ, out);
-          out[3] = in[3];
-
-          in += ch;
-          out += ch;
+          // lift gamma gain
+          rgb[c] = ((( rgb[c]  - 1.0f) * lift[c]) + 1.0f) * gain[c];
+          rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c], gamma_inv[c] * 2.2f);
         }
+
+        // main saturation output
+        if (run_saturation_out)
+        {
+          dt_prophotorgb_to_XYZ(rgb, XYZ);
+          luma = XYZ[1];
+          for(int c = 0; c < 3; c++) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
+        }
+
+        // fulcrum contrat
+        if (run_contrast) for(int c = 0; c < 3; c++) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        dt_prophotorgb_to_XYZ(rgb, XYZ);
+
+        // XYZ -> Lab
+        dt_XYZ_to_Lab(XYZ, out);
+
+        out[3] = in[3];
+
       }
-
       break;
-
    }
     case SLOPE_OFFSET_POWER:
     {
@@ -457,62 +451,61 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                               (2.0f - d->gamma[CHANNEL_BLUE]) * (2.0f - d->gamma[CHANNEL_FACTOR])};
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to RGB:
+        // Lab -> XYZ
+        float XYZ[3];
+        dt_Lab_to_XYZ(in, XYZ);
+
+        // XYZ -> RGB
+        float rgb[3];
+        dt_XYZ_to_prophotorgb(XYZ, rgb);
+
+        float luma = XYZ[1]; // the Y channel is the RGB luminance
+
+        // do the calculation in RGB space
+        for(int c = 0; c < 3; c++)
         {
-          // transform the pixel to RGB:
-          // Lab -> XYZ
-          float XYZ[3];
-          dt_Lab_to_XYZ(in, XYZ);
+          // main saturation input
+          if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
 
-          // XYZ -> RGB
-          float rgb[3];
-          dt_XYZ_to_prophotorgb(XYZ, rgb);
-
-          float luma = XYZ[1]; // the Y channel is the RGB luminance
-
-          // do the calculation in RGB space
-          for(int c = 0; c < 3; c++)
-          {
-            // main saturation input
-            if (run_saturation) rgb[c] = luma + d->saturation * (rgb[c] - luma);
-
-            // channel CDL
-            rgb[c] = CDL(rgb[c], gain[c], lift[c], gamma[c]);
-
-            // main saturation output
-            dt_prophotorgb_to_XYZ(rgb, XYZ);
-            luma = XYZ[1];
-            if (run_saturation_out) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
-
-            // fulcrum contrat
-            if (run_contrast) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          dt_prophotorgb_to_XYZ(rgb , XYZ);
-
-          // XYZ -> Lab
-          dt_XYZ_to_Lab(XYZ, out);
-          out[3] = in[3];
-
-          in += ch;
-          out += ch;
+          // channel CDL
+          rgb[c] = CDL(rgb[c], gain[c], lift[c], gamma[c]);
         }
+
+        // main saturation output
+        if (run_saturation_out)
+        {
+          dt_prophotorgb_to_XYZ(rgb, XYZ);
+          luma = XYZ[1];
+          for(int c = 0; c < 3; c++) rgb[c] = luma + d->saturation_out * (rgb[c] - luma);
+        }
+
+        // fulcrum contrat
+        if (run_contrast) for(int c = 0; c < 3; c++) rgb[c] = (rgb[c] <= 0.0f) ? 0.0f : powf(rgb[c] / grey, contrast) * grey;
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        dt_prophotorgb_to_XYZ(rgb , XYZ);
+
+        // XYZ -> Lab
+        dt_XYZ_to_Lab(XYZ, out);
+
+        out[3] = in[3];
       }
       break;
     }
   }
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
 #if defined(__SSE__)
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -558,34 +551,31 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                                        0.0f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
-        {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-          // XYZ -> sRGB
-          __m128 rgb = dt_XYZ_to_sRGB_sse2(XYZ);
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
 
-          // do the calculation in RGB space
-          // regular lift gamma gain
-          rgb = ((rgb - one) * lift + one) * gain;
-          rgb = _mm_max_ps(rgb, zero);
-          rgb = _mm_pow_ps(rgb, gamma_inv);
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
+        // XYZ -> sRGB
+        __m128 rgb = dt_XYZ_to_sRGB_sse2(XYZ);
 
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          XYZ = dt_sRGB_to_XYZ_sse2(rgb);
-          // XYZ -> Lab
-          _mm_store_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
-        }
+        // do the calculation in RGB space
+        // regular lift gamma gain
+        rgb = ((rgb - one) * lift + one) * gain;
+        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_pow_ps(rgb, gamma_inv);
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        XYZ = dt_sRGB_to_XYZ_sse2(rgb);
+        // XYZ -> Lab
+        _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
       }
-
       break;
     }
 
@@ -609,58 +599,56 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
       const __m128 gamma_inv_RGB = _mm_set1_ps(1.0f/2.2f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD()default(none) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
+        // XYZ -> sRGB
+        __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
+
+        __m128 luma;
+
+        // adjust main saturation input
+        if (run_saturation)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-          // XYZ -> sRGB
-          __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
-
-          __m128 luma;
-
-          // adjust main saturation input
-          if (run_saturation)
-          {
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation * (rgb - luma);
-          }
-
-          // RGB gamma adjustement
-          rgb = _mm_pow_ps(_mm_max_ps(rgb, zero), gamma_inv_RGB);
-
-          // regular lift gamma gain
-          rgb = ((rgb - one) * lift + one) * gain;
-          rgb = _mm_max_ps(rgb, zero);
-          rgb = _mm_pow_ps(rgb, gamma_inv * gamma_RGB);
-
-          // adjust main saturation output
-          if (run_saturation_out)
-          {
-            XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation_out * (rgb - luma);
-          }
-
-          // fulcrum contrast
-          if (run_contrast)
-          {
-            rgb = _mm_max_ps(rgb, zero);
-            rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-          // XYZ -> Lab
-          _mm_store_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation * (rgb - luma);
         }
+
+        // RGB gamma adjustement
+        rgb = _mm_pow_ps(_mm_max_ps(rgb, zero), gamma_inv_RGB);
+
+        // regular lift gamma gain
+        rgb = ((rgb - one) * lift + one) * gain;
+        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_pow_ps(rgb, gamma_inv * gamma_RGB);
+
+        // adjust main saturation output
+        if (run_saturation_out)
+        {
+          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation_out * (rgb - luma);
+        }
+
+        // fulcrum contrast
+        if (run_contrast)
+        {
+          rgb = _mm_max_ps(rgb, zero);
+          rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
+        }
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+        // XYZ -> Lab
+        _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
       }
 
       break;
@@ -679,63 +667,59 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
                                       0.0f);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
-      for(int j = 0; j < roi_out->height; j++)
+      for(size_t k = 0; k < (size_t)ch * roi_in->width * roi_out->height; k += ch)
       {
-        float *in = ((float *)ivoid) + (size_t)ch * roi_in->width * j;
-        float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
-        for(int i = 0; i < roi_out->width; i++, in += ch, out += ch)
+        float *in = ((float *)ivoid) + k;
+        float *out = ((float *)ovoid) + k;
+
+        // transform the pixel to sRGB:
+        // Lab -> XYZ
+        __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
+        // XYZ -> sRGB
+        __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
+
+        __m128 luma;
+
+        // adjust main saturation
+        if (run_saturation)
         {
-          // transform the pixel to sRGB:
-          // Lab -> XYZ
-          __m128 XYZ = dt_Lab_to_XYZ_sse2(_mm_load_ps(in));
-          // XYZ -> sRGB
-          __m128 rgb = dt_XYZ_to_prophotoRGB_sse2(XYZ);
-
-          __m128 luma;
-
-          // adjust main saturation
-          if (run_saturation)
-          {
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation * (rgb - luma);
-          }
-
-          // slope offset
-          rgb = rgb * gain + lift;
-
-          //power
-          rgb = _mm_max_ps(rgb, zero);
-          rgb = _mm_pow_ps(rgb, gamma);
-
-          // adjust main saturation output
-          if (run_saturation_out)
-          {
-            XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-            luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
-            rgb = luma + saturation_out * (rgb - luma);
-          }
-
-          // fulcrum contrast
-          if (run_contrast)
-          {
-            rgb = _mm_max_ps(rgb, zero);
-            rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
-          }
-
-          // transform the result back to Lab
-          // sRGB -> XYZ
-          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
-          // XYZ -> Lab
-          _mm_store_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation * (rgb - luma);
         }
+
+        // slope offset
+        rgb = rgb * gain + lift;
+
+        //power
+        rgb = _mm_max_ps(rgb, zero);
+        rgb = _mm_pow_ps(rgb, gamma);
+
+        // adjust main saturation output
+        if (run_saturation_out)
+        {
+          XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+          luma = _mm_set1_ps(XYZ[1]); // the Y channel is the relative luminance
+          rgb = luma + saturation_out * (rgb - luma);
+        }
+
+        // fulcrum contrast
+        if (run_contrast)
+        {
+          rgb = _mm_max_ps(rgb, zero);
+          rgb = _mm_pow_ps(rgb / grey, contrast) * grey;
+        }
+
+        // transform the result back to Lab
+        // sRGB -> XYZ
+        XYZ = dt_prophotoRGB_to_XYZ_sse2(rgb);
+        // XYZ -> Lab
+        _mm_stream_ps(out, dt_XYZ_to_Lab_sse2(XYZ));
       }
       break;
     }
   }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 #endif
 

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -138,6 +138,7 @@ void connect_key_accels(dt_iop_module_t *self)
 
 #endif
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -178,6 +179,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -378,6 +378,7 @@ static inline float gaussian(float x, float std)
   return expf(- (x * x) / (2.0f * std * std)) / (std * powf(2.0f * M_PI, 0.5f));
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid, void *const ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -488,6 +489,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
 
 #if defined(__SSE__)
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -1099,6 +1101,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   if(!in) dt_iop_color_picker_reset(&g->color_picker, TRUE);
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void compute_curve_lut(dt_iop_filmic_params_t *p, float *table, float *table_temp, int res,
   dt_iop_filmic_data_t *d, dt_iop_filmic_nodes_t *nodes_data)
 {

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -369,6 +369,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   return;
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -420,7 +421,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const float *const Labminf = (float *)&Labmin;
   const float *const Labmaxf = (float *)&Labmax;
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(in, out, data) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(in, out, data) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)roi_out->width * roi_out->height; k++)
   {

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -368,6 +368,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   return;
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -274,6 +274,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
   return;
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -318,7 +319,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 // gauss blur the image horizontally
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -358,7 +359,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 // gauss blur the image vertically
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = rad; j < roi_out->height - wd4 * 4 + rad; j++)
   {
@@ -385,7 +386,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
   }
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = roi_out->height - wd4 * 4 + rad; j < roi_out->height - rad; j++)
   {
@@ -418,7 +419,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   dt_free_align(tmp);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = rad; j < roi_out->height - rad; j++)
   {
@@ -429,7 +430,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   // subtract blurred image, if diff > thrs, add *amount to original image
   for(int j = 0; j < roi_out->height; j++)
@@ -458,6 +459,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -502,7 +504,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
 // gauss blur the image horizontally
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -543,7 +545,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
 // gauss blur the image vertically
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = rad; j < roi_out->height - wd4 * 4 + rad; j++)
   {
@@ -571,7 +573,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     }
   }
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = roi_out->height - wd4 * 4 + rad; j < roi_out->height - rad; j++)
   {
@@ -606,7 +608,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   dt_free_align(tmp);
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(int j = rad; j < roi_out->height - rad; j++)
   {
@@ -617,7 +619,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(data) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(data) schedule(static)
 #endif
   // subtract blurred image, if diff > thrs, add *amount to original image
   for(int j = 0; j < roi_out->height; j++)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -288,6 +288,7 @@ error:
 }
 #endif
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -307,7 +308,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int unbound_ab = d->unbound_ab;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(d) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(d) schedule(static)
 #endif
   for(int k = 0; k < height; k++)
   {

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -192,6 +192,7 @@ static void process_common_setup(struct dt_iop_module_t *self, dt_dev_pixelpipe_
   }
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                    const void *const ivoid, void *const ovoid,
                                    const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
@@ -224,7 +225,7 @@ static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpip
     if(gauss && tmp)
     {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(tmp) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(tmp) schedule(static)
 #endif
       for(size_t k = 0; k < (size_t)width * height; k++) tmp[k] = ((float *)ivoid)[ch * k];
 
@@ -233,7 +234,7 @@ static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpip
       /* create zonemap preview for input */
       dt_pthread_mutex_lock(&g->lock);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(tmp, g) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(tmp, g) schedule(static)
 #endif
       for(size_t k = 0; k < (size_t)width * height; k++)
       {
@@ -253,7 +254,7 @@ static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpip
       /* create zonemap preview for output */
       dt_pthread_mutex_lock(&g->lock);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) shared(tmp, g) schedule(static)
+#pragma omp parallel for SIMD() default(none) shared(tmp, g) schedule(static)
 #endif
       for(size_t k = 0; k < (size_t)width * height; k++)
       {
@@ -267,6 +268,7 @@ static void process_common_cleanup(struct dt_iop_module_t *self, dt_dev_pixelpip
   }
 }
 
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -300,6 +302,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
+__attribute__((target_clones( "avx2", "avx", "sse4.2", "sse3", "popcnt", "default")))
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
                   void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -311,7 +314,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int size = d->params.size;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for default(none) schedule(static) collapse(2)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {


### PR DESCRIPTION
* add SIMD() OpenMP pragma in every loop for auto-vectorization when possible
* add target clones for SSE3, SSE4.1, AVX and AVX2 so generic builds for distro packaging embed optimized variants for each architecture, and not only older SSE2.

This needs to be tested and benchmarked. So far, I get ×2 to ×3 performance gain in OpenMP SIMD codepath, wich is on-par with manually optimized SSE2 codepath. Also, tell me if you think more clones should be added.

Ideally, it would be great to have a way to auto-tune the SIMD buffer size too, but that's too low-level for my understanding (@darix @cryptomilk help !).