### PR TITLE
Accels fixes & enhancements

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2148,6 +2148,7 @@ gchar *dt_iop_get_localized_name(const gchar *op)
 
 void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t state)
 {
+  const dt_iop_module_state_t old_state = module->state;
   module->state = state;
 
   char option[1024];
@@ -2211,6 +2212,41 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
     dt_conf_set_bool(option, TRUE);
     snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
     dt_conf_set_bool(option, TRUE);
+  }
+
+  // (dis)connect key accels
+  if(old_state == dt_iop_state_HIDDEN && state != dt_iop_state_HIDDEN)
+  {
+    // connect
+    mods = g_list_first(darktable.develop->iop);
+    while(mods)
+    {
+      dt_iop_module_t *mod = (dt_iop_module_t *)mods->data;
+      if(mod->so == module)
+      {
+        if(mod->connect_key_accels) mod->connect_key_accels(mod);
+        dt_iop_connect_common_accels(mod);
+      }
+      mods = g_list_next(mods);
+    }
+    dt_dynamic_accel_get_valid_list();
+  }
+  else if(state == dt_iop_state_HIDDEN && old_state != dt_iop_state_HIDDEN)
+  {
+    // disconnect
+    mods = g_list_first(darktable.develop->iop);
+    while(mods)
+    {
+      dt_iop_module_t *mod = (dt_iop_module_t *)mods->data;
+      if(mod->so == module)
+      {
+        dt_accel_disconnect_list(mod->accel_closures);
+        dt_accel_cleanup_locals_iop(mod);
+        mod->accel_closures = NULL;
+      }
+      mods = g_list_next(mods);
+    }
+    dt_dynamic_accel_get_valid_list();
   }
 
   dt_view_manager_t *vm = darktable.view_manager;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -243,7 +243,7 @@ void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType m
 }
 
 
-static dt_accel_t *_lookup_accel(gchar *path)
+static dt_accel_t *_lookup_accel(const gchar *path)
 {
   GSList *l = darktable.control->accelerator_list;
   while(l)
@@ -1067,6 +1067,10 @@ void dt_dynamic_accel_get_valid_list()
   }
 }
 
+dt_accel_t *dt_accel_find_by_path(const gchar *path)
+{
+  return _lookup_accel(path);
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -239,7 +239,8 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
   g_strlcpy(daccel->module, so->op, sizeof(daccel->module));
   daccel->local = local;
   daccel->views = DT_VIEW_DARKROOM;
-  
+  daccel->mod_so = so;
+
   darktable.control->dynamic_accelerator_list
       = g_slist_prepend(darktable.control->dynamic_accelerator_list, daccel);
 }
@@ -541,6 +542,8 @@ void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, Gtk
     }
     l = g_slist_next(l);
   }
+  accel = _lookup_accel(dynamic_path);
+  module->accel_closures = g_slist_prepend(module->accel_closures, accel);
 }
 
 void dt_accel_connect_locals_iop(dt_iop_module_t *module)
@@ -1068,7 +1071,7 @@ void dt_dynamic_accel_get_valid_list()
   while(l)
   {
     dt_accel_dynamic_t *da = (dt_accel_dynamic_t *)l->data;
-    if(da)
+    if(da && da->mod_so->state != dt_iop_state_HIDDEN)
     {
       GtkAccelKey ak;
       if(gtk_accel_map_lookup_entry(da->path, &ak))

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -123,6 +123,7 @@ void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierTyp
 
   *(accel->module) = '\0';
   accel->local = FALSE;
+  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -140,6 +141,7 @@ void dt_accel_register_view(dt_view_t *self, const gchar *path, guint accel_key,
 
   g_strlcpy(accel->module, self->module_name, sizeof(accel->module));
   accel->local = FALSE;
+  accel->views = self->view(self);
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -158,6 +160,7 @@ void dt_accel_register_iop(dt_iop_module_so_t *so, gboolean local, const gchar *
 
   g_strlcpy(accel->module, so->op, sizeof(accel->module));
   accel->local = local;
+  accel->views = DT_VIEW_DARKROOM;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -174,6 +177,20 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
 
   g_strlcpy(accel->module, self->plugin_name, sizeof(accel->module));
   accel->local = FALSE;
+  // we get the views in which the lib will be displayed
+  accel->views = 0;
+  int i=0;
+  const gchar **views = self->views(self);
+  while (views[i])
+  {
+    if (strcmp(views[i], "lighttable") == 0) accel->views |= DT_VIEW_LIGHTTABLE;
+    else if (strcmp(views[i], "darkroom") == 0) accel->views |= DT_VIEW_DARKROOM;
+    else if (strcmp(views[i], "print") == 0) accel->views |= DT_VIEW_PRINT;
+    else if (strcmp(views[i], "slideshow") == 0) accel->views |= DT_VIEW_SLIDESHOW;
+    else if (strcmp(views[i], "map") == 0) accel->views |= DT_VIEW_MAP;
+    else if (strcmp(views[i], "tethering") == 0) accel->views |= DT_VIEW_TETHERING;
+    i++;  
+  }
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -209,6 +226,7 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
     g_strlcpy(accel->translated_path, paths_trans[i], sizeof(accel->translated_path));
     g_strlcpy(accel->module, so->op, sizeof(accel->module));
     accel->local = local;
+    accel->views = DT_VIEW_DARKROOM;
 
     darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
   }
@@ -220,7 +238,8 @@ void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const 
   g_strlcpy(daccel->translated_path, paths_trans[4], sizeof(daccel->translated_path));
   g_strlcpy(daccel->module, so->op, sizeof(daccel->module));
   daccel->local = local;
-
+  daccel->views = DT_VIEW_DARKROOM;
+  
   darktable.control->dynamic_accelerator_list
       = g_slist_prepend(darktable.control->dynamic_accelerator_list, daccel);
 }
@@ -239,6 +258,7 @@ void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType m
 
   *(accel->module) = '\0';
   accel->local = FALSE;
+  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -189,6 +189,9 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
     else if (strcmp(views[i], "slideshow") == 0) accel->views |= DT_VIEW_SLIDESHOW;
     else if (strcmp(views[i], "map") == 0) accel->views |= DT_VIEW_MAP;
     else if (strcmp(views[i], "tethering") == 0) accel->views |= DT_VIEW_TETHERING;
+    else if(strcmp(views[i], "*") == 0)
+      accel->views |= DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT
+                      | DT_VIEW_SLIDESHOW;
     i++;  
   }
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -46,6 +46,7 @@ typedef struct dt_accel_dynamic_t
   dt_view_type_flags_t views;
   GtkAccelKey accel_key;
   GtkWidget *widget;
+  dt_iop_module_so_t *mod_so;
 
 } dt_accel_dynamic_t;
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -31,6 +31,7 @@ typedef struct dt_accel_t
   gchar translated_path[256];
   gchar module[256];
   gboolean local;
+  dt_view_type_flags_t views;
   GClosure *closure;
 
 } dt_accel_t;
@@ -42,6 +43,7 @@ typedef struct dt_accel_dynamic_t
   gchar translated_path[256];
   gchar module[256];
   gboolean local;
+  dt_view_type_flags_t views;
   GtkAccelKey accel_key;
   GtkWidget *widget;
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -62,8 +62,11 @@ void dt_accel_path_lua(char *s, size_t n, const char *path);
  * 4 - Slider dynamic path
  */
 void dt_accel_paths_slider_iop(char *s[], size_t n, char *module, const char *path);
+
+// Accelerator search functions
 dt_accel_dynamic_t *dt_dynamic_accel_find_by_key(guint accel_key, GdkModifierType mods);
 void dt_dynamic_accel_get_valid_list();
+dt_accel_t *dt_accel_find_by_path(const gchar *path);
 
 // Accelerator registration functions
 void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierType mods);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -832,7 +832,8 @@ static void delete_matching_accels(gpointer current, gpointer mapped)
   if(current_key.accel_key == mapped_key.accel_key                 // Key code matches
      && current_key.accel_mods == mapped_key.accel_mods            // Key state matches
      && !(current_accel->local && mapped_accel->local              // Not both local to
-          && strcmp(current_accel->module, mapped_accel->module))) // diff mods
+          && strcmp(current_accel->module, mapped_accel->module))
+     && (current_accel->views & mapped_accel->views) != 0) // diff mods
     gtk_accel_map_change_entry(current_accel->path, 0, 0, TRUE);
 }
 
@@ -938,28 +939,6 @@ static void tree_selection_changed(GtkTreeSelection *selection, gpointer data)
   darktable.control->accel_remap_path = NULL;
 }
 
-static void _accel_find_conflict(gpointer data, const gchar *accel_path, guint accel_key,
-                                 GdkModifierType accel_mods, gboolean changed)
-{
-  dt_accel_dynamic_t *cur = (dt_accel_dynamic_t *)data;
-  if(accel_key == cur->accel_key.accel_key && accel_mods == cur->accel_key.accel_mods)
-  {
-    // we get the corresponding accel
-    dt_accel_t *a = dt_accel_find_by_path(accel_path);
-
-    if(a && !(a->local && cur->local && strcmp(cur->module, a->module)))
-    {
-      g_strlcpy(cur->path, accel_path, sizeof(cur->path));
-      g_strlcpy(cur->translated_path, a->translated_path, sizeof(cur->translated_path));
-    }
-    else if(!a)
-    {
-      g_strlcpy(cur->path, accel_path, sizeof(cur->path));
-      g_strlcpy(cur->translated_path, accel_path, sizeof(cur->translated_path));
-    }
-  }
-}
-
 static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
   GtkTreeModel *model = (GtkTreeModel *)data;
@@ -988,15 +967,27 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
     const dt_accel_t *accel_current = (dt_accel_t *)remapped->data;
 
     // let's search for conflicts
-    dt_accel_dynamic_t accel_tmp; // dummy accels to carry values for the above foreach
-    g_strlcpy(accel_tmp.path, "", sizeof(accel_tmp.path));
-    accel_tmp.accel_key.accel_key = gdk_keyval_to_lower(event->keyval);
-    accel_tmp.accel_key.accel_mods = event->state & KEY_STATE_MASK;
-    accel_tmp.local = accel_current->local;
-    g_strlcpy(accel_tmp.module, accel_current->module, sizeof(accel_tmp.module));
-    gtk_accel_map_foreach_unfiltered(&accel_tmp, _accel_find_conflict);
+    dt_accel_t *accel_conflict = NULL;
+    GSList *l = darktable.control->accelerator_list;
+    while (l)
+    {
+      dt_accel_t *a = (dt_accel_t *)l->data;
+      GtkAccelKey key;
+      if (a != accel_current && gtk_accel_map_lookup_entry(a->path, &key))
+      {
+        if (key.accel_key == gdk_keyval_to_lower(event->keyval) &&
+            key.accel_mods == (event->state & KEY_STATE_MASK) &&
+            !(a->local && accel_current->local && strcmp(a->module, accel_current->module)) &&
+            (a->views & accel_current->views) != 0)
+        {
+          accel_conflict = a;
+          break;
+        }
+      }
+      l = g_slist_next(l);
+    }
 
-    if(strncmp(accel_tmp.path, "", sizeof(accel_tmp.path)) == 0)
+    if(!accel_conflict)
     {
       // no conflict
       gtk_accel_map_change_entry(darktable.control->accel_remap_str, gdk_keyval_to_lower(event->keyval),
@@ -1009,10 +1000,10 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
       gchar *accel_txt
           = gtk_accelerator_get_label(gdk_keyval_to_lower(event->keyval), event->state & KEY_STATE_MASK);
       gchar txt[512] = { 0 };
-      if(g_str_has_prefix(accel_tmp.translated_path, "<Darktable>/"))
-        g_strlcpy(txt, accel_tmp.translated_path + 12, sizeof(txt));
+      if(g_str_has_prefix(accel_conflict->translated_path, "<Darktable>/"))
+        g_strlcpy(txt, accel_conflict->translated_path + 12, sizeof(txt));
       else
-        g_strlcpy(txt, accel_tmp.translated_path, sizeof(txt));
+        g_strlcpy(txt, accel_conflict->translated_path, sizeof(txt));
       GtkWidget *dialog = gtk_message_dialog_new(
           GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
           _("%s accel is already mapped to\n%s.\ndo you want to replace it ?"), accel_txt, txt);
@@ -1031,7 +1022,7 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
                                       event->state & KEY_STATE_MASK, TRUE))
         {
           // Then remove conflicts
-          g_slist_foreach(darktable.control->accelerator_list, delete_matching_accels, (gpointer)(remapped->data));
+          g_slist_foreach(darktable.control->accelerator_list, delete_matching_accels, (gpointer)(accel_current));
         }
       }
     }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2400,10 +2400,13 @@ void enter(dt_view_t *self)
       dt_iop_gui_set_expanded(module, dt_conf_get_bool(option), FALSE);
     }
 
-    /* setup key accelerators */
+    /* setup key accelerators (only if not hidden) */
     module->accel_closures = NULL;
-    if(module->connect_key_accels) module->connect_key_accels(module);
-    dt_iop_connect_common_accels(module);
+    if(module->so->state != dt_iop_state_HIDDEN)
+    {
+      if(module->connect_key_accels) module->connect_key_accels(module);
+      dt_iop_connect_common_accels(module);
+    }
 
     modules = g_list_previous(modules);
   }


### PR DESCRIPTION
This contains : 
- accels from hidden iop (with the "more module" lib) are now not connected. This avoid to blindly change (and activate) invisible iops. The accel states are updated when the iop visibility change.
- in pref, you can now set same accels for different actions if they don't "overlap" (belongs to different views) This allow to set same accels to undo/redo, for example. This should allow to use little more accels too, as lighttable ones can be reused for other things in darkroom
- in pref, when you try to set an already used key, dt will ask you what to do (replace or cancel) instead of silently replace accels.