### PR TITLE
blend: just reformating

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -17,9 +17,9 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include "blend.h"
+#include "common/colorspaces_inline_conversions.h"
 #include "common/gaussian.h"
 #include "common/guided_filter.h"
-#include "common/colorspaces_inline_conversions.h"
 #include "common/math.h"
 #include "common/opencl.h"
 #include "control/control.h"
@@ -166,9 +166,9 @@ static inline void _HSV_2_RGB(const float *HSV, float *RGB)
 
 static inline void _CLAMP_XYZ(float *XYZ, const float *min, const float *max)
 {
-  XYZ[0] =clamp_range_f(XYZ[0], min[0], max[0]);
-  XYZ[1] =clamp_range_f(XYZ[1], min[1], max[1]);
-  XYZ[2] =clamp_range_f(XYZ[2], min[2], max[2]);
+  XYZ[0] = clamp_range_f(XYZ[0], min[0], max[0]);
+  XYZ[1] = clamp_range_f(XYZ[1], min[1], max[1]);
+  XYZ[2] = clamp_range_f(XYZ[2], min[2], max[2]);
 }
 
 static inline void _PX_COPY(const float *src, float *dst)
@@ -192,16 +192,12 @@ static inline float _blendif_factor(dt_iop_colorspace_type_t cst, const float *i
   switch(cst)
   {
     case iop_cs_Lab:
-      scaled[DEVELOP_BLENDIF_L_in] =clamp_range_f(input[0]/100.0f, 0.0f, 1.0f); // L scaled to 0..1
-      scaled[DEVELOP_BLENDIF_A_in]
-          =clamp_range_f((input[1]+128.0f)/256.0f, 0.0f, 1.0f); // a scaled to 0..1
-      scaled[DEVELOP_BLENDIF_B_in]
-          =clamp_range_f((input[2]+128.0f)/256.0f, 0.0f, 1.0f);                 // b scaled to 0..1
-      scaled[DEVELOP_BLENDIF_L_out] =clamp_range_f(output[0]/100.0f, 0.0f, 1.0f); // L scaled to 0..1
-      scaled[DEVELOP_BLENDIF_A_out]
-          =clamp_range_f((output[1]+128.0f)/256.0f, 0.0f, 1.0f); // a scaled to 0..1
-      scaled[DEVELOP_BLENDIF_B_out]
-          =clamp_range_f((output[2]+128.0f)/256.0f, 0.0f, 1.0f); // b scaled to 0..1
+      scaled[DEVELOP_BLENDIF_L_in] = clamp_range_f(input[0] / 100.0f, 0.0f, 1.0f);              // L scaled to 0..1
+      scaled[DEVELOP_BLENDIF_A_in] = clamp_range_f((input[1] + 128.0f) / 256.0f, 0.0f, 1.0f);   // a scaled to 0..1
+      scaled[DEVELOP_BLENDIF_B_in] = clamp_range_f((input[2] + 128.0f) / 256.0f, 0.0f, 1.0f);   // b scaled to 0..1
+      scaled[DEVELOP_BLENDIF_L_out] = clamp_range_f(output[0] / 100.0f, 0.0f, 1.0f);            // L scaled to 0..1
+      scaled[DEVELOP_BLENDIF_A_out] = clamp_range_f((output[1] + 128.0f) / 256.0f, 0.0f, 1.0f); // a scaled to 0..1
+      scaled[DEVELOP_BLENDIF_B_out] = clamp_range_f((output[2] + 128.0f) / 256.0f, 0.0f, 1.0f); // b scaled to 0..1
 
       if(blendif & 0x7f00) // do we need to consider LCh ?
       {
@@ -210,13 +206,13 @@ static inline float _blendif_factor(dt_iop_colorspace_type_t cst, const float *i
         dt_Lab_2_LCH(input, LCH_input);
         dt_Lab_2_LCH(output, LCH_output);
 
-        scaled[DEVELOP_BLENDIF_C_in] =clamp_range_f(LCH_input[1]/(128.0f*sqrtf(2.0f)), 0.0f,
-                                                    1.0f);                     // C scaled to 0..1
-        scaled[DEVELOP_BLENDIF_h_in] =clamp_range_f(LCH_input[2], 0.0f, 1.0f); // h scaled to 0..1
+        scaled[DEVELOP_BLENDIF_C_in] = clamp_range_f(LCH_input[1] / (128.0f * sqrtf(2.0f)), 0.0f,
+                                                     1.0f);                     // C scaled to 0..1
+        scaled[DEVELOP_BLENDIF_h_in] = clamp_range_f(LCH_input[2], 0.0f, 1.0f); // h scaled to 0..1
 
-        scaled[DEVELOP_BLENDIF_C_out] =clamp_range_f(LCH_output[1]/(128.0f*sqrtf(2.0f)), 0.0f,
-                                                     1.0f);                      // C scaled to 0..1
-        scaled[DEVELOP_BLENDIF_h_out] =clamp_range_f(LCH_output[2], 0.0f, 1.0f); // h scaled to 0..1
+        scaled[DEVELOP_BLENDIF_C_out] = clamp_range_f(LCH_output[1] / (128.0f * sqrtf(2.0f)), 0.0f,
+                                                      1.0f);                      // C scaled to 0..1
+        scaled[DEVELOP_BLENDIF_h_out] = clamp_range_f(LCH_output[2], 0.0f, 1.0f); // h scaled to 0..1
       }
 
       channel_mask = DEVELOP_BLENDIF_Lab_MASK;
@@ -224,23 +220,25 @@ static inline float _blendif_factor(dt_iop_colorspace_type_t cst, const float *i
       break;
     case iop_cs_rgb:
       if(work_profile == NULL)
-        scaled[DEVELOP_BLENDIF_GRAY_in] =clamp_range_f(0.3f*input[0]+0.59f*input[1]+0.11f*input[2], 0.0f,
-                                                       1.0f); // Gray scaled to 0..1
+        scaled[DEVELOP_BLENDIF_GRAY_in]
+            = clamp_range_f(0.3f * input[0] + 0.59f * input[1] + 0.11f * input[2], 0.0f,
+                            1.0f); // Gray scaled to 0..1
       else
-        scaled[DEVELOP_BLENDIF_GRAY_in] =clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(input, work_profile), 0.0f,
-                                                       1.0f);                // Gray scaled to 0..1
-      scaled[DEVELOP_BLENDIF_RED_in] =clamp_range_f(input[0], 0.0f, 1.0f);   // Red
-      scaled[DEVELOP_BLENDIF_GREEN_in] =clamp_range_f(input[1], 0.0f, 1.0f); // Green
-      scaled[DEVELOP_BLENDIF_BLUE_in] =clamp_range_f(input[2], 0.0f, 1.0f);  // Blue
+        scaled[DEVELOP_BLENDIF_GRAY_in]
+            = clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(input, work_profile), 0.0f,
+                            1.0f);                                            // Gray scaled to 0..1
+      scaled[DEVELOP_BLENDIF_RED_in] = clamp_range_f(input[0], 0.0f, 1.0f);   // Red
+      scaled[DEVELOP_BLENDIF_GREEN_in] = clamp_range_f(input[1], 0.0f, 1.0f); // Green
+      scaled[DEVELOP_BLENDIF_BLUE_in] = clamp_range_f(input[2], 0.0f, 1.0f);  // Blue
       if(work_profile == NULL)
-        scaled[DEVELOP_BLENDIF_GRAY_out] =clamp_range_f(0.3f*output[0]+0.59f*output[1]+0.11f*output[2],
-                                                        0.0f, 1.0f); // Gray scaled to 0..1
+        scaled[DEVELOP_BLENDIF_GRAY_out] = clamp_range_f(0.3f * output[0] + 0.59f * output[1] + 0.11f * output[2],
+                                                         0.0f, 1.0f); // Gray scaled to 0..1
       else
-        scaled[DEVELOP_BLENDIF_GRAY_out] =clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(output, work_profile),
-                                                        0.0f, 1.0f);           // Gray scaled to 0..1
-      scaled[DEVELOP_BLENDIF_RED_out] =clamp_range_f(output[0], 0.0f, 1.0f);   // Red
-      scaled[DEVELOP_BLENDIF_GREEN_out] =clamp_range_f(output[1], 0.0f, 1.0f); // Green
-      scaled[DEVELOP_BLENDIF_BLUE_out] =clamp_range_f(output[2], 0.0f, 1.0f);  // Blue
+        scaled[DEVELOP_BLENDIF_GRAY_out] = clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(output, work_profile),
+                                                         0.0f, 1.0f);           // Gray scaled to 0..1
+      scaled[DEVELOP_BLENDIF_RED_out] = clamp_range_f(output[0], 0.0f, 1.0f);   // Red
+      scaled[DEVELOP_BLENDIF_GREEN_out] = clamp_range_f(output[1], 0.0f, 1.0f); // Green
+      scaled[DEVELOP_BLENDIF_BLUE_out] = clamp_range_f(output[2], 0.0f, 1.0f);  // Blue
 
       if(blendif & 0x7f00) // do we need to consider HSL ?
       {
@@ -249,13 +247,13 @@ static inline float _blendif_factor(dt_iop_colorspace_type_t cst, const float *i
         dt_RGB_2_HSL(input, HSL_input);
         dt_RGB_2_HSL(output, HSL_output);
 
-        scaled[DEVELOP_BLENDIF_H_in] =clamp_range_f(HSL_input[0], 0.0f, 1.0f); // H scaled to 0..1
-        scaled[DEVELOP_BLENDIF_S_in] =clamp_range_f(HSL_input[1], 0.0f, 1.0f); // S scaled to 0..1
-        scaled[DEVELOP_BLENDIF_l_in] =clamp_range_f(HSL_input[2], 0.0f, 1.0f); // L scaled to 0..1
+        scaled[DEVELOP_BLENDIF_H_in] = clamp_range_f(HSL_input[0], 0.0f, 1.0f); // H scaled to 0..1
+        scaled[DEVELOP_BLENDIF_S_in] = clamp_range_f(HSL_input[1], 0.0f, 1.0f); // S scaled to 0..1
+        scaled[DEVELOP_BLENDIF_l_in] = clamp_range_f(HSL_input[2], 0.0f, 1.0f); // L scaled to 0..1
 
-        scaled[DEVELOP_BLENDIF_H_out] =clamp_range_f(HSL_output[0], 0.0f, 1.0f); // H scaled to 0..1
-        scaled[DEVELOP_BLENDIF_S_out] =clamp_range_f(HSL_output[1], 0.0f, 1.0f); // S scaled to 0..1
-        scaled[DEVELOP_BLENDIF_l_out] =clamp_range_f(HSL_output[2], 0.0f, 1.0f); // L scaled to 0..1
+        scaled[DEVELOP_BLENDIF_H_out] = clamp_range_f(HSL_output[0], 0.0f, 1.0f); // H scaled to 0..1
+        scaled[DEVELOP_BLENDIF_S_out] = clamp_range_f(HSL_output[1], 0.0f, 1.0f); // S scaled to 0..1
+        scaled[DEVELOP_BLENDIF_l_out] = clamp_range_f(HSL_output[2], 0.0f, 1.0f); // L scaled to 0..1
       }
 
       channel_mask = DEVELOP_BLENDIF_RGB_MASK;
@@ -351,7 +349,8 @@ static inline void _blend_noop(const _blend_buffer_desc_t *bd, const float *a, f
 {
   for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
   {
-    for(int k = 0; k < bd->bch; k++) b[j + k] =clamp_range_f(a[j+k], min ? min[k] : -INFINITY, max ? max[k] : INFINITY);
+    for(int k = 0; k < bd->bch; k++)
+      b[j + k] = clamp_range_f(a[j + k], min ? min[k] : -INFINITY, max ? max[k] : INFINITY);
     if(bd->cst != iop_cs_RAW) b[j + 3] = mask[i];
   }
 }
@@ -368,8 +367,8 @@ static void _blend_make_mask(const _blend_buffer_desc_t *bd, const unsigned int 
     float form = mask[i];
     float conditional = _blendif_factor(bd->cst, &a[j], &b[j], blendif, blendif_parameters, mask_mode,
                                         mask_combine, work_profile);
-    float opacity = (mask_combine & DEVELOP_COMBINE_INCL) ? 1.0f - (1.0f - form) * (1.0f - conditional)
-                                                          : form * conditional;
+    float opacity
+        = (mask_combine & DEVELOP_COMBINE_INCL) ? 1.0f - (1.0f - form) * (1.0f - conditional) : form * conditional;
     opacity = (mask_combine & DEVELOP_COMBINE_INV) ? 1.0f - opacity : opacity;
     mask[i] = opacity * gopacity;
   }
@@ -391,12 +390,12 @@ static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+tb[1]*local_opacity, min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+tb[2]*local_opacity, min[2], max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity, min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity, min[2], max[2]);
       }
       else
       {
@@ -414,8 +413,7 @@ static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k]
-            =clamp_range_f(a[j+k]*(1.0f-local_opacity)+b[j+k]*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity, min[k], max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -425,15 +423,14 @@ static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k]
-            =clamp_range_f(a[j+k]*(1.0f-local_opacity)+b[j+k]*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity, min[k], max[k]);
     }
   }
 }
 
 /* normal blend without any clamping */
-static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float *a, float *b,
-                                    const float *mask, int flag)
+static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
+                                    int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -469,8 +466,7 @@ static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float 
     for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
     {
       float local_opacity = mask[i];
-      for(int k = 0; k < bd->bch; k++)
-        b[j + k] = a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity;
+      for(int k = 0; k < bd->bch; k++) b[j + k] = a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity;
       b[j + 3] = local_opacity;
     }
   }
@@ -479,15 +475,13 @@ static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float 
     for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
     {
       float local_opacity = mask[i];
-      for(int k = 0; k < bd->bch; k++)
-        b[j + k] = a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity;
+      for(int k = 0; k < bd->bch; k++) b[j + k] = a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity;
     }
   }
 }
 
 /* lighten */
-static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -502,15 +496,15 @@ static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&b[j], tb);
 
       tbo = tb[0];
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]>tb[0] ? ta[0] : tb[0])*local_opacity,
-                           min[0], max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] > tb[0] ? ta[0] : tb[0]) * local_opacity,
+                            min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[1]+tb[1])*fabsf(tbo-tb[0]),
-                             min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[2]+tb[2])*fabsf(tbo-tb[0]),
-                             min[2], max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[1] + tb[1]) * fabsf(tbo - tb[0]),
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[2] + tb[2]) * fabsf(tbo - tb[0]),
+                              min[2], max[2]);
       }
       else
       {
@@ -528,8 +522,8 @@ static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(a[j+k]*(1.0f-local_opacity)+fmaxf(a[j+k], b[j+k])*local_opacity,
-                                min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + fmaxf(a[j + k], b[j + k]) * local_opacity,
+                                 min[k], max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -539,15 +533,14 @@ static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(a[j+k]*(1.0f-local_opacity)+fmaxf(a[j+k], b[j+k])*local_opacity,
-                                min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + fmaxf(a[j + k], b[j + k]) * local_opacity,
+                                 min[k], max[k]);
     }
   }
 }
 
 /* darken */
-static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                          int flag)
+static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -562,15 +555,15 @@ static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float 
       _blend_Lab_scale(&b[j], tb);
 
       tbo = tb[0];
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]<tb[0] ? ta[0] : tb[0])*local_opacity,
-                           min[0], max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] < tb[0] ? ta[0] : tb[0]) * local_opacity,
+                            min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[1]+tb[1])*fabsf(tbo-tb[0]),
-                             min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[2]+tb[2])*fabsf(tbo-tb[0]),
-                             min[2], max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[1] + tb[1]) * fabsf(tbo - tb[0]),
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[2] + tb[2]) * fabsf(tbo - tb[0]),
+                              min[2], max[2]);
       }
       else
       {
@@ -588,8 +581,8 @@ static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float 
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(a[j+k]*(1.0f-local_opacity)+fminf(a[j+k], b[j+k])*local_opacity,
-                                min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + fminf(a[j + k], b[j + k]) * local_opacity,
+                                 min[k], max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -599,16 +592,15 @@ static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float 
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(a[j+k]*(1.0f-local_opacity)+fminf(a[j+k], b[j+k])*local_opacity,
-                                min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + fminf(a[j + k], b[j + k]) * local_opacity,
+                                 min[k], max[k]);
     }
   }
   // return fminf(a,b);
 }
 
 /* multiply */
-static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                            int flag)
+static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -624,31 +616,27 @@ static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, floa
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
 
-      tb[0] =clamp_range_f((la*(1.0f-local_opacity))+((la*lb)*local_opacity), min[0], max[0])
+      tb[0] = clamp_range_f((la * (1.0f - local_opacity)) + ((la * lb) * local_opacity), min[0], max[0])
               - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1]
-              =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity,
-                             min[1], max[1]);
-          tb[2]
-              =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity,
-                             min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1]
-              =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])*tb[0]/0.01f*local_opacity,
-                             min[1], max[1]);
-          tb[2]
-              =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])*tb[0]/0.01f*local_opacity,
-                             min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity,
+                                min[2], max[2]);
         }
       }
       else
@@ -667,8 +655,8 @@ static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, floa
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(
-            a[j+k]*(1.0f-local_opacity)+(a[j+k]*b[j+k])*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + (a[j + k] * b[j + k]) * local_opacity, min[k],
+                                 max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -679,16 +667,15 @@ static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, floa
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
 
-        b[j + k] =clamp_range_f(
-            a[j+k]*(1.0f-local_opacity)+(a[j+k]*b[j+k])*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + (a[j + k] * b[j + k]) * local_opacity, min[k],
+                                 max[k]);
     }
   }
   // return (a*b);
 }
 
 /* average */
-static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -702,15 +689,15 @@ static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]+tb[0])/2.0f*local_opacity, min[0],
-                           max[0]);
+      tb[0]
+          = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] + tb[0]) / 2.0f * local_opacity, min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])/2.0f*local_opacity, min[1],
-                             max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])/2.0f*local_opacity, min[2],
-                             max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) / 2.0f * local_opacity, min[1],
+                              max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) / 2.0f * local_opacity, min[2],
+                              max[2]);
       }
       else
       {
@@ -728,8 +715,8 @@ static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(
-            a[j+k]*(1.0f-local_opacity)+(a[j+k]+b[j+k])/2.0f*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + (a[j + k] + b[j + k]) / 2.0f * local_opacity,
+                                 min[k], max[k]);
 
       b[j + 3] = local_opacity;
     }
@@ -740,8 +727,8 @@ static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(
-            a[j+k]*(1.0f-local_opacity)+(a[j+k]+b[j+k])/2.0f*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + (a[j + k] + b[j + k]) / 2.0f * local_opacity,
+                                 min[k], max[k]);
     }
   }
   // return (a+b)/2.0;
@@ -762,15 +749,12 @@ static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b,
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]+tb[0])*local_opacity, min[0],
-                           max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] + tb[0]) * local_opacity, min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])*local_opacity, min[1],
-                             max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])*local_opacity, min[2],
-                             max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) * local_opacity, min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) * local_opacity, min[2], max[2]);
       }
       else
       {
@@ -788,8 +772,8 @@ static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b,
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(
-            a[j+k]*(1.0f-local_opacity)+(a[j+k]+b[j+k])*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + (a[j + k] + b[j + k]) * local_opacity, min[k],
+                                 max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -799,8 +783,8 @@ static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b,
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(
-            a[j+k]*(1.0f-local_opacity)+(a[j+k]+b[j+k])*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + (a[j + k] + b[j + k]) * local_opacity, min[k],
+                                 max[k]);
     }
   }
   /*
@@ -811,8 +795,7 @@ static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b,
 }
 
 /* substract */
-static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -826,18 +809,18 @@ static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, flo
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(
-          ta[0]*(1.0f-local_opacity)+((tb[0]+ta[0])-(fabsf(min[0]+max[0])))*local_opacity,
-          min[0], max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity)
+                                + ((tb[0] + ta[0]) - (fabsf(min[0] + max[0]))) * local_opacity,
+                            min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(
-            ta[1]*(1.0f-local_opacity)+((tb[1]+ta[1])-(fabsf(min[1]+max[1])))*local_opacity,
-            min[1], max[1]);
-        tb[2] =clamp_range_f(
-            ta[2]*(1.0f-local_opacity)+((tb[2]+ta[2])-(fabsf(min[2]+max[2])))*local_opacity,
-            min[2], max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity)
+                                  + ((tb[1] + ta[1]) - (fabsf(min[1] + max[1]))) * local_opacity,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity)
+                                  + ((tb[2] + ta[2]) - (fabsf(min[2] + max[2]))) * local_opacity,
+                              min[2], max[2]);
       }
       else
       {
@@ -855,9 +838,9 @@ static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, flo
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(a[j+k]*(1.0f-local_opacity)
-                                +((b[j+k]+a[j+k])-(fabsf(min[k]+max[k])))*local_opacity,
-                                min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity)
+                                     + ((b[j + k] + a[j + k]) - (fabsf(min[k] + max[k]))) * local_opacity,
+                                 min[k], max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -867,9 +850,9 @@ static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, flo
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k] =clamp_range_f(a[j+k]*(1.0f-local_opacity)
-                                +((b[j+k]+a[j+k])-(fabsf(min[k]+max[k])))*local_opacity,
-                                min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity)
+                                     + ((b[j + k] + a[j + k]) - (fabsf(min[k] + max[k]))) * local_opacity,
+                                 min[k], max[k]);
     }
   }
   /*
@@ -880,8 +863,7 @@ static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* difference (deprecated) */
-static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                              int flag)
+static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -896,23 +878,23 @@ static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, fl
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
 
-      tb[0] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+      tb[0] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
               - fabsf(min[0]);
 
       if(flag == 0)
       {
         lmax = max[1] + fabsf(min[1]);
-        la =clamp_range_f(ta[1]+fabsf(min[1]), lmin, lmax);
-        lb =clamp_range_f(tb[1]+fabsf(min[1]), lmin, lmax);
-        tb[1] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+        la = clamp_range_f(ta[1] + fabsf(min[1]), lmin, lmax);
+        lb = clamp_range_f(tb[1] + fabsf(min[1]), lmin, lmax);
+        tb[1] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
                 - fabsf(min[1]);
         lmax = max[2] + fabsf(min[2]);
-        la =clamp_range_f(ta[2]+fabsf(min[2]), lmin, lmax);
-        lb =clamp_range_f(tb[2]+fabsf(min[2]), lmin, lmax);
-        tb[2] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+        la = clamp_range_f(ta[2] + fabsf(min[2]), lmin, lmax);
+        lb = clamp_range_f(tb[2] + fabsf(min[2]), lmin, lmax);
+        tb[2] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
                 - fabsf(min[2]);
       }
       else
@@ -937,7 +919,7 @@ static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, fl
         la = a[j + k] + fabsf(min[k]);
         lb = b[j + k] + fabsf(min[k]);
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
                    - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
@@ -955,7 +937,7 @@ static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, fl
         la = a[j + k] + fabsf(min[k]);
         lb = b[j + k] + fabsf(min[k]);
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -984,7 +966,7 @@ static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, f
       tb[2] = fabsf(ta[2] - tb[2]) / fabsf(max[2] - min[2]);
       tb[0] = fmaxf(tb[0], fmaxf(tb[1], tb[2]));
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
 
       if(flag == 0)
       {
@@ -1013,7 +995,7 @@ static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, f
         la = a[j + k] + fabsf(min[k]);
         lb = b[j + k] + fabsf(min[k]);
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
                    - fabsf(min[k]);
       }
 
@@ -1032,7 +1014,7 @@ static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, f
         la = a[j + k] + fabsf(min[k]);
         lb = b[j + k] + fabsf(min[k]);
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -1041,8 +1023,7 @@ static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, f
 }
 
 /* screen */
-static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                          int flag)
+static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1057,32 +1038,32 @@ static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float 
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
 
-      tb[0] =clamp_range_f(la*(1.0f-local_opacity)+((lmax-(lmax-la)*(lmax-lb)))*local_opacity,
-                           lmin, lmax)
+      tb[0] = clamp_range_f(la * (1.0f - local_opacity) + ((lmax - (lmax - la) * (lmax - lb))) * local_opacity,
+                            lmin, lmax)
               - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)
-                               +0.5f*(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)
-                               +0.5f*(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity)
+                                    + 0.5f * (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity)
+                                    + 0.5f * (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)
-                               +0.5f*(ta[1]+tb[1])*tb[0]/0.01f*local_opacity,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)
-                               +0.5f*(ta[2]+tb[2])*tb[0]/0.01f*local_opacity,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity)
+                                    + 0.5f * (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity)
+                                    + 0.5f * (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity,
+                                min[2], max[2]);
         }
       }
       else
@@ -1104,13 +1085,12 @@ static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float 
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
 
-        b[j + k]
-            =clamp_range_f(la*(1.0f-local_opacity)+(lmax-(lmax-la)*(lmax-lb))*local_opacity,
-                           lmin, lmax)
-              - fabsf(min[k]);
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity) + (lmax - (lmax - la) * (lmax - lb)) * local_opacity,
+                                 lmin, lmax)
+                   - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
     }
@@ -1124,13 +1104,12 @@ static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float 
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
 
-        b[j + k]
-            =clamp_range_f(la*(1.0f-local_opacity)+(lmax-(lmax-la)*(lmax-lb))*local_opacity,
-                           lmin, lmax)
-              - fabsf(min[k]);
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity) + (lmax - (lmax - la) * (lmax - lb)) * local_opacity,
+                                 lmin, lmax)
+                   - fabsf(min[k]);
       }
     }
   }
@@ -1142,8 +1121,7 @@ static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float 
 }
 
 /* overlay */
-static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1159,37 +1137,33 @@ static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
       halfmax = lmax / 2.0f;
       doublemax = lmax * 2.0f;
 
-      tb[0] =clamp_range_f(la*(1.0f-local_opacity2)
-                           +(la>halfmax ? lmax-(lmax-doublemax*(la-halfmax))*(lmax-lb)
-                                        : (doublemax*la)*lb)
-                            *local_opacity2,
-                           lmin, lmax)
+      tb[0] = clamp_range_f(la * (1.0f - local_opacity2)
+                                + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                                                : (doublemax * la) * lb)
+                                      * local_opacity2,
+                            lmin, lmax)
               - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                                min[2], max[2]);
         }
       }
       else
@@ -1212,16 +1186,16 @@ static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)
-                                +(la>halfmax ? lmax-(lmax-doublemax*(la-halfmax))*(lmax-lb)
-                                             : doublemax*la*lb)
-                                 *local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2)
+                                     + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                                                     : doublemax * la * lb)
+                                           * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
@@ -1237,16 +1211,16 @@ static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)
-                                +(la>halfmax ? lmax-(lmax-doublemax*(la-halfmax))*(lmax-lb)
-                                             : doublemax*la*lb)
-                                 *local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2)
+                                     + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                                                     : doublemax * la * lb)
+                                           * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -1262,8 +1236,7 @@ static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float
 }
 
 /* softlight */
-static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
 
   float max[4] = { 0 }, min[4] = { 0 };
@@ -1280,36 +1253,32 @@ static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, flo
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
       halfmax = lmax / 2.0f;
 
-      tb[0] =clamp_range_f(
-          la*(1.0f-local_opacity2)
-          +(lb>halfmax ? lmax-(lmax-la)*(lmax-(lb-halfmax)) : la*(lb+halfmax))
-           *local_opacity2,
-          lmin, lmax)
-              - fabsf(min[0]);
+      tb[0]
+          = clamp_range_f(la * (1.0f - local_opacity2)
+                              + (lb > halfmax ? lmax - (lmax - la) * (lmax - (lb - halfmax)) : la * (lb + halfmax))
+                                    * local_opacity2,
+                          lmin, lmax)
+            - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                                min[2], max[2]);
         }
       }
       else
@@ -1332,15 +1301,15 @@ static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, flo
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
 
-        b[j + k] =clamp_range_f(
-            la*(1.0f-local_opacity2)
-            +(lb>halfmax ? lmax-(lmax-la)*(lmax-(lb-halfmax)) : la*(lb+halfmax))
-             *local_opacity2,
-            lmin, lmax)
+        b[j + k] = clamp_range_f(
+                       la * (1.0f - local_opacity2)
+                           + (lb > halfmax ? lmax - (lmax - la) * (lmax - (lb - halfmax)) : la * (lb + halfmax))
+                                 * local_opacity2,
+                       lmin, lmax)
                    - fabsf(min[k]);
 
         b[j + 3] = local_opacity;
@@ -1357,15 +1326,15 @@ static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, flo
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
 
-        b[j + k] =clamp_range_f(
-            la*(1.0f-local_opacity2)
-            +(lb>halfmax ? lmax-(lmax-la)*(lmax-(lb-halfmax)) : la*(lb+halfmax))
-             *local_opacity2,
-            lmin, lmax)
+        b[j + k] = clamp_range_f(
+                       la * (1.0f - local_opacity2)
+                           + (lb > halfmax ? lmax - (lmax - la) * (lmax - (lb - halfmax)) : la * (lb + halfmax))
+                                 * local_opacity2,
+                       lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -1379,8 +1348,7 @@ static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* hardlight */
-static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1396,37 +1364,33 @@ static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, flo
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
       halfmax = lmax / 2.0f;
       doublemax = lmax * 2.0f;
 
-      tb[0] =clamp_range_f((la*(1.0f-local_opacity2))
-                           +(lb>halfmax ? lmax-(lmax-doublemax*(la-halfmax))*(lmax-lb)
-                                        : doublemax*la*lb)
-                            *local_opacity2,
-                           lmin, lmax)
+      tb[0] = clamp_range_f((la * (1.0f - local_opacity2))
+                                + (lb > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                                                : doublemax * la * lb)
+                                      * local_opacity2,
+                            lmin, lmax)
               - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                                min[2], max[2]);
         }
       }
       else
@@ -1449,16 +1413,16 @@ static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, flo
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)
-                                +(lb>halfmax ? lmax-(lmax-doublemax*(la-halfmax))*(lmax-lb)
-                                             : doublemax*la*lb)
-                                 *local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2)
+                                     + (lb > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                                                     : doublemax * la * lb)
+                                           * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
@@ -1474,16 +1438,16 @@ static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, flo
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)
-                                +(lb>halfmax ? lmax-(lmax-doublemax*(la-halfmax))*(lmax-lb)
-                                             : doublemax*la*lb)
-                                 *local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2)
+                                     + (lb > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                                                     : doublemax * la * lb)
+                                           * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -1499,8 +1463,7 @@ static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* vividlight */
-static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                              int flag)
+static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1516,37 +1479,33 @@ static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, fl
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
       halfmax = lmax / 2.0f;
       doublemax = lmax * 2.0f;
 
-      tb[0] =clamp_range_f(la*(1.0f-local_opacity2)
-                           +(lb>halfmax ? (lb>=lmax ? lmax : la/(doublemax*(lmax-lb)))
-                                        : (lb<=lmin ? lmin : lmax-(lmax-la)/(doublemax*lb)))
-                            *local_opacity2,
-                           lmin, lmax)
+      tb[0] = clamp_range_f(la * (1.0f - local_opacity2)
+                                + (lb > halfmax ? (lb >= lmax ? lmax : la / (doublemax * (lmax - lb)))
+                                                : (lb <= lmin ? lmin : lmax - (lmax - la) / (doublemax * lb)))
+                                      * local_opacity2,
+                            lmin, lmax)
               - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                                min[2], max[2]);
         }
       }
       else
@@ -1569,16 +1528,16 @@ static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, fl
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f((la*(1.0f-local_opacity2))
-                                +(lb>halfmax ? (lb>=lmax ? lmax : la/(doublemax*(lmax-lb)))
-                                             : (lb<=lmin ? lmin : lmax-(lmax-la)/(doublemax*lb)))
-                                 *local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f((la * (1.0f - local_opacity2))
+                                     + (lb > halfmax ? (lb >= lmax ? lmax : la / (doublemax * (lmax - lb)))
+                                                     : (lb <= lmin ? lmin : lmax - (lmax - la) / (doublemax * lb)))
+                                           * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
@@ -1594,16 +1553,16 @@ static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, fl
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)
-                                +(lb>halfmax ? (lb>=lmax ? lmax : la/(doublemax*(lmax-lb)))
-                                             : (lb<=lmin ? lmin : lmax-(lmax-la)/(doublemax*lb)))
-                                 *local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2)
+                                     + (lb > halfmax ? (lb >= lmax ? lmax : la / (doublemax * (lmax - lb)))
+                                                     : (lb <= lmin ? lmin : lmax - (lmax - la) / (doublemax * lb)))
+                                           * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -1635,33 +1594,29 @@ static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, f
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
       doublemax = lmax * 2.0f;
 
-      tb[0] =clamp_range_f(la*(1.0f-local_opacity2)+(la+doublemax*lb-lmax)*local_opacity2, lmin,
-                           lmax)
-              - fabsf(min[0]);
+      tb[0]
+          = clamp_range_f(la * (1.0f - local_opacity2) + (la + doublemax * lb - lmax) * local_opacity2, lmin, lmax)
+            - fabsf(min[0]);
 
       if(flag == 0)
       {
         if(ta[0] > 0.01f)
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                                min[2], max[2]);
         }
         else
         {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
+          tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                                min[1], max[1]);
+          tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                                min[2], max[2]);
         }
       }
       else
@@ -1684,12 +1639,12 @@ static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, f
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)+(la+doublemax*lb-lmax)*local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2) + (la + doublemax * lb - lmax) * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
@@ -1705,12 +1660,12 @@ static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, f
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(la*(1.0f-local_opacity2)+(la+doublemax*lb-lmax)*local_opacity2,
-                                lmin, lmax)
+        b[j + k] = clamp_range_f(la * (1.0f - local_opacity2) + (la + doublemax * lb - lmax) * local_opacity2,
+                                 lmin, lmax)
                    - fabsf(min[k]);
       }
     }
@@ -1725,8 +1680,7 @@ static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, f
 }
 
 /* pinlight */
-static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                            int flag)
+static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1742,20 +1696,20 @@ static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, floa
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
       halfmax = lmax / 2.0f;
       doublemax = lmax * 2.0f;
 
       tb[0]
-          =clamp_range_f(la*(1.0f-local_opacity2)
-                         +(lb>halfmax ? fmaxf(la, doublemax*(lb-halfmax)) : fminf(la, doublemax*lb))
-                          *local_opacity2,
-                         lmin, lmax)
+          = clamp_range_f(la * (1.0f - local_opacity2)
+                              + (lb > halfmax ? fmaxf(la, doublemax * (lb - halfmax)) : fminf(la, doublemax * lb))
+                                    * local_opacity2,
+                          lmin, lmax)
             - fabsf(min[0]);
 
-      tb[1] =clamp_range_f(ta[1], min[1], max[1]);
-      tb[2] =clamp_range_f(ta[2], min[2], max[2]);
+      tb[1] = clamp_range_f(ta[1], min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2], min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -1771,16 +1725,16 @@ static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, floa
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(
-            (la*(1.0f-local_opacity2))
-            +(lb>halfmax ? fmaxf(la, doublemax*(lb-halfmax)) : fminf(la, doublemax*lb))
-             *local_opacity2,
-            lmin, lmax)
+        b[j + k] = clamp_range_f(
+                       (la * (1.0f - local_opacity2))
+                           + (lb > halfmax ? fmaxf(la, doublemax * (lb - halfmax)) : fminf(la, doublemax * lb))
+                                 * local_opacity2,
+                       lmin, lmax)
                    - fabsf(min[k]);
       }
       b[j + 3] = local_opacity;
@@ -1796,17 +1750,17 @@ static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, floa
       for(int k = 0; k < bd->bch; k++)
       {
         lmax = max[k] + fabsf(min[k]);
-        la =clamp_range_f(a[j+k]+fabsf(min[k]), lmin, lmax);
-        lb =clamp_range_f(b[j+k]+fabsf(min[k]), lmin, lmax);
+        la = clamp_range_f(a[j + k] + fabsf(min[k]), lmin, lmax);
+        lb = clamp_range_f(b[j + k] + fabsf(min[k]), lmin, lmax);
         halfmax = lmax / 2.0f;
         doublemax = lmax * 2.0f;
 
-        b[j + k] =clamp_range_f(
-            (la*(1.0f-local_opacity2)
-             +(lb>halfmax ? fmaxf(la, doublemax*(lb-halfmax)) : fminf(la, doublemax*lb))
-              *local_opacity2),
-            lmin, lmax)
-                   - fabsf(min[k]);
+        b[j + k]
+            = clamp_range_f((la * (1.0f - local_opacity2)
+                             + (lb > halfmax ? fmaxf(la, doublemax * (lb - halfmax)) : fminf(la, doublemax * lb))
+                                   * local_opacity2),
+                            lmin, lmax)
+              - fabsf(min[k]);
       }
     }
   }
@@ -1820,8 +1774,7 @@ static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, floa
 }
 
 /* lightness blend */
-static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1837,9 +1790,9 @@ static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, flo
 
       // no need to transfer to LCH as L is the same as in Lab, and C and H
       // remain unchanged
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
-      tb[1] =clamp_range_f(ta[1], min[1], max[1]);
-      tb[2] =clamp_range_f(ta[2], min[2], max[2]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1], min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2], min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -1869,13 +1822,12 @@ static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, flo
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_RAW) */
+  else                                     /* if(bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, min, max); // Noop for Raw
 }
 
 /* chroma blend */
-static void _blend_chroma(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                          int flag)
+static void _blend_chroma(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1930,7 +1882,7 @@ static void _blend_chroma(const _blend_buffer_desc_t *bd, const float *a, float 
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_RAW) */
+  else                                     /* if(bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, min, max); // Noop for Raw
 }
 
@@ -1996,7 +1948,7 @@ static void _blend_hue(const _blend_buffer_desc_t *bd, const float *a, float *b,
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_RAW) */
+  else                                     /* if(bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, min, max); // Noop for Raw
 }
 
@@ -2065,7 +2017,7 @@ static void _blend_color(const _blend_buffer_desc_t *bd, const float *a, float *
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_RAW) */
+  else                                     /* if(bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, min, max); // Noop for Raw
 }
 
@@ -2134,13 +2086,12 @@ static void _blend_coloradjust(const _blend_buffer_desc_t *bd, const float *a, f
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_RAW) */
+  else                                     /* if(bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, min, max); // Noop for Raw
 }
 
 /* inverse blend */
-static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -2154,12 +2105,12 @@ static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
 
       if(flag == 0)
       {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+tb[1]*local_opacity, min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+tb[2]*local_opacity, min[2], max[2]);
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity, min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity, min[2], max[2]);
       }
       else
       {
@@ -2177,8 +2128,7 @@ static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k]
-            =clamp_range_f(a[j+k]*(1.0f-local_opacity)+b[j+k]*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity, min[k], max[k]);
       b[j + 3] = local_opacity;
     }
   }
@@ -2188,8 +2138,7 @@ static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float
     {
       float local_opacity = mask[i];
       for(int k = 0; k < bd->bch; k++)
-        b[j + k]
-            =clamp_range_f(a[j+k]*(1.0f-local_opacity)+b[j+k]*local_opacity, min[k], max[k]);
+        b[j + k] = clamp_range_f(a[j + k] * (1.0f - local_opacity) + b[j + k] * local_opacity, min[k], max[k]);
     }
   }
 }
@@ -2216,14 +2165,13 @@ static void _blend_Lab_lightness(const _blend_buffer_desc_t *bd, const float *a,
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for RGB and Raw (unclamped)
 }
 
 /* blend only a-channel in Lab color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_Lab_a(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_Lab_a(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2242,14 +2190,13 @@ static void _blend_Lab_a(const _blend_buffer_desc_t *bd, const float *a, float *
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for RGB and Raw (unclamped)
 }
 
 /* blend only b-channel in Lab color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_Lab_b(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_Lab_b(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2268,15 +2215,14 @@ static void _blend_Lab_b(const _blend_buffer_desc_t *bd, const float *a, float *
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for RGB and Raw (unclamped)
 }
 
 
 /* blend only color in Lab color space without any clamping (a noop for other
  * color spaces) */
-static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2301,7 +2247,7 @@ static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, flo
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_rgb || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for RGB and Raw (unclamped)
 }
 
@@ -2330,14 +2276,13 @@ static void _blend_HSV_lightness(const _blend_buffer_desc_t *bd, const float *a,
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for Lab and Raw (unclamped)
 }
 
 /* blend only color in HSV color space without any clamping (a noop for other
  * color spaces) */
-static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2369,14 +2314,13 @@ static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, flo
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for Lab and Raw (unclamped)
 }
 
 /* blend only R-channel in RGB color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_RGB_R(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_RGB_R(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2390,15 +2334,13 @@ static void _blend_RGB_R(const _blend_buffer_desc_t *bd, const float *a, float *
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for Lab and Raw (unclamped)
-
 }
 
 /* blend only R-channel in RGB color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_RGB_G(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_RGB_G(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2412,14 +2354,13 @@ static void _blend_RGB_G(const _blend_buffer_desc_t *bd, const float *a, float *
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for Lab and Raw (unclamped)
 }
 
 /* blend only R-channel in RGB color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_RGB_B(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_RGB_B(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2433,7 +2374,7 @@ static void _blend_RGB_B(const _blend_buffer_desc_t *bd, const float *a, float *
       b[j + 3] = local_opacity;
     }
   }
-  else /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
+  else                                       /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for Lab and Raw (unclamped)
 }
 
@@ -2448,84 +2389,84 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
     case DT_DEV_PIXELPIPE_DISPLAY_L:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(a[j]/100.0f, 0.0f, 1.0f);
+        const float c = clamp_range_f(a[j] / 100.0f, 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_L | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_L | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(b[j]/100.0f, 0.0f, 1.0f);
+        const float c = clamp_range_f(b[j] / 100.0f, 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_a:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f((a[j+1]+128.0f)/256.0f, 0.0f, 1.0f);
+        const float c = clamp_range_f((a[j + 1] + 128.0f) / 256.0f, 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_a | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_a | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f((b[j+1]+128.0f)/256.0f, 0.0f, 1.0f);
+        const float c = clamp_range_f((b[j + 1] + 128.0f) / 256.0f, 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_b:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f((a[j+2]+128.0f)/256.0f, 0.0f, 1.0f);
+        const float c = clamp_range_f((a[j + 2] + 128.0f) / 256.0f, 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_b | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_b | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f((b[j+2]+128.0f)/256.0f, 0.0f, 1.0f);
+        const float c = clamp_range_f((b[j + 2] + 128.0f) / 256.0f, 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_R:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(a[j], 0.0f, 1.0f);
+        const float c = clamp_range_f(a[j], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(b[j], 0.0f, 1.0f);
+        const float c = clamp_range_f(b[j], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_G:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(a[j+1], 0.0f, 1.0f);
+        const float c = clamp_range_f(a[j + 1], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(b[j+1], 0.0f, 1.0f);
+        const float c = clamp_range_f(b[j + 1], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
     case DT_DEV_PIXELPIPE_DISPLAY_B:
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(a[j+2], 0.0f, 1.0f);
+        const float c = clamp_range_f(a[j + 2], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
-        const float c =clamp_range_f(b[j+2], 0.0f, 1.0f);
+        const float c = clamp_range_f(b[j + 2], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2533,17 +2474,17 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         const float c = (work_profile == NULL)
-                            ? clamp_range_f(0.3f*a[j]+0.59f*a[j+1]+0.11f*a[j+2], 0.0f, 1.0f)
-                            : clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(a+j, work_profile), 0.0f, 1.0f);
+                            ? clamp_range_f(0.3f * a[j] + 0.59f * a[j + 1] + 0.11f * a[j + 2], 0.0f, 1.0f)
+                            : clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(a + j, work_profile), 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         const float c = (work_profile == NULL)
-                            ? clamp_range_f(0.3f*b[j]+0.59f*b[j+1]+0.11f*b[j+2], 0.0f, 1.0f)
-                            : clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(b+j, work_profile), 0.0f, 1.0f);
+                            ? clamp_range_f(0.3f * b[j] + 0.59f * b[j + 1] + 0.11f * b[j + 2], 0.0f, 1.0f)
+                            : clamp_range_f(dt_ioppr_get_rgb_matrix_luminance(b + j, work_profile), 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2552,16 +2493,16 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
       {
         float LCH[3];
         dt_Lab_2_LCH(a + j, LCH);
-        const float c =clamp_range_f(LCH[1]/(128.0f*sqrtf(2.0f)), 0.0f, 1.0f);
+        const float c = clamp_range_f(LCH[1] / (128.0f * sqrtf(2.0f)), 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_LCH_C | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_LCH_C | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         float LCH[3];
         dt_Lab_2_LCH(b + j, LCH);
-        const float c =clamp_range_f(LCH[1]/(128.0f*sqrtf(2.0f)), 0.0f, 1.0f);
+        const float c = clamp_range_f(LCH[1] / (128.0f * sqrtf(2.0f)), 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2570,16 +2511,16 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
       {
         float LCH[3];
         dt_Lab_2_LCH(a + j, LCH);
-        const float c =clamp_range_f(LCH[2], 0.0f, 1.0f);
+        const float c = clamp_range_f(LCH[2], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_LCH_h | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_LCH_h | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         float LCH[3];
         dt_Lab_2_LCH(b + j, LCH);
-        const float c =clamp_range_f(LCH[2], 0.0f, 1.0f);
+        const float c = clamp_range_f(LCH[2], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2588,16 +2529,16 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
       {
         float HSL[3];
         dt_RGB_2_HSL(a + j, HSL);
-        const float c =clamp_range_f(HSL[0], 0.0f, 1.0f);
+        const float c = clamp_range_f(HSL[0], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_HSL_H | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_HSL_H | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         float HSL[3];
         dt_RGB_2_HSL(b + j, HSL);
-        const float c =clamp_range_f(HSL[0], 0.0f, 1.0f);
+        const float c = clamp_range_f(HSL[0], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2606,16 +2547,16 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
       {
         float HSL[3];
         dt_RGB_2_HSL(a + j, HSL);
-        const float c =clamp_range_f(HSL[1], 0.0f, 1.0f);
+        const float c = clamp_range_f(HSL[1], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_HSL_S | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_HSL_S | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         float HSL[3];
         dt_RGB_2_HSL(b + j, HSL);
-        const float c =clamp_range_f(HSL[1], 0.0f, 1.0f);
+        const float c = clamp_range_f(HSL[1], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2624,16 +2565,16 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
       {
         float HSL[3];
         dt_RGB_2_HSL(a + j, HSL);
-        const float c =clamp_range_f(HSL[2], 0.0f, 1.0f);
+        const float c = clamp_range_f(HSL[2], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
-    case (DT_DEV_PIXELPIPE_DISPLAY_HSL_l | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
+    case(DT_DEV_PIXELPIPE_DISPLAY_HSL_l | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT):
       for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
       {
         float HSL[3];
         dt_RGB_2_HSL(b + j, HSL);
-        const float c =clamp_range_f(HSL[2], 0.0f, 1.0f);
+        const float c = clamp_range_f(HSL[2], 0.0f, 1.0f);
         for(int k = 0; k < bd->bch; k++) b[j + k] = c;
       }
       break;
@@ -2647,8 +2588,7 @@ static void display_channel(const _blend_buffer_desc_t *bd, const float *a, floa
 
   if(bd->cst != iop_cs_rgb)
   {
-    for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch)
-      b[j + 3] = mask[i];
+    for(size_t i = 0, j = 0; j < bd->stride; i++, j += bd->ch) b[j + 3] = mask[i];
   }
 }
 
@@ -2811,11 +2751,11 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
   const dt_dev_pixelpipe_display_mask_t mask_display = piece->pipe->mask_display;
 
   // does user want us to display a specific channel?
-  const dt_dev_pixelpipe_display_mask_t request_mask_display =
-    (self->dev->gui_attached && (self == self->dev->gui_module) && (piece->pipe == self->dev->pipe)
-     && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL))
-        ? self->request_mask_display
-        : DT_DEV_PIXELPIPE_DISPLAY_NONE;
+  const dt_dev_pixelpipe_display_mask_t request_mask_display
+      = (self->dev->gui_attached && (self == self->dev->gui_module) && (piece->pipe == self->dev->pipe)
+         && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL))
+            ? self->request_mask_display
+            : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
   // check if we only should blend lightness channel. will affect only Lab space
   const int blendflag = self->flags() & IOP_FLAGS_BLEND_ONLY_LIGHTNESS;
@@ -2857,20 +2797,20 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
   {
     /* use a raster mask from another module earlier in the pipe */
     gboolean free_mask = FALSE; // if no transformations were applied we get the cached original back
-    float *raster_mask = dt_dev_get_raster_mask(piece->pipe, self->raster_mask.sink.source, self->raster_mask.sink.id,
-                                                self, &free_mask);
+    float *raster_mask = dt_dev_get_raster_mask(piece->pipe, self->raster_mask.sink.source,
+                                                self->raster_mask.sink.id, self, &free_mask);
 
     if(raster_mask)
     {
       // invert if required
       if(d->raster_mask_invert)
 #ifdef _OPENMP
-  #pragma omp parallel for default(none) shared(raster_mask)
+#pragma omp parallel for default(none) shared(raster_mask)
 #endif
         for(size_t i = 0; i < buffsize; i++) mask[i] = (1.0 - raster_mask[i]) * opacity;
       else
 #ifdef _OPENMP
-  #pragma omp parallel for default(none) shared(raster_mask)
+#pragma omp parallel for default(none) shared(raster_mask)
 #endif
         for(size_t i = 0; i < buffsize; i++) mask[i] = raster_mask[i] * opacity;
       if(free_mask) dt_free_align(raster_mask);
@@ -2880,7 +2820,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
       // fallback for when the raster mask couldn't be applied
       const float value = d->raster_mask_invert ? 0.0 : 1.0;
 #ifdef _OPENMP
-  #pragma omp parallel for default(none)
+#pragma omp parallel for default(none)
 #endif
       for(size_t i = 0; i < buffsize; i++) mask[i] = value;
     }
@@ -3005,11 +2945,11 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
       {
         float x = mask[k] / opacity;
         x = 2.f * x - 1.f;
-        if (1.f - brightness <= 0.f)
+        if(1.f - brightness <= 0.f)
           x = mask[k] <= FLT_EPSILON ? -1.f : 1.f;
-        else if (1.f + brightness <= 0.f)
+        else if(1.f + brightness <= 0.f)
           x = mask[k] >= 1.f - FLT_EPSILON ? 1.f : -1.f;
-        else if (brightness > 0.f)
+        else if(brightness > 0.f)
         {
           x = (x + brightness) / (1.f - brightness);
           x = fminf(x, 1.f);
@@ -3068,8 +3008,8 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
 }
 
 #ifdef HAVE_OPENCL
-int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
-                                cl_mem dev_in, cl_mem dev_out, const struct dt_iop_roi_t *roi_in,
+int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, cl_mem dev_in,
+                                cl_mem dev_out, const struct dt_iop_roi_t *roi_in,
                                 const struct dt_iop_roi_t *roi_out)
 {
   if(self->bypass_blendif && self->dev->gui_attached && (self == self->dev->gui_module)) return TRUE;
@@ -3215,20 +3155,20 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
   {
     /* use a raster mask from another module earlier in the pipe */
     gboolean free_mask = FALSE; // if no transformations were applied we get the cached original back
-    float *raster_mask = dt_dev_get_raster_mask(piece->pipe, self->raster_mask.sink.source, self->raster_mask.sink.id,
-                                                self, &free_mask);
+    float *raster_mask = dt_dev_get_raster_mask(piece->pipe, self->raster_mask.sink.source,
+                                                self->raster_mask.sink.id, self, &free_mask);
 
     if(raster_mask)
     {
       // invert if required
       if(d->raster_mask_invert)
 #ifdef _OPENMP
-  #pragma omp parallel for default(none) shared(raster_mask)
+#pragma omp parallel for default(none) shared(raster_mask)
 #endif
         for(size_t i = 0; i < buffsize; i++) mask[i] = (1.0 - raster_mask[i]) * opacity;
       else
 #ifdef _OPENMP
-  #pragma omp parallel for default(none) shared(raster_mask)
+#pragma omp parallel for default(none) shared(raster_mask)
 #endif
         for(size_t i = 0; i < buffsize; i++) mask[i] = raster_mask[i] * opacity;
       if(free_mask) dt_free_align(raster_mask);
@@ -3238,7 +3178,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       // fallback for when the raster mask couldn't be applied
       const float value = d->raster_mask_invert ? 0.0 : 1.0;
 #ifdef _OPENMP
-  #pragma omp parallel for default(none)
+#pragma omp parallel for default(none)
 #endif
       for(size_t i = 0; i < buffsize; i++) mask[i] = value;
     }
@@ -3261,7 +3201,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       {
         // if we have a mask and this flag is set -> invert the mask
 #ifdef _OPENMP
-  #pragma omp parallel for default(none)
+#pragma omp parallel for default(none)
 #endif
         for(size_t i = 0; i < buffsize; i++) mask[i] = 1.0f - mask[i];
       }
@@ -3272,7 +3212,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       // we fill the buffer with 1.0f or 0.0f depending on mask_combine
       const float fill = (d->mask_combine & DEVELOP_COMBINE_MASKS_POS) ? 0.0f : 1.0f;
 #ifdef _OPENMP
-  #pragma omp parallel for default(none)
+#pragma omp parallel for default(none)
 #endif
       for(size_t i = 0; i < buffsize; i++) mask[i] = fill;
     }
@@ -3281,7 +3221,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       // we fill the buffer with 1.0f or 0.0f depending on mask_combine
       const float fill = (d->mask_combine & DEVELOP_COMBINE_INCL) ? 0.0f : 1.0f;
 #ifdef _OPENMP
-  #pragma omp parallel for default(none)
+#pragma omp parallel for default(none)
 #endif
       for(size_t i = 0; i < buffsize; i++) mask[i] = fill;
     }
@@ -3329,21 +3269,20 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     if(mask_feather)
     {
       int w = (int)(2 * d->feathering_radius * roi_out->scale / piece->iscale + 0.5f);
-      if (w < 1)
-        w = 1;
+      if(w < 1) w = 1;
       float sqrt_eps = 1.f;
       float guide_weight = 1.f;
       switch(cst)
       {
-      case iop_cs_rgb:
-        guide_weight = 100.f;
-        break;
-      case iop_cs_Lab:
-        guide_weight = 1.f;
-        break;
-      case iop_cs_RAW:
-      default:
-        assert(0);
+        case iop_cs_rgb:
+          guide_weight = 100.f;
+          break;
+        case iop_cs_Lab:
+          guide_weight = 1.f;
+          break;
+        case iop_cs_RAW:
+        default:
+          assert(0);
       }
       cl_mem guide = d->feathering_guide == DEVELOP_MASK_GUIDE_IN ? dev_in : dev_out;
       if(!rois_equal && d->feathering_guide == DEVELOP_MASK_GUIDE_IN)
@@ -3482,7 +3421,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
       if(err != CL_SUCCESS) goto error;
     }
     g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(0), _mask);
-    }
+  }
   else
   {
     g_hash_table_remove(piece->raster_masks, GINT_TO_POINTER(0));
@@ -3583,9 +3522,8 @@ gboolean dt_develop_blend_params_is_all_zero(const void *params, size_t length)
 }
 
 /** update blendop params from older versions */
-int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const old_params,
-                                   const int old_version, void *new_params, const int new_version,
-                                   const int length)
+int dt_develop_blend_legacy_params(dt_iop_module_t *module, const void *const old_params, const int old_version,
+                                   void *new_params, const int new_version, const int length)
 {
   // first deal with all-zero parmameter sets, regardless of version number.
   // these occurred in previous
@@ -3804,8 +3742,7 @@ int dt_develop_blend_legacy_params_from_so(dt_iop_module_so_t *module_so, const 
   }
 
   // convert the old blend params to new
-  int res = dt_develop_blend_legacy_params(module, old_params, old_version,
-                                           new_params, dt_develop_blend_version(),
+  int res = dt_develop_blend_legacy_params(module, old_params, old_version, new_params, dt_develop_blend_version(),
                                            length);
   dt_iop_cleanup_module(module);
   free(module);


### PR DESCRIPTION
Code was reformated via the new clang-format support in Clion, not by using clang-format directly. I hope the IDE applied the right rules, i.e. the ones in `.clang-format`. But results look reasonable to me.