### PR TITLE
mask jump - 12387

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -197,6 +197,8 @@ typedef struct dt_masks_form_gui_t
 
   // values for mouse positions, etc...
   float posx, posy, dx, dy, scrollx, scrolly, posx_source, posy_source;
+  // TRUE if mouse has leaved the center window
+  gboolean mouse_leaved_center;
   gboolean form_selected;
   gboolean border_selected;
   gboolean source_selected;
@@ -307,6 +309,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
 void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, int32_t width, int32_t height,
                                  int32_t pointerx, int32_t pointery);
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module);
+int dt_masks_events_mouse_enter(struct dt_iop_module_t *module);
 
 /** functions used to manipulate gui datas */
 void dt_masks_gui_form_create(dt_masks_form_t *form, dt_masks_form_gui_t *gui, int index);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2157,7 +2157,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       float radius2 = masks_border * MIN(wd, ht);
 
       float xpos, ypos;
-      if(gui->posx == -1.f && gui->posy == -1.f)
+      if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
       {
         xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
         ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -515,7 +515,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       radius2 *= MIN(wd, ht);
 
       float xpos, ypos;
-      if(gui->posx == -1.f && gui->posy == -1.f)
+      if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
       {
         const float zoom_x = dt_control_get_dev_zoom_x();
         const float zoom_y = dt_control_get_dev_zoom_y();

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -1096,7 +1096,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       float pzx = gui->posx;
       float pzy = gui->posy;
 
-      if(pzx == -1.f && pzy == -1.f)
+      if((pzx == -1.f && pzy == -1.f) || gui->mouse_leaved_center)
       {
         const float zoom_x = dt_control_get_dev_zoom_x();
         const float zoom_y = dt_control_get_dev_zoom_y();

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -211,6 +211,7 @@ void dt_masks_init_form_gui(dt_masks_form_gui_t *gui)
   memset(gui, 0, sizeof(dt_masks_form_gui_t));
 
   gui->posx = gui->posy = -1.0f;
+  gui->mouse_leaved_center = TRUE;
   gui->posx_source = gui->posy_source = -1.0f;
   gui->source_pos_type = DT_MASKS_SOURCE_POS_RELATIVE_TEMP;
 }
@@ -1294,17 +1295,20 @@ void dt_masks_free_form(dt_masks_form_t *form)
 
 int dt_masks_events_mouse_leave(struct dt_iop_module_t *module)
 {
-  // reset mouse position for masks
   if(darktable.develop->form_gui)
   {
     dt_masks_form_gui_t *gui = darktable.develop->form_gui;
+    gui->mouse_leaved_center = TRUE;
+  }
+  return 0;
+}
 
-    // if masks are being created or edited don't reset the position
-    if(gui->creation || gui->form_dragging || gui->source_dragging || gui->point_dragging >= 0
-       || gui->feather_dragging >= 0 || gui->seg_dragging >= 0 || gui->point_border_dragging >= 0)
-      return 0;
-
-    gui->posx = gui->posy = -1.f;
+int dt_masks_events_mouse_enter(struct dt_iop_module_t *module)
+{
+  if(darktable.develop->form_gui)
+  {
+    dt_masks_form_gui_t *gui = darktable.develop->form_gui;
+    gui->mouse_leaved_center = FALSE;
   }
   return 0;
 }
@@ -1322,6 +1326,8 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
 
   if(gui)
   {
+    // This assume that if this event is generated the mouse is over the center window
+    gui->mouse_leaved_center = FALSE;
     gui->posx = pzx * darktable.develop->preview_pipe->backbuf_width;
     gui->posy = pzy * darktable.develop->preview_pipe->backbuf_height;
   }

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1958,7 +1958,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
     else
     {
       float xpos, ypos;
-      if(gui->posx == -1.f && gui->posy == -1.f)
+      if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
       {
         xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
         ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1945,6 +1945,13 @@ void mouse_leave(dt_view_t *self)
   dt_control_change_cursor(GDK_LEFT_PTR);
 }
 
+void mouse_enter(dt_view_t *self)
+{
+  dt_develop_t *dev = (dt_develop_t *)self->data;
+  // masks
+  dt_masks_events_mouse_enter(dev->gui_module);
+}
+
 void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which)
 {
   const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));


### PR DESCRIPTION
This fixes bug 12387
https://redmine.darktable.org/issues/12387

To duplicate it, at least on xubuntu 16.04, display a circle on spot removal, place the mouse over it and without moving the mouse:
-press ALT
-press mouse button
-release ALT
-release mouse button
-press mouse button
-release mouse button
-the shape "jumps"

The issue here and on the reported bug is that a mouse_leave event is generated that overwrite the stored mouse coordinates and there's no mouse_move event to set them back, so the shape is moved to the wrong position.

This approach  should work even if the mouse_leave event is randomly generated, as long as a matching mouse_enter is triggered, or a mouse_move with mouse coordinates inside the window.
