### PR TITLE
colorbalance: BUGFIX

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1024,14 +1024,14 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
   // Get the parameter
   for(int c = 0; c < 3; ++c) RGB[c] = logf(XYZ[1])/ logf(RGB[c] * p->gain[c + 1] + p->lift[c + 1] - 1.0f);
 
-  p->gamma[CHANNEL_RED] = 2.0 - RGB[0];
-  p->gamma[CHANNEL_GREEN] = 2.0 - RGB[1];
-  p->gamma[CHANNEL_BLUE] = 2.0 - RGB[2];
+  p->gamma[CHANNEL_RED] = CLAMP(2.0 - RGB[0], 0.0001f, 2.0f);
+  p->gamma[CHANNEL_GREEN] = CLAMP(2.0 - RGB[1], 0.0001f, 2.0f);
+  p->gamma[CHANNEL_BLUE] = CLAMP(2.0 - RGB[2], 0.0001f, 2.0f);
 
   darktable.gui->reset = 1;
-  dt_bauhaus_slider_set_soft(g->gamma_r, RGB[0] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_g, RGB[1] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_b, RGB[2] - 1.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_r, -RGB[0] + 1.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_g, -RGB[1] + 1.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_b, -RGB[2] + 1.0f);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
   darktable.gui->reset = 0;
 


### PR DESCRIPTION
when using the auto-neutralization on the gamma channel, the RGB values could come out of bounds and were reversed (+ instead of -) in the RGB UI sliders.
Although I dont understand why they were ok in the global neutralization since it was the same formula.

Test to ensure it's ok :
- use the gamma auto-neutralization
- change the gamma RGB values by small increments and check the hue/saturation slider are not jumping big steps (as it was before)
- note the RGB values
- go back in the lighttable and then, back to to picture
- ensure the gamma RGB values are the same (i.e. the RGB sliders setting in `gui_update` is consistent with the auto-neutralization sliders setting).

STILL UNFIXED:
the auto-tuned RGB parameters are not normalized in lightness, so if you edit the values with the HSL sliders after auto-tuning, you will get big jumps in the RGB sliders
(especially the non-dominant ones). Overall, the image will not change a lot, but that's annoying.

TODO :
The auto-neutralization is not yet 100 % perfect and a bit of desaturation is necessary in HSL to get pure neutral values. That means a second pass of HSL optimization
is necessary after the auto-neutralization in RGB is performed, but the maths are not obvious here. That would make the RGB sliders consistent with the HSL ones.