### PR TITLE
Cmake: add -fopt-info-vec-missed for Release build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -516,7 +516,7 @@ if(NOT CUSTOM_CFLAGS)
   # also, in IOPs, in-loops branches could be forced to be compiled as different loops variants
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MARCH} ${DT_REQ_INSTRUCTIONS} -g")
   set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O2")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3")
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -fopt-info-vec-missed")
   if(CMAKE_COMPILER_IS_GNUCC)
     if(BUILD_SSE2_CODEPATHS)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpmath=sse")


### PR DESCRIPTION
Release build uses `-O3` flag which enable autovectorization. We add `-fopt-info-vec-missed` for this build to get feedback on the loops the compiler was unable to autovectorize. This is done in the spirit of making devs aware of SIMD and push them to write vectorizable code.