### PR TITLE
remove auto tags

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -435,6 +435,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   dt_pthread_mutex_init(&(darktable.plugin_threadsafe), NULL);
   dt_pthread_mutex_init(&(darktable.capabilities_threadsafe), NULL);
   dt_pthread_mutex_init(&(darktable.exiv2_threadsafe), NULL);
+  dt_pthread_mutex_init(&(darktable.readFile_mutex), NULL);
   darktable.control = (dt_control_t *)calloc(1, sizeof(dt_control_t));
 
   // database
@@ -1130,6 +1131,7 @@ void dt_cleanup()
   dt_pthread_mutex_destroy(&(darktable.plugin_threadsafe));
   dt_pthread_mutex_destroy(&(darktable.capabilities_threadsafe));
   dt_pthread_mutex_destroy(&(darktable.exiv2_threadsafe));
+  dt_pthread_mutex_destroy(&(darktable.readFile_mutex));
 
   dt_exif_cleanup();
 }

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -252,6 +252,7 @@ typedef struct darktable_t
   dt_pthread_mutex_t plugin_threadsafe;
   dt_pthread_mutex_t capabilities_threadsafe;
   dt_pthread_mutex_t exiv2_threadsafe;
+  dt_pthread_mutex_t readFile_mutex;
   char *progname;
   char *datadir;
   char *plugindir;

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -436,7 +436,7 @@ static bool dt_exif_read_iptc_data(dt_image_t *img, Exiv2::IptcData &iptcData)
         char *tag = dt_util_foo_to_utf8(str.c_str());
         guint tagid = 0;
         dt_tag_new(tag, &tagid);
-        dt_tag_attach(tagid, img->id);
+        dt_tag_attach_from_gui(tagid, img->id);
         g_free(tag);
         ++pos;
       }
@@ -932,7 +932,7 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       {
        // If no supported Illuminant is found it's better NOT to use the found matrix.
        // The colorin module will write an error message and use a fallback matrix
-       // instead of showing wrong colors. 
+       // instead of showing wrong colors.
        switch(illu)
         {
           case 21:

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1711,6 +1711,8 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
 
         // write xmp file
         dt_image_write_sidecar_file(newid);
+
+        dt_collection_update_query(darktable.collection);
       }
 
       g_free(filename);

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -125,7 +125,9 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
   {
     dt_rawspeed_load_meta();
 
+    dt_pthread_mutex_lock(&darktable.readFile_mutex);
     m = f.readFile();
+    dt_pthread_mutex_unlock(&darktable.readFile_mutex);
 
     RawParser t(m.get());
     d = t.getDecoder(meta);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -742,8 +742,8 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
     guint tagid = 0;
     gchar ntag[512] = { 0 };
     g_snprintf(ntag, sizeof(ntag), "darktable|style|%s", name);
-    if(dt_tag_new(ntag, &tagid)) dt_tag_attach(tagid, newimgid);
-    if(dt_tag_new("darktable|changed", &tagid)) dt_tag_attach(tagid, newimgid);
+    if(dt_tag_new(ntag, &tagid)) dt_tag_attach_from_gui(tagid, newimgid);
+    if(dt_tag_new("darktable|changed", &tagid)) dt_tag_attach_from_gui(tagid, newimgid);
 
     /* if current image in develop reload history */
     if(dt_dev_is_current_image(darktable.develop, newimgid))

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -367,16 +367,24 @@ gboolean _tag_is_attached(guint tagid, gint imgid)
   return result;
 }
 
-void dt_tag_attach(guint tagid, gint imgid)
+gboolean dt_tag_attach(guint tagid, gint imgid)
 {
+  gboolean attached = FALSE;
   if(!_tag_is_attached(tagid, imgid))
   {
     _attach_tag(tagid, imgid, TRUE);
 
     dt_tag_update_used_tags();
 
-    dt_collection_update_query(darktable.collection);
+    attached = TRUE;
   }
+  return attached;
+}
+
+void dt_tag_attach_from_gui(guint tagid, gint imgid)
+{
+  if(dt_tag_attach(tagid, imgid))
+    dt_collection_update_query(darktable.collection);
 }
 
 void dt_tag_attach_list(GList *tags, gint imgid)
@@ -485,8 +493,6 @@ void dt_tag_detach_by_string(const char *name, gint imgid)
   sqlite3_finalize(stmt);
 
   dt_tag_update_used_tags();
-
-  dt_collection_update_query(darktable.collection);
 }
 
 

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -59,7 +59,9 @@ gboolean dt_tag_exists(const char *name, guint *tagid);
 
 /** attach a list of tags on selected images. \param[in] tagid id of tag to attach. \param[in] imgid the image
  * id to attach tag to, if < 0 selected images are used. */
-void dt_tag_attach(guint tagid, gint imgid);
+gboolean dt_tag_attach(guint tagid, gint imgid);
+/** same as above but raises a dt_collection_update_query() */
+void dt_tag_attach_from_gui(guint tagid, gint imgid);
 
 /** attach a list of tags on selected images. \param[in] tags a list of ids of tags. \param[in] imgid the
  * image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's created.*/

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -17,6 +17,7 @@
 */
 
 #include "common/darktable.h"
+#include "common/collection.h"
 #include "common/undo.h"
 #include <glib.h>    // for GList, gpointer, g_list_first, g_list_prepend
 #include <stdlib.h>  // for NULL, malloc, free
@@ -225,6 +226,8 @@ void dt_undo_do_redo(dt_undo_t *self, uint32_t filter)
     l = g_list_next(l);
   }
   UNLOCK;
+
+  dt_collection_update_query(darktable.collection);
 }
 
 void dt_undo_do_undo(dt_undo_t *self, uint32_t filter)
@@ -305,6 +308,8 @@ void dt_undo_do_undo(dt_undo_t *self, uint32_t filter)
   }
 
   UNLOCK;
+
+  dt_collection_update_query(darktable.collection);
 }
 
 static void _undo_clear_list(GList **list, uint32_t filter)

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -538,7 +538,11 @@ static int32_t dt_control_duplicate_images_job_run(dt_job_t *job)
   {
     imgid = GPOINTER_TO_INT(t->data);
     newimgid = dt_image_duplicate(imgid);
-    if(newimgid != -1) dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL);
+    if(newimgid != -1)
+    {
+      dt_history_copy_and_paste_on_image(imgid, newimgid, FALSE, NULL);
+      dt_collection_update_query(darktable.collection);
+    }
     t = g_list_delete_link(t, t);
     fraction = 1.0 / total;
     dt_control_job_set_progress(job, fraction);
@@ -1253,7 +1257,7 @@ static int32_t dt_control_local_copy_images_job_run(dt_job_t *job)
     if(is_copy)
     {
       if (dt_image_local_copy_set(imgid) == 0)
-        dt_tag_attach(tagid, imgid);
+        dt_tag_attach_from_gui(tagid, imgid);
     }
     else
     {
@@ -1349,7 +1353,7 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
     // remove 'changed' tag from image
     dt_tag_detach(tagid, imgid);
     // make sure the 'exported' tag is set on the image
-    dt_tag_attach(etagid, imgid);
+    dt_tag_attach_from_gui(etagid, imgid);
     // check if image still exists:
     char imgfilename[PATH_MAX] = { 0 };
     const dt_image_t *image = dt_image_cache_get(darktable.image_cache, (int32_t)imgid, 'r');

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -907,7 +907,7 @@ void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolea
   const int imgid = dev->image_storage.id;
   guint tagid = 0;
   dt_tag_new("darktable|changed", &tagid);
-  dt_tag_attach(tagid, imgid);
+  dt_tag_attach_from_gui(tagid, imgid);
 
   // invalidate buffers and force redraw of darkroom
   dt_dev_invalidate_all(dev);

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -852,7 +852,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const int imgid,
         guint tagid = 0;
         if(!dt_tag_exists((char *)cvalue, &tagid)) dt_tag_new((char *)cvalue, &tagid);
 
-        dt_tag_attach(tagid, imgid);
+        dt_tag_attach_from_gui(tagid, imgid);
         data->has_tags = TRUE;
         xmlFree(cvalue);
       }

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -222,6 +222,7 @@ static void delete_button_clicked(GtkWidget *widget, gpointer user_data)
     else
       dt_history_delete_on_image(img);
 
+    dt_collection_update_query(darktable.collection);
     dt_control_queue_redraw_center();
   }
 }
@@ -244,6 +245,7 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
   else
     dt_history_copy_and_paste_on_image(d->imageid, img, (mode == 0) ? TRUE : FALSE, d->dg.selops);
 
+  dt_collection_update_query(darktable.collection);
   /* redraw */
   dt_control_queue_redraw_center();
 }

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -18,6 +18,7 @@
 
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "common/collection.h"
 #include "common/metadata.h"
 #include "common/mipmap_cache.h"
 #include "common/history.h"
@@ -111,6 +112,7 @@ static void _lib_duplicate_new_clicked_callback(GtkWidget *widget, GdkEventButto
   const int newid = dt_image_duplicate(imgid);
   if (newid <= 0) return;
   dt_history_delete_on_image(newid);
+  dt_collection_update_query(darktable.collection);
   // to select the duplicate, we reuse the filmstrip proxy
   dt_view_filmstrip_scroll_to_image(darktable.view_manager,newid,TRUE);
 }
@@ -122,6 +124,7 @@ static void _lib_duplicate_duplicate_clicked_callback(GtkWidget *widget, GdkEven
   const int newid = dt_image_duplicate(imgid);
   if (newid <= 0) return;
   dt_history_copy_and_paste_on_image(imgid,newid,FALSE,NULL);
+  dt_collection_update_query(darktable.collection);
   // to select the duplicate, we reuse the filmstrip proxy
   dt_view_filmstrip_scroll_to_image(darktable.view_manager,newid,TRUE);
 }

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -360,7 +360,7 @@ static int _print_job_run(dt_job_t *job)
   guint tagid = 0;
   snprintf (tag, sizeof(tag), "darktable|printed|%s", params->prt.printer.name);
   dt_tag_new(tag, &tagid);
-  dt_tag_attach(tagid, params->imgid);
+  dt_tag_attach_from_gui(tagid, params->imgid);
 
   return 0;
 }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -181,7 +181,7 @@ static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
 
   imgsel = dt_view_get_image_to_act_on();
 
-  dt_tag_attach(tagid, imgsel);
+  dt_tag_attach_from_gui(tagid, imgsel);
   dt_image_synch_xmp(imgsel);
 
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -984,6 +984,7 @@ static gboolean _lib_filmstrip_paste_history_key_accel_callback(GtkAccelGroup *a
     dt_history_copy_and_paste_on_image(strip->history_copy_imgid, img, (mode == 0) ? TRUE : FALSE,
                                        strip->dg.selops);
 
+  dt_collection_update_query(darktable.collection);
   dt_control_queue_redraw_center();
   return TRUE;
 }
@@ -1009,6 +1010,7 @@ static gboolean _lib_filmstrip_paste_history_parts_key_accel_callback(GtkAccelGr
     dt_history_copy_and_paste_on_image(strip->history_copy_imgid, img, (mode == 0) ? TRUE : FALSE,
                                        strip->dg.selops);
 
+  dt_collection_update_query(darktable.collection);
   dt_control_queue_redraw_center();
   return TRUE;
 }
@@ -1023,6 +1025,7 @@ static gboolean _lib_filmstrip_discard_history_key_accel_callback(GtkAccelGroup 
   if(mouse_over_id <= 0) return FALSE;
 
   dt_history_delete_on_image(mouse_over_id);
+  dt_collection_update_query(darktable.collection);
   dt_control_queue_redraw_center();
   return TRUE;
 }
@@ -1044,7 +1047,11 @@ static gboolean _lib_filmstrip_duplicate_image_key_accel_callback(GtkAccelGroup 
   if(!_is_on_lighttable() && dt_dev_is_current_image(darktable.develop, mouse_over_id)) dt_dev_write_history(darktable.develop);
 
   const int32_t newimgid = dt_image_duplicate(mouse_over_id);
-  if(newimgid != -1) dt_history_copy_and_paste_on_image(mouse_over_id, newimgid, FALSE, NULL);
+  if(newimgid != -1)
+  {
+    dt_history_copy_and_paste_on_image(mouse_over_id, newimgid, FALSE, NULL);
+    dt_collection_update_query(darktable.collection);
+  }
 
   dt_control_queue_redraw_center();
   return TRUE;

--- a/src/lua/tags.c
+++ b/src/lua/tags.c
@@ -148,7 +148,7 @@ static int tag_delete(lua_State *L)
 {
   dt_lua_tag_t tagid;
   luaA_to(L, dt_lua_tag_t, &tagid, -1);
-  
+
   GList *tagged_images = NULL;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.tagged_images WHERE tagid=?1",
@@ -190,7 +190,7 @@ int dt_lua_tag_attach(lua_State *L)
     luaA_to(L, dt_lua_tag_t, &tagid, 1);
     luaA_to(L, dt_lua_image_t, &imgid, 2);
   }
-  dt_tag_attach(tagid, imgid);
+  dt_tag_attach_from_gui(tagid, imgid);
   dt_image_synch_xmp(imgid);
   return 0;
 }


### PR DESCRIPTION
remove auto tags:

Some operation on the filemanager are slow down by some tags access. On my system, discarding the history to 200 images take a few seconds, if I bypass the tag access it takes a second.
I have added a config option under core options->miscellaneous->add informational tags to the image, enabled by default, that will allow to skip the access to the darktable|* tags (darktable|changed, darktable|exported, ..). This tags are not used internally so its ok to be user's choice.

lock rawspeed read file:

Right now, when thumbs are generated, sometimes darktable stops processing (or it seems so) for a while, then it start again. 
To test it:
- start darktable with -d perf
- set a collection that take several pages
- copy the history from one image and paste it onto the entire collection
- scroll down until all visible thumbs are unprocessed

eventually on the console no process is displayed, and after a while it start again, sometimes it takes longer than other.

The delay happens when rawspeed is reading the raw and there's several reads at the same time, so I added a lock, this way only one read happens.
This is kind of a patch, in the sense that I'm not sure what's going on, in theory we should be able to read different files from multiple threads without any noticeable delay. Maybe the file should be readed in chunks instead of all at once, or maybe there's some lock that I'm not aware of. But for now this makes the thumbs generation faster, and if this is ever fixed removing the lock is easy.
