### PR TITLE
Fix build with exiv2 >= 0.27

### DIFF
--- a/tools/basecurve/exif-wrapper.cpp
+++ b/tools/basecurve/exif-wrapper.cpp
@@ -17,6 +17,7 @@
 */
 
 #include <exiv2/exif.hpp>
+#include <exiv2/error.hpp>
 #include <exiv2/image.hpp>
 
 #include <cstdio>


### PR DESCRIPTION
this is proposal to fix the following build error using latest version of exiv2 (0.27.1):

```
$ make
Scanning dependencies of target darktable-curve-tool
[ 33%] Building CXX object CMakeFiles/darktable-curve-tool.dir/exif-wrapper.o
/darktable/tools/basecurve/exif-wrapper.cpp: In function ‘int exif_get_ascii_datafield(const char*, const char*, char*, size_t)’:
/darktable/tools/basecurve/exif-wrapper.cpp:63:17: error: ‘Error’ in namespace ‘Exiv2’ does not name a type
   catch (Exiv2::Error& e)
                 ^~~~~
make[2]: *** [CMakeFiles/darktable-curve-tool.dir/build.make:76: CMakeFiles/darktable-curve-tool.dir/exif-wrapper.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/darktable-curve-tool.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

```