### PR TITLE
add a iop search box

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -136,6 +136,12 @@ when updating from the currently stable 2.4.x series, please bear in mind that y
   Both the contrast and the auto feature use the middle grey point, the
   default for this setting is based on the work profile.
 
+- A search text has been added to the module groups in the darkroom. It has a
+  config option to show only the modules groups, only the search text or both.
+  Modules are searched by name (localized).
+  If displaying only the search text, the active pipe modules are displayed when the search text is empty.
+  A darkroom shortcut ctrl+a set the focus on the search box.
+
 ## Bug fixes
 
 - The color picker support has been fixed by a complete rewrite. It

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -668,6 +668,19 @@
     <shortdescription>position of the image infos line</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig prefs="gui" section="darkroom">
+    <name>plugins/darkroom/search_iop_by_text</name>
+    <type>
+      <enum>
+        <option>show search text</option>
+        <option>show groups</option>
+        <option>show both</option>
+      </enum>
+    </type>
+    <default>show both</default>
+    <shortdescription>show search module text entry</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig>
     <name>database_cache_quality</name>
     <type>int</type>

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -703,6 +703,13 @@ int dt_control_key_pressed_override(guint key, guint state)
     darktable.develop->darkroom_skip_mouse_events = TRUE;
     return 1;
   }
+  // set focus to the search module text box
+  else if(key == accels->darkroom_search_modules_focus.accel_key
+          && state == accels->darkroom_search_modules_focus.accel_mods)
+  {
+    dt_dev_modulegroups_search_text_focus(darktable.develop);
+    return 1;
+  }
   return 0;
 }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -110,7 +110,7 @@ typedef struct dt_control_accels_t
       lighttable_center, lighttable_preview, lighttable_preview_display_focus, lighttable_preview_sticky,
       lighttable_preview_sticky_focus, lighttable_preview_sticky_exit, lighttable_timeline, global_sideborders,
       global_header, darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out,
-      darkroom_skip_mouse_events;
+      darkroom_skip_mouse_events, darkroom_search_modules_focus;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1751,6 +1751,12 @@ void dt_dev_modulegroups_switch(dt_develop_t *dev, dt_iop_module_t *module)
     dev->proxy.modulegroups.switch_group(dev->proxy.modulegroups.module, module);
 }
 
+void dt_dev_modulegroups_search_text_focus(dt_develop_t *dev)
+{
+  if(dev->proxy.modulegroups.module && dev->proxy.modulegroups.search_text_focus && dev->first_load == 0)
+    dev->proxy.modulegroups.search_text_focus(dev->proxy.modulegroups.module);
+}
+
 void dt_dev_masks_list_change(dt_develop_t *dev)
 {
   if(dev->proxy.masks.module && dev->proxy.masks.list_change)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -216,6 +216,8 @@ typedef struct dt_develop_t
       gboolean (*test)(struct dt_lib_module_t *self, uint32_t group, uint32_t iop_group);
       /* switch to modulegroup */
       void (*switch_group)(struct dt_lib_module_t *self, struct dt_iop_module_t *module);
+      /* set focus to the search module text box */
+      void (*search_text_focus)(struct dt_lib_module_t *self);
     } modulegroups;
 
     // snapshots plugin hooks
@@ -349,6 +351,8 @@ float dt_dev_exposure_get_black(dt_develop_t *dev);
 gboolean dt_dev_modulegroups_available(dt_develop_t *dev);
 /** switch to modulegroup of module */
 void dt_dev_modulegroups_switch(dt_develop_t *dev, struct dt_iop_module_t *module);
+/** set the focus to modulegroup search text */
+void dt_dev_modulegroups_search_text_focus(dt_develop_t *dev);
 /** set the active modulegroup */
 void dt_dev_modulegroups_set(dt_develop_t *dev, uint32_t group);
 /** get the active modulegroup */

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -167,6 +167,9 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   // add an option to allow skip mouse events while editing masks
   dt_accel_path_view(path, sizeof(path), "darkroom", "allow to pan & zoom while editing masks");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_skip_mouse_events);
+  // set focus to the search module text box
+  dt_accel_path_view(path, sizeof(path), "darkroom", "search modules");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_search_modules_focus);
 
   // Global
   dt_accel_path_global(path, sizeof(path), "toggle side borders");

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -37,7 +37,16 @@ typedef struct dt_lib_modulegroups_t
 {
   uint32_t current;
   GtkWidget *buttons[DT_MODULEGROUP_SIZE];
+  GtkWidget *text_entry;
+  GtkWidget *hbox_buttons;
+  GtkWidget *hbox_search_box;
 } dt_lib_modulegroups_t;
+
+typedef enum dt_lib_modulegroup_iop_visibility_type_t {
+  DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE,
+  DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE,
+  DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE
+} dt_lib_modulegroup_iop_visibility_type_t;
 
 /* toggle button callback */
 static void _lib_modulegroups_toggle(GtkWidget *button, gpointer data);
@@ -60,6 +69,10 @@ static gboolean _lib_modulegroups_test(dt_lib_module_t *self, uint32_t group, ui
    sets the active group which module belongs too.
 */
 static void _lib_modulegroups_switch_group(dt_lib_module_t *self, dt_iop_module_t *module);
+/* modulergroups proxy search text focus function
+   \see dt_dev_modulegroups_search_text_focus()
+*/
+static void _lib_modulegroups_search_text_focus(dt_lib_module_t *self);
 
 /* hook up with viewmanager view change to initialize modulegroup */
 static void _lib_modulegroups_viewchanged_callback(gpointer instance, dt_view_t *old_view,
@@ -114,16 +127,49 @@ int _iop_get_group_order(const int group_id, const int default_order)
   return prefs<1 ? 1 : (prefs>DT_MODULEGROUP_SIZE? DT_MODULEGROUP_SIZE: prefs);
 }
 
+static dt_lib_modulegroup_iop_visibility_type_t _get_search_iop_visibility()
+{
+  dt_lib_modulegroup_iop_visibility_type_t ret = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
+  const gchar *show_text_entry = dt_conf_get_string("plugins/darkroom/search_iop_by_text");
+
+  if(strcmp(show_text_entry, "show search text") == 0)
+    ret = DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE;
+  else if(strcmp(show_text_entry, "show groups") == 0)
+    ret = DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE;
+  else if(strcmp(show_text_entry, "show both") == 0)
+    ret = DT_MODULEGROUP_SEARCH_IOP_TEXT_GROUPS_VISIBLE;
+
+  return ret;
+}
+
+static void _text_entry_changed_callback(GtkEntry *entry, dt_lib_module_t *self)
+{
+  _lib_modulegroups_update_iop_visibility(self);
+}
+
+static gboolean _text_entry_icon_press_callback(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event,
+                                                dt_lib_module_t *self)
+{
+  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
+
+  gtk_entry_set_text(GTK_ENTRY(d->text_entry), "");
+
+  return TRUE;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)g_malloc0(sizeof(dt_lib_modulegroups_t));
   self->data = (void *)d;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   dtgtk_cairo_paint_flags_t pf = CPF_STYLE_FLAT;
+
+  d->hbox_buttons = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
+  d->hbox_search_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
 
   /* active */
   d->buttons[DT_MODULEGROUP_ACTIVE_PIPE] = dtgtk_togglebutton_new(dtgtk_cairo_paint_modulegroup_active, pf, NULL);
@@ -175,14 +221,49 @@ void gui_init(dt_lib_module_t *self)
    * layout button row
    */
   int iconsize = DT_PIXEL_APPLY_DPI(28);
-  GtkWidget *br = self->widget;
+  GtkWidget *br = d->hbox_buttons;
   for(int k = 0; k < DT_MODULEGROUP_SIZE; k++)
   {
     gtk_widget_set_size_request(d->buttons[k], iconsize, iconsize);
     gtk_box_pack_start(GTK_BOX(br), d->buttons[k], TRUE, TRUE, 0);
   }
+
+  /* search box */
+  GtkWidget *label = gtk_label_new(_("search module  "));
+  gtk_box_pack_start(GTK_BOX(d->hbox_search_box), label, FALSE, TRUE, 0);
+
+  d->text_entry = gtk_entry_new();
+  dt_gui_key_accel_block_on_focus_connect(d->text_entry);
+  gtk_widget_add_events(d->text_entry, GDK_FOCUS_CHANGE_MASK);
+
+  gtk_widget_set_tooltip_text(d->text_entry, _("search modules by name or tag"));
+  gtk_widget_add_events(d->text_entry, GDK_KEY_PRESS_MASK);
+  g_signal_connect(G_OBJECT(d->text_entry), "changed", G_CALLBACK(_text_entry_changed_callback), self);
+  g_signal_connect(G_OBJECT(d->text_entry), "icon-press", G_CALLBACK(_text_entry_icon_press_callback), self);
+  gtk_box_pack_start(GTK_BOX(d->hbox_search_box), d->text_entry, TRUE, TRUE, 0);
+  gtk_entry_set_width_chars(GTK_ENTRY(d->text_entry), 0);
+  gtk_entry_set_icon_from_icon_name(GTK_ENTRY(d->text_entry), GTK_ENTRY_ICON_SECONDARY, "edit-clear");
+  gtk_entry_set_icon_tooltip_text(GTK_ENTRY(d->text_entry), GTK_ENTRY_ICON_SECONDARY, _("clear text"));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), d->hbox_buttons, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->hbox_search_box, TRUE, TRUE, 0);
+
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->buttons[d->current]), TRUE);
   gtk_widget_show_all(self->widget);
+  gtk_widget_show_all(d->hbox_buttons);
+  gtk_widget_set_no_show_all(d->hbox_buttons, TRUE);
+  gtk_widget_show_all(d->hbox_search_box);
+  gtk_widget_set_no_show_all(d->hbox_search_box, TRUE);
+
+  dt_lib_modulegroup_iop_visibility_type_t show_text_entry = _get_search_iop_visibility();
+  if(show_text_entry == DT_MODULEGROUP_SEARCH_IOP_GROUPS_VISIBLE)
+  {
+    gtk_widget_hide(d->hbox_search_box);
+  }
+  else if(show_text_entry == DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE)
+  {
+    gtk_widget_hide(d->hbox_buttons);
+  }
 
   /*
    * set the proxy functions
@@ -192,6 +273,7 @@ void gui_init(dt_lib_module_t *self)
   darktable.develop->proxy.modulegroups.get = _lib_modulegroups_get;
   darktable.develop->proxy.modulegroups.test = _lib_modulegroups_test;
   darktable.develop->proxy.modulegroups.switch_group = _lib_modulegroups_switch_group;
+  darktable.develop->proxy.modulegroups.search_text_focus = _lib_modulegroups_search_text_focus;
 
   /* let's connect to view changed signal to set default group */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED,
@@ -200,6 +282,10 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
+  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
+
+  dt_gui_key_accel_block_on_focus_disconnect(d->text_entry);
+
   /* let's not listen to signals anymore.. */
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_modulegroups_viewchanged_callback), self);
 
@@ -246,6 +332,11 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
 {
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
 
+  const dt_lib_modulegroup_iop_visibility_type_t visibility = _get_search_iop_visibility();
+  const gchar *text_entered = (gtk_widget_is_visible(GTK_WIDGET(d->hbox_search_box)))
+                                  ? gtk_entry_get_text(GTK_ENTRY(d->text_entry))
+                                  : NULL;
+
   GList *modules = darktable.develop->iop;
   if(modules)
   {
@@ -260,6 +351,50 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
 
       /* skip modules without an gui */
       if(dt_iop_is_hidden(module)) continue;
+
+      // do not show non-active modules
+      // we don't want the user to mess with those
+      if(module->iop_order == DBL_MAX)
+      {
+        if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
+        if(w) gtk_widget_hide(w);
+        continue;
+      }
+
+      // if there's some search text show matching modules only
+      if(text_entered && text_entered[0] != '\0')
+      {
+        /* don't show deprecated ones */
+        if(module->flags() & IOP_FLAGS_DEPRECATED)
+        {
+          if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
+          if(w) gtk_widget_hide(w);
+        }
+        else
+        {
+          int is_match = (g_strstr_len(dt_iop_get_localized_name(module->op), -1, text_entered) != NULL);
+
+          if(is_match)
+            gtk_widget_show(w);
+          else
+            gtk_widget_hide(w);
+        }
+        continue;
+      }
+      // if only the search box is visible show the active pipe
+      else if(visibility == DT_MODULEGROUP_SEARCH_IOP_TEXT_VISIBLE)
+      {
+        if(module->enabled)
+        {
+          if(w) gtk_widget_show(w);
+        }
+        else
+        {
+          if(darktable.develop->gui_module == module) dt_iop_request_focus(NULL);
+          if(w) gtk_widget_hide(w);
+        }
+        continue;
+      }
 
       /* lets show/hide modules dependent on current group*/
       switch(d->current)
@@ -322,13 +457,6 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
             if(w) gtk_widget_hide(w);
           }
         }
-      }
-
-      // do not show non-active modules
-      // we don't want the user to mess with thouse
-      if(module->iop_order == DBL_MAX)
-      {
-        if(w) gtk_widget_hide(w);
       }
     } while((modules = g_list_next(modules)) != NULL);
   }
@@ -408,6 +536,22 @@ static gboolean _lib_modulegroups_set_gui_thread(gpointer user_data)
   return FALSE;
 }
 
+static gboolean _lib_modulegroups_search_text_focus_gui_thread(gpointer user_data)
+{
+  _set_gui_thread_t *params = (_set_gui_thread_t *)user_data;
+
+  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)params->self->data;
+
+  if(GTK_IS_ENTRY(d->text_entry))
+  {
+    if(!gtk_widget_is_visible(GTK_WIDGET(d->hbox_search_box))) gtk_widget_show(GTK_WIDGET(d->hbox_search_box));
+    gtk_widget_grab_focus(GTK_WIDGET(d->text_entry));
+  }
+
+  free(params);
+  return FALSE;
+}
+
 /* this is a proxy function so it might be called from another thread */
 static void _lib_modulegroups_set(dt_lib_module_t *self, uint32_t group)
 {
@@ -416,6 +560,16 @@ static void _lib_modulegroups_set(dt_lib_module_t *self, uint32_t group)
   params->self = self;
   params->group = group;
   g_main_context_invoke(NULL, _lib_modulegroups_set_gui_thread, params);
+}
+
+/* this is a proxy function so it might be called from another thread */
+static void _lib_modulegroups_search_text_focus(dt_lib_module_t *self)
+{
+  _set_gui_thread_t *params = (_set_gui_thread_t *)malloc(sizeof(_set_gui_thread_t));
+  if(!params) return;
+  params->self = self;
+  params->group = 0;
+  g_main_context_invoke(NULL, _lib_modulegroups_search_text_focus_gui_thread, params);
 }
 
 static void _lib_modulegroups_switch_group(dt_lib_module_t *self, dt_iop_module_t *module)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2773,6 +2773,14 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     return 1;
   }
 
+  // set focus to the search module text box
+  if(key == accels->darkroom_search_modules_focus.accel_key
+     && state == accels->darkroom_search_modules_focus.accel_mods)
+  {
+    dt_dev_modulegroups_search_text_focus(darktable.develop);
+    return 1;
+  }
+
   return 1;
 }
 
@@ -2833,6 +2841,9 @@ void init_key_accels(dt_view_t *self)
 
   // add an option to allow skip mouse events while editing masks
   dt_accel_register_view(self, NC_("accel", "allow to pan & zoom while editing masks"), GDK_KEY_a, 0);
+
+  // set focus to the search modules text box
+  dt_accel_register_view(self, NC_("accel", "search modules"), GDK_KEY_a, GDK_CONTROL_MASK);
 }
 
 static gboolean _darkroom_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,


### PR DESCRIPTION
This add a search text to the module groups. 

-It has a config option to show only the modules groups, only the search text or both.
-Modules are searched by name (localized).
-If displaying only the search text, the active pipe modules are displayed when the search text is empty.
-A darkroom shortcut cntrl+r set the focus on the search box