### PR TITLE
add a passthrough mode to colorin and colorout

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1349,6 +1349,13 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>darkroom/ui/iccprofile_passthrough_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>whether to show the passthrough option in colorin and colorout</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/darkroom/demosaic/fdc_xover_iso</name>
     <type>int</type>
     <default>1600</default>

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1788,6 +1788,13 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)module->params;
   dt_bauhaus_combobox_set(g->clipping_combobox, p->normalize);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_passthrough), p->passthrough);
+  
+  // passthrough
+  const gboolean iccprofile_passthrough_visible = dt_conf_get_bool("darkroom/ui/iccprofile_passthrough_visible");
+  if(iccprofile_passthrough_visible || p->passthrough)
+    gtk_widget_show(g->chk_passthrough);
+  else
+    gtk_widget_hide(g->chk_passthrough);
 
   update_profile_list(self);
 
@@ -2136,6 +2143,9 @@ void gui_init(struct dt_iop_module_t *self)
                               _("when this option is active no profile is applied to the image."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->chk_passthrough, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->chk_passthrough), "toggled", G_CALLBACK(passthrough_color_callback), self);
+  
+  gtk_widget_show_all(g->chk_passthrough);
+  gtk_widget_set_no_show_all(g->chk_passthrough, TRUE);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -54,7 +54,7 @@
 
 #define LUT_SAMPLES 0x10000
 
-DT_MODULE_INTROSPECTION(6, dt_iop_colorin_params_t)
+DT_MODULE_INTROSPECTION(7, dt_iop_colorin_params_t)
 
 static void update_profile_list(dt_iop_module_t *self);
 
@@ -77,11 +77,13 @@ typedef struct dt_iop_colorin_params_t
   // working color profile
   dt_colorspaces_color_profile_type_t type_work;
   char filename_work[DT_IOP_COLOR_ICC_LEN];
+  int passthrough;
 } dt_iop_colorin_params_t;
 
 typedef struct dt_iop_colorin_gui_data_t
 {
   GtkWidget *profile_combobox, *clipping_combobox, *work_combobox;
+  GtkWidget *chk_passthrough;
   GList *image_profiles;
   int n_image_profiles;
 } dt_iop_colorin_gui_data_t;
@@ -110,6 +112,7 @@ typedef struct dt_iop_colorin_data_t
   dt_colorspaces_color_profile_type_t type;
   dt_colorspaces_color_profile_type_t type_work;
   char filename_work[DT_IOP_COLOR_ICC_LEN];
+  int passthrough;
 } dt_iop_colorin_data_t;
 
 
@@ -156,7 +159,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 {
 #define DT_IOP_COLOR_ICC_LEN_V5 100
 
-  if(old_version == 1 && new_version == 6)
+  if(old_version == 1 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v1_t
     {
@@ -205,9 +208,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->blue_mapping = 1;
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
+    new->passthrough = 0;
     return 0;
   }
-  if(old_version == 2 && new_version == 6)
+  if(old_version == 2 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v2_t
     {
@@ -257,9 +261,10 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->blue_mapping = 1;
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
+    new->passthrough = 0;
     return 0;
   }
-  if(old_version == 3 && new_version == 6)
+  if(old_version == 3 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v3_t
     {
@@ -310,10 +315,11 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->blue_mapping = old->blue_mapping;
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
+    new->passthrough = 0;
 
     return 0;
   }
-  if(old_version == 4 && new_version == 6)
+  if(old_version == 4 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v4_t
     {
@@ -335,10 +341,11 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->blue_mapping = old->blue_mapping;
     new->type_work = DT_COLORSPACE_LIN_REC709;
     new->filename_work[0] = '\0';
+    new->passthrough = 0;
 
     return 0;
   }
-  if(old_version == 5 && new_version == 6)
+  if(old_version == 5 && new_version == 7)
   {
     typedef struct dt_iop_colorin_params_v5_t
     {
@@ -363,6 +370,36 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->blue_mapping = old->blue_mapping;
     new->type_work = old->type_work;
     g_strlcpy(new->filename_work, old->filename_work, sizeof(new->filename_work));
+    new->passthrough = 0;
+
+    return 0;
+  }
+  if(old_version == 6 && new_version == 7)
+  {
+    typedef struct dt_iop_colorin_params_v6_t
+    {
+      dt_colorspaces_color_profile_type_t type;
+      char filename[DT_IOP_COLOR_ICC_LEN];
+      dt_iop_color_intent_t intent;
+      int normalize;
+      int blue_mapping;
+      // working color profile
+      dt_colorspaces_color_profile_type_t type_work;
+      char filename_work[DT_IOP_COLOR_ICC_LEN];
+    } dt_iop_colorin_params_v6_t;
+
+    const dt_iop_colorin_params_v6_t *old = (dt_iop_colorin_params_v6_t *)old_params;
+    dt_iop_colorin_params_t *new = (dt_iop_colorin_params_t *)new_params;
+    memset(new_params, 0, sizeof(*new_params));
+
+    new->type = old->type;
+    g_strlcpy(new->filename, old->filename, sizeof(new->filename));
+    new->intent = old->intent;
+    new->normalize = old->normalize;
+    new->blue_mapping = old->blue_mapping;
+    new->type_work = old->type_work;
+    g_strlcpy(new->filename_work, old->filename_work, sizeof(new->filename_work));
+    new->passthrough = 0;
 
     return 0;
   }
@@ -498,6 +535,14 @@ static void normalize_changed(GtkWidget *widget, gpointer user_data)
   if(self->dt->gui->reset) return;
   dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)self->params;
   p->normalize = dt_bauhaus_combobox_get(widget);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void passthrough_color_callback(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)self->params;
+  p->passthrough = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -1428,6 +1473,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->type = p->type;
   d->type_work = p->type_work;
   g_strlcpy(d->filename_work, p->filename_work, sizeof(d->filename_work));
+  d->passthrough = p->passthrough;
 
   const cmsHPROFILE Lab = dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;
 
@@ -1484,7 +1530,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_loc_get_datadir(datadir, sizeof(datadir));
 
   dt_colorspaces_color_profile_type_t type = p->type;
-  if(type == DT_COLORSPACE_LAB)
+  if(type == DT_COLORSPACE_LAB || d->passthrough)
   {
     piece->enabled = 0;
     return;
@@ -1741,6 +1787,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
   dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)module->params;
   dt_bauhaus_combobox_set(g->clipping_combobox, p->normalize);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_passthrough), p->passthrough);
 
   update_profile_list(self);
 
@@ -1804,7 +1851,8 @@ void reload_defaults(dt_iop_module_t *module)
                                                            .normalize = DT_NORMALIZE_OFF,
                                                            .blue_mapping = 0,
                                                            .type_work = DT_COLORSPACE_LIN_REC2020,
-                                                           .filename_work = "" };
+                                                           .filename_work = "",
+                                                           .passthrough = 0 };
 
   // we might be called from presets update infrastructure => there is no image
   if(!module->dev || module->dev->image_storage.id <= 0) goto end;
@@ -2080,6 +2128,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->clipping_combobox, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(g->clipping_combobox), "value-changed", G_CALLBACK(normalize_changed), (gpointer)self);
+
+  // passthrough
+  g->chk_passthrough = gtk_check_button_new_with_label(_("passthrough"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_passthrough), FALSE);
+  gtk_widget_set_tooltip_text(g->chk_passthrough,
+                              _("when this option is active no profile is applied to the image."));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->chk_passthrough, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->chk_passthrough), "toggled", G_CALLBACK(passthrough_color_callback), self);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -45,7 +45,7 @@
 #define DT_IOP_COLOR_ICC_LEN 512
 #define LUT_SAMPLES 0x10000
 
-DT_MODULE_INTROSPECTION(5, dt_iop_colorout_params_t)
+DT_MODULE_INTROSPECTION(6, dt_iop_colorout_params_t)
 
 typedef struct dt_iop_colorout_data_t
 {
@@ -55,6 +55,7 @@ typedef struct dt_iop_colorout_data_t
   float cmatrix[9];
   cmsHTRANSFORM *xform;
   float unbounded_coeffs[3][3]; // for extrapolation of shaper curves
+  int passthrough;
 } dt_iop_colorout_data_t;
 
 typedef struct dt_iop_colorout_global_data_t
@@ -67,11 +68,12 @@ typedef struct dt_iop_colorout_params_t
   dt_colorspaces_color_profile_type_t type;
   char filename[DT_IOP_COLOR_ICC_LEN];
   dt_iop_color_intent_t intent;
+  int passthrough;
 } dt_iop_colorout_params_t;
 
 typedef struct dt_iop_colorout_gui_data_t
 {
-  GtkWidget *output_intent, *output_profile;
+  GtkWidget *output_intent, *output_profile, *chk_passthrough;
 } dt_iop_colorout_gui_data_t;
 
 
@@ -130,7 +132,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->seq = 0;
     return 0;
     }*/
-  if((old_version == 2 || old_version == 3) && new_version == 5)
+  if((old_version == 2 || old_version == 3) && new_version == 6)
   {
     typedef struct dt_iop_colorout_params_v3_t
     {
@@ -165,10 +167,11 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     }
 
     n->intent = o->intent;
+    n->passthrough = 0;
 
     return 0;
   }
-  if(old_version == 4 && new_version == 5)
+  if(old_version == 4 && new_version == 6)
   {
     typedef struct dt_iop_colorout_params_v4_t
     {
@@ -185,6 +188,28 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->type = o->type;
     g_strlcpy(n->filename, o->filename, sizeof(n->filename));
     n->intent = o->intent;
+    n->passthrough = 0;
+
+    return 0;
+  }
+  if(old_version == 5 && new_version == 6)
+  {
+    typedef struct dt_iop_colorout_params_v5_t
+    {
+      dt_colorspaces_color_profile_type_t type;
+      char filename[DT_IOP_COLOR_ICC_LEN];
+      dt_iop_color_intent_t intent;
+    } dt_iop_colorout_params_v5_t;
+
+
+    dt_iop_colorout_params_v5_t *o = (dt_iop_colorout_params_v5_t *)old_params;
+    dt_iop_colorout_params_t *n = (dt_iop_colorout_params_t *)new_params;
+    memset(n, 0, sizeof(dt_iop_colorout_params_t));
+
+    n->type = o->type;
+    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
+    n->intent = o->intent;
+    n->passthrough = 0;
 
     return 0;
   }
@@ -241,6 +266,14 @@ static void output_profile_changed(GtkWidget *widget, gpointer user_data)
   }
 
   fprintf(stderr, "[colorout] color profile %s seems to have disappeared!\n", dt_colorspaces_get_name(p->type, p->filename));
+}
+
+static void passthrough_color_callback(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_colorout_params_t *p = (dt_iop_colorout_params_t *)self->params;
+  p->passthrough = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void _signal_profile_changed(gpointer instance, gpointer user_data)
@@ -561,6 +594,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   dt_iop_colorout_data_t *d = (dt_iop_colorout_data_t *)piece->data;
 
   d->type = p->type;
+  d->passthrough = p->passthrough;
 
   const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
 
@@ -620,6 +654,13 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
   d->type = out_type;
   if(out_type == DT_COLORSPACE_LAB)
     return;
+
+  if(d->passthrough)
+  {
+    piece->enabled = 0;
+    return;
+  }
+  piece->enabled = 1;
 
   /*
    * Setup transform flags
@@ -767,6 +808,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_colorout_gui_data_t *g = (dt_iop_colorout_gui_data_t *)self->gui_data;
   dt_iop_colorout_params_t *p = (dt_iop_colorout_params_t *)module->params;
   dt_bauhaus_combobox_set(g->output_intent, (int)p->intent);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_passthrough), p->passthrough);
 
   for(GList *iter = darktable.color_profiles->profiles; iter; iter = g_list_next(iter))
   {
@@ -791,7 +833,7 @@ void init(dt_iop_module_t *module)
   module->gui_data = NULL;
   module->hide_enable_button = 1;
   module->default_enabled = 1;
-  dt_iop_colorout_params_t tmp = (dt_iop_colorout_params_t){ DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL};
+  dt_iop_colorout_params_t tmp = (dt_iop_colorout_params_t){ DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL, 0 };
   memcpy(module->params, &tmp, sizeof(dt_iop_colorout_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_colorout_params_t));
 }
@@ -870,6 +912,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   g_signal_connect(G_OBJECT(g->output_intent), "value-changed", G_CALLBACK(intent_changed), (gpointer)self);
   g_signal_connect(G_OBJECT(g->output_profile), "value-changed", G_CALLBACK(output_profile_changed), (gpointer)self);
+
+  // passthrough
+  g->chk_passthrough = gtk_check_button_new_with_label(_("passthrough"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_passthrough), FALSE);
+  gtk_widget_set_tooltip_text(g->chk_passthrough,
+                              _("when this option is active no profile is applied to the image."));
+  gtk_box_pack_start(GTK_BOX(self->widget), g->chk_passthrough, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->chk_passthrough), "toggled", G_CALLBACK(passthrough_color_callback), self);
 
   // reload the profiles when the display or softproof profile changed!
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_CHANGED,

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -809,6 +809,13 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_colorout_params_t *p = (dt_iop_colorout_params_t *)module->params;
   dt_bauhaus_combobox_set(g->output_intent, (int)p->intent);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_passthrough), p->passthrough);
+  
+  // passthrough
+  const gboolean iccprofile_passthrough_visible = dt_conf_get_bool("darkroom/ui/iccprofile_passthrough_visible");
+  if(iccprofile_passthrough_visible || p->passthrough)
+    gtk_widget_show(g->chk_passthrough);
+  else
+    gtk_widget_hide(g->chk_passthrough);
 
   for(GList *iter = darktable.color_profiles->profiles; iter; iter = g_list_next(iter))
   {
@@ -920,6 +927,9 @@ void gui_init(struct dt_iop_module_t *self)
                               _("when this option is active no profile is applied to the image."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->chk_passthrough, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->chk_passthrough), "toggled", G_CALLBACK(passthrough_color_callback), self);
+  
+  gtk_widget_show_all(g->chk_passthrough);
+  gtk_widget_set_no_show_all(g->chk_passthrough, TRUE);
 
   // reload the profiles when the display or softproof profile changed!
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_CHANGED,


### PR DESCRIPTION
This add a passthrough mode to colorin and colorout and also changes the len of the icc profiles to match colorspaces.h definition.

The idea is to have both modules with this setting and no other module after colorin enabled, if not some error/warning messages can be displayed. This is for advanced users only, so I won't do anything about it.

The intended use is to be able to export the image in camera rgb for the denoise profiles generation.
