### PR TITLE
Aspect ratio fix

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -73,8 +73,10 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "UPDATE main.images SET history_end = 0, iop_order_version = 0 WHERE id = ?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+      dt_database_get(darktable.db),
+      "UPDATE main.images SET history_end = 0, iop_order_version = 0, aspect_ratio = 0.0 WHERE id = ?1", -1, &stmt,
+      NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2507,6 +2507,18 @@ void leave(dt_view_t *self)
   // commit image ops to db
   dt_dev_write_history(dev);
 
+  // update aspect ratio
+  if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
+  {
+    double aspect_ratio = (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
+    printf("aspect_ratio updated to %f\n", aspect_ratio);
+    dt_image_set_aspect_ratio_to(dev->preview_pipe->image.id, aspect_ratio);
+  }
+  else
+  {
+    dt_image_set_aspect_ratio(dev->image_storage.id);
+  }
+  
   // be sure light table will regenerate the thumbnail:
   // TODO: only if changed!
   // if()
@@ -2516,9 +2528,6 @@ void leave(dt_view_t *self)
     // dump new xmp data
     dt_image_synch_xmp(dev->image_storage.id);
   }
-
-  // update possibly changed aspect ratio
-  dt_image_set_aspect_ratio(dev->image_storage.id);
 
   // clear gui.
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -584,6 +584,17 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   // stop crazy users from sleeping on key-repeat spacebar:
   if(dev->image_loading) return;
 
+  // update aspect ratio
+  if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
+  {
+    double aspect_ratio = (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
+    dt_image_set_aspect_ratio_to(dev->preview_pipe->image.id, aspect_ratio);
+  }
+  else
+  {
+    dt_image_set_aspect_ratio(dev->image_storage.id);
+  }
+
   // make sure we can destroy and re-setup the pixel pipes.
   // we acquire the pipe locks, which will block the processing threads
   // in darkroom mode before they touch the pipes (init buffers etc).
@@ -2511,7 +2522,6 @@ void leave(dt_view_t *self)
   if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
   {
     double aspect_ratio = (double)dev->preview_pipe->backbuf_width / (double)dev->preview_pipe->backbuf_height;
-    printf("aspect_ratio updated to %f\n", aspect_ratio);
     dt_image_set_aspect_ratio_to(dev->preview_pipe->image.id, aspect_ratio);
   }
   else


### PR DESCRIPTION
this fix some case where aspect ratio is not computed : 
- when switching to another image in darkroom view
- when deleting history stack in lighttable

this also improve a little ratio computation by reusing preview pipe if available in darkroom
this as been discussed in #2565 (but doesn't fix the main issue)