### PR TITLE
For hidden slider move show toast with value

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2219,6 +2219,19 @@ static void dt_bauhaus_slider_set_normalized(dt_bauhaus_widget_t *w, float pos)
   {
     g_signal_emit_by_name(G_OBJECT(w), "value-changed");
     d->is_changed = 0;
+
+    if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
+    {
+      char text[256];
+      const float f = d->min + d->pos * (d->max - d->min);
+      const float fc = d->callback(GTK_WIDGET(w), f, DT_BAUHAUS_GET);
+      snprintf(text, sizeof(text), d->format, fc);
+
+      if(w->module && !strstr(w->module->name(), w->label))
+        dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, text);
+      else
+        dt_control_log(_("%s: %s"), w->label, text);
+    }
   }
 }
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -542,7 +542,10 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   // switch off auto exposure when we lose focus (switching images etc)
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->autoexpp, 0.01);
+  darktable.gui->reset = reset;
 }
 
 void init(dt_iop_module_t *module)


### PR DESCRIPTION
When moving hidden slider via shortcut or mouse wheel, pop up toast to show new value.