### PR TITLE
Fix bug in middle button zoom for second preview window

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3623,8 +3623,8 @@ static int second_window_button_pressed(GtkWidget *widget, dt_develop_t *dev, do
     dt_second_window_get_processed_size(dev, &procw, &proch);
     const float scale = dt_second_window_get_zoom_scale(dev, zoom, 1 << closeup, 0);
 
-    zoom_x += (1.0 / scale) * (x - .5f * dev->width) / procw;
-    zoom_y += (1.0 / scale) * (y - .5f * dev->height) / proch;
+    zoom_x += (1.0 / scale) * (x - .5f * dev->second_window.width) / procw;
+    zoom_y += (1.0 / scale) * (y - .5f * dev->second_window.height) / proch;
 
     if(zoom == DT_ZOOM_1)
     {


### PR DESCRIPTION
Fix a bug where zooming in the second preview window, with a middle mouse button click, would use the size of the image in the main darktable window to calculate the location of the click. Especially when using the 2nd preview on a larger second monitor and with the panels showing in the main window, these different sizes would lead to the zoomed window being centered far away from the point that was middle clicked on.

Turned out to be a simple fix; working correctly now.