### PR TITLE
don't reset mouse_over_id

### DIFF
--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -727,7 +727,6 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
 
   if(darktable.gui->center_tooltip == 1) darktable.gui->center_tooltip++;
 
-  int mouse_over_id = -1;
   strip->image_over = DT_VIEW_DESERT;
 
   /* fill background */
@@ -798,6 +797,7 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
   cairo_translate(cr, empty_edge, 0.0f);
   const int before_last_exposed_id = strip->last_exposed_id;
   const int initial_mouse_over_id = strip->mouse_over_id;
+  int mouse_over_id = -1;
   int missing = 0;
 
   for(int col = 0; col < max_cols; col++)
@@ -840,7 +840,7 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
         dt_view_image_expose_t params = { 0 };
         params.image_over = &(strip->image_over);
         params.imgid = id;
-        params.mouse_over = (id == strip->mouse_over_id);
+        params.mouse_over = (id == mouse_over_id);
         params.cr = cr;
         params.width = wd;
         params.height = ht;

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -800,11 +800,6 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
   const int initial_mouse_over_id = strip->mouse_over_id;
   int missing = 0;
 
-  // invalidate mouse_over_id to ensure the exposed image won't get the over background until set below
-  // when we reach seli.
-
-  dt_control_set_mouse_over_id(-1);
-
   for(int col = 0; col < max_cols; col++)
   {
     if(col < col_start)
@@ -845,6 +840,7 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
         dt_view_image_expose_t params = { 0 };
         params.image_over = &(strip->image_over);
         params.imgid = id;
+        params.mouse_over = (id == strip->mouse_over_id);
         params.cr = cr;
         params.width = wd;
         params.height = ht;
@@ -874,10 +870,6 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
 failure:
   cairo_restore(cr);
   sqlite3_finalize(stmt);
-
-  // don't reset the global mouse_over_id when the cursor isn't even over the filmstrip
-  if(pointerx >= 0 && pointery >= 0)
-    dt_control_set_mouse_over_id(mouse_over_id);
 
   if(darktable.gui->center_tooltip == 1) // set in this round
   {

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1268,6 +1268,7 @@ end_query_cache:
           dt_view_image_expose_t params = { 0 };
           params.image_over = &(lib->image_over);
           params.imgid = id;
+          params.mouse_over = (id == mouse_over_id);
           params.cr = cr;
           params.width = wd;
           params.height = iir == 1 ? height : ht;
@@ -1776,6 +1777,7 @@ static int expose_zoomable(dt_view_t *self, cairo_t *cr, int32_t width, int32_t 
           dt_view_image_expose_t params = { 0 };
           params.image_over = &(lib->image_over);
           params.imgid = id;
+          params.mouse_over = (id == mouse_over_id);
           params.cr = cr;
           params.width = wd;
           params.height = zoom == 1 ? height : ht;
@@ -2315,12 +2317,6 @@ static void _culling_prefetch(dt_view_t *self)
   }
 }
 
-static gboolean _culling_redefine_mouseoverid(gpointer data)
-{
-  dt_control_set_mouse_over_id(GPOINTER_TO_INT(data));
-  return FALSE;
-}
-
 static int expose_culling(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t pointerx,
                           int32_t pointery, const dt_lighttable_layout_t layout)
 {
@@ -2347,7 +2343,7 @@ static int expose_culling(dt_view_t *self, cairo_t *cr, int32_t width, int32_t h
   }
 
   const int max_in_memory_images = _get_max_in_memory_images();
-  int32_t mouse_over_id = dt_control_get_mouse_over_id();
+  int mouse_over_id = -1;
 
   for(int i = 0; i < lib->slots_count; i++)
   {
@@ -2372,6 +2368,7 @@ static int expose_culling(dt_view_t *self, cairo_t *cr, int32_t width, int32_t h
     dt_view_image_expose_t params = { 0 };
     params.image_over = &(lib->image_over);
     params.imgid = lib->slots[i].imgid;
+    params.mouse_over = (mouse_over_id == lib->slots[i].imgid);
     params.cr = cr;
     params.width = lib->slots[i].width;
     params.height = lib->slots[i].height;
@@ -2409,9 +2406,6 @@ static int expose_culling(dt_view_t *self, cairo_t *cr, int32_t width, int32_t h
   // if needed, we prefetch the next and previous images
   // note that we only guess their sizes so they may be computed anyway
   if(prefetch) _culling_prefetch(self);
-
-  // filmstrip reset mouse_over_id, so let's redefine it in a moment
-  g_timeout_add(200, _culling_redefine_mouseoverid, GINT_TO_POINTER(mouse_over_id));
 
   if(darktable.unmuted & DT_DEBUG_CACHE) dt_mipmap_cache_print(darktable.mipmap_cache);
   return missing;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -172,6 +172,7 @@ typedef struct dt_view_image_expose_t
   gboolean full_preview;
   gboolean image_only;
   gboolean no_deco;
+  gboolean mouse_over;
   float full_zoom;
   float full_zoom100;
   float *full_w1;


### PR DESCRIPTION
currently, to ensure correct drawing in `dt_view_image_expose`, filmstrip (and culling in rare cases) reset the global `mouse_over_id` value, and set it again during the draw loop if the mouse is over a thumb. This is bad, as it will reset the value if the mouse is not here (example if the mouse is inside culling area and filmstrip is redrawn).
This is a better fix for issue #2558 , it solves some mouse_over jump and false highlight in culling too.