### PR TITLE
darkroom : fix gtk errors with some iop

### DIFF
--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -348,6 +348,7 @@ end:
 
 void gui_update(dt_iop_module_t *self)
 {
+  if(!self->widget) return;
   if(self->default_enabled)
     gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel rotation"));
   else

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -265,6 +265,7 @@ end:
 
 void gui_update(dt_iop_module_t *self)
 {
+  if(!self->widget) return;
   if(self->default_enabled)
     gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel scaling"));
   else


### PR DESCRIPTION
Avoid gtk_criticals with scalepixels and rotatepixels iops when entering darkroom.