### PR TITLE
allow caching within OpenCL pixelpipe

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -112,13 +112,6 @@
     <longdescription>if set to TRUE OpenCL pixelpipe will not be synchronized on a per-module basis. this can improve pixelpipe latency. however, potential OpenCL errors would be detected late; in such a case the complete pixelpipe needs to be reprocessed instead of only a single module. export pixelpipe will always be run synchronously.</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>opencl_synch_cache</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>copy back OpenCL buffers into pixelpipe cache after each module</shortdescription>
-    <longdescription>this brings pixelpipe cache and OpenCL buffers in synch after each module. on slow GPUs this might improve speed as it avoids reprocessing the whole pixelpipe on every parameter change. on fast GPUs the additional memory transfer overhead will slow down OpenCL considerably.</longdescription>
-  </dtconfig>
-  <dtconfig>
     <name>opencl_micro_nap</name>
     <type>int</type>
     <default>1000</default>
@@ -227,6 +220,19 @@
     <default>default</default>
     <shortdescription>OpenCL scheduling profile</shortdescription>
     <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems. default - GPU processes full and CPU processes preview pipe (adaptable by config parameters); multiple GPUs - process both pixelpipes in parallel on two different GPUs; very fast GPU - process both pixelipes sequentially on the GPU.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="core" capability="opencl" section="cpugpu">
+    <name>opencl_synch_cache</name>
+    <type>
+      <enum>
+        <option>true</option>
+        <option>active module</option>
+        <option>false</option>
+      </enum>
+    </type>
+    <default>active module</default>
+    <shortdescription>cache intermediate OpenCL output</shortdescription>
+    <longdescription>active module (default) - cache the input to the currently focused module, which allows for faster response time when making multiple adjustments to that module (though the whole pipeline may need to be reprocessed when another module is changed); true - cache the output after each module, which may improve speed, as the whole pixelpipe won't be reprocessed on every parameter change, though will require more memory transfers from the GPU; false - do not sync the pixelpipe cache from OpenCL, which avoids memory transfers from GPUs fast enough to smoothly reprocess the whole pixelpipe.</longdescription>
   </dtconfig>
   <dtconfig>
     <name>opencl_library</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -221,7 +221,7 @@
     <shortdescription>OpenCL scheduling profile</shortdescription>
     <longdescription>defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled systems. default - GPU processes full and CPU processes preview pipe (adaptable by config parameters); multiple GPUs - process both pixelpipes in parallel on two different GPUs; very fast GPU - process both pixelipes sequentially on the GPU.</longdescription>
   </dtconfig>
-  <dtconfig prefs="core" capability="opencl" section="cpugpu">
+  <dtconfig>
     <name>opencl_synch_cache</name>
     <type>
       <enum>

--- a/doc/usermanual/topics/opencl.xml
+++ b/doc/usermanual/topics/opencl.xml
@@ -613,12 +613,14 @@ crw-rw-rw- 1 root root 250,   0 Jul 28 21:13 /dev/nvidia-uvm
           </term>
 
           <listitem><para>
-            This parameter, if set to TRUE, will force darktable to fetch image buffers from
-            your GPU after each module and store them in its pixelpipe cache. This is a very
-            resource consuming operation. It only makes sense if you have a rather slow GPU. In
-            that case darktable might in fact save some time when module parameters have
-            changed, as it can go back to some cached intermediate state and reprocess only part
-            of the pixelpipe. In most cases this parameter should be set to FALSE (default).
+            This parameter, if set to "true", will force darktable to fetch image buffers from
+            your GPU after each module and store them in its pixelpipe cache. This is a
+            resource consuming operation, but makes sense depending on your GPU (including if the
+	    GPU is rather slow). In that case darktable might in fact save some time when module
+	    parameters have changed, as it can go back to some cached intermediate state and
+	    reprocess only part of the pixelpipe. In many cases this parameter should be set to
+	    "active module" (default), which will only cache the input of the currently focused
+	    module.
           </para></listitem>
 
         </varlistentry>

--- a/src/common/opencl.h
+++ b/src/common/opencl.h
@@ -60,6 +60,13 @@ typedef enum dt_opencl_scheduling_profile_t
   OPENCL_PROFILE_VERYFAST_GPU
 } dt_opencl_scheduling_profile_t;
 
+typedef enum dt_opencl_sync_cache_t
+{
+  OPENCL_SYNC_TRUE,
+  OPENCL_SYNC_ACTIVE_MODULE,
+  OPENCL_SYNC_FALSE
+} dt_opencl_sync_cache_t;
+
 /**
  * Accounting information used for OpenCL events.
  */
@@ -130,7 +137,7 @@ typedef struct dt_opencl_t
   int async_pixelpipe;
   int number_event_handles;
   int print_statistics;
-  int synch_cache;
+  dt_opencl_sync_cache_t sync_cache;
   int micro_nap;
   int enabled;
   int stopped;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1696,7 +1696,8 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
              But it is worth copying data back from the GPU which is the input to the currently focused iop,
              as that is the iop which is most likely to change next.
           */
-          if(darktable.opencl->synch_cache || (module == darktable.develop->gui_module))
+          if((darktable.opencl->sync_cache == OPENCL_SYNC_TRUE) ||
+             ((darktable.opencl->sync_cache == OPENCL_SYNC_ACTIVE_MODULE) && (module == darktable.develop->gui_module)))
           {
             /* write back input into cache for faster re-usal (not for export or thumbnails) */
             if(cl_mem_input != NULL && pipe->type != DT_DEV_PIXELPIPE_EXPORT

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1692,8 +1692,11 @@ static int dt_dev_pixelpipe_process_rec(dt_dev_pixelpipe_t *pipe, dt_develop_t *
 
           /* this is reasonable on slow GPUs only, where it's more expensive to reprocess the whole pixelpipe
              than
-             regularly copying device buffers back to host. This would slow down fast GPUs considerably. */
-          if(darktable.opencl->synch_cache)
+             regularly copying device buffers back to host. This would slow down fast GPUs considerably.
+             But it is worth copying data back from the GPU which is the input to the currently focused iop,
+             as that is the iop which is most likely to change next.
+          */
+          if(darktable.opencl->synch_cache || (module == darktable.develop->gui_module))
           {
             /* write back input into cache for faster re-usal (not for export or thumbnails) */
             if(cl_mem_input != NULL && pipe->type != DT_DEV_PIXELPIPE_EXPORT


### PR DESCRIPTION
Make `opencl_synch_cache` an enum, with new default option "active module". This will cache input to the current module in the OpenCL pipe. This offers a speed-up when the current module is repeatedly adjusted (a normal case) and the time to run the pixelpipe up to the current module is noticeable.

As suggested by #2230.