### PR TITLE
add target clones

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -93,6 +93,15 @@ typedef unsigned int u_int;
 
 #endif /* _OPENMP */
 
+/* Create cloned functions for various CPU SSE generations */
+/* See for instructions https://hannes.hauswedell.net/post/2017/12/09/fmv/ */
+/* TL;DR : use only on SIMD functions containing low-level paralellized/vectorized loops */
+#if __has_attribute(target_clones)
+#define __DT_CLONE_TARGETS__ __attribute__((target_clones("default", "sse2", "sse3", "sse4.1", "sse4.2", "popcnt", "avx", "avx2", "avx512f", "fma4")))
+#else
+#define __DT_CLONE_TARGETS__
+#endif
+
 #ifndef _RELEASE
 #include "common/poison.h"
 #endif


### PR DESCRIPTION
For compilers that support it, add target clone support. By tagging the functions containing vectorized loops and such, it will compile the functions several times with special optimizations for different SSE generations, in order to get optimized versions in generic release builds.