### PR TITLE
filmstrip : reuse in-memory sqlite table

### DIFF
--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -760,22 +760,11 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
   const int img_pointerx = (int)fmodf(pointerx, wd);
   const int img_pointery = (int)pointery;
 
-  const dt_collection_sort_t current_sort = dt_collection_get_sort_field(darktable.collection);
-  const gboolean reverse = dt_collection_get_sort_descending(darktable.collection);
-
-  // we disable the shuffle sort on the filmstrip as this cannot be work with the current implementation. On each redraw
-  // we get a new order for the collection.
-  if(current_sort == DT_COLLECTION_SORT_SHUFFLE)
-  {
-    dt_collection_set_sort(darktable.collection, DT_COLLECTION_SORT_ID, reverse);
-    dt_collection_update(darktable.collection);
-  }
-
   /* get the count of current collection */
   strip->collection_count = dt_collection_get_count(darktable.collection);
 
   /* get the collection query */
-  const gchar *query = dt_collection_get_query(darktable.collection);
+  const gchar *query = "SELECT imgid FROM memory.collected_images ORDER BY rowid LIMIT ?1, ?2";
   if(!query) return FALSE;
 
   if(offset < 0) strip->offset = offset = 0;
@@ -784,13 +773,6 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, offset - max_cols / 2);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, max_cols);
-
-  // reset previous sort
-  if(current_sort == DT_COLLECTION_SORT_SHUFFLE)
-  {
-    dt_collection_set_sort(darktable.collection, current_sort, reverse);
-    dt_collection_update(darktable.collection);
-  }
 
   cairo_save(cr);
   cairo_translate(cr, empty_edge, 0.0f);


### PR DESCRIPTION
this will speedup redraw and keep shuffle order on if needed
this fix #2734