### PR TITLE
expose : refactor to limit recompute

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1771,6 +1771,8 @@ void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t p, gboolean show, gboolea
     gtk_widget_show(ui->panels[p]);
   else
     gtk_widget_hide(ui->panels[p]);
+
+  dt_view_lighttable_force_expose_all(darktable.view_manager);
 }
 
 gboolean dt_ui_panel_visible(dt_ui_t *ui, const dt_ui_panel_t p)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2185,7 +2185,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
     params.zoom = 1;
     params.full_preview = TRUE;
 
-    if(lib->slots_count <= max_in_memory_images)
+    if(lib->slots_count <= max_in_memory_images && lib->full_zoom > 1.0f)
     {
       params.full_zoom = lib->full_zoom;
       params.full_x = lib->full_x;
@@ -2197,8 +2197,7 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
       params.full_surface_wd = &lib->fp_surf[i].width;
       params.full_surface_ht = &lib->fp_surf[i].height;
       params.full_surface_w_lock = &lib->fp_surf[i].w_lock;
-      if(lib->full_zoom > 1.0f
-         && (lib->fp_surf[i].zoom_100 >= 1000.0f || lib->fp_surf[i].imgid != lib->slots[i].imgid))
+      if(lib->fp_surf[i].zoom_100 >= 1000.0f || lib->fp_surf[i].imgid != lib->slots[i].imgid)
         lib->fp_surf[i].zoom_100
             = _preview_get_zoom100(lib->slots[i].width, lib->slots[i].height, lib->slots[i].imgid);
       params.full_zoom100 = lib->fp_surf[i].zoom_100;
@@ -2382,24 +2381,25 @@ static int expose_full_preview(dt_view_t *self, cairo_t *cr, int32_t width, int3
   params.zoom = 1;
   params.full_preview = TRUE;
   params.full_zoom = lib->full_zoom;
-  if(lib->full_zoom > 1.0f
-     && (lib->fp_surf[0].zoom_100 >= 1000.0f || lib->fp_surf[0].imgid != lib->full_preview_id))
-    lib->fp_surf[0].zoom_100 = _preview_get_zoom100(width, height, lib->full_preview_id);
-  params.full_zoom100 = lib->fp_surf[0].zoom_100;
-  params.full_maxdx = &lib->fp_surf[0].max_dx;
-  params.full_maxdy = &lib->fp_surf[0].max_dy;
-  params.full_w1 = &lib->fp_surf[0].w_fit;
-  params.full_h1 = &lib->fp_surf[0].h_fit;
-  params.full_x = lib->full_x;
-  params.full_y = lib->full_y;
-  params.full_surface = &lib->fp_surf[0].surface;
-  params.full_rgbbuf = &lib->fp_surf[0].rgbbuf;
-  params.full_surface_mip = &lib->fp_surf[0].mip;
-  params.full_surface_id = &lib->fp_surf[0].imgid;
-  params.full_surface_wd = &lib->fp_surf[0].width;
-  params.full_surface_ht = &lib->fp_surf[0].height;
-  params.full_surface_w_lock = &lib->fp_surf[0].w_lock;
-
+  if(lib->full_zoom > 1.0f)
+  {
+    if(lib->fp_surf[0].zoom_100 >= 1000.0f || lib->fp_surf[0].imgid != lib->full_preview_id)
+      lib->fp_surf[0].zoom_100 = _preview_get_zoom100(width, height, lib->full_preview_id);
+    params.full_zoom100 = lib->fp_surf[0].zoom_100;
+    params.full_maxdx = &lib->fp_surf[0].max_dx;
+    params.full_maxdy = &lib->fp_surf[0].max_dy;
+    params.full_w1 = &lib->fp_surf[0].w_fit;
+    params.full_h1 = &lib->fp_surf[0].h_fit;
+    params.full_x = lib->full_x;
+    params.full_y = lib->full_y;
+    params.full_surface = &lib->fp_surf[0].surface;
+    params.full_rgbbuf = &lib->fp_surf[0].rgbbuf;
+    params.full_surface_mip = &lib->fp_surf[0].mip;
+    params.full_surface_id = &lib->fp_surf[0].imgid;
+    params.full_surface_wd = &lib->fp_surf[0].width;
+    params.full_surface_ht = &lib->fp_surf[0].height;
+    params.full_surface_w_lock = &lib->fp_surf[0].w_lock;
+  }
   const int missing = dt_view_image_expose(&params);
 
   if(lib->display_focus && (lib->full_res_thumb_id == lib->full_preview_id))

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1431,7 +1431,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   cairo_restore(cr);
 
   if(buf_mipmap) dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-  if(buf_mipmap && !missing && vals->full_surface && !*(vals->full_surface_w_lock))
+  if(buf_mipmap && !missing && vals->full_surface && !*(vals->full_surface_w_lock) && mip >= DT_MIPMAP_7)
   {
     // we don't need this in the cache anymore, as we already have it in memory for zoom&pan
     // let's drop it to free space. This reduce the risk of getting out of space...


### PR DESCRIPTION
currently, the expose/culling layout (images sizes and places) are recompute on each expose call. That means each time one move the mouse. That's unnecessary, hence the refactoring.
@edgardoh : can you double check if I've done this right with culling ? I hope I didn't forgot to reset layout at some places...
Note that I didn't change (and/or understand) the layout logic...