### PR TITLE
fix combobox behavior to mimic pre-d5053b1 state

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1043,6 +1043,7 @@ void dt_bauhaus_combobox_add_full(GtkWidget *widget, const char *text, dt_bauhau
   d->num_labels++;
   dt_bauhaus_combobox_entry_t *entry = new_combobox_entry(text, align, TRUE, data, free_func);
   d->entries = g_list_append(d->entries, entry);
+  if(d->active < 0) d->active = 0;
 }
 
 void dt_bauhaus_combobox_set_editable(GtkWidget *widget, int editable)
@@ -1069,6 +1070,13 @@ void dt_bauhaus_combobox_remove_at(GtkWidget *widget, int pos)
 
   if(pos < 0 || pos >= d->num_labels) return;
 
+  // move active position up if removing anything before it
+  // or when removing last position that is currently active.
+  // this also sets active to -1 when removing the last remaining entry in a combobox.
+  if(d->active > pos) d->active--;
+  else if((d->active == pos) && (d->active >= d->num_labels-1))
+    d->active = d->num_labels-2;
+
   GList *rm = g_list_nth(d->entries, pos);
   free_combobox_entry(rm->data);
   d->entries = g_list_delete_link(d->entries, rm);
@@ -1089,6 +1097,7 @@ void dt_bauhaus_combobox_insert_full(GtkWidget *widget, const char *text, dt_bau
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   d->num_labels++;
   d->entries = g_list_insert(d->entries, new_combobox_entry(text, align, TRUE, data, free_func), pos);
+  if(d->active < 0) d->active = 0;
 }
 
 int dt_bauhaus_combobox_length(GtkWidget *widget)


### PR DESCRIPTION
While working on #2793 I noticed that comboboxes for setting focal length, f-stop and distance in lens correction module are not being set to any value automaticaly. This worked fine in 2.6.2. @TurboGit pointed it out too in https://github.com/darktable-org/darktable/pull/2793#issuecomment-513809052. Initialiy I planned to fix this in place, but since this part of lens.c code didn't really change, it looked like an issue potentialy affecting all comboboxes. So I went hunting.

This got broken in 08e9290cd7c7e8a3eb8bb7f783834fc50eaf4884, which together with dbdbbcd97445bffd1bc7e9ad6037c91b53a4af66 and 964a3c35056f2c38ad013bf9c4c7eadd8b7f02c5 were fixes for #2413 introduced in d5053b13865e5a7d2ee08061c3f1a617f7e730f4. Before this series of changes all comboboxes had position 0 active by default, as I understand. Lens correction UI relied on that, perhaps other modules do as well. After this change, comboboxes have now active=-1 until position is explicitly set.

This PR makes combobox mimic the original behavior:
- when (and only when) the first entry is inserted or added to a combobox, it becames the active one,
- when the last entry is removed from a combobox, it is deactivated.

Additionaly, when removing entries from a combobox with dt_bauhaus_combobox_remove_at(), it will now move the active position up when necessary.

@TurboGit @houz - let me know if the proposed solution is acceptable or requires more work. This can alternatively be solved by adding explicit dt_bauhaus_combobox_set() in all places where a combobox is populated but not set to any position (if the intention was to disallow having any comboboxes without an explicit default state).