### PR TITLE
replace free by g_free

### DIFF
--- a/src/lua/database.c
+++ b/src/lua/database.c
@@ -123,7 +123,7 @@ static int import_images(lua_State *L)
       return luaL_error(L, "Error while importing : %s\n", strerror(errno));
     }
     result = dt_film_new(&new_film, final_path);
-    free(final_path);
+    g_free(final_path);
     if(result == 0)
     {
       if(dt_film_is_empty(new_film.id)) dt_film_remove(new_film.id);

--- a/src/lua/film.c
+++ b/src/lua/film.c
@@ -197,7 +197,7 @@ static int films_new(lua_State *L)
   dt_film_t my_film;
   dt_film_init(&my_film);
   int film_id = dt_film_new(&my_film, final_path);
-  free(final_path);
+  g_free(final_path);
   if(film_id)
   {
     luaA_push(L, dt_lua_film_t, &film_id);

--- a/src/lua/preferences.c
+++ b/src/lua/preferences.c
@@ -254,7 +254,6 @@ static int write_pref(lua_State *L)
 }
 
 
-
 static void response_callback_enum(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -266,6 +265,8 @@ static void response_callback_enum(GtkDialog *dialog, gint response_id, pref_ele
     g_free(text);
   }
 }
+
+
 static void response_callback_dir(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -277,6 +278,8 @@ static void response_callback_dir(GtkDialog *dialog, gint response_id, pref_elem
     g_free(folder);
   }
 }
+
+
 static void response_callback_file(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -286,6 +289,8 @@ static void response_callback_file(GtkDialog *dialog, gint response_id, pref_ele
     dt_conf_set_string(pref_name, gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(cur_elt->widget)));
   }
 }
+
+
 static void response_callback_string(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -295,6 +300,8 @@ static void response_callback_string(GtkDialog *dialog, gint response_id, pref_e
     dt_conf_set_string(pref_name, gtk_entry_get_text(GTK_ENTRY(cur_elt->widget)));
   }
 }
+
+
 static void response_callback_bool(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -304,6 +311,8 @@ static void response_callback_bool(GtkDialog *dialog, gint response_id, pref_ele
     dt_conf_set_bool(pref_name, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cur_elt->widget)));
   }
 }
+
+
 static void response_callback_int(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -313,6 +322,8 @@ static void response_callback_int(GtkDialog *dialog, gint response_id, pref_elem
     dt_conf_set_int(pref_name, gtk_spin_button_get_value(GTK_SPIN_BUTTON(cur_elt->widget)));
   }
 }
+
+
 static void response_callback_float(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -322,6 +333,8 @@ static void response_callback_float(GtkDialog *dialog, gint response_id, pref_el
     dt_conf_set_float(pref_name, gtk_spin_button_get_value(GTK_SPIN_BUTTON(cur_elt->widget)));
   }
 }
+
+
 static void response_callback_lua(GtkDialog *dialog, gint response_id, pref_element *cur_elt)
 {
   if(response_id == GTK_RESPONSE_ACCEPT)
@@ -346,6 +359,8 @@ static gboolean reset_widget_enum(GtkWidget *label, GdkEventButton *event, pref_
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_dir(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -356,6 +371,8 @@ static gboolean reset_widget_dir(GtkWidget *label, GdkEventButton *event, pref_e
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_file(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -366,6 +383,8 @@ static gboolean reset_widget_file(GtkWidget *label, GdkEventButton *event, pref_
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_string(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -375,6 +394,8 @@ static gboolean reset_widget_string(GtkWidget *label, GdkEventButton *event, pre
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_bool(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -385,6 +406,8 @@ static gboolean reset_widget_bool(GtkWidget *label, GdkEventButton *event, pref_
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_int(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -394,6 +417,8 @@ static gboolean reset_widget_int(GtkWidget *label, GdkEventButton *event, pref_e
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_float(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -403,6 +428,8 @@ static gboolean reset_widget_float(GtkWidget *label, GdkEventButton *event, pref
   }
   return FALSE;
 }
+
+
 static gboolean reset_widget_lua(GtkWidget *label, GdkEventButton *event, pref_element *cur_elt)
 {
   if(event->type == GDK_2BUTTON_PRESS)
@@ -426,7 +453,6 @@ static gboolean reset_widget_lua(GtkWidget *label, GdkEventButton *event, pref_e
 }
 
 
-
 static void update_widget_enum(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
   char pref_name[1024];
@@ -434,23 +460,29 @@ static void update_widget_enum(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_enum), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_enum), cur_elt);
   gtk_combo_box_set_active(GTK_COMBO_BOX(cur_elt->widget), 0);
-  char*value= dt_conf_get_string(pref_name);
+  char*value = dt_conf_get_string(pref_name);
   do {
     char * active_entry = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(cur_elt->widget));
-    if(!active_entry) {
+    if(!active_entry)
+    {
       gtk_combo_box_set_active(GTK_COMBO_BOX(cur_elt->widget), -1);
       g_free(active_entry);
       break;
-    }else if(!strcmp(active_entry,value )) {
+    }
+    else if(!strcmp(active_entry, value))
+    {
       g_free(active_entry);
       break;
-    } else {
+    }
+    else
+    {
       gtk_combo_box_set_active(GTK_COMBO_BOX(cur_elt->widget), gtk_combo_box_get_active(GTK_COMBO_BOX(cur_elt->widget))+1);
       g_free(active_entry);
     }
-  } while (true);
-  free(value);
+  } while(true);
+  g_free(value);
 }
+
 
 static void update_widget_dir(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
@@ -463,6 +495,7 @@ static void update_widget_dir(pref_element* cur_elt,GtkWidget* dialog,GtkWidget*
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_dir), cur_elt);
 }
 
+
 static void update_widget_file(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
   char pref_name[1024];
@@ -473,6 +506,7 @@ static void update_widget_file(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_file), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_file), cur_elt);
 }
+
 
 static void update_widget_string(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
@@ -485,6 +519,7 @@ static void update_widget_string(pref_element* cur_elt,GtkWidget* dialog,GtkWidg
   g_free(str);
 }
 
+
 static void update_widget_bool(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
   char pref_name[1024];
@@ -493,6 +528,7 @@ static void update_widget_bool(pref_element* cur_elt,GtkWidget* dialog,GtkWidget
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_bool), cur_elt);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cur_elt->widget), dt_conf_get_bool(pref_name));
 }
+
 
 static void update_widget_int(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
@@ -503,6 +539,7 @@ static void update_widget_int(pref_element* cur_elt,GtkWidget* dialog,GtkWidget*
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_int), cur_elt);
 }
 
+
 static void update_widget_float(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
   char pref_name[1024];
@@ -511,6 +548,7 @@ static void update_widget_float(pref_element* cur_elt,GtkWidget* dialog,GtkWidge
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_float), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_float), cur_elt);
 }
+
 
 static void update_widget_lua(pref_element* cur_elt,GtkWidget* dialog,GtkWidget* labelev)
 {
@@ -524,6 +562,7 @@ static void update_widget_lua(pref_element* cur_elt,GtkWidget* dialog,GtkWidget*
   g_signal_connect(G_OBJECT(labelev), "button-press-event", G_CALLBACK(reset_widget_lua), cur_elt);
   g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(response_callback_lua), cur_elt);
 }
+
 
 static int register_pref_sub(lua_State *L)
 {
@@ -786,11 +825,14 @@ GtkGrid* init_tab_lua(GtkWidget *dialog, GtkWidget *tab)
   return GTK_GRID(grid);
 }
 
+
 void destroy_tab_lua(GtkGrid *grid)
 {
   if(!grid) return;
   gtk_grid_remove_column(grid,1); // detach all special widgets to avoid having them destroyed
 }
+
+
 int dt_lua_init_preferences(lua_State *L)
 {
   luaA_enum(L, lua_pref_type);


### PR DESCRIPTION
Replace `free` by `g_free` when memory has been allocated by GTK functions. Some minor reformating.