### PR TITLE
accels "remind-me" window

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -757,7 +757,7 @@ int dt_control_key_released(guint key, guint state)
   // this line is here to find the right key code on different platforms (mac).
   // printf("key code pressed: %d\n", which);
 
-  dt_control_accels_t *accels = &darktable.control->accels;
+  const dt_control_accels_t *accels = &darktable.control->accels;
 
   // be sure to reset dynamic accel
   if(darktable.view_manager->current_view->dynamic_accel_current) dt_control_hinter_message(darktable.control, "");

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -736,6 +736,12 @@ int dt_control_key_pressed_override(guint key, guint state)
     dt_dev_modulegroups_search_text_focus(darktable.develop);
     return 1;
   }
+  // show/hide the accels window
+  else if(key == accels->global_accels_window.accel_key && state == accels->global_accels_window.accel_mods)
+  {
+    dt_view_accels_show(darktable.view_manager);
+    return 1;
+  }
   return 0;
 }
 
@@ -751,9 +757,16 @@ int dt_control_key_released(guint key, guint state)
   // this line is here to find the right key code on different platforms (mac).
   // printf("key code pressed: %d\n", which);
 
+  dt_control_accels_t *accels = &darktable.control->accels;
+
   // be sure to reset dynamic accel
   if(darktable.view_manager->current_view->dynamic_accel_current) dt_control_hinter_message(darktable.control, "");
   darktable.view_manager->current_view->dynamic_accel_current = NULL;
+
+  if(key == accels->global_accels_window.accel_key && state == accels->global_accels_window.accel_mods)
+  {
+    dt_view_accels_hide(darktable.view_manager);
+  }
 
   int handled = 0;
   switch(key)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -109,8 +109,8 @@ typedef struct dt_control_accels_t
   GtkAccelKey filmstrip_forward, filmstrip_back, lighttable_up, lighttable_down, lighttable_right, lighttable_left,
       lighttable_center, lighttable_preview, lighttable_preview_display_focus, lighttable_preview_sticky,
       lighttable_preview_sticky_focus, lighttable_timeline, lighttable_preview_zoom_100,
-      lighttable_preview_zoom_fit, global_sideborders, global_header, darkroom_preview, slideshow_start,
-      global_zoom_in, global_zoom_out, darkroom_skip_mouse_events, darkroom_search_modules_focus;
+      lighttable_preview_zoom_fit, global_sideborders, global_header, global_accels_window, darkroom_preview,
+      slideshow_start, global_zoom_in, global_zoom_out, darkroom_skip_mouse_events, darkroom_search_modules_focus;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -272,6 +272,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
 
   if(!g_module_symbol(module->module, "disconnect_key_accels", (gpointer) & (module->disconnect_key_accels)))
     module->disconnect_key_accels = NULL;
+  if(!g_module_symbol(module->module, "mouse_actions", (gpointer) & (module->mouse_actions)))
+    module->mouse_actions = NULL;
   if(!g_module_symbol(module->module, "mouse_leave", (gpointer) & (module->mouse_leave)))
     module->mouse_leave = NULL;
   if(!g_module_symbol(module->module, "mouse_moved", (gpointer) & (module->mouse_moved)))
@@ -461,6 +463,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
 
   module->connect_key_accels = so->connect_key_accels;
   module->disconnect_key_accels = so->disconnect_key_accels;
+  module->mouse_actions = so->mouse_actions;
 
   module->have_introspection = so->have_introspection;
   module->get_introspection = so->get_introspection;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -218,6 +218,7 @@ typedef struct dt_iop_module_so_t
   void (*connect_key_accels)(struct dt_iop_module_t *self);
   void (*original_connect_key_accels)(struct dt_iop_module_t *self);
   void (*disconnect_key_accels)(struct dt_iop_module_t *self);
+  GSList *(*mouse_actions)(struct dt_iop_module_t *self);
 
   int (*mouse_leave)(struct dt_iop_module_t *self);
   int (*mouse_moved)(struct dt_iop_module_t *self, double x, double y, double pressure, int which);
@@ -532,6 +533,7 @@ typedef struct dt_iop_module_t
   void (*connect_key_accels)(struct dt_iop_module_t *self);
   void (*original_connect_key_accels)(struct dt_iop_module_t *self);
   void (*disconnect_key_accels)(struct dt_iop_module_t *self);
+  GSList *(*mouse_actions)(struct dt_iop_module_t *self);
 
   // introspection related data
   gboolean have_introspection;

--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -358,6 +358,9 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          const float initial_ypos, const float xpos, const float ypos, float *px,
                                          float *py, const int adding);
 
+/** return the list of possible mouse actions */
+GSList *dt_masks_mouse_actions(dt_masks_form_t *form);
+
 /** code for dynamic handling of intermediate buffers */
 static inline
 dt_masks_dynbuf_t *dt_masks_dynbuf_init(size_t size, const char *tag)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -123,6 +123,182 @@ static int _get_opacity(dt_masks_form_gui_t *gui, const dt_masks_form_t *form)
   return opacity;
 }
 
+static dt_masks_type_t _get_all_types_in_group(dt_masks_form_t *form)
+{
+  if(form->type & DT_MASKS_GROUP)
+  {
+    dt_masks_type_t tp = 0;
+    GList *l = form->points;
+    while(l)
+    {
+      const dt_masks_point_group_t *pt = (dt_masks_point_group_t *)l->data;
+      dt_masks_form_t *f = dt_masks_get_from_id(darktable.develop, pt->formid);
+      tp |= _get_all_types_in_group(f);
+      l = g_list_next(l);
+    }
+    return tp;
+  }
+  else
+  {
+    return form->type;
+  }
+}
+
+GSList *dt_masks_mouse_actions(dt_masks_form_t *form)
+{
+  dt_masks_type_t formtype = _get_all_types_in_group(form);
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  if(formtype != 0)
+  {
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_RIGHT;
+    g_strlcpy(a->name, _("[SHAPE] remove shape"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+  }
+  if((formtype & DT_MASKS_PATH) == DT_MASKS_PATH)
+  {
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_LEFT;
+    g_strlcpy(a->name, _("[PATH creation] add a smooth node"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_LEFT;
+    g_strlcpy(a->name, _("[PATH creation] add a sharp node"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_RIGHT;
+    g_strlcpy(a->name, _("[PATH creation] terminate path creation"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[PATH on node] switch between smooth/sharp node"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_RIGHT;
+    g_strlcpy(a->name, _("[PATH on node] remove the node"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_RIGHT;
+    g_strlcpy(a->name, _("[PATH on feather] reset curvature"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_LEFT;
+    g_strlcpy(a->name, _("[PATH on segment] add node"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[PATH] change size"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[PATH] change opacity"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_SHIFT_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[PATH] change feather size"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+  }
+  if((formtype & DT_MASKS_GRADIENT) == DT_MASKS_GRADIENT)
+  {
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_PAN;
+    g_strlcpy(a->name, _("[GRADIENT on pivot] rotate shape"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[GRADIENT] change opacity"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+  }
+  if((formtype & DT_MASKS_ELLIPSE) == DT_MASKS_ELLIPSE)
+  {
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[ELLIPSE] change size"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[ELLIPSE] change opacity"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_SHIFT_MASK;
+    a->action = DT_MOUSE_ACTION_LEFT;
+    g_strlcpy(a->name, _("[ELLIPSE] switch feathering mode"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_PAN;
+    g_strlcpy(a->name, _("[ELLIPSE] rotate shape"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+  }
+  if((formtype & DT_MASKS_BRUSH) == DT_MASKS_BRUSH)
+  {
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[BRUSH creation] change size"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_SHIFT_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[BRUSH creation] change hardness"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[BRUSH] change opacity"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[BRUSH] change hardness"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+  }
+  if((formtype & DT_MASKS_CIRCLE) == DT_MASKS_CIRCLE)
+  {
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[CIRCLE] change size"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_CONTROL_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[CIRCLE] change opacity"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+
+    a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+    a->key.accel_mods = GDK_SHIFT_MASK;
+    a->action = DT_MOUSE_ACTION_SCROLL;
+    g_strlcpy(a->name, _("[CIRCLE] change feather size"), sizeof(a->name));
+    lm = g_slist_append(lm, a);
+  }
+
+  return lm;
+}
+
 static void _set_hinter_message(dt_masks_form_gui_t *gui, const dt_masks_form_t *form)
 {
   char msg[256] = "";

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -217,7 +217,7 @@ GSList *dt_masks_mouse_actions(dt_masks_form_t *form)
   if((formtype & DT_MASKS_GRADIENT) == DT_MASKS_GRADIENT)
   {
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_PAN;
+    a->action = DT_MOUSE_ACTION_LEFT_DRAG;
     g_strlcpy(a->name, _("[GRADIENT on pivot] rotate shape"), sizeof(a->name));
     lm = g_slist_append(lm, a);
 
@@ -248,7 +248,7 @@ GSList *dt_masks_mouse_actions(dt_masks_form_t *form)
 
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
     a->key.accel_mods = GDK_CONTROL_MASK;
-    a->action = DT_MOUSE_ACTION_PAN;
+    a->action = DT_MOUSE_ACTION_LEFT_DRAG;
     g_strlcpy(a->name, _("[ELLIPSE] rotate shape"), sizeof(a->name));
     lm = g_slist_append(lm, a);
   }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -185,6 +185,9 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
 
   dt_accel_path_global(path, sizeof(path), "zoom out");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_zoom_out);
+
+  dt_accel_path_global(path, sizeof(path), "show accels window");
+  gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_accels_window);
 }
 
 static gboolean fullscreen_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
@@ -1236,6 +1239,9 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   // Global zoom in & zoom out
   dt_accel_register_global(NC_("accel", "zoom in"), GDK_KEY_plus, GDK_CONTROL_MASK);
   dt_accel_register_global(NC_("accel", "zoom out"), GDK_KEY_minus, GDK_CONTROL_MASK);
+
+  // accels window
+  dt_accel_register_global(NC_("accel", "show accels window"), 0, 0);
 
   darktable.gui->reset = 0;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5034,6 +5034,35 @@ void gui_cleanup(struct dt_iop_module_t *self)
   self->gui_data = NULL;
 }
 
+GSList *mouse_actions(struct dt_iop_module_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on segment] select segment"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_RIGHT;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on segment] unselect segment"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s] select all segment from zone"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_RIGHT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s] unselect all segment from zone"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5052,13 +5052,13 @@ GSList *mouse_actions(struct dt_iop_module_t *self)
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_SHIFT_MASK;
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s] select all segment from zone"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s] select all segments from zone"), self->name(self));
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_SHIFT_MASK;
   a->action = DT_MOUSE_ACTION_RIGHT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s] unselect all segment from zone"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s] unselect all segments from zone"), self->name(self));
   lm = g_slist_append(lm, a);
 
   return lm;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3227,6 +3227,30 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "angle", GTK_WIDGET(g->angle));
 }
 
+GSList *mouse_actions(struct dt_iop_module_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on borders] crop"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on borders] crop keeping ratio"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_RIGHT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s] define/rotate horizon"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
+
 #undef PHI
 #undef INVPHI
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1282,6 +1282,35 @@ void gui_cleanup(struct dt_iop_module_t *self)
   self->gui_data = NULL;
 }
 
+GSList *mouse_actions(struct dt_iop_module_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on nodes] change line rotation"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on line] move line"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on line] change density"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on line] change compression"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -123,6 +123,7 @@ void original_init_key_accels(struct dt_iop_module_so_t *so);
 void connect_key_accels(struct dt_iop_module_t *self);
 void original_connect_key_accels(struct dt_iop_module_t *self);
 void disconnect_key_accels(struct dt_iop_module_t *self);
+GSList *mouse_actions(struct dt_iop_module_t *self);
 
 /** optional event callbacks */
 int mouse_leave(struct dt_iop_module_t *self);

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1210,6 +1210,30 @@ void gui_cleanup(struct dt_iop_module_t *self)
   self->gui_data = NULL;
 }
 
+GSList *mouse_actions(struct dt_iop_module_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on node] change vignette/feather size"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on node] change vignette/feather size keeping ratio"),
+             self->name(self));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT_DRAG;
+  g_snprintf(a->name, sizeof(a->name), _("[%s on center] move vignette"), self->name(self));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3253,6 +3253,30 @@ void connect_key_accels(dt_view_t *self)
   dt_dynamic_accel_get_valid_list();
 }
 
+GSList *mouse_actions(const dt_view_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("zoom in the image"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("unbounded zoom in the image"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_MIDDLE;
+  g_strlcpy(a->name, _("zoom to 100% 200% and back"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
+
 //-----------------------------------------------------------
 // second darkroom window
 //-----------------------------------------------------------

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3280,6 +3280,18 @@ GSList *mouse_actions(const dt_view_t *self)
   g_strlcpy(a->name, _("zoom to 100% 200% and back"), sizeof(a->name));
   lm = g_slist_append(lm, a);
 
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK;
+  a->action = DT_MOUSE_ACTION_SCROLL;
+  g_strlcpy(a->name, _("[modules] expand module without closing others"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->key.accel_mods = GDK_SHIFT_MASK | GDK_CONTROL_MASK;
+  a->action = DT_MOUSE_ACTION_DRAG_DROP;
+  g_strlcpy(a->name, _("[modules] change module position in pipe"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
   dt_develop_t *dev = (dt_develop_t *)self->data;
   if(dev->form_visible)
   {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3286,9 +3286,10 @@ GSList *mouse_actions(const dt_view_t *self)
     // masks
     lm2 = dt_masks_mouse_actions(dev->form_visible);
   }
-  else if(dev->gui_module)
+  else if(dev->gui_module && dev->gui_module->mouse_actions)
   {
     // modules with on canvas actions
+    lm2 = dev->gui_module->mouse_actions(dev->gui_module);
   }
 
   // we concatenate the 2 lists

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3292,7 +3292,7 @@ GSList *mouse_actions(const dt_view_t *self)
   g_strlcpy(a->name, _("[modules] change module position in pipe"), sizeof(a->name));
   lm = g_slist_append(lm, a);
 
-  dt_develop_t *dev = (dt_develop_t *)self->data;
+  const dt_develop_t *dev = (dt_develop_t *)self->data;
   if(dev->form_visible)
   {
     // masks

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3256,7 +3256,13 @@ void connect_key_accels(dt_view_t *self)
 GSList *mouse_actions(const dt_view_t *self)
 {
   GSList *lm = NULL;
+  GSList *lm2 = NULL;
   dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_DOUBLE_LEFT;
+  g_strlcpy(a->name, _("switch to lighttable"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_SCROLL;
@@ -3273,6 +3279,27 @@ GSList *mouse_actions(const dt_view_t *self)
   a->action = DT_MOUSE_ACTION_MIDDLE;
   g_strlcpy(a->name, _("zoom to 100% 200% and back"), sizeof(a->name));
   lm = g_slist_append(lm, a);
+
+  dt_develop_t *dev = (dt_develop_t *)self->data;
+  if(dev->form_visible)
+  {
+    // masks
+    lm2 = dt_masks_mouse_actions(dev->form_visible);
+  }
+  else if(dev->gui_module)
+  {
+    // modules with on canvas actions
+  }
+
+  // we concatenate the 2 lists
+  GSList *l = lm2;
+  while(l)
+  {
+    a = (dt_mouse_action_t *)l->data;
+    if(a) lm = g_slist_append(lm, a);
+    l = g_slist_next(l);
+  }
+  g_slist_free(lm2);
 
   return lm;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -101,7 +101,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid);
 static void _darkroom_display_second_window(dt_develop_t *dev);
 static void _darkroom_ui_second_window_write_config(GtkWidget *widget);
 
-const char *name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return _("darkroom");
 }

--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -329,7 +329,7 @@ typedef struct dt_knight_t
   uint8_t *bunker_buf[4];
 } dt_knight_t;
 
-const char *name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return _("good knight");
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -243,7 +243,7 @@ static void _unregister_custom_image_order_drag_n_drop(dt_view_t *self);
 
 static void _stop_audio(dt_library_t *lib);
 
-const char *name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return _("lighttable");
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -4522,7 +4522,7 @@ GSList *mouse_actions(const dt_view_t *self)
     lm = g_slist_append(lm, a);
 
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_PAN;
+    a->action = DT_MOUSE_ACTION_LEFT_DRAG;
     g_strlcpy(a->name, _("pan inside all the images"), sizeof(a->name));
     lm = g_slist_append(lm, a);
 
@@ -4534,7 +4534,7 @@ GSList *mouse_actions(const dt_view_t *self)
 
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
     a->key.accel_mods = GDK_SHIFT_MASK;
-    a->action = DT_MOUSE_ACTION_PAN;
+    a->action = DT_MOUSE_ACTION_LEFT_DRAG;
     g_strlcpy(a->name, _("pan inside current image"), sizeof(a->name));
     lm = g_slist_append(lm, a);
   }
@@ -4546,7 +4546,7 @@ GSList *mouse_actions(const dt_view_t *self)
     lm = g_slist_append(lm, a);
 
     a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
-    a->action = DT_MOUSE_ACTION_PAN;
+    a->action = DT_MOUSE_ACTION_LEFT_DRAG;
     g_strlcpy(a->name, _("pan inside the main view"), sizeof(a->name));
     lm = g_slist_append(lm, a);
   }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -128,7 +128,7 @@ static gboolean _view_map_center_on_image_list(dt_view_t *self, const GList *sel
 /* center map on the given image */
 static void _view_map_center_on_image(dt_view_t *self, const int32_t imgid);
 
-const char *name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return _("map");
 }

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -45,8 +45,7 @@ typedef struct dt_print_t
 }
 dt_print_t;
 
-const char
-*name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return C_("view", "print");
 }

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -311,7 +311,7 @@ static void _step_state(dt_slideshow_t *d, dt_slideshow_event_t event)
 
 // callbacks for a view module:
 
-const char *name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return _("slideshow");
 }

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -88,7 +88,7 @@ static void _capture_view_set_jobcode(const dt_view_t *view, const char *name);
 static const char *_capture_view_get_jobcode(const dt_view_t *view);
 static uint32_t _capture_view_get_selected_imgid(const dt_view_t *view);
 
-const char *name(dt_view_t *self)
+const char *name(const dt_view_t *self)
 {
   return _("tethering");
 }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2157,7 +2157,7 @@ void dt_view_print_settings(const dt_view_manager_t *vm, dt_print_info_t *pinfo)
 #endif
 
 
-gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
+static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
 {
   gchar *atxt = dt_util_dstrcat(NULL, "%s", gtk_accelerator_get_label(ma->key.accel_key, ma->key.accel_mods));
   if(strcmp(atxt, "")) atxt = dt_util_dstrcat(atxt, "+");

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2319,7 +2319,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
   bl = blocs;
   while(bl)
   {
-    _bloc_t *bb = (_bloc_t *)bl->data;
+    const _bloc_t *bb = (_bloc_t *)bl->data;
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     // the title
     GtkWidget *lb = gtk_label_new(bb->title);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2181,6 +2181,12 @@ gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
     case DT_MOUSE_ACTION_DOUBLE_RIGHT:
       atxt = dt_util_dstrcat(atxt, _("Right double-click"));
       break;
+    case DT_MOUSE_ACTION_DRAG_DROP:
+      atxt = dt_util_dstrcat(atxt, _("Drag and drop"));
+      break;
+    case DT_MOUSE_ACTION_PAN:
+      atxt = dt_util_dstrcat(atxt, _("Pan"));
+      break;
   }
 
   return atxt;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2196,12 +2196,21 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 {
   if(vm->accels_window) return; // dt_view_accels_hide(vm);
 
+  GtkStyleContext *context;
   vm->accels_window = gtk_window_new(GTK_WINDOW_POPUP);
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(darktable.bauhaus->popup_window);
 #endif
+  context = gtk_widget_get_style_context(vm->accels_window);
+  gtk_style_context_add_class(context, "accels_window");
+
+  GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
+  context = gtk_widget_get_style_context(sw);
+  gtk_style_context_add_class(context, "accels_window_scroll");
 
   GtkWidget *fb = gtk_flow_box_new();
+  context = gtk_widget_get_style_context(fb);
+  gtk_style_context_add_class(context, "accels_window_box");
   gtk_orientable_set_orientation(GTK_ORIENTABLE(fb), GTK_ORIENTATION_HORIZONTAL);
   // get the list of valid accel for this view
   const dt_view_t *cv = dt_view_manager_get_current_view(vm);
@@ -2280,7 +2289,6 @@ void dt_view_accels_show(dt_view_manager_t *vm)
   // we add the mouse actions too
   if(cv->mouse_actions)
   {
-    printf("coucou\n");
     _bloc_t *bm = (_bloc_t *)calloc(1, sizeof(_bloc_t));
     bm->base = NULL;
     bm->title = dt_util_dstrcat(NULL, _("mouse actions"));
@@ -2311,10 +2319,15 @@ void dt_view_accels_show(dt_view_manager_t *vm)
     _bloc_t *bb = (_bloc_t *)bl->data;
     GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     // the title
-    gtk_box_pack_start(GTK_BOX(box), gtk_label_new(bb->title), FALSE, FALSE, 0);
+    GtkWidget *lb = gtk_label_new(bb->title);
+    context = gtk_widget_get_style_context(lb);
+    gtk_style_context_add_class(context, "accels_window_cat_title");
+    gtk_box_pack_start(GTK_BOX(box), lb, FALSE, FALSE, 0);
 
     // the list of accels
     GtkWidget *list = gtk_tree_view_new_with_model(GTK_TREE_MODEL(bb->list_store));
+    context = gtk_widget_get_style_context(list);
+    gtk_style_context_add_class(context, "accels_window_list");
     GtkCellRenderer *renderer = gtk_cell_renderer_text_new();
     GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("Accel"), renderer, "text", 0, NULL);
     gtk_tree_view_append_column(GTK_TREE_VIEW(list), column);
@@ -2333,12 +2346,15 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 
   GtkAllocation alloc;
   gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
+  gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
+  gtk_scrolled_window_set_max_content_width(GTK_SCROLLED_WINDOW(sw), alloc.width);
+  gtk_container_add(GTK_CONTAINER(sw), fb);
+  gtk_container_add(GTK_CONTAINER(vm->accels_window), sw);
 
-  gtk_widget_set_size_request(fb, alloc.width, alloc.height);
   gtk_window_set_resizable(GTK_WINDOW(vm->accels_window), FALSE);
   gtk_window_set_default_size(GTK_WINDOW(vm->accels_window), alloc.width, alloc.height);
   gtk_window_set_transient_for(GTK_WINDOW(vm->accels_window), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  gtk_container_add(GTK_CONTAINER(vm->accels_window), fb);
   gtk_window_set_keep_above(GTK_WINDOW(vm->accels_window), TRUE);
   gtk_window_set_gravity(GTK_WINDOW(vm->accels_window), GDK_GRAVITY_STATIC);
   gtk_window_set_position(GTK_WINDOW(vm->accels_window), GTK_WIN_POS_CENTER_ON_PARENT);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2184,8 +2184,11 @@ gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
     case DT_MOUSE_ACTION_DRAG_DROP:
       atxt = dt_util_dstrcat(atxt, _("Drag and drop"));
       break;
-    case DT_MOUSE_ACTION_PAN:
-      atxt = dt_util_dstrcat(atxt, _("Pan"));
+    case DT_MOUSE_ACTION_LEFT_DRAG:
+      atxt = dt_util_dstrcat(atxt, _("Left click+Drag"));
+      break;
+    case DT_MOUSE_ACTION_RIGHT_DRAG:
+      atxt = dt_util_dstrcat(atxt, _("Right click+Drag"));
       break;
   }
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -80,6 +80,24 @@ typedef enum dt_lighttable_culling_zoom_mode_t
   DT_LIGHTTABLE_ZOOM_DYNAMIC = 1
 } dt_lighttable_culling_zoom_mode_t;
 
+// mouse actions struct
+typedef enum dt_mouse_action_type_t
+{
+  DT_MOUSE_ACTION_LEFT = 0,
+  DT_MOUSE_ACTION_RIGHT,
+  DT_MOUSE_ACTION_MIDDLE,
+  DT_MOUSE_ACTION_SCROLL,
+  DT_MOUSE_ACTION_DOUBLE_LEFT,
+  DT_MOUSE_ACTION_DOUBLE_RIGHT
+} dt_mouse_action_type_t;
+
+typedef struct dt_mouse_action_t
+{
+  GtkAccelKey key;
+  dt_mouse_action_type_t action;
+  gchar name[256];
+} dt_mouse_action_t;
+
 #define DT_VIEW_ALL                                                                              \
   (DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_SLIDESHOW | \
    DT_VIEW_PRINT | DT_VIEW_KNIGHT)
@@ -132,6 +150,9 @@ typedef struct dt_view_t
   // keyboard accel callbacks
   void (*init_key_accels)(struct dt_view_t *self);
   void (*connect_key_accels)(struct dt_view_t *self);
+
+  // list of mouse actions
+  GSList *(*mouse_actions)(const struct dt_view_t *self);
 
   GSList *accel_closures;
   struct dt_accel_dynamic_t *dynamic_accel_current;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -90,7 +90,8 @@ typedef enum dt_mouse_action_type_t
   DT_MOUSE_ACTION_DOUBLE_LEFT,
   DT_MOUSE_ACTION_DOUBLE_RIGHT,
   DT_MOUSE_ACTION_DRAG_DROP,
-  DT_MOUSE_ACTION_PAN
+  DT_MOUSE_ACTION_LEFT_DRAG,
+  DT_MOUSE_ACTION_RIGHT_DRAG
 } dt_mouse_action_type_t;
 
 typedef struct dt_mouse_action_t

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -88,7 +88,9 @@ typedef enum dt_mouse_action_type_t
   DT_MOUSE_ACTION_MIDDLE,
   DT_MOUSE_ACTION_SCROLL,
   DT_MOUSE_ACTION_DOUBLE_LEFT,
-  DT_MOUSE_ACTION_DOUBLE_RIGHT
+  DT_MOUSE_ACTION_DOUBLE_RIGHT,
+  DT_MOUSE_ACTION_DRAG_DROP,
+  DT_MOUSE_ACTION_PAN
 } dt_mouse_action_type_t;
 
 typedef struct dt_mouse_action_t

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -102,7 +102,7 @@ typedef struct dt_view_t
   // scroll bar control
   float vscroll_size, vscroll_lower, vscroll_viewport_size, vscroll_pos;
   float hscroll_size, hscroll_lower, hscroll_viewport_size, hscroll_pos;
-  const char *(*name)(struct dt_view_t *self);    // get translatable name
+  const char *(*name)(const struct dt_view_t *self); // get translatable name
   uint32_t (*view)(const struct dt_view_t *self); // get the view type
   uint32_t (*flags)();                            // get the view flags
   void (*init)(struct dt_view_t *self);           // init *data
@@ -220,6 +220,8 @@ typedef struct dt_view_manager_t
 {
   GList *views;
   dt_view_t *current_view;
+
+  GtkWidget *accels_window;
 
   /* reusable db statements
    * TODO: reconsider creating a common/database helper API
@@ -448,6 +450,10 @@ void dt_view_filmstrip_set_active_image(dt_view_manager_t *vm, int iid);
     TODO: move to control ?
 */
 void dt_view_filmstrip_prefetch();
+
+/* accel window */
+void dt_view_accels_show(dt_view_manager_t *vm);
+void dt_view_accels_hide(dt_view_manager_t *vm);
 
 /*
  * Map View Proxy

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -65,6 +65,9 @@ void scrollbar_changed(struct dt_view_t *self, double x, double y); // scrollbar
 void init_key_accels(struct dt_view_t *self);
 void connect_key_accels(struct dt_view_t *self);
 
+// list of mouse actions
+GSList *mouse_actions(const struct dt_view_t *self);
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus

--- a/src/views/view_api.h
+++ b/src/views/view_api.h
@@ -34,7 +34,7 @@ struct dt_view_t;
 
 #pragma GCC visibility push(default)
 
-const char *name(struct dt_view_t *self);    // get translatable name
+const char *name(const struct dt_view_t *self); // get translatable name
 uint32_t view(const struct dt_view_t *self); // get the view type
 uint32_t flags();                            // get flags of the view
 void init(struct dt_view_t *self);           // init *data


### PR DESCRIPTION
Accels are really great, but remembering all of those can become a pain at certain point... (or maybe at certain age...)
This allow to quickly show the list of currently active accels keys and mouse actions. By "currently active", I mean the ones you can really use at the moment of the popup.
It's WIP and doesn't currently looks very well but it looks like that actually : 
![Capture d’écran_2019-06-09_18-58-05](https://user-images.githubusercontent.com/1818223/59161892-ab26c000-8ae8-11e9-86b3-fbf30a1fe647.png)
How it works : 
- set an accel in the pref for global shortcuts -> show accel window (There's currently no default accel. We'll have to decide one in the future, as the feature can be especially useful for beginners)
- When you press this accel, you see the popup on top of everything, and when you release it, the popup disappear.

What is shown : 
1- every accel with valid key which is "accessible" at the current moment.
2- every possible mouse actions at the current moment.

For point 2, I've added a new function in view api to return them. Currently, I've only added some actions for lighttable and darkroom, and even those should be refined and rechecked.

Of course, it's WIP, there's still some work to be done : 
- add all mouse actions for all views, masks, etc...
- enhance the design
- check my english ;)
- check for problem if one wants to interact with the popup
- fix bugs :)