### PR TITLE
lib duplicate : preview with zoom

### DIFF
--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -165,16 +165,10 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget, GdkEventButto
       int fw, fh;
       fw = fh = 0;
       dt_image_get_final_size(imgid, &fw, &fh);
-      if(d->cur_final_width - fw < DUPLICATE_COMPARE_SIZE && d->cur_final_width - fw > -DUPLICATE_COMPARE_SIZE
-         && d->cur_final_height - fh < DUPLICATE_COMPARE_SIZE
-         && d->cur_final_height - fh > -DUPLICATE_COMPARE_SIZE)
-      {
-        d->allow_zoom = TRUE;
-      }
-      else
-      {
-        d->allow_zoom = FALSE;
-      }
+      d->allow_zoom
+          = (d->cur_final_width - fw < DUPLICATE_COMPARE_SIZE && d->cur_final_width - fw > -DUPLICATE_COMPARE_SIZE
+             && d->cur_final_height - fh < DUPLICATE_COMPARE_SIZE
+             && d->cur_final_height - fh > -DUPLICATE_COMPARE_SIZE);
       dt_control_queue_redraw_center();
     }
     else if(event->type == GDK_2BUTTON_PRESS)
@@ -231,7 +225,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
   if(d->allow_zoom)
   {
     dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
-    int closeup = dt_control_get_dev_closeup();
+    const int closeup = dt_control_get_dev_closeup();
     zoom_x = dt_control_get_dev_zoom_x();
     zoom_y = dt_control_get_dev_zoom_y();
     const float min_scale = dt_dev_get_zoom_scale(dev, DT_ZOOM_FIT, 1 << closeup, 0);
@@ -239,8 +233,8 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     nz = cur_scale / min_scale;
   }
 
-  float zx = zoom_x * nz * (float)(nimgw + 1.0f);
-  float zy = zoom_y * nz * (float)(nimgh + 1.0f);
+  const float zx = zoom_x * nz * (float)(nimgw + 1.0f);
+  const float zy = zoom_y * nz * (float)(nimgh + 1.0f);
 
   // we erase everything
   dt_gui_gtk_set_source_rgb(cri, DT_GUI_COLOR_DARKROOM_BG);
@@ -262,7 +256,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
   params.full_y = -zy + 1.0f;
 
 
-  int res = dt_view_image_expose(&params);
+  const int res = dt_view_image_expose(&params);
 
   if(res)
   {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -983,20 +983,19 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   const int imgsel = dt_control_get_mouse_over_id(); //  darktable.control->global_settings.lib_image_mouse_over_id;
 
   dt_view_image_over_t *image_over = vals->image_over;
-  uint32_t imgid = vals->imgid;
+  const uint32_t imgid = vals->imgid;
   cairo_t *cr = vals->cr;
-  int32_t width = vals->width;
-  int32_t height = vals->height;
-  int32_t zoom = vals->zoom;
-  int32_t px = vals->px;
-  int32_t py = vals->py;
-  gboolean full_preview = vals->full_preview;
-  gboolean image_only = vals->image_only;
-  gboolean no_deco = vals->no_deco;
-  if(image_only) no_deco = TRUE;
-  float full_zoom = vals->full_zoom;
-  float full_x = vals->full_x;
-  float full_y = vals->full_y;
+  const int32_t width = vals->width;
+  const int32_t height = vals->height;
+  const int32_t zoom = vals->zoom;
+  const int32_t px = vals->px;
+  const int32_t py = vals->py;
+  const gboolean full_preview = vals->full_preview;
+  const gboolean image_only = vals->image_only;
+  const gboolean no_deco = image_only ? TRUE : vals->no_deco;
+  const float full_zoom = vals->full_zoom;
+  const float full_x = vals->full_x;
+  const float full_y = vals->full_y;
 
   // active if zoom>1 or in the proper area
   const gboolean in_metadata_zone = (px < width && py < height / 2) || (zoom > 1);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -992,6 +992,8 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   int32_t py = vals->py;
   gboolean full_preview = vals->full_preview;
   gboolean image_only = vals->image_only;
+  gboolean no_deco = vals->no_deco;
+  if(image_only) no_deco = TRUE;
   float full_zoom = vals->full_zoom;
   float full_x = vals->full_x;
   float full_y = vals->full_y;
@@ -1000,13 +1002,13 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
   const gboolean in_metadata_zone = (px < width && py < height / 2) || (zoom > 1);
 
   const gboolean draw_thumb = TRUE;
-  const gboolean draw_colorlabels = !image_only && (darktable.gui->show_overlays || in_metadata_zone);
-  const gboolean draw_local_copy = !image_only && (darktable.gui->show_overlays || in_metadata_zone);
-  const gboolean draw_grouping = !image_only;
-  const gboolean draw_selected = !image_only;
-  const gboolean draw_history = !image_only;
-  const gboolean draw_metadata = !image_only && (darktable.gui->show_overlays || in_metadata_zone);
-  const gboolean draw_audio = !image_only;
+  const gboolean draw_colorlabels = !no_deco && (darktable.gui->show_overlays || in_metadata_zone);
+  const gboolean draw_local_copy = !no_deco && (darktable.gui->show_overlays || in_metadata_zone);
+  const gboolean draw_grouping = !no_deco;
+  const gboolean draw_selected = !no_deco;
+  const gboolean draw_history = !no_deco;
+  const gboolean draw_metadata = !no_deco && (darktable.gui->show_overlays || in_metadata_zone);
+  const gboolean draw_audio = !no_deco;
 
   cairo_save(cr);
   dt_gui_color_t bgcol = DT_GUI_COLOR_THUMBNAIL_BG;
@@ -1381,7 +1383,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
 
     if(!vals->full_rgbbuf || !*(vals->full_rgbbuf)) free(rgbbuf);
 
-    if (image_only)
+    if(no_deco)
     {
       cairo_restore(cr);
       cairo_save(cr);

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -166,6 +166,7 @@ typedef struct dt_view_image_expose_t
   int32_t py;
   gboolean full_preview;
   gboolean image_only;
+  gboolean no_deco;
   float full_zoom;
   float full_zoom100;
   float *full_w1;


### PR DESCRIPTION
this enhance the preview of duplicates on top of the currently edited image (when you keep left mouse button pressed on a duplicate thumbnail) :
- It now show the preview at same zoom/position. There's still a very small shift, thought, but I've no idea where it comes from... (I suspect some parameters in the mipmap compute)
- It now show a "working..." label, during the preview compute.

If image sizes are too different, it show the full image of the duplicate (zoom fit). The limit here is hardcoded to 40 pixels.