### PR TITLE
Cmake: use C11 std if available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,14 +173,22 @@ include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/external)
 # initial compiler flags
 add_definitions("-DHAVE_CONFIG_H")
 
+message(STATUS "Checking for -std=c99 support")
 CHECK_C_COMPILER_FLAG("-std=c99" COMPILER_SUPPORTS_C99)
 if(NOT COMPILER_SUPPORTS_C99)
-        message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER} has no C99 support. Please use a different C compiler.")
+  message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER} has no C99 support. Please use a different C compiler.")
+else()
+  message(STATUS "Checking for -std=c99 support - works")
 endif()
 
+message(STATUS "Checking for -std=c11 support")
 CHECK_C_COMPILER_FLAG("-std=c11" COMPILER_SUPPORTS_C11)
 if(NOT COMPILER_SUPPORTS_C11)
-  message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER} has no C11 support. Please use a different C compiler.")
+  message(STATUS "The compiler ${CMAKE_C_COMPILER} has no C11 support. Please use a different C compiler.")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+  message(STATUS "Checking for -std=c11 support - works")
 endif()
 
 # yes, need to keep both the CMAKE_CXX_FLAGS and CMAKE_CXX_STANDARD.
@@ -194,16 +202,13 @@ CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
 if(NOT COMPILER_SUPPORTS_CXX14)
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
 else()
+  set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
   message(STATUS "Checking for -std=c++14 support - works")
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(APPLE AND (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")


### PR DESCRIPTION
C11 is mandatory to be able to unlock Fused Multiply Add : https://accurate-algorithms.readthedocs.io/en/latest/ch03fma.html

Right now, Cmake checks for C11 but sets C99. Similarly, it checks for C++14 but sets C++11. This change allows to use the highest version available.