### PR TITLE
dt_control_queue_redraw() is causing recursion

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -221,7 +221,6 @@ void expose(
   if(dev->image_status == DT_DEV_PIXELPIPE_DIRTY || dev->image_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp < dev->preview_pipe->input_timestamp)
   {
-    dt_control_queue_redraw();
     dev->image_timeout_handle = g_timeout_add(DT_DARKROOM_PROCESS_TIMEOUT, G_SOURCE_FUNC(dt_dev_process_image), dev);
   }
 


### PR DESCRIPTION
dt_control_queue_redraw() is causing recursion, to test run dt with -d perf:

6,193952 [dev] took 0,211 secs (0,181 CPU) to load the image.
7,293687 [dev] took 0,000 secs (0,000 CPU) to load the image.
7,407167 [dev_pixelpipe] took 0,000 secs (0,000 CPU) initing base buffer [full]
7,423194 [dev_pixelpipe] took 0,016 secs (0,041 CPU) processed `raw black/white point' on CPU, blended on CPU [full]
7,440804 [dev_pixelpipe] took 0,018 secs (0,068 CPU) processed `white balance' on CPU, blended on CPU [full]
7,459428 [dev_pixelpipe] took 0,019 secs (0,067 CPU) processed `highlight reconstruction' on CPU, blended on CPU [full]
7,512458 [dev_pixelpipe] took 0,053 secs (0,082 CPU) processed `hot pixels' on CPU, blended on CPU [full]
8,310029 [dev_pixelpipe] took 0,798 secs (5,688 CPU) processed `raw denoise' on CPU, blended on CPU [full]
8,821389 [dev_pixelpipe] took 0,511 secs (3,169 CPU) processed `demosaic' on CPU, blended on CPU [full]
8,940998 [dev_pixelpipe] took 0,120 secs (0,149 CPU) processed `exposure' on CPU, blended on CPU [full]
8,973271 [dev_pixelpipe] took 0,032 secs (0,058 CPU) processed `exposure 1' on CPU, blended on CPU [full]
9,000515 [dev_pixelpipe] took 0,027 secs (0,052 CPU) processed `exposure 2' on CPU, blended on CPU [full]
9,215437 [dev_pixelpipe] took 0,215 secs (0,509 CPU) processed `retouch' on CPU, blended on CPU [full]
9,218615 [dev_pixelpipe] took 0,003 secs (0,014 CPU) processed `base curve' on CPU, blended on CPU [full]
9,221695 [dev_pixelpipe] took 0,003 secs (0,016 CPU) processed `input color profile' on CPU, blended on CPU [full]
9,228279 [dev_pixelpipe] took 0,007 secs (0,036 CPU) processed `sharpen' on CPU, blended on CPU [full]
9,249403 [dev_pixelpipe] took 0,021 secs (0,126 CPU) processed `lowpass' on CPU, blended on CPU [full]
9,257166 [dev_pixelpipe] took 0,008 secs (0,037 CPU) processed `output color profile' on CPU, blended on CPU [full]
9,260789 [dev_pixelpipe] took 0,004 secs (0,021 CPU) processed `gamma' on CPU, blended on CPU [full]
9,260857 [dev_process_image] pixel pipeline processing took 1,856 secs (10,141 CPU)
9,260896 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,260977 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,302050 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,302173 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,353275 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,353378 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,440795 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,440906 [dev_process_image] pixel pipeline processing took 0,000 secs (0,003 CPU)
9,494164 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,494259 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,506879 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,506954 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,548917 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,549008 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,602631 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,602739 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,661684 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,661825 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,672816 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,673004 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,716285 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,716423 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,765645 [dev] took 0,000 secs (0,000 CPU) to load the image.
9,765741 [dev_process_image] pixel pipeline processing took 0,000 secs (0,000 CPU)
9,972753 [dev_pixelpipe] took 0,000 secs (0,000 CPU) initing base buffer [preview]
9,974363 [dev_pixelpipe] took 0,002 secs (0,000 CPU) processed `raw black/white point' on CPU, blended on CPU [preview]
9,975432 [dev_pixelpipe] took 0,001 secs (0,004 CPU) processed `white balance' on CPU, blended on CPU [preview]
9,976565 [dev_pixelpipe] took 0,001 secs (0,004 CPU) processed `highlight reconstruction' on CPU, blended on CPU [preview]
9,979126 [dev_pixelpipe] took 0,003 secs (0,000 CPU) processed `hot pixels' on CPU, blended on CPU [preview]
10,001437 [dev_pixelpipe] took 0,022 secs (0,143 CPU) processed `raw denoise' on CPU, blended on CPU [preview]
10,017906 [dev_pixelpipe] took 0,016 secs (0,061 CPU) processed `demosaic' on CPU, blended on CPU [preview]
10,125192 [dev_pixelpipe] took 0,107 secs (0,153 CPU) processed `exposure' on CPU, blended on CPU [preview]
10,147949 [dev_pixelpipe] took 0,022 secs (0,061 CPU) processed `exposure 1' on CPU, blended on CPU [preview]
10,166531 [dev_pixelpipe] took 0,018 secs (0,062 CPU) processed `exposure 2' on CPU, blended on CPU [preview]
10,463780 [dev_pixelpipe] took 0,297 secs (0,632 CPU) processed `retouch' on CPU, blended on CPU [preview]
10,467547 [dev_pixelpipe] took 0,004 secs (0,024 CPU) processed `base curve' on CPU, blended on CPU [preview]
10,470977 [dev_pixelpipe] took 0,003 secs (0,026 CPU) processed `input color profile' on CPU, blended on CPU [preview]
10,480352 [dev_pixelpipe] took 0,009 secs (0,054 CPU) processed `sharpen' on CPU, blended on CPU [preview]
10,509463 [dev_pixelpipe] took 0,029 secs (0,147 CPU) processed `lowpass' on CPU, blended on CPU [preview]
10,519134 [dev_pixelpipe] took 0,010 secs (0,052 CPU) processed `output color profile' on CPU, blended on CPU [preview]
10,524584 [dev_pixelpipe] took 0,005 secs (0,029 CPU) processed `gamma' on CPU, blended on CPU [preview]
image colorspace transform RGB-->RGB took 0,020 secs (0,129 CPU) [final histogram]
10,654463 [dev_process_preview] pixel pipeline processing took 0,716 secs (1,740 CPU)
10,654546 [dev_process_preview] pixel pipeline processing took 0,000 secs (0,000 CPU)

