### PR TITLE
exposure: display a warning in GUI when there are negative RGB values

### DIFF
--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -161,6 +161,22 @@ exposure (read_only image2d_t in, write_only image2d_t out, const int width, con
   write_imagef (out, (int2)(x, y), pixel);
 }
 
+kernel void
+exposure_check_negatives (read_only image2d_t in, write_only image2d_t out, const int width, const int height, const float black, const float scale,
+          global int *negatives)
+{
+  const int x = get_global_id(0);
+  const int y = get_global_id(1);
+
+  if(x >= width || y >= height) return;
+  float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
+  pixel.xyz = (pixel.xyz - black)*scale;
+  write_imagef (out, (int2)(x, y), pixel);
+
+  if(any(isless(pixel.xyz, (float3)0.0f)))
+    *negatives = 1;
+}
+
 /* kernel for the highlights plugin. */
 kernel void
 highlights_4f_clip (read_only image2d_t in, write_only image2d_t out, const int width, const int height,


### PR DESCRIPTION
Check for negative values after exposure module in the preview pipe and display a warning in control log.

Since checks are expensive in OpenCL, we introduce an additional kernel with the negative checking built-in that will be used only for display pipelines.

Negative values are a burden when using log or square root based algorithm since darktable doesn't clip them. Many users have taken the wrong habit to adjust the contrast using the black level compensation, which is too soon in the pipe and will harm other modules output.