### PR TITLE
fix buffer overflow

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1178,24 +1178,35 @@ void dt_free_align(void *mem)
 }
 #endif
 
-void dt_show_times(const dt_times_t *start, const char *prefix, const char *suffix, ...)
+void dt_show_times(const dt_times_t *start, const char *prefix)
 {
-  dt_times_t end;
-  char buf[160]; /* Arbitrary size, should be lots big enough for everything used in DT */
-  int i;
-
   /* Skip all the calculations an everything if -d perf isn't on */
   if(darktable.unmuted & DT_DEBUG_PERF)
   {
+    dt_times_t end;
     dt_get_times(&end);
-    i = snprintf(buf, sizeof(buf), "%s took %.3f secs (%.3f CPU)", prefix, end.clock - start->clock,
-                 end.user - start->user);
-    if(suffix != NULL)
+    char buf[64]; /* Arbitrary size, should be lots big enough for everything used in DT */
+    snprintf(buf, sizeof(buf), "%s took %.3f secs (%.3f CPU)", prefix, end.clock - start->clock,
+             end.user - start->user);
+    dt_print(DT_DEBUG_PERF, "%s\n", buf);
+  }
+}
+
+void dt_show_times_f(const dt_times_t *start, const char *prefix, const char *suffix, ...)
+{
+  /* Skip all the calculations an everything if -d perf isn't on */
+  if(darktable.unmuted & DT_DEBUG_PERF)
+  {
+    dt_times_t end;
+    dt_get_times(&end);
+    char buf[160]; /* Arbitrary size, should be lots big enough for everything used in DT */
+    const int n = snprintf(buf, sizeof(buf), "%s took %.3f secs (%.3f CPU) ", prefix, end.clock - start->clock,
+                           end.user - start->user);
+    if(n < sizeof(buf) - 1)
     {
       va_list ap;
       va_start(ap, suffix);
-      buf[i++] = ' ';
-      vsnprintf(buf + i, sizeof buf - i, suffix, ap);
+      vsnprintf(buf + n, sizeof(buf) - n, suffix, ap);
       va_end(ap);
     }
     dt_print(DT_DEBUG_PERF, "%s\n", buf);

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -292,7 +292,9 @@ static inline void dt_get_times(dt_times_t *t)
   t->user = ru.ru_utime.tv_sec + ru.ru_utime.tv_usec * (1.0 / 1000000.0);
 }
 
-void dt_show_times(const dt_times_t *start, const char *prefix, const char *suffix, ...) __attribute__((format(printf, 3, 4)));
+void dt_show_times(const dt_times_t *start, const char *prefix);
+
+void dt_show_times_f(const dt_times_t *start, const char *prefix, const char *suffix, ...) __attribute__((format(printf, 3, 4)));
 
 /** \brief check if file is a supported image */
 gboolean dt_supported_image(const gchar *filename);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -677,7 +677,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,
                                   &pipe.processed_height);
 
-  dt_show_times(&start, "[export] creating pixelpipe", NULL);
+  dt_show_times(&start, "[export] creating pixelpipe");
 
   // find output color profile for this image:
   int sRGB = 1;
@@ -769,8 +769,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
     if(finalscale) finalscale->enabled = 1;
   }
   dt_show_times(&start, thumbnail_export ? "[dev_process_thumbnail] pixel pipeline processing"
-                                         : "[dev_process_export] pixel pipeline processing",
-                NULL);
+                                         : "[dev_process_export] pixel pipeline processing");
 
   uint8_t *outbuf = pipe.backbuf;
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -305,7 +305,7 @@ restart:
 
   dev->preview_status = DT_DEV_PIXELPIPE_VALID;
 
-  dt_show_times(&start, "[dev_process_preview] pixel pipeline processing", NULL);
+  dt_show_times(&start, "[dev_process_preview] pixel pipeline processing");
   dt_dev_average_delay_update(&start, &dev->preview_average_delay);
 
   // redraw the whole thing, to also update color picker values and histograms etc.
@@ -334,7 +334,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
   dt_get_times(&start);
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, dev->image_storage.id, DT_MIPMAP_FULL,
                            DT_MIPMAP_BLOCKING, 'r');
-  dt_show_times(&start, "[dev]", "to load the image.");
+  dt_show_times_f(&start, "[dev]", "to load the image.");
 
   // failed to load raw?
   if(!buf.buf)
@@ -429,7 +429,7 @@ restart:
     else
       goto restart;
   }
-  dt_show_times(&start, "[dev_process_image] pixel pipeline processing", NULL);
+  dt_show_times(&start, "[dev_process_image] pixel pipeline processing");
   dt_dev_average_delay_update(&start, &dev->average_delay);
 
   // maybe we got zoomed/panned in the meantime?
@@ -455,7 +455,7 @@ static inline void _dt_dev_load_raw(dt_develop_t *dev, const uint32_t imgid)
   dt_get_times(&start);
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, DT_MIPMAP_FULL, DT_MIPMAP_BLOCKING, 'r');
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-  dt_show_times(&start, "[dev]", "to load the image.");
+  dt_show_times_f(&start, "[dev]", "to load the image.");
 
   const dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
   dev->image_storage = *image;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1151,7 +1151,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
       // else found in cache.
     }
 
-    dt_show_times(&start, "[dev_pixelpipe]", "initing base buffer [%s]", _pipe_type_to_str(pipe->type));
+    dt_show_times_f(&start, "[dev_pixelpipe]", "initing base buffer [%s]", _pipe_type_to_str(pipe->type));
     dt_pthread_mutex_unlock(&pipe->busy_mutex);
   }
   else
@@ -2282,7 +2282,7 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
     }
 
     gchar *module_label = dt_history_item_get_name(module);
-    dt_show_times(
+    dt_show_times_f(
         &start, "[dev_pixelpipe]", "processed `%s' on %s%s%s, blended on %s [%s]", module_label,
         pixelpipe_flow & PIXELPIPE_FLOW_PROCESSED_ON_GPU
             ? "GPU"


### PR DESCRIPTION
The current implementation of the function `dt_show_times` has two issues. It does not ensure that the `vsnprintf` function writes beyond the end of the buffer `buf` if it was already exhausted by the previous call to `snprintf`. Note that the man page states

The functions snprintf() and vsnprintf() do not write  more  than  size bytes  (including the terminating null byte ('\0')).  If the output was truncated due to this limit, then the return value  is  **the  number  of characters  (excluding the terminating null byte) which would have been written to the final string if enough space had been available.**   Thus, a  return  value  of  size or more means that the output was truncated.

In this case `sizeof buf - i` becomes a large unsigned integer.

Furthermore, `dt_show_times` uses its last non-variadic parameter to modify the function's behavior for the case that it is a NULL pointer. I think it is better to employ two different functions rather than this signaling parameter. Considering the declaration

    void dt_show_times(const dt_times_t *start, const char *prefix,
        const char *suffix, ...) __attribute__((format(printf, 3, 4)));

it is surprising that gcc and clang accept the function's current usage (E.g., icc does not.) because

    printf(NULL);

is not a legal usage of the `printf` function.

