### PR TITLE
lighttabe : full preview & exposé zoom

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -42,6 +42,13 @@
     <shortdescription>enable disk backend for thumbnail cache</shortdescription>
     <longdescription>if enabled, write thumbnails to disk (.cache/darktable/) when evicted from the memory cache. note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again. it's safe though to delete these manually, if you want. light table performance will be increased greatly when browsing a lot. to generate all thumbnails of your entire collection offline, run 'darktable-generate-cache'.</longdescription>
   </dtconfig>
+  <dtconfig prefs="core" section="cpugpu">
+    <name>cache_disk_backend_full</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>enable disk backend for full preview cache</shortdescription>
+    <longdescription>if enabled, write full preview to disk (.cache/darktable/) when evicted from the memory cache. note that this can take a lot of memory (several gigabytes for 20k images) and will never delete cached thumbnails again. it's safe though to delete these manually, if you want. light table performance will be increased greatly when zooming image in full preview mode.</longdescription>
+  </dtconfig>
   <dtconfig prefs="core" section="quality">
     <name>cache_color_managed</name>
     <type>bool</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1844,6 +1844,13 @@
     <longdescription>number of images to load in advance in the background when showing full-size preview</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/preview/max_in_memory_images</name>
+    <type>int</type>
+    <default>4</default>
+    <shortdescription>maximum number of full-res images to load in memory</shortdescription>
+    <longdescription>if more images are display in expose mode, zooming will be desactivated</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>codepaths/sse2</name>
     <type>bool</type>
     <default>true</default>

--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -216,7 +216,8 @@ static void dt_focus_create_clusters(dt_focus_cluster_t *focus, int frows, int f
 }
 
 static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid, int buffer_width,
-                                   int buffer_height, dt_focus_cluster_t *focus, int frows, int fcols)
+                                   int buffer_height, dt_focus_cluster_t *focus, int frows, int fcols,
+                                   float full_zoom, float full_x, float full_y)
 {
   const int fs = frows * fcols;
   cairo_save(cr);
@@ -272,10 +273,22 @@ static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid
   }
 
   const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
-  const float scale = fminf((width-2*tb) / (float)wd, (height-2*tb) / (float)ht);
+  const float scale = fminf((width - 2 * tb) / (float)wd, (height - 2 * tb) / (float)ht) * full_zoom;
   cairo_scale(cr, scale, scale);
+  float fx = 0.0f;
+  float fy = 0.0f;
+  if(full_zoom > 1.0f)
+  {
+    // we want to be sure the image stay in the window
+    fx = fminf((wd * scale - width) / 2, fabsf(full_x));
+    if(full_x < 0) fx = -fx;
+    if(wd * scale <= width) fx = 0;
+    fy = fminf((ht * scale - height) / 2, fabsf(full_y));
+    if(full_y < 0) fy = -fy;
+    if(ht * scale <= height) fy = 0;
+  }
 
-  cairo_translate(cr, -wd / 2.0f, -ht / 2.0f);
+  cairo_translate(cr, -wd / 2.0f + fx / scale, -ht / 2.0f + fy / scale);
 
   cairo_rectangle(cr, 0, 0, wd, ht);
   cairo_clip(cr);

--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -23,8 +23,7 @@
 #include "common/image.h"
 
 // sizes stored in the mipmap cache, set to fixed values in mipmap_cache.c
-typedef enum dt_mipmap_size_t
-{
+typedef enum dt_mipmap_size_t {
   DT_MIPMAP_0 = 0,
   DT_MIPMAP_1,
   DT_MIPMAP_2,
@@ -33,6 +32,7 @@ typedef enum dt_mipmap_size_t
   DT_MIPMAP_5,
   DT_MIPMAP_6,
   DT_MIPMAP_7,
+  DT_MIPMAP_8,
   DT_MIPMAP_F,
   DT_MIPMAP_FULL,
   DT_MIPMAP_NONE

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -108,9 +108,9 @@ typedef struct dt_control_accels_t
 {
   GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right, lighttable_left,
       lighttable_center, lighttable_preview, lighttable_preview_display_focus, lighttable_preview_sticky,
-      lighttable_preview_sticky_focus, lighttable_preview_sticky_exit, lighttable_timeline, global_sideborders,
-      global_header, darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out,
-      darkroom_skip_mouse_events, darkroom_search_modules_focus;
+      lighttable_preview_sticky_focus, lighttable_preview_sticky_exit, lighttable_timeline,
+      lighttable_preview_zoom_100, lighttable_preview_zoom_fit, global_sideborders, global_header,
+      darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out, darkroom_skip_mouse_events, darkroom_search_modules_focus;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -161,6 +161,10 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_exit);
   dt_accel_path_view(path, sizeof(path), "lighttable", "toggle timeline");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_timeline);
+  dt_accel_path_view(path, sizeof(path), "lighttable", "preview zoom 100%");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_zoom_100);
+  dt_accel_path_view(path, sizeof(path), "lighttable", "preview zoom fit");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_zoom_fit);
   // darkroom
   dt_accel_path_view(path, sizeof(path), "darkroom", "full preview");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_preview);

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -222,7 +222,18 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
 
   //we draw the cached image
   dt_view_image_over_t image_over = DT_VIEW_DESERT;
-  dt_view_image_expose(&image_over, d->imgid, cri, nw, nh, 1, px+tb, py+tb, TRUE, TRUE);
+  dt_view_image_expose_t params = { 0 };
+  params.image_over = &image_over;
+  params.imgid = d->imgid;
+  params.cr = cri;
+  params.width = nw;
+  params.height = nh;
+  params.px = px + tb;
+  params.py = py + tb;
+  params.zoom = 1;
+  params.full_preview = TRUE;
+  params.image_only = TRUE;
+  dt_view_image_expose(&params);
 
   //and the nice border line
   cairo_rectangle(cri, tb+px, tb+py, nimgw, nimgh);
@@ -241,9 +252,16 @@ static gboolean _lib_duplicate_thumb_draw_callback (GtkWidget *widget, cairo_t *
 
   int imgid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget),"imgid"));
   dt_view_image_over_t image_over = DT_VIEW_DESERT;
-  dt_view_image_expose(&image_over, imgid, cr, width, height, 5, 0, 0, FALSE, FALSE);
+  dt_view_image_expose_t params = { 0 };
+  params.image_over = &image_over;
+  params.imgid = imgid;
+  params.cr = cr;
+  params.width = width;
+  params.height = height;
+  params.zoom = 5;
+  dt_view_image_expose(&params);
 
- return FALSE;
+  return FALSE;
 }
 
 static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *self)

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -842,8 +842,16 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
       {
         if(!strip->force_expose_all && id == mouse_over_id) strip->last_exposed_id = id;
 
-        const int thumb_missed = dt_view_image_expose
-          (&(strip->image_over), id, cr, wd, ht, max_cols, img_pointerx, img_pointery, FALSE, FALSE);
+        dt_view_image_expose_t params = { 0 };
+        params.image_over = &(strip->image_over);
+        params.imgid = id;
+        params.cr = cr;
+        params.width = wd;
+        params.height = ht;
+        params.px = img_pointerx;
+        params.py = img_pointery;
+        params.zoom = max_cols;
+        const int thumb_missed = dt_view_image_expose(&params);
 
         // if thumb is missing, record it for expose int next round
         if(thumb_missed)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -154,6 +154,18 @@ typedef struct dt_library_t
   int32_t audio_player_id; // the imgid of the image the audio is played for
   guint audio_player_event_source;
 
+  // zoom in image preview (full)
+  float full_zoom;
+  float full_x;
+  float full_y;
+  int fp_surface_mip;
+  int32_t fp_surface_id;
+  int32_t fp_surface_wd;
+  int32_t fp_surface_ht;
+  cairo_surface_t *fp_surface;
+  uint8_t *fp_surface_buf;
+  int fp_surface_w_lock;
+
   /* prepared and reusable statements */
   struct
   {
@@ -256,6 +268,20 @@ static void check_layout(dt_view_t *self)
     if(vs) gtk_widget_show(GTK_WIDGET(timeline->widget));
     g_timeout_add(200, _expose_again_full, self);
   }
+}
+
+static void _full_preview_destroy(dt_view_t *self)
+{
+  dt_library_t *lib = (dt_library_t *)self->data;
+  if(lib->fp_surface) cairo_surface_destroy(lib->fp_surface);
+  lib->fp_surface = NULL;
+  if(lib->fp_surface_buf) free(lib->fp_surface_buf);
+  lib->fp_surface_buf = NULL;
+  lib->fp_surface_mip = 0;
+  lib->fp_surface_wd = 0;
+  lib->fp_surface_ht = 0;
+  lib->fp_surface_id = -1;
+  lib->fp_surface_w_lock = 0;
 }
 
 static void move_view(dt_library_t *lib, dt_lighttable_direction_t dir)
@@ -546,6 +572,16 @@ void init(dt_view_t *self)
   lib->force_expose_all = FALSE;
   lib->offset_x = 0;
   lib->offset_y = 0;
+
+  lib->full_zoom = 1.0f;
+  lib->full_x = 0;
+  lib->full_y = 0;
+  lib->fp_surface_mip = 0;
+  lib->fp_surface_id = -1;
+  lib->fp_surface_wd = 0;
+  lib->fp_surface_ht = 0;
+  lib->fp_surface = NULL;
+  lib->fp_surface_buf = NULL;
 
   lib->thumbs_table = g_hash_table_new(g_int_hash, g_int_equal);
 
@@ -903,10 +939,16 @@ end_query_cache:
             || g_hash_table_contains(lib->thumbs_table, (gpointer)&id))
         {
           if(!lib->force_expose_all && id == mouse_over_id) lib->last_exposed_id = id;
-          const int thumb_missed = dt_view_image_expose(
-            &(lib->image_over), id, cr, wd, iir == 1 ? height : ht, iir,
-            pi == col && pj == row ? img_pointerx : -1,
-            pi == col && pj == row ? img_pointery : -1, FALSE, FALSE);
+          dt_view_image_expose_t params = { 0 };
+          params.image_over = &(lib->image_over);
+          params.imgid = id;
+          params.cr = cr;
+          params.width = wd;
+          params.height = iir == 1 ? height : ht;
+          params.px = pi == col && pj == row ? img_pointerx : -1;
+          params.py = pi == col && pj == row ? img_pointery : -1;
+          params.zoom = iir;
+          const int thumb_missed = dt_view_image_expose(&params);
 
           if(id == mouse_over_id)
           {
@@ -1405,8 +1447,16 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
             || g_hash_table_contains(lib->thumbs_table, (gpointer)&id))
         {
           if(!lib->force_expose_all && id == mouse_over_id) lib->last_exposed_id = id;
-          const int thumb_missed = dt_view_image_expose(&(lib->image_over), id, cr, wd, zoom == 1 ? height : ht, zoom,
-                                                        img_pointerx, img_pointery, FALSE, FALSE);
+          dt_view_image_expose_t params = { 0 };
+          params.image_over = &(lib->image_over);
+          params.imgid = id;
+          params.cr = cr;
+          params.width = wd;
+          params.height = zoom == 1 ? height : ht;
+          params.px = img_pointerx;
+          params.py = img_pointery;
+          params.zoom = zoom;
+          const int thumb_missed = dt_view_image_expose(&params);
 
           if(id == mouse_over_id)
           {
@@ -1704,8 +1754,17 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
       ? pointery - images[i].y
       : images[i].height;
 
-    dt_view_image_expose(&(lib->image_over), images[i].imgid, cr, images[i].width, images[i].height, 1,
-                         img_pointerx, img_pointery, TRUE, FALSE);
+    dt_view_image_expose_t params = { 0 };
+    params.image_over = &(lib->image_over);
+    params.imgid = images[i].imgid;
+    params.cr = cr;
+    params.width = images[i].width;
+    params.height = images[i].height;
+    params.px = img_pointerx;
+    params.py = img_pointery;
+    params.zoom = 1;
+    params.full_preview = TRUE;
+    dt_view_image_expose(&params);
     cairo_restore(cr);
 
     // set mouse over id
@@ -1741,6 +1800,8 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
   if(lib->track < -2) offset = -1;
   lib->track = 0;
 
+  int n_width = width * lib->full_zoom;
+  int n_height = height * lib->full_zoom;
   // only look for images to preload or update the one shown when we moved to another image
   if(offset != 0)
   {
@@ -1813,14 +1874,16 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
 
     if(preload)
     {
-      dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, width, height);
+      dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(darktable.mipmap_cache, n_width, n_height);
       /* Preload these images.
       * The job queue is not a queue, but a stack, so we have to do it backwards.
       * Simply swapping DESC and ASC in the SQL won't help because we rely on the LIMIT clause, and
       * that LIMIT has to work with the "correct" sort order. One could use a subquery, but I don't
       * think that would be terribly elegant, either. */
       while(--count >= 0 && preload_stack[count] != -1)
+      {
         dt_mipmap_cache_get(darktable.mipmap_cache, NULL, preload_stack[count], mip, DT_MIPMAP_PREFETCH, 'r');
+      }
     }
 
     free(preload_stack);
@@ -1857,12 +1920,33 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
       }
     }
   }
-  const int missing = dt_view_image_expose(&(lib->image_over), lib->full_preview_id, cr,
-                                           width, height, 1, pointerx, pointery, TRUE, FALSE);
+
+  dt_view_image_expose_t params = { 0 };
+  params.image_over = &(lib->image_over);
+  params.imgid = lib->full_preview_id;
+  params.cr = cr;
+  params.width = width;
+  params.height = height;
+  params.px = pointerx;
+  params.py = pointery;
+  params.zoom = 1;
+  params.full_preview = TRUE;
+  params.full_zoom = &lib->full_zoom;
+  params.full_x = &lib->full_x;
+  params.full_y = &lib->full_y;
+  params.full_surface = &lib->fp_surface;
+  params.full_rgbbuf = &lib->fp_surface_buf;
+  params.full_surface_mip = &lib->fp_surface_mip;
+  params.full_surface_id = &lib->fp_surface_id;
+  params.full_surface_wd = &lib->fp_surface_wd;
+  params.full_surface_ht = &lib->fp_surface_ht;
+  params.full_surface_w_lock = &lib->fp_surface_w_lock;
+
+  const int missing = dt_view_image_expose(&params);
 
   if(lib->display_focus && (lib->full_res_thumb_id == lib->full_preview_id))
-    dt_focus_draw_clusters(cr, width, height, lib->full_preview_id, lib->full_res_thumb_wd,
-                           lib->full_res_thumb_ht, lib->full_res_focus, frows, fcols);
+    dt_focus_draw_clusters(cr, width, height, lib->full_preview_id, lib->full_res_thumb_wd, lib->full_res_thumb_ht,
+                           lib->full_res_focus, frows, fcols, lib->full_zoom, lib->full_x, lib->full_y);
   return missing;
 }
 
@@ -2298,6 +2382,9 @@ void leave(dt_view_t *self)
     lib->display_focus = 0;
   }
 
+  // cleanup full preview image if any
+  _full_preview_destroy(self);
+
   dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
 }
 
@@ -2375,7 +2462,15 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   lib->force_expose_all = TRUE;
   const dt_lighttable_layout_t layout = get_layout();
 
-  if(lib->full_preview_id > -1)
+  if(lib->full_preview_id > -1 && (state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
+  {
+    if(up)
+      lib->full_zoom = fminf(8.0f, lib->full_zoom + 0.5f);
+    else
+      lib->full_zoom = fmaxf(1.0f, lib->full_zoom - 0.5f);
+    dt_control_queue_redraw_center();
+  }
+  else if(lib->full_preview_id > -1)
   {
     if(up)
       lib->track = -DT_LIBRARY_MAX_ZOOM;
@@ -2455,6 +2550,14 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
   dt_library_t *lib = (dt_library_t *)self->data;
 
   lib->using_arrows = 0;
+
+  if(lib->pan && lib->full_preview_id > -1 && lib->full_zoom > 1.0f)
+  {
+    lib->full_x += x - lib->pan_x;
+    lib->full_y += y - lib->pan_y;
+    lib->pan_x = x;
+    lib->pan_y = y;
+  }
 
   if(lib->pan || lib->pointed_img_over == DT_VIEW_ERR || x < lib->pointed_img_x || y < lib->pointed_img_y
      || x > lib->pointed_img_x + lib->pointed_img_wd || y > lib->pointed_img_y + lib->pointed_img_ht
@@ -2547,7 +2650,8 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
         // the pointer to GDK_HAND1 until we can exclude that it is a click,
         // namely until the pointer has moved a little distance. The code taking
         // care of this is in expose(). Pan only makes sense in zoomable lt.
-        if(layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE) begin_pan(lib, x, y);
+        if(layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE || (lib->full_preview_id > -1 && lib->full_zoom > 1.0f))
+          begin_pan(lib, x, y);
 
         if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER && lib->using_arrows)
         {
@@ -2690,7 +2794,6 @@ int key_released(dt_view_t *self, guint key, guint state)
       || (key == accels->lighttable_preview_display_focus.accel_key
           && state == accels->lighttable_preview_display_focus.accel_mods)) && lib->full_preview_id != -1)
   {
-
     lib->full_preview_id = -1;
     lib->full_preview_rowid = -1;
     if(!lib->using_arrows)
@@ -2704,6 +2807,10 @@ int key_released(dt_view_t *self, guint key, guint state)
 
     lib->full_preview = 0;
     lib->display_focus = 0;
+    _full_preview_destroy(self);
+    lib->full_zoom = 1.0f;
+    lib->full_x = 0.0f;
+    lib->full_y = 0.0f;
     lib->force_expose_all = TRUE;
   }
 
@@ -2741,6 +2848,10 @@ int key_pressed(dt_view_t *self, guint key, guint state)
 
     lib->full_preview = 0;
     lib->display_focus = 0;
+    _full_preview_destroy(self);
+    lib->full_zoom = 1.0f;
+    lib->full_x = 0.0f;
+    lib->full_y = 0.0f;
     lib->force_expose_all = TRUE;
     return 1;
   }
@@ -2804,6 +2915,12 @@ int key_pressed(dt_view_t *self, guint key, guint state)
       {
         lib->display_focus = 1;
       }
+
+      // reset preview values
+      lib->full_zoom = 1.0f;
+      lib->full_x = 0.0f;
+      lib->full_y = 0.0f;
+      _full_preview_destroy(self);
 
       lib->force_expose_all = TRUE;
       return 1;
@@ -3009,6 +3126,10 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);
   dt_accel_register_view(self, NC_("accel", "redo"), GDK_KEY_y, GDK_CONTROL_MASK);
 
+  // zoom for full preview
+  dt_accel_register_view(self, NC_("accel", "preview zoom 100%"), 0, 0);
+  dt_accel_register_view(self, NC_("accel", "preview zoom fit"), 0, 0);
+
   // timeline
   dt_accel_register_view(self, NC_("accel", "toggle timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
 }
@@ -3035,6 +3156,40 @@ static gboolean _lighttable_redo_callback(GtkAccelGroup *accel_group, GObject *a
 
   lib->force_expose_all = TRUE;
   return TRUE;
+}
+
+static gboolean _lighttable_preview_zoom_100(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                             GdkModifierType modifier, gpointer data)
+{
+  dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  if(lib->full_preview_id > -1)
+  {
+    lib->full_zoom = 100.0f; // this is ugly, but I don't find a way to know image output size at this stage
+    dt_control_queue_redraw_center();
+    return TRUE;
+  }
+
+  return FALSE;
+}
+static gboolean _lighttable_preview_zoom_fit(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                             GdkModifierType modifier, gpointer data)
+{
+  dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  printf("fit\n");
+  if(lib->full_preview_id > -1)
+  {
+    lib->full_zoom = 1.0f;
+    lib->full_x = 0;
+    lib->full_y = 0;
+    dt_control_queue_redraw_center();
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 void connect_key_accels(dt_view_t *self)
@@ -3092,6 +3247,12 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "undo", closure);
   closure = g_cclosure_new(G_CALLBACK(_lighttable_redo_callback), (gpointer)self, NULL);
   dt_accel_connect_view(self, "redo", closure);
+
+  // full_preview zoom
+  closure = g_cclosure_new(G_CALLBACK(_lighttable_preview_zoom_100), (gpointer)self, NULL);
+  dt_accel_connect_view(self, "preview zoom 100%", closure);
+  closure = g_cclosure_new(G_CALLBACK(_lighttable_preview_zoom_fit), (gpointer)self, NULL);
+  dt_accel_connect_view(self, "preview zoom fit", closure);
 
   // timeline
   closure = g_cclosure_new(G_CALLBACK(timeline_key_accel_callback), (gpointer)self, NULL);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -57,7 +57,7 @@
 
 DT_MODULE(1)
 
-#define FULL_PREVIEW_IN_MEMORY_LIMIT 6
+#define FULL_PREVIEW_IN_MEMORY_LIMIT 9
 
 typedef enum dt_lighttable_direction_t
 {
@@ -1787,7 +1787,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
     params.py = img_pointery;
     params.zoom = 1;
     params.full_preview = TRUE;
-    if(sel_img_count <= FULL_PREVIEW_IN_MEMORY_LIMIT)
+    if(sel_img_count <= dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"))
     {
       params.full_zoom = &lib->full_zoom;
       params.full_x = &lib->full_x;
@@ -2504,9 +2504,11 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   {
     GList *selected = dt_collection_get_selected(darktable.collection, -1);
     const int sel_img_count = g_list_length(selected);
-    if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE && sel_img_count > FULL_PREVIEW_IN_MEMORY_LIMIT)
+    if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE
+       && sel_img_count > dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"))
     {
-      dt_control_log(_("zooming is limited to %d images"), FULL_PREVIEW_IN_MEMORY_LIMIT);
+      dt_control_log(_("zooming is limited to %d images"),
+                     dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"));
     }
     else if(lib->missing_thumbnails == 0)
     {

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -203,8 +203,16 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
   else if(lib->image_id >= 0) // First of all draw image if available
   {
     cairo_translate(cr, MARGIN, MARGIN);
-    dt_view_image_expose(&(lib->image_over), lib->image_id, cr, width - (MARGIN * 2.0f),
-                         height - (MARGIN * 2.0f), 1, pointerx, pointery, FALSE, FALSE);
+    dt_view_image_expose_t params = { 0 };
+    params.image_over = &(lib->image_over);
+    params.imgid = lib->image_id;
+    params.cr = cr;
+    params.width = width - (MARGIN * 2.0f);
+    params.height = height - (MARGIN * 2.0f);
+    params.px = pointerx;
+    params.py = pointery;
+    params.zoom = 1;
+    dt_view_image_expose(&params);
   }
 }
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -153,9 +153,32 @@ int32_t dt_view_get_image_to_act_on();
 /** guess the image_over flag assuming that all possible controls are displayed */
 dt_view_image_over_t dt_view_guess_image_over(int32_t width, int32_t height, int32_t zoom, int32_t px, int32_t py);
 
+typedef struct dt_view_image_expose_t
+{
+  dt_view_image_over_t *image_over;
+  uint32_t imgid;
+  cairo_t *cr;
+  int32_t width;
+  int32_t height;
+  int32_t zoom;
+  int32_t px;
+  int32_t py;
+  gboolean full_preview;
+  gboolean image_only;
+  float *full_zoom;
+  float *full_x;
+  float *full_y;
+
+  cairo_surface_t **full_surface;
+  uint8_t **full_rgbbuf;
+  int *full_surface_mip;
+  int *full_surface_id;
+  int *full_surface_wd;
+  int *full_surface_ht;
+  int *full_surface_w_lock;
+} dt_view_image_expose_t;
 /** expose an image, set image over flags. return != 0 if thumbnail wasn't loaded yet. */
-int dt_view_image_expose(dt_view_image_over_t *image_over, uint32_t index, cairo_t *cr, int32_t width,
-                         int32_t height, int32_t zoom, int32_t px, int32_t py, gboolean full_preview, gboolean image_only);
+int dt_view_image_expose(dt_view_image_expose_t *vals);
 
 /* expose only the image imgid at position (offsetx,offsety) into the cairo surface occupying width/height pixels.
    this routine does not output any meta-data as the version above.


### PR DESCRIPTION
This add the ability to zoom and pan inside images in full preview mode and exposé layout (in exposé, zooms and positions are synchronized between images)

To handle this I've added some caching mechanisms to avoid exporting full image multiple times : 
- a new mipmap size to load full size images. This "special" mipmap level images are only store on disk if user tick a new preference entry (deactivated by default, because it can create huge cache size)
- full image are keep in memory to avoid reload when panning. This can eat quite a lot of memory, especially in expose layout. So there's an hardcoded limit (fixed at 6) above that, no zooming is allowed (and no caching occurred). Not sure if this limit should better grow darktable.rc

Here it "seems" to work, but please test as there's so many way to display images in lighttable...