### PR TITLE
accels window enhancements

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1151,3 +1151,9 @@ cell:selected
    font-family: courier;
    font-weight: bold;
 }
+
+.accels_window_stick
+{
+  min-width: 2em;
+  min-height : 2em;
+}

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1741,6 +1741,10 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     if(module->gui_focus) module->gui_focus(module, TRUE);
   }
 
+  /* update sticky accels window */
+  if(darktable.view_manager->accels_window.window && darktable.view_manager->accels_window.sticky)
+    dt_view_accels_refresh(darktable.view_manager);
+
   dt_control_change_cursor(GDK_LEFT_PTR);
 }
 

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1719,6 +1719,10 @@ void dt_masks_change_form_gui(dt_masks_form_t *newform)
 {
   dt_masks_clear_form_gui(darktable.develop);
   darktable.develop->form_visible = newform;
+
+  /* update sticky accels window */
+  if(darktable.view_manager->accels_window.window && darktable.view_manager->accels_window.sticky)
+    dt_view_accels_refresh(darktable.view_manager);
 }
 
 void dt_masks_reset_form_gui(void)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1395,6 +1395,28 @@ static void _view_map_build_main_query(dt_map_t *lib)
   g_free(geo_query);
 }
 
+GSList *mouse_actions(const dt_view_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_DOUBLE_LEFT;
+  g_strlcpy(a->name, _("[on image] open in darkroom"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_DOUBLE_LEFT;
+  g_strlcpy(a->name, _("[on map] zoom map"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_DRAG_DROP;
+  g_strlcpy(a->name, _("move image location"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -596,6 +596,23 @@ void connect_key_accels(dt_view_t *self)
 {
 }
 
+GSList *mouse_actions(const dt_view_t *self)
+{
+  GSList *lm = NULL;
+  dt_mouse_action_t *a = NULL;
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_LEFT;
+  g_strlcpy(a->name, _("go to next image"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
+  a->action = DT_MOUSE_ACTION_RIGHT;
+  g_strlcpy(a->name, _("go to previous image"), sizeof(a->name));
+  lm = g_slist_append(lm, a);
+
+  return lm;
+}
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -2214,6 +2214,9 @@ static void _accels_window_sticky(GtkWidget *widget, GdkEventButton *event, dt_v
 
   // creating new window
   GtkWindow *win = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(win);
+#endif
   GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(win));
   gtk_style_context_add_class(context, "accels_window");
   gtk_window_set_title(win, _("darktable - accels window"));

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -453,6 +453,9 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
   /* update the scrollbars */
   dt_ui_update_scrollbars(darktable.gui->ui);
 
+  /* update sticky accels window */
+  if(vm->accels_window.window && vm->accels_window.sticky) dt_view_accels_refresh(vm);
+
   /* raise view changed signal */
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_VIEWMANAGER_VIEW_CHANGED, old_view, new_view);
 
@@ -2199,6 +2202,12 @@ static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
   return atxt;
 }
 
+static void _accels_window_destroy(GtkWidget *widget, dt_view_manager_t *vm)
+{
+  // set to NULL so we can rely on it after
+  vm->accels_window.window = NULL;
+}
+
 static void _accels_window_sticky(GtkWidget *widget, GdkEventButton *event, dt_view_manager_t *vm)
 {
   if(!vm->accels_window.window) return;
@@ -2207,13 +2216,14 @@ static void _accels_window_sticky(GtkWidget *widget, GdkEventButton *event, dt_v
   GtkWindow *win = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
   GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(win));
   gtk_style_context_add_class(context, "accels_window");
-  gtk_window_set_title(win, _("darktable accels window"));
+  gtk_window_set_title(win, _("darktable - accels window"));
   GtkAllocation alloc;
   gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
 
   gtk_window_set_resizable(win, TRUE);
-  gtk_window_set_skip_taskbar_hint(win, TRUE);
+  gtk_window_set_icon_name(win, "darktable");
   gtk_window_set_default_size(win, alloc.width * 0.7, alloc.height * 0.7);
+  g_signal_connect(win, "destroy", G_CALLBACK(_accels_window_destroy), vm);
 
   GtkWidget *sw
       = (GtkWidget *)g_list_first(gtk_container_get_children(GTK_CONTAINER(vm->accels_window.window)))->data;
@@ -2269,9 +2279,50 @@ void dt_view_accels_show(dt_view_manager_t *vm)
   gtk_box_pack_start(GTK_BOX(vb), vm->accels_window.sticky_btn, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, FALSE, 0);
 
+  dt_view_accels_refresh(vm);
+
+  GtkAllocation alloc;
+  gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
+  // gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
+  gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
+  gtk_scrolled_window_set_max_content_width(GTK_SCROLLED_WINDOW(sw), alloc.width);
+  gtk_container_add(GTK_CONTAINER(sw), hb);
+  gtk_container_add(GTK_CONTAINER(vm->accels_window.window), sw);
+
+  gtk_window_set_resizable(GTK_WINDOW(vm->accels_window.window), FALSE);
+  gtk_window_set_default_size(GTK_WINDOW(vm->accels_window.window), alloc.width, alloc.height);
+  gtk_window_set_transient_for(GTK_WINDOW(vm->accels_window.window),
+                               GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
+  gtk_window_set_keep_above(GTK_WINDOW(vm->accels_window.window), TRUE);
+  gtk_window_set_gravity(GTK_WINDOW(vm->accels_window.window), GDK_GRAVITY_STATIC);
+  gtk_window_set_position(GTK_WINDOW(vm->accels_window.window), GTK_WIN_POS_CENTER_ON_PARENT);
+  gtk_widget_show_all(vm->accels_window.window);
+}
+
+void dt_view_accels_hide(dt_view_manager_t *vm)
+{
+  if(vm->accels_window.window && vm->accels_window.sticky) return;
+  gtk_widget_destroy(vm->accels_window.window);
+  vm->accels_window.window = NULL;
+}
+
+void dt_view_accels_refresh(dt_view_manager_t *vm)
+{
+  if(!vm->accels_window.window) return;
+
+  // drop all existing tables
+  GList *lw = gtk_container_get_children(GTK_CONTAINER(vm->accels_window.flow_box));
+  while(lw)
+  {
+    GtkWidget *w = (GtkWidget *)lw->data;
+    gtk_widget_destroy(w);
+    lw = g_list_next(lw);
+  }
+
   // get the list of valid accel for this view
   const dt_view_t *cv = dt_view_manager_get_current_view(vm);
   const dt_view_type_flags_t v = cv->view(cv);
+  GtkStyleContext *context;
 
   typedef struct _bloc_t
   {
@@ -2401,29 +2452,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
   }
   g_list_free_full(blocs, free);
 
-  GtkAllocation alloc;
-  gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
-  // gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
-  gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
-  gtk_scrolled_window_set_max_content_width(GTK_SCROLLED_WINDOW(sw), alloc.width);
-  gtk_container_add(GTK_CONTAINER(sw), hb);
-  gtk_container_add(GTK_CONTAINER(vm->accels_window.window), sw);
-
-  gtk_window_set_resizable(GTK_WINDOW(vm->accels_window.window), FALSE);
-  gtk_window_set_default_size(GTK_WINDOW(vm->accels_window.window), alloc.width, alloc.height);
-  gtk_window_set_transient_for(GTK_WINDOW(vm->accels_window.window),
-                               GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  gtk_window_set_keep_above(GTK_WINDOW(vm->accels_window.window), TRUE);
-  gtk_window_set_gravity(GTK_WINDOW(vm->accels_window.window), GDK_GRAVITY_STATIC);
-  gtk_window_set_position(GTK_WINDOW(vm->accels_window.window), GTK_WIN_POS_CENTER_ON_PARENT);
-  gtk_widget_show_all(vm->accels_window.window);
-}
-
-void dt_view_accels_hide(dt_view_manager_t *vm)
-{
-  if(vm->accels_window.window && vm->accels_window.sticky) return;
-  gtk_widget_destroy(vm->accels_window.window);
-  vm->accels_window.window = NULL;
+  gtk_widget_show_all(vm->accels_window.flow_box);
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -32,6 +32,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "dtgtk/button.h"
 #include "dtgtk/expander.h"
 #include "gui/accelerators.h"
 #include "gui/draw.h"
@@ -331,6 +332,9 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
     for(int l = 0; l < DT_UI_CONTAINER_SIZE; l++)
       dt_ui_container_destroy_children(darktable.gui->ui, l);
     vm->current_view = NULL;
+
+    /* remove sticky accels window */
+    if(vm->accels_window.window) dt_view_accels_hide(vm);
     return 0;
   }
 
@@ -2195,26 +2199,76 @@ static gchar *_mouse_action_get_string(dt_mouse_action_t *ma)
   return atxt;
 }
 
+static void _accels_window_sticky(GtkWidget *widget, GdkEventButton *event, dt_view_manager_t *vm)
+{
+  if(!vm->accels_window.window) return;
+
+  // creating new window
+  GtkWindow *win = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(win));
+  gtk_style_context_add_class(context, "accels_window");
+  gtk_window_set_title(win, _("darktable accels window"));
+  GtkAllocation alloc;
+  gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
+
+  gtk_window_set_resizable(win, TRUE);
+  gtk_window_set_skip_taskbar_hint(win, TRUE);
+  gtk_window_set_default_size(win, alloc.width * 0.7, alloc.height * 0.7);
+
+  GtkWidget *sw
+      = (GtkWidget *)g_list_first(gtk_container_get_children(GTK_CONTAINER(vm->accels_window.window)))->data;
+  g_object_ref(sw);
+
+  gtk_container_remove(GTK_CONTAINER(vm->accels_window.window), sw);
+  gtk_container_add(GTK_CONTAINER(win), sw);
+  g_object_unref(sw);
+  gtk_widget_destroy(vm->accels_window.window);
+  vm->accels_window.window = GTK_WIDGET(win);
+  gtk_widget_show_all(vm->accels_window.window);
+  gtk_widget_hide(vm->accels_window.sticky_btn);
+
+  vm->accels_window.sticky = TRUE;
+}
+
 void dt_view_accels_show(dt_view_manager_t *vm)
 {
-  if(vm->accels_window) return; // dt_view_accels_hide(vm);
+  if(vm->accels_window.window) return;
+
+  vm->accels_window.sticky = FALSE;
 
   GtkStyleContext *context;
-  vm->accels_window = gtk_window_new(GTK_WINDOW_POPUP);
+  vm->accels_window.window = gtk_window_new(GTK_WINDOW_POPUP);
 #ifdef GDK_WINDOWING_QUARTZ
-  dt_osx_disallow_fullscreen(darktable.bauhaus->popup_window);
+  dt_osx_disallow_fullscreen(vm->accels_window.window);
 #endif
-  context = gtk_widget_get_style_context(vm->accels_window);
+  context = gtk_widget_get_style_context(vm->accels_window.window);
   gtk_style_context_add_class(context, "accels_window");
 
   GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
   context = gtk_widget_get_style_context(sw);
   gtk_style_context_add_class(context, "accels_window_scroll");
 
-  GtkWidget *fb = gtk_flow_box_new();
-  context = gtk_widget_get_style_context(fb);
+  GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
+
+  vm->accels_window.flow_box = gtk_flow_box_new();
+  context = gtk_widget_get_style_context(vm->accels_window.flow_box);
   gtk_style_context_add_class(context, "accels_window_box");
-  gtk_orientable_set_orientation(GTK_ORIENTABLE(fb), GTK_ORIENTATION_HORIZONTAL);
+  gtk_orientable_set_orientation(GTK_ORIENTABLE(vm->accels_window.flow_box), GTK_ORIENTATION_HORIZONTAL);
+
+  gtk_box_pack_start(GTK_BOX(hb), vm->accels_window.flow_box, TRUE, TRUE, 0);
+
+  GtkWidget *vb = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  vm->accels_window.sticky_btn
+      = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  g_object_set(G_OBJECT(vm->accels_window.sticky_btn), "tooltip-text",
+               _("switch to a classic window which will stay open after key release."), (char *)NULL);
+  g_signal_connect(G_OBJECT(vm->accels_window.sticky_btn), "button-press-event", G_CALLBACK(_accels_window_sticky),
+                   vm);
+  context = gtk_widget_get_style_context(vm->accels_window.sticky_btn);
+  gtk_style_context_add_class(context, "accels_window_stick");
+  gtk_box_pack_start(GTK_BOX(vb), vm->accels_window.sticky_btn, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hb), vb, FALSE, FALSE, 0);
+
   // get the list of valid accel for this view
   const dt_view_t *cv = dt_view_manager_get_current_view(vm);
   const dt_view_type_flags_t v = cv->view(cv);
@@ -2339,7 +2393,7 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 
     gtk_box_pack_start(GTK_BOX(box), list, FALSE, FALSE, 0);
 
-    gtk_flow_box_insert(GTK_FLOW_BOX(fb), box, -1);
+    gtk_flow_box_insert(GTK_FLOW_BOX(vm->accels_window.flow_box), box, -1);
     g_free(bb->base);
     g_free(bb->title);
 
@@ -2349,25 +2403,27 @@ void dt_view_accels_show(dt_view_manager_t *vm)
 
   GtkAllocation alloc;
   gtk_widget_get_allocation(dt_ui_main_window(darktable.gui->ui), &alloc);
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
+  // gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
   gtk_scrolled_window_set_max_content_height(GTK_SCROLLED_WINDOW(sw), alloc.height);
   gtk_scrolled_window_set_max_content_width(GTK_SCROLLED_WINDOW(sw), alloc.width);
-  gtk_container_add(GTK_CONTAINER(sw), fb);
-  gtk_container_add(GTK_CONTAINER(vm->accels_window), sw);
+  gtk_container_add(GTK_CONTAINER(sw), hb);
+  gtk_container_add(GTK_CONTAINER(vm->accels_window.window), sw);
 
-  gtk_window_set_resizable(GTK_WINDOW(vm->accels_window), FALSE);
-  gtk_window_set_default_size(GTK_WINDOW(vm->accels_window), alloc.width, alloc.height);
-  gtk_window_set_transient_for(GTK_WINDOW(vm->accels_window), GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
-  gtk_window_set_keep_above(GTK_WINDOW(vm->accels_window), TRUE);
-  gtk_window_set_gravity(GTK_WINDOW(vm->accels_window), GDK_GRAVITY_STATIC);
-  gtk_window_set_position(GTK_WINDOW(vm->accels_window), GTK_WIN_POS_CENTER_ON_PARENT);
-  gtk_widget_show_all(vm->accels_window);
+  gtk_window_set_resizable(GTK_WINDOW(vm->accels_window.window), FALSE);
+  gtk_window_set_default_size(GTK_WINDOW(vm->accels_window.window), alloc.width, alloc.height);
+  gtk_window_set_transient_for(GTK_WINDOW(vm->accels_window.window),
+                               GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)));
+  gtk_window_set_keep_above(GTK_WINDOW(vm->accels_window.window), TRUE);
+  gtk_window_set_gravity(GTK_WINDOW(vm->accels_window.window), GDK_GRAVITY_STATIC);
+  gtk_window_set_position(GTK_WINDOW(vm->accels_window.window), GTK_WIN_POS_CENTER_ON_PARENT);
+  gtk_widget_show_all(vm->accels_window.window);
 }
 
 void dt_view_accels_hide(dt_view_manager_t *vm)
 {
-  gtk_widget_destroy(vm->accels_window);
-  vm->accels_window = NULL;
+  if(vm->accels_window.window && vm->accels_window.sticky) return;
+  gtk_widget_destroy(vm->accels_window.window);
+  vm->accels_window.window = NULL;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -245,7 +245,13 @@ typedef struct dt_view_manager_t
   GList *views;
   dt_view_t *current_view;
 
-  GtkWidget *accels_window;
+  struct
+  {
+    GtkWidget *window;
+    GtkWidget *sticky_btn;
+    GtkWidget *flow_box;
+    gboolean sticky;
+  } accels_window;
 
   /* reusable db statements
    * TODO: reconsider creating a common/database helper API

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -484,6 +484,7 @@ void dt_view_filmstrip_prefetch();
 /* accel window */
 void dt_view_accels_show(dt_view_manager_t *vm);
 void dt_view_accels_hide(dt_view_manager_t *vm);
+void dt_view_accels_refresh(dt_view_manager_t *vm);
 
 /*
  * Map View Proxy


### PR DESCRIPTION
This contain : 
- set default accel to 'H'
- add mouse actions for slideshow and map views
- implement "sticky" accels window : by clicking on the little icon on top-right of the accels window, the window become a normal one, with title, decoration, resizable, ...
This window can be keep around if you want. Window content is updated when changing view, active iop or drawn mask. This fix #2738
- certainly fix compile bug in osx