### PR TITLE
Expose culling : zoom and pan enhancements + return to filemanager on quit

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -741,6 +741,13 @@
     <longdescription>select a layout for the lighttable: 0 - zoomable lighttable or 1 - file manager.</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/base_layout</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>lighttable basic layout mode</shortdescription>
+    <longdescription>the layout to return to when exiting expose or culling layout</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/images_in_row</name>
     <type>int</type>
     <default>5</default>

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2011,7 +2011,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
     params.full_preview = TRUE;
     if(sel_img_count <= max_in_memory_images)
     {
-      params.full_zoom = &lib->full_zoom;
+      params.full_zoom = lib->full_zoom;
       params.full_x = &lib->full_x;
       params.full_y = &lib->full_y;
       params.full_surface = &lib->fp_surf[i].surface;
@@ -2193,7 +2193,7 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
   params.py = pointery;
   params.zoom = 1;
   params.full_preview = TRUE;
-  params.full_zoom = &lib->full_zoom;
+  params.full_zoom = lib->full_zoom;
   params.full_zoom100 = &lib->fp_surf[0].zoom_100;
   params.full_w1 = &lib->fp_surf[0].w_fit;
   params.full_h1 = &lib->fp_surf[0].h_fit;
@@ -2939,8 +2939,12 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       float nz = 40.0f;
       if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
       {
-        // we stop at the minimum zoom
-        for(int i = 0; i < sel_img_count; i++) nz = fminf(nz, lib->fp_surf[i].zoom_100);
+        // we get the 100% zoom of the largest image
+        nz = 1.0f;
+        for(int i = 0; i < sel_img_count; i++)
+        {
+          if(lib->fp_surf[i].zoom_100 > nz) nz = lib->fp_surf[i].zoom_100;
+        }
       }
       else
         nz = lib->fp_surf[0].zoom_100;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -3097,8 +3097,17 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     {
       float dx = 0.0f;
       float dy = 0.0f;
-      GList *selected = dt_collection_get_selected(darktable.collection, -1);
-      const int sel_img_count = g_list_length(selected);
+      int sel_img_count = 1;
+      if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+      {
+        GList *selected = dt_collection_get_selected(darktable.collection, -1);
+        sel_img_count = g_list_length(selected);
+        if(selected) g_list_free(selected);
+      }
+      else if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
+      {
+        sel_img_count = get_display_num_images();
+      }
       for(int i = 0; i < sel_img_count; i++)
       {
         dx = fminf(dx, -lib->fp_surf[i].max_dx);
@@ -3106,7 +3115,6 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
         dy = fminf(dy, -lib->fp_surf[i].max_dy);
         dy = fmaxf(dy, lib->fp_surf[i].max_dy);
       }
-      if(selected) g_list_free(selected);
       lib->full_x = fminf(lib->full_x, dx);
       lib->full_x = fmaxf(lib->full_x, -dx);
       lib->full_y = fminf(lib->full_y, dy);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2936,8 +2936,17 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
      && (state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
   {
-    GList *selected = dt_collection_get_selected(darktable.collection, -1);
-    const int sel_img_count = g_list_length(selected);
+    int sel_img_count = 1;
+    if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE)
+    {
+      GList *selected = dt_collection_get_selected(darktable.collection, -1);
+      sel_img_count = g_list_length(selected);
+      if(selected) g_list_free(selected);
+    }
+    else if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      sel_img_count = get_display_num_images();
+    }
     if((get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
        && sel_img_count > dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"))
     {
@@ -2982,7 +2991,6 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
         dt_control_queue_redraw_center();
       }
     }
-    if(selected) g_list_free(selected);
   }
   else if(lib->full_preview_id > -1)
   {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1015,8 +1015,8 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   gboolean full_preview = vals->full_preview;
   gboolean image_only = vals->image_only;
   float full_zoom = vals->full_zoom;
-  float *full_x = vals->full_x;
-  float *full_y = vals->full_y;
+  float full_x = vals->full_x;
+  float full_y = vals->full_y;
 
   // active if zoom>1 or in the proper area
   const gboolean in_metadata_zone = (px < width && py < height / 2) || (zoom > 1);
@@ -1367,7 +1367,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
       // we move the full preview
       float fx = 0.0f;
       float fy = 0.0f;
-      if(fz > 1.0f && full_x && full_y)
+      if(fz > 1.0f)
       {
         int w = width;
         int h = height;
@@ -1378,29 +1378,23 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
           h -= 2 * tb;
         }
         // we want to be sure the image stay in the window
-        fx = fminf((buf_wd * scale - w) / 2, fabsf(*full_x));
-        if(*full_x < 0) fx = -fx;
-        if(buf_wd * scale <= w) fx = 0;
-        fy = fminf((buf_ht * scale - h) / 2, fabsf(*full_y));
-        if(*full_y < 0) fy = -fy;
-        if(buf_ht * scale <= h) fy = 0;
-
-        if(buf_sizeok)
+        if(buf_sizeok && vals->full_maxdx && vals->full_maxdy)
         {
-          *full_x = fx;
-          *full_y = fy;
+          *(vals->full_maxdx) = fmaxf(0.0f, (buf_wd * scale - w) / 2);
+          *(vals->full_maxdy) = fmaxf(0.0f, (buf_ht * scale - h) / 2);
         }
+        fx = fminf((buf_wd * scale - w) / 2, fabsf(full_x));
+        if(full_x < 0) fx = -fx;
+        if(buf_wd * scale <= w) fx = 0;
+        fy = fminf((buf_ht * scale - h) / 2, fabsf(full_y));
+        if(full_y < 0) fy = -fy;
+        if(buf_ht * scale <= h) fy = 0;
 
         // and we determine the rectangle where the image is display
         rectw = fminf(w / scale, rectw);
         recth = fminf(h / scale, recth);
         rectx = 0.5 * buf_wd - fx / scale - 0.5 * rectw;
         recty = 0.5 * buf_ht - fy / scale - 0.5 * recth;
-      }
-      else if(full_x && full_y)
-      {
-        *full_x = 0.0f;
-        *full_y = 0.0f;
       }
 
       if(buf_ok && fz == 1.0f && vals->full_w1 && vals->full_h1)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1014,7 +1014,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   int32_t py = vals->py;
   gboolean full_preview = vals->full_preview;
   gboolean image_only = vals->image_only;
-  float *full_zoom = vals->full_zoom;
+  float full_zoom = vals->full_zoom;
   float *full_x = vals->full_x;
   float *full_y = vals->full_y;
 
@@ -1096,7 +1096,8 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
 
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
   float fz = 1.0f;
-  if(full_zoom) fz = *full_zoom;
+  if(full_zoom > 0.0f) fz = full_zoom;
+  if(vals->full_zoom100 && *(vals->full_zoom100) > 0.0f) fz = fminf(*(vals->full_zoom100), fz);
   dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(cache, imgwd * width * fz, imgwd * height * fz);
 
 
@@ -1144,10 +1145,9 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
     {
       float zoom_100 = fmaxf((float)buf_wd / ((float)width * imgwd), (float)buf_ht / ((float)height * imgwd));
       if(zoom_100 < 1.0f) zoom_100 = 1.0f;
-      *(vals->full_zoom100) = zoom_100;
+      if(vals->full_zoom100) *(vals->full_zoom100) = zoom_100;
       if(fz > zoom_100)
       {
-        *full_zoom = zoom_100;
         fz = zoom_100;
       }
     }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1095,6 +1095,8 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
 
 
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
+  if(vals->full_surface_id && vals->full_zoom100 && *(vals->full_surface_id) != imgid)
+    *(vals->full_zoom100) = 40.0f;
   float fz = 1.0f;
   if(full_zoom > 0.0f) fz = full_zoom;
   if(vals->full_zoom100 && *(vals->full_zoom100) > 0.0f) fz = fminf(*(vals->full_zoom100), fz);

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -170,8 +170,10 @@ typedef struct dt_view_image_expose_t
   float *full_zoom100;
   float *full_w1;
   float *full_h1;
-  float *full_x;
-  float *full_y;
+  float full_x;
+  float full_y;
+  float *full_maxdx;
+  float *full_maxdy;
 
   cairo_surface_t **full_surface;
   uint8_t **full_rgbbuf;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -166,7 +166,7 @@ typedef struct dt_view_image_expose_t
   int32_t py;
   gboolean full_preview;
   gboolean image_only;
-  float *full_zoom;
+  float full_zoom;
   float *full_zoom100;
   float *full_w1;
   float *full_h1;


### PR DESCRIPTION
- If you have images with different sizes, it allow each images to zoom until they reach there 100% zoom. smaller images just stop growing.
- Same for panning until edges of each images

- The other change is that when you toggle the key accel to quit expose or culling layout, you always come back to filemanager or zoomable layout (depending of the last used). Previously, if you enter expose layout and switch directly to culling, when you quit culling layout, you come back to expose, which can be confusing, especially if you don't see the layout combobox...