### PR TITLE
do not run darktable-cli if db is out-of-date

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1704,6 +1704,13 @@ static gboolean _lock_databases(dt_database_t *db)
 
 void ask_for_upgrade(const gchar *dbname)
 {
+  // if there's no gui just leave
+  if(darktable.gui == NULL)
+  {
+    fprintf(stderr, "[init] database `%s' is out-of-date. aborting.\n", dbname);
+    exit(1);
+  }
+
   // the database has to be upgraded, let's ask user
 
   char *label_text = g_markup_printf_escaped(_("the database schema has to be upgraded for\n"


### PR DESCRIPTION
If db is out-of-date darktable-cli crashes when trying to display the confirm dialog box, so if there's no gui just leave.

Fixes #2522