### PR TITLE
paste history duplicate masks

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1185,7 +1185,7 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
   sqlite3_finalize(stmt);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.masks_history WHERE imgid = ?1", -1,
                               &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->image_storage.id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
   GList *history = dev->history;


### PR DESCRIPTION
When pasting history, if the destination image has modules with masks, the masks are duplicated.

Fixes #2485