### PR TITLE
Drawing masks continious drawing support

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -223,6 +223,7 @@ typedef struct dt_masks_form_gui_t
 
 
   gboolean creation;
+  gboolean creation_pause;
   gboolean creation_continuous;
   gboolean creation_closing_form;
   dt_iop_module_t *creation_module;


### PR DESCRIPTION
Adds support for drawing masks in brush mode with graphical tablet in continuous mode with CTRL key pressed.
The main idea to allow draw series of strokes with graphical tablet and finish drawing without pressed CTRL key.
Works with mouse pointer too, but without easy control of thickness/opacity property of the brush.