### PR TITLE
Culling prefetch & selection fixes

### DIFF
--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -414,16 +414,6 @@ static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_l
     gtk_widget_hide(d->zoom_entry);
     gtk_widget_show(d->display_num_images);
     gtk_widget_show(d->display_num_images_entry);
-
-    // if we have a selected image activate the filmstrip
-    GList *first_selected = dt_collection_get_selected(darktable.collection, 1);
-    if(first_selected)
-    {
-      const int imgid = GPOINTER_TO_INT(first_selected->data);
-      if(imgid >= 0 && dt_view_filmstrip_get_activated_imgid(darktable.view_manager) != imgid)
-        dt_view_filmstrip_set_active_image(darktable.view_manager, imgid);
-      g_list_free(first_selected);
-    }
   }
   else
   {
@@ -431,41 +421,6 @@ static void _lib_lighttable_change_layout(dt_lib_module_t *self, dt_lighttable_l
     gtk_widget_show(d->zoom_entry);
     gtk_widget_hide(d->display_num_images);
     gtk_widget_hide(d->display_num_images_entry);
-  }
-
-  // if changing from culling select all displayed images
-  if(current_layout == DT_LIGHTTABLE_LAYOUT_CULLING && current_layout != layout)
-  {
-    GList *first_selected = dt_collection_get_selected(darktable.collection, -1);
-    if(first_selected && g_list_length(first_selected) == 1)
-    {
-      const int sel_imgid = GPOINTER_TO_INT(first_selected->data);
-      GList *collected = dt_collection_get_all(darktable.collection, -1);
-      if(collected)
-      {
-        // search the selected image
-        GList *l = collected;
-        while(l)
-        {
-          const int id = GPOINTER_TO_INT(l->data);
-          if(sel_imgid == id) break;
-
-          l = g_list_next(l);
-        }
-        // now go to the last visible image
-        int i = 1;
-        while(l && i < d->current_display_num_images)
-        {
-          l = g_list_next(l);
-          i++;
-        }
-
-        if(l) dt_selection_select_range(darktable.selection, GPOINTER_TO_INT(l->data));
-      }
-
-      if(collected) g_list_free(collected);
-    }
-    if(first_selected) g_list_free(first_selected);
   }
 
   if(current_layout != layout)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2205,6 +2205,14 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
 
   for(int i = 0; i < lib->slots_count; i++)
   {
+    // set mouse over id
+    if(pointerx > lib->slots[i].x && pointerx < lib->slots[i].x + lib->slots[i].width && pointery > lib->slots[i].y
+       && pointery < lib->slots[i].y + lib->slots[i].height)
+    {
+      mouse_over_id = lib->slots[i].imgid;
+      dt_control_set_mouse_over_id(mouse_over_id);
+    }
+
     cairo_save(cr);
     // if(zoom == 1) dt_image_prefetch(image, DT_IMAGE_MIPF);
     cairo_translate(cr, lib->slots[i].x, lib->slots[i].y);
@@ -2250,14 +2258,6 @@ static int expose_expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t he
 
     missing += dt_view_image_expose(&params);
     cairo_restore(cr);
-
-    // set mouse over id
-    if(pointerx > lib->slots[i].x && pointerx < lib->slots[i].x + lib->slots[i].width && pointery > lib->slots[i].y
-       && pointery < lib->slots[i].y + lib->slots[i].height)
-    {
-      mouse_over_id = lib->slots[i].imgid;
-      dt_control_set_mouse_over_id(mouse_over_id);
-    }
   }
 
   // if needed, we prefetch the next and previous images

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2950,6 +2950,7 @@ static void _ensure_image_visibility(dt_view_t *self, uint32_t rowid)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
   if(get_layout() != DT_LIGHTTABLE_LAYOUT_FILEMANAGER) return;
+  if(lib->images_in_row == 0 || lib->visible_rows == 0) return;
 
   // if we are before the first visible image, we move back
   int offset = lib->offset;

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1827,10 +1827,11 @@ static gboolean _expose_recreate_slots(dt_view_t *self, const dt_lighttable_layo
     else
       rowid_txt = dt_util_dstrcat(NULL, "%d", 0);
 
-    query = dt_util_dstrcat(NULL,
-                            "SELECT m.imgid, b.aspect_ratio FROM memory.collected_images AS m, images AS b WHERE "
-                            "m.imgid = b.id AND m.rowid >= %s ORDER BY m.rowid LIMIT %d",
-                            rowid_txt, img_count);
+    query = dt_util_dstrcat(
+        NULL,
+        "SELECT m.imgid, b.aspect_ratio FROM (SELECT rowid, imgid FROM memory.collected_images WHERE rowid < %s + "
+        "%d ORDER BY rowid DESC LIMIT %d) AS m, images AS b WHERE m.imgid = b.id ORDER BY m.rowid",
+        rowid_txt, img_count, img_count);
     g_free(rowid_txt);
   }
 
@@ -2109,7 +2110,6 @@ static void _culling_prefetch(dt_view_t *self)
       if(mip < DT_MIPMAP_8)
         dt_mipmap_cache_get(darktable.mipmap_cache, NULL, lib->culling_previous.imgid, mip, DT_MIPMAP_PREFETCH,
                             'r');
-      printf("prefetch prev %d at %d\n", lib->culling_previous.imgid, mip);
     }
   }
 
@@ -2152,7 +2152,6 @@ static void _culling_prefetch(dt_view_t *self)
 
       if(mip < DT_MIPMAP_8)
         dt_mipmap_cache_get(darktable.mipmap_cache, NULL, lib->culling_next.imgid, mip, DT_MIPMAP_PREFETCH, 'r');
-      printf("prefetch next %d at %d\n", lib->culling_next.imgid, mip);
     }
   }
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -743,6 +743,9 @@ static void _sort_preview_surface(dt_library_t *lib, dt_layout_image_t *images, 
 
   const int in_memory_limit = MIN(max_in_memory_images, FULL_PREVIEW_IN_MEMORY_LIMIT);
 
+  // if nb of images > in_memory_limit, we shouldn't have surfaces created, so nothing to do
+  if(sel_img_count > in_memory_limit) return;
+
   for(int i = 0; i < sel_img_count; i++)
   {
     // we assume that there's only one cache per image

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1398,6 +1398,8 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
         cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1. / scale));
         if(zoom == 1)
         {
+          const dt_gui_color_t b_col
+              = (imgsel == imgid) ? DT_GUI_COLOR_THUMBNAIL_HOVER_OUTLINE : DT_GUI_COLOR_THUMBNAIL_BORDER;
           cairo_stroke(cr);
           cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
           float alpha = 1.0f;
@@ -1407,7 +1409,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
             cairo_new_sub_path(cr);
             cairo_rectangle(cr, rectx - k / scale, recty - k / scale, rectw + 2. * k / scale,
                             recth + 2. * k / scale);
-            cairo_set_source_rgba(cr, 0, 0, 0, alpha);
+            dt_gui_gtk_set_source_rgba(cr, b_col, alpha);
             alpha *= 0.6f;
             cairo_fill(cr);
           }


### PR DESCRIPTION
- fix prefetch which doesn't happen
- reuse previous/next image infos collected in prefetch for moving (less database call)
- ensure we always show the requested nb of image in collection end
- ensure the selection follow culling images when returning to filemanager and in filmstrip
- ensure the last culling images are visible when returning to filemanager