### PR TITLE
color picker updates

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2010,6 +2010,15 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_set_pipe_work_profile_info(struct dt_de
   return profile_info;
 }
 
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev)
+{
+  dt_colorspaces_color_profile_type_t histogram_profile_type;
+  char *histogram_profile_filename;
+  dt_ioppr_get_histogram_profile_type(&histogram_profile_type, &histogram_profile_filename);
+  return dt_ioppr_add_profile_info_to_list(dev, histogram_profile_type, histogram_profile_filename,
+                                           DT_INTENT_PERCEPTUAL);
+}
+
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe)
 {
   return pipe->dsc.work_profile_info;
@@ -2113,6 +2122,31 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_typ
   }
   else
     fprintf(stderr, "[dt_ioppr_get_export_profile_type] can't find colorout iop\n");
+}
+
+void dt_ioppr_get_histogram_profile_type(int *profile_type, char **profile_filename)
+{
+  const dt_colorspaces_color_mode_t mode = darktable.color_profiles->mode;
+
+  // if in gamut check use soft proof
+  if(mode != DT_PROFILE_NORMAL || darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
+  {
+    *profile_type = darktable.color_profiles->softproof_type;
+    *profile_filename = darktable.color_profiles->softproof_filename;
+  }
+  else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_WORK)
+  {
+    dt_ioppr_get_work_profile_type(darktable.develop, profile_type, profile_filename);
+  }
+  else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_EXPORT)
+  {
+    dt_ioppr_get_export_profile_type(darktable.develop, profile_type, profile_filename);
+  }
+  else
+  {
+    *profile_type = darktable.color_profiles->histogram_type;
+    *profile_filename = darktable.color_profiles->histogram_filename;
+  }
 }
 
 float dt_ioppr_get_rgb_matrix_luminance(const float *const rgb, const dt_iop_order_iccprofile_info_t *const profile_info)

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -126,6 +126,10 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(struct dt_iop
  */
 dt_iop_order_iccprofile_info_t *dt_ioppr_set_pipe_work_profile_info(struct dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, 
     const int type, const char *filename, const int intent);
+/** returns a reference to the histogram profile info
+ * histogram profile must not be cleanup()
+ */
+dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev);
 
 /** returns the active work profile on the pipe */
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe);
@@ -134,6 +138,8 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_de
 void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename);
 /** returns the current setting of the export profile on colorout iop */
 void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename);
+/** returns the current setting of the histogram profile */
+void dt_ioppr_get_histogram_profile_type(int *profile_type, char **profile_filename);
 
 /** transforms image from cst_from to cst_to colorspace using profile_info */
 void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const float *const image_in,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -759,31 +759,6 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
   }
 }
 
-static void _pixelpipe_get_histogram_profile_type(dt_colorspaces_color_profile_type_t *out_type, gchar **out_filename)
-{
-  dt_colorspaces_color_mode_t mode = darktable.color_profiles->mode;
-  
-  // if in gamut check use soft proof
-  if(mode != DT_PROFILE_NORMAL || darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
-  {
-    *out_type = darktable.color_profiles->softproof_type;
-    *out_filename = darktable.color_profiles->softproof_filename;
-  }
-  else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_WORK)
-  {
-    dt_ioppr_get_work_profile_type(darktable.develop, out_type, out_filename);
-  }
-  else if(darktable.color_profiles->histogram_type == DT_COLORSPACE_EXPORT)
-  {
-    dt_ioppr_get_export_profile_type(darktable.develop, out_type, out_filename);
-  }
-  else
-  {
-    *out_type = darktable.color_profiles->histogram_type;
-    *out_filename = darktable.color_profiles->histogram_filename;
-  }
-}
-
 static void _pixelpipe_pick_live_samples(const float *const input, const dt_iop_roi_t *roi_in)
 {
   cmsHPROFILE display_profile = NULL;
@@ -795,7 +770,7 @@ static void _pixelpipe_pick_live_samples(const float *const input, const dt_iop_
   gchar *histogram_filename = NULL;
   gchar _histogram_filename[1] = { 0 };
 
-  _pixelpipe_get_histogram_profile_type(&histogram_type, &histogram_filename);
+  dt_ioppr_get_histogram_profile_type(&histogram_type, &histogram_filename);
   if(histogram_filename == NULL) histogram_filename = _histogram_filename;
   
   if(darktable.color_profiles->display_type == DT_COLORSPACE_DISPLAY || histogram_type == DT_COLORSPACE_DISPLAY)
@@ -865,7 +840,7 @@ static void _pixelpipe_pick_primary_colorpicker(dt_develop_t *dev, const float *
   gchar *histogram_filename = NULL;
   gchar _histogram_filename[1] = { 0 };
 
-  _pixelpipe_get_histogram_profile_type(&histogram_type, &histogram_filename);
+  dt_ioppr_get_histogram_profile_type(&histogram_type, &histogram_filename);
   if(histogram_filename == NULL) histogram_filename = _histogram_filename;
   
   if(darktable.color_profiles->display_type == DT_COLORSPACE_DISPLAY || histogram_type == DT_COLORSPACE_DISPLAY)
@@ -944,7 +919,7 @@ static void _pixelpipe_final_histogram(dt_develop_t *dev, const float *const inp
   gchar *histogram_filename = NULL;
   gchar _histogram_filename[1] = { 0 };
 
-  _pixelpipe_get_histogram_profile_type(&histogram_type, &histogram_filename);
+  dt_ioppr_get_histogram_profile_type(&histogram_type, &histogram_filename);
   if(histogram_filename == NULL) histogram_filename = _histogram_filename;
   
   if((histogram_type != darktable.color_profiles->display_type) || 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -82,12 +82,18 @@ void dt_iop_color_picker_apply_module(dt_iop_module_t *module, dt_dev_pixelpipe_
 {
   if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && module->picker && module->picker->apply)
   {
-    module->picker->apply(module, piece);
+    if(module->picker->skip_apply)
+      module->picker->skip_apply = FALSE;
+    else
+      module->picker->apply(module, piece);
     _iop_record_point(module->picker);
   }
   else if(module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && module->blend_picker && module->blend_picker->apply)
   {
-    module->blend_picker->apply(module, piece);
+    if(module->blend_picker->skip_apply)
+      module->blend_picker->skip_apply = FALSE;
+    else
+      module->blend_picker->apply(module, piece);
     _iop_record_point(module->blend_picker);
   }
 }
@@ -117,7 +123,10 @@ int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button
 
 void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker, dt_dev_pixelpipe_iop_t *piece)
 {
-  picker->apply(picker->module, piece);
+  if(picker->skip_apply)
+    picker->skip_apply = FALSE;
+  else
+    picker->apply(picker->module, piece);
 }
 
 void dt_iop_color_picker_update(dt_iop_color_picker_t *picker)
@@ -141,6 +150,7 @@ static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *mod
   picker->kind    = kind;
   picker->requested_by = requested_by;
   picker->picker_cst = iop_cs_NONE;
+  picker->skip_apply = FALSE;
   if(picker->requested_by == DT_COLOR_PICKER_REQ_MODULE)
     module->picker  = picker;
   else

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -51,6 +51,8 @@ typedef struct dt_iop_color_picker_t
    */
   dt_iop_colorspace_type_t picker_cst;
   unsigned short current_picker;
+  /** used to avoid recursion when a parameter is modified in the apply() */
+  gboolean skip_apply;
   GtkWidget *colorpick;
   float pick_pos[9][2]; // last picker positions (max 9 picker per module)
   /* get and set the selected picker corresponding to button, the module must record the previous

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -55,6 +55,7 @@ typedef struct dt_iop_color_picker_t
   gboolean skip_apply;
   GtkWidget *colorpick;
   float pick_pos[9][2]; // last picker positions (max 9 picker per module)
+  float pick_box[9][4]; // last picker areas (max 9 picker per module)
   /* get and set the selected picker corresponding to button, the module must record the previous
      selected picker and return DT_COLOR_PICKER_ALREADY_SELECTED if the same picker has been selected. The return
      value corresponds to the module internal picker id. */

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -530,6 +530,9 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
   dt_bauhaus_slider_set(g->sl_middle_grey, p->middle_grey);
   darktable.gui->reset = 0;
 
+  // avoid recursion
+  self->picker->skip_apply = TRUE;
+
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -27,6 +27,7 @@
 #include "dtgtk/drawingarea.h"
 #include "gui/color_picker_proxy.h"
 #include "gui/presets.h"
+#include "libs/colorpicker.h"
 
 DT_MODULE_INTROSPECTION(4, dt_iop_colorzones_params_t)
 
@@ -640,8 +641,90 @@ static int _select_base_display_color(dt_iop_module_t *self, float *picked_color
 
 static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorzones_params_t *p,
                                dt_iop_colorzones_gui_data_t *c, const int width, const int height,
-                               float *picked_color, float *picker_min, float *picker_max)
+                               const float *const picker_color, const float *const picker_min,
+                               const float *const picker_max)
 {
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  {
+    // the global live samples ...
+    GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
+    if(samples)
+    {
+      const dt_iop_order_iccprofile_info_t *const histogram_profile
+          = dt_ioppr_get_histogram_profile_info(self->dev);
+      const dt_iop_order_iccprofile_info_t *const work_profile
+          = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+      float pick_mean[4], pick_min[4], pick_max[4];
+      int converted_cst;
+
+      if(work_profile && histogram_profile)
+      {
+        dt_colorpicker_sample_t *sample = NULL;
+        while(samples)
+        {
+          sample = samples->data;
+
+          float picked_i = -1.0;
+          float picked_min_i = -1.0;
+          float picked_max_i = -1.0;
+
+          dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_mean, pick_mean, 1, 1,
+                                                  histogram_profile, work_profile, "color zones");
+          dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_min, pick_min, 1, 1, histogram_profile,
+                                                  work_profile, "color zones");
+          dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_max, pick_max, 1, 1, histogram_profile,
+                                                  work_profile, "color zones");
+
+          dt_ioppr_transform_image_colorspace(self, pick_mean, pick_mean, 1, 1, iop_cs_rgb, iop_cs_Lab,
+                                              &converted_cst, work_profile);
+          dt_ioppr_transform_image_colorspace(self, pick_min, pick_min, 1, 1, iop_cs_rgb, iop_cs_Lab,
+                                              &converted_cst, work_profile);
+          dt_ioppr_transform_image_colorspace(self, pick_max, pick_max, 1, 1, iop_cs_rgb, iop_cs_Lab,
+                                              &converted_cst, work_profile);
+
+          dt_Lab_2_LCH(pick_mean, pick_mean);
+          dt_Lab_2_LCH(pick_min, pick_min);
+          dt_Lab_2_LCH(pick_max, pick_max);
+
+          switch(p->channel)
+          {
+            // select by channel, abscissa:
+            case DT_IOP_COLORZONES_L:
+              picked_i = pick_mean[0] / 100.0;
+              picked_min_i = pick_min[0] / 100.0;
+              picked_max_i = pick_max[0] / 100.0;
+              break;
+            case DT_IOP_COLORZONES_C:
+              picked_i = pick_mean[1] / (128.0f * sqrtf(2.f));
+              picked_min_i = pick_min[1] / (128.0f * sqrtf(2.f));
+              picked_max_i = pick_max[1] / (128.0f * sqrtf(2.f));
+              break;
+            default: // case DT_IOP_COLORZONES_h:
+              picked_i = pick_mean[2];
+              picked_min_i = pick_min[2];
+              picked_max_i = pick_max[2];
+              break;
+          }
+
+          // Convert abcissa to log coordinates if needed
+          picked_i = _curve_to_mouse(picked_i, c->zoom_factor, c->offset_x);
+          picked_min_i = _curve_to_mouse(picked_min_i, c->zoom_factor, c->offset_x);
+          picked_max_i = _curve_to_mouse(picked_max_i, c->zoom_factor, c->offset_x);
+
+          cairo_set_source_rgba(cr, 0.5, 0.7, 0.5, 0.15);
+          cairo_rectangle(cr, width * picked_min_i, 0, width * fmax(picked_max_i - picked_min_i, 0.0f), height);
+          cairo_fill(cr);
+          cairo_set_source_rgba(cr, 0.5, 0.7, 0.5, 0.5);
+          cairo_move_to(cr, width * picked_i, 0);
+          cairo_line_to(cr, width * picked_i, height);
+          cairo_stroke(cr);
+
+          samples = g_slist_next(samples);
+        }
+      }
+    }
+  }
+
   if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
   {
     // draw marker for currently selected color:
@@ -652,17 +735,17 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
     {
       // select by channel, abscissa:
       case DT_IOP_COLORZONES_L:
-        picked_i = picked_color[0] / 100.0;
+        picked_i = picker_color[0] / 100.0;
         picked_min_i = picker_min[0] / 100.0;
         picked_max_i = picker_max[0] / 100.0;
         break;
       case DT_IOP_COLORZONES_C:
-        picked_i = picked_color[1] / (128.0f * sqrtf(2.f));
+        picked_i = picker_color[1] / (128.0f * sqrtf(2.f));
         picked_min_i = picker_min[1] / (128.0f * sqrtf(2.f));
         picked_max_i = picker_max[1] / (128.0f * sqrtf(2.f));
         break;
       default: // case DT_IOP_COLORZONES_h:
-        picked_i = picked_color[2];
+        picked_i = picker_color[2];
         picked_min_i = picker_min[2];
         picked_max_i = picker_max[2];
         break;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2029,6 +2029,9 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     x += feather;
     if(x > 0.f && x < 1.f) _add_node(curve, &p->curve_num_nodes[ch_curve], x, .5f);
 
+    // avoid recursion
+    self->picker->skip_apply = TRUE;
+
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -668,12 +668,21 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
           float picked_min_i = -1.0;
           float picked_max_i = -1.0;
 
-          dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_mean, pick_mean, 1, 1,
-                                                  histogram_profile, work_profile, "color zones");
-          dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_min, pick_min, 1, 1, histogram_profile,
-                                                  work_profile, "color zones");
-          dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_max, pick_max, 1, 1, histogram_profile,
-                                                  work_profile, "color zones");
+          // this functions need a 4c image
+          for(int k = 0; k < 3; k++)
+          {
+            pick_mean[k] = sample->picked_color_rgb_mean[k];
+            pick_min[k] = sample->picked_color_rgb_min[k];
+            pick_max[k] = sample->picked_color_rgb_max[k];
+          }
+          pick_mean[3] = pick_min[3] = pick_max[3] = 1.f;
+
+          dt_ioppr_transform_image_colorspace_rgb(pick_mean, pick_mean, 1, 1, histogram_profile, work_profile,
+                                                  "color zones");
+          dt_ioppr_transform_image_colorspace_rgb(pick_min, pick_min, 1, 1, histogram_profile, work_profile,
+                                                  "color zones");
+          dt_ioppr_transform_image_colorspace_rgb(pick_max, pick_max, 1, 1, histogram_profile, work_profile,
+                                                  "color zones");
 
           dt_ioppr_transform_image_colorspace(self, pick_mean, pick_mean, 1, 1, iop_cs_rgb, iop_cs_Lab,
                                               &converted_cst, work_profile);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -968,47 +968,52 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
       const dt_iop_order_iccprofile_info_t *const work_profile
           = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
 
-      float picker_mean[3], picker_min[3], picker_max[3];
+      float picker_mean[4], picker_min[4], picker_max[4];
 
-      const float *const raw_mean = self->picked_color;
-      const float *const raw_min = self->picked_color_min;
-      const float *const raw_max = self->picked_color_max;
-      const float *const raw_mean_output = self->picked_output_color;
-
-/* this is working with the export profile while the module histogram works with the work profile or the
-   compensated one, so we need to transform the data to the work profile and then compensate if required. For
-   now just disable it. */
-#if 0
       // the global live samples ...
       GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
-      dt_colorpicker_sample_t *sample = NULL;
-      while(samples)
+      if(samples)
       {
-        sample = samples->data;
+        const dt_iop_order_iccprofile_info_t *const histogram_profile = dt_ioppr_get_histogram_profile_info(dev);
+        if(work_profile && histogram_profile)
+        {
+          dt_colorpicker_sample_t *sample = NULL;
+          while(samples)
+          {
+            sample = samples->data;
 
-        picker_scale(sample->picked_color_rgb_mean, picker_mean, p, work_profile);
-        picker_scale(sample->picked_color_rgb_min, picker_min, p, work_profile);
-        picker_scale(sample->picked_color_rgb_max, picker_max, p, work_profile);
+            dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_mean, picker_mean, 1, 1,
+                                                    histogram_profile, work_profile, "rgb curve");
+            dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_min, picker_min, 1, 1,
+                                                    histogram_profile, work_profile, "rgb curve");
+            dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_max, picker_max, 1, 1,
+                                                    histogram_profile, work_profile, "rgb curve");
 
-        // Convert abcissa to log coordinates if needed
-        picker_min[ch] = _curve_to_mouse(picker_min[ch], g->zoom_factor, g->offset_x);
-        picker_max[ch] = _curve_to_mouse(picker_max[ch], g->zoom_factor, g->offset_x);
-        picker_mean[ch] = _curve_to_mouse(picker_mean[ch], g->zoom_factor, g->offset_x);
+            picker_scale(picker_mean, picker_mean, p, work_profile);
+            picker_scale(picker_min, picker_min, p, work_profile);
+            picker_scale(picker_max, picker_max, p, work_profile);
 
-        cairo_set_source_rgba(cr, 0.5, 0.7, 0.5, 0.15);
-        cairo_rectangle(cr, width * picker_min[ch], 0, width * fmax(picker_max[ch] - picker_min[ch], 0.0f),
-                        -height);
-        cairo_fill(cr);
-        cairo_set_source_rgba(cr, 0.5, 0.7, 0.5, 0.5);
-        cairo_move_to(cr, width * picker_mean[ch], 0);
-        cairo_line_to(cr, width * picker_mean[ch], -height);
-        cairo_stroke(cr);
+            // Convert abcissa to log coordinates if needed
+            picker_min[ch] = _curve_to_mouse(picker_min[ch], g->zoom_factor, g->offset_x);
+            picker_max[ch] = _curve_to_mouse(picker_max[ch], g->zoom_factor, g->offset_x);
+            picker_mean[ch] = _curve_to_mouse(picker_mean[ch], g->zoom_factor, g->offset_x);
 
-        samples = g_slist_next(samples);
+            cairo_set_source_rgba(cr, 0.5, 0.7, 0.5, 0.15);
+            cairo_rectangle(cr, width * picker_min[ch], 0, width * fmax(picker_max[ch] - picker_min[ch], 0.0f),
+                            -height);
+            cairo_fill(cr);
+            cairo_set_source_rgba(cr, 0.5, 0.7, 0.5, 0.5);
+            cairo_move_to(cr, width * picker_mean[ch], 0);
+            cairo_line_to(cr, width * picker_mean[ch], -height);
+            cairo_stroke(cr);
+
+            samples = g_slist_next(samples);
+          }
       }
-#endif
+      }
+
       // ... and the local sample
-      if(raw_max[ch] >= 0.0f)
+      if(self->picked_color_max[ch] >= 0.0f)
       {
         PangoLayout *layout;
         PangoRectangle ink;
@@ -1018,9 +1023,9 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
         layout = pango_cairo_create_layout(cr);
         pango_layout_set_font_description(layout, desc);
 
-        picker_scale(raw_mean, picker_mean, p, work_profile);
-        picker_scale(raw_min, picker_min, p, work_profile);
-        picker_scale(raw_max, picker_max, p, work_profile);
+        picker_scale(self->picked_color, picker_mean, p, work_profile);
+        picker_scale(self->picked_color_min, picker_min, p, work_profile);
+        picker_scale(self->picked_color_max, picker_max, p, work_profile);
 
         // scale conservatively to 100% of width:
         snprintf(text, sizeof(text), "100.00 / 100.00 ( +100.00)");
@@ -1042,7 +1047,7 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
         cairo_line_to(cr, width * picker_mean[ch], -height);
         cairo_stroke(cr);
 
-        snprintf(text, sizeof(text), "%.1f → %.1f", raw_mean[ch], raw_mean_output[ch]);
+        snprintf(text, sizeof(text), "%.1f → %.1f", self->picked_color[ch], self->picked_output_color[ch]);
 
         cairo_set_source_rgb(cr, 0.1, 0.1, 0.1);
         cairo_set_font_size(cr, DT_PIXEL_APPLY_DPI(0.04) * height);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -595,6 +595,9 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
                 p->curve_nodes[ch][1].x - increment + (p->curve_nodes[ch][3].x - p->curve_nodes[ch][1].x) / 2.f,
                 p->curve_nodes[ch][1].y + increment + (p->curve_nodes[ch][3].y - p->curve_nodes[ch][1].y) / 2.f);
 
+    // avoid recursion
+    self->picker->skip_apply = TRUE;
+
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
 

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -985,12 +985,21 @@ static gboolean _area_draw_callback(GtkWidget *widget, cairo_t *crf, dt_iop_modu
           {
             sample = samples->data;
 
-            dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_mean, picker_mean, 1, 1,
-                                                    histogram_profile, work_profile, "rgb curve");
-            dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_min, picker_min, 1, 1,
-                                                    histogram_profile, work_profile, "rgb curve");
-            dt_ioppr_transform_image_colorspace_rgb(sample->picked_color_rgb_max, picker_max, 1, 1,
-                                                    histogram_profile, work_profile, "rgb curve");
+            // this functions need a 4c image
+            for(int k = 0; k < 3; k++)
+            {
+              picker_mean[k] = sample->picked_color_rgb_mean[k];
+              picker_min[k] = sample->picked_color_rgb_min[k];
+              picker_max[k] = sample->picked_color_rgb_max[k];
+            }
+            picker_mean[3] = picker_min[3] = picker_max[3] = 1.f;
+
+            dt_ioppr_transform_image_colorspace_rgb(picker_mean, picker_mean, 1, 1, histogram_profile,
+                                                    work_profile, "rgb curve");
+            dt_ioppr_transform_image_colorspace_rgb(picker_min, picker_min, 1, 1, histogram_profile, work_profile,
+                                                    "rgb curve");
+            dt_ioppr_transform_image_colorspace_rgb(picker_max, picker_max, 1, 1, histogram_profile, work_profile,
+                                                    "rgb curve");
 
             picker_scale(picker_mean, picker_mean, p, work_profile);
             picker_scale(picker_min, picker_min, p, work_profile);

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -448,6 +448,20 @@ static void _set_sample_area(dt_lib_module_t *self, float size)
   d->from_proxy = FALSE;
 }
 
+static void _set_sample_box_area(dt_lib_module_t *self, const float *const box)
+{
+  dt_lib_colorpicker_t *d = (dt_lib_colorpicker_t *)self->data;
+
+  if(darktable.develop->gui_module)
+  {
+    for(int k = 0; k < 4; k++) darktable.develop->gui_module->color_picker_box[k] = box[k];
+  }
+
+  d->from_proxy = TRUE;
+  gtk_combo_box_set_active(GTK_COMBO_BOX(d->size_selector), DT_COLORPICKER_SIZE_BOX);
+  d->from_proxy = FALSE;
+}
+
 static void _set_sample_point(dt_lib_module_t *self, float x, float y)
 {
   dt_lib_colorpicker_t *d = (dt_lib_colorpicker_t *)self->data;
@@ -506,6 +520,7 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.update_panel = _update_picker_output;
   darktable.lib->proxy.colorpicker.update_samples = _update_samples_output;
   darktable.lib->proxy.colorpicker.set_sample_area = _set_sample_area;
+  darktable.lib->proxy.colorpicker.set_sample_box_area = _set_sample_box_area;
   darktable.lib->proxy.colorpicker.set_sample_point = _set_sample_point;
 
   // Setting up the GUI
@@ -622,6 +637,7 @@ void gui_cleanup(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.update_samples = NULL;
 
   darktable.lib->proxy.colorpicker.set_sample_area = NULL;
+  darktable.lib->proxy.colorpicker.set_sample_box_area = NULL;
 
   free(darktable.lib->proxy.colorpicker.picked_color_rgb_mean);
   free(darktable.lib->proxy.colorpicker.picked_color_rgb_min);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1200,6 +1200,13 @@ void dt_lib_colorpicker_set_area(dt_lib_t *lib, float size)
   gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 }
 
+void dt_lib_colorpicker_set_box_area(dt_lib_t *lib, const float *const box)
+{
+  if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_box_area) return;
+  lib->proxy.colorpicker.set_sample_box_area(lib->proxy.colorpicker.module, box);
+  gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
+}
+
 void dt_lib_colorpicker_set_point(dt_lib_t *lib, float x, float y)
 {
   if(!lib->proxy.colorpicker.module || !lib->proxy.colorpicker.set_sample_point) return;

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -61,6 +61,7 @@ typedef struct dt_lib_t
       void (*update_panel)(struct dt_lib_module_t *self);
       void (*update_samples)(struct dt_lib_module_t *self);
       void (*set_sample_area)(struct dt_lib_module_t *self, float size);
+      void (*set_sample_box_area)(struct dt_lib_module_t *self, const float *const size);
       void (*set_sample_point)(struct dt_lib_module_t *self, float x, float y);
     } colorpicker;
 
@@ -175,6 +176,8 @@ void dt_lib_presets_add(const char *name, const char *plugin_name, const int32_t
 
 /** set the colorpicker area selection tool and size, size 0.0 - 1.0 */
 void dt_lib_colorpicker_set_area(dt_lib_t *lib, float size);
+/** set the colorpicker area selection tool and size, box[k] 0.0 - 1.0 */
+void dt_lib_colorpicker_set_box_area(dt_lib_t *lib, const float *const box);
 
 /** set the colorpicker point selection tool and position */
 void dt_lib_colorpicker_set_point(dt_lib_t *lib, float x, float y);


### PR DESCRIPTION
-Add the global color picker to rgb curve and color zones

-Avoid recursion when calling apply()

-Make modules remember the color picker area