### PR TITLE
bauhaus: fix zero-point of soft-bound sliders

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1377,7 +1377,7 @@ static void dt_bauhaus_draw_baseline(dt_bauhaus_widget_t *w, cairo_t *cr)
   cairo_fill(cr);
 
   // get the reference of the slider aka the position of the 0 value
-  const float origin = fmaxf(fminf(-(d->hard_min / (d->hard_max - d->hard_min)) * slider_width, slider_width), 0.0f);
+  const float origin = fmaxf(fminf(-(d->min / (d->max - d->min)) * slider_width, slider_width), 0.0f);
   const float position = d->pos * slider_width;
   const float delta = position - origin;
 
@@ -1402,7 +1402,7 @@ static void dt_bauhaus_draw_baseline(dt_bauhaus_widget_t *w, cairo_t *cr)
 
   // If the max of the slider is 180 or 360, it is likely a hue slider in degrees
   // a zero in periodic stuff has not much meaning so we skip it
-  if(d->hard_max != 180.0f && d->hard_max != 326.0f)
+  if(d->hard_max != 180.0f && d->hard_max != 360.0f)
   {
     // translate the dot if it overflows the widget frame
     if(origin < graduation_height)


### PR DESCRIPTION
The zero position of sliders with soft bounds is currently indicated incorrectly unless hard and soft bounds feature some symmetries. This issue can be observed for the contrast slider of the basic adjustments module. This slider has soft bounds [-1, 1] and hard bounds [-1, 5]. This pull request provides a fix for the described bug. It also fixes a typo, which might be relevant for periodic sliders, see comment in code.

To demonstrate the bug here two screen shorts before and after the fix. Picture show basic adjustment module with default settings. Compare the contrast slider.

Broken soft-bound slider:
![broken](https://user-images.githubusercontent.com/1159508/56231785-8fbaae00-607f-11e9-9ed9-618a0cd8a5ac.png)

Fixed soft-bound slider:
![fixed](https://user-images.githubusercontent.com/1159508/56231792-934e3500-607f-11e9-8425-12bbac9c1272.png)
