### PR TITLE
Crop guides: flexible grid

### DIFF
--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -198,6 +198,19 @@ static inline void dt_draw_vertical_lines(cairo_t *cr, const int num, const int 
   }
 }
 
+static inline void dt_draw_horizontal_lines(cairo_t *cr, const int num, const int left, const int top,
+                                            const int right, const int bottom)
+{
+  float height = bottom - top;
+
+  for(int k = 1; k < num; k++)
+  {
+    cairo_move_to(cr, left, top + k / (float)num * height);
+    cairo_line_to(cr, right, top + k / (float)num * height);
+    cairo_stroke(cr);
+  }
+}
+
 static inline void dt_draw_endmarker(cairo_t *cr, const int width, const int height, const int left)
 {
   // fibonacci spiral:


### PR DESCRIPTION
Currently, "grid" crop guides have almost the same functionality as "rules of thirds". The only difference is that it also subdivides each grid rectangle into another 3x3. In its current form it brings nothing distinctive to the table. Also, there is no other, configurable grid to help with cropping in dt.

This patch is an effort to make the grid great again by:
* adding sliders to control number of horizontal and vertical grid lines,
* adding slider to control number of subdivisions within each grid rectangle,
* making main grid lines 1px wide and drawn with alternating color (instead of two 1px lines side by side drawn with different colors to make it visible in dark and bright areas, which may be confusing - guide lines "jump" by one pixel when the background changes in brightness drastically),
* enhancing the visibility of subdivisions in bright areas.

Default configuration stays as it was before: rules of thirds with 3x3 subdivision.

This solution is something I can see being useful, but comments and suggestions are most certainly welcome.