### PR TITLE
place hq export in export module

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1230,7 +1230,7 @@
     <shortdescription>do high quality processing for slideshow</shortdescription>
     <longdescription>same option as for export, but applies to slideshow.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core" section="quality">
+  <dtconfig>
     <name>plugins/lighttable/export/high_quality_processing</name>
     <type>bool</type>
     <default>false</default>


### PR DESCRIPTION
This moves the "do high quality resampling during export" setting from config option to the export module.

Addresses #2269