### PR TITLE
blend: replace macro by inline function

### DIFF
--- a/src/common/math.h
+++ b/src/common/math.h
@@ -1,6 +1,6 @@
 /*
  *    This file is part of darktable,
- *    copyright (c) 2018 Heiko Bauke.
+ *    copyright (c) 2018-2019 Heiko Bauke.
  *
  *    darktable is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -20,3 +20,8 @@
 
 #define DT_M_PI_F (3.14159265358979324f)
 #define DT_M_PI (3.14159265358979324)
+
+static inline float clamp_range_f(const float x, const float low, const float high)
+{
+  return x > high ? high : (x < low ? low : x);
+}


### PR DESCRIPTION
Employing macro functions is bad, in particular when complex expressions are passed as macro arguments. This can lead to multiple evaluations of these complex expressions. Not to mention the lack of type safety. Negative effects of macros can be avoided by inline functions without compromising performance.

Furthermore, I have removed many of the redundant parentheses. I tend to agree that redundant parentheses can be useful to clarify intent in complex expressions when operator precedence might be not easy to gasp. Here, however, the use of redundant parentheses was excessive (imho).
