### PR TITLE
remove warnings and special treatment for 32-bit architectures

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1824,13 +1824,6 @@
     <longdescription>number of images to load in advance in the background when showing full-size preview</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>please_let_me_suffer_by_using_32bit_darktable</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>if using a 32-bit build, hide the message recommending a 64-bit build</shortdescription>
-    <longdescription>the 32-bit build of darktable is known to exhibit sporadic issues and crashes. we show a warning message hinting at this issue. with this option, you can suppress the warning.</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>codepaths/sse2</name>
     <type>bool</type>
     <default>true</default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -77,6 +77,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <locale.h>
+#include <limits.h>
 
 #if defined(__SSE__)
 #include <xmmintrin.h>
@@ -488,7 +489,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                                       STR(LUA_API_VERSION_PATCH);
 #endif
         printf("this is %s\ncopyright (c) 2009-%s johannes hanika\n" PACKAGE_BUGREPORT "\n\ncompile options:\n"
-               "  bit depth is %s\n"
+               "  bit depth is %zu bit\n"
 #ifdef _DEBUG
                "  debug build\n"
 #else
@@ -543,7 +544,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
                ,
                darktable_package_string,
                darktable_last_commit_year,
-               (sizeof(void *) == 8 ? "64 bit" : sizeof(void *) == 4 ? "32 bit" : "unknown")
+               CHAR_BIT * sizeof(void *)
 #if USE_LUA
                    ,
                lua_api_version
@@ -1189,15 +1190,14 @@ void dt_configure_performance()
   const int atom_cores = dt_get_num_atom_cores();
   const int threads = dt_get_num_threads();
   const size_t mem = dt_get_total_memory();
-  const int bits = (sizeof(void *) == 4) ? 32 : 64;
+  const size_t bits = CHAR_BIT * sizeof(void *);
   gchar *demosaic_quality = dt_conf_get_string("plugins/darkroom/demosaic/quality");
 
-  fprintf(stderr, "[defaults] found a %d-bit system with %zu kb ram and %d cores (%d atom based)\n", bits, mem,
-          threads, atom_cores);
-
-  if(mem >= (8u << 20) && threads > 4 && bits == 64 && atom_cores == 0)
+  fprintf(stderr, "[defaults] found a %zu-bit system with %zu kb ram and %d cores (%d atom based)\n",
+          bits, mem, threads, atom_cores);
+  if(mem >= (8lu << 20) && threads > 4 && atom_cores == 0)
   {
-    // CONFIG 1: at least 8GB RAM, and more than 4 CPU cores, no atom, 64 bit
+    // CONFIG 1: at least 8GB RAM, and more than 4 CPU cores, no atom
     // But respect if user has set higher values manually earlier
     fprintf(stderr, "[defaults] setting very high quality defaults\n");
 
@@ -1209,9 +1209,9 @@ void dt_configure_performance()
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
   }
-  else if(mem > (2u << 20) && threads >= 4 && bits == 64 && atom_cores == 0)
+  else if(mem > (2lu << 20) && threads >= 4 && atom_cores == 0)
   {
-    // CONFIG 2: at least 2GB RAM, and at least 4 CPU cores, no atom, 64 bit
+    // CONFIG 2: at least 2GB RAM, and at least 4 CPU cores, no atom
     // But respect if user has set higher values manually earlier
     fprintf(stderr, "[defaults] setting high quality defaults\n");
 
@@ -1222,9 +1222,9 @@ void dt_configure_performance()
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
   }
-  else if(mem < (1u << 20) || threads <= 2 || bits == 32 || atom_cores > 0)
+  else if(mem < (1lu << 20) || threads <= 2 || atom_cores > 0)
   {
-    // CONFIG 3: For less than 1GB RAM or 2 or less cores, or 32-bit or for atom processors
+    // CONFIG 3: For less than 1GB RAM or 2 or less cores, or for atom processors
     // use very low/conservative settings
     fprintf(stderr, "[defaults] setting very conservative defaults\n");
     dt_conf_set_int("worker_threads", 1);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -21,6 +21,8 @@
 #include "config.h"
 #endif
 
+#include "is_supported_platform.h"
+
 #if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
 #include <malloc.h>
 #endif
@@ -348,8 +350,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 #endif
 
   dt_set_signal_handlers();
-
-#include "is_supported_platform.h"
 
   int sse2_supported = 0;
 

--- a/src/is_supported_platform.h
+++ b/src/is_supported_platform.h
@@ -24,8 +24,7 @@
 #error "Unfortunately we only work on litte-endian systems."
 #endif
 
-#if(defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(__i386__)       \
-    || defined(__i386))
+#if (defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64))
 #define DT_SUPPORTED_X86 1
 #else
 #define DT_SUPPORTED_X86 0
@@ -48,20 +47,7 @@
 #endif
 
 #if !DT_SUPPORTED_X86 && !DT_SUPPORTED_ARMv8A && !DT_SUPPORTED_PPC64
-#error                                                                                                            \
-    "Unfortunately we only work on amd64/x86 (64-bit and maybe 32-bit); and ARMv8-A, PPC64 (64-bit little-endian only)."
-#endif
-
-#if !DT_SUPPORTED_X86
-#if !defined(__SIZEOF_POINTER__) || __SIZEOF_POINTER__ < 8
-#error "On non-x86, we only support 64-bit."
-#else
-if(sizeof(void *) < 8)
-{
-  fprintf(stderr, "[dt_init] On non-x86, we only support 64-bit.\n");
-  return 1;
-}
-#endif
+#error "Unfortunately we only work on amd64, ARMv8-A and PPC64 (64-bit little-endian only)."
 #endif
 
 #undef DT_SUPPORTED_PPC64
@@ -73,8 +59,9 @@ if(sizeof(void *) < 8)
 #pragma message "Expect a LOT of functionality to be broken. You have been warned."
 #endif
 
+// double check for 32-bit architecture
 #if defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ < 8
-#pragma message "Warning: 32-bit build."
+#error "Unfortunately we only work on the 64-bit architectures amd64, ARMv8-A and PPC64."
 #endif
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -254,41 +254,6 @@ static void _remove_child(GtkWidget *child,GtkContainer *container)
     }
 }
 
-static void bitness_nagging()
-{
-  const int bits = (sizeof(void *) == 4) ? 32 : 64;
-  if((bits < 64) && !dt_conf_get_bool("please_let_me_suffer_by_using_32bit_darktable"))
-  {
-    fprintf(stderr, "warning: 32-bit build!\n");
-
-    GtkWidget *dialog, *content_area;
-    GtkDialogFlags flags;
-
-    // Create the widgets
-    flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
-    dialog = gtk_dialog_new_with_buttons(
-        _("you are making a mistake!"), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), flags,
-        _("_yes, i understood. please let me suffer by using 32-bit darktable."), GTK_RESPONSE_NONE,
-        NULL);
-#ifdef GDK_WINDOWING_QUARTZ
-    dt_osx_disallow_fullscreen(dialog);
-#endif
-    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-
-    const gchar *msg = _("warning!\nyou are using a 32-bit build of darktable.\nthe 32-bit build has "
-                          "severely limited virtual address space.\nwe have had numerous reports that "
-                          "darktable exhibits sporadic issues and crashes when using 32-bit builds.\nwe "
-                          "strongly recommend you switch to a proper 64-bit build.\notherwise, you are "
-                          "GUARANTEED to experience issues which cannot be fixed.\n");
-
-    gtk_container_add(GTK_CONTAINER(content_area), gtk_label_new(msg));
-    gtk_widget_show_all(dialog);
-
-    (void)gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-  }
-}
-
 int dt_view_manager_switch(dt_view_manager_t *vm, const char *view_name)
 {
   gboolean switching_to_none = *view_name == '\0';
@@ -374,9 +339,6 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
     int error = new_view->try_enter(new_view);
     if(error) return error;
   }
-
-  // annoy the users that are still on 32 bit systems!
-  bitness_nagging();
 
   /* cleanup current view before initialization of new  */
   if(old_view)


### PR DESCRIPTION
This PR is to determine the bitwidth of the target architecture (32-bit vs. 64-bit architectures) at compile time rather than at run time.