### PR TITLE
upgrade color picker

### DIFF
--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -18,13 +18,15 @@
 
 #include "common/color_picker.h"
 #include "common/darktable.h"
+#include "common/colorspaces_inline_conversions.h"
 #include "develop/format.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 
 static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                         const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                                        float *const picked_color_min, float *const picked_color_max)
+                                        float *const picked_color_min, float *const picked_color_max,
+                                        const int cst_to)
 {
   const int width = roi->width;
 
@@ -38,18 +40,20 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *dsc, const fl
     for(size_t i = box[0]; i < box[2]; i++)
     {
       const size_t k = 4 * (width * j + i);
-      const float L = pixel[k];
-      const float a = pixel[k + 1];
-      const float b = pixel[k + 2];
-      picked_color[0] += w * L;
-      picked_color[1] += w * a;
-      picked_color[2] += w * b;
-      picked_color_min[0] = fminf(picked_color_min[0], L);
-      picked_color_min[1] = fminf(picked_color_min[1], a);
-      picked_color_min[2] = fminf(picked_color_min[2], b);
-      picked_color_max[0] = fmaxf(picked_color_max[0], L);
-      picked_color_max[1] = fmaxf(picked_color_max[1], a);
-      picked_color_max[2] = fmaxf(picked_color_max[2], b);
+      float Lab[3] = { pixel[k], pixel[k + 1], pixel[k + 2] };
+      if(cst_to == iop_cs_LCh)
+        dt_Lab_2_LCH(pixel + k, Lab);
+      if(cst_to == iop_cs_HSL)
+        dt_RGB_2_HSL(pixel + k, Lab);
+      picked_color[0] += w * Lab[0];
+      picked_color[1] += w * Lab[1];
+      picked_color[2] += w * Lab[2];
+      picked_color_min[0] = fminf(picked_color_min[0], Lab[0]);
+      picked_color_min[1] = fminf(picked_color_min[1], Lab[1]);
+      picked_color_min[2] = fminf(picked_color_min[2], Lab[2]);
+      picked_color_max[0] = fmaxf(picked_color_max[0], Lab[0]);
+      picked_color_max[1] = fmaxf(picked_color_max[1], Lab[1]);
+      picked_color_max[2] = fmaxf(picked_color_max[2], Lab[2]);
     }
   }
 }
@@ -57,7 +61,7 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *dsc, const fl
 static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                              const dt_iop_roi_t *roi, const int *const box,
                                              float *const picked_color, float *const picked_color_min,
-                                             float *const picked_color_max)
+                                             float *const picked_color_max, const int cst_to)
 {
   const int width = roi->width;
 
@@ -96,18 +100,20 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *dsc, con
       for(size_t i = box[0]; i < box[2]; i++)
       {
         const size_t k = 4 * (width * j + i);
-        const float L = pixel[k];
-        const float a = pixel[k + 1];
-        const float b = pixel[k + 2];
-        tmean[0] += w * L;
-        tmean[1] += w * a;
-        tmean[2] += w * b;
-        tmmin[0] = fminf(tmmin[0], L);
-        tmmin[1] = fminf(tmmin[1], a);
-        tmmin[2] = fminf(tmmin[2], b);
-        tmmax[0] = fmaxf(tmmax[0], L);
-        tmmax[1] = fmaxf(tmmax[1], a);
-        tmmax[2] = fmaxf(tmmax[2], b);
+        float Lab[3] = { pixel[k], pixel[k + 1], pixel[k + 2] };
+        if(cst_to == iop_cs_LCh)
+          dt_Lab_2_LCH(pixel + k, Lab);
+        if(cst_to == iop_cs_HSL)
+          dt_RGB_2_HSL(pixel + k, Lab);
+        tmean[0] += w * Lab[0];
+        tmean[1] += w * Lab[1];
+        tmean[2] += w * Lab[2];
+        tmmin[0] = fminf(tmmin[0], Lab[0]);
+        tmmin[1] = fminf(tmmin[1], Lab[1]);
+        tmmin[2] = fminf(tmmin[2], Lab[2]);
+        tmmax[0] = fmaxf(tmmax[0], Lab[0]);
+        tmmax[1] = fmaxf(tmmax[1], Lab[1]);
+        tmmax[2] = fmaxf(tmmax[2], Lab[2]);
       }
     }
   }
@@ -129,14 +135,14 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *dsc, con
 
 static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                     const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                                    float *const picked_color_min, float *const picked_color_max)
+                                    float *const picked_color_min, float *const picked_color_max, const int cst_to)
 {
   const size_t size = ((box[3] - box[1]) * (box[2] - box[0]));
 
   if(size > 100) // avoid inefficient multi-threading in case of small region size (arbitrary limit)
-    return color_picker_helper_4ch_parallel(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+    return color_picker_helper_4ch_parallel(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, cst_to);
   else
-    return color_picker_helper_4ch_seq(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+    return color_picker_helper_4ch_seq(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, cst_to);
 }
 
 static void color_picker_helper_bayer_seq(const dt_iop_buffer_dsc_t *const dsc, const float *const pixel,
@@ -395,10 +401,14 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *dsc, const flo
 
 void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
                             const int *const box, float *const picked_color, float *const picked_color_min,
-                            float *const picked_color_max)
+                            float *const picked_color_max, const int image_cst, const int picker_cst)
 {
-  if(dsc->channels == 4u)
-    color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+  if((dsc->channels == 4u) && ((image_cst == picker_cst) || (picker_cst == -1)))
+    color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst);
+  else if(dsc->channels == 4u && image_cst == iop_cs_Lab && picker_cst == iop_cs_LCh)
+    color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst);
+  else if(dsc->channels == 4u && image_cst == iop_cs_rgb && picker_cst == iop_cs_HSL)
+    color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst);
   else if(dsc->channels == 1u && dsc->filters && dsc->filters != 9u)
     color_picker_helper_bayer(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
   else if(dsc->channels == 1u && dsc->filters && dsc->filters == 9u)

--- a/src/common/color_picker.c
+++ b/src/common/color_picker.c
@@ -26,7 +26,7 @@
 static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                         const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
                                         float *const picked_color_min, float *const picked_color_max,
-                                        const int cst_to)
+                                        const dt_iop_colorspace_type_t cst_to)
 {
   const int width = roi->width;
 
@@ -61,7 +61,7 @@ static void color_picker_helper_4ch_seq(const dt_iop_buffer_dsc_t *dsc, const fl
 static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                              const dt_iop_roi_t *roi, const int *const box,
                                              float *const picked_color, float *const picked_color_min,
-                                             float *const picked_color_max, const int cst_to)
+                                             float *const picked_color_max, const dt_iop_colorspace_type_t cst_to)
 {
   const int width = roi->width;
 
@@ -135,7 +135,7 @@ static void color_picker_helper_4ch_parallel(const dt_iop_buffer_dsc_t *dsc, con
 
 static void color_picker_helper_4ch(const dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                                     const dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                                    float *const picked_color_min, float *const picked_color_max, const int cst_to)
+                                    float *const picked_color_min, float *const picked_color_max, const dt_iop_colorspace_type_t cst_to)
 {
   const size_t size = ((box[3] - box[1]) * (box[2] - box[0]));
 
@@ -401,7 +401,7 @@ static void color_picker_helper_xtrans(const dt_iop_buffer_dsc_t *dsc, const flo
 
 void dt_color_picker_helper(const dt_iop_buffer_dsc_t *dsc, const float *const pixel, const dt_iop_roi_t *roi,
                             const int *const box, float *const picked_color, float *const picked_color_min,
-                            float *const picked_color_max, const int image_cst, const int picker_cst)
+                            float *const picked_color_max, const dt_iop_colorspace_type_t image_cst, const dt_iop_colorspace_type_t picker_cst)
 {
   if((dsc->channels == 4u) && ((image_cst == picker_cst) || (picker_cst == -1)))
     color_picker_helper_4ch(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max, picker_cst);

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -20,11 +20,12 @@
 
 struct dt_iop_buffer_dsc_t;
 struct dt_iop_roi_t;
+enum dt_iop_colorspace_type_t;
 
 void dt_color_picker_helper(const struct dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                             const struct dt_iop_roi_t *roi, const int *const box, float *const picked_color,
                             float *const picked_color_min, float *const picked_color_max,
-                            const int image_cst, const int picker_cst);
+                            const enum dt_iop_colorspace_type_t image_cst, const enum dt_iop_colorspace_type_t picker_cst);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/color_picker.h
+++ b/src/common/color_picker.h
@@ -23,7 +23,8 @@ struct dt_iop_roi_t;
 
 void dt_color_picker_helper(const struct dt_iop_buffer_dsc_t *dsc, const float *const pixel,
                             const struct dt_iop_roi_t *roi, const int *const box, float *const picked_color,
-                            float *const picked_color_min, float *const picked_color_max);
+                            float *const picked_color_min, float *const picked_color_max,
+                            const int image_cst, const int picker_cst);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -22,6 +22,7 @@
 
 #ifdef __SSE2__
 #include "common/sse.h"
+#include "common/math.h"
 #include <xmmintrin.h>
 
 static inline __m128 lab_f_inv_m(const __m128 x)
@@ -302,6 +303,68 @@ static inline void dt_prophotorgb_to_Lab(const float *const rgb, float *Lab)
   float XYZ[3] = { 0.0f };
   dt_prophotorgb_to_XYZ(rgb, XYZ);
   dt_XYZ_to_Lab(XYZ, Lab);
+}
+
+static inline void dt_RGB_2_HSL(const float *RGB, float *HSL)
+{
+  float H, S, L;
+
+  float R = RGB[0];
+  float G = RGB[1];
+  float B = RGB[2];
+
+  float var_Min = fminf(R, fminf(G, B));
+  float var_Max = fmaxf(R, fmaxf(G, B));
+  float del_Max = var_Max - var_Min;
+
+  L = (var_Max + var_Min) / 2.0f;
+
+  if(del_Max == 0.0f)
+  {
+    H = 0.0f;
+    S = 0.0f;
+  }
+  else
+  {
+    if(L < 0.5f)
+      S = del_Max / (var_Max + var_Min);
+    else
+      S = del_Max / (2.0f - var_Max - var_Min);
+
+    float del_R = (((var_Max - R) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+    float del_G = (((var_Max - G) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+    float del_B = (((var_Max - B) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+
+    if(R == var_Max)
+      H = del_B - del_G;
+    else if(G == var_Max)
+      H = (1.0f / 3.0f) + del_R - del_B;
+    else if(B == var_Max)
+      H = (2.0f / 3.0f) + del_G - del_R;
+    else
+      H = 0.0f; // make GCC happy
+
+    if(H < 0.0f) H += 1.0f;
+    if(H > 1.0f) H -= 1.0f;
+  }
+
+  HSL[0] = H;
+  HSL[1] = S;
+  HSL[2] = L;
+}
+
+static inline void dt_Lab_2_LCH(const float *Lab, float *LCH)
+{
+  float var_H = atan2f(Lab[2], Lab[1]);
+
+  if(var_H > 0.0f)
+    var_H = var_H / (2.0f * DT_M_PI_F);
+  else
+    var_H = 1.0f - fabs(var_H) / (2.0f * DT_M_PI_F);
+
+  LCH[0] = Lab[0];
+  LCH[1] = sqrtf(Lab[1] * Lab[1] + Lab[2] * Lab[2]);
+  LCH[2] = var_H;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -23,6 +23,7 @@
 #include "develop/pixelpipe.h"
 #include "dtgtk/button.h"
 #include "dtgtk/gradientslider.h"
+#include "gui/color_picker_proxy.h"
 
 #define DEVELOP_BLEND_VERSION (9)
 
@@ -398,6 +399,9 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *upper_polarity;
   GtkWidget *lower_polarity;
   GtkWidget *colorpicker;
+  GtkWidget *colorpicker_set_values;
+  dt_iop_color_picker_t color_picker;
+  int picker_set_upper_lower;
   GtkWidget *showmask;
   GtkWidget *suppress;
   void (*scale_print[8])(float value, char *string, int n);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -527,9 +527,9 @@ static void _blendop_blendif_polarity_callback(GtkToggleButton *togglebutton, dt
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
 }
 
-static int _blendop_blendif_get_picker_colorspace(dt_iop_gui_blend_data_t *bd)
+static dt_iop_colorspace_type_t _blendop_blendif_get_picker_colorspace(dt_iop_gui_blend_data_t *bd)
 {
-  int picker_cst = -1;
+  dt_iop_colorspace_type_t picker_cst = -1;
 
   if(bd->csp == iop_cs_rgb)
   {
@@ -614,7 +614,8 @@ static void _blendop_blendif_tab_switch(GtkNotebook *notebook, GtkWidget *page, 
 
   data->tab = page_num;
 
-  if(data->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && cst_old != _blendop_blendif_get_picker_colorspace(data))
+  if(data->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && 
+      (cst_old != _blendop_blendif_get_picker_colorspace(data) || data->color_picker.current_picker == DT_BLENDIF_PICK_SET_VALUES))
   {
     data->module->picker_cst = _blendop_blendif_get_picker_colorspace(data);
     dt_dev_reprocess_all(data->module->dev);
@@ -756,6 +757,7 @@ static void _blendop_blendif_reset(GtkButton *button, dt_iop_module_t *module)
   memcpy(module->blend_params->blendif_parameters, module->default_blendop_params->blendif_parameters,
          4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
 
+  dt_iop_color_picker_reset(module, TRUE);
   dt_iop_gui_update_blendif(module);
   dt_dev_add_history_item(darktable.develop, module, TRUE);
 }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1042,10 +1042,10 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module)
     _blendif_scale(cst, raw_min, picker_min);
     _blendif_scale(cst, raw_max, picker_max);
 
-    picker_values[0] = CLAMP(picker_min[tab] - .01f, 0.f, 1.f);
+    picker_values[0] = CLAMP(picker_min[tab] - .02f, 0.f, 1.f);
     picker_values[1] = CLAMP(picker_min[tab], 0.f, 1.f);
     picker_values[2] = CLAMP(picker_max[tab], 0.f, 1.f);
-    picker_values[3] = CLAMP(picker_max[tab] + .01f, 0.f, 1.f);
+    picker_values[3] = CLAMP(picker_max[tab] + .02f, 0.f, 1.f);
     
     picker_values[0] = CLAMP(picker_values[0], 0.f, picker_values[1]);
     picker_values[3] = CLAMP(picker_values[3], picker_values[2], 1.f);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -55,6 +55,12 @@ typedef enum _iop_gui_blendif_channel_t
   ch_max = 4
 } _iop_gui_blendif_channel_t;
 
+typedef enum dt_gui_blendif_pickcolor_type_t
+{
+  DT_BLENDIF_PICK_NONE = 0,
+  DT_BLENDIF_PICK_COLORPICK = 1,
+  DT_BLENDIF_PICK_SET_VALUES = 2
+} dt_gui_blendif_pickcolor_type_t;
 
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_L[]
@@ -114,94 +120,72 @@ static const dt_iop_gui_blendif_colorstop_t _gradient_HUE[]
         { 1.0f, { NEUTRAL_GRAY, 0, 0, 1.0 } } };
 
 
-static inline void _RGB_2_HSL(const float *RGB, float *HSL)
+static void _cairo_paint_colorpicker_set_values(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float H, S, L;
+  gint s = (w < h ? w : h);
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
 
-  float R = RGB[0];
-  float G = RGB[1];
-  float B = RGB[2];
+  /* draw pipette */
 
-  float var_Min = fminf(R, fminf(G, B));
-  float var_Max = fmaxf(R, fmaxf(G, B));
-  float del_Max = var_Max - var_Min;
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
-  L = (var_Max + var_Min) / 2.0f;
+  // drop
+  cairo_set_line_width(cr, 0.15);
+  cairo_move_to(cr, 0.08, 1. - 0.01 + 0.05);
+  cairo_line_to(cr, 0.08, 1. - 0.09 + 0.05);
+  cairo_stroke(cr);
 
-  if(del_Max == 0.0f)
-  {
-    H = 0.0f;
-    S = 0.0f;
-  }
-  else
-  {
-    if(L < 0.5f)
-      S = del_Max / (var_Max + var_Min);
-    else
-      S = del_Max / (2.0f - var_Max - var_Min);
+  cairo_set_line_width(cr, 0.2);
+  // cross line
+  cairo_move_to(cr, 0.48, 1. - 0.831 + 0.05);
+  cairo_line_to(cr, 0.739, 1. - 0.482 + 0.05);
+  // shaft
+  cairo_move_to(cr, 0.124, 1. - 0.297 + 0.05);
+  cairo_line_to(cr, 0.823, 1. - 0.814 + 0.05);
+  cairo_stroke(cr);
 
-    float del_R = (((var_Max - R) / 6.0f) + (del_Max / 2.0f)) / del_Max;
-    float del_G = (((var_Max - G) / 6.0f) + (del_Max / 2.0f)) / del_Max;
-    float del_B = (((var_Max - B) / 6.0f) + (del_Max / 2.0f)) / del_Max;
-
-    if(R == var_Max)
-      H = del_B - del_G;
-    else if(G == var_Max)
-      H = (1.0f / 3.0f) + del_R - del_B;
-    else if(B == var_Max)
-      H = (2.0f / 3.0f) + del_G - del_R;
-    else
-      H = 0.0f; // make GCC happy
-
-    if(H < 0.0f) H += 1.0f;
-    if(H > 1.0f) H -= 1.0f;
-  }
-
-  HSL[0] = H;
-  HSL[1] = S;
-  HSL[2] = L;
+  // end
+  cairo_set_line_width(cr, 0.35);
+  cairo_move_to(cr, 0.823, 1. - 0.814 + 0.05);
+  cairo_line_to(cr, 0.648, 1. - 0.685 + 0.05);
+  cairo_stroke(cr);
+  
+  // plus sign
+  cairo_set_line_width(cr, 0.2);
+  cairo_move_to(cr, 0.20, 0.01);
+  cairo_line_to(cr, 0.20, 0.41);
+  cairo_stroke(cr);
+  cairo_move_to(cr, 0.01, 0.20);
+  cairo_line_to(cr, 0.41, 0.20);
+  cairo_stroke(cr);
 }
-
-
-static inline void _Lab_2_LCH(const float *Lab, float *LCH)
-{
-  float var_H = atan2f(Lab[2], Lab[1]);
-
-  if(var_H > 0.0f)
-    var_H = var_H / (2.0f * M_PI);
-  else
-    var_H = 1.0f - fabs(var_H) / (2.0f * M_PI);
-
-  LCH[0] = Lab[0];
-  LCH[1] = sqrtf(Lab[1] * Lab[1] + Lab[2] * Lab[2]);
-  LCH[2] = var_H;
-}
-
 
 static void _blendif_scale(dt_iop_colorspace_type_t cst, const float *in, float *out)
 {
-  float temp[4];
+  out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
 
   switch(cst)
   {
     case iop_cs_Lab:
-      _Lab_2_LCH(in, temp);
       out[0] = CLAMP_RANGE(in[0] / 100.0f, 0.0f, 1.0f);
       out[1] = CLAMP_RANGE((in[1] + 128.0f) / 256.0f, 0.0f, 1.0f);
       out[2] = CLAMP_RANGE((in[2] + 128.0f) / 256.0f, 0.0f, 1.0f);
-      out[3] = CLAMP_RANGE(temp[1] / (128.0f * sqrtf(2.0f)), 0.0f, 1.0f);
-      out[4] = CLAMP_RANGE(temp[2], 0.0f, 1.0f);
-      out[5] = out[6] = out[7] = -1;
       break;
     case iop_cs_rgb:
-      _RGB_2_HSL(in, temp);
       out[0] = CLAMP_RANGE(0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2], 0.0f, 1.0f);
       out[1] = CLAMP_RANGE(in[0], 0.0f, 1.0f);
       out[2] = CLAMP_RANGE(in[1], 0.0f, 1.0f);
       out[3] = CLAMP_RANGE(in[2], 0.0f, 1.0f);
-      out[4] = CLAMP_RANGE(temp[0], 0.0f, 1.0f);
-      out[5] = CLAMP_RANGE(temp[1], 0.0f, 1.0f);
-      out[6] = CLAMP_RANGE(temp[2], 0.0f, 1.0f);
+      break;
+    case iop_cs_LCh:
+      out[3] = CLAMP_RANGE(in[1] / (128.0f * sqrtf(2.0f)), 0.0f, 1.0f);
+      out[4] = CLAMP_RANGE(in[2], 0.0f, 1.0f);
+      break;
+    case iop_cs_HSL:
+      out[4] = CLAMP_RANGE(in[0], 0.0f, 1.0f);
+      out[5] = CLAMP_RANGE(in[1], 0.0f, 1.0f);
+      out[6] = CLAMP_RANGE(in[2], 0.0f, 1.0f);
       out[7] = -1;
       break;
     default:
@@ -211,29 +195,29 @@ static void _blendif_scale(dt_iop_colorspace_type_t cst, const float *in, float 
 
 static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *out)
 {
-  float temp[4];
+  out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
 
   switch(cst)
   {
     case iop_cs_Lab:
-      _Lab_2_LCH(in, temp);
       out[0] = in[0];
       out[1] = in[1];
       out[2] = in[2];
-      out[3] = temp[1] / (128.0f * sqrtf(2.0f)) * 100.0f;
-      out[4] = temp[2] * 360.0f;
-      out[5] = out[6] = out[7] = -1;
       break;
     case iop_cs_rgb:
-      _RGB_2_HSL(in, temp);
       out[0] = (0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2]) * 255.0f;
       out[1] = in[0] * 255.0f;
       out[2] = in[1] * 255.0f;
       out[3] = in[2] * 255.0f;
-      out[4] = temp[0] * 360.0f;
-      out[5] = temp[1] * 100.0f;
-      out[6] = temp[2] * 100.0f;
-      out[7] = -1;
+      break;
+    case iop_cs_LCh:
+      out[3] = in[1] / (128.0f * sqrtf(2.0f)) * 100.0f;
+      out[4] = in[2] * 360.0f;
+      break;
+    case iop_cs_HSL:
+      out[4] = in[0] * 360.0f;
+      out[5] = in[1] * 100.0f;
+      out[6] = in[2] * 100.0f;
       break;
     default:
       out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
@@ -378,12 +362,8 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
   }
   else if(data->blendif_inited)
   {
-    /* switch off color picker - only if it was requested by blendif */
-    if(data->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND)
-    {
-      data->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->colorpicker), 0);
-    }
+    /* switch off color picker */
+    dt_iop_color_picker_reset(data->module, TRUE);
 
     gtk_widget_hide(GTK_WIDGET(data->blendif_box));
   }
@@ -547,41 +527,101 @@ static void _blendop_blendif_polarity_callback(GtkToggleButton *togglebutton, dt
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
 }
 
+static int _blendop_blendif_get_picker_colorspace(dt_iop_gui_blend_data_t *bd)
+{
+  int picker_cst = -1;
+
+  if(bd->csp == iop_cs_rgb)
+  {
+    if(bd->tab < 4)
+      picker_cst = iop_cs_rgb;
+    else
+      picker_cst = iop_cs_HSL;
+  }
+  else if(bd->csp == iop_cs_Lab)
+  {
+    if(bd->tab < 3)
+      picker_cst = iop_cs_Lab;
+    else
+      picker_cst = iop_cs_LCh;
+  }
+
+  return picker_cst;
+}
+
+static void _update_gradient_slider(GtkWidget *widget, dt_iop_module_t *module)
+{
+  dt_iop_gui_blend_data_t *data = module->blend_data;
+  float picker_mean[8], picker_min[8], picker_max[8];
+  float cooked[8];
+  float *raw_mean, *raw_min, *raw_max;
+  char text[256];
+  GtkLabel *label;
+
+  if(widget == GTK_WIDGET(data->lower_slider))
+  {
+    raw_mean = module->picked_color;
+    raw_min = module->picked_color_min;
+    raw_max = module->picked_color_max;
+    label = data->lower_picker_label;
+  }
+  else
+  {
+    raw_mean = module->picked_output_color;
+    raw_min = module->picked_output_color_min;
+    raw_max = module->picked_output_color_max;
+    label = data->upper_picker_label;
+  }
+
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+  if((module->request_color_pick == DT_REQUEST_COLORPICK_BLEND) && (raw_min[0] != INFINITY))
+  {
+    const int cst = (module->picker_cst == -1) ? data->csp: module->picker_cst;
+    _blendif_scale(cst, raw_mean, picker_mean);
+    _blendif_scale(cst, raw_min, picker_min);
+    _blendif_scale(cst, raw_max, picker_max);
+    _blendif_cook(cst, raw_mean, cooked);
+
+    snprintf(text, sizeof(text), "(%.1f)", cooked[data->tab]);
+
+    dtgtk_gradient_slider_multivalue_set_picker_meanminmax(
+        DTGTK_GRADIENT_SLIDER(widget), picker_mean[data->tab], picker_min[data->tab], picker_max[data->tab]);
+    gtk_label_set_text(label, text);
+  }
+  else
+  {
+    dtgtk_gradient_slider_multivalue_set_picker(DTGTK_GRADIENT_SLIDER(widget), NAN);
+    gtk_label_set_text(label, "");
+  }
+
+  darktable.gui->reset = reset;
+}
+
+static gboolean _blendop_blendif_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *module)
+{
+  if(darktable.gui->reset) return FALSE;
+
+  _update_gradient_slider(widget, module);
+
+  return FALSE;
+}
 
 static void _blendop_blendif_tab_switch(GtkNotebook *notebook, GtkWidget *page, guint page_num,
                                         dt_iop_gui_blend_data_t *data)
 {
+  const int cst_old = _blendop_blendif_get_picker_colorspace(data);
+
   data->tab = page_num;
-  dt_iop_gui_update_blendif(data->module);
-}
 
-
-static void _blendop_blendif_pick_toggled(GtkToggleButton *togglebutton, dt_iop_module_t *module)
-{
-  if(darktable.gui->reset) return;
-
-  /* if module itself already requested color pick don't tamper with it. A module color picker takes
-   * precedence. */
-  if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  if(data->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && cst_old != _blendop_blendif_get_picker_colorspace(data))
   {
-    gtk_toggle_button_set_active(togglebutton, 0);
-    return;
-  }
-
-  module->request_color_pick
-      = (gtk_toggle_button_get_active(togglebutton) ? DT_REQUEST_COLORPICK_BLEND : DT_REQUEST_COLORPICK_OFF);
-
-  /* set the area sample size */
-  if(module->request_color_pick != DT_REQUEST_COLORPICK_OFF)
-  {
-    dt_lib_colorpicker_set_point(darktable.lib, 0.5, 0.5);
-    dt_dev_reprocess_all(module->dev);
-  }
-  else
+    data->module->picker_cst = _blendop_blendif_get_picker_colorspace(data);
+    dt_dev_reprocess_all(data->module->dev);
     dt_control_queue_redraw();
+  }
 
-  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
-  dt_iop_request_focus(module);
+  dt_iop_gui_update_blendif(data->module);
 }
 
 static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton *event, dt_iop_module_t *module)
@@ -741,6 +781,11 @@ static void _blendop_blendif_invert(GtkButton *button, dt_iop_module_t *module)
     case iop_cs_RAW:
       toggle_mask = 0;
       break;
+
+    case iop_cs_LCh:
+    case iop_cs_HSL:
+      toggle_mask = 0;
+      break;
   }
 
   module->blend_params->blendif ^= toggle_mask;
@@ -759,7 +804,7 @@ static int _blendop_masks_add_path(GtkWidget *widget, GdkEventButton *event, dt_
   {
     // we want to be sure that the iop has focus
     dt_iop_request_focus(self);
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    dt_iop_color_picker_reset(self, TRUE);
     bd->masks_shown = DT_MASKS_EDIT_FULL;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
@@ -784,7 +829,7 @@ static int _blendop_masks_add_circle(GtkWidget *widget, GdkEventButton *event, d
   {
     // we want to be sure that the iop has focus
     dt_iop_request_focus(self);
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    dt_iop_color_picker_reset(self, TRUE);
     bd->masks_shown = DT_MASKS_EDIT_FULL;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
@@ -809,7 +854,7 @@ static int _blendop_masks_add_ellipse(GtkWidget *widget, GdkEventButton *event, 
   {
     // we want to be sure that the iop has focus
     dt_iop_request_focus(self);
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    dt_iop_color_picker_reset(self, TRUE);
     bd->masks_shown = DT_MASKS_EDIT_FULL;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
@@ -834,7 +879,7 @@ static int _blendop_masks_add_brush(GtkWidget *widget, GdkEventButton *event, dt
   {
     // we want to be sure that the iop has focus
     dt_iop_request_focus(self);
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    dt_iop_color_picker_reset(self, TRUE);
     bd->masks_shown = DT_MASKS_EDIT_FULL;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
@@ -859,7 +904,7 @@ static int _blendop_masks_add_gradient(GtkWidget *widget, GdkEventButton *event,
   {
     // we want to be sure that the iop has focus
     dt_iop_request_focus(self);
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    dt_iop_color_picker_reset(self, TRUE);
     bd->masks_shown = DT_MASKS_EDIT_FULL;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), TRUE);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
@@ -886,7 +931,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     darktable.gui->reset = 1;
 
     dt_iop_request_focus(self);
-    self->request_color_pick = DT_REQUEST_COLORPICK_OFF;
+    dt_iop_color_picker_reset(self, TRUE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
@@ -937,62 +982,148 @@ static void _blendop_masks_polarity_callback(GtkToggleButton *togglebutton, dt_i
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static gboolean _blendop_blendif_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *module)
+static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
+{
+  dt_iop_gui_blend_data_t *data = self->blend_data;
+  const int current_picker = data->color_picker.current_picker;
+
+  data->color_picker.current_picker = DT_BLENDIF_PICK_NONE;
+
+  if(button == data->colorpicker)
+    data->color_picker.current_picker = DT_BLENDIF_PICK_COLORPICK;
+  else if(button == data->colorpicker_set_values)
+    data->color_picker.current_picker = DT_BLENDIF_PICK_SET_VALUES;
+
+  if(current_picker == data->color_picker.current_picker)
+    return DT_COLOR_PICKER_ALREADY_SELECTED;
+  else
+    return data->color_picker.current_picker;
+}
+
+static void _iop_color_picker_apply(struct dt_iop_module_t *module)
+{
+  if(darktable.gui->reset) return;
+  
+  dt_iop_gui_blend_data_t *data = module->blend_data;
+  switch(data->color_picker.current_picker)
+  {
+  case DT_BLENDIF_PICK_SET_VALUES:
+  {
+    const int reset = darktable.gui->reset;
+    darktable.gui->reset = 1;
+    
+    dt_develop_blend_params_t *bp = module->blend_params;
+    const int tab = data->tab;
+    const int lower_upper = data->picker_set_upper_lower; // lower=0, upper=1
+    const int ch = data->channels[tab][lower_upper];
+    float *parameters = &(bp->blendif_parameters[4 * ch]);
+    float *raw_mean, *raw_min, *raw_max;
+    float picker_mean[8], picker_min[8], picker_max[8];
+    float picker_values[4];
+    GtkDarktableGradientSlider *slider = (lower_upper == 0) ? data->lower_slider: data->upper_slider;
+
+    if(lower_upper == 0)
+    {
+      raw_mean = module->picked_color;
+      raw_min = module->picked_color_min;
+      raw_max = module->picked_color_max;
+    }
+    else
+    {
+      raw_mean = module->picked_output_color;
+      raw_min = module->picked_output_color_min;
+      raw_max = module->picked_output_color_max;
+    }
+    
+    const int cst = (module->picker_cst == -1) ? data->csp: module->picker_cst;
+    _blendif_scale(cst, raw_mean, picker_mean);
+    _blendif_scale(cst, raw_min, picker_min);
+    _blendif_scale(cst, raw_max, picker_max);
+
+    picker_values[0] = CLAMP(picker_min[tab] - .01f, 0.f, 1.f);
+    picker_values[1] = CLAMP(picker_min[tab], 0.f, 1.f);
+    picker_values[2] = CLAMP(picker_max[tab], 0.f, 1.f);
+    picker_values[3] = CLAMP(picker_max[tab] + .01f, 0.f, 1.f);
+    
+    picker_values[0] = CLAMP(picker_values[0], 0.f, picker_values[1]);
+    picker_values[3] = CLAMP(picker_values[3], picker_values[2], 1.f);
+    
+    for(int k = 0; k < 4; k++)
+      dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k);
+
+    // update picked values
+    _update_gradient_slider(GTK_WIDGET(data->lower_slider), module);
+    _update_gradient_slider(GTK_WIDGET(data->upper_slider), module);
+    
+    darktable.gui->reset = reset;
+
+    // save values to parameters
+    for(int k = 0; k < 4; k++)
+      parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+    
+    // de-activate processing of this channel if maximum span is selected
+    if(parameters[1] == 0.0f && parameters[2] == 1.0f)
+      bp->blendif &= ~(1 << ch);
+    else
+      bp->blendif |= (1 << ch);
+
+    dt_dev_add_history_item(darktable.develop, module, TRUE);
+  }
+  break;
+  case DT_BLENDIF_PICK_COLORPICK:
+    _update_gradient_slider(GTK_WIDGET(data->upper_slider), module);
+    _update_gradient_slider(GTK_WIDGET(data->lower_slider), module);
+    break;
+  default:
+    break;
+  }
+}
+
+static void _iop_color_picker_update(dt_iop_module_t *self)
+{
+  dt_iop_gui_blend_data_t *data = self->blend_data;
+  const int which_colorpicker = data->color_picker.current_picker;
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+  
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->colorpicker), which_colorpicker == DT_BLENDIF_PICK_COLORPICK);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values), which_colorpicker == DT_BLENDIF_PICK_SET_VALUES);
+  
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_BLEND)
+  {
+    self->picker_cst = -1;
+    
+    dtgtk_gradient_slider_multivalue_set_picker(DTGTK_GRADIENT_SLIDER(data->upper_slider), NAN);
+    gtk_label_set_text(data->upper_picker_label, "");
+    dtgtk_gradient_slider_multivalue_set_picker(DTGTK_GRADIENT_SLIDER(data->lower_slider), NAN);
+    gtk_label_set_text(data->lower_picker_label, "");
+  }
+
+  darktable.gui->reset = reset;
+}
+
+static gboolean _blendop_blendif_color_picker_callback_button_press(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *module)
 {
   if(darktable.gui->reset) return FALSE;
 
-  dt_iop_gui_blend_data_t *data = module->blend_data;
-
-  float picker_mean[8], picker_min[8], picker_max[8];
-  float cooked[8];
-  float *raw_mean, *raw_min, *raw_max;
-  char text[256];
-  GtkLabel *label;
-
-  if(widget == GTK_WIDGET(data->lower_slider))
-  {
-    raw_mean = module->picked_color;
-    raw_min = module->picked_color_min;
-    raw_max = module->picked_color_max;
-    label = data->lower_picker_label;
-  }
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+  dt_iop_color_picker_t *color_picker = &bd->color_picker;
+  module->picker_cst = _blendop_blendif_get_picker_colorspace(bd);
+  
+  // this is not pretty but we don't have a kind per-picker
+  // if at some some point a module needs it we can think something more elegant
+  if(widget == bd->colorpicker)
+    color_picker->kind = DT_COLOR_PICKER_POINT_AREA;
   else
-  {
-    raw_mean = module->picked_output_color;
-    raw_min = module->picked_output_color_min;
-    raw_max = module->picked_output_color_max;
-    label = data->upper_picker_label;
-  }
-
-  darktable.gui->reset = 1;
-  if((module->request_color_pick == DT_REQUEST_COLORPICK_BLEND) && (raw_min[0] != INFINITY))
-  {
-    _blendif_scale(data->csp, raw_mean, picker_mean);
-    _blendif_scale(data->csp, raw_min, picker_min);
-    _blendif_scale(data->csp, raw_max, picker_max);
-    _blendif_cook(data->csp, raw_mean, cooked);
-
-    if(data->channels[data->tab][0] >= 8) // min and max make no sense for HSL and LCh
-      picker_min[data->tab] = picker_max[data->tab] = picker_mean[data->tab];
-
-    snprintf(text, sizeof(text), "(%.1f)", cooked[data->tab]);
-
-    dtgtk_gradient_slider_multivalue_set_picker_meanminmax(
-        DTGTK_GRADIENT_SLIDER(widget), picker_mean[data->tab], picker_min[data->tab], picker_max[data->tab]);
-    gtk_label_set_text(label, text);
-  }
+    color_picker->kind = DT_COLOR_PICKER_AREA;
+  
+  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  if((e->state & modifiers) == GDK_CONTROL_MASK) // lower=0, upper=1
+    bd->picker_set_upper_lower = 1;
   else
-  {
-    dtgtk_gradient_slider_multivalue_set_picker(DTGTK_GRADIENT_SLIDER(widget), NAN);
-    gtk_label_set_text(label, "");
-  }
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->colorpicker),
-                               (module->request_color_pick == DT_REQUEST_COLORPICK_BLEND ? 1 : 0));
-
-  darktable.gui->reset = 0;
-
-  return FALSE;
+    bd->picker_set_upper_lower = 0;
+  
+  return dt_iop_color_picker_callback_button_press(widget, e, color_picker);
 }
 
 // magic mode: if mouse curser enters a gradient slider with shift and/or control pressed we
@@ -1093,7 +1224,6 @@ static gboolean _blendop_blendif_leave(GtkWidget *widget, GdkEventCrossing *even
 
   return TRUE;
 }
-
 
 void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 {
@@ -1373,8 +1503,14 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->colorpicker
         = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-    gtk_widget_set_tooltip_text(bd->colorpicker, _("pick GUI color from image"));
+    gtk_widget_set_tooltip_text(bd->colorpicker, _("pick GUI color from image\ncntrl + click to select an area"));
     gtk_widget_set_size_request(GTK_WIDGET(bd->colorpicker), bs, bs);
+
+    bd->colorpicker_set_values
+        = dtgtk_togglebutton_new(_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+    gtk_widget_set_tooltip_text(bd->colorpicker_set_values, _("set the range based on an area from the image\n"
+        "click + drag to use the input image\ncntrl + click + drag to use the output image"));
+    gtk_widget_set_size_request(GTK_WIDGET(bd->colorpicker_set_values), bs, bs);
 
     GtkWidget *res = dtgtk_button_new(dtgtk_cairo_paint_reset, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_tooltip_text(res, _("reset blend mask settings"));
@@ -1387,6 +1523,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(header), GTK_WIDGET(notebook), TRUE, TRUE, 0);
     gtk_box_pack_end(GTK_BOX(header), GTK_WIDGET(res), FALSE, FALSE, 0);
     gtk_box_pack_end(GTK_BOX(header), GTK_WIDGET(inv), FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(header), GTK_WIDGET(bd->colorpicker_set_values), FALSE, FALSE, 0);
     gtk_box_pack_end(GTK_BOX(header), GTK_WIDGET(bd->colorpicker), FALSE, FALSE, 0);
 
     bd->lower_slider = DTGTK_GRADIENT_SLIDER_MULTIVALUE(dtgtk_gradient_slider_multivalue_new(4));
@@ -1454,7 +1591,9 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
     g_signal_connect(G_OBJECT(bd->upper_slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
 
-    g_signal_connect(G_OBJECT(bd->colorpicker), "toggled", G_CALLBACK(_blendop_blendif_pick_toggled), module);
+    g_signal_connect(G_OBJECT(bd->colorpicker), "button-press-event", G_CALLBACK(_blendop_blendif_color_picker_callback_button_press), module);
+
+    g_signal_connect(G_OBJECT(bd->colorpicker_set_values), "button-press-event", G_CALLBACK(_blendop_blendif_color_picker_callback_button_press), module);
 
     g_signal_connect(G_OBJECT(res), "clicked", G_CALLBACK(_blendop_blendif_reset), module);
 
@@ -1472,6 +1611,13 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(upslider), TRUE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(lowlabel), TRUE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(lowslider), TRUE, FALSE, 0);
+
+    dt_iop_init_blend_picker(&bd->color_picker,
+                       module,
+                       DT_COLOR_PICKER_POINT_AREA,
+                       _iop_color_picker_get_set,
+                       _iop_color_picker_apply,
+                       _iop_color_picker_update);
 
     bd->blendif_inited = 1;
   }
@@ -1989,12 +2135,8 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   }
   else if(bd->blendif_inited)
   {
-    /* switch off color picker if it was requested by blendif */
-    if(module->request_color_pick == DT_REQUEST_COLORPICK_BLEND)
-    {
-      module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->colorpicker), 0);
-    }
+    /* switch off color picker */
+    dt_iop_color_picker_reset(module, TRUE);
 
     gtk_widget_hide(GTK_WIDGET(bd->blendif_box));
   }
@@ -2063,6 +2205,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     bd->timeout_handle = 0;
     bd->save_for_leave = 0;
     dt_pthread_mutex_unlock(&bd->lock);
+    
+    bd->picker_set_upper_lower = 0;
 
 
     /** generate a list of all available blend modes */
@@ -2324,6 +2468,9 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                              DEVELOP_BLEND_LINEARLIGHT);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_PINLIGHT);
+        break;
+      case iop_cs_LCh:
+      case iop_cs_HSL:
         break;
     }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -383,6 +383,8 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
     module->picked_color_max[k] = module->picked_output_color_max[k] = -666.0f;
   }
   module->picker = NULL;
+  module->blend_picker = NULL;
+  module->picker_cst = -1;
   module->color_picker_box[0] = module->color_picker_box[1] = .25f;
   module->color_picker_box[2] = module->color_picker_box[3] = .75f;
   module->color_picker_point[0] = module->color_picker_point[1] = 0.5f;
@@ -1429,6 +1431,7 @@ void dt_iop_cleanup_module(dt_iop_module_t *module)
   free(module->default_blendop_params);
   module->default_blendop_params = NULL;
   module->picker = NULL;
+  module->blend_picker = NULL;
   free(module->histogram);
   module->histogram = NULL;
   g_hash_table_destroy(module->raster_mask.source.users);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -117,6 +117,16 @@ typedef enum dt_dev_request_colorpick_flags_t
   DT_REQUEST_COLORPICK_BLEND = 1 << 1   // requested by parametric blending gui
 } dt_dev_request_colorpick_flags_t;
 
+/** colorspace enums */
+typedef enum dt_iop_colorspace_type_t
+{
+  iop_cs_RAW = 0,
+  iop_cs_Lab = 1,
+  iop_cs_rgb = 2,
+  iop_cs_LCh = 3,
+  iop_cs_HSL = 4
+} dt_iop_colorspace_type_t;
+
 /** part of the module which only contains the cached dlopen stuff. */
 struct dt_iop_module_so_t;
 struct dt_iop_module_t;
@@ -286,7 +296,7 @@ typedef struct dt_iop_module_t
    * iop_cs_LCh: for Lab modules
    * iop_cs_HSL: for RGB modules
    */
-  int picker_cst;
+  dt_iop_colorspace_type_t picker_cst;
   /** pointer to pre-module histogram data; if available: histogram_bins_count bins with 4 channels each */
   uint32_t *histogram;
   /** stats of captured histogram */
@@ -561,16 +571,6 @@ int dt_iop_breakpoint(struct dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe)
 
 /** allow plugins to relinquish CPU and go to sleep for some time */
 void dt_iop_nap(int32_t usec);
-
-/** colorspace enums */
-typedef enum dt_iop_colorspace_type_t
-{
-  iop_cs_RAW = 0,
-  iop_cs_Lab = 1,
-  iop_cs_rgb = 2,
-  iop_cs_LCh = 3,
-  iop_cs_HSL = 4
-} dt_iop_colorspace_type_t;
 
 /** find which colorspace the module works within */
 dt_iop_colorspace_type_t dt_iop_module_colorspace(const dt_iop_module_t *module);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -270,8 +270,9 @@ typedef struct dt_iop_module_t
   /** set to 1 if you want the blendif to be completely suppressed in the module in focus. only when the module has
    * the focus. */
   int32_t bypass_blendif;
-  /** color picker proxy */
+  /** color picker proxys */
   struct dt_iop_color_picker_t *picker;
+  struct dt_iop_color_picker_t *blend_picker;
   /** bounding box in which the mean color is requested. */
   float color_picker_box[4];
   /** single point to pick if in point mode */
@@ -280,6 +281,12 @@ typedef struct dt_iop_module_t
   float picked_color[4], picked_color_min[4], picked_color_max[4];
   /** place to store the picked color of module output (before blending). */
   float picked_output_color[4], picked_output_color_min[4], picked_output_color_max[4];
+  /** requested colorspace for the color picker, valid options are:
+   * -1: module colorspace
+   * iop_cs_LCh: for Lab modules
+   * iop_cs_HSL: for RGB modules
+   */
+  int picker_cst;
   /** pointer to pre-module histogram data; if available: histogram_bins_count bins with 4 channels each */
   uint32_t *histogram;
   /** stats of captured histogram */
@@ -558,9 +565,11 @@ void dt_iop_nap(int32_t usec);
 /** colorspace enums */
 typedef enum dt_iop_colorspace_type_t
 {
-  iop_cs_RAW,
-  iop_cs_Lab,
-  iop_cs_rgb
+  iop_cs_RAW = 0,
+  iop_cs_Lab = 1,
+  iop_cs_rgb = 2,
+  iop_cs_LCh = 3,
+  iop_cs_HSL = 4
 } dt_iop_colorspace_type_t;
 
 /** find which colorspace the module works within */

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -533,7 +533,8 @@ static void pixelpipe_picker(dt_iop_module_t *module, dt_iop_buffer_dsc_t *dsc, 
   if(pixelpipe_picker_helper(module, roi, picked_color, picked_color_min, picked_color_max, picker_source, box))
     return;
 
-  dt_color_picker_helper(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max);
+  dt_color_picker_helper(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max,
+      dt_iop_module_colorspace(module), module->picker_cst);
 }
 
 
@@ -591,7 +592,8 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
   box[2] = region[0];
   box[3] = region[1];
 
-  dt_color_picker_helper(dsc, pixel, &roi_copy, box, picked_color, picked_color_min, picked_color_max);
+  dt_color_picker_helper(dsc, pixel, &roi_copy, box, picked_color, picked_color_min, picked_color_max,
+      dt_iop_module_colorspace(module), module->picker_cst);
 
 error:
   dt_free_align(tmpbuf);
@@ -1039,14 +1041,6 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   free(buf);
 }
 
-static inline void _pixelpipe_apply_module_colorpicker(dt_iop_module_t *module)
-{
-  if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
-    dt_iop_color_picker_apply_module(module);
-  else if(module->widget)
-    dt_control_queue_redraw_widget(module->widget);
-}
-
 // recursive helper for process:
 static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev, void **output,
                                         void **cl_mem_output, dt_iop_buffer_dsc_t **out_format,
@@ -1462,7 +1456,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            _pixelpipe_apply_module_colorpicker(module);
+            dt_iop_color_picker_apply_module(module);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1594,7 +1588,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            _pixelpipe_apply_module_colorpicker(module);
+            dt_iop_color_picker_apply_module(module);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1808,7 +1802,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            _pixelpipe_apply_module_colorpicker(module);
+            dt_iop_color_picker_apply_module(module);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1941,7 +1935,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
           dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-          _pixelpipe_apply_module_colorpicker(module);
+          dt_iop_color_picker_apply_module(module);
 
           dt_pthread_mutex_lock(&pipe->busy_mutex);
         }
@@ -2039,7 +2033,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
         dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-        _pixelpipe_apply_module_colorpicker(module);
+        dt_iop_color_picker_apply_module(module);
 
         dt_pthread_mutex_lock(&pipe->busy_mutex);
       }
@@ -2123,7 +2117,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
       dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-      _pixelpipe_apply_module_colorpicker(module);
+      dt_iop_color_picker_apply_module(module);
 
       dt_pthread_mutex_lock(&pipe->busy_mutex);
     }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -27,6 +27,12 @@ typedef enum _internal__status
   PICKER_STATUS_SELECTED
 } dt_internal_status_t;
 
+typedef enum dt_iop_color_picker_requested_by_t
+{
+  DT_COLOR_PICKER_REQ_MODULE = 0,
+  DT_COLOR_PICKER_REQ_BLEND
+} dt_iop_color_picker_requested_by_t;
+
 static void _iop_record_point(dt_iop_color_picker_t *self)
 {
   const int pick_index = CLAMP(self->current_picker, 1, 9) - 1;
@@ -40,7 +46,7 @@ static void _iop_get_point(dt_iop_color_picker_t *self, float *pos)
 
   pos[0] = pos[1] = 0.5f;
 
-  if(self->pick_pos[pick_index][0] != NAN && self->pick_pos[pick_index][1] != NAN)
+  if(!isnan(self->pick_pos[pick_index][0]) && !isnan(self->pick_pos[pick_index][1]))
   {
     pos[0] = self->pick_pos[pick_index][0];
     pos[1] = self->pick_pos[pick_index][1];
@@ -53,7 +59,7 @@ static int _internal_iop_color_picker_get_set(dt_iop_color_picker_t *picker, Gtk
 
   picker->current_picker = PICKER_STATUS_SELECTED;
 
-  if (current_picker == picker->current_picker)
+  if(current_picker == picker->current_picker)
     return DT_COLOR_PICKER_ALREADY_SELECTED;
   else
     return picker->current_picker;
@@ -74,19 +80,31 @@ static void _internal_iop_color_picker_update(dt_iop_color_picker_t *picker)
 
 void dt_iop_color_picker_apply_module(dt_iop_module_t *module)
 {
-  if(module->picker && module->picker->apply)
+  if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && module->picker && module->picker->apply)
   {
     module->picker->apply(module);
     _iop_record_point(module->picker);
   }
+  else if(module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && module->blend_picker && module->blend_picker->apply)
+  {
+    module->blend_picker->apply(module);
+    _iop_record_point(module->blend_picker);
+  }
 }
 
-void dt_iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean update)
+static void _iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean update)
 {
-  if(picker->module->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  if((picker->requested_by == DT_COLOR_PICKER_REQ_MODULE && picker->module->request_color_pick == DT_REQUEST_COLORPICK_MODULE) ||
+      (picker->requested_by == DT_COLOR_PICKER_REQ_BLEND && picker->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND))
     picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   picker->current_picker = PICKER_STATUS_NONE;
   if(update) dt_iop_color_picker_update(picker);
+}
+
+void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update)
+{
+  if(module->picker) _iop_color_picker_reset(module->picker, update);
+  if(module->blend_picker) _iop_color_picker_reset(module->blend_picker, update);
 }
 
 int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button)
@@ -110,6 +128,32 @@ void dt_iop_color_picker_update(dt_iop_color_picker_t *picker)
     _internal_iop_color_picker_update(picker);
 }
 
+static void _iop_init_picker(dt_iop_color_picker_t *picker,
+                  dt_iop_module_t *module,
+                  dt_iop_color_picker_kind_t kind,
+                  const int requested_by,
+                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                  void (*apply)(dt_iop_module_t *self),
+                  void (*update)(dt_iop_module_t *self))
+{
+  picker->module  = module;
+  picker->get_set = get_set;
+  picker->apply   = apply;
+  picker->update  = update;
+  picker->kind    = kind;
+  picker->requested_by = requested_by;
+  if(picker->requested_by == DT_COLOR_PICKER_REQ_MODULE)
+    module->picker  = picker;
+  else
+    module->blend_picker  = picker;
+
+  for(int i = 0; i<9; i++)
+    for(int j = 0; j<2; j++)
+      picker->pick_pos[i][j] = NAN;
+
+  _iop_color_picker_reset(picker, TRUE);
+}
+
 void dt_iop_init_single_picker(dt_iop_color_picker_t *picker,
                          dt_iop_module_t *module,
                          GtkWidget *colorpick,
@@ -127,26 +171,37 @@ void dt_iop_init_picker(dt_iop_color_picker_t *picker,
                   void (*apply)(dt_iop_module_t *self),
                   void (*update)(dt_iop_module_t *self))
 {
-  picker->module  = module;
-  picker->get_set = get_set;
-  picker->apply   = apply;
-  picker->update  = update;
-  picker->kind    = kind;
-  module->picker  = picker;
-
-  for(int i = 0; i<9; i++)
-    for(int j = 0; j<2; j++)
-      picker->pick_pos[i][j] = NAN;
-
-  dt_iop_color_picker_reset(picker, TRUE);
+  _iop_init_picker(picker,
+                    module,
+                    kind,
+                    DT_COLOR_PICKER_REQ_MODULE,
+                    get_set,
+                    apply,
+                    update);
 }
 
-void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
+void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker,
+                  dt_iop_module_t *module,
+                  dt_iop_color_picker_kind_t kind,
+                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                  void (*apply)(dt_iop_module_t *self),
+                  void (*update)(dt_iop_module_t *self))
 {
-  if(self->module->dt->gui->reset) return;
+  _iop_init_picker(picker,
+                    module,
+                    kind,
+                    DT_COLOR_PICKER_REQ_BLEND,
+                    get_set,
+                    apply,
+                    update);
+}
+
+static gboolean _iop_color_picker_callback(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
+{
+  if(self->module->dt->gui->reset) return FALSE;
 
   // set module active if not yet the case
-  if(self->module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->module->off), 1);
+  if(self->module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->module->off), TRUE);
 
   // get the current color picker (a module can have multiple one)
   // should returns -1 if the same picker was already selected.
@@ -154,13 +209,38 @@ void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self
 
   if(self->module->request_color_pick == DT_REQUEST_COLORPICK_OFF || clicked_colorpick != DT_COLOR_PICKER_ALREADY_SELECTED)
   {
-    self->module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+    if(self->requested_by == DT_COLOR_PICKER_REQ_MODULE)
+    {
+      if(self->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && self->module->blend_picker)
+        _iop_color_picker_reset(self->module->blend_picker, TRUE);
+
+      self->module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+    }
+    else
+    {
+      if(self->module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && self->module->picker)
+        _iop_color_picker_reset(self->module->picker, TRUE);
+
+      self->module->request_color_pick = DT_REQUEST_COLORPICK_BLEND;
+    }
 
     if(clicked_colorpick != DT_COLOR_PICKER_ALREADY_SELECTED)
       self->current_picker = clicked_colorpick;
 
-    if(self->kind == DT_COLOR_PICKER_AREA)
+    dt_iop_color_picker_kind_t kind = self->kind;
+    if(kind == DT_COLOR_PICKER_POINT_AREA)
+    {
+      const uint32_t state = (e != NULL) ? e->state: 0;
+      GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+      if((state & modifiers) == GDK_CONTROL_MASK)
+        kind = DT_COLOR_PICKER_AREA;
+      else
+        kind = DT_COLOR_PICKER_POINT;
+    }
+    if(kind == DT_COLOR_PICKER_AREA)
+    {
       dt_lib_colorpicker_set_area(darktable.lib, 0.99);
+    }
     else
     {
       float pos[2];
@@ -173,11 +253,22 @@ void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self
   else
   {
     /* focus on the center area, to force a redraw when focus on module is called below */
-    dt_iop_color_picker_reset(self, FALSE);
+    _iop_color_picker_reset(self, FALSE);
   }
   dt_iop_color_picker_update(self);
   dt_control_queue_redraw();
   dt_iop_request_focus(self->module);
+  return TRUE;
+}
+
+void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
+{
+  _iop_color_picker_callback(button, NULL, self);
+}
+
+gboolean dt_iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
+{
+  return _iop_color_picker_callback(button, e, self);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -35,13 +35,15 @@
 typedef enum _iop_color_picker_kind_t
 {
   DT_COLOR_PICKER_POINT = 0,
-  DT_COLOR_PICKER_AREA
+  DT_COLOR_PICKER_AREA,
+  DT_COLOR_PICKER_POINT_AREA // allow the user to select between point and area
 } dt_iop_color_picker_kind_t;
 
 typedef struct dt_iop_color_picker_t
 {
   dt_iop_module_t *module;
   dt_iop_color_picker_kind_t kind;
+  int requested_by;
   unsigned short current_picker;
   GtkWidget *colorpick;
   float pick_pos[9][2]; // last picker positions (max 9 picker per module)
@@ -71,6 +73,14 @@ void dt_iop_init_single_picker(dt_iop_color_picker_t *picker,
                          dt_iop_color_picker_kind_t kind,
                          void (*apply)(dt_iop_module_t *self));
 
+/* same as previous but for the blend module */
+void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker,
+                  dt_iop_module_t *module,
+                  dt_iop_color_picker_kind_t kind,
+                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                  void (*apply)(dt_iop_module_t *self),
+                  void (*update)(dt_iop_module_t *self));
+
 /* the color picker callback which must be used for every picker, as an example:
 
       g_signal_connect(G_OBJECT(g->button), "quad-pressed",
@@ -83,6 +93,13 @@ or for a simple togglebutton:
 */
 void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self);
 
+/* same as before but when DT_COLOR_PICKER_POINT_AREA is used, works only with togglebutton
+
+      g_signal_connect(G_OBJECT(g->color_picker_button), "button-press-event",
+                       G_CALLBACK(dt_iop_color_picker_callback_button_press), &g->color_picker);
+*/
+gboolean dt_iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self);
+
 /* called by pixelpipe when color has been updated */
 void dt_iop_color_picker_apply_module(dt_iop_module_t *module);
 
@@ -92,8 +109,8 @@ int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button
 void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker);
 /* call proxy update */
 void dt_iop_color_picker_update(dt_iop_color_picker_t *picker);
-/* reset current color picker, and if update is TRUE also call update proxy */
-void dt_iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean update);
+/* reset current color picker and/or blend color picker, and if update is TRUE also call update proxy */
+void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -690,17 +690,16 @@ static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)
     g_strlcpy(p->aspect_text, text, sizeof(p->aspect_text));
     p->aspect = g->aspect_ratios[which];
   }
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void aspect_orient_changed(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   p->aspect_orient = dt_bauhaus_combobox_get(widget);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -738,7 +737,7 @@ static void position_h_changed(GtkWidget *combo, dt_iop_module_t *self)
     g_strlcpy(p->pos_h_text, text, sizeof(p->pos_h_text));
     p->pos_h = g->pos_h_ratios[which];
   }
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -776,48 +775,44 @@ static void position_v_changed(GtkWidget *combo, dt_iop_module_t *self)
     g_strlcpy(p->pos_v_text, text, sizeof(p->pos_v_text));
     p->pos_v = g->pos_h_ratios[which];
   }
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void size_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   p->size = dt_bauhaus_slider_get(slider) / 100.0f;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void frame_size_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   p->frame_size = dt_bauhaus_slider_get(slider) / 100.0f;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void frame_offset_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
   p->frame_offset = dt_bauhaus_slider_get(slider) / 100.0f;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void colorpick_color_set(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
   // turn off the other color picker so that this tool actually works ...
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   GdkRGBA c;
   gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(widget), &c);
@@ -832,11 +827,10 @@ static void colorpick_color_set(GtkColorButton *widget, dt_iop_module_t *self)
 static void frame_colorpick_color_set(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
 
   // turn off the other color picker so that this tool actually works ...
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   GdkRGBA c;
   gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(widget), &c);

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1200,7 +1200,7 @@ static void apply_autocolor(dt_iop_module_t *self)
     }
   }
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   // Build the CDL-corrected samples (after the factors)
   float samples_lift[3] = { 0.f };
@@ -1314,7 +1314,7 @@ static void apply_autoluma(dt_iop_module_t *self)
     g->luma_patches_flags[GAIN] = AUTO_SELECTED;
   }
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   /** Optimization loop :
   * We try to find the CDL curves that neutralize the 3 input luma patches
@@ -1421,8 +1421,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(!in) dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  if(!in) dt_iop_color_picker_reset(self, TRUE);
 }
 
 void init(dt_iop_module_t *module)
@@ -1610,7 +1609,7 @@ void gui_update(dt_iop_module_t *self)
     gtk_widget_set_visible(g->auto_luma, TRUE);
   }
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   _check_tuner_picker_labels(self);
 
   if(p->mode == LEGACY)
@@ -1723,7 +1722,7 @@ void gui_reset(dt_iop_module_t *self)
   gtk_widget_set_visible(g->hue_gain, TRUE);
   gtk_widget_set_visible(g->sat_gain, TRUE);
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void mode_callback(GtkWidget *combo, dt_iop_module_t *self)
@@ -1747,7 +1746,7 @@ static void mode_callback(GtkWidget *combo, dt_iop_module_t *self)
     gtk_widget_set_visible(g->auto_luma, TRUE);
   }
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   if (p->mode == LEGACY)
   {
@@ -1829,7 +1828,7 @@ static void controls_callback(GtkWidget *combo, dt_iop_module_t *self)
       gtk_widget_set_visible(g->sat_gain, TRUE);
     }
   }
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void hue_lift_callback(GtkWidget *slider, gpointer user_data)
@@ -1839,7 +1838,7 @@ static void hue_lift_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float hsl[3] = {dt_bauhaus_slider_get(slider) / 360.0f,
                   dt_bauhaus_slider_get(g->sat_lift) / 100.0f,
@@ -1859,7 +1858,7 @@ static void sat_lift_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float hsl[3] = {dt_bauhaus_slider_get(g->hue_lift) / 360.0f,
                   dt_bauhaus_slider_get(slider) / 100.0f,
@@ -1876,7 +1875,7 @@ static void hue_gamma_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float hsl[3] = {dt_bauhaus_slider_get(slider) / 360.0f,
                   dt_bauhaus_slider_get(g->sat_gamma) / 100.0f,
@@ -1896,7 +1895,7 @@ static void sat_gamma_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float hsl[3] = {dt_bauhaus_slider_get(g->hue_gamma) / 360.0f,
                   dt_bauhaus_slider_get(slider) / 100.0f,
@@ -1914,7 +1913,7 @@ static void hue_gain_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float hsl[3] = {dt_bauhaus_slider_get(slider) / 360.0f,
                   dt_bauhaus_slider_get(g->sat_gain) / 100.0f,
@@ -1934,7 +1933,7 @@ static void sat_gain_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float hsl[3] = {dt_bauhaus_slider_get(g->hue_gain) / 360.0f,
                   dt_bauhaus_slider_get(slider) / 100.0f,
@@ -1948,10 +1947,9 @@ static void sat_gain_callback(GtkWidget *slider, gpointer user_data)
 static void saturation_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->saturation = dt_bauhaus_slider_get(slider) / 100.0f;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1960,10 +1958,9 @@ static void saturation_callback(GtkWidget *slider, dt_iop_module_t *self)
 static void saturation_out_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->saturation_out = dt_bauhaus_slider_get(slider) / 100.0f;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1972,10 +1969,9 @@ static void saturation_out_callback(GtkWidget *slider, dt_iop_module_t *self)
 static void contrast_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->contrast = - dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1984,10 +1980,9 @@ static void contrast_callback(GtkWidget *slider, dt_iop_module_t *self)
 static void grey_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->grey = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1996,10 +1991,9 @@ static void grey_callback(GtkWidget *slider, dt_iop_module_t *self)
 static void lift_factor_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->lift[CHANNEL_FACTOR] = dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -2010,7 +2004,7 @@ static void lift_red_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->lift[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2026,7 +2020,7 @@ static void lift_green_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->lift[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2042,7 +2036,7 @@ static void lift_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->lift[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2056,10 +2050,9 @@ static void lift_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 static void gamma_factor_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gamma[CHANNEL_FACTOR] = dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -2070,7 +2063,7 @@ static void gamma_red_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gamma[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2085,7 +2078,7 @@ static void gamma_green_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gamma[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2101,7 +2094,7 @@ static void gamma_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gamma[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2114,10 +2107,9 @@ static void gamma_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 static void gain_factor_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gain[CHANNEL_FACTOR] = dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -2128,7 +2120,7 @@ static void gain_red_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gain[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2144,7 +2136,7 @@ static void gain_green_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gain[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
@@ -2159,7 +2151,7 @@ static void gain_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   p->gain[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -229,22 +229,20 @@ static inline void update_saturation_slider_end_color(GtkWidget *slider, float h
 static void lightness_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
   p->lightness = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void source_lightness_mix_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
   p->source_lightness_mix = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -262,18 +260,17 @@ static void hue_callback(GtkWidget *slider, gpointer user_data)
   gtk_widget_queue_draw(GTK_WIDGET(g->gslider2));
 
   p->hue = hue;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void saturation_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
 
   p->saturation = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -311,8 +308,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
@@ -368,7 +364,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)module->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_bauhaus_slider_set(g->gslider1, p->hue);
   dt_bauhaus_slider_set(g->gslider2, p->saturation);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1012,12 +1012,11 @@ static void colorzones_tab_switch(GtkNotebook *notebook, GtkWidget *page, guint 
 static void select_by_changed(GtkWidget *widget, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
   memcpy(p, self->default_params, sizeof(dt_iop_colorzones_params_t));
   p->channel = 2 - (dt_iop_colorzones_channel_t)dt_bauhaus_combobox_get(widget);
-  dt_iop_color_picker_reset(&c->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1025,11 +1024,10 @@ static void select_by_changed(GtkWidget *widget, gpointer user_data)
 static void strength_changed(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   if(self->dt->gui->reset) return;
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
   p->strength = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&c->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -473,8 +473,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 static void autoexp_disable(dt_iop_module_t *self)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
-  if(g) dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 void gui_update(struct dt_iop_module_t *self)
@@ -494,7 +493,7 @@ void gui_update(struct dt_iop_module_t *self)
     gtk_widget_set_sensitive(GTK_WIDGET(g->mode), TRUE);
   }
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_bauhaus_combobox_set(g->mode, g_list_index(g->modes, GUINT_TO_POINTER(p->mode)));
 
@@ -592,7 +591,7 @@ static void mode_callback(GtkWidget *combo, gpointer user_data)
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
   dt_iop_exposure_params_t *p = (dt_iop_exposure_params_t *)self->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   
   const dt_iop_exposure_mode_t new_mode
       = GPOINTER_TO_UINT(g_list_nth_data(g->modes, dt_bauhaus_combobox_get(combo)));
@@ -750,7 +749,7 @@ static void deflicker_params_callback(GtkWidget *slider, gpointer user_data)
 
   if(p->mode != EXPOSURE_MODE_DEFLICKER) return;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   
   p->deflicker_percentile = dt_bauhaus_slider_get(g->deflicker_percentile);
   p->deflicker_target_level = dt_bauhaus_slider_get(g->deflicker_target_level);
@@ -762,9 +761,8 @@ static void exposure_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   autoexp_disable(self);
 
   const float exposure = dt_bauhaus_slider_get(slider);
@@ -775,9 +773,8 @@ static void black_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   
   const float black = dt_bauhaus_slider_get(slider);
   dt_iop_exposure_set_black(self, black);
@@ -818,8 +815,7 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -825,7 +825,7 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
 
   sanitize_latitude(p, g);
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -944,7 +944,7 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   darktable.gui->reset = 0;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -960,7 +960,7 @@ static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
 
   sanitize_latitude(p, g);
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -976,7 +976,7 @@ static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
 
   sanitize_latitude(p, g);
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -987,9 +987,8 @@ static void grey_point_target_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->grey_point_target = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1005,7 +1004,7 @@ static void latitude_stops_callback(GtkWidget *slider, gpointer user_data)
 
   sanitize_latitude(p, g);
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1015,9 +1014,8 @@ static void contrast_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->contrast = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1027,9 +1025,8 @@ static void saturation_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->saturation = logf(9.0f * dt_bauhaus_slider_get(slider)/100.0 + 1.0f) / logf(10.0f) * 100.0f;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -1038,9 +1035,8 @@ static void global_saturation_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->global_saturation = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -1049,9 +1045,8 @@ static void white_point_target_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->white_point_target = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1061,9 +1056,8 @@ static void black_point_target_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->black_point_target = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1073,9 +1067,8 @@ static void output_power_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->output_power = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1085,9 +1078,8 @@ static void balance_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   p->balance = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
 }
@@ -1096,8 +1088,7 @@ static void interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   const int combo = dt_bauhaus_combobox_get(widget);
 
   switch (combo)
@@ -1143,8 +1134,7 @@ static void preserve_color_callback(GtkWidget *widget, dt_iop_module_t *self)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  if(!in) dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  if(!in) dt_iop_color_picker_reset(self, TRUE);
 }
 
 void compute_curve_lut(dt_iop_filmic_params_t *p, float *table, float *table_temp, int res,
@@ -1447,7 +1437,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)module->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   self->color_picker_box[0] = self->color_picker_box[1] = .25f;
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;
@@ -1535,7 +1525,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 void gui_reset(dt_iop_module_t *self)
 {
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->extra_expander), FALSE);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->extra_toggle), dtgtk_cairo_paint_solid_arrow,
                                CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -449,8 +449,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
@@ -1124,7 +1123,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)module->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_bauhaus_slider_set(g->scale1, p->density);
   dt_bauhaus_slider_set(g->scale2, p->compression);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -186,7 +186,7 @@ static void colorpicker_callback(GtkColorButton *widget, dt_iop_module_t *self)
   dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   GdkRGBA c;
   gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(widget), &c);

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1072,7 +1072,7 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
-  dt_iop_color_picker_reset(&c->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   if(c->dragging)
   {
@@ -1098,7 +1098,7 @@ static void dt_iop_levels_autoadjust_callback(GtkRange *range, dt_iop_module_t *
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
 
-  dt_iop_color_picker_reset(&c->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_iop_levels_compute_levels_manual(self->histogram, p->levels);
 
@@ -1117,7 +1117,7 @@ static void dt_iop_levels_mode_callback(GtkWidget *combo, gpointer user_data)
   dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   const dt_iop_levels_mode_t new_mode
       = GPOINTER_TO_UINT(g_list_nth_data(g->modes, dt_bauhaus_combobox_get(combo)));

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -489,7 +489,7 @@ static gboolean dt_iop_monochrome_button_press(GtkWidget *widget, GdkEventButton
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
     dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
     dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
-    dt_iop_color_picker_reset(&g->color_picker, TRUE);
+    dt_iop_color_picker_reset(self, TRUE);
     if(event->type == GDK_2BUTTON_PRESS)
     {
       // reset
@@ -523,7 +523,7 @@ static gboolean dt_iop_monochrome_button_release(GtkWidget *widget, GdkEventButt
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
     dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
-    dt_iop_color_picker_reset(&g->color_picker, TRUE);
+    dt_iop_color_picker_reset(self, TRUE);
     g->dragging = 0;
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     g_object_set(G_OBJECT(widget), "has-tooltip", TRUE, (gchar *)0);
@@ -544,10 +544,9 @@ static gboolean dt_iop_monochrome_leave_notify(GtkWidget *widget, GdkEventCrossi
 static gboolean dt_iop_monochrome_scrolled(GtkWidget *widget, GdkEventScroll *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   gdouble delta_y;
   if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
@@ -564,9 +563,8 @@ static gboolean dt_iop_monochrome_scrolled(GtkWidget *widget, GdkEventScroll *ev
 static void highlights_callback(GtkWidget *w, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   p->highlights = dt_bauhaus_slider_get(w);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -469,7 +469,7 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   float previous = p->security_factor;
   p->security_factor = dt_bauhaus_slider_get(slider);
@@ -531,8 +531,7 @@ static void grey_point_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
   p->grey_point = dt_bauhaus_slider_get(slider);
@@ -544,8 +543,7 @@ static void dynamic_range_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
   p->dynamic_range = dt_bauhaus_slider_get(slider);
@@ -557,8 +555,7 @@ static void shadows_range_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
 
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
   p->shadows_range = dt_bauhaus_slider_get(slider);
@@ -574,7 +571,7 @@ static void mode_callback(GtkWidget *combo, gpointer user_data)
   dt_iop_profilegamma_params_t *p = (dt_iop_profilegamma_params_t *)self->params;
   p->mode = dt_bauhaus_combobox_get(combo);
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   switch(p->mode)
   {
@@ -650,9 +647,7 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-
-  if(!in) dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  if(!in) dt_iop_color_picker_reset(self, TRUE);
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
@@ -748,8 +743,7 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 void gui_reset(dt_iop_module_t *self)
 {
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 void gui_update(dt_iop_module_t *self)
@@ -762,7 +756,7 @@ void gui_update(dt_iop_module_t *self)
   self->color_picker_box[2] = self->color_picker_box[3] = .75f;
   self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   switch(p->mode)
   {

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1092,11 +1092,10 @@ static gboolean rt_add_shape(GtkWidget *widget, const int creation_continuous, d
 static void rt_colorpick_color_set_callback(GtkColorButton *widget, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
   // turn off the other color picker
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   GdkRGBA c
       = (GdkRGBA){.red = p->fill_color[0], .green = p->fill_color[1], .blue = p->fill_color[2], .alpha = 1.0 };
@@ -2079,7 +2078,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
     const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
 
-    dt_iop_color_picker_reset(&g->color_picker, TRUE);
+    dt_iop_color_picker_reset(self, TRUE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -276,10 +276,9 @@ static void balance_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
   p->balance = dt_bauhaus_slider_get(slider) / 100.0f;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -287,10 +286,9 @@ static void compress_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
   p->compress = dt_bauhaus_slider_get(slider);
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -331,7 +329,7 @@ static void hue_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   double hue = 0;
   double saturation = 0;
@@ -371,7 +369,7 @@ static void saturation_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
 
   double hue = 0;
   double saturation = 0;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -743,7 +743,7 @@ void gui_update(struct dt_iop_module_t *self)
   }
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "enabled");
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_hide(g->colorpicker);
 
   double TempK, tint;
@@ -1146,7 +1146,7 @@ static void temp_changed(dt_iop_module_t *self)
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   
   const double TempK = dt_bauhaus_slider_get(g->scale_k);
   const double tint = dt_bauhaus_slider_get(g->scale_tint);
@@ -1195,7 +1195,7 @@ static void rgb_callback(GtkWidget *slider, gpointer user_data)
   if(self->dt->gui->reset) return;
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   const float value = dt_bauhaus_slider_get(slider);
   if(slider == g->scale_r)
     p->coeffs[0] = value;
@@ -1215,7 +1215,7 @@ static void apply_preset(dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
   dt_iop_temperature_params_t *fp = (dt_iop_temperature_params_t *)self->default_params;
   const int tune = dt_bauhaus_slider_get(g->finetune);
@@ -1481,8 +1481,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_reset(struct dt_iop_module_t *self)
 {
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_iop_color_picker_reset(&g->color_picker, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   gui_sliders_update(self);
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2098,8 +2098,6 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
       dev->gui_module->color_picker_point[1] = .5f + zoom_y;
     }
 
-    dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
-    dt_dev_invalidate_all(dev);
     dt_control_queue_redraw();
     return;
   }
@@ -2147,6 +2145,13 @@ int button_released(dt_view_t *self, double x, double y, int which, uint32_t sta
   if(height_i > capht) y += (capht - height_i) * .5f;
 
   int handled = 0;
+  if(dev->gui_module && dev->gui_module->request_color_pick != DT_REQUEST_COLORPICK_OFF && which == 1)
+  {
+    dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
+    dt_dev_invalidate_all(dev);
+    dt_control_queue_redraw();
+    return 1;
+  }
   // masks
   if(dev->form_visible) handled = dt_masks_events_button_released(dev->gui_module, x, y, which, state);
   if(handled) return handled;


### PR DESCRIPTION
This PR adds:

-ported blend_gui to the new proxy schema
-add display range to the lch and hsl tabs on blend module
-cntrl + click on the color picker display an area on the blend module, tone curve and fill light
-a new color picker on the blend module that sets the range on the slider based on the selected area
