### PR TITLE
Lua API: Add view toolbox sort, sort order, rating, and rating comparator control

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -1722,6 +1722,119 @@ end</programlisting></para>
 </entry>
     </row></tbody>
     </tgroup></informaltable>
+
+<section status="final" id="darktable_gui_libs_filter_sort">
+<title>darktable.gui.libs.filter.sort</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>sort</secondary>
+</indexterm>
+<synopsis>function( 
+	[<emphasis><link linkend="darktable_gui_libs_filter_sort_sort">sort</link></emphasis> : <link linkend="types_dt_collection_sort_t">types.dt_collection_sort_t</link>]
+) : <link linkend="types_dt_collection_sort_t">types.dt_collection_sort_t</link></synopsis>
+<para>Change the collection sort field.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_libs_filter_sort_sort"><term>[sort]</term><listitem>
+<synopsis><link linkend="types_dt_collection_sort_t">types.dt_collection_sort_t</link></synopsis>
+<para>The new field to sort by. If empty the current sort field is unchanged</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis><link linkend="types_dt_collection_sort_t">types.dt_collection_sort_t</link></synopsis>
+<para>The current sort field.</para>
+
+</listitem></varlistentry>
+
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_libs_filter_sort_order">
+<title>darktable.gui.libs.filter.sort_order</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>sort_order</secondary>
+</indexterm>
+<synopsis>function( 
+	[<emphasis><link linkend="darktable_gui_libs_filter_sort_order_order">order</link></emphasis> : <link linkend="types_dt_collection_sort_order_t">types.dt_collection_sort_order_t</link>]
+) : <link linkend="types_dt_collection_sort_order_t">types.dt_collection_sort_order_t</link></synopsis>
+<para>Change the collection sort order.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_libs_filter_sort_order_order"><term>[order]</term><listitem>
+<synopsis><link linkend="types_dt_collection_sort_order_t">types.dt_collection_sort_order_t</link></synopsis>
+<para>The order to sort by. If empty the current sort order is unchanged.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis><link linkend="types_dt_collection_sort_order_t">types.dt_collection_sort_order_t</link></synopsis>
+<para>The current sort order.</para>
+
+</listitem></varlistentry>
+
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_libs_filter_rating">
+<title>darktable.gui.libs.filter.rating</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>rating</secondary>
+</indexterm>
+<synopsis>function( 
+	[<emphasis><link linkend="darktable_gui_libs_filter_rating_rating">rating</link></emphasis> : <link linkend="types_dt_collection_filter_t">types.dt_collection_filter_t</link>]
+) : <link linkend="types_dt_collection_filter_t">types.dt_collection_filter_t</link></synopsis>
+<para>Change the collection rating filter.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_libs_filter_rating_rating"><term>[rating]</term><listitem>
+<synopsis><link linkend="types_dt_collection_filter_t">types.dt_collection_filter_t</link></synopsis>
+<para>The new rating field to filter by. If empty the current rating field is unchanged.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis><link linkend="types_dt_collection_filter_t">types.dt_collection_filter_t</link></synopsis>
+<para>The current rating field.</para>
+
+</listitem></varlistentry>
+
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_libs_filter_rating_comparator">
+<title>darktable.gui.libs.filter.rating_comparator</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>rating_comparator</secondary>
+</indexterm>
+<synopsis>function( 
+	[<emphasis><link linkend="darktable_gui_libs_filter_rating_comparator_comparator">comparator</link></emphasis> : <link linkend="types_dt_collection_rating_comperator_t">types.dt_collection_rating_comperator_t</link>]
+) : <link linkend="types_dt_collection_rating_comperator_t">types.dt_collection_rating_comperator_t</link></synopsis>
+<para>Change the collection filter comparison field.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_libs_filter_rating_comparator_comparator"><term>[comparator]</term><listitem>
+<synopsis><link linkend="types_dt_collection_rating_comperator_t">types.dt_collection_rating_comperator_t</link></synopsis>
+<para>The new comparison field to filter the rating by. If empty the current rating comparison field is unchanged</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis><link linkend="types_dt_collection_rating_comperator_t">types.dt_collection_rating_comperator_t</link></synopsis>
+<para>The current rating comparison field.</para>
+
+</listitem></varlistentry>
+
+
+</variablelist>
+</section>
+
 </section>
 
 <section status="final" id="darktable_gui_libs_ratings">
@@ -1730,7 +1843,7 @@ end</programlisting></para>
 <primary>Lua API</primary>
 <secondary>ratings</secondary>
 </indexterm>
-<para>The starts to set the rating of an image</para>
+<para>The stars to set the rating of an image</para>
 <informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
     <colspec colwidth="2*"/>
     <colspec colwidth="8*"/>
@@ -7086,6 +7199,133 @@ This function is recursion-safe and can be used to dump _G if needed.</para>
 <listitem><para>DT_COLLECTION_PROP_APERTURE</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_FILENAME</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_GEOTAGGING</para></listitem>
+</itemizedlist>
+</para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
+<section status="final" id="types_dt_collection_sort_t">
+<title>types.dt_collection_sort_t</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>dt_collection_sort_t</secondary>
+</indexterm>
+<synopsis>enum</synopsis>
+<para>The different elements on which a collection can be sorted</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis>values : </emphasis></para>
+<para><itemizedlist>
+<listitem><para>DT_COLLECTION_SORT_NONE</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_FILENAME</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_DATETIME</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_RATING</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_ID</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_COLOR</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_GROUP</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_PATH</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_CUSTOM_ORDER</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_TITLE</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_DESCRIPTION</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_ASPECT_RATIO</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_SHUFFLE</para></listitem>
+</itemizedlist>
+</para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
+<section status="final" id="types_dt_collection_sort_order_t">
+<title>types.dt_collection_sort_order_t</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>dt_collection_sort_order_t</secondary>
+</indexterm>
+<synopsis>enum</synopsis>
+<para>The different orders that a collection can be sorted in</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis>values : </emphasis></para>
+<para><itemizedlist>
+<listitem><para>DT_COLLECTION_SORT_ORDER_ASCENDING</para></listitem>
+<listitem><para>DT_COLLECTION_SORT_ORDER_DESCENDING</para></listitem>
+</itemizedlist>
+</para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
+<section status="final" id="types_dt_collection_filter_t">
+<title>types.dt_collection_filter_t</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>dt_collection_filter_t</secondary>
+</indexterm>
+<synopsis>enum</synopsis>
+<para>The different elements on which a collection can be filtered</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis>values : </emphasis></para>
+<para><itemizedlist>
+<listitem><para>DT_COLLECTION_FILTER_ALL</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_STAR_NO</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_STAR_1</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_STAR_2</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_STAR_3</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_STAR_4</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_STAR_5</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_REJECT</para></listitem>
+<listitem><para>DT_COLLECTION_FILTER_NOT_REJECT</para></listitem>
+</itemizedlist>
+</para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
+<section status="final" id="types_dt_collection_rating_comperator_t">
+<title>types.dt_collection_rating_comperator_t</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>dt_collection_rating_comperator_t</secondary>
+</indexterm>
+<synopsis>enum</synopsis>
+<para>The different ways in which a collection filter can be compared</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis>values : </emphasis></para>
+<para><itemizedlist>
+<listitem><para>DT_COLLECTION_RATING_COMP_LT</para></listitem>
+<listitem><para>DT_COLLECTION_RATING_COMP_LEQ</para></listitem>
+<listitem><para>DT_COLLECTION_RATING_COMP_EQ</para></listitem>
+<listitem><para>DT_COLLECTION_RATING_COMP_GEQ</para></listitem>
+<listitem><para>DT_COLLECTION_RATING_COMP_GT</para></listitem>
+<listitem><para>DT_COLLECTION_RATING_COMP_NE</para></listitem>
+<listitem><para>DT_COLLECTION_RATING_N_COMPS</para></listitem>
 </itemizedlist>
 </para></listitem>
 </itemizedlist>

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -39,7 +39,7 @@ typedef struct dt_lib_tool_filter_t
 typedef enum dt_collection_sort_order_t
 {
   DT_COLLECTION_SORT_ORDER_ASCENDING = 0,
-  DT_COLLECTION_SORT_ORDER_DECENDING
+  DT_COLLECTION_SORT_ORDER_DESCENDING
 } dt_collection_sort_order_t;
 #endif
 

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -89,7 +89,7 @@ int expandable(dt_lib_module_t *self)
 
 int position()
 {
-  return 1001;
+  return 2001;
 }
 
 void gui_init(dt_lib_module_t *self)

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -35,6 +35,14 @@ typedef struct dt_lib_tool_filter_t
   GtkWidget *reverse;
 } dt_lib_tool_filter_t;
 
+#ifdef USE_LUA
+typedef enum dt_collection_sort_order_t
+{
+  DT_COLLECTION_SORT_ORDER_ASCENDING = 0,
+  DT_COLLECTION_SORT_ORDER_DECENDING
+} dt_collection_sort_order_t;
+#endif
+
 /* proxy function to intelligently reset filter */
 static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter);
 
@@ -81,7 +89,7 @@ int expandable(dt_lib_module_t *self)
 
 int position()
 {
-  return 2001;
+  return 1001;
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -319,6 +327,138 @@ static void _lib_filter_reset(dt_lib_module_t *self, gboolean smart_filter)
     gtk_combo_box_set_active(GTK_COMBO_BOX(dropdowns->filter), 0);
   }
 }
+
+#ifdef USE_LUA
+static int sort_cb(lua_State *L)
+{
+  dt_lib_module_t *self = lua_touserdata(L, lua_upvalueindex(1));
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  const dt_collection_sort_t tmp = dt_collection_get_sort_field(darktable.collection);
+  if(lua_gettop(L) > 0){
+    dt_collection_sort_t value;
+    luaA_to(L,dt_collection_sort_t,&value,1);
+    dt_collection_set_sort(darktable.collection, (uint32_t)value, 0);
+    gtk_combo_box_set_active(GTK_COMBO_BOX(d->sort), dt_collection_get_sort_field(darktable.collection));
+    _lib_filter_update_query(self);
+  }
+  luaA_push(L, dt_collection_sort_t, &tmp);
+  return 1;
+}
+static int sort_order_cb(lua_State *L)
+{
+  dt_lib_module_t *self = lua_touserdata(L, lua_upvalueindex(1));
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  const gboolean tmp = dt_collection_get_sort_descending(darktable.collection);
+   if(lua_gettop(L) > 0){
+    dt_collection_sort_order_t value;
+    luaA_to(L,dt_collection_sort_order_t,&value,1);
+    dt_collection_sort_t sort_value = dt_collection_get_sort_field(darktable.collection);
+    dt_collection_set_sort(darktable.collection, sort_value, value);
+    gtk_combo_box_set_active(GTK_COMBO_BOX(d->sort), dt_collection_get_sort_field(darktable.collection));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse),
+                               dt_collection_get_sort_descending(darktable.collection));
+    _lib_filter_update_query(self);
+  }
+  luaA_push(L, dt_collection_sort_order_t, &tmp);
+  return 1;
+}
+static int rating_cb(lua_State *L)
+{
+  dt_lib_module_t *self = lua_touserdata(L, lua_upvalueindex(1));
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  const dt_collection_filter_t tmp = dt_collection_get_rating(darktable.collection);
+  if(lua_gettop(L) > 0){
+    dt_collection_filter_t value;
+    luaA_to(L,dt_collection_filter_t,&value,1);
+    dt_collection_set_rating(darktable.collection, (uint32_t)value);
+    gtk_combo_box_set_active(GTK_COMBO_BOX(d->filter), dt_collection_get_rating(darktable.collection));
+    _lib_filter_update_query(self);
+  }
+  luaA_push(L, dt_collection_filter_t, &tmp);
+  return 1;
+}
+static int rating_comparator_cb(lua_State *L)
+{
+  dt_lib_module_t *self = lua_touserdata(L, lua_upvalueindex(1));
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  const dt_collection_rating_comperator_t tmp = dt_collection_get_rating_comparator(darktable.collection);
+  if(lua_gettop(L) > 0){
+    dt_collection_rating_comperator_t value;
+    luaA_to(L,dt_collection_rating_comperator_t,&value,1);
+    dt_collection_set_rating_comparator(darktable.collection, (uint32_t)value);
+    gtk_combo_box_set_active(GTK_COMBO_BOX(d->comparator), dt_collection_get_rating_comparator(darktable.collection));
+    _lib_filter_update_query(self);
+  }
+  luaA_push(L, dt_collection_rating_comperator_t, &tmp);
+  return 1;
+}
+
+void init(struct dt_lib_module_t *self)
+{
+  lua_State *L = darktable.lua_state.state;
+  int my_type = dt_lua_module_entry_get_type(L, "lib", self->plugin_name);
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, sort_cb, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "sort");
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, sort_order_cb,1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "sort_order");
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, rating_cb,1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "rating");
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, rating_comparator_cb,1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "rating_comparator");
+
+  luaA_enum(L,dt_collection_sort_t);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_NONE);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_FILENAME);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_DATETIME);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_RATING);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_ID);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_COLOR);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_GROUP);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_PATH);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_CUSTOM_ORDER);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_TITLE);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_DESCRIPTION);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_ASPECT_RATIO);
+  luaA_enum_value(L,dt_collection_sort_t,DT_COLLECTION_SORT_SHUFFLE);
+
+  luaA_enum(L,dt_collection_filter_t);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_ALL);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_STAR_NO);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_STAR_1);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_STAR_2);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_STAR_3);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_STAR_4);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_STAR_5);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_REJECT);
+  luaA_enum_value(L,dt_collection_filter_t,DT_COLLECTION_FILTER_NOT_REJECT);
+
+  luaA_enum(L,dt_collection_sort_order_t);
+  luaA_enum_value(L,dt_collection_sort_order_t,DT_COLLECTION_SORT_ORDER_ASCENDING);
+  luaA_enum_value(L,dt_collection_sort_order_t,DT_COLLECTION_SORT_ORDER_DESCENDING);
+
+  luaA_enum(L,dt_collection_rating_comperator_t);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_COMP_LT);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_COMP_LEQ);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_COMP_EQ);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_COMP_GEQ);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_COMP_GT);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_COMP_NE);
+  luaA_enum_value(L,dt_collection_rating_comperator_t,DT_COLLECTION_RATING_N_COMPS);
+
+}
+#endif
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Extended lua API to allow control of the view toolbox.  Sort, sort order, rating, and rating comparator can now be set to control the images displayed in the lighttable view.

Fixed a typo in darktable_gui_libs_ratings in the API manual.

This satisfies issue 12613.