### PR TITLE
Prevent cache pull of image id -1

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1767,7 +1767,7 @@ void reload_defaults(dt_iop_module_t *module)
                                                            .filename_work = "" };
 
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) goto end;
+  if(!module->dev || module->dev->image_storage.id <= 0) goto end;
 
   gboolean use_eprofile = FALSE;
   // some file formats like jpeg can have an embedded color profile


### PR DESCRIPTION
Trying to do this twice causes deadlock, as cache get checks uint32,
which release checks int32. In the end the cache rwlock remains held.