### PR TITLE
rgb curve - added preserve colors norms

### DIFF
--- a/data/kernels/rgbcurve.cl
+++ b/data/kernels/rgbcurve.cl
@@ -63,11 +63,15 @@ rgbcurve(read_only image2d_t in, write_only image2d_t out, const int width, cons
       {
         lum = (pixel.x + pixel.y + pixel.z) / 3.0f;
       }
-      else if (preserve_colors == 4) // DT_RGBCURVE_PRESERVE_LNORM
+      else if (preserve_colors == 4) // DT_RGBCURVE_PRESERVE_LSUM
+      {
+        lum = pixel.x + pixel.y + pixel.z;
+      }
+      else if (preserve_colors == 5) // DT_RGBCURVE_PRESERVE_LNORM
       {
         lum = native_powr(pixel.x * pixel.x + pixel.y * pixel.y + pixel.z * pixel.z, 0.5f);
       }
-      else if (preserve_colors == 5) // DT_RGBCURVE_PRESERVE_LBP
+      else if (preserve_colors == 6) // DT_RGBCURVE_PRESERVE_LBP
       {
         float R, G, B;
         R = pixel.x * pixel.x;

--- a/data/kernels/rgbcurve.cl
+++ b/data/kernels/rgbcurve.cl
@@ -41,19 +41,7 @@ rgbcurve(read_only image2d_t in, write_only image2d_t out, const int width, cons
   }
   else if(autoscale == 0) // DT_S_SCALE_AUTOMATIC_RGB
   {
-    if(preserve_colors == 1) // DT_RGBCURVE_PRESERVE_LUMINANCE
-    {
-      float ratio = 1.f;
-      const float lum = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, lut);
-      if(lum > 0.f)
-      {
-        const float curve_lum = lookup_unbounded(table_r, lum, coeffs_r);
-        ratio = curve_lum / lum;
-      }
-
-      pixel.xyz *= ratio;
-    }
-    else if (preserve_colors == 0) // DT_RGBCURVE_PRESERVE_NONE
+    if (preserve_colors == 0) // DT_RGBCURVE_PRESERVE_NONE
     {
       pixel.x = lookup_unbounded(table_r, pixel.x, coeffs_r);
       pixel.y = lookup_unbounded(table_r, pixel.y, coeffs_r);
@@ -63,6 +51,10 @@ rgbcurve(read_only image2d_t in, write_only image2d_t out, const int width, cons
     {
       float ratio = 1.f;
       float lum = 0.0f;
+      if(preserve_colors == 1) // DT_RGBCURVE_PRESERVE_LUMINANCE
+      {
+        lum = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, lut);
+      }
       if (preserve_colors == 2) // DT_RGBCURVE_PRESERVE_LMAX
       {
         lum = max(pixel.x, max(pixel.y, pixel.z));

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -52,8 +52,9 @@ typedef enum dt_iop_rgbcurve_preservecolors_t
   DT_RGBCURVE_PRESERVE_LUMINANCE = 1,
   DT_RGBCURVE_PRESERVE_LMAX = 2,
   DT_RGBCURVE_PRESERVE_LAVG = 3,
-  DT_RGBCURVE_PRESERVE_LNORM = 4,
-  DT_RGBCURVE_PRESERVE_LBP = 5,
+  DT_RGBCURVE_PRESERVE_LSUM = 4,
+  DT_RGBCURVE_PRESERVE_LNORM = 5,
+  DT_RGBCURVE_PRESERVE_LBP = 6,
 } dt_iop_rgbcurve_preservecolors_t;
 
 typedef enum rgbcurve_channel_t
@@ -1595,6 +1596,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("luminance"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("max rgb"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("average rgb"));
+  dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("sum rgb"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("norm rgb"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("basic power"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->cmb_preserve_colors, TRUE, TRUE, 0);
@@ -1999,6 +2001,10 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
           else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LAVG)
           {
             lum = (in[0] + in[1] + in[2]) / 3.0f;
+          }
+          else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LSUM)
+          {
+            lum = in[0] + in[1] + in[2];
           }
           else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LNORM)
           {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -49,7 +49,11 @@ typedef enum dt_iop_rgbcurve_pickcolor_type_t
 typedef enum dt_iop_rgbcurve_preservecolors_t
 {
   DT_RGBCURVE_PRESERVE_NONE = 0,
-  DT_RGBCURVE_PRESERVE_LUMINANCE = 1
+  DT_RGBCURVE_PRESERVE_LUMINANCE = 1,
+  DT_RGBCURVE_PRESERVE_LMAX = 2,
+  DT_RGBCURVE_PRESERVE_LAVG = 3,
+  DT_RGBCURVE_PRESERVE_LNORM = 4,
+  DT_RGBCURVE_PRESERVE_LBP = 5,
 } dt_iop_rgbcurve_preservecolors_t;
 
 typedef enum rgbcurve_channel_t
@@ -1589,6 +1593,10 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->cmb_preserve_colors, NULL, _("preserve colors"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("none"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("luminance"));
+  dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("max rgb"));
+  dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("average rgb"));
+  dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("norm rgb"));
+  dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("basic power"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->cmb_preserve_colors, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->cmb_preserve_colors, _("method to preserve colors when applying contrast"));
   g_signal_connect(G_OBJECT(g->cmb_preserve_colors), "value-changed", G_CALLBACK(preserve_colors_callback), self);
@@ -1986,7 +1994,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
             out[c] = (ratio * in[c]);
           }
         }
-        else
+        else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_NONE)
         {
           for(int c = 0; c < 3; c++)
           {
@@ -1994,8 +2002,44 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
                                     : dt_iop_eval_exp(d->unbounded_coeffs[DT_IOP_RGBCURVE_R], in[c]);
           }
         }
-      }
+        else
+        {
+          float ratio = 1.f;
+          float lum = 0.0f;
+          if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LMAX)
+          {
+            lum = fmaxf(in[0], fmaxf(in[1], in[2]));
+          }
+          else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LAVG)
+          {
+            lum = (in[0] + in[1] + in[2]) / 3.0f;
+          }
+          else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LNORM)
+          {
+            lum = powf(in[0] * in[0] + in[1] * in[1 ]+ in[2] * in[2], 0.5f);
+          }
+          else if (d->params.preserve_colors == DT_RGBCURVE_PRESERVE_LBP)
+          {
+            float R, G, B;
+            R = in[0] * in[0];
+            G = in[1] * in[1];
+            B = in[2] * in[2];
+            lum = (in[0] * R + in[1] * G + in[2] * B) / (R + G + B);
+          }
+          if(lum > 0.f)
+          {
+            const float curve_lum = (lum < xm_L)
+                                        ? d->table[DT_IOP_RGBCURVE_R][CLAMP((int)(lum * 0x10000ul), 0, 0xffff)]
+                                        : dt_iop_eval_exp(d->unbounded_coeffs[DT_IOP_RGBCURVE_R], lum);
+            ratio = curve_lum / lum;
+          }
 
+          for(size_t c = 0; c < 3; c++)
+          {
+            out[c] = (ratio * in[c]);
+          }
+        }
+      }
       out[3] = in[3];
     }
   }


### PR DESCRIPTION
Added the following norms (preserve colors parameter) to rgb curve:
- max(r,g,b)
- average(r,g,b)
- norm(r,g,b) = (r^2+g^2+b^2)^(1/2)
- power norm =  (r^3+g^3+b^3)/ (r^2+g^2+b^2)
