### PR TITLE
presets & usability enhancement

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -115,7 +115,7 @@ typedef struct dt_iop_atrous_data_t
 
 const char *name()
 {
-  return _("equalizer");
+  return _("contrast equalizer");
 }
 
 int groups()

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -92,7 +92,7 @@ void init_presets(dt_iop_module_so_t *self)
   // restrict to raw images
   dt_gui_presets_update_ldr(_("sharpen"), self->op, self->version(), FOR_RAW);
   // make it auto-apply for matching images:
-  dt_gui_presets_update_autoapply(_("sharpen"), self->op, self->version(), 1);
+  dt_gui_presets_update_autoapply(_("sharpen"), self->op, self->version(), 0);
 }
 
 void init_key_accels(dt_iop_module_so_t *self)

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -63,7 +63,7 @@ int groups()
 
 int flags()
 {
-  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS;
+  return IOP_FLAGS_SUPPORTS_BLENDING | IOP_FLAGS_NO_MASKS | IOP_FLAGS_DEPRECATED;
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,


### PR DESCRIPTION
1. rename the equalizer "contrast equalizer" because it's clearer and prepare the field for my tone equalizer
2. deprecate the spot removal tool because there is retouch now.