### PR TITLE
[WIP] implement detachable left/right panels

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -23,6 +23,20 @@
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
   <dtconfig prefs="gui">
+    <name>panels/detached_left</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>detach the left panel (needs a restart)</shortdescription>
+    <longdescription>Be carefull : don't trust colors in this panel !</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui">
+    <name>panels/detached_right</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>detach the right panel (needs a restart)</shortdescription>
+    <longdescription>Be carefull : don't trust colors in this panel !</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui">
     <name>slideshow_delay</name>
     <type>int</type>
     <default>5</default>

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -108,6 +108,7 @@ typedef struct dt_gui_gtk_t
   GtkWidget *scroll_to[2]; // one for left, one for right
 
   gint scroll_mask;
+
 } dt_gui_gtk_t;
 
 #if (CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 13, 1))
@@ -288,6 +289,8 @@ void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
 void dt_ui_notify_user();
 /** \brief get visible state of panel */
 gboolean dt_ui_panel_visible(struct dt_ui_t *ui, const dt_ui_panel_t);
+/** \brief get visible state of panel */
+gboolean dt_ui_panel_detached(struct dt_ui_t *ui, const dt_ui_panel_t p);
 /** \brief get the center drawable widget */
 GtkWidget *dt_ui_center(struct dt_ui_t *ui);
 /** \brief get the main window widget */

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -100,6 +100,18 @@ static gboolean main_draw_callback(GtkWidget *widget, cairo_t *cr, gpointer data
   cairo_rectangle(cr, 0, 0, width, height);
   cairo_fill (cr);
 
+  if(dt_ui_panel_detached(darktable.gui->ui, DT_UI_PANEL_LEFT))
+  {
+    GdkRGBA fg_color;
+    gtk_style_context_get_color(gtk_widget_get_style_context(widget), gtk_widget_get_state_flags(widget),
+                                &fg_color);
+
+    gdk_cairo_set_source_rgba(cr, &fg_color);
+    dtgtk_cairo_paint_gamut_check(cr, 0, 0, DT_PIXEL_APPLY_DPI(25), DT_PIXEL_APPLY_DPI(25),
+                                  CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+    gtk_widget_set_tooltip_text(widget, _("don't trust the color displayed here !"));
+  }
+
   return FALSE;
 }
 

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -225,6 +225,18 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
     cairo_fill(cr);
     cairo_surface_destroy(surface);
 
+    if(dt_ui_panel_detached(darktable.gui->ui, DT_UI_PANEL_LEFT))
+    {
+      GdkRGBA fg_color;
+      gtk_style_context_get_color(gtk_widget_get_style_context(widget), gtk_widget_get_state_flags(widget),
+                                  &fg_color);
+
+      gdk_cairo_set_source_rgba(cr, &fg_color);
+      dtgtk_cairo_paint_gamut_check(cr, 0, 0, DT_PIXEL_APPLY_DPI(25) / scale, DT_PIXEL_APPLY_DPI(25) / scale,
+                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+      gtk_widget_set_tooltip_text(widget, _("don't trust the color displayed here !"));
+    }
+
     // draw box where we are
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
     int closeup = dt_control_get_dev_closeup();


### PR DESCRIPTION
Quick and basic detachable panel implementation. At first sight, it works but it certainly break lot of things...
About color management, left and right panels haven't a lot of critical colors. I've added an icon and a tooltip for the navigation and color picker to warn user that color can be false.
The filmstrip is not detachable, because here color management is critical and I don't know a way to handle that point across multiple windows/screens