### PR TITLE
atrous (equalizer): optimize loops and vectorization

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -463,8 +463,7 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
      * to avoid unneeded branching in the inner loops */
     for(size_t i = 2 * mult; i < width - 2 * mult; i++)
     {
-      __m128 sum_jj[5] = { _mm_setzero_ps() };
-      __m128 wgt_jj[5] = { _mm_setzero_ps() };
+      __m128 sum_jj[5], wgt_jj[5];
 
       const size_t inc = 4 * (j * width + i);
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -345,7 +345,11 @@ static void eaw_decompose(float *const out, const float *const in, float *const 
       {
         for(size_t ii = 0; ii < 5; ii++)
         {
-          px2 = ((float *)in) + 4 * (i - 2 * mult + (j - 2 * mult) * width + jj * (width - 5) * mult + ii * mult);
+          const size_t iii = (ii)-2;
+          const size_t jjj = (jj)-2;
+          const size_t x = i + mult * iii;
+          const size_t y = j + mult * jjj;
+          px2 = (float *)in +  4 * (x + y * width);
           SUM_PIXEL_CONTRIBUTION_COMMON(ii, jj);
         }
       }
@@ -458,7 +462,11 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
       {
         for(int ii = 0; ii < 5; ii++)
         {
-          px2 = _mm_load_ps(((float *)in) + 4 * (i - 2 * mult + (j - 2 * mult) * width + jj * (width - 5) * mult + ii * mult));
+          const size_t iii = (ii)-2;
+          const size_t jjj = (jj)-2;
+          const size_t x = i + mult * iii;
+          const size_t y = j + mult * jjj;
+          px2 = _mm_load_ps((float *)in +  4 * (x + y * width));
           SUM_PIXEL_CONTRIBUTION_COMMON_SSE2(ii, jj);
         }
       }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -584,7 +584,7 @@ static void eaw_synthesize(float *const out, const float *const in, const float 
   const float boost[4] = { boostf[0], boostf[1], boostf[2], boostf[3] };
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#pragma omp parallel for default(none) schedule(static) collapse(2)
 #endif
   for(size_t k = 0; k < (size_t)4 * width * height; k += 4)
   {
@@ -609,7 +609,7 @@ static void eaw_synthesize_sse2(float *const out, const float *const in, const f
   __m128 *const mask = (__m128 *)&maski;
 
 #ifdef _OPENMP
-#pragma omp parallel for simd schedule(static) default(none)
+#pragma omp parallel for schedule(static) default(none)
 #endif
   for(size_t k = 0; k < width * height * 4; k += 4)
   {

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -34,6 +34,7 @@
 #include <memory.h>
 #include <stdlib.h>
 #if defined(__SSE__)
+#include "common/sse.h"
 #include <xmmintrin.h>
 #endif
 
@@ -146,27 +147,17 @@ void connect_key_accels(dt_iop_module_t *self)
     (a), (a), (a), (a)                                                                                       \
   }
 
-static const __m128 fone ALIGNED(16) = VEC4(0x3f800000u);
-static const __m128 femo ALIGNED(16) = VEC4(0x00adf880u);
 static const __m128 ooo1 ALIGNED(16) = { 0.f, 0.f, 0.f, 1.f };
-
-/* SSE intrinsics version of dt_fast_expf defined in darktable.h */
-static inline __m128 dt_fast_expf_sse2(const __m128 x)
-{
-  __m128 f = _mm_add_ps(fone, _mm_mul_ps(x, femo)); // f(n) = i1 + x(n)*(i2-i1)
-  __m128i i = _mm_cvtps_epi32(f);                   // i(n) = int(f(n))
-  __m128i mask = _mm_srai_epi32(i, 31);             // mask(n) = 0xffffffff if i(n) < 0
-  i = _mm_andnot_si128(mask, i);                    // i(n) = 0 if i(n) < 0
-  return _mm_castsi128_ps(i);                       // return *(float*)&i
-}
-
 #endif
 
 static inline void weight(const float *c1, const float *c2, const float sharpen, float *weight)
 {
   float square[3];
-  for(int c = 0; c < 3; c++) square[c] = c1[c] - c2[c];
-  for(int c = 0; c < 3; c++) square[c] = square[c] * square[c];
+  for(int c = 0; c < 3; c++)
+  {
+    square[c] = c1[c] - c2[c];
+    square[c] *= square[c];
+  }
 
   const float wl = dt_fast_expf(-sharpen * square[0]);
   const float wc = dt_fast_expf(-sharpen * (square[1] + square[2]));
@@ -187,21 +178,35 @@ static inline void weight(const float *c1, const float *c2, const float sharpen,
  * wc = exp(-sharpen*(SQR(c1[1] - c2[1]) + SQR(c1[2] - c2[2]))
  *    = exp(-s*(d2+d3)) (as noted in code comments below)
  */
-static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float sharpen)
+static inline __m128 weight_sse2(const __m128 c1, const __m128 c2, const float sharpen)
 {
-  const __m128 vsharpen = _mm_set1_ps(-sharpen); // (-s, -s, -s, -s)
-  __m128 diff = _mm_sub_ps(*c1, *c2);
-  __m128 square = _mm_mul_ps(diff, diff);                                   // (?, d3, d2, d1)
-  __m128 square2 = _mm_shuffle_ps(square, square, _MM_SHUFFLE(3, 1, 2, 0)); // (?, d2, d3, d1)
-  __m128 added = _mm_add_ps(square, square2);                               // (?, d2+d3, d2+d3, 2*d1)
-  added = _mm_sub_ss(added, square);                                        // (?, d2+d3, d2+d3, d1)
-  __m128 sharpened = _mm_mul_ps(added, vsharpen);                   // (?, -s*(d2+d3), -s*(d2+d3), -s*d1)
-  __m128 exp = dt_fast_expf_sse2(sharpened);                        // (?, wc, wc, wl)
+  const __m128 vsharpen = _mm_set1_ps(-sharpen);                    // (-s, -s, -s, -s)
+  const __m128 diff = (c1 - c2);
+  const __m128 square = diff * diff;                                // (?, d3, d2, d1)
+  const __m128 square2 = _mm_shuffle_ps(square, square, _MM_SHUFFLE(3, 1, 2, 0)); // (?, d2, d3, d1)
+  const __m128 added = square + square2 - square;                   // (?, d2+d3, d2+d3, d1)
+  const __m128 sharpened = added * vsharpen;                        // (?, -s*(d2+d3), -s*(d2+d3), -s*d1)
+  __m128 exp = _mm_expf_ps(sharpened);                        // (?, wc, wc, wl)
   exp = _mm_castsi128_ps(_mm_slli_si128(_mm_castps_si128(exp), 4)); // (wc, wc, wl, 0)
   exp = _mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(exp), 4)); // (0, wc, wc, wl)
-  exp = _mm_or_ps(exp, ooo1);                                       // (1, wc, wc, wl)
-  return exp;
+  return _mm_or_ps(exp, ooo1);                                      // (1, wc, wc, wl)
 }
+
+#define CONVOLVE_SSE \
+  const __m128 L_0 =  _mm_set1_ps( pin0[0] );  \
+  const __m128 a_0 =  _mm_set1_ps( pin0[1] );  \
+  const __m128 b_0 =  _mm_set1_ps( pin0[2] );  \
+  const __m128 L_f = _mm_set_ps(pin4[0], pin3[0], pin2[0], pin1[0]); \
+  const __m128 a_f = _mm_set_ps(pin4[1], pin3[1], pin2[1], pin1[1]); \
+  const __m128 b_f = _mm_set_ps(pin4[2], pin3[2], pin2[2], pin1[2]); \
+  const __m128 w_L = filter * weight_chan_sse2(L_0, L_f, sharpen); \
+  const __m128 w_c = filter * weight_chan_sse2(a_0 + b_0, a_f + b_f, sharpen); \
+  const __m128 wgt = (_mm_set_ps(0.0f, sum_vect_sse(w_L)[0], sum_vect_sse(w_c)[0], sum_vect_sse(w_c)[0]) + w_0); \
+  const __m128 w_1 = _mm_set_ps(0.0f, w_c[0], w_c[0], w_L[0]); \
+  const __m128 w_2 = _mm_set_ps(0.0f, w_c[1], w_c[1], w_L[1]); \
+  const __m128 w_3 = _mm_set_ps(0.0f, w_c[2], w_c[2], w_L[2]); \
+  const __m128 w_4 = _mm_set_ps(0.0f, w_c[3], w_c[3], w_L[3]); \
+  const __m128 sum = (w_1 * pin1 + w_2 * pin2 + w_3 * pin3 + w_4 * pin4 + w_0 * pin0) * _mm_rcp_ps(wgt);
 #endif
 
 #define SUM_PIXEL_CONTRIBUTION_COMMON(ii, jj)                                                                \
@@ -220,29 +225,27 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
 #if defined(__SSE2__)
 #define SUM_PIXEL_CONTRIBUTION_COMMON_SSE2(ii, jj)                                                           \
   {                                                                                                          \
-    const __m128 f = _mm_set1_ps(filter[(ii)] * filter[(jj)]);                                               \
-    const __m128 wp = weight_sse2(px, px2, sharpen);                                                         \
-    const __m128 w = _mm_mul_ps(f, wp);                                                                      \
-    const __m128 pd = _mm_mul_ps(w, *px2);                                                                   \
-    sum = _mm_add_ps(sum, pd);                                                                               \
-    wgt = _mm_add_ps(wgt, w);                                                                                \
+    const float f = filter[(ii)] * filter[(jj)];                                                             \
+    const __m128 wp = weight_sse2(*px, *px2, sharpen);                                                       \
+    const __m128 w = f * wp;                                                                                 \
+    const __m128 pd = w * *px2;                                                                              \
+    sum += pd;                                                                                               \
+    wgt += w;                                                                                                \
   }
 #endif
 
 #define SUM_PIXEL_CONTRIBUTION_WITH_TEST(ii, jj)                                                             \
   do                                                                                                         \
   {                                                                                                          \
-    const int iii = (ii)-2;                                                                                  \
-    const int jjj = (jj)-2;                                                                                  \
-    int x = i + mult * iii;                                                                                  \
-    int y = j + mult * jjj;                                                                                  \
+    const size_t iii = (ii)-2;                                                                               \
+    const size_t jjj = (jj)-2;                                                                               \
+    size_t x = i + mult * iii;                                                                               \
+    size_t y = j + mult * jjj;                                                                               \
                                                                                                              \
-    if(x < 0) x = 0;                                                                                         \
     if(x >= width) x = width - 1;                                                                            \
-    if(y < 0) y = 0;                                                                                         \
     if(y >= height) y = height - 1;                                                                          \
                                                                                                              \
-    px2 = ((float *)in) + 4 * x + (size_t)4 * y * width;                                                     \
+    px2 = ((float *)in) + 4 * (x + y * width);                                                               \
                                                                                                              \
     SUM_PIXEL_CONTRIBUTION_COMMON(ii, jj);                                                                   \
   } while(0)
@@ -251,90 +254,76 @@ static inline __m128 weight_sse2(const __m128 *c1, const __m128 *c2, const float
 #define SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(ii, jj)                                                        \
   do                                                                                                         \
   {                                                                                                          \
-    const int iii = (ii)-2;                                                                                  \
-    const int jjj = (jj)-2;                                                                                  \
-    int x = i + mult * iii;                                                                                  \
-    int y = j + mult * jjj;                                                                                  \
+    const size_t iii = (ii)-2;                                                                               \
+    const size_t jjj = (jj)-2;                                                                               \
+    size_t x = i + mult * iii;                                                                               \
+    size_t y = j + mult * jjj;                                                                               \
                                                                                                              \
-    if(x < 0) x = 0;                                                                                         \
     if(x >= width) x = width - 1;                                                                            \
-    if(y < 0) y = 0;                                                                                         \
     if(y >= height) y = height - 1;                                                                          \
                                                                                                              \
-    px2 = ((__m128 *)in) + x + (size_t)y * width;                                                            \
+    px2 = ((__m128 *)in) + x + y * width;                                                                    \
                                                                                                              \
     SUM_PIXEL_CONTRIBUTION_COMMON_SSE2(ii, jj);                                                              \
   } while(0)
 #endif
 
-#define ROW_PROLOGUE                                                                                         \
-  const float *px = ((float *)in) + (size_t)4 * j * width;                                                   \
-  const float *px2;                                                                                          \
-  float *pdetail = detail + (size_t)4 * j * width;                                                           \
-  float *pcoarse = out + (size_t)4 * j * width;
-
-#if defined(__SSE2__)
-#define ROW_PROLOGUE_SSE                                                                                     \
-  const __m128 *px = ((__m128 *)in) + (size_t)j * width;                                                     \
-  const __m128 *px2;                                                                                         \
-  float *pdetail = detail + (size_t)4 * j * width;                                                           \
-  float *pcoarse = out + (size_t)4 * j * width;
-#endif
-
 #define SUM_PIXEL_PROLOGUE                                                                                   \
   float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };                                                                 \
-  float wgt[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+  float wgt[4] = { 0.0f, 0.0f, 0.0f, 0.0f };                                                                 \
+  const size_t inc = 4 * (j * width + i);                                                                    \
+  const float *px = ((float *)in) + inc;                                                                     \
+  const float *px2;                                                                                          \
+  float *pdetail = detail + inc;                                                                             \
+  float *pcoarse = out + inc;
 
 #if defined(__SSE2__)
 #define SUM_PIXEL_PROLOGUE_SSE                                                                               \
   __m128 sum = _mm_setzero_ps();                                                                             \
-  __m128 wgt = _mm_setzero_ps();
+  __m128 wgt = _mm_setzero_ps();                                                                             \
+  const size_t inc = 4 * (j * width + i);                                                                    \
+  const __m128 *px = (__m128 *)(in + inc);                                                                   \
+  const __m128 *px2;                                                                                         \
+  float *pdetail = detail + inc;                                                                             \
+  float *pcoarse = out + inc;
 #endif
+
 
 #define SUM_PIXEL_EPILOGUE                                                                                   \
   for(int c = 0; c < 4; c++) sum[c] /= wgt[c];                                                               \
-                                                                                                             \
   for(int c = 0; c < 4; c++) pdetail[c] = (px[c] - sum[c]);                                                  \
-  for(int c = 0; c < 4; c++) pcoarse[c] = sum[c];                                                            \
-  px += 4;                                                                                                   \
-  pdetail += 4;                                                                                              \
-  pcoarse += 4;
+  for(int c = 0; c < 4; c++) pcoarse[c] = sum[c];
 
 #if defined(__SSE2__)
 #define SUM_PIXEL_EPILOGUE_SSE                                                                               \
-  sum = _mm_mul_ps(sum, _mm_rcp_ps(wgt));                                                                    \
-                                                                                                             \
-  _mm_stream_ps(pdetail, _mm_sub_ps(*px, sum));                                                              \
-  _mm_stream_ps(pcoarse, sum);                                                                               \
-  px++;                                                                                                      \
-  pdetail += 4;                                                                                              \
-  pcoarse += 4;
+  sum /= wgt;                                                                                                \
+  _mm_stream_ps(pdetail, *px - sum);                                                              \
+  _mm_stream_ps(pcoarse, sum);
 #endif
 
+
 typedef void((*eaw_decompose_t)(float *const out, const float *const in, float *const detail, const int scale,
-                                const float sharpen, const int32_t width, const int32_t height));
+                                const float sharpen, const size_t width, const size_t height));
 
 static void eaw_decompose(float *const out, const float *const in, float *const detail, const int scale,
-                          const float sharpen, const int32_t width, const int32_t height)
+                          const float sharpen, const size_t width, const size_t height)
 {
-  const int mult = 1 << scale;
+  const size_t mult = 1 << scale;
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
 
 /* The first "2*mult" lines use the macro with tests because the 5x5 kernel
  * requires nearest pixel interpolation for at least a pixel in the sum */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
-  for(int j = 0; j < 2 * mult; j++)
+  for(size_t j = 0; j < 2 * mult; j++)
   {
-    ROW_PROLOGUE
-
-    for(int i = 0; i < width; i++)
+    for(size_t i = 0; i < width; i++)
     {
       SUM_PIXEL_PROLOGUE
-      for(int jj = 0; jj < 5; jj++)
+      for(size_t jj = 0; jj < 5; jj++)
       {
-        for(int ii = 0; ii < 5; ii++)
+        for(size_t ii = 0; ii < 5; ii++)
         {
           SUM_PIXEL_CONTRIBUTION_WITH_TEST(ii, jj);
         }
@@ -344,20 +333,18 @@ static void eaw_decompose(float *const out, const float *const in, float *const 
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd default(none) schedule(static)
 #endif
-  for(int j = 2 * mult; j < height - 2 * mult; j++)
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
   {
-    ROW_PROLOGUE
-
     /* The first "2*mult" pixels use the macro with tests because the 5x5 kernel
      * requires nearest pixel interpolation for at least a pixel in the sum */
-    for(int i = 0; i < 2 * mult; i++)
+    for(size_t i = 0; i < 2 * mult; i++)
     {
       SUM_PIXEL_PROLOGUE
-      for(int jj = 0; jj < 5; jj++)
+      for(size_t jj = 0; jj < 5; jj++)
       {
-        for(int ii = 0; ii < 5; ii++)
+        for(size_t ii = 0; ii < 5; ii++)
         {
           SUM_PIXEL_CONTRIBUTION_WITH_TEST(ii, jj);
         }
@@ -367,29 +354,27 @@ static void eaw_decompose(float *const out, const float *const in, float *const 
 
     /* For pixels [2*mult, width-2*mult], we can safely use macro w/o tests
      * to avoid unneeded branching in the inner loops */
-    for(int i = 2 * mult; i < width - 2 * mult; i++)
+    for(size_t i = 2 * mult; i < width - 2 * mult; i++)
     {
       SUM_PIXEL_PROLOGUE
-      px2 = ((float *)in) + (size_t)4 * (i - 2 * mult + (size_t)(j - 2 * mult) * width);
-      for(int jj = 0; jj < 5; jj++)
+      for(size_t jj = 0; jj < 5; jj++)
       {
-        for(int ii = 0; ii < 5; ii++)
+        for(size_t ii = 0; ii < 5; ii++)
         {
+          px2 = ((float *)in) + 4 * (i - 2 * mult + (j - 2 * mult) * width + jj * (width - 5) * mult + ii * mult);
           SUM_PIXEL_CONTRIBUTION_COMMON(ii, jj);
-          px2 += (size_t)4 * mult;
         }
-        px2 += (size_t)4 * (width - 5) * mult;
       }
       SUM_PIXEL_EPILOGUE
     }
 
     /* Last two pixels in the row require a slow variant... blablabla */
-    for(int i = width - 2 * mult; i < width; i++)
+    for(size_t i = width - 2 * mult; i < width; i++)
     {
       SUM_PIXEL_PROLOGUE
-      for(int jj = 0; jj < 5; jj++)
+      for(size_t jj = 0; jj < 5; jj++)
       {
-        for(int ii = 0; ii < 5; ii++)
+        for(size_t ii = 0; ii < 5; ii++)
         {
           SUM_PIXEL_CONTRIBUTION_WITH_TEST(ii, jj);
         }
@@ -401,18 +386,16 @@ static void eaw_decompose(float *const out, const float *const in, float *const 
 /* The last "2*mult" lines use the macro with tests because the 5x5 kernel
  * requires nearest pixel interpolation for at least a pixel in the sum */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
-  for(int j = height - 2 * mult; j < height; j++)
+  for(size_t j = height - 2 * mult; j < height; j++)
   {
-    ROW_PROLOGUE
-
-    for(int i = 0; i < width; i++)
+    for(size_t i = 0; i < width; i++)
     {
       SUM_PIXEL_PROLOGUE
-      for(int jj = 0; jj < 5; jj++)
+      for(size_t jj = 0; jj < 5; jj++)
       {
-        for(int ii = 0; ii < 5; ii++)
+        for(size_t ii = 0; ii < 5; ii++)
         {
           SUM_PIXEL_CONTRIBUTION_WITH_TEST(ii, jj);
         }
@@ -430,7 +413,7 @@ static void eaw_decompose(float *const out, const float *const in, float *const 
 
 #if defined(__SSE2__)
 static void eaw_decompose_sse2(float *const out, const float *const in, float *const detail, const int scale,
-                               const float sharpen, const int32_t width, const int32_t height)
+                               const float sharpen, const size_t width, const size_t height)
 {
   const int mult = 1 << scale;
   static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
@@ -438,13 +421,11 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
 /* The first "2*mult" lines use the macro with tests because the 5x5 kernel
  * requires nearest pixel interpolation for at least a pixel in the sum */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
-  for(int j = 0; j < 2 * mult; j++)
+  for(size_t j = 0; j < 2 * mult; j++)
   {
-    ROW_PROLOGUE_SSE
-
-    for(int i = 0; i < width; i++)
+    for(size_t i = 0; i < width; i++)
     {
       SUM_PIXEL_PROLOGUE_SSE
       for(int jj = 0; jj < 5; jj++)
@@ -459,15 +440,13 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
   }
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
-  for(int j = 2 * mult; j < height - 2 * mult; j++)
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
   {
-    ROW_PROLOGUE_SSE
-
     /* The first "2*mult" pixels use the macro with tests because the 5x5 kernel
      * requires nearest pixel interpolation for at least a pixel in the sum */
-    for(int i = 0; i < 2 * mult; i++)
+    for(size_t i = 0; i < 2 * mult; i++)
     {
       SUM_PIXEL_PROLOGUE_SSE
       for(int jj = 0; jj < 5; jj++)
@@ -479,10 +458,16 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
       }
       SUM_PIXEL_EPILOGUE_SSE
     }
+  }
 
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#endif
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
+  {
     /* For pixels [2*mult, width-2*mult], we can safely use macro w/o tests
      * to avoid unneeded branching in the inner loops */
-    for(int i = 2 * mult; i < width - 2 * mult; i++)
+    for(size_t i = 2 * mult; i < width - 2 * mult; i++)
     {
       SUM_PIXEL_PROLOGUE_SSE
       px2 = ((__m128 *)in) + i - 2 * mult + (size_t)(j - 2 * mult) * width;
@@ -497,9 +482,15 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
       }
       SUM_PIXEL_EPILOGUE_SSE
     }
+  }
 
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#endif
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
+  {
     /* Last two pixels in the row require a slow variant... blablabla */
-    for(int i = width - 2 * mult; i < width; i++)
+    for(size_t i = width - 2 * mult; i < width; i++)
     {
       SUM_PIXEL_PROLOGUE_SSE
       for(int jj = 0; jj < 5; jj++)
@@ -516,13 +507,11 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
 /* The last "2*mult" lines use the macro with tests because the 5x5 kernel
  * requires nearest pixel interpolation for at least a pixel in the sum */
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
-  for(int j = height - 2 * mult; j < height; j++)
+  for(size_t j = height - 2 * mult; j < height; j++)
   {
-    ROW_PROLOGUE_SSE
-
-    for(int i = 0; i < width; i++)
+    for(size_t i = 0; i < width; i++)
     {
       SUM_PIXEL_PROLOGUE_SSE
       for(int jj = 0; jj < 5; jj++)
@@ -547,17 +536,17 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
 #endif
 
 typedef void((*eaw_synthesize_t)(float *const out, const float *const in, const float *const detail,
-                                 const float *thrsf, const float *boostf, const int32_t width,
-                                 const int32_t height));
+                                 const float *thrsf, const float *boostf, const size_t width,
+                                 const size_t height));
 
 static void eaw_synthesize(float *const out, const float *const in, const float *const detail,
-                           const float *thrsf, const float *boostf, const int32_t width, const int32_t height)
+                           const float *thrsf, const float *boostf, const size_t width, const size_t height)
 {
   const float threshold[4] = { thrsf[0], thrsf[1], thrsf[2], thrsf[3] };
   const float boost[4] = { boostf[0], boostf[1], boostf[2], boostf[3] };
 
 #ifdef _OPENMP
-#pragma omp parallel for SIMD() default(none) schedule(static) collapse(2)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
   for(size_t k = 0; k < (size_t)4 * width * height; k += 4)
   {
@@ -572,33 +561,28 @@ static void eaw_synthesize(float *const out, const float *const in, const float 
 
 #if defined(__SSE2__)
 static void eaw_synthesize_sse2(float *const out, const float *const in, const float *const detail,
-                                const float *thrsf, const float *boostf, const int32_t width,
-                                const int32_t height)
+                                const float *thrsf, const float *boostf, const size_t width,
+                                const size_t height)
 {
   const __m128 threshold = _mm_set_ps(thrsf[3], thrsf[2], thrsf[1], thrsf[0]);
   const __m128 boost = _mm_set_ps(boostf[3], boostf[2], boostf[1], boostf[0]);
+  const __m128 zeros = _mm_setzero_ps();
+  const __m128i maski = _mm_set1_epi32(0x80000000u);
+  __m128 *const mask = (__m128 *)&maski;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) schedule(static)
+#pragma omp parallel for simd schedule(static) default(none)
 #endif
-  for(int j = 0; j < height; j++)
+  for(size_t k = 0; k < width * height * 4; k += 4)
   {
-    // TODO: prefetch? _mm_prefetch()
-    const __m128 *pin = (__m128 *)in + (size_t)j * width;
-    __m128 *pdetail = (__m128 *)detail + (size_t)j * width;
-    float *pout = out + (size_t)4 * j * width;
-    for(int i = 0; i < width; i++)
-    {
-      const __m128i maski = _mm_set1_epi32(0x80000000u);
-      const __m128 *mask = (__m128 *)&maski;
-      const __m128 absamt
-          = _mm_max_ps(_mm_setzero_ps(), _mm_sub_ps(_mm_andnot_ps(*mask, *pdetail), threshold));
-      const __m128 amount = _mm_or_ps(_mm_and_ps(*pdetail, *mask), absamt);
-      _mm_stream_ps(pout, _mm_add_ps(*pin, _mm_mul_ps(boost, amount)));
-      pdetail++;
-      pin++;
-      pout += 4;
-    }
+    const __m128 *pin = (__m128 *)(in + k);
+    const __m128 *pdetail = (__m128 *)(detail + k);
+    float *pout = out + k;
+
+    const __m128 absamt
+        = _mm_max_ps(zeros, (_mm_andnot_ps(*mask, *pdetail) - threshold));
+    const __m128 amount = _mm_or_ps(_mm_and_ps(*pdetail, *mask), absamt);
+    _mm_stream_ps(pout, (*pin + (boost * amount)));
   }
   _mm_sfence();
 }
@@ -697,8 +681,8 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   float *buf2 = NULL;
   float *buf1 = NULL;
 
-  const int width = roi_out->width;
-  const int height = roi_out->height;
+  const size_t width = roi_out->width;
+  const size_t height = roi_out->height;
 
   tmp = (float *)dt_alloc_align(64, (size_t)sizeof(float) * 4 * width * height);
   if(tmp == NULL)

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -191,22 +191,6 @@ static inline __m128 weight_sse2(const __m128 c1, const __m128 c2, const float s
   exp = _mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(exp), 4)); // (0, wc, wc, wl)
   return _mm_or_ps(exp, ooo1);                                      // (1, wc, wc, wl)
 }
-
-#define CONVOLVE_SSE \
-  const __m128 L_0 =  _mm_set1_ps( pin0[0] );  \
-  const __m128 a_0 =  _mm_set1_ps( pin0[1] );  \
-  const __m128 b_0 =  _mm_set1_ps( pin0[2] );  \
-  const __m128 L_f = _mm_set_ps(pin4[0], pin3[0], pin2[0], pin1[0]); \
-  const __m128 a_f = _mm_set_ps(pin4[1], pin3[1], pin2[1], pin1[1]); \
-  const __m128 b_f = _mm_set_ps(pin4[2], pin3[2], pin2[2], pin1[2]); \
-  const __m128 w_L = filter * weight_chan_sse2(L_0, L_f, sharpen); \
-  const __m128 w_c = filter * weight_chan_sse2(a_0 + b_0, a_f + b_f, sharpen); \
-  const __m128 wgt = (_mm_set_ps(0.0f, sum_vect_sse(w_L)[0], sum_vect_sse(w_c)[0], sum_vect_sse(w_c)[0]) + w_0); \
-  const __m128 w_1 = _mm_set_ps(0.0f, w_c[0], w_c[0], w_L[0]); \
-  const __m128 w_2 = _mm_set_ps(0.0f, w_c[1], w_c[1], w_L[1]); \
-  const __m128 w_3 = _mm_set_ps(0.0f, w_c[2], w_c[2], w_L[2]); \
-  const __m128 w_4 = _mm_set_ps(0.0f, w_c[3], w_c[3], w_L[3]); \
-  const __m128 sum = (w_1 * pin1 + w_2 * pin2 + w_3 * pin3 + w_4 * pin4 + w_0 * pin0) * _mm_rcp_ps(wgt);
 #endif
 
 #define SUM_PIXEL_CONTRIBUTION_COMMON(ii, jj)                                                                \

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -184,9 +184,10 @@ static inline __m128 weight_sse2(const __m128 c1, const __m128 c2, const float s
   const __m128 diff = (c1 - c2);
   const __m128 square = diff * diff;                                // (?, d3, d2, d1)
   const __m128 square2 = _mm_shuffle_ps(square, square, _MM_SHUFFLE(3, 1, 2, 0)); // (?, d2, d3, d1)
-  const __m128 added = square + square2 - square;                   // (?, d2+d3, d2+d3, d1)
+  __m128 added = square + square2;                                  // (?, d2+d3, d2+d3, 2*d1)
+  added = _mm_sub_ss(added, square);                                // (?, d2+d3, d2+d3, d1)
   const __m128 sharpened = added * vsharpen;                        // (?, -s*(d2+d3), -s*(d2+d3), -s*d1)
-  __m128 exp = _mm_expf_ps(sharpened);                        // (?, wc, wc, wl)
+  __m128 exp = _mm_expf_ps(sharpened);                              // (?, wc, wc, wl)
   exp = _mm_castsi128_ps(_mm_slli_si128(_mm_castps_si128(exp), 4)); // (wc, wc, wl, 0)
   exp = _mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(exp), 4)); // (0, wc, wc, wl)
   return _mm_or_ps(exp, ooo1);                                      // (1, wc, wc, wl)

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -206,6 +206,18 @@ static inline __m128 weight_sse2(const __m128 c1, const __m128 c2, const float s
     for(int c = 0; c < 4; c++) wgt[c] += w[c];                                                               \
   }
 
+#if defined(__SSE2__)
+#define SUM_PIXEL_CONTRIBUTION_COMMON_SSE2(ii, jj)                                                           \
+  {                                                                                                          \
+    const __m128 f = _mm_set1_ps(filter[(ii)] * filter[(jj)]);                                                             \
+    const __m128 wp = weight_sse2(px, px2, sharpen);                                                       \
+    const __m128 w = f * wp;                                                                                 \
+    const __m128 pd = w * px2;                                                                              \
+    sum += pd;                                                                                               \
+    wgt += w;                                                                                                \
+  }
+#endif
+
 #define SUM_PIXEL_CONTRIBUTION_WITH_TEST(ii, jj)                                                             \
   do                                                                                                         \
   {                                                                                                          \
@@ -222,6 +234,24 @@ static inline __m128 weight_sse2(const __m128 c1, const __m128 c2, const float s
     SUM_PIXEL_CONTRIBUTION_COMMON(ii, jj);                                                                   \
   } while(0)
 
+#if defined(__SSE2__)
+#define SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(ii, jj)                                                        \
+  do                                                                                                         \
+  {                                                                                                          \
+    const size_t iii = (ii)-2;                                                                               \
+    const size_t jjj = (jj)-2;                                                                               \
+    size_t x = i + mult * iii;                                                                               \
+    size_t y = j + mult * jjj;                                                                               \
+                                                                                                             \
+    if(x >= width) x = width - 1;                                                                            \
+    if(y >= height) y = height - 1;                                                                          \
+                                                                                                             \
+    const __m128 px2 = _mm_load_ps((float *)in +  4 * (x + y * width));                                                   \
+                                                                                                             \
+    SUM_PIXEL_CONTRIBUTION_COMMON_SSE2(ii, jj);                                                              \
+  } while(0)
+#endif
+
 #define SUM_PIXEL_PROLOGUE                                                                                   \
   float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };                                                                 \
   float wgt[4] = { 0.0f, 0.0f, 0.0f, 0.0f };                                                                 \
@@ -231,11 +261,28 @@ static inline __m128 weight_sse2(const __m128 c1, const __m128 c2, const float s
   float *pdetail = detail + inc;                                                                             \
   float *pcoarse = out + inc;
 
+#if defined(__SSE2__)
+#define SUM_PIXEL_PROLOGUE_SSE                                                                               \
+  __m128 sum = _mm_setzero_ps();                                                                             \
+  __m128 wgt = _mm_setzero_ps();                                                                             \
+  const size_t inc = 4 * (j * width + i);                                                                    \
+  const __m128 px = _mm_load_ps(in + inc);                                                                   \
+  float *pdetail = detail + inc;                                                                             \
+  float *pcoarse = out + inc;
+#endif
+
 
 #define SUM_PIXEL_EPILOGUE                                                                                   \
   for(int c = 0; c < 4; c++) sum[c] /= wgt[c];                                                               \
   for(int c = 0; c < 4; c++) pdetail[c] = (px[c] - sum[c]);                                                  \
   for(int c = 0; c < 4; c++) pcoarse[c] = sum[c];
+
+#if defined(__SSE2__)
+#define SUM_PIXEL_EPILOGUE_SSE                                                                               \
+  sum /= wgt;                                                                                                \
+  _mm_stream_ps(pdetail, px - sum);                                                                          \
+  _mm_stream_ps(pcoarse, sum);
+#endif
 
 
 typedef void((*eaw_decompose_t)(float *const out, const float *const in, float *const detail, const int scale,
@@ -351,38 +398,75 @@ static void eaw_decompose(float *const out, const float *const in, float *const 
 #undef SUM_PIXEL_PROLOGUE
 #undef SUM_PIXEL_EPILOGUE
 
-/** This is the outer product of
- * filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
- * computed at once, outside of the pixels loops, saving 25 multiplications per pixel
- * */
-static const float filter[5][5] = { {0.00390625f, 0.015625f, 0.0234375f, 0.015625f, 0.00390625f},
-                                    {0.01562500f, 0.062500f, 0.0937500f, 0.062500f, 0.01562500f},
-                                    {0.02343750f, 0.093750f, 0.1406250f, 0.093750f, 0.02343750f},
-                                    {0.01562500f, 0.062500f, 0.0937500f, 0.062500f, 0.01562500f},
-                                    {0.00390625f, 0.015625f, 0.0234375f, 0.015625f, 0.00390625f} };
-
-static inline void shift_filter_x(size_t *const x, const int mult, const size_t i)
-{
-  for (size_t ii = 0; ii < 5; ii++) x[ii] = i - mult * (-2 + ii);
-}
-
-static inline void shift_filter_y(size_t *const y, const int mult, const size_t j, const size_t width)
-{
-  for(size_t jj = 0; jj < 5; jj++) y[jj] = (j + mult * (-2 + jj)) * width;
-}
-
 #if defined(__SSE2__)
+static inline void shift_filter_x(size_t *x, const int mult, const size_t i)
+{
+  for(int ii = 0; ii < 5; ii++) x[ii] = i - mult * (-2 + ii);
+}
+
+static inline void shift_filter_y(size_t *y, const int mult, const size_t j, const size_t width)
+{
+  for(int jj = 0; jj < 5; jj++) y[jj] = (j + mult * (-2 + jj)) * width;
+}
+
 static void eaw_decompose_sse2(float *const out, const float *const in, float *const detail, const int scale,
                                const float sharpen, const size_t width, const size_t height)
 {
   const int mult = 1 << scale;
+  static const float filter[5] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
 
+/* The first "2*mult" lines use the macro with tests because the 5x5 kernel
+ * requires nearest pixel interpolation for at least a pixel in the sum */
 #ifdef _OPENMP
-#pragma omp parallel for simd collapse(2)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
-  for(size_t j = 0; j < height; j++)
+  for(size_t j = 0; j < 2 * mult; j++)
   {
     for(size_t i = 0; i < width; i++)
+    {
+      SUM_PIXEL_PROLOGUE_SSE
+      for(int jj = 0; jj < 5; jj++)
+      {
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(0, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(1, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(2, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(3, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(4, jj);
+      }
+      SUM_PIXEL_EPILOGUE_SSE
+    }
+  }
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#endif
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
+  {
+    /* The first "2*mult" pixels use the macro with tests because the 5x5 kernel
+     * requires nearest pixel interpolation for at least a pixel in the sum */
+    for(size_t i = 0; i < 2 * mult; i++)
+    {
+      SUM_PIXEL_PROLOGUE_SSE
+      for(int jj = 0; jj < 5; jj++)
+      {
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(0, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(1, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(2, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(3, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(4, jj);
+      }
+      SUM_PIXEL_EPILOGUE_SSE
+    }
+  }
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#endif
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
+  {
+    /* For pixels [2*mult, width-2*mult], we can safely use macro w/o tests
+     * to avoid unneeded branching in the inner loops */
+    for(size_t i = 2 * mult; i < width - 2 * mult; i++)
     {
       __m128 sum_jj[5], wgt_jj[5];
 
@@ -395,22 +479,15 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
       size_t y[5];
       shift_filter_y(y, mult, j, width);
 
-      if(j < 2 * mult || j >= height - 2 * mult)
+      for(int jj = 0; jj < 5; jj++)
       {
-        for(size_t jj = 0; jj < 5; jj++) y[jj] = (y[jj] >= height) ? height - 1 : y[jj];
-      }
+        float filter_jj[5];
+        for (int ii = 0; ii < 5; ++ii) filter_jj[ii] = filter[ii] * filter[jj];
 
-      for(size_t jj = 0; jj < 5; jj++)
-      {
         __m128 w[5], pd[5], pix[5];
 
         size_t x[5];
         shift_filter_x(x, mult, i);
-
-        if(i < 2 * mult || i >= width - 2 * mult)
-        {
-          for (size_t ii = 0; ii < 5; ii++) x[ii] = (x[ii] >= width) ? width - 1 : x[ii];
-        }
 
         // Loop on memory : load vectors
         pix[0] = _mm_load_ps((float *)in + 4 * (x[0] + y[jj]));
@@ -419,12 +496,12 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
         pix[3] = _mm_load_ps((float *)in + 4 * (x[3] + y[jj]));
         pix[4] = _mm_load_ps((float *)in + 4 * (x[4] + y[jj]));
 
-        // Loop on cache
-        w[0] = _mm_set1_ps(filter[jj][0]) * weight_sse2(px, pix[0], sharpen);
-        w[1] = _mm_set1_ps(filter[jj][1]) * weight_sse2(px, pix[1], sharpen);
-        w[2] = _mm_set1_ps(filter[jj][2]) * weight_sse2(px, pix[2], sharpen);
-        w[3] = _mm_set1_ps(filter[jj][3]) * weight_sse2(px, pix[3], sharpen);
-        w[4] = _mm_set1_ps(filter[jj][4]) * weight_sse2(px, pix[4], sharpen);
+        // Loop on values
+        w[0] = _mm_set1_ps(filter_jj[0]) * weight_sse2(px, pix[0], sharpen);
+        w[1] = _mm_set1_ps(filter_jj[1]) * weight_sse2(px, pix[1], sharpen);
+        w[2] = _mm_set1_ps(filter_jj[2]) * weight_sse2(px, pix[2], sharpen);
+        w[3] = _mm_set1_ps(filter_jj[3]) * weight_sse2(px, pix[3], sharpen);
+        w[4] = _mm_set1_ps(filter_jj[4]) * weight_sse2(px, pix[4], sharpen);
 
         pd[0] = w[0] * pix[0];
         pd[1] = w[1] * pix[1];
@@ -443,8 +520,57 @@ static void eaw_decompose_sse2(float *const out, const float *const in, float *c
       _mm_stream_ps(pcoarse, sum);
     }
   }
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#endif
+  for(size_t j = 2 * mult; j < height - 2 * mult; j++)
+  {
+    /* Last two pixels in the row require a slow variant... blablabla */
+    for(size_t i = width - 2 * mult; i < width; i++)
+    {
+      SUM_PIXEL_PROLOGUE_SSE
+      for(int jj = 0; jj < 5; jj++)
+      {
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(0, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(1, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(2, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(3, jj);
+        SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(4, jj);
+      }
+      SUM_PIXEL_EPILOGUE_SSE
+    }
+  }
+
+/* The last "2*mult" lines use the macro with tests because the 5x5 kernel
+ * requires nearest pixel interpolation for at least a pixel in the sum */
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
+#endif
+  for(size_t j = height - 2 * mult; j < height; j++)
+  {
+    for(size_t i = 0; i < width; i++)
+    {
+      SUM_PIXEL_PROLOGUE_SSE
+      for(int jj = 0; jj < 5; jj++)
+      {
+        for(int ii = 0; ii < 5; ii++)
+        {
+          SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2(ii, jj);
+        }
+      }
+      SUM_PIXEL_EPILOGUE_SSE
+    }
+  }
+
   _mm_sfence();
 }
+
+#undef SUM_PIXEL_CONTRIBUTION_COMMON_SSE2
+#undef SUM_PIXEL_CONTRIBUTION_WITH_TEST_SSE2
+#undef ROW_PROLOGUE_SSE
+#undef SUM_PIXEL_PROLOGUE_SSE
+#undef SUM_PIXEL_EPILOGUE_SSE
 #endif
 
 typedef void((*eaw_synthesize_t)(float *const out, const float *const in, const float *const detail,
@@ -458,7 +584,7 @@ static void eaw_synthesize(float *const out, const float *const in, const float 
   const float boost[4] = { boostf[0], boostf[1], boostf[2], boostf[3] };
 
 #ifdef _OPENMP
-#pragma omp parallel for simd schedule(static) collapse(2)
+#pragma omp parallel for simd default(none) schedule(static) collapse(2)
 #endif
   for(size_t k = 0; k < (size_t)4 * width * height; k += 4)
   {
@@ -483,7 +609,7 @@ static void eaw_synthesize_sse2(float *const out, const float *const in, const f
   __m128 *const mask = (__m128 *)&maski;
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none)
+#pragma omp parallel for simd schedule(static) default(none)
 #endif
   for(size_t k = 0; k < width * height * 4; k += 4)
   {
@@ -1765,4 +1891,4 @@ void gui_cleanup(struct dt_iop_module_t *self)
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
-// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces


### PR DESCRIPTION
Improve the performance by up to 30 % on AVX2 CPU (SSE2 codepath only).

* rewrite the pointers increments to move them to inner loops 
* consequently, ask OpenMP to collapse outer loops (width and height loops)
* avoid `size_t` and `int` castings and use only `size_t` indexers (avoid 2 (< 0) checks per pixel on indices)
* factorize some code and move `fast_expf_sse` to the `common/sse.h` lib
* use the same increment for `float` and `__m128` pointers (saves 2 multiplications per pixel)
* move constant definitions outsive of loops when possible
* rewrite SSE2 intrinsics into pure algebraic operations when possible (better readability, more compiler optimization in some cases)
* use `simd` pragma in OpenMP loops so compilers can do magic taking 128-bits SSE2 vectors and turning them into 512-bits AVX2 vectors on compatible architectures (it seems).

Now, zoomed in full-screen mode, atrous runs on-par or faster than local-contrast laplacian (which works on 1 channel instead of 3), and twice as slow at 100 % zoom (much better).