### PR TITLE
2479: fix file action on highlighted, not selected

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -59,6 +59,8 @@ void dt_view_manager_init(dt_view_manager_t *vm)
   /* prepare statements */
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images "
                               "WHERE imgid = ?1", -1, &vm->statements.is_selected, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images ",
+                              -1, &vm->statements.all_selected, NULL);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.selected_images WHERE imgid = ?1",
                               -1, &vm->statements.delete_from_selected, NULL);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -765,13 +767,9 @@ int32_t dt_view_get_image_to_act_on()
   else
   {
     /* clear and reset statement */
-    DT_DEBUG_SQLITE3_CLEAR_BINDINGS(darktable.view_manager->statements.is_selected);
-    DT_DEBUG_SQLITE3_RESET(darktable.view_manager->statements.is_selected);
+    DT_DEBUG_SQLITE3_RESET(darktable.view_manager->statements.all_selected);
 
-    /* setup statement and iterate over rows */
-    DT_DEBUG_SQLITE3_BIND_INT(darktable.view_manager->statements.is_selected, 1, mouse_over_id);
-
-    if(mouse_over_id <= 0 || sqlite3_step(darktable.view_manager->statements.is_selected) == SQLITE_ROW)
+    if(mouse_over_id <= 0 || sqlite3_step(darktable.view_manager->statements.all_selected) == SQLITE_ROW)
       return -1;
     else
       return mouse_over_id;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -224,6 +224,8 @@ typedef struct dt_view_manager_t
     sqlite3_stmt *have_history;
     /* select * from selected_images where imgid = ?1 */
     sqlite3_stmt *is_selected;
+    /* select * from selected_images */
+    sqlite3_stmt *all_selected;
     /* delete from selected_images where imgid = ?1 */
     sqlite3_stmt *delete_from_selected;
     /* insert into selected_images values (?1) */


### PR DESCRIPTION
The problem takes place when
some images are selected (lighttable view) and mouse hovers over
non-selected one.
If, say, delete key is pressed on keyboard, then hovered (not selected) image is processed (deleted).

In this case
`mouse_over_id > 0` and
`sqlite3_step(darktable.view_manager->statements.is_selected) != SQLITE_ROW`.
Hence, mouse_over_id is returned, and hovered image is processed
when `-1` should be returned for selected images to be processed.

New statement
`darktable.view_manager->statements.all_selected`
is prepared to check if any images are selected.
In new version if no images are selected, mouse_over_id is returned.
If at least one image is selected,
`sqlite3_step(darktable.view_manager->statements.all_selected) == SQLITE_ROW`
and therefore, `-1` is returned.