### PR TITLE
Tags - set tag entry with selected tag in the list

### DIFF
--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -296,6 +296,24 @@ static void tag_name_changed(GtkEntry *entry, gpointer user_data)
   set_keyword(self, d);
 }
 
+static void set_selected_entry(GtkTreeView *view, gpointer user_data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+
+  GtkTreeIter iter;
+  GtkTreeModel *model = NULL;
+  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
+  if(!gtk_tree_selection_get_selected(selection, &model, &iter)) return;
+
+  char *tag;
+  gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_TAG, &tag, -1);
+  if (!tag) return;
+  gtk_entry_set_text(d->entry, tag);
+  g_free(tag);
+  set_keyword(self, d);
+}
+
 static void delete_button_clicked(GtkButton *button, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
@@ -563,6 +581,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->related), _("related tags,\ndoubleclick to attach"));
   dt_gui_add_help_link(GTK_WIDGET(d->related), "tagging.html#tagging_usage");
   g_signal_connect(G_OBJECT(d->related), "row-activated", G_CALLBACK(attach_activated), (gpointer)self);
+  g_signal_connect(G_OBJECT(d->related), "cursor-changed", G_CALLBACK(set_selected_entry), (gpointer)self);
   gtk_container_add(GTK_CONTAINER(w), GTK_WIDGET(d->related));
 
   // attach and delete buttons

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -48,7 +48,7 @@ typedef struct dt_lib_tagging_t
   GtkTreeView *current, *related;
   int imgsel;
 
-  GtkWidget *attach_button, *detach_button, *new_button, *delete_button, *import_button, *export_button;
+  GtkWidget *attach_button, *detach_button, *copy_button, *new_button, *delete_button, *import_button, *export_button;
 
   GtkWidget *floating_tag_window;
   int floating_tag_imgid;
@@ -90,6 +90,7 @@ void init_key_accels(dt_lib_module_t *self)
 {
   dt_accel_register_lib(self, NC_("accel", "attach"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "detach"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "copy"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "new"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "delete"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "tag"), GDK_KEY_t, GDK_CONTROL_MASK);
@@ -101,6 +102,7 @@ void connect_key_accels(dt_lib_module_t *self)
 
   dt_accel_connect_button_lib(self, "attach", d->attach_button);
   dt_accel_connect_button_lib(self, "detach", d->detach_button);
+  dt_accel_connect_button_lib(self, "copy", d->copy_button);
   dt_accel_connect_button_lib(self, "new", d->new_button);
   dt_accel_connect_button_lib(self, "delete", d->delete_button);
   dt_accel_connect_lib(self, "tag", g_cclosure_new(G_CALLBACK(_lib_tagging_tag_show), self, NULL));
@@ -587,7 +589,7 @@ void gui_init(dt_lib_module_t *self)
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
   button = gtk_button_new_with_label(_("copy"));
-  d->new_button = button;
+  d->copy_button = button;
   gtk_widget_set_tooltip_text(button, _("copy selected tag into entry field for edition"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -490,7 +490,6 @@ static void _lib_tagging_tags_changed_callback(gpointer instance, gpointer user_
 
 void gui_init(dt_lib_module_t *self)
 {
-  setvbuf(stdout, NULL, _IONBF, 0);
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)malloc(sizeof(dt_lib_tagging_t));
   self->data = (void *)d;
   d->imgsel = -1;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -311,7 +311,6 @@ static void set_selected_entry(GtkTreeView *view, gpointer user_data)
   if (!tag) return;
   gtk_entry_set_text(d->entry, tag);
   g_free(tag);
-  set_keyword(self, d);
 }
 
 static void delete_button_clicked(GtkButton *button, gpointer user_data)
@@ -491,6 +490,7 @@ static void _lib_tagging_tags_changed_callback(gpointer instance, gpointer user_
 
 void gui_init(dt_lib_module_t *self)
 {
+  setvbuf(stdout, NULL, _IONBF, 0);
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)malloc(sizeof(dt_lib_tagging_t));
   self->data = (void *)d;
   d->imgsel = -1;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -296,21 +296,22 @@ static void tag_name_changed(GtkEntry *entry, gpointer user_data)
   set_keyword(self, d);
 }
 
-static void set_selected_entry(GtkTreeView *view, gpointer user_data)
+static void copy_button_clicked(GtkButton *button, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
+  char *tag;
   GtkTreeIter iter;
   GtkTreeModel *model = NULL;
+  GtkTreeView *view = d->related;
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(view));
   if(!gtk_tree_selection_get_selected(selection, &model, &iter)) return;
-
-  char *tag;
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_TAG, &tag, -1);
   if (!tag) return;
   gtk_entry_set_text(d->entry, tag);
   g_free(tag);
+  gtk_entry_grab_focus_without_selecting(d->entry);
 }
 
 static void delete_button_clicked(GtkButton *button, gpointer user_data)
@@ -580,11 +581,17 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(d->related), _("related tags,\ndoubleclick to attach"));
   dt_gui_add_help_link(GTK_WIDGET(d->related), "tagging.html#tagging_usage");
   g_signal_connect(G_OBJECT(d->related), "row-activated", G_CALLBACK(attach_activated), (gpointer)self);
-  g_signal_connect(G_OBJECT(d->related), "cursor-changed", G_CALLBACK(set_selected_entry), (gpointer)self);
   gtk_container_add(GTK_CONTAINER(w), GTK_WIDGET(d->related));
 
   // attach and delete buttons
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+
+  button = gtk_button_new_with_label(_("copy"));
+  d->new_button = button;
+  gtk_widget_set_tooltip_text(button, _("copy selected tag into entry field for edition"));
+  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
+  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(copy_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(_("new"));
   d->new_button = button;


### PR DESCRIPTION
It happens the tag name is very long, example:
`Eukaryota|Plantae|Angiosperms|Magnoliids|Nymphaeales|Nymphaeaceae|Nénuphar rose`

When one needs to create a new entry, for example `Nénuphar blanc`, the full tag name must be written.
With this PR, I enter `Nénu` to get the existing list, select one of them, replace `rose` by `blanc` and I'm done with the new tag.

