### PR TITLE
Add version string to opencl kernel cache dir to rebuild caches after driver update

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -352,6 +352,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   char dtcache[PATH_MAX] = { 0 };
   char cachedir[PATH_MAX] = { 0 };
   char devname[1024];
+  char drvversion[1024];
   double tstart, tend, tdiff;
   dt_loc_get_user_cache_dir(dtcache, sizeof(dtcache));
 
@@ -361,7 +362,13 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   for(int i = 0; i < len; i++)
     if(isalnum(infostr[i])) devname[j++] = infostr[i];
   devname[j] = 0;
-  snprintf(cachedir, sizeof(cachedir), "%s" G_DIR_SEPARATOR_S "cached_kernels_for_%s", dtcache, devname);
+  len = strlen(driverversion);
+  j = 0;
+  // remove non-alphanumeric chars from driver version
+  for(int i = 0; i < len; i++)
+    if(isalnum(driverversion[i])) drvversion[j++] = driverversion[i];
+  drvversion[j] = 0;
+  snprintf(cachedir, sizeof(cachedir), "%s" G_DIR_SEPARATOR_S "cached_kernels_for_%s_%s", dtcache, devname, drvversion);
   if(g_mkdir_with_parents(cachedir, 0700) == -1)
   {
     dt_print(DT_DEBUG_OPENCL, "[opencl_init] failed to create directory `%s'!\n", cachedir);


### PR DESCRIPTION
This adds the opencl driver version string to the kernel cache to cause a rebuild after a driver update.
According to https://github.com/intel/compute-runtime/issues/125#issuecomment-455504686 OpenCV is using a similar naming scheme.

This could solve https://redmine.darktable.org/issues/12541 .