### PR TITLE
[WIP] scroll images is slower

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -224,19 +224,19 @@ void expose(
   if(dev->image_status == DT_DEV_PIXELPIPE_DIRTY || dev->image_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp < dev->preview_pipe->input_timestamp)
   {
-    dev->image_timeout_handle = g_timeout_add(DT_DARKROOM_PROCESS_MAIN_TIMEOUT, G_SOURCE_FUNC(dt_dev_process_image), dev);
+    dt_dev_process_image(dev);
   }
 
   if(dev->preview_status == DT_DEV_PIXELPIPE_DIRTY || dev->preview_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp > dev->preview_pipe->input_timestamp)
   {
-    dev->image_timeout_handle = g_timeout_add(DT_DARKROOM_PROCESS_PREVIEW_TIMEOUT, G_SOURCE_FUNC(dt_dev_process_preview), dev);
+    dt_dev_process_preview(dev);
   }
 
   if(dev->preview2_status == DT_DEV_PIXELPIPE_DIRTY || dev->preview2_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp > dev->preview2_pipe->input_timestamp)
   {
-    dev->image_timeout_handle = g_timeout_add(DT_DARKROOM_PROCESS_PREVIEW2_TIMEOUT, G_SOURCE_FUNC(dt_dev_process_preview2), dev);
+    dt_dev_process_preview2(dev);
   }
 
   dt_pthread_mutex_t *mutex = NULL;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1072,9 +1072,11 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   }
 
   dt_mipmap_cache_t *cache = darktable.mipmap_cache;
+  if(vals->full_surface_id && vals->full_zoom100 && *(vals->full_surface_id) != imgid)
+    *(vals->full_zoom100) = 40.0f;
   float fz = 1.0f;
   if(full_zoom > 0.0f) fz = full_zoom;
-  if(vals->full_zoom100 > 0.0f) fz = fminf(vals->full_zoom100, fz);
+  if(vals->full_zoom100 && *(vals->full_zoom100) > 0.0f) fz = fminf(*(vals->full_zoom100), fz);
   dt_mipmap_size_t mip = dt_mipmap_cache_get_matching_size(cache, imgwd * width * fz, imgwd * height * fz);
 
   // if needed, we load the mimap buffer
@@ -1112,6 +1114,21 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   {
     buf_wd = *(vals->full_surface_wd);
     buf_ht = *(vals->full_surface_ht);
+  }
+  // we want to sanitize full_zoom value to be sure not to exceed 100%
+  if(fz > 1.0f && buf_sizeok)
+  {
+    // is the mipmap loaded the full one ?
+    if(cache->max_width[mip] > buf_wd + 4 && cache->max_height[mip] > buf_ht + 4)
+    {
+      float zoom_100 = fmaxf((float)buf_wd / ((float)width * imgwd), (float)buf_ht / ((float)height * imgwd));
+      if(zoom_100 < 1.0f) zoom_100 = 1.0f;
+      if(vals->full_zoom100) *(vals->full_zoom100) = zoom_100;
+      if(fz > zoom_100)
+      {
+        fz = zoom_100;
+      }
+    }
   }
 
   if(draw_thumb_background)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -167,7 +167,7 @@ typedef struct dt_view_image_expose_t
   gboolean full_preview;
   gboolean image_only;
   float full_zoom;
-  float full_zoom100;
+  float *full_zoom100;
   float *full_w1;
   float *full_h1;
   float full_x;


### PR DESCRIPTION
When scrolling through images in culling there's some delay, it seems to be introduced by _preview_get_zoom100()

I have partially removed that change and also added a prefetch on culling to avoid the refresh of the images.
