### PR TITLE
fix blend rgb grey

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -16,8 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "common.h"
 #include "colorspace.cl"
+#include "color_conversion.cl"
 
 #define BLEND_ONLY_LIGHTNESS     8
 
@@ -83,14 +83,6 @@ typedef enum dt_develop_mask_combine_mode_t
   DEVELOP_COMBINE_INV_EXCL = (DEVELOP_COMBINE_INV | DEVELOP_COMBINE_EXCL),
   DEVELOP_COMBINE_INV_INCL = (DEVELOP_COMBINE_INV | DEVELOP_COMBINE_INCL)
 } dt_develop_mask_combine_mode_t;
-
-
-typedef enum iop_cs_t 
-{
-  iop_cs_Lab, 
-  iop_cs_rgb, 
-  iop_cs_RAW
-} iop_cs_t;
 
 
 typedef enum dt_develop_blendif_channels_t
@@ -229,18 +221,25 @@ blendif_factor_Lab(const float4 input, const float4 output, const unsigned int b
 
 
 float
-blendif_factor_rgb(const float4 input, const float4 output, const unsigned int blendif, global const float *parameters, const unsigned int mask_mode, const unsigned int mask_combine)
+blendif_factor_rgb(const float4 input, const float4 output, const unsigned int blendif, global const float *parameters, const unsigned int mask_mode, const unsigned int mask_combine,
+    global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t profile_lut)
 {
   float result = 1.0f;
   float scaled[DEVELOP_BLENDIF_SIZE];
 
   if(!(mask_mode & DEVELOP_MASK_CONDITIONAL)) return (mask_combine & DEVELOP_COMBINE_INCL) ? 0.0f : 1.0f;
 
-  scaled[DEVELOP_BLENDIF_GRAY_in]  = clamp(0.3f*input.x + 0.59f*input.y + 0.11f*input.z, 0.0f, 1.0f);	// Gray scaled to 0..1
+  if(profile_info == 0)
+    scaled[DEVELOP_BLENDIF_GRAY_in]  = clamp(0.3f*input.x + 0.59f*input.y + 0.11f*input.z, 0.0f, 1.0f); // Gray scaled to 0..1
+  else
+    scaled[DEVELOP_BLENDIF_GRAY_in]  = clamp(get_rgb_matrix_luminance(input, profile_info, profile_lut), 0.0f, 1.0f); // Gray scaled to 0..1
   scaled[DEVELOP_BLENDIF_RED_in]   = clamp(input.x, 0.0f, 1.0f);						// Red
   scaled[DEVELOP_BLENDIF_GREEN_in] = clamp(input.y, 0.0f, 1.0f);						// Green
   scaled[DEVELOP_BLENDIF_BLUE_in]  = clamp(input.z, 0.0f, 1.0f);						// Blue
-  scaled[DEVELOP_BLENDIF_GRAY_out]  = clamp(0.3f*output.x + 0.59f*output.y + 0.11f*output.z, 0.0f, 1.0f);	// Gray scaled to 0..1
+  if(profile_info == 0)
+    scaled[DEVELOP_BLENDIF_GRAY_out]  = clamp(0.3f*output.x + 0.59f*output.y + 0.11f*output.z, 0.0f, 1.0f); // Gray scaled to 0..1
+  else
+    scaled[DEVELOP_BLENDIF_GRAY_out]  = clamp(get_rgb_matrix_luminance(output, profile_info, profile_lut), 0.0f, 1.0f); // Gray scaled to 0..1
   scaled[DEVELOP_BLENDIF_RED_out]   = clamp(output.x, 0.0f, 1.0f);						// Red
   scaled[DEVELOP_BLENDIF_GREEN_out] = clamp(output.y, 0.0f, 1.0f);						// Green
   scaled[DEVELOP_BLENDIF_BLUE_out]  = clamp(output.z, 0.0f, 1.0f);						// Blue
@@ -297,7 +296,8 @@ blendif_factor_rgb(const float4 input, const float4 output, const unsigned int b
 
 __kernel void
 blendop_mask_Lab (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask_in, __write_only image2d_t mask, const int width, const int height, 
-             const float gopacity, const int blendif, global const float *blendif_parameters, const unsigned int mask_mode, const unsigned int mask_combine, const int2 offs)
+             const float gopacity, const int blendif, global const float *blendif_parameters, const unsigned int mask_mode, const unsigned int mask_combine, const int2 offs,
+             global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t profile_lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -318,7 +318,8 @@ blendop_mask_Lab (__read_only image2d_t in_a, __read_only image2d_t in_b, __read
 
 __kernel void
 blendop_mask_RAW (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask_in, __write_only image2d_t mask, const int width, const int height, 
-             const float gopacity, const int blendif, global const float *blendif_parameters, const unsigned int mask_mode, const unsigned int mask_combine, const int2 offs)
+             const float gopacity, const int blendif, global const float *blendif_parameters, const unsigned int mask_mode, const unsigned int mask_combine, const int2 offs,
+             global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t profile_lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -333,7 +334,8 @@ blendop_mask_RAW (__read_only image2d_t in_a, __read_only image2d_t in_b, __read
 
 __kernel void
 blendop_mask_rgb (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask_in, __write_only image2d_t mask, const int width, const int height, 
-             const float gopacity, const int blendif, global const float *blendif_parameters, const unsigned int mask_mode, const unsigned int mask_combine, const int2 offs)
+             const float gopacity, const int blendif, global const float *blendif_parameters, const unsigned int mask_mode, const unsigned int mask_combine, const int2 offs,
+             global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t profile_lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -344,7 +346,7 @@ blendop_mask_rgb (__read_only image2d_t in_a, __read_only image2d_t in_b, __read
   float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
   float form = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
 
-  float conditional = blendif_factor_rgb(a, b, blendif, blendif_parameters, mask_mode, mask_combine);
+  float conditional = blendif_factor_rgb(a, b, blendif, blendif_parameters, mask_mode, mask_combine, profile_info, profile_lut);
   
   float opacity = (mask_combine & DEVELOP_COMBINE_INCL) ? 1.0f - (1.0f - form) * (1.0f - conditional) : form * conditional ;
   opacity = (mask_combine & DEVELOP_COMBINE_INV) ? 1.0f - opacity : opacity;
@@ -1052,7 +1054,8 @@ blendop_set_mask (__write_only image2d_t mask, const int width, const int height
 
 __kernel void
 blendop_display_channel (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask, __write_only image2d_t out, const int width, const int height, 
-                         const int2 offs, const int mask_display)
+                         const int2 offs, const int mask_display,
+                         global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t profile_lut)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -1108,10 +1111,16 @@ blendop_display_channel (__read_only image2d_t in_a, __read_only image2d_t in_b,
       c = clamp(b.z, 0.0f, 1.0f);
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
-      c = clamp(0.3f * a.x + 0.59f * a.y + 0.11f * a.z, 0.0f, 1.0f);
+      if(profile_info == 0)
+        c = clamp(0.3f * a.x + 0.59f * a.y + 0.11f * a.z, 0.0f, 1.0f);
+      else
+        c = clamp(get_rgb_matrix_luminance(a, profile_info, profile_lut), 0.0f, 1.0f);
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
-      c = clamp(0.3f * b.x + 0.59f * b.y + 0.11f * b.z, 0.0f, 1.0f);
+      if(profile_info == 0)
+        c = clamp(0.3f * b.x + 0.59f * b.y + 0.11f * b.z, 0.0f, 1.0f);
+      else
+        c = clamp(get_rgb_matrix_luminance(b, profile_info, profile_lut), 0.0f, 1.0f);
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_LCH_C:
       LCH = Lab_2_LCH(a);

--- a/data/kernels/color_conversion.cl
+++ b/data/kernels/color_conversion.cl
@@ -21,9 +21,12 @@
 // must be in synch with dt_iop_colorspace_type_t in imageop.h
 typedef enum dt_iop_colorspace_type_t
 {
+  iop_cs_NONE = -1,
   iop_cs_RAW = 0,
   iop_cs_Lab = 1,
-  iop_cs_rgb = 2
+  iop_cs_rgb = 2,
+  iop_cs_LCh = 3,
+  iop_cs_HSL = 4
 } dt_iop_colorspace_type_t;
 
 // must be in synch with dt_colorspaces_iccprofile_info_cl_t
@@ -75,34 +78,6 @@ float lookup_unbounded(read_only image2d_t lut, const float x, global const floa
     else return a[1] * native_powr(x*a[0], a[2]);
   }
   else return x;
-}
-
-float get_lut_pow4(const float x, read_only image2d_t lut)
-{
-  if(x > 1.0f)
-  {
-    return native_powr(x, 4.f);
-  }
-  else
-  {
-    const int xi = clamp((int)(x * 0x10000ul), 0, 0xffff);
-    const int2 p = (int2)((xi & 0xff), (xi >> 8));
-    return read_imagef(lut, sampleri, p).x;
-  }
-}
-
-float get_lut_pow5(const float x, read_only image2d_t lut)
-{
-  if(x > 1.0f)
-  {
-    return native_powr(x, 5.f);
-  }
-  else
-  {
-    const int xi = clamp((int)(x * 0x10000ul), 0, 0xffff);
-    const int2 p = (int2)((xi & 0xff), (xi >> 8));
-    return read_imagef(lut, sampleri, p).x;
-  }
 }
 
 float4 apply_trc_in(const float4 rgb_in, global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -231,6 +231,26 @@ double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name)
   return iop_order;
 }
 
+double dt_ioppr_get_colorin_iop_order(GList *iop_list)
+{
+  double iop_order = DBL_MAX;
+
+  GList *modules = g_list_first(iop_list);
+  while(modules)
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)(modules->data);
+    if(strcmp(mod->op, "colorin") == 0)
+    {
+      iop_order = mod->iop_order;
+      break;
+    }
+
+    modules = g_list_next(modules);
+  }
+
+  return iop_order;
+}
+
 // insert op_new before op_next on *_iop_order_list
 // it sets the iop_order on op_new
 // if check_history == 1 it check that the generated iop_order do not exists on any module in history

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1903,14 +1903,7 @@ static int dt_ioppr_generate_profile_info(dt_iop_order_iccprofile_info_t *profil
   if(!isnan(profile_info->matrix_in[0]) && !isnan(profile_info->matrix_out[0]) && profile_info->nonlinearlut)
   {
     float rgb[3] = { 0.1842f, 0.1842f, 0.1842f };
-    float linear_rgb[3] = { 0.f };
-
-    _apply_trc_out(rgb, linear_rgb, profile_info);
-    
-    if(linear_rgb[0] == linear_rgb[1] && linear_rgb[1] == linear_rgb[2])
-      profile_info->grey = linear_rgb[0];
-    else // FIXME: not sure about this, if the luts are different, how to calculate the middle grey?
-      profile_info->grey = profile_info->matrix_out[3] * linear_rgb[0] + profile_info->matrix_out[4] * linear_rgb[1] + profile_info->matrix_out[5] * linear_rgb[2];
+    profile_info->grey = dt_ioppr_get_rgb_matrix_luminance(rgb, profile_info);
   }
   
   return err_code;

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -45,6 +45,8 @@ GList *dt_ioppr_get_iop_order_list(int *_version);
 dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list, const char *op_name);
 /** returns the iop_order from iop_order_list list with operation = op_name */
 double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name);
+/** returns colorin's iop_order */
+double dt_ioppr_get_colorin_iop_order(GList *iop_list);
 
 /** check if there's duplicate iop_order entries in iop_list */
 void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -180,7 +180,8 @@ static inline void _PX_COPY(const float *src, float *dst)
 
 static inline float _blendif_factor(dt_iop_colorspace_type_t cst, const float *input, const float *output,
                                     const unsigned int blendif, const float *parameters,
-                                    const unsigned int mask_mode, const unsigned int mask_combine)
+                                    const unsigned int mask_mode, const unsigned int mask_combine,
+                                    const dt_iop_order_iccprofile_info_t *work_profile)
 {
   float result = 1.0f;
   float scaled[DEVELOP_BLENDIF_SIZE] = { 0.5f };
@@ -222,14 +223,21 @@ static inline float _blendif_factor(dt_iop_colorspace_type_t cst, const float *i
 
       break;
     case iop_cs_rgb:
-      scaled[DEVELOP_BLENDIF_GRAY_in]
-          = CLAMP_RANGE(0.3f * input[0] + 0.59f * input[1] + 0.11f * input[2], 0.0f,
-                        1.0f);                                              // Gray scaled to 0..1
+      if(work_profile == NULL)
+        scaled[DEVELOP_BLENDIF_GRAY_in] = CLAMP_RANGE(0.3f * input[0] + 0.59f * input[1] + 0.11f * input[2], 0.0f,
+                                                      1.0f); // Gray scaled to 0..1
+      else
+        scaled[DEVELOP_BLENDIF_GRAY_in] = CLAMP_RANGE(dt_ioppr_get_rgb_matrix_luminance(input, work_profile), 0.0f,
+                                                      1.0f);                // Gray scaled to 0..1
       scaled[DEVELOP_BLENDIF_RED_in] = CLAMP_RANGE(input[0], 0.0f, 1.0f);   // Red
       scaled[DEVELOP_BLENDIF_GREEN_in] = CLAMP_RANGE(input[1], 0.0f, 1.0f); // Green
       scaled[DEVELOP_BLENDIF_BLUE_in] = CLAMP_RANGE(input[2], 0.0f, 1.0f);  // Blue
-      scaled[DEVELOP_BLENDIF_GRAY_out] = CLAMP_RANGE(0.3f * output[0] + 0.59f * output[1] + 0.11f * output[2],
-                                                     0.0f, 1.0f);             // Gray scaled to 0..1
+      if(work_profile == NULL)
+        scaled[DEVELOP_BLENDIF_GRAY_out] = CLAMP_RANGE(0.3f * output[0] + 0.59f * output[1] + 0.11f * output[2],
+                                                       0.0f, 1.0f); // Gray scaled to 0..1
+      else
+        scaled[DEVELOP_BLENDIF_GRAY_out] = CLAMP_RANGE(dt_ioppr_get_rgb_matrix_luminance(output, work_profile),
+                                                       0.0f, 1.0f);           // Gray scaled to 0..1
       scaled[DEVELOP_BLENDIF_RED_out] = CLAMP_RANGE(output[0], 0.0f, 1.0f);   // Red
       scaled[DEVELOP_BLENDIF_GREEN_out] = CLAMP_RANGE(output[1], 0.0f, 1.0f); // Green
       scaled[DEVELOP_BLENDIF_BLUE_out] = CLAMP_RANGE(output[2], 0.0f, 1.0f);  // Blue
@@ -352,14 +360,14 @@ static inline void _blend_noop(const _blend_buffer_desc_t *bd, const float *a, f
 /* generate blend mask */
 static void _blend_make_mask(const _blend_buffer_desc_t *bd, const unsigned int blendif,
                              const float *blendif_parameters, const unsigned int mask_mode,
-                             const unsigned int mask_combine, const float gopacity, const float *a,
-                             const float *b, float *mask)
+                             const unsigned int mask_combine, const float gopacity, const float *a, const float *b,
+                             float *mask, const dt_iop_order_iccprofile_info_t *const work_profile)
 {
   for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
   {
     float form = mask[i];
-    float conditional
-        = _blendif_factor(bd->cst, &a[j], &b[j], blendif, blendif_parameters, mask_mode, mask_combine);
+    float conditional = _blendif_factor(bd->cst, &a[j], &b[j], blendif, blendif_parameters, mask_mode,
+                                        mask_combine, work_profile);
     float opacity = (mask_combine & DEVELOP_COMBINE_INCL) ? 1.0f - (1.0f - form) * (1.0f - conditional)
                                                           : form * conditional;
     opacity = (mask_combine & DEVELOP_COMBINE_INV) ? 1.0f - opacity : opacity;
@@ -2431,7 +2439,8 @@ static void _blend_RGB_B(const _blend_buffer_desc_t *bd, const float *a, float *
 
 
 static void display_channel(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                            dt_dev_pixelpipe_display_mask_t channel)
+                            dt_dev_pixelpipe_display_mask_t channel,
+                            const dt_iop_order_iccprofile_info_t *work_profile)
 {
 
   switch(channel & DT_DEV_PIXELPIPE_DISPLAY_ANY)
@@ -2523,14 +2532,18 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
     case DT_DEV_PIXELPIPE_DISPLAY_GRAY:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c = CLAMP_RANGE(0.3f * a[j] + 0.59f * a[j + 1] + 0.11f * a[j + 2], 0.0f, 1.0f);
+        const float c = (work_profile == NULL)
+                            ? CLAMP_RANGE(0.3f * a[j] + 0.59f * a[j + 1] + 0.11f * a[j + 2], 0.0f, 1.0f)
+                            : CLAMP_RANGE(dt_ioppr_get_rgb_matrix_luminance(a + j, work_profile), 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
     case (DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c = CLAMP_RANGE(0.3f * b[j] + 0.59f * b[j + 1] + 0.11f * b[j + 2], 0.0f, 1.0f);
+        const float c = (work_profile == NULL)
+                            ? CLAMP_RANGE(0.3f * b[j] + 0.59f * b[j + 1] + 0.11f * b[j + 2], 0.0f, 1.0f)
+                            : CLAMP_RANGE(dt_ioppr_get_rgb_matrix_luminance(b + j, work_profile), 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2809,6 +2822,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 
   // get channel max values depending on colorspace
   const dt_iop_colorspace_type_t cst = self->blend_colorspace(self, piece->pipe, piece);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 
   // check if mask should be suppressed temporarily (i.e. just set to global
   // opacity value)
@@ -2923,7 +2937,8 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
       float *in = (float *)ivoid + iindex;
       float *out = (float *)ovoid + oindex;
       float *m = mask + y * owidth;
-      _blend_make_mask(&bd, d->blendif, d->blendif_parameters, d->mask_mode, d->mask_combine, opacity, in, out, m);
+      _blend_make_mask(&bd, d->blendif, d->blendif_parameters, d->mask_mode, d->mask_combine, opacity, in, out, m,
+                       work_profile);
     }
 
     if(mask_feather)
@@ -3025,7 +3040,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
     float *m = mask + y * owidth;
 
     if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
-      display_channel(&bd, in, out, m, request_mask_display);
+      display_channel(&bd, in, out, m, request_mask_display, work_profile);
     else
       blend(&bd, in, out, m, blendflag);
 
@@ -3163,6 +3178,10 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   cl_mem dev_mask_2 = NULL;
   cl_mem dev_tmp = NULL;
   cl_mem dev_guide = NULL;
+  cl_mem dev_profile_info = NULL;
+  cl_mem dev_profile_lut = NULL;
+  dt_colorspaces_iccprofile_info_cl_t profile_info_cl;
+  cl_float *profile_lut_cl = NULL;
   size_t origin[] = { 0, 0, 0 };
   size_t region[] = { owidth, oheight, 1 };
 
@@ -3173,6 +3192,29 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
 
   dev_mask_1 = dt_opencl_alloc_device(devid, owidth, oheight, sizeof(float));
   if(dev_mask_1 == NULL) goto error;
+
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
+
+  if(work_profile)
+  {
+    dt_ioppr_get_profile_info_cl(work_profile, &profile_info_cl);
+    profile_lut_cl = dt_ioppr_get_trc_cl(work_profile);
+
+    dev_profile_info = dt_opencl_copy_host_to_device_constant(devid, sizeof(profile_info_cl), &profile_info_cl);
+    if(dev_profile_info == NULL)
+    {
+      fprintf(stderr, "[dt_develop_blend_process_cl] error allocating memory for color transformation 1\n");
+      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+      goto error;
+    }
+    dev_profile_lut = dt_opencl_copy_host_to_device(devid, profile_lut_cl, 256, 256 * 6, sizeof(float));
+    if(dev_profile_lut == NULL)
+    {
+      fprintf(stderr, "[dt_develop_blend_process_cl] error allocating memory for color transformation 2\n");
+      err = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+      goto error;
+    }
+  }
 
   if(mask_mode == DEVELOP_MASK_ENABLED || suppress_mask)
   {
@@ -3290,6 +3332,8 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     dt_opencl_set_kernel_arg(devid, kernel_mask, 9, sizeof(unsigned), (void *)&mask_mode);
     dt_opencl_set_kernel_arg(devid, kernel_mask, 10, sizeof(unsigned), (void *)&mask_combine);
     dt_opencl_set_kernel_arg(devid, kernel_mask, 11, 2 * sizeof(int), (void *)&offs);
+    dt_opencl_set_kernel_arg(devid, kernel_mask, 12, sizeof(cl_mem), (void *)&dev_profile_info);
+    dt_opencl_set_kernel_arg(devid, kernel_mask, 13, sizeof(cl_mem), (void *)&dev_profile_lut);
     err = dt_opencl_enqueue_kernel_2d(devid, kernel_mask, sizes);
     if(err != CL_SUCCESS) goto error;
 
@@ -3402,6 +3446,8 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 5, sizeof(int), (void *)&oheight);
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 6, 2 * sizeof(int), (void *)&offs);
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 7, sizeof(int), (void *)&request_mask_display);
+    dt_opencl_set_kernel_arg(devid, kernel_display_channel, 8, sizeof(cl_mem), (void *)&dev_profile_info);
+    dt_opencl_set_kernel_arg(devid, kernel_display_channel, 9, sizeof(cl_mem), (void *)&dev_profile_lut);
     err = dt_opencl_enqueue_kernel_2d(devid, kernel_display_channel, sizes);
     if(err != CL_SUCCESS) goto error;
   }
@@ -3451,6 +3497,9 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   dt_opencl_release_mem_object(dev_m);
   dt_opencl_release_mem_object(dev_mask_1);
   dt_opencl_release_mem_object(dev_tmp);
+  if(dev_profile_info) dt_opencl_release_mem_object(dev_profile_info);
+  if(dev_profile_lut) dt_opencl_release_mem_object(dev_profile_lut);
+  if(profile_lut_cl) free(profile_lut_cl);
   return TRUE;
 
 error:
@@ -3460,6 +3509,9 @@ error:
   dt_opencl_release_mem_object(dev_mask_2);
   dt_opencl_release_mem_object(dev_tmp);
   dt_opencl_release_mem_object(dev_guide);
+  if(dev_profile_info) dt_opencl_release_mem_object(dev_profile_info);
+  if(dev_profile_lut) dt_opencl_release_mem_object(dev_profile_lut);
+  if(profile_lut_cl) free(profile_lut_cl);
   dt_print(DT_DEBUG_OPENCL, "[opencl_blendop] couldn't enqueue kernel! %d\n", err);
   return FALSE;
 }

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -3320,6 +3320,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     // get parametric mask (if any) and apply global opacity
     const unsigned blendif = d->blendif;
     const unsigned int mask_combine = d->mask_combine;
+    const int use_work_profile = (work_profile == NULL) ? 0 : 1;
     dt_opencl_set_kernel_arg(devid, kernel_mask, 0, sizeof(cl_mem), (void *)&dev_in);
     dt_opencl_set_kernel_arg(devid, kernel_mask, 1, sizeof(cl_mem), (void *)&dev_out);
     dt_opencl_set_kernel_arg(devid, kernel_mask, 2, sizeof(cl_mem), (void *)&dev_mask_1);
@@ -3334,6 +3335,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     dt_opencl_set_kernel_arg(devid, kernel_mask, 11, 2 * sizeof(int), (void *)&offs);
     dt_opencl_set_kernel_arg(devid, kernel_mask, 12, sizeof(cl_mem), (void *)&dev_profile_info);
     dt_opencl_set_kernel_arg(devid, kernel_mask, 13, sizeof(cl_mem), (void *)&dev_profile_lut);
+    dt_opencl_set_kernel_arg(devid, kernel_mask, 14, sizeof(int), (void *)&use_work_profile);
     err = dt_opencl_enqueue_kernel_2d(devid, kernel_mask, sizes);
     if(err != CL_SUCCESS) goto error;
 
@@ -3438,6 +3440,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
   {
     // let us display a specific channel
+    const int use_work_profile = (work_profile == NULL) ? 0 : 1;
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 0, sizeof(cl_mem), (void *)&dev_in);
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 1, sizeof(cl_mem), (void *)&dev_tmp);
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 2, sizeof(cl_mem), (void *)&dev_mask_1);
@@ -3448,6 +3451,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 7, sizeof(int), (void *)&request_mask_display);
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 8, sizeof(cl_mem), (void *)&dev_profile_info);
     dt_opencl_set_kernel_arg(devid, kernel_display_channel, 9, sizeof(cl_mem), (void *)&dev_profile_lut);
+    dt_opencl_set_kernel_arg(devid, kernel_display_channel, 10, sizeof(int), (void *)&use_work_profile);
     err = dt_opencl_enqueue_kernel_2d(devid, kernel_display_channel, sizes);
     if(err != CL_SUCCESS) goto error;
   }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -556,7 +556,9 @@ static void _update_gradient_slider(GtkWidget *widget, dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    const dt_iop_order_iccprofile_info_t *work_profile = dt_ioppr_get_iop_work_profile_info(module->dev);
+    const int use_work_profile = (module->iop_order > dt_ioppr_get_colorin_iop_order(module->dev->iop));
+    const dt_iop_order_iccprofile_info_t *work_profile
+        = (use_work_profile) ? dt_ioppr_get_iop_work_profile_info(module->dev) : NULL;
     _blendif_scale(cst, raw_mean, picker_mean, work_profile);
     _blendif_scale(cst, raw_min, picker_min, work_profile);
     _blendif_scale(cst, raw_max, picker_max, work_profile);
@@ -1020,7 +1022,9 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    const dt_iop_order_iccprofile_info_t *work_profile = dt_ioppr_get_iop_work_profile_info(module->dev);
+    const int use_work_profile = (module->iop_order > dt_ioppr_get_colorin_iop_order(module->dev->iop));
+    const dt_iop_order_iccprofile_info_t *work_profile
+        = (use_work_profile) ? dt_ioppr_get_iop_work_profile_info(module->dev) : NULL;
     _blendif_scale(cst, raw_mean, picker_mean, work_profile);
     _blendif_scale(cst, raw_min, picker_min, work_profile);
     _blendif_scale(cst, raw_max, picker_max, work_profile);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -17,12 +17,12 @@
     You should have received a copy of the GNU General Public License
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include "develop/blend.h"
 #include "bauhaus/bauhaus.h"
 #include "common/debug.h"
 #include "common/dtpthread.h"
 #include "common/opencl.h"
 #include "control/control.h"
-#include "develop/blend.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/masks.h"
@@ -119,8 +119,8 @@ static const dt_iop_gui_blendif_colorstop_t _gradient_HUE[]
         { 0.830f, { NEUTRAL_GRAY, 0, NEUTRAL_GRAY, 1.0 } },
         { 1.0f, { NEUTRAL_GRAY, 0, 0, 1.0 } } };
 
-
-static void _blendif_scale(dt_iop_colorspace_type_t cst, const float *in, float *out)
+static void _blendif_scale(dt_iop_colorspace_type_t cst, const float *in, float *out,
+                           const dt_iop_order_iccprofile_info_t *work_profile)
 {
   out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
 
@@ -132,7 +132,10 @@ static void _blendif_scale(dt_iop_colorspace_type_t cst, const float *in, float 
       out[2] = CLAMP_RANGE((in[2] + 128.0f) / 256.0f, 0.0f, 1.0f);
       break;
     case iop_cs_rgb:
-      out[0] = CLAMP_RANGE(0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2], 0.0f, 1.0f);
+      if(work_profile == NULL)
+        out[0] = CLAMP_RANGE(0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2], 0.0f, 1.0f);
+      else
+        out[0] = CLAMP_RANGE(dt_ioppr_get_rgb_matrix_luminance(in, work_profile), 0.0f, 1.0f);
       out[1] = CLAMP_RANGE(in[0], 0.0f, 1.0f);
       out[2] = CLAMP_RANGE(in[1], 0.0f, 1.0f);
       out[3] = CLAMP_RANGE(in[2], 0.0f, 1.0f);
@@ -152,7 +155,8 @@ static void _blendif_scale(dt_iop_colorspace_type_t cst, const float *in, float 
   }
 }
 
-static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *out)
+static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *out,
+                          const dt_iop_order_iccprofile_info_t *const work_profile)
 {
   out[0] = out[1] = out[2] = out[3] = out[4] = out[5] = out[6] = out[7] = -1.0f;
 
@@ -164,7 +168,10 @@ static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *
       out[2] = in[2];
       break;
     case iop_cs_rgb:
-      out[0] = (0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2]) * 255.0f;
+      if(work_profile == NULL)
+        out[0] = (0.3f * in[0] + 0.59f * in[1] + 0.11f * in[2]) * 255.0f;
+      else
+        out[0] = dt_ioppr_get_rgb_matrix_luminance(in, work_profile) * 255.0f;
       out[1] = in[0] * 255.0f;
       out[2] = in[1] * 255.0f;
       out[3] = in[2] * 255.0f;
@@ -549,10 +556,11 @@ static void _update_gradient_slider(GtkWidget *widget, dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    _blendif_scale(cst, raw_mean, picker_mean);
-    _blendif_scale(cst, raw_min, picker_min);
-    _blendif_scale(cst, raw_max, picker_max);
-    _blendif_cook(cst, raw_mean, cooked);
+    const dt_iop_order_iccprofile_info_t *work_profile = dt_ioppr_get_iop_work_profile_info(module->dev);
+    _blendif_scale(cst, raw_mean, picker_mean, work_profile);
+    _blendif_scale(cst, raw_min, picker_min, work_profile);
+    _blendif_scale(cst, raw_max, picker_max, work_profile);
+    _blendif_cook(cst, raw_mean, cooked, work_profile);
 
     snprintf(text, sizeof(text), "(%.1f)", cooked[data->tab]);
 
@@ -1012,9 +1020,10 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    _blendif_scale(cst, raw_mean, picker_mean);
-    _blendif_scale(cst, raw_min, picker_min);
-    _blendif_scale(cst, raw_max, picker_max);
+    const dt_iop_order_iccprofile_info_t *work_profile = dt_ioppr_get_iop_work_profile_info(module->dev);
+    _blendif_scale(cst, raw_mean, picker_mean, work_profile);
+    _blendif_scale(cst, raw_min, picker_min, work_profile);
+    _blendif_scale(cst, raw_max, picker_max, work_profile);
 
     const float feather = 0.01f;
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -118,7 +118,7 @@ typedef enum dt_dev_request_colorpick_flags_t
   DT_REQUEST_COLORPICK_BLEND = 1 << 1   // requested by parametric blending gui
 } dt_dev_request_colorpick_flags_t;
 
-/** colorspace enums */
+/** colorspace enums, must be in synch with dt_iop_colorspace_type_t in color_conversion.cl */
 typedef enum dt_iop_colorspace_type_t
 {
   iop_cs_NONE = -1,

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -291,6 +291,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_release_mem_object(dev_g);
   dt_opencl_release_mem_object(dev_b);
   dt_opencl_release_mem_object(dev_coeffs);
+
+  // we no longer use the working profile
+  piece->pipe->dsc.work_profile_info = NULL;
+
   return TRUE;
 
 error:
@@ -419,6 +423,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     }
   }
 
+  // we no longer use the working profile
+  piece->pipe->dsc.work_profile_info = NULL;
+
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }
 
@@ -497,6 +504,9 @@ void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, c
     }
     _mm_sfence();
   }
+
+  // we no longer use the working profile
+  piece->pipe->dsc.work_profile_info = NULL;
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 }


### PR DESCRIPTION
The blend module is calculating the rgb grey with:

0.3f * input[0] + 0.59f * input[1] + 0.11f * input[2]

This changes it to use the work profile when available.