### PR TITLE
recompute aspect ratio on styles and copy/paste

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -629,9 +629,10 @@ static int _history_copy_and_paste_on_image_overwrite(int32_t imgid, int32_t des
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "UPDATE main.images SET history_end = 0, iop_order_version = 0 WHERE id = ?1",
-                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+      dt_database_get(darktable.db),
+      "UPDATE main.images SET history_end = 0, iop_order_version = 0, aspect_ratio = 0.0 WHERE id = ?1", -1, &stmt,
+      NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dest_imgid);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
@@ -745,10 +746,11 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
   dt_mipmap_cache_remove(darktable.mipmap_cache, dest_imgid);
   dt_image_reset_final_size(imgid);
 
-  /* update the aspect ratio if the current sorting is based on aspect ratio, otherwise the aspect ratio will be
-     recalculated when the mimpap will be recreated */
-  if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+  /* update the aspect ratio. recompute only if really needed for performance reasons */
+  if(darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
     dt_image_set_aspect_ratio(dest_imgid);
+  else
+    dt_image_reset_aspect_ratio(dest_imgid);
 
   return ret_val;
 }

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -607,6 +607,20 @@ void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio)
   }
 }
 
+void dt_image_reset_aspect_ratio(const int32_t imgid)
+{
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE images SET aspect_ratio=0.0 WHERE id=?1", -1,
+                              &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+
+  if(darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
+}
+
 double dt_image_set_aspect_ratio(const int32_t imgid)
 {
   dt_mipmap_buffer_t buf;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -248,6 +248,8 @@ int dt_image_altered(const uint32_t imgid);
 double dt_image_set_aspect_ratio(const int32_t imgid);
 /** set the image final/cropped aspect ratio */
 void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio);
+/** reset the image final/cropped aspect ratio to 0.0 */
+void dt_image_reset_aspect_ratio(const int32_t imgid);
 /** returns the orientation bits of the image from exif. */
 static inline dt_image_orientation_t dt_image_orientation(const dt_image_t *img)
 {

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -17,15 +17,16 @@
 */
 
 #include "common/styles.h"
+#include "common/collection.h"
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/exif.h"
 #include "common/file_location.h"
 #include "common/history.h"
+#include "common/history_snapshot.h"
 #include "common/image_cache.h"
 #include "common/imageio.h"
 #include "common/tags.h"
-#include "common/history_snapshot.h"
 #include "control/control.h"
 #include "develop/develop.h"
 
@@ -757,6 +758,12 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
     /* remove old obsolete thumbnails */
     dt_mipmap_cache_remove(darktable.mipmap_cache, newimgid);
     dt_image_reset_final_size(newimgid);
+
+    /* update the aspect ratio. recompute only if really needed for performance reasons */
+    if(darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+      dt_image_set_aspect_ratio(newimgid);
+    else
+      dt_image_reset_aspect_ratio(newimgid);
 
     /* if we have created a duplicate, reset collected images */
     if(duplicate) dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);


### PR DESCRIPTION
second round. This recompute aspect ratio after applying a style in lighttable and after copy/pasting history stack 