### PR TITLE
dt_history_get_items: order by num as in previous version.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -756,7 +756,8 @@ GList *dt_history_get_items(int32_t imgid, gboolean enabled)
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "SELECT num, operation, enabled, multi_name FROM main.history WHERE imgid=?1 AND "
                               "num IN (SELECT MAX(num) FROM main.history hst2 WHERE hst2.imgid=?1 AND "
-                              "hst2.operation=main.history.operation GROUP BY multi_priority) ORDER BY iop_order DESC",
+                              "hst2.operation=main.history.operation GROUP BY multi_priority) "
+                              "ORDER BY num ASC",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   while(sqlite3_step(stmt) == SQLITE_ROW)


### PR DESCRIPTION
This order corresponds to the history order as seen by the user
and is more natural to find some specific items in the list.

Fixes #2300