### PR TITLE
optimize render image

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -517,6 +517,11 @@ void dt_control_queue_redraw_center()
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_CENTER);
 }
 
+void dt_control_navigation_redraw()
+{
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_CONTROL_NAVIGATION_REDRAW);
+}
+
 static gboolean _gtk_widget_queue_draw(gpointer user_data)
 {
   gtk_widget_queue_draw(GTK_WIDGET(user_data));

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -87,6 +87,11 @@ void dt_control_queue_redraw_center();
 */
 void dt_control_queue_redraw_widget(GtkWidget *widget);
 
+/** \brief request redraw of the navigation widget.
+    This redraws the wiget of the navigation module.
+ */
+void dt_control_navigation_redraw();
+
 void dt_ctl_switch_mode();
 void dt_ctl_switch_mode_to(const char *mode);
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -26,9 +26,10 @@
 
 #define DT_CONTROL_DESCRIPTION_LEN 256
 // reserved workers
-#define DT_CTL_WORKER_RESERVED 2
+#define DT_CTL_WORKER_RESERVED 3
 #define DT_CTL_WORKER_ZOOM_1 0    // dev zoom 1
 #define DT_CTL_WORKER_ZOOM_FILL 1 // dev zoom fill
+#define DT_CTL_WORKER_ZOOM_2 2    // dev zoom for preview2
 
 typedef enum dt_job_state_t
 {

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -121,6 +121,9 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   { "dt-camera-detected", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,
     NULL, NULL, FALSE }, // DT_SIGNAL_CAMERA_DETECTED,
 
+  { "dt-control-navigation-redraw", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0,
+    NULL, NULL, FALSE }, // DT_SIGNAL_CONTROL_NAVIGATION_REDRAW
+
 };
 
 static GType _signal_type;

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -181,6 +181,11 @@ typedef enum dt_signal_t
    * */
   DT_SIGNAL_CAMERA_DETECTED,
 
+  /** \brief This signal is raised when dt_control_navigation_redraw() is called.
+    no param, no returned value
+  */
+  DT_SIGNAL_CONTROL_NAVIGATION_REDRAW,
+
   /* do not touch !*/
   DT_SIGNAL_COUNT
 } dt_signal_t;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -230,7 +230,7 @@ void dt_dev_process_preview2(dt_develop_t *dev)
   if(!dev->gui_attached) return;
   if(!(dev->second_window.widget && GTK_IS_WIDGET(dev->second_window.widget))) return;
   int err = dt_control_add_job_res(darktable.control, dt_dev_process_preview2_job_create(dev),
-                                   DT_CTL_WORKER_ZOOM_FILL);
+                                   DT_CTL_WORKER_ZOOM_2);
   if(err) fprintf(stderr, "[dev_process_preview2] job queue exceeded!\n");
 }
 
@@ -338,6 +338,8 @@ restart:
   dt_control_log_busy_leave();
   dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
+
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED);
 }
 
 void dt_dev_process_preview2_job(dt_develop_t *dev)
@@ -455,6 +457,10 @@ restart:
       goto restart;
   }
 
+  dev->preview2_pipe->backbuf_scale = scale;
+  dev->preview2_pipe->backbuf_zoom_x = zoom_x;
+  dev->preview2_pipe->backbuf_zoom_y = zoom_y;
+
   dev->preview2_status = DT_DEV_PIXELPIPE_VALID;
 
   dt_show_times(&start, "[dev_process_preview2] pixel pipeline processing");
@@ -463,6 +469,8 @@ restart:
   dt_control_log_busy_leave();
   dt_pthread_mutex_unlock(&dev->preview2_pipe_mutex);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
+
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED);
 }
 
 void dt_dev_process_image_job(dt_develop_t *dev)
@@ -589,6 +597,10 @@ restart:
   if(dev->pipe->changed != DT_DEV_PIPE_UNCHANGED) goto restart;
 
   // cool, we got a new image!
+  dev->pipe->backbuf_scale = scale;
+  dev->pipe->backbuf_zoom_x = zoom_x;
+  dev->pipe->backbuf_zoom_y = zoom_y;
+
   dev->image_status = DT_DEV_PIXELPIPE_VALID;
   dev->image_loading = 0;
 
@@ -596,6 +608,9 @@ restart:
   // if a widget needs to be redraw there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_log_busy_leave();
   dt_pthread_mutex_unlock(&dev->pipe_mutex);
+
+  if(dev->gui_attached && !dev->gui_leaving)
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED);
 }
 
 // load the raw and get the new image struct, blocking in gui thread

--- a/src/develop/pixelpipe_hb.h
+++ b/src/develop/pixelpipe_hb.h
@@ -115,8 +115,14 @@ typedef struct dt_dev_pixelpipe_t
   uint8_t *backbuf;
   size_t backbuf_size;
   int backbuf_width, backbuf_height;
+  float backbuf_scale;
+  float backbuf_zoom_x, backbuf_zoom_y;
   uint64_t backbuf_hash;
   dt_pthread_mutex_t backbuf_mutex, busy_mutex;
+  // output buffer (for display)
+  uint8_t *output_backbuf;
+  int output_backbuf_width, output_backbuf_height;
+  int output_imgid;
   // working?
   int processing;
   // shutting down?

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -157,7 +157,7 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget, GdkEventButto
       if(!dev) return;
 
       dt_dev_invalidate(dev);
-      dt_control_queue_redraw();
+      dt_control_queue_redraw_center();
 
       dt_dev_invalidate(darktable.develop);
 
@@ -294,14 +294,14 @@ static gboolean _lib_duplicate_thumb_draw_callback (GtkWidget *widget, cairo_t *
 
   int lk = 0;
   // if this is the actual thumb, we want to use the preview pipe
-  if(imgid == dev->image_storage.id)
+  if(imgid == dev->preview_pipe->output_imgid)
   {
     // we recreate the surface if needed
-    if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
+    if(dev->preview_pipe->output_backbuf)
     {
       /* re-allocate in case of changed image dimensions */
-      if(d->rgbbuf == NULL || dev->preview_pipe->backbuf_width != d->buf_width
-         || dev->preview_pipe->backbuf_height != d->buf_height)
+      if(d->rgbbuf == NULL || dev->preview_pipe->output_backbuf_width != d->buf_width
+         || dev->preview_pipe->output_backbuf_height != d->buf_height)
       {
         if(d->surface)
         {
@@ -309,8 +309,8 @@ static gboolean _lib_duplicate_thumb_draw_callback (GtkWidget *widget, cairo_t *
           d->surface = NULL;
         }
         g_free(d->rgbbuf);
-        d->buf_width = dev->preview_pipe->backbuf_width;
-        d->buf_height = dev->preview_pipe->backbuf_height;
+        d->buf_width = dev->preview_pipe->output_backbuf_width;
+        d->buf_height = dev->preview_pipe->output_backbuf_height;
         d->rgbbuf = g_malloc0((size_t)d->buf_width * d->buf_height * 4 * sizeof(unsigned char));
       }
 
@@ -325,7 +325,7 @@ static gboolean _lib_duplicate_thumb_draw_callback (GtkWidget *widget, cairo_t *
 
         dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
         dt_pthread_mutex_lock(mutex);
-        memcpy(d->rgbbuf, dev->preview_pipe->backbuf,
+        memcpy(d->rgbbuf, dev->preview_pipe->output_backbuf,
                (size_t)d->buf_width * d->buf_height * 4 * sizeof(unsigned char));
         d->buf_timestamp = dev->preview_pipe->input_timestamp;
         dt_pthread_mutex_unlock(mutex);

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -36,10 +36,6 @@ typedef struct dt_lib_navigation_t
 {
   int dragging;
   int zoom_w, zoom_h;
-  unsigned char* buffer;
-  int wd;
-  int ht;
-  int timestamp;
 } dt_lib_navigation_t;
 
 
@@ -117,11 +113,6 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_navigation_t *d = (dt_lib_navigation_t *)g_malloc0(sizeof(dt_lib_navigation_t));
   self->data = (void *)d;
 
-  d->buffer = NULL;
-  d->wd = -1;
-  d->ht = -1;
-  d->timestamp = -1;
-
   /* create drawingarea */
   self->widget = gtk_drawing_area_new();
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
@@ -149,15 +140,14 @@ void gui_init(dt_lib_module_t *self)
   /* connect a redraw callback to control draw all and preview pipe finish signals */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,
                             G_CALLBACK(_lib_navigation_control_redraw_callback), self);
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_NAVIGATION_REDRAW,
+                            G_CALLBACK(_lib_navigation_control_redraw_callback), self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
 {
   /* disconnect from signal */
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_navigation_control_redraw_callback), self);
-
-  dt_lib_navigation_t *d = self->data;
-  g_free(d->buffer);
 
   g_free(self->data);
   self->data = NULL;
@@ -176,29 +166,6 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
 
   dt_develop_t *dev = darktable.develop;
 
-  /* double buffering of image data: only take new data if valid */
-  if(dev->preview_pipe->backbuf && dev->preview_status == DT_DEV_PIXELPIPE_VALID)
-  {
-    /* re-allocate in case of changed image dimensions */
-    if(d->buffer == NULL || dev->preview_pipe->backbuf_width != d->wd || dev->preview_pipe->backbuf_height != d->ht)
-    {
-      g_free(d->buffer);
-      d->wd = dev->preview_pipe->backbuf_width;
-      d->ht = dev->preview_pipe->backbuf_height;
-      d->buffer = g_malloc0((size_t)d->wd * d->ht * 4 * sizeof(unsigned char));
-    }
-
-    /* update buffer if new data is available */
-    if(d->buffer && dev->preview_pipe->input_timestamp > d->timestamp)
-    {
-      dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
-      dt_pthread_mutex_lock(mutex);
-      memcpy(d->buffer, dev->preview_pipe->backbuf, (size_t)d->wd * d->ht * 4 * sizeof(unsigned char));
-      d->timestamp = dev->preview_pipe->input_timestamp;
-      dt_pthread_mutex_unlock(mutex);
-    }
-  }
-
   /* get the current style */
   cairo_surface_t *cst = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
   cairo_t *cr = cairo_create(cst);
@@ -207,16 +174,19 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
   gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
 
   /* draw navigation image if available */
-  if(d->buffer)
+  if(dev->preview_pipe->output_backbuf)
   {
+    dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
+    dt_pthread_mutex_lock(mutex);
+
     cairo_save(cr);
-    const int wd = d->wd;
-    const int ht = d->ht;
+    const int wd = dev->preview_pipe->output_backbuf_width;
+    const int ht = dev->preview_pipe->output_backbuf_height;
     const float scale = fminf(width / (float)wd, height / (float)ht);
 
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
     cairo_surface_t *surface
-        = cairo_image_surface_create_for_data(d->buffer, CAIRO_FORMAT_RGB24, wd, ht, stride);
+        = cairo_image_surface_create_for_data(dev->preview_pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     cairo_translate(cr, width / 2.0, height / 2.0f);
     cairo_scale(cr, scale, scale);
     cairo_translate(cr, -.5f * wd, -.5f * ht);
@@ -366,6 +336,8 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
     cairo_line_to(cr, width - 0.5 * h, -0.1 * h);
     cairo_fill(cr);
     cairo_surface_destroy(surface);
+
+    dt_pthread_mutex_unlock(mutex);
   }
 
   /* blit memsurface into widget */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -243,12 +243,10 @@ void expose(
   const float zoom_x = dt_control_get_dev_zoom_x();
   const dt_dev_zoom_t zoom = dt_control_get_dev_zoom();
   const int closeup = dt_control_get_dev_closeup();
+  const float backbuf_scale = dt_dev_get_zoom_scale(dev, zoom, 1.0f, 0) * darktable.gui->ppd;
+
   static cairo_surface_t *image_surface = NULL;
   static int image_surface_width = 0, image_surface_height = 0, image_surface_imgid = -1;
-  static float roi_hash_old = -1.0f;
-  // compute patented dreggn hash so we don't need to check all values:
-  const float roi_hash = width + 7.0f * height + 23.0f * zoom + 42.0f * zoom_x + 91.0f * zoom_y
-                         + 666.0f * zoom;
 
   if(image_surface_width != width || image_surface_height != height || image_surface == NULL)
   {
@@ -269,17 +267,18 @@ void expose(
     dt_view_set_scrollbar(self, zx, -0.5 + boxw/2, 0.5, boxw/2, zy, -0.5+ boxh/2, 0.5, boxh/2);
   }
 
-  if((dev->image_status == DT_DEV_PIXELPIPE_VALID)
-     && dev->pipe->input_timestamp >= dev->preview_pipe->input_timestamp)
+  if(dev->pipe->output_backbuf && // do we have an image?
+    dev->pipe->output_imgid == dev->image_storage.id && // is the right image?
+    dev->pipe->backbuf_scale == backbuf_scale && // is this the zoom scale we want to display?
+    dev->pipe->backbuf_zoom_x == zoom_x && dev->pipe->backbuf_zoom_y == zoom_y)
   {
     // draw image
-    roi_hash_old = roi_hash;
     mutex = &dev->pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
-    float wd = dev->pipe->backbuf_width;
-    float ht = dev->pipe->backbuf_height;
+    float wd = dev->pipe->output_backbuf_width;
+    float ht = dev->pipe->output_backbuf_height;
     stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
-    surface = dt_cairo_image_surface_create_for_data(dev->pipe->backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
+    surface = dt_cairo_image_surface_create_for_data(dev->pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     wd /= darktable.gui->ppd;
     ht /= darktable.gui->ppd;
     if(dev->full_preview)
@@ -302,15 +301,14 @@ void expose(
     dt_pthread_mutex_unlock(mutex);
     image_surface_imgid = dev->image_storage.id;
   }
-  else if((dev->preview_status == DT_DEV_PIXELPIPE_VALID) && (roi_hash != roi_hash_old))
+  else if(dev->preview_pipe->output_backbuf && dev->preview_pipe->output_imgid == dev->image_storage.id)
   {
     // draw preview
-    roi_hash_old = roi_hash;
     mutex = &dev->preview_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
 
-    const float wd = dev->preview_pipe->backbuf_width;
-    const float ht = dev->preview_pipe->backbuf_height;
+    const float wd = dev->preview_pipe->output_backbuf_width;
+    const float ht = dev->preview_pipe->output_backbuf_height;
     const float zoom_scale = dt_dev_get_zoom_scale(dev, zoom, 1<<closeup, 1);
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
@@ -318,7 +316,7 @@ void expose(
     cairo_clip(cr);
     stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
     surface
-        = cairo_image_surface_create_for_data(dev->preview_pipe->backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
+        = cairo_image_surface_create_for_data(dev->preview_pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     cairo_translate(cr, width / 2.0, height / 2.0f);
     cairo_scale(cr, zoom_scale, zoom_scale);
     cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
@@ -2727,7 +2725,8 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     ctl->button_x = x - offx;
     ctl->button_y = y - offy;
     dt_dev_invalidate(dev);
-    dt_control_queue_redraw();
+    dt_control_queue_redraw_center();
+    dt_control_navigation_redraw();
   }
 }
 
@@ -2857,7 +2856,8 @@ void scrollbar_changed(dt_view_t *self, double x, double y)
 
   /* redraw pipe */
   dt_dev_invalidate(darktable.develop);
-  dt_control_queue_redraw();
+  dt_control_queue_redraw_center();
+  dt_control_navigation_redraw();
 }
 
 void scrolled(dt_view_t *self, double x, double y, int up, int state)
@@ -2985,7 +2985,8 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   dt_control_set_dev_zoom_x(zoom_x);
   dt_control_set_dev_zoom_y(zoom_y);
   dt_dev_invalidate(dev);
-  dt_control_queue_redraw();
+  dt_control_queue_redraw_center();
+  dt_control_navigation_redraw();
 }
 
 int key_released(dt_view_t *self, guint key, guint state)
@@ -3007,7 +3008,8 @@ int key_released(dt_view_t *self, guint key, guint state)
     dt_iop_request_focus(lib->full_preview_last_module);
     dt_masks_set_edit_mode(darktable.develop->gui_module, lib->full_preview_masks_state);
     dt_dev_invalidate(darktable.develop);
-    dt_control_queue_redraw();
+    dt_control_queue_redraw_center();
+    dt_control_navigation_redraw();
   }
   // add an option to allow skip mouse events while editing masks
   if(key == accels->darkroom_skip_mouse_events.accel_key && state == accels->darkroom_skip_mouse_events.accel_mods)
@@ -3113,7 +3115,8 @@ int key_pressed(dt_view_t *self, guint key, guint state)
     dt_control_set_dev_zoom_y(zy);
 
     dt_dev_invalidate(dev);
-    dt_control_queue_redraw();
+    dt_control_queue_redraw_center();
+    dt_control_navigation_redraw();
 
     return 1;
   }
@@ -3386,13 +3389,10 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
   const float zoom_x = dt_second_window_get_dev_zoom_x(dev);
   const dt_dev_zoom_t zoom = dt_second_window_get_dev_zoom(dev);
   const int closeup = dt_second_window_get_dev_closeup(dev);
+  const float backbuf_scale = dt_second_window_get_zoom_scale(dev, zoom, 1.0f, 0) * dev->second_window.ppd;
 
   static cairo_surface_t *image_surface = NULL;
   static int image_surface_width = 0, image_surface_height = 0, image_surface_imgid = -1;
-  static float roi_hash_old = -1.0f;
-  static int img_id_old = -1;
-  // compute patented dreggn hash so we don't need to check all values:
-  const float roi_hash = width + 7.0f * height + 23.0f * zoom + 42.0f * zoom_x + 91.0f * zoom_y + 666.0f * zoom;
 
   if(image_surface_width != width || image_surface_height != height || image_surface == NULL)
   {
@@ -3406,19 +3406,18 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
   cairo_surface_t *surface;
   cairo_t *cr = cairo_create(image_surface);
 
-  if((dev->preview2_status == DT_DEV_PIXELPIPE_VALID)
-     && dev->preview2_pipe->input_timestamp >= dev->preview_pipe->input_timestamp)
+  if(dev->preview2_pipe->output_backbuf && // do we have an image?
+    dev->preview2_pipe->backbuf_scale == backbuf_scale && // is this the zoom scale we want to display?
+    dev->preview2_pipe->backbuf_zoom_x == zoom_x && dev->preview2_pipe->backbuf_zoom_y == zoom_y)
   {
     // draw image
-    roi_hash_old = roi_hash;
-    img_id_old = dev->image_storage.id;
     mutex = &dev->preview2_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
-    float wd = dev->preview2_pipe->backbuf_width;
-    float ht = dev->preview2_pipe->backbuf_height;
+    float wd = dev->preview2_pipe->output_backbuf_width;
+    float ht = dev->preview2_pipe->output_backbuf_height;
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
     surface
-        = dt_cairo_image_surface_create_for_data(dev->preview2_pipe->backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
+        = dt_cairo_image_surface_create_for_data(dev->preview2_pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     wd /= dev->second_window.ppd;
     ht /= dev->second_window.ppd;
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
@@ -3440,23 +3439,21 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
     dt_pthread_mutex_unlock(mutex);
     image_surface_imgid = dev->image_storage.id;
   }
-  else if((dev->preview_status == DT_DEV_PIXELPIPE_VALID) && ((roi_hash != roi_hash_old) || (dev->image_storage.id != img_id_old)))
+  else if(dev->preview_pipe->output_backbuf)
   {
     // draw preview
-    roi_hash_old = roi_hash;
-    img_id_old = dev->image_storage.id;
     mutex = &dev->preview_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);
 
-    const float wd = dev->preview_pipe->backbuf_width;
-    const float ht = dev->preview_pipe->backbuf_height;
+    const float wd = dev->preview_pipe->output_backbuf_width;
+    const float ht = dev->preview_pipe->output_backbuf_height;
     const float zoom_scale = dt_second_window_get_zoom_scale(dev, zoom, 1 << closeup, 1);
     dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_DARKROOM_BG);
     cairo_paint(cr);
     cairo_rectangle(cr, tb, tb, width - 2 * tb, height - 2 * tb);
     cairo_clip(cr);
     const int stride = cairo_format_stride_for_width(CAIRO_FORMAT_RGB24, wd);
-    surface = cairo_image_surface_create_for_data(dev->preview_pipe->backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
+    surface = cairo_image_surface_create_for_data(dev->preview_pipe->output_backbuf, CAIRO_FORMAT_RGB24, wd, ht, stride);
     cairo_translate(cr, width / 2.0, height / 2.0f);
     cairo_scale(cr, zoom_scale, zoom_scale);
     cairo_translate(cr, -.5f * wd - zoom_x * wd, -.5f * ht - zoom_y * ht);
@@ -3584,8 +3581,6 @@ static void second_window_scrolled(GtkWidget *widget, dt_develop_t *dev, double 
 
   // pipe needs to be reconstructed
   dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-  dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
-  dev->preview2_pipe->cache_obsolete = 1;
 
   gtk_widget_queue_draw(widget);
 }
@@ -3596,7 +3591,7 @@ static void second_window_leave(dt_develop_t *dev)
   dt_second_window_change_cursor(dev, GDK_LEFT_PTR);
 }
 
-static int second_window_button_pressed(dt_develop_t *dev, double x, double y, const double pressure,
+static int second_window_button_pressed(GtkWidget *widget, dt_develop_t *dev, double x, double y, const double pressure,
                                         const int which, const int type, const uint32_t state)
 {
   const int32_t tb = 0; // DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
@@ -3653,8 +3648,8 @@ static int second_window_button_pressed(dt_develop_t *dev, double x, double y, c
 
     // pipe needs to be reconstructed
     dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-    dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
-    dev->preview2_pipe->cache_obsolete = 1;
+
+    gtk_widget_queue_draw(widget);
 
     return 1;
   }
@@ -3705,8 +3700,6 @@ static void second_window_mouse_moved(GtkWidget *widget, dt_develop_t *dev, doub
 
     // pipe needs to be reconstructed
     dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-    dev->preview2_pipe->changed |= DT_DEV_PIPE_REMOVE;
-    dev->preview2_pipe->cache_obsolete = 1;
 
     gtk_widget_queue_draw(widget);
   }
@@ -3886,7 +3879,7 @@ static gboolean _second_window_button_pressed_callback(GtkWidget *w, GdkEventBut
   {
     gdk_event_get_axis((GdkEvent *)event, GDK_AXIS_PRESSURE, &pressure);
   }
-  second_window_button_pressed(dev, event->x, event->y, pressure, event->button, event->type, event->state & 0xf);
+  second_window_button_pressed(w, dev, event->x, event->y, pressure, event->button, event->type, event->state & 0xf);
   gtk_widget_grab_focus(w);
   gtk_widget_queue_draw(w);
   return FALSE;


### PR DESCRIPTION
Right now the darkroom center window (the image) is refreshed only when the full pipe is valid, so when playing with some settings we have to wait until the process finish. To test it, grab any curve and start dragging it, the image is refreshed only when the drag stops.

I have added an image buffer for the full and preview2 pipes and moved the preview buffer from the navigation, this buffers are updated when the pipe finish the process, so now the image is updated with the last edit result, making the display more fluid.

I also replaced some draw on the entire window with the center and navigation and added a queue res for the preview2 pipe. This probably won't be noticed as performance goes, but everything counts.
