### PR TITLE
allow rgb modules to be before colorin

### DIFF
--- a/data/kernels/basicadj.cl
+++ b/data/kernels/basicadj.cl
@@ -95,7 +95,8 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
            const int process_saturation, const float saturation,
            const int process_hlcompr, const float hlcomp, const float hlrange,
            const float middle_grey, const float inv_middle_grey,
-           global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut)
+           global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut,
+           const int use_work_profile)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -111,7 +112,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
   // highlight compression
   if(process_hlcompr)
   {
-    const float lum = get_rgb_matrix_luminance(pixel, profile_info, lut);
+    const float lum = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, lut);
     if(lum > 0.f)
     {
       const float ratio = hlcurve(lum, hlcomp, hlrange);
@@ -139,7 +140,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
   if(preserve_colors == 1) // DT_BASICADJ_PRESERVE_LUMINANCE
   {
     float ratio = 1.f;
-    const float lum = get_rgb_matrix_luminance(pixel, profile_info, lut);
+    const float lum = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, lut);
     if(lum > 0.f)
     {
       const float contrast_lum = native_powr(lum / middle_grey, contrast) * middle_grey;
@@ -152,7 +153,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
   // saturation
   if(process_saturation)
   {
-    const float luminance = get_rgb_matrix_luminance(pixel, profile_info, lut);
+    const float luminance = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, lut);
 
     pixel = luminance + saturation * (pixel - luminance);
   }

--- a/data/kernels/color_conversion.cl
+++ b/data/kernels/color_conversion.cl
@@ -158,3 +158,8 @@ float get_rgb_matrix_luminance(const float4 rgb, global const dt_colorspaces_icc
   
   return luminance;
 }
+
+float dt_camera_rgb_luminance(const float4 rgb)
+{
+  return (rgb.x * 0.2225045f + rgb.y * 0.7168786f + rgb.z * 0.0606169f);
+}

--- a/data/kernels/rgbcurve.cl
+++ b/data/kernels/rgbcurve.cl
@@ -23,7 +23,8 @@ rgbcurve(read_only image2d_t in, write_only image2d_t out, const int width, cons
            read_only image2d_t table_r, read_only image2d_t table_g, read_only image2d_t table_b,
            global float *coeffs_r, global float *coeffs_g, global float *coeffs_b,
            const int autoscale, const int preserve_colors,
-           global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut)
+           global const dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut,
+           const int use_work_profile)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -43,7 +44,7 @@ rgbcurve(read_only image2d_t in, write_only image2d_t out, const int width, cons
     if(preserve_colors == 1) // DT_RGBCURVE_PRESERVE_LUMINANCE
     {
       float ratio = 1.f;
-      const float lum = get_rgb_matrix_luminance(pixel, profile_info, lut);
+      const float lum = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, lut);
       if(lum > 0.f)
       {
         const float curve_lum = lookup_unbounded(table_r, lum, coeffs_r);

--- a/src/common/colorspaces_inline_conversions.h
+++ b/src/common/colorspaces_inline_conversions.h
@@ -374,6 +374,11 @@ static inline void dt_LCH_2_Lab(const float *LCH, float *Lab)
   Lab[2] = sinf(2.0f * DT_M_PI_F * LCH[2]) * LCH[1];
 }
 
+static inline float dt_camera_rgb_luminance(const float *const rgb)
+{
+  return (rgb[0] * 0.2225045f + rgb[1] * 0.7168786f + rgb[2] * 0.0606169f);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -45,8 +45,6 @@ GList *dt_ioppr_get_iop_order_list(int *_version);
 dt_iop_order_entry_t *dt_ioppr_get_iop_order_entry(GList *iop_order_list, const char *op_name);
 /** returns the iop_order from iop_order_list list with operation = op_name */
 double dt_ioppr_get_iop_order(GList *iop_order_list, const char *op_name);
-/** returns colorin's iop_order */
-double dt_ioppr_get_colorin_iop_order(GList *iop_list);
 
 /** check if there's duplicate iop_order entries in iop_list */
 void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list);
@@ -117,9 +115,10 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_profile_info_from_list(struct dt_de
 dt_iop_order_iccprofile_info_t *dt_ioppr_add_profile_info_to_list(struct dt_develop_t *dev, const int profile_type, const char *profile_filename, const int intent);
 
 /** returns a reference to the work profile info as set on colorin iop
- * must not be cleanup()
+ * only if module is between colorin and colorout, otherwise returns NULL
+ * work profile must not be cleanup()
  */
-dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(struct dt_develop_t *dev);
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(struct dt_iop_module_t *module, GList *iop_list);
 
 /** set the work profile (type, filename) on the pipe, should be called on process*()
  * if matrix cannot be generated it defauls to linear rec 2020
@@ -179,6 +178,16 @@ void dt_ioppr_get_profile_info_cl(const dt_iop_order_iccprofile_info_t *const pr
  * to be used as a parameter when calling opencl
  */
 cl_float *dt_ioppr_get_trc_cl(const dt_iop_order_iccprofile_info_t *const profile_info);
+
+/** build the required parameters for a kernell that uses a profile info */
+cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t *const profile_info,
+                                           const int devid, dt_colorspaces_iccprofile_info_cl_t **_profile_info_cl,
+                                           cl_float **_profile_lut_cl, cl_mem *_dev_profile_info,
+                                           cl_mem *_dev_profile_lut);
+/** free parameters build with the previous function */
+void dt_ioppr_free_iccprofile_params_cl(dt_colorspaces_iccprofile_info_cl_t **_profile_info_cl,
+                                        cl_float **_profile_lut_cl, cl_mem *_dev_profile_info,
+                                        cl_mem *_dev_profile_lut);
 
 /** same as the C version */
 int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const int devid, cl_mem dev_img_in,

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -556,9 +556,8 @@ static void _update_gradient_slider(GtkWidget *widget, dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    const int use_work_profile = (module->iop_order > dt_ioppr_get_colorin_iop_order(module->dev->iop));
     const dt_iop_order_iccprofile_info_t *work_profile
-        = (use_work_profile) ? dt_ioppr_get_iop_work_profile_info(module->dev) : NULL;
+        = dt_ioppr_get_iop_work_profile_info(module, module->dev->iop);
     _blendif_scale(cst, raw_mean, picker_mean, work_profile);
     _blendif_scale(cst, raw_min, picker_min, work_profile);
     _blendif_scale(cst, raw_max, picker_max, work_profile);
@@ -1022,9 +1021,8 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    const int use_work_profile = (module->iop_order > dt_ioppr_get_colorin_iop_order(module->dev->iop));
     const dt_iop_order_iccprofile_info_t *work_profile
-        = (use_work_profile) ? dt_ioppr_get_iop_work_profile_info(module->dev) : NULL;
+        = dt_ioppr_get_iop_work_profile_info(module, module->dev->iop);
     _blendif_scale(cst, raw_mean, picker_mean, work_profile);
     _blendif_scale(cst, raw_min, picker_min, work_profile);
     _blendif_scale(cst, raw_max, picker_max, work_profile);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -320,13 +320,33 @@ static float _mouse_to_curve(const float x, const float zoom_factor, const float
 static void picker_scale(const float *const in, float *out, dt_iop_rgbcurve_params_t *p,
                          const dt_iop_order_iccprofile_info_t *const work_profile)
 {
-  if(p->compensate_middle_grey && work_profile)
+  switch(p->curve_autoscale)
   {
-    for(int c = 0; c < 3; c++) out[c] = dt_ioppr_compensate_middle_grey(in[c], work_profile);
-  }
-  else
-  {
-    for(int c = 0; c < 3; c++) out[c] = in[c];
+    case DT_S_SCALE_MANUAL_RGB:
+      if(p->compensate_middle_grey && work_profile)
+      {
+        for(int c = 0; c < 3; c++) out[c] = dt_ioppr_compensate_middle_grey(in[c], work_profile);
+      }
+      else
+      {
+        for(int c = 0; c < 3; c++) out[c] = in[c];
+      }
+      break;
+    case DT_S_SCALE_AUTOMATIC_RGB:
+    {
+      const float val
+          = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(in, work_profile) : dt_camera_rgb_luminance(in);
+      if(p->compensate_middle_grey && work_profile)
+      {
+        out[0] = dt_ioppr_compensate_middle_grey(val, work_profile);
+      }
+      else
+      {
+        out[0] = val;
+      }
+      out[1] = out[2] = 0.f;
+    }
+    break;
   }
 
   for(int c = 0; c < 3; c++) out[c] = CLAMP(out[c], 0.0f, 1.0f);


### PR DESCRIPTION
Fixes #2245

-basic adjustments and rgb curve can now be before colorin
-fixed the opencl call in blend module that wasn't allowing NULL parameters
-fixed linked curve creation nodes when using the 2nd color picker