### PR TITLE
darkroom : add dynamic accels

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -674,7 +674,7 @@ int dt_control_key_pressed_override(guint key, guint state)
   darktable.view_manager->current_view->dynamic_accel_current = dt_dynamic_accel_find_by_key(key, state);
   if(darktable.view_manager->current_view->dynamic_accel_current)
   {
-    gchar **vals = g_strsplit_set(darktable.view_manager->current_view->dynamic_accel_current->path, "/", -1);
+    gchar **vals = g_strsplit_set(darktable.view_manager->current_view->dynamic_accel_current->translated_path, "/", -1);
     if(vals[0] && vals[1] && vals[2] && vals[3])
     {
       gchar *txt = dt_util_dstrcat(NULL, "scroll to change <b>%s</b> of %s module", vals[3], vals[2]);

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -180,6 +180,11 @@ void dt_control_cleanup(dt_control_t *s)
   {
     g_slist_free_full(s->accelerator_list, g_free);
   }
+  if(s->dynamic_accelerator_list)
+  {
+    g_slist_free(s->dynamic_accelerator_valid);
+    g_slist_free_full(s->dynamic_accelerator_list, g_free);
+  }
 }
 
 

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -675,13 +675,13 @@ int dt_control_key_pressed_override(guint key, guint state)
   if(darktable.view_manager->current_view->dynamic_accel_current)
   {
     gchar **vals = g_strsplit_set(darktable.view_manager->current_view->dynamic_accel_current->path, "/", -1);
-    gchar *txt = "";
     if(vals[0] && vals[1] && vals[2] && vals[3])
     {
-      txt = dt_util_dstrcat(NULL, "scroll to change <b>%s</b> of %s module", vals[3], vals[2]);
+      gchar *txt = dt_util_dstrcat(NULL, "scroll to change <b>%s</b> of %s module", vals[3], vals[2]);
+      dt_control_hinter_message(darktable.control, txt);
+      g_free(txt);
     }
-    dt_control_hinter_message(darktable.control, txt);
-    g_free(txt);
+    else dt_control_hinter_message(darktable.control, "");
     g_strfreev(vals);
     return 1;
   }

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -128,6 +128,8 @@ typedef struct dt_control_t
 
   // Accelerator group path lists
   GSList *accelerator_list;
+  GSList *dynamic_accelerator_list;
+  GSList *dynamic_accelerator_valid;
 
   // Cached accelerator keys for key_pressed shortcuts
   dt_control_accels_t accels;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -1024,6 +1024,7 @@ static gint _dynamic_accel_find(gconstpointer a, gconstpointer b)
   // not the right one
   return 1;
 }
+
 dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierType mods)
 {
   GtkAccelKey ak = { 0 };
@@ -1033,10 +1034,15 @@ dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierTyp
   if(da && da->data) return (dt_accel_dynamic_t *)da->data;
   return NULL;
 }
+
 void dt_dynamic_accel_get_valid_list()
 {
-  // remove all elements from the valid list (no need to free them, as they are in the norml list anyway
-  g_slist_free(darktable.control->dynamic_accelerator_valid);
+  // remove all elements from the valid list (no need to free them, as they are in the norml list anyway)
+  if (darktable.control->dynamic_accelerator_valid)
+  {
+    g_slist_free(darktable.control->dynamic_accelerator_valid);
+    darktable.control->dynamic_accelerator_valid = NULL;
+  }
 
   GSList *l = darktable.control->dynamic_accelerator_list;
   while(l)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -57,6 +57,8 @@ void dt_accel_paths_slider_iop(char *s[], size_t n, char *module, const char *pa
            NC_("accel", "reset"));
   snprintf(s[3], n, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), module, path,
            NC_("accel", "edit"));
+  snprintf(s[4], n, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), module, path,
+           NC_("accel", "dynamic"));
 }
 
 void dt_accel_path_lua(char *s, size_t n, const char *path)
@@ -98,6 +100,8 @@ static void dt_accel_paths_slider_iop_translated(char *s[], size_t n, dt_iop_mod
            g_dpgettext2(NULL, "accel", path), C_("accel", "reset"));
   snprintf(s[3], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
            g_dpgettext2(NULL, "accel", path), C_("accel", "edit"));
+  snprintf(s[4], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
+           g_dpgettext2(NULL, "accel", path), C_("accel", "dynamic"));
 }
 
 static void dt_accel_path_lua_translated(char *s, size_t n, const char *path)
@@ -179,13 +183,16 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
   gchar decrease_path[256];
   gchar reset_path[256];
   gchar edit_path[256];
+  gchar dynamic_path[256];
   gchar increase_path_trans[256];
   gchar decrease_path_trans[256];
   gchar reset_path_trans[256];
   gchar edit_path_trans[256];
+  gchar dynamic_path_trans[256];
 
-  char *paths[] = { increase_path, decrease_path, reset_path, edit_path };
-  char *paths_trans[] = { increase_path_trans, decrease_path_trans, reset_path_trans, edit_path_trans };
+  char *paths[] = { increase_path, decrease_path, reset_path, edit_path, dynamic_path };
+  char *paths_trans[]
+      = { increase_path_trans, decrease_path_trans, reset_path_trans, edit_path_trans, dynamic_path_trans };
 
   int i = 0;
   dt_accel_t *accel = NULL;
@@ -193,7 +200,7 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
   dt_accel_paths_slider_iop(paths, 256, so->op, path);
   dt_accel_paths_slider_iop_translated(paths_trans, 256, so, path);
 
-  for(i = 0; i < 4; i++)
+  for(i = 0; i < 5; i++)
   {
     gtk_accel_map_add_entry(paths[i], 0, 0);
     accel = (dt_accel_t *)g_malloc(sizeof(dt_accel_t));
@@ -205,6 +212,17 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
 
     darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
   }
+
+  // dynamic accel
+  dt_accel_dynamic_t *daccel = (dt_accel_dynamic_t *)g_malloc0(sizeof(dt_accel_dynamic_t));
+
+  g_strlcpy(daccel->path, paths[4], sizeof(daccel->path));
+  g_strlcpy(daccel->translated_path, paths_trans[4], sizeof(daccel->translated_path));
+  g_strlcpy(daccel->module, so->op, sizeof(daccel->module));
+  daccel->local = local;
+
+  darktable.control->dynamic_accelerator_list
+      = g_slist_prepend(darktable.control->dynamic_accelerator_list, daccel);
 }
 
 void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType mods)
@@ -419,9 +437,10 @@ void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, Gtk
   gchar decrease_path[256];
   gchar reset_path[256];
   gchar edit_path[256];
+  gchar dynamic_path[256];
   dt_accel_t *accel = NULL;
   GClosure *closure;
-  char *paths[] = { increase_path, decrease_path, reset_path, edit_path };
+  char *paths[] = { increase_path, decrease_path, reset_path, edit_path, dynamic_path };
   dt_accel_paths_slider_iop(paths, 256, module->op, path);
 
   assert(DT_IS_BAUHAUS_WIDGET(slider));
@@ -488,6 +507,19 @@ void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, Gtk
   {
     gtk_accel_group_connect_by_path(darktable.control->accelerators, edit_path, closure);
     module->accel_closures = g_slist_prepend(module->accel_closures, accel);
+  }
+
+  // dynamic accel : no closure, as we'll use key_press/release/scroll
+  GSList *l = darktable.control->dynamic_accelerator_list;
+  while(l)
+  {
+    dt_accel_dynamic_t *da = (dt_accel_dynamic_t *)l->data;
+    if(da && !strcmp(da->path, dynamic_path))
+    {
+      da->widget = slider;
+      break;
+    }
+    l = g_slist_next(l);
   }
 }
 
@@ -770,6 +802,23 @@ void dt_accel_deregister_iop(dt_iop_module_t *module, const gchar *path)
       l = g_slist_next(l);
     }
   }
+  l = darktable.control->dynamic_accelerator_list;
+  while(l)
+  {
+    dt_accel_t *accel = (dt_accel_t *)l->data;
+    if(accel && !strncmp(accel->path, build_path, 1024))
+    {
+      darktable.control->dynamic_accelerator_list
+          = g_slist_delete_link(darktable.control->dynamic_accelerator_list, l);
+      l = NULL;
+      g_free(accel);
+    }
+    else
+    {
+      l = g_slist_next(l);
+    }
+  }
+  dt_dynamic_accel_get_valid_list();
 }
 
 void dt_accel_deregister_lib(dt_lib_module_t *module, const gchar *path)
@@ -964,6 +1013,51 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_path)
     {
       l = g_slist_next(l);
     }
+  }
+}
+
+static gint _dynamic_accel_find(gconstpointer a, gconstpointer b)
+{
+  dt_accel_dynamic_t *da = (dt_accel_dynamic_t *)a;
+  GtkAccelKey *ak = (GtkAccelKey *)b;
+  if(da->accel_key.accel_key == ak->accel_key && da->accel_key.accel_mods == ak->accel_mods) return 0;
+  // not the right one
+  return 1;
+}
+dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierType mods)
+{
+  GtkAccelKey ak = { 0 };
+  ak.accel_key = accel_key;
+  ak.accel_mods = mods;
+  GSList *da = g_slist_find_custom(darktable.control->dynamic_accelerator_valid, &ak, _dynamic_accel_find);
+  if(da && da->data) return (dt_accel_dynamic_t *)da->data;
+  return NULL;
+}
+void dt_dynamic_accel_get_valid_list()
+{
+  // remove all elements from the valid list (no need to free them, as they are in the norml list anyway
+  g_slist_free(darktable.control->dynamic_accelerator_valid);
+
+  GSList *l = darktable.control->dynamic_accelerator_list;
+  while(l)
+  {
+    dt_accel_dynamic_t *da = (dt_accel_dynamic_t *)l->data;
+    if(da)
+    {
+      GtkAccelKey ak;
+      if(gtk_accel_map_lookup_entry(da->path, &ak))
+      {
+        if(ak.accel_key > 0)
+        {
+          da->accel_key.accel_key = ak.accel_key;
+          da->accel_key.accel_mods = ak.accel_mods;
+          da->accel_key.accel_flags = ak.accel_flags;
+          darktable.control->dynamic_accelerator_valid
+              = g_slist_append(darktable.control->dynamic_accelerator_valid, da);
+        }
+      }
+    }
+    l = g_slist_next(l);
   }
 }
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -35,6 +35,18 @@ typedef struct dt_accel_t
 
 } dt_accel_t;
 
+typedef struct dt_accel_dynamic_t
+{
+
+  gchar path[256];
+  gchar translated_path[256];
+  gchar module[256];
+  gboolean local;
+  GtkAccelKey accel_key;
+  GtkWidget *widget;
+
+} dt_accel_dynamic_t;
+
 // Accel path string building functions
 void dt_accel_path_global(char *s, size_t n, const char *path);
 void dt_accel_path_view(char *s, size_t n, char *module, const char *path);
@@ -42,13 +54,16 @@ void dt_accel_path_iop(char *s, size_t n, char *module, const char *path);
 void dt_accel_path_lib(char *s, size_t n, char *module, const char *path);
 void dt_accel_path_lua(char *s, size_t n, const char *path);
 /**
-  * Accepts an array of 4 char*, writes the following paths to them
-  * 0 - Slider increase path
-  * 1 - Slider decrease path
-  * 2 - Slider reset path
-  * 3 - Slider edit path
-  */
+ * Accepts an array of 5 char*, writes the following paths to them
+ * 0 - Slider increase path
+ * 1 - Slider decrease path
+ * 2 - Slider reset path
+ * 3 - Slider edit path
+ * 4 - Slider dynamic path
+ */
 void dt_accel_paths_slider_iop(char *s[], size_t n, char *module, const char *path);
+dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierType mods);
+void dt_dynamic_accel_get_valid_list();
 
 // Accelerator registration functions
 void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierType mods);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1066,6 +1066,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   darktable.control->accelerators = gtk_accel_group_new();
 
   darktable.control->accelerator_list = NULL;
+  darktable.control->dynamic_accelerator_list = NULL;
 
   // Connecting the callback to update keyboard accels for key_pressed
   g_signal_connect(G_OBJECT(gtk_accel_map_get()), "changed", G_CALLBACK(key_accel_changed), NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2837,6 +2837,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   // dynamic accels
   if(self->dynamic_accel_current && self->dynamic_accel_current->widget)
   {
+    gtk_widget_grab_focus(self->dynamic_accel_current->widget);
     float value = dt_bauhaus_slider_get(self->dynamic_accel_current->widget);
     float step = dt_bauhaus_slider_get_step(self->dynamic_accel_current->widget);
 
@@ -2953,10 +2954,6 @@ int key_released(dt_view_t *self, guint key, guint state)
 {
   const dt_control_accels_t *accels = &darktable.control->accels;
   dt_develop_t *lib = (dt_develop_t *)self->data;
-
-  // be sure to reset dynamic accel
-  if(self->dynamic_accel_current) dt_control_hinter_message(darktable.control, "");
-  self->dynamic_accel_current = NULL;
 
   if(!darktable.control->key_accelerators_on)
     return 0;
@@ -3080,22 +3077,6 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     dt_dev_invalidate(dev);
     dt_control_queue_redraw();
 
-    return 1;
-  }
-
-  // search if it's a dynamic accel
-  self->dynamic_accel_current = dt_dynamic_accel_find_by_key(key, state);
-  if(self->dynamic_accel_current)
-  {
-    gchar **vals = g_strsplit_set(self->dynamic_accel_current->path, "/", -1);
-    gchar *txt = "";
-    if(vals[0] && vals[1] && vals[2] && vals[3])
-    {
-      txt = dt_util_dstrcat(NULL, "scroll to change <b>%s</b> of %s module", vals[3], vals[2]);
-    }
-    dt_control_hinter_message(darktable.control, txt);
-    g_free(txt);
-    g_strfreev(vals);
     return 1;
   }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1621,6 +1621,9 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_no_show_all(display_intent, TRUE);
     gtk_widget_set_visible(display_intent, FALSE);
   }
+
+  // reconstruct dynamic accels list
+  dt_dynamic_accel_get_valid_list();
 }
 
 static void _update_display_profile_cmb(GtkWidget *cmb_display_profile)
@@ -2831,6 +2834,19 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   if(height_i > capht) y += (capht - height_i) * .5f;
 
   int handled = 0;
+  // dynamic accels
+  if(self->dynamic_accel_current && self->dynamic_accel_current->widget)
+  {
+    float value = dt_bauhaus_slider_get(self->dynamic_accel_current->widget);
+    float step = dt_bauhaus_slider_get_step(self->dynamic_accel_current->widget);
+
+    if(up)
+      dt_bauhaus_slider_set(self->dynamic_accel_current->widget, value + step);
+    else
+      dt_bauhaus_slider_set(self->dynamic_accel_current->widget, value - step);
+    g_signal_emit_by_name(G_OBJECT(self->dynamic_accel_current->widget), "value-changed");
+    return;
+  }
   // masks
   if(dev->form_visible) handled = dt_masks_events_mouse_scrolled(dev->gui_module, x, y, up, state);
   if(handled) return;
@@ -2937,6 +2953,10 @@ int key_released(dt_view_t *self, guint key, guint state)
 {
   const dt_control_accels_t *accels = &darktable.control->accels;
   dt_develop_t *lib = (dt_develop_t *)self->data;
+
+  // be sure to reset dynamic accel
+  if(self->dynamic_accel_current) dt_control_hinter_message(darktable.control, "");
+  self->dynamic_accel_current = NULL;
 
   if(!darktable.control->key_accelerators_on)
     return 0;
@@ -3060,6 +3080,22 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     dt_dev_invalidate(dev);
     dt_control_queue_redraw();
 
+    return 1;
+  }
+
+  // search if it's a dynamic accel
+  self->dynamic_accel_current = dt_dynamic_accel_find_by_key(key, state);
+  if(self->dynamic_accel_current)
+  {
+    gchar **vals = g_strsplit_set(self->dynamic_accel_current->path, "/", -1);
+    gchar *txt = "";
+    if(vals[0] && vals[1] && vals[2] && vals[3])
+    {
+      txt = dt_util_dstrcat(NULL, "scroll to change <b>%s</b> of %s module", vals[3], vals[2]);
+    }
+    dt_control_hinter_message(darktable.control, txt);
+    g_free(txt);
+    g_strfreev(vals);
     return 1;
   }
 
@@ -3226,6 +3262,9 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "undo", closure);
   closure = g_cclosure_new(G_CALLBACK(_darkroom_redo_callback), (gpointer)self, NULL);
   dt_accel_connect_view(self, "redo", closure);
+
+  // dynamics accels
+  dt_dynamic_accel_get_valid_list();
 }
 
 //-----------------------------------------------------------

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -134,6 +134,7 @@ typedef struct dt_view_t
   void (*connect_key_accels)(struct dt_view_t *self);
 
   GSList *accel_closures;
+  struct dt_accel_dynamic_t *dynamic_accel_current;
 } dt_view_t;
 
 typedef enum dt_view_image_over_t


### PR DESCRIPTION
For all iop sliders which can have accels, you can now set a "dynamic" accel.

More than complex explanation, here is an example how this works : 
- you set "E" key to image operation/exposure/exposure/dynamic
- enter darkroom with an image
- you can now set the exposure value, with mouse scroll AND key "E" pressed

Current dynamic accel if any are written in the hinter message box