### PR TITLE
new lighttable mode: culling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -158,6 +158,11 @@ when updating from the currently stable 2.4.x series, please bear in mind that y
 - A new option 'skip' is added to the 'on conflic' setting on the export module
   that skips the export if the file already exists.
 
+- A new lighttable mode 'culling' is added. It displays a fixed number of consecutive images,
+  starting from the first selected image and allows to pan & zoom them.
+  It can be navigated with the mouse wheel and keyboard and the number of
+  displayed images can be set with an entry at the bottom.
+
 ## Bug fixes
 
 - The color picker support has been fixed by a complete rewrite. It

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -18,6 +18,7 @@
 
 #include <gdk/gdkkeysyms.h>
 
+#include "common/collection.h"
 #include "common/selection.h"
 #include "control/conf.h"
 #include "control/control.h"
@@ -35,6 +36,9 @@ typedef struct dt_lib_tool_lighttable_t
   GtkWidget *layout_combo;
   dt_lighttable_layout_t layout, previous_layout;
   int current_zoom;
+  GtkWidget *display_num_images; // slider & entry for number of images to be displayed in culling mode
+  GtkWidget *display_num_images_entry;
+  int current_display_num_images; // number of images to be displayed in culling mode
 } dt_lib_tool_lighttable_t;
 
 /* set zoom proxy function */
@@ -45,6 +49,9 @@ static gint _lib_lighttable_get_zoom(dt_lib_module_t *self);
 static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self);
 static void _lib_lighttable_set_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout);
 
+static void _lib_lighttable_set_display_num_images(dt_lib_module_t *self, const int display_num_images);
+static int _lib_lighttable_get_display_num_images(dt_lib_module_t *self);
+
 /* lightable layout changed */
 static void _lib_lighttable_layout_changed(GtkComboBox *widget, gpointer user_data);
 /* zoom slider change callback */
@@ -52,6 +59,13 @@ static void _lib_lighttable_zoom_slider_changed(GtkRange *range, gpointer user_d
 /* zoom entry change callback */
 static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey *event,
                                                    dt_lib_module_t *self);
+
+/* number of displayed images slider change callback */
+static void _lib_lighttable_display_num_images_slider_changed(GtkRange *range, gpointer user_data);
+/* number of displayed images entry change callback */
+static gboolean _lib_lighttable_display_num_images_entry_changed(GtkWidget *entry, GdkEventKey *event,
+                                                                 dt_lib_module_t *self);
+
 /* zoom key accel callback */
 static gboolean _lib_lighttable_key_accel_zoom_max_callback(GtkAccelGroup *accel_group,
                                                             GObject *acceleratable, guint keyval,
@@ -68,6 +82,9 @@ static gboolean _lib_lighttable_key_accel_zoom_out_callback(GtkAccelGroup *accel
 static gboolean _lib_lighttable_key_accel_toggle_expose_mode(GtkAccelGroup *accel_group,
                                                              GObject *acceleratable, guint keyval,
                                                              GdkModifierType modifier, gpointer data);
+static gboolean _lib_lighttable_key_accel_toggle_culling_mode(GtkAccelGroup *accel_group, GObject *acceleratable,
+                                                              guint keyval, GdkModifierType modifier,
+                                                              gpointer data);
 
 const char *name(dt_lib_module_t *self)
 {
@@ -103,14 +120,18 @@ void gui_init(dt_lib_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
   d->layout =  dt_conf_get_int("plugins/lighttable/layout");
-  d->previous_layout = d->layout == DT_LIGHTTABLE_LAYOUT_EXPOSE ? DT_LIGHTTABLE_LAYOUT_FILEMANAGER : DT_LIGHTTABLE_LAYOUT_EXPOSE;
+  d->previous_layout = (d->layout == DT_LIGHTTABLE_LAYOUT_EXPOSE || d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+                           ? DT_LIGHTTABLE_LAYOUT_FILEMANAGER
+                           : DT_LIGHTTABLE_LAYOUT_EXPOSE;
   d->current_zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
+  d->current_display_num_images = dt_conf_get_int("plugins/lighttable/display_num_images");
 
   /* create layout selection combobox */
   d->layout_combo = gtk_combo_box_text_new();
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("zoomable light table"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("file manager"));
   gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("expose"));
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(d->layout_combo), _("culling"));
 
   gtk_combo_box_set_active(GTK_COMBO_BOX(d->layout_combo), d->layout);
 
@@ -144,6 +165,35 @@ void gui_init(dt_lib_module_t *self)
                                                                  // it to 1 => empty text box
   gtk_widget_set_no_show_all(d->zoom, TRUE);
   gtk_widget_set_no_show_all(d->zoom_entry, TRUE);
+
+  /* create horizontal display number of images slider */
+  d->display_num_images = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 1, 21, 1);
+  gtk_widget_set_size_request(GTK_WIDGET(d->display_num_images), DT_PIXEL_APPLY_DPI(140), -1);
+  gtk_scale_set_draw_value(GTK_SCALE(d->display_num_images), FALSE);
+  gtk_range_set_increments(GTK_RANGE(d->display_num_images), 1, 1);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->display_num_images, TRUE, TRUE, 0);
+
+  /* manual entry of the visible number of images in culling */
+  d->display_num_images_entry = gtk_entry_new();
+  gtk_entry_set_alignment(GTK_ENTRY(d->display_num_images_entry), 1.0);
+  gtk_entry_set_max_length(GTK_ENTRY(d->display_num_images_entry), 2);
+  gtk_entry_set_width_chars(GTK_ENTRY(d->display_num_images_entry), 3);
+  gtk_entry_set_max_width_chars(GTK_ENTRY(d->display_num_images_entry), 3);
+  dt_gui_key_accel_block_on_focus_connect(d->display_num_images_entry);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->display_num_images_entry, TRUE, TRUE, 0);
+
+  g_signal_connect(G_OBJECT(d->display_num_images), "value-changed",
+                   G_CALLBACK(_lib_lighttable_display_num_images_slider_changed), (gpointer)self);
+  g_signal_connect(d->display_num_images_entry, "key-press-event",
+                   G_CALLBACK(_lib_lighttable_display_num_images_entry_changed), self);
+  gtk_range_set_value(GTK_RANGE(d->display_num_images), d->current_display_num_images);
+  _lib_lighttable_display_num_images_slider_changed(GTK_RANGE(d->display_num_images),
+                                                    self); // the slider defaults to 1 and GTK doesn't
+                                                           // fire a value-changed signal when setting
+                                                           // it to 1 => empty text box
+  gtk_widget_set_no_show_all(d->display_num_images, TRUE);
+  gtk_widget_set_no_show_all(d->display_num_images_entry, TRUE);
+
   _lib_lighttable_layout_changed(GTK_COMBO_BOX(d->layout_combo), self);
 
   darktable.view_manager->proxy.lighttable.module = self;
@@ -151,6 +201,8 @@ void gui_init(dt_lib_module_t *self)
   darktable.view_manager->proxy.lighttable.get_zoom = _lib_lighttable_get_zoom;
   darktable.view_manager->proxy.lighttable.get_layout = _lib_lighttable_get_layout;
   darktable.view_manager->proxy.lighttable.set_layout = _lib_lighttable_set_layout;
+  darktable.view_manager->proxy.lighttable.get_display_num_images = _lib_lighttable_get_display_num_images;
+  darktable.view_manager->proxy.lighttable.set_display_num_images = _lib_lighttable_set_display_num_images;
 }
 
 void init_key_accels(dt_lib_module_t *self)
@@ -162,6 +214,7 @@ void init_key_accels(dt_lib_module_t *self)
   dt_accel_register_lib(self, NC_("accel", "zoom min"), GDK_KEY_4, GDK_MOD1_MASK);
 
   dt_accel_register_lib(self, NC_("accel", "toggle exposé mode"), GDK_KEY_x, 0);
+  dt_accel_register_lib(self, NC_("accel", "toggle culling mode"), GDK_KEY_x, GDK_CONTROL_MASK);
 }
 
 void connect_key_accels(dt_lib_module_t *self)
@@ -179,12 +232,15 @@ void connect_key_accels(dt_lib_module_t *self)
                        g_cclosure_new(G_CALLBACK(_lib_lighttable_key_accel_zoom_min_callback), self, NULL));
   dt_accel_connect_lib(self, "toggle exposé mode",
                        g_cclosure_new(G_CALLBACK(_lib_lighttable_key_accel_toggle_expose_mode), self, NULL));
+  dt_accel_connect_lib(self, "toggle culling mode",
+                       g_cclosure_new(G_CALLBACK(_lib_lighttable_key_accel_toggle_culling_mode), self, NULL));
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
   dt_gui_key_accel_block_on_focus_disconnect(d->zoom_entry);
+  dt_gui_key_accel_block_on_focus_disconnect(d->display_num_images_entry);
   g_free(self->data);
   self->data = NULL;
 }
@@ -264,6 +320,82 @@ static gboolean _lib_lighttable_zoom_entry_changed(GtkWidget *entry, GdkEventKey
   }
 }
 
+static void _lib_lighttable_display_num_images_slider_changed(GtkRange *range, gpointer user_data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+
+  const int i = gtk_range_get_value(range);
+  dt_conf_set_int("plugins/lighttable/display_num_images", i);
+  gchar *i_as_str = g_strdup_printf("%d", i);
+  gtk_entry_set_text(GTK_ENTRY(d->display_num_images_entry), i_as_str);
+  d->current_display_num_images = i;
+  g_free(i_as_str);
+  dt_control_queue_redraw_center();
+}
+
+static gboolean _lib_lighttable_display_num_images_entry_changed(GtkWidget *entry, GdkEventKey *event,
+                                                                 dt_lib_module_t *self)
+{
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+  switch(event->keyval)
+  {
+    case GDK_KEY_Escape:
+    case GDK_KEY_Tab:
+    {
+      // reset
+      int i = dt_conf_get_int("plugins/lighttable/display_num_images");
+      gchar *i_as_str = g_strdup_printf("%d", i);
+      gtk_entry_set_text(GTK_ENTRY(d->display_num_images_entry), i_as_str);
+      g_free(i_as_str);
+      gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
+      return FALSE;
+    }
+
+    case GDK_KEY_Return:
+    case GDK_KEY_KP_Enter:
+    {
+      // apply display number of images
+      const gchar *value = gtk_entry_get_text(GTK_ENTRY(d->display_num_images_entry));
+      int i = atoi(value);
+      gtk_range_set_value(GTK_RANGE(d->display_num_images), i);
+      gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
+      return FALSE;
+    }
+
+    // allow 0 .. 9, left/right movement using arrow keys and del/backspace
+    case GDK_KEY_0:
+    case GDK_KEY_KP_0:
+    case GDK_KEY_1:
+    case GDK_KEY_KP_1:
+    case GDK_KEY_2:
+    case GDK_KEY_KP_2:
+    case GDK_KEY_3:
+    case GDK_KEY_KP_3:
+    case GDK_KEY_4:
+    case GDK_KEY_KP_4:
+    case GDK_KEY_5:
+    case GDK_KEY_KP_5:
+    case GDK_KEY_6:
+    case GDK_KEY_KP_6:
+    case GDK_KEY_7:
+    case GDK_KEY_KP_7:
+    case GDK_KEY_8:
+    case GDK_KEY_KP_8:
+    case GDK_KEY_9:
+    case GDK_KEY_KP_9:
+
+    case GDK_KEY_Left:
+    case GDK_KEY_Right:
+    case GDK_KEY_Delete:
+    case GDK_KEY_BackSpace:
+      return FALSE;
+
+    default: // block everything else
+      return TRUE;
+  }
+}
+
 static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_layout_t layout)
 {
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
@@ -275,11 +407,32 @@ static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_l
   {
     gtk_widget_hide(d->zoom);
     gtk_widget_hide(d->zoom_entry);
+    gtk_widget_hide(d->display_num_images);
+    gtk_widget_hide(d->display_num_images_entry);
+  }
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    gtk_widget_hide(d->zoom);
+    gtk_widget_hide(d->zoom_entry);
+    gtk_widget_show(d->display_num_images);
+    gtk_widget_show(d->display_num_images_entry);
+
+    // if we have a selected image activate the filmstrip
+    GList *first_selected = dt_collection_get_selected(darktable.collection, 1);
+    if(first_selected)
+    {
+      const int imgid = GPOINTER_TO_INT(first_selected->data);
+      if(imgid >= 0 && dt_view_filmstrip_get_activated_imgid(darktable.view_manager) != imgid)
+        dt_view_filmstrip_set_active_image(darktable.view_manager, imgid);
+      g_list_free(first_selected);
+    }
   }
   else
   {
     gtk_widget_show(d->zoom);
     gtk_widget_show(d->zoom_entry);
+    gtk_widget_hide(d->display_num_images);
+    gtk_widget_hide(d->display_num_images_entry);
   }
 
   if(current_layout != layout)
@@ -324,6 +477,19 @@ static gint _lib_lighttable_get_zoom(dt_lib_module_t *self)
 {
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
   return d->current_zoom;
+}
+
+static void _lib_lighttable_set_display_num_images(dt_lib_module_t *self, const int display_num_images)
+{
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+  gtk_range_set_value(GTK_RANGE(d->display_num_images), display_num_images);
+  d->current_display_num_images = display_num_images;
+}
+
+static int _lib_lighttable_get_display_num_images(dt_lib_module_t *self)
+{
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+  return d->current_display_num_images;
 }
 
 static gboolean _lib_lighttable_key_accel_zoom_max_callback(GtkAccelGroup *accel_group,
@@ -395,6 +561,25 @@ static gboolean _lib_lighttable_key_accel_toggle_expose_mode(GtkAccelGroup *acce
   return TRUE;
 }
 
+static gboolean _lib_lighttable_key_accel_toggle_culling_mode(GtkAccelGroup *accel_group, GObject *acceleratable,
+                                                              guint keyval, GdkModifierType modifier,
+                                                              gpointer data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)data;
+  dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
+
+  if(d->layout != DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    d->previous_layout = d->layout;
+    _lib_lighttable_set_layout(self, DT_LIGHTTABLE_LAYOUT_CULLING);
+  }
+  else
+    _lib_lighttable_set_layout(self, d->previous_layout);
+
+  dt_control_queue_redraw_center();
+  return TRUE;
+}
+
 #ifdef USE_LUA
 static int layout_cb(lua_State *L)
 {
@@ -441,6 +626,7 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_ZOOMABLE);
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_FILEMANAGER);
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_EXPOSE);
+  luaA_enum_value(L, dt_lighttable_layout_t, DT_LIGHTTABLE_LAYOUT_CULLING);
   luaA_enum_value(L,dt_lighttable_layout_t,DT_LIGHTTABLE_LAYOUT_LAST);
 }
 #endif

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -435,6 +435,41 @@ static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_l
     gtk_widget_hide(d->display_num_images_entry);
   }
 
+  // if changing from culling select all displayed images
+  if(current_layout == DT_LIGHTTABLE_LAYOUT_CULLING && current_layout != layout)
+  {
+    GList *first_selected = dt_collection_get_selected(darktable.collection, -1);
+    if(first_selected && g_list_length(first_selected) == 1)
+    {
+      const int sel_imgid = GPOINTER_TO_INT(first_selected->data);
+      GList *collected = dt_collection_get_all(darktable.collection, -1);
+      if(collected)
+      {
+        // search the selected image
+        GList *l = collected;
+        while(l)
+        {
+          const int id = GPOINTER_TO_INT(l->data);
+          if(sel_imgid == id) break;
+
+          l = g_list_next(l);
+        }
+        // now go to the last visible image
+        int i = 1;
+        while(l && i < d->current_display_num_images)
+        {
+          l = g_list_next(l);
+          i++;
+        }
+
+        if(l) dt_selection_select_range(darktable.selection, GPOINTER_TO_INT(l->data));
+      }
+
+      if(collected) g_list_free(collected);
+    }
+    if(first_selected) g_list_free(first_selected);
+  }
+
   if(current_layout != layout)
   {
     dt_conf_set_int("plugins/lighttable/layout", layout);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -168,6 +168,8 @@ typedef struct dt_library_t
 
   int32_t collection_count;
 
+  int last_first_selected; // offset of the last selected image inside the current selection
+
   // stuff for the audio player
   GPid audio_player_pid;   // the pid of the child process
   int32_t audio_player_id; // the imgid of the image the audio is played for
@@ -243,6 +245,38 @@ static inline gint get_zoom(void)
   return dt_view_lighttable_get_zoom(darktable.view_manager);
 }
 
+static inline int get_display_num_images(void)
+{
+  return dt_view_lighttable_get_display_num_images(darktable.view_manager);
+}
+
+static inline void filmstrip_set_active_image(dt_library_t *lib, const int imgid)
+{
+  int offset = -1;
+  GList *collected = dt_collection_get_all(darktable.collection, -1);
+  if(collected)
+  {
+    int id = -1;
+    int i = 0;
+    GList *l = collected;
+    while(l)
+    {
+      id = GPOINTER_TO_INT(l->data);
+      if(imgid == id) break;
+      i++;
+
+      l = g_list_next(l);
+    }
+    if(imgid == id && id >= 0) offset = i;
+
+    g_list_free(collected);
+  }
+
+  lib->last_first_selected = offset;
+  dt_selection_select_single(darktable.selection, imgid);
+  dt_view_filmstrip_set_active_image(darktable.view_manager, imgid);
+}
+
 static void check_layout(dt_view_t *self)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
@@ -272,7 +306,7 @@ static void check_layout(dt_view_t *self)
   dt_lib_module_t *timeline = darktable.view_manager->proxy.timeline.module;
   gboolean vs = dt_lib_is_visible(timeline);
 
-  if(layout == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  if(layout == DT_LIGHTTABLE_LAYOUT_EXPOSE || layout == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     gtk_widget_hide(GTK_WIDGET(timeline->widget));
     gtk_widget_show(GTK_WIDGET(m->widget));
@@ -393,10 +427,8 @@ static void zoom_around_image(dt_library_t *lib, double pointerx, double pointer
   lib->offset_changed = TRUE;
 }
 
-static void _view_lighttable_collection_listener_callback(gpointer instance, gpointer user_data)
+static void _view_lighttable_collection_listener_internal(dt_view_t *self, dt_library_t *lib)
 {
-  dt_view_t *self = (dt_view_t *)user_data;
-  dt_library_t *lib = (dt_library_t *)self->data;
   lib->force_expose_all = TRUE;
   _unregister_custom_image_order_drag_n_drop(self);
   _register_custom_image_order_drag_n_drop(self);
@@ -408,6 +440,7 @@ static void _view_lighttable_collection_listener_callback(gpointer instance, gpo
 
   _update_collected_images(self);
 }
+
 static void _view_lighttable_query_listener_callback(gpointer instance, gpointer user_data)
 {
   // this will always happen in conjonction with the _view_lighttable_collection_listener_callback
@@ -423,6 +456,64 @@ static void _view_lighttable_query_listener_callback(gpointer instance, gpointer
     lib->offset = lib->first_visible_filemanager = 0;
     lib->offset_changed = TRUE;
   }
+  // also in culling
+  if(layout == lib->current_layout && layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    lib->last_first_selected = -1;
+    GList *collected = dt_collection_get_all(darktable.collection, 1);
+    if(collected)
+    {
+      const int imgid = GPOINTER_TO_INT(collected->data);
+      if(imgid >= 0) filmstrip_set_active_image(lib, imgid);
+      g_list_free(collected);
+    }
+  }
+}
+
+static void _view_lighttable_collection_listener_callback(gpointer instance, gpointer user_data)
+{
+  dt_view_t *self = (dt_view_t *)user_data;
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  _view_lighttable_collection_listener_internal(self, lib);
+
+  if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    // save the offset of the first selected image
+    GList *first_selected = dt_collection_get_selected(darktable.collection, 1);
+    // we have a selected image
+    if(first_selected)
+    {
+      const int imgid = GPOINTER_TO_INT(first_selected->data);
+      lib->last_first_selected = dt_collection_image_offset(imgid);
+      if(imgid >= 0 && dt_view_filmstrip_get_activated_imgid(darktable.view_manager) != imgid)
+        dt_view_filmstrip_set_active_image(darktable.view_manager, imgid);
+      g_list_free(first_selected);
+    }
+    // we have the previous selected image
+    else if(lib->last_first_selected >= 0)
+    {
+      GList *collected = dt_collection_get_all(darktable.collection, -1);
+      if(collected)
+      {
+        GList *l = g_list_nth(collected, lib->last_first_selected);
+        const int imgid = (l) ? GPOINTER_TO_INT(l->data) : -1;
+        if(imgid >= 0) filmstrip_set_active_image(lib, imgid);
+        g_list_free(collected);
+      }
+    }
+    // this is a new collection, select the first image
+    else
+    {
+      GList *collected = dt_collection_get_all(darktable.collection, 1);
+      if(collected)
+      {
+        const int imgid = GPOINTER_TO_INT(collected->data);
+        if(imgid >= 0) filmstrip_set_active_image(lib, imgid);
+        g_list_free(collected);
+      }
+    }
+  }
 }
 
 static void _view_lighttable_selection_listener_callback(gpointer instance, gpointer user_data)
@@ -434,10 +525,11 @@ static void _view_lighttable_selection_listener_callback(gpointer instance, gpoi
   lib->force_expose_all = TRUE;
 
   // we handle change of selection only in expose mode. it is needed
-  // here as the selection from the filmstrip is actually was must be
+  // here as the selection from the filmstrip is actually what must be
   // displayed in the expose view.
-  if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_EXPOSE)
-    _view_lighttable_collection_listener_callback(instance, user_data);
+  if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_EXPOSE) _view_lighttable_collection_listener_internal(self, lib);
+
+  if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING) dt_control_queue_redraw_center();
 }
 
 static void _update_collected_images(dt_view_t *self)
@@ -621,6 +713,8 @@ void init(dt_view_t *self)
   lib->full_zoom = 1.0f;
   lib->full_x = 0;
   lib->full_y = 0;
+
+  lib->last_first_selected = -1;
 
   for(int i = 0; i < FULL_PREVIEW_IN_MEMORY_LIMIT; i++)
   {
@@ -1563,7 +1657,7 @@ failure:
 }
 
 static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
-                           int32_t pointery)
+                         int32_t pointery, const dt_lighttable_layout_t layout)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
   int32_t mouse_over_id;
@@ -1577,8 +1671,20 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
 
   dt_view_set_scrollbar(self, 0, 0, 1, 1, 0, 0, 1, 1);
 
-  GList *selected = dt_collection_get_selected(darktable.collection, -1);
-  const int sel_img_count = g_list_length(selected);
+  int sel_img_count = 0;
+  GList *selected = NULL;
+
+  if(layout == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  {
+    selected = dt_collection_get_selected(darktable.collection, -1);
+    sel_img_count = g_list_length(selected);
+  }
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    selected = dt_collection_get_all(darktable.collection, -1);
+    sel_img_count = g_list_length(selected);
+  }
+
   if(sel_img_count == 0) return 0;
 
   mouse_over_id = dt_control_get_mouse_over_id();
@@ -1588,17 +1694,65 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
   gchar *imgids = NULL;
 
   // build the image ids for the SQL 'in' where clause.
-
-  GList *l = selected;
-  while(l)
+  if(layout == DT_LIGHTTABLE_LAYOUT_EXPOSE)
   {
-    const int imgid = GPOINTER_TO_INT(l->data);
-    if(imgids)
-      imgids = dt_util_dstrcat(imgids, ", %d", imgid);
-    else
-      imgids = dt_util_dstrcat(imgids, "(%d", imgid);
-    l = g_list_next(l);
+    GList *l = selected;
+    while(l)
+    {
+      const int imgid = GPOINTER_TO_INT(l->data);
+      if(imgids)
+        imgids = dt_util_dstrcat(imgids, ", %d", imgid);
+      else
+        imgids = dt_util_dstrcat(imgids, "(%d", imgid);
+      l = g_list_next(l);
+    }
   }
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    // number of images to be displayed
+    const int display_num_images = get_display_num_images();
+    // starting with the first selected image
+    GList *first_selected = dt_collection_get_selected(darktable.collection, 1);
+    int display_first_image = (first_selected) ? GPOINTER_TO_INT(first_selected->data) : -1;
+    if(display_first_image < 0 && lib->last_first_selected >= 0)
+    {
+      GList *l = g_list_nth(selected, lib->last_first_selected);
+      if(l) display_first_image = GPOINTER_TO_INT(l->data);
+    }
+
+    // skip images until we reach the first selected
+    // if no selection start with the first image
+    int i = 0;
+    GList *l = selected;
+    if(display_first_image >= 0)
+    {
+      while(l && i + display_num_images < sel_img_count)
+      {
+        const int imgid = GPOINTER_TO_INT(l->data);
+        if(imgid == display_first_image) break;
+
+        l = g_list_next(l);
+        i++;
+      }
+    }
+
+    // now make the sql sentece with the number of images to display
+    i = 0;
+    while(l && i < display_num_images)
+    {
+      const int imgid = GPOINTER_TO_INT(l->data);
+      if(imgids)
+        imgids = dt_util_dstrcat(imgids, ", %d", imgid);
+      else
+        imgids = dt_util_dstrcat(imgids, "(%d", imgid);
+      l = g_list_next(l);
+      i++;
+    }
+    sel_img_count = i;
+
+    if(first_selected) g_list_free(first_selected);
+  }
+
   imgids = dt_util_dstrcat(imgids, ")");
 
   g_list_free(selected);
@@ -1795,6 +1949,8 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
     images[i].y = images[i].y * factor + yoff;
   }
 
+  const int max_in_memory_images = dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images");
+
   for(i = 0; i < sel_img_count; i++)
   {
     cairo_save(cr);
@@ -1821,7 +1977,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
     params.py = img_pointery;
     params.zoom = 1;
     params.full_preview = TRUE;
-    if(sel_img_count <= dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"))
+    if(sel_img_count <= max_in_memory_images)
     {
       params.full_zoom = &lib->full_zoom;
       params.full_x = &lib->full_x;
@@ -1838,7 +1994,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
       params.full_h1 = &lib->fp_surf[i].h_fit;
     }
 
-    dt_view_image_expose(&params);
+    missing += dt_view_image_expose(&params);
     cairo_restore(cr);
 
     // set mouse over id
@@ -2086,7 +2242,8 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
         lib->missing_thumbnails = expose_zoomable(self, cr, width, height, pointerx, pointery);
         break;
       case DT_LIGHTTABLE_LAYOUT_EXPOSE: // compare
-        lib->missing_thumbnails = expose_expose(self, cr, width, height, pointerx, pointery);
+      case DT_LIGHTTABLE_LAYOUT_CULLING:
+        lib->missing_thumbnails = expose_expose(self, cr, width, height, pointerx, pointery, layout);
         break;
       case DT_LIGHTTABLE_LAYOUT_FIRST:
       case DT_LIGHTTABLE_LAYOUT_LAST:
@@ -2144,6 +2301,14 @@ static gboolean go_up_key_accel_callback(GtkAccelGroup *accel_group, GObject *ac
 
   if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
     move_view(lib, DIRECTION_TOP);
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    // go to the first image on the collection
+    GList *collected = dt_collection_get_all(darktable.collection, 1);
+    const int imgid = (collected) ? GPOINTER_TO_INT(collected->data) : -1;
+    if(imgid >= 0) filmstrip_set_active_image(lib, imgid);
+    if(collected) g_list_free(collected);
+  }
   else
     lib->offset = 0;
   dt_control_queue_redraw_center();
@@ -2159,6 +2324,15 @@ static gboolean go_down_key_accel_callback(GtkAccelGroup *accel_group, GObject *
 
   if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
     move_view(lib, DIRECTION_BOTTOM);
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    // go to the last image on the collection
+    GList *collected = dt_collection_get_all(darktable.collection, -1);
+    GList *l = g_list_last(collected);
+    const int imgid = (l) ? GPOINTER_TO_INT(l->data) : -1;
+    if(imgid >= 0) filmstrip_set_active_image(lib, imgid);
+    if(collected) g_list_free(collected);
+  }
   else
     lib->offset = 0x1fffffff;
   dt_control_queue_redraw_center();
@@ -2298,7 +2472,8 @@ static gboolean rating_key_accel_callback(GtkAccelGroup *accel_group, GObject *a
 
   dt_collection_update_query(darktable.collection); // update the counter
 
-  if(layout != DT_LIGHTTABLE_LAYOUT_EXPOSE && lib->collection_count != dt_collection_get_count(darktable.collection))
+  if(layout != DT_LIGHTTABLE_LAYOUT_EXPOSE && layout != DT_LIGHTTABLE_LAYOUT_CULLING
+     && lib->collection_count != dt_collection_get_count(darktable.collection))
   {
     // some images disappeared from collection. Selection is now invisible.
     // lib->collection_count  --> before the rating
@@ -2372,6 +2547,51 @@ static void drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, g
   gtk_drag_finish(context, success, FALSE, time);
 }
 
+// shitf the first select image by 1 with up direction
+static void shift_first_selected_image(dt_library_t *lib, const int up)
+{
+  // we're going to shift the selection by 1 if there's still room
+  GList *collected = dt_collection_get_all(darktable.collection, -1);
+  GList *first_selected = dt_collection_get_selected(darktable.collection, 1);
+  int display_first_image = (first_selected) ? GPOINTER_TO_INT(first_selected->data) : -1;
+  if(display_first_image < 0 && lib->last_first_selected >= 0)
+  {
+    GList *l = g_list_nth(collected, lib->last_first_selected);
+    if(l) display_first_image = GPOINTER_TO_INT(l->data);
+  }
+
+  // get the first selected image in the collected list
+  GList *l = collected;
+  if(display_first_image >= 0)
+  {
+    while(l)
+    {
+      const int imgid = GPOINTER_TO_INT(l->data);
+      if(imgid == display_first_image) break;
+
+      l = g_list_next(l);
+    }
+  }
+
+  // move the collected list according the the mouse wheel
+  GList *l_tmp = NULL;
+  if(up)
+    l_tmp = g_list_previous(l);
+  else
+    l_tmp = g_list_next(l);
+  if(l_tmp) l = l_tmp;
+
+  // make the image active
+  if(l)
+  {
+    const int imgid = GPOINTER_TO_INT(l->data);
+    filmstrip_set_active_image(lib, imgid);
+  }
+
+  if(collected) g_list_free(collected);
+  if(first_selected) g_list_free(first_selected);
+}
+
 void enter(dt_view_t *self)
 {
   // clean the undo list
@@ -2382,7 +2602,7 @@ void enter(dt_view_t *self)
   dt_lib_module_t *timeline = darktable.view_manager->proxy.timeline.module;
   gboolean vs = dt_lib_is_visible(timeline);
 
-  if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     gtk_widget_hide(GTK_WIDGET(timeline->widget));
     gtk_widget_show(GTK_WIDGET(m->widget));
@@ -2548,12 +2768,13 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   lib->force_expose_all = TRUE;
   const dt_lighttable_layout_t layout = get_layout();
 
-  if((lib->full_preview_id > -1 || get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  if((lib->full_preview_id > -1 || get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE
+      || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
      && (state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
   {
     GList *selected = dt_collection_get_selected(darktable.collection, -1);
     const int sel_img_count = g_list_length(selected);
-    if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE
+    if((get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
        && sel_img_count > dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"))
     {
       dt_control_log(_("zooming is limited to %d images"),
@@ -2562,7 +2783,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
     else if(lib->missing_thumbnails == 0)
     {
       float nz = 10.0f;
-      if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+      if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
       {
         // we stop at the minimum zoom
         for(int i = 0; i < sel_img_count; i++) nz = fminf(nz, lib->fp_surf[i].zoom_100);
@@ -2577,7 +2798,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
       if(lib->full_zoom != nz)
       {
-        if(get_layout() != DT_LIGHTTABLE_LAYOUT_EXPOSE)
+        if(get_layout() != DT_LIGHTTABLE_LAYOUT_EXPOSE && get_layout() != DT_LIGHTTABLE_LAYOUT_CULLING)
         {
           // we want to zoom "around" the pointer
           float dx = nz / lib->full_zoom
@@ -2593,6 +2814,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
         dt_control_queue_redraw_center();
       }
     }
+    if(selected) g_list_free(selected);
   }
   else if(lib->full_preview_id > -1)
   {
@@ -2608,7 +2830,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
     else
       move_view(lib, DIRECTION_DOWN);
   }
-  else if(layout != DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  else if(layout != DT_LIGHTTABLE_LAYOUT_EXPOSE && layout != DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     int zoom = get_zoom();
     if(up)
@@ -2629,6 +2851,10 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
     }
     dt_view_lighttable_set_zoom(darktable.view_manager, zoom);
   }
+  else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING && state == 0)
+  {
+    shift_first_selected_image(lib, up);
+  }
 }
 
 void activate_control_element(dt_view_t *self)
@@ -2640,7 +2866,7 @@ void activate_control_element(dt_view_t *self)
   {
     case DT_VIEW_DESERT:
     {
-      if(layout != DT_LIGHTTABLE_LAYOUT_EXPOSE)
+      if(layout != DT_LIGHTTABLE_LAYOUT_EXPOSE && layout != DT_LIGHTTABLE_LAYOUT_CULLING)
       {
         int32_t id = dt_control_get_mouse_over_id();
         if((lib->modifiers & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) == 0)
@@ -2675,7 +2901,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
 
   lib->using_arrows = 0;
 
-  if(lib->pan && (lib->full_preview_id > -1 || get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  if(lib->pan && (lib->full_preview_id > -1 || get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE
+                  || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
      && lib->full_zoom > 1.0f)
   {
     lib->full_x += x - lib->pan_x;
@@ -2898,7 +3125,8 @@ int button_pressed(dt_view_t *self, double x, double y, double pressure, int whi
         // namely until the pointer has moved a little distance. The code taking
         // care of this is in expose(). Pan only makes sense in zoomable lt.
         if(layout == DT_LIGHTTABLE_LAYOUT_ZOOMABLE || (lib->full_preview_id > -1 && lib->full_zoom > 1.0f)
-           || (get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE && lib->full_zoom > 1.0f))
+           || ((get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
+               && lib->full_zoom > 1.0f))
           begin_pan(lib, x, y);
 
         if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER && lib->using_arrows)
@@ -3130,6 +3358,11 @@ int key_pressed(dt_view_t *self, guint key, guint state)
         lib->track = -1;
       }
     }
+    else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      lib->track = -1;
+      shift_first_selected_image(lib, TRUE);
+    }
     else
       lib->track = -1;
     return 1;
@@ -3157,6 +3390,11 @@ int key_pressed(dt_view_t *self, guint key, guint state)
         lib->track = -1;
       }
     }
+    else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      lib->track = 1;
+      shift_first_selected_image(lib, FALSE);
+    }
     else
       lib->track = 1;
     return 1;
@@ -3181,6 +3419,11 @@ int key_pressed(dt_view_t *self, guint key, guint state)
         lib->using_arrows = 1;
         lib->key_jump_offset = zoom*-1;
       }
+    }
+    else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      lib->track = -DT_LIBRARY_MAX_ZOOM;
+      shift_first_selected_image(lib, TRUE);
     }
     else
       lib->track = -DT_LIBRARY_MAX_ZOOM;
@@ -3207,6 +3450,11 @@ int key_pressed(dt_view_t *self, guint key, guint state)
         lib->using_arrows = 1;
         lib->key_jump_offset = zoom;
       }
+    }
+    else if(layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      lib->track = DT_LIBRARY_MAX_ZOOM;
+      shift_first_selected_image(lib, FALSE);
     }
     else
       lib->track = DT_LIBRARY_MAX_ZOOM;
@@ -3249,7 +3497,7 @@ static gboolean timeline_key_accel_callback(GtkAccelGroup *accel_group, GObject 
                                             GdkModifierType modifier, gpointer data)
 {
   dt_lib_module_t *m = darktable.view_manager->proxy.timeline.module;
-  if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     gtk_widget_hide(GTK_WIDGET(m->widget)); // to be sure
   }
@@ -3584,6 +3832,32 @@ void gui_init(dt_view_t *self)
 
   g_signal_connect(G_OBJECT(display_intent), "value-changed", G_CALLBACK(display_intent_callback), NULL);
   g_signal_connect(G_OBJECT(display_profile), "value-changed", G_CALLBACK(display_profile_callback), NULL);
+
+  GList *first_selected = dt_collection_get_selected(darktable.collection, 1);
+  GList *collected = dt_collection_get_all(darktable.collection, -1);
+  if(first_selected && collected)
+  {
+    int offset = -1;
+    int i = 0;
+    const int imgid = GPOINTER_TO_INT(first_selected->data);
+    GList *l = collected;
+    while(l)
+    {
+      const int id = GPOINTER_TO_INT(l->data);
+      if(imgid == id)
+      {
+        offset = i;
+        break;
+      }
+      i++;
+
+      l = g_list_next(l);
+    }
+
+    lib->last_first_selected = offset;
+  }
+  if(first_selected) g_list_free(first_selected);
+  if(collected) g_list_free(collected);
 }
 
 static gboolean _is_order_actif(dt_view_t *self, dt_collection_sort_t sort)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -785,7 +785,8 @@ int32_t dt_view_get_image_to_act_on()
   const int layout = darktable.view_manager->proxy.lighttable.get_layout(
       darktable.view_manager->proxy.lighttable.module);
 
-  if(zoom == 1 || full_preview_id > 1 || layout == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+  if(zoom == 1 || full_preview_id > 1 || layout == DT_LIGHTTABLE_LAYOUT_EXPOSE
+     || layout == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     return mouse_over_id;
   }
@@ -2041,6 +2042,20 @@ gint dt_view_lighttable_get_zoom(dt_view_manager_t *vm)
     return vm->proxy.lighttable.get_zoom(vm->proxy.lighttable.module);
   else
     return 10;
+}
+
+void dt_view_lighttable_set_display_num_images(dt_view_manager_t *vm, const int display_num_images)
+{
+  if(vm->proxy.lighttable.module)
+    vm->proxy.lighttable.set_display_num_images(vm->proxy.lighttable.module, display_num_images);
+}
+
+int dt_view_lighttable_get_display_num_images(dt_view_manager_t *vm)
+{
+  if(vm->proxy.lighttable.module)
+    return vm->proxy.lighttable.get_display_num_images(vm->proxy.lighttable.module);
+  else
+    return 2;
 }
 
 dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -70,7 +70,8 @@ typedef enum dt_lighttable_layout_t
   DT_LIGHTTABLE_LAYOUT_ZOOMABLE = 0,
   DT_LIGHTTABLE_LAYOUT_FILEMANAGER = 1,
   DT_LIGHTTABLE_LAYOUT_EXPOSE = 2,
-  DT_LIGHTTABLE_LAYOUT_LAST = 3
+  DT_LIGHTTABLE_LAYOUT_CULLING = 3,
+  DT_LIGHTTABLE_LAYOUT_LAST = 4
 } dt_lighttable_layout_t;
 
 
@@ -287,6 +288,8 @@ typedef struct dt_view_manager_t
       uint32_t (*get_position)(struct dt_view_t *view);
       int (*get_images_in_row)(struct dt_view_t *view);
       int (*get_full_preview_id)(struct dt_view_t *view);
+      void (*set_display_num_images)(struct dt_lib_module_t *self, const int display_num_images);
+      int (*get_display_num_images)(struct dt_lib_module_t *self);
     } lighttable;
 
     /* tethering view proxy object */
@@ -413,8 +416,12 @@ int32_t dt_view_filmstrip_get_activated_imgid(dt_view_manager_t *vm);
 dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm);
 /** sets the lighttable image in row zoom */
 void dt_view_lighttable_set_zoom(dt_view_manager_t *vm, gint zoom);
-/** sets the lighttable image in row zoom */
+/** gets the lighttable image in row zoom */
 gint dt_view_lighttable_get_zoom(dt_view_manager_t *vm);
+/** sets the lighttable number of images displayed in culling mode */
+void dt_view_lighttable_set_display_num_images(dt_view_manager_t *vm, const int display_num_images);
+/** gets the lighttable number of images displayed in culling mode */
+int dt_view_lighttable_get_display_num_images(dt_view_manager_t *vm);
 /** set first visible image offset */
 void dt_view_lighttable_set_position(dt_view_manager_t *vm, uint32_t pos);
 /** read first visible image offset */


### PR DESCRIPTION
This new mode is very similar to the 'expose' mode, but it display a fixed number of consecutive images, starting from the first selected image. It can be navigated with the mouse wheel and keyboard and the number of displayed images can be set with an entry at the bottom.