### PR TITLE
Lighttable panels + full preview filmstrip

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1160,6 +1160,48 @@
     <shortdescription>scroll to lighttable modules when expanded/collapsed</shortdescription>
     <longdescription>when this option is enabled then darktable will try to scroll the module to the top of the visible list</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/bottom_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show bottom panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/left_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show left panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/right_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show right panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/header_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show header panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/toolbar_bottom_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show toolbar bottom panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/toolbar_top_visible</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show toolbar top panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig prefs="gui" section="darkroom">
     <name>darkroom/ui/scroll_to_module</name>
     <type>bool</type>

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -708,14 +708,20 @@ int dt_control_key_pressed_override(guint key, guint state)
   {
     char param[512];
     const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+    // in lighttable, we store panels states per layout
+    char lay[32] = "";
+    if(g_strcmp0(cv->module_name, "lighttable") == 0)
+    {
+      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+    }
 
     /* do nothing if in collapse panel state
        TODO: reconsider adding this check to ui api */
-    g_snprintf(param, sizeof(param), "%s/ui/panel_collaps_state", cv->module_name);
+    g_snprintf(param, sizeof(param), "%s/ui/%spanel_collaps_state", cv->module_name, lay);
     if(dt_conf_get_int(param)) return 0;
 
     /* toggle the header visibility state */
-    g_snprintf(param, sizeof(param), "%s/ui/show_header", cv->module_name);
+    g_snprintf(param, sizeof(param), "%s/ui/%sshow_header", cv->module_name, lay);
     const gboolean header = !dt_conf_get_bool(param);
     dt_conf_set_bool(param, header);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -238,7 +238,10 @@ static gboolean borders_button_pressed(GtkWidget *w, GdkEventButton *event, gpoi
   char lay[32] = "";
   if(g_strcmp0(cv->module_name, "lighttable") == 0)
   {
-    g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+    if(dt_view_lighttable_preview_state(darktable.view_manager))
+      g_snprintf(lay, sizeof(lay), "preview/");
+    else
+      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
   }
 
   int which = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(w), "border"));
@@ -1540,7 +1543,10 @@ void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui)
   char lay[32] = "";
   if(g_strcmp0(cv->module_name, "lighttable") == 0)
   {
-    g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+    if(dt_view_lighttable_preview_state(darktable.view_manager))
+      g_snprintf(lay, sizeof(lay), "preview/");
+    else
+      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
   }
 
   g_snprintf(key, sizeof(key), "%s/ui/%spanel_collaps_state", cv->module_name, lay);
@@ -1591,7 +1597,10 @@ void dt_ui_restore_panels(dt_ui_t *ui)
   char lay[32] = "";
   if(g_strcmp0(cv->module_name, "lighttable") == 0)
   {
-    g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+    if(dt_view_lighttable_preview_state(darktable.view_manager))
+      g_snprintf(lay, sizeof(lay), "preview/");
+    else
+      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
   }
 
   /* restore from a previous collapse all panel state if enabled */
@@ -1608,7 +1617,7 @@ void dt_ui_restore_panels(dt_ui_t *ui)
     for(int k = 0; k < DT_UI_PANEL_SIZE; k++)
     {
       g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay, _ui_panel_config_names[k]);
-      if(dt_conf_key_exists(key))
+      if(dt_conf_key_exists(key) || g_strcmp0(lay, "preview/") == 0)
         gtk_widget_set_visible(ui->panels[k], dt_conf_get_bool(key));
       else
         gtk_widget_set_visible(ui->panels[k], 1);
@@ -1692,7 +1701,10 @@ void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t p, gboolean show, gboolea
     char lay[32] = "";
     if(g_strcmp0(cv->module_name, "lighttable") == 0)
     {
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+      if(dt_view_lighttable_preview_state(darktable.view_manager))
+        g_snprintf(lay, sizeof(lay), "preview/");
+      else
+        g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
     }
     char key[512];
     g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay, _ui_panel_config_names[p]);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -281,9 +281,20 @@ static gboolean borders_button_pressed(GtkWidget *w, GdkEventButton *event, gpoi
     {
       g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
                  _ui_panel_config_names[DT_UI_PANEL_CENTER_BOTTOM]);
-      gboolean show = !dt_conf_get_bool(key);
-      dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_BOTTOM, show, TRUE);
-      dt_ui_panel_show(ui, DT_UI_PANEL_BOTTOM, show, TRUE);
+      const gboolean show_cb = dt_conf_get_bool(key);
+      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
+                 _ui_panel_config_names[DT_UI_PANEL_BOTTOM]);
+      const gboolean show_b = dt_conf_get_bool(key);
+      // all visible => toolbar hidden => all hidden => all visible
+      if(show_cb && show_b)
+        dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_BOTTOM, FALSE, TRUE);
+      else if(!show_cb && show_b)
+        dt_ui_panel_show(ui, DT_UI_PANEL_BOTTOM, FALSE, TRUE);
+      else
+      {
+        dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_BOTTOM, TRUE, TRUE);
+        dt_ui_panel_show(ui, DT_UI_PANEL_BOTTOM, TRUE, TRUE);
+      }
     }
     break;
   }
@@ -563,7 +574,8 @@ static gboolean draw_borders(GtkWidget *widget, cairo_t *crf, gpointer user_data
       }
       break;
     default: // bottom
-      if(dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM))
+      if(dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM)
+         || dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM))
       {
         cairo_move_to(cr, width / 2 - height, 0.0);
         cairo_rel_line_to(cr, 2 * height, 0.0);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -3059,6 +3059,8 @@ static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int
   dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, FALSE, FALSE);
   lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_TOP) & 1) << 4;
   dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, FALSE, FALSE);
+  lib->full_preview |= (dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM) & 1) << 5;
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, FALSE, FALSE);
 
   // preview with focus detection
   lib->display_focus = focus;
@@ -3091,6 +3093,7 @@ static void _preview_quit(dt_view_t *self)
   dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, (lib->full_preview & 4), FALSE);
   dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, (lib->full_preview & 8), FALSE);
   dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, (lib->full_preview & 16), FALSE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, (lib->full_preview & 32), FALSE);
 
   lib->full_preview = 0;
   lib->display_focus = 0;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -286,6 +286,9 @@ static void check_layout(dt_view_t *self)
   if(lib->current_layout == layout) return;
   lib->current_layout = layout;
 
+  // layout has changed, let restore panels
+  dt_ui_restore_panels(darktable.gui->ui);
+
   if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
   {
     if(lib->first_visible_zoomable >= 0 && layout_old == DT_LIGHTTABLE_LAYOUT_ZOOMABLE)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2070,6 +2070,14 @@ dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm)
     return DT_LIGHTTABLE_LAYOUT_FILEMANAGER;
 }
 
+gboolean dt_view_lighttable_preview_state(dt_view_manager_t *vm)
+{
+  if(vm->proxy.lighttable.module)
+    return (vm->proxy.lighttable.get_full_preview_id(vm->proxy.lighttable.view) != -1);
+  else
+    return FALSE;
+}
+
 void dt_view_lighttable_set_position(dt_view_manager_t *vm, uint32_t pos)
 {
   if(vm->proxy.lighttable.view) vm->proxy.lighttable.set_position(vm->proxy.lighttable.view, pos);

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -414,6 +414,8 @@ int32_t dt_view_filmstrip_get_activated_imgid(dt_view_manager_t *vm);
 
 /** get the lighttable current layout */
 dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm);
+/** get the lighttable full preview state */
+gboolean dt_view_lighttable_preview_state(dt_view_manager_t *vm);
 /** sets the lighttable image in row zoom */
 void dt_view_lighttable_set_zoom(dt_view_manager_t *vm, gint zoom);
 /** gets the lighttable image in row zoom */


### PR DESCRIPTION
- Store specific panel states per layout, with a special mode for preview. This allow for example to hide lateral bars specifically for expose, etc...
- Filmstrip is enabled in full preview mode. It's hidden by default, but you can show the bottom panel to see it (and dt will remember it's state with the previous point)
- (All views) : clicking on the arrow of the bottom panel now change states like this : all visible => toolbar hidden => all hidden => all visible => ... This allow finer tuning of this 2 panels states