### PR TITLE
speedup: enable simd and loop collapsing for bilateral filter lib

### DIFF
--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -135,8 +135,8 @@ void dt_bilateral_splat(dt_bilateral_t *b, const float *const in)
 // splat into downsampled grid
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, oy, oz, ox, sigma_s) \
-  shared(b, buf) \
+  dt_omp_firstprivate(in, oy, oz, ox, sigma_s, buf) \
+  shared(b) \
   collapse(2)
 #endif
   for(int j = 0; j < b->height; j++)
@@ -184,8 +184,8 @@ static void blur_line_z(float *buf, const int offset1, const int offset2, const 
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3, w1, w2) \
-    shared(buf) collapse(2)
+    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3, w1, w2, buf) \
+    collapse(2)
 #endif
   for(int k = 0; k < size1; k++)
   {
@@ -230,8 +230,8 @@ static void blur_line(float *buf, const int offset1, const int offset2, const in
   const float w2 = 1.f / 16.f;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3, w0, w1, w2) \
-    shared(buf) collapse(2)
+    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3, w0, w1, w2, buf) \
+    collapse(2)
 #endif
   for(int k = 0; k < size1; k++)
   {
@@ -297,8 +297,8 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(b, in, norm, oy, oz, ox, size_x, size_y, size_z, height, width) \
-    shared(out, buf) collapse(2)
+    dt_omp_firstprivate(b, in, norm, oy, oz, ox, size_x, size_y, size_z, height, width, buf) \
+    shared(out) collapse(2)
 #endif
   for(int j = 0; j < height; j++)
   {
@@ -350,8 +350,8 @@ void dt_bilateral_slice_to_output(const dt_bilateral_t *const b, const float *co
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(b, in, norm, oy, oz, ox) \
-    shared(out, buf) collapse(2)
+    dt_omp_firstprivate(b, in, norm, oy, oz, ox, buf) \
+    shared(out) collapse(2)
 #endif
   for(int j = 0; j < b->height; j++)
   {

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -123,7 +123,6 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
 #ifdef _OPENMP
 #pragma omp declare simd aligned(in:64)
 #endif
-__DT_CLONE_TARGETS__
 void dt_bilateral_splat(dt_bilateral_t *b, const float *const in)
 {
   const int ox = 1;
@@ -177,7 +176,6 @@ void dt_bilateral_splat(dt_bilateral_t *b, const float *const in)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(buf:64)
 #endif
-__DT_CLONE_TARGETS__
 static void blur_line_z(float *buf, const int offset1, const int offset2, const int offset3, const int size1,
                         const int size2, const int size3)
 {
@@ -224,7 +222,6 @@ static void blur_line_z(float *buf, const int offset1, const int offset2, const 
 #ifdef _OPENMP
 #pragma omp declare simd aligned(buf:64)
 #endif
-__DT_CLONE_TARGETS__
 static void blur_line(float *buf, const int offset1, const int offset2, const int offset3, const int size1,
                       const int size2, const int size3)
 {
@@ -283,7 +280,6 @@ void dt_bilateral_blur(dt_bilateral_t *b)
 #ifdef _OPENMP
 #pragma omp declare simd aligned(out, in :64)
 #endif
-__DT_CLONE_TARGETS__
 void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, float *out, const float detail)
 {
   // detail: 0 is leave as is, -1 is bilateral filtered, +1 is contrast boost
@@ -341,7 +337,6 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
 #ifdef _OPENMP
 #pragma omp declare simd aligned(out, in :64)
 #endif
-__DT_CLONE_TARGETS__
 void dt_bilateral_slice_to_output(const dt_bilateral_t *const b, const float *const in, float *out,
                                   const float detail)
 {

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -120,20 +120,31 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   return b;
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(in:64)
+#endif
+__DT_CLONE_TARGETS__
 void dt_bilateral_splat(dt_bilateral_t *b, const float *const in)
 {
   const int ox = 1;
   const int oy = b->size_x;
   const int oz = b->size_y * b->size_x;
+
+  const float sigma_s = b->sigma_s * b->sigma_s;
+  float *const buf = b->buf;
+
 // splat into downsampled grid
 #ifdef _OPENMP
-#pragma omp parallel for default(none) dt_omp_firstprivate(in, oy, oz) shared(b)
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(in, oy, oz, sigma_s) \
+  shared(b, buf) \
+  collapse(2)
 #endif
   for(int j = 0; j < b->height; j++)
   {
-    size_t index = 4 * j * b->width;
     for(int i = 0; i < b->width; i++)
     {
+      size_t index = 4 * (j * b->width + i);
       float x, y, z;
       const float L = in[index];
       image_to_grid(b, i, j, L, &x, &y, &z);
@@ -149,60 +160,71 @@ void dt_bilateral_splat(dt_bilateral_t *b, const float *const in)
       // for cross bilateral applications.
       // also note that this is not clipped (as L->z is), so potentially hdr/out of gamut
       // should not cause clipping here.
+#ifdef _OPENMP
+#pragma omp simd aligned(buf:64)
+#endif
       for(int k = 0; k < 8; k++)
       {
         const size_t ii = grid_index + ((k & 1) ? ox : 0) + ((k & 2) ? oy : 0) + ((k & 4) ? oz : 0);
         const float contrib = ((k & 1) ? xf : (1.0f - xf)) * ((k & 2) ? yf : (1.0f - yf))
-                              * ((k & 4) ? zf : (1.0f - zf)) * 100.0f / (b->sigma_s * b->sigma_s);
-#ifdef _OPENMP
-#pragma omp atomic
-#endif
-        b->buf[ii] += contrib;
+                              * ((k & 4) ? zf : (1.0f - zf)) * 100.0f / (sigma_s);
+        buf[ii] += contrib;
       }
-      index += 4;
     }
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(buf:64)
+#endif
+__DT_CLONE_TARGETS__
 static void blur_line_z(float *buf, const int offset1, const int offset2, const int offset3, const int size1,
                         const int size2, const int size3)
 {
   const float w1 = 4.f / 16.f;
   const float w2 = 2.f / 16.f;
+
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3) \
-    shared(buf)
+    shared(buf) collapse(2)
 #endif
   for(int k = 0; k < size1; k++)
   {
-    size_t index = (size_t)k * offset1;
     for(int j = 0; j < size2; j++)
     {
+      size_t index = (size_t)k * offset1 + j * offset2;
       float tmp1 = buf[index];
       buf[index] = w1 * buf[index + offset3] + w2 * buf[index + 2 * offset3];
-      index += offset3;
-      float tmp2 = buf[index];
-      buf[index] = w1 * (buf[index + offset3] - tmp1) + w2 * buf[index + 2 * offset3];
-      index += offset3;
+
+      /** index += offset3; **/
+
+      float tmp2 = buf[index + offset3];
+      buf[index + offset3] = w1 * (buf[index + 2 * offset3] - tmp1) + w2 * buf[index + 3 * offset3];
+
+      /** index += offset3; **/
+
       for(int i = 2; i < size3 - 2; i++)
       {
-        const float tmp3 = buf[index];
-        buf[index] = +w1 * (buf[index + offset3] - tmp2) + w2 * (buf[index + 2 * offset3] - tmp1);
-        index += offset3;
+        const float tmp3 = buf[index + i * offset3];
+        buf[index + i * offset3] = +w1 * (buf[index + (i + 1) * offset3] - tmp2) + w2 * (buf[index + (i + 2) * offset3] - tmp1);
         tmp1 = tmp2;
         tmp2 = tmp3;
       }
+
+      index += (size3 - 2) * offset3;
       const float tmp3 = buf[index];
       buf[index] = w1 * (buf[index + offset3] - tmp2) - w2 * tmp1;
       index += offset3;
       buf[index] = -w1 * tmp3 - w2 * tmp2;
-      index += offset3;
-      index += offset2 - offset3 * size3;
     }
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(buf:64)
+#endif
+__DT_CLONE_TARGETS__
 static void blur_line(float *buf, const int offset1, const int offset2, const int offset3, const int size1,
                       const int size2, const int size3)
 {
@@ -212,34 +234,36 @@ static void blur_line(float *buf, const int offset1, const int offset2, const in
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3) \
-    shared(buf)
+    shared(buf) collapse(2)
 #endif
   for(int k = 0; k < size1; k++)
   {
-    size_t index = (size_t)k * offset1;
     for(int j = 0; j < size2; j++)
     {
+      size_t index = (size_t)k * offset1 + j * offset2;
       float tmp1 = buf[index];
       buf[index] = buf[index] * w0 + w1 * buf[index + offset3] + w2 * buf[index + 2 * offset3];
-      index += offset3;
-      float tmp2 = buf[index];
-      buf[index] = buf[index] * w0 + w1 * (buf[index + offset3] + tmp1) + w2 * buf[index + 2 * offset3];
-      index += offset3;
+
+      /** index += offset3; **/
+
+      float tmp2 = buf[index + offset3];
+      buf[index + offset3] = buf[index + offset3] * w0 + w1 * (buf[index + 2 * offset3] + tmp1) + w2 * buf[index + 3 * offset3];
+
+      /** index += offset3; **/
+
       for(int i = 2; i < size3 - 2; i++)
       {
-        const float tmp3 = buf[index];
-        buf[index]
-            = buf[index] * w0 + w1 * (buf[index + offset3] + tmp2) + w2 * (buf[index + 2 * offset3] + tmp1);
-        index += offset3;
+        const float tmp3 = buf[index + i * offset3];
+        buf[index + i * offset3]
+            = buf[index + i * offset3] * w0 + w1 * (buf[+ (i + 1) * offset3] + tmp2) + w2 * (buf[index + (i + 2) * offset3] + tmp1);
         tmp1 = tmp2;
         tmp2 = tmp3;
       }
+      index += (size3 - 2) * offset3;
       const float tmp3 = buf[index];
       buf[index] = buf[index] * w0 + w1 * (buf[index + offset3] + tmp2) + w2 * tmp1;
       index += offset3;
       buf[index] = buf[index] * w0 + w1 * tmp3 + w2 * tmp2;
-      index += offset3;
-      index += offset2 - offset3 * size3;
     }
   }
 }
@@ -256,6 +280,10 @@ void dt_bilateral_blur(dt_bilateral_t *b)
 }
 
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(out, in :64)
+#endif
+__DT_CLONE_TARGETS__
 void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, float *out, const float detail)
 {
   // detail: 0 is leave as is, -1 is bilateral filtered, +1 is contrast boost
@@ -263,16 +291,19 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
   const int ox = 1;
   const int oy = b->size_x;
   const int oz = b->size_y * b->size_x;
+
+  float *const buf = b->buf;
+
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
+#pragma omp parallel for simd default(none) \
     dt_omp_firstprivate(b, in, norm, oy, oz) \
-    shared(out)
+    shared(out, buf) collapse(2) aligned(in, out, buf:64)
 #endif
   for(int j = 0; j < b->height; j++)
   {
-    size_t index = 4 * j * b->width;
     for(int i = 0; i < b->width; i++)
     {
+      size_t index = 4 * (j * b->width + i);
       float x, y, z;
       const float L = in[index];
       image_to_grid(b, i, j, L, &x, &y, &z);
@@ -285,24 +316,27 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
       const float zf = z - zi;
       const size_t gi = xi + b->size_x * (yi + b->size_y * zi);
       const float Lout = L
-                         + norm * (b->buf[gi] * (1.0f - xf) * (1.0f - yf) * (1.0f - zf)
-                                   + b->buf[gi + ox] * (xf) * (1.0f - yf) * (1.0f - zf)
-                                   + b->buf[gi + oy] * (1.0f - xf) * (yf) * (1.0f - zf)
-                                   + b->buf[gi + ox + oy] * (xf) * (yf) * (1.0f - zf)
-                                   + b->buf[gi + oz] * (1.0f - xf) * (1.0f - yf) * (zf)
-                                   + b->buf[gi + ox + oz] * (xf) * (1.0f - yf) * (zf)
-                                   + b->buf[gi + oy + oz] * (1.0f - xf) * (yf) * (zf)
-                                   + b->buf[gi + ox + oy + oz] * (xf) * (yf) * (zf));
+                         + norm * (buf[gi] * (1.0f - xf) * (1.0f - yf) * (1.0f - zf)
+                                   + buf[gi + ox] * (xf) * (1.0f - yf) * (1.0f - zf)
+                                   + buf[gi + oy] * (1.0f - xf) * (yf) * (1.0f - zf)
+                                   + buf[gi + ox + oy] * (xf) * (yf) * (1.0f - zf)
+                                   + buf[gi + oz] * (1.0f - xf) * (1.0f - yf) * (zf)
+                                   + buf[gi + ox + oz] * (xf) * (1.0f - yf) * (zf)
+                                   + buf[gi + oy + oz] * (1.0f - xf) * (yf) * (zf)
+                                   + buf[gi + ox + oy + oz] * (xf) * (yf) * (zf));
       out[index] = Lout;
       // and copy color and mask
       out[index + 1] = in[index + 1];
       out[index + 2] = in[index + 2];
       out[index + 3] = in[index + 3];
-      index += 4;
     }
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd aligned(out, in :64)
+#endif
+__DT_CLONE_TARGETS__
 void dt_bilateral_slice_to_output(const dt_bilateral_t *const b, const float *const in, float *out,
                                   const float detail)
 {
@@ -311,16 +345,20 @@ void dt_bilateral_slice_to_output(const dt_bilateral_t *const b, const float *co
   const int ox = 1;
   const int oy = b->size_x;
   const int oz = b->size_y * b->size_x;
+
+  float *const buf = b->buf;
+
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
+#pragma omp parallel for simd default(none) \
     dt_omp_firstprivate(b, in, norm, oy, oz) \
-    shared(out)
+    shared(out, buf) collapse(2) \
+    aligned(out, in, buf:64)
 #endif
   for(int j = 0; j < b->height; j++)
   {
-    size_t index = 4 * j * b->width;
     for(int i = 0; i < b->width; i++)
     {
+      size_t index = 4 * (j * b->width + i);
       float x, y, z;
       const float L = in[index];
       image_to_grid(b, i, j, L, &x, &y, &z);
@@ -332,16 +370,15 @@ void dt_bilateral_slice_to_output(const dt_bilateral_t *const b, const float *co
       const float yf = y - yi;
       const float zf = z - zi;
       const size_t gi = xi + b->size_x * (yi + b->size_y * zi);
-      const float Lout = norm * (b->buf[gi] * (1.0f - xf) * (1.0f - yf) * (1.0f - zf)
-                                 + b->buf[gi + ox] * (xf) * (1.0f - yf) * (1.0f - zf)
-                                 + b->buf[gi + oy] * (1.0f - xf) * (yf) * (1.0f - zf)
-                                 + b->buf[gi + ox + oy] * (xf) * (yf) * (1.0f - zf)
-                                 + b->buf[gi + oz] * (1.0f - xf) * (1.0f - yf) * (zf)
-                                 + b->buf[gi + ox + oz] * (xf) * (1.0f - yf) * (zf)
-                                 + b->buf[gi + oy + oz] * (1.0f - xf) * (yf) * (zf)
-                                 + b->buf[gi + ox + oy + oz] * (xf) * (yf) * (zf));
-      out[index] = MAX(0.0f, out[index] + Lout);
-      index += 4;
+      const float Lout = norm * (buf[gi] * (1.0f - xf) * (1.0f - yf) * (1.0f - zf)
+                                 + buf[gi + ox] * (xf) * (1.0f - yf) * (1.0f - zf)
+                                 + buf[gi + oy] * (1.0f - xf) * (yf) * (1.0f - zf)
+                                 + buf[gi + ox + oy] * (xf) * (yf) * (1.0f - zf)
+                                 + buf[gi + oz] * (1.0f - xf) * (1.0f - yf) * (zf)
+                                 + buf[gi + ox + oz] * (xf) * (1.0f - yf) * (zf)
+                                 + buf[gi + oy + oz] * (1.0f - xf) * (yf) * (zf)
+                                 + buf[gi + ox + oy + oz] * (xf) * (yf) * (zf));
+      out[index] = fmaxf(0.0f, out[index] + Lout);
     }
   }
 }

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -136,7 +136,7 @@ void dt_bilateral_splat(dt_bilateral_t *b, const float *const in)
 // splat into downsampled grid
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, oy, oz, sigma_s) \
+  dt_omp_firstprivate(in, oy, oz, ox, sigma_s) \
   shared(b, buf) \
   collapse(2)
 #endif
@@ -186,7 +186,7 @@ static void blur_line_z(float *buf, const int offset1, const int offset2, const 
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3) \
+    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3, w1, w2) \
     shared(buf) collapse(2)
 #endif
   for(int k = 0; k < size1; k++)
@@ -233,7 +233,7 @@ static void blur_line(float *buf, const int offset1, const int offset2, const in
   const float w2 = 1.f / 16.f;
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3) \
+    dt_omp_firstprivate(size1, size2, size3, offset1, offset2, offset3, w0, w1, w2) \
     shared(buf) collapse(2)
 #endif
   for(int k = 0; k < size1; k++)
@@ -296,7 +296,7 @@ void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, fl
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(b, in, norm, oy, oz) \
+    dt_omp_firstprivate(b, in, norm, oy, oz, ox) \
     shared(out, buf) collapse(2) aligned(in, out, buf:64)
 #endif
   for(int j = 0; j < b->height; j++)
@@ -350,7 +350,7 @@ void dt_bilateral_slice_to_output(const dt_bilateral_t *const b, const float *co
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(b, in, norm, oy, oz) \
+    dt_omp_firstprivate(b, in, norm, oy, oz, ox) \
     shared(out, buf) collapse(2) \
     aligned(out, in, buf:64)
 #endif

--- a/src/common/bilateral.h
+++ b/src/common/bilateral.h
@@ -25,8 +25,8 @@ typedef struct dt_bilateral_t
   size_t size_x, size_y, size_z;
   int width, height;
   float sigma_s, sigma_r;
-  float *buf;
-} dt_bilateral_t;
+  float *buf __attribute__((aligned(64)));
+} __attribute__((packed)) dt_bilateral_t;
 
 size_t dt_bilateral_memory_use(const int width,      // width of input image
                                const int height,     // height of input image

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -74,6 +74,9 @@ typedef unsigned int u_int;
 #include <sys/sysctl.h>
 #endif
 
+/* Create clone architectures for various CPU SSE generations */
+#define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "fma4")))
+
 #ifdef _OPENMP
 # include <omp.h>
 

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -75,7 +75,9 @@ typedef unsigned int u_int;
 #endif
 
 /* Create clone architectures for various CPU SSE generations */
+#if defined(__GNUC__)
 #define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "fma4")))
+#endif
 
 #ifdef _OPENMP
 # include <omp.h>

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -75,8 +75,12 @@ typedef unsigned int u_int;
 #endif
 
 /* Create clone architectures for various CPU SSE generations */
-#if defined(__GNUC__)
-#define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "fma4")))
+/* See for instructions https://hannes.hauswedell.net/post/2017/12/09/fmv/ */
+/* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
+#if __has_attribute(target_clones)
+#define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "avx512f", "fma4")))
+#else
+#define __DT_CLONE_TARGETS__
 #endif
 
 #ifdef _OPENMP
@@ -147,7 +151,7 @@ static inline int dt_version()
 }
 
 #ifndef M_PI
-#define M_PI 3.14159265358979323846
+#define M_PI 3.14159265358979323846F
 #endif
 
 // Golden number (1+sqrt(5))/2

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -74,15 +74,6 @@ typedef unsigned int u_int;
 #include <sys/sysctl.h>
 #endif
 
-/* Create clone architectures for various CPU SSE generations */
-/* See for instructions https://hannes.hauswedell.net/post/2017/12/09/fmv/ */
-/* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
-#if __has_attribute(target_clones)
-#define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "avx512f", "fma4")))
-#else
-#define __DT_CLONE_TARGETS__
-#endif
-
 #ifdef _OPENMP
 # include <omp.h>
 


### PR DESCRIPTION
Rewrite the loops as perfectly nested ones and collapse them, enable SIMD and target clones.

The speed-up expected is ×4 for CPU bilateral filters (in local contrast).