### PR TITLE
color transform performance

### DIFF
--- a/data/kernels/colorspaces.cl
+++ b/data/kernels/colorspaces.cl
@@ -58,3 +58,25 @@ colorspaces_transform_rgb_matrix_to_lab(read_only image2d_t in, write_only image
 
   write_imagef(out, (int2)(x, y), pixel);
 }
+
+kernel void
+colorspaces_transform_rgb_matrix_to_rgb(read_only image2d_t in, write_only image2d_t out, const int width, const int height,
+    global const dt_colorspaces_iccprofile_info_cl_t *profile_info_from, read_only image2d_t lut_from,
+    global const dt_colorspaces_iccprofile_info_cl_t *profile_info_to, read_only image2d_t lut_to)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+
+  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+
+  float4 xyz, linear_rgb;
+
+  linear_rgb = apply_trc_in(pixel, profile_info_from, lut_from);
+  xyz = linear_rgb_matrix_to_xyz(linear_rgb, profile_info_from);
+  linear_rgb = xyz_to_linear_rgb_matrix(xyz, profile_info_to);
+  pixel.xyz = apply_trc_out(linear_rgb, profile_info_to, lut_to).xyz;
+
+  write_imagef(out, (int2)(x, y), pixel);
+}

--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -119,6 +119,7 @@ typedef struct dt_colorspaces_t
 typedef struct dt_colorspaces_color_profile_t
 {
   dt_colorspaces_color_profile_type_t type; // filename is only used for type DT_COLORSPACE_FILE
+  // must be in synch with DT_IOPPR_COLOR_ICC_LEN in iop_order.h
   char filename[512];                       // icc file name
   char name[512];                           // product name, displayed in GUI
   cmsHPROFILE profile;                      // the actual profile

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -79,7 +79,8 @@ int dt_ioppr_move_iop_before(GList **_iop_list, struct dt_iop_module_t *module, 
 int dt_ioppr_move_iop_after(GList **_iop_list, struct dt_iop_module_t *module, struct dt_iop_module_t *module_prev,
                       const int validate_order, const int log_error);
 
-#define DT_IOPPR_COLOR_ICC_LEN 100
+// must be in synch with filename in dt_colorspaces_color_profile_t in colorspaces.h
+#define DT_IOPPR_COLOR_ICC_LEN 512
 
 typedef struct dt_iop_order_iccprofile_info_t
 {
@@ -134,14 +135,23 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type,
 void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename);
 
 /** transforms image from cst_from to cst_to colorspace using profile_info */
-void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, float *const image, const int width, const int height,
-    const int cst_from, const int cst_to, int *converted_cst, const dt_iop_order_iccprofile_info_t *const profile_info);
+void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const float *const image_in,
+                                         float *const image_out, const int width, const int height,
+                                         const int cst_from, const int cst_to, int *converted_cst,
+                                         const dt_iop_order_iccprofile_info_t *const profile_info);
+
+void dt_ioppr_transform_image_colorspace_rgb(const float *const image_in, float *const image_out, const int width,
+                                             const int height,
+                                             const dt_iop_order_iccprofile_info_t *const profile_info_from,
+                                             const dt_iop_order_iccprofile_info_t *const profile_info_to,
+                                             const char *message);
 
 #ifdef HAVE_OPENCL
 typedef struct dt_colorspaces_cl_global_t
 {
   int kernel_colorspaces_transform_lab_to_rgb_matrix;
   int kernel_colorspaces_transform_rgb_matrix_to_lab;
+  int kernel_colorspaces_transform_rgb_matrix_to_rgb;
 } dt_colorspaces_cl_global_t;
 
 // must be in synch with colorspaces.cl dt_colorspaces_iccprofile_info_cl_t
@@ -169,8 +179,16 @@ void dt_ioppr_get_profile_info_cl(const dt_iop_order_iccprofile_info_t *const pr
 cl_float *dt_ioppr_get_trc_cl(const dt_iop_order_iccprofile_info_t *const profile_info);
 
 /** same as the C version */
-int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const int devid, cl_mem dev_img, const int width, const int height,
-    const int cst_from, const int cst_to, int *converted_cst, const dt_iop_order_iccprofile_info_t *const profile_info);
+int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const int devid, cl_mem dev_img_in,
+                                           cl_mem dev_img_out, const int width, const int height,
+                                           const int cst_from, const int cst_to, int *converted_cst,
+                                           const dt_iop_order_iccprofile_info_t *const profile_info);
+
+int dt_ioppr_transform_image_colorspace_rgb_cl(const int devid, cl_mem dev_img_in, cl_mem dev_img_out,
+                                               const int width, const int height,
+                                               const dt_iop_order_iccprofile_info_t *const profile_info_from,
+                                               const dt_iop_order_iccprofile_info_t *const profile_info_to,
+                                               const char *message);
 #endif
 
 /** the folowing must have the matrix_in and matrix out generated */

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -3494,8 +3494,8 @@ static void rt_process_stats(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   int count = 0;
   int converted_cst;
 
-  dt_ioppr_transform_image_colorspace(self, img_src, width, height,
-      iop_cs_rgb, iop_cs_Lab, &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
+  dt_ioppr_transform_image_colorspace(self, img_src, img_src, width, height, iop_cs_rgb, iop_cs_Lab,
+                                      &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(static) reduction(+ : count, l_sum) reduction(max : l_max)        \
@@ -3509,8 +3509,8 @@ static void rt_process_stats(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     count++;
   }
 
-  dt_ioppr_transform_image_colorspace(self, img_src, width, height,
-      iop_cs_Lab, iop_cs_rgb, &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
+  dt_ioppr_transform_image_colorspace(self, img_src, img_src, width, height, iop_cs_Lab, iop_cs_rgb,
+                                      &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
 
   levels[0] = l_min / 100.f;
   levels[2] = l_max / 100.f;
@@ -3533,9 +3533,9 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
   const float tmp = (middle - mid) / delta;
   const float in_inv_gamma = pow(10, tmp);
   int converted_cst;
-  
-  dt_ioppr_transform_image_colorspace(self, img_src, width, height,
-      iop_cs_rgb, iop_cs_Lab, &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
+
+  dt_ioppr_transform_image_colorspace(self, img_src, img_src, width, height, iop_cs_rgb, iop_cs_Lab,
+                                      &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) shared(img_src) schedule(static)
@@ -3557,9 +3557,9 @@ static void rt_adjust_levels(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piec
       }
     }
   }
-  
-  dt_ioppr_transform_image_colorspace(self, img_src, width, height,
-      iop_cs_Lab, iop_cs_rgb, &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
+
+  dt_ioppr_transform_image_colorspace(self, img_src, img_src, width, height, iop_cs_Lab, iop_cs_rgb,
+                                      &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
 }
 
 #undef RT_WDBAR_INSET
@@ -3895,17 +3895,19 @@ static void retouch_blur(dt_iop_module_t *self, float *const in, dt_iop_roi_t *c
     if(b)
     {
       int converted_cst;
-      
-      dt_ioppr_transform_image_colorspace(self, img_dest, roi_mask_scaled->width, roi_mask_scaled->height,
-          iop_cs_rgb, iop_cs_Lab, &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
+
+      dt_ioppr_transform_image_colorspace(self, img_dest, img_dest, roi_mask_scaled->width,
+                                          roi_mask_scaled->height, iop_cs_rgb, iop_cs_Lab, &converted_cst,
+                                          dt_ioppr_get_pipe_work_profile_info(piece->pipe));
 
       dt_bilateral_splat(b, img_dest);
       dt_bilateral_blur(b);
       dt_bilateral_slice(b, img_dest, img_dest, detail);
       dt_bilateral_free(b);
 
-      dt_ioppr_transform_image_colorspace(self, img_dest, roi_mask_scaled->width, roi_mask_scaled->height,
-          iop_cs_Lab, iop_cs_rgb, &converted_cst, dt_ioppr_get_pipe_work_profile_info(piece->pipe));
+      dt_ioppr_transform_image_colorspace(self, img_dest, img_dest, roi_mask_scaled->width,
+                                          roi_mask_scaled->height, iop_cs_Lab, iop_cs_rgb, &converted_cst,
+                                          dt_ioppr_get_pipe_work_profile_info(piece->pipe));
     }
   }
 


### PR DESCRIPTION
This uses internal routines for the color transformation when available for the overexposed and final histogram.
On my system is 30 times faster.

This addresses #2183