### PR TITLE
fix some format string related issues

### DIFF
--- a/src/chart/main.c
+++ b/src/chart/main.c
@@ -1675,12 +1675,7 @@ static int parse_csv(dt_lut_t *self, const char *filename, double **target_L_ptr
   N--;
 
   // skip the column title line
-  for (;;)
-  {
-    int c = fgetc(f);
-    if (c == '\n' || c == EOF)
-      break;
-  }
+  read_res = fscanf(f, "%*[^\n]\n");
   N--;
 
   double *target_L = (double *)calloc(sizeof(double), (N + 4));

--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -470,7 +470,7 @@ void dt_print_file(const int32_t imgid, const char *filename, const char *job_ti
       {
         char optname[100];
         char optvalue[100];
-        const int ropt = fscanf(stream, "%*s %[^= ]=%s", optname, optvalue);
+        const int ropt = fscanf(stream, "%*s %99[^= ]=%99s", optname, optvalue);
 
         // if we parsed an option name=value
         if (ropt==2)

--- a/src/common/imageio_pnm.c
+++ b/src/common/imageio_pnm.c
@@ -72,7 +72,7 @@ static dt_imageio_retval_t _read_pgm(dt_image_t *img, FILE*f, float *buf)
   dt_imageio_retval_t result = DT_IMAGEIO_OK;
 
   unsigned int max;
-  int ret = fscanf(f, "%d ", &max);
+  int ret = fscanf(f, "%u", &max);
   if(ret != 1 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
 
   if(max <= 255)
@@ -132,7 +132,7 @@ static dt_imageio_retval_t _read_ppm(dt_image_t *img, FILE*f, float *buf)
   dt_imageio_retval_t result = DT_IMAGEIO_OK;
 
   unsigned int max;
-  int ret = fscanf(f, "%d ", &max);
+  int ret = fscanf(f, "%u", &max);
   if(ret != 1 || max > 65535) return DT_IMAGEIO_FILE_CORRUPTED;
 
   if(max <= 255)

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 DT_MODULE(1)
 
@@ -614,7 +615,7 @@ static void _piwigo_refresh_albums(dt_storage_piwigo_gui_data_t *ui, const gchar
         while(*p++) if(*p == ',') indent++;
       }
 
-      snprintf(data, sizeof(data), "%*c%s (%ld)", indent * 3, ' ', new_album->name, new_album->size);
+      snprintf(data, sizeof(data), "%*c%s (%"PRId64")", indent * 3, ' ', new_album->name, new_album->size);
 
       if(to_select && !strcmp(new_album->name, to_select)) index = i + 1;
 
@@ -646,7 +647,7 @@ static const gboolean _piwigo_api_create_new_album(dt_storage_piwigo_params_t *p
   if(p->parent_album_id != 0)
   {
     char pid[100];
-    snprintf(pid, sizeof(pid), "%ld", p->parent_album_id);
+    snprintf(pid, sizeof(pid), "%"PRId64, p->parent_album_id);
     args = _piwigo_query_add_arguments(args, "parent", pid);
   }
   args = _piwigo_query_add_arguments(args, "status", p->privacy==0?"public":"private");
@@ -676,7 +677,7 @@ static const gboolean _piwigo_api_upload_photo(dt_storage_piwigo_params_t *p, gc
   char cat[10];
   char privacy[10];
 
-  snprintf(cat, sizeof(cat), "%ld", p->album_id);
+  snprintf(cat, sizeof(cat), "%"PRId64, p->album_id);
   snprintf(privacy, sizeof(privacy), "%d", p->privacy);
 
   args = _piwigo_query_add_arguments(args, "method", "pwg.images.addSimple");

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -355,7 +355,7 @@ static void _expose_info_bar(dt_lib_module_t *self, cairo_t *cr, int32_t width, 
   pango_font_description_set_absolute_size(desc, fontsize * PANGO_SCALE);
   pango_layout_set_font_description(layout, desc);
   char model[4096] = { 0 };
-  sprintf(model + strlen(model), "%s", lib->data.camera_model);
+  snprintf(model, strlen(model), "%s", lib->data.camera_model);
   pango_layout_set_text(layout, model, -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
   cairo_move_to(cr, DT_PIXEL_APPLY_DPI(5), DT_PIXEL_APPLY_DPI(1) + BAR_HEIGHT - ink.height / 2 - fontsize);


### PR DESCRIPTION
Among others, this pull request also reverts a recent change in `src/chart/main.c`, which I submitted. The format string in the `fscanf` function was actually ok. I was not fully aware of the meaning of an asterix in an `fscanf` format string. (An optional starting asterisk indicates that the data is to be read from the stream but ignored (i.e. it is not stored in the location pointed by an argument).) Reading to the end of line via `fscanf` is probably smarter than my `fgetc` approach.