### PR TITLE
Nlmeans: enable bilateral filtering (P=0)

### DIFF
--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -185,15 +185,6 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   const int K = ceilf(7 * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f));         // nbhood
   const float sharpness = 3000.0f / (1.0f + d->strength);
 
-  if(P < 1)
-  {
-    size_t origin[] = { 0, 0, 0 };
-    size_t region[] = { width, height, 1 };
-    err = dt_opencl_enqueue_copy_image(devid, dev_in, dev_out, origin, origin, region);
-    if(err != CL_SUCCESS) goto error;
-    return TRUE;
-  }
-
   float max_L = 120.0f, max_C = 512.0f;
   float nL = 1.0f / max_L, nC = 1.0f / max_C;
   float nL2 = nL * nL, nC2 = nC * nC;
@@ -375,12 +366,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int P = ceilf(d->radius * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f)); // pixel filter size
   const int K = ceilf(7 * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f));         // nbhood
   const float sharpness = 3000.0f / (1.0f + d->strength);
-  if(P < 1)
-  {
-    // nothing to do from this distance:
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * 4 * roi_out->width * roi_out->height);
-    return;
-  }
 
   // adjust to Lab, make L more important
   // float max_L = 100.0f, max_C = 256.0f;
@@ -519,12 +504,6 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int P = ceilf(d->radius * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f)); // pixel filter size
   const int K = ceilf(7 * fmin(roi_in->scale, 2.0f) / fmax(piece->iscale, 1.0f));         // nbhood
   const float sharpness = 3000.0f / (1.0f + d->strength);
-  if(P < 1)
-  {
-    // nothing to do from this distance:
-    memcpy(ovoid, ivoid, (size_t)sizeof(float) * 4 * roi_out->width * roi_out->height);
-    return;
-  }
 
   // adjust to Lab, make L more important
   // float max_L = 100.0f, max_C = 256.0f;


### PR DESCRIPTION
This is already possible in denoise profile, but was not available here, while it does not require any code change to the core of the algorithm.
Note that I did not test the opencl code yet, I currently do not have access to my main computer.

To test this, in denoise non local, set patch size to 0 (the slider bound is a soft boundary. It is already possible to set it to 0 without this PR because I made a mistake on it earlier as I copy pasted the range from denoiseprofile without thinking there would be some memcpy in the case of P=0, and I tested only bigger values and did not paid attention to the value 0. Anyway, this PR gives a denoising behavior for P=0)