### PR TITLE
equalizer: new deblurring presets

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1146,7 +1146,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: large ++++"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: large blur, strength 4"), self->op, self->version(), &p, sizeof(p), 1);
 
   for(int k = 0; k < BANDS; k++)
   {
@@ -1162,7 +1162,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: large +++"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: large blur, strength 3"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1176,7 +1176,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: medium +++"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: medium blur, strength 3"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1189,21 +1189,9 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: fine +++"), self->op, self->version(), &p, sizeof(p), 1);
-  for(int k = 0; k < BANDS; k++)
-  {
-    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
-    float fine = GAUSS(x, 0.5 * sigma);
-    float medium = GAUSS(x, sigma);
-    float coarse = GAUSS(x, 2 * sigma);
-    float coeff = 0.5f + (coarse + medium + fine) / 48.0f;
-    float noise = (coarse + medium + fine) / 2160;
+  dt_gui_presets_add_generic(_("deblur: fine blur, strength 3"), self->op, self->version(), &p, sizeof(p), 1);
 
-    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
-    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
-    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
-    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
-  }
+
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1218,7 +1206,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: large ++"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: large blur, strength 2"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1232,7 +1220,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: medium ++"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: medium blur, strength 2"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1245,7 +1233,9 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: fine ++"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: fine blur, strength 2"), self->op, self->version(), &p, sizeof(p), 1);
+
+
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1260,7 +1250,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: large +"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: large blur, strength 1"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1274,7 +1264,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: medium +"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: medium blur, strength 1"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
     float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
@@ -1287,7 +1277,7 @@ void init_presets(dt_iop_module_so_t *self)
     p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
     p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
   }
-  dt_gui_presets_add_generic(_("deblur: fine +"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("deblur: fine blur, strength 1"), self->op, self->version(), &p, sizeof(p), 1);
 
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1134,7 +1134,23 @@ void init_presets(dt_iop_module_so_t *self)
 
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coarse = GAUSS(x, 2 * sigma);
+    float coeff = 0.5f + (coarse + medium + fine) / 18.0f;
+    float noise = (coarse + medium + fine) / 810;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: large ++++"), self->op, self->version(), &p, sizeof(p), 1);
+
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coarse = GAUSS(x, 2 * sigma);
@@ -1149,7 +1165,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: large +++"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 64.0 * k / (BANDS - 1.0) + 1.0) / log2f(65.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coeff = 0.5f + (medium + fine) / 21.0f;
@@ -1163,7 +1179,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: medium +++"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float coeff = 0.5f + fine / 14.25f;
     float noise = fine / 360;
@@ -1176,7 +1192,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: fine +++"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coarse = GAUSS(x, 2 * sigma);
@@ -1190,7 +1206,7 @@ void init_presets(dt_iop_module_so_t *self)
   }
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coarse = GAUSS(x, 2 * sigma);
@@ -1205,7 +1221,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: large ++"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 64.0 * k / (BANDS - 1.0) + 1.0) / log2f(65.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coeff = 0.5f + (medium + fine) / 28.0f;
@@ -1219,7 +1235,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: medium ++"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float coeff = 0.5f + fine / 19.0f;
     float noise = fine / 480;
@@ -1232,7 +1248,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: fine ++"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coarse = GAUSS(x, 2 * sigma);
@@ -1247,7 +1263,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: large +"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 64.0 * k / (BANDS - 1.0) + 1.0) / log2f(65.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float medium = GAUSS(x, sigma);
     float coeff = 0.5f + (medium + fine) / 42.0f;
@@ -1261,7 +1277,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("deblur: medium +"), self->op, self->version(), &p, sizeof(p), 1);
   for(int k = 0; k < BANDS; k++)
   {
-    float x = log2f( 128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float x = log2f(128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
     float fine = GAUSS(x, 0.5 * sigma);
     float coeff = 0.5f + fine / 28.5f;
     float noise = fine / 720;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1022,6 +1022,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
+#define GAUSS(x, sigma) expf( -(1.0f - x) * (1.0f - x) / (sigma * sigma)) / (2.0 * sigma * powf(M_PI, 0.5f))
+
 void init_presets(dt_iop_module_so_t *self)
 {
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
@@ -1127,6 +1129,150 @@ void init_presets(dt_iop_module_so_t *self)
     p.y[atrous_ct][k] = 0.0f;
   }
   dt_gui_presets_add_generic(_("clarity"), self->op, self->version(), &p, sizeof(p), 1);
+
+  float sigma = 1 / (BANDS - 1.0);
+
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coarse = GAUSS(x, 2 * sigma);
+    float coeff = 0.5f + (coarse + medium + fine) / 24.0f;
+    float noise = (coarse + medium + fine) / 1080;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: large +++"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 64.0 * k / (BANDS - 1.0) + 1.0) / log2f(65.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coeff = 0.5f + (medium + fine) / 21.0f;
+    float noise = (medium + fine) / 720;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: medium +++"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float coeff = 0.5f + fine / 14.25f;
+    float noise = fine / 360;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: fine +++"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coarse = GAUSS(x, 2 * sigma);
+    float coeff = 0.5f + (coarse + medium + fine) / 48.0f;
+    float noise = (coarse + medium + fine) / 2160;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coarse = GAUSS(x, 2 * sigma);
+    float coeff = 0.5f + (coarse + medium + fine) / 32.0f;
+    float noise = (coarse + medium + fine) / 1440;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: large ++"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 64.0 * k / (BANDS - 1.0) + 1.0) / log2f(65.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coeff = 0.5f + (medium + fine) / 28.0f;
+    float noise = (medium + fine) / 960;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: medium ++"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float coeff = 0.5f + fine / 19.0f;
+    float noise = fine / 480;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: fine ++"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 32.0 * k / (BANDS - 1.0) + 1.0) / log2f(33.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coarse = GAUSS(x, 2 * sigma);
+    float coeff = 0.5f + (coarse + medium + fine) / 48.0f;
+    float noise = (coarse + medium + fine) / 2160;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: large +"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 64.0 * k / (BANDS - 1.0) + 1.0) / log2f(65.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float medium = GAUSS(x, sigma);
+    float coeff = 0.5f + (medium + fine) / 42.0f;
+    float noise = (medium + fine) / 1440;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: medium +"), self->op, self->version(), &p, sizeof(p), 1);
+  for(int k = 0; k < BANDS; k++)
+  {
+    float x = log2f( 128.0 * k / (BANDS - 1.0) + 1.0) / log2f(129.0);
+    float fine = GAUSS(x, 0.5 * sigma);
+    float coeff = 0.5f + fine / 28.5f;
+    float noise = fine / 720;
+
+    p.x[atrous_L][k] = p.x[atrous_c][k] = p.x[atrous_s][k] = x;
+    p.y[atrous_L][k] = p.y[atrous_c][k] = p.y[atrous_s][k] = coeff;
+    p.x[atrous_Lt][k] = p.x[atrous_ct][k] = x;
+    p.y[atrous_Lt][k] = p.y[atrous_ct][k] = noise;
+  }
+  dt_gui_presets_add_generic(_("deblur: fine +"), self->op, self->version(), &p, sizeof(p), 1);
+
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 }
 


### PR DESCRIPTION
These presets use the equalizer module to define a band-pass filter using a gaussian window in high-frequencies and increase local-contrast while applying a subtle denoising to avoid noise amplification.

This is intended to undo the lens blur and the demoisaicing/interpolation blur that occurs as a side-effect, to replace the basic unsharp mask for better results.

9 presets are provided : 3 blur sizes × 3 intensities of deblurring. The low intensities are better used with full-frame DSLR + prime lenses, the high ones are better used with cropped sensors and entry-level zooms. The low blur sizes are better used for close subjects and portraits, the high blur sizes are better used with far subjects and atmospheric diffusion.