### PR TITLE
Allow upscaling on export by setting one one size limit zero

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -612,7 +612,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
 
   const int wd = img->width;
   const int ht = img->height;
-  const float max_scale = upscale ? 100.0 : 1.0;
+
 
   int res = 0;
 
@@ -767,8 +767,11 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
 
   const int width = format_params->max_width;
   const int height = format_params->max_height;
-  const double scalex = width > 0 ? fminf(width / (double)pipe.processed_width, max_scale) : 1.0;
-  const double scaley = height > 0 ? fminf(height / (double)pipe.processed_height, max_scale) : 1.0;
+
+  const float max_scale = ( upscale && ( width > 0 || height > 0 )) ? 100.0 : 1.0;
+
+  const double scalex = width > 0 ? fminf(width / (double)pipe.processed_width, max_scale) : max_scale;
+  const double scaley = height > 0 ? fminf(height / (double)pipe.processed_height, max_scale) : max_scale;
   const double scale = fminf(scalex, scaley);
 
   const int processed_width = scale * pipe.processed_width + .5f;


### PR DESCRIPTION
This is my first pull request for darktable. So, I hope I did it right.  It is just a minor change/fix regarding the export with up-scaling enabled when only one size limit is given and the other is set to zero. Currently this always results in a scale of 1.0 and the image is exported in its native size, but not scaled.
I did not find a bug report addressing this behavior, but I assume it is not intended. I think this commit fixes it.