### PR TITLE
remove meaningless const declarations in return types

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1528,10 +1528,10 @@ void dt_colorspaces_set_display_profile()
   g_free(profile_source);
 }
 
-static const gboolean _colorspaces_is_base_name(const char *profile)
+static gboolean _colorspaces_is_base_name(const char *profile)
 {
-  char *f = (char *)profile;
-  while(*f)
+  const char *f = profile;
+  while(*f != '\0')
   {
     if(*f == '/' || *f == '\\') return FALSE;
     f++;

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -636,7 +636,7 @@ static void _piwigo_refresh_albums(dt_storage_piwigo_gui_data_t *ui, const gchar
 }
 
 
-static const gboolean _piwigo_api_create_new_album(dt_storage_piwigo_params_t *p)
+static gboolean _piwigo_api_create_new_album(dt_storage_piwigo_params_t *p)
 {
   GList *args = NULL;
 
@@ -668,8 +668,8 @@ static const gboolean _piwigo_api_create_new_album(dt_storage_piwigo_params_t *p
   return TRUE;
 }
 
-static const gboolean _piwigo_api_upload_photo(dt_storage_piwigo_params_t *p, gchar *fname,
-                                               gchar *author, gchar *caption, gchar *description)
+static gboolean _piwigo_api_upload_photo(dt_storage_piwigo_params_t *p, gchar *fname,
+                                         gchar *author, gchar *caption, gchar *description)
 {
   GList *args = NULL;
   char cat[10];

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -529,8 +529,7 @@ static void green_equilibration_favg(float *out, const float *const in, const in
 #define TS 122
 
 /** Lookup for allhex[], making sure that row/col aren't negative **/
-static inline const short *const hexmap(const int row, const int col,
-                                        short (*const allhex)[3][8])
+static inline const short * hexmap(const int row, const int col, short (*const allhex)[3][8])
 {
   // Row and column offsets may be negative, but C's modulo function
   // is not useful here with a negative dividend. To be safe, add a

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -313,7 +313,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 /* Code common to op-engine and gui.                                          */
 /******************************************************************************/
 
-static const float get_rot(const dt_liquify_warp_type_enum_t warp_type)
+static float get_rot(const dt_liquify_warp_type_enum_t warp_type)
 {
   if (warp_type == DT_LIQUIFY_WARP_TYPE_RADIAL_SHRINK)
     return M_PI;
@@ -778,7 +778,7 @@ static GList *interpolate_paths (dt_iop_liquify_params_t *p);
   Used to approximate the arc length of a bezier curve.
 */
 
-static const float get_arc_length (const float complex points[], const int n_points)
+static float get_arc_length (const float complex points[], const int n_points)
 {
   float length = 0.0;
   for (int i = 1; i < n_points; i++)
@@ -799,10 +799,8 @@ typedef struct
   the arc length.
 */
 
-static const float complex point_at_arc_length (const float complex points[],
-                                                const int n_points,
-                                                const float arc_length,
-                                                restart_cookie_t *restart)
+static float complex point_at_arc_length (const float complex points[], const int n_points,
+                                          const float arc_length, restart_cookie_t *restart)
 {
   float length = restart ? restart->length : 0.0;
   int i        = restart ? restart->i      : 1;
@@ -2482,7 +2480,7 @@ static void smooth_path_linsys (size_t n,
   free (d);
 }
 
-static const int path_length(dt_iop_liquify_params_t *p, dt_liquify_path_data_t *n)
+static int path_length(dt_iop_liquify_params_t *p, dt_liquify_path_data_t *n)
 {
   int count = 1;
   while (n->header.next != -1)


### PR DESCRIPTION
Const declarations for return types are meaningless and unusual. They may confuse programmers and trigger warnings by pedantic compilers. Also removes a const cast.