### PR TITLE
module list: add comprehensive toolboxes

### DIFF
--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -362,11 +362,11 @@ void init_presets(dt_lib_module_t *self)
                                     "|demosaic|exposure|flip|graduatednd|grain|lens|levels|monochrome"
                                     "|shadhi|sharpen|temperature|tonecurve|vignette|");
 
-  dt_lib_presets_add(_("show none"), self->plugin_name, self->version(), params_none, len);
-  dt_lib_presets_add(_("show all"), self->plugin_name, self->version(), params_all, len);
+  dt_lib_presets_add(_("subset: no module"), self->plugin_name, self->version(), params_none, len);
+  dt_lib_presets_add(_("subset: all modules"), self->plugin_name, self->version(), params_all, len);
 
   /* the modules that are activated by default in the initial configuration */
-  dt_lib_presets_add(_("default"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("subset: default modules"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
@@ -375,7 +375,7 @@ void init_presets(dt_lib_module_t *self)
                         "|sharpen|bilat|atrous"                                     // sharpness
                         "|cacorrect|defringe|highlights|lens|colorreconstruction");   // image reconstruction
 
-  dt_lib_presets_add(_("0. all-purpose toolbox"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("workspace: all-purpose"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
@@ -386,7 +386,7 @@ void init_presets(dt_lib_module_t *self)
                         "|graduatednd|zonesystem|tonemap|shadhi"                    // HDR reconstruction - tones
                         "|hazeremoval|channelmixer");                                 // HDR reconstruction - colors
 
-  dt_lib_presets_add(_("3. landscape & HDR toolbox"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("workspace: landscape & HDR"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
@@ -397,7 +397,7 @@ void init_presets(dt_lib_module_t *self)
                         "|graduatednd|zonesystem|tonemap|shadhi|"                   // HDR reconstruction - tones
                         "|ashift|channelmixer|retouch");
 
-  dt_lib_presets_add(_("2. architecture & streets toolbox"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("workspace: architecture & streets"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
@@ -407,7 +407,7 @@ void init_presets(dt_lib_module_t *self)
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
                         "|retouch|liquify|soften");                      // retouch
 
-  dt_lib_presets_add(_("1. portrait & beauty toolbox"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("workspace: portrait & beauty"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
@@ -417,15 +417,14 @@ void init_presets(dt_lib_module_t *self)
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
                         "|denoiseprofile|bilateral|hotpixels");                       // denoising
 
-  dt_lib_presets_add(_("4. lowlight & high ISO toolbox"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("workspace: lowlight & high ISO"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|velvia|splittoning|colormapping|colorize|colorcorrection"
                         "|vignette|relight|lowlight|bloom|soften|colisa|monochrome"
-                        "|watermark|border|grain"
-                        );
+                        "|watermark|border|grain|colorcontrast");
 
-  dt_lib_presets_add(_("I. creative filters only"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("subset: creative modules only"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
                         "|demosaic|exposure|colorin|temperature|colorout|rawprepare"// raw handling
@@ -434,7 +433,7 @@ void init_presets(dt_lib_module_t *self)
                         "|denoiseprofile|bilateral|hotpixels|rawdenoise|nlmeans"    // denoising
                         "|dither|profile_gamma|invert|scalepixels|rotatepixels|colorchecker");
 
-  dt_lib_presets_add(_("II. technical modules only"), self->plugin_name, self->version(), params, len);
+  dt_lib_presets_add(_("subset: technical modules only"), self->plugin_name, self->version(), params, len);
 
 
   free(params_none);

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -357,7 +357,7 @@ void init_presets(dt_lib_module_t *self)
   int len;
   char *params_none = gen_params(0, &len, NULL);
   char *params_all = gen_params(1, &len, NULL);
-  char *params_default = gen_params(1, &len,
+  char *params = gen_params(1, &len,
                                     "|basecurve|clipping|colisa|colorcorrection|colorin|colorout"
                                     "|demosaic|exposure|flip|graduatednd|grain|lens|levels|monochrome"
                                     "|shadhi|sharpen|temperature|tonecurve|vignette|");
@@ -366,10 +366,79 @@ void init_presets(dt_lib_module_t *self)
   dt_lib_presets_add(_("show all"), self->plugin_name, self->version(), params_all, len);
 
   /* the modules that are activated by default in the initial configuration */
-  dt_lib_presets_add(_("default"), self->plugin_name, self->version(), params_default, len);
+  dt_lib_presets_add(_("default"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
+                        "|filmic|tonecurve|levels"                                  // tones
+                        "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
+                        "|sharpen|bilat|atrous"                                     // sharpness
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
+                        );
+  dt_lib_presets_add(_("0. all-purpose toolbox"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
+                        "|filmic|tonecurve|levels"                                  // tones
+                        "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
+                        "|sharpen|bilat|atrous"                                     // sharpness
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
+                        "|graduatednd|zonesystem|tonemap|shadhi"                    // HDR reconstruction - tones
+                        "|hazeremoval|channelmixer"                                 // HDR reconstruction - colors
+                        );
+  dt_lib_presets_add(_("3. landscape & HDR toolbox"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
+                        "|filmic|tonecurve|levels"                                  // tones
+                        "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
+                        "|sharpen|bilat|atrous"                                     // sharpness
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
+                        "|graduatednd|zonesystem|tonemap|shadhi|"                   // HDR reconstruction - tones
+                        "|ashift|channelmixer|retouch"
+                        );
+  dt_lib_presets_add(_("2. architecture & streets toolbox"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
+                        "|filmic|tonecurve|levels"                                  // tones
+                        "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
+                        "|sharpen|bilat|atrous"                                     // sharpness
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
+                        "|retouch|liquify|soften"                      // retouch
+                        );
+  dt_lib_presets_add(_("1. portrait & beauty toolbox"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|demosaic|exposure|colorin|temperature|clipping"           // raw handling
+                        "|filmic|tonecurve|levels"                                  // tones
+                        "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
+                        "|sharpen|bilat|atrous"                                     // sharpness
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
+                        "|denoiseprofile|bilateral|hotpixels"                       // denoising
+                        );
+  dt_lib_presets_add(_("4. lowlight & high ISO toolbox"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|velvia|splittoning|colormapping|colorize|colorcorrection"
+                        "|vignette|relight|lowlight|bloom|soften|colisa|monochrome"
+                        "|watermark|border|grain"
+                        );
+  dt_lib_presets_add(_("I. creative filters only"), self->plugin_name, self->version(), params, len);
+
+  params = gen_params(1, &len,
+                        "|demosaic|exposure|colorin|temperature|colorout|rawprepare"// raw handling
+                        "|sharpen|bilat|atrous|highpass|lowpass"                    // sharpness
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
+                        "|denoiseprofile|bilateral|hotpixels|rawdenoise|nlmeans"    // denoising
+                        "|dither|profile_gamma|invert|scalepixels|rotatepixels|colorchecker"
+                        );
+  dt_lib_presets_add(_("II. technical modules only"), self->plugin_name, self->version(), params, len);
+
 
   free(params_none);
   free(params_all);
+  free(params);
 }
 
 void *get_params(dt_lib_module_t *self, int *size)

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -373,8 +373,8 @@ void init_presets(dt_lib_module_t *self)
                         "|filmic|tonecurve|levels"                                  // tones
                         "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
                         "|sharpen|bilat|atrous"                                     // sharpness
-                        "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
-                        );
+                        "|cacorrect|defringe|highlights|lens|colorreconstruction");   // image reconstruction
+
   dt_lib_presets_add(_("0. all-purpose toolbox"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
@@ -384,8 +384,8 @@ void init_presets(dt_lib_module_t *self)
                         "|sharpen|bilat|atrous"                                     // sharpness
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
                         "|graduatednd|zonesystem|tonemap|shadhi"                    // HDR reconstruction - tones
-                        "|hazeremoval|channelmixer"                                 // HDR reconstruction - colors
-                        );
+                        "|hazeremoval|channelmixer");                                 // HDR reconstruction - colors
+
   dt_lib_presets_add(_("3. landscape & HDR toolbox"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
@@ -395,8 +395,8 @@ void init_presets(dt_lib_module_t *self)
                         "|sharpen|bilat|atrous"                                     // sharpness
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
                         "|graduatednd|zonesystem|tonemap|shadhi|"                   // HDR reconstruction - tones
-                        "|ashift|channelmixer|retouch"
-                        );
+                        "|ashift|channelmixer|retouch");
+
   dt_lib_presets_add(_("2. architecture & streets toolbox"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
@@ -405,8 +405,8 @@ void init_presets(dt_lib_module_t *self)
                         "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
                         "|sharpen|bilat|atrous"                                     // sharpness
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
-                        "|retouch|liquify|soften"                      // retouch
-                        );
+                        "|retouch|liquify|soften");                      // retouch
+
   dt_lib_presets_add(_("1. portrait & beauty toolbox"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
@@ -415,8 +415,8 @@ void init_presets(dt_lib_module_t *self)
                         "|channelmixer|colorbalance|colorzones|colorchecker|vibrance" // colors
                         "|sharpen|bilat|atrous"                                     // sharpness
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
-                        "|denoiseprofile|bilateral|hotpixels"                       // denoising
-                        );
+                        "|denoiseprofile|bilateral|hotpixels");                       // denoising
+
   dt_lib_presets_add(_("4. lowlight & high ISO toolbox"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
@@ -424,6 +424,7 @@ void init_presets(dt_lib_module_t *self)
                         "|vignette|relight|lowlight|bloom|soften|colisa|monochrome"
                         "|watermark|border|grain"
                         );
+
   dt_lib_presets_add(_("I. creative filters only"), self->plugin_name, self->version(), params, len);
 
   params = gen_params(1, &len,
@@ -431,8 +432,8 @@ void init_presets(dt_lib_module_t *self)
                         "|sharpen|bilat|atrous|highpass|lowpass"                    // sharpness
                         "|cacorrect|defringe|highlights|lens|colorreconstruction"   // image reconstruction
                         "|denoiseprofile|bilateral|hotpixels|rawdenoise|nlmeans"    // denoising
-                        "|dither|profile_gamma|invert|scalepixels|rotatepixels|colorchecker"
-                        );
+                        "|dither|profile_gamma|invert|scalepixels|rotatepixels|colorchecker");
+
   dt_lib_presets_add(_("II. technical modules only"), self->plugin_name, self->version(), params, len);
 
 


### PR DESCRIPTION
add more module lists presets ("toolboxes") for display in darkroom:
    * all-purpose
    * portrait & beauty
    * landscape & HDR
    * lowlight & high ISO
    * architecture & streets.

These toolboxes are intended to provide minimal comprehensive lists of modules to achieve different sort of editings, based on my experience. They discard duplicate modules (for example sharpen ~= highpass, shadow-highlights ~= lowpass) and modules having funky side-effects (halos, messed-up  saturation while you change the luminance, etc.). 

Also, fix a possible memory leak because the pointer `char *param_default` was never freed.