### PR TITLE
data/noiseprofiles.schema: reduce minimum ISO check

### DIFF
--- a/data/noiseprofiles.schema
+++ b/data/noiseprofiles.schema
@@ -66,7 +66,7 @@
                       },
                       "iso": {
                         "type": "integer",
-                        "minimum": 31,
+                        "minimum": 1,
                         "maximum": 2048000
                       },
                       "a": {


### PR DESCRIPTION
31 seems to be a pretty arbitrary number, CHDK allowed me to take
pictures at ISO 10. Since there are no restrictions in the code, let's
just go with the lowest sane value: 1.

Signed-off-by: Hartmut Knaack <knaack.h@gmx.de>