### PR TITLE
fix for #2725 - rgb_norms.h missing

### DIFF
--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -2,7 +2,7 @@
 # install opencl kernel source files
 #
 FILE(GLOB DT_OPENCL_KERNELS "*.cl" "common.h")
-FILE(GLOB DT_OPENCL_EXTRA "programs.conf")
+FILE(GLOB DT_OPENCL_EXTRA "programs.conf" "rgb_norms.h")
 
 add_custom_target(testcompile_opencl_kernels ALL)
 


### PR DESCRIPTION
attempt to fix the issue rgb_norms.h missing file at open_cl start-up.
the rgb_norms.h file is copied to installed kernels folder.
remain to check that travis is happy.
