### PR TITLE
[UI usability] [WIP] masks selection from icons in 1-click 

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -387,7 +387,6 @@ typedef struct dt_iop_gui_blend_data_t
   GList *blend_modes;
   GList *masks_modes;
   GList *masks_modes_toggles;
-	GtkWidget *selected_mask_mode;//FLO
   GList *masks_combine;
   GList *masks_invert;
   GList *masks_feathering_guide;
@@ -395,7 +394,7 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *iopw;
   GtkBox *top_box;
   GtkBox *bottom_box;
-  GtkBox *masks_modes_box;//FLO
+  GtkBox *masks_modes_box;
   GtkBox *blendif_box;
   GtkBox *masks_box;
   GtkBox *raster_box;
@@ -405,6 +404,7 @@ typedef struct dt_iop_gui_blend_data_t
   GtkLabel *lower_label[8];
   GtkLabel *upper_picker_label;
   GtkLabel *lower_picker_label;
+	GtkWidget *selected_mask_mode;
   GtkWidget *upper_polarity;
   GtkWidget *lower_polarity;
   GtkWidget *colorpicker;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -362,6 +362,7 @@ typedef struct dt_iop_blend_mode_t
   unsigned int mode;
 } dt_iop_blend_mode_t;
 
+
 /** blend gui data */
 typedef struct dt_iop_gui_blend_data_t
 {

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -393,7 +393,7 @@ typedef struct dt_iop_gui_blend_data_t
   GtkLabel *lower_label[8];
   GtkLabel *upper_picker_label;
   GtkLabel *lower_picker_label;
-	GtkWidget *selected_mask_mode;
+  GtkWidget *selected_mask_mode;
   GtkWidget *upper_polarity;
   GtkWidget *lower_polarity;
   GtkWidget *colorpicker;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -362,6 +362,17 @@ typedef struct dt_iop_blend_mode_t
   unsigned int mode;
 } dt_iop_blend_mode_t;
 
+typedef struct masks_modes_toggles_t
+{
+	  GtkWidget *none;
+  	GtkWidget *uni;
+	  GtkWidget *drawn;
+	  GtkWidget *param;
+	  GtkWidget *both;
+	  GtkWidget *raster;
+} masks_modes_toggles_t;
+
+
 /** blend gui data */
 typedef struct dt_iop_gui_blend_data_t
 {
@@ -398,8 +409,15 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *suppress;
   void (*scale_print[8])(float value, char *string, int n);
   GtkWidget *masks_modes_combo;
-  GtkWidget *blend_modes_combo;
+
+  //FLO
+  GtkBox *masks_modes_box;
+	masks_modes_toggles_t masks_modes_toggles;
+	GtkWidget *selected_mask_mode;
+  //
+
   GtkWidget *masks_combine_combo;
+  GtkWidget *blend_modes_combo;
   GtkWidget *masks_invert_combo;
   GtkWidget *opacity_slider;
   GtkWidget *masks_feathering_guide_combo;

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -362,17 +362,6 @@ typedef struct dt_iop_blend_mode_t
   unsigned int mode;
 } dt_iop_blend_mode_t;
 
-typedef struct masks_modes_toggles_t
-{
-	  GtkWidget *none;
-  	GtkWidget *uni;
-	  GtkWidget *drawn;
-	  GtkWidget *param;
-	  GtkWidget *both;
-	  GtkWidget *raster;
-} masks_modes_toggles_t;
-
-
 /** blend gui data */
 typedef struct dt_iop_gui_blend_data_t
 {

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -386,6 +386,8 @@ typedef struct dt_iop_gui_blend_data_t
   dt_iop_module_t *module;
   GList *blend_modes;
   GList *masks_modes;
+  GList *masks_modes_toggles;
+	GtkWidget *selected_mask_mode;//FLO
   GList *masks_combine;
   GList *masks_invert;
   GList *masks_feathering_guide;
@@ -393,6 +395,7 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *iopw;
   GtkBox *top_box;
   GtkBox *bottom_box;
+  GtkBox *masks_modes_box;//FLO
   GtkBox *blendif_box;
   GtkBox *masks_box;
   GtkBox *raster_box;
@@ -408,14 +411,6 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *showmask;
   GtkWidget *suppress;
   void (*scale_print[8])(float value, char *string, int n);
-  GtkWidget *masks_modes_combo;
-
-  //FLO
-  GtkBox *masks_modes_box;
-	masks_modes_toggles_t masks_modes_toggles;
-	GtkWidget *selected_mask_mode;
-  //
-
   GtkWidget *masks_combine_combo;
   GtkWidget *blend_modes_combo;
   GtkWidget *masks_invert_combo;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1816,7 +1816,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
 	{
 		GtkWidget* to_be_activated = GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, mode));
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(to_be_activated), TRUE);
-		bd->selected_mask_mode = tb_activated;
+		bd->selected_mask_mode = to_be_activated;
 	}
 	else
 	{
@@ -2103,7 +2103,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     GtkWidget *but = NULL;
 
 		//DEVELOP_MASK_DISABLED
-		dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+		but = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_tooltip_text(but, _("off"));
 		bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED));
     bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
@@ -2433,10 +2433,10 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     //box enclosing the mask mode selection buttons
     bd->masks_modes_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE));
     //mask selection buttons packing in mask_box
-    for (int i = 0; i < g_list_length(masks_modes_toggles; i++)
+    for (int i = 0; i < g_list_length(bd->masks_modes_toggles); i++)
       gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, i)), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);
-    dt_gui_add_help_link(GTK_WIDGET(masks_modes_box), "blending.html");
+    dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_box), "blending.html");
     
 		bd->top_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
     gtk_box_pack_start(GTK_BOX(bd->top_box), bd->blend_modes_combo, TRUE, TRUE, 0);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2126,7 +2126,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(but), "button-press-event", G_CALLBACK(_blendop_masks_modes_none_clicked), module);
 
     // DEVELOP_MASK_ENABLED
-    but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_vertgradient, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+    but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_uniform, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_tooltip_text(but, _("uniformly"));
     bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED));
     bd->masks_modes_toggles  = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
@@ -2134,7 +2134,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     if(bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
       gtk_widget_set_tooltip_text(but, _("drawn mask"));
       bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
@@ -2142,7 +2142,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     }
     if(bd->blendif_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_inverse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_parametric, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER,
+                                   NULL);
       gtk_widget_set_tooltip_text(but, _("parametric mask"));
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL));
@@ -2152,7 +2153,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     if(bd->blendif_support && bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush_and_inverse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL); //overlays and
+      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn_and_parametric,
+                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL); // overlays and
       gtk_widget_set_tooltip_text(but, _("drawn & parametric mask"));
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL));
@@ -2162,7 +2164,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
     if(bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER
     {
-      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_effect, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+      but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_raster, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
       gtk_widget_set_tooltip_text(but, _("raster mask"));
       bd->masks_modes
           = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER));

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -637,10 +637,10 @@ static void _blendop_masks_modes_none_clicked(GtkWidget *button, GdkEventButton 
 
   if(event->button == 1)
   {
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode), FALSE);  //unsets currently toggled
-		
-		_blendop_masks_mode_callback(DEVELOP_MASK_DISABLED, data);
-		data->selected_mask_mode = button;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode), FALSE);  //unsets currently toggled
+    
+    _blendop_masks_mode_callback(DEVELOP_MASK_DISABLED, data);
+    data->selected_mask_mode = button;
   }
 }
 
@@ -652,42 +652,42 @@ static void _blendop_masks_modes_toggle(GtkToggleButton *button, dt_iop_module_t
   gboolean was_toggled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode), FALSE);  //unsets currently toggled in any case
 
-	if (was_toggled)
-	{
-		_blendop_masks_mode_callback(mask_mode, data);
-		data->selected_mask_mode = GTK_WIDGET(button);
-	}
+  if (was_toggled)
+  {
+    _blendop_masks_mode_callback(mask_mode, data);
+    data->selected_mask_mode = GTK_WIDGET(button);
+  }
   else
   {
-		_blendop_masks_mode_callback(DEVELOP_MASK_DISABLED, data);
+    _blendop_masks_mode_callback(DEVELOP_MASK_DISABLED, data);
     data->selected_mask_mode = GTK_WIDGET(g_list_nth_data(data->masks_modes_toggles, 
-																					g_list_index(data->masks_modes, DEVELOP_MASK_DISABLED)));
+                                          g_list_index(data->masks_modes, DEVELOP_MASK_DISABLED)));
   }
 }
 
 static void _blendop_masks_modes_uni_toggled(GtkToggleButton *button, dt_iop_module_t *module)
 {
-	_blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED);
+  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED);
 }
 
 static void _blendop_masks_modes_drawn_toggled(GtkToggleButton *button, dt_iop_module_t *module)
 {
-	_blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK);
+  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK);
 }
 
 static void _blendop_masks_modes_param_toggled(GtkToggleButton *button, dt_iop_module_t *module)
 {
-	_blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL);
+  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL);
 }
 
 static void _blendop_masks_modes_both_toggled(GtkToggleButton *button, dt_iop_module_t *module)
 {
-	_blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL);
+  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL);
 }
 
 static void _blendop_masks_modes_raster_toggled(GtkToggleButton *button, dt_iop_module_t *module)
 {
-	_blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER);
+  _blendop_masks_modes_toggle(button, module, DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER);
 }
 
 static void _blendop_blendif_suppress_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *module)
@@ -1809,19 +1809,19 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
 
   if(!(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || !bd || !bd->blend_inited) return;
 
-	unsigned int mode = g_list_index(bd->masks_modes, GUINT_TO_POINTER(module->blend_params->mask_mode));
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->selected_mask_mode), FALSE);  //unsets currently toggled
-	
-	if(mode > 0)
-	{
-		GtkWidget* to_be_activated = GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, mode));
-		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(to_be_activated), TRUE);
-		bd->selected_mask_mode = to_be_activated;
-	}
-	else
-	{
-		bd->selected_mask_mode = g_list_nth_data(bd->masks_modes_toggles, DEVELOP_MASK_DISABLED);
-	}
+  unsigned int mode = g_list_index(bd->masks_modes, GUINT_TO_POINTER(module->blend_params->mask_mode));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->selected_mask_mode), FALSE);  //unsets currently toggled
+  
+  if(mode > 0)
+  {
+    GtkWidget* to_be_activated = GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, mode));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(to_be_activated), TRUE);
+    bd->selected_mask_mode = to_be_activated;
+  }
+  else
+  {
+    bd->selected_mask_mode = g_list_nth_data(bd->masks_modes_toggles, DEVELOP_MASK_DISABLED);
+  }
 
   int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
@@ -2102,62 +2102,62 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     //toggle buttons creation for masks modes
     GtkWidget *but = NULL;
 
-		//DEVELOP_MASK_DISABLED
-		but = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+    //DEVELOP_MASK_DISABLED
+    but = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_tooltip_text(but, _("off"));
-		bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED));
+    bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_DISABLED));
     bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
-		g_signal_connect(G_OBJECT(but), "button-press-event", G_CALLBACK(_blendop_masks_modes_none_clicked), module);
+    g_signal_connect(G_OBJECT(but), "button-press-event", G_CALLBACK(_blendop_masks_modes_none_clicked), module);
 
-		// DEVELOP_MASK_ENABLED 
+    // DEVELOP_MASK_ENABLED 
     but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_vertgradient, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_tooltip_text(but, _("uniformly"));
-		bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED));
+    bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED));
     bd->masks_modes_toggles  = g_list_append(bd->masks_modes_toggles , GTK_WIDGET(but));
-		g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_uni_toggled), module);
+    g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_uni_toggled), module);
 
     if(bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK
     {
       but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
       gtk_widget_set_tooltip_text(but, _("drawn mask"));
-		  bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK));
+      bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-		  g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_drawn_toggled), module);
+      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_drawn_toggled), module);
     }
     if(bd->blendif_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL
     {
       but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_inverse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
       gtk_widget_set_tooltip_text(but, _("parametric mask"));
-		  bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL));
+      bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-		  g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_param_toggled), module);
+      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_param_toggled), module);
     }
 
     if(bd->blendif_support && bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL
     {
       but = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush_and_inverse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL); //overlays and
       gtk_widget_set_tooltip_text(but, _("drawn & parametric mask"));
-		  bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL));
+      bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_MASK_CONDITIONAL));
       bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-			g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_both_toggled), module);
+      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_both_toggled), module);
     }
 
     if(bd->masks_support) //DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER
     {
       but = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_effect, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
       gtk_widget_set_tooltip_text(but, _("raster mask"));
-		  bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER));
-			bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
-  		g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_raster_toggled), module);
+      bd->masks_modes = g_list_append(bd->masks_modes, GUINT_TO_POINTER(DEVELOP_MASK_ENABLED | DEVELOP_MASK_RASTER));
+      bd->masks_modes_toggles = g_list_append(bd->masks_modes_toggles, GTK_WIDGET(but));
+      g_signal_connect(G_OBJECT(but), "toggled", G_CALLBACK(_blendop_masks_modes_raster_toggled), module);
     }
-		//initial state is no mask
-		bd->selected_mask_mode = GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, g_list_index(bd->masks_modes, DEVELOP_MASK_DISABLED)));
+    //initial state is no mask
+    bd->selected_mask_mode = GTK_WIDGET(g_list_nth_data(bd->masks_modes_toggles, g_list_index(bd->masks_modes, DEVELOP_MASK_DISABLED)));
 
     bd->blend_modes_combo = dt_bauhaus_combobox_new(module);
     dt_bauhaus_widget_set_label(bd->blend_modes_combo, _("blend"), _("blend mode"));
     gtk_widget_set_tooltip_text(bd->blend_modes_combo, _("choose blending mode"));
     
-		switch(bd->csp)
+    switch(bd->csp)
     {
       case iop_cs_Lab:
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2425,7 +2425,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
     gtk_box_pack_start(GTK_BOX(iopw), GTK_WIDGET(box), TRUE, TRUE, 0);
 
-		GtkWidget *blend_label = dt_ui_section_label_new(_("blend options"));
+    GtkWidget *blend_label = dt_ui_section_label_new(_("blend options"));
     gtk_box_pack_start(GTK_BOX(box), blend_label, TRUE, TRUE, 0);
     gtk_widget_set_tooltip_text(GTK_WIDGET(blend_label), _("activate blending: uniformly, with drawn mask, with "
                                                         "parametric mask, or combination of both"));
@@ -2438,7 +2438,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);
     dt_gui_add_help_link(GTK_WIDGET(bd->masks_modes_box), "blending.html");
     
-		bd->top_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
+    bd->top_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
     gtk_box_pack_start(GTK_BOX(bd->top_box), bd->blend_modes_combo, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->top_box), bd->opacity_slider, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->top_box), TRUE, TRUE, 0);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -654,12 +654,18 @@ static void _blendop_masks_modes_toggle(GtkToggleButton *button, dt_iop_module_t
   if(darktable.gui->reset) return;
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
-	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
+  gboolean was_toggled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode), FALSE);  //unsets currently toggled in any case
+	if (was_toggled)
 	{
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->selected_mask_mode), FALSE);  //unsets currently toggled
 		dt_bauhaus_combobox_set(data->masks_modes_combo, mask_mode);
-		data->selected_mask_mode = (GtkWidget*) button;
+		data->selected_mask_mode = GTK_WIDGET(button);
 	}
+  else
+  {
+    dt_bauhaus_combobox_set(data->masks_modes_combo, DEVELOP_MASK_DISABLED);
+    data->selected_mask_mode = GTK_WIDGET(data->masks_modes_toggles.none);
+  }
 }
 
 static void _blendop_masks_modes_uni_toggled(GtkToggleButton *button, dt_iop_module_t *module)
@@ -1799,7 +1805,6 @@ void dt_iop_gui_cleanup_blending(dt_iop_module_t *module)
   module->blend_data = NULL;
 }
 
-
 void dt_iop_gui_update_blending(dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
@@ -2460,7 +2465,7 @@ switch(bd->csp)
     gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(bd->masks_modes_toggles.param), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(bd->masks_modes_toggles.both), TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(bd->masks_modes_box), GTK_WIDGET(bd->masks_modes_toggles.raster), TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(bd->masks_modes_box), FALSE, FALSE, 0);
     
 		bd->top_box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
     gtk_box_pack_start(GTK_BOX(bd->top_box), bd->blend_modes_combo, TRUE, TRUE, 0);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -555,6 +555,163 @@ void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_identity_matrix(cr);
 }
 
+void dtgtk_cairo_paint_masks_uniform(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
+  cairo_scale(cr, s, s);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_set_line_width(cr, 0.125);
+
+  cairo_arc(cr, 0.5, 0.5, 0.5, -M_PI, M_PI);
+  cairo_stroke(cr);
+}
+
+void dtgtk_cairo_paint_masks_drawn(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
+  cairo_set_line_width(cr, 0.05);
+
+  // draw the body of the pencil (filled)
+  cairo_move_to(cr, 0.9, 0.6);
+  cairo_line_to(cr, 0.3, 0.0);
+  cairo_line_to(cr, 0.0, 0.3);
+  cairo_line_to(cr, 0.6, 0.9);
+  // cairo_stroke_preserve(cr);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+  // draw the tip of the pencil
+  cairo_move_to(cr, 1.0, 1.0);
+  cairo_line_to(cr, 0.9, 0.6);
+  cairo_line_to(cr, 0.6, 0.9);
+  cairo_line_to(cr, 1.0, 1.0);
+  cairo_stroke(cr);
+  cairo_identity_matrix(cr);
+}
+
+/** draws an arc with a B&W gradient following the arc path.
+ *  nb_steps must be adjusted depending on the displayed size of the element, 16 is fine for small buttons*/
+void _gradient_arc(cairo_t *cr, double lw, int nb_steps, double x_center, double y_center, double radius,
+                   double angle_from, double angle_to, double color_from, double color_to)
+{
+  cairo_set_line_width(cr, lw);
+
+  double *portions = malloc((1 + nb_steps) * sizeof(double));
+
+  // note: cairo angles seems to be shifted by M_PI relatively to the unit circle
+  angle_from = angle_from + M_PI;
+  angle_to = angle_to + M_PI;
+  double step = (angle_to - angle_from) / nb_steps;
+  for(int i = 0; i < nb_steps; i++) portions[i] = angle_from + i * step;
+  portions[nb_steps] = angle_to;
+
+  for(int i = 0; i < nb_steps; i++)
+  {
+    double color = color_from + i * (color_to - color_from) / nb_steps;
+    cairo_set_source_rgb(cr, color, color, color);
+    cairo_arc(cr, x_center, y_center, radius, portions[i], portions[i + 1]);
+    cairo_stroke(cr);
+  }
+  free(portions);
+}
+
+void dtgtk_cairo_paint_masks_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, 0.125);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
+  _gradient_arc(cr, 0.125, 16, 0.5, 0.5, 0.5, -M_PI / 3.0, M_PI + M_PI / 3.0, 0.3, 0.9);
+
+  cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
+  cairo_set_line_width(cr, 0.05);
+  // draw one tick up right
+  cairo_move_to(cr, 1, 0.2);
+  cairo_line_to(cr, 1.2, 0.2);
+  cairo_line_to(cr, 1.1, 0.0);
+  cairo_fill(cr);
+  // draw another tick center right
+  cairo_move_to(cr, 1.1, 0.6);
+  cairo_line_to(cr, 1.325, 0.55);
+  cairo_line_to(cr, 1.275, 0.75);
+  cairo_fill(cr);
+
+  cairo_identity_matrix(cr);
+}
+
+void dtgtk_cairo_paint_masks_drawn_and_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags,
+                                                  void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, 0.1);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
+  _gradient_arc(cr, 0.125, 16, 0.75, 0.6, 0.4, -M_PI / 3.0, M_PI + M_PI / 3.0, 0.3, 0.9);
+
+  cairo_set_line_width(cr, 0.05);
+  cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
+  // draw one tick up right
+  cairo_move_to(cr, 1.2, 0.35);
+  cairo_line_to(cr, 1.35, 0.35);
+  cairo_line_to(cr, 1.275, 0.15);
+  cairo_fill(cr);
+  // draw another tick center right
+  cairo_move_to(cr, 1.25, 0.7);
+  cairo_line_to(cr, 1.4, 0.6);
+  cairo_line_to(cr, 1.4, 0.8);
+  cairo_fill(cr);
+
+  cairo_set_source_rgb(cr, 0.6, 0.6, 0.6);
+  double szf = 0.8;     // size factor to reduce the size of the pencil
+  double shift = -0.10; // shift factor on x axis
+  // draw the body of the pencil (filled)
+  cairo_move_to(cr, 0.9 * szf + shift, 0.6 * szf);
+  cairo_line_to(cr, 0.3 * szf + shift, 0.0 * szf);
+  cairo_line_to(cr, 0.0 * szf + shift, 0.3 * szf);
+  cairo_line_to(cr, 0.6 * szf + shift, 0.9 * szf);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+  // draw the tip of the pencil
+  cairo_move_to(cr, 1.0 * szf + shift, 1.0 * szf);
+  cairo_line_to(cr, 0.9 * szf + shift, 0.6 * szf);
+  cairo_line_to(cr, 0.6 * szf + shift, 0.9 * szf);
+  cairo_line_to(cr, 1.0 * szf + shift, 1.0 * szf);
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+}
+
+void dtgtk_cairo_paint_masks_raster(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, 0.1);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
+  cairo_arc(cr, 0.5, 0.5, 0.5, 0, 2 * M_PI);
+  cairo_clip(cr);
+  cairo_new_path(cr);
+
+  for(int i = 0; i < 4; i++)
+    for(int j = 0; j < 4; j++)
+    {
+      double color = (i + j) % 2 ? 0.2 : 0.9;
+      cairo_set_source_rgb(cr, color, color, color);
+      cairo_rectangle(cr, i / 4.0, j / 4.0, 1.0 / 4.0, 1.0 / 4.0);
+      cairo_fill(cr);
+    }
+}
+
+
 void dtgtk_cairo_paint_masks_multi(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gint s = w < h ? w : h;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -478,6 +478,61 @@ void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, g
   cairo_identity_matrix(cr);
 }
 
+void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  if(flags & CPF_ACTIVE)
+    cairo_set_line_width(cr, 0.25);
+  else
+    cairo_set_line_width(cr, 0.125);
+  cairo_rectangle(cr, 0.0, 0.0, 1.0, 1.0);
+  cairo_stroke_preserve(cr);
+  cairo_pattern_t *pat = NULL;
+  pat = cairo_pattern_create_linear(0.0, 0.5, 1.0, 0.5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, 0.6, 0.6, 0.6, 1.0);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, 0.2, 0.2, 0.2, 1.0);
+  cairo_rectangle(cr, 0.1, 0.1, 0.8, 0.8);
+  cairo_set_source(cr, pat);
+  cairo_fill(cr);
+  cairo_pattern_destroy(pat);
+  cairo_identity_matrix(cr);
+}
+
+
+void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  if(flags & CPF_ACTIVE)
+    cairo_set_line_width(cr, 0.25);
+  else
+    cairo_set_line_width(cr, 0.125);
+  cairo_move_to(cr, 0.0, 1.0);
+  cairo_line_to(cr, 0.1, 0.7);
+  cairo_line_to(cr, 0.8, 0.0);
+  cairo_line_to(cr, 1.0, 0.2);
+  cairo_line_to(cr, 0.3, 0.9);
+  cairo_line_to(cr, 0.0, 1.0);
+  //  cairo_fill_preserve(cr);
+  cairo_stroke(cr);
+
+  //cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_set_line_width(cr, 0.15);
+  cairo_arc(cr, 0.5, 0.5, 0.46, 0, 2.0 * M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.5, 0.5, 0.46, 3.0 * M_PI / 2.0, M_PI / 2.0);
+  cairo_fill(cr);
+
+  cairo_stroke(cr);
+  cairo_identity_matrix(cr);
+}
+
 void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gint s = w < h ? w : h;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -174,6 +174,10 @@ void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint 
 void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a brush icon for masks*/
 void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a vertical gradient icon for masks selection*/
+void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a brush + inverse icon for masks selection*/
+void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a multi-path icon for masks*/
 void dtgtk_cairo_paint_masks_multi(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a inverse icon for masks*/

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -173,6 +173,16 @@ void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint 
 /** Paint a path icon for masks*/
 void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a brush icon for masks*/
+
+// FLO
+void dtgtk_cairo_paint_masks_uniform(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_masks_drawn(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_masks_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_masks_drawn_and_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags,
+                                                  void *data);
+void dtgtk_cairo_paint_masks_raster(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
+
 void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a vertical gradient icon for masks selection*/
 void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);


### PR DESCRIPTION
Following [feature request #2011](https://github.com/darktable-org/darktable/issues/2011)

I tried to implement on a minimal change basis in order to avoid breaking something than works (especially the callback for the removed combobox) and to respect the logic of already existing code.

The new glist introduced in develop/blend.h is freed in dt_iop_gui_cleanup_blending (like all the already existing ones).

My manual testing consisted of :
- changing masks from one to another, everything gui element displaying fine 
- disable current mask by clicking on cross or untoggling the current mask
- having previous masks state properly restored when selecting another image in the film roll


