### PR TITLE
collection: fix group filtering

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -205,9 +205,9 @@ int dt_collection_update(const dt_collection_t *collection)
                               * representative image.
                               * The *2+CASE statement are to break ties, so that when id < group_id, it's
                               * weighted a little higher than when id > group_id. */
-                             "(ABS(id-group_id)*2 + CASE WHEN (id-group_id) < 0 THEN 1 ELSE 0 END) IN "
-                             "(SELECT MIN(ABS(id-group_id)*2 + CASE WHEN (id-group_id) < 0 THEN 1 ELSE 0 END) "
-                             "FROM main.images WHERE %s GROUP BY group_id))",
+                             "id IN (SELECT id FROM "
+                             "(SELECT id, MIN(ABS(id-group_id)*2 + CASE WHEN (id-group_id) < 0 THEN 1 ELSE 0 END) "
+                             "FROM main.images WHERE %s GROUP BY group_id)))",
                          darktable.gui->expanded_group_id, wq_no_group);
 
     /* Additionally, when a group is expanded, make sure the representative image wasn't filtered out.


### PR DESCRIPTION
The previous logic in lines 208-210 did not work as intended.
This is due to the `IN` selection not being specific for each `group_id`, which leads to cases where more than one image can be displayed per `group_id` even when in "collapse groups" mode.

Basically in this part of the query we want to ask for each image if the image has the lowest calculated min value (`MIN(ABS...)`) between other images with the same `group_id` (that passed the filters).

How to reproduce / test:
1. Assume we filter by `unstarred only`, and that the filtered images are divided as groups containing pairs of JPG + RAW images, with the RAW image being the representative of each group.
If we are in collapsed group mode (`G` button is active), at this stage we expect to see a list containing only the RAW representatives.
2. Now we take one such group, and give only it's RAW representative a star rating.
You might need to manually unstar the corresponding JPG as the new behavior star all the group members.
3. We will suddenly see that all the images are showing (except the 1 RAW we starred), this includes the JPGs and the RAWs (although the `G` button is still active).


I've built and tested release 2.6 including this change and got the original intended behavior.