### PR TITLE
Lua API: hide, show and query visibility of gui panels

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -742,6 +742,100 @@
 </variablelist>
 </section>
 
+<section status="final" id="darktable_gui_panel_visible">
+<title>darktable.gui.panel_visible</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_visible</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_panel_visible_panel">panel</link></emphasis> : <link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link>
+) : boolean</synopsis>
+<para>Determines if the specified panel is visible.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_panel_visible_panel"><term>panel</term><listitem>
+<synopsis><link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link></synopsis>
+<para>The panel to check.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis>boolean</synopsis>
+<para>true if the panel is visible, false if not</para>
+
+</listitem></varlistentry>
+
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_panel_hide">
+<title>darktable.gui.panel_hide</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_hide</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_panel_hide_panel">panel</link></emphasis> : <link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link>
+)</synopsis>
+<para>Hides the specified panel.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_panel_hide_panel"><term>panel</term><listitem>
+<synopsis><link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link></synopsis>
+<para>The panel to hide.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_panel_show">
+<title>darktable.gui.panel_show</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_show</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_panel_show_panel">panel</link></emphasis> : <link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link>
+)</synopsis>
+<para>Shows the specified panel.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_panel_show_panel"><term>panel</term><listitem>
+<synopsis><link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link></synopsis>
+<para>The panel to show.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_panel_hide_all">
+<title>darktable.gui.panel_hide_all</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_hide_all</secondary>
+</indexterm>
+<synopsis>function( 
+)</synopsis>
+<para>Hide all panels.</para>
+
+</section>
+
+<section status="final" id="darktable_gui_panel_show_all">
+<title>darktable.gui.panel_show_all</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_show_all</secondary>
+</indexterm>
+<synopsis>function( 
+)</synopsis>
+<para>Show all panels.</para>
+
+</section>
+
 <section status="final" id="darktable_gui_create_job">
 <title>darktable.gui.create_job</title>
 <indexterm>
@@ -7466,6 +7560,37 @@ This function is recursion-safe and can be used to dump _G if needed.</para>
 </variablelist>
 </section>
 
+</section>
+
+<section status="final" id="types_dt_ui_panel_t">
+<title>types.dt_ui_panel_t</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>dt_ui_panel_t</secondary>
+</indexterm>
+<synopsis>enum</synopsis>
+<para>The different user interface panels</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis>values : </emphasis></para>
+<para><itemizedlist>
+<listitem><para>DT_UI_PANEL_TOP</para></listitem>
+<listitem><para>DT_UI_PANEL_CENTER_TOP</para></listitem>
+<listitem><para>DT_UI_PANEL_CENTER_BOTTOM</para></listitem>
+<listitem><para>DT_UI_PANEL_LEFT</para></listitem>
+<listitem><para>DT_UI_PANEL_RIGHT</para></listitem>
+<listitem><para>DT_UI_PANEL_BOTTOM</para></listitem>
+<listitem><para>DT_UI_PANEL_SIZE</para></listitem>
+</itemizedlist>
+</para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
 </section>
 
 <section status="final" id="types_lua_widget">

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -113,7 +113,67 @@ static int current_view_cb(lua_State *L)
   return 1;
 }
 
+static int panel_visible_cb(lua_State *L)
+{
+  dt_ui_panel_t p;
 
+  if(lua_gettop(L) > 0)
+  {
+    gboolean result;
+    luaA_to(L, dt_ui_panel_t, &p, 1);
+    result = dt_ui_panel_visible(darktable.gui->ui, p);
+    lua_pushboolean(L, result);
+    return 1;
+  }
+  else
+  {
+    return luaL_error(L, "no panel specified");
+  }
+}
+
+static int panel_hide_cb(lua_State *L)
+{
+  dt_ui_panel_t p;
+  if(lua_gettop(L) > 0)
+  {
+    luaA_to(L, dt_ui_panel_t, &p, 1);
+    dt_ui_panel_show(darktable.gui->ui, p, FALSE, TRUE);
+    return 0;
+  }
+  else
+  {
+    return luaL_error(L, "no panel specified");
+  }
+}
+
+static int panel_show_cb(lua_State *L)
+{
+  dt_ui_panel_t p;
+  if(lua_gettop(L) > 0)
+  {
+    luaA_to(L, dt_ui_panel_t, &p, 1);
+    dt_ui_panel_show(darktable.gui->ui, p, TRUE, TRUE);
+    return 0;
+  }
+  else
+  {
+    return luaL_error(L, "no panel specified");
+  }
+}
+
+static int panel_hide_all_cb(lua_State *L)
+{
+  for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(darktable.gui->ui, k, FALSE, TRUE);
+  // code goes here
+  return 0;
+}
+
+static int panel_show_all_cb(lua_State *L)
+{
+  for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(darktable.gui->ui, k, TRUE, TRUE);
+  // code goes here
+  return 0;
+}
 
 typedef dt_progress_t *dt_lua_backgroundjob_t;
 
@@ -253,6 +313,21 @@ int dt_lua_init_gui(lua_State *L)
     lua_pushcfunction(L, current_view_cb);
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "current_view");
+    lua_pushcfunction(L, panel_visible_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_visible");
+    lua_pushcfunction(L, panel_hide_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_hide");
+    lua_pushcfunction(L, panel_show_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_show");
+    lua_pushcfunction(L, panel_hide_all_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_hide_all");
+    lua_pushcfunction(L, panel_show_all_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_show_all");
     lua_pushcfunction(L, lua_create_job);
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "create_job");
@@ -262,6 +337,15 @@ int dt_lua_init_gui(lua_State *L)
     dt_lua_module_push(L, "view");
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "views");
+
+    luaA_enum(L,dt_ui_panel_t);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_TOP);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_CENTER_TOP);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_CENTER_BOTTOM);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_LEFT);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_RIGHT);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_BOTTOM);
+    luaA_enum_value(L,dt_ui_panel_t,DT_UI_PANEL_SIZE);
 
 
 


### PR DESCRIPTION
Extended the lua API to allow hiding, showing and querying the visibility of the gui top, bottom and side panels.  

These functions are useful for making more space available for the central window.  

My specific use case is I've written a lua script to compare images.  So if for instance you've taken a series of headshots and are trying to select the best one to work on you would select the images, click the compare button in the selected images module and enter "compare" mode.  The lighttable gets set to filemanager mode and 2 images (issue 12614) with the panels collapsed to get the largest view available.  The first image is the "selected" one.  Using shortcuts you step through the images comparing them to the "selected" one.  If you find one you like better, you swap them.  When you exit compare mode you go back to lighttable with the "selected" image as the selection. The lighttable view goes back to the previous settings and the panel visibility is restored.

This satisfies issue 12641 and partially satisfies issue 9902