### PR TITLE
color picker updates

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -983,7 +983,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     return data->color_picker.current_picker;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *module)
+static void _iop_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece)
 {
   if(darktable.gui->reset) return;
 
@@ -1021,8 +1021,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module)
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
                         ? data->csp
                         : dt_iop_color_picker_get_active_cst(module);
-    const dt_iop_order_iccprofile_info_t *work_profile
-        = dt_ioppr_get_iop_work_profile_info(module, module->dev->iop);
+    const dt_iop_order_iccprofile_info_t *work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
     _blendif_scale(cst, raw_mean, picker_mean, work_profile);
     _blendif_scale(cst, raw_min, picker_min, work_profile);
     _blendif_scale(cst, raw_max, picker_max, work_profile);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -474,12 +474,6 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   const int width = roi->width;
   const int height = roi->height;
 
-  // initialize picker values. a positive value of picked_color_max[0] can later be used to check for validity
-  // of data
-  for(int k = 0; k < 4; k++) picked_color_min[k] = INFINITY;
-  for(int k = 0; k < 4; k++) picked_color_max[k] = -INFINITY;
-  for(int k = 0; k < 4; k++) picked_color[k] = 0.0f;
-
   // do not continue if one of the point coordinates is set to a negative value indicating a not yet defined
   // position
   if(module->color_picker_point[0] < 0 || module->color_picker_point[1] < 0) return 1;
@@ -541,10 +535,34 @@ static void pixelpipe_picker(dt_iop_module_t *module, dt_iop_buffer_dsc_t *dsc, 
   int box[4];
 
   if(pixelpipe_picker_helper(module, roi, picked_color, picked_color_min, picked_color_max, picker_source, box))
-    return;
+  {
+    for(int k = 0; k < 4; k++)
+    {
+      picked_color_min[k] = INFINITY;
+      picked_color_max[k] = -INFINITY;
+      picked_color[k] = 0.0f;
+    }
 
-  dt_color_picker_helper(dsc, pixel, roi, box, picked_color, picked_color_min, picked_color_max,
-      image_cst, dt_iop_color_picker_get_active_cst(module));
+    return;
+  }
+
+  float min[4], max[4], avg[4];
+  for(int k = 0; k < 4; k++)
+  {
+    min[k] = INFINITY;
+    max[k] = -INFINITY;
+    avg[k] = 0.0f;
+  }
+
+  dt_color_picker_helper(dsc, pixel, roi, box, avg, min, max, image_cst,
+                         dt_iop_color_picker_get_active_cst(module));
+
+  for(int k = 0; k < 4; k++)
+  {
+    picked_color_min[k] = min[k];
+    picked_color_max[k] = max[k];
+    picked_color[k] = avg[k];
+  }
 }
 
 
@@ -561,7 +579,16 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
   int box[4];
 
   if(pixelpipe_picker_helper(module, roi, picked_color, picked_color_min, picked_color_max, picker_source, box))
+  {
+    for(int k = 0; k < 4; k++)
+    {
+      picked_color_min[k] = INFINITY;
+      picked_color_max[k] = -INFINITY;
+      picked_color[k] = 0.0f;
+    }
+
     return;
+  }
 
   size_t origin[3];
   size_t region[3];
@@ -602,8 +629,23 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
   box[2] = region[0];
   box[3] = region[1];
 
-  dt_color_picker_helper(dsc, pixel, &roi_copy, box, picked_color, picked_color_min, picked_color_max,
-      image_cst, dt_iop_color_picker_get_active_cst(module));
+  float min[4], max[4], avg[4];
+  for(int k = 0; k < 4; k++)
+  {
+    min[k] = INFINITY;
+    max[k] = -INFINITY;
+    avg[k] = 0.0f;
+  }
+
+  dt_color_picker_helper(dsc, pixel, &roi_copy, box, avg, min, max, image_cst,
+                         dt_iop_color_picker_get_active_cst(module));
+
+  for(int k = 0; k < 4; k++)
+  {
+    picked_color_min[k] = min[k];
+    picked_color_max[k] = max[k];
+    picked_color[k] = avg[k];
+  }
 
 error:
   dt_free_align(tmpbuf);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1446,7 +1446,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            dt_iop_color_picker_apply_module(module);
+            dt_iop_color_picker_apply_module(module, piece);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1608,7 +1608,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            dt_iop_color_picker_apply_module(module);
+            dt_iop_color_picker_apply_module(module, piece);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -1848,7 +1848,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
             dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-            dt_iop_color_picker_apply_module(module);
+            dt_iop_color_picker_apply_module(module, piece);
 
             dt_pthread_mutex_lock(&pipe->busy_mutex);
           }
@@ -2003,7 +2003,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
           dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-          dt_iop_color_picker_apply_module(module);
+          dt_iop_color_picker_apply_module(module, piece);
 
           dt_pthread_mutex_lock(&pipe->busy_mutex);
         }
@@ -2122,7 +2122,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
         dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-        dt_iop_color_picker_apply_module(module);
+        dt_iop_color_picker_apply_module(module, piece);
 
         dt_pthread_mutex_lock(&pipe->busy_mutex);
       }
@@ -2226,7 +2226,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
       dt_pthread_mutex_unlock(&pipe->busy_mutex);
 
-      dt_iop_color_picker_apply_module(module);
+      dt_iop_color_picker_apply_module(module, piece);
 
       dt_pthread_mutex_lock(&pipe->busy_mutex);
     }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -78,16 +78,16 @@ static void _internal_iop_color_picker_update(dt_iop_color_picker_t *picker)
   darktable.gui->reset = old_reset;
 }
 
-void dt_iop_color_picker_apply_module(dt_iop_module_t *module)
+void dt_iop_color_picker_apply_module(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece)
 {
   if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && module->picker && module->picker->apply)
   {
-    module->picker->apply(module);
+    module->picker->apply(module, piece);
     _iop_record_point(module->picker);
   }
   else if(module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && module->blend_picker && module->blend_picker->apply)
   {
-    module->blend_picker->apply(module);
+    module->blend_picker->apply(module, piece);
     _iop_record_point(module->blend_picker);
   }
 }
@@ -115,9 +115,9 @@ int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button
     return _internal_iop_color_picker_get_set(picker, button);
 }
 
-void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker)
+void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker, dt_dev_pixelpipe_iop_t *piece)
 {
-  picker->apply(picker->module);
+  picker->apply(picker->module, piece);
 }
 
 void dt_iop_color_picker_update(dt_iop_color_picker_t *picker)
@@ -128,13 +128,11 @@ void dt_iop_color_picker_update(dt_iop_color_picker_t *picker)
     _internal_iop_color_picker_update(picker);
 }
 
-static void _iop_init_picker(dt_iop_color_picker_t *picker,
-                  dt_iop_module_t *module,
-                  dt_iop_color_picker_kind_t kind,
-                  const int requested_by,
-                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                  void (*apply)(dt_iop_module_t *self),
-                  void (*update)(dt_iop_module_t *self))
+static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
+                             dt_iop_color_picker_kind_t kind, const int requested_by,
+                             int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                             void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
+                             void (*update)(dt_iop_module_t *self))
 {
   picker->module  = module;
   picker->get_set = get_set;
@@ -155,22 +153,18 @@ static void _iop_init_picker(dt_iop_color_picker_t *picker,
   _iop_color_picker_reset(picker, TRUE);
 }
 
-void dt_iop_init_single_picker(dt_iop_color_picker_t *picker,
-                         dt_iop_module_t *module,
-                         GtkWidget *colorpick,
-                         dt_iop_color_picker_kind_t kind,
-                         void (*apply)(dt_iop_module_t *self))
+void dt_iop_init_single_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, GtkWidget *colorpick,
+                               dt_iop_color_picker_kind_t kind,
+                               void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece))
 {
   picker->colorpick = colorpick;
   dt_iop_init_picker(picker, module, kind, NULL, apply, NULL);
 }
 
-void dt_iop_init_picker(dt_iop_color_picker_t *picker,
-                  dt_iop_module_t *module,
-                  dt_iop_color_picker_kind_t kind,
-                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                  void (*apply)(dt_iop_module_t *self),
-                  void (*update)(dt_iop_module_t *self))
+void dt_iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, dt_iop_color_picker_kind_t kind,
+                        int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                        void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
+                        void (*update)(dt_iop_module_t *self))
 {
   _iop_init_picker(picker,
                     module,
@@ -181,12 +175,11 @@ void dt_iop_init_picker(dt_iop_color_picker_t *picker,
                     update);
 }
 
-void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker,
-                  dt_iop_module_t *module,
-                  dt_iop_color_picker_kind_t kind,
-                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                  void (*apply)(dt_iop_module_t *self),
-                  void (*update)(dt_iop_module_t *self))
+void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
+                              dt_iop_color_picker_kind_t kind,
+                              int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                              void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
+                              void (*update)(dt_iop_module_t *self))
 {
   _iop_init_picker(picker,
                     module,

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -59,33 +59,28 @@ typedef struct dt_iop_color_picker_t
   int (*get_set)(dt_iop_module_t *self, GtkWidget *button);
   /* apply the picked color to the selected picker (internal picker id, if multiple are available
      on the module */
-  void (*apply)(dt_iop_module_t *self);
+  void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece);
   /* update the picker icon to correspond to the current selected picker if any */
   void (*update)(dt_iop_module_t *self);
 } dt_iop_color_picker_t;
 
 /* init color picker, this must be called when all picker widgets are created */
-void dt_iop_init_picker(dt_iop_color_picker_t *picker,
-                  dt_iop_module_t *module,
-                  dt_iop_color_picker_kind_t kind,
-                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                  void (*apply)(dt_iop_module_t *self),
-                  void (*update)(dt_iop_module_t *self));
+void dt_iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, dt_iop_color_picker_kind_t kind,
+                        int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                        void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
+                        void (*update)(dt_iop_module_t *self));
 
 /* init for a single color picker in iop, this must be called when all picker widget are created */
-void dt_iop_init_single_picker(dt_iop_color_picker_t *picker,
-                         dt_iop_module_t *module,
-                         GtkWidget *colorpick,
-                         dt_iop_color_picker_kind_t kind,
-                         void (*apply)(dt_iop_module_t *self));
+void dt_iop_init_single_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, GtkWidget *colorpick,
+                               dt_iop_color_picker_kind_t kind,
+                               void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece));
 
 /* same as previous but for the blend module */
-void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker,
-                  dt_iop_module_t *module,
-                  dt_iop_color_picker_kind_t kind,
-                  int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                  void (*apply)(dt_iop_module_t *self),
-                  void (*update)(dt_iop_module_t *self));
+void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
+                              dt_iop_color_picker_kind_t kind,
+                              int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
+                              void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
+                              void (*update)(dt_iop_module_t *self));
 
 /* the color picker callback which must be used for every picker, as an example:
 
@@ -107,12 +102,12 @@ void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self
 gboolean dt_iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self);
 
 /* called by pixelpipe when color has been updated */
-void dt_iop_color_picker_apply_module(dt_iop_module_t *module);
+void dt_iop_color_picker_apply_module(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece);
 
 /* call proxy get_set */
 int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button);
 /* call proxy apply */
-void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker);
+void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker, dt_dev_pixelpipe_iop_t *piece);
 /* call proxy update */
 void dt_iop_color_picker_update(dt_iop_color_picker_t *picker);
 /* reset current color picker and/or blend color picker, and if update is TRUE also call update proxy */

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -522,8 +522,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
   dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
 
-  const dt_iop_order_iccprofile_info_t *const work_profile
-      = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
   p->middle_grey = (work_profile) ? (dt_ioppr_get_rgb_matrix_luminance(self->picked_color, work_profile) * 100.f)
                                   : dt_camera_rgb_luminance(self->picked_color);
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -516,7 +516,7 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -613,7 +613,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     return g->color_picker.current_picker;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1356,7 +1356,7 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
   dt_bauhaus_widget_set_quad_active(g->auto_color, which_colorpicker == DT_PICKCOLBAL_AUTOCOLOR);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
   switch(g->color_picker.current_picker)

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -279,7 +279,7 @@ static void saturation_callback(GtkWidget *slider, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -951,7 +951,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
     pango_font_description_set_absolute_size(desc, width * 1.0 / ink.width * PANGO_SCALE);
     pango_layout_set_font_description(layout, desc);
 
-    snprintf(text, sizeof(text), "zoom: %i x: %i y: %ia", (int)((c->zoom_factor - 1.f) * 100.f),
+    snprintf(text, sizeof(text), "zoom: %i x: %i y: %i", (int)((c->zoom_factor - 1.f) * 100.f),
              (int)(c->offset_x * 100.f), (int)(c->offset_y * 100.f));
 
     cairo_set_source_rgba(cr, 0.1, 0.1, 0.1, 0.5);
@@ -2022,7 +2022,7 @@ void gui_init(struct dt_iop_module_t *self)
     (void)dt_draw_curve_add_point(c->minmax_curve[ch], p->curve[ch][1].x + 1.0, p->curve[ch][1].y);
   }
 
-  c->mouse_x = c->mouse_y = /*c->mouse_pick =*/-1.0;
+  c->mouse_x = c->mouse_y = -1.0;
   c->selected = -1;
   c->offset_x = c->offset_y = 0.f;
   c->zoom_factor = 1.f;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1878,7 +1878,7 @@ static void _mode_callback(GtkWidget *widget, dt_iop_module_t *self)
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   if(g->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -717,7 +717,7 @@ static float dt_iop_exposure_get_black(struct dt_iop_module_t *self)
   return p->black;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -899,7 +899,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     return g->color_picker.current_picker;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
   switch(g->color_picker.current_picker)

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -424,7 +424,7 @@ static inline void update_saturation_slider_end_color(GtkWidget *slider, float h
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -164,7 +164,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   static float old[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -258,7 +258,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     return g->color_picker.current_picker;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -431,7 +431,7 @@ static gboolean dt_iop_monochrome_draw(GtkWidget *widget, cairo_t *crf, gpointer
   return TRUE;
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
 

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -619,7 +619,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     return g->color_picker.current_picker;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
   switch(g->color_picker.current_picker)

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -299,7 +299,7 @@ void cleanup(dt_iop_module_t *module)
 }
 
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
   float mean, min, max;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1852,7 +1852,7 @@ static gboolean rt_levelsbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module
   return TRUE;
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -572,8 +572,7 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     dt_iop_rgbcurve_params_t *d = (dt_iop_rgbcurve_params_t *)self->default_params;
 
     const int ch = g->channel;
-    const dt_iop_order_iccprofile_info_t *const work_profile
-        = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+    const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 
     // reset current curve
     p->curve_num_nodes[ch] = d->curve_num_nodes[ch];

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -976,6 +976,10 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
       const float *const raw_max = self->picked_color_max;
       const float *const raw_mean_output = self->picked_output_color;
 
+/* this is working with the export profile while the module histogram works with the work profile or the
+   compensated one, so we need to transform the data to the work profile and then compensate if required. For
+   now just disable it. */
+#if 0
       // the global live samples ...
       GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
       dt_colorpicker_sample_t *sample = NULL;
@@ -1003,7 +1007,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
 
         samples = g_slist_next(samples);
       }
-
+#endif
       // ... and the local sample
       if(raw_max[ch] >= 0.0f)
       {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -563,7 +563,7 @@ static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float
   return _add_node(p->curve_nodes[ch], &p->curve_num_nodes[ch], x, y);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
   if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES)

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -439,7 +439,7 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
     return g->color_picker.current_picker;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1312,7 +1312,7 @@ static void finetune_changed(GtkWidget *widget, gpointer user_data)
   apply_preset((dt_iop_module_t *)user_data);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self)
+static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -997,7 +997,7 @@ static float to_lin(const float x, const float base, const int ch, const int sem
   }
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_tonecurve_global_data_t *gd = (dt_iop_tonecurve_global_data_t *)self->data;
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1044,7 +1044,7 @@ static void watermark_callback(GtkWidget *tb, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self)
+static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;


### PR DESCRIPTION
-This adds the piece to the picker->apply() so the color space profile can be used if needed.

-There is some flickering on the rgb curve histogram when using the second color picker, this is because the picked values are set to -inf long before the new values are calculated and the draw() is picking this intermediate values, so I use a temp variable for the calculations and then update the actual fields.

-The global picker is not showing the right values, but for now there's no way to fix this.