### PR TITLE
Tagging.c - avoid to reinit the tag tree/list on common events

### DIFF
--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -127,6 +127,12 @@ void dt_tag_free_result(GList **result);
 /** reorganize tags */
 void dt_tag_reorganize(const gchar *source, const gchar *dest);
 
+/** get number of seleted images */
+uint32_t dt_selected_images_count();
+
+/** get number of images affected with that tag */
+uint32_t dt_tag_images_count(gint tagid);
+
 /** make sure that main.used_tags has everything. to be used after changes to main.tagged_images */
 void dt_tag_update_used_tags();
 


### PR DESCRIPTION
The goal of this PR is to make easier the tagging workflow keeping the tag window as stable as possible.
Compared to the previous version the window is now maintained for the following events:
- hover on images
- new selection of images
- lighttable <-> darkroom move
- attach & detach tag
- rename tag
- delete tag

Thanks to @Nilvus and @junkyardsparkle for their comments.