### PR TITLE
ashift: Extend maximum lensshift range

### DIFF
--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -53,8 +53,8 @@
 
 #define ROTATION_RANGE 10                   // allowed min/max default range for rotation parameter
 #define ROTATION_RANGE_SOFT 20              // allowed min/max range for rotation parameter with manual adjustment
-#define LENSSHIFT_RANGE 0.5                 // allowed min/max default range for lensshift parameters
-#define LENSSHIFT_RANGE_SOFT 1              // allowed min/max range for lensshift parameters with manual adjustment
+#define LENSSHIFT_RANGE 1.0                 // allowed min/max default range for lensshift parameters
+#define LENSSHIFT_RANGE_SOFT 2.0            // allowed min/max range for lensshift parameters with manual adjustment
 #define SHEAR_RANGE 0.2                     // allowed min/max range for shear parameter
 #define SHEAR_RANGE_SOFT 0.5                // allowed min/max range for shear parameter with manual adjustment
 #define MIN_LINE_LENGTH 5                   // the minimum length of a line in pixels to be regarded as relevant


### PR DESCRIPTION
Some pictures need it, and both GUI and automatic calculation algorithm allow this
This fixes https://github.com/darktable-org/darktable/issues/2617