### PR TITLE
Correctly restore previous state of darktable.gui->reset

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -898,6 +898,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
 
   if(event->button == 1)
   {
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
 
     dt_iop_request_focus(self);
@@ -929,7 +930,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), bd->masks_shown != DT_MASKS_EDIT_OFF);
     dt_masks_set_edit_mode(self, bd->masks_shown);
 
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
 
     return TRUE;
   }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -799,9 +799,10 @@ static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module
         {
           if(module->off)
           {
+            const int reset = darktable.gui->reset;
             darktable.gui->reset = 1;
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), module->enabled);
-            darktable.gui->reset = 0;
+            darktable.gui->reset = reset;
           }
         }
       }
@@ -848,9 +849,10 @@ static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module
         {
           if(module->off)
           {
+            const int reset = darktable.gui->reset;
             darktable.gui->reset = 1;
             gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), module->enabled);
-            darktable.gui->reset = 0;
+            darktable.gui->reset = reset;
           }
         }
       }
@@ -1125,6 +1127,7 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt)
 void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   GList *dev_iop = g_list_copy(dev->iop);
 
@@ -1178,7 +1181,7 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
     dev->preview2_pipe->cache_obsolete = 1;
   }
 
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_invalidate_all(dev);
   dt_pthread_mutex_unlock(&dev->history_mutex);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -571,6 +571,7 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   dt_iop_gui_set_expanded(next, TRUE, FALSE);
   gtk_widget_grab_focus(next->expander);
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   // we remove the plugin effectively
@@ -656,7 +657,7 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   /* redraw */
   dt_control_queue_redraw_center();
 
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 }
 
 dt_iop_module_t *dt_iop_gui_get_previous_visible_module(dt_iop_module_t *module)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1180,7 +1180,7 @@ dt_masks_form_t *dt_masks_create(dt_masks_type_t type)
 dt_masks_form_t *dt_masks_create_ext(dt_masks_type_t type)
 {
   dt_masks_form_t *form = dt_masks_create(type);
-  
+
   // all forms created here are registered in darktable.develop->allforms for later cleanup
   if(form)
   darktable.develop->allforms = g_list_append(darktable.develop->allforms, form);
@@ -1191,7 +1191,7 @@ dt_masks_form_t *dt_masks_create_ext(dt_masks_type_t type)
 void dt_masks_replace_current_forms(dt_develop_t *dev, GList *forms)
 {
   GList *forms_tmp = dt_masks_dup_forms_deep(forms, NULL);
-  
+
   while(dev->forms)
   {
     darktable.develop->allforms = g_list_append(darktable.develop->allforms, dev->forms->data);
@@ -1222,7 +1222,7 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
   dt_dev_history_item_t *hist_item = NULL;
   dt_dev_history_item_t *hist_item_last = NULL;
   int num_prev = -1;
-  
+
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get(darktable.db),
@@ -1349,7 +1349,7 @@ void dt_masks_read_masks_history(dt_develop_t *dev, const int imgid)
     if(num < dev->history_end) hist_item_last = hist_item;
   }
   sqlite3_finalize(stmt);
-  
+
   // and we update the current forms snapshot
   dt_masks_replace_current_forms(dev, (hist_item_last)?hist_item_last->forms:NULL);
 }
@@ -2097,9 +2097,10 @@ void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module
   if(sel == 0) return;
   if(sel == 1)
   {
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_combobox_set(bd->masks_combo, 0);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
     return;
   }
   if(sel > 0)
@@ -2580,7 +2581,7 @@ int _masks_cleanup_unused(GList **_forms, GList *history_list, const int history
 {
   int masks_removed = 0;
   GList *forms = *_forms;
-  
+
   // we create a table to store the ids of used forms
   guint nbf = g_list_length(forms);
   int *used = calloc(nbf, sizeof(int));
@@ -2628,9 +2629,9 @@ int _masks_cleanup_unused(GList **_forms, GList *history_list, const int history
   }
 
   free(used);
-  
+
   *_forms = forms;
-  
+
   return masks_removed;
 }
 
@@ -2661,10 +2662,10 @@ void dt_masks_cleanup_unused_from_list(GList *history_list)
 void dt_masks_cleanup_unused(dt_develop_t *dev)
 {
   dt_masks_change_form_gui(NULL);
-  
+
   // we remove the forms from history
   dt_masks_cleanup_unused_from_list(dev->history);
-  
+
   // and we save all that
   GList *forms = NULL;
   dt_iop_module_t *module = NULL;
@@ -2673,16 +2674,16 @@ void dt_masks_cleanup_unused(dt_develop_t *dev)
   while(history && num < dev->history_end)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)history->data;
-    
+
     if(hist->forms) forms = hist->forms;
     if(hist->module && strcmp(hist->op_name, "mask_manager") != 0) module = hist->module;
-    
+
     num++;
     history = g_list_next(history);
   }
-  
+
   dt_masks_replace_current_forms(dev, forms);
-  
+
   if(module)
     dt_dev_add_history_item(dev, module, module->enabled);
   else

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -85,7 +85,7 @@ static int _internal_iop_color_picker_get_set(dt_iop_color_picker_t *picker, Gtk
 
 static void _internal_iop_color_picker_update(dt_iop_color_picker_t *picker)
 {
-  const int old_reset = darktable.gui->reset;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   if(DTGTK_IS_TOGGLEBUTTON(picker->colorpick))
@@ -93,7 +93,7 @@ static void _internal_iop_color_picker_update(dt_iop_color_picker_t *picker)
   else
     dt_bauhaus_widget_set_quad_active(picker->colorpick, picker->current_picker == PICKER_STATUS_SELECTED);
 
-  darktable.gui->reset = old_reset;
+  darktable.gui->reset = reset;
 }
 
 void dt_iop_color_picker_apply_module(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4231,12 +4231,13 @@ static int fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
       // module is enable -> we process directly
       if(do_fit(self, p, fitaxis))
       {
+        const int reset = darktable.gui->reset;
         darktable.gui->reset = 1;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = 0;
+        darktable.gui->reset = reset;
       }
     }
     else
@@ -4284,12 +4285,13 @@ static int fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
       // module is enable -> we process directly
       if(do_fit(self, p, fitaxis))
       {
+        const int reset = darktable.gui->reset;
         darktable.gui->reset = 1;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = 0;
+        darktable.gui->reset = reset;
       }
     }
     else
@@ -4339,12 +4341,13 @@ static int fit_both_button_clicked(GtkWidget *widget, GdkEventButton *event, gpo
       // module is enable -> we process directly
       if(do_fit(self, p, fitaxis))
       {
+        const int reset = darktable.gui->reset;
         darktable.gui->reset = 1;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = 0;
+        darktable.gui->reset = reset;
       }
     }
     else
@@ -4464,12 +4467,13 @@ static void process_after_preview_callback(gpointer instance, gpointer user_data
     case ASHIFT_JOBCODE_FIT:
       if(do_fit(self, p, (dt_iop_ashift_fitaxis_t)jobparams))
       {
+        const int reset = darktable.gui->reset;
         darktable.gui->reset = 1;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = 0;
+        darktable.gui->reset = reset;
       }
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       break;
@@ -4723,11 +4727,12 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   snprintf(string_v, sizeof(string_v), _("lens shift (%s)"), isflipped ? _("horizontal") : _("vertical"));
   snprintf(string_h, sizeof(string_h), _("lens shift (%s)"), isflipped ? _("vertical") : _("horizontal"));
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_widget_set_label(g->lensshift_v, NULL, string_v);
   dt_bauhaus_widget_set_label(g->lensshift_h, NULL, string_h);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->eye), g->lines_suppressed);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   return FALSE;
 }

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1983,9 +1983,10 @@ static void fusion_callback(GtkWidget *widget, gpointer user_data)
     gtk_widget_set_visible(g->exposure_bias, TRUE);
     // do not preserve color on fusion for now
     p->preserve_colors = DT_RGB_NORM_NONE;
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_combobox_set(g->cmb_preserve_colors, p->preserve_colors);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
     gtk_widget_set_visible(g->cmb_preserve_colors, FALSE);
   }
   if(p->exposure_fusion != 0 && fuse == 0)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -521,9 +521,10 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
   p->middle_grey = (work_profile) ? (dt_ioppr_get_rgb_matrix_luminance(self->picked_color, work_profile) * 100.f)
                                   : dt_camera_rgb_luminance(self->picked_color);
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->sl_middle_grey, p->middle_grey);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   // avoid recursion
   self->picker->skip_apply = TRUE;

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -661,10 +661,11 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   const dt_iop_borders_pickcolor_type_t which_colorpicker = g->color_picker.current_picker;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   gtk_toggle_button_set_active(g->frame_picker, which_colorpicker == DT_BORDERS_FRAME);
   gtk_toggle_button_set_active(g->border_picker, which_colorpicker == DT_BORDERS_BORDER);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 }
 
 static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -916,11 +916,12 @@ static inline void set_RGB_sliders(GtkWidget *R, GtkWidget *G, GtkWidget *B, flo
     p[CHANNEL_GREEN] = rgb[1] * 2.0f;
     p[CHANNEL_BLUE] = rgb[2] * 2.0f;
 
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_slider_set_soft(R, p[CHANNEL_RED] - 1.0f);
     dt_bauhaus_slider_set_soft(G, p[CHANNEL_GREEN] - 1.0f);
     dt_bauhaus_slider_set_soft(B, p[CHANNEL_BLUE] - 1.0f);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
   }
 }
 
@@ -1000,9 +1001,10 @@ static void apply_autogrey(dt_iop_module_t *self)
 
   p->grey = XYZ[1] * 100.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->grey, p->grey);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1036,12 +1038,13 @@ static void apply_lift_neutralize(dt_iop_module_t *self)
   p->lift[CHANNEL_GREEN] = RGB[1] + 1.0f;
   p->lift[CHANNEL_BLUE] = RGB[2] + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->lift_r, RGB[0]);
   dt_bauhaus_slider_set_soft(g->lift_g, RGB[1]);
   dt_bauhaus_slider_set_soft(g->lift_b, RGB[2]);
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1075,12 +1078,13 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
   p->gamma[CHANNEL_GREEN] = CLAMP(2.0 - RGB[1], 0.0001f, 2.0f);
   p->gamma[CHANNEL_BLUE] = CLAMP(2.0 - RGB[2], 0.0001f, 2.0f);
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->gamma_r, -RGB[0] + 1.0f);
   dt_bauhaus_slider_set_soft(g->gamma_g, -RGB[1] + 1.0f);
   dt_bauhaus_slider_set_soft(g->gamma_b, -RGB[2] + 1.0f);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1114,12 +1118,13 @@ static void apply_gain_neutralize(dt_iop_module_t *self)
   p->gain[CHANNEL_GREEN] = RGB[1];
   p->gain[CHANNEL_BLUE] = RGB[2];
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->gain_r, RGB[0] - 1.0f);
   dt_bauhaus_slider_set_soft(g->gain_g, RGB[1] - 1.0f);
   dt_bauhaus_slider_set_soft(g->gain_b, RGB[2] - 1.0f);
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1141,9 +1146,10 @@ static void apply_lift_auto(dt_iop_module_t *self)
 
   p->lift[CHANNEL_FACTOR] = -p->gain[CHANNEL_FACTOR] * XYZ[1] + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1166,9 +1172,10 @@ static void apply_gamma_auto(dt_iop_module_t *self)
   p->gamma[CHANNEL_FACTOR]
       = 2.0f - logf(0.1842f) / logf(MAX(p->gain[CHANNEL_FACTOR] * XYZ[1] + p->lift[CHANNEL_FACTOR] - 1.0f, 0.000001f));
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1190,9 +1197,10 @@ static void apply_gain_auto(dt_iop_module_t *self)
 
   p->gain[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR] / (XYZ[1]);
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1294,6 +1302,7 @@ static void apply_autocolor(dt_iop_module_t *self)
   p->gain[CHANNEL_GREEN] = RGB_gain[1];
   p->gain[CHANNEL_BLUE] = RGB_gain[2];
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->lift_r, RGB_lift[0]);
   dt_bauhaus_slider_set_soft(g->lift_g, RGB_lift[1]);
@@ -1310,7 +1319,7 @@ static void apply_autocolor(dt_iop_module_t *self)
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1358,11 +1367,12 @@ static void apply_autoluma(dt_iop_module_t *self)
     p->gamma[CHANNEL_FACTOR] = CLAMP(2.0f - logf(0.1842f) / logf(MAX(p->gain[CHANNEL_FACTOR] * g->luma_patches[GAMMA] + p->lift[CHANNEL_FACTOR] - 1.0f, 0.000001f)), 0.0f, 2.0f);
   }
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
   dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
   dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2039,9 +2049,10 @@ static void lift_red_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->lift[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2055,9 +2066,10 @@ static void lift_green_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->lift[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2071,9 +2083,10 @@ static void lift_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->lift[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2098,9 +2111,10 @@ static void gamma_red_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gamma[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 static void gamma_green_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -2113,9 +2127,10 @@ static void gamma_green_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gamma[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2129,9 +2144,10 @@ static void gamma_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gamma[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2155,9 +2171,10 @@ static void gain_red_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gain[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2171,9 +2188,10 @@ static void gain_green_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gain[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 static void gain_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -2186,9 +2204,10 @@ static void gain_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gain[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1178,11 +1178,12 @@ static gboolean checker_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data
     // freshly picked, also select it in gui:
     int pick = self->request_color_pick;
     g->drawn_patch = cells_x * bestj + besti;
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_combobox_set(g->combobox_patch, g->drawn_patch);
     g->patch = g->drawn_patch;
     self->gui_update(self);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
     self->request_color_pick = pick; // restore, the combobox will kill it
   }
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1011,6 +1011,7 @@ static void process_clusters(gpointer instance, gpointer user_data)
   if(!g || !g->buffer) return;
   if(!(p->flag & ACQUIRE)) return;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   dt_pthread_mutex_lock(&g->lock);
@@ -1077,7 +1078,7 @@ static void process_clusters(gpointer instance, gpointer user_data)
   }
 
   p->flag &= ~(GET_TARGET | GET_SOURCE | ACQUIRE);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   if(p->flag & HAS_SOURCE) dt_dev_add_history_item(darktable.develop, self, TRUE);
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2181,7 +2181,7 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
   const int which_colorpicker = g->color_picker.current_picker;
-  const int old_reset = darktable.gui->reset;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker),
@@ -2189,7 +2189,7 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker_set_values),
                                which_colorpicker == DT_IOP_COLORZONES_PICK_SET_VALUES);
 
-  darktable.gui->reset = old_reset;
+  darktable.gui->reset = reset;
   dt_control_queue_redraw_widget(self->widget);
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2873,25 +2873,28 @@ static gboolean denoiseprofile_draw_variance(GtkWidget *widget, cairo_t *crf, gp
   if(!isnan(c->variance_R))
   {
     gchar *str = g_strdup_printf("%.2f", c->variance_R);
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     gtk_label_set_text(c->label_var_R, str);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
     g_free(str);
   }
   if(!isnan(c->variance_G))
   {
     gchar *str = g_strdup_printf("%.2f", c->variance_G);
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     gtk_label_set_text(c->label_var_G, str);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
     g_free(str);
   }
   if(!isnan(c->variance_B))
   {
     gchar *str = g_strdup_printf("%.2f", c->variance_B);
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     gtk_label_set_text(c->label_var_B, str);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
     g_free(str);
   }
   return FALSE;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -646,9 +646,10 @@ static void exposure_set_white(struct dt_iop_module_t *self, const float white)
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -662,9 +663,10 @@ static void dt_iop_exposure_set_exposure(struct dt_iop_module_t *self, const flo
 
     p->deflicker_target_level = exposure;
 
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_slider_set(g->deflicker_target_level, p->deflicker_target_level);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
 
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
@@ -703,9 +705,10 @@ static void exposure_set_black(struct dt_iop_module_t *self, const float black)
   }
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->black, p->black);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -799,9 +802,10 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   {
     gchar *str = g_strdup_printf("%.2fEV", g->deflicker_computed_exposure);
 
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     gtk_label_set_text(g->deflicker_used_EC, str);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
 
     g_free(str);
   }

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -723,9 +723,10 @@ static void sanitize_latitude(dt_iop_filmic_params_t *p, dt_iop_filmic_gui_data_
     // The film latitude is its linear part
     // it can never be higher than the dynamic range
     p->latitude_stops =  (p->white_point_source - p->black_point_source) * 0.99f;
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_slider_set_soft(g->latitude_stops, p->latitude_stops);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
   }
 }
 
@@ -745,11 +746,12 @@ static void apply_auto_grey(dt_iop_module_t *self)
   p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -772,9 +774,10 @@ static void apply_auto_black(dt_iop_module_t *self)
 
   p->black_point_source = EVmin;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   sanitize_latitude(p, g);
 
@@ -800,9 +803,10 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
 
   p->white_point_source = EVmax;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   sanitize_latitude(p, g);
 
@@ -830,10 +834,11 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->white_point_source = EVmax;
   p->black_point_source = EVmin;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   sanitize_latitude(p, g);
 
@@ -871,11 +876,12 @@ static void apply_autotune(dt_iop_module_t *self)
   p->black_point_source = EVmin;
   p->white_point_source = EVmax;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   sanitize_latitude(p, g);
 
@@ -951,10 +957,11 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_iop_color_picker_reset(self, TRUE);
 

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -439,9 +439,10 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   char *str = g_strdup_printf(ngettext("fixed %d pixel", "fixed %d pixels", g->pixels_fixed), g->pixels_fixed);
   g->pixels_fixed = -1;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   gtk_label_set_text(g->message, str);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   g_free(str);
 

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -177,9 +177,10 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   dt_iop_invert_params_t *p = self->params;
   for(int k = 0; k < 4; k++) p->color[k] = grayrgb[k];
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   gui_update_from_coeffs(self);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   dt_control_queue_redraw_widget(self->widget);

--- a/src/iop/lens.c
+++ b/src/iop/lens.c
@@ -2153,10 +2153,11 @@ static void corrections_done(gpointer instance, gpointer user_data)
     modifiers = g_list_next(modifiers);
   }
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   gtk_label_set_text(g->message, message);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->message), message);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -329,11 +329,12 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
   const dt_iop_levels_pick_t which_colorpicker = g->color_picker.current_picker;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->blackpick), which_colorpicker == BLACK);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->greypick), which_colorpicker == GREY);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->whitepick), which_colorpicker == WHITE);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 }
 
 /*

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -401,9 +401,10 @@ static void apply_auto_grey(dt_iop_module_t *self)
   float grey = fmax(fmax(self->picked_color[0], self->picked_color[1]), self->picked_color[2]);
   p->grey_point = 100.f * grey;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->grey_point, p->grey_point);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -423,9 +424,10 @@ static void apply_auto_black(dt_iop_module_t *self)
 
   p->shadows_range = EVmin;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->shadows_range, p->shadows_range);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -448,9 +450,10 @@ static void apply_auto_dynamic_range(dt_iop_module_t *self)
 
   p->dynamic_range = EVmax - EVmin;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->dynamic_range, p->dynamic_range);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -495,10 +498,11 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->dynamic_range = EVmax - EVmin;
   p->shadows_range = EVmin;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
   dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -527,11 +531,12 @@ static void apply_autotune(dt_iop_module_t *self)
   p->shadows_range = EVmin;
   p->dynamic_range = EVmax - EVmin;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->grey_point, p->grey_point);
   dt_bauhaus_slider_set(g->shadows_range, p->shadows_range);
   dt_bauhaus_slider_set(g->dynamic_range, p->dynamic_range);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -335,12 +335,12 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
 static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
-  const int old_reset = darktable.gui->reset;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->tbutton1), g->color_picker.current_picker == 1);
 
-  darktable.gui->reset = old_reset;
+  darktable.gui->reset = reset;
 
   if(g->color_picker.current_picker != 1)
     dtgtk_gradient_slider_multivalue_set_picker(DTGTK_GRADIENT_SLIDER(g->gslider1), NAN);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2041,9 +2041,10 @@ void gui_post_expose (struct dt_iop_module_t *self,
 
   if(rt_get_selected_shape_id() > 0)
   {
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     dt_bauhaus_slider_set(g->sl_mask_opacity, rt_masks_form_get_opacity(self, rt_get_selected_shape_id()));
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
   }
 }
 

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -621,7 +621,7 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
   const int which_colorpicker = g->color_picker.current_picker;
-  const int old_reset = darktable.gui->reset;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker),
@@ -629,7 +629,7 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker_set_values),
                                which_colorpicker == DT_IOP_RGBCURVE_PICK_SET_VALUES);
 
-  darktable.gui->reset = old_reset;
+  darktable.gui->reset = reset;
   dt_control_queue_redraw_widget(self->widget);
 }
 

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -854,11 +854,12 @@ static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
   const dt_iop_rgblevels_pick_t which_colorpicker = g->color_picker.current_picker;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->blackpick), which_colorpicker == DT_IOP_RGBLEVELS_PICK_BLACK);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->greypick), which_colorpicker == DT_IOP_RGBLEVELS_PICK_GREY);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->whitepick), which_colorpicker == DT_IOP_RGBLEVELS_PICK_WHITE);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -481,12 +481,13 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
   *p_hue        = H;
   *p_saturation = S;
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(hue, H);
   dt_bauhaus_slider_set(sat, S);
   update_colorpicker_color(colorpicker, H, S);
   update_saturation_slider_end_color(sat, H);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1153,6 +1153,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   double TempK, tint;
   mul2temp(self, p->coeffs, &TempK, &tint);
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->scale_k, TempK);
   dt_bauhaus_slider_set(g->scale_tint, tint);
@@ -1160,7 +1161,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->scale_g, p->coeffs[1]);
   dt_bauhaus_slider_set(g->scale_b, p->coeffs[2]);
   dt_bauhaus_slider_set(g->scale_g2, p->coeffs[3]);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
 }
 
 static void temp_changed(dt_iop_module_t *self)
@@ -1169,7 +1170,7 @@ static void temp_changed(dt_iop_module_t *self)
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
   dt_iop_color_picker_reset(self, TRUE);
-  
+
   const double TempK = dt_bauhaus_slider_get(g->scale_k);
   const double tint = dt_bauhaus_slider_get(g->scale_tint);
 
@@ -1184,12 +1185,13 @@ static void temp_changed(dt_iop_module_t *self)
 
   for(int c = 0; c < 4; c++) p->coeffs[c] = coeffs[c];
 
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   dt_bauhaus_slider_set(g->scale_r, p->coeffs[0]);
   dt_bauhaus_slider_set(g->scale_g, p->coeffs[1]);
   dt_bauhaus_slider_set(g->scale_b, p->coeffs[2]);
   dt_bauhaus_slider_set(g->scale_g2, p->coeffs[3]);
-  darktable.gui->reset = 0;
+  darktable.gui->reset = reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1129,12 +1129,12 @@ static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
 static void _iop_color_picker_update(dt_iop_module_t *self)
 {
   dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
-  const int old_reset = darktable.gui->reset;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker), g->color_picker.current_picker == 1);
 
-  darktable.gui->reset = old_reset;
+  darktable.gui->reset = reset;
   dt_control_queue_redraw_widget(self->widget);
 }
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1511,7 +1511,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
   // we check if something as change since last call
   if(d->view_rule != -1) return;
 
-  const int old = darktable.gui->reset;
+  const int reset = darktable.gui->reset;
   darktable.gui->reset = 1;
   const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules") - 1;
   const int active = CLAMP(_a, 0, (MAX_RULES - 1));
@@ -1573,7 +1573,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
 
   // update list of proposals
   update_view(d->rule + d->active_rule);
-  darktable.gui->reset = old;
+  darktable.gui->reset = reset;
 }
 
 void gui_reset(dt_lib_module_t *self)

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -140,10 +140,11 @@ static void _update_picker_output(dt_lib_module_t *self)
   dt_iop_module_t *module = get_colorout_module();
   if(module)
   {
+    const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->picker_button),
                                  module->request_color_pick != DT_REQUEST_COLORPICK_OFF);
-    darktable.gui->reset = 0;
+    darktable.gui->reset = reset;
 
     int input_color = dt_conf_get_int("ui_last/colorpicker_model");
 


### PR DESCRIPTION
Consistantly switch on darktable.gui->reset by enclosing code that requires it with pairs of :
const int reset = darktable.gui->reset;
darktable.gui->reset = 1;
/
darktable.gui->reset = reset;

Remove one instance in darkroom.c where darktable.gui->reset got switched off twice. The current code corresponds to what happened previously though perhaps not to what was intended.