### PR TITLE
preview zoom : dynamic memory allocation for full-res image

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -327,7 +327,7 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
       dt_dev_init(&dev, 0);
       dt_dev_load_image(&dev, imgid);
       dt_dev_pixelpipe_t pipe;
-      int res = dt_dev_pixelpipe_init_dummy(&pipe, imgtmp.width, imgtmp.height);
+      const int res = dt_dev_pixelpipe_init_dummy(&pipe, imgtmp.width, imgtmp.height);
       if(res)
       {
         // set mem pointer to 0, won't be used.
@@ -341,7 +341,7 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
       }
       else
       {
-        // for some raison pipeline didn't success, let's allocate huge memory
+        // for some raison pipeline didn't succeed, let's allocate huge memory
         entry->data_size = cache->buffer_size[mip];
       }
       dt_dev_cleanup(&dev);


### PR DESCRIPTION
The idea is to allocate only the needed memory for the full resolution image "on the fly". We can't use the same "fixed" system as for the other mipmaps, as the full-res image can potentially be really large.
Please review and test carefully. I'm not really sure to understand all the caching mechanisms...
In particular, I fear concurrency calls...