### PR TITLE
mipmaps : increase default size

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -37,7 +37,7 @@
   <dtconfig prefs="core" section="cpugpu">
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
-    <default>(1024 * 1024 * 256)</default>
+    <default>(1024 * 1024 * 512)</default>
     <shortdescription>memory in megabytes to use for thumbnail cache</shortdescription>
     <longdescription>this controls how much memory is going to be used for thumbnails and other buffers (needs a restart).</longdescription>
   </dtconfig>

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2254,7 +2254,7 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
       * Simply swapping DESC and ASC in the SQL won't help because we rely on the LIMIT clause, and
       * that LIMIT has to work with the "correct" sort order. One could use a subquery, but I don't
       * think that would be terribly elegant, either. */
-      while(--count >= 0 && preload_stack[count] != -1)
+      while(--count >= 0 && preload_stack[count] != -1 && mip != DT_MIPMAP_8)
       {
         dt_mipmap_cache_get(darktable.mipmap_cache, NULL, preload_stack[count], mip, DT_MIPMAP_PREFETCH, 'r');
       }


### PR DESCRIPTION
too low cache size can be problematic when zooming with multiple images (expose or culling) or with big images (pano)
Also avoid to preload full res mipmaps as they are not stored in cache anyway
