### PR TITLE
fix hierarchical tags with different upper/lower cases

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -922,26 +922,26 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       char *name = g_strdup((const char *)sqlite3_column_text(stmt, 0));
-      char *name_folded = g_utf8_casefold(name, -1);
       gchar *collate_key = NULL;
 
       const int count = sqlite3_column_int(stmt, 2);
 
       if(folders)
       {
+        char *name_folded = g_utf8_casefold(name, -1);
         char *name_folded_slash = g_strconcat(name_folded, G_DIR_SEPARATOR_S, NULL);
         collate_key = g_utf8_collate_key_for_filename(name_folded_slash, -1);
         g_free(name_folded_slash);
+        g_free(name_folded);
       }
       else if(tags)
-        collate_key = tag_collate_key(name_folded);
+        collate_key = tag_collate_key(name);
 
       name_key_tuple_t *tuple = (name_key_tuple_t *)malloc(sizeof(name_key_tuple_t));
       tuple->name = name;
       tuple->collate_key = collate_key;
       tuple->count = count;
       sorted_names = g_list_prepend(sorted_names, tuple);
-      g_free(name_folded);
     }
     sqlite3_finalize(stmt);
 


### PR DESCRIPTION
Consider you have the following tags:

- a|a
- A|b
- a|c

In the collect module instead of

- A -> b 
- a -> a, c

you get

- a -> a
- A -> b
- a -> c

as the hierarchy. This happens because for the sorting the case independent name is used but afterwards the grouping is case dependent. So there are 3 parents a, A and a, because the case change triggers a new group. 
This PR removes the case independent sorting for tags.
Perhaps a similar problem exists for folders, but this was not tested.