### PR TITLE
Add new metadata editing interface

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -123,7 +123,8 @@ void dt_accel_register_global(const gchar *path, guint accel_key, GdkModifierTyp
 
   *(accel->module) = '\0';
   accel->local = FALSE;
-  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
+  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW
+                 | DT_VIEW_METADATA;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
@@ -189,9 +190,10 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
     else if (strcmp(views[i], "slideshow") == 0) accel->views |= DT_VIEW_SLIDESHOW;
     else if (strcmp(views[i], "map") == 0) accel->views |= DT_VIEW_MAP;
     else if (strcmp(views[i], "tethering") == 0) accel->views |= DT_VIEW_TETHERING;
+    else if (strcmp(views[i], "metadata") == 0) accel->views |= DT_VIEW_METADATA;
     else if(strcmp(views[i], "*") == 0)
       accel->views |= DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT
-                      | DT_VIEW_SLIDESHOW;
+                      | DT_VIEW_SLIDESHOW | DT_VIEW_METADATA;
     i++;  
   }
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
@@ -262,7 +264,8 @@ void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType m
 
   *(accel->module) = '\0';
   accel->local = FALSE;
-  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW;
+  accel->views = DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT | DT_VIEW_SLIDESHOW
+                 | DT_VIEW_METADATA;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -207,7 +207,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "map", "print", NULL};
+  static const char *v[] = {"lighttable", "map", "print", "metadata_v", NULL};
   return v;
 }
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -142,7 +142,7 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"*", NULL};
+  static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
   return v;
 }
 

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -53,7 +53,7 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "map", NULL};
+  static const char *v[] = {"lighttable", "map", "metadata_v", NULL};
   return v;
 }
 

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -42,7 +42,7 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "tethering", NULL};
+  static const char *v[] = {"lighttable", "tethering", "metadata_v", NULL};
   return v;
 }
 

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -154,7 +154,7 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
+  static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", "metadata_v", NULL};
   return v;
 }
 

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -56,7 +56,7 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "tethering", NULL};
+  static const char *v[] = {"lighttable", "tethering", "metadata_v", NULL};
   return v;
 }
 

--- a/src/views/CMakeLists.txt
+++ b/src/views/CMakeLists.txt
@@ -5,12 +5,13 @@ include(manage-symbol-visibility)
 add_definitions(-include common/module_api.h)
 add_definitions(-include views/view_api.h)
 
-set(MODULES darkroom lighttable slideshow knight)
+set(MODULES darkroom lighttable slideshow knight metadata_v)
 
 add_library(darkroom MODULE "darkroom.c")
 add_library(lighttable MODULE "lighttable.c")
 add_library(slideshow MODULE "slideshow.c")
 add_library(knight MODULE "knight.c")
+add_library(metadata_v MODULE "metadata.c")
 
 if(USE_MAP)
     add_library(map MODULE "map.c")

--- a/src/views/metadata.c
+++ b/src/views/metadata.c
@@ -1,0 +1,157 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2019 sam smith.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common/collection.h"
+#include "common/darktable.h"
+#include "common/debug.h"
+#include "control/control.h"
+#include "gui/accelerators.h"
+#include "views/view.h"
+#include "views/view_api.h"
+
+#include "control/conf.h"
+#include "develop/develop.h"
+#include "gui/gtk.h"
+#include "gui/presets.h"
+#include <gdk/gdkkeysyms.h>
+
+DT_MODULE(1)
+
+const char *name(const dt_view_t *self)
+{
+  return C_("view", "metadata");
+}
+
+uint32_t view(const dt_view_t *self)
+{
+  return DT_VIEW_METADATA;
+}
+
+static void _mipmaps_updated_signal_callback(gpointer instance, gpointer user_data)
+{
+  dt_control_queue_redraw_center();
+}
+
+/*
+static void _film_strip_activated(const int imgid, void *data)
+{
+  //const dt_view_t *self = (dt_view_t *)data;
+
+  dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, FALSE);
+  dt_view_lighttable_set_position(darktable.view_manager, dt_collection_image_offset(imgid));
+
+  dt_control_queue_redraw();
+}
+*/
+
+void init(dt_view_t *self)
+{
+  dt_view_filmstrip_prefetch();
+}
+
+void cleanup(dt_view_t *self)
+{
+}
+
+void expose(dt_view_t *self, cairo_t *cri, int32_t width_i, int32_t height_i, int32_t pointerx, int32_t pointery)
+{
+  cairo_set_source_rgb(cri, 0.1, 0.1, 0.1);
+  cairo_paint(cri);
+}
+
+int try_enter(dt_view_t *self)
+{
+  int selected = dt_control_get_mouse_over_id();
+  if(selected < 0)
+  {
+    sqlite3_stmt *stmt;
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
+                                NULL);
+    if(sqlite3_step(stmt) == SQLITE_ROW) selected = sqlite3_column_int(stmt, 0);
+    sqlite3_finalize(stmt);
+
+    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.selected_images", NULL, NULL, NULL);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                "INSERT OR IGNORE INTO main.selected_images VALUES (?1)", -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, selected);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+  }
+
+  if(selected < 0)
+  {
+    dt_control_log(_("no image selected!"));
+    return 1;
+  }
+
+  return 0;
+}
+
+void enter(dt_view_t *self)
+{
+  /* scroll filmstrip to first selected image */
+  GList *selected_images = dt_collection_get_selected(darktable.collection, 1);
+  if(selected_images)
+  {
+    const int imgid = GPOINTER_TO_INT(selected_images->data);
+    dt_view_filmstrip_scroll_to_image(darktable.view_manager, imgid, TRUE);
+  }
+  g_list_free(selected_images);
+
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED,
+                            G_CALLBACK(_mipmaps_updated_signal_callback),
+                            (gpointer)self);
+
+  gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
+
+  dt_view_filmstrip_prefetch();
+
+  darktable.control->mouse_over_id = -1;
+}
+
+void leave(dt_view_t *self)
+{
+}
+
+static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                     GdkModifierType modifier, gpointer data)
+{
+  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
+  const gboolean vs = dt_lib_is_visible(m);
+  dt_lib_set_visible(m, !vs);
+  return TRUE;
+}
+
+void init_key_accels(dt_view_t *self)
+{
+  // Film strip shortcuts
+  dt_accel_register_view(self, NC_("accel", "toggle film strip"), GDK_KEY_f, GDK_CONTROL_MASK);
+}
+
+void connect_key_accels(dt_view_t *self)
+{
+  GClosure *closure;
+
+  // Film strip shortcuts
+  closure = g_cclosure_new(G_CALLBACK(film_strip_key_accel), (gpointer)self, NULL);
+  dt_accel_connect_view(self, "toggle film strip", closure);
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -54,7 +54,8 @@ typedef enum
   DT_VIEW_MAP = 8,
   DT_VIEW_SLIDESHOW = 16,
   DT_VIEW_PRINT = 32,
-  DT_VIEW_KNIGHT = 64
+  DT_VIEW_KNIGHT = 64,
+  DT_VIEW_METADATA = 128
 } dt_view_type_flags_t;
 
 // flags that a view can set in flags()
@@ -103,7 +104,7 @@ typedef struct dt_mouse_action_t
 
 #define DT_VIEW_ALL                                                                              \
   (DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_SLIDESHOW | \
-   DT_VIEW_PRINT | DT_VIEW_KNIGHT)
+   DT_VIEW_PRINT | DT_VIEW_KNIGHT | DT_VIEW_METADATA)
 
 /**
  * main dt view module (as lighttable or darkroom)


### PR DESCRIPTION
So far all I've done is add a new empty view but I'd like some suggestions about how we design this interface. As a starting point I've attached a screenshot of the new view with digiKam's metadata editing interface pasted on top, and some other bits I added into the side.

![dt_meta_1](https://user-images.githubusercontent.com/1129989/61995597-81b6f900-b082-11e9-9a62-723ae5ca593d.png)

Any suggestions for interface design will be helpful, and if anyone wants to help me to implement it let me know.

Thanks

Edit:
I just wanted to add links to the discussions on the mailing list for anyone who wants to catch up
https://www.mail-archive.com/darktable-dev@lists.darktable.org/msg04528.html
https://www.mail-archive.com/darktable-user@lists.darktable.org/msg07760.html