### PR TITLE
exposure: rename the black setting

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -864,11 +864,11 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->black = dt_bauhaus_slider_new_with_range(self, -0.1, 0.1, .001, p->black, 4);
   gtk_widget_set_tooltip_text(g->black, _("adjust the black level to unclip negative RGB values.\n"
-                                          "you should never use it to add more density in blacks !\n"
+                                          "you should never use it to add more density in blacks!\n"
                                           "if poorly set, it will clip near-black colors out of gamut\n"
                                           "by pushing RGB values into negatives."));
   dt_bauhaus_slider_set_format(g->black, "%.4f");
-  dt_bauhaus_widget_set_label(g->black, NULL, _("unclip negative values"));
+  dt_bauhaus_widget_set_label(g->black, NULL, _("black level correction"));
   dt_bauhaus_slider_enable_soft_boundaries(g->black, -1.0, 1.0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->black), TRUE, TRUE, 0);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -863,9 +863,12 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->mode), TRUE, TRUE, 0);
 
   g->black = dt_bauhaus_slider_new_with_range(self, -0.1, 0.1, .001, p->black, 4);
-  gtk_widget_set_tooltip_text(g->black, _("adjust the black level"));
+  gtk_widget_set_tooltip_text(g->black, _("adjust the black level to unclip negative RGB values.\n"
+                                          "you should never use it to add more density in blacks !\n"
+                                          "if poorly set, it will clip near-black colors out of gamut\n"
+                                          "by pushing RGB values into negatives."));
   dt_bauhaus_slider_set_format(g->black, "%.4f");
-  dt_bauhaus_widget_set_label(g->black, NULL, _("black"));
+  dt_bauhaus_widget_set_label(g->black, NULL, _("unclip negative values"));
   dt_bauhaus_slider_enable_soft_boundaries(g->black, -1.0, 1.0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->black), TRUE, TRUE, 0);
 


### PR DESCRIPTION
Users have taken the poor habit to use the black parameter to add more density in blacks. This is not the place to do it (use levels instead) and can seriously harm colors by pushing near-black RGB values into negatives, thus out of gamut: https://discuss.pixls.us/t/darktable-filmic-and-saturation/10622/11

We rename the "black" parameter "unclip negative values" to make its technical purpose clear and add a warning tooltip.

This setting should be let alone most of the time, except if the raw black level is wrong.