### PR TITLE
Variance computation mode in denoiseprofile

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1300,6 +1300,13 @@
     <shortdescription>crossover iso for X-Trans fdc demosaicing</shortdescription>
     <longdescription>up to, and including, this iso, X-Trans frequency domain chroma demosaicing uses the hybrid mode for determining chroma; for all higher iso values the pure fdc is used.</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/denoiseprofile/show_compute_variance_mode</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>whether to show the compute variance mode in denoiseprofile</shortdescription>
+    <longdescription>adds a mode in denoiseprofile that allows to compute the variance after the generalized anscombe transform is performed</longdescription>
+  </dtconfig>
   <dtconfig prefs="core" section="quality">
     <name>plugins/darkroom/demosaic/quality</name>
     <type>

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2766,7 +2766,6 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->strength, p->strength);
   dt_bauhaus_slider_set_soft(g->scattering, p->scattering);
   dt_bauhaus_slider_set_soft(g->central_pixel_weight, p->central_pixel_weight);
-  dt_bauhaus_combobox_set(g->mode, p->mode);
   dt_bauhaus_combobox_set(g->profile, -1);
   if(p->mode == MODE_WAVELETS)
   {
@@ -2780,12 +2779,17 @@ void gui_update(dt_iop_module_t *self)
     gtk_widget_hide(g->box_variance);
     gtk_widget_show_all(g->box_nlm);
   }
-  else
+  else if(p->mode == MODE_VARIANCE)
   {
     gtk_widget_hide(g->box_wavelets);
     gtk_widget_hide(g->box_nlm);
     gtk_widget_show_all(g->box_variance);
+    if(dt_bauhaus_combobox_length(g->mode) == 2)
+    {
+      dt_bauhaus_combobox_add(g->mode, _("compute variance"));
+    }
   }
+  dt_bauhaus_combobox_set(g->mode, p->mode);
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);
@@ -3341,7 +3345,11 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means"));
   dt_bauhaus_combobox_add(g->mode, _("wavelets"));
-  dt_bauhaus_combobox_add(g->mode, _("compute variance"));
+  gboolean compute_variance = dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");
+  if(compute_variance)
+  {
+    dt_bauhaus_combobox_add(g->mode, _("compute variance"));
+  }
   gtk_widget_set_tooltip_text(g->profile, _("profile used for variance stabilization"));
   gtk_widget_set_tooltip_text(g->mode, _("method used in the denoising core. "
                                          "non-local means works best for `lightness' blending, "

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -135,7 +135,6 @@ typedef struct dt_iop_denoiseprofile_gui_data_t
   GtkWidget *central_pixel_weight;
   dt_noiseprofile_t interpolated; // don't use name, maker or model, they may point to garbage
   GList *profiles;
-  GtkWidget *stack;
   GtkWidget *box_nlm;
   GtkWidget *box_wavelets;
   dt_draw_curve_t *transition_curve; // curve for gui to draw
@@ -2556,9 +2555,15 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   p->mode = dt_bauhaus_combobox_get(w);
   if(p->mode == MODE_WAVELETS)
-    gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "wavelets");
+  {
+    gtk_widget_hide(g->box_nlm);
+    gtk_widget_show_all(g->box_wavelets);
+  }
   else
-    gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "nlm");
+  {
+    gtk_widget_hide(g->box_wavelets);
+    gtk_widget_show_all(g->box_nlm);
+  }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2610,9 +2615,15 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->mode, p->mode);
   dt_bauhaus_combobox_set(g->profile, -1);
   if(p->mode == MODE_WAVELETS)
-    gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "wavelets");
+  {
+    gtk_widget_hide(g->box_nlm);
+    gtk_widget_show_all(g->box_wavelets);
+  }
   else
-    gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "nlm");
+  {
+    gtk_widget_hide(g->box_wavelets);
+    gtk_widget_show_all(g->box_nlm);
+  }
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);
@@ -3064,12 +3075,11 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->wb_adaptive_anscombe), "toggled", G_CALLBACK(wb_adaptive_anscombe_callback), self);
 
 
-  g->stack = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(g->stack), FALSE);
   gtk_box_pack_start(GTK_BOX(self->widget), g->profile, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->wb_adaptive_anscombe, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->mode, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->stack, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->box_nlm, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->box_wavelets, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->strength, TRUE, TRUE, 0);
 
   g->fix_anscombe_and_nlmeans_norm = gtk_check_button_new_with_label(_("migrate to fixed algorithm"));
@@ -3088,9 +3098,6 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_show_all(g->box_nlm);
   gtk_widget_show_all(g->box_wavelets);
-  gtk_stack_add_named(GTK_STACK(g->stack), g->box_nlm, "nlm");
-  gtk_stack_add_named(GTK_STACK(g->stack), g->box_wavelets, "wavelets");
-  gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "nlm");
 
   dt_bauhaus_widget_set_label(g->profile, NULL, _("profile"));
   dt_bauhaus_widget_set_label(g->mode, NULL, _("mode"));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -28,7 +28,6 @@
 #include "develop/imageop_math.h"
 #include "develop/tiling.h"
 #include "dtgtk/drawingarea.h"
-#include "dtgtk/expander.h"
 #include "gui/accelerators.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3344,7 +3344,7 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means"));
   dt_bauhaus_combobox_add(g->mode, _("wavelets"));
-  gboolean compute_variance = dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");
+  const gboolean compute_variance = dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");
   if(compute_variance)
   {
     dt_bauhaus_combobox_add(g->mode, _("compute variance"));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3219,10 +3219,8 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(g->box_nlm), g->central_pixel_weight, TRUE, TRUE, 0);
 
   g->label_var = GTK_LABEL(gtk_label_new(_("use only with a perfectly\n"
-                                           "uniform image if you want\n"
-                                           "variance values to accurately\n"
-                                           "estimate the noise variance.\n"
-                                           "use only at 100% zoom level.")));
+                                           "uniform image if you want to\n"
+                                           "estimate the noise variance.")));
   gtk_widget_set_halign(GTK_WIDGET(g->label_var), GTK_ALIGN_START);
   gtk_box_pack_start(GTK_BOX(g->box_variance), GTK_WIDGET(g->label_var), TRUE, TRUE, 0);
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1722,7 +1722,6 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     return;
   }
 
-  const float scale = fminf(roi_in->scale, 2.0f) / fmaxf(piece->iscale, 1.0f);
   float *in = dt_alloc_align(64, (size_t)4 * sizeof(float) * roi_in->width * roi_in->height);
 
   const float wb_mean = (piece->pipe->dsc.temperature.coeffs[0] + piece->pipe->dsc.temperature.coeffs[1]
@@ -1750,8 +1749,8 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   {
     for(int i = 0; i < 3; i++) wb[i] = piece->pipe->dsc.processed_maximum[i];
   }
-  // update the coeffs with strength and scale
-  for(int i = 0; i < 3; i++) wb[i] *= d->strength * (scale * scale);
+  // update the coeffs with strength
+  for(int i = 0; i < 3; i++) wb[i] *= d->strength;
 
   const float aa[3] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2] };
   const float bb[3] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2] };


### PR DESCRIPTION
### Add the ability to compute the variance after the anscombe transform is performed and show it in the GUI of denoiseprofile:
![Capture du 2019-03-24 23-23-09](https://user-images.githubusercontent.com/34063828/54886789-2387c880-4e8c-11e9-9744-bdbc1c2b6051.png)

### Why checking variance in denoiseprofile?
denoiseprofile is doing a generalized anscombe transform based on a profile to transform the image so that the noise variance become independant of the overall brightness, and becomes equal to 1.

The noise profiling tool seems to be based on the hypothesis that noise is fine grain:
the noiseprofiling tool assumes all the noise lies in the finest scale of a wavelet decomposition, which is not true in practice.
The real problem is that the noiseprofiling tool is validating itself its own profiles, with the same methods, so the profiles appeared ok even if they were not.
That's why we need a way to compute variance in denoiseprofile: computing variance on a noisy picture of a uniform surface that has been transformed using the profile allows to check that the profile is correct.

### How to use?
Take a picture of a uniform surface (the variance computed is the global variance, thus is it influenced by all variations in the image). As an example, you should get a picture like this, perfectly uniform, with only variations coming from the noise: 
![DSCF6591](https://user-images.githubusercontent.com/34063828/54886888-64cca800-4e8d-11e9-9333-2dc28fd37a0b.jpg)
In the darkroom, zoom at 100% and activate denoiseprofile in computevariance mode. The variance values should be close to 1 if the profile is accurate.
On my test pictures, profiles are strongly erroneous unfortunately, I have to push force to 12-15 to get proper variance values...

### Why is it implemented this way?
I wanted to keep this implementation simple, as it will be used for a very sensitive purpose.
That's why there is no opencl implementation, and that the cpu implementation is not parallelized and use recursive functions.
Note that it is already efficient: it takes about half a second to process 24Mpix. So, to process the darkroom preview, I usually had execution times of about 0.001 seconds.
Now why having a recursive implementation? The implementation uses a divide-and-conqueer principle so that the sums of 2 floats always sum 2 numbers of the same order of magnitude, in order to have a precise result.