### PR TITLE
lighttable : enhance full preview zoom memory

### DIFF
--- a/src/common/mipmap_cache.h
+++ b/src/common/mipmap_cache.h
@@ -141,6 +141,7 @@ void dt_mipmap_cache_release_with_caller(dt_mipmap_cache_t *cache, dt_mipmap_buf
 
 // remove thumbnails, so they will be regenerated:
 void dt_mipmap_cache_remove(dt_mipmap_cache_t *cache, const uint32_t imgid);
+void dt_mipmap_cache_remove_at_size(dt_mipmap_cache_t *cache, const uint32_t imgid, dt_mipmap_size_t mip);
 
 // evict thumbnails from cache. They will be written to disc if not existing
 void dt_mimap_cache_evict(dt_mipmap_cache_t *cache, const uint32_t imgid);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2953,7 +2953,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       dt_control_log(_("zooming is limited to %d images"),
                      dt_conf_get_int("plugins/lighttable/preview/max_in_memory_images"));
     }
-    else if(lib->missing_thumbnails == 0)
+    else
     {
       float nz = 40.0f;
       if(get_layout() == DT_LIGHTTABLE_LAYOUT_EXPOSE || get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1476,6 +1476,12 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   cairo_restore(cr);
 
   if(buf_mipmap) dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
+  if(buf_mipmap && !missing && vals->full_surface && !*(vals->full_surface_w_lock))
+  {
+    // we don't need this in the cache anymore, as we already have it in memory for zoom&pan
+    // let's drop it to free space. This reduce the risk of getting out of space...
+    dt_mipmap_cache_remove_at_size(cache, imgid, mip);
+  }
 
   cairo_save(cr);
 


### PR DESCRIPTION
- This should limit the flickering/black image problem when zooming in expose/culling layout.
- This should avoid the zoom "lock" when zooming quickly

Technically the problem is that when we have for example 4 images at 5000x3000, this is about 240M in memory, just for the MIPMAP_8 level, and the cache by default (at least here) is set to 256M so we get quickly out of memory and dt drop images from the cache, which in turn provoke recomputing of this thumbnails...
To avoid that, I drop the cache of this mipmap once we have computed the corresponding surface (only when zooming is > 1.0f).
This seems to work fine.

But we still can fill the cache to easily and I wonder if increasing it's default value would make sense ? (and how to do it, because I've not understand how it is set, darketableconfig.xml.in has very strange value...)