### PR TITLE
Bugfix: do not suppress mouse move events when panning

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2000,9 +2000,9 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
 
   lib->using_arrows = 0;
 
-  if(lib->images_in_row == 1 || lib->full_preview_id != -1 || lib->thumb_size == -1 || px < 0 || py < 0)
+  if(lib->pan || lib->images_in_row == 1 || lib->full_preview_id != -1 || lib->thumb_size == -1 || px < 0 || py < 0)
   {
-    // a single image in a row or full preview or we don't have yet the thumb size (first expose)
+    // we are panning or a single image in a row or full preview or we don't have yet the thumb size (first expose)
     do_redraw = TRUE;
   }
   else


### PR DESCRIPTION
The new logic in lighttable.c that suppresses mouse move events has a bug whereby it hinders panning in certain circumstances.

To reproduce: In zoomable mode, zoom in such a way that the thumbnails are rather large. Then put the mouse pointer in the center of a thumbnail and, keeping it stationary, left-click. The pan action is initiated, but no pan occurs until the pointer leaves the thumbnail. (For me the bug does not show up every time, I couldn't figure out why.)

This pull request is a trivial fix: inhibit the suppression of mouse move events while panning.