### PR TITLE
Fix potentially invalid structure typecast

### DIFF
--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -122,10 +122,7 @@ position ()
 
 typedef struct dt_print_format_t
 {
-  int max_width, max_height;
-  int width, height;
-  char style[128];
-  gboolean style_append;
+  dt_imageio_module_data_t head;
   int bpp;
   dt_lib_print_job_t *params;
 } dt_print_format_t;
@@ -153,15 +150,15 @@ static int write_image(dt_imageio_module_data_t *data, const char *filename, con
 {
   dt_print_format_t *d = (dt_print_format_t *)data;
 
-  d->params->buf = (uint16_t *)malloc(d->width * d->height * 3 * (d->bpp == 8?1:2));
+  d->params->buf = (uint16_t *)malloc(d->head.width * d->head.height * 3 * (d->bpp == 8?1:2));
 
   if (d->bpp == 8)
   {
     const uint8_t *in_ptr = (const uint8_t *)in;
     uint8_t *out_ptr = (uint8_t *)d->params->buf;
-    for(int y = 0; y < d->height; y++)
+    for(int y = 0; y < d->head.height; y++)
     {
-      for(int x = 0; x < d->width; x++, in_ptr += 4, out_ptr += 3)
+      for(int x = 0; x < d->head.width; x++, in_ptr += 4, out_ptr += 3)
         memcpy(out_ptr, in_ptr, 3);
     }
   }
@@ -169,9 +166,9 @@ static int write_image(dt_imageio_module_data_t *data, const char *filename, con
   {
     const uint16_t *in_ptr = (const uint16_t *)in;
     uint16_t *out_ptr = (uint16_t *)d->params->buf;
-    for(int y = 0; y < d->height; y++)
+    for(int y = 0; y < d->head.height; y++)
     {
-      for(int x = 0; x < d->width; x++, in_ptr += 4, out_ptr += 3)
+      for(int x = 0; x < d->head.width; x++, in_ptr += 4, out_ptr += 3)
         memcpy(out_ptr, in_ptr, 6);
     }
   }
@@ -225,14 +222,14 @@ static int _print_job_run(dt_job_t *job)
   buf.write_image = write_image;
 
   dt_print_format_t dat;
-  dat.max_width = max_width;
-  dat.max_height = max_height;
-  dat.style[0] = '\0';
-  dat.style_append = params->style_append;
+  dat.head.max_width = max_width;
+  dat.head.max_height = max_height;
+  dat.head.style[0] = '\0';
+  dat.head.style_append = params->style_append;
   dat.bpp = *params->p_icc_profile ? 16 : 8; // set to 16bit when a profile is to be applied
   dat.params = params;
 
-  if (params->style) g_strlcpy(dat.style, params->style, sizeof(dat.style));
+  if (params->style) g_strlcpy(dat.head.style, params->style, sizeof(dat.head.style));
 
   // let the user know something is happening
   dt_control_job_set_progress(job, 0.05);
@@ -254,7 +251,7 @@ static int _print_job_run(dt_job_t *job)
   int32_t px=0, py=0, pwidth=0, pheight=0;
   int32_t ax=0, ay=0, awidth=0, aheight=0;
   int32_t ix=0, iy=0, iwidth=0, iheight=0;
-  int32_t iwpix=dat.width, ihpix=dat.height;
+  int32_t iwpix=dat.head.width, ihpix=dat.head.height;
 
   dt_get_print_layout (params->imgid, &params->prt, width_pix, height_pix,
                        &iwpix, &ihpix,
@@ -292,7 +289,7 @@ static int _print_job_run(dt_job_t *job)
         dt_control_queue_redraw();
         return 1;
       }
-      if (dt_apply_printer_profile((void **)&(params->buf), dat.width, dat.height, dat.bpp, buf_profile->profile,
+      if (dt_apply_printer_profile((void **)&(params->buf), dat.head.width, dat.head.height, dat.bpp, buf_profile->profile,
                                    pprof->profile, params->p_icc_intent, params->black_point_compensation))
       {
         dt_control_log(_("cannot apply printer profile `%s'"), params->p_icc_profile);
@@ -330,7 +327,7 @@ static int _print_job_run(dt_job_t *job)
   if (*printer_profile)
     icc_id = dt_pdf_add_icc(pdf, printer_profile);
 */
-  params->pdf_image = dt_pdf_add_image(pdf, (uint8_t *)params->buf, dat.width, dat.height, 8, icc_id, 0.0);
+  params->pdf_image = dt_pdf_add_image(pdf, (uint8_t *)params->buf, dat.head.width, dat.head.height, 8, icc_id, 0.0);
 
   //  PDF bounding-box has origin on bottom-left
   params->pdf_image->bb_x      = dt_pdf_pixel_to_point((float)margin_left, params->prt.printer.resolution);
@@ -338,7 +335,7 @@ static int _print_job_run(dt_job_t *job)
   params->pdf_image->bb_width  = dt_pdf_pixel_to_point((float)iwidth, params->prt.printer.resolution);
   params->pdf_image->bb_height = dt_pdf_pixel_to_point((float)iheight, params->prt.printer.resolution);
 
-  if (params->prt.page.landscape && (dat.width > dat.height))
+  if (params->prt.page.landscape && (dat.head.width > dat.head.height))
     params->pdf_image->rotate_to_fit = TRUE;
   else
     params->pdf_image->rotate_to_fit = FALSE;

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -79,10 +79,7 @@ typedef struct dt_slideshow_t
 
 typedef struct dt_slideshow_format_t
 {
-  int max_width, max_height;
-  int width, height;
-  char style[128];
-  gboolean style_append;
+  dt_imageio_module_data_t head;
   dt_slideshow_t *d;
   dt_slideshow_slot_t slot;
   int32_t rank;
@@ -176,9 +173,9 @@ static int process_image(dt_slideshow_t *d, dt_slideshow_slot_t slot)
   buf.write_image = write_image;
 
   dt_slideshow_format_t dat;
-  dat.width = dat.max_width = d->width;
-  dat.height = dat.max_height = d->height;
-  dat.style[0] = '\0';
+  dat.head.width = dat.head.max_width = d->width;
+  dat.head.height = dat.head.max_height = d->height;
+  dat.head.style[0] = '\0';
   dat.d = d;
   dat.slot = slot;
   dat.rank = d->buf[slot].rank;


### PR DESCRIPTION
Structures `dt_print_format_t` and `dt_slideshow_format_t` explicitly converted to the `dt_imageio_module_data_t` (via pointer typecast) in the code.

At the moment everything is fine, but `dt_print_format_t` and `dt_slideshow_format_t` contains copy of fields of `dt_imageio_module_data_t`, but not nested `dt_imageio_module_data_t` inclusion, thus once the structure of `dt_imageio_module_data_t` will change one day this typecast will become invalid without any compiler warning or error.