### PR TITLE
Fix #2138 by making handling of tag "changed" more effective

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1098,6 +1098,11 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
   else
     ret_val = _history_copy_and_paste_on_image_overwrite(imgid, dest_imgid, ops);
 
+  /* attach changed tag reflecting actual change */
+  guint tagid = 0;
+  dt_tag_new("darktable|changed", &tagid);
+  dt_tag_attach(tagid, dest_imgid);
+
   /* if current image in develop reload history */
   if(dt_dev_is_current_image(darktable.develop, dest_imgid))
   {

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1098,11 +1098,6 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
   else
     ret_val = _history_copy_and_paste_on_image_overwrite(imgid, dest_imgid, ops);
 
-  /* attach changed tag reflecting actual change */
-  guint tagid = 0;
-  dt_tag_new("darktable|changed", &tagid);
-  dt_tag_attach(tagid, dest_imgid);
-
   /* if current image in develop reload history */
   if(dt_dev_is_current_image(darktable.develop, dest_imgid))
   {

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -361,6 +361,7 @@ void dt_history_delete_on_image(int32_t imgid)
 
   /* remove darktable|style|* tags */
   dt_tag_detach_by_string("darktable|style%", imgid);
+  dt_tag_detach_by_string("darktable|changed", imgid);
 }
 
 void dt_history_delete_on_selection()
@@ -1096,6 +1097,11 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
     ret_val = _history_copy_and_paste_on_image_merge(imgid, dest_imgid, ops);
   else
     ret_val = _history_copy_and_paste_on_image_overwrite(imgid, dest_imgid, ops);
+
+  /* attach changed tag reflecting actual change */
+  guint tagid = 0;
+  dt_tag_new("darktable|changed", &tagid);
+  dt_tag_attach(tagid, dest_imgid);
 
   /* if current image in develop reload history */
   if(dt_dev_is_current_image(darktable.develop, dest_imgid))

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1940,11 +1940,6 @@ void leave(dt_view_t *self)
 
   dt_develop_t *dev = (dt_develop_t *)self->data;
 
-  // tag image as changed
-  // TODO: only tag the image when there was a real change.
-  guint tagid = 0;
-  dt_tag_new_from_gui("darktable|changed", &tagid);
-  dt_tag_attach(tagid, dev->image_storage.id);
   // commit image ops to db
   dt_dev_write_history(dev);
 


### PR DESCRIPTION
This pull request changes the behaviour of the "changed" tag for images, in order to fix #2138.

Previously, the tag "changed" was set more or less unconditionally on `darktable.c leave()` and `develop.c dt_dev_write_history_ext()`. Now it is set on `dt_dev_add_history_item()`, `dt_history_copy_and_paste_on_image` and removed on `dt_history_delete_on_image()`.

I am not sure if these are all the correct places or if I am missing sommething, but I wanted to put it out there to get some feedback.