### PR TITLE
UI css minor tweaks

### DIFF
--- a/data/themes/darktable-elegant.css
+++ b/data/themes/darktable-elegant.css
@@ -89,6 +89,14 @@ button
 
 }
 
+#recent-collection-button,
+#history-button
+{
+  /* Exception because history and recent collections modules make use of a
+   * list of GTK buttons but we don't want them to look like action buttons */
+    font-weight: normal;
+}
+
 #iop-panel-label,
 #lib-panel-label
 {
@@ -106,10 +114,10 @@ button
 
 #section_label
 {
-    font-weight: 500;
     font-family: "Roboto Medium", "Segoe UI Semibold",
                  "SF Pro Display Medium",
                  "Ubuntu Medium", "Cantarell", sans-serif;
+    font-weight: 600;
 }
 
 notebook tabs,

--- a/data/themes/darktable-icons.css
+++ b/data/themes/darktable-icons.css
@@ -24,6 +24,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-soften
@@ -32,6 +33,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-ashift
@@ -40,6 +42,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-atrous
@@ -48,6 +51,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-basecurve
@@ -56,6 +60,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-bilateral
@@ -64,6 +69,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-bloom
@@ -72,6 +78,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-borders
@@ -80,6 +87,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-cacorrect
@@ -88,6 +96,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-channelmixer
@@ -104,6 +113,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-clipping
@@ -112,6 +122,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colisa
@@ -120,6 +131,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colorcorrection
@@ -128,6 +140,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colorin
@@ -136,6 +149,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colormapping
@@ -144,6 +158,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colorout
@@ -152,6 +167,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colorreconstruct
@@ -160,6 +176,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colortransfer
@@ -168,6 +185,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colorzones
@@ -176,6 +194,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-demosaic
@@ -184,6 +203,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-dither
@@ -192,6 +212,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-exposure
@@ -200,6 +221,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-flip
@@ -208,6 +230,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-graduatednd
@@ -216,6 +239,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-grain
@@ -224,6 +248,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-hazeremoval
@@ -232,6 +257,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-highlights
@@ -240,6 +266,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-highpass
@@ -248,6 +275,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-hotpixels
@@ -256,6 +284,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-invert
@@ -264,6 +293,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-lens
@@ -272,6 +302,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-levels
@@ -280,6 +311,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-liquify
@@ -288,6 +320,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-lowlight
@@ -296,6 +329,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-lowpass
@@ -304,6 +338,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-monochrome
@@ -312,6 +347,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-nlmeans
@@ -320,6 +356,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-overexposed
@@ -328,6 +365,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-gamma
@@ -336,6 +374,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-rawdenoise
@@ -344,6 +383,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-rawimport
@@ -352,6 +392,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-rawprepare
@@ -360,6 +401,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-relight
@@ -368,6 +410,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-shadhi
@@ -376,6 +419,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-sharpen
@@ -384,6 +428,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-soften
@@ -392,6 +437,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-splittoning
@@ -400,6 +446,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-spots
@@ -408,6 +455,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-temperature
@@ -416,6 +464,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-template
@@ -424,6 +473,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-tonecurve
@@ -432,6 +482,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-tonemap
@@ -440,6 +491,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-velvia
@@ -448,6 +500,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-vignette
@@ -456,6 +509,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-watermark
@@ -464,6 +518,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-zonesystem
@@ -472,6 +527,7 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }
 
 #iop-panel-icon-colorize,
@@ -497,4 +553,5 @@
     background-size: contain;
     background-repeat: no-repeat;
     padding-left: 18px;
+    margin: 1px 0px;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -313,7 +313,7 @@ button
   border: 1px solid @button_border;
   background-color: @button_bg;
   color: @button_fg;
-  font-weight: 600;
+  font-weight: 400;
   font-family: sans-serif;
   min-height: 1em;
   min-width: 1em;
@@ -327,7 +327,7 @@ button
   background-color: transparent;
   border-color: transparent;
   border: 0;
-  font-weight: normal;
+  font-weight: 400;
 }
 
 button:selected,
@@ -521,7 +521,7 @@ entry selection
   padding: 0 0 3pt 0;
   color: @section_label;
   border-bottom: 0.5pt solid  @section_label;
-  font-weight: 600;
+  font-weight: 500;
   font-family: sans-serif;
 }
 
@@ -905,7 +905,7 @@ dialog
 dialog *
 {
   margin: 1pt;
-  padding:0;
+  padding: 0;
 }
 
 dialog headerbar


### PR DESCRIPTION
This PR is related to #2547 one as it make darktable theme more suitable on text fonts too bold with OS font, as proposed by @pmjdebruijn. darktable-elegant.css has been adjusted to avoid changing his design on dark and grey themes as it's related to darktable.css.

As suggested on pixl.us, I also modify icons module alignment to center them vertically, what seems more suitable. This is for darktable icons theme (both dark and grey).

I suggest to close #2547 as this one correct font weight as wanted by @pmjdebruijn and adjust as necessary css related to darktable.css and grey background had been discussed on his PR and was decided on UI rework PR.

See this capture screen for new icons alignment  :

![Capture-20190516221840-327x447](https://user-images.githubusercontent.com/45535283/57884325-a859e780-7828-11e9-84c1-0c285e8bdc4a.png)