### PR TITLE
remove a bit of contrast on modules header (names)

### DIFF
--- a/data/darktable-elegant.css
+++ b/data/darktable-elegant.css
@@ -79,6 +79,7 @@
 @define-color plugin_bg_color @grey_20;
 @define-color plugin_fg_color @grey_80;
 @define-color section_label @grey_55;
+@define-color plugin_label_color @grey_55;
 
 /* Modules controls */
 @define-color bauhaus_fg @grey_70;
@@ -495,6 +496,7 @@ entry selection
 #lib-panel-label
 {
   background-color: @bg_color;
+  color: @plugin_label_color;
   border:0;
   padding: 0 2pt 2pt 0.5em;
   font-weight: 400;

--- a/data/darktable.css
+++ b/data/darktable.css
@@ -79,6 +79,7 @@
 @define-color plugin_bg_color @grey_20;
 @define-color plugin_fg_color @grey_80;
 @define-color section_label @grey_55;
+@define-color plugin_label_color @grey_55;
 
 /* Modules controls (sliders and comboboxes) */
 @define-color bauhaus_fg @grey_70;
@@ -504,6 +505,7 @@ entry selection
 #lib-panel-label
 {
   background-color: @bg_color;
+  color: @plugin_label_color;
   border:0;
   padding: 0 2pt 2pt 0.5em;
   font-weight: 400;


### PR DESCRIPTION
The extra contrast was not necessary for readability but a bit distracting from the picture.
On @cryptomilk 's request.