### PR TITLE
Revert store method API on PR #2692

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -396,8 +396,8 @@ int main(int argc, char *arg[])
   for(GList *iter = id_list; iter; iter = g_list_next(iter), num++)
   {
     int id = GPOINTER_TO_INT(iter->data);
-    storage->store(storage, sdata, id, format, fdata, num, total, width, height,
-                   high_quality, upscale, icc_type, icc_filename, icc_intent);
+    storage->store(storage, sdata, id, format, fdata, num, total, high_quality, upscale,
+                   icc_type, icc_filename, icc_intent);
   }
 
   // cleanup time

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -175,8 +175,7 @@ typedef struct dt_imageio_module_storage_t
   /* this actually does the work */
   int (*store)(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data,
                const int imgid, dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata,
-               const int num, const int total, const int max_width, const int max_height,
-               const gboolean high_quality, const gboolean upscale,
+               const int num, const int total, const gboolean high_quality, const gboolean upscale,
                dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                dt_iop_color_intent_t icc_intent);
   /* called once at the end (after exporting all images), if implemented. */

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1367,9 +1367,8 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
       else
       {
         dt_image_cache_read_release(darktable.image_cache, image);
-        if(mstorage->store(mstorage, sdata, imgid, mformat, fdata, num, total, settings->max_width, settings->max_height,
-                           settings->high_quality, settings->upscale, settings->icc_type, settings->icc_filename,
-                           settings->icc_intent) != 0)
+        if(mstorage->store(mstorage, sdata, imgid, mformat, fdata, num, total, settings->high_quality, settings->upscale,
+                           settings->icc_type, settings->icc_filename, settings->icc_intent) != 0)
           dt_control_job_cancel(job);
       }
     }

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -237,7 +237,6 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   gboolean from_cache = FALSE;
   dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
   // set max_width and max_height values to expand them afterwards in darktable variables
-  // dt_variables_set_max_width_height(d->vp, max_width, max_height);
   dt_variables_set_max_width_height(d->vp, fdata->max_width, fdata->max_height);
   int fail = 0;
   // we're potentially called in parallel. have sequence number synchronized:

--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -225,8 +225,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_disk_t *d = (dt_imageio_disk_t *)sdata;
 
@@ -237,7 +237,8 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
   gboolean from_cache = FALSE;
   dt_image_full_path(imgid, input_dir, sizeof(input_dir), &from_cache);
   // set max_width and max_height values to expand them afterwards in darktable variables
-  dt_variables_set_max_width_height(d->vp, max_width, max_height);
+  // dt_variables_set_max_width_height(d->vp, max_width, max_height);
+  dt_variables_set_max_width_height(d->vp, fdata->max_width, fdata->max_height);
   int fail = 0;
   // we're potentially called in parallel. have sequence number synchronized:
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);

--- a/src/imageio/storage/email.c
+++ b/src/imageio/storage/email.c
@@ -97,8 +97,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_email_t *d = (dt_imageio_email_t *)sdata;
 

--- a/src/imageio/storage/facebook.c
+++ b/src/imageio/storage/facebook.c
@@ -1253,8 +1253,8 @@ int supported(struct dt_imageio_module_storage_t *self, struct dt_imageio_module
 /* this actually does the work */
 int store(dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   gint result = 1;
   dt_storage_facebook_param_t *p = (dt_storage_facebook_param_t *)sdata;

--- a/src/imageio/storage/flickr.c
+++ b/src/imageio/storage/flickr.c
@@ -596,8 +596,8 @@ void gui_reset(dt_imageio_module_storage_t *self)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   gint result = 0;
   dt_storage_flickr_params_t *p = (dt_storage_flickr_params_t *)sdata;

--- a/src/imageio/storage/gallery.c
+++ b/src/imageio/storage/gallery.c
@@ -219,8 +219,8 @@ static gint sort_pos(pair_t *a, pair_t *b)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_gallery_t *d = (dt_imageio_gallery_t *)sdata;
 

--- a/src/imageio/storage/googlephoto.c
+++ b/src/imageio/storage/googlephoto.c
@@ -1333,8 +1333,8 @@ int supported(struct dt_imageio_module_storage_t *self, struct dt_imageio_module
 /* this actually does the work */
 int store(dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_storage_gphoto_gui_data_t *ui = self->gui_data;
 

--- a/src/imageio/storage/imageio_storage_api.h
+++ b/src/imageio/storage/imageio_storage_api.h
@@ -67,9 +67,8 @@ int initialize_store(struct dt_imageio_module_storage_t *self, struct dt_imageio
 /* this actually does the work */
 int store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data, const int imgid,
           struct dt_imageio_module_format_t *format, struct dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          enum dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
-          enum dt_iop_color_intent_t icc_intent);
+          const gboolean high_quality, const gboolean upscale, enum dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, enum dt_iop_color_intent_t icc_intent);
 /* called once at the end (after exporting all images), if implemented. */
 void finalize_store(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *data);
 

--- a/src/imageio/storage/latex.c
+++ b/src/imageio/storage/latex.c
@@ -222,8 +222,8 @@ static gint sort_pos(pair_t *a, pair_t *b)
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_imageio_latex_t *d = (dt_imageio_latex_t *)sdata;
 

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -908,8 +908,8 @@ void finalize_store(struct dt_imageio_module_storage_t *self, dt_imageio_module_
 
 int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, const int imgid,
           dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata, const int num, const int total,
-          const int max_width, const int max_height, const gboolean high_quality, const gboolean upscale,
-          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
+          const gboolean high_quality, const gboolean upscale, dt_colorspaces_color_profile_type_t icc_type,
+          const gchar *icc_filename, dt_iop_color_intent_t icc_intent)
 {
   dt_storage_piwigo_gui_data_t *ui = self->gui_data;
 

--- a/src/lua/luastorage.c
+++ b/src/lua/luastorage.c
@@ -77,8 +77,7 @@ static int default_dimension_wrapper(struct dt_imageio_module_storage_t *self, d
 
 static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_imageio_module_data_t *self_data,
                          const int imgid, dt_imageio_module_format_t *format, dt_imageio_module_data_t *fdata,
-                         const int num, const int total, const int max_width, const int max_height,
-                         const gboolean high_quality, const gboolean upscale,
+                         const int num, const int total, const gboolean high_quality, const gboolean upscale,
                          dt_colorspaces_color_profile_type_t icc_type, const gchar *icc_filename,
                          dt_iop_color_intent_t icc_intent)
 {
@@ -139,8 +138,6 @@ static int store_wrapper(struct dt_imageio_module_storage_t *self, struct dt_ima
   lua_pushstring(L, complete_name);
   lua_pushinteger(L, num);
   lua_pushinteger(L, total);
-//  lua_pushinteger(L, max_width);
-//  lua_pushinteger(L, max_height);
   lua_pushboolean(L, high_quality);
   push_lua_data(L,d);
   dt_lua_goto_subtable(L,"extra");


### PR DESCRIPTION
Revert store method API on PR #2692:
1) Remove parameters `const int max_width, const int max_height` from `dt_imageio_module_storage_t` method `(*store)`. Update all dt_imageio_module_storage_t implementations.
2) Change call `dt_variables_set_max_width_height(d->vp, max_width, max_height)` to `dt_variables_set_max_width_height(d->vp, fdata->max_width, fdata->max_height)`.