### PR TITLE
fixes compiling with exiv v0.27.2.1

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2035,9 +2035,16 @@ static GHashTable *read_masks(Exiv2::XmpData &xmpData, const char *filename, con
     && (mask_id = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.mask_id"))) != xmpData.end()
     && (mask_nb = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.mask_nb"))) != xmpData.end())
   {
-    const size_t cnt = mask->count();
-    if(cnt == mask_src->count() && cnt == mask_name->count() && cnt == mask_type->count()
-      && cnt == mask_version->count() && cnt == mask_id->count() && cnt == mask_nb->count())
+    // fixes API change happened after exiv2 v0.27.2.1
+    const size_t cnt = (size_t)mask->count();
+    const size_t mask_src_cnt = (size_t)mask_src->count();
+    const size_t mask_name_cnt = (size_t)mask_name->count();
+    const size_t mask_type_cnt = (size_t)mask_type->count();
+    const size_t mask_version_cnt = (size_t)mask_version->count();
+    const size_t mask_id_cnt = (size_t)mask_id->count();
+    const size_t mask_nb_cnt = (size_t)mask_nb->count();
+    if(cnt == mask_src_cnt && cnt == mask_name_cnt && cnt == mask_type_cnt
+       && cnt == mask_version_cnt && cnt == mask_id_cnt && cnt == mask_nb_cnt)
     {
       for(size_t i = 0; i < cnt; i++)
       {

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2035,11 +2035,11 @@ static GHashTable *read_masks(Exiv2::XmpData &xmpData, const char *filename, con
     && (mask_id = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.mask_id"))) != xmpData.end()
     && (mask_nb = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.mask_nb"))) != xmpData.end())
   {
-    const int cnt = mask->count();
+    const size_t cnt = mask->count();
     if(cnt == mask_src->count() && cnt == mask_name->count() && cnt == mask_type->count()
       && cnt == mask_version->count() && cnt == mask_id->count() && cnt == mask_nb->count())
     {
-      for(int i = 0; i < cnt; i++)
+      for(size_t i = 0; i < cnt; i++)
       {
         mask_entry_t *entry = (mask_entry_t *)calloc(1, sizeof(mask_entry_t));
 


### PR DESCRIPTION
fixes compilation issues:
```/home/dave/workspace/darktable.git/src/common/exif.cc: In function ‘GHashTable* read_masks(Exiv2::XmpData&, const char*, int)’:
/home/dave/workspace/darktable.git/src/common/exif.cc:2039:12: error: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
     if(cnt == mask_src->count() && cnt == mask_name->count() && cnt == mask_type->count()
        ~~~~^~~~~~~~~~~~~~~~~~~~
/home/dave/workspace/darktable.git/src/common/exif.cc:2039:40: error: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
     if(cnt == mask_src->count() && cnt == mask_name->count() && cnt == mask_type->count()
                                    ~~~~^~~~~~~~~~~~~~~~~~~~~
/home/dave/workspace/darktable.git/src/common/exif.cc:2039:69: error: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
     if(cnt == mask_src->count() && cnt == mask_name->count() && cnt == mask_type->count()
                                                                 ~~~~^~~~~~~~~~~~~~~~~~~~~
/home/dave/workspace/darktable.git/src/common/exif.cc:2040:14: error: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
       && cnt == mask_version->count() && cnt == mask_id->count() && cnt == mask_nb->count())
          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/home/dave/workspace/darktable.git/src/common/exif.cc:2040:46: error: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
       && cnt == mask_version->count() && cnt == mask_id->count() && cnt == mask_nb->count())
                                          ~~~~^~~~~~~~~~~~~~~~~~~
/home/dave/workspace/darktable.git/src/common/exif.cc:2040:73: error: comparison of integer expressions of different signedness: ‘const int’ and ‘size_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
       && cnt == mask_version->count() && cnt == mask_id->count() && cnt == mask_nb->count())
                                                                     ~~~~^~~~~~~~~~~~~~~~~~~
```