### PR TITLE
lensfun: fix library version check, fix db loading

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -53,7 +53,7 @@ extern "C" {
 #define LF_SEARCH_SORT_AND_UNIQUIFY 2
 #endif
 
-#if LF_VERSION >= ((0 << 24) | (3 << 16) | (95 << 8) | 0)
+#if LF_VERSION == ((0 << 24) | (3 << 16) | (95 << 8) | 0)
 #define LF_0395
 #endif
 


### PR DESCRIPTION
#2793 introduced lensfun library version check used to determine whether LF_0395 should be #defined, but wrong comparison operator was used. LF_0395 should be defined _only_ for 0.3.95, as future releases break the API again.

Additionaly, #2793 missed changes introduced in #2606. Those were added and ported to 0.3.95 C++ API.