### PR TITLE
tonecurve - cleanup histogram with log scale

### DIFF
--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -370,17 +370,6 @@ static inline void dt_draw_histogram_8_log_base(cairo_t *cr, const uint32_t *his
     dt_draw_histogram_8_logxliny(cr, hist, channels, channel, base_log);
   else  // log y
     dt_draw_histogram_8_logxlogy(cr, hist, channels, channel, base_log);
-/*
-  cairo_move_to(cr, 0, 0);
-  for(int k = 0; k < 256; k++)
-  {
-    const float x = (float)k / 255.0f;
-    cairo_line_to(cr, logf(x * (base_log - 1.0f) + 1.0f) / logf(base_log), logf(1.0 + hist[channels * k + channel]));
-  }
-
-  cairo_line_to(cr, 255, 0);
-  cairo_close_path(cr);
-  cairo_fill(cr);*/
 }
 
 // linear x

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -296,7 +296,8 @@ static inline int dt_draw_curve_add_point(dt_draw_curve_t *c, const float x, con
   return 0;
 }
 
-static inline void dt_draw_histogram_8_linear(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel)
+// linear x linear y
+static inline void dt_draw_histogram_8_linxliny(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel)
 {
   cairo_move_to(cr, 0, 0);
   for(int k = 0; k < 256; k++) cairo_line_to(cr, k, hist[channels * k + channel]);
@@ -321,7 +322,38 @@ static inline void dt_draw_histogram_8_zoomed(cairo_t *cr, const uint32_t *hist,
   cairo_fill(cr);
 }
 
-static inline void dt_draw_histogram_8_log(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel)
+// log x (scalable) & linear y
+static inline void dt_draw_histogram_8_logxliny(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel, float base_log)
+{
+  cairo_move_to(cr, 0, 0);
+  for(int k = 0; k < 256; k++)
+  {
+    const float x = logf((float)k / 255.0f * (base_log - 1.0f) + 1.0f) / logf(base_log) * 255.0f;
+    const float y = hist[channels * k + channel];
+    cairo_line_to(cr, x, y);
+  }
+  cairo_line_to(cr, 255, 0);
+  cairo_close_path(cr);
+  cairo_fill(cr);
+}
+
+// log x (scalable) & log y
+static inline void dt_draw_histogram_8_logxlogy(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel, float base_log)
+{
+  cairo_move_to(cr, 0, 0);
+  for(int k = 0; k < 256; k++)
+  {
+    const float x = logf((float)k / 255.0f * (base_log - 1.0f) + 1.0f) / logf(base_log) * 255.0f;
+    const float y = logf(1.0 + hist[channels * k + channel]);
+    cairo_line_to(cr, x, y);
+  }
+  cairo_line_to(cr, 255, 0);
+  cairo_close_path(cr);
+  cairo_fill(cr);
+}
+
+// linear x log y
+static inline void dt_draw_histogram_8_linxlogy(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel)
 {
   cairo_move_to(cr, 0, 0);
   for(int k = 0; k < 256; k++) cairo_line_to(cr, k, logf(1.0 + hist[channels * k + channel]));
@@ -330,8 +362,15 @@ static inline void dt_draw_histogram_8_log(cairo_t *cr, const uint32_t *hist, in
   cairo_fill(cr);
 }
 
-static inline void dt_draw_histogram_8_log_base(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel, float base_log)
+// log x (scalable)
+static inline void dt_draw_histogram_8_log_base(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel, const gboolean linear, float base_log)
 {
+
+  if(linear) // linear y
+    dt_draw_histogram_8_logxliny(cr, hist, channels, channel, base_log);
+  else  // log y
+    dt_draw_histogram_8_logxlogy(cr, hist, channels, channel, base_log);
+/*
   cairo_move_to(cr, 0, 0);
   for(int k = 0; k < 256; k++)
   {
@@ -341,15 +380,16 @@ static inline void dt_draw_histogram_8_log_base(cairo_t *cr, const uint32_t *his
 
   cairo_line_to(cr, 255, 0);
   cairo_close_path(cr);
-  cairo_fill(cr);
+  cairo_fill(cr);*/
 }
 
+// linear x
 static inline void dt_draw_histogram_8(cairo_t *cr, const uint32_t *hist, int32_t channels, int32_t channel, const gboolean linear)
 {
-  if(linear)
-    dt_draw_histogram_8_linear(cr, hist, channels, channel);
-  else
-    dt_draw_histogram_8_log(cr, hist, channels, channel);
+  if(linear) // linear y
+    dt_draw_histogram_8_linxliny(cr, hist, channels, channel);
+  else  // log y
+    dt_draw_histogram_8_linxlogy(cr, hist, channels, channel);
 }
 
 /** transform a data blob from cairo's premultiplied rgba/bgra to GdkPixbuf's un-premultiplied bgra/rgba */

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -825,6 +825,7 @@ static void scale_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  gtk_widget_set_visible(g->scale, TRUE);
   switch(dt_bauhaus_combobox_get(widget))
   {
     case 0:
@@ -1421,14 +1422,14 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   cairo_stroke_preserve(cr);
 
   // Draw the background gradient along the diagonal
-  // ch == 0 : black to white
+  // ch == 0 : grey
   // ch == 1 : green to magenta
   // ch == 2 : blue to yellow
-  const float origin[3][3] = { { 0.0f, 0.0f, 0.0f },                  // L = 0, @ (a, b) = 0
+  const float origin[3][3] = { { 0.45f, 0.45f, 0.45f },                  // L = 0, @ (a, b) = 0
                                { 0.0f, 231.0f/255.0f, 181.0f/255.0f },// a = -128 @ L = 75, b = 0
                                { 0.0f, 30.0f/255.0f, 195.0f/255.0f}}; // b = -128 @ L = 75, a = 0
 
-  const float destin[3][3] = { { 1.0f, 1.0f, 1.0f },                  // L = 100 @ (a, b) = 0
+  const float destin[3][3] = { { 0.45f, 0.45f, 0.45f },                  // L = 100 @ (a, b) = 0
                                { 1.0f, 0.0f, 192.0f/255.0f } ,        // a = 128 @ L = 75, b = 0
                                { 215.0f/255.0f, 182.0f/255.0f, 0.0f}};// b = 128 @ L = 75, a = 0
 
@@ -1509,10 +1510,9 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_move_to(cr, 0, height);
       set_color(cr, darktable.bauhaus->inset_histogram);
 
-      if (ch == ch_L && c->loglogscale > 0.0f && c->semilog != -1)
+      if (ch == ch_L && c->loglogscale > 0.0f)
       {
-        // not working
-        // dt_draw_histogram_8_log_base(cr, hist, 4, ch, c->loglogscale);
+        dt_draw_histogram_8_log_base(cr, hist, 4, ch, dev->histogram_type == DT_DEV_HISTOGRAM_LINEAR, c->loglogscale);
       }
       else
       {

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1423,11 +1423,10 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
                                  { 1.0f, 0.0f, 192.0f/255.0f } ,        // a = 128 @ L = 75, b = 0
                                  { 215.0f/255.0f, 182.0f/255.0f, 0.0f}};// b = 128 @ L = 75, a = 0
 
-    // since Cairo paints with sRGB at gamma 2.4, linear gradients are not linear but garbage and, at 50%,
-    // we dont see the neutral grey we would expect in the middle of a linear gradient between
-    // 2 complimentary colors. So we add it artificially, but that will break the smoothness
-    // of the transition. Maybe this will help people understand how broken are Lab and non-linear
-    // spaces for editing, so let it be ugly to teach them a lesson.
+   // since Cairo paints with sRGB at gamma 2.4, linear gradients are not linear and, at 50%,
+   // we dont see the neutral grey we would expect in the middle of a linear gradient between
+   // 2 complimentary colors. So we add it artificially, but that will break the smoothness
+   // of the transition.
 
     // middle step for gradients (50 %)
     const float midgrey = to_log(0.45f, c->loglogscale, ch, c->semilog, 0);

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1411,41 +1411,41 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   }
   else
   {
-  // Draw the background gradient along the diagonal
-  // ch == 0 : black to white
-  // ch == 1 : green to magenta
-  // ch == 2 : blue to yellow
-  const float origin[3][3] = { { 0.0f, 0.0f, 0.0f },                  // L = 0, @ (a, b) = 0
-                               { 0.0f, 231.0f/255.0f, 181.0f/255.0f },// a = -128 @ L = 75, b = 0
-                               { 0.0f, 30.0f/255.0f, 195.0f/255.0f}}; // b = -128 @ L = 75, a = 0
+    // Draw the background gradient along the diagonal
+    // ch == 0 : black to white
+    // ch == 1 : green to magenta
+    // ch == 2 : blue to yellow
+    const float origin[3][3] = { { 0.0f, 0.0f, 0.0f },                  // L = 0, @ (a, b) = 0
+                                 { 0.0f, 231.0f/255.0f, 181.0f/255.0f },// a = -128 @ L = 75, b = 0
+                                 { 0.0f, 30.0f/255.0f, 195.0f/255.0f}}; // b = -128 @ L = 75, a = 0
 
-  const float destin[3][3] = { { 1.0f, 1.0f, 1.0f },                  // L = 100 @ (a, b) = 0
-                               { 1.0f, 0.0f, 192.0f/255.0f } ,        // a = 128 @ L = 75, b = 0
-                               { 215.0f/255.0f, 182.0f/255.0f, 0.0f}};// b = 128 @ L = 75, a = 0
+    const float destin[3][3] = { { 1.0f, 1.0f, 1.0f },                  // L = 100 @ (a, b) = 0
+                                 { 1.0f, 0.0f, 192.0f/255.0f } ,        // a = 128 @ L = 75, b = 0
+                                 { 215.0f/255.0f, 182.0f/255.0f, 0.0f}};// b = 128 @ L = 75, a = 0
 
-  // since Cairo paints with sRGB at gamma 2.4, linear gradients are not linear but garbage and, at 50%,
-  // we dont see the neutral grey we would expect in the middle of a linear gradient between
-  // 2 complimentary colors. So we add it artificially, but that will break the smoothness
-  // of the transition. Maybe this will help people understand how broken are Lab and non-linear
-  // spaces for editing, so let it be ugly to teach them a lesson.
+    // since Cairo paints with sRGB at gamma 2.4, linear gradients are not linear but garbage and, at 50%,
+    // we dont see the neutral grey we would expect in the middle of a linear gradient between
+    // 2 complimentary colors. So we add it artificially, but that will break the smoothness
+    // of the transition. Maybe this will help people understand how broken are Lab and non-linear
+    // spaces for editing, so let it be ugly to teach them a lesson.
 
-  // middle step for gradients (50 %)
-  const float midgrey = to_log(0.45f, c->loglogscale, ch, c->semilog, 0);
+    // middle step for gradients (50 %)
+    const float midgrey = to_log(0.45f, c->loglogscale, ch, c->semilog, 0);
 
-  const float middle[3][3] = { { midgrey, midgrey, midgrey },   // L = 50 @ (a, b) = 0
-                               { 0.67f, 0.67f, 0.67f},          // L = 75 @ (a, b) = 0
-                               { 0.67f, 0.67f, 0.67f}};         // L = 75 @ (a, b) = 0
+    const float middle[3][3] = { { midgrey, midgrey, midgrey },   // L = 50 @ (a, b) = 0
+                                 { 0.67f, 0.67f, 0.67f},          // L = 75 @ (a, b) = 0
+                                 { 0.67f, 0.67f, 0.67f}};         // L = 75 @ (a, b) = 0
 
-  const float opacities[3] = { 0.5f, 0.5f, 0.5f};
+    const float opacities[3] = { 0.5f, 0.5f, 0.5f};
 
-  cairo_pattern_t *pat;
-  pat = cairo_pattern_create_linear (height, 0.0,  0.0, width);
-  cairo_pattern_add_color_stop_rgba (pat, 1, origin[ch][0], origin[ch][1], origin[ch][2], opacities[ch]);
-  cairo_pattern_add_color_stop_rgba (pat, 0.5, middle[ch][0], middle[ch][1], middle[ch][2], opacities[ch]);
-  cairo_pattern_add_color_stop_rgba (pat, 0, destin[ch][0], destin[ch][1], destin[ch][2], opacities[ch]);
-  cairo_set_source (cr, pat);
-  cairo_fill (cr);
-  cairo_pattern_destroy (pat);
+    cairo_pattern_t *pat;
+    pat = cairo_pattern_create_linear (height, 0.0,  0.0, width);
+    cairo_pattern_add_color_stop_rgba (pat, 1, origin[ch][0], origin[ch][1], origin[ch][2], opacities[ch]);
+    cairo_pattern_add_color_stop_rgba (pat, 0.5, middle[ch][0], middle[ch][1], middle[ch][2], opacities[ch]);
+    cairo_pattern_add_color_stop_rgba (pat, 0, destin[ch][0], destin[ch][1], destin[ch][2], opacities[ch]);
+    cairo_set_source (cr, pat);
+    cairo_fill (cr);
+    cairo_pattern_destroy (pat);
   }
 
   // draw grid


### PR DESCRIPTION
Work in progress

**Problem**: The histogram is not displayed as soon as scale is set as not linear.
The scale can be set for both x & y, x or y.
![image](https://user-images.githubusercontent.com/23012047/58503778-a87ab100-815f-11e9-9f91-dda2749864d8.png)

There is a basic conflict with the pipeline histogram, which has also an option linear/log (for y).

I suggest to remove the scale options y and xy (log-log(xy) and semi-log(y)) to keep only linear and log x in tonecurve.
If the user wants to have also log for y, he selects log on the global histogram. In that case log y is not scalable but I don't think that's an issue.

What do you think ?
I ask the question before going further because there is a lot of cleaning (including with tonecurve color picker)

For the time being some screenshots for the current changes:

tc linear + histo linear
![image](https://user-images.githubusercontent.com/23012047/58503256-b7ad2f00-815e-11e9-935f-3210967f9ad1.png)

tc linear + histo log(y)
![image](https://user-images.githubusercontent.com/23012047/58503279-c562b480-815e-11e9-8bed-3a460c894954.png)

tc log(x) + histo linear
![image](https://user-images.githubusercontent.com/23012047/58503389-ed521800-815e-11e9-9376-2cc4fd02e1fa.png)

tc log(x) + histo log(y)
![image](https://user-images.githubusercontent.com/23012047/58503479-1377b800-815f-11e9-81aa-1e2b51a05fd4.png)
