### PR TITLE
[WIP] Correct live sample size on picker module

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -363,6 +363,7 @@ static void _add_sample(GtkButton *widget, gpointer self)
   gtk_box_pack_start(GTK_BOX(data->samples_container), sample->container, TRUE, TRUE, 0);
 
   sample->color_patch = gtk_drawing_area_new();
+  gtk_widget_set_size_request(sample->color_patch, DT_PIXEL_APPLY_DPI(40), -1);
   gtk_widget_set_events(sample->color_patch, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_BUTTON_PRESS_MASK);
   gtk_widget_set_tooltip_text(sample->color_patch, _("hover to highlight sample on canvas, "
                                                        "click to lock sample"));


### PR DESCRIPTION
This resolve issue #2524. I find what line break this by testing some commits. This issue was cause by this commit : https://github.com/darktable-org/darktable/commit/db27f068a4dc145c2edb0109e42456b34874aa5f

@TurboGit : as I don't know anything on GTK and as it revert one line on the last commit from you, could you please see if it's ok or if there a better way as you want remove these type of lines on the commit.

I've also test to put this line instead of revert the original line, to use CSS as other lines you made : `gtk_widget_set_name(GTK_WIDGET(sample->color_patch), "live-sample-picker");`
But it seems not possible to use css for this widget. My line seems correct as when launching darktable after with GTK inspector, I find this css tag. I've use margin, padding and min-width on CSS, the live sample remains small strips.

Maybe It's possible on another way but as this line correct this issue, maybe we could just revert it back to have correct live sample. 