### PR TITLE
Apply selected IOP preset on mouse button release

### DIFF
--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -698,19 +698,17 @@ static void menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
   gtk_widget_queue_draw(module->widget);
 }
 
-static gboolean menuitem_button_pressed_preset(GtkMenuItem *menuitem, GdkEventButton *event, dt_iop_module_t *module)
+static gboolean menuitem_button_released_preset(GtkMenuItem *menuitem, GdkEventButton *event, dt_iop_module_t *module)
 {
   if (event->button == 1 || (module->flags() & IOP_FLAGS_ONE_INSTANCE))
   {
     menuitem_pick_preset(menuitem, module);
-    return TRUE;
   }
   else if (event->button == 2)
   {
     dt_iop_module_t *new_module = dt_iop_gui_duplicate(module, FALSE);
     if (new_module)
       menuitem_pick_preset(menuitem, new_module);
-    return TRUE;
   }
   return FALSE;
 }
@@ -908,7 +906,7 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
       g_object_set_data_full(G_OBJECT(mi), "dt-preset-name", g_strdup(name), g_free);
       if(module)
       {
-        g_signal_connect(G_OBJECT(mi), "button-press-event", G_CALLBACK(menuitem_button_pressed_preset), module);
+        g_signal_connect(G_OBJECT(mi), "button-release-event", G_CALLBACK(menuitem_button_released_preset), module);
       }
       else if(pick_callback)
         g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(pick_callback), callback_data);


### PR DESCRIPTION
Fixes issue #2707.

Expected behavior described in the bug report is common for desktop GUI applications and most likely assumed by majority of users. Additionaly, I'd say there are three cases of selecting an entry from a drop-down menu:
1. Click (press and release) the menu icon - menu opens - move to desired position - click to select.
2. Press on the menu icon - menu opens - move to desided position - release to select.
3. Click the menu icon - menu opens - press on a position - realise that this is not what you wanted - move to another position while holding the mouse button - release to select the correct entry.

When selecting a preset from the presets menu, Darktable allows only for case 1. But for "favourite" and "store new preset.." menu entries it (inconsistently) allows also for 2. and 3.

This patch moves the preset activation from "mouse press" to "mouse release", thus fixing the original issue as well as making the menu behavior consistent.