### PR TITLE
Denoise profile updates

### DIFF
--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -160,8 +160,9 @@ denoiseprofile_horiz(global float* U4_in, global float* U4_out, const int width,
 
 
 kernel void
-denoiseprofile_vert(global float* U4_in, global float* U4_out, const int width, const int height, 
-              const int2 q, const int P, const float norm, local float *buffer)
+denoiseprofile_vert(global float* U4_in, global float* U4_out, const int width, const int height,
+              const int2 q, const int P, const float norm, local float *buffer,
+              const float central_pixel_weight, global float* U4_single_pixel)
 {
   const int lid = get_local_id(1);
   const int lsz = get_local_size(1);
@@ -206,6 +207,9 @@ denoiseprofile_vert(global float* U4_in, global float* U4_out, const int width, 
   {
     distacc += buffer[pj];
   }
+
+  distacc += U4_single_pixel[gidx] * (2 * P + 1) * (2 * P + 1) * central_pixel_weight;
+  distacc /= (1.0f + central_pixel_weight);
 
   distacc = fast_mexp2f(fmax(0.0f, distacc*norm - 2.0f));
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3107,7 +3107,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->mode, _("method used in the denoising core. "
                                          "non-local means works best for `lightness' blending, "
                                          "wavelets work best for `color' blending"));
-  gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match. increase for more sharpness"));
+  gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match.\n"
+                                           "increase for more sharpness on strong edges, and better denoising of smooth areas.\n"
+                                           "if details are oversmoothed, reduce this value or increase the details slider."));
   gtk_widget_set_tooltip_text(g->nbhood, _("emergency use only: radius of the neighbourhood to search patches in. increase for better denoising performance, but watch the long runtimes! large radii can be very slow. you have been warned"));
   gtk_widget_set_tooltip_text(g->scattering,
                               _("scattering of the neighbourhood to search patches in. increase for better "

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1033,9 +1033,20 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   float wb[3] = { wb_mean, wb_mean, wb_mean };
   if(d->fix_anscombe)
   {
-    wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (in_scale * in_scale);
-    wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (in_scale * in_scale);
-    wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (in_scale * in_scale);
+    if(wb_mean != 0.0f)
+    {
+      wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (in_scale * in_scale);
+      wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (in_scale * in_scale);
+      wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (in_scale * in_scale);
+    }
+    else
+    {
+      // temperature coeffs are equal to 0 if we open a JPG image.
+      // in this case, consider them equal to 1.
+      wb[0] = d->strength * (in_scale * in_scale);
+      wb[1] = d->strength * (in_scale * in_scale);
+      wb[2] = d->strength * (in_scale * in_scale);
+    }
   }
   else
   {
@@ -1209,9 +1220,20 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   float wb[3] = { wb_mean, wb_mean, wb_mean };
   if(d->fix_anscombe)
   {
-    wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
-    wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
-    wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    if(wb_mean != 0.0f)
+    {
+      wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
+      wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
+      wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    }
+    else
+    {
+      // temperature coeffs are equal to 0 if we open a JPG image.
+      // in this case, consider them equal to 1.
+      wb[0] = d->strength * (scale * scale);
+      wb[1] = d->strength * (scale * scale);
+      wb[2] = d->strength * (scale * scale);
+    }
   }
   else
   {
@@ -1379,9 +1401,20 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   float wb[3] = { wb_mean, wb_mean, wb_mean };
   if(d->fix_anscombe)
   {
-    wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
-    wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
-    wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    if(wb_mean != 0.0f)
+    {
+      wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
+      wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
+      wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    }
+    else
+    {
+      // temperature coeffs are equal to 0 if we open a JPG image.
+      // in this case, consider them equal to 1.
+      wb[0] = d->strength * (scale * scale);
+      wb[1] = d->strength * (scale * scale);
+      wb[2] = d->strength * (scale * scale);
+    }
   }
   else
   {
@@ -1614,9 +1647,20 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   float wb[4] = { wb_mean, wb_mean, wb_mean, 0.0f };
   if(d->fix_anscombe)
   {
-    wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
-    wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
-    wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    if(wb_mean != 0.0f)
+    {
+      wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
+      wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
+      wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    }
+    else
+    {
+      // temperature coeffs are equal to 0 if we open a JPG image.
+      // in this case, consider them equal to 1.
+      wb[0] = d->strength * (scale * scale);
+      wb[1] = d->strength * (scale * scale);
+      wb[2] = d->strength * (scale * scale);
+    }
   }
   else
   {
@@ -1911,9 +1955,20 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   float wb[4] = { wb_mean, wb_mean, wb_mean, 0.0f };
   if(d->fix_anscombe)
   {
-    wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
-    wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
-    wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    if(wb_mean != 0.0f)
+    {
+      wb[0] = piece->pipe->dsc.temperature.coeffs[0] * d->strength * (scale * scale);
+      wb[1] = piece->pipe->dsc.temperature.coeffs[1] * d->strength * (scale * scale);
+      wb[2] = piece->pipe->dsc.temperature.coeffs[2] * d->strength * (scale * scale);
+    }
+    else
+    {
+      // temperature coeffs are equal to 0 if we open a JPG image.
+      // in this case, consider them equal to 1.
+      wb[0] = d->strength * (scale * scale);
+      wb[1] = d->strength * (scale * scale);
+      wb[2] = d->strength * (scale * scale);
+    }
   }
   else
   {

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -121,8 +121,7 @@ typedef struct dt_iop_denoiseprofile_params_t
   float y[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS]; // values to change wavelet force by frequency
   gboolean wb_adaptive_anscombe; // whether to adapt anscombe transform to wb coeffs
   // backward compatibility options
-  gboolean fix_anscombe;
-  gboolean fix_nlmeans_norm;
+  gboolean fix_anscombe_and_nlmeans_norm;
 } dt_iop_denoiseprofile_params_t;
 
 typedef struct dt_iop_denoiseprofile_gui_data_t
@@ -152,11 +151,8 @@ typedef struct dt_iop_denoiseprofile_gui_data_t
   float draw_min_xs[DT_IOP_DENOISE_PROFILE_RES], draw_min_ys[DT_IOP_DENOISE_PROFILE_RES];
   float draw_max_xs[DT_IOP_DENOISE_PROFILE_RES], draw_max_ys[DT_IOP_DENOISE_PROFILE_RES];
   GtkWidget *wb_adaptive_anscombe;
-  GtkWidget *extra_expander;
-  GtkWidget *extra_toggle;
   // backward compatibility options
-  GtkWidget *fix_anscombe;
-  GtkWidget *fix_nlmeans_norm;
+  GtkWidget *fix_anscombe_and_nlmeans_norm;
 } dt_iop_denoiseprofile_gui_data_t;
 
 typedef struct dt_iop_denoiseprofile_data_t
@@ -173,8 +169,7 @@ typedef struct dt_iop_denoiseprofile_data_t
   float force[DT_DENOISE_PROFILE_NONE][DT_IOP_DENOISE_PROFILE_BANDS];
   gboolean wb_adaptive_anscombe; // whether to adapt anscombe transform to wb coeffs
   // backward compatibility options
-  gboolean fix_anscombe;
-  gboolean fix_nlmeans_norm;
+  gboolean fix_anscombe_and_nlmeans_norm;
 } dt_iop_denoiseprofile_data_t;
 
 typedef struct dt_iop_denoiseprofile_global_data_t
@@ -338,8 +333,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     }
     v7->scattering = v6.scattering;
     v7->central_pixel_weight = 0.0;
-    v7->fix_anscombe = FALSE;     // don't fix anscombe to ensure backward compatibility
-    v7->fix_nlmeans_norm = FALSE; // don't fix norm to ensure backward compatibility
+    v7->fix_anscombe_and_nlmeans_norm = FALSE; // don't fix anscombe and norm to ensure backward compatibility
     v7->wb_adaptive_anscombe = TRUE;
     return 0;
   }
@@ -1043,7 +1037,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   // we init wb by the mean of the coeffs, which corresponds to the mean
   // amplification that is done in addition to the "ISO" related amplification
   float wb[3] = { wb_mean, wb_mean, wb_mean };
-  if(d->fix_anscombe)
+  if(d->fix_anscombe_and_nlmeans_norm)
   {
     if(wb_mean != 0.0f && d->wb_adaptive_anscombe)
     {
@@ -1230,7 +1224,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   // we init wb by the mean of the coeffs, which corresponds to the mean
   // amplification that is done in addition to the "ISO" related amplification
   float wb[3] = { wb_mean, wb_mean, wb_mean };
-  if(d->fix_anscombe)
+  if(d->fix_anscombe_and_nlmeans_norm)
   {
     if(wb_mean != 0.0f && d->wb_adaptive_anscombe)
     {
@@ -1331,7 +1325,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
             // norm identical when P=1, as the norm for P=1 seemed
             // to work quite well: 0.045 = 0.015 * (2 * P + 1) with P=1.
             float norm = .045f / ((2 * P + 1) * (2 * P + 1));
-            if(!d->fix_nlmeans_norm)
+            if(!d->fix_anscombe_and_nlmeans_norm)
             {
               // use old formula
               norm = .015f / (2 * P + 1);
@@ -1429,7 +1423,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   // we init wb by the mean of the coeffs, which corresponds to the mean
   // amplification that is done in addition to the "ISO" related amplification
   float wb[3] = { wb_mean, wb_mean, wb_mean };
-  if(d->fix_anscombe)
+  if(d->fix_anscombe_and_nlmeans_norm)
   {
     if(wb_mean != 0.0f && d->wb_adaptive_anscombe)
     {
@@ -1527,7 +1521,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
             // norm identical when P=1, as the norm for P=1 seemed
             // to work quite well: 0.045 = 0.015 * (2 * P + 1) with P=1.
             float norm = .045f / ((2 * P + 1) * (2 * P + 1));
-            if(!d->fix_nlmeans_norm)
+            if(!d->fix_anscombe_and_nlmeans_norm)
             {
               // use old formula
               norm = .015f / (2 * P + 1);
@@ -1692,7 +1686,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   // norm identical when P=1, as the norm for P=1 seemed
   // to work quite well: 0.045 = 0.015 * (2 * P + 1) with P=1.
   float norm = .045f / ((2 * P + 1) * (2 * P + 1));
-  if(!d->fix_nlmeans_norm)
+  if(!d->fix_anscombe_and_nlmeans_norm)
   {
     // use old formula
     norm = .015f / (2 * P + 1);
@@ -1704,7 +1698,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   // we init wb by the mean of the coeffs, which corresponds to the mean
   // amplification that is done in addition to the "ISO" related amplification
   float wb[4] = { wb_mean, wb_mean, wb_mean, 0.0f };
-  if(d->fix_anscombe)
+  if(d->fix_anscombe_and_nlmeans_norm)
   {
     if(wb_mean != 0.0f && d->wb_adaptive_anscombe)
     {
@@ -2013,7 +2007,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   // we init wb by the mean of the coeffs, which corresponds to the mean
   // amplification that is done in addition to the "ISO" related amplification
   float wb[4] = { wb_mean, wb_mean, wb_mean, 0.0f };
-  if(d->fix_anscombe)
+  if(d->fix_anscombe_and_nlmeans_norm)
   {
     if(wb_mean != 0.0f && d->wb_adaptive_anscombe)
     {
@@ -2365,8 +2359,7 @@ void reload_defaults(dt_iop_module_t *module)
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->central_pixel_weight = 0.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->strength = 1.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->mode = MODE_NLMEANS;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->fix_anscombe = TRUE;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->fix_nlmeans_norm = TRUE;
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->fix_anscombe_and_nlmeans_norm = TRUE;
     for(int k = 0; k < 3; k++)
     {
       ((dt_iop_denoiseprofile_params_t *)module->default_params)->a[k] = g->interpolated.a[k];
@@ -2394,8 +2387,7 @@ void init(dt_iop_module_t *module)
       tmp.y[ch][k] = 0.5f;
     }
   }
-  tmp.fix_anscombe = TRUE;
-  tmp.fix_nlmeans_norm = TRUE;
+  tmp.fix_anscombe_and_nlmeans_norm = TRUE;
   tmp.wb_adaptive_anscombe = TRUE;
   memcpy(module->params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
@@ -2444,15 +2436,6 @@ void cleanup_global(dt_iop_module_so_t *module)
   dt_opencl_free_kernel(gd->kernel_denoiseprofile_reduce_second);
   free(module->data);
   module->data = NULL;
-}
-
-void gui_reset(dt_iop_module_t *self)
-{
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), FALSE);
-  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->extra_toggle), FALSE);
 }
 
 static dt_noiseprofile_t dt_iop_denoiseprofile_get_auto_profile(dt_iop_module_t *self)
@@ -2526,8 +2509,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   }
 
   d->wb_adaptive_anscombe = p->wb_adaptive_anscombe;
-  d->fix_anscombe = p->fix_anscombe;
-  d->fix_nlmeans_norm = p->fix_nlmeans_norm;
+  d->fix_anscombe_and_nlmeans_norm = p->fix_anscombe_and_nlmeans_norm;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -2650,10 +2632,15 @@ void gui_update(dt_iop_module_t *self)
     }
   }
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->wb_adaptive_anscombe), p->wb_adaptive_anscombe);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander),
-                              gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->extra_toggle)));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe), p->fix_anscombe);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_nlmeans_norm), p->fix_nlmeans_norm);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe_and_nlmeans_norm), p->fix_anscombe_and_nlmeans_norm);
+  gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm, !p->fix_anscombe_and_nlmeans_norm);
+}
+
+void gui_reset(dt_iop_module_t *self)
+{
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
+  gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm, !p->fix_anscombe_and_nlmeans_norm);
 }
 
 static void dt_iop_denoiseprofile_get_params(dt_iop_denoiseprofile_params_t *p, const int ch, const double mouse_x,
@@ -2977,17 +2964,6 @@ static void denoiseprofile_tab_switch(GtkNotebook *notebook, GtkWidget *page, gu
   gtk_widget_queue_draw(self->widget);
 }
 
-static void _extra_options_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->extra_toggle));
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), active);
-  dtgtk_togglebutton_set_paint(
-      DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
-      CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | (active ? CPF_DIRECTION_DOWN : CPF_DIRECTION_LEFT), NULL);
-}
-
 static void wb_adaptive_anscombe_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -2996,22 +2972,13 @@ static void wb_adaptive_anscombe_callback(GtkWidget *widget, dt_iop_module_t *se
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void fix_anscombe_callback(GtkWidget *widget, dt_iop_module_t *self)
+static void fix_anscombe_and_nlmeans_norm_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  p->fix_anscombe = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  p->fix_anscombe_and_nlmeans_norm = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
-
-static void fix_nlmeans_norm_callback(GtkWidget *widget, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
-  p->fix_nlmeans_norm = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
 
 void gui_init(dt_iop_module_t *self)
 {
@@ -3105,36 +3072,19 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->stack, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->strength, TRUE, TRUE, 0);
 
-  // add collapsable section for those extra options that are generally not to be used
-  GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  GtkWidget *destdisp = dt_ui_section_label_new(_("backward compatibility"));
-  g->extra_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow,
-                                           CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
-  gtk_widget_set_size_request(g->extra_toggle, DT_PIXEL_APPLY_DPI(15), DT_PIXEL_APPLY_DPI(15));
-  GtkWidget *extra_options = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), destdisp, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(destdisp_head), g->extra_toggle, FALSE, FALSE, 0);
-  gtk_widget_set_visible(extra_options, FALSE);
-  g->extra_expander = dtgtk_expander_new(destdisp_head, extra_options);
-  dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), TRUE);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->extra_expander, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->extra_toggle), "toggled", G_CALLBACK(_extra_options_button_changed), (gpointer)self);
-  g->fix_anscombe = gtk_check_button_new_with_label(_("fix anscombe transform"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe), p->fix_anscombe);
-  gtk_widget_set_tooltip_text(g->fix_anscombe, _("fix bugs in anscombe transform resulting\n"
+  g->fix_anscombe_and_nlmeans_norm = gtk_check_button_new_with_label(_("migrate to fixed algorithm"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe_and_nlmeans_norm), p->fix_anscombe_and_nlmeans_norm);
+  gtk_widget_set_tooltip_text(g->fix_anscombe_and_nlmeans_norm, _("fix bugs in anscombe transform resulting\n"
                                                  "in undersmoothing of the green channel in\n"
                                                  "wavelets mode, combined with a bad handling\n"
-                                                 "of white balance coefficients."));
-  gtk_box_pack_start(GTK_BOX(extra_options), g->fix_anscombe, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->fix_anscombe), "toggled", G_CALLBACK(fix_anscombe_callback), self);
-  g->fix_nlmeans_norm = gtk_check_button_new_with_label(_("fix patch normalization"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_nlmeans_norm), p->fix_nlmeans_norm);
-  gtk_widget_set_tooltip_text(g->fix_nlmeans_norm, _("fix patch norm computation in non-local\n"
-                                                     "means so that the denoising force becomes\n"
-                                                     "independent of patch size."));
-  gtk_box_pack_start(GTK_BOX(extra_options), g->fix_nlmeans_norm, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->fix_nlmeans_norm), "toggled", G_CALLBACK(fix_nlmeans_norm_callback), self);
-
+                                                 "of white balance coefficients, and a bug in\n"
+                                                 "non local means normalization resulting in\n"
+                                                 "undersmoothing when patch size was increased.\n"
+                                                 "enabling this option will change the denoising\n"
+                                                 "you get. once enabled, you won't be able to\n"
+                                                 "return back to old algorithm."));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->fix_anscombe_and_nlmeans_norm, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->fix_anscombe_and_nlmeans_norm), "toggled", G_CALLBACK(fix_anscombe_and_nlmeans_norm_callback), self);
 
   gtk_widget_show_all(g->box_nlm);
   gtk_widget_show_all(g->box_wavelets);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1274,7 +1274,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
 // do this in parallel with a little threading overhead. could parallelize the outer loops with a bit more
 // memory
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide) shared(kj, ki, in, Sa)
+#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide, d) shared(kj, ki, in, Sa)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {
@@ -1321,7 +1321,17 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
           {
             // TODO: could put that outside the loop.
             // DEBUG XXX bring back to computable range:
-            const float norm = .015f / (2 * P + 1);
+            // Each patch has a width of 2P+1 and a height of 2P+1
+            // thus, divide by (2P+1)^2.
+            // The 0.045 was derived from the old formula, to keep the
+            // norm identical when P=1, as the norm for P=1 seemed
+            // to work quite well: 0.045 = 0.015 * (2 * P + 1) with P=1.
+            float norm = .045f / ((2 * P + 1) * (2 * P + 1));
+            if(!d->fix_nlmeans_norm)
+            {
+              // use old formula
+              norm = .015f / (2 * P + 1);
+            }
             const float iv[4] = { ins[0], ins[1], ins[2], 1.0f };
 #if defined(_OPENMP) && defined(OPENMP_SIMD_)
 #pragma omp SIMD()
@@ -1386,7 +1396,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
 {
   // this is called for preview and full pipe separately, each with its own pixelpipe piece.
   // get our data struct:
-  dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
+  dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)piece->data;
 
   // adjust to zoom size:
   const float scale = fminf(roi_in->scale, 2.0f) / fmaxf(piece->iscale, 1.0f);
@@ -1451,7 +1461,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
 // do this in parallel with a little threading overhead. could parallelize the outer loops with a bit more
 // memory
 #ifdef _OPENMP
-#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide) shared(kj, ki, in, Sa)
+#pragma omp parallel for schedule(static) default(none) firstprivate(inited_slide, d) shared(kj, ki, in, Sa)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {
@@ -1498,7 +1508,17 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
           {
             // TODO: could put that outside the loop.
             // DEBUG XXX bring back to computable range:
-            const float norm = .015f / (2 * P + 1);
+            // Each patch has a width of 2P+1 and a height of 2P+1
+            // thus, divide by (2P+1)^2.
+            // The 0.045 was derived from the old formula, to keep the
+            // norm identical when P=1, as the norm for P=1 seemed
+            // to work quite well: 0.045 = 0.015 * (2 * P + 1) with P=1.
+            float norm = .045f / ((2 * P + 1) * (2 * P + 1));
+            if(!d->fix_nlmeans_norm)
+            {
+              // use old formula
+              norm = .015f / (2 * P + 1);
+            }
             const __m128 iv = { ins[0], ins[1], ins[2], 1.0f };
             _mm_store_ps(out,
                          _mm_load_ps(out) + iv * _mm_set1_ps(fast_mexp2f(fmaxf(0.0f, slide * norm - 2.0f))));
@@ -1621,7 +1641,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
                               cl_mem dev_out, const dt_iop_roi_t *const roi_in,
                               const dt_iop_roi_t *const roi_out)
 {
-  dt_iop_denoiseprofile_params_t *d = (dt_iop_denoiseprofile_params_t *)piece->data;
+  dt_iop_denoiseprofile_data_t *d = (dt_iop_denoiseprofile_data_t *)piece->data;
   dt_iop_denoiseprofile_global_data_t *gd = (dt_iop_denoiseprofile_global_data_t *)self->data;
 
   const int devid = piece->pipe->devid;
@@ -1643,7 +1663,18 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   const float scale = fminf(roi_in->scale, 2.0f) / fmaxf(piece->iscale, 1.0f);
   const int P = ceilf(d->radius * scale); // pixel filter size
   const int K = ceilf(d->nbhood * scale); // nbhood
-  const float norm = 0.015f / (2 * P + 1);
+
+  // Each patch has a width of 2P+1 and a height of 2P+1
+  // thus, divide by (2P+1)^2.
+  // The 0.045 was derived from the old formula, to keep the
+  // norm identical when P=1, as the norm for P=1 seemed
+  // to work quite well: 0.045 = 0.015 * (2 * P + 1) with P=1.
+  float norm = .045f / ((2 * P + 1) * (2 * P + 1));
+  if(!d->fix_nlmeans_norm)
+  {
+    // use old formula
+    norm = .015f / (2 * P + 1);
+  }
 
   const float wb_mean = (piece->pipe->dsc.temperature.coeffs[0] + piece->pipe->dsc.temperature.coeffs[1]
                          + piece->pipe->dsc.temperature.coeffs[2])
@@ -2337,6 +2368,9 @@ void init(dt_iop_module_t *module)
       tmp.y[ch][k] = 0.5f;
     }
   }
+  tmp.fix_anscombe = TRUE;
+  tmp.fix_nlmeans_norm = TRUE;
+  tmp.wb_adaptive_anscombe = TRUE;
   memcpy(module->params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
 }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -399,10 +399,10 @@ void init_presets(dt_iop_module_so_t *self)
 {
   // these blobs were exported as dtstyle and copied from there:
   add_preset(self, _("chroma (use on 1st instance)"),
-             "gz03eJxjYGiwZ2B44MAApkGgYf+22P2WdQpGVtxijKbJe3lMs3bfNWFkgIEGOyABVOtgj6SHLDHxqH923cv/2ZlxstofeGdsL3uk3h4iTx4GAIb7H9w=", 6,
+             "gz03eJxjYGiwZ2B44MAApmGgYf+22P2WdQpGVtxijKbJe3lMs3bfNWFEyNsBCaB6B3uEPvLExKP+2XUv/2dnxslqf+Cdsb3skXp7iDx5GORGEAYAkHIf3g==", 7,
              "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
   add_preset(self, _("luma (use on 2nd instance)"),
-             "gz03eJxjYGiwZ2B44DBr5kw7BjBo2O9nGWDpPnef5SU9VdNEjucm4ZnWpowMMNAAUgfU4wDEIL3ki/k9+GN7QlXb7nf5QjvD7B92ha1LofLkYQDhMyJ5", 6,
+             "gz03eJxjYGiwZ2B44DBr5kw7Bjho2O9nGWDpPnef5SU9VdNEjucm4ZnWpowIeZBaoD4HIAbpJ1/M78Ef2xOq2na/yxfaGWb/sCtsXQqVJxszgNwJAATFIno=", 7,
              "gz12eJxjZGBgEGAAgR4nBqJBgz0Ejyw+AIdGGMA=", 7);
 }
 


### PR DESCRIPTION
Current state:
1- Fix anscombe transform so that the white balance coefficients are correctly taken into account
2- Adds an option in case user doesn't want a white balance adaptive transform
3- Fix non local means patch norm computation (as a result, increasing patch size does not require to increase the force anymore -> easier to use)
4- Add a slider to control the weight of central pixel in non local means patch comparison metric

Basically I currently use non local means like this :
- I put the patch size to 4
- I increase the coarse grain noise slider until no very coarse chroma noise remains (some fine grain chrominance noise can sometimes remain)
- if image is too much blurred, I reduce the force *slightly*
- then I increase the details slider to my taste
- I fix the remaining chroma noise with the equalizer
Note that with these changes, I am mostly using only one instance of denoiseprofile, without any particular blending mode.

It works very well for medium and high iso, but is not perfect for very high iso. In such case, it can be combined with denoise bilateral to get nice results.

This is work in progress, I did not update the presets yet, and I have ongoing work to make the anscombe transform perform better.