### PR TITLE
OpenCL: remove -cl-fast-relaxed-math compiler flag

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -391,7 +391,7 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
   escapedkerneldir = dt_util_str_replace(kerneldir, " ", "\\ ");
 #endif
 
-  options = g_strdup_printf("-cl-fast-relaxed-math %s -D%s=1 -I%s",
+  options = g_strdup_printf("-cl-mad-enable %s -D%s=1 -I%s",
                             (cl->dev[dev].nvidia_sm_20 ? " -DNVIDIA_SM_20=1" : ""),
                             dt_opencl_get_vendor_by_id(vendor_id), escapedkerneldir);
   cl->dev[dev].options = strdup(options);


### PR DESCRIPTION
Same as for the CPU build, this option removes the NaN checks and enables unsafe optimizations possibly harmful given the absence of code quality insurance in dt.

On the other hand, we enable `-cl-mad-enable` which is only an approximation of `a * b + c` (a bit less accurate, but doesn't skip checks). See https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html