### PR TITLE
Lua : return image displayed in darkroom

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -1015,7 +1015,7 @@
 <variablelist>
 <varlistentry id="darktable_gui_views_darkroom_display_image_image"><term>[image]</term><listitem>
 <synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
-<para>The image to be displayed. If the image is not givven, nothing will be changed.</para>
+<para>The image to be displayed. If the image is not given, nothing will be changed.</para>
 
 </listitem></varlistentry>
 

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -1008,14 +1008,20 @@
 <secondary>display_image</secondary>
 </indexterm>
 <synopsis>function( 
-	<emphasis><link linkend="darktable_gui_views_darkroom_display_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>
-)</synopsis>
+	[<emphasis><link linkend="darktable_gui_views_darkroom_display_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>]
+) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
 <para>Display an image in darkroom view.</para>
 
 <variablelist>
-<varlistentry id="darktable_gui_views_darkroom_display_image_image"><term>image</term><listitem>
+<varlistentry id="darktable_gui_views_darkroom_display_image_image"><term>[image]</term><listitem>
 <synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
-<para>The image to be displayed.</para>
+<para>The image to be displayed. If the image is not givven, nothing will be changed.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>The image currently displayed.</para>
 
 </listitem></varlistentry>
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -119,9 +119,11 @@ static int display_image_cb(lua_State *L)
   }
   else
   {
-    return luaL_error(L, "error: dt_lua_image_t expected\n");
+    // ensure the image infos in db is up to date
+    dt_dev_write_history(dev);
   }
-  return 0;
+  luaA_push(L, dt_lua_image_t, &dev->image_storage.id);
+  return 1;
 }
 
 #endif


### PR DESCRIPTION
extend the actual `darktable.gui.views.darkroom.display_image()` function to 
- return the actual image displayed in darkroom
- accept no argument in enter (if we don't want to change the image)

This allow to apply some Lua scripts to the current darkroom image (special export, ...)

Although it seems to work here, please review carefully : it's the very first time I touch this area of code