### PR TITLE
Piwigo: escape username and password strings to support usage of special characters

### DIFF
--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -446,8 +446,8 @@ static void _piwigo_authenticate(dt_storage_piwigo_gui_data_t *ui)
   if(!ui->api) ui->api = _piwigo_ctx_init();
 
   ui->api->server = g_strdup(gtk_entry_get_text(ui->server_entry));
-  ui->api->username = g_strdup(gtk_entry_get_text(ui->user_entry));
-  ui->api->password = g_strdup(gtk_entry_get_text(ui->pwd_entry));
+  ui->api->username = g_uri_escape_string(gtk_entry_get_text(ui->user_entry), NULL, FALSE);
+  ui->api->password = g_uri_escape_string(gtk_entry_get_text(ui->pwd_entry), NULL, FALSE);
 
   _piwigo_api_authenticate(ui->api);
 


### PR DESCRIPTION
Fixes https://github.com/darktable-org/darktable/issues/2564