### PR TITLE
Expose zoom fix

### DIFF
--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -337,7 +337,9 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
         dt_dev_pixelpipe_get_dimensions(&pipe, &dev, pipe.iwidth, pipe.iheight, &pipe.processed_width,
                                         &pipe.processed_height);
         dt_dev_pixelpipe_cleanup(&pipe);
-        entry->data_size = sizeof(struct dt_mipmap_buffer_dsc) + pipe.processed_width * pipe.processed_height * 4;
+        // we enlarge the output size by 4 to handle rounding errors in mipmap computation
+        entry->data_size
+            = sizeof(struct dt_mipmap_buffer_dsc) + (pipe.processed_width + 4) * (pipe.processed_height + 4) * 4;
       }
       else
       {
@@ -442,6 +444,8 @@ read_error:
   // cost is just flat one for the buffer, as the buffers might have different sizes,
   // to make sure quota is meaningful.
   if(mip >= DT_MIPMAP_F) entry->cost = 1;
+  else if(mip == DT_MIPMAP_8)
+    entry->cost = entry->data_size;
   else entry->cost = cache->buffer_size[mip];
 }
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -335,7 +335,7 @@ static void _full_preview_destroy(dt_view_t *self)
     lib->fp_surf[i].imgid = -1;
     lib->fp_surf[i].w_lock = 0;
 
-    lib->fp_surf[i].zoom_100 = 10.0f;
+    lib->fp_surf[i].zoom_100 = 40.0f;
     lib->fp_surf[i].w_fit = 0.0f;
     lib->fp_surf[i].h_fit = 0.0f;
   }
@@ -733,7 +733,7 @@ void init(dt_view_t *self)
     lib->fp_surf[i].surface = NULL;
     lib->fp_surf[i].rgbbuf = NULL;
     lib->fp_surf[i].w_lock = 0;
-    lib->fp_surf[i].zoom_100 = 10.0f;
+    lib->fp_surf[i].zoom_100 = 40.0f;
     lib->fp_surf[i].w_fit = 0.0f;
     lib->fp_surf[i].h_fit = 0.0f;
   }
@@ -2790,7 +2790,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
     }
     else if(lib->missing_thumbnails == 0)
     {
-      float nz = 10.0f;
+      float nz = 40.0f;
       if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
       {
         // we stop at the minimum zoom

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1123,7 +1123,11 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
     dt_mipmap_cache_get(cache, &buf, imgid, mip, DT_MIPMAP_BEST_EFFORT, 'r');
     buf_wd = buf.width;
     buf_ht = buf.height;
-    if(!buf.buf) buf_ok = FALSE;
+    if(!buf.buf)
+    {
+      buf_ok = FALSE;
+      buf_sizeok = FALSE;
+    }
     if(mip != buf.size) buf_sizeok = FALSE;
     buf_mipmap = TRUE;
   }
@@ -1136,7 +1140,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   if(fz > 1.0f && buf_sizeok)
   {
     // is the mipmap loaded the full one ?
-    if(cache->max_width[mip] > buf_wd && cache->max_height[mip] > buf_ht)
+    if(cache->max_width[mip] > buf_wd + 4 && cache->max_height[mip] > buf_ht + 4)
     {
       float zoom_100 = fmaxf((float)buf_wd / ((float)width * imgwd), (float)buf_ht / ((float)height * imgwd));
       if(zoom_100 < 1.0f) zoom_100 = 1.0f;


### PR DESCRIPTION
This fix an error which prevent zooming in some cases because of rounding errors in mipmap computation.
This fix also a bug which can cause multiple full-res image computation because of the cache system max memory. This one should avoid grey/black thumbnails on quick zooming to the full size, especially in expose mode