### PR TITLE
accels : ask before replacing accels

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -243,7 +243,7 @@ void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType m
 }
 
 
-static dt_accel_t *_lookup_accel(gchar *path)
+static dt_accel_t *_lookup_accel(const gchar *path)
 {
   GSList *l = darktable.control->accelerator_list;
   while(l)
@@ -1067,6 +1067,10 @@ void dt_dynamic_accel_get_valid_list()
   }
 }
 
+dt_accel_t *dt_accel_find_by_path(const gchar *path)
+{
+  return _lookup_accel(path);
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -62,8 +62,11 @@ void dt_accel_path_lua(char *s, size_t n, const char *path);
  * 4 - Slider dynamic path
  */
 void dt_accel_paths_slider_iop(char *s[], size_t n, char *module, const char *path);
+
+// Accelerator search functions
 dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierType mods);
 void dt_dynamic_accel_get_valid_list();
+dt_accel_t *dt_accel_find_by_path(const gchar *path);
 
 // Accelerator registration functions
 void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierType mods);


### PR DESCRIPTION
currently, when you record an already mapped accel, the old one is silently deleted to avoid conflict.
This add a confirmation box in this case to let the user choose.