### PR TITLE
Fix for #2618 and #2535

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1071,14 +1071,14 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
       if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
         darktable.gui->scroll_to[1] = module->expander;
 
-      if(dt_conf_get_bool("darkroom/ui/activate_expand"))
+      if(dt_conf_get_bool("darkroom/ui/activate_expand") && !module->expanded)
         dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
     }
     else
     {
       module->enabled = 0;
 
-      if(dt_conf_get_bool("darkroom/ui/activate_expand"))
+      if(dt_conf_get_bool("darkroom/ui/activate_expand") && module->expanded)
         dt_iop_gui_set_expanded(module, FALSE, FALSE);
     }
     dt_dev_add_history_item(module->dev, module, FALSE);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1068,8 +1068,6 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
     {
       module->enabled = 1;
 
-      dt_iop_request_focus(module);
-
       if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
         darktable.gui->scroll_to[1] = module->expander;
 
@@ -1082,8 +1080,6 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
 
       if(dt_conf_get_bool("darkroom/ui/activate_expand"))
         dt_iop_gui_set_expanded(module, FALSE, FALSE);
-
-      dt_iop_request_focus(NULL);
     }
     dt_dev_add_history_item(module->dev, module, FALSE);
   }


### PR DESCRIPTION
This is fixing both https://github.com/darktable-org/darktable/issues/2618 and https://github.com/darktable-org/darktable/issues/2535 when auto-expand option is not used
Still some glitch when the auto-expand option is used