### PR TITLE
undo: fix meaningless casts

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -38,7 +38,7 @@ typedef struct dt_undo_colorlabels_t
   uint8_t after;
 } dt_undo_colorlabels_t;
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
 {
   if(type == DT_UNDO_COLORLABELS)
   {
@@ -194,7 +194,7 @@ void dt_colorlabels_toggle_label_selection(const int color)
   }
   sqlite3_finalize(stmt);
 
-  dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, (dt_undo_data_t *)undo, &_pop_undo, _colorlabels_undo_data_free);
+  dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, (dt_undo_data_t)undo, _pop_undo, _colorlabels_undo_data_free);
   dt_undo_end_group(darktable.undo);
 
   dt_collection_hint_message(darktable.collection);
@@ -235,7 +235,7 @@ void dt_colorlabels_toggle_label(const int imgid, const int color)
   }
   sqlite3_finalize(stmt);
 
-  dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, (dt_undo_data_t *)undo, &_pop_undo, _colorlabels_undo_data_free);
+  dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, (dt_undo_data_t)undo, _pop_undo, _colorlabels_undo_data_free);
   dt_undo_end_group(darktable.undo);
 
   dt_collection_hint_message(darktable.collection);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -102,8 +102,8 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
     dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
 
     dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t *)hist,
-                   &dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t)hist,
+                   dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
     dt_undo_end_group(darktable.undo);
   }
 }
@@ -132,8 +132,8 @@ void dt_history_delete_on_selection()
     dt_history_delete_on_image_ext(imgid, FALSE);
 
     dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t *)hist,
-                   &dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t)hist,
+                   dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
 
     /* update the aspect ratio if the current sorting is based on aspect ratio, otherwise the aspect ratio will be
        recalculated when the mimpap will be recreated */
@@ -158,8 +158,8 @@ int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only
 
     dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
     dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t *)hist,
-                   &dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t)hist,
+                   dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
     dt_undo_end_group(darktable.undo);
 
     /* if current image in develop reload history */
@@ -719,8 +719,8 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
 
   dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
   dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
-  dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t *)hist,
-                 &dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
+  dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t)hist,
+                 dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
   dt_undo_end_group(darktable.undo);
 
   /* attach changed tag reflecting actual change */

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -161,7 +161,7 @@ void dt_history_snapshot_undo_lt_history_data_free(gpointer data)
   g_free(hist);
 }
 
-void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action)
+void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
 {
   if(type == DT_UNDO_LT_HISTORY)
   {

--- a/src/common/history_snapshot.h
+++ b/src/common/history_snapshot.h
@@ -33,7 +33,7 @@ dt_undo_lt_history_t *dt_history_snapshot_item_init(void);
 
 void dt_history_snapshot_undo_create(int32_t imgid, int *snap_id, int *history_end);
 
-void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action);
+void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action);
 
 void dt_history_snapshot_undo_lt_history_data_free(gpointer data);
 

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -33,7 +33,7 @@ typedef struct dt_undo_metadata_t
 
 static void _metadata_set_xmp(int id, const gint keyid, const char *value, gboolean undo_actif);
 
-static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t *data, const dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action)
 {
   if(type == DT_UNDO_METADATA)
   {
@@ -186,7 +186,7 @@ static void _metadata_set_xmp(const int id, const gint keyid, const char *value,
 
   if(undo_actif)
   {
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, (dt_undo_data_t *)undo, &_pop_undo, _metadata_undo_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, (dt_undo_data_t)undo, _pop_undo, _metadata_undo_data_free);
     dt_undo_end_group(darktable.undo);
   }
 }

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -34,7 +34,7 @@ typedef struct dt_undo_ratings_t
 
 static void _ratings_apply_to_image(int imgid, int rating, gboolean undo);
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
 {
   if(type == DT_UNDO_RATINGS)
   {
@@ -64,7 +64,7 @@ static void _ratings_apply_to_image(int imgid, int rating, gboolean undo)
       ratings->imgid = imgid;
       ratings->before_rating = 0x7 & image->flags;
       ratings->after_rating = rating;
-      dt_undo_record(darktable.undo, NULL, DT_UNDO_RATINGS, (dt_undo_data_t *)ratings,
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_RATINGS, (dt_undo_data_t)ratings,
                      _pop_undo, _ratings_undo_data_free);
     }
 

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -729,8 +729,8 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
 
     dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
     dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t *)hist,
-                   &dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t)hist,
+                   dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
     dt_undo_end_group(darktable.undo);
 
     dt_dev_cleanup(dev_dest);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -39,7 +39,7 @@ typedef struct dt_undo_tags_t
 static void _attach_tag(guint tagid, gint imgid, gboolean undo_actif);
 static void _detach_tag(guint tagid, gint imgid, gboolean undo_actif);
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
 {
   if(type == DT_UNDO_TAGS)
   {
@@ -344,7 +344,7 @@ static void _attach_tag(guint tagid, gint imgid, gboolean undo_actif)
 
   if(undo_actif)
   {
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, (dt_undo_data_t *)undo, &_pop_undo, _tags_undo_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, (dt_undo_data_t)undo, _pop_undo, _tags_undo_data_free);
     dt_undo_end_group(darktable.undo);
   }
 }
@@ -457,7 +457,7 @@ void _detach_tag(guint tagid, gint imgid, gboolean undo_actif)
 
   if(undo_actif)
   {
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, (dt_undo_data_t *)undo, &_pop_undo, _tags_undo_data_free);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, (dt_undo_data_t)undo, _pop_undo, _tags_undo_data_free);
     dt_undo_end_group(darktable.undo);
   }
 

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -28,10 +28,10 @@ typedef struct dt_undo_item_t
 {
   gpointer user_data;
   dt_undo_type_t type;
-  dt_undo_data_t *data;
+  dt_undo_data_t data;
   double ts;
   gboolean is_group;
-  void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action);
+  void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action);
   void (*free_data)(gpointer data);
 } dt_undo_item_t;
 
@@ -72,9 +72,9 @@ static void _free_undo_data(void *p)
   free(item);
 }
 
-static void _undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
+static void _undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t data,
                          gboolean is_group,
-                         void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item, dt_undo_action_t action),
+                         void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action),
                          void (*free_data)(gpointer data))
 {
   if(!self) return;
@@ -141,8 +141,8 @@ void dt_undo_end_group(dt_undo_t *self)
   }
 }
 
-void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
-                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item, dt_undo_action_t action),
+void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t data,
+                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action),
                     void (*free_data)(gpointer data))
 {
   _undo_record(self, user_data, type, data, FALSE, undo, free_data);
@@ -341,7 +341,7 @@ void dt_undo_clear(dt_undo_t *self, uint32_t filter)
 }
 
 static void _undo_iterate(GList *list, uint32_t filter, gpointer user_data,
-                          void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item))
+                          void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item))
 {
   GList *l = g_list_first(list);
 
@@ -359,7 +359,7 @@ static void _undo_iterate(GList *list, uint32_t filter, gpointer user_data,
 }
 
 void dt_undo_iterate_internal(dt_undo_t *self, uint32_t filter, gpointer user_data,
-                              void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item))
+                              void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item))
 {
   if(!self) return;
 
@@ -369,7 +369,7 @@ void dt_undo_iterate_internal(dt_undo_t *self, uint32_t filter, gpointer user_da
 
 
 void dt_undo_iterate(dt_undo_t *self, uint32_t filter, gpointer user_data,
-                     void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item))
+                     void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item))
 {
   if(!self) return;
 

--- a/src/common/undo.h
+++ b/src/common/undo.h
@@ -66,8 +66,8 @@ void dt_undo_start_group(dt_undo_t *self, dt_undo_type_t type);
 void dt_undo_end_group(dt_undo_t *self);
 
 // record a change that will be insered into the undo list
-void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data,
-                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item, dt_undo_action_t action),
+void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t data,
+                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action),
                     void (*free_data)(gpointer data));
 
 //  undo an element which correspond to filter. filter here is expected to be
@@ -81,10 +81,10 @@ void dt_undo_do_redo(dt_undo_t *self, uint32_t filter);
 void dt_undo_clear(dt_undo_t *self, uint32_t filter);
 
 void dt_undo_iterate_internal(dt_undo_t *self, uint32_t filter, gpointer user_data,
-                              void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item));
+                              void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item));
 
 void dt_undo_iterate(dt_undo_t *self, uint32_t filter, gpointer user_data,
-                     void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item));
+                     void (*apply)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item));
 
 // disable the next record, this is to avoid recording when reverting a value (in undo callbacks)
 void dt_undo_disable_next(dt_undo_t *self);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1052,7 +1052,7 @@ delete_next_file:
   return 0;
 }
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action)
 {
   dt_undo_geotag_t *geotags = (dt_undo_geotag_t *)item;
   GList *l;
@@ -1188,7 +1188,7 @@ static int32_t dt_control_gpx_apply_job_run(dt_job_t *job)
   if(geotags->before)
   {
     dt_undo_start_group(darktable.undo, DT_UNDO_LT_GEOTAG);
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_GEOTAG, (dt_undo_data_t *)geotags, _pop_undo, _geotags_free_undo_data_t);
+    dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_GEOTAG, (dt_undo_data_t)geotags, _pop_undo, _geotags_free_undo_data_t);
     dt_undo_end_group(darktable.undo);
   }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -265,14 +265,14 @@ struct _cb_data
   int multi_priority;
 };
 
-static void _undo_items_cb(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data)
+static void _undo_items_cb(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data)
 {
   struct _cb_data *udata = (struct _cb_data *)user_data;
   dt_undo_history_t *hdata = (dt_undo_history_t *)data;
   _reset_module_instance(hdata->snapshot, udata->module, udata->multi_priority);
 }
 
-static void _history_invalidate_cb(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *item)
+static void _history_invalidate_cb(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)user_data;
   dt_undo_history_t *hist = (dt_undo_history_t *)item;
@@ -543,7 +543,7 @@ static int _create_deleted_modules(GList **_iop_list, GList *history_list)
   return changed;
 }
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
 
@@ -657,7 +657,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
     hist->snapshot = _duplicate_history(darktable.develop->history);
     hist->end = darktable.develop->history_end;
 
-    dt_undo_record(darktable.undo, self, DT_UNDO_HISTORY, (dt_undo_data_t *)hist,
+    dt_undo_record(darktable.undo, self, DT_UNDO_HISTORY, (dt_undo_data_t)hist,
                    _pop_undo, _history_undo_data_free);
   }
   else

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1192,7 +1192,7 @@ static void _view_map_filmstrip_activate_callback(gpointer instance, gpointer us
   _view_map_center_on_image(self, imgid);
 }
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t *data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
 {
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
@@ -1242,7 +1242,7 @@ static void _view_map_add_image_to_map(dt_view_t *self, int imgid, gint x, gint 
   geotag->after.latitude = latitude;
   geotag->after.elevation = 0.0;
 
-  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t *)geotag, &_pop_undo, free);
+  dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t)geotag, _pop_undo, free);
 
   _set_image_location(self, imgid, &(geotag->after), FALSE);
 }


### PR DESCRIPTION
This pull request fixes some casting issues. The undo facility has to deal with data of different types for which `dt_undo_data_t` is introduced and the undo API utilizes arguments of type `dt_undo_data_t *`. `dt_undo_data_t` is defined as

    typedef void *dt_undo_data_t;

Consequently, `dt_undo_data_t *` is a pointer to a void-pointer. But what we actually need here is a generic pointer,i.e., a void-pointer. 

Furthermore, to get a pointer to a function the address-of operator can be omitted. It is odd that the current code sometimes utilizes the `&` operator and sometimes not. Thus, I have removed the `&` where not required.