### PR TITLE
common/opencl_drivers_blacklist: Only blacklist NEO on Windows

### DIFF
--- a/src/common/opencl_drivers_blacklist.h
+++ b/src/common/opencl_drivers_blacklist.h
@@ -27,7 +27,16 @@ static const gchar *bad_opencl_drivers[] =
 
   "beignet",
   "pocl",
+/*
+  Neo was originally blacklisted due to improper cache invalidation, but this has been fixed.
+  During the discussion of that issue in pull request 2033, it was hinted that Neo may be still be
+  problematic on Windows, so keep it blacklisted there for now
+
+  TODO:  Determine if Windows failures were due to the same cache invalidation issue.
+*/
+#if defined _WIN32
   "neo",
+#endif
   NULL
 
   // clang-format on


### PR DESCRIPTION
The issue that caused this driver to be blacklisted across the board was fixed in
pull request #2033.  There have been no reported issues on Linux machines
since then, and on an i5-7200U, the blacklist causes a 4x reduction in
performance for compute intensive pipelines (12 seconds vs. 3 for a flow
including exposure fusion).

TODO:  There is very little information about the Windows failures hinted at in pull 2033 comments,
it may turn out it is the same issue fixed by #2033 and a blacklist on Windows is also not necessary.