### PR TITLE
fix memory leaks

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -952,9 +952,12 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  const gchar *css_theme = dt_conf_get_string("ui_last/theme");
+  gchar *css_theme = dt_conf_get_string("ui_last/theme");
   if(css_theme)
+  {
     g_snprintf(gui->gtkrc, sizeof(gui->gtkrc), "%s", css_theme);
+    g_free(css_theme);
+  }
   else
     g_snprintf(gui->gtkrc, sizeof(gui->gtkrc), "darktable");
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -244,10 +244,9 @@ static void hardcoded_gui(GtkWidget *grid, int *line)
   widget = gtk_combo_box_text_new();
 
   // read all themes
-  const char *theme_name = dt_conf_get_string("ui_last/theme");
+  char *theme_name = dt_conf_get_string("ui_last/theme");
   int selected = 0;
   int k = 0;
-
   for(GList *iter = darktable.themes; iter; iter = g_list_next(iter))
   {
     gchar *name = g_strdup((gchar*)(iter->data));
@@ -258,6 +257,7 @@ static void hardcoded_gui(GtkWidget *grid, int *line)
     if(!g_strcmp0(name, theme_name)) selected = k;
     k++;
   }
+  g_free(theme_name);
 
   gtk_combo_box_set_active(GTK_COMBO_BOX(widget), selected);
 


### PR DESCRIPTION
The call to `dt_conf_get_string` returns the result of the `g_strdup` function, which allocates memory for the duplicated string. The returned string must be freed with `g_free` when no longer needed. See https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html#g-strdup 
