### PR TITLE
3D LUT module

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1869,6 +1869,13 @@
     <shortdescription>executable for playing audio files</shortdescription>
     <longdescription>this external program is used to play audio files some cameras record to keep notes for images</longdescription>
   </dtconfig>
+  <dtconfig prefs="core">
+    <name>plugins/darkroom/lut3d/def_path</name>
+    <type>dir</type>
+    <default></default>
+    <shortdescription>3D lut root folder</shortdescription>
+    <longdescription>this folder (and sub-folders) contains Lut files used but lut3d modules</longdescription>
+  </dtconfig>
   <dtconfig prefs="core" section="quality">
     <name>plugins/darkroom/basecurve/auto_apply</name>
     <type>bool</type>

--- a/data/kernels/lut3d.cl
+++ b/data/kernels/lut3d.cl
@@ -217,3 +217,16 @@ lut3d_pyramid(read_only image2d_t in, write_only image2d_t out, const int width,
   write_imagef(out, (int2)(x, y), output);
 }
 
+kernel void
+lut3d_none(read_only image2d_t in, write_only image2d_t out, const int width, const int height)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 input = read_imagef(in, sampleri, (int2)(x, y));
+  
+  write_imagef(out, (int2)(x, y), input);
+}
+

--- a/data/kernels/lut3d.cl
+++ b/data/kernels/lut3d.cl
@@ -1,0 +1,225 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2019 philippe weyland.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+
+kernel void
+lut3d_tetrahedral(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+           global float *clut, const int level)
+{
+  int4 rgbi = (int4)(0);
+  float4 rgbd = (float4)(0.0f);
+  const int level2 = level * level;
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 input = read_imagef(in, sampleri, (int2)(x, y));
+  float4 output = (float4)(0.0f);
+
+  input.x = (input.x < 0.0f) ? 0.0f : (input.x > 1.0f) ? 1.0f : input.x;
+  input.y = (input.y < 0.0f) ? 0.0f : (input.y > 1.0f) ? 1.0f : input.y;
+  input.z = (input.z < 0.0f) ? 0.0f : (input.z > 1.0f) ? 1.0f : input.z;
+
+  rgbd = input * (float)(level - 1); 
+  rgbi = min( max( convert_int4(rgbd), 0), (int)(level - 2));
+
+// delta r, g, b
+  rgbd = rgbd - convert_float4(rgbi); 
+
+// indexes of P000 to P111 in clut
+  const int color = rgbi.x + rgbi.y * level + rgbi.z * level2;
+  const int i000 = color * 3 ;  // P000
+  const int i100 = i000 + 3;  // P100
+  const int i010 = (int)(color + level) * 3;  // P010
+  const int i110 = i010 + 3;  //P110
+  const int i001 = (int)(color + level2) * 3;  // P001
+  const int i101 = i001 + 3;  // P101
+  const int i011 = (int)(color + level + level2) * 3;  // P011
+  const int i111 = i011 + 3;  // P111
+
+// float3 are 16 bytes aligned. So no way to set clut as an array of float3.
+  const float4 clut000 = (float4)(clut[i000], clut[i000+1], clut[i000+2], 0.0f);
+  const float4 clut100 = (float4)(clut[i100], clut[i100+1], clut[i100+2], 0.0f);
+  const float4 clut010 = (float4)(clut[i010], clut[i010+1], clut[i010+2], 0.0f);
+  const float4 clut110 = (float4)(clut[i110], clut[i110+1], clut[i110+2], 0.0f);
+  const float4 clut001 = (float4)(clut[i001], clut[i001+1], clut[i001+2], 0.0f);
+  const float4 clut101 = (float4)(clut[i101], clut[i101+1], clut[i101+2], 0.0f);
+  const float4 clut011 = (float4)(clut[i011], clut[i011+1], clut[i011+2], 0.0f);
+  const float4 clut111 = (float4)(clut[i111], clut[i111+1], clut[i111+2], 0.0f);
+
+  if (rgbd.x > rgbd.y)
+  {
+    if (rgbd.y > rgbd.z)
+    {
+      output = (1.0f-rgbd.x)*clut000 + (rgbd.x-rgbd.y)*clut100 + (rgbd.y-rgbd.z)*clut110 + rgbd.z*clut111;
+    }
+    else if (rgbd.x > rgbd.z)
+    {
+      output = (1.0f-rgbd.x)*clut000 + (rgbd.x-rgbd.z)*clut100 + (rgbd.z-rgbd.y)*clut101 + rgbd.y*clut111;
+    }
+    else
+    {
+      output = (1.0f-rgbd.z)*clut000 + (rgbd.z-rgbd.x)*clut001 + (rgbd.x-rgbd.y)*clut101 + rgbd.y*clut111;
+    }
+  }
+  else
+  {
+    if (rgbd.z > rgbd.y)
+    {
+      output = (1.0f-rgbd.z)*clut000 + (rgbd.z-rgbd.y)*clut001 + (rgbd.y-rgbd.x)*clut011 + rgbd.x*clut111;
+    }
+    else if (rgbd.z > rgbd.x)
+    {
+      output = (1.0f-rgbd.y)*clut000 + (rgbd.y-rgbd.z)*clut010 + (rgbd.z-rgbd.x)*clut011 + rgbd.x*clut111;
+    }
+    else
+    {
+      output = (1.0f-rgbd.y)*clut000 + (rgbd.y-rgbd.x)*clut010 + (rgbd.x-rgbd.z)*clut110 + rgbd.z*clut111;
+    }
+  }
+  output.w = input.w;
+  write_imagef(out, (int2)(x, y), output);
+}
+
+kernel void
+lut3d_trilinear(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+           global float *clut, const uint level)
+{
+  int4 rgbi = (int4)(0);
+  float4 rgbd = (float4)(0.0f);
+  const int level2 = level * level;
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+  float4 tmp1;
+  float4 tmp2;
+  
+  if(x >= width || y >= height) return;
+
+  float4 input = read_imagef(in, sampleri, (int2)(x, y));
+  float4 output = (float4)(0.0f);
+
+  input.x = (input.x < 0.0f) ? 0.0f : (input.x > 1.0f) ? 1.0f : input.x;
+  input.y = (input.y < 0.0f) ? 0.0f : (input.y > 1.0f) ? 1.0f : input.y;
+  input.z = (input.z < 0.0f) ? 0.0f : (input.z > 1.0f) ? 1.0f : input.z;
+
+  rgbd = input * (float)(level - 1); 
+  rgbi = min( max( convert_int4(rgbd), 0), (int)(level - 2));
+
+  // delta r, g, b
+  rgbd = rgbd - convert_float4(rgbi); 
+
+  // indexes of P000 to P111 in clut
+  const int color = rgbi.x + rgbi.y * level + rgbi.z * level2;
+  const int i000 = color * 3 ;  // P000
+  const int i100 = i000 + 3;  // P100
+  const int i010 = (int)(color + level) * 3;  // P010
+  const int i110 = i010 + 3;  //P110
+  const int i001 = (int)(color + level2) * 3;  // P001
+  const int i101 = i001 + 3;  // P101
+  const int i011 = (int)(color + level + level2) * 3;  // P011
+  const int i111 = i011 + 3;  // P111
+
+  // float3 are 16 bytes aligned. So no way to set clut as an array of float3.
+  const float4 clut000 = (float4)(clut[i000], clut[i000+1], clut[i000+2], 0.0f);
+  const float4 clut100 = (float4)(clut[i100], clut[i100+1], clut[i100+2], 0.0f);
+  const float4 clut010 = (float4)(clut[i010], clut[i010+1], clut[i010+2], 0.0f);
+  const float4 clut110 = (float4)(clut[i110], clut[i110+1], clut[i110+2], 0.0f);
+  const float4 clut001 = (float4)(clut[i001], clut[i001+1], clut[i001+2], 0.0f);
+  const float4 clut101 = (float4)(clut[i101], clut[i101+1], clut[i101+2], 0.0f);
+  const float4 clut011 = (float4)(clut[i011], clut[i011+1], clut[i011+2], 0.0f);
+  const float4 clut111 = (float4)(clut[i111], clut[i111+1], clut[i111+2], 0.0f);
+  
+  tmp1 = clut000*(1.0f-rgbd.x) + clut100*rgbd.x;
+  tmp2 = clut010*(1.0f-rgbd.x) + clut110*rgbd.x;
+  output = tmp1*(1.0f-rgbd.y) + tmp2*rgbd.y;
+  tmp1 = clut001*(1.0f-rgbd.x) + clut101*rgbd.x;
+  tmp2 = clut011*(1.0f-rgbd.x) + clut111*rgbd.x;
+  tmp1 = tmp1*(1.0f-rgbd.y) + tmp2*rgbd.y;
+  output = output*(1.0f-rgbd.z) + tmp1*rgbd.z;
+
+  output.w = input.w;
+  write_imagef(out, (int2)(x, y), output);
+}
+
+kernel void
+lut3d_pyramid(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+           global float *clut, const uint level)
+{
+  int4 rgbi = (int4)(0);
+  float4 rgbd = (float4)(0.0f);
+  const int level2 = level * level;
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 input = read_imagef(in, sampleri, (int2)(x, y));
+  float4 output = (float4)(0.0f);
+
+  input.x = (input.x < 0.0f) ? 0.0f : (input.x > 1.0f) ? 1.0f : input.x;
+  input.y = (input.y < 0.0f) ? 0.0f : (input.y > 1.0f) ? 1.0f : input.y;
+  input.z = (input.z < 0.0f) ? 0.0f : (input.z > 1.0f) ? 1.0f : input.z;
+
+  rgbd = input * (float)(level - 1); 
+  rgbi = min( max( convert_int4(rgbd), 0), (int)(level - 2));
+
+  // delta r, g, b
+  rgbd = rgbd - convert_float4(rgbi); 
+
+  // indexes of P000 to P111 in clut
+  const int color = rgbi.x + rgbi.y * level + rgbi.z * level2;
+  const int i000 = color * 3 ;  // P000
+  const int i100 = i000 + 3;  // P100
+  const int i010 = (int)(color + level) * 3;  // P010
+  const int i110 = i010 + 3;  //P110
+  const int i001 = (int)(color + level2) * 3;  // P001
+  const int i101 = i001 + 3;  // P101
+  const int i011 = (int)(color + level + level2) * 3;  // P011
+  const int i111 = i011 + 3;  // P111
+
+  // float3 are 16 bytes aligned. So no way to set clut as an array of float3.
+  const float4 clut000 = (float4)(clut[i000], clut[i000+1], clut[i000+2], 0.0f);
+  const float4 clut100 = (float4)(clut[i100], clut[i100+1], clut[i100+2], 0.0f);
+  const float4 clut010 = (float4)(clut[i010], clut[i010+1], clut[i010+2], 0.0f);
+  const float4 clut110 = (float4)(clut[i110], clut[i110+1], clut[i110+2], 0.0f);
+  const float4 clut001 = (float4)(clut[i001], clut[i001+1], clut[i001+2], 0.0f);
+  const float4 clut101 = (float4)(clut[i101], clut[i101+1], clut[i101+2], 0.0f);
+  const float4 clut011 = (float4)(clut[i011], clut[i011+1], clut[i011+2], 0.0f);
+  const float4 clut111 = (float4)(clut[i111], clut[i111+1], clut[i111+2], 0.0f);
+
+  if (rgbd.y > rgbd.x && rgbd.z > rgbd.x)
+  {
+    output = clut000 + (clut111-clut011)*rgbd.x + (clut010-clut000)*rgbd.y + (clut001-clut000)*rgbd.z
+      + (clut011-clut001-clut010+clut000)*rgbd.y*rgbd.z;
+  }
+  else if (rgbd.x > rgbd.y && rgbd.z > rgbd.y)
+  {
+    output = clut000 + (clut100-clut000)*rgbd.x + (clut111-clut101)*rgbd.y + (clut001-clut000)*rgbd.z
+      + (clut101-clut001-clut100+clut000)*rgbd.x*rgbd.z;
+  }
+  else
+  {
+    output = clut000 + (clut100-clut000)*rgbd.x + (clut010-clut000)*rgbd.y + (clut111-clut110)*rgbd.z
+      + (clut110-clut100-clut010+clut000)*rgbd.x*rgbd.y;
+  }
+  output.w = input.w;
+  write_imagef(out, (int2)(x, y), output);
+}
+

--- a/data/kernels/lut3d.cl
+++ b/data/kernels/lut3d.cl
@@ -33,10 +33,8 @@ lut3d_tetrahedral(read_only image2d_t in, write_only image2d_t out, const int wi
   float4 input = read_imagef(in, sampleri, (int2)(x, y));
   float4 output = (float4)(0.0f);
 
-  input.x = (input.x < 0.0f) ? 0.0f : (input.x > 1.0f) ? 1.0f : input.x;
-  input.y = (input.y < 0.0f) ? 0.0f : (input.y > 1.0f) ? 1.0f : input.y;
-  input.z = (input.z < 0.0f) ? 0.0f : (input.z > 1.0f) ? 1.0f : input.z;
-
+  input = clamp(input, (float4)0.0f, (float4)1.0f);
+  
   rgbd = input * (float)(level - 1); 
   rgbi = min( max( convert_int4(rgbd), 0), (int)(level - 2));
 
@@ -115,9 +113,7 @@ lut3d_trilinear(read_only image2d_t in, write_only image2d_t out, const int widt
   float4 input = read_imagef(in, sampleri, (int2)(x, y));
   float4 output = (float4)(0.0f);
 
-  input.x = (input.x < 0.0f) ? 0.0f : (input.x > 1.0f) ? 1.0f : input.x;
-  input.y = (input.y < 0.0f) ? 0.0f : (input.y > 1.0f) ? 1.0f : input.y;
-  input.z = (input.z < 0.0f) ? 0.0f : (input.z > 1.0f) ? 1.0f : input.z;
+  input = clamp(input, (float4)0.0f, (float4)1.0f);
 
   rgbd = input * (float)(level - 1); 
   rgbi = min( max( convert_int4(rgbd), 0), (int)(level - 2));
@@ -173,9 +169,7 @@ lut3d_pyramid(read_only image2d_t in, write_only image2d_t out, const int width,
   float4 input = read_imagef(in, sampleri, (int2)(x, y));
   float4 output = (float4)(0.0f);
 
-  input.x = (input.x < 0.0f) ? 0.0f : (input.x > 1.0f) ? 1.0f : input.x;
-  input.y = (input.y < 0.0f) ? 0.0f : (input.y > 1.0f) ? 1.0f : input.y;
-  input.z = (input.z < 0.0f) ? 0.0f : (input.z > 1.0f) ? 1.0f : input.z;
+  input = clamp(input, (float4)0.0f, (float4)1.0f);
 
   rgbd = input * (float)(level - 1); 
   rgbi = min( max( convert_int4(rgbd), 0), (int)(level - 2));

--- a/data/kernels/programs.conf
+++ b/data/kernels/programs.conf
@@ -28,3 +28,5 @@ basicadj.cl             24
 rgbcurve.cl             25
 guided_filter.cl        26
 hazeremoval.cl          27
+lut3d.cl                28
+

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1259,8 +1259,8 @@ dt_colorspaces_t *dt_colorspaces_init()
                                      ++work_pos, ++display2_pos));
 
   res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_REC709, dt_colorspaces_create_gamma_rec709_rgb_profile(),
-                                     _("gamma Rec709 RGB"), ++in_pos, ++out_pos, ++display_pos, ++category_pos,
-                                     ++work_pos, ++display2_pos));
+                                     _("gamma Rec709 RGB"), ++in_pos, ++out_pos, -1, -1,
+                                     ++work_pos, -1));
                                      
   res->profiles = g_list_append(
       res->profiles, _create_profile(DT_COLORSPACE_LIN_REC2020, dt_colorspaces_create_linear_rec2020_rgb_profile(),

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -325,6 +325,19 @@ static cmsHPROFILE dt_colorspaces_create_brg_profile()
   return profile;
 }
 
+static cmsHPROFILE dt_colorspaces_create_gamma_rec709_rgb_profile(void)
+{
+  cmsFloat64Number srgb_parameters[5] = { 2.2, 1.0 / 1.099,  0.099 / 1.099, 1.0 / 4.5, 0.081 };
+  cmsToneCurve *transferFunction = cmsBuildParametricToneCurve(NULL, 4, srgb_parameters);
+
+  cmsHPROFILE profile = _create_lcms_profile("Gamma Rec709 RGB", "Gamma Rec709 RGB",
+                                             &rec709_primaries_pre_quantized, transferFunction, TRUE);
+
+  cmsFreeToneCurve(transferFunction);
+
+  return profile;
+}
+
 // Create the ICC virtual profile for adobe rgb space
 static cmsHPROFILE dt_colorspaces_create_adobergb_profile(void)
 {
@@ -1245,6 +1258,10 @@ dt_colorspaces_t *dt_colorspaces_init()
                                      _("linear Rec709 RGB"), ++in_pos, ++out_pos, ++display_pos, ++category_pos,
                                      ++work_pos, ++display2_pos));
 
+  res->profiles = g_list_append(res->profiles, _create_profile(DT_COLORSPACE_REC709, dt_colorspaces_create_gamma_rec709_rgb_profile(),
+                                     _("gamma Rec709 RGB"), ++in_pos, ++out_pos, ++display_pos, ++category_pos,
+                                     ++work_pos, ++display2_pos));
+                                     
   res->profiles = g_list_append(
       res->profiles, _create_profile(DT_COLORSPACE_LIN_REC2020, dt_colorspaces_create_linear_rec2020_rgb_profile(),
                                      _("linear Rec2020 RGB"), ++in_pos, ++out_pos, ++display_pos, ++category_pos,

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -72,7 +72,8 @@ typedef enum dt_colorspaces_color_profile_type_t
   DT_COLORSPACE_SOFTPROOF = 17,
   DT_COLORSPACE_WORK = 18,
   DT_COLORSPACE_DISPLAY2 = 19,
-  DT_COLORSPACE_LAST = 20
+  DT_COLORSPACE_REC709 = 20,
+  DT_COLORSPACE_LAST = 21
 } dt_colorspaces_color_profile_type_t;
 
 typedef enum dt_colorspaces_color_mode_t

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -121,7 +121,7 @@ static inline __m128 dt_sRGB_to_XYZ_sse2(__m128 rgb)
   rgb = _mm_or_ps(_mm_and_ps(mask, rgb0), _mm_andnot_ps(mask, rgb1));
 
   __m128 XYZ
-      = srgb_to_xyz_0 * _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(0, 0, 0, 0)) + 
+      = srgb_to_xyz_0 * _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(0, 0, 0, 0)) +
         srgb_to_xyz_1 * _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(1, 1, 1, 1)) +
         srgb_to_xyz_2 * _mm_shuffle_ps(rgb, rgb, _MM_SHUFFLE(2, 2, 2, 2));
   return XYZ;

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -236,18 +236,6 @@ static inline void dt_XYZ_to_sRGB(const float *const XYZ, float *sRGB)
     sRGB[c] = rgb[c] <= 0.0031308 ? 12.92 * rgb[c] : (1.0 + 0.055) * powf(rgb[c], 1.0 / 2.4) - 0.055;
 }
 
-/** uses D50 white point. */
-static inline void dt_XYZ_to_linear_sRGB(const float *const XYZ, float *sRGB)
-{
-  const float xyz_to_srgb_matrix[3][3] = { { 3.1338561, -1.6168667, -0.4906146 },
-                                           { -0.9787684, 1.9161415, 0.0334540 },
-                                           { 0.0719453, -0.2289914, 1.4052427 } };
-
-  // XYZ -> sRGB
-  for(int r = 0; r < 3; r++)
-    for(int c = 0; c < 3; c++) sRGB[r] += xyz_to_srgb_matrix[r][c] * XYZ[c];
-}
-
 /** uses D50 white point and clips the output to [0..1]. */
 static inline void dt_XYZ_to_sRGB_clipped(const float *const XYZ, float *sRGB)
 {
@@ -274,18 +262,6 @@ static inline void dt_sRGB_to_XYZ(const float *const sRGB, float *XYZ)
     rgb[c] = sRGB[c] <= 0.04045 ? sRGB[c] / 12.92 : powf((sRGB[c] + 0.055) / (1 + 0.055), 2.4);
   for(int r = 0; r < 3; r++)
     for(int c = 0; c < 3; c++) XYZ[r] += srgb_to_xyz[r][c] * rgb[c];
-}
-
-static inline void dt_linear_sRGB_to_XYZ(const float *const sRGB, float *XYZ)
-{
-  const float srgb_to_xyz[3][3] = { { 0.4360747, 0.3850649, 0.1430804 },
-                                    { 0.2225045, 0.7168786, 0.0606169 },
-                                    { 0.0139322, 0.0971045, 0.7141733 } };
-
-  // sRGB -> XYZ
-  XYZ[0] = XYZ[1] = XYZ[2] = 0.0;
-  for(int r = 0; r < 3; r++)
-    for(int c = 0; c < 3; c++) XYZ[r] += srgb_to_xyz[r][c] * sRGB[c];
 }
 
 static inline void dt_XYZ_to_prophotorgb(const float *const XYZ, float *rgb)

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -236,6 +236,18 @@ static inline void dt_XYZ_to_sRGB(const float *const XYZ, float *sRGB)
     sRGB[c] = rgb[c] <= 0.0031308 ? 12.92 * rgb[c] : (1.0 + 0.055) * powf(rgb[c], 1.0 / 2.4) - 0.055;
 }
 
+/** uses D50 white point. */
+static inline void dt_XYZ_to_linear_sRGB(const float *const XYZ, float *sRGB)
+{
+  const float xyz_to_srgb_matrix[3][3] = { { 3.1338561, -1.6168667, -0.4906146 },
+                                           { -0.9787684, 1.9161415, 0.0334540 },
+                                           { 0.0719453, -0.2289914, 1.4052427 } };
+
+  // XYZ -> sRGB
+  for(int r = 0; r < 3; r++)
+    for(int c = 0; c < 3; c++) sRGB[r] += xyz_to_srgb_matrix[r][c] * XYZ[c];
+}
+
 /** uses D50 white point and clips the output to [0..1]. */
 static inline void dt_XYZ_to_sRGB_clipped(const float *const XYZ, float *sRGB)
 {
@@ -262,6 +274,18 @@ static inline void dt_sRGB_to_XYZ(const float *const sRGB, float *XYZ)
     rgb[c] = sRGB[c] <= 0.04045 ? sRGB[c] / 12.92 : powf((sRGB[c] + 0.055) / (1 + 0.055), 2.4);
   for(int r = 0; r < 3; r++)
     for(int c = 0; c < 3; c++) XYZ[r] += srgb_to_xyz[r][c] * rgb[c];
+}
+
+static inline void dt_linear_sRGB_to_XYZ(const float *const sRGB, float *XYZ)
+{
+  const float srgb_to_xyz[3][3] = { { 0.4360747, 0.3850649, 0.1430804 },
+                                    { 0.2225045, 0.7168786, 0.0606169 },
+                                    { 0.0139322, 0.0971045, 0.7141733 } };
+
+  // sRGB -> XYZ
+  XYZ[0] = XYZ[1] = XYZ[2] = 0.0;
+  for(int r = 0; r < 3; r++)
+    for(int c = 0; c < 3; c++) XYZ[r] += srgb_to_xyz[r][c] * sRGB[c];
 }
 
 static inline void dt_XYZ_to_prophotorgb(const float *const XYZ, float *rgb)

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -24,23 +24,12 @@
 
 #include "common/colorspaces.h"
 #include "common/darktable.h"
+#include "imageio_png.h"
 #include "common/exif.h"
 #include "control/conf.h"
 #include "develop/develop.h"
 #include "imageio.h"
 #include "imageio_tiff.h"
-
-typedef struct dt_imageio_png_t
-{
-  int max_width, max_height;
-  int width, height;
-  int color_type, bit_depth;
-  int bpp;
-  FILE *f;
-  png_structp png_ptr;
-  png_infop info_ptr;
-} dt_imageio_png_t;
-
 
 int read_header(const char *filename, dt_imageio_png_t *png)
 {

--- a/src/common/imageio_png.h
+++ b/src/common/imageio_png.h
@@ -21,6 +21,22 @@
 #include "common/image.h"
 #include "common/mipmap_cache.h"
 
+#include <png.h>
+
+typedef struct dt_imageio_png_t
+{
+  int max_width, max_height;
+  int width, height;
+  int color_type, bit_depth;
+  int bpp;
+  FILE *f;
+  png_structp png_ptr;
+  png_infop info_ptr;
+} dt_imageio_png_t;
+
+int read_header(const char *filename, dt_imageio_png_t *png);
+int read_image(dt_imageio_png_t *png, void *out);
+
 dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
 int dt_imageio_png_read_profile(const char *filename, uint8_t **out);
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -61,7 +61,8 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
     _ioppr_move_iop_before(_iop_order_list, "colorout", "clahe", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorin", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "rgbcurve", "levels", dont_move);
-
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "velvia", dont_move);
+    
     new_version = 2;
   }
 
@@ -173,7 +174,6 @@ static GList *_ioppr_get_iop_order_v1()
                                                   { 0.0, "vignette" },
                                                   { 0.0, "splittoning" },
                                                   { 0.0, "velvia" },
-                                                  { 0.0, "lut3d" },
                                                   { 0.0, "clahe" },
                                                   { 0.0, "finalscale" },
                                                   { 0.0, "overexposed" },

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -48,7 +48,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
 static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_list, const int old_version, const int dont_move)
 {
   int new_version = -1;
-
+  
   if(0) // I left this for now so I don't get the unused error, we'll add some modules soon and we'll remove it
   {
     _ioppr_insert_iop_before(_iop_order_list, history_list, "dummy1", "colorin", dont_move);
@@ -67,7 +67,7 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
 
   if(new_version <= 0)
     fprintf(stderr, "[_ioppr_legacy_iop_order_step] missing step migrating from version %i\n", old_version);
-
+  
   return new_version;
 }
 
@@ -173,6 +173,7 @@ static GList *_ioppr_get_iop_order_v1()
                                                   { 0.0, "vignette" },
                                                   { 0.0, "splittoning" },
                                                   { 0.0, "velvia" },
+                                                  { 0.0, "lut3d" },
                                                   { 0.0, "clahe" },
                                                   { 0.0, "finalscale" },
                                                   { 0.0, "overexposed" },
@@ -203,7 +204,7 @@ static GList *_ioppr_get_iop_order_v1()
 dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list, const char *op_name)
 {
   dt_iop_order_entry_t *iop_order_entry = NULL;
-
+  
   GList *iops_order = g_list_first(iop_order_list);
   while(iops_order)
   {
@@ -226,7 +227,7 @@ double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name)
 {
   double iop_order = DBL_MAX;
   dt_iop_order_entry_t *order_entry = dt_ioppr_get_iop_order_entry(iop_order_list, op_name);
-
+  
   if(order_entry)
     iop_order = order_entry->iop_order;
 
@@ -239,14 +240,14 @@ double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name)
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int check_history)
 {
   GList *iop_order_list = *_iop_order_list;
-
+  
   // check that the new operation don't exists on the list
   if(dt_ioppr_get_iop_order_entry(iop_order_list, op_new) == NULL)
   {
     // create a new iop order entry
     dt_iop_order_entry_t *iop_order_new = (dt_iop_order_entry_t*)calloc(1, sizeof(dt_iop_order_entry_t));
     snprintf(iop_order_new->operation, sizeof(iop_order_new->operation), "%s", op_new);
-
+    
     // search for the previous one
     int position = 0;
     int found = 0;
@@ -264,10 +265,10 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
       }
       iop_order_prev = order_entry->iop_order;
       position++;
-
+      
       iops_order = g_list_next(iops_order);
     }
-
+    
     // now we have to check if there's a module with iop_order between iop_order_prev and iop_order_next
     if(found)
     {
@@ -277,22 +278,22 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
         while(history)
         {
           dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-
+          
           if(hist->iop_order >= iop_order_prev && hist->iop_order <= iop_order_next)
             iop_order_prev = hist->iop_order;
-
+          
           history = g_list_next(history);
         }
       }
     }
     else
       fprintf(stderr, "[_ioppr_insert_iop_before] module %s don't exists on iop order list\n", op_next);
-
+    
     if(found)
     {
       // set the iop_order
       iop_order_new->iop_order = iop_order_prev + (iop_order_next - iop_order_prev) / 2.0;
-
+      
       // insert it on the proper order
       iop_order_list = g_list_insert(iop_order_list, iop_order_new, position);
     }
@@ -309,7 +310,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_prev, const int check_history)
 {
   GList *iop_order_list = *_iop_order_list;
-
+  
   // inserting after op_prev is the same as moving before the very next one after op_prev
   dt_iop_order_entry_t *prior_next = NULL;
   GList *iops_order = g_list_last(iop_order_list);
@@ -339,16 +340,16 @@ static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list
 static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_current, const char *op_next, const int dont_move)
 {
   if(dont_move) return;
-
+  
   GList *iop_order_list = *_iop_order_list;
-
+  
   int position = 0;
   int found = 0;
   dt_iop_order_entry_t *iop_order_prev = NULL;
   dt_iop_order_entry_t *iop_order_next = NULL;
   dt_iop_order_entry_t *iop_order_current = NULL;
   GList *iops_order_current = NULL;
-
+  
   // search for the current one
   GList *iops_order = g_list_first(iop_order_list);
   while(iops_order)
@@ -361,7 +362,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
       found = 1;
       break;
     }
-
+    
     iops_order = g_list_next(iops_order);
   }
 
@@ -389,16 +390,16 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
       }
       iop_order_prev = order_entry;
       position++;
-
+      
       iops_order = g_list_next(iops_order);
     }
   }
-
+  
   if(found)
   {
     // set the iop_order
     iop_order_current->iop_order = iop_order_prev->iop_order + (iop_order_next->iop_order - iop_order_prev->iop_order) / 2.0;
-
+    
     // insert it on the proper order
     iop_order_list = g_list_insert(iop_order_list, iop_order_current, position);
   }
@@ -413,9 +414,9 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
 static void _ioppr_move_iop_after(GList **_iop_order_list, const char *op_current, const char *op_prev, const int dont_move)
 {
   if(dont_move) return;
-
+  
   GList *iop_order_list = *_iop_order_list;
-
+  
   // moving after op_prev is the same as moving before the very next one after op_prev
   dt_iop_order_entry_t *prior_next = NULL;
   GList *iops_order = g_list_last(iop_order_list);
@@ -447,19 +448,19 @@ GList *dt_ioppr_get_iop_order_list(int *_version)
   GList *iop_order_list = _ioppr_get_iop_order_v1();
   int old_version = 1;
   const int version = ((_version == NULL) || (*_version == 0)) ? DT_IOP_ORDER_VERSION: *_version;
-
+  
   while(old_version < version && old_version > 0)
   {
     old_version = _ioppr_legacy_iop_order_step(&iop_order_list, NULL, old_version, FALSE);
   }
-
+  
   if(old_version != version)
   {
     fprintf(stderr, "[dt_ioppr_get_iop_order_list] error building iop_order_list to version %i\n", version);
   }
-
+  
   if(_version && *_version == 0 && old_version > 0) *_version = old_version;
-
+  
   return iop_order_list;
 }
 
@@ -469,7 +470,7 @@ GList *dt_ioppr_get_iop_order_list(int *_version)
 void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
 {
   GList *iop_list = *_iop_list;
-
+  
   GList *modules = g_list_first(iop_list);
   while(modules)
   {
@@ -484,7 +485,7 @@ void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
     {
       mod->iop_order = DBL_MAX;
     }
-
+    
     modules = g_list_next(modules);
   }
   // we need to set the right order
@@ -497,18 +498,18 @@ void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
 static dt_dev_history_item_t *_ioppr_search_history_by_module(GList *history_list, dt_iop_module_t *mod)
 {
   dt_dev_history_item_t *hist_entry = NULL;
-
+  
   GList *history = g_list_first(history_list);
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-
+    
     if(hist->module == mod)
     {
       hist_entry = hist;
       break;
     }
-
+    
     history = g_list_next(history);
   }
 
@@ -521,7 +522,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
 {
   GList *iop_list = *_iop_list;
   dt_iop_module_t *mod_prev = NULL;
-
+  
   // get the first module
   GList *modules = g_list_first(iop_list);
   if(modules)
@@ -539,11 +540,11 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
     if(mod->iop_order == mod_prev->iop_order && mod->iop_order != DBL_MAX)
     {
       int can_move = 0;
-
+      
       if(!mod->enabled && _ioppr_search_history_by_module(history_list, mod) == NULL)
       {
         can_move = 1;
-
+        
         GList *modules1 = g_list_next(modules);
         if(modules1)
         {
@@ -566,7 +567,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
       else if(!mod_prev->enabled && _ioppr_search_history_by_module(history_list, mod_prev) == NULL)
       {
         can_move = 1;
-
+        
         GList *modules1 = g_list_previous(modules);
         if(modules1) modules1 = g_list_previous(modules1);
         if(modules1)
@@ -579,7 +580,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
           else
           {
             can_move = 0;
-            fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%f) and %s %s(%f) has the same iop_order\n",
+            fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%f) and %s %s(%f) has the same iop_order\n", 
                 mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op, mod->multi_name, mod->iop_order);
           }
         }
@@ -591,11 +592,11 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
 
       if(!can_move)
       {
-        fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%f) and %s %s(%f) has the same iop_order\n",
+        fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%f) and %s %s(%f) has the same iop_order\n", 
             mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op, mod->multi_name, mod->iop_order);
       }
     }
-
+    
     if(reset_list)
     {
       modules = g_list_first(iop_list);
@@ -611,7 +612,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
       modules = g_list_next(modules);
     }
   }
-
+  
   *_iop_list = iop_list;
 }
 
@@ -622,14 +623,14 @@ void dt_ioppr_legacy_iop_order(GList **_iop_list, GList **_iop_order_list, GList
   GList *iop_order_list = *_iop_order_list;
   int dt_version = DT_IOP_ORDER_VERSION;
   int old_version = _old_version;
-
+  
   // we want to add any module created after this version of iop_order
   // but we won't move existing modules so only add methods will be executed
   while(old_version < dt_version && old_version > 0)
   {
     old_version = _ioppr_legacy_iop_order_step(&iop_order_list, history_list, old_version, TRUE);
   }
-
+  
   // now that we have a list of iop_order for version new_version but with all new modules
   // we take care of the iop_order of new modules on iop list
   GList *modules = g_list_first(iop_list);
@@ -643,12 +644,12 @@ void dt_ioppr_legacy_iop_order(GList **_iop_list, GList **_iop_order_list, GList
       if(mod->iop_order == DBL_MAX)
         fprintf(stderr, "[dt_ioppr_legacy_iop_order] can't find iop_order for module %s\n", mod->op);
     }
-
+    
     modules = g_list_next(modules);
   }
   // we need to set the right order
   iop_list = g_list_sort(iop_list, dt_sort_iop_by_order);
-
+  
   // and check for duplicates
   dt_ioppr_check_duplicate_iop_order(&iop_list, history_list);
 
@@ -666,7 +667,7 @@ int dt_ioppr_check_so_iop_order(GList *iop_list, GList *iop_order_list)
   while(modules)
   {
     dt_iop_module_so_t *mod = (dt_iop_module_so_t *)(modules->data);
-
+    
     dt_iop_order_entry_t *entry = dt_ioppr_get_iop_order_entry(iop_order_list, mod->op);
     if(entry == NULL)
     {
@@ -713,13 +714,13 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
   if((module->flags() & IOP_FLAGS_FENCE) && validate_order)
   {
     if(log_error)
-      fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] module %s(%f) is a fence, can't move it before %s %s(%f)\n",
+      fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] module %s(%f) is a fence, can't move it before %s %s(%f)\n", 
           module->op, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
     return -1.0;
   }
-
+  
   double iop_order = -1.0;
-
+  
   // module is before on the pipe
   // move it up
   if(module->iop_order < module_next->iop_order)
@@ -745,14 +746,14 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
       while(modules)
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-
+        
         // if we reach module_next everithing is OK
         if(mod == module_next)
         {
           mod2 = mod;
           break;
         }
-
+        
         // check for rules
         if(validate_order)
         {
@@ -760,11 +761,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           if(mod->flags() & IOP_FLAGS_FENCE)
           {
             if(log_error)
-              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n",
+              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n", 
                   module->op, module->multi_name, module->iop_order, mod->op, mod->multi_name, mod->iop_order);
             break;
           }
-
+          
           // is there a rule about swapping this two?
           int rule_found = 0;
           GList *rules = g_list_first(darktable.iop_order_rules);
@@ -785,11 +786,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           }
           if(rule_found) break;
         }
-
+        
         mod1 = mod;
         modules = g_list_next(modules);
       }
-
+      
       // we reach the module_next module
       if(mod2)
       {
@@ -797,12 +798,12 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         if(module == mod1)
         {
           if(log_error)
-            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n",
+            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n", 
                 module->op, module->multi_name, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
         }
         else if(mod1->iop_order == mod2->iop_order)
         {
-          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n",
+          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n", 
               mod1->op, mod1->multi_name, mod1->iop_order, mod2->op, mod2->multi_name, mod2->iop_order);
         }
         else
@@ -842,7 +843,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
       while(modules)
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-
+        
         // we reach the module next to module_next, everithing is OK
         if(mod2 != NULL)
         {
@@ -857,11 +858,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           if(mod->flags() & IOP_FLAGS_FENCE)
           {
             if(log_error)
-              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n",
+              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n", 
                   module->op, module->multi_name, module->iop_order, mod->op, mod->multi_name, mod->iop_order);
             break;
           }
-
+          
           // is there a rule about swapping this two?
           int rule_found = 0;
           GList *rules = g_list_first(darktable.iop_order_rules);
@@ -882,11 +883,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           }
           if(rule_found) break;
         }
-
+        
         if(mod == module_next) mod2 = mod;
         modules = g_list_previous(modules);
       }
-
+      
       // we reach the module_next module
       if(mod1)
       {
@@ -894,12 +895,12 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         if(module == mod2)
         {
           if(log_error)
-            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n",
+            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n", 
                 module->op, module->multi_name, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
         }
         else if(mod1->iop_order == mod2->iop_order)
         {
-          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n",
+          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n", 
               mod1->op, mod1->multi_name, mod1->iop_order, mod2->op, mod2->multi_name, mod2->iop_order);
         }
         else
@@ -916,10 +917,10 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
   }
   else
   {
-    fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] modules %s %s(%f) and %s %s(%f) has the same iop_order\n",
+    fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] modules %s %s(%f) and %s %s(%f) has the same iop_order\n", 
         module->op, module->multi_name, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
   }
-
+  
   return iop_order;
 }
 
@@ -982,7 +983,7 @@ int dt_ioppr_move_iop_before(GList **_iop_list, dt_iop_module_t *module, dt_iop_
   // dt_ioppr_check_iop_order(dev, "dt_ioppr_move_iop_before end");
 
   *_iop_list = iop_list;
-
+  
   return moved;
 }
 
@@ -1010,7 +1011,7 @@ int dt_ioppr_move_iop_after(GList **_iop_list, dt_iop_module_t *module, dt_iop_m
   // dt_ioppr_check_iop_order(dev, "dt_ioppr_move_iop_after end");
 
   *_iop_list = iop_list;
-
+  
   return moved;
 }
 
@@ -1070,7 +1071,7 @@ void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg)
   while(modules)
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
-
+    
     fprintf(stderr, "[%s] module %s %s multi_priority=%i, iop_order=%f\n", msg, mod->op, mod->multi_name, mod->multi_priority, mod->iop_order);
 
     modules = g_list_next(modules);
@@ -1083,7 +1084,7 @@ void dt_ioppr_print_history_iop_order(GList *history_list, const char *msg)
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-
+    
     fprintf(stderr, "[%s] module %s %s multi_priority=%i, iop_order=%f\n", msg, hist->op_name, hist->multi_name, hist->multi_priority, hist->iop_order);
 
     history = g_list_next(history);
@@ -1096,7 +1097,7 @@ void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg)
   while(iops_order)
   {
     dt_iop_order_entry_t *order_entry = (dt_iop_order_entry_t *)(iops_order->data);
-
+    
     fprintf(stderr, "[%s] operation %s iop_order=%f\n", msg, order_entry->operation, order_entry->iop_order);
 
     iops_order = g_list_next(iops_order);
@@ -1263,7 +1264,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
       dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
       if(mod->iop_order != DBL_MAX)
         break;
-
+      
       modules = g_list_previous(dev->iop);
     }
     if(modules)
@@ -1304,7 +1305,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
                   mod->op, mod->multi_name, mod->iop_order,imgid, msg);
         }
       }
-
+      
       modules = g_list_previous(dev->iop);
     }
   }
@@ -1334,7 +1335,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
             fprintf(
                 stderr,
                 "[dt_ioppr_check_iop_order] module %s %s(%i)(%f) and %s %s(%i)(%f) has the same order image %i (%s)\n",
-                mod->op, mod->multi_name, mod->multi_priority, mod->iop_order, mod_prev->op,
+                mod->op, mod->multi_name, mod->multi_priority, mod->iop_order, mod_prev->op, 
                 mod_prev->multi_name, mod_prev->multi_priority, mod_prev->iop_order, imgid, msg);
           }
         }
@@ -1350,7 +1351,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-
+    
     if(hist->iop_order == DBL_MAX)
     {
       if(hist->enabled)
@@ -1385,7 +1386,7 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in, float 
   cmsHTRANSFORM *xform = NULL;
   cmsHPROFILE *rgb_profile = NULL;
   cmsHPROFILE *lab_profile = NULL;
-
+  
   if(type != DT_COLORSPACE_NONE)
   {
     const dt_colorspaces_color_profile_t *profile = dt_colorspaces_get_profile(type, filename, DT_PROFILE_DIRECTION_WORK);
@@ -1411,14 +1412,14 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in, float 
     rgb_profile = dt_colorspaces_get_profile(DT_COLORSPACE_LIN_REC2020, "", DT_PROFILE_DIRECTION_WORK)->profile;
     fprintf(stderr, _("unsupported working profile %s has been replaced by Rec2020 RGB!\n"), filename);
   }
-
+  
   lab_profile = dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;
 
   cmsHPROFILE *input_profile = NULL;
   cmsHPROFILE *output_profile = NULL;
   cmsUInt32Number input_format = TYPE_RGBA_FLT;
   cmsUInt32Number output_format = TYPE_LabA_FLT;
-
+  
   if(direction == 1) // rgb --> lab
   {
     input_profile = rgb_profile;
@@ -1559,7 +1560,7 @@ static void _transform_lcms2(struct dt_iop_module_t *self, const float *const im
     *converted_cst = cst_to;
     return;
   }
-
+  
   *converted_cst = cst_to;
 
   if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
@@ -1656,7 +1657,7 @@ static void _apply_tonecurves(const float *const image_in, float *const image_ou
   const float *const lut[3] = { lutr, lutg, lutb };
   const float *const unbounded_coeffs[3] = { unbounded_coeffsr, unbounded_coeffsg, unbounded_coeffsb };
   const size_t stride = (size_t)ch * width * height;
-
+  
   // do we have any lut to apply, or is this a linear profile?
   if((lut[0][0] >= 0.0f) && (lut[1][0] >= 0.0f) && (lut[2][0] >= 0.0f))
   {
@@ -1753,7 +1754,7 @@ static void _transform_lab_to_rgb_matrix(const float *const image_in, float *con
     float *const out = image_out + y * ch;
 
     float xyz[3] = { 0.0f, 0.0f, 0.0f };
-
+    
     dt_Lab_to_XYZ(in, xyz);
     _ioppr_xyz_to_linear_rgb_matrix(xyz, out, profile_info);
   }
@@ -1814,13 +1815,13 @@ static void _transform_matrix_rgb(const float *const image_in, float *const imag
                     profile_info_to->lutsize);
 }
 
-static int _init_unbounded_coeffs(float *lutr, float *lutg, float *lutb,
+static int _init_unbounded_coeffs(float *lutr, float *lutg, float *lutb, 
     float *unbounded_coeffsr, float *unbounded_coeffsg, float *unbounded_coeffsb, const int lutsize)
 {
   int nonlinearlut = 0;
   float *lut[3] = { lutr, lutg, lutb };
   float *unbounded_coeffs[3] = { unbounded_coeffsr, unbounded_coeffsg, unbounded_coeffsb };
-
+  
   for(int k = 0; k < 3; k++)
   {
     // omit luts marked as linear (negative as marker)
@@ -1830,13 +1831,13 @@ static int _init_unbounded_coeffs(float *lutr, float *lutg, float *lutb,
       const float y[4] = { lerp_lut(lut[k], x[0], lutsize), lerp_lut(lut[k], x[1], lutsize), lerp_lut(lut[k], x[2], lutsize),
                            lerp_lut(lut[k], x[3], lutsize) };
       dt_iop_estimate_exp(x, y, 4, unbounded_coeffs[k]);
-
+      
       nonlinearlut++;
     }
     else
       unbounded_coeffs[k][0] = -1.0f;
   }
-
+  
   return nonlinearlut;
 }
 
@@ -1849,7 +1850,7 @@ static void _transform_matrix(struct dt_iop_module_t *self, const float *const i
     *converted_cst = cst_to;
     return;
   }
-
+  
   *converted_cst = cst_to;
 
   if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
@@ -1920,7 +1921,7 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
 
   profile_info->nonlinearlut = 0;
   profile_info->grey = 0.1842f;
-
+  
   profile_info->type = type;
   g_strlcpy(profile_info->filename, filename, sizeof(profile_info->filename));
   profile_info->intent = intent;
@@ -1949,14 +1950,14 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
       rgb_profile = NULL;
     }
   }
-
+  
   // get the matrix
   if(rgb_profile)
   {
-    if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in,
+    if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in, 
         profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
         profile_info->lutsize, profile_info->intent) ||
-        dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out,
+        dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out, 
             profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
             profile_info->lutsize, profile_info->intent))
     {
@@ -1986,25 +1987,25 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
   // in our hands, i.e. for the fast builtin-dt-matrix-profile path.
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]))
   {
-    profile_info->nonlinearlut = _init_unbounded_coeffs(profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
+    profile_info->nonlinearlut = _init_unbounded_coeffs(profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2], 
         profile_info->unbounded_coeffs_in[0], profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2], profile_info->lutsize);
-    _init_unbounded_coeffs(profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
+    _init_unbounded_coeffs(profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2], 
         profile_info->unbounded_coeffs_out[0], profile_info->unbounded_coeffs_out[1], profile_info->unbounded_coeffs_out[2], profile_info->lutsize);
   }
-
+  
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]) && profile_info->nonlinearlut)
   {
     float rgb[3] = { 0.1842f, 0.1842f, 0.1842f };
     profile_info->grey = dt_ioppr_get_rgb_matrix_luminance(rgb, profile_info);
   }
-
+  
   return err_code;
 }
 
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_profile_info_from_list(struct dt_develop_t *dev, const int profile_type, const char *profile_filename)
 {
   dt_iop_order_iccprofile_info_t *profile_info = NULL;
-
+  
   GList *profiles = g_list_first(dev->allprofile_info);
   while(profiles)
   {
@@ -2016,7 +2017,7 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_profile_info_from_list(struct dt_de
     }
     profiles = g_list_next(profiles);
   }
-
+  
   return profile_info;
 }
 
@@ -2090,14 +2091,14 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_set_pipe_work_profile_info(struct dt_de
     const int type, const char *filename, const int intent)
 {
   dt_iop_order_iccprofile_info_t *profile_info = dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
-
+  
   if(profile_info == NULL || isnan(profile_info->matrix_in[0]) || isnan(profile_info->matrix_out[0]))
   {
     fprintf(stderr, "[dt_ioppr_set_pipe_work_profile_info] unsupported working profile %i %s, it will be replaced with linear rec2020\n", type, filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }
   pipe->dsc.work_profile_info = profile_info;
-
+  
   return profile_info;
 }
 
@@ -2121,7 +2122,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type,
 {
   *profile_type = DT_COLORSPACE_NONE;
   *profile_filename = NULL;
-
+  
   // use introspection to get the params values
   dt_iop_module_so_t *colorin_so = NULL;
   dt_iop_module_t *colorin = NULL;
@@ -2170,7 +2171,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_typ
 {
   *profile_type = DT_COLORSPACE_NONE;
   *profile_filename = NULL;
-
+  
   // use introspection to get the params values
   dt_iop_module_so_t *colorout_so = NULL;
   dt_iop_module_t *colorout = NULL;
@@ -2243,7 +2244,7 @@ void dt_ioppr_get_histogram_profile_type(int *profile_type, char **profile_filen
 float dt_ioppr_get_rgb_matrix_luminance(const float *const rgb, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   float luminance = 0.f;
-
+  
   if(profile_info->nonlinearlut)
   {
     float linear_rgb[3] = { 0.f };
@@ -2253,7 +2254,7 @@ float dt_ioppr_get_rgb_matrix_luminance(const float *const rgb, const dt_iop_ord
   }
   else
     luminance = profile_info->matrix_in[3] * rgb[0] + profile_info->matrix_in[4] * rgb[1] + profile_info->matrix_in[5] * rgb[2];
-
+  
   return luminance;
 }
 
@@ -2272,11 +2273,11 @@ void dt_ioppr_rgb_matrix_to_xyz(const float *const rgb, float *xyz, const dt_iop
 void dt_ioppr_lab_to_rgb_matrix(const float *const lab, float *rgb, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   float xyz[3] = { 0.0f, 0.0f, 0.0f };
-
+  
   dt_Lab_to_XYZ(lab, xyz);
-
+  
   _ioppr_xyz_to_linear_rgb_matrix(xyz, rgb, profile_info);
-
+  
   if(profile_info->nonlinearlut) _apply_trc_out(rgb, rgb, profile_info);
 }
 
@@ -2366,7 +2367,7 @@ static void _transform_rgb_to_lab_matrix_sse(float *const image, const int width
 
   _apply_tonecurves(image, width, height, profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
       profile_info->unbounded_coeffs_in[0], profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2], profile_info->lutsize);
-
+    
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
 #endif
@@ -2407,7 +2408,7 @@ static void _transform_lab_to_rgb_matrix_sse(float *const image, const int width
     _mm_stream_ps(in, lab);
     in[3] = a;
   }
-
+  
   _apply_tonecurves(image, width, height, profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
       profile_info->unbounded_coeffs_out[0], profile_info->unbounded_coeffs_out[1], profile_info->unbounded_coeffs_out[2], profile_info->lutsize);
 }
@@ -2500,7 +2501,7 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
 
   dt_times_t start_time = { 0 }, end_time = { 0 };
   if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
-
+  
   // matrix should be never NAN, this is only to test it against lcms2!
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]))
   {
@@ -2518,8 +2519,8 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n",
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
+      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n", 
+          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab", 
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -2530,12 +2531,12 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n",
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
+      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n", 
+          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab", 
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
-
+  
   if(*converted_cst == cst_from)
     fprintf(stderr, "[dt_ioppr_transform_image_colorspace] invalid convertion from %i to %i\n", cst_from, cst_to);
 }
@@ -2738,7 +2739,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
                                            const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   cl_int err = CL_SUCCESS;
-
+  
   if(cst_from == cst_to)
   {
     *converted_cst = cst_to;
@@ -2755,7 +2756,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     *converted_cst = cst_from;
     return FALSE;
   }
-
+  
   const int ch = 4;
   float *src_buffer = NULL;
   int in_place = (dev_img_in == dev_img_out);
@@ -2766,7 +2767,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   cl_mem dev_lut = NULL;
   dt_colorspaces_iccprofile_info_cl_t profile_info_cl;
   cl_float *lut_cl = NULL;
-
+  
   *converted_cst = cst_from;
 
   // if we have a matrix use opencl
@@ -2774,10 +2775,10 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   {
     dt_times_t start_time = { 0 }, end_time = { 0 };
     if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
-
+    
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
-
+    
     if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
     {
       kernel_transform = darktable.opencl->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_lab;
@@ -2793,7 +2794,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] invalid convertion from %i to %i\n", cst_from, cst_to);
       goto cleanup;
     }
-
+    
     dt_ioppr_get_profile_info_cl(profile_info, &profile_info_cl);
     lut_cl = dt_ioppr_get_trc_cl(profile_info);
 
@@ -2834,9 +2835,9 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       goto cleanup;
     }
-
+    
     size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-
+    
     dt_opencl_set_kernel_arg(devid, kernel_transform, 0, sizeof(cl_mem), (void *)&dev_tmp);
     dt_opencl_set_kernel_arg(devid, kernel_transform, 1, sizeof(cl_mem), (void *)&dev_img_out);
     dt_opencl_set_kernel_arg(devid, kernel_transform, 2, sizeof(int), (void *)&width);
@@ -2855,8 +2856,8 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n",
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
+      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n", 
+          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab", 
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -2877,7 +2878,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] error allocating memory for color transformation 2\n");
       goto cleanup;
     }
-
+  
     // just call the CPU version for now
     dt_ioppr_transform_image_colorspace(self, src_buffer, src_buffer, width, height, cst_from, cst_to,
                                         converted_cst, profile_info);
@@ -2889,7 +2890,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       goto cleanup;
     }
   }
-
+  
 cleanup:
   if(src_buffer) dt_free_align(src_buffer);
   if(dev_tmp && in_place) dt_opencl_release_mem_object(dev_tmp);

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -61,7 +61,7 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
     _ioppr_move_iop_before(_iop_order_list, "colorout", "clahe", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorin", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "rgbcurve", "levels", dont_move);
-    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "splittoning", dont_move);
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "grain", dont_move);
     
     new_version = 2;
   }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -48,7 +48,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
 static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_list, const int old_version, const int dont_move)
 {
   int new_version = -1;
-  
+
   if(0) // I left this for now so I don't get the unused error, we'll add some modules soon and we'll remove it
   {
     _ioppr_insert_iop_before(_iop_order_list, history_list, "dummy1", "colorin", dont_move);
@@ -67,7 +67,7 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
 
   if(new_version <= 0)
     fprintf(stderr, "[_ioppr_legacy_iop_order_step] missing step migrating from version %i\n", old_version);
-  
+
   return new_version;
 }
 
@@ -203,7 +203,7 @@ static GList *_ioppr_get_iop_order_v1()
 dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list, const char *op_name)
 {
   dt_iop_order_entry_t *iop_order_entry = NULL;
-  
+
   GList *iops_order = g_list_first(iop_order_list);
   while(iops_order)
   {
@@ -226,7 +226,7 @@ double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name)
 {
   double iop_order = DBL_MAX;
   dt_iop_order_entry_t *order_entry = dt_ioppr_get_iop_order_entry(iop_order_list, op_name);
-  
+
   if(order_entry)
     iop_order = order_entry->iop_order;
 
@@ -239,14 +239,14 @@ double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name)
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int check_history)
 {
   GList *iop_order_list = *_iop_order_list;
-  
+
   // check that the new operation don't exists on the list
   if(dt_ioppr_get_iop_order_entry(iop_order_list, op_new) == NULL)
   {
     // create a new iop order entry
     dt_iop_order_entry_t *iop_order_new = (dt_iop_order_entry_t*)calloc(1, sizeof(dt_iop_order_entry_t));
     snprintf(iop_order_new->operation, sizeof(iop_order_new->operation), "%s", op_new);
-    
+
     // search for the previous one
     int position = 0;
     int found = 0;
@@ -264,10 +264,10 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
       }
       iop_order_prev = order_entry->iop_order;
       position++;
-      
+
       iops_order = g_list_next(iops_order);
     }
-    
+
     // now we have to check if there's a module with iop_order between iop_order_prev and iop_order_next
     if(found)
     {
@@ -277,22 +277,22 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
         while(history)
         {
           dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-          
+
           if(hist->iop_order >= iop_order_prev && hist->iop_order <= iop_order_next)
             iop_order_prev = hist->iop_order;
-          
+
           history = g_list_next(history);
         }
       }
     }
     else
       fprintf(stderr, "[_ioppr_insert_iop_before] module %s don't exists on iop order list\n", op_next);
-    
+
     if(found)
     {
       // set the iop_order
       iop_order_new->iop_order = iop_order_prev + (iop_order_next - iop_order_prev) / 2.0;
-      
+
       // insert it on the proper order
       iop_order_list = g_list_insert(iop_order_list, iop_order_new, position);
     }
@@ -309,7 +309,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_prev, const int check_history)
 {
   GList *iop_order_list = *_iop_order_list;
-  
+
   // inserting after op_prev is the same as moving before the very next one after op_prev
   dt_iop_order_entry_t *prior_next = NULL;
   GList *iops_order = g_list_last(iop_order_list);
@@ -339,16 +339,16 @@ static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list
 static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_current, const char *op_next, const int dont_move)
 {
   if(dont_move) return;
-  
+
   GList *iop_order_list = *_iop_order_list;
-  
+
   int position = 0;
   int found = 0;
   dt_iop_order_entry_t *iop_order_prev = NULL;
   dt_iop_order_entry_t *iop_order_next = NULL;
   dt_iop_order_entry_t *iop_order_current = NULL;
   GList *iops_order_current = NULL;
-  
+
   // search for the current one
   GList *iops_order = g_list_first(iop_order_list);
   while(iops_order)
@@ -361,7 +361,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
       found = 1;
       break;
     }
-    
+
     iops_order = g_list_next(iops_order);
   }
 
@@ -389,16 +389,16 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
       }
       iop_order_prev = order_entry;
       position++;
-      
+
       iops_order = g_list_next(iops_order);
     }
   }
-  
+
   if(found)
   {
     // set the iop_order
     iop_order_current->iop_order = iop_order_prev->iop_order + (iop_order_next->iop_order - iop_order_prev->iop_order) / 2.0;
-    
+
     // insert it on the proper order
     iop_order_list = g_list_insert(iop_order_list, iop_order_current, position);
   }
@@ -413,9 +413,9 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
 static void _ioppr_move_iop_after(GList **_iop_order_list, const char *op_current, const char *op_prev, const int dont_move)
 {
   if(dont_move) return;
-  
+
   GList *iop_order_list = *_iop_order_list;
-  
+
   // moving after op_prev is the same as moving before the very next one after op_prev
   dt_iop_order_entry_t *prior_next = NULL;
   GList *iops_order = g_list_last(iop_order_list);
@@ -447,19 +447,19 @@ GList *dt_ioppr_get_iop_order_list(int *_version)
   GList *iop_order_list = _ioppr_get_iop_order_v1();
   int old_version = 1;
   const int version = ((_version == NULL) || (*_version == 0)) ? DT_IOP_ORDER_VERSION: *_version;
-  
+
   while(old_version < version && old_version > 0)
   {
     old_version = _ioppr_legacy_iop_order_step(&iop_order_list, NULL, old_version, FALSE);
   }
-  
+
   if(old_version != version)
   {
     fprintf(stderr, "[dt_ioppr_get_iop_order_list] error building iop_order_list to version %i\n", version);
   }
-  
+
   if(_version && *_version == 0 && old_version > 0) *_version = old_version;
-  
+
   return iop_order_list;
 }
 
@@ -469,7 +469,7 @@ GList *dt_ioppr_get_iop_order_list(int *_version)
 void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
 {
   GList *iop_list = *_iop_list;
-  
+
   GList *modules = g_list_first(iop_list);
   while(modules)
   {
@@ -484,7 +484,7 @@ void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
     {
       mod->iop_order = DBL_MAX;
     }
-    
+
     modules = g_list_next(modules);
   }
   // we need to set the right order
@@ -497,18 +497,18 @@ void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
 static dt_dev_history_item_t *_ioppr_search_history_by_module(GList *history_list, dt_iop_module_t *mod)
 {
   dt_dev_history_item_t *hist_entry = NULL;
-  
+
   GList *history = g_list_first(history_list);
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    
+
     if(hist->module == mod)
     {
       hist_entry = hist;
       break;
     }
-    
+
     history = g_list_next(history);
   }
 
@@ -521,7 +521,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
 {
   GList *iop_list = *_iop_list;
   dt_iop_module_t *mod_prev = NULL;
-  
+
   // get the first module
   GList *modules = g_list_first(iop_list);
   if(modules)
@@ -539,11 +539,11 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
     if(mod->iop_order == mod_prev->iop_order && mod->iop_order != DBL_MAX)
     {
       int can_move = 0;
-      
+
       if(!mod->enabled && _ioppr_search_history_by_module(history_list, mod) == NULL)
       {
         can_move = 1;
-        
+
         GList *modules1 = g_list_next(modules);
         if(modules1)
         {
@@ -566,7 +566,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
       else if(!mod_prev->enabled && _ioppr_search_history_by_module(history_list, mod_prev) == NULL)
       {
         can_move = 1;
-        
+
         GList *modules1 = g_list_previous(modules);
         if(modules1) modules1 = g_list_previous(modules1);
         if(modules1)
@@ -579,7 +579,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
           else
           {
             can_move = 0;
-            fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%f) and %s %s(%f) has the same iop_order\n", 
+            fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%f) and %s %s(%f) has the same iop_order\n",
                 mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op, mod->multi_name, mod->iop_order);
           }
         }
@@ -591,11 +591,11 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
 
       if(!can_move)
       {
-        fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%f) and %s %s(%f) has the same iop_order\n", 
+        fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%f) and %s %s(%f) has the same iop_order\n",
             mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op, mod->multi_name, mod->iop_order);
       }
     }
-    
+
     if(reset_list)
     {
       modules = g_list_first(iop_list);
@@ -611,7 +611,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
       modules = g_list_next(modules);
     }
   }
-  
+
   *_iop_list = iop_list;
 }
 
@@ -622,14 +622,14 @@ void dt_ioppr_legacy_iop_order(GList **_iop_list, GList **_iop_order_list, GList
   GList *iop_order_list = *_iop_order_list;
   int dt_version = DT_IOP_ORDER_VERSION;
   int old_version = _old_version;
-  
+
   // we want to add any module created after this version of iop_order
   // but we won't move existing modules so only add methods will be executed
   while(old_version < dt_version && old_version > 0)
   {
     old_version = _ioppr_legacy_iop_order_step(&iop_order_list, history_list, old_version, TRUE);
   }
-  
+
   // now that we have a list of iop_order for version new_version but with all new modules
   // we take care of the iop_order of new modules on iop list
   GList *modules = g_list_first(iop_list);
@@ -643,12 +643,12 @@ void dt_ioppr_legacy_iop_order(GList **_iop_list, GList **_iop_order_list, GList
       if(mod->iop_order == DBL_MAX)
         fprintf(stderr, "[dt_ioppr_legacy_iop_order] can't find iop_order for module %s\n", mod->op);
     }
-    
+
     modules = g_list_next(modules);
   }
   // we need to set the right order
   iop_list = g_list_sort(iop_list, dt_sort_iop_by_order);
-  
+
   // and check for duplicates
   dt_ioppr_check_duplicate_iop_order(&iop_list, history_list);
 
@@ -666,7 +666,7 @@ int dt_ioppr_check_so_iop_order(GList *iop_list, GList *iop_order_list)
   while(modules)
   {
     dt_iop_module_so_t *mod = (dt_iop_module_so_t *)(modules->data);
-    
+
     dt_iop_order_entry_t *entry = dt_ioppr_get_iop_order_entry(iop_order_list, mod->op);
     if(entry == NULL)
     {
@@ -713,13 +713,13 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
   if((module->flags() & IOP_FLAGS_FENCE) && validate_order)
   {
     if(log_error)
-      fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] module %s(%f) is a fence, can't move it before %s %s(%f)\n", 
+      fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] module %s(%f) is a fence, can't move it before %s %s(%f)\n",
           module->op, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
     return -1.0;
   }
-  
+
   double iop_order = -1.0;
-  
+
   // module is before on the pipe
   // move it up
   if(module->iop_order < module_next->iop_order)
@@ -745,14 +745,14 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
       while(modules)
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-        
+
         // if we reach module_next everithing is OK
         if(mod == module_next)
         {
           mod2 = mod;
           break;
         }
-        
+
         // check for rules
         if(validate_order)
         {
@@ -760,11 +760,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           if(mod->flags() & IOP_FLAGS_FENCE)
           {
             if(log_error)
-              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n", 
+              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n",
                   module->op, module->multi_name, module->iop_order, mod->op, mod->multi_name, mod->iop_order);
             break;
           }
-          
+
           // is there a rule about swapping this two?
           int rule_found = 0;
           GList *rules = g_list_first(darktable.iop_order_rules);
@@ -785,11 +785,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           }
           if(rule_found) break;
         }
-        
+
         mod1 = mod;
         modules = g_list_next(modules);
       }
-      
+
       // we reach the module_next module
       if(mod2)
       {
@@ -797,12 +797,12 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         if(module == mod1)
         {
           if(log_error)
-            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n", 
+            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n",
                 module->op, module->multi_name, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
         }
         else if(mod1->iop_order == mod2->iop_order)
         {
-          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n", 
+          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n",
               mod1->op, mod1->multi_name, mod1->iop_order, mod2->op, mod2->multi_name, mod2->iop_order);
         }
         else
@@ -842,7 +842,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
       while(modules)
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
-        
+
         // we reach the module next to module_next, everithing is OK
         if(mod2 != NULL)
         {
@@ -857,11 +857,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           if(mod->flags() & IOP_FLAGS_FENCE)
           {
             if(log_error)
-              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n", 
+              fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] can't move %s %s(%f) pass %s %s(%f)\n",
                   module->op, module->multi_name, module->iop_order, mod->op, mod->multi_name, mod->iop_order);
             break;
           }
-          
+
           // is there a rule about swapping this two?
           int rule_found = 0;
           GList *rules = g_list_first(darktable.iop_order_rules);
@@ -882,11 +882,11 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
           }
           if(rule_found) break;
         }
-        
+
         if(mod == module_next) mod2 = mod;
         modules = g_list_previous(modules);
       }
-      
+
       // we reach the module_next module
       if(mod1)
       {
@@ -894,12 +894,12 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         if(module == mod2)
         {
           if(log_error)
-            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n", 
+            fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) is already previous to %s %s(%f)\n",
                 module->op, module->multi_name, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
         }
         else if(mod1->iop_order == mod2->iop_order)
         {
-          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n", 
+          fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] %s %s(%f) and %s %s(%f) has the same iop_order\n",
               mod1->op, mod1->multi_name, mod1->iop_order, mod2->op, mod2->multi_name, mod2->iop_order);
         }
         else
@@ -916,10 +916,10 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
   }
   else
   {
-    fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] modules %s %s(%f) and %s %s(%f) has the same iop_order\n", 
+    fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] modules %s %s(%f) and %s %s(%f) has the same iop_order\n",
         module->op, module->multi_name, module->iop_order, module_next->op, module_next->multi_name, module_next->iop_order);
   }
-  
+
   return iop_order;
 }
 
@@ -982,7 +982,7 @@ int dt_ioppr_move_iop_before(GList **_iop_list, dt_iop_module_t *module, dt_iop_
   // dt_ioppr_check_iop_order(dev, "dt_ioppr_move_iop_before end");
 
   *_iop_list = iop_list;
-  
+
   return moved;
 }
 
@@ -1010,7 +1010,7 @@ int dt_ioppr_move_iop_after(GList **_iop_list, dt_iop_module_t *module, dt_iop_m
   // dt_ioppr_check_iop_order(dev, "dt_ioppr_move_iop_after end");
 
   *_iop_list = iop_list;
-  
+
   return moved;
 }
 
@@ -1070,7 +1070,7 @@ void dt_ioppr_print_module_iop_order(GList *iop_list, const char *msg)
   while(modules)
   {
     dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
-    
+
     fprintf(stderr, "[%s] module %s %s multi_priority=%i, iop_order=%f\n", msg, mod->op, mod->multi_name, mod->multi_priority, mod->iop_order);
 
     modules = g_list_next(modules);
@@ -1083,7 +1083,7 @@ void dt_ioppr_print_history_iop_order(GList *history_list, const char *msg)
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    
+
     fprintf(stderr, "[%s] module %s %s multi_priority=%i, iop_order=%f\n", msg, hist->op_name, hist->multi_name, hist->multi_priority, hist->iop_order);
 
     history = g_list_next(history);
@@ -1096,7 +1096,7 @@ void dt_ioppr_print_iop_order(GList *iop_order_list, const char *msg)
   while(iops_order)
   {
     dt_iop_order_entry_t *order_entry = (dt_iop_order_entry_t *)(iops_order->data);
-    
+
     fprintf(stderr, "[%s] operation %s iop_order=%f\n", msg, order_entry->operation, order_entry->iop_order);
 
     iops_order = g_list_next(iops_order);
@@ -1263,7 +1263,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
       dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
       if(mod->iop_order != DBL_MAX)
         break;
-      
+
       modules = g_list_previous(dev->iop);
     }
     if(modules)
@@ -1304,7 +1304,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
                   mod->op, mod->multi_name, mod->iop_order,imgid, msg);
         }
       }
-      
+
       modules = g_list_previous(dev->iop);
     }
   }
@@ -1334,7 +1334,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
             fprintf(
                 stderr,
                 "[dt_ioppr_check_iop_order] module %s %s(%i)(%f) and %s %s(%i)(%f) has the same order image %i (%s)\n",
-                mod->op, mod->multi_name, mod->multi_priority, mod->iop_order, mod_prev->op, 
+                mod->op, mod->multi_name, mod->multi_priority, mod->iop_order, mod_prev->op,
                 mod_prev->multi_name, mod_prev->multi_priority, mod_prev->iop_order, imgid, msg);
           }
         }
@@ -1350,7 +1350,7 @@ int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg
   while(history)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    
+
     if(hist->iop_order == DBL_MAX)
     {
       if(hist->enabled)
@@ -1385,7 +1385,7 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in, float 
   cmsHTRANSFORM *xform = NULL;
   cmsHPROFILE *rgb_profile = NULL;
   cmsHPROFILE *lab_profile = NULL;
-  
+
   if(type != DT_COLORSPACE_NONE)
   {
     const dt_colorspaces_color_profile_t *profile = dt_colorspaces_get_profile(type, filename, DT_PROFILE_DIRECTION_WORK);
@@ -1411,14 +1411,14 @@ static void _transform_from_to_rgb_lab_lcms2(const float *const image_in, float 
     rgb_profile = dt_colorspaces_get_profile(DT_COLORSPACE_LIN_REC2020, "", DT_PROFILE_DIRECTION_WORK)->profile;
     fprintf(stderr, _("unsupported working profile %s has been replaced by Rec2020 RGB!\n"), filename);
   }
-  
+
   lab_profile = dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;
 
   cmsHPROFILE *input_profile = NULL;
   cmsHPROFILE *output_profile = NULL;
   cmsUInt32Number input_format = TYPE_RGBA_FLT;
   cmsUInt32Number output_format = TYPE_LabA_FLT;
-  
+
   if(direction == 1) // rgb --> lab
   {
     input_profile = rgb_profile;
@@ -1559,7 +1559,7 @@ static void _transform_lcms2(struct dt_iop_module_t *self, const float *const im
     *converted_cst = cst_to;
     return;
   }
-  
+
   *converted_cst = cst_to;
 
   if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
@@ -1656,7 +1656,7 @@ static void _apply_tonecurves(const float *const image_in, float *const image_ou
   const float *const lut[3] = { lutr, lutg, lutb };
   const float *const unbounded_coeffs[3] = { unbounded_coeffsr, unbounded_coeffsg, unbounded_coeffsb };
   const size_t stride = (size_t)ch * width * height;
-  
+
   // do we have any lut to apply, or is this a linear profile?
   if((lut[0][0] >= 0.0f) && (lut[1][0] >= 0.0f) && (lut[2][0] >= 0.0f))
   {
@@ -1704,6 +1704,7 @@ static void _transform_rgb_to_lab_matrix(const float *const image_in, float *con
                       profile_info->lut_in[2], profile_info->unbounded_coeffs_in[0],
                       profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2],
                       profile_info->lutsize);
+>>>>>>> synchro with master
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
@@ -1752,7 +1753,7 @@ static void _transform_lab_to_rgb_matrix(const float *const image_in, float *con
     float *const out = image_out + y * ch;
 
     float xyz[3] = { 0.0f, 0.0f, 0.0f };
-    
+
     dt_Lab_to_XYZ(in, xyz);
     _ioppr_xyz_to_linear_rgb_matrix(xyz, out, profile_info);
   }
@@ -1813,13 +1814,13 @@ static void _transform_matrix_rgb(const float *const image_in, float *const imag
                     profile_info_to->lutsize);
 }
 
-static int _init_unbounded_coeffs(float *lutr, float *lutg, float *lutb, 
+static int _init_unbounded_coeffs(float *lutr, float *lutg, float *lutb,
     float *unbounded_coeffsr, float *unbounded_coeffsg, float *unbounded_coeffsb, const int lutsize)
 {
   int nonlinearlut = 0;
   float *lut[3] = { lutr, lutg, lutb };
   float *unbounded_coeffs[3] = { unbounded_coeffsr, unbounded_coeffsg, unbounded_coeffsb };
-  
+
   for(int k = 0; k < 3; k++)
   {
     // omit luts marked as linear (negative as marker)
@@ -1829,13 +1830,13 @@ static int _init_unbounded_coeffs(float *lutr, float *lutg, float *lutb,
       const float y[4] = { lerp_lut(lut[k], x[0], lutsize), lerp_lut(lut[k], x[1], lutsize), lerp_lut(lut[k], x[2], lutsize),
                            lerp_lut(lut[k], x[3], lutsize) };
       dt_iop_estimate_exp(x, y, 4, unbounded_coeffs[k]);
-      
+
       nonlinearlut++;
     }
     else
       unbounded_coeffs[k][0] = -1.0f;
   }
-  
+
   return nonlinearlut;
 }
 
@@ -1848,7 +1849,7 @@ static void _transform_matrix(struct dt_iop_module_t *self, const float *const i
     *converted_cst = cst_to;
     return;
   }
-  
+
   *converted_cst = cst_to;
 
   if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
@@ -1919,7 +1920,7 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
 
   profile_info->nonlinearlut = 0;
   profile_info->grey = 0.1842f;
-  
+
   profile_info->type = type;
   g_strlcpy(profile_info->filename, filename, sizeof(profile_info->filename));
   profile_info->intent = intent;
@@ -1948,14 +1949,14 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
       rgb_profile = NULL;
     }
   }
-  
+
   // get the matrix
   if(rgb_profile)
   {
-    if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in, 
+    if(dt_colorspaces_get_matrix_from_input_profile(rgb_profile, profile_info->matrix_in,
         profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
         profile_info->lutsize, profile_info->intent) ||
-        dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out, 
+        dt_colorspaces_get_matrix_from_output_profile(rgb_profile, profile_info->matrix_out,
             profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
             profile_info->lutsize, profile_info->intent))
     {
@@ -1985,25 +1986,25 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
   // in our hands, i.e. for the fast builtin-dt-matrix-profile path.
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]))
   {
-    profile_info->nonlinearlut = _init_unbounded_coeffs(profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2], 
+    profile_info->nonlinearlut = _init_unbounded_coeffs(profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
         profile_info->unbounded_coeffs_in[0], profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2], profile_info->lutsize);
-    _init_unbounded_coeffs(profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2], 
+    _init_unbounded_coeffs(profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
         profile_info->unbounded_coeffs_out[0], profile_info->unbounded_coeffs_out[1], profile_info->unbounded_coeffs_out[2], profile_info->lutsize);
   }
-  
+
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]) && profile_info->nonlinearlut)
   {
     float rgb[3] = { 0.1842f, 0.1842f, 0.1842f };
     profile_info->grey = dt_ioppr_get_rgb_matrix_luminance(rgb, profile_info);
   }
-  
+
   return err_code;
 }
 
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_profile_info_from_list(struct dt_develop_t *dev, const int profile_type, const char *profile_filename)
 {
   dt_iop_order_iccprofile_info_t *profile_info = NULL;
-  
+
   GList *profiles = g_list_first(dev->allprofile_info);
   while(profiles)
   {
@@ -2015,7 +2016,7 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_profile_info_from_list(struct dt_de
     }
     profiles = g_list_next(profiles);
   }
-  
+
   return profile_info;
 }
 
@@ -2089,14 +2090,14 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_set_pipe_work_profile_info(struct dt_de
     const int type, const char *filename, const int intent)
 {
   dt_iop_order_iccprofile_info_t *profile_info = dt_ioppr_add_profile_info_to_list(dev, type, filename, intent);
-  
+
   if(profile_info == NULL || isnan(profile_info->matrix_in[0]) || isnan(profile_info->matrix_out[0]))
   {
     fprintf(stderr, "[dt_ioppr_set_pipe_work_profile_info] unsupported working profile %i %s, it will be replaced with linear rec2020\n", type, filename);
     profile_info = dt_ioppr_add_profile_info_to_list(dev, DT_COLORSPACE_LIN_REC2020, "", intent);
   }
   pipe->dsc.work_profile_info = profile_info;
-  
+
   return profile_info;
 }
 
@@ -2120,7 +2121,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type,
 {
   *profile_type = DT_COLORSPACE_NONE;
   *profile_filename = NULL;
-  
+
   // use introspection to get the params values
   dt_iop_module_so_t *colorin_so = NULL;
   dt_iop_module_t *colorin = NULL;
@@ -2169,7 +2170,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_typ
 {
   *profile_type = DT_COLORSPACE_NONE;
   *profile_filename = NULL;
-  
+
   // use introspection to get the params values
   dt_iop_module_so_t *colorout_so = NULL;
   dt_iop_module_t *colorout = NULL;
@@ -2242,7 +2243,7 @@ void dt_ioppr_get_histogram_profile_type(int *profile_type, char **profile_filen
 float dt_ioppr_get_rgb_matrix_luminance(const float *const rgb, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   float luminance = 0.f;
-  
+
   if(profile_info->nonlinearlut)
   {
     float linear_rgb[3] = { 0.f };
@@ -2252,7 +2253,7 @@ float dt_ioppr_get_rgb_matrix_luminance(const float *const rgb, const dt_iop_ord
   }
   else
     luminance = profile_info->matrix_in[3] * rgb[0] + profile_info->matrix_in[4] * rgb[1] + profile_info->matrix_in[5] * rgb[2];
-  
+
   return luminance;
 }
 
@@ -2271,11 +2272,11 @@ void dt_ioppr_rgb_matrix_to_xyz(const float *const rgb, float *xyz, const dt_iop
 void dt_ioppr_lab_to_rgb_matrix(const float *const lab, float *rgb, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   float xyz[3] = { 0.0f, 0.0f, 0.0f };
-  
+
   dt_Lab_to_XYZ(lab, xyz);
-  
+
   _ioppr_xyz_to_linear_rgb_matrix(xyz, rgb, profile_info);
-  
+
   if(profile_info->nonlinearlut) _apply_trc_out(rgb, rgb, profile_info);
 }
 
@@ -2365,7 +2366,7 @@ static void _transform_rgb_to_lab_matrix_sse(float *const image, const int width
 
   _apply_tonecurves(image, width, height, profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
       profile_info->unbounded_coeffs_in[0], profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2], profile_info->lutsize);
-    
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)
 #endif
@@ -2406,7 +2407,7 @@ static void _transform_lab_to_rgb_matrix_sse(float *const image, const int width
     _mm_stream_ps(in, lab);
     in[3] = a;
   }
-  
+
   _apply_tonecurves(image, width, height, profile_info->lut_out[0], profile_info->lut_out[1], profile_info->lut_out[2],
       profile_info->unbounded_coeffs_out[0], profile_info->unbounded_coeffs_out[1], profile_info->unbounded_coeffs_out[2], profile_info->lutsize);
 }
@@ -2499,7 +2500,7 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
 
   dt_times_t start_time = { 0 }, end_time = { 0 };
   if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
-  
+
   // matrix should be never NAN, this is only to test it against lcms2!
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]))
   {
@@ -2517,8 +2518,8 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n", 
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab", 
+      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f CPU) [%s %s]\n",
+          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -2529,12 +2530,12 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n", 
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab", 
+      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f lcms2) [%s %s]\n",
+          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
-  
+
   if(*converted_cst == cst_from)
     fprintf(stderr, "[dt_ioppr_transform_image_colorspace] invalid convertion from %i to %i\n", cst_from, cst_to);
 }
@@ -2737,7 +2738,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
                                            const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   cl_int err = CL_SUCCESS;
-  
+
   if(cst_from == cst_to)
   {
     *converted_cst = cst_to;
@@ -2754,7 +2755,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     *converted_cst = cst_from;
     return FALSE;
   }
-  
+
   const int ch = 4;
   float *src_buffer = NULL;
   int in_place = (dev_img_in == dev_img_out);
@@ -2765,7 +2766,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   cl_mem dev_lut = NULL;
   dt_colorspaces_iccprofile_info_cl_t profile_info_cl;
   cl_float *lut_cl = NULL;
-  
+
   *converted_cst = cst_from;
 
   // if we have a matrix use opencl
@@ -2773,10 +2774,10 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   {
     dt_times_t start_time = { 0 }, end_time = { 0 };
     if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
-    
+
     size_t origin[] = { 0, 0, 0 };
     size_t region[] = { width, height, 1 };
-    
+
     if(cst_from == iop_cs_rgb && cst_to == iop_cs_Lab)
     {
       kernel_transform = darktable.opencl->colorspaces->kernel_colorspaces_transform_rgb_matrix_to_lab;
@@ -2792,7 +2793,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] invalid convertion from %i to %i\n", cst_from, cst_to);
       goto cleanup;
     }
-    
+
     dt_ioppr_get_profile_info_cl(profile_info, &profile_info_cl);
     lut_cl = dt_ioppr_get_trc_cl(profile_info);
 
@@ -2833,9 +2834,9 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
       goto cleanup;
     }
-    
+
     size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
-    
+
     dt_opencl_set_kernel_arg(devid, kernel_transform, 0, sizeof(cl_mem), (void *)&dev_tmp);
     dt_opencl_set_kernel_arg(devid, kernel_transform, 1, sizeof(cl_mem), (void *)&dev_img_out);
     dt_opencl_set_kernel_arg(devid, kernel_transform, 2, sizeof(int), (void *)&width);
@@ -2854,8 +2855,8 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
     if(darktable.unmuted & DT_DEBUG_PERF)
     {
       dt_get_times(&end_time);
-      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n", 
-          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab", 
+      fprintf(stderr, "image colorspace transform %s-->%s took %.3f secs (%.3f GPU) [%s %s]\n",
+          (cst_from == iop_cs_rgb) ? "RGB": "Lab", (cst_to == iop_cs_rgb) ? "RGB": "Lab",
           end_time.clock - start_time.clock, end_time.user - start_time.user, self->op, self->multi_name);
     }
   }
@@ -2876,7 +2877,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] error allocating memory for color transformation 2\n");
       goto cleanup;
     }
-  
+
     // just call the CPU version for now
     dt_ioppr_transform_image_colorspace(self, src_buffer, src_buffer, width, height, cst_from, cst_to,
                                         converted_cst, profile_info);
@@ -2888,7 +2889,7 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
       goto cleanup;
     }
   }
-  
+
 cleanup:
   if(src_buffer) dt_free_align(src_buffer);
   if(dev_tmp && in_place) dt_opencl_release_mem_object(dev_tmp);

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -61,7 +61,7 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
     _ioppr_move_iop_before(_iop_order_list, "colorout", "clahe", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorin", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "rgbcurve", "levels", dont_move);
-    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "velvia", dont_move);
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "splittoning", dont_move);
     
     new_version = 2;
   }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1705,7 +1705,6 @@ static void _transform_rgb_to_lab_matrix(const float *const image_in, float *con
                       profile_info->lut_in[2], profile_info->unbounded_coeffs_in[0],
                       profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2],
                       profile_info->lutsize);
->>>>>>> synchro with master
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static)

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -138,6 +138,7 @@ add_iop(ashift "ashift.c")
 add_iop(hazeremoval "hazeremoval.c")
 add_iop(filmic "filmic.c" DEFAULT_VISIBLE)
 add_iop(mask_manager "mask_manager.c")
+add_iop(lut3d "lut3d.c")
 
 if(RSVG2_FOUND)
   add_iop(watermark "watermark.c")

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -203,7 +203,7 @@ uint8_t parse_cube_line(char *line, char *token)
   while (*l != 0 && c < 3 && i < 50)
   {
     if (*l == '#' || *l == '\n' || *l == '\r')
-    { // end of useful line
+    { // end of useful part of the line
       if (i > 0)
       {
         *t = 0;
@@ -271,7 +271,7 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       }
       else if (strcmp("LUT_1D_SIZE", token[0]) == 0)
       {
-        fprintf(stderr, "[lut3d] 1D cube lut not supported\n");
+        fprintf(stderr, "[lut3d] 1D cube lut is not supported\n");
         free(line);
         fclose(cube_file);
         return 0;
@@ -295,7 +295,7 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       {
         if (!level)
         {
-          fprintf(stderr, "[lut3d] error cube lut size not defined\n");
+          fprintf(stderr, "[lut3d] error cube lut size is not defined\n");
           dt_free_align(lclut);
           free(line);
           fclose(cube_file);
@@ -309,7 +309,7 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
   }
   if (i != buf_size || i == 0)
   {
-    fprintf(stderr, "[lut3d] error cube lut lines number not correct\n");
+    fprintf(stderr, "[lut3d] error cube lut lines number is not correct\n");
     dt_free_align(lclut);
     free(line);
     fclose(cube_file);
@@ -454,12 +454,12 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_lut3d_global_data_t *gp = (dt_iop_lut3d_global_data_t *)self->data;
   if (!gp->clut)
   {
-    if (!g_str_has_suffix (p->filepath, ".cube"))
+    if (g_str_has_suffix (p->filepath, ".png") || g_str_has_suffix (p->filepath, ".PNG"))
     {
       gp->level = calculate_clut_haldclut(p->filepath, &gp->clut);
       gp->level *= gp->level;
     }
-    else if (!g_str_has_suffix (p->filepath, ".png"))
+    else if (g_str_has_suffix (p->filepath, ".cube") || g_str_has_suffix (p->filepath, ".CUBE"))
     {
       gp->level = calculate_clut_cube(p->filepath, &gp->clut);
     }
@@ -481,22 +481,13 @@ static void filepath_callback(GtkWidget *w, dt_iop_module_t *self)
   snprintf(p->filepath, sizeof(p->filepath), "%s", gtk_entry_get_text(GTK_ENTRY(w)));
 
   if (gp->clut)
-  {
+  { // the clut is obsolete
     dt_free_align(gp->clut);
   }
   gp->clut = NULL;
   gp->level = 0;
-/*
-  if (!g_str_has_suffix (p->filepath, ".cube"))
-  {
-    gp->level = calculate_clut_haldclut(p->filepath, &gp->clut);
-    gp->level *= gp->level;
-  }
-  else if (!g_str_has_suffix (p->filepath, ".png"))
-  {
-    gp->level = calculate_clut_cube(p->filepath, &gp->clut);
-  }
-  dt_dev_add_history_item(darktable.develop, self, TRUE); */
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void colorspace_callback(GtkWidget *widget, dt_iop_module_t *self)
@@ -504,7 +495,6 @@ static void colorspace_callback(GtkWidget *widget, dt_iop_module_t *self)
 //printf("colorspace_callback\n");
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
-//  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
   p->colorspace = dt_bauhaus_combobox_get(widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -522,9 +512,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 
   if (strlen(p->filepath) == 0 || access(p->filepath, F_OK) == -1)
   {
-    // not sure about this. How to init def_path ?
     gchar* def_path = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
-//printf("filepath = null; default path %s\n", def_path);
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), def_path);
     g_free(def_path);
   }
@@ -574,7 +562,6 @@ setvbuf(stdout, NULL, _IONBF, 0);
 //printf("gui_init\n");
   self->gui_data = malloc(sizeof(dt_iop_lut3d_gui_data_t));
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
-//  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
@@ -604,7 +591,6 @@ setvbuf(stdout, NULL, _IONBF, 0);
                                                  "if log RGB is desired, use unbreak module first then select linear RGB here\n"));
   g_signal_connect(G_OBJECT(g->colorspace), "value-changed", G_CALLBACK(colorspace_callback), self);
 
-//  self->widget = hbox;
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -734,7 +734,7 @@ printf("process colorspace %d ch %d\n", colorspace, ch);
       : colorspace == DT_IOP_SRGB ? dt_ioppr_add_profile_info_to_list(self->dev, DT_COLORSPACE_SRGB, "", INTENT_PERCEPTUAL)
       : colorspace == DT_IOP_LIN_REC709 ? dt_ioppr_add_profile_info_to_list(self->dev, DT_COLORSPACE_LIN_REC709, "", INTENT_PERCEPTUAL)
       : NULL;
-  const dt_iop_order_iccprofile_info_t *const rgb_profile = dt_ioppr_get_iop_work_profile_info(self->dev);
+  const dt_iop_order_iccprofile_info_t *const rgb_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 
   if (colorspace == DT_IOP_REC709 || colorspace == DT_IOP_SRGB || colorspace == DT_IOP_LIN_REC709)
   {
@@ -850,7 +850,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 printf("commit\n");
     dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)p1;
     dt_iop_lut3d_data_t *d = (dt_iop_lut3d_data_t *)piece->data;
-    if (strcmp(p->filepath, d->params.filepath) != 0)
+    if (p->filepath[0] && strcmp(p->filepath, d->params.filepath) != 0)
     {
       if (d->clut)
       {
@@ -863,7 +863,7 @@ printf("commit\n");
     gchar *lutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
     if (p->filepath[0] && lutfolder[0] && !d->clut)
     {
-printf("commit - new clut\n");
+printf("commit - new clut - file %s\n", p->filepath);
       char *fullpath = g_build_filename(lutfolder, p->filepath, NULL);
       if (g_str_has_suffix (p->filepath, ".png") || g_str_has_suffix (p->filepath, ".PNG"))
       {

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -711,7 +711,7 @@ static inline void log2_to_lin(float *lout, const float middle_grey,
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ibuf, void *const obuf,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
-printf("process\n");
+//printf("process\n");
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   dt_iop_lut3d_global_data_t *gp = (dt_iop_lut3d_global_data_t *)self->data;
   const int ch = piece->colors;
@@ -823,7 +823,7 @@ void reload_defaults(dt_iop_module_t *self)
 
 void init(dt_iop_module_t *self)
 {
-printf("init\n");
+//printf("init\n");
   self->data = NULL;
   self->params = calloc(1, sizeof(dt_iop_lut3d_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_lut3d_params_t));
@@ -847,7 +847,7 @@ printf("init\n");
 
 void init_global(dt_iop_module_so_t *self)
 {
-printf("init_global\n");
+//printf("init_global\n");
   dt_iop_lut3d_global_data_t *gd
       = (dt_iop_lut3d_global_data_t *)malloc(sizeof(dt_iop_lut3d_global_data_t));
   self->data = gd;
@@ -857,14 +857,14 @@ printf("init_global\n");
 
 void cleanup(dt_iop_module_t *self)
 {
-printf("cleanup\n");
+//printf("cleanup\n");
   free(self->params);
   self->params = NULL;
 }
 
 void cleanup_global(dt_iop_module_so_t *self)
 {
-printf("cleanup_global\n");
+//printf("cleanup_global\n");
   dt_iop_lut3d_global_data_t *gp = (dt_iop_lut3d_global_data_t *)self->data;
   if (gp->clut)
   {
@@ -878,7 +878,7 @@ printf("cleanup_global\n");
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {
-  printf("commit\n");
+//printf("commit\n");
     dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
     dt_iop_lut3d_global_data_t *gp = (dt_iop_lut3d_global_data_t *)self->data;
     gchar *lutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
@@ -900,7 +900,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
-printf("init_pipe\n");
+//printf("init_pipe\n");
   // create part of the pixelpipe
 }
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1,0 +1,509 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2016 Chih-Mao Chen
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "bauhaus/bauhaus.h"
+#include "common/imageio_png.h"
+#include "develop/imageop.h"
+#include "dtgtk/button.h"
+#include "gui/gtk.h"
+#include "iop/iop_api.h"
+
+#include <gtk/gtk.h>
+#include <libgen.h>
+#include <png.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#if defined (_WIN32)
+#include "win/getdelim.h"
+#endif // defined (_WIN32)
+
+DT_MODULE_INTROSPECTION(1, dt_iop_lut3d_params_t)
+
+typedef struct dt_iop_lut3d_params_t
+{
+  char filepath[512];
+} dt_iop_lut3d_params_t;
+
+typedef struct dt_iop_lut3d_gui_data_t
+{
+  GtkWidget *filepath;
+} dt_iop_lut3d_gui_data_t;
+
+typedef struct dt_iop_lut3d_global_data_t
+{
+} dt_iop_lut3d_global_data_t;
+
+const char *name()
+{
+  return _("lut 3D");
+}
+
+int flags()
+{
+  return IOP_FLAGS_INCLUDE_IN_STYLES | IOP_FLAGS_SUPPORTS_BLENDING;
+}
+
+int groups()
+{
+  return IOP_GROUP_COLOR;
+}
+
+// From `HaldCLUT_correct.c' by Eskil Steenberg (http://www.quelsolaar.com) (BSD licensed)
+void correct_pixel(float *input, float *output, float *clut, unsigned int level)
+{
+  int color, red, green, blue, i, j;
+  float tmp[6], r, g, b;
+//  level *= level;
+
+  red = input[0] * (float)(level - 1);
+  if(red > level - 2) red = (float)level - 2;
+  if(red < 0) red = 0;
+
+  green = input[1] * (float)(level - 1);
+  if(green > level - 2) green = (float)level - 2;
+  if(green < 0) green = 0;
+
+  blue = input[2] * (float)(level - 1);
+  if(blue > level - 2) blue = (float)level - 2;
+  if(blue < 0) blue = 0;
+
+  r = input[0] * (float)(level - 1) - red;
+  g = input[1] * (float)(level - 1) - green;
+  b = input[2] * (float)(level - 1) - blue;
+
+  color = red + green * level + blue * level * level;
+
+  i = color * 3;
+  j = (color + 1) * 3;
+
+  tmp[0] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[1] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[2] = clut[i] * (1 - r) + clut[j] * r;
+
+  i = (color + level) * 3;
+  j = (color + level + 1) * 3;
+
+  tmp[3] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[4] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[5] = clut[i] * (1 - r) + clut[j] * r;
+
+  output[0] = tmp[0] * (1 - g) + tmp[3] * g;
+  output[1] = tmp[1] * (1 - g) + tmp[4] * g;
+  output[2] = tmp[2] * (1 - g) + tmp[5] * g;
+
+  i = (color + level * level) * 3;
+  j = (color + level * level + 1) * 3;
+
+  tmp[0] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[1] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[2] = clut[i] * (1 - r) + clut[j] * r;
+
+  i = (color + level + level * level) * 3;
+  j = (color + level + level * level + 1) * 3;
+
+  tmp[3] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[4] = clut[i++] * (1 - r) + clut[j++] * r;
+  tmp[5] = clut[i] * (1 - r) + clut[j] * r;
+
+  tmp[0] = tmp[0] * (1 - g) + tmp[3] * g;
+  tmp[1] = tmp[1] * (1 - g) + tmp[4] * g;
+  tmp[2] = tmp[2] * (1 - g) + tmp[5] * g;
+
+  output[0] = output[0] * (1 - b) + tmp[0] * b;
+  output[1] = output[1] * (1 - b) + tmp[1] * b;
+  output[2] = output[2] * (1 - b) + tmp[2] * b;
+}
+
+uint8_t process_haldclut(dt_dev_pixelpipe_iop_t *piece, float **clut)
+{
+  dt_iop_lut3d_params_t *params = (dt_iop_lut3d_params_t *)piece->data;
+  dt_imageio_png_t png;
+  if(read_header(params->filepath, &png))
+  {
+    fprintf(stderr, "[lut3d] invalid png header from `%s'\n", params->filepath);
+    return 0;
+  }
+  dt_print(DT_DEBUG_DEV, "[lut3d] png: width=%d, height=%d, color_type=%d, bit_depth=%d\n", png.width,
+           png.height, png.color_type, png.bit_depth);
+  uint8_t level = 2;
+  while(level * level * level < png.width) ++level;
+  if(level * level * level != png.width)
+  {
+    fprintf(stderr, "[lut3d] invalid level in png file %d %d\n", level, png.width);
+    fclose(png.f);
+    png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
+    return 0;
+  }
+  const size_t buf_size = (size_t)png.height * png_get_rowbytes(png.png_ptr, png.info_ptr);
+  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for png lut\n", buf_size);
+  uint8_t *buf = dt_alloc_align(16, buf_size);
+  if(!buf)
+  {
+    fclose(png.f);
+    png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
+    fprintf(stderr, "[lut3d] error allocating buffer for png lut\n");
+    return 0;
+  }
+  if(read_image(&png, (void *)buf))
+  {
+    dt_free_align(buf);
+    fprintf(stderr, "[lut3d] could not read png image `%s'\n", params->filepath);
+    return 0;
+  }
+  float *lclut = dt_alloc_align(16, buf_size * sizeof(float));
+  if(!lclut)
+  {
+    dt_free_align(buf);
+    fprintf(stderr, "[lut3d] error allocating buffer for png lut\n");
+    return 0;
+  }
+  for(size_t i = 0; i < buf_size; ++i)
+  {
+    lclut[i] = buf[i] / 256.0f;
+  }
+  dt_free_align(buf);
+  *clut = lclut;
+//printf("haldclut ok - level %d, size %d; clut %p\n", level, buf_size, lclut);
+  return level;
+}
+
+uint8_t parse_line(char *line, char *token)
+{
+  uint8_t i, c;
+  i = c = 0;
+  char *t = token;
+  char *l = line;
+
+//printf("input line %s size %d last %02hhx\n", line, strlen(line), line[strlen(line)-1]);
+  while (*l != 0 && c < 3 && i < 50)
+  {
+    if (*l == '#' || *l == '\n' || *l == '\r')
+    {
+      if (i > 0)
+      {
+        *t = 0;
+        c++;
+        return c;
+      }
+      else
+      {
+        *t = 0;
+        return c;
+      }
+    }
+    if (*l == ' ')
+    {
+      if (i > 0)
+      {
+        *t = 0;
+        c++;
+        i = 0;
+        t = token + (50 * c);
+      }
+    }
+    else
+    {
+      *t = *l;
+      t++;
+      i++;
+    }
+    l++;
+  }
+  return c;
+}
+uint8_t process_cube(dt_dev_pixelpipe_iop_t *piece, float **clut)
+{
+  dt_iop_lut3d_params_t *params = (dt_iop_lut3d_params_t *)piece->data;
+  FILE *cube_file;
+  char *line = NULL;
+  size_t len = 0;
+  ssize_t read;
+  char token[3][50];
+  uint8_t level = 0;
+  float *lclut = NULL;
+  uint32_t i = 0;
+  uint32_t buf_size = 0;
+
+  if(!(cube_file = g_fopen(params->filepath, "r")))
+  {
+    fprintf(stderr, "[lut3d] invalid cube file from `%s'\n", params->filepath);
+    return 0;
+  }
+//printf("cube file opened\n");
+  while ((read = getline(&line, &len, cube_file)) != -1)
+  {
+    uint8_t nb_token = parse_line(line, &token[0][0]);
+    if (nb_token)
+    {
+//printf("line parsed: %d tokens: %s, %s, %s\n", nb_token, (nb_token > 0) ? token[0] : "", (nb_token > 1) ? token[1] : "", (nb_token > 2) ? token[2] : "" );
+      if (token[0][0] == 'T') continue;
+      if (strcmp("DOMAIN_MIN", token[0]) == 0)
+      {
+//        printf("->Domain min %d\n", atoll(token[1]));
+      }
+      else if (strcmp("DOMAIN_MAX", token[0]) == 0)
+      {
+//        printf("->Domain max %d\n", atoll(token[1]));
+      }
+      else if (strcmp("LUT_1D_SIZE", token[0]) == 0)
+      {
+        fprintf(stderr, "[lut3d] 1D cube lut not supported\n");
+        free(line);
+        fclose(cube_file);
+        return 0;
+//        printf("->Lut 1D %d\n", atoll(token[1]));
+      }
+      else if (strcmp("LUT_3D_SIZE", token[0]) == 0)
+      {
+        level = atoll(token[1]);
+        buf_size = level * level * level * 3;
+        lclut = dt_alloc_align(16, buf_size * sizeof(float));
+//printf("->Lut 3D %d buf_size %d\n", level, buf_size);
+        if(!lclut)
+        {
+          fprintf(stderr, "[lut3d] error allocating buffer for cube lut\n");
+          free(line);
+          fclose(cube_file);
+          return 0;
+        }
+      }
+      else
+      {
+        if (!level)
+        {
+          fprintf(stderr, "[lut3d] error cube lut size not defined\n");
+          dt_free_align(lclut);
+          free(line);
+          fclose(cube_file);
+          return 0;
+        }
+        for (int j=0; j < 3; j++) lclut[i+j] = strtod(token[j], NULL);
+        i += 3;
+//printf("->Values %f %f %f\n", strtod(token[0], NULL), strtod(token[1], NULL), strtod(token[2], NULL));
+      }
+    }
+  }
+  if (i != buf_size || i == 0)
+  {
+    fprintf(stderr, "[lut3d] error cube lut lines number not correct\n");
+    dt_free_align(lclut);
+    free(line);
+    fclose(cube_file);
+    return 0;
+  }
+  *clut = lclut;
+//printf("cube ok - level %d, buf_size %d nb colors %d clut %p\n", level, buf_size, i, lclut);
+  free(line);
+  fclose(cube_file);
+  return level;
+}
+
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ibuf, void *const obuf,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  dt_iop_lut3d_params_t *params = (dt_iop_lut3d_params_t *)piece->data;
+  const int ch = piece->colors;
+  float *clut = NULL;
+  uint8_t level = 0;
+
+  if (!g_str_has_suffix (params->filepath, ".cube"))
+  {
+    level = process_haldclut(piece, &clut);
+    level *= level;
+  }
+  else
+  {
+    level = process_cube(piece, &clut);
+  }
+  if (clut)
+  {
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static) shared(clut, level)
+#endif
+    for(int j = 0; j < roi_out->height; j++)
+    {
+      float *in = ((float *)ibuf) + (size_t)ch * roi_in->width * j;
+      float *out = ((float *)obuf) + (size_t)ch * roi_out->width * j;
+      for(int i = 0; i < roi_out->width; i++)
+      {
+        for(int c = 0; c < 3; ++c) in[c] = in[c] < 0.0f ? 0.0f : (in[c] > 1.0f ? 1.0f : in[c]);
+        correct_pixel(in, out, clut, level);
+        in += ch;
+        out += ch;
+      }
+    }
+    dt_free_align(clut);
+    return;
+  }
+  // no clut
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static)
+#endif
+  for(int j = 0; j < roi_out->height; j++)
+  {
+    float *in = ((float *)ibuf) + (size_t)ch * roi_in->width * j;
+    float *out = ((float *)obuf) + (size_t)ch * roi_out->width * j;
+    for(int i = 0; i < roi_out->width; i++)
+    {
+      for(int c = 0; c < 3; ++c) out[c] = in[c];
+      in += ch;
+      out += ch;
+    }
+  }
+}
+void reload_defaults(dt_iop_module_t *module)
+{
+}
+
+void init(dt_iop_module_t *module)
+{
+//printf("init\n");
+  module->data = NULL;
+  module->params = calloc(1, sizeof(dt_iop_lut3d_params_t));
+  module->default_params = calloc(1, sizeof(dt_iop_lut3d_params_t));
+  module->default_enabled = 0;
+  module->priority = 910; // module order created by iop_dependencies.py, do not edit!
+  module->params_size = sizeof(dt_iop_lut3d_params_t);
+  module->gui_data = NULL;
+  dt_iop_lut3d_params_t tmp = (dt_iop_lut3d_params_t){ { "" } };
+
+  memcpy(module->params, &tmp, sizeof(dt_iop_lut3d_params_t));
+  memcpy(module->default_params, &tmp, sizeof(dt_iop_lut3d_params_t));
+}
+
+void init_global(dt_iop_module_so_t *module)
+{
+  module->data = malloc(sizeof(dt_iop_lut3d_global_data_t));
+}
+
+void cleanup(dt_iop_module_t *module)
+{
+  free(module->params);
+  module->params = NULL;
+}
+
+void cleanup_global(dt_iop_module_so_t *module)
+{
+  free(module->data);
+  module->data = NULL;
+}
+
+static void filepath_callback(GtkWidget *w, dt_iop_module_t *self)
+{
+//printf("filepath_callback\n");
+  if(darktable.gui->reset) return;
+  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
+  snprintf(p->filepath, sizeof(p->filepath), "%s", gtk_entry_get_text(GTK_ENTRY(w)));
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
+{
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
+  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
+      _("select lut file"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_OPEN, _("_cancel"), GTK_RESPONSE_CANCEL,
+      _("_select"), GTK_RESPONSE_ACCEPT, (char *)NULL);
+  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
+
+  if (strlen(p->filepath) == 0 || access(p->filepath, F_OK) == -1)
+  {
+    // not sure about this. How to init def_path ?
+    gchar* def_path = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
+//printf("filepath = null; default path %s\n", def_path);
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), def_path);
+    g_free(def_path);
+  }
+  else
+  {
+//printf("filepath <> null\n");
+    gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(filechooser), p->filepath);
+  }
+
+  GtkFileFilter* filter = GTK_FILE_FILTER(gtk_file_filter_new());
+  gtk_file_filter_add_mime_type(filter, "image/png");
+  gtk_file_filter_set_name(filter, _("hald cluts (png)"));
+  gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
+
+  filter = GTK_FILE_FILTER(gtk_file_filter_new());
+  gtk_file_filter_add_pattern(filter, "*.cube");
+  gtk_file_filter_set_name(filter, _("3Dlut (cube)"));
+  gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
+
+  filter = GTK_FILE_FILTER(gtk_file_filter_new());
+  gtk_file_filter_add_pattern(filter, "*");
+  gtk_file_filter_set_name(filter, _("all files"));
+  gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
+
+  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
+  {
+    gchar *filepath = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
+    gtk_entry_set_text(GTK_ENTRY(g->filepath), filepath);
+    snprintf(p->filepath, sizeof(p->filepath), "%s", filepath);
+    g_free(filepath);
+  }
+  gtk_widget_destroy(filechooser);
+}
+
+void gui_update(dt_iop_module_t *self)
+{
+//printf("gui_update\n");
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
+  gtk_entry_set_text(GTK_ENTRY(g->filepath), p->filepath);
+}
+
+void gui_init(dt_iop_module_t *self)
+{
+setvbuf(stdout, NULL, _IONBF, 0);
+//printf("gui_init\n");
+  self->gui_data = malloc(sizeof(dt_iop_lut3d_gui_data_t));
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(8));
+  g->filepath = gtk_entry_new();
+  gtk_box_pack_start(GTK_BOX(hbox), g->filepath, TRUE, TRUE, 0);
+  dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(g->filepath));
+  g_signal_connect(G_OBJECT(g->filepath), "changed", G_CALLBACK(filepath_callback), self);
+
+  GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_widget_set_size_request(button, DT_PIXEL_APPLY_DPI(18), DT_PIXEL_APPLY_DPI(18));
+  gtk_widget_set_tooltip_text(button, _("select haldcult file"));
+  gtk_box_pack_start(GTK_BOX(hbox), button, FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), self);
+
+  self->widget = hbox;
+}
+
+void gui_cleanup(dt_iop_module_t *self)
+{
+//printf("gui_cleanup\n");
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_gui_key_accel_block_on_focus_disconnect(GTK_WIDGET(g->filepath));
+  free(self->gui_data);
+  self->gui_data = NULL;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -102,6 +102,11 @@ int groups()
   return IOP_GROUP_COLOR;
 }
 
+int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
+{
+  return iop_cs_Lab;
+}
+
 // From `HaldCLUT_correct.c' by Eskil Steenberg (http://www.quelsolaar.com) (BSD licensed)
 void correct_pixel_trilinear(float *input, float *output, const float *const clut, const uint8_t level)
 {
@@ -705,7 +710,7 @@ printf("init\n");
   self->params = calloc(1, sizeof(dt_iop_lut3d_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_lut3d_params_t));
   self->default_enabled = 0;
-  self->priority = 710; // self order created by iop_dependencies.py, do not edit!
+//  self->priority = 710; // self order created by iop_dependencies.py, do not edit!
   self->params_size = sizeof(dt_iop_lut3d_params_t);
   self->gui_data = NULL;
   dt_iop_lut3d_params_t tmp = (dt_iop_lut3d_params_t)

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -114,12 +114,12 @@ void correct_pixel_trilinear(const float *const in, float *const out,
 {
   const int level2 = level * level;
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)(pixel_nb * 4); k+=4)
   {
-    float *const input = ((float *const)in) + k;
-    float *const output = ((float *const)out) + k;
+    float *input = ((float *)in) + k;
+    float *output = ((float *)out) + k;
     
     int rgbi[3], i, j;
     float tmp[6];
@@ -190,12 +190,13 @@ void correct_pixel_tetrahedral(const float *const in, float *const out,
 {
   const int level2 = level * level;
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)(pixel_nb * 4); k+=4)
   {
     float *const input = ((float *const)in) + k;
-    float *const output = ((float *const)out) + k;  int rgbi[3];
+    float *const output = ((float *const)out) + k; 
+    int rgbi[3];
 
     float rgbd[3];
     for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
@@ -275,7 +276,7 @@ void correct_pixel_pyramid(const float *const in, float *const out,
 {
   const int level2 = level * level;
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) schedule(static)
+#pragma omp parallel for SIMD() default(none) schedule(static)
 #endif
   for(size_t k = 0; k < (size_t)(pixel_nb * 4); k+=4)
   {

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -114,7 +114,7 @@ void correct_pixel_trilinear(float *const input, float *const output, const floa
   float rgbd[3];
   const int level2 = level * level;
 
-  for(int c = 0; c < 3; ++c) input[c] = input[c] < 0.0f ? 0.0f : (input[c] > 1.0f ? 1.0f : input[c]);
+  for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
   
   rgbd[0] = input[0] * (float)(level - 1);
   rgbd[1] = input[1] * (float)(level - 1);
@@ -178,7 +178,7 @@ void correct_pixel_tetrahedral(float *const input, float *const output, const fl
   float rgbd[3];
   const int level2 = level * level;
 
-  for(int c = 0; c < 3; ++c) input[c] = input[c] < 0.0f ? 0.0f : (input[c] > 1.0f ? 1.0f : input[c]);
+  for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
   
   rgbd[0] = input[0] * (float)(level - 1);
   rgbd[1] = input[1] * (float)(level - 1);
@@ -254,7 +254,7 @@ void correct_pixel_pyramid(float *const input, float *const output, const float 
   float rgbd[3];
   const int level2 = level * level;
 
-  for(int c = 0; c < 3; ++c) input[c] = input[c] < 0.0f ? 0.0f : (input[c] > 1.0f ? 1.0f : input[c]);
+  for(int c = 0; c < 3; ++c) input[c] = fminf(fmaxf(input[c], 0.0f), 1.0f);
   
   rgbd[0] = input[0] * (float)(level - 1);
   rgbd[1] = input[1] * (float)(level - 1);
@@ -707,7 +707,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   {
     if (transform)
     {
-      dt_ioppr_transform_image_colorspace_rgb(ibuf, obuf, roi_in->width, roi_in->height, work_profile, lut_profile, "linrec2020 to LUT Space");
+      dt_ioppr_transform_image_colorspace_rgb(ibuf, obuf, width, height, work_profile, lut_profile, "linrec2020 to LUT Space");
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) schedule(static)
 #endif
@@ -716,7 +716,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         float *const out = ((float *const)obuf) + i;
         interpolation_worker(out, out, clut, level);
       }
-      dt_ioppr_transform_image_colorspace_rgb(obuf, obuf, roi_in->width, roi_in->height, lut_profile, work_profile, "LUT space to linrec2020");
+      dt_ioppr_transform_image_colorspace_rgb(obuf, obuf, width, height, lut_profile, work_profile, "LUT space to linrec2020");
     }
     else
     {

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -71,7 +71,7 @@ typedef struct dt_iop_lut3d_params_t
 
 typedef struct dt_iop_lut3d_gui_data_t
 {
-  GtkWidget *lutfolder;
+//  GtkWidget *lutfolder;
   GtkWidget *hbox;
   GtkWidget *filepath;
   GtkWidget *colorspace;
@@ -526,8 +526,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
 
   if(!(cube_file = g_fopen(filepath, "r")))
   {
-    fprintf(stderr, "[lut3d] invalid cube file from %s\n", filepath);
-    dt_control_log(_("error - invalid cube file from %s"), filepath);
+    fprintf(stderr, "[lut3d] invalid cube file: %s\n", filepath);
+    dt_control_log(_("error - invalid cube file: %s"), filepath);
     return 0;
   }
 //printf("cube file opened\n");
@@ -906,7 +906,7 @@ printf("init_pipe\n");
 
 static void filepath_callback(GtkWidget *w, dt_iop_module_t *self)
 {
-printf("filepath_callback\n");
+//printf("filepath_callback\n");
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   dt_iop_lut3d_global_data_t *gp = (dt_iop_lut3d_global_data_t *)self->data;
@@ -924,7 +924,7 @@ printf("filepath_callback\n");
 
 static void colorspace_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
-printf("colorspace_callback\n");
+//printf("colorspace_callback\n");
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
@@ -938,7 +938,7 @@ printf("colorspace_callback\n");
 
 static void interpolation_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
-printf("interpolation_callback\n");
+//printf("interpolation_callback\n");
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   p->interpolation = dt_bauhaus_combobox_get(widget);
@@ -980,49 +980,6 @@ static void log2tolin_callback(GtkWidget *widget, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void button0_clicked(GtkWidget *widget, dt_iop_module_t *self)
-{
-//printf("button0_clicked\n");
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
-  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
-  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GtkWidget *filechooser = gtk_file_chooser_dialog_new(
-      _("select root lut folder"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"), GTK_RESPONSE_CANCEL,
-      _("_select"), GTK_RESPONSE_ACCEPT, (char *)NULL);
-  gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(filechooser), FALSE);
-  gtk_entry_set_text(GTK_ENTRY(g->filepath), "");
-  p->filepath[0] = 0;
-  gchar *oldlutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
-  char *c = g_strstr_len(oldlutfolder, -1, "$");
-  if(c) *c = '\0';
-  gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(filechooser), oldlutfolder);
-  g_free(oldlutfolder);
-  if(gtk_dialog_run(GTK_DIALOG(filechooser)) == GTK_RESPONSE_ACCEPT)
-  {
-    gchar *lutfolder = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    gtk_entry_set_text(GTK_ENTRY(g->lutfolder), lutfolder); // the signal handler will write this to conf
-    if (lutfolder[0] != 0)
-    {
-      gtk_widget_set_visible(g->hbox, TRUE);
-    }
-    else
-    {
-      gtk_widget_set_visible(g->hbox, FALSE);
-    }
-    g_free(lutfolder);
-  }
-  else
-  {
-    gtk_widget_set_visible(g->hbox, FALSE);
-  }
-  gtk_widget_destroy(filechooser);
-}
-
-static void lutfolder_callback(GtkEntry *entry, gpointer user_data)
-{
-  dt_conf_set_string("plugins/darkroom/lut3d/def_path", gtk_entry_get_text(entry));
-}
-
 static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 {
   int filetype;
@@ -1060,7 +1017,6 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
     filetype = 2;
 
   GtkFileFilter* filter = GTK_FILE_FILTER(gtk_file_filter_new());
-//  gtk_file_filter_add_mime_type(filter, "image/png");
   gtk_file_filter_add_pattern(filter, "*.png");
   gtk_file_filter_set_name(filter, _("hald cluts (png)"));
   gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
@@ -1068,7 +1024,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 
   filter = GTK_FILE_FILTER(gtk_file_filter_new());
   gtk_file_filter_add_pattern(filter, "*.cube");
-  gtk_file_filter_set_name(filter, _("3Dlut (cube)"));
+  gtk_file_filter_set_name(filter, _("3D lut (cube)"));
   gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(filechooser), filter);
   if (filetype == 2) gtk_file_chooser_set_filter (GTK_FILE_CHOOSER(filechooser), filter);
 
@@ -1083,7 +1039,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 //    printf("button_clicked entered filepath %s\n", filepath);
 
     if (strcmp(lutfolder, filepath) < 0)
-    {
+    { // remove root lut folder from file path
       gchar *c = filepath + strlen(lutfolder) + 1;
 //      printf("button_clicked should be filepath %s\n", (gchar *)c);
       strcpy(filepath, (gchar *)c);
@@ -1107,16 +1063,21 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 
 void gui_update(dt_iop_module_t *self)
 {
-printf("gui_update\n");
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   gchar *lutfolder = dt_conf_get_string("plugins/darkroom/lut3d/def_path");
-  gtk_entry_set_text(GTK_ENTRY(g->lutfolder), lutfolder);
+//printf("gui_update, lut folder %s\n", lutfolder);
   gtk_entry_set_text(GTK_ENTRY(g->filepath), p->filepath);
-  if (lutfolder[0] != 0)
-    gtk_widget_set_visible(g->hbox, TRUE);
+  if (lutfolder[0] == 0)
+  {
+    dt_control_log(_("Lut folder not set in preferences (core options)"));
+    gtk_widget_set_sensitive(g->hbox, FALSE);
+  }
   else
-    gtk_widget_set_visible(g->hbox, FALSE);
+  {
+    gtk_widget_set_sensitive(g->hbox, TRUE);
+  }
+  g_free(lutfolder);
   dt_bauhaus_combobox_set(g->colorspace, p->colorspace);
   dt_bauhaus_slider_set_soft(g->middle_grey, p->middle_grey);
   dt_bauhaus_slider_set_soft(g->min_exposure, p->min_exposure);
@@ -1130,28 +1091,13 @@ printf("gui_update\n");
 void gui_init(dt_iop_module_t *self)
 {
 setvbuf(stdout, NULL, _IONBF, 0);
-printf("gui_init\n");
+//printf("gui_init\n");
   self->gui_data = malloc(sizeof(dt_iop_lut3d_gui_data_t));
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
-
-  GtkWidget *hbox0 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(8));
-  g->lutfolder = gtk_entry_new();
-  gtk_box_pack_start(GTK_BOX(hbox0), g->lutfolder, TRUE, TRUE, 0);
-  dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(g->lutfolder));
-  gtk_widget_set_tooltip_text(g->lutfolder, _("the lut folder is global and must be set once. Saved as a preference and not with the image (xmp)"));
-  g_signal_connect(G_OBJECT(g->lutfolder), "changed", G_CALLBACK(lutfolder_callback), self);
-
-  GtkWidget *button0 = dtgtk_button_new(dtgtk_cairo_paint_directory, CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_size_request(button0, DT_PIXEL_APPLY_DPI(18), DT_PIXEL_APPLY_DPI(18));
-  gtk_widget_set_tooltip_text(button0, _("select the lut 3D root folder"));
-  gtk_box_pack_start(GTK_BOX(hbox0), button0, FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(button0), "clicked", G_CALLBACK(button0_clicked), self);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox0), TRUE, TRUE, 0);
 
   g->hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(8));
   g->filepath = gtk_entry_new();
@@ -1234,7 +1180,7 @@ printf("gui_init\n");
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-printf("gui_cleanup\n");
+//printf("gui_cleanup\n");
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
   dt_gui_key_accel_block_on_focus_disconnect(GTK_WIDGET(g->filepath));
   free(self->gui_data);

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -120,9 +120,9 @@ void correct_pixel_trilinear(float *const input, float *const output, const floa
   rgbd[1] = input[1] * (float)(level - 1);
   rgbd[2] = input[2] * (float)(level - 1);
 
-  rgbi[0] = min( max( (int)rgbd[0], 0), level - 2);
-  rgbi[1] = min( max( (int)rgbd[1], 0), level - 2);
-  rgbi[2] = min( max( (int)rgbd[2], 0), level - 2);
+  rgbi[0] = CLAMP((int)rgbd[0], 0, level - 2);
+  rgbi[1] = CLAMP((int)rgbd[1], 0, level - 2);
+  rgbi[2] = CLAMP((int)rgbd[2], 0, level - 2);
 
   rgbd[0] = rgbd[0] - rgbi[0]; // delta red
   rgbd[1] = rgbd[1] - rgbi[1]; // delta green
@@ -184,9 +184,9 @@ void correct_pixel_tetrahedral(float *const input, float *const output, const fl
   rgbd[1] = input[1] * (float)(level - 1);
   rgbd[2] = input[2] * (float)(level - 1);
 
-  rgbi[0] = min( max( (int)rgbd[0], 0), level - 2);
-  rgbi[1] = min( max( (int)rgbd[1], 0), level - 2);
-  rgbi[2] = min( max( (int)rgbd[2], 0), level - 2);
+  rgbi[0] = CLAMP((int)rgbd[0], 0, level - 2);
+  rgbi[1] = CLAMP((int)rgbd[1], 0, level - 2);
+  rgbi[2] = CLAMP((int)rgbd[2], 0, level - 2);
 
   rgbd[0] = rgbd[0] - rgbi[0]; // delta red
   rgbd[1] = rgbd[1] - rgbi[1]; // delta green
@@ -260,9 +260,9 @@ void correct_pixel_pyramid(float *const input, float *const output, const float 
   rgbd[1] = input[1] * (float)(level - 1);
   rgbd[2] = input[2] * (float)(level - 1);
 
-  rgbi[0] = min( max( (int)rgbd[0], 0), level - 2);
-  rgbi[1] = min( max( (int)rgbd[1], 0), level - 2);
-  rgbi[2] = min( max( (int)rgbd[2], 0), level - 2);
+  rgbi[0] = CLAMP((int)rgbd[0], 0, level - 2);
+  rgbi[1] = CLAMP((int)rgbd[1], 0, level - 2);
+  rgbi[2] = CLAMP((int)rgbd[2], 0, level - 2);
 
   rgbd[0] = rgbd[0] - rgbi[0]; // delta red
   rgbd[1] = rgbd[1] - rgbi[1]; // delta green
@@ -339,7 +339,7 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
   }
   level *= level;  // to be equivalent to cube level
   const size_t buf_size = (size_t)png.height * png_get_rowbytes(png.png_ptr, png.info_ptr);
-  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for png file\n", buf_size);
+  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %d bytes for png file\n", buf_size);
   uint8_t *buf = NULL;
   buf = dt_alloc_align(16, buf_size);
   if(!buf)
@@ -358,7 +358,7 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
     return 0;
   }
   const size_t buf_size_lut = (size_t)png.height * png.height * 3;
-  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu floats for png lut - level %d\n", buf_size_lut, level);
+  dt_print(DT_DEBUG_DEV, "[lut3d] allocating %d floats for png lut - level %d\n", buf_size_lut, level);
   float *lclut = dt_alloc_align(16, buf_size_lut * sizeof(float));
   if(!lclut)
   {
@@ -562,7 +562,7 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       {
         level = atoll(token[1]);
         buf_size = level * level * level * 3;
-        dt_print(DT_DEBUG_DEV, "[lut3d] allocating %zu bytes for cube lut - level %d\n", buf_size, level);
+        dt_print(DT_DEBUG_DEV, "[lut3d] allocating %d bytes for cube lut - level %d\n", buf_size, level);
         lclut = dt_alloc_align(16, buf_size * sizeof(float));
         if(!lclut)
         {
@@ -911,8 +911,11 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
 
     if (strcmp(lutfolder, filepath) < 0)
     { // remove root lut folder from file path
-      gchar *c = filepath + strlen(lutfolder) + 1;
-      strcpy(filepath, (gchar *)c);
+      const int j = strlen(lutfolder) + 1;
+      int i;
+      for(i = 0; filepath[i+j] != '\0'; i++)
+        filepath[i] = filepath[i+j];
+      filepath[i] = '\0';
     }
     else // file chosen outside of root folder
     {

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -739,7 +739,6 @@ printf("process colorspace %d ch %d\n", colorspace, ch);
   if (colorspace == DT_IOP_REC709 || colorspace == DT_IOP_SRGB || colorspace == DT_IOP_LIN_REC709)
   {
     dt_ioppr_transform_image_colorspace_rgb(ibuf, obuf, roi_out->width, roi_out->height, rgb_profile, dest_profile, "linrec2020 to specific");
-    return; // for testing
   }
   if (clut)
   {

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -314,16 +314,18 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
   dt_imageio_png_t png;
   if(read_header(filepath, &png))
   {
-    fprintf(stderr, "[lut3d] invalid png header from `%s'\n", filepath);
+    fprintf(stderr, "[lut3d] invalid png header from %s\n", filepath);
+    dt_control_log(_("invalid png header from %s"), filepath);
     return 0;
   }
   dt_print(DT_DEBUG_DEV, "[lut3d] png: width=%d, height=%d, color_type=%d, bit_depth=%d\n", png.width,
            png.height, png.color_type, png.bit_depth);
-  printf("[lut3d] png: width=%d, height=%d, color_type=%d, bit_depth=%d\n", png.width,
-           png.height, png.color_type, png.bit_depth);
+//  printf("[lut3d] png: width=%d, height=%d, color_type=%d, bit_depth=%d\n", png.width,
+//           png.height, png.color_type, png.bit_depth);
   if (png.bit_depth !=8 && png.bit_depth != 16)
   {
-    fprintf(stderr, "[lut3d] png bit-depth %d not supported", png.bit_depth);
+    fprintf(stderr, "[lut3d] png bit-depth %d not supported\n", png.bit_depth);
+    dt_control_log(_("png bit-depth %d not supported"), png.bit_depth);
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
     return 0;
@@ -333,6 +335,7 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
   if(level * level * level != png.width)
   {
     fprintf(stderr, "[lut3d] invalid level in png file %d %d\n", level, png.width);
+    dt_control_log(_("invalid level in png file %d %d"), level, png.width);
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
     return 0;
@@ -346,13 +349,15 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
   {
     fclose(png.f);
     png_destroy_read_struct(&png.png_ptr, &png.info_ptr, NULL);
-    fprintf(stderr, "[lut3d] error allocating buffer for png lut\n");
+    fprintf(stderr, "[lut3d] error - allocating buffer for png lut\n");
+    dt_control_log(_("error - allocating buffer for png lut"));
     return 0;
   }
   if (read_image(&png, buf))
   {
     dt_free_align(buf);
-    fprintf(stderr, "[lut3d] could not read png image `%s'\n", filepath);
+    fprintf(stderr, "[lut3d] error - could not read png image `%s'\n", filepath);
+    dt_control_log(_("error - could not read png image %s"), filepath);
     return 0;
   }
   const size_t buf_size_lut = (size_t)png.height * png.height * 3;
@@ -360,7 +365,8 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
   if(!lclut)
   {
     dt_free_align(buf);
-    fprintf(stderr, "[lut3d] error allocating buffer for png lut\n");
+    fprintf(stderr, "[lut3d] error - allocating buffer for png lut\n");
+    dt_control_log(_("error - allocating buffer for png lut"));
     return 0;
   }
   const float norm = powf(2.f, png.bit_depth) - 1.0f;
@@ -382,7 +388,7 @@ uint8_t calculate_clut_haldclut(char *filepath, float **clut)
   return level;
 }
 
-// provided by @rabauke ato replace strtod & sccanf which are locale dependent
+// provided by @rabauke, atof replaces strtod & sccanf which are locale dependent
 double dt_atof(const char *str)
 {
   if (strncmp(str, "nan", 3) == 0 || strncmp(str, "NAN", 3) == 0)
@@ -520,7 +526,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
 
   if(!(cube_file = g_fopen(filepath, "r")))
   {
-    fprintf(stderr, "[lut3d] invalid cube file from `%s'\n", filepath);
+    fprintf(stderr, "[lut3d] invalid cube file from %s\n", filepath);
+    dt_control_log(_("error - invalid cube file from %s"), filepath);
     return 0;
   }
 //printf("cube file opened\n");
@@ -535,7 +542,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       {
         if (strtod(token[1], NULL) != 0.0f)
         {
-          fprintf(stderr, "DOMAIN MIN <> 0.0 is not supported\n");
+          fprintf(stderr, "[lut3d] DOMAIN MIN <> 0.0 is not supported\n");
+          dt_control_log(_("DOMAIN MIN <> 0.0 is not supported"));
           if (lclut) dt_free_align(lclut);
           free(line);
           fclose(cube_file);
@@ -546,7 +554,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       {
         if (strtod(token[1], NULL) != 1.0f)
         {
-          fprintf(stderr, "DOMAIN MAX <> 1.0 is not supported\n");
+          fprintf(stderr, "[lut3d] DOMAIN MAX <> 1.0 is not supported\n");
+          dt_control_log(_("DOMAIN MAX <> 1.0 is not supported"));
           if (lclut) dt_free_align(lclut);
           free(line);
           fclose(cube_file);
@@ -556,6 +565,7 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       else if (strcmp("LUT_1D_SIZE", token[0]) == 0)
       {
         fprintf(stderr, "[lut3d] 1D cube lut is not supported\n");
+        dt_control_log(_("[1D cube lut is not supported"));
         free(line);
         fclose(cube_file);
         return 0;
@@ -569,7 +579,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
 //printf("->Lut 3D %d buf_size %d\n", level, buf_size);
         if(!lclut)
         {
-          fprintf(stderr, "[lut3d] error allocating buffer for cube lut\n");
+          fprintf(stderr, "[lut3d] error - allocating buffer for cube lut\n");
+          dt_control_log(_("error - allocating buffer for cube lut"));
           free(line);
           fclose(cube_file);
           return 0;
@@ -579,7 +590,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
       {
         if (!level)
         {
-          fprintf(stderr, "[lut3d] error cube lut size is not defined\n");
+          fprintf(stderr, "[lut3d] error - cube lut size is not defined\n");
+          dt_control_log(_("error - cube lut size is not defined"));
           free(line);
           fclose(cube_file);
           return 0;
@@ -596,7 +608,8 @@ uint8_t calculate_clut_cube(char *filepath, float **clut)
   }
   if (i != buf_size || i == 0)
   {
-    fprintf(stderr, "[lut3d] error cube lut lines number is not correct\n");
+    fprintf(stderr, "[lut3d] error - cube lut lines number is not correct\n");
+    dt_control_log(_("error - cube lut lines number is not correct"));
     dt_free_align(lclut);
     free(line);
     fclose(cube_file);
@@ -1020,6 +1033,7 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
   if (strlen(lutfolder) == 0)
   {
     fprintf(stderr, "[lut3d] Lut root folder not defined\n");
+    dt_control_log(_("Lut root folder not defined"));
     g_free(lutfolder);
     return;
   }
@@ -1076,7 +1090,8 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
     }
     else // file chosen outside of root folder
     {
-      fprintf(stderr, "[lut3d] Selecting file outside Lut root folder is not allowed\n");
+      fprintf(stderr, "[lut3d] Select file outside Lut root folder is not allowed\n");
+      dt_control_log(_("Select file outside Lut root folder is not allowed"));
       g_free(lutfolder);
       gtk_widget_destroy(filechooser);
       return;

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -352,6 +352,15 @@
     </xsl:for-each>
   </xsl:template>
 
+	<xsl:template match="dtconfig[type='dir']" mode="reset">
+		<xsl:text>
+			dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", "</xsl:text><xsl:value-of select="default"/><xsl:text>");
+			gchar *folder = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
+			gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(widget), folder);
+			g_free(folder);
+		</xsl:text>
+	</xsl:template>
+
 <!-- CALLBACK -->
   <xsl:template match="dtconfig[type='string']" mode="change">
     <xsl:text>  dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", gtk_entry_get_text(GTK_ENTRY(widget)));</xsl:text>
@@ -388,6 +397,14 @@
 </xsl:text>
   </xsl:template>
 
+	<xsl:template match="dtconfig[type='dir']" mode="change">
+		<xsl:text>
+		gchar *folder =	gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
+		dt_conf_set_string("</xsl:text><xsl:value-of select="name"/><xsl:text>", folder);
+		g_free(folder);
+		</xsl:text>
+	</xsl:template>
+
 <!-- TAB -->
   <xsl:template match="dtconfig[type='string']" mode="tab">
     <xsl:text>    widget = gtk_entry_new();
@@ -402,6 +419,22 @@
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
 </xsl:text>
   </xsl:template>
+
+  <xsl:template match="dtconfig[type='dir']" mode="tab">
+		<xsl:text>    widget = gtk_file_chooser_button_new(_("select directory"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
+		gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(widget), 20);
+//		g_object_ref_sink(G_OBJECT(widget));
+		gtk_widget_set_hexpand(widget, TRUE);
+		gtk_widget_set_halign(widget, GTK_ALIGN_FILL);
+    gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(widget), setting);
+    g_free(setting);
+    g_signal_connect(G_OBJECT(widget), "button-press-event", G_CALLBACK(preferences_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), NULL);
+    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
+    snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
+    g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
+    </xsl:text>
+	</xsl:template>
 
   <xsl:template match="dtconfig[type='int']" mode="tab">
     <xsl:text>    gint min = 0;&#xA;    gint max = G_MAXINT;&#xA;</xsl:text>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -423,7 +423,6 @@
   <xsl:template match="dtconfig[type='dir']" mode="tab">
 		<xsl:text>    widget = gtk_file_chooser_button_new(_("select directory"), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
 		gtk_file_chooser_button_set_width_chars(GTK_FILE_CHOOSER_BUTTON(widget), 20);
-//		g_object_ref_sink(G_OBJECT(widget));
 		gtk_widget_set_hexpand(widget, TRUE);
 		gtk_widget_set_halign(widget, GTK_ALIGN_FILL);
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");

--- a/tools/iop-layout.sh
+++ b/tools/iop-layout.sh
@@ -82,6 +82,7 @@ group_correct=(
     'colorreconstruct'
     'defringe'
     'bilateral'
+    'lut3d'
     'nlmeans'
     'denoiseprofile'
     'dither'


### PR DESCRIPTION
I've reused the work of https://github.com/PkmX/darktable which apply haldclut (png files) and adapted it to apply 3D LUT cube files.
There is still some work to be done and some choices as well. I open a PR to get feedback.
It is not just a color grading tool, 3D Lut can be applied to mimic a lot a treatments: camera profile, log transform, black & white transform ... so the position in pixelpipe may be critical (and features of the PR 1841 useful).
See https://github.com/darktable-org/darktable/issues/1981 opened by @aurelienpierre.

