### PR TITLE
 colorzones: add display selection

### DIFF
--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2771,7 +2771,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
                               const void *const ivoid, void *const ovoid, const struct dt_iop_roi_t *const roi_in,
                               const struct dt_iop_roi_t *const roi_out)
 {
-  if(self->bypass_blendif && self->dev->gui_attached && (self == self->dev->gui_module)) return;
+  if(piece->pipe->bypass_blendif && self->dev->gui_attached && (self == self->dev->gui_module)) return;
 
   const dt_develop_blend_params_t *const d = (const dt_develop_blend_params_t *const)piece->blendop_data;
   if(!d) return;
@@ -3088,7 +3088,7 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
                                 cl_mem dev_in, cl_mem dev_out, const struct dt_iop_roi_t *roi_in,
                                 const struct dt_iop_roi_t *roi_out)
 {
-  if(self->bypass_blendif && self->dev->gui_attached && (self == self->dev->gui_module)) return TRUE;
+  if(piece->pipe->bypass_blendif && self->dev->gui_attached && (self == self->dev->gui_module)) return TRUE;
 
   dt_develop_blend_params_t *const d = (dt_develop_blend_params_t *const)piece->blendop_data;
   if(!d) return TRUE;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -609,19 +609,6 @@ static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton 
 {
   if(darktable.gui->reset) return;
 
-  // if blendif is bypassed don't allow to set this button on
-  if(module->bypass_blendif)
-  {
-    dt_control_log(_("display mask is currently disabled by another module"));
-
-    if(darktable.gui->reset) return;
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
-    dtgtk_button_set_active(DTGTK_BUTTON(button), FALSE);
-    darktable.gui->reset = reset;
-    return;
-  }
-
   if(event->button == 1)
   {
     const int has_mask_display = module->request_mask_display & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -397,7 +397,6 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->histogram_middle_grey = FALSE;
   module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
   module->suppress_mask = 0;
-  module->bypass_blendif = 0;
   module->enabled = module->default_enabled = 0; // all modules disabled by default.
   g_strlcpy(module->op, so->op, 20);
   module->raster_mask.source.users = g_hash_table_new(NULL, NULL);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -304,9 +304,6 @@ typedef struct dt_iop_module_t
   int request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the module in focus. gui mode only. */
   int32_t suppress_mask;
-  /** set to 1 if you want the blendif to be completely suppressed in the module in focus. only when the module has
-   * the focus. */
-  int32_t bypass_blendif;
   /** color picker proxys */
   struct dt_iop_color_picker_t *picker;
   struct dt_iop_color_picker_t *blend_picker;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -161,6 +161,7 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   pipe->opencl_error = 0;
   pipe->tiling = 0;
   pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
+  pipe->bypass_blendif = 0;
   pipe->input_timestamp = 0;
   pipe->levels = IMAGEIO_RGB | IMAGEIO_INT8;
   dt_pthread_mutex_init(&(pipe->backbuf_mutex), NULL);
@@ -2661,6 +2662,8 @@ restart:
 
   // mask display off as a starting point
   pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
+  // and blendif active
+  pipe->bypass_blendif = 0;
 
   void *buf = NULL;
   void *cl_mem_out = NULL;

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -129,6 +129,8 @@ typedef struct dt_dev_pixelpipe_t
   int tiling;
   // should this pixelpipe display a mask in the end?
   int mask_display;
+  // should this pixelpipe completely suppressed the blendif module?
+  int bypass_blendif;
   // input data based on this timestamp:
   int input_timestamp;
   dt_dev_pixelpipe_type_t type;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1834,13 +1834,22 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       return TRUE;
     }
 
-    for(int k = c->selected; k < nodes - 1; k++)
+    // ctrl+right click reset the node to y-zero
+    if((event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK)
     {
-      curve[k].x = curve[k + 1].x;
-      curve[k].y = curve[k + 1].y;
+      curve[c->selected].y = 0.5f;
+    }
+    // right click deletes the node
+    else
+    {
+      for(int k = c->selected; k < nodes - 1; k++)
+      {
+        curve[k].x = curve[k + 1].x;
+        curve[k].y = curve[k + 1].y;
+      }
+      p->curve_num_nodes[ch]--;
     }
     c->selected = -2; // avoid re-insertion of that point immediately after this
-    p->curve_num_nodes[ch]--;
 
     if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
     gtk_widget_queue_draw(self->widget);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2301,23 +2301,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(dabox), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(vbox), TRUE, TRUE, 0);
 
+  GtkWidget *hbox_select_by = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+  // edit by area
   c->chk_edit_by_area = gtk_check_button_new_with_label(_("edit by area"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->chk_edit_by_area), c->edit_by_area);
   gtk_widget_set_tooltip_text(c->chk_edit_by_area, _("edit the curve nodes by area"));
-  gtk_box_pack_start(GTK_BOX(self->widget), c->chk_edit_by_area, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox_select_by), c->chk_edit_by_area, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->chk_edit_by_area), "toggled", G_CALLBACK(_edit_by_area_callback), self);
-
-  // select by which dimension
-  GtkWidget *hbox_select_by = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
-  c->select_by = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(c->select_by, NULL, _("select by"));
-  gtk_widget_set_tooltip_text(c->select_by, _("choose selection criterion, will be the abscissa in the graph"));
-  dt_bauhaus_combobox_add(c->select_by, _("hue"));
-  dt_bauhaus_combobox_add(c->select_by, _("saturation"));
-  dt_bauhaus_combobox_add(c->select_by, _("lightness"));
-  gtk_box_pack_start(GTK_BOX(hbox_select_by), c->select_by, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(c->select_by), "value-changed", G_CALLBACK(_select_by_callback), (gpointer)self);
 
   // display selection
   c->bt_showmask
@@ -2328,6 +2319,16 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_end(GTK_BOX(hbox_select_by), c->bt_showmask, FALSE, FALSE, 0);
 
   gtk_box_pack_start(GTK_BOX(self->widget), hbox_select_by, TRUE, TRUE, 0);
+
+  // select by which dimension
+  c->select_by = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(c->select_by, NULL, _("select by"));
+  gtk_widget_set_tooltip_text(c->select_by, _("choose selection criterion, will be the abscissa in the graph"));
+  dt_bauhaus_combobox_add(c->select_by, _("hue"));
+  dt_bauhaus_combobox_add(c->select_by, _("saturation"));
+  dt_bauhaus_combobox_add(c->select_by, _("lightness"));
+  gtk_box_pack_start(GTK_BOX(self->widget), c->select_by, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(c->select_by), "value-changed", G_CALLBACK(_select_by_callback), (gpointer)self);
 
   c->mode = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(c->mode, NULL, _("process mode"));

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -1037,6 +1037,8 @@ static gboolean dt_iop_levels_button_press(GtkWidget *widget, GdkEventButton *ev
   {
     dt_iop_module_t *self = (dt_iop_module_t *)user_data;
 
+    if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
+
     if(event->type == GDK_2BUTTON_PRESS)
     {
       // Reset
@@ -1084,6 +1086,8 @@ static gboolean dt_iop_levels_scroll(GtkWidget *widget, GdkEventScroll *event, g
   {
     return FALSE;
   }
+
+  if(darktable.develop->gui_module != self) dt_iop_request_focus(self);
 
   const float interval = 0.002; // Distance moved for each scroll event
   gdouble delta_y;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -4390,7 +4390,8 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
 
   // init the decompose routine
   dwt_p = dt_dwt_init(in_retouch, roi_rt->width, roi_rt->height, ch, p->num_scales,
-                      (!display_wavelet_scale) ? 0 : p->curr_scale, p->merge_from_scale, &usr_data,
+                      (!display_wavelet_scale || piece->pipe->type != DT_DEV_PIXELPIPE_FULL) ? 0 : p->curr_scale,
+                      p->merge_from_scale, &usr_data,
                       roi_in->scale / piece->iscale, use_sse);
   if(dwt_p == NULL) goto cleanup;
 
@@ -5233,7 +5234,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   // init the decompose routine
   dwt_p = dt_dwt_init_cl(devid, in_retouch, roi_rt->width, roi_rt->height, p->num_scales,
-                         (!display_wavelet_scale) ? 0 : p->curr_scale, p->merge_from_scale, &usr_data,
+                         (!display_wavelet_scale || piece->pipe->type != DT_DEV_PIXELPIPE_FULL) ? 0 : p->curr_scale,
+                         p->merge_from_scale, &usr_data,
                          roi_in->scale / piece->iscale);
   if(dwt_p == NULL)
   {

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1941,7 +1941,6 @@ static void rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, dt_
   dt_iop_request_focus(self);
 
   g->display_wavelet_scale = gtk_toggle_button_get_active(togglebutton);
-  self->bypass_blendif = (g->mask_display || g->display_wavelet_scale);
 
   rt_show_hide_controls(self, g, p, g);
 
@@ -2245,7 +2244,6 @@ static void rt_showmask_callback(GtkToggleButton *togglebutton, dt_iop_module_t 
   }
 
   g->mask_display = gtk_toggle_button_get_active(togglebutton);
-  module->bypass_blendif = (g->mask_display || g->display_wavelet_scale);
 
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
   dt_iop_request_focus(module);
@@ -4403,6 +4401,7 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     for(size_t j = 0; j < roi_rt->width * roi_rt->height * ch; j += ch) in_retouch[j + 3] = 0.f;
 
     piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_MASK;
+    piece->pipe->bypass_blendif = 1;
     usr_data.mask_display = 1;
   }
 
@@ -5257,6 +5256,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     if(err != CL_SUCCESS) goto cleanup;
 
     piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_MASK;
+    piece->pipe->bypass_blendif = 1;
     usr_data.mask_display = 1;
   }
 


### PR DESCRIPTION
This:
- add an option to display the selection on the color zones module, in the same way the blend module does. The selection itself is usually too weak to be visible, so I multiply it by 4, I don't like that very much so suggestions are welcome.
I have also moved the bypass_blendif from the module to the pipe, so different pipes can display the final image or the selection/mask/etc.

- the retouch module now display the scale on the full pipe only, so on darkroom we can have the scale displayed and on the second window the final image.

- fixed a bug on levels, that sometimes it doesn't grab the focus and the cache is not used.

- allow to reset to Y = 0 a single node on color zones by ctrl+right click on it.