### PR TITLE
UI: set font weight to normal in history stack

### DIFF
--- a/data/darktable.css.in
+++ b/data/darktable.css.in
@@ -317,6 +317,7 @@ button
   background-color: transparent;
   border-color: transparent;
   border: 0;
+  font-weight: normal;
 }
 
 button:selected,
@@ -711,7 +712,7 @@ notebook tabs,
   margin: 0;
   color: @button_fg;
   font-weight: 400;
-  font-family: "Roboto", "Segoe UI", "SF Pro Text", "Cantarell", sans-serif;
+  font-family: "Roboto", "Segoe UI", "SF Pro Text", "Ubuntu", "Cantarell", sans-serif;
 }
 
 #modules-tabs,


### PR DESCRIPTION
The bold font weight for items of the history stack gives (imho) too much emphasis to the history stack. Looks distracting to me. Fixes also some inconsistency in the font selection.