### PR TITLE
Optimize exposure module

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -396,6 +396,7 @@ error:
 }
 #endif
 
+__DT_CLONE_TARGETS__
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict i, void *const restrict o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -427,6 +428,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 }
 
 #if defined(__SSE__)
+__DT_CLONE_TARGETS__
 void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict i,
                   void *const restrict o, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {


### PR DESCRIPTION
Make the simple `process` function run on-par with the SSE one (± 2 ms) by setting OpenMP properly. Collapse the loops and make use of fused multiply-add for performance.

Notice that I get CPU runtimes about half the OpenCL one (8 ms with SSE on Intel Xeon 1505M @ 3 Ghz, 16 ms on Nividia Quadro M2000). I think we should deprecate the OpenCL kernel since the algorithmic complexity is not worth the buffer copies overhead.