### PR TITLE
do not use cache for gamma on preview pipe

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -334,8 +334,7 @@ restart:
   dt_show_times(&start, "[dev_process_preview] pixel pipeline processing");
   dt_dev_average_delay_update(&start, &dev->preview_average_delay);
 
-  // redraw the whole thing, to also update color picker values and histograms etc.
-  if(dev->gui_attached) dt_control_queue_redraw();
+  // if a widget needs to be redraw there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_log_busy_leave();
   dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -594,8 +593,7 @@ restart:
   dev->image_loading = 0;
 
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-  // redraw the whole thing, to also update color picker values and histograms etc.
-  if(dev->gui_attached) dt_control_queue_redraw();
+  // if a widget needs to be redraw there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_log_busy_leave();
   dt_pthread_mutex_unlock(&dev->pipe_mutex);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -979,7 +979,7 @@ static gboolean skip_b_key_accel_callback(GtkAccelGroup *accel_group, GObject *a
 
 static void _darkroom_ui_pipe_finish_signal_callback(gpointer instance, gpointer data)
 {
-  dt_control_queue_redraw();
+  dt_control_queue_redraw_center();
 }
 
 static void _darkroom_ui_preview2_pipe_finish_signal_callback(gpointer instance, gpointer user_data)


### PR DESCRIPTION
When gamma iop is retrieved from cache the final histogram is computed with the gamma output image, causing some rounding errors. By not using the cache on the preview pipe the gamma is always processed and the histogram is correct.
The difference in performance is noticeable if you look for it, but this only happens when a module is turned on/off and the only module processed is gamma & histogram, and that's better than having an incorrect histogram.

Also this do not redraw the main window when the pipe finishes, that was causing a redraw of every widget for every pipe.