### PR TITLE
update picker in point mode while dragging

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2392,6 +2392,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     {
       dev->gui_module->color_picker_point[0] = .5f + zoom_x;
       dev->gui_module->color_picker_point[1] = .5f + zoom_y;
+
+      dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
     }
 
     dt_control_queue_redraw();

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1110,7 +1110,11 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
      && (*(vals->full_surface_id) != imgid || *(vals->full_surface_mip) != mip || !full_preview))
   {
     cairo_surface_destroy(*(vals->full_surface));
-    if(vals->full_rgbbuf && *(vals->full_rgbbuf)) free(*(vals->full_rgbbuf));
+    if(vals->full_rgbbuf && *(vals->full_rgbbuf))
+    {
+      free(*(vals->full_rgbbuf));
+      *(vals->full_rgbbuf) = NULL;
+    }
     *(vals->full_surface) = NULL;
   }
   if(!vals->full_surface || !*(vals->full_surface) || *(vals->full_surface_w_lock))


### PR DESCRIPTION
This restores the "update picker in point mode while dragging" functionality.

Also fixes a random crash when using the full preview.