### PR TITLE
Bugfix for opencl of nlmeans (denoiseprofile)

### DIFF
--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -92,11 +92,8 @@ denoiseprofile_dist(read_only image2d_t in, global float* U4, const int width, c
   int ypq = y + q.y;
   // Convert out of bounds indexes to 0
   // Reminder: q.x and q.y can be negative
-  // the boolean conditions will be equal to
-  // 0 in case of out of bounds, and will be
-  // equal to 1 in the other case
-  xpq *= (x+q.x < width && x+q.x >= 0);
-  ypq *= (y+q.y < height && y+q.y >= 0);
+  xpq *= (x+q.x < width && x+q.x >= 0) ? 1 : 0;
+  ypq *= (y+q.y < height && y+q.y >= 0) ? 1 : 0;
 
   float4 p1 = read_imagef(in, sampleri, (int2)(x, y));
   float4 p2 = read_imagef(in, sampleri, (int2)(xpq, ypq));
@@ -104,7 +101,7 @@ denoiseprofile_dist(read_only image2d_t in, global float* U4, const int width, c
   float dist = tmp.x + tmp.y + tmp.z;
 
   // make dist equal to 0 in case xpq or ypq is out of bounds
-  dist *= (x+q.x < width && x+q.x >= 0 && y+q.y < height && y+q.y >= 0);
+  dist *= (x+q.x < width && x+q.x >= 0 && y+q.y < height && y+q.y >= 0)  ? 1.0f : 0.0f;
 
   U4[gidx] = dist;
 }
@@ -236,17 +233,17 @@ denoiseprofile_accu(read_only image2d_t in, global float4* U2, global float* U4,
 
   // handle bounds for x
   // Reminder: q.x can be negative
-  wpq *= (x+q.x < width);
-  wmq *= (x-q.x < width);
-  wpq *= (x+q.x >= 0);
-  wmq *= (x-q.x >= 0);
+  wpq *= (x+q.x < width) ? 1 : 0;
+  wmq *= (x-q.x < width) ? 1 : 0;
+  wpq *= (x+q.x >= 0) ? 1 : 0;
+  wmq *= (x-q.x >= 0) ? 1 : 0;
 
   // handle bounds for y
   // Reminder: q.y can be negative
-  wpq *= (y+q.y >= 0);
-  wmq *= (y-q.y >= 0);
-  wpq *= (y+q.y < height);
-  wmq *= (y-q.y < height);
+  wpq *= (y+q.y >= 0) ? 1 : 0;
+  wmq *= (y-q.y >= 0) ? 1 : 0;
+  wpq *= (y+q.y < height) ? 1 : 0;
+  wmq *= (y-q.y < height) ? 1 : 0;
 
   float4 u1_pq = wpq ? read_imagef(in, sampleri, (int2)(x, y) + q) : (float4)0.0f;
   float4 u1_mq = wmq ? read_imagef(in, sampleri, (int2)(x, y) - q) : (float4)0.0f;

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -86,16 +86,19 @@ denoiseprofile_dist(read_only image2d_t in, global float* U4, const int width, c
   const int y = get_global_id(1);
   const int gidx = mad24(y, width, x);
 
-  // Reminder: q.x and q.y can be negative
   if(x >= width || y >= height) return;
-  if(x+q.x >= width || y+q.y >= height) return;
-  if(x+q.x < 0 || y+q.y < 0) return;
 
-  float4 p1 = read_imagef(in, sampleri, (int2)(x, y));
-  float4 p2 = read_imagef(in, sampleri, (int2)(x, y) + q);
-  float4 tmp = (p1 - p2)*(p1 - p2);
-  float dist = tmp.x + tmp.y + tmp.z;
-  
+  // Reminder: q.x and q.y can be negative
+  float dist = 0.0f;
+  if(x+q.x < width && y+q.y < height
+    && x+q.x >= 0 && y+q.y >= 0)
+  {
+    float4 p1 = read_imagef(in, sampleri, (int2)(x, y));
+    float4 p2 = read_imagef(in, sampleri, (int2)(x, y) + q);
+    float4 tmp = (p1 - p2)*(p1 - p2);
+    dist = tmp.x + tmp.y + tmp.z;
+  }
+
   U4[gidx] = dist;
 }
 
@@ -214,25 +217,36 @@ denoiseprofile_accu(read_only image2d_t in, global float4* U2, global float* U4,
   const int y = get_global_id(1);
   const int gidx = mad24(y, width, x);
 
+  if(x >= width || y >= height) return;
+
+  int wpq = 1;
+  int wmq = 1;
   if(q.x<0)
   {
-    if(x-q.x >= width || x<-q.x) return;
+    if(x-q.x >= width) wmq = 0;
+    if(x+q.x < 0) wpq = 0;
   }
   else
   {
-    if(x+q.x >= width || x<q.x) return;
+    if(x+q.x >= width) wpq = 0;
+    if(x-q.x < 0) wmq = 0;
   }
   if(q.y<0)
   {
-    if(y-q.y >= height || y<-q.y) return;
+    if(y-q.y >= height) wmq = 0;
+    if(y+q.y < 0) wpq = 0;
   }
   else
   {
-    if(y+q.y >= height || y<q.y) return;
+    if(y+q.y >= height) wpq = 0;
+    if(y-q.y < 0) wmq = 0;
   }
 
-  float4 u1_pq = read_imagef(in, sampleri, (int2)(x, y) + q);
-  float4 u1_mq = read_imagef(in, sampleri, (int2)(x, y) - q);
+
+  float4 u1_pq = 0;
+  if(wpq) u1_pq = read_imagef(in, sampleri, (int2)(x, y) + q);
+  float4 u1_mq = 0;
+  if(wmq) u1_mq = read_imagef(in, sampleri, (int2)(x, y) - q);
 
   float  u4    = U4[gidx];
   float  u4_mq = U4[mad24(clamp(y-q.y, 0, height-1), width, clamp(x-q.x, 0, width-1))];
@@ -240,7 +254,7 @@ denoiseprofile_accu(read_only image2d_t in, global float4* U2, global float* U4,
   float u4_mq_dd = u4_mq * ddirac(q);
 
   float4 accu = (u4 * u1_pq) + (u4_mq_dd * u1_mq);
-  accu.w = (u4 + u4_mq_dd);
+  accu.w = (wpq * u4 + wmq * u4_mq_dd);
 
   U2[gidx] += accu;
 }


### PR DESCRIPTION
Fixes #12400

Updated code is very similar to the one of https://github.com/darktable-org/darktable/pull/1999

This was tested with intel neo driver which is now blacklisted, it should be tested with another driver but unfortunately I do not have any other GPU than the intel one

I made a separated pull request as I experienced some strange behavior (the first 0-15 columns were sometimes oversmoothed, the number of oversmoothed columns depended on the image width), and I do not know if it was due to the driver (or something else), but I do not see it anymore. I did not see this issue with the "normal" non local means, hence the separated pull request.

Thus, this needs to be tested with a driver we are confident with, and with several images of different width (or using cropping)