### PR TITLE
sharpen: add preference to auto-apply or not the sharpen module.

### DIFF
--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -702,3 +702,14 @@ cell:selected
 {
     color: #FFFF00;
 }
+
+#pref_section
+{
+    border-bottom: 2px solid @fg_color;
+}
+#pref_section *
+{
+    font-size: 1.3em;
+    margin-left: 10em;
+    margin-right: 10em;
+}

--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -2,6 +2,7 @@
 <!ELEMENT dtconfig (name,type,default,capability?,shortdescription?,longdescription?)>
 <!ATTLIST dtconfig
 	prefs (core|gui|session) #IMPLIED
+        section (import|lighttable|darkroom|geoloc|security|cpugpu|xmp|quality) #IMPLIED
         capability CDATA #IMPLIED
 >
 <!ELEMENT name (#PCDATA)>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -22,42 +22,42 @@
     <shortdescription>width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="cpugpu">
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
     <default>(1024 * 1024 * 256)</default>
     <shortdescription>memory in megabytes to use for thumbnail cache</shortdescription>
     <longdescription>this controls how much memory is going to be used for thumbnails and other buffers (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="cpugpu">
     <name>cache_disk_backend</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>enable disk backend for thumbnail cache</shortdescription>
     <longdescription>if enabled, write thumbnails to disk (.cache/darktable/) when evicted from the memory cache. note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again. it's safe though to delete these manually, if you want. light table performance will be increased greatly when browsing a lot. to generate all thumbnails of your entire collection offline, run 'darktable-generate-cache'.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="quality">
     <name>cache_color_managed</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>color manage cached thumbnails</shortdescription>
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="cpugpu">
     <name>worker_threads</name>
     <type>int</type>
     <default>2</default>
     <shortdescription>number of background threads</shortdescription>
     <longdescription>this controls for example how many threads are used to create thumbnails during import. the cache will grow to a maximum of twice this number of full resolution image buffers (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="cpugpu">
     <name>host_memory_limit</name>
     <type>int</type>
     <default>1500</default>
     <shortdescription>host memory limit (in MB) for tiling</shortdescription>
     <longdescription>this variable controls the maximum amount of memory (in MB) a module may use during image processing. lower values will force memory hungry modules to process image with increasing number of tiles. setting this to 0 will omit any limit. values below 500 will be treated as 500 (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="cpugpu">
     <name>singlebuffer_limit</name>
     <type min="2" max="64">int</type>
     <default>16</default>
@@ -155,21 +155,21 @@
     <shortdescription>timeout period of pixelpipe synchronization</shortdescription>
     <longdescription>time period (in units of 5ms) after which synchronization of preview and full pixelpipe is assumed to have failed. set to zero to omit pixelpipe synchronization. defaults to 200.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="lighttable">
     <name>never_use_embedded_thumb</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>don't use embedded preview JPEG but half-size raw</shortdescription>
     <longdescription>check this option to not use the embedded JPEG from the raw file but process the raw data. this is slower but gives you color managed thumbnails.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="xmp">
     <name>write_sidecar_files</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>write sidecar file for each image</shortdescription>
     <longdescription>these redundant files can later be re-imported into a different database, preserving your changes to the image.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="xmp">
     <name>compress_xmp_tags</name>
     <type>
       <enum>
@@ -189,14 +189,14 @@
     <shortdescription>omit hierarchy in simple tag lists</shortdescription>
     <longdescription>when exporting images the hierarchical tags are also added as a simple list of non-hierarchical ones to make them visible to some other programs. when this option is checked darktable will only include their last part and ignore the rest. so 'foo|bar|baz' will only add 'baz'.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core" capability="opencl">
+  <dtconfig prefs="core" capability="opencl" section="cpugpu">
     <name>opencl</name>
     <type>bool</type>
     <default>${DEFCONFIG_OPENCL}</default>
     <shortdescription>activate OpenCL support</shortdescription>
     <longdescription>if found, use OpenCL runtime on your system for improved processing speed. can be switched on and off at any time.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core" capability="opencl">
+  <dtconfig prefs="core" capability="opencl" section="cpugpu">
     <name>opencl_scheduling_profile</name>
     <type>
       <enum>
@@ -237,42 +237,42 @@
     <shortdescription>assumed maximum sane number of tiles</shortdescription>
     <longdescription>if during tiling this number is exceeded darktable assumes that tiling is not possible and falls back to untiled processing - with all system memory limits taking full effect. in case you want to process huge images you may want to increase this number.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>ask_before_remove</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before removing images from database</shortdescription>
     <longdescription>always ask the user before any image is removed from DB.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>ask_before_delete</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before erasing images from disk / discarding history stack</shortdescription>
     <longdescription>always ask the user before any image file is deleted / history stack is discarded.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>send_to_trash</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>send files to trash when erasing images</shortdescription>
     <longdescription>send files to trash instead of permanently deleting files on system that supports it</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>ask_before_move</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before moving images from film roll folder</shortdescription>
     <longdescription>always ask the user before any image file is moved.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>ask_before_copy</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>ask before copying images to new film roll folder</shortdescription>
     <longdescription>always ask the user before any image file is copied.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>ask_before_rmdir</name>
     <type>bool</type>
     <default>false</default>
@@ -468,42 +468,42 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_ignore_jpegs</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>ignore JPEG images when importing film rolls</shortdescription>
     <longdescription>when having raw+JPEG images together in one directory it makes no sense to import both. with this flag one can ignore all JPEGs found.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_recursive</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>recursive directory traversal when importing filmrolls</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_last_creator</name>
     <type>string</type>
     <default/>
     <shortdescription>creator to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_last_publisher</name>
     <type>string</type>
     <default/>
     <shortdescription>publisher to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_last_rights</name>
     <type>string</type>
     <default/>
     <shortdescription>rights to be applied when importing</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_last_tags</name>
     <type>string</type>
     <default/>
@@ -517,7 +517,7 @@
     <shortdescription>last opened directory.</shortdescription>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="import">
     <name>ui_last/import_initial_rating</name>
     <type min="0" max="5">int</type>
     <default>1</default>
@@ -552,7 +552,7 @@
     <shortdescription>low quality thumbnails</shortdescription>
     <longdescription>if set to true, thumbnails will be processed by first downscaling rather than demosaicing the full image. this can result in much faster processing times and blurrier images, especially when you cropped a lot.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="lighttable">
     <name>plugins/lighttable/thumbnail_hq_min_level</name>
     <type>
       <enum>
@@ -571,14 +571,14 @@
     <shortdescription>high quality thumb processing from size</shortdescription>
     <longdescription>if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="lighttable">
     <name>plugins/lighttable/extended_thumb_overlay</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>enable extended thumb overlay</shortdescription>
     <longdescription>if set to true, thumb overlay shows filename and some exif data.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="darkroom">
     <name>pressure_sensitivity</name>
     <type>
       <enum>
@@ -594,7 +594,7 @@
     <shortdescription>pen pressure control for brush masks</shortdescription>
     <longdescription>off - pressure reading ignored, hardness/opacity/brush size - pressure reading controls specified attribute, absolute/relative - pressure reading is taken directly as attribute value or multiplied with pre-defined setting.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="darkroom">
     <name>brush_smoothing</name>
     <type>
       <enum>
@@ -607,7 +607,7 @@
     <shortdescription>smoothing of brush strokes</shortdescription>
     <longdescription>sets level for smoothing of brush strokes. stronger smoothing leads to less nodes and easier editing but with lower control of accuracy.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="darkroom">
     <name>channel_display</name>
     <type>
       <enum>
@@ -980,7 +980,7 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="security">
     <name>plugins/lighttable/tagging/ask_before_delete_tag</name>
     <type>bool</type>
     <default>true</default>
@@ -1008,21 +1008,21 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="geoloc">
     <name>plugins/map/filter_images_drawn</name>
     <type>bool</type>
     <default>FALSE</default>
     <shortdescription>only draw images on map that are currently collected and filtered</shortdescription>
     <longdescription>use the current filter settings to select the geotagged images drawn on the map, i.e. limit the images drawn to the current filmstrip. this limits the number of images drawn and thus reduces the time needed to draw the images.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="geoloc">
     <name>plugins/map/max_images_drawn</name>
     <type>int</type>
     <default>100</default>
     <shortdescription>maximum number of images drawn on map</shortdescription>
     <longdescription>the maximum number of geotagged images drawn on the map. increasing this number can slow drawing of the map down.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="geoloc">
     <name>plugins/lighttable/metadata_view/pretty_location</name>
     <type>bool</type>
     <default>true</default>
@@ -1036,7 +1036,7 @@
     <shortdescription>overlay txt sidecar over zoomed images</shortdescription>
     <longdescription>when there is a txt file next to an image it can be shown as an overlay over zoomed images on the lighttable. the txt file either has to be there at import time or the crawler has to be enabled</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="lighttable">
     <name>lighttable/ui/single_module</name>
     <type>bool</type>
     <default>false</default>
@@ -1050,28 +1050,28 @@
     <shortdescription>always show thumbnail overlays</shortdescription>
     <longdescription>show overlays (rating stars, "edited" mark, etc) for all thumbnails in file manager, not only hovered one</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="darkroom">
     <name>darkroom/ui/single_module</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>expand a single darkroom module at a time</shortdescription>
     <longdescription>this option toggles the behavior of shift clicking in darkroom mode</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="lighttable">
     <name>lighttable/ui/scroll_to_module</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>scroll to lighttable modules when expanded/collapsed</shortdescription>
     <longdescription>when this option is enabled then darktable will try to scroll the module to the top of the visible list</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="darkroom">
     <name>darkroom/ui/scroll_to_module</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>scroll to darkroom modules when expanded/collapsed</shortdescription>
     <longdescription>when this option is enabled then darktable will try to scroll the module to the top of the visible list</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="gui" section="darkroom">
     <name>plugins/darkroom/ui/border_size</name>
     <type>int</type>
     <default>20</default>
@@ -1126,28 +1126,28 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="quality">
     <name>plugins/lighttable/export/force_lcms2</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>always use LittleCMS 2 to apply output color profile</shortdescription>
     <longdescription>this is slower than the default.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
+  <dtconfig prefs="core" section="quality">
     <name>plugins/slideshow/high_quality</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>do high quality processing for slideshow</shortdescription>
     <longdescription>same option as for export, but applies to slideshow.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="quality">
     <name>plugins/lighttable/export/high_quality_processing</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>do high quality resampling during export</shortdescription>
     <longdescription>the image will first be processed in full resolution, and downscaled at the very end. this can result in better quality sometimes, but will always be slower.</longdescription>
   </dtconfig>
- <dtconfig prefs="gui">
+ <dtconfig prefs="gui" section="lighttable">
     <name>rating_one_double_tap</name>
     <type>bool</type>
     <default>false</default>
@@ -1196,7 +1196,7 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="quality">
     <name>plugins/darkroom/demosaic/quality</name>
     <type>
       <enum>
@@ -1209,7 +1209,7 @@
     <shortdescription>demosaicing for zoomed out darkroom mode</shortdescription>
     <longdescription>interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, but not as sharp. middle ground is using PPG + interpolation modes specified below, full will use exactly the settings for full-size export. X-Trans sensors use VNG rather than PPG as middle ground.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="quality">
     <name>plugins/lighttable/export/pixel_interpolator</name>
     <type>
       <enum>
@@ -1669,7 +1669,7 @@
     <shortdescription/>
     <longdescription/>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="xmp">
     <name>run_crawler_on_start</name>
     <type>bool</type>
     <default>false</default>
@@ -1683,7 +1683,7 @@
     <shortdescription>executable for playing audio files</shortdescription>
     <longdescription>this external program is used to play audio files some cameras record to keep notes for images</longdescription>
   </dtconfig>
-  <dtconfig prefs="core">
+  <dtconfig prefs="core" section="quality">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>
     <type>bool</type>
     <default>false</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1690,6 +1690,13 @@
     <shortdescription>auto-apply per camera basecurve presets</shortdescription>
     <longdescription>use the per-camera basecurve by default instead of the generic manufacturer one if there is one available (needs a restart)</longdescription>
   </dtconfig>
+  <dtconfig prefs="core" section="quality">
+    <name>plugins/darkroom/sharpen/auto_apply</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>auto-apply shapen</shortdescription>
+    <longdescription>this added shapen is not recommanded on cameras without a low pass filter. the default is to not add any sharpen automatically as most recent cameras have not low-pass filter. (need a restart)</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>screen_dpi_overwrite</name>
     <type>float</type>

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -91,8 +91,9 @@ void init_presets(dt_iop_module_so_t *self)
                              1);
   // restrict to raw images
   dt_gui_presets_update_ldr(_("sharpen"), self->op, self->version(), FOR_RAW);
-  // make it auto-apply for matching images:
-  dt_gui_presets_update_autoapply(_("sharpen"), self->op, self->version(), 1);
+  // make it auto-apply if needed for matching images:
+  const gboolean auto_apply = dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply");
+  dt_gui_presets_update_autoapply(_("sharpen"), self->op, self->version(), auto_apply);
 }
 
 void init_key_accels(dt_iop_module_so_t *self)

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -84,7 +84,105 @@
 
 	<xsl:text>&#xA;static void&#xA;init_tab_gui</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_notebook_append_page(GTK_NOTEBOOK(tab), scroll, gtk_label_new(_("GUI options")));&#xA;</xsl:text>
 
-	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui']">
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("import"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui' and @section='import']">
+		<xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("lighttable"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui' and @section='lighttable']">
+		<xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("darkroom"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui' and @section='darkroom']">
+		<xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("map / geolocalisation"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui' and @section='geoloc']">
+		<xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("security"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui' and @section='security']">
+		<xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("miscellaneous"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='gui' and not(@section)]">
 		<xsl:apply-templates select="." mode="tab_block"/>
 	</xsl:for-each>
 	<xsl:value-of select="$tab_end" />
@@ -93,11 +191,77 @@
 
 	<xsl:text>&#xA;static void&#xA;init_tab_core</xsl:text><xsl:value-of select="$tab_start"/><xsl:text>  gtk_notebook_append_page(GTK_NOTEBOOK(tab), scroll, gtk_label_new(_("core options")));&#xA;</xsl:text>
 
-	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='core']">
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("quality"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+      gtk_grid_attach(GTK_GRID(grid), seclabel, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='core' and @section='quality']">
+	  <xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("xmp"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='core' and @section='xmp']">
+	  <xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("cpu / gpu / memory"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='core' and @section='cpugpu']">
 		<xsl:if test="name != 'opencl' or $HAVE_OPENCL=1">
 			<xsl:apply-templates select="." mode="tab_block"/>
 		</xsl:if>
 	</xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("miscelaneous"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
+      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+   }
+</xsl:text>
+
+	<xsl:for-each select="./dtconfiglist/dtconfig[@prefs='core' and not(@section)]">
+	  <xsl:apply-templates select="." mode="tab_block"/>
+	</xsl:for-each>
+
 	<xsl:value-of select="$tab_end" />
 
         <!-- session -->


### PR DESCRIPTION
The idea is that most recent cameras do not have a low pass filter
and it is better to not add any sharpen for those.