### PR TITLE
use CAIRO_FILTER_GOOD on navigation instead of CAIRO_FILTER_BEST

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -147,8 +147,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_name(GTK_WIDGET(self->widget), "navigation-module");
 
   /* connect a redraw callback to control draw all and preview pipe finish signals */
-  dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
-                            G_CALLBACK(_lib_navigation_control_redraw_callback), self);
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
                             G_CALLBACK(_lib_navigation_control_redraw_callback), self);
 }

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -225,7 +225,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
 
     cairo_rectangle(cr, 0, 0, wd, ht);
     cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_BEST);
+    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_GOOD);
     cairo_fill(cr);
 
     // draw box where we are


### PR DESCRIPTION
Use CAIRO_FILTER_GOOD on navigation instead of CAIRO_FILTER_BEST. The difference in quality is visible depending on the image, but the navigation don't need to be high quality, and this makes the sliders and curves a lot more responsive, and saves some time on the overall process.
The CAIRO_FILTER_FAST is (obviously) better for performance, but the difference in quality is too noticeable, so let's try this one first.

Also, don't redraw the navigation when full pipe finish, it only need the preview pipe.
