### PR TITLE
Optional side panel mouse wheel scrolling

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1222,7 +1222,7 @@
     <shortdescription>scroll to darkroom modules when expanded/collapsed</shortdescription>
     <longdescription>when this option is enabled then darktable will try to scroll the module to the top of the visible list</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui" section="darkroom">
+  <dtconfig prefs="gui" section="miscellaneous">
     <name>darkroom/ui/sidebar_scroll_default</name>
     <type>bool</type>
     <default>false</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1222,7 +1222,7 @@
     <shortdescription>scroll to darkroom modules when expanded/collapsed</shortdescription>
     <longdescription>when this option is enabled then darktable will try to scroll the module to the top of the visible list</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui" section="miscellaneous">
+  <dtconfig prefs="gui">
     <name>darkroom/ui/sidebar_scroll_default</name>
     <type>bool</type>
     <default>false</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1223,6 +1223,13 @@
     <longdescription>when this option is enabled then darktable will try to scroll the module to the top of the visible list</longdescription>
   </dtconfig>
   <dtconfig prefs="gui" section="darkroom">
+    <name>darkroom/ui/sidebar_scroll_default</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>mouse wheel scrolls modules side panel by default</shortdescription>
+    <longdescription>when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to use mouse wheel for data entry.  when disabled, this behavior is reversed</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui" section="darkroom">
     <name>plugins/darkroom/ui/border_size</name>
     <type>int</type>
     <default>20</default>

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1929,7 +1929,7 @@ static gboolean dt_bauhaus_slider_scroll(GtkWidget *widget, GdkEventScroll *even
   gdouble delta_y;
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   if(w->type != DT_BAUHAUS_SLIDER) return FALSE;
-  if((event->state & gtk_accelerator_get_default_mod_mask()) == darktable.gui->sidebar_scroll_mask) return FALSE;
+  if(((event->state & gtk_accelerator_get_default_mod_mask()) == darktable.gui->sidebar_scroll_mask) != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default")) return FALSE;
   gtk_widget_grab_focus(widget);
 
   gtk_widget_set_state_flags(GTK_WIDGET(w), GTK_STATE_FLAG_FOCUSED, TRUE);
@@ -1975,7 +1975,7 @@ static gboolean dt_bauhaus_combobox_scroll(GtkWidget *widget, GdkEventScroll *ev
   int delta_y;
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)widget;
   if(w->type != DT_BAUHAUS_COMBOBOX) return FALSE;
-  if((event->state & gtk_accelerator_get_default_mod_mask()) == darktable.gui->sidebar_scroll_mask) return FALSE;
+  if(((event->state & gtk_accelerator_get_default_mod_mask()) == darktable.gui->sidebar_scroll_mask) != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default")) return FALSE;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   gtk_widget_grab_focus(widget);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1809,7 +1809,7 @@ static GtkWidget *_ui_init_panel_container_top(GtkWidget *container)
 static gboolean _ui_init_panel_container_center_scroll_event(GtkWidget *widget, GdkEventScroll *event)
 {
   // just make sure nothing happens unless ctrl-alt are pressed:
-  return ((event->state & gtk_accelerator_get_default_mod_mask()) != darktable.gui->sidebar_scroll_mask);
+  return (((event->state & gtk_accelerator_get_default_mod_mask()) != darktable.gui->sidebar_scroll_mask) != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default"));
 }
 
 // this should work as long as everything happens in the gui thread


### PR DESCRIPTION
Give users the option to use the mouse wheel to scroll darkroom side panel by default, data entry with accelerator. 
The new variable can be added to darktablerc and set to FALSE to give current behavior.
darkroom/ui/sidebar_scroll_default=FALSE