### PR TITLE
Soft boundaries for denoising sliders

### DIFF
--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -293,11 +293,11 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_module_t *module = (dt_iop_module_t *)self;
   dt_iop_bilateral_gui_data_t *g = (dt_iop_bilateral_gui_data_t *)self->gui_data;
   dt_iop_bilateral_params_t *p = (dt_iop_bilateral_params_t *)module->params;
-  dt_bauhaus_slider_set(g->scale1, p->sigma[0]);
+  dt_bauhaus_slider_set_soft(g->scale1, p->sigma[0]);
   // dt_bauhaus_slider_set(g->scale2, p->sigma[1]);
-  dt_bauhaus_slider_set(g->scale3, p->sigma[2]);
-  dt_bauhaus_slider_set(g->scale4, p->sigma[3]);
-  dt_bauhaus_slider_set(g->scale5, p->sigma[4]);
+  dt_bauhaus_slider_set_soft(g->scale3, p->sigma[2]);
+  dt_bauhaus_slider_set_soft(g->scale4, p->sigma[3]);
+  dt_bauhaus_slider_set_soft(g->scale5, p->sigma[4]);
 }
 
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
@@ -347,9 +347,13 @@ void gui_init(dt_iop_module_t *self)
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
   g->scale1 = dt_bauhaus_slider_new_with_range(self, 1.0, 30.0, 1.0, p->sigma[0], 1);
+  dt_bauhaus_slider_enable_soft_boundaries(g->scale1, 1.0, 50.0);
   g->scale3 = dt_bauhaus_slider_new_with_range(self, 0.0001, .1, 0.001, p->sigma[2], 4);
+  dt_bauhaus_slider_enable_soft_boundaries(g->scale3, 0.0001, 1.0);
   g->scale4 = dt_bauhaus_slider_new_with_range(self, 0.0001, .1, 0.001, p->sigma[3], 4);
+  dt_bauhaus_slider_enable_soft_boundaries(g->scale4, 0.0001, 1.0);
   g->scale5 = dt_bauhaus_slider_new_with_range(self, 0.0001, .1, 0.001, p->sigma[4], 4);
+  dt_bauhaus_slider_enable_soft_boundaries(g->scale5, 0.0001, 1.0);
   gtk_widget_set_tooltip_text(g->scale1, _("spatial extent of the gaussian"));
   gtk_widget_set_tooltip_text(g->scale3, _("how much to blur red"));
   gtk_widget_set_tooltip_text(g->scale4, _("how much to blur green"));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2257,9 +2257,9 @@ void gui_update(dt_iop_module_t *self)
   // let gui slider match current parameters:
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  dt_bauhaus_slider_set(g->radius, p->radius);
+  dt_bauhaus_slider_set_soft(g->radius, p->radius);
   dt_bauhaus_slider_set(g->nbhood, p->nbhood);
-  dt_bauhaus_slider_set(g->strength, p->strength);
+  dt_bauhaus_slider_set_soft(g->strength, p->strength);
   dt_bauhaus_combobox_set(g->mode, p->mode);
   dt_bauhaus_combobox_set(g->profile, -1);
   if(p->mode == MODE_WAVELETS)
@@ -2619,8 +2619,10 @@ void gui_init(dt_iop_module_t *self)
   g->profile = dt_bauhaus_combobox_new(self);
   g->mode = dt_bauhaus_combobox_new(self);
   g->radius = dt_bauhaus_slider_new_with_range(self, 0.0f, 4.0f, 1.f, 1.f, 0);
+  dt_bauhaus_slider_enable_soft_boundaries(g->radius, 0.0, 10.0);
   g->nbhood = dt_bauhaus_slider_new_with_range(self, 1.0f, 30.0f, 1.f, 7.f, 0);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
+  dt_bauhaus_slider_enable_soft_boundaries(g->strength, 0.001f, 1000.0f);
   g->channel = dt_conf_get_int("plugins/darkroom/denoiseprofile/gui_channel");
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile, TRUE, TRUE, 0);

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -825,8 +825,8 @@ void gui_update(dt_iop_module_t *self)
   // let gui slider match current parameters:
   dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
   dt_iop_nlmeans_params_t *p = (dt_iop_nlmeans_params_t *)self->params;
-  dt_bauhaus_slider_set(g->radius, p->radius);
-  dt_bauhaus_slider_set(g->strength, p->strength);
+  dt_bauhaus_slider_set_soft(g->radius, p->radius);
+  dt_bauhaus_slider_set_soft(g->strength, p->strength);
   dt_bauhaus_slider_set(g->luma, p->luma * 100.f);
   dt_bauhaus_slider_set(g->chroma, p->chroma * 100.f);
 }
@@ -839,7 +839,9 @@ void gui_init(dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
   g->radius = dt_bauhaus_slider_new_with_range(self, 1.0f, 4.0f, 1., 2.f, 0);
+  dt_bauhaus_slider_enable_soft_boundaries(g->radius, 0.0, 10.0);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 50.f, 0);
+  dt_bauhaus_slider_enable_soft_boundaries(g->strength, 0.0f, 100000.0f);
   g->luma = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 50.f, 0);
   g->chroma = dt_bauhaus_slider_new_with_range(self, 0.0f, 100.0f, 1., 100.f, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->radius, TRUE, TRUE, 0);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -600,7 +600,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_rawdenoise_gui_data_t *g = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
 
-  dt_bauhaus_slider_set(g->threshold, p->threshold);
+  dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "non_raw" : "raw");
   gtk_widget_queue_draw(self->widget);
 }
@@ -992,6 +992,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(rawdenoise_scrolled), self);
 
   c->threshold = dt_bauhaus_slider_new_with_range(self, 0.0, 0.1, 0.001, p->threshold, 3);
+  dt_bauhaus_slider_enable_soft_boundaries(c->threshold, 0.0, 1.0);
   gtk_box_pack_start(GTK_BOX(c->box_raw), GTK_WIDGET(c->threshold), TRUE, TRUE, 0);
   dt_bauhaus_widget_set_label(c->threshold, NULL, _("noise threshold"));
   g_signal_connect(G_OBJECT(c->threshold), "value-changed", G_CALLBACK(threshold_callback), self);


### PR DESCRIPTION
We don't know how noisy will be the user's picture.
Thus, enable soft boundaries to let the possibility of increasing strength and some denoising parameters much more than currently.
I set the boundaries such that the noisiest raws that I have can be denoised, as jpegs, and without camera profile. 