### PR TITLE
colorbalance: add film-emulation presets

### DIFF
--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -274,6 +274,26 @@ void init_presets(dt_iop_module_so_t *self)
   add_preset(self, _("split-toning teal-orange (1st instance)"),
              "gz02eJxjZACBBvugHXX2E3fU219f3GAP4n/TqLFvfd1oL8HZaH/2jI/9prn1cLHUtDSwGgaGCY7//tfbAwBRixpm", 3,
              "gz04eJxjZWBgYGUAgRNODFDApgwiq5wZIVyHD4E7bBnwggZ7CIYBRiBbBA8fXT1l/P5DX21i+pnA/Pfv8uw6OzzIMq9I5rgtSH//4wii1AMASbIlcw==", 8);
+
+  add_preset(self, _("generic film"),
+             "gz02eJxjZACBBntN5gb7op/19u5AGsSX3dFgr+jYaL+vttb+0NcM+1Pnq+3XyFTZr/rYBJZPS0sD0hMcQDQA29kXSQ==", 3,
+             "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
+
+  add_preset(self, _("similar to Kodak Portra"),
+             "gz02eJxjZACBBnsQfh3YYK8VU28P43s8rLKP6W+yP/Q1w36deyMYLymoBcsZGxcDaQGHs2d87AGnphWu", 3,
+             "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
+
+  add_preset(self, _("similar to Kodak Ektar"),
+             "gz02eJxjZACBBvvrixvsrXIb7IN21NnD+CA2iOa6nmxvZFxsX15ebp+e1gaWNwbyGRgEHNLS0uwBE7wWhw==", 3,
+             "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
+
+  add_preset(self, _("similar to Kodachrome"),
+             "gz02eJxjZACBBvvrixvsrXIb7IN21NnD+CA2iG59HWhvZFxsX15ebp+e1gaWT0tLA9ICDrNmRtoDACjOF7c=", 3,
+             "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
+
+  add_preset(self, _("similar to Fujichrome"),
+             "gz02eJxjZACBBvvrixvs39XU2wftqLMH8fsOldrvlGsF49bXgWAaJAbCIPm0tDQgLeAwa2akPQBNwxjQ", 3,
+             "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
 }
 
 void init_key_accels(dt_iop_module_so_t *self)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -290,10 +290,6 @@ void init_presets(dt_iop_module_so_t *self)
   add_preset(self, _("similar to Kodachrome"),
              "gz02eJxjZACBBvvrixvsrXIb7IN21NnD+CA2iG59HWhvZFxsX15ebp+e1gaWT0tLA9ICDrNmRtoDACjOF7c=", 3,
              "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
-
-  add_preset(self, _("similar to Fujichrome"),
-             "gz02eJxjZACBBvvrixvs39XU2wftqLMH8fsOldrvlGsF49bXgWAaJAbCIPm0tDQgLeAwa2akPQBNwxjQ", 3,
-             "gz11eJxjYGBgkGAAgRNODGiAEV0AJ2iwh+CRxQcA5qIZBA==", 8);
 }
 
 void init_key_accels(dt_iop_module_so_t *self)


### PR DESCRIPTION
add presets to reproduce color film look:
- generic film
- Kodachrome
- Kodak Portra NC 
- Kodak Ektar

These presets need a neutral white balance and filmic to work as planned. They have been adjusted visually from the look and RGB response curves of the emulations and are not completely accurate. They are in beta state and need more testing from people used to work with film.

The most accurate should be the Kodachrome, then the Portra. The generic film is an intended to get very neutral whites.

About film emulations
--

The most accurate film emulations would use the color checker module and LUTs. However, good LUTs are incredibly difficult to produce, because the film masters should be neutralized and cleaned from any flaws of the scanner, and should be applied on properly linearized and calibrated digital RAWs. Moreover, completely reproducing the film look is often not desirable since we want to preserve the linearity of the RAW RGB signal for the most part of the processing, while keeping the film color feeling. Since no color science is able to predict accurately color shifts at given luminance (Lab, CIECAM02, etc.), it is not trivial to linearize the film tone-curve and extract only the color shifts to keep working on linear luminance, until the final filmic tone-curve application. Finally, LUT can produce local contrast losses, depending on their resolution, and could give different results on different cameras.

Also, there is not one film look for each emulsion, but a lot of looks depending on the processing and the storage of the chemicals. So much for reproductibility… The gamut mapping is a real concern too, since some emulations have a very large gamut (Kodachrome is very weird on that part), and clever decisions would have to be made to address that part.

To sum up, a true film emulation would be independant from the color-response of the digital camera, its dynamic range, and leave the tone-curve interpretation to the retoucher, who would choose it depending of the input dynamic range. And that set of specifications is nearly impossible, so it all sums up to experienced people matching colors on screens.

So, using general color transfer functions, while being inaccurate, is relatively universal and makes no assumption on the camera color response. These presets add just a bit of contrast, using the fulcrum algorithm, to reproduce the toe from the filmic tone-curve (the filmic modules adds a toe too, which works great for B&W films emulations, but lacks a bit of density in blacks for color films).

Examples
--
![shoot minh-ly-0009-_dsc0009](https://user-images.githubusercontent.com/2779157/50812760-f9d5f100-12e1-11e9-863a-e62effd1140e.jpg)
![shoot minh-ly-0009-_dsc0009_02](https://user-images.githubusercontent.com/2779157/50812765-ffcbd200-12e1-11e9-8a39-218a3eb2c23f.jpg)
![shoot minh-ly-0009-_dsc0009_03](https://user-images.githubusercontent.com/2779157/50812779-09edd080-12e2-11e9-884f-e5a0279c3df2.jpg)
![shoot minh-ly-0009-_dsc0009_05](https://user-images.githubusercontent.com/2779157/50812782-0ce8c100-12e2-11e9-8ba8-7f7f5e3cef5b.jpg)

Picture by Nicolas Tissot:
![nft_7225_01](https://user-images.githubusercontent.com/2779157/50812804-1e31cd80-12e2-11e9-9e89-d41924cc02fa.jpg)
![nft_7225_04](https://user-images.githubusercontent.com/2779157/50812808-225deb00-12e2-11e9-8312-60184642f1cf.jpg)
![nft_7225_05](https://user-images.githubusercontent.com/2779157/50812810-2427ae80-12e2-11e9-968b-517b1ae1a32c.jpg)
![nft_7225_06](https://user-images.githubusercontent.com/2779157/50812812-25f17200-12e2-11e9-9d88-f861e9c1c5f1.jpg)




