### PR TITLE
process histogram waveform when needed

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -416,6 +416,13 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
       darktable.develop->histogram_type = (darktable.develop->histogram_type + 1) % DT_DEV_HISTOGRAM_N;
       dt_conf_set_string("plugins/darkroom/histogram/mode",
                          dt_dev_histogram_type_names[darktable.develop->histogram_type]);
+      // we need to reprocess the preview pipe
+      if(darktable.develop->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+      {
+        darktable.develop->preview_status = DT_DEV_PIXELPIPE_DIRTY;
+        darktable.develop->preview_pipe->cache_obsolete = 1;
+        dt_control_queue_redraw();
+      }
     }
     else if(d->highlight == 4) // red button
     {


### PR DESCRIPTION
Process histogram waveform only when needed, this saves a bit of time on each preview pipe process, at the expense of having to reprocess when the histogram type is changed.