### PR TITLE
Some more css tweaks

### DIFF
--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -59,7 +59,7 @@
 @define-color plugin_label_color @grey_80;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_fg @grey_80;
+@define-color bauhaus_fg @grey_85;
 @define-color bauhaus_indicator_border @grey_45;
 @define-color bauhaus_fill @grey_60;
 @define-color bauhaus_bg @grey_55;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1011,13 +1011,13 @@ entry
   margin: 2px 0;
 }
 
-#left #lib-plugin-ui entry /* This will avoid have too much height on entry item in filter collections modules */
+#left #lib-plugin-ui entry /* This will avoid have too much height on entry items in filter collections modules */
 {
   padding: 0px;
   margin: 8px 0px;
 }
 
-#left #lib-plugin-ui scrolledwindow entry /* This will avoid have too much height on entry item in clone manager without touching other parts of the UI */
+#left #lib-plugin-ui scrolledwindow entry /* This will avoid having too much height on entry item in clone manager without touching other parts of the UI */
 {
   padding: 0px;
   margin: 40px 3px;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1017,10 +1017,16 @@ entry
   margin: 8px 0px;
 }
 
+#left #lib-plugin-ui scrolledwindow entry /* This will avoid have too much height on entry item in clone manager without touching other parts of the UI */
+{
+  padding: 0px;
+  margin: 40px 3px;
+  min-width: 150px;
+}
+
 #right #lib-plugin-ui entry /* This will adjust entry height on right panel */
 {
   padding: 1px;
-  margin: 2px 0px;
 }
 
 #lib-plugin-ui checkbutton check,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -862,7 +862,7 @@ notebook tab:focus label
   color: @button_checked_fg;
 }
 
-/* This will avoid have too much height on entry item in dialog windows; label and button are needed as they are related */
+/* This will avoid have too much height on entry items in dialog windows; label and button are needed as they are related */
 
 #preferences_notebook *
 {
@@ -1017,7 +1017,7 @@ entry
   margin: 8px 0px;
 }
 
-#left #lib-plugin-ui scrolledwindow entry /* This will avoid having too much height on entry item in clone manager without touching other parts of the UI */
+#left #lib-plugin-ui scrolledwindow entry /* This will avoid having too much height on entry items in clone manager without touching other parts of the UI */
 {
   padding: 0px;
   margin: 40px 3px;


### PR DESCRIPTION
Two minor tweaks for css themes :
- Most important one (1st commit): entries on clone manager was way too big in height and too short in width. This make entries better sized. This commit also remove a redundant line.
- Text on some modules (bauhaus sliders) has now better contrast, so more readable.