### PR TITLE
culling: make filmstrip follow full preview

### DIFF
--- a/src/control/control.h
+++ b/src/control/control.h
@@ -108,9 +108,9 @@ typedef struct dt_control_accels_t
 {
   GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right, lighttable_left,
       lighttable_center, lighttable_preview, lighttable_preview_display_focus, lighttable_preview_sticky,
-      lighttable_preview_sticky_focus, lighttable_preview_sticky_exit, lighttable_timeline,
-      lighttable_preview_zoom_100, lighttable_preview_zoom_fit, global_sideborders, global_header,
-      darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out, darkroom_skip_mouse_events, darkroom_search_modules_focus;
+      lighttable_preview_sticky_focus, lighttable_timeline, lighttable_preview_zoom_100,
+      lighttable_preview_zoom_fit, global_sideborders, global_header, darkroom_preview, slideshow_start,
+      global_zoom_in, global_zoom_out, darkroom_skip_mouse_events, darkroom_search_modules_focus;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -157,8 +157,6 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky);
   dt_accel_path_view(path, sizeof(path), "lighttable", "sticky preview with focus detection");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_focus);
-  dt_accel_path_view(path, sizeof(path), "lighttable", "exit sticky preview");
-  gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_exit);
   dt_accel_path_view(path, sizeof(path), "lighttable", "toggle timeline");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_timeline);
   dt_accel_path_view(path, sizeof(path), "lighttable", "preview zoom 100%");

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -3295,10 +3295,8 @@ int key_pressed(dt_view_t *self, guint key, guint state)
 
   const dt_lighttable_layout_t layout = get_layout();
 
-  if(lib->full_preview_id != -1 && ((key == accels->lighttable_preview_sticky_exit.accel_key
-                                     && state == accels->lighttable_preview_sticky_exit.accel_mods)
-                                    || (key == accels->lighttable_preview_sticky.accel_key
-                                        && state == accels->lighttable_preview_sticky.accel_mods)
+  if(lib->full_preview_id != -1 && ((key == accels->lighttable_preview_sticky.accel_key
+                                     && state == accels->lighttable_preview_sticky.accel_mods)
                                     || (key == accels->lighttable_preview_sticky_focus.accel_key
                                         && state == accels->lighttable_preview_sticky_focus.accel_mods)))
   {
@@ -3559,7 +3557,6 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "preview with focus detection"), GDK_KEY_z, GDK_CONTROL_MASK);
   dt_accel_register_view(self, NC_("accel", "sticky preview"), 0, 0);
   dt_accel_register_view(self, NC_("accel", "sticky preview with focus detection"), 0, 0);
-  dt_accel_register_view(self, NC_("accel", "exit sticky preview"), 0, 0);
 
   // undo/redo
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -275,6 +275,7 @@ static inline void filmstrip_set_active_image(dt_library_t *lib, const int imgid
   lib->last_first_selected = offset;
   dt_selection_select_single(darktable.selection, imgid);
   dt_view_filmstrip_set_active_image(darktable.view_manager, imgid);
+  if(lib->full_preview_id > -1) lib->full_preview_id = imgid;
 }
 
 static void check_layout(dt_view_t *self)
@@ -2830,6 +2831,8 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       lib->track = -DT_LIBRARY_MAX_ZOOM;
     else
       lib->track = +DT_LIBRARY_MAX_ZOOM;
+
+    if(layout == DT_LIGHTTABLE_LAYOUT_CULLING && state == 0) shift_first_selected_image(lib, up);
   }
   else if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER && state == 0)
   {
@@ -3349,6 +3352,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     if(lib->full_preview_id > -1)
     {
       lib->track = -DT_LIBRARY_MAX_ZOOM;
+      if(layout == DT_LIGHTTABLE_LAYOUT_CULLING) shift_first_selected_image(lib, TRUE);
     }
     else if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
     {
@@ -3381,6 +3385,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     if(lib->full_preview_id > -1)
     {
       lib->track = +DT_LIBRARY_MAX_ZOOM;
+      if(layout == DT_LIGHTTABLE_LAYOUT_CULLING) shift_first_selected_image(lib, FALSE);
     }
     else if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
     {
@@ -3413,6 +3418,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     if(lib->full_preview_id > -1)
     {
       lib->track = -DT_LIBRARY_MAX_ZOOM;
+      if(layout == DT_LIGHTTABLE_LAYOUT_CULLING) shift_first_selected_image(lib, TRUE);
     }
     else if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
     {
@@ -3443,6 +3449,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     if(lib->full_preview_id > -1)
     {
       lib->track = +DT_LIBRARY_MAX_ZOOM;
+      if(layout == DT_LIGHTTABLE_LAYOUT_CULLING) shift_first_selected_image(lib, FALSE);
     }
     else if(layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER)
     {


### PR DESCRIPTION
This makes the sticky preview to update the filmstrip and vice-versa. Also uses the up & down shortcuts.

It removes the exit sticky preview shortcut, there's no need for it as the actual shortcut toggles it.