### PR TITLE
fix overexposed

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -1953,7 +1953,7 @@ borders_fill (write_only image2d_t out, const int left, const int top, const int
 
 /* kernel for the overexposed plugin. */
 kernel void
-overexposed (read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+overexposed (read_only image2d_t in, write_only image2d_t out, read_only image2d_t tmp, const int width, const int height,
              const float lower, const float upper, const float4 lower_color, const float4 upper_color)
 {
   const int x = get_global_id(0);
@@ -1962,12 +1962,13 @@ overexposed (read_only image2d_t in, write_only image2d_t out, const int width, 
   if(x >= width || y >= height) return;
 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  float4 pixel_tmp = read_imagef(tmp, sampleri, (int2)(x, y));
 
-  if(pixel.x >= upper || pixel.y >= upper || pixel.z >= upper)
+  if(pixel_tmp.x >= upper || pixel_tmp.y >= upper || pixel_tmp.z >= upper)
   {
     pixel.xyz = upper_color.xyz;
   }
-  else if(pixel.x <= lower && pixel.y <= lower && pixel.z <= lower)
+  else if(pixel_tmp.x <= lower && pixel_tmp.y <= lower && pixel_tmp.z <= lower)
   {
     pixel.xyz = lower_color.xyz;
   }

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -546,37 +546,10 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   }
   else
   {
-    // we are not exporting
-    if(!self->dev->overexposed.enabled)
-    {
-      // not display overexposed, using display profile as output
-      out_type = darktable.color_profiles->display_type;
-      out_filename = darktable.color_profiles->display_filename;
-      out_intent = darktable.color_profiles->display_intent;
-    }
-    else
-    {
-      // display mask, using histogram profile as output
-      // category types must be handled dynamically
-      if(darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
-      {
-        out_type = darktable.color_profiles->softproof_type;
-        out_filename = darktable.color_profiles->softproof_filename;
-        out_intent = darktable.color_profiles->softproof_intent;
-      }
-      else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_EXPORT)
-      {
-        out_type = p->type;
-        out_filename = p->filename;
-        out_intent = p->intent;
-      }
-      else
-      {
-        out_type = darktable.color_profiles->histogram_type;
-        out_filename = darktable.color_profiles->histogram_filename;
-        out_intent = darktable.color_profiles->display_intent;
-      }
-    }
+    /* we are not exporting, using display profile as output */
+    out_type = darktable.color_profiles->display_type;
+    out_filename = darktable.color_profiles->display_filename;
+    out_intent = darktable.color_profiles->display_intent;
   }
 
   // when the output type is Lab then process is a nop, so we can avoid creating a transform


### PR DESCRIPTION
This displays the image on display profile while in overexpose check, keeping the check in histogram profile.

I didn't change the behaviour, still shows the clipped areas and that's probably what we want. Maybe we can change the name to clipped check, at least is what RT does.
The only thing I don't like is that it doesn't give any clue about which channel is clipped.