### PR TITLE
fix color picker

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -42,6 +42,7 @@
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "gui/color_picker_proxy.h"
 #include "libs/modulegroups.h"
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
@@ -381,6 +382,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
     module->picked_color_min[k] = module->picked_output_color_min[k] = 666.0f;
     module->picked_color_max[k] = module->picked_output_color_max[k] = -666.0f;
   }
+  module->picker = NULL;
   module->color_picker_box[0] = module->color_picker_box[1] = .25f;
   module->color_picker_box[2] = module->color_picker_box[3] = .75f;
   module->color_picker_point[0] = module->color_picker_point[1] = 0.5f;
@@ -1426,6 +1428,7 @@ void dt_iop_cleanup_module(dt_iop_module_t *module)
   module->blend_params = NULL;
   free(module->default_blendop_params);
   module->default_blendop_params = NULL;
+  module->picker = NULL;
   free(module->histogram);
   module->histogram = NULL;
   g_hash_table_destroy(module->raster_mask.source.users);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -44,6 +44,7 @@ struct dt_dev_pixelpipe_t;
 struct dt_dev_pixelpipe_iop_t;
 struct dt_develop_blend_params_t;
 struct dt_develop_tiling_t;
+struct dt_iop_color_picker_t;
 
 /** module group */
 typedef enum dt_iop_group_t
@@ -269,6 +270,8 @@ typedef struct dt_iop_module_t
   /** set to 1 if you want the blendif to be completely suppressed in the module in focus. only when the module has
    * the focus. */
   int32_t bypass_blendif;
+  /** color picker proxy */
+  struct dt_iop_color_picker_t *picker;
   /** bounding box in which the mean color is requested. */
   float color_picker_box[4];
   /** single point to pick if in point mode */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -33,6 +33,7 @@
 #include "gui/gtk.h"
 #include "libs/colorpicker.h"
 #include "libs/lib.h"
+#include "gui/color_picker_proxy.h"
 
 #include <assert.h>
 #include <math.h>
@@ -1038,6 +1039,14 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   free(buf);
 }
 
+static inline void _pixelpipe_apply_module_colorpicker(dt_iop_module_t *module)
+{
+  if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+    dt_iop_color_picker_apply_module(module);
+  else if(module->widget)
+    dt_control_queue_redraw_widget(module->widget);
+}
+
 // recursive helper for process:
 static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, void **output,
                                         void **cl_mem_output, dt_iop_buffer_dsc_t **out_format,
@@ -1453,7 +1462,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            if(module->widget) dt_control_queue_redraw_widget(module->widget);
+            _pixelpipe_apply_module_colorpicker(module);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1585,7 +1594,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            if(module->widget) dt_control_queue_redraw_widget(module->widget);
+            _pixelpipe_apply_module_colorpicker(module);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1799,7 +1808,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            if(module->widget) dt_control_queue_redraw_widget(module->widget);
+            _pixelpipe_apply_module_colorpicker(module);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1932,7 +1941,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
           dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-          if(module->widget) dt_control_queue_redraw_widget(module->widget);
+          _pixelpipe_apply_module_colorpicker(module);
 
           dt_pthread_mutex_lock(&pipe->busy_mutex);
         }
@@ -2030,7 +2039,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
         dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-        if(module->widget) dt_control_queue_redraw_widget(module->widget);
+        _pixelpipe_apply_module_colorpicker(module);
 
         dt_pthread_mutex_lock(&pipe->busy_mutex);
       }
@@ -2114,7 +2123,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
       dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-      if(module->widget) dt_control_queue_redraw_widget(module->widget);
+      _pixelpipe_apply_module_colorpicker(module);
 
       dt_pthread_mutex_lock(&pipe->busy_mutex);
     }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -54,7 +54,7 @@ static int _internal_iop_color_picker_get_set(dt_iop_color_picker_t *picker, Gtk
   picker->current_picker = PICKER_STATUS_SELECTED;
 
   if (current_picker == picker->current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return picker->current_picker;
 }
@@ -152,11 +152,11 @@ void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self
   // should returns -1 if the same picker was already selected.
   const int clicked_colorpick = dt_iop_color_picker_get_set(self, button);
 
-  if(self->module->request_color_pick == DT_REQUEST_COLORPICK_OFF || clicked_colorpick != ALREADY_SELECTED)
+  if(self->module->request_color_pick == DT_REQUEST_COLORPICK_OFF || clicked_colorpick != DT_COLOR_PICKER_ALREADY_SELECTED)
   {
     self->module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
-    if(clicked_colorpick != ALREADY_SELECTED)
+    if(clicked_colorpick != DT_COLOR_PICKER_ALREADY_SELECTED)
       self->current_picker = clicked_colorpick;
 
     if(self->kind == DT_COLOR_PICKER_AREA)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -27,10 +27,6 @@ typedef enum _internal__status
   PICKER_STATUS_SELECTED
 } dt_internal_status_t;
 
-/* a callback for the "draw" signal on the main IOP widget (self->widget) passed to gui_init. this is
-   to used to apply the picked value (requested in dt_iop_color_picker_callback) when available. */
-static gboolean _iop_color_picker_draw(GtkWidget *widget, cairo_t *cr, dt_iop_color_picker_t *self);
-
 static void _iop_record_point(dt_iop_color_picker_t *self)
 {
   const int pick_index = CLAMP(self->current_picker, 1, 9) - 1;
@@ -76,11 +72,21 @@ static void _internal_iop_color_picker_update(dt_iop_color_picker_t *picker)
   darktable.gui->reset = old_reset;
 }
 
+void dt_iop_color_picker_apply_module(dt_iop_module_t *module)
+{
+  if(module->picker && module->picker->apply)
+  {
+    module->picker->apply(module);
+    _iop_record_point(module->picker);
+  }
+}
+
 void dt_iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean update)
 {
-  picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+  if(picker->module->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+    picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   picker->current_picker = PICKER_STATUS_NONE;
-  if (update) dt_iop_color_picker_update(picker);
+  if(update) dt_iop_color_picker_update(picker);
 }
 
 int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button)
@@ -104,17 +110,17 @@ void dt_iop_color_picker_update(dt_iop_color_picker_t *picker)
     _internal_iop_color_picker_update(picker);
 }
 
-void init_single_picker (dt_iop_color_picker_t *picker,
+void dt_iop_init_single_picker(dt_iop_color_picker_t *picker,
                          dt_iop_module_t *module,
                          GtkWidget *colorpick,
                          dt_iop_color_picker_kind_t kind,
                          void (*apply)(dt_iop_module_t *self))
 {
   picker->colorpick = colorpick;
-  init_picker(picker, module, kind, NULL, apply, NULL);
+  dt_iop_init_picker(picker, module, kind, NULL, apply, NULL);
 }
 
-void init_picker (dt_iop_color_picker_t *picker,
+void dt_iop_init_picker(dt_iop_color_picker_t *picker,
                   dt_iop_module_t *module,
                   dt_iop_color_picker_kind_t kind,
                   int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
@@ -126,16 +132,13 @@ void init_picker (dt_iop_color_picker_t *picker,
   picker->apply   = apply;
   picker->update  = update;
   picker->kind    = kind;
+  module->picker  = picker;
 
   for(int i = 0; i<9; i++)
     for(int j = 0; j<2; j++)
       picker->pick_pos[i][j] = NAN;
 
   dt_iop_color_picker_reset(picker, TRUE);
-
-  /* The widget receives a draw signal right before being applied in
-     the pipeline. This is when we want to take into account the  picked color. */
-  g_signal_connect(G_OBJECT(picker->module->widget), "draw", G_CALLBACK(_iop_color_picker_draw), picker);
 }
 
 void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
@@ -175,26 +178,6 @@ void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self
   dt_iop_color_picker_update(self);
   dt_control_queue_redraw();
   dt_iop_request_focus(self->module);
-}
-
-static gboolean _iop_color_picker_draw(GtkWidget *widget, cairo_t *cr, dt_iop_color_picker_t *self)
-{
-  if(darktable.gui->reset) return FALSE;
-
-  /* The color picker is off */
-  if(self->module->request_color_pick == DT_REQUEST_COLORPICK_OFF) return FALSE;
-
-  /* No color picked, or picked color already applied */
-  if(self->module->picked_color_max[0] < 0.0f) return FALSE;
-
-  self->apply(self->module);
-
-  _iop_record_point(self);
-
-  /* Make sure next call won't re-apply in loop: draw -> picker -> set_sliders -> draw. */
-  self->module->picked_color_max[0] = -INFINITY;
-
-  return FALSE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -38,7 +38,7 @@ typedef enum _iop_color_picker_kind_t
   DT_COLOR_PICKER_AREA
 } dt_iop_color_picker_kind_t;
 
-typedef struct _iop_color_picker_t
+typedef struct dt_iop_color_picker_t
 {
   dt_iop_module_t *module;
   dt_iop_color_picker_kind_t kind;
@@ -57,7 +57,7 @@ typedef struct _iop_color_picker_t
 } dt_iop_color_picker_t;
 
 /* init color picker, this must be called when all picker widgets are created */
-void init_picker (dt_iop_color_picker_t *picker,
+void dt_iop_init_picker(dt_iop_color_picker_t *picker,
                   dt_iop_module_t *module,
                   dt_iop_color_picker_kind_t kind,
                   int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
@@ -65,7 +65,7 @@ void init_picker (dt_iop_color_picker_t *picker,
                   void (*update)(dt_iop_module_t *self));
 
 /* init for a single color picker in iop, this must be called when all picker widget are created */
-void init_single_picker (dt_iop_color_picker_t *picker,
+void dt_iop_init_single_picker(dt_iop_color_picker_t *picker,
                          dt_iop_module_t *module,
                          GtkWidget *colorpick,
                          dt_iop_color_picker_kind_t kind,
@@ -82,6 +82,9 @@ or for a simple togglebutton:
                        G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
 */
 void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self);
+
+/* called by pixelpipe when color has been updated */
+void dt_iop_color_picker_apply_module(dt_iop_module_t *module);
 
 /* call proxy get_set */
 int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button);

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -27,7 +27,7 @@
   a single color picker is available in a module.
 */
 
-#define ALREADY_SELECTED -1
+#define DT_COLOR_PICKER_ALREADY_SELECTED -1
 
 #include <gtk/gtk.h>
 #include "develop/imageop.h"
@@ -46,7 +46,7 @@ typedef struct dt_iop_color_picker_t
   GtkWidget *colorpick;
   float pick_pos[9][2]; // last picker positions (max 9 picker per module)
   /* get and set the selected picker corresponding to button, the module must record the previous
-     selected picker and return ALREADY_SELECTED if the same picker has been selected. The return
+     selected picker and return DT_COLOR_PICKER_ALREADY_SELECTED if the same picker has been selected. The return
      value corresponds to the module internal picker id. */
   int (*get_set)(dt_iop_module_t *self, GtkWidget *button);
   /* apply the picked color to the selected picker (internal picker id, if multiple are available

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -603,7 +603,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     g->color_picker.current_picker = DT_BORDERS_BORDER;
 
   if (current_picker == g->color_picker.current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return g->color_picker.current_picker;
 }

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1095,7 +1095,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->frame_picker), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
 
-  init_picker(&g->color_picker,
+  dt_iop_init_picker(&g->color_picker,
               self,
               DT_COLOR_PICKER_POINT,
               _iop_color_picker_get_set,

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1414,7 +1414,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     g->color_picker.current_picker = DT_PICKCOLBAL_AUTOCOLOR;
 
   if (current_picker == g->color_picker.current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return g->color_picker.current_picker;
 }

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -2644,7 +2644,7 @@ void gui_init(dt_iop_module_t *self)
 #undef ADD_FACTOR
 #undef ADD_CHANNEL
 
-  init_picker(&g->color_picker,
+  dt_iop_init_picker(&g->color_picker,
               self,
               DT_COLOR_PICKER_AREA,
               _iop_color_picker_get_set,

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -299,11 +299,12 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self)
   p->hue        = H;
   p->saturation = S;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->gslider1, p->hue);
   dt_bauhaus_slider_set(g->gslider2, p->saturation);
   update_saturation_slider_end_color(g->gslider2, p->hue);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -452,7 +453,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->scale1), "value-changed", G_CALLBACK(lightness_callback), self);
   g_signal_connect(G_OBJECT(g->scale2), "value-changed", G_CALLBACK(source_lightness_mix_callback), self);
 
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      g->gslider1,
                      DT_COLOR_PICKER_POINT,

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1042,6 +1042,7 @@ static void _iop_color_picker_apply(dt_iop_module_t *self)
     gd->picked_color[k] = self->picked_color[k];
     gd->picked_color_max[k] = self->picked_color_max[k];
   }
+  dt_control_queue_redraw_widget(self->widget);
 }
 
 void gui_init(struct dt_iop_module_t *self)
@@ -1135,7 +1136,7 @@ void gui_init(struct dt_iop_module_t *self)
   cmsHPROFILE hLab = dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;
   c->xform = cmsCreateTransform(hLab, TYPE_Lab_DBL, hsRGB, TYPE_RGB_DBL, INTENT_PERCEPTUAL, 0);
 
-  init_single_picker(&c->color_picker,
+  dt_iop_init_single_picker(&c->color_picker,
                      self,
                      GTK_WIDGET(c->colorpicker),
                      DT_COLOR_PICKER_POINT,

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -889,7 +889,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     g->color_picker.current_picker = DT_PICKPROFLOG_AUTOTUNE;
 
   if (current_picker == g->color_picker.current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return g->color_picker.current_picker;
 }

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1862,7 +1862,7 @@ void gui_init(dt_iop_module_t *self)
                                                  "you should never touch that unless you know what you are doing."));
   g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
 
-  init_picker(&g->color_picker,
+  dt_iop_init_picker(&g->color_picker,
               self,
               DT_COLOR_PICKER_AREA,
               _iop_color_picker_get_set,

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -437,11 +437,12 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self)
   p->hue        = H;
   p->saturation = S;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->gslider1, p->hue);
   dt_bauhaus_slider_set(g->gslider2, p->saturation);
   update_saturation_slider_end_color(g->gslider2, p->hue);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1253,7 +1254,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->dragging = 0;
   g->define = 0;
 
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      g->gslider1,
                      DT_COLOR_PICKER_POINT,

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -177,6 +177,7 @@ static void _iop_color_picker_apply(dt_iop_module_t *self)
   darktable.gui->reset = 0;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+  dt_control_queue_redraw_widget(self->widget);
 }
 
 static void colorpicker_callback(GtkColorButton *widget, dt_iop_module_t *self)
@@ -613,7 +614,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->picker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
   gtk_box_pack_start(GTK_BOX(g->pickerbuttons), g->picker, TRUE, TRUE, 5);
 
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      GTK_WIDGET(g->picker),
                      DT_COLOR_PICKER_AREA,

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -248,7 +248,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     g->color_picker.current_picker = WHITE;
 
   if (current_picker == g->color_picker.current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return g->color_picker.current_picker;
 }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -775,7 +775,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->greypick), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &c->color_picker);
   g_signal_connect(G_OBJECT(c->whitepick), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &c->color_picker);
 
-  init_picker(&c->color_picker,
+  dt_iop_init_picker(&c->color_picker,
               self,
               DT_COLOR_PICKER_POINT,
               _iop_color_picker_get_set,

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -445,6 +445,7 @@ static void _iop_color_picker_apply(dt_iop_module_t *self)
   p->size = CLAMP((da + db)/128.0, .5, 3.0);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+  dt_control_queue_redraw_widget(self->widget);
 }
 
 static gboolean dt_iop_monochrome_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
@@ -614,7 +615,7 @@ void gui_init(struct dt_iop_module_t *self)
   cmsHPROFILE hLab = dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;
   g->xform = cmsCreateTransform(hLab, TYPE_Lab_DBL, hsRGB, TYPE_RGB_DBL, INTENT_PERCEPTUAL,
                                 0); // cmsFLAGS_NOTPRECALC);
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      GTK_WIDGET(g->colorpicker),
                      DT_COLOR_PICKER_AREA,

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -612,7 +612,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     g->color_picker.current_picker = DT_PICKPROFLOG_AUTOTUNE;
 
   if (current_picker == g->color_picker.current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return g->color_picker.current_picker;
 }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -947,7 +947,7 @@ void gui_init(dt_iop_module_t *self)
       break;
   }
 
-  init_picker(&g->color_picker,
+  dt_iop_init_picker(&g->color_picker,
               self,
               DT_COLOR_PICKER_AREA,
               _iop_color_picker_get_set,

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -234,6 +234,7 @@ static void center_callback(GtkDarktableGradientSlider *slider, gpointer user_da
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
+  if(self->dt->gui->reset) return;
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)self->params;
   dt_iop_color_picker_reset(&g->color_picker, TRUE);
 
@@ -314,8 +315,6 @@ static void _iop_color_picker_apply(dt_iop_module_t *self)
   }
 
   dtgtk_gradient_slider_set_picker_meanminmax(DTGTK_GRADIENT_SLIDER(g->gslider1), mean, min, max);
-
-  gtk_widget_queue_draw(GTK_WIDGET(g->gslider1));
 }
 
 void gui_init(struct dt_iop_module_t *self)
@@ -367,7 +366,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->tbutton1), _("toggle tool for picking median lightness in image"));
 
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      GTK_WIDGET(g->tbutton1),
                      DT_COLOR_PICKER_POINT,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2939,7 +2939,7 @@ void gui_init(dt_iop_module_t *self)
 
   rt_show_hide_controls(self, g, p, g);
 
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      GTK_WIDGET(g->colorpicker),
                      DT_COLOR_PICKER_POINT,

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -663,7 +663,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->colorpick1), "color-set", G_CALLBACK(colorpick_callback), self);
   g_signal_connect(G_OBJECT(g->colorpick2), "color-set", G_CALLBACK(colorpick_callback), self);
 
-  init_picker(&g->color_picker,
+  dt_iop_init_picker(&g->color_picker,
               self,
               DT_COLOR_PICKER_POINT,
               _iop_color_picker_get_set,

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -431,7 +431,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     g->color_picker.current_picker = DT_SPLITTONING_SHADOWS;
 
   if (current_picker == g->color_picker.current_picker)
-    return ALREADY_SELECTED;
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return g->color_picker.current_picker;
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1004,6 +1004,7 @@ static void _iop_color_picker_apply(dt_iop_module_t *self)
     gd->picked_color_max[k] = self->picked_color_max[k];
     gd->picked_output_color[k] = self->picked_output_color[k];
   }
+  dt_control_queue_redraw_widget(self->widget);
 }
 
 static void dt_iop_tonecurve_sanity_check(dt_iop_module_t *self, GtkWidget *widget)
@@ -1278,7 +1279,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_size_group_add_widget(c->sizegroup, GTK_WIDGET(c->area));
   gtk_size_group_add_widget(c->sizegroup, GTK_WIDGET(c->channel_tabs));
 
-  init_single_picker(&c->color_picker,
+  dt_iop_init_single_picker(&c->color_picker,
                      self,
                      GTK_WIDGET(c->colorpicker),
                      DT_COLOR_PICKER_POINT,
@@ -1513,7 +1514,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_restore(cr);
     }
 
-    if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
+    if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
     {
       // the global live samples ...
       GSList *samples = darktable.lib->proxy.colorpicker.live_samples;

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1498,7 +1498,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(colorpick_color_set), self);
   g_signal_connect(G_OBJECT(g->fontsel), "font-set", G_CALLBACK(fontsel_callback), self);
 
-  init_single_picker(&g->color_picker,
+  dt_iop_init_single_picker(&g->color_picker,
                      self,
                      GTK_WIDGET(g->color_picker_button),
                      DT_COLOR_PICKER_POINT,


### PR DESCRIPTION
This fixes  #2145

Also:

When the colorpicker modify the values of a module, like the monochrome, the blend colorpicker also was modifying it.

When a module display the colorpicker values, like the tonecurve, the blend colorpicker also was displaying it.

I have ported the exposure and temperature to the new proxy schema.

The colorchecker still needs to be ported, but I have no idea how it works, so someone else will have to do it.

There's still some minor issues, mostly iop related, I'll work on some of them on a separate PR.