### PR TITLE
basecurve: BUGFIX

### DIFF
--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -329,7 +329,7 @@ static void set_presets(dt_iop_module_so_t *self, const basecurve_preset_t *pres
     dt_gui_presets_update_ldr(_(presets[k].name), self->op, self->version(), FOR_RAW);
     // make it auto-apply for matching images:
     dt_gui_presets_update_autoapply(_(presets[k].name), self->op, self->version(),
-                                    force_autoapply ? 1 : presets[k].autoapply);
+                                    (force_autoapply) 1 : (presets[k].autoapply && force_autoapply));
     // hide all non-matching presets in case the model string is set.
     // When force_autoapply was given always filter (as these are per-camera presets)
     dt_gui_presets_update_filter(_(presets[k].name), self->op, self->version(),


### PR DESCRIPTION
fix an old bug where the camera base curve was applied no matter the global option `plugins/darkroom/basecurve/auto_apply_percamera_presets` setting.

Basically, the boolean `auto_apply` was handled by a pointer, but what was tested was if the pointer was defined, not its actual value.