### PR TITLE
fix format string issues

### DIFF
--- a/src/common/dtpthread.c
+++ b/src/common/dtpthread.c
@@ -25,6 +25,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #ifdef _WIN32
 #include "win/dtwin.h"
@@ -56,7 +57,7 @@ int dt_pthread_create(pthread_t *thread, void *(*start_routine)(void *), void *a
   {
     // looks like we need to bump/set it...
 
-    fprintf(stderr, "[dt_pthread_create] info: bumping pthread's stacksize from %zu to %ju\n", stacksize,
+    fprintf(stderr, "[dt_pthread_create] info: bumping pthread's stacksize from %zu to %"PRIuMAX"\n", stacksize,
             (uintmax_t)WANTED_THREADS_STACK_SIZE);
 
     ret = pthread_attr_setstacksize(&attr, WANTED_THREADS_STACK_SIZE);

--- a/src/common/resource_limits.c
+++ b/src/common/resource_limits.c
@@ -26,6 +26,8 @@
 #include <stdint.h>       // for uintmax_t
 #include <stdio.h>        // for fprintf, stderr
 #include <string.h>       // for strerror
+#include <inttypes.h>
+
 #ifdef _WIN32
 #include "win/rlimit.h"
 #else
@@ -55,8 +57,8 @@ static void dt_set_rlimits_stack()
   {
     // looks like we need to bump/set it...
 
-    fprintf(stderr, "[dt_set_rlimits_stack] info: bumping RLIMIT_STACK rlim_cur from %ju to %i\n",
-            (uintmax_t)rlim.rlim_cur, WANTED_STACK_SIZE);
+    fprintf(stderr, "[dt_set_rlimits_stack] info: bumping RLIMIT_STACK rlim_cur from %"PRIuMAX" to %"PRIuMAX"\n",
+            (uintmax_t)rlim.rlim_cur, (uintmax_t)WANTED_STACK_SIZE);
 
     rlim.rlim_cur = WANTED_STACK_SIZE;
 


### PR DESCRIPTION
Platform dependent integer aliases require special format strings. See also https://en.cppreference.com/w/c/types/integer .