### PR TITLE
Fix "find location" function

### DIFF
--- a/cmake/windows-macros.cmake
+++ b/cmake/windows-macros.cmake
@@ -206,6 +206,13 @@ if (WIN32 AND NOT BUILD_MSYS2_INSTALL)
     endforeach()
   endif(ISO_CODES_FOUND)
 
+  # Add ca-cert for curl
+  install(FILES
+      "${MINGW_PATH}/../ssl/certs/ca-bundle.crt"
+      DESTINATION share/curl/
+      RENAME curl-ca-bundle.crt
+      COMPONENT DTApplication)
+
 endif(WIN32 AND NOT BUILD_MSYS2_INSTALL)
 
 endfunction()

--- a/src/libs/location.c
+++ b/src/libs/location.c
@@ -358,6 +358,12 @@ static gboolean _lib_location_search(gpointer user_data)
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 20L);
 
+  char datadir[PATH_MAX] = { 0 };
+  dt_loc_get_datadir(datadir, sizeof(datadir));
+  gchar *crtfilename = g_build_filename(datadir, "..", "curl", "curl-ca-bundle.crt", NULL);
+  if(g_file_test(crtfilename, G_FILE_TEST_EXISTS)) curl_easy_setopt(curl, CURLOPT_CAINFO, crtfilename);
+  g_free(crtfilename);
+
   res = curl_easy_perform(curl);
   if(res != 0) goto bail_out;
 


### PR DESCRIPTION
Fixes #2006 

Similar changes are needed for using curl at facebook, piwigo and picasa upload, but I could not test those cases unfortunately. Facebook is not working for me in it's original state, and I don't have piwigo and picasa account, so I decided not to change them blindly.

In case somebody is maintaining those, it would be trivial to apply this solution before each `curl_easy_perform() `call


