### PR TITLE
Grey theme for new UI

### DIFF
--- a/data/darktable-elegant-grey.css
+++ b/data/darktable-elegant-grey.css
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2019 Aurélien Pierre.
+    copyright (c) 2019 Nicolas Auffray
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/data/darktable-elegant-grey.css
+++ b/data/darktable-elegant-grey.css
@@ -1,0 +1,121 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2019 Aurélien Pierre.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+@import url("darktable-elegant.css");
+
+/* This has been tested with GTK 3.24 on Gnome */
+
+/* Perceptually uniform grey gradient */
+
+/* grey_00 = pure black is forbidden for visual assessment */
+@define-color grey_05 #454545;
+@define-color grey_10 #4f4f4f;
+@define-color grey_15 #525252;
+@define-color grey_20 #5c5c5c;
+@define-color grey_25 #626262;
+@define-color grey_30 #6a6a6a;
+@define-color grey_35 #6d6d6d;
+@define-color grey_40 #6f6f6f;
+@define-color grey_45 #717171;
+@define-color grey_50 #777777;
+@define-color grey_55 #7c7c7c;
+@define-color grey_60 #8d8d8d;
+@define-color grey_65 #9c9c9c;
+@define-color grey_70 #ababab;
+@define-color grey_75 #b9b9b9;
+@define-color grey_80 #c6c6c6;
+@define-color grey_85 #dddddd;
+@define-color grey_90 #e2e2e2;
+@define-color grey_95 #f1f1f1;
+/* grey_100 = pure white is forbidden for visual assessment */
+
+
+/* General */
+@define-color selected_bg_color @grey_30; /* legacy stuff */
+@define-color border_color @grey_15; /* border, when used */
+@define-color bg_color @grey_30; /* general background */
+@define-color fg_color @grey_85; /* general text */
+@define-color text_color @grey_10; /* same */
+@define-color disabled_fg_color @grey_65; /* disabled controls */
+
+/* Scroll bars (sliders) */
+@define-color scroll_bar_inactive @grey_50;
+@define-color scroll_bar_active @grey_60;
+@define-color scroll_bar_focus @grey_55;
+@define-color scroll_bar_bg @grey_20;
+
+/* Modules box (plugins) */
+@define-color plugin_bg_color @grey_45;
+@define-color plugin_fg_color @grey_90;
+@define-color section_label @grey_75;
+@define-color plugin_label_color @grey_80;
+
+/* Modules controls (sliders and comboboxes) */
+@define-color bauhaus_fg @grey_80;
+@define-color bauhaus_indicator_border @grey_45;
+@define-color bauhaus_fill @grey_60;
+@define-color bauhaus_bg @grey_55;
+@define-color bauhaus_fg_hover @grey_90;
+
+/* GTK Buttons and tabs */
+@define-color button_bg @grey_25;
+@define-color button_fg @grey_95;
+@define-color button_border @grey_55;
+@define-color button_focus_bg @grey_60;
+@define-color button_hover_bg @grey_65;
+
+/* text fields */
+@define-color field_bg @grey_25;
+@define-color field_fg @grey_85;
+@define-color field_active_bg @grey_40;
+@define-color field_active_fg @grey_90;
+@define-color field_hover_bg @grey_40;
+@define-color field_hover_fg @grey_85;
+@define-color field_select_bg @grey_05;
+
+/* Tooltips and contextual helpers */
+@define-color tooltip_bg_color @grey_15;
+@define-color tooltip_fg_color @grey_75;
+
+/* Views */
+@define-color darkroom_preview_bg_color @grey_35;
+@define-color lighttable_preview_bg_color @grey_35;
+
+/* Lighttable and film-strip */
+@define-color thumbnail_bg_color @grey_55; /* area between border and outline */
+@define-color thumbnail_border_color @grey_20;
+@define-color thumbnail_selected_border_color @grey_80;
+
+/* Graphs : histogram and tone curve */
+@define-color graph_bg @grey_20;
+@define-color graph_border @grey_05;
+
+#outer-border
+{
+  background-color: @grey_20;
+}
+
+separator, separator:hover
+{
+  border-color: @grey_15;
+}
+
+treeview *:selected
+{
+    background-color: @field_active_bg;
+}

--- a/data/darktable-icons-grey.css
+++ b/data/darktable-icons-grey.css
@@ -1,0 +1,21 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2019 Pascal Obry
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+@import url("darktable-icons.css");
+@import url("darktable-elegant-grey.css");
+

--- a/data/darktable-icons-grey.css
+++ b/data/darktable-icons-grey.css
@@ -1,6 +1,6 @@
 /*
     This file is part of darktable,
-    copyright (c) 2019 Pascal Obry
+    copyright (c) 2019 Nicolas Auffray
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Here it is, the grey css theme for the new UI. As seen with @aurelienpierre, I've worked on this theme and tested it with few users who makes some feedback.

The idea is to have an interface who reduce optic illusions that could add a dark or bright one about exposure. Having a grey theme as an alternative as the dark default one let the user choose.

For optic illusions about grey and shadows (so proximity of dark zones and the perception of colors), one of the best known experience is the checker shadows illusion from Adelson. See :
https://en.wikipedia.org/wiki/Checker_shadow_illusion
https://www.deviantart.com/butisit/art/Checker-shadow-illusion-263331875

I've tried to propose the better compromise between reducing optic illusions, having a good contrast between elements of the interface, and having a good design. That was not so easy and had need some few hours to find that.

![Capture-20190430212952-1920x1052](https://user-images.githubusercontent.com/45535283/56987989-3a0df780-6b8f-11e9-8780-b47c8f842c0d.png)

![Capture-20190430213043-1920x1052](https://user-images.githubusercontent.com/45535283/56987991-3bd7bb00-6b8f-11e9-9853-08a03ac86921.png)
