### PR TITLE
Lua API: darkroom_display_image

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -906,6 +906,28 @@
 </entry>
     </row></tbody>
     </tgroup></informaltable>
+
+<section status="final" id="darktable_gui_views_darkroom_display_image">
+<title>darktable.gui.views.darkroom.display_image</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>display_image</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_views_darkroom_display_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>
+)</synopsis>
+<para>Display an image in darkroom view.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_views_darkroom_display_image_image"><term>image</term><listitem>
+<synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>The image to be displayed.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
 </section>
 
 <section status="final" id="darktable_gui_views_lighttable">

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -110,6 +110,10 @@ static int display_image_cb(lua_State *L)
     luaA_to(L, dt_lua_image_t, &imgid, 1);
     dt_dev_change_image(dev, imgid);
   }
+  else
+  {
+    return luaL_error(L, "error: dt_lua_image_t expected\n");
+  }
   return 0;
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -43,6 +43,10 @@
 #include "views/view.h"
 #include "views/view_api.h"
 
+#ifdef USE_LUA
+#include "lua/image.h"
+#endif
+
 #include <gdk/gdkkeysyms.h>
 #include <math.h>
 #include <stdlib.h>
@@ -87,17 +91,45 @@ static void _update_softproof_gamut_checking(dt_develop_t *d);
 /* signal handler for filmstrip image switching */
 static void _view_darkroom_filmstrip_activate_callback(gpointer instance, gpointer user_data);
 
+static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid);
+
 
 const char *name(dt_view_t *self)
 {
   return _("darkroom");
 }
 
+#ifdef USE_LUA
+
+static int display_image_cb(lua_State *L)
+{
+  dt_develop_t *dev = darktable.develop;
+  dt_lua_image_t imgid = -1;
+  if(luaL_testudata(L, 1, "dt_lua_image_t"))
+  {
+    luaA_to(L, dt_lua_image_t, &imgid, 1);
+    dt_dev_change_image(dev, imgid);
+  }
+  return 0;
+}
+
+#endif
+
 
 void init(dt_view_t *self)
 {
   self->data = malloc(sizeof(dt_develop_t));
   dt_dev_init((dt_develop_t *)self->data, 1);
+
+#ifdef USE_LUA
+  lua_State *L = darktable.lua_state.state;
+  int my_type = dt_lua_module_entry_get_type(L, "view", self->module_name);
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, display_image_cb, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "display_image");
+#endif
 }
 
 uint32_t view(const dt_view_t *self)


### PR DESCRIPTION
Adds a function to darktable.gui.views.darkroom to change the displayed image.  Currently the only way to change the image displayed in darkroom view from lua is by changing back to lighttable view, selecting a different image, then changing to darkroom view.

This would allow tethering type scripts (i.e. tools/watch_folder.sh) to open an imported image in darkroom view, then import a new image and simply display it.

Satisfies issue 12640.