### PR TITLE
expose/culling : enhance layout

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -607,23 +607,26 @@ void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio)
   }
 }
 
-void dt_image_set_aspect_ratio(const int32_t imgid)
+double dt_image_set_aspect_ratio(const int32_t imgid)
 {
   dt_mipmap_buffer_t buf;
+  double aspect_ratio = 0.0;
 
   // mipmap cache must be initialized, otherwise we'll update next call
   if(darktable.mipmap_cache)
   {
     dt_mipmap_cache_get(darktable.mipmap_cache, &buf, imgid, DT_MIPMAP_0, DT_MIPMAP_BLOCKING, 'r');
 
-    if (buf.buf && buf.height && buf.width)
+    if(buf.buf && buf.height && buf.width)
     {
-      const double aspect_ratio = (double)buf.width / (double)buf.height;
+      aspect_ratio = (double)buf.width / (double)buf.height;
       dt_image_set_aspect_ratio_to(imgid, aspect_ratio);
     }
 
     dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
   }
+
+  return aspect_ratio;
 }
 
 int32_t dt_image_duplicate(const int32_t imgid)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -245,7 +245,7 @@ void dt_image_set_location_and_elevation(const int32_t imgid, dt_image_geoloc_t 
 /** returns 1 if there is history data found for this image, 0 else. */
 int dt_image_altered(const uint32_t imgid);
 /** set the image final/cropped aspect ratio */
-void dt_image_set_aspect_ratio(const int32_t imgid);
+double dt_image_set_aspect_ratio(const int32_t imgid);
 /** set the image final/cropped aspect ratio */
 void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio);
 /** returns the orientation bits of the image from exif. */

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1909,8 +1909,8 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
 
   g_list_free(selected);
 
-  gchar *query =  g_strdup_printf("SELECT id, aspect_ratio, width, height FROM images WHERE id IN (%s) ORDER BY INSTR('%s', id)",
-                                  imgids, imgids);
+  gchar *query = g_strdup_printf("SELECT id, aspect_ratio FROM images WHERE id IN (%s) ORDER BY INSTR('%s', id)",
+                                 imgids, imgids);
 
   g_free(imgids);
 
@@ -1929,11 +1929,11 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
   {
     const int32_t id = sqlite3_column_int(stmt, 0);
     double aspect_ratio = sqlite3_column_double(stmt, 1);
-    if(!aspect_ratio)
+    if(!aspect_ratio || aspect_ratio < 0.0001)
     {
-      aspect_ratio = (double)sqlite3_column_int(stmt, 2) / (double)sqlite3_column_int(stmt, 3);
-      // record aspect ratio now
-      dt_image_set_aspect_ratio_to(id, aspect_ratio);
+      aspect_ratio = dt_image_set_aspect_ratio(id);
+      // if an error occurs, let's use 1:1 value
+      if(aspect_ratio < 0.0001) aspect_ratio = 1.0;
     }
 
     images[i].imgid = id;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2068,15 +2068,17 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
   total_width -= distance;
   total_height -= distance;
 
-  for (GList *iter = rows; iter != NULL; iter = iter->next)
+  for(GList *iter = g_list_first(rows); iter != NULL; iter = iter->next)
   {
     GList *row = (GList *) iter->data;
     int row_w = 0, xoff;
+    int max_rh = 0;
 
     for (GList *slot_cw_iter = row; slot_cw_iter != NULL; slot_cw_iter = slot_cw_iter->next)
     {
       dt_layout_image_t *cw = (dt_layout_image_t *) slot_cw_iter->data;
       row_w = MAX(row_w, cw->x + cw->width);
+      max_rh = MAX(max_rh, cw->height);
     }
 
     xoff = (total_width - row_w) / 2;
@@ -2085,6 +2087,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
     {
       dt_layout_image_t *cw = (dt_layout_image_t *) cw_iter->data;
       cw->x += xoff;
+      cw->height = max_rh;
     }
     g_list_free(row);
   }


### PR DESCRIPTION
2 changes : 
- fix a problem with aspect ratio if you have an image distorted which don't have aspect ratio set (ex : import a portrait raw ; import an image with some history stack in the xmp, ...)
- center images vertically in each row. As a side effect, when you zoom in you have the full row height as zooming area