### PR TITLE
Make disk export more configurable

### DIFF
--- a/doc/usermanual/lighttable/panels/export.xml
+++ b/doc/usermanual/lighttable/panels/export.xml
@@ -133,6 +133,22 @@
             </row>
             <row>
               <entry>
+                <code>$(MAX_WIDTH)</code>
+              </entry>
+              <entry>
+                maximum image width to limit within export session
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <code>$(MAX_HEIGHT)</code>
+              </entry>
+              <entry>
+                maximum image height to limit within export session
+              </entry>
+            </row>
+            <row>
+              <entry>
                 <code>$(YEAR)</code>
               </entry>
               <entry>

--- a/doc/usermanual/preferences/session_options.xml
+++ b/doc/usermanual/preferences/session_options.xml
@@ -97,6 +97,22 @@
         </row>
         <row>
           <entry>
+            $(MAX_WIDTH)
+          </entry>
+          <entry>
+            maximum image width to limit within export session
+          </entry>
+        </row>
+        <row>
+          <entry>
+            $(MAX_HEIGHT)
+          </entry>
+          <entry>
+            maximum image height to limit within export session
+          </entry>
+        </row>
+        <row>
+          <entry>
             $(ID)
           </entry>
           <entry>

--- a/po/ru.po
+++ b/po/ru.po
@@ -3624,98 +3624,106 @@ msgid "$(SEQUENCE) - sequence number"
 msgstr "$(SEQUENCE) — номер последовательности"
 
 #: ../src/gui/gtkentry.c:192
+msgid "$(MAX_WIDTH) - maximum image export width"
+msgstr "$(MAX_WIDTH) - максимальная ширина снимка"
+
+#: ../src/gui/gtkentry.c:193
+msgid "$(MAX_HEIGHT) - maximum image export height"
+msgstr "$(MAX_HEIGHT) - максимальная высота снимка"
+
+#: ../src/gui/gtkentry.c:194
 msgid "$(YEAR) - year"
 msgstr "$(YEAR) — год"
 
-#: ../src/gui/gtkentry.c:193
+#: ../src/gui/gtkentry.c:195
 msgid "$(MONTH) - month"
 msgstr "$(MONTH) — месяц"
 
-#: ../src/gui/gtkentry.c:194
+#: ../src/gui/gtkentry.c:196
 msgid "$(DAY) - day"
 msgstr "$(DAY) — день"
 
-#: ../src/gui/gtkentry.c:195
+#: ../src/gui/gtkentry.c:197
 msgid "$(HOUR) - hour"
 msgstr "$(HOUR) — час"
 
-#: ../src/gui/gtkentry.c:196
+#: ../src/gui/gtkentry.c:198
 msgid "$(MINUTE) - minute"
 msgstr "$(MINUTE) — минута"
 
-#: ../src/gui/gtkentry.c:197
+#: ../src/gui/gtkentry.c:199
 msgid "$(SECOND) - second"
 msgstr "$(SECOND) — секунда"
 
-#: ../src/gui/gtkentry.c:198
+#: ../src/gui/gtkentry.c:200
 msgid "$(EXIF_YEAR) - EXIF year"
 msgstr "$(EXIF_YEAR) — год по EXIF"
 
-#: ../src/gui/gtkentry.c:199
+#: ../src/gui/gtkentry.c:201
 msgid "$(EXIF_MONTH) - EXIF month"
 msgstr "$(EXIF_MONTH) — месяц по EXIF"
 
-#: ../src/gui/gtkentry.c:200
+#: ../src/gui/gtkentry.c:202
 msgid "$(EXIF_DAY) - EXIF day"
 msgstr "$(EXIF_DAY) — день по EXIF"
 
-#: ../src/gui/gtkentry.c:201
+#: ../src/gui/gtkentry.c:203
 msgid "$(EXIF_HOUR) - EXIF hour"
 msgstr "$(EXIF_HOUR) — час по EXIF"
 
-#: ../src/gui/gtkentry.c:202
+#: ../src/gui/gtkentry.c:204
 msgid "$(EXIF_MINUTE) - EXIF minute"
 msgstr "$(EXIF_MINUTE) — минута по EXIF"
 
-#: ../src/gui/gtkentry.c:203
+#: ../src/gui/gtkentry.c:205
 msgid "$(EXIF_SECOND) - EXIF second"
 msgstr "$(EXIF_SECOND) — секунда по EXIF"
 
-#: ../src/gui/gtkentry.c:204
+#: ../src/gui/gtkentry.c:206
 msgid "$(EXIF_ISO) - ISO value"
 msgstr "$(EXIF_ISO) — значение ISO"
 
-#: ../src/gui/gtkentry.c:205
+#: ../src/gui/gtkentry.c:207
 msgid "$(MAKER) - camera maker"
 msgstr "$(MAKER) — изготовитель камеры"
 
-#: ../src/gui/gtkentry.c:206
+#: ../src/gui/gtkentry.c:208
 msgid "$(MODEL) - camera model"
 msgstr "$(MODEL) — модель камеры"
 
-#: ../src/gui/gtkentry.c:207
+#: ../src/gui/gtkentry.c:209
 msgid "$(STARS) - star rating"
 msgstr "$(STARS) — оценка"
 
-#: ../src/gui/gtkentry.c:208
+#: ../src/gui/gtkentry.c:210
 msgid "$(LABELS) - colorlabels"
 msgstr "$(LABELS) — цветовые метки"
 
-#: ../src/gui/gtkentry.c:209
+#: ../src/gui/gtkentry.c:211
 msgid "$(PICTURES_FOLDER) - pictures folder"
 msgstr "$(PICTURES_FOLDER) — каталог со снимками"
 
-#: ../src/gui/gtkentry.c:210
+#: ../src/gui/gtkentry.c:212
 msgid "$(HOME) - home folder"
 msgstr "$(HOME) — домашний каталог"
 
-#: ../src/gui/gtkentry.c:211
+#: ../src/gui/gtkentry.c:213
 msgid "$(DESKTOP) - desktop folder"
 msgstr "$(DESKTOP) — каталог рабочего стола"
 
-#: ../src/gui/gtkentry.c:212
+#: ../src/gui/gtkentry.c:214
 msgid "$(TITLE) - title from metadata"
 msgstr "$(TITLE) — заголовок из метаданных"
 
-#: ../src/gui/gtkentry.c:213
+#: ../src/gui/gtkentry.c:215
 msgid "$(CREATOR) - creator from metadata"
 msgstr "$(TITLE) — создатель из метаданных"
 
-#: ../src/gui/gtkentry.c:214
+#: ../src/gui/gtkentry.c:216
 msgid "$(PUBLISHER) - publisher from metadata"
 msgstr "$(TITLE) — публикующий из метаданных"
 
-#: ../src/gui/gtkentry.c:215
+#: ../src/gui/gtkentry.c:217
 msgid "$(RIGHTS) - rights from metadata"
 msgstr "$(TITLE) — авторские права из метаданных"
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -396,8 +396,8 @@ int main(int argc, char *arg[])
   for(GList *iter = id_list; iter; iter = g_list_next(iter), num++)
   {
     int id = GPOINTER_TO_INT(iter->data);
-    storage->store(storage, sdata, id, format, fdata, num, total, high_quality, upscale, icc_type, icc_filename,
-                   icc_intent);
+    storage->store(storage, sdata, id, format, fdata, num, total, width, height,
+                   high_quality, upscale, icc_type, icc_filename, icc_intent);
   }
 
   // cleanup time

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -175,7 +175,8 @@ typedef struct dt_imageio_module_storage_t
   /* this actually does the work */
   int (*store)(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data,
                const int imgid, dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata,
-               const int num, const int total, const gboolean high_quality, const gboolean upscale,
+               const int num, const int total, const int max_width, const int max_height,
+               const gboolean high_quality, const gboolean upscale,
                dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                dt_iop_color_intent_t icc_intent);
   /* called once at the end (after exporting all images), if implemented. */

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -217,14 +217,6 @@ void dt_import_session_set_filename(struct dt_import_session_t *self, const char
 }
 
 
-/*
-void dt_import_session_set_max_width_height(struct dt_import_session_t *self, int max_width, max_height)
-{
-  dt_variables_set_max_width_height(self->vp, max_width, max_height);
-}
-*/
-
-
 int32_t dt_import_session_film_id(struct dt_import_session_t *self)
 {
   if(self->film) return self->film->id;

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -217,6 +217,14 @@ void dt_import_session_set_filename(struct dt_import_session_t *self, const char
 }
 
 
+/*
+void dt_import_session_set_max_width_height(struct dt_import_session_t *self, int max_width, max_height)
+{
+  dt_variables_set_max_width_height(self->vp, max_width, max_height);
+}
+*/
+
+
 int32_t dt_import_session_film_id(struct dt_import_session_t *self)
 {
   if(self->film) return self->film->id;

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -37,6 +37,10 @@ typedef struct dt_variables_data_t
   time_t exif_time;
   guint sequence;
 
+  /* export settings for image maximum width and height taken from GUI */
+  int max_width;
+  int max_height;
+
   char *homedir;
   char *pictures_folder;
   const char *file_ext;
@@ -354,6 +358,10 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     }
     g_list_free_full(res, &g_free);
   }
+  else if(has_prefix(variable, "MAX_WIDTH"))
+    result = g_strdup_printf("%d", params->data->max_width);
+  else if(has_prefix(variable, "MAX_HEIGHT"))
+    result = g_strdup_printf("%d", params->data->max_height);
   else
   {
     // go past what looks like an invalid variable. we only expect to see [a-zA-Z]* in a variable name.
@@ -724,6 +732,12 @@ void dt_variables_params_destroy(dt_variables_params_t *params)
 {
   g_free(params->data);
   g_free(params);
+}
+
+void dt_variables_set_max_width_height(dt_variables_params_t *params, int max_width, int max_height)
+{
+  params->data->max_width = max_width;
+  params->data->max_height = max_height;
 }
 
 void dt_variables_set_time(dt_variables_params_t *params, time_t time)

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -45,6 +45,8 @@ typedef struct dt_variables_params_t
 void dt_variables_params_init(dt_variables_params_t **params);
 /** destroys an initialized dt_variables_params_t, pointer is garbage after this call. */
 void dt_variables_params_destroy(dt_variables_params_t *params);
+/** set max image width and height defined for an export session in a dt_variables_params_t. */
+void dt_variables_set_max_width_height(dt_variables_params_t *params, int max_width, int max_height);
 /** set the time in a dt_variables_params_t. */
 void dt_variables_set_time(dt_variables_params_t *params, time_t time);
 /** set the time to use for EXIF variables */

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1364,8 +1364,9 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
       else
       {
         dt_image_cache_read_release(darktable.image_cache, image);
-        if(mstorage->store(mstorage, sdata, imgid, mformat, fdata, num, total, settings->high_quality,
-                           settings->upscale, settings->icc_type, settings->icc_filename, settings->icc_intent) != 0)
+        if(mstorage->store(mstorage, sdata, imgid, mformat, fdata, num, total, settings->max_width, settings->max_height,
+                           settings->high_quality, settings->upscale, settings->icc_type, settings->icc_filename,
+                           settings->icc_intent) != 0)
           dt_control_job_cancel(job);
       }
     }

--- a/src/gui/gtkentry.c
+++ b/src/gui/gtkentry.c
@@ -189,6 +189,8 @@ const dt_gtkentry_completion_spec *dt_gtkentry_get_default_path_compl_list()
           { "FILE_EXTENSION", N_("$(FILE_EXTENSION) - extension of the input image") },
           { "VERSION", N_("$(VERSION) - duplicate version") },
           { "SEQUENCE", N_("$(SEQUENCE) - sequence number") },
+          { "MAX_WIDTH", N_("$(MAX_WIDTH) - maximum image export width") },
+          { "MAX_HEIGHT", N_("$(MAX_HEIGHT) - maximum image export height") },
           { "YEAR", N_("$(YEAR) - year") },
           { "MONTH", N_("$(MONTH) - month") },
           { "DAY", N_("$(DAY) - day") },

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -225,8 +225,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)sdata;
 
@@ -236,6 +236,8 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   g_strlcpy(pattern, d->filename, sizeof(pattern));
   gboolean from_cache = FALSE;
   dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
+  // set max_width and max_height values to expand them afterwards in darktable variables
+  dt_variables_set_max_width_height(d->vp, max_width, max_height);
   int fail = 0;
   // we're potentially called in parallel. have sequence number synchronized:
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -97,8 +97,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_email_t *d = (dt_imageio_email_t *)sdata;
 

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -1253,8 +1253,8 @@ int supported(struct dt_imageio_module_storage_t *self, struct dt_imageio_module
 /* this actually does the work */
 int store(dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   gint result = 1;
   dt_storage_facebook_param_t *p = (dt_storage_facebook_param_t *)sdata;

--- a/src/imageio/storage/flickr.c
+++ b/src/imageio/storage/flickr.c
@@ -596,8 +596,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   gint result = 0;
   dt_storage_flickr_params_t *p = (dt_storage_flickr_params_t *)sdata;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -219,8 +219,8 @@ static gint sort_pos(pair_t *a, pair_t *b)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)sdata;
 
@@ -368,8 +368,8 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 
   /* also export thumbnail: */
   // write with reduced resolution:
-  const int max_width = fdata->max_width;
-  const int max_height = fdata->max_height;
+  const int save_max_width = fdata->max_width;
+  const int save_max_height = fdata->max_height;
   fdata->max_width = 200;
   fdata->max_height = 200;
   // alter filename with -thumb:
@@ -387,8 +387,8 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
     return 1;
   }
   // restore for next image:
-  fdata->max_width = max_width;
-  fdata->max_height = max_height;
+  fdata->max_width = save_max_width;
+  fdata->max_height = save_max_height;
 
   printf("[export_job] exported to `%s'\n", filename);
   dt_control_log(ngettext("%d/%d exported to `%s'", "%d/%d exported to `%s'", num),

--- a/src/imageio/storage/googlephoto.c
+++ b/src/imageio/storage/googlephoto.c
@@ -1333,8 +1333,8 @@ int supported(struct dt_imageio_module_storage_t *self, struct dt_imageio_module
 /* this actually does the work */
 int store(dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_storage_gphoto_gui_data_t *ui = self->gui_data;
 

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -65,9 +65,9 @@ int initialize_store(struct dt_imageio_module_storage_t *self, struct dt_imageio
                      struct dt_imageio_module_format_t **format, struct dt_imageio_module_data_t **fdata,
                      GList **images, const gboolean high_quality, const gboolean upscale);
 /* this actually does the work */
-int store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data,
-          const int imgid, struct dt_imageio_module_format_t *format, struct dt_imageio_module_data_t *fdata,
-          const int num, const int total, const gboolean high_quality, const gboolean upscale,
+int store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data, const int imgid,
+          struct dt_imageio_module_format_t *format, struct dt_imageio_module_data_t *fdata, const int num, const int total,
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
           enum dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
           enum dt_iop_color_intent_t icc_intent);
 /* called once at the end (after exporting all images), if implemented. */

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -222,8 +222,8 @@ static gint sort_pos(pair_t *a, pair_t *b)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale,dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)sdata;
 

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -908,8 +908,8 @@ void finalize_store(struct dt_imageio_module_storage_t *self, dt_imageio_module_
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
-          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
+          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_storage_piwigo_gui_data_t *ui = self->gui_data;
 

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -77,7 +77,8 @@ static int default_dimension_wrapper(struct dt_imageio_module_storage_t *self, d
 
 static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data,
                          const int imgid, dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata,
-                         const int num, const int total, const gboolean high_quality, const gboolean upscale,
+                         const int num, const int total, const int max_width, const int max_height,
+                         const gboolean high_quality, const gboolean upscale,
                          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                          dt_iop_color_intent_t icc_intent)
 {
@@ -138,6 +139,8 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_ima
   lua_pushstring(L, complete_name);
   lua_pushinteger(L, num);
   lua_pushinteger(L, total);
+//  lua_pushinteger(L, max_width);
+//  lua_pushinteger(L, max_height);
   lua_pushboolean(L, high_quality);
   push_lua_data(L,d);
   dt_lua_goto_subtable(L,"extra");


### PR DESCRIPTION
Make image disk export even more configurable with implementation of 2 extra variables: `$(MAX_WIDTH)` and `$(MAX_HEIGHT)`. New variables allow to create path template like this `$(FILE_FOLDER)/darktable_exported_$(MAX_WIDTH)x$(MAX_HEIGHT)/$(FILE_NAME)`, which in turn make it possible to create multiple `darktable_exported` folders. In my case, with this template I can generate full resolution images and images limited to 2048x2048 which automatically sorted by 2 folders (`darktable_exported_0x0` and `darktable_exported_2048x2048`).

Implementation steps taken:
1) Add extra parameters (int max_width, int max_height) to dt_imageio_module_storage_t (*store) method. All dt_imageio_module_storage_t implementations were updated.
2) Add public `$(MAX_WIDTH)`, `$(MAX_HEIGHT)` variables to expand, once found in export path template.
3) Lua API doesn't change (store function), since I don't want to break existing scripts. Though it is possible to change in the future.
4) Add russian localization for `$(MAX_WIDTH)`, `$(MAX_HEIGHT)` variables description.