### PR TITLE
copy history : respect dt selection scheme

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -866,6 +866,108 @@ int dt_history_copy_and_paste_on_selection(int32_t imgid, gboolean merge, GList 
   return res;
 }
 
+void dt_history_compress_on_image(int32_t imgid)
+{
+  // make sure the right history is in there:
+  dt_dev_write_history(darktable.develop);
+
+  // compress history and remove disabled modules - adapted from libs/history.c
+  sqlite3_stmt *stmt_local;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "DELETE FROM main.history WHERE imgid = ?1 AND num "
+                              "NOT IN (SELECT MAX(num) FROM main.history WHERE "
+                              "imgid = ?1 AND enabled = 1 GROUP BY operation, "
+                              "multi_priority)",
+                              -1, &stmt_local, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+  sqlite3_step(stmt_local);
+  sqlite3_finalize(stmt_local);
+
+  // delete all mask_manager entries - copied from libs/history.c
+  int masks_count = 0;
+  char op_mask_manager[20] = { 0 };
+  g_strlcpy(op_mask_manager, "mask_manager", sizeof(op_mask_manager));
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "DELETE FROM main.history WHERE imgid = ?1 AND operation = ?2", -1, &stmt_local,
+                              NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt_local, 2, op_mask_manager, -1, SQLITE_TRANSIENT);
+  sqlite3_step(stmt_local);
+  sqlite3_finalize(stmt_local);
+
+  // if there's masks create a mask manage entry
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT COUNT(*) FROM main.masks_history WHERE imgid = ?1", -1, &stmt_local, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+  if(sqlite3_step(stmt_local) == SQLITE_ROW) masks_count = sqlite3_column_int(stmt_local, 0);
+  sqlite3_finalize(stmt_local);
+
+  if(masks_count > 0)
+  {
+    // set the masks history as first entry
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "UPDATE main.masks_history SET num = 0 WHERE imgid = ?1", -1, &stmt_local, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+    sqlite3_step(stmt_local);
+    sqlite3_finalize(stmt_local);
+
+    // make room for mask manager history entry
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "UPDATE main.history SET num=num+1 WHERE imgid = ?1", -1, &stmt_local, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+    sqlite3_step(stmt_local);
+    sqlite3_finalize(stmt_local);
+
+    // update history end
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "UPDATE main.images SET history_end = history_end+1 WHERE id = ?1", -1,
+                                &stmt_local, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+    sqlite3_step(stmt_local);
+    sqlite3_finalize(stmt_local);
+
+    const double iop_order = dt_ioppr_get_iop_order(darktable.develop->iop_order_list, op_mask_manager);
+
+    // create a mask manager entry in history as first entry
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "INSERT INTO main.history (imgid, num, operation, op_params, module, enabled, "
+                                "blendop_params, blendop_version, multi_priority, multi_name, iop_order) "
+                                "VALUES(?1, 0, ?2, NULL, 1, 0, NULL, 0, 0, '', ?3)",
+                                -1, &stmt_local, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt_local, 1, imgid);
+    DT_DEBUG_SQLITE3_BIND_TEXT(stmt_local, 2, op_mask_manager, -1, SQLITE_TRANSIENT);
+    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt_local, 3, iop_order);
+    sqlite3_step(stmt_local);
+    sqlite3_finalize(stmt_local);
+  }
+
+  /* if current image in develop reload history */
+  if(dt_dev_is_current_image(darktable.develop, imgid))
+  {
+    dt_dev_reload_history_items(darktable.develop);
+    dt_dev_write_history(darktable.develop);
+    dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
+  }
+
+  // Update XMP files
+  dt_image_synch_xmp(imgid);
+}
+
+void dt_history_compress_on_selection()
+{
+  // Get the list of selected images
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
+                              NULL);
+
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    dt_history_compress_on_image(sqlite3_column_int(stmt, 0));
+  }
+  sqlite3_finalize(stmt);
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -52,6 +52,10 @@ int dt_history_load_and_apply(int imgid, gchar *filename, int history_only);
 /** delete historystack of selected images */
 void dt_history_delete_on_selection();
 
+/** compress history stack */
+void dt_history_compress_on_selection();
+void dt_history_compress_on_image(int32_t imgid);
+
 typedef struct dt_history_item_t
 {
   guint num;

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -994,15 +994,13 @@ static gboolean _lib_filmstrip_paste_history_key_accel_callback(GtkAccelGroup *a
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
   const int mode = dt_conf_get_int("plugins/lighttable/copy_history/pastemode");
 
-  if(dt_history_copy_and_paste_on_selection(strip->history_copy_imgid, (mode == 0) ? TRUE : FALSE,
-                                            strip->dg.selops) != 0)
-  {
-    const int32_t mouse_over_id = dt_control_get_mouse_over_id();
-    if(mouse_over_id <= 0) return FALSE;
+  const int img = dt_view_get_image_to_act_on();
 
-    dt_history_copy_and_paste_on_image(strip->history_copy_imgid, mouse_over_id, (mode == 0) ? TRUE : FALSE,
+  if(img < 0)
+    dt_history_copy_and_paste_on_selection(strip->history_copy_imgid, (mode == 0) ? TRUE : FALSE, strip->dg.selops);
+  else
+    dt_history_copy_and_paste_on_image(strip->history_copy_imgid, img, (mode == 0) ? TRUE : FALSE,
                                        strip->dg.selops);
-  }
 
   dt_control_queue_redraw_center();
   return TRUE;
@@ -1017,20 +1015,17 @@ static gboolean _lib_filmstrip_paste_history_parts_key_accel_callback(GtkAccelGr
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
   const int mode = dt_conf_get_int("plugins/lighttable/copy_history/pastemode");
 
-  // get mouse over before launching the dialog
-  const int32_t mouse_over_id = dt_control_get_mouse_over_id();
+  // get image id before launching the dialog
+  const int img = dt_view_get_image_to_act_on();
 
   const int res = dt_gui_hist_dialog_new(&(strip->dg), strip->history_copy_imgid, FALSE);
   if(res == GTK_RESPONSE_CANCEL) return FALSE;
 
-  if(dt_history_copy_and_paste_on_selection(strip->history_copy_imgid, (mode == 0) ? TRUE : FALSE,
-                                            strip->dg.selops) != 0)
-  {
-    if(mouse_over_id <= 0) return FALSE;
-
-    dt_history_copy_and_paste_on_image(strip->history_copy_imgid, mouse_over_id, (mode == 0) ? TRUE : FALSE,
+  if(img < 0)
+    dt_history_copy_and_paste_on_selection(strip->history_copy_imgid, (mode == 0) ? TRUE : FALSE, strip->dg.selops);
+  else
+    dt_history_copy_and_paste_on_image(strip->history_copy_imgid, img, (mode == 0) ? TRUE : FALSE,
                                        strip->dg.selops);
-  }
 
   dt_control_queue_redraw_center();
   return TRUE;


### PR DESCRIPTION
actions on history (copy/paste/...) are applied on mouse_over image except : 
- if mouse_over is inside the selection
- if no mouse_over or mouse is outside view

In that 2 cases, action is applied on the selection if any.
This is how dt works for everything else, like rating, labels, ...

As a side effect, this allow to use those actions in culling layout, where you can't rely on selection : this fix #2718