### PR TITLE
do not create preview2 nodes if not needed

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -717,7 +717,8 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
 
   dt_dev_pixelpipe_create_nodes(dev->pipe, dev);
   dt_dev_pixelpipe_create_nodes(dev->preview_pipe, dev);
-  dt_dev_pixelpipe_create_nodes(dev->preview2_pipe, dev);
+  if(dev->second_window.widget && GTK_IS_WIDGET(dev->second_window.widget))
+    dt_dev_pixelpipe_create_nodes(dev->preview2_pipe, dev);
   dt_dev_read_history(dev);
 
   // we have to init all module instances other than "base" instance


### PR DESCRIPTION
This fixes #2398 and #2394

When changing images in darkroom, if the second window is not open, the following errors were displayed:

[image_cache_allocate] failed to open image 1275328648 from database: unknown error

and/or

unsupported input color profile has been replaced by linear Rec709 RGB!