### PR TITLE
add colorspace to color picker

### DIFF
--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -57,7 +57,9 @@ typedef enum dt_colorspaces_color_profile_type_t
   DT_COLORSPACE_VENDOR_MATRIX = 13,
   DT_COLORSPACE_ALTERNATE_MATRIX = 14,
   DT_COLORSPACE_BRG = 15,
-  DT_COLORSPACE_LAST = 16
+  DT_COLORSPACE_EXPORT = 16, // export and softproof are categories and will return NULL with dt_colorspaces_get_profile()
+  DT_COLORSPACE_SOFTPROOF = 17,
+  DT_COLORSPACE_LAST = 18
 } dt_colorspaces_color_profile_type_t;
 
 typedef enum dt_colorspaces_color_mode_t
@@ -72,7 +74,8 @@ typedef enum dt_colorspaces_profile_direction_t
   DT_PROFILE_DIRECTION_IN = 1 << 0,
   DT_PROFILE_DIRECTION_OUT = 1 << 1,
   DT_PROFILE_DIRECTION_DISPLAY = 1 << 2,
-  DT_PROFILE_DIRECTION_ANY = DT_PROFILE_DIRECTION_IN | DT_PROFILE_DIRECTION_OUT | DT_PROFILE_DIRECTION_DISPLAY
+  DT_PROFILE_DIRECTION_CATEGORY = 1 << 3,  // categories will return NULL with dt_colorspaces_get_profile()
+  DT_PROFILE_DIRECTION_ANY = DT_PROFILE_DIRECTION_IN | DT_PROFILE_DIRECTION_OUT | DT_PROFILE_DIRECTION_DISPLAY | DT_PROFILE_DIRECTION_CATEGORY
 } dt_colorspaces_profile_direction_t;
 
 typedef struct dt_colorspaces_t
@@ -88,8 +91,10 @@ typedef struct dt_colorspaces_t
   // the current set of selected profiles
   dt_colorspaces_color_profile_type_t display_type;
   dt_colorspaces_color_profile_type_t softproof_type;
+  dt_colorspaces_color_profile_type_t histogram_type;
   char display_filename[512];
   char softproof_filename[512];
+  char histogram_filename[512];
   dt_iop_color_intent_t display_intent;
   dt_iop_color_intent_t softproof_intent;
 
@@ -108,6 +113,7 @@ typedef struct dt_colorspaces_color_profile_t
   int in_pos;                               // position in input combo box, -1 if not applicable
   int out_pos;                              // position in output combo box, -1 if not applicable
   int display_pos;                          // position in display combo box, -1 if not applicable
+  int category_pos;                         // position in category combo box, -1 if not applicable
 } dt_colorspaces_color_profile_t;
 
 int mat3inv_float(float *const dst, const float *const src);

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -546,10 +546,37 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   else
   {
-    /* we are not exporting, using display profile as output */
-    out_type = darktable.color_profiles->display_type;
-    out_filename = darktable.color_profiles->display_filename;
-    out_intent = darktable.color_profiles->display_intent;
+    // we are not exporting
+    if(!self->dev->overexposed.enabled)
+    {
+      // not display overexposed, using display profile as output
+      out_type = darktable.color_profiles->display_type;
+      out_filename = darktable.color_profiles->display_filename;
+      out_intent = darktable.color_profiles->display_intent;
+    }
+    else
+    {
+      // display mask, using histogram profile as output
+      // category types must be handled dynamically
+      if(darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
+      {
+        out_type = darktable.color_profiles->softproof_type;
+        out_filename = darktable.color_profiles->softproof_filename;
+        out_intent = darktable.color_profiles->softproof_intent;
+      }
+      else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_EXPORT)
+      {
+        out_type = p->type;
+        out_filename = p->filename;
+        out_intent = p->intent;
+      }
+      else
+      {
+        out_type = darktable.color_profiles->histogram_type;
+        out_filename = darktable.color_profiles->histogram_filename;
+        out_intent = darktable.color_profiles->display_intent;
+      }
+    }
   }
 
   // when the output type is Lab then process is a nop, so we can avoid creating a transform
@@ -789,7 +816,7 @@ void gui_init(struct dt_iop_module_t *self)
   }
 
   g->output_profile = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->output_profile, NULL, _("output profile"));
+  dt_bauhaus_widget_set_label(g->output_profile, NULL, _("export profile"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->output_profile, TRUE, TRUE, 0);
   for(GList *l = darktable.color_profiles->profiles; l; l = g_list_next(l))
   {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1392,6 +1392,39 @@ end:
   }
 }
 
+static void histogram_profile_callback(GtkWidget *combo, gpointer user_data)
+{
+  dt_develop_t *d = (dt_develop_t *)user_data;
+  gboolean profile_changed = FALSE;
+  const int pos = dt_bauhaus_combobox_get(combo);
+  for(GList *profiles = darktable.color_profiles->profiles; profiles; profiles = g_list_next(profiles))
+  {
+    dt_colorspaces_color_profile_t *pp = (dt_colorspaces_color_profile_t *)profiles->data;
+    if(pp->category_pos == pos)
+    {
+      if(darktable.color_profiles->histogram_type != pp->type
+        || (darktable.color_profiles->histogram_type == DT_COLORSPACE_FILE
+            && strcmp(darktable.color_profiles->histogram_filename, pp->filename)))
+      {
+        darktable.color_profiles->histogram_type = pp->type;
+        g_strlcpy(darktable.color_profiles->histogram_filename, pp->filename,
+                  sizeof(darktable.color_profiles->histogram_filename));
+        profile_changed = TRUE;
+      }
+      goto end;
+    }
+  }
+
+  // profile not found, fall back to export profile. shouldn't happen
+  fprintf(stderr, "can't find histogram profile `%s', using export profile instead\n", dt_bauhaus_combobox_get_text(combo));
+  profile_changed = darktable.color_profiles->histogram_type != DT_COLORSPACE_EXPORT;
+  darktable.color_profiles->histogram_type = DT_COLORSPACE_EXPORT;
+  darktable.color_profiles->histogram_filename[0] = '\0';
+
+end:
+  if(profile_changed) dt_dev_reprocess_all(d);
+}
+
 // FIXME: turning off lcms2 in prefs hides the widget but leaves the window sized like before -> ugly-ish
 static void _preference_changed(gpointer instance, gpointer user_data)
 {
@@ -1688,10 +1721,13 @@ void gui_init(dt_view_t *self)
 
     GtkWidget *display_profile = dt_bauhaus_combobox_new(NULL);
     GtkWidget *softproof_profile = dt_bauhaus_combobox_new(NULL);
+    GtkWidget *histogram_profile = dt_bauhaus_combobox_new(NULL);
     dt_bauhaus_widget_set_label(softproof_profile, NULL, _("softproof profile"));
     dt_bauhaus_widget_set_label(display_profile, NULL, _("display profile"));
+    dt_bauhaus_widget_set_label(histogram_profile, NULL, _("histogram profile"));
     gtk_box_pack_start(GTK_BOX(vbox), softproof_profile, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(vbox), display_profile, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(vbox), histogram_profile, TRUE, TRUE, 0);
 
     GList *l = darktable.color_profiles->profiles;
     while(l)
@@ -1716,6 +1752,16 @@ void gui_init(dt_view_t *self)
               || !strcmp(prof->filename, darktable.color_profiles->softproof_filename)))
           dt_bauhaus_combobox_set(softproof_profile, prof->out_pos);
       }
+      if(prof->category_pos > -1)
+      {
+        dt_bauhaus_combobox_add(histogram_profile, prof->name);
+        if(prof->type == darktable.color_profiles->histogram_type
+          && (prof->type != DT_COLORSPACE_FILE
+              || !strcmp(prof->filename, darktable.color_profiles->histogram_filename)))
+        {
+          dt_bauhaus_combobox_set(histogram_profile, prof->category_pos);
+        }
+      }
       l = g_list_next(l);
     }
 
@@ -1727,13 +1773,17 @@ void gui_init(dt_view_t *self)
     tooltip = g_strdup_printf(_("softproof ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
     gtk_widget_set_tooltip_text(softproof_profile, tooltip);
     g_free(tooltip);
+    tooltip = g_strdup_printf(_("histogram and color picker ICC profiles in %s or %s"), user_profile_dir, system_profile_dir);
+    gtk_widget_set_tooltip_text(histogram_profile, tooltip);
+    g_free(tooltip);
     g_free(system_profile_dir);
     g_free(user_profile_dir);
 
     g_signal_connect(G_OBJECT(display_intent), "value-changed", G_CALLBACK(display_intent_callback), dev);
     g_signal_connect(G_OBJECT(display_profile), "value-changed", G_CALLBACK(display_profile_callback), dev);
     g_signal_connect(G_OBJECT(softproof_profile), "value-changed", G_CALLBACK(softproof_profile_callback), dev);
-
+    g_signal_connect(G_OBJECT(histogram_profile), "value-changed", G_CALLBACK(histogram_profile_callback), dev);
+    
     _update_softproof_gamut_checking(dev);
 
     // update the gui when the preferences changed (i.e. show intent when using lcms2)


### PR DESCRIPTION
This adds to the over/under exposed button the option to select a profile, that is also used for the histogram and color picker.

There's a current design limitation, there are modules after colorout, if any is enabled results may be inaccurate. This is fixed in PR #1841.