### PR TITLE
iop/denoiseprofile.c: initialize ISO for interpolation

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2016,6 +2016,7 @@ void reload_defaults(dt_iop_module_t *module)
       }
       if(last && last->iso < iso && current->iso > iso)
       {
+        g->interpolated.iso = iso;
         dt_noiseprofile_interpolate(last, current, &g->interpolated);
         // signal later autodetection in commit_params:
         g->interpolated.a[0] = -1.0f;
@@ -2130,6 +2131,7 @@ static dt_noiseprofile_t dt_iop_denoiseprofile_get_auto_profile(dt_iop_module_t 
     }
     if(last && last->iso < iso && current->iso > iso)
     {
+      interpolated.iso = iso;
       dt_noiseprofile_interpolate(last, current, &interpolated);
       break;
     }


### PR DESCRIPTION
dt_noiseprofile_interpolate() should be called with the target ISO value
as third parameter, so it can calculate the desired value between the
lower and upper limits.
So far, it used ISO 0, which in the interpolation formula resulted in
	(0 - lowerISO)/(upperISO - lowerISO)
which is always a negative value, that is clamped to [0;1], resulting in
0. That means, the interpolation uses just the values of lowerISO in
every case.
This fix sets the desired ISO before calling
dt_denoiseprofile_interpolate().

Signed-off-by: Hartmut Knaack <knaack.h@gmx.de>