### PR TITLE
display a confirm message on export

### DIFF
--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -253,6 +253,8 @@ static int dt_imageio_load_module_storage(dt_imageio_module_storage_t *module, c
     module->recommended_dimension = _default_storage_dimension;
   if(!g_module_symbol(module->module, "export_dispatched", (gpointer) & (module->export_dispatched)))
     module->export_dispatched = _default_storage_nop;
+  if(!g_module_symbol(module->module, "ask_user_confirmation", (gpointer) & (module->ask_user_confirmation)))
+    module->ask_user_confirmation = NULL;
 #ifdef USE_LUA
   {
     char pseudo_type_name[1024];

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -190,6 +190,8 @@ typedef struct dt_imageio_module_storage_t
   int (*set_params)(struct dt_imageio_module_storage_t *self, const void *params, const int size);
 
   void (*export_dispatched)(struct dt_imageio_module_storage_t *self);
+  
+  char *(*ask_user_confirmation)(struct dt_imageio_module_storage_t *self);
 
   luaA_Type parameter_lua_type;
 } dt_imageio_module_storage_t;

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -83,6 +83,8 @@ int set_params(struct dt_imageio_module_storage_t *self, const void *params, con
 
 void export_dispatched(struct dt_imageio_module_storage_t *self);
 
+char *ask_user_confirmation(struct dt_imageio_module_storage_t *self);
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -104,6 +104,32 @@ static void export_button_clicked(GtkWidget *widget, gpointer user_data)
     return;
   }
 
+  char *confirm_message = NULL;
+  dt_imageio_module_storage_t *mstorage = dt_imageio_get_storage();
+  if(mstorage->ask_user_confirmation)
+    confirm_message = mstorage->ask_user_confirmation(mstorage);
+  if(confirm_message)
+  {
+    const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+    GtkWidget *dialog = gtk_message_dialog_new(
+        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+        "%s", confirm_message);
+#ifdef GDK_WINDOWING_QUARTZ
+    dt_osx_disallow_fullscreen(dialog);
+#endif
+
+    gtk_window_set_title(GTK_WINDOW(dialog), _("export to disk"));
+    const gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    g_free(confirm_message);
+    confirm_message = NULL;
+
+    if(res != GTK_RESPONSE_YES)
+    {
+      return;
+    }
+  }
+  
   gboolean upscale = dt_conf_get_bool("plugins/lighttable/export/upscale");
   gboolean high_quality = dt_conf_get_bool("plugins/lighttable/export/high_quality_processing");
   char *tmp = dt_conf_get_string("plugins/lighttable/export/style");

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -311,6 +311,11 @@ static int set_params_wrapper(struct dt_imageio_module_storage_t *self, const vo
   return 0;
 }
 
+static char *ask_user_confirmation_wrapper(struct dt_imageio_module_storage_t *self)
+{
+  return NULL;
+}
+
 static int version_wrapper()
 {
   return 0;
@@ -359,6 +364,7 @@ static dt_imageio_module_storage_t ref_storage = {
   .free_params = free_params_wrapper,
   .set_params = set_params_wrapper,
   .export_dispatched = empty_wrapper,
+  .ask_user_confirmation = ask_user_confirmation_wrapper,
   .parameter_lua_type = LUAA_INVALID_TYPE,
   .version = version_wrapper,
 


### PR DESCRIPTION
This PR display a confirm message when exporting to disk on overwrite mode.

This way user settings are not overwritten and it get consistent with other potentially dangerous operations.