### PR TITLE
themes : change bauhaus themes on the fly too

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -472,14 +472,8 @@ static void dt_bh_class_init(DtBauhausWidgetClass *class)
   // widget_class->draw = dt_bauhaus_draw;
 }
 
-void dt_bauhaus_init()
+void dt_bauhaus_load_theme()
 {
-  darktable.bauhaus = (dt_bauhaus_t *)calloc(1, sizeof(dt_bauhaus_t));
-  darktable.bauhaus->keys_cnt = 0;
-  darktable.bauhaus->current = NULL;
-  darktable.bauhaus->popup_area = gtk_drawing_area_new();
-  gtk_widget_set_name(darktable.bauhaus->popup_area, "bauhaus-popup");
-
   darktable.bauhaus->line_space = 1.5;
   darktable.bauhaus->line_height = 10;
   darktable.bauhaus->marker_size = 0.25f;
@@ -536,6 +530,17 @@ void dt_bauhaus_init()
   darktable.bauhaus->baseline_size = darktable.bauhaus->line_height / 2.0f; // absolute size in Cairo unit
   darktable.bauhaus->border_width = 3.0f; // absolute size in Cairo unit
   darktable.bauhaus->marker_size = (darktable.bauhaus->baseline_size + darktable.bauhaus->border_width) * 0.75f;
+}
+
+void dt_bauhaus_init()
+{
+  darktable.bauhaus = (dt_bauhaus_t *)calloc(1, sizeof(dt_bauhaus_t));
+  darktable.bauhaus->keys_cnt = 0;
+  darktable.bauhaus->current = NULL;
+  darktable.bauhaus->popup_area = gtk_drawing_area_new();
+  gtk_widget_set_name(darktable.bauhaus->popup_area, "bauhaus-popup");
+
+  dt_bauhaus_load_theme();
 
   // keys are freed with g_free, values are ptrs to the widgets, these don't need to be cleaned up.
   darktable.bauhaus->keymap = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -231,6 +231,9 @@ typedef struct dt_bauhaus_t
 void dt_bauhaus_init();
 void dt_bauhaus_cleanup();
 
+// load theme colors, fonts, etc
+void dt_bauhaus_load_theme();
+
 // common functions:
 // set the label text:
 void dt_bauhaus_widget_set_label(GtkWidget *w, const char *section, const char *label);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -178,6 +178,7 @@ static void theme_callback(GtkWidget *widget, gpointer user_data)
   gchar *i = g_strrstr(theme, ".");
   if(i) *i = '\0';
   dt_gui_load_theme(theme);
+  dt_bauhaus_load_theme();
 }
 
 ///////////// gui language selection


### PR DESCRIPTION
no need to restart dt anymore to see the effect of a theme change on bauhaus controls, especially colors and fonts.
For widgets sizes (margins, ...) this don't works (as before, and as for the other "classic" widgets)
