### PR TITLE
Fix TLS issues on darktable

### DIFF
--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -204,6 +204,13 @@ if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
     endforeach()
   endif(ISO_CODES_FOUND)
 
+  # Add ca-cert for curl
+  install(FILES
+      "${MINGW_PATH}/../ssl/certs/ca-bundle.crt"
+      DESTINATION share/curl/
+      RENAME curl-ca-bundle.crt
+      COMPONENT DTApplication)
+
 endif(WIN32 AND NOT BUILD_MSYS2_INSTALL)
 
 endfunction()

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -332,7 +332,7 @@ static JsonObject *fb_query_get(FBContext *ctx, const gchar *method, GHashTable 
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_VERBOSE, 2);
 #endif
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_SSL_VERIFYPEER, FALSE);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
   int res = curl_easy_perform(ctx->curl_ctx);
 
@@ -410,7 +410,7 @@ static JsonObject *fb_query_post(FBContext *ctx, const gchar *method, GHashTable
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_VERBOSE, 2);
 #endif
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_HTTPPOST, formlist.formpost);
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_SSL_VERIFYPEER, FALSE);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
   int res = curl_easy_perform(ctx->curl_ctx);

--- a/src/imageio/storage/picasa.c
+++ b/src/imageio/storage/picasa.c
@@ -314,7 +314,7 @@ static JsonObject *picasa_query_get(PicasaContext *ctx, const gchar *method, GHa
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_VERBOSE, 2);
 #endif
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_SSL_VERIFYPEER, FALSE);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
   int res = curl_easy_perform(ctx->curl_ctx);
 
@@ -367,7 +367,7 @@ static JsonObject *picasa_query_post_auth(PicasaContext *ctx, const gchar *metho
 #ifdef picasa_EXTRA_VERBOSE
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_VERBOSE, 2);
 #endif
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_SSL_VERIFYPEER, FALSE);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
 
@@ -507,6 +507,7 @@ static const gchar *picasa_upload_photo_to_album(PicasaContext *ctx, gchar *albu
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_POSTFIELDSIZE, postdata_length);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, _picasa_api_buffer_write_func);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, &buffer);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
 
   int res = curl_easy_perform(ctx->curl_ctx);
 
@@ -616,6 +617,7 @@ static const gchar *picasa_upload_photo_to_album(PicasaContext *ctx, gchar *albu
       curl_easy_setopt(ctx->curl_ctx, CURLOPT_READFUNCTION, _picasa_api_buffer_read_func);
       curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, _picasa_api_buffer_write_func);
       curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, &response);
+      curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
       res = curl_easy_perform(ctx->curl_ctx);
 
       if(res != CURLE_OK)

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -282,7 +282,7 @@ static int _piwigo_api_post_internal(_piwigo_api_context_t *ctx, GList *args, ch
 #ifdef piwigo_EXTRA_VERBOSE
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_VERBOSE, 2);
 #endif
-  curl_easy_setopt(ctx->curl_ctx, CURLOPT_SSL_VERIFYPEER, FALSE);
+  curl_easy_setopt(ctx->curl_ctx, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEFUNCTION, curl_write_data_cb);
   curl_easy_setopt(ctx->curl_ctx, CURLOPT_WRITEDATA, response);
 

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -357,6 +357,7 @@ static gboolean _lib_location_search(gpointer user_data)
   curl_easy_setopt(curl, CURLOPT_USERAGENT, (char *)darktable_package_string);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 20L);
+  curl_easy_setopt(curl, CURLOPT_CAINFO, "../share/curl/curl-ca-bundle.crt");
 
   res = curl_easy_perform(curl);
   if(res != 0) goto bail_out;


### PR DESCRIPTION
On the way to fix https://github.com/darktable-org/darktable/issues/2006.

The file `curl-ca-bundle.crt` should end up in `./share/curl/`.

The idea is to allow curl to use the bundle of root certificates to verify TLS connections to https websites, including openstreetmap (used in the map module, broken on Windows right now), facebook, picasa and
piwigo.

Please edit the PR, because I have absolutely no idea how to package anything :smile:.