### PR TITLE
Fix clamp killing highlights in "denoise (profiled)" module.

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -406,10 +406,12 @@ void init_presets(dt_iop_module_so_t *self)
   // these blobs were exported as dtstyle and copied from there:
   add_preset(self, _("chroma (use on 1st instance)"),
              "gz03eJxjYGiwZ2B44MAApmGgYf+22P2WdQpGVtxijKbJe3lMs3bfNWFEyNsBCaB6B3uEPvLExKP+2XUv/2dnxslqf+Cdsb3skXp7iDx5GORGEAYAkHIf3g==", 7,
-             "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
+             // gz11eJxjZGBgkGUAgRNODGiAEV0AJ2iwh+CRyscOAA9yGQo= requests blend mode HSV color
+             "gz11eJxjZGBgkGUAgRNODGiAEV0AJ2iwh+CRyscOAA9yGQo=", 7);
   add_preset(self, _("luma (use on 2nd instance)"),
              "gz03eJxjYGiwZ2B44DBr5kw7Bjho2O9nGWDpPnef5SU9VdNEjucm4ZnWpowIeZBaoD4HIAbpJ1/M78Ef2xOq2na/yxfaGWb/sCtsXQqVJxszgNwJAATFIno=", 7,
-             "gz12eJxjZGBgEGAAgR4nBqJBgz0Ejyw+AIdGGMA=", 7);
+             // gz11eJxjZGBgkGEAgR4nBjTAiC6AEzTYQ/BI5WMHAL7TGM0= requests blend mode HSV lightness
+             "gz11eJxjZGBgkGEAgR4nBjTAiC6AEzTYQ/BI5WMHAL7TGM0=", 7);
 }
 
 typedef union floatint_t


### PR DESCRIPTION
Before this patch, a RAW image that was overexposed and well recovered
would get its highlights clipped when applying chroma or luma presets in
denoise (profiled) module.

The reason is: blend modes "color" and "lightness" operate in Lab space,
which is undefined above 100% lightness.  At the position in the pipeline
where "denoise (profiled)" operates, before "exposure" module applies,
Lab is not yet properly defined.

This patch requests the blend modes "HSV color" and "HSV lightness" which
are properly defined above 100% lightness.

Signed-off-by: Stéphane Gourichon <stephane.gourichon@fidergo.fr>

Discussed on IRC, where Aurélien invited me to ping @rawfiner.