### PR TITLE
add option to disable next modules in pipe

### DIFF
--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -305,6 +305,8 @@ typedef struct dt_iop_module_t
   int request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the module in focus. gui mode only. */
   int32_t suppress_mask;
+  /** set to TRUE if modules after this one should be skipped when the pipe is processed, must be used with skip_next_modules in dt_dev_pixelpipe_t */
+  gboolean skip_next_modules;
   /** color picker proxys */
   struct dt_iop_color_picker_t *picker;
   struct dt_iop_color_picker_t *blend_picker;

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -131,6 +131,8 @@ typedef struct dt_dev_pixelpipe_t
   int mask_display;
   // should this pixelpipe completely suppressed the blendif module?
   int bypass_blendif;
+  // set to TRUE if modules after the one with skip_next_modules=TRUE in dt_iop_module_t should be skipped when the pipe is processed
+  gboolean skip_next_modules;
   // input data based on this timestamp:
   int input_timestamp;
   dt_dev_pixelpipe_type_t type;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -669,6 +669,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   darktable.gui->reset = 1;
 
   const guint nb_iop = g_list_length(dev->iop);
+  dev->pipe->skip_next_modules = dev->preview_pipe->skip_next_modules = dev->preview2_pipe->skip_next_modules = FALSE;
   dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2_pipe);
@@ -769,6 +770,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
         dt_iop_gui_update_header(module);
       }
     }
+    module->skip_next_modules = FALSE;
 
     modules = g_list_previous(modules);
   }
@@ -2561,6 +2563,7 @@ void leave(dt_view_t *self)
 
   dev->gui_leaving = 1;
 
+  dev->pipe->skip_next_modules = dev->preview_pipe->skip_next_modules = dev->preview2_pipe->skip_next_modules = FALSE;
   dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview2_pipe);
   dt_dev_pixelpipe_cleanup_nodes(dev->preview_pipe);


### PR DESCRIPTION
This add an option in the multy-instance menu to skip processing modules after the current one.
Only modules that has a GUI and are not default enabled are skipped.

This is useful only for a couple of scenarios, but when needed is nice to have it.

I could use some help with the GUI:
-I'm using a check box menu, but the check is not displayed. The separator is barely visible, so maybe is a CSS thing.
-There should be a visual clue when the option is active, maybe the module name with a different color, configurable via CSS, but I have no idea how to do that.
