### PR TITLE
[needs testing on various CPUs] denoiseprofile: nlmeans speedup

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1305,7 +1305,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
       dt_omp_firstprivate(d, ovoid, P, roi_in, roi_out) \
       firstprivate(inited_slide) \
       shared(kj, ki, in, Sa) \
-      schedule(static)
+      schedule(dynamic)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {
@@ -1508,7 +1508,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
       dt_omp_firstprivate(ovoid, P, roi_in, roi_out) \
       firstprivate(inited_slide, d) \
       shared(kj, ki, in, Sa) \
-      schedule(static)
+      schedule(dynamic)
 #endif
       for(int j = 0; j < roi_out->height; j++)
       {


### PR DESCRIPTION
Changing openmp scheduling from static to dynamic results on a 2x speedup for denoiseprofile's non local means on my main computer (with an intel i7).
However, on some other computers (like my laptop with an intel atom), it does not give any speedup, and even gives a slight slowdown (<10%).
Thus, I don't know if we should integrate this or not, but it is worth testing on various CPU to see if I am not alone to experience huge gain on a CPU, and if so if there is more to win than to loose in general.