### PR TITLE
lighttable : fix drag-n-drop and zoom center

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2720,6 +2720,102 @@ static void _ensure_image_visibility(dt_library_t *lib, uint32_t rowid)
   }
 }
 
+static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int32_t mouse_over_id)
+{
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  lib->full_preview_sticky = sticky;
+  // encode panel visibility into full_preview
+  lib->full_preview = 0;
+  lib->full_preview_id = mouse_over_id;
+
+  // set corresponding rowid in the collected images
+  {
+    sqlite3_stmt *stmt;
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "SELECT rowid FROM memory.collected_images WHERE imgid=?1", -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, lib->full_preview_id);
+    if(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      lib->full_preview_rowid = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+  }
+
+  // if there's only 1 image selected, and it's the one display
+  sqlite3_stmt *stmt;
+  int nb_sel = 0;
+  uint32_t imgid_sel = -1;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
+                              NULL);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    nb_sel++;
+    if(nb_sel > 1) break;
+    imgid_sel = sqlite3_column_int(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+  if(nb_sel == 1 && imgid_sel == lib->full_preview_id)
+    lib->full_preview_follow_sel = TRUE;
+  else
+    lib->full_preview_follow_sel = FALSE;
+
+  // let's hide some gui components
+  lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_LEFT) & 1) << 0;
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE, FALSE);
+  lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_RIGHT) & 1) << 1;
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE, FALSE);
+  lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM) & 1) << 2;
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, FALSE, FALSE);
+  lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP) & 1) << 3;
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, FALSE, FALSE);
+  lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_TOP) & 1) << 4;
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, FALSE);
+
+  // preview with focus detection
+  lib->display_focus = focus;
+
+  // reset preview values
+  lib->full_zoom = 1.0f;
+  lib->full_x = 0.0f;
+  lib->full_y = 0.0f;
+  _full_preview_destroy(self);
+
+  // we don't want want drag and drop here
+  _unregister_custom_image_order_drag_n_drop(self);
+
+  lib->force_expose_all = TRUE;
+}
+static void _preview_quit(dt_view_t *self)
+{
+  dt_library_t *lib = (dt_library_t *)self->data;
+  if(lib->full_preview_follow_sel)
+  {
+    dt_selection_select_single(darktable.selection, lib->full_preview_id);
+    _ensure_image_visibility(lib, lib->full_preview_rowid);
+  }
+  lib->full_preview_id = -1;
+  lib->full_preview_rowid = -1;
+  if(!lib->using_arrows) dt_control_set_mouse_over_id(-1);
+
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, (lib->full_preview & 1), FALSE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, (lib->full_preview & 2), FALSE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, (lib->full_preview & 4), FALSE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, (lib->full_preview & 8), FALSE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, (lib->full_preview & 16), FALSE);
+
+  lib->full_preview = 0;
+  lib->display_focus = 0;
+  _full_preview_destroy(self);
+  lib->full_zoom = 1.0f;
+  lib->full_x = 0.0f;
+  lib->full_y = 0.0f;
+
+  // restore drag and drop
+  _register_custom_image_order_drag_n_drop(self);
+
+  lib->force_expose_all = TRUE;
+}
 
 int button_pressed(dt_view_t *self, double x, double y, double pressure, int which, int type, uint32_t state)
 {
@@ -2893,25 +2989,7 @@ int key_released(dt_view_t *self, guint key, guint state)
       || (key == accels->lighttable_preview_display_focus.accel_key
           && state == accels->lighttable_preview_display_focus.accel_mods)) && lib->full_preview_id != -1)
   {
-    if(lib->full_preview_follow_sel) dt_selection_select_single(darktable.selection, lib->full_preview_id);
-    lib->full_preview_id = -1;
-    lib->full_preview_rowid = -1;
-    if(!lib->using_arrows)
-      dt_control_set_mouse_over_id(-1);
-
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, (lib->full_preview & 1), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, (lib->full_preview & 2), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, (lib->full_preview & 4), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, (lib->full_preview & 8), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, (lib->full_preview & 16), FALSE);
-
-    lib->full_preview = 0;
-    lib->display_focus = 0;
-    _full_preview_destroy(self);
-    lib->full_zoom = 1.0f;
-    lib->full_x = 0.0f;
-    lib->full_y = 0.0f;
-    lib->force_expose_all = TRUE;
+    _preview_quit(self);
   }
 
   return 1;
@@ -2935,29 +3013,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
                                     || (key == accels->lighttable_preview_sticky_focus.accel_key
                                         && state == accels->lighttable_preview_sticky_focus.accel_mods)))
   {
-    if(lib->full_preview_follow_sel)
-    {
-      dt_selection_select_single(darktable.selection, lib->full_preview_id);
-      _ensure_image_visibility(lib, lib->full_preview_rowid);
-    }
-    lib->full_preview_id = -1;
-    lib->full_preview_rowid = -1;
-    if(!lib->using_arrows)
-      dt_control_set_mouse_over_id(-1);
-
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, (lib->full_preview & 1), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, (lib->full_preview & 2), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, (lib->full_preview & 4), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, (lib->full_preview & 8), FALSE);
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, (lib->full_preview & 16), FALSE);
-
-    lib->full_preview = 0;
-    lib->display_focus = 0;
-    _full_preview_destroy(self);
-    lib->full_zoom = 1.0f;
-    lib->full_x = 0.0f;
-    lib->full_y = 0.0f;
-    lib->force_expose_all = TRUE;
+    _preview_quit(self);
     return 1;
   }
 
@@ -2972,80 +3028,23 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     const int32_t mouse_over_id = dt_control_get_mouse_over_id();
     if(lib->full_preview_id == -1 && mouse_over_id != -1)
     {
+      gboolean sticky = TRUE;
+      gboolean focus = FALSE;
       if((key == accels->lighttable_preview.accel_key && state == accels->lighttable_preview.accel_mods)
          || (key == accels->lighttable_preview_display_focus.accel_key
              && state == accels->lighttable_preview_display_focus.accel_mods))
       {
-        lib->full_preview_sticky = 0;
+        sticky = FALSE;
       }
-      else
-      {
-        lib->full_preview_sticky = 1;
-      }
-      // encode panel visibility into full_preview
-      lib->full_preview = 0;
-      lib->full_preview_id = mouse_over_id;
-
-      // set corresponding rowid in the collected images
-      {
-        sqlite3_stmt *stmt;
-        DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                    "SELECT rowid FROM memory.collected_images WHERE imgid=?1", -1, &stmt,
-                                    NULL);
-        DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, lib->full_preview_id);
-        if(sqlite3_step(stmt) == SQLITE_ROW)
-        {
-          lib->full_preview_rowid = sqlite3_column_int(stmt, 0);
-        }
-        sqlite3_finalize(stmt);
-      }
-
-      // if there's only 1 image selected, and it's the one display
-      sqlite3_stmt *stmt;
-      int nb_sel = 0;
-      uint32_t imgid_sel = -1;
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1,
-                                  &stmt, NULL);
-      while(sqlite3_step(stmt) == SQLITE_ROW)
-      {
-        nb_sel++;
-        if(nb_sel > 1) break;
-        imgid_sel = sqlite3_column_int(stmt, 0);
-      }
-      sqlite3_finalize(stmt);
-      if(nb_sel == 1 && imgid_sel == lib->full_preview_id)
-        lib->full_preview_follow_sel = TRUE;
-      else
-        lib->full_preview_follow_sel = FALSE;
-
-      // let's hide some gui components
-      lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_LEFT) & 1) << 0;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE, FALSE);
-      lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_RIGHT) & 1) << 1;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE, FALSE);
-      lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM) & 1) << 2;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, FALSE, FALSE);
-      lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP) & 1) << 3;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, FALSE, FALSE);
-      lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_TOP) & 1) << 4;
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, FALSE);
-
-      // preview with focus detection
       if((key == accels->lighttable_preview_display_focus.accel_key
           && state == accels->lighttable_preview_display_focus.accel_mods)
          || (key == accels->lighttable_preview_sticky_focus.accel_key
              && state == accels->lighttable_preview_sticky_focus.accel_mods))
       {
-        lib->display_focus = 1;
+        focus = TRUE;
       }
 
-      // reset preview values
-      lib->full_zoom = 1.0f;
-      lib->full_x = 0.0f;
-      lib->full_y = 0.0f;
-      _full_preview_destroy(self);
-
-      lib->force_expose_all = TRUE;
+      _preview_enter(self, sticky, focus, mouse_over_id);
       return 1;
     }
     return 0;
@@ -3542,7 +3541,9 @@ static gboolean _is_order_actif(dt_view_t *self, dt_collection_sort_t sort)
         && current_view
         && current_view->view(self) == DT_VIEW_LIGHTTABLE)
     {
-      return TRUE;
+      // not in full_preview mode
+      dt_library_t *lib = (dt_library_t *)self->data;
+      if(lib->full_preview_id == -1) return TRUE;
     }
   }
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1139,6 +1139,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
     {
       float zoom_100 = fmaxf((float)buf_wd / ((float)width * imgwd), (float)buf_ht / ((float)height * imgwd));
       if(zoom_100 < 1.0f) zoom_100 = 1.0f;
+      *(vals->full_zoom100) = zoom_100;
       if(fz > zoom_100)
       {
         *full_zoom = zoom_100;
@@ -1391,6 +1392,18 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
         rectx = 0.5 * buf_wd - fx / scale - 0.5 * rectw;
         recty = 0.5 * buf_ht - fy / scale - 0.5 * recth;
       }
+      else if(full_x && full_y)
+      {
+        *full_x = 0.0f;
+        *full_y = 0.0f;
+      }
+
+      if(buf_ok && fz == 1.0f && vals->full_w1 && vals->full_h1)
+      {
+        *(vals->full_w1) = buf_wd * scale;
+        *(vals->full_h1) = buf_ht * scale;
+      }
+
       if(!image_only) cairo_translate(cr, -0.5 * buf_wd + fx / scale, -0.5 * buf_ht + fy / scale);
       cairo_set_source_surface(cr, surface, 0, 0);
       // set filter no nearest:

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -166,6 +166,9 @@ typedef struct dt_view_image_expose_t
   gboolean full_preview;
   gboolean image_only;
   float *full_zoom;
+  float *full_zoom100;
+  float *full_w1;
+  float *full_h1;
   float *full_x;
   float *full_y;
 


### PR DESCRIPTION
This PR should fix #2305 : 
- The bug that doesn't deactivate drag_n_drop in full preview mode
- The feature to center the zoom at pointer position in full preview (deactivated in expose mode as it's way more complex)