### PR TITLE
align all memory buffers on 64 bytes blocks

### DIFF
--- a/src/chart/pfm.c
+++ b/src/chart/pfm.c
@@ -58,7 +58,7 @@ float *read_pfm(const char *filename, int *wd, int *ht)
   float scale_factor = g_ascii_strtod(scale_factor_string, NULL);
   int swap_byte_order = (scale_factor >= 0.0) ^ (G_BYTE_ORDER == G_BIG_ENDIAN);
 
-  float *image = (float *)dt_alloc_align(16, sizeof(float) * width * height * 3);
+  float *image = (float *)dt_alloc_align(64, sizeof(float) * width * height * 3);
   if(!image)
   {
     fprintf(stderr, "error allocating memory\n");
@@ -132,7 +132,7 @@ void write_pfm(const char *filename, int width, int height, float *data)
   {
     // INFO: per-line fwrite call seems to perform best. LebedevRI, 18.04.2014
     (void)fprintf(f, "PF\n%d %d\n-1.0\n", width, height);
-    void *buf_line = dt_alloc_align(16, 3 * sizeof(float) * width);
+    void *buf_line = dt_alloc_align(64, 3 * sizeof(float) * width);
     for(int j = 0; j < height; j++)
     {
       // NOTE: pfm has rows in reverse order

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -109,7 +109,7 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   b->height = height;
   b->sigma_s = MAX(height / (b->size_y - 1.0f), width / (b->size_x - 1.0f));
   b->sigma_r = 100.0f / (b->size_z - 1.0f);
-  b->buf = dt_alloc_align(16, b->size_x * b->size_y * b->size_z * sizeof(float));
+  b->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(float));
 
   memset(b->buf, 0, b->size_x * b->size_y * b->size_z * sizeof(float));
 #if 0

--- a/src/common/cache.c
+++ b/src/common/cache.c
@@ -232,7 +232,7 @@ restart:
   if(cache->allocate)
     cache->allocate(cache->allocate_data, entry);
   else
-    entry->data = dt_alloc_align(16, entry->data_size);
+    entry->data = dt_alloc_align(64, entry->data_size);
 
   assert(entry->data_size);
   ASAN_POISON_MEMORY_REGION(entry->data, entry->data_size);

--- a/src/common/imageio_png.c
+++ b/src/common/imageio_png.c
@@ -188,7 +188,7 @@ dt_imageio_retval_t dt_imageio_open_png(dt_image_t *img, const char *filename, d
     return DT_IMAGEIO_CACHE_FULL;
   }
 
-  buf = dt_alloc_align(16, (size_t)image.height * png_get_rowbytes(image.png_ptr, image.info_ptr));
+  buf = dt_alloc_align(64, (size_t)image.height * png_get_rowbytes(image.png_ptr, image.info_ptr));
 
   if(!buf)
   {

--- a/src/common/interpolation.c
+++ b/src/common/interpolation.c
@@ -45,7 +45,7 @@ enum border_mode
 #define INTERPOLATION_BORDER_MODE BORDER_MIRROR
 
 // Defines minimum alignment requirement for critical SIMD code
-#define SSE_ALIGNMENT 16
+#define SSE_ALIGNMENT 64
 
 // Defines the maximum kernel half length
 // !! Make sure to sync this with the filter array !!

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -139,7 +139,7 @@ static inline void gauss_reduce_sse2(
   //   - do vertical convolution via sse and write to coarse output buf
 
   const int stride = ((cw+8)&~7); // assure sse alignment of rows
-  float *ringbuf = dt_alloc_align(16, sizeof(*ringbuf)*stride*5);
+  float *ringbuf = dt_alloc_align(64, sizeof(*ringbuf)*stride*5);
   float *rows[5] = {0};
   int rowj = 0; // we initialised this many rows so far
 
@@ -246,7 +246,7 @@ static inline float *ll_pad_input(
   const int stride = 4;
   *wd2 = 2*max_supp + wd;
   *ht2 = 2*max_supp + ht;
-  float *const out = dt_alloc_align(16, *wd2**ht2*sizeof(*out));
+  float *const out = dt_alloc_align(64, *wd2**ht2*sizeof(*out));
 
   if(b && b->mode == 2)
   { // pad by preview buffer
@@ -553,12 +553,12 @@ void local_laplacian_internal(
 
   // allocate pyramid pointers for padded input
   for(int l=1;l<=last_level;l++)
-    padded[l] = dt_alloc_align(16, sizeof(float)*dl(w,l)*dl(h,l));
+    padded[l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
 
   // allocate pyramid pointers for output
   float *output[max_levels] = {0};
   for(int l=0;l<=last_level;l++)
-    output[l] = dt_alloc_align(16, sizeof(float)*dl(w,l)*dl(h,l));
+    output[l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
 
   // create gauss pyramid of padded input, write coarse directly to output
 #if defined(__SSE2__)
@@ -584,7 +584,7 @@ void local_laplacian_internal(
   // allocate memory for intermediate laplacian pyramids
   float *buf[num_gamma][max_levels] = {{0}};
   for(int k=0;k<num_gamma;k++) for(int l=0;l<=last_level;l++)
-    buf[k][l] = dt_alloc_align(16, sizeof(float)*dl(w,l)*dl(h,l));
+    buf[k][l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
 
   // the paper says remapping only level 3 not 0 does the trick, too
   // (but i really like the additional octave of sharpness we get,

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -45,7 +45,7 @@
 
 #if !defined(_WIN32)
 #include <sys/statvfs.h>
-#else 
+#else
 //statvfs does not exist in Windows, providing implementation
 #include "win/statvfs.h"
 #endif
@@ -325,7 +325,7 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
       entry->data_size = sizeof(*dsc) + sizeof(float) * 4 * 64;
     }
 
-    entry->data = dt_alloc_align(16, entry->data_size);
+    entry->data = dt_alloc_align(64, entry->data_size);
 
     // fprintf(stderr, "[mipmap cache] alloc dynamic for key %u %p\n", key, *buf);
     if(!(entry->data))

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -953,7 +953,7 @@ static float dt_opencl_benchmark_gpu(const int devid, const size_t width, const 
 
   unsigned int *const tea_states = calloc(2 * dt_get_num_threads(), sizeof(unsigned int));
 
-  buf = dt_alloc_align(16, width * height * bpp);
+  buf = dt_alloc_align(64, width * height * bpp);
   if(buf == NULL) goto error;
 
 #ifdef _OPENMP
@@ -1026,7 +1026,7 @@ static float dt_opencl_benchmark_cpu(const size_t width, const size_t height, co
 
   unsigned int *const tea_states = calloc(2 * dt_get_num_threads(), sizeof(unsigned int));
 
-  buf = dt_alloc_align(16, width * height * bpp);
+  buf = dt_alloc_align(64, width * height * bpp);
   if(buf == NULL) goto error;
 
 #ifdef _OPENMP

--- a/src/common/points.h
+++ b/src/common/points.h
@@ -145,10 +145,10 @@ static inline float dt_points_get()
 */
 
 /** These definitions are part of a 128-bit period certification vector.
-#define PARITY1	0x00000001U
-#define PARITY2	0x00000000U
-#define PARITY3	0x00000000U
-#define PARITY4	0xc98e126aU
+#define PARITY1 0x00000001U
+#define PARITY2 0x00000000U
+#define PARITY3 0x00000000U
+#define PARITY4 0xc98e126aU
 */
 
 #if 0
@@ -1125,7 +1125,7 @@ void init_by_array(sfmt_state_t *s, uint32_t *init_key, int key_length)
 
 static inline void dt_points_init(dt_points_t *p, const unsigned int num_threads)
 {
-  sfmt_state_t *states = (sfmt_state_t *)dt_alloc_align(16, sizeof(sfmt_state_t) * num_threads);
+  sfmt_state_t *states = (sfmt_state_t *)dt_alloc_align(64, sizeof(sfmt_state_t) * num_threads);
   p->s = (sfmt_state_t **)calloc(num_threads, sizeof(sfmt_state_t *));
   p->num = num_threads;
 

--- a/src/develop/imageop_math.c
+++ b/src/develop/imageop_math.c
@@ -430,7 +430,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_sse2(uint16_t *const out, const uint1
       num = 1.0f / num;
       col = _mm_mul_ps(col, _mm_set1_ps(num));
 
-      float fcol[4] __attribute__((aligned(16)));
+      float fcol[4] __attribute__((aligned(64)));
       _mm_store_ps(fcol, col);
 
       const int c = (2 * ((y + rggby) % 2) + ((x + rggbx) % 2));
@@ -826,7 +826,7 @@ void dt_iop_clip_and_zoom_mosaic_half_size_f_sse2(float *const out, const float 
       num = 1.0f / num;
       col = _mm_mul_ps(col, _mm_set1_ps(num));
 
-      float fcol[4] __attribute__((aligned(16)));
+      float fcol[4] __attribute__((aligned(64)));
       _mm_store_ps(fcol, col);
 
       const int c = (2 * ((y + rggby) % 2) + ((x + rggbx) % 2));

--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -48,7 +48,7 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
     cache->size[k] = size;
     if(size)
     { // allow 0 initial buffer size (yet unknown dimensions)
-      cache->data[k] = (void *)dt_alloc_align(16, size);
+      cache->data[k] = (void *)dt_alloc_align(64, size);
       if(!cache->data[k]) goto alloc_memory_fail;
 #ifdef _DEBUG
       memset(cache->data[k], 0x5d, size);
@@ -170,7 +170,7 @@ int dt_dev_pixelpipe_cache_get_weighted(dt_dev_pixelpipe_cache_t *cache, const u
     if(cache->size[max] < size)
     {
       dt_free_align(cache->data[max]);
-      cache->data[max] = (void *)dt_alloc_align(16, size);
+      cache->data[max] = (void *)dt_alloc_align(64, size);
       cache->size[max] = size;
     }
     *data = cache->data[max];

--- a/src/imageio/format/pfm.c
+++ b/src/imageio/format/pfm.c
@@ -47,7 +47,7 @@ int write_image(dt_imageio_module_data_t *data, const char *filename, const void
     while((len + 1 + off) & 0xf) off++;
     while(off-- > 0) fprintf(f, "0");
     fprintf(f, "\n");
-    void *buf_line = dt_alloc_align(16, 3 * sizeof(float) * pfm->width);
+    void *buf_line = dt_alloc_align(64, 3 * sizeof(float) * pfm->width);
     for(int j = 0; j < pfm->height; j++)
     {
       // NOTE: pfm has rows in reverse order

--- a/src/iop/amaze_demosaic_RT.cc
+++ b/src/iop/amaze_demosaic_RT.cc
@@ -2109,8 +2109,8 @@ void amaze_demosaic_RT(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
                                     * tempv;
               vfloat redv2 = greenv - vdup(LVFU(Dgrb[0][indx >> 1]));
               vfloat bluev2 = greenv - vdup(LVFU(Dgrb[1][indx >> 1]));
-              __attribute__((aligned(16))) float _r[4];
-              __attribute__((aligned(16))) float _b[4];
+              __attribute__((aligned(64))) float _r[4];
+              __attribute__((aligned(64))) float _b[4];
               STVF(*_r, vself(selmask, redv1, redv2));
               STVF(*_b, vself(selmask, bluev1, bluev2));
               for(int c = 0; c < 4; c++)

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -146,9 +146,9 @@ void connect_key_accels(dt_iop_module_t *self)
     (a), (a), (a), (a)                                                                                       \
   }
 
-static const __m128 fone ALIGNED(16) = VEC4(0x3f800000u);
-static const __m128 femo ALIGNED(16) = VEC4(0x00adf880u);
-static const __m128 ooo1 ALIGNED(16) = { 0.f, 0.f, 0.f, 1.f };
+static const __m128 fone ALIGNED(64) = VEC4(0x3f800000u);
+static const __m128 femo ALIGNED(64) = VEC4(0x00adf880u);
+static const __m128 ooo1 ALIGNED(64) = { 0.f, 0.f, 0.f, 1.f };
 
 /* SSE intrinsics version of dt_fast_expf defined in darktable.h */
 static inline __m128 dt_fast_expf_sse2(const __m128 x)

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -268,7 +268,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_in
   b->scale = iscale / roi->scale;
   b->sigma_s = MAX(roi->height / (b->size_y - 1.0f), roi->width / (b->size_x - 1.0f));
   b->sigma_r = 100.0f / (b->size_z - 1.0f);
-  b->buf = dt_alloc_align(16, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  b->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
   if(!b->buf)
   {
     fprintf(stderr, "[color reconstruction] not able to allocate buffer (b)\n");
@@ -306,7 +306,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(16, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  bf->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
   if(bf->buf && b->buf)
   {
     memcpy(bf->buf, b->buf, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
@@ -342,7 +342,7 @@ static dt_iop_colorreconstruct_bilateral_t *dt_iop_colorreconstruct_bilateral_th
   b->scale = bf->scale;
   b->sigma_s = bf->sigma_s;
   b->sigma_r = bf->sigma_r;
-  b->buf = dt_alloc_align(16, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  b->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
   if(b->buf && bf->buf)
   {
     memcpy(b->buf, bf->buf, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
@@ -812,7 +812,7 @@ static dt_iop_colorreconstruct_bilateral_frozen_t *dt_iop_colorreconstruct_bilat
   bf->scale = b->scale;
   bf->sigma_s = b->sigma_s;
   bf->sigma_r = b->sigma_r;
-  bf->buf = dt_alloc_align(16, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
+  bf->buf = dt_alloc_align(64, b->size_x * b->size_y * b->size_z * sizeof(dt_iop_colorreconstruct_Lab_t));
   if(bf->buf && b->dev_grid)
   {
     // read bilateral grid from device memory to host buffer (blocking)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -548,7 +548,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
   const int ndir = 4 << (passes > 1);
 
   const size_t buffer_size = (size_t)TS * TS * (ndir * 4 + 3) * sizeof(float);
-  char *const all_buffers = (char *)dt_alloc_align(16, dt_get_num_threads() * buffer_size);
+  char *const all_buffers = (char *)dt_alloc_align(64, dt_get_num_threads() * buffer_size);
   if(!all_buffers)
   {
     printf("[demosaic] not able to allocate Markesteijn buffers\n");
@@ -1541,7 +1541,7 @@ static void xtrans_fdc_interpolate(struct dt_iop_module_t *self, float *out, con
               1.221201e-03f - 5.982162e-19f * _Complex_I } } };
 
   const size_t buffer_size = (size_t)TS * TS * (ndir * 4 + 7) * sizeof(float);
-  char *const all_buffers = (char *)dt_alloc_align(16, dt_get_num_threads() * buffer_size);
+  char *const all_buffers = (char *)dt_alloc_align(64, dt_get_num_threads() * buffer_size);
   if(!all_buffers)
   {
     fprintf(stderr, "[demosaic] not able to allocate FDC base buffers\n");
@@ -2272,7 +2272,7 @@ static void vng_interpolate(float *out, const float *const in,
   if(only_vng_linear) return;
 
   char *buffer
-      = (char *)dt_alloc_align(16, (size_t)sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
+      = (char *)dt_alloc_align(64, (size_t)sizeof(**brow) * width * 3 + sizeof(*ip) * prow * pcol * 320);
   if(!buffer)
   {
     fprintf(stderr, "[demosaic] not able to allocate VNG buffer\n");
@@ -2466,7 +2466,7 @@ static void demosaic_ppg(float *const out, const float *const in, const dt_iop_r
   const float *input = in;
   if(median)
   {
-    float *med_in = (float *)dt_alloc_align(16, (size_t)roi_in->height * roi_in->width * sizeof(float));
+    float *med_in = (float *)dt_alloc_align(64, (size_t)roi_in->height * roi_in->width * sizeof(float));
     pre_median(med_in, in, roi_in, filters, 1, thrs);
     input = med_in;
   }
@@ -2826,7 +2826,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       roo.width = roi_in->width;
       roo.height = roi_in->height;
       roo.scale = 1.0f;
-      tmp = (float *)dt_alloc_align(16, (size_t)roo.width * roo.height * 4 * sizeof(float));
+      tmp = (float *)dt_alloc_align(64, (size_t)roo.width * roo.height * 4 * sizeof(float));
     }
 
     if(demosaicing_method == DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME)
@@ -2850,7 +2850,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
       if(!(img->flags & DT_IMAGE_4BAYER) && data->green_eq != DT_IOP_GREEN_EQ_NO)
       {
-        in = (float *)dt_alloc_align(16, (size_t)roi_in->height * roi_in->width * sizeof(float));
+        in = (float *)dt_alloc_align(64, (size_t)roi_in->height * roi_in->width * sizeof(float));
         switch(data->green_eq)
         {
           case DT_IOP_GREEN_EQ_FULL:
@@ -2862,7 +2862,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                      roi_in->x, roi_in->y, threshold);
             break;
           case DT_IOP_GREEN_EQ_BOTH:
-            aux = dt_alloc_align(16, (size_t)roi_in->height * roi_in->width * sizeof(float));
+            aux = dt_alloc_align(64, (size_t)roi_in->height * roi_in->width * sizeof(float));
             green_equilibration_favg(aux, pixels, roi_in->width, roi_in->height, piece->pipe->dsc.filters,
                                      roi_in->x, roi_in->y);
             green_equilibration_lavg(in, aux, roi_in->width, roi_in->height, piece->pipe->dsc.filters, roi_in->x,
@@ -3084,7 +3084,7 @@ static int green_equilibration_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe
                                                  slocal);
     if(err != CL_SUCCESS) goto error;
 
-    sumsum = dt_alloc_align(16, (size_t)reducesize * 2 * sizeof(float));
+    sumsum = dt_alloc_align(64, (size_t)reducesize * 2 * sizeof(float));
     if(sumsum == NULL) goto error;
     err = dt_opencl_read_buffer_from_device(devid, (void *)sumsum, dev_r, 0,
                                             (size_t)reducesize * 2 * sizeof(float), CL_TRUE);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1767,7 +1767,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   dev_r = dt_opencl_alloc_device_buffer(devid, (size_t)reducesize * 4 * sizeof(float));
   if(dev_r == NULL) goto error;
 
-  sumsum = dt_alloc_align(16, (size_t)reducesize * 4 * sizeof(float));
+  sumsum = dt_alloc_align(64, (size_t)reducesize * 4 * sizeof(float));
   if(sumsum == NULL) goto error;
 
   dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -408,7 +408,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       err = dt_opencl_enqueue_kernel_2d_with_local(devid, gd->kernel_pixelmax_second, sizes, local);
       if(err != CL_SUCCESS) goto error;
 
-      maximum = dt_alloc_align(16, reducesize * sizeof(float));
+      maximum = dt_alloc_align(64, reducesize * sizeof(float));
       err = dt_opencl_read_buffer_from_device(devid, (void *)maximum, dev_r, 0,
                                             (size_t)reducesize * sizeof(float), CL_TRUE);
       if(err != CL_SUCCESS) goto error;

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -366,7 +366,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       // acquire temp memory for distorted pixel coords
       const size_t bufsize = (size_t)roi_out->width * 2 * 3;
-      void *buf = dt_alloc_align(16, bufsize * dt_get_num_threads() * sizeof(float));
+      void *buf = dt_alloc_align(64, bufsize * dt_get_num_threads() * sizeof(float));
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(buf, modifier) schedule(static)
@@ -439,7 +439,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   {
     // acquire temp memory for image buffer
     const size_t bufsize = (size_t)roi_in->width * roi_in->height * ch * sizeof(float);
-    void *buf = dt_alloc_align(16, bufsize);
+    void *buf = dt_alloc_align(64, bufsize);
     memcpy(buf, ivoid, bufsize);
 
     if(modflags & LF_MODIFY_VIGNETTING)
@@ -461,7 +461,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
     {
       // acquire temp memory for distorted pixel coords
       const size_t buf2size = (size_t)roi_out->width * 2 * 3;
-      void *buf2 = dt_alloc_align(16, buf2size * sizeof(float) * dt_get_num_threads());
+      void *buf2 = dt_alloc_align(64, buf2size * sizeof(float) * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(buf2, buf, modifier) schedule(static)
@@ -593,7 +593,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
       return FALSE;
   }
 
-  tmpbuf = (float *)dt_alloc_align(16, tmpbuflen);
+  tmpbuf = (float *)dt_alloc_align(64, tmpbuflen);
   if(tmpbuf == NULL) goto error;
 
   dev_tmp = dt_opencl_alloc_device(devid, width, height, 4 * sizeof(float));
@@ -881,7 +881,7 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 
   // acquire temp memory for distorted pixel coords
   const size_t bufsize = (size_t)roi_out->width * 2 * 3;
-  float *buf = dt_alloc_align(16, bufsize * sizeof(float) * dt_get_num_threads());
+  float *buf = dt_alloc_align(64, bufsize * sizeof(float) * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(buf, modifier) schedule(static)
@@ -948,7 +948,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     float xm = FLT_MAX, xM = -FLT_MAX, ym = FLT_MAX, yM = -FLT_MAX;
     const size_t nbpoints = 2 * awidth + 2 * aheight;
 
-    float *const buf = dt_alloc_align(16, nbpoints * 2 * 3 * sizeof(float));
+    float *const buf = dt_alloc_align(64, nbpoints * 2 * 3 * sizeof(float));
 
 #ifdef _OPENMP
 #pragma omp parallel default(none) shared(modifier) reduction(min : xm, ym) reduction(max : xM, yM)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -786,13 +786,13 @@ static const float complex point_at_arc_length (const float complex points[],
 static float *
 build_lookup_table (const int distance, const float control1, const float control2)
 {
-  float complex *clookup = dt_alloc_align (16, (distance + 2) * sizeof (float complex));
+  float complex *clookup = dt_alloc_align(64, (distance + 2) * sizeof (float complex));
 
   interpolate_cubic_bezier (I, control1 + I, control2, 1.0, clookup, distance + 2);
 
   // reparameterize bezier by x and keep only y values
 
-  float *lookup = dt_alloc_align(16, (distance + 2) * sizeof(float));
+  float *lookup = dt_alloc_align(64, (distance + 2) * sizeof(float));
   float *ptr = lookup;
   float complex *cptr = clookup + 1;
   const float complex *cptr_end = cptr + distance;
@@ -1099,7 +1099,7 @@ static float complex *create_global_distortion_map (const cairo_rectangle_int_t 
 {
   // allocate distortion map big enough to contain all paths
   const int mapsize = map_extent->width * map_extent->height;
-  float complex * map = dt_alloc_align (16, mapsize * sizeof (float complex));
+  float complex * map = dt_alloc_align(64, mapsize * sizeof (float complex));
   memset (map, 0, mapsize * sizeof (float complex));
 
   // build map
@@ -3188,7 +3188,7 @@ int button_released (struct dt_iop_module_t *module,
       if (g->last_hit.layer == DT_LIQUIFY_LAYER_CENTERPOINT)
       {
         const int oldsel = !!g->last_hit.elem->header.selected;
-	unselect_all (&g->params);
+  unselect_all (&g->params);
         g->last_hit.elem->header.selected = oldsel ? 0 : g->last_hit.layer;
         handled = 1;
         goto done;
@@ -3221,7 +3221,7 @@ int button_released (struct dt_iop_module_t *module,
         dt_liquify_path_data_t *prev = node_prev (&g->params, e);
         if (prev && e->header.type == DT_LIQUIFY_PATH_CURVE_TO_V1)
         {
-	  // add node to curve
+    // add node to curve
           dt_liquify_path_data_t *curve1 = (dt_liquify_path_data_t *) e;
 
           dt_liquify_path_data_t *curve2 = (dt_liquify_path_data_t *)alloc_curve_to (module, 0);
@@ -3251,7 +3251,7 @@ int button_released (struct dt_iop_module_t *module,
         }
         if (prev && e->header.type == DT_LIQUIFY_PATH_LINE_TO_V1)
         {
-	  // add node to line
+    // add node to line
           dt_liquify_warp_t *warp1 = &prev->warp;
           dt_liquify_warp_t *warp3 = &e->warp;
           const float t = find_nearest_on_line_t (warp1->point, warp3->point, pt);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1115,7 +1115,7 @@ static float complex *create_global_distortion_map (const cairo_rectangle_int_t 
 
   if (inverted)
   {
-    float complex * const imap = dt_alloc_align (16, mapsize * sizeof (float complex));
+    float complex * const imap = dt_alloc_align (64, mapsize * sizeof (float complex));
     memset (imap, 0, mapsize * sizeof (float complex));
 
     // copy map into imap (inverted map).

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -44,7 +44,7 @@ typedef struct dt_iop_rawoverexposed_t
   int dummy;
 } dt_iop_rawoverexposed_t;
 
-static const float dt_iop_rawoverexposed_colors[][4] __attribute__((aligned(16))) = {
+static const float dt_iop_rawoverexposed_colors[][4] __attribute__((aligned(64))) = {
   { 1.0f, 0.0f, 0.0f, 1.0f }, // red
   { 0.0f, 1.0f, 0.0f, 1.0f }, // green
   { 0.0f, 0.0f, 1.0f, 1.0f }, // blue
@@ -185,7 +185,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   // acquire temp memory for distorted pixel coords
   const size_t coordbufsize = (size_t)roi_out->width * 2;
-  void *coordbuf = dt_alloc_align(16, coordbufsize * sizeof(float) * dt_get_num_threads());
+  void *coordbuf = dt_alloc_align(64, coordbufsize * sizeof(float) * dt_get_num_threads());
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) shared(self, coordbuf, buf) schedule(static)
@@ -307,7 +307,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   const size_t coordbufsize = (size_t)height * width * 2 * sizeof(float);
 
-  coordbuf = dt_alloc_align(16, coordbufsize);
+  coordbuf = dt_alloc_align(64, coordbufsize);
   if(coordbuf == NULL) goto error;
 
 #ifdef _OPENMP

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -294,7 +294,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     return;
   }
 
-  float *const tmp = dt_alloc_align(16, (size_t)sizeof(float) * roi_out->width * roi_out->height);
+  float *const tmp = dt_alloc_align(64, (size_t)sizeof(float) * roi_out->width * roi_out->height);
   if(tmp == NULL)
   {
     fprintf(stderr, "[sharpen] failed to allocate temporary buffer\n");
@@ -305,7 +305,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int wd4 = (wd & 3) ? (wd >> 2) + 1 : wd >> 2;
 
   const size_t mat_size = wd4 * 4 * sizeof(float);
-  float *const mat = dt_alloc_align(16, mat_size);
+  float *const mat = dt_alloc_align(64, mat_size);
   memset(mat, 0, mat_size);
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)
@@ -328,7 +328,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(i = rad; i < roi_out->width - wd4 * 4 + rad; i++)
     {
       const float *inp = in - ch * rad;
-      __attribute__((aligned(16))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      __attribute__((aligned(64))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
       for(int k = 0; k < wd4 * 4; k += 4, inp += 4 * ch)
       {
@@ -370,7 +370,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(int i = 0; i < roi_out->width; i++)
     {
       const float *inp = in - step * rad;
-      __attribute__((aligned(16))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      __attribute__((aligned(64))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
       for(int k = 0; k < wd4 * 4; k += 4, inp += step * 4)
       {
@@ -478,7 +478,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     return;
   }
 
-  float *const tmp = dt_alloc_align(16, (size_t)sizeof(float) * roi_out->width * roi_out->height);
+  float *const tmp = dt_alloc_align(64, (size_t)sizeof(float) * roi_out->width * roi_out->height);
   if(tmp == NULL)
   {
     fprintf(stderr, "[sharpen] failed to allocate temporary buffer\n");
@@ -489,7 +489,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
   const int wd4 = (wd & 3) ? (wd >> 2) + 1 : wd >> 2;
 
   const size_t mat_size = wd4 * 4 * sizeof(float);
-  float *const mat = dt_alloc_align(16, mat_size);
+  float *const mat = dt_alloc_align(64, mat_size);
   memset(mat, 0, mat_size);
 
   const float sigma2 = (1.0f / (2.5 * 2.5)) * (data->radius * roi_in->scale / piece->iscale)
@@ -512,7 +512,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     for(i = rad; i < roi_out->width - wd4 * 4 + rad; i++)
     {
       const float *inp = in - ch * rad;
-      __attribute__((aligned(16))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      __attribute__((aligned(64))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
       __m128 msum = _mm_setzero_ps();
 
       for(int k = 0; k < wd4 * 4; k += 4, inp += 4 * ch)
@@ -552,7 +552,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
     const int step = roi_in->width;
 
-    __attribute__((aligned(16))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    __attribute__((aligned(64))) float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
     for(int i = 0; i < roi_out->width; i++)
     {

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -148,7 +148,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   const int size = roi_out->width > roi_out->height ? roi_out->width : roi_out->height;
 
   const size_t scanline_size = (size_t)4 * size;
-  float *const scanline_buf = dt_alloc_align(16, scanline_size * dt_get_num_threads() * sizeof(float));
+  float *const scanline_buf = dt_alloc_align(64, scanline_size * dt_get_num_threads() * sizeof(float));
 
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {
@@ -159,7 +159,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(int y = 0; y < roi_out->height; y++)
     {
       float *scanline = scanline_buf + scanline_size * dt_get_thread_num();
-      __attribute__((aligned(16))) float L[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      __attribute__((aligned(64))) float L[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
       size_t index = (size_t)y * roi_out->width;
       int hits = 0;
@@ -210,7 +210,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     for(int x = 0; x < roi_out->width; x++)
     {
       float *scanline = scanline_buf + scanline_size * dt_get_thread_num();
-      __attribute__((aligned(16))) float L[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+      __attribute__((aligned(64))) float L[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
       int hits = 0;
       size_t index = (size_t)x - radius * roi_out->width;
@@ -305,7 +305,7 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
 
   const int size = roi_out->width > roi_out->height ? roi_out->width : roi_out->height;
 
-  __m128 *const scanline_buf = dt_alloc_align(16, size * dt_get_num_threads() * sizeof(__m128));
+  __m128 *const scanline_buf = dt_alloc_align(64, size * dt_get_num_threads() * sizeof(__m128));
 
   for(int iteration = 0; iteration < BOX_ITERATIONS; iteration++)
   {


### PR DESCRIPTION
This is a first step to allow casting to AVX2 vectors on supported platforms and enable further SIMD optimizations