### PR TITLE
Tagging improvements

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -201,6 +201,27 @@
     <shortdescription>omit hierarchy in simple tag lists</shortdescription>
     <longdescription>when exporting images the hierarchical tags are also added as a simple list of non-hierarchical ones to make them visible to some other programs. when this option is checked darktable will only include their last part and ignore the rest. so 'foo|bar|baz' will only add 'baz'.</longdescription>
   </dtconfig>
+  <dtconfig prefs="core">
+    <name>plugins/lighttable/export/export_private_tags</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>force exportation of private tags</shortdescription>
+    <longdescription>darktable doesn't export private tags per default. this option allows to export them to XMP-dc Subject and XMP-lr Hierarchical Subject.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="core">
+    <name>plugins/lighttable/export/export_tag_synonyms</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>request exportation of synonyms</shortdescription>
+    <longdescription>darktable doesn't export the synonyms per default. this option allows to export them along with tags to XMP-dc Subject.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="core">
+    <name>plugins/lighttable/tagging/no_entry_completion</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>disable the entry completion</shortdescription>
+    <longdescription>the entry completion is useful for those who enter tags from keybord only. for others the entry completion can be embarassing. need to restart darktable.</longdescription>
+  </dtconfig>
   <dtconfig prefs="core" capability="opencl" section="cpugpu">
     <name>opencl</name>
     <type>bool</type>
@@ -1902,7 +1923,7 @@
     <type>dir</type>
     <default></default>
     <shortdescription>3D lut root folder</shortdescription>
-    <longdescription>this folder (and sub-folders) contains Lut files used but lut3d modules</longdescription>
+    <longdescription>this folder (and sub-folders) contains Lut files used but lut3d modules. need to restart darktable.</longdescription>
   </dtconfig>
   <dtconfig prefs="core" section="quality">
     <name>plugins/darkroom/basecurve/auto_apply</name>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1410,7 +1410,8 @@ static void _create_memory_schema(dt_database_t *db)
                            "(tmpid INTEGER PRIMARY KEY, id INTEGER UNIQUE ON CONFLICT IGNORE, count INTEGER)",
                NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.similar_tags (tagid INTEGER)", NULL, NULL, NULL);
-  sqlite3_exec(
+  sqlite3_exec(db->handle, "CREATE TABLE memory.darktable_tags (tagid INTEGER)", NULL, NULL, NULL);
+    sqlite3_exec(
       db->handle,
       "CREATE TABLE memory.history (imgid INTEGER, num INTEGER, module INTEGER, "
       "operation VARCHAR(256) UNIQUE ON CONFLICT REPLACE, op_params BLOB, enabled INTEGER, "

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -40,7 +40,7 @@
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
 #define CURRENT_DATABASE_VERSION_LIBRARY 19
-#define CURRENT_DATABASE_VERSION_DATA 2
+#define CURRENT_DATABASE_VERSION_DATA 3
 
 typedef struct dt_database_t
 {
@@ -1226,6 +1226,15 @@ static int _upgrade_data_schema_step(dt_database_t *db, int version)
 
     new_version = 2;
   }
+  else if(version == 2)
+  {
+    TRY_EXEC("ALTER TABLE data.tags RENAME COLUMN description TO synonyms;",
+             "[init] can't change tags column name from description to synonyms\n");
+
+    sqlite3_exec(db->handle, "COMMIT", NULL, NULL, NULL);
+
+    new_version = 3;
+  }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop
 
@@ -1368,7 +1377,7 @@ static void _create_data_schema(dt_database_t *db)
   sqlite3_finalize(stmt);
   ////////////////////////////// tags
   sqlite3_exec(db->handle, "CREATE TABLE data.tags (id INTEGER PRIMARY KEY, name VARCHAR, icon BLOB, "
-                           "description VARCHAR, flags INTEGER)", NULL, NULL, NULL);
+                           "synonyms VARCHAR, flags INTEGER)", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE UNIQUE INDEX data.tags_name_idx ON tags (name)", NULL, NULL, NULL);
   ////////////////////////////// styles
   sqlite3_exec(db->handle, "CREATE TABLE data.styles (id INTEGER, name VARCHAR, description VARCHAR)",
@@ -1411,7 +1420,7 @@ static void _create_memory_schema(dt_database_t *db)
                NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.similar_tags (tagid INTEGER)", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE TABLE memory.darktable_tags (tagid INTEGER)", NULL, NULL, NULL);
-    sqlite3_exec(
+  sqlite3_exec(
       db->handle,
       "CREATE TABLE memory.history (imgid INTEGER, num INTEGER, module INTEGER, "
       "operation VARCHAR(256) UNIQUE ON CONFLICT REPLACE, op_params BLOB, enabled INTEGER, "

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2932,7 +2932,7 @@ static void dt_exif_xmp_read_data(Exiv2::XmpData &xmpData, const int imgid)
 
   std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
 
-  GList *tags = dt_tag_get_list_export(imgid);
+  GList *tags = dt_tag_get_list(imgid);
   while(tags)
   {
     v1->read((char *)tags->data);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -670,7 +670,7 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         img->exif_crop = 1.0f;
     }
 
-    if (dt_check_usercrop(exifData, img)) 
+    if (dt_check_usercrop(exifData, img))
       {
         img->flags |= DT_IMAGE_HAS_USERCROP;
         guint tagid = 0;
@@ -2932,7 +2932,7 @@ static void dt_exif_xmp_read_data(Exiv2::XmpData &xmpData, const int imgid)
 
   std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
 
-  GList *tags = dt_tag_get_list(imgid);
+  GList *tags = dt_tag_get_list_export(imgid);
   while(tags)
   {
     v1->read((char *)tags->data);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -724,50 +724,6 @@ uint32_t dt_tag_get_attached_export(gint imgid, GList **result)
   return count;
 }
 
-GList *dt_tag_get_list(gint imgid)
-{
-  GList *taglist = NULL;
-  GList *tags = NULL;
-
-  gboolean omit_tag_hierarchy = dt_conf_get_bool("omit_tag_hierarchy");
-
-  uint32_t count = dt_tag_get_attached(imgid, &taglist, TRUE);
-
-  if(count < 1) return NULL;
-
-  for(; taglist; taglist = g_list_next(taglist))
-  {
-    dt_tag_t *t = (dt_tag_t *)taglist->data;
-    gchar *value = t->tag;
-
-    size_t j = 0;
-    gchar **pch = g_strsplit(value, "|", -1);
-
-    if(pch != NULL)
-    {
-      if(omit_tag_hierarchy)
-      {
-        char **iter = pch;
-        for(; *iter && *(iter + 1); iter++);
-        if(*iter) tags = g_list_prepend(tags, g_strdup(*iter));
-      }
-      else
-      {
-        while(pch[j] != NULL)
-        {
-          tags = g_list_prepend(tags, g_strdup(pch[j]));
-          j++;
-        }
-      }
-      g_strfreev(pch);
-    }
-  }
-
-  dt_tag_free_result(&taglist);
-
-  return dt_util_glist_uniq(tags);
-}
-
 static gint sort_tag_by_path(gconstpointer a, gconstpointer b)
 {
   const dt_tag_t *tuple_a = (const dt_tag_t *)a;
@@ -819,7 +775,7 @@ GList *dt_sort_tag(GList *tags, gint sort_type)
   return sorted_tags;
 }
 
-GList *dt_tag_get_list_export(gint imgid)
+GList *dt_tag_get_list(gint imgid)
 {
   GList *taglist = NULL;
   GList *tags = NULL;

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -714,7 +714,6 @@ static gint sort_tag_by_path(gconstpointer a, gconstpointer b)
   const dt_tag_t *tuple_b = (const dt_tag_t *)b;
 
   return g_ascii_strcasecmp(tuple_a->tag, tuple_b->tag);
-//  return g_strcmp0(tuple_a->tag, tuple_b->tag);
 }
 
 static gint sort_tag_by_leave(gconstpointer a, gconstpointer b)
@@ -723,7 +722,6 @@ static gint sort_tag_by_leave(gconstpointer a, gconstpointer b)
   const dt_tag_t *tuple_b = (const dt_tag_t *)b;
 
   return g_ascii_strcasecmp(tuple_a->leave, tuple_b->leave);
-//  return g_strcmp0(tuple_a->leave, tuple_b->leave);
 }
 
 static gint sort_tag_by_count(gconstpointer a, gconstpointer b)
@@ -740,7 +738,8 @@ GList *dt_sort_tag(GList *tags, gint sort_type)
   if (sort_type <= 1)
   {
     for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
-    { // order such that sub tags are coming directly behind their parent
+    {
+      // order such that sub tags are coming directly behind their parent
       gchar *tag = ((dt_tag_t *)taglist->data)->tag;
       for(char *letter = tag; *letter; letter++)
         if(*letter == '|') *letter = '\1';
@@ -1123,7 +1122,6 @@ uint32_t dt_tag_get_with_usage(GList **result)
 
   sqlite3_finalize(stmt);
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.taglist", NULL, NULL, NULL);
-//  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.similar_tags", NULL, NULL, NULL);
 
   return count;
 }
@@ -1331,7 +1329,8 @@ ssize_t dt_tag_import(const char *filename)
     }
 
     if (synonym)
-    { // associate the synonym to last tag
+    {
+      // associate the synonym to last tag
       if (tagid)
       {
         char *tagname = g_strdup(start);
@@ -1360,13 +1359,15 @@ ssize_t dt_tag_import(const char *filename)
       {
         char *tag = dt_util_glist_to_str("|", hierarchy);
         if (previous_category && (depth > previous_category_depth + 1))
-        { // reuse previous tag
+        {
+          // reuse previous tag
           dt_tag_rename(tagid, tag);
           if (!category)
             dt_tag_set_flags(tagid, 0);
         }
         else
-        { // create a new tag
+        {
+          // create a new tag
           count++;
           dt_tag_new(tag, &tagid);
           if (category)

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -432,7 +432,11 @@ void dt_tag_attach_string_list(const gchar *tags, gint imgid)
     {
       // remove leading and trailing spaces
       char *e = *entry + strlen(*entry) - 1;
-      while(*e == ' ' && e > *entry) *e = '\0';
+      while(*e == ' ' && e > *entry)
+      {
+        *e = '\0';
+        e--;
+      }
       e = *entry;
       while(*e == ' ' && *e != '\0') e++;
       if(*e)
@@ -524,7 +528,8 @@ uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags
   if(imgid > 0)
   {
     char query[1024] = { 0 };
-    snprintf(query, sizeof(query), "SELECT DISTINCT T.id, T.name, 1 AS inb FROM main.tagged_images AS I "
+    snprintf(query, sizeof(query), "SELECT DISTINCT T.id, T.name, T.flags, 1 AS inb "
+                                   "FROM main.tagged_images AS I "
                                    "JOIN data.tags T on T.id = I.tagid "
                                    "WHERE I.imgid = %d %s ORDER BY T.name",
              imgid, ignore_dt_tags ? "AND NOT T.name LIKE \"darktable|%\"" : "");
@@ -533,9 +538,8 @@ uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags
   else
   {
     if(ignore_dt_tags)
-      DT_DEBUG_SQLITE3_PREPARE_V2(
-          dt_database_get(darktable.db),
-              "SELECT DISTINCT I.tagid, T.name, COUNT(DISTINCT S.imgid) AS inb "
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+              "SELECT DISTINCT I.tagid, T.name, T.flags, COUNT(DISTINCT S.imgid) AS inb "
               "FROM main.selected_images AS S "
               "LEFT JOIN main.tagged_images AS I ON I.imgid = S.imgid "
               "LEFT JOIN data.tags AS T ON T.id = I.tagid "
@@ -545,7 +549,7 @@ uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags
               -1, &stmt, NULL);
     else
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-              "SELECT DISTINCT I.tagid, T.name, COUNT(DISTINCT S.imgid) AS inb "
+              "SELECT DISTINCT I.tagid, T.name, T.flags, COUNT(DISTINCT S.imgid) AS inb "
               "FROM main.selected_images AS S "
               "LEFT JOIN main.tagged_images AS I ON I.imgid = S.imgid "
               "LEFT JOIN data.tags AS T ON T.id = I.tagid "
@@ -563,11 +567,65 @@ uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags
     dt_tag_t *t = g_malloc0(sizeof(dt_tag_t));
     t->id = sqlite3_column_int(stmt, 0);
     t->tag = g_strdup((char *)sqlite3_column_text(stmt, 1));
-    uint32_t imgnb = sqlite3_column_int(stmt, 2);
+    t->flags = sqlite3_column_int(stmt, 2);
+    uint32_t imgnb = sqlite3_column_int(stmt, 3);
+    t->count = imgnb;
     // 0: no selection or no tag not attached
     // 1: tag attached on some selected images
     // 2: tag attached on all selected images
     t->select = (nb_selected == 0) ? 0 : (imgnb == nb_selected) ? 2 : (imgnb == 0) ? 0 : 1;
+    *result = g_list_append(*result, t);
+    count++;
+  }
+  sqlite3_finalize(stmt);
+  return count;
+}
+
+uint32_t dt_tag_get_attached_export(gint imgid, GList **result)
+{
+  sqlite3_stmt *stmt;
+  if(imgid > 0)
+  {
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+            "SELECT DISTINCT T.id, T.name, T.flags, S.selected FROM data.tags AS T "
+            "JOIN (SELECT DISTINCT I.tagid, T.name "
+              "FROM main.tagged_images AS I  "
+              "LEFT JOIN data.tags AS T ON T.id = I.tagid "
+              "WHERE I.imgid = ?1 AND NOT T.name LIKE 'darktable|%' "
+              "ORDER by T.name) AS T1 ON T.name = SUBSTR(T1.name, 1, LENGTH(T.name)) "
+            "LEFT JOIN (SELECT DISTINCT I.tagid, 1 as selected "
+              "FROM main.tagged_images AS I WHERE I.imgid = ?1 "
+              ") AS S ON S.tagid = T.id ",
+            -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  }
+  else
+  {
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+            "SELECT DISTINCT T.id, T.name, T.flags, S.selected FROM data.tags AS T "
+            "JOIN (SELECT DISTINCT I.tagid, T.name "
+              "FROM main.selected_images AS S "
+              "LEFT JOIN main.tagged_images AS I ON I.imgid = S.imgid "
+              "LEFT JOIN data.tags AS T ON T.id = I.tagid "
+              "WHERE NOT T.name LIKE 'darktable|%' "
+              "ORDER by T.name) AS T1 ON T.name = SUBSTR(T1.name, 1, LENGTH(T.name)) "
+            "LEFT JOIN (SELECT DISTINCT I.tagid, 1 as selected "
+              "FROM main.selected_images AS S "
+              "LEFT JOIN main.tagged_images AS I ON I.imgid = S.imgid "
+              ") AS S ON S.tagid = T.id ",
+            -1, &stmt, NULL);
+  }
+
+  // Create result
+  uint32_t count = 0;
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    dt_tag_t *t = g_malloc0(sizeof(dt_tag_t));
+    t->id = sqlite3_column_int(stmt, 0);
+    t->tag = g_strdup((char *)sqlite3_column_text(stmt, 1));
+    t->flags = sqlite3_column_int(stmt, 2);
+    if (sqlite3_column_int(stmt, 3) != 1)
+      t->flags = t->flags | DT_TF_PATH; // just to say that this tag is not really attached but is on the path
     *result = g_list_append(*result, t);
     count++;
   }
@@ -614,7 +672,101 @@ GList *dt_tag_get_list(gint imgid)
     }
   }
 
-  g_list_free_full(taglist, g_free);
+  dt_tag_free_result(&taglist);
+
+  return dt_util_glist_uniq(tags);
+}
+
+static gint sort_tag_by_name(gconstpointer a, gconstpointer b)
+{
+  const dt_tag_t *tuple_a = (const dt_tag_t *)a;
+  const dt_tag_t *tuple_b = (const dt_tag_t *)b;
+
+  return g_strcmp0(tuple_a->tag, tuple_b->tag);
+}
+
+static gint sort_tag_by_count(gconstpointer a, gconstpointer b)
+{
+  const dt_tag_t *tuple_a = (const dt_tag_t *)a;
+  const dt_tag_t *tuple_b = (const dt_tag_t *)b;
+
+  return (tuple_b->count - tuple_a->count);
+//  return (tuple_a->count < tuple_b->count) ? 1 : (tuple_a->count > tuple_b->count) ? -1 : 0;
+}
+
+GList *dt_sort_tag(GList *tags, gboolean byname)
+{
+  GList *sorted_tags;
+  if (byname)
+  {
+    for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
+    { // order such that sub tags are coming directly behind their parent
+      gchar *tag = ((dt_tag_t *)taglist->data)->tag;
+      for(char *letter = tag; *letter; letter++)
+        if(*letter == '|') *letter = '\1';
+    }
+    sorted_tags = g_list_sort(tags, sort_tag_by_name);
+    for(GList *taglist = sorted_tags; taglist; taglist = g_list_next(taglist))
+    {
+      gchar *tag = ((dt_tag_t *)taglist->data)->tag;
+      for(char *letter = tag; *letter; letter++)
+        if(*letter == '\1') *letter = '|';
+    }
+  }
+  else
+  {
+    sorted_tags = g_list_sort(tags, sort_tag_by_count);
+  }
+  return sorted_tags;
+}
+
+GList *dt_tag_get_list_export(gint imgid)
+{
+  GList *taglist = NULL;
+  GList *tags = NULL;
+
+  gboolean omit_tag_hierarchy = dt_conf_get_bool("omit_tag_hierarchy");
+  gboolean export_private_tags = dt_conf_get_bool("plugins/lighttable/export/export_private_tags");
+  gboolean export_tag_synomyms = dt_conf_get_bool("plugins/lighttable/export/export_tag_synonyms");
+
+  uint32_t count = dt_tag_get_attached_export(imgid, &taglist);
+
+  if(count < 1) return NULL;
+  GList *sorted_tags = dt_sort_tag(taglist, true);
+
+  for(; sorted_tags; sorted_tags = g_list_next(sorted_tags))
+  {
+    dt_tag_t *t = (dt_tag_t *)sorted_tags->data;
+    if ((export_private_tags || !(t->flags & DT_TF_PRIVATE))
+        && !(t->flags & DT_TF_HELPER)
+        && !(omit_tag_hierarchy && (t->flags & DT_TF_PATH)))
+    {
+      gchar *tagname = t->tag;
+      char *subtag = g_strrstr(tagname, "|");
+      tags = g_list_prepend(tags, g_strdup(subtag ? subtag + 1 : tagname));
+      if (export_tag_synomyms)
+      {
+        gchar *synonyms = dt_tag_get_synonyms(t->id);
+        if (synonyms)
+          {
+          gchar **tokens = g_strsplit(synonyms, ",", 0);
+          if(tokens)
+          {
+            gchar **entry = tokens;
+            while(*entry)
+            {
+              char *e = *entry;
+              if (*e == ' ') e++;
+              tags = g_list_append(tags, g_strdup(e));
+              entry++;
+            }
+          }
+          g_strfreev(tokens);
+        }
+      }
+    }
+  }
+  dt_tag_free_result(&taglist);
 
   return dt_util_glist_uniq(tags);
 }
@@ -627,19 +779,20 @@ GList *dt_tag_get_hierarchical(gint imgid)
   int count = dt_tag_get_attached(imgid, &taglist, TRUE);
 
   if(count < 1) return NULL;
+  gboolean export_private_tags = dt_conf_get_bool("plugins/lighttable/export/export_private_tags");
 
   while(taglist)
   {
     dt_tag_t *t = (dt_tag_t *)taglist->data;
-
-    tags = g_list_prepend(tags, t->tag);
-
+    if (export_private_tags || !(t->flags & DT_TF_PRIVATE))
+    {
+      tags = g_list_append(tags, t->tag);
+    }
     taglist = g_list_next(taglist);
   }
 
-  g_list_free_full(taglist, g_free);
+  dt_tag_free_result(&taglist);
 
-  tags = g_list_reverse(tags);
   return tags;
 }
 
@@ -682,7 +835,7 @@ uint32_t dt_tag_get_suggestions(const gchar *keyword, GList **result)
   /* Quick sanity check - is keyword empty? If so .. return 0 */
   if(!keyword) return 0;
 
-  /* select tags from select images */
+  /* select tags from selected images */
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "INSERT INTO memory.similar_tags (tagid) "
                               "SELECT DISTINCT TI.tagid "
@@ -736,9 +889,12 @@ uint32_t dt_tag_get_suggestions(const gchar *keyword, GList **result)
   const uint32_t nb_selected = dt_selected_images_count();
   /* Now put all the bits together */
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT T.name, T.id "
+                              "SELECT T.name, T.id, MT.count, CT.imgnb, T.flags "
                               "FROM memory.taglist MT "
                               "LEFT JOIN data.tags T ON MT.id = T.id "
+                              "LEFT JOIN (SELECT tagid, COUNT(DISTINCT imgid) AS imgnb FROM main.tagged_images "
+                                "WHERE imgid IN (SELECT imgid FROM main.selected_images) GROUP BY tagid) AS CT "
+                                "ON CT.tagid = MT.id "
                               "WHERE T.id NOT IN (SELECT DISTINCT tagid "
                                 "FROM (SELECT TI.tagid, COUNT(DISTINCT SI.imgid) AS imgnb "
                                   "FROM main.selected_images AS SI "
@@ -757,7 +913,15 @@ uint32_t dt_tag_get_suggestions(const gchar *keyword, GList **result)
     dt_tag_t *t = g_malloc0(sizeof(dt_tag_t));
     t->tag = g_strdup((char *)sqlite3_column_text(stmt, 0));
     t->id = sqlite3_column_int(stmt, 1);
-    *result = g_list_append((*result), t);
+
+    t->count = sqlite3_column_int(stmt, 2);
+    uint32_t imgnb = sqlite3_column_int(stmt, 3);
+    // 0: no selection or no tag not attached
+    // 1: tag attached on some selected images
+    // 2: tag attached on all selected images
+    t->select = (nb_selected == 0) ? 0 : (imgnb == nb_selected) ? 2 : (imgnb == 0) ? 0 : 1;
+    t->flags = sqlite3_column_int(stmt, 4);
+    *result = g_list_append(*result, t);
     count++;
   }
 
@@ -915,7 +1079,7 @@ uint32_t dt_tag_get_with_usage(const gchar *keyword, GList **result)
 
   /* Now put all the bits together */
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT T.name, ST.tagid, MT.count, CT.imgnb FROM memory.similar_tags ST "
+                              "SELECT T.name, ST.tagid, MT.count, CT.imgnb, T.flags FROM memory.similar_tags ST "
                               "LEFT JOIN memory.taglist MT ON MT.id = ST.tagid "
                               "JOIN data.tags T ON T.id = ST.tagid "
                               "LEFT JOIN (SELECT tagid, COUNT(DISTINCT imgid) AS imgnb FROM main.tagged_images "
@@ -938,7 +1102,8 @@ uint32_t dt_tag_get_with_usage(const gchar *keyword, GList **result)
     // 1: tag attached on some selected images
     // 2: tag attached on all selected images
     t->select = (nb_selected == 0) ? 0 : (imgnb == nb_selected) ? 2 : (imgnb == 0) ? 0 : 1;
-    *result = g_list_append((*result), t);
+    t->flags = sqlite3_column_int(stmt, 4);
+    *result = g_list_append(*result, t);
     count++;
   }
 
@@ -947,6 +1112,104 @@ uint32_t dt_tag_get_with_usage(const gchar *keyword, GList **result)
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.similar_tags", NULL, NULL, NULL);
 
   return count;
+}
+
+static gchar *dt_cleanup_synonyms(gchar *synonyms_entry)
+{
+  gchar *synonyms = NULL;
+  for(char *letter = synonyms_entry; *letter; letter++)
+    if(*letter == ';') *letter = ',';
+  gchar **tokens = g_strsplit(synonyms_entry, ",", 0);
+  if(tokens)
+  {
+    gchar **entry = tokens;
+    while (*entry)
+    {
+      // remove leading and trailing spaces
+      char *e = *entry + strlen(*entry) - 1;
+      while(*e == ' ' && e > *entry)
+      {
+        *e = '\0';
+        e--;
+      }
+      e = *entry;
+      while(*e == ' ' && *e != '\0') e++;
+      if(*e)
+      {
+        synonyms = dt_util_dstrcat(synonyms, "%s, ", e);
+      }
+      entry++;
+    }
+    if (synonyms)
+      synonyms[strlen(synonyms) - 2] = '\0';
+  }
+  g_strfreev(tokens);
+  return synonyms;
+}
+
+gchar *dt_tag_get_synonyms(gint tagid)
+{
+  sqlite3_stmt *stmt;
+  gchar *synonyms = NULL;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT description FROM data.tags WHERE id = ?1 ",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
+
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    synonyms = g_strdup((char *)sqlite3_column_text(stmt, 0));
+  }
+  sqlite3_finalize(stmt);
+  return synonyms;
+}
+
+void dt_tag_set_synonyms(gint tagid, gchar *synonyms_entry)
+{
+  if (!synonyms_entry) return;
+  char *synonyms = dt_cleanup_synonyms(synonyms_entry);
+
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE data.tags SET description = ?2 WHERE id = ?1 ",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, synonyms, -1, SQLITE_TRANSIENT);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
+  g_free(synonyms);
+}
+
+gint dt_tag_get_flags(gint tagid)
+{
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT flags FROM data.tags WHERE id = ?1 ",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
+
+  gint flags = 0;
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    flags = sqlite3_column_int(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+  return flags;
+}
+
+void dt_tag_set_flags(gint tagid, gint flags)
+{
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE data.tags SET flags = ?2 WHERE id = ?1 ",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, flags);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
 }
 
 static void _free_result_item(dt_tag_t *t, gpointer unused)

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -105,9 +105,6 @@ uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags
 /** sort tags per name (including '|') or per count (desc) */
 GList *dt_sort_tag(GList *tags, gboolean byname);
 
-/** get the list of tag for export */
-GList *dt_tag_get_list_export(gint imgid);
-
 /** get a list of tags,
  *  the difference to dt_tag_get_attached() is that this one splits at '|' and filters out the "darktable|"
  * tags. */

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -28,7 +28,17 @@ typedef struct dt_tag_t
   gchar *tag;
   guint count;
   guint select;
+  gint flags;
 } dt_tag_t;
+
+typedef enum dt_tag_flags_t
+{
+  DT_TF_NONE = 0,
+  DT_TF_HELPER = 1 << 0,  // this tag (or path) is not a keyword to be exported
+  DT_TF_PRIVATE = 1 << 1, // this tag is private. Will be exported only on demand
+  DT_TF_PATH = 1 << 2, // this tag is on the path of others in the list
+} dt_tag_flags_t;
+
 
 /** creates a new tag, returns tagid \param[in] name the tag name. \param[in] tagid a pointer to tagid of new
  * tag, this can be NULL \return false if failed to create a tag and indicates that tagid is invalid to use.
@@ -87,12 +97,18 @@ void dt_tag_detach_by_string(const char *name, gint imgid);
 /** retrieves a list of tags of specified imgid \param[out] result a list of dt_tag_t, sorted by tag. */
 uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags);
 
-/** get a list of tags, call dt_util_glist_to_str() to make it into a string.
+/** sort tags per name (including '|') or per count (desc) */
+GList *dt_sort_tag(GList *tags, gboolean byname);
+
+/** get the list of tag for export */
+GList *dt_tag_get_list_export(gint imgid);
+
+/** get a list of tags,
  *  the difference to dt_tag_get_attached() is that this one splits at '|' and filters out the "darktable|"
  * tags. */
 GList *dt_tag_get_list(gint imgid);
 
-/** get a flat list of only hierarchical tags, call dt_util_glist_to_str() to make it into a string.
+/** get a flat list of only hierarchical tags,
  *  the difference to dt_tag_get_attached() is that this one filters out the "darktable|" tags. */
 GList *dt_tag_get_hierarchical(gint imgid);
 
@@ -116,6 +132,18 @@ void dt_tag_get_tags_images(const gchar *keyword, GList **tag_list, GList **img_
  * result a pointer to list populated with result. \return the count \note the limit of result is decided by
  * conf value "xxx" */
 uint32_t dt_tag_get_with_usage(const gchar *keyword, GList **result);
+
+/** retrieves synonyms of the tag */
+gchar *dt_tag_get_synonyms(gint tagid);
+
+/** sets synonyms of the tag */
+void dt_tag_set_synonyms(gint tagid, gchar *synonyms);
+
+/** retrieves flags of the tag */
+gint dt_tag_get_flags(gint tagid);
+
+/** sets flags of the tag */
+void dt_tag_set_flags(gint tagid, gint flags);
 
 /** retrieves a list of recent tags used. \param[out] result a pointer to list populated with result. \return
  * the count \note the limit of result is decided by conf value "xxx" */

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -68,6 +68,9 @@ gchar *dt_tag_get_name(const guint tagid);
  * the amount of images affected. */
 guint dt_tag_remove(const guint tagid, gboolean final);
 
+/** removes a list of tags from db and from assigned images. \return the number of tags deleted */
+guint dt_tag_remove_list(GList *tag_list);
+
 /** set the name of specified id */
 void dt_tag_rename(const guint tagid, const gchar *new_tagname);
 

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -27,6 +27,7 @@ typedef struct dt_tag_t
   guint id;
   gchar *tag;
   gchar *leave;
+  gchar *synonym;
   guint count;
   guint select;
   gint flags;
@@ -119,7 +120,7 @@ GList *dt_tag_get_images_from_selection(gint imgid, gint tagid);
 /** retrieves a list of suggested tags matching keyword. \param[in] keyword the keyword to search \param[out]
  * result a pointer to list populated with result. \return the count \note the limit of result is decided by
  * conf value "xxx" */
-uint32_t dt_tag_get_suggestions(const gchar *keyword, GList **result);
+uint32_t dt_tag_get_suggestions(GList **result);
 
 /** retrieves count of tagged images. \param[in] keyword the keyword to search \return
  * the count \note the limit of result is decided by conf value "xxx" */
@@ -132,7 +133,7 @@ void dt_tag_get_tags_images(const gchar *keyword, GList **tag_list, GList **img_
 /** retrieves the list of tags matching keyword. \param[in] keyword the keyword to search \param[out]
  * result a pointer to list populated with result. \return the count \note the limit of result is decided by
  * conf value "xxx" */
-uint32_t dt_tag_get_with_usage(const gchar *keyword, GList **result);
+uint32_t dt_tag_get_with_usage(GList **result);
 
 /** retrieves synonyms of the tag */
 gchar *dt_tag_get_synonyms(gint tagid);

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -26,6 +26,7 @@ typedef struct dt_tag_t
 {
   guint id;
   gchar *tag;
+  gchar *leave;
   guint count;
   guint select;
   gint flags;
@@ -34,7 +35,7 @@ typedef struct dt_tag_t
 typedef enum dt_tag_flags_t
 {
   DT_TF_NONE = 0,
-  DT_TF_HELPER = 1 << 0,  // this tag (or path) is not a keyword to be exported
+  DT_TF_CATEGORY = 1 << 0,  // this tag (or path) is not a keyword to be exported
   DT_TF_PRIVATE = 1 << 1, // this tag is private. Will be exported only on demand
   DT_TF_PATH = 1 << 2, // this tag is on the path of others in the list
 } dt_tag_flags_t;

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -326,6 +326,28 @@ void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_restore(cr);
 }
 
+void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  cairo_save(cr);
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+
+  cairo_set_line_width(cr, 0.1);
+  cairo_move_to(cr, 0.4, 0.1);
+  cairo_line_to(cr, 0.4, 0.9);
+  cairo_line_to(cr, 0.2, 0.7);
+  cairo_move_to(cr, 0.6, 0.9);
+  cairo_line_to(cr, 0.6, 0.1);
+  cairo_line_to(cr, 0.8, 0.3);
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+  cairo_restore(cr);
+}
+
 void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
@@ -336,10 +358,28 @@ void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
   cairo_set_line_width(cr, 0.1);
-  cairo_move_to(cr, 0.5, 0.2);
-  cairo_line_to(cr, 0.5, 0.8);
-  cairo_move_to(cr, 0.2, 0.5);
-  cairo_line_to(cr, 0.8, 0.5);
+  cairo_move_to(cr, 0.5, 0.1);
+  cairo_line_to(cr, 0.5, 0.9);
+  cairo_move_to(cr, 0.1, 0.5);
+  cairo_line_to(cr, 0.9, 0.5);
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+  cairo_restore(cr);
+}
+
+void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  cairo_save(cr);
+  gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+
+  cairo_set_line_width(cr, 0.1);
+  cairo_move_to(cr, 0.1, 0.5);
+  cairo_line_to(cr, 0.9, 0.5);
   cairo_stroke(cr);
 
   cairo_identity_matrix(cr);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -46,7 +46,7 @@ void dtgtk_cairo_paint_color(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_presets(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -76,7 +76,7 @@ void dtgtk_cairo_paint_triangle(cairo_t *cr, gint x, int y, gint w, gint h, gint
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
   /* scale and transform*/
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_save(cr);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
@@ -113,7 +113,7 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
   /* scale and transform*/
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_save(cr);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
@@ -148,7 +148,7 @@ void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -202,7 +202,7 @@ void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   double C = cos(-1.570796327), S = sin(-1.570796327);
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -226,7 +226,7 @@ void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 
 void dtgtk_cairo_paint_reset(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -240,7 +240,7 @@ void dtgtk_cairo_paint_reset(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_store(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -266,7 +266,7 @@ void dtgtk_cairo_paint_store(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 
 void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -295,7 +295,7 @@ void dtgtk_cairo_paint_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -329,7 +329,7 @@ void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -351,7 +351,7 @@ void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -371,7 +371,7 @@ void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, 
 void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -389,7 +389,7 @@ void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h,
 void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -423,7 +423,7 @@ void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 
 void dtgtk_cairo_paint_invert(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -437,7 +437,7 @@ void dtgtk_cairo_paint_invert(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 
 void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -457,7 +457,7 @@ void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 
 void dtgtk_cairo_paint_masks_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.08);
@@ -486,7 +486,7 @@ void dtgtk_cairo_paint_masks_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_masks_circle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -502,7 +502,7 @@ void dtgtk_cairo_paint_masks_circle(cairo_t *cr, gint x, gint y, gint w, gint h,
 
 void dtgtk_cairo_paint_masks_ellipse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -521,7 +521,7 @@ void dtgtk_cairo_paint_masks_ellipse(cairo_t *cr, gint x, gint y, gint w, gint h
 
 void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -543,7 +543,7 @@ void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint 
 
 void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   if(flags & CPF_ACTIVE)
@@ -563,7 +563,7 @@ void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -587,7 +587,7 @@ void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, g
 
 void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -620,7 +620,7 @@ void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint
 
 void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -644,7 +644,7 @@ void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_masks_uniform(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -656,7 +656,7 @@ void dtgtk_cairo_paint_masks_uniform(cairo_t *cr, gint x, gint y, gint w, gint h
 
 void dtgtk_cairo_paint_masks_drawn(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -708,7 +708,7 @@ void _gradient_arc(cairo_t *cr, double lw, int nb_steps, double x_center, double
 
 void dtgtk_cairo_paint_masks_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -735,7 +735,7 @@ void dtgtk_cairo_paint_masks_parametric(cairo_t *cr, gint x, gint y, gint w, gin
 void dtgtk_cairo_paint_masks_drawn_and_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags,
                                                   void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -778,7 +778,7 @@ void dtgtk_cairo_paint_masks_drawn_and_parametric(cairo_t *cr, gint x, gint y, g
 
 void dtgtk_cairo_paint_masks_raster(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -801,7 +801,7 @@ void dtgtk_cairo_paint_masks_raster(cairo_t *cr, gint x, gint y, gint w, gint h,
 
 void dtgtk_cairo_paint_masks_multi(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -815,7 +815,7 @@ void dtgtk_cairo_paint_masks_multi(cairo_t *cr, gint x, gint y, gint w, gint h, 
 }
 void dtgtk_cairo_paint_masks_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -828,7 +828,7 @@ void dtgtk_cairo_paint_masks_inverse(cairo_t *cr, gint x, gint y, gint w, gint h
 }
 void dtgtk_cairo_paint_masks_union(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s * 1.4, s);
 
@@ -841,7 +841,7 @@ void dtgtk_cairo_paint_masks_union(cairo_t *cr, gint x, gint y, gint w, gint h, 
 }
 void dtgtk_cairo_paint_masks_intersection(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s * 1.4, s);
 
@@ -862,7 +862,7 @@ void dtgtk_cairo_paint_masks_intersection(cairo_t *cr, gint x, gint y, gint w, g
 }
 void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s * 1.4, s);
 
@@ -881,7 +881,7 @@ void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gin
 }
 void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s * 1.4, s);
 
@@ -894,7 +894,7 @@ void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint
 }
 void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -909,7 +909,7 @@ void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -941,7 +941,7 @@ void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_timer(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -962,7 +962,7 @@ void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   gdouble sw = 0.6;
   gdouble bend = 0.3;
 
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_scale(cr, 0.7, 0.7);
@@ -1018,7 +1018,7 @@ void dtgtk_cairo_paint_directory(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_refresh(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   if(flags & 1)
@@ -1043,7 +1043,7 @@ void dtgtk_cairo_paint_refresh(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 
 void dtgtk_cairo_paint_perspective(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1081,7 +1081,7 @@ void dtgtk_cairo_paint_perspective(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1104,7 +1104,7 @@ void dtgtk_cairo_paint_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1121,7 +1121,7 @@ void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 void dtgtk_cairo_paint_aspectflip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   if(flags & 1)
@@ -1145,7 +1145,7 @@ void dtgtk_cairo_paint_aspectflip(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1170,7 +1170,7 @@ void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gboolean def = FALSE;
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   double r = 0.4;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
@@ -1226,7 +1226,7 @@ void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   if(!flags) return;
 
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   double r = 0.4;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
@@ -1246,7 +1246,7 @@ void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_colorpicker(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1278,7 +1278,7 @@ void dtgtk_cairo_paint_colorpicker(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_colorpicker_set_values(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1319,7 +1319,7 @@ void dtgtk_cairo_paint_colorpicker_set_values(cairo_t *cr, gint x, gint y, gint 
 
 void dtgtk_cairo_paint_showmask(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1342,7 +1342,7 @@ void dtgtk_cairo_paint_showmask(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 
 void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = (w < h ? w / 1.75 : h / 1.75);
+  const gint s = (w < h ? w / 1.75 : h / 1.75);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1358,7 +1358,7 @@ void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_overlays(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = (w < h ? w / 1.75 : h / 1.75);
+  const gint s = (w < h ? w / 1.75 : h / 1.75);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, .1);
@@ -1376,7 +1376,7 @@ void dtgtk_cairo_paint_help(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   // leading to imprecise positioning
   static const float grow = 12.0;
   layout = pango_cairo_create_layout(cr);
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
   cairo_scale(cr, s / grow, s / grow);
 
@@ -1396,7 +1396,7 @@ void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   // leading to imprecise positioning
   static const float grow = 12.0;
   layout = pango_cairo_create_layout(cr);
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
   cairo_scale(cr, s / grow, s / grow);
 
@@ -1409,7 +1409,7 @@ void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 
 void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1471,7 +1471,7 @@ void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_or(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1485,7 +1485,7 @@ void dtgtk_cairo_paint_or(cairo_t *cr, gint x, gint y, gint w, gint h, gint flag
 
 void dtgtk_cairo_paint_and(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1499,7 +1499,7 @@ void dtgtk_cairo_paint_and(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 
 void dtgtk_cairo_paint_andnot(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1513,7 +1513,7 @@ void dtgtk_cairo_paint_andnot(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 
 void dtgtk_cairo_paint_dropdown(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1528,7 +1528,7 @@ void dtgtk_cairo_paint_dropdown(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 
 void dtgtk_cairo_paint_bracket(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1549,7 +1549,7 @@ void dtgtk_cairo_paint_bracket(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 
 void dtgtk_cairo_paint_lock(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
 
@@ -1568,7 +1568,7 @@ void dtgtk_cairo_paint_lock(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 
 void dtgtk_cairo_paint_check_mark(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
 
@@ -1581,7 +1581,7 @@ void dtgtk_cairo_paint_check_mark(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_overexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1644,7 +1644,7 @@ void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint 
 
 void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
 
@@ -1684,7 +1684,7 @@ void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_softproof(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
 
@@ -1712,7 +1712,7 @@ void dtgtk_cairo_paint_softproof(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_display(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_save(cr);
 
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
@@ -1748,7 +1748,7 @@ void dtgtk_cairo_paint_display(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 
 void dtgtk_cairo_paint_display2(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_save(cr);
 
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
@@ -1791,7 +1791,7 @@ void dtgtk_cairo_paint_display2(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 
 void dtgtk_cairo_paint_rect_landscape(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.10);
@@ -1808,7 +1808,7 @@ void dtgtk_cairo_paint_rect_landscape(cairo_t *cr, gint x, gint y, gint w, gint 
 
 void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.10);
@@ -1825,7 +1825,7 @@ void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h
 
 void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = (w < h ? w : h);
+  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1848,7 +1848,7 @@ void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);
@@ -1866,7 +1866,7 @@ void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h
 
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1881,7 +1881,7 @@ void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, g
 
 void dtgtk_cairo_paint_modulegroup_favorites(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -1905,7 +1905,7 @@ void dtgtk_cairo_paint_modulegroup_favorites(cairo_t *cr, gint x, gint y, gint w
 
 void dtgtk_cairo_paint_modulegroup_basic(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -1918,7 +1918,7 @@ void dtgtk_cairo_paint_modulegroup_basic(cairo_t *cr, gint x, gint y, gint w, gi
 
 void dtgtk_cairo_paint_modulegroup_tone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -1941,7 +1941,7 @@ void dtgtk_cairo_paint_modulegroup_tone(cairo_t *cr, gint x, gint y, gint w, gin
 
 void dtgtk_cairo_paint_modulegroup_color(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -1968,7 +1968,7 @@ void dtgtk_cairo_paint_modulegroup_color(cairo_t *cr, gint x, gint y, gint w, gi
 
 void dtgtk_cairo_paint_modulegroup_correct(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -1983,7 +1983,7 @@ void dtgtk_cairo_paint_modulegroup_correct(cairo_t *cr, gint x, gint y, gint w, 
 
 void dtgtk_cairo_paint_modulegroup_effect(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
@@ -2037,7 +2037,7 @@ void dtgtk_cairo_paint_modulegroup_effect(cairo_t *cr, gint x, gint y, gint w, g
 
 void dtgtk_cairo_paint_map_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  gint s = w < h ? w : h;
+  const gint s = w < h ? w : h;
   cairo_scale(cr, s, s);
   cairo_move_to(cr, 0.2, 0.0);
   cairo_line_to(cr, 0.0, 1.0);

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -69,8 +69,12 @@ void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 /** Same as dtgtk_cairo_paint_plusminus, but render as a plus even
  * when CFP_ACTIVE is disabled. */
 void dtgtk_cairo_paint_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a double arrow up/down */
+void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a simple plus icon */
 void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a simple minus icon */
+void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a treelist icon */
 void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a invert icon */

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -21,6 +21,7 @@
 #include "common/debug.h"
 #include "common/image_cache.h"
 #include "common/metadata.h"
+#include "common/tags.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
@@ -81,6 +82,9 @@ enum
   md_geotagging_lon,
   md_geotagging_ele,
 
+  /* tags */
+  md_tag_names,
+
   /* entries, do not touch! */
   md_size
 };
@@ -127,6 +131,9 @@ static void _lib_metatdata_view_init_labels()
   _md_labels[md_geotagging_lat] = _("latitude");
   _md_labels[md_geotagging_lon] = _("longitude");
   _md_labels[md_geotagging_ele] = _("elevation");
+
+  /* tags */
+  _md_labels[md_tag_names] = _("tags");
 }
 
 
@@ -570,6 +577,20 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
         _metadata_update_value(d->metadata[md_geotagging_ele], value);
       }
     }
+
+    /* tags */
+    GList *tags = NULL;
+    if (dt_tag_get_attached(mouse_over_id, &tags, TRUE))
+    {
+      char *tagname = NULL;
+      for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
+      {
+        tagname = dt_util_dstrcat(tagname, "%s, ", ((dt_tag_t *)taglist->data)->leave);
+      }
+      if (strlen(tagname) > 2) tagname[strlen(tagname)-2] = '\0';
+      _metadata_update_value(d->metadata[md_tag_names], tagname);
+    }
+    dt_tag_free_result(&tags);
 
     /* release img */
     dt_image_cache_read_release(darktable.image_cache, img);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -580,23 +580,24 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
     /* tags */
     GList *tags = NULL;
-    if (dt_tag_get_attached(mouse_over_id, &tags, TRUE))
+    if(dt_tag_get_attached(mouse_over_id, &tags, TRUE))
     {
-      char *tagname = NULL;
+      char *tagstring = NULL;
       gint length = 0;
       for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
       {
-        if (tagname) length =+ strlen(tagname);
-        if(length < 30)
-          tagname = dt_util_dstrcat(tagname, "%s, ", ((dt_tag_t *)taglist->data)->leave);
+        const char *tagname = ((dt_tag_t *)taglist->data)->leave;
+        length = length + strlen(tagname) + 2;
+        if(length < 40)
+          tagstring = dt_util_dstrcat(tagstring, "%s, ", tagname);
         else
         {
-          tagname = dt_util_dstrcat(tagname, "\n%s, ", ((dt_tag_t *)taglist->data)->leave);
-          length = 0;
+          tagstring = dt_util_dstrcat(tagstring, "\n%s, ", tagname);
+          length = strlen(tagname) + 2;
         }
       }
-      if (strlen(tagname) > 2) tagname[strlen(tagname)-2] = '\0';
-      _metadata_update_value(d->metadata[md_tag_names], tagname);
+      if(strlen(tagstring) > 2) tagstring[strlen(tagstring)-2] = '\0';
+      _metadata_update_value(d->metadata[md_tag_names], tagstring);
     }
     dt_tag_free_result(&tags);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -583,9 +583,17 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     if (dt_tag_get_attached(mouse_over_id, &tags, TRUE))
     {
       char *tagname = NULL;
+      gint length = 0;
       for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
       {
-        tagname = dt_util_dstrcat(tagname, "%s, ", ((dt_tag_t *)taglist->data)->leave);
+        if (tagname) length =+ strlen(tagname);
+        if(length < 30)
+          tagname = dt_util_dstrcat(tagname, "%s, ", ((dt_tag_t *)taglist->data)->leave);
+        else
+        {
+          tagname = dt_util_dstrcat(tagname, "\n%s, ", ((dt_tag_t *)taglist->data)->leave);
+          length = 0;
+        }
       }
       if (strlen(tagname) > 2) tagname[strlen(tagname)-2] = '\0';
       _metadata_update_value(d->metadata[md_tag_names], tagname);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1830,7 +1830,7 @@ static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_l
   {
     guint count;
     gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_COUNT, &count, -1);
-    if (count)
+    if (count || d->collection[0])
     {
       menuitem = gtk_separator_menu_item_new();
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1705,15 +1705,13 @@ static gboolean row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean 
       GtkTooltip* tooltip, dt_lib_module_t *self)
 {
   gboolean res = FALSE;
-  GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(treeview));
   GtkTreePath *path = NULL;
   // Get tree path mouse position
   if(gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(treeview), x, y, &path, NULL, NULL, NULL))
   {
-    GtkTreeModel *model;
+    GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(treeview));
     GtkTreeIter iter;
-    gtk_tree_selection_select_path(selection, path);
-    if (gtk_tree_selection_get_selected(selection, &model, &iter))
+    if (gtk_tree_model_get_iter(model, &iter, path))
     {
       char *tagname;
       guint tagid;
@@ -1728,7 +1726,7 @@ static gboolean row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean 
           char *text = dt_util_dstrcat(NULL, _("%s"), tagname);
           text = dt_util_dstrcat(text, " %s\n", (flags & DT_TF_PRIVATE) ? _("(private)") : "");
           text = dt_util_dstrcat(text, "synonyms: %s", (synonyms && synonyms[0]) ? synonyms : " - ");
-          gtk_tooltip_set_text (tooltip, text);
+          gtk_tooltip_set_text(tooltip, text);
           g_free(text);
           res = TRUE;
         }
@@ -2076,7 +2074,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_view_set_model(view, GTK_TREE_MODEL(liststore));
   g_object_unref(liststore);
   gtk_widget_set_tooltip_text(GTK_WIDGET(view), _("attached tags,\ndouble-click to detach"
-                                                        "\nCtrl-wheel scroll to resize the window"));
+                                                  "\nright-click for other actions on attached tag,"
+                                                  "\nCtrl-wheel scroll to resize the window"));
   dt_gui_add_help_link(GTK_WIDGET(view), "tagging.html#tagging_usage");
   g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(click_on_view_attached), (gpointer)self);
   g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(mouse_scroll_attached), (gpointer)self);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1076,16 +1076,10 @@ static void view_popup_menu_delete_path(GtkWidget *menuitem, dt_lib_module_t *se
   GList *tagged_images = NULL;
   dt_tag_get_tags_images(tagname, &tag_family, &tagged_images);
 
-  // dt_tag_remove raises DT_SIGNAL_TAG_CHANGED. We don't want to reintialize the tree
-  for (GList *taglist = tag_family; taglist ; taglist = g_list_next(taglist))
-  {
-    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-    dt_tag_remove(((dt_tag_t *)taglist->data)->id, TRUE);
-    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-//    dt_control_log(_("tag %s removed"), ((dt_tag_t *)taglist->data)->tag); // doesn't appear ...
-  }
-
-  g_free(tagname);
+  dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
+  tag_count = dt_tag_remove_list(tag_family);
+  dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
+  dt_control_log(_("%d tags removed"), tag_count);
 
   GtkTreeIter store_iter;
   GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
@@ -1105,6 +1099,7 @@ static void view_popup_menu_delete_path(GtkWidget *menuitem, dt_lib_module_t *se
   dt_tag_free_result(&tag_family);
   g_list_free(tagged_images);
   raise_signal_tag_changed(self);
+  g_free(tagname);
 }
 
 // edit tag allows the user to rename a single tag, which can be an element of the hierarchy and change other parameters

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -374,6 +374,7 @@ static void init_treeview(dt_lib_module_t *self, int which)
     else
       sort_attached_list(self, FALSE);
   }
+  // Free result...
   dt_tag_free_result(&tags);
 }
 


### PR DESCRIPTION
Some improvements for tagging:
- toggle button to mask darktable tags in attached tags window to save visual room
- toggle button to present the short tag name instead of the full tag name (for both attached and dictionary tags windows)
- toggle button to sort by name or by number (for both attached and dictionary tags windows)
- Ctrl-scroll to resize both the attached and dictionary tags windows
- added synonyms => exported if "plugins/lighttable/export/export_tag_synonyms" set
- added category flag. => the tag is not to be exported but still can have synonyms
- added private flag => the tag is exported if "plugins/lighttable/export/export_private_tags" set
- menu entry `rename tag` changed to menu `edit tag` to integrate the 2 flags and the synonyms with the tag name
- overlay tooltip to show the tag's associated data if any to avoid to have to edit it to see them
- add menu entry `delete branch` (deleting 1000 tags one by one can be tedious)
- suggestions are now related to already attached tags on selected images
- filtering doesn't involve any more the db, speeding up a lot the search of tags
- filtering takes in account the synonyms
- display of tags inside image information module
- import and export tags updated to take in account the synonyms
- export updated to apply the private and synonyms choices
- some display speed optimization

![image](https://user-images.githubusercontent.com/23012047/62841675-6b638c80-bc81-11e9-9e12-1a420b264250.png)

![image](https://user-images.githubusercontent.com/23012047/62841556-0491a380-bc80-11e9-8759-8074e6b9a7dc.png)

What I've not done:

- integrate "plugins/lighttable/export/export_tag_synonyms" and "plugins/lighttable/export/export_private_tags" in export module. I think this should be done but the module is already big...
- apply the effect of the previous flags on piwigo & flicker
- optimize `rename path` to keep the tree opened


