### PR TITLE
fix relative filepath issue between OS - issue #2681

### DIFF
--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -793,13 +793,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 void filepath_set_OS_separator(char *filepath)
 {
   const int len = strlen(filepath);
-#if defined(_WIN32)
-  for(int i=0; i<len; ++i)
-    if (filepath[i]=='/') filepath[i] = '\\';
-#else
   for(int i=0; i<len; ++i)
     if (filepath[i]=='\\') filepath[i] = '/';
-#endif
 }
 
 void init(dt_iop_module_t *self)
@@ -888,8 +883,6 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_lut3d_data_t *d = (dt_iop_lut3d_data_t *)piece->data;
   d->clut = NULL;
   d->level = 0;
-  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
-  filepath_set_OS_separator(p->filepath);
   self->commit_params(self, self->default_params, pipe, piece);
 }
 
@@ -910,6 +903,7 @@ static void filepath_callback(GtkWidget *w, dt_iop_module_t *self)
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   snprintf(p->filepath, sizeof(p->filepath), "%s", gtk_entry_get_text(GTK_ENTRY(w)));
+  filepath_set_OS_separator(p->filepath);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -790,6 +790,18 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 }
 
+void filepath_set_OS_separator(char *filepath)
+{
+  const int len = strlen(filepath);
+#if defined(_WIN32)
+  for(int i=0; i<len; ++i)
+    if (filepath[i]=='/') filepath[i] = '\\';
+#else
+  for(int i=0; i<len; ++i)
+    if (filepath[i]=='\\') filepath[i] = '/';
+#endif
+}
+
 void init(dt_iop_module_t *self)
 {
   self->data = NULL;
@@ -876,6 +888,8 @@ void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pi
   dt_iop_lut3d_data_t *d = (dt_iop_lut3d_data_t *)piece->data;
   d->clut = NULL;
   d->level = 0;
+  dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
+  filepath_set_OS_separator(p->filepath);
   self->commit_params(self, self->default_params, pipe, piece);
 }
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -790,7 +790,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 }
 
-void filepath_set_all_OS_separator(char *filepath)
+void filepath_set_unix_separator(char *filepath)
 { // use the unix separator as it works also on windows
   const int len = strlen(filepath);
   for(int i=0; i<len; ++i)
@@ -903,7 +903,7 @@ static void filepath_callback(GtkWidget *w, dt_iop_module_t *self)
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   snprintf(p->filepath, sizeof(p->filepath), "%s", gtk_entry_get_text(GTK_ENTRY(w)));
-  filepath_set_all_OS_separator(p->filepath);
+  filepath_set_unix_separator(p->filepath);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -790,8 +790,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 }
 
-void filepath_set_OS_separator(char *filepath)
-{
+void filepath_set_all_OS_separator(char *filepath)
+{ // use the unix separator as it works also on windows
   const int len = strlen(filepath);
   for(int i=0; i<len; ++i)
     if (filepath[i]=='\\') filepath[i] = '/';
@@ -903,7 +903,7 @@ static void filepath_callback(GtkWidget *w, dt_iop_module_t *self)
   if(darktable.gui->reset) return;
   dt_iop_lut3d_params_t *p = (dt_iop_lut3d_params_t *)self->params;
   snprintf(p->filepath, sizeof(p->filepath), "%s", gtk_entry_get_text(GTK_ENTRY(w)));
-  filepath_set_OS_separator(p->filepath);
+  filepath_set_all_OS_separator(p->filepath);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 


### PR DESCRIPTION
Try to fix the issue #2681 
Before using the filepath parameter it should convert '\\' characters to '/' on Linux. The other way on Windows.

