### PR TITLE
Tagging - bug fixing + presets enabled

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3148,10 +3148,10 @@ static void dt_exif_xmp_read_data_export(Exiv2::XmpData &xmpData, const int imgi
     longitude = fabs(longitude);
     latitude = fabs(latitude);
 
-    int long_deg = (int)floor(longitude);
-    int lat_deg = (int)floor(latitude);
-    double long_min = (longitude - (double)long_deg) * 60.0;
-    double lat_min = (latitude - (double)lat_deg) * 60.0;
+    const int long_deg = (int)floor(longitude);
+    const int lat_deg = (int)floor(latitude);
+    const double long_min = (longitude - (double)long_deg) * 60.0;
+    const double lat_min = (latitude - (double)lat_deg) * 60.0;
 
     char *str = (char *)g_malloc(G_ASCII_DTOSTR_BUF_SIZE);
 
@@ -3272,14 +3272,14 @@ static void dt_exif_xmp_read_data_export(Exiv2::XmpData &xmpData, const int imgi
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    int32_t mask_num = sqlite3_column_int(stmt, 8);
-    int32_t mask_id = sqlite3_column_int(stmt, 1);
-    int32_t mask_type = sqlite3_column_int(stmt, 2);
+    const int32_t mask_num = sqlite3_column_int(stmt, 8);
+    const int32_t mask_id = sqlite3_column_int(stmt, 1);
+    const int32_t mask_type = sqlite3_column_int(stmt, 2);
     const char *mask_name = (const char *)sqlite3_column_text(stmt, 3);
-    int32_t mask_version = sqlite3_column_int(stmt, 4);
+    const int32_t mask_version = sqlite3_column_int(stmt, 4);
     int32_t len = sqlite3_column_bytes(stmt, 5);
     char *mask_d = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 5), len, NULL);
-    int32_t mask_nb = sqlite3_column_int(stmt, 6);
+    const int32_t mask_nb = sqlite3_column_int(stmt, 6);
     len = sqlite3_column_bytes(stmt, 7);
     char *mask_src = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 7), len, NULL);
 
@@ -3512,8 +3512,6 @@ int dt_exif_xmp_attach_export(const int imgid, const char *filename)
 
     // last but not least attach what we have in DB to the XMP. in theory that should be
     // the same as what we just copied over from the sidecar file, but you never know ...
-    // the previous comment is not ok. First for exportation tags (and metadata) can be different
-    // second we could save time not reading the xmp file, just using the database data
     dt_exif_xmp_read_data_export(xmpData, imgid);
 
     img->writeMetadata();

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3097,6 +3097,293 @@ static void dt_exif_xmp_read_data(Exiv2::XmpData &xmpData, const int imgid)
   g_list_free_full(hierarchical, g_free);
 }
 
+// helper to create an xmp data thing. throws exiv2 exceptions if stuff goes wrong.
+static void dt_exif_xmp_read_data_export(Exiv2::XmpData &xmpData, const int imgid)
+{
+  const int xmp_version = 3;
+  int stars = 1, raw_params = 0, history_end = -1;
+  int iop_order_version = 0;
+  double longitude = NAN, latitude = NAN, altitude = NAN;
+  gchar *filename = NULL;
+  gchar *datetime_taken = NULL;
+
+  // get stars and raw params from db
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT filename, flags, raw_parameters, "
+                                                             "longitude, latitude, altitude, history_end, iop_order_version, datetime_taken "
+                                                             "FROM main.images WHERE id = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    filename = (gchar *)sqlite3_column_text(stmt, 0);
+    stars = sqlite3_column_int(stmt, 1);
+    raw_params = sqlite3_column_int(stmt, 2);
+    if(sqlite3_column_type(stmt, 3) == SQLITE_FLOAT) longitude = sqlite3_column_double(stmt, 3);
+    if(sqlite3_column_type(stmt, 4) == SQLITE_FLOAT) latitude = sqlite3_column_double(stmt, 4);
+    if(sqlite3_column_type(stmt, 5) == SQLITE_FLOAT) altitude = sqlite3_column_double(stmt, 5);
+    history_end = sqlite3_column_int(stmt, 6);
+    iop_order_version = sqlite3_column_int(stmt, 7);
+    datetime_taken = (gchar *)sqlite3_column_text(stmt, 8);
+  }
+
+  // Store datetime_taken as DateTimeOriginal to take into account the user's selected date/time
+  xmpData["Xmp.exif.DateTimeOriginal"] = datetime_taken;
+
+  // We have to erase the old ratings first as exiv2 seems to not change it otherwise.
+  Exiv2::XmpData::iterator pos = xmpData.findKey(Exiv2::XmpKey("Xmp.xmp.Rating"));
+  if(pos != xmpData.end()) xmpData.erase(pos);
+  xmpData["Xmp.xmp.Rating"] = ((stars & 0x7) == 6) ? -1 : (stars & 0x7); // rejected image = -1, others = 0..5
+
+  // The original file name
+  if(filename) xmpData["Xmp.xmpMM.DerivedFrom"] = filename;
+
+  // GPS data
+  if(!std::isnan(longitude) && !std::isnan(latitude))
+  {
+    char long_dir = 'E', lat_dir = 'N';
+    if(longitude < 0) long_dir = 'W';
+    if(latitude < 0) lat_dir = 'S';
+
+    longitude = fabs(longitude);
+    latitude = fabs(latitude);
+
+    int long_deg = (int)floor(longitude);
+    int lat_deg = (int)floor(latitude);
+    double long_min = (longitude - (double)long_deg) * 60.0;
+    double lat_min = (latitude - (double)lat_deg) * 60.0;
+
+    char *str = (char *)g_malloc(G_ASCII_DTOSTR_BUF_SIZE);
+
+    g_ascii_formatd(str, G_ASCII_DTOSTR_BUF_SIZE, "%08f", long_min);
+    gchar *long_str = g_strdup_printf("%d,%s%c", long_deg, str, long_dir);
+    g_ascii_formatd(str, G_ASCII_DTOSTR_BUF_SIZE, "%08f", lat_min);
+    gchar *lat_str = g_strdup_printf("%d,%s%c", lat_deg, str, lat_dir);
+
+    xmpData["Xmp.exif.GPSVersionID"] = "2.2.0.0";
+    xmpData["Xmp.exif.GPSLongitude"] = long_str;
+    xmpData["Xmp.exif.GPSLatitude"] = lat_str;
+    g_free(long_str);
+    g_free(lat_str);
+    g_free(str);
+  }
+  if(!std::isnan(altitude))
+  {
+    xmpData["Xmp.exif.GPSAltitudeRef"] = (altitude < 0) ? "1" : "0";
+
+    long ele_dm = (int)floor(fabs(10.0 * altitude));
+    gchar *ele_str = g_strdup_printf("%ld/10", ele_dm);
+    xmpData["Xmp.exif.GPSAltitude"] = ele_str;
+    g_free(ele_str);
+  }
+  sqlite3_finalize(stmt);
+
+  // the meta data
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT key, value FROM main.meta_data WHERE id = ?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    int key = sqlite3_column_int(stmt, 0);
+    switch(key)
+    {
+      case DT_METADATA_XMP_DC_CREATOR:
+        xmpData["Xmp.dc.creator"] = sqlite3_column_text(stmt, 1);
+        break;
+      case DT_METADATA_XMP_DC_PUBLISHER:
+        xmpData["Xmp.dc.publisher"] = sqlite3_column_text(stmt, 1);
+        break;
+      case DT_METADATA_XMP_DC_TITLE:
+        xmpData["Xmp.dc.title"] = sqlite3_column_text(stmt, 1);
+        break;
+      case DT_METADATA_XMP_DC_DESCRIPTION:
+        xmpData["Xmp.dc.description"] = sqlite3_column_text(stmt, 1);
+        break;
+      case DT_METADATA_XMP_DC_RIGHTS:
+        xmpData["Xmp.dc.rights"] = sqlite3_column_text(stmt, 1);
+        break;
+    }
+  }
+  sqlite3_finalize(stmt);
+
+  xmpData["Xmp.darktable.xmp_version"] = xmp_version;
+  xmpData["Xmp.darktable.raw_params"] = raw_params;
+
+  if(stars & DT_IMAGE_AUTO_PRESETS_APPLIED)
+    xmpData["Xmp.darktable.auto_presets_applied"] = 1;
+  else
+    xmpData["Xmp.darktable.auto_presets_applied"] = 0;
+
+  // get tags from db, store in dublin core
+  std::unique_ptr<Exiv2::Value> v1(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+
+  std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+
+  GList *tags = dt_tag_get_list_export(imgid);
+  while(tags)
+  {
+    v1->read((char *)tags->data);
+    tags = g_list_next(tags);
+  }
+
+  GList *hierarchical = dt_tag_get_hierarchical_export(imgid);
+  while(hierarchical)
+  {
+    v2->read((char *)hierarchical->data);
+    hierarchical = g_list_next(hierarchical);
+  }
+
+  if(v1->count() > 0) xmpData.add(Exiv2::XmpKey("Xmp.dc.subject"), v1.get());
+  if(v2->count() > 0) xmpData.add(Exiv2::XmpKey("Xmp.lr.hierarchicalSubject"), v2.get());
+  /* TODO: Add tags to IPTC namespace as well */
+
+  // color labels
+  char val[2048];
+  std::unique_ptr<Exiv2::Value> v(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+
+  /* Already initialized v = Exiv2::Value::create(Exiv2::xmpSeq); // or xmpBag or xmpAlt.*/
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT color FROM main.color_labels WHERE imgid=?1",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    snprintf(val, sizeof(val), "%d", sqlite3_column_int(stmt, 0));
+    v->read(val);
+  }
+  sqlite3_finalize(stmt);
+  if(v->count() > 0) xmpData.add(Exiv2::XmpKey("Xmp.darktable.colorlabels"), v.get());
+
+  // masks:
+  char key[1024];
+  int num = 1;
+
+  // masks history:
+  num = 1;
+
+  // create an array:
+  Exiv2::XmpTextValue tvm("");
+  tvm.setXmpArrayType(Exiv2::XmpValue::xaSeq);
+  xmpData.add(Exiv2::XmpKey("Xmp.darktable.masks_history"), &tvm);
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+      dt_database_get(darktable.db),
+      "SELECT imgid, formid, form, name, version, points, points_count, source, num FROM main.masks_history WHERE imgid = ?1 ORDER BY num",
+      -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    int32_t mask_num = sqlite3_column_int(stmt, 8);
+    int32_t mask_id = sqlite3_column_int(stmt, 1);
+    int32_t mask_type = sqlite3_column_int(stmt, 2);
+    const char *mask_name = (const char *)sqlite3_column_text(stmt, 3);
+    int32_t mask_version = sqlite3_column_int(stmt, 4);
+    int32_t len = sqlite3_column_bytes(stmt, 5);
+    char *mask_d = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 5), len, NULL);
+    int32_t mask_nb = sqlite3_column_int(stmt, 6);
+    len = sqlite3_column_bytes(stmt, 7);
+    char *mask_src = dt_exif_xmp_encode((const unsigned char *)sqlite3_column_blob(stmt, 7), len, NULL);
+
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_num", num);
+    xmpData[key] = mask_num;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_id", num);
+    xmpData[key] = mask_id;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_type", num);
+    xmpData[key] = mask_type;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_name", num);
+    xmpData[key] = mask_name;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_version", num);
+    xmpData[key] = mask_version;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_points", num);
+    xmpData[key] = mask_d;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_nb", num);
+    xmpData[key] = mask_nb;
+    snprintf(key, sizeof(key), "Xmp.darktable.masks_history[%d]/darktable:mask_src", num);
+    xmpData[key] = mask_src;
+
+    free(mask_d);
+    free(mask_src);
+
+    num++;
+  }
+  sqlite3_finalize(stmt);
+
+
+  // history stack:
+  num = 1;
+
+  // create an array:
+  Exiv2::XmpTextValue tv("");
+  tv.setXmpArrayType(Exiv2::XmpValue::xaSeq);
+  xmpData.add(Exiv2::XmpKey("Xmp.darktable.history"), &tv);
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+      dt_database_get(darktable.db),
+      "SELECT module, operation, op_params, enabled, blendop_params, "
+      "blendop_version, multi_priority, multi_name, num, iop_order FROM main.history WHERE imgid = ?1 ORDER BY num",
+      -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    int32_t modversion = sqlite3_column_int(stmt, 0);
+    const char *operation = (const char *)sqlite3_column_text(stmt, 1);
+    int32_t params_len = sqlite3_column_bytes(stmt, 2);
+    const void *params_blob = sqlite3_column_blob(stmt, 2);
+    int32_t enabled = sqlite3_column_int(stmt, 3);
+    const void *blendop_blob = sqlite3_column_blob(stmt, 4);
+    int32_t blendop_params_len = sqlite3_column_bytes(stmt, 4);
+    int32_t blendop_version = sqlite3_column_int(stmt, 5);
+    int32_t multi_priority = sqlite3_column_int(stmt, 6);
+    const char *multi_name = (const char *)sqlite3_column_text(stmt, 7);
+    int32_t hist_num = sqlite3_column_int(stmt, 8);
+    double iop_order = sqlite3_column_double(stmt, 9);
+
+    if(!operation) continue; // no op is fatal.
+
+    char *params = dt_exif_xmp_encode((const unsigned char *)params_blob, params_len, NULL);
+
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:num", num);
+    xmpData[key] = hist_num;
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:operation", num);
+    xmpData[key] = operation;
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:enabled", num);
+    xmpData[key] = enabled;
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:modversion", num);
+    xmpData[key] = modversion;
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:params", num);
+    xmpData[key] = params;
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:multi_name", num);
+    xmpData[key] = multi_name ? multi_name : "";
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:multi_priority", num);
+    xmpData[key] = multi_priority;
+    snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:iop_order", num);
+    xmpData[key] = iop_order;
+    if(blendop_blob)
+    {
+      // this shouldn't fail in general, but reading is robust enough to allow it,
+      // and flipping images from LT will result in this being left out
+      char *blendop_params = dt_exif_xmp_encode((const unsigned char *)blendop_blob, blendop_params_len, NULL);
+      snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:blendop_version", num);
+      xmpData[key] = blendop_version;
+      snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:blendop_params", num);
+      xmpData[key] = blendop_params;
+      free(blendop_params);
+    }
+
+    free(params);
+
+    num++;
+  }
+
+  if(history_end == -1) history_end = num - 1;
+  else history_end = MIN(history_end, num - 1); // safeguard for some old buggy libraries
+  xmpData["Xmp.darktable.history_end"] = history_end;
+  xmpData["Xmp.darktable.iop_order_version"] = iop_order_version;
+
+  sqlite3_finalize(stmt);
+  g_list_free_full(tags, g_free);
+  g_list_free_full(hierarchical, g_free);
+}
+
 #if EXIV2_VERSION >= EXIV2_MAKE_VERSION(0,27,0)
 #define ERROR_CODE(a) (static_cast<Exiv2::ErrorCode>((a)))
 #else
@@ -3163,7 +3450,7 @@ char *dt_exif_xmp_read_string(const int imgid)
   }
 }
 
-int dt_exif_xmp_attach(const int imgid, const char *filename)
+int dt_exif_xmp_attach_export(const int imgid, const char *filename)
 {
   try
   {
@@ -3225,7 +3512,9 @@ int dt_exif_xmp_attach(const int imgid, const char *filename)
 
     // last but not least attach what we have in DB to the XMP. in theory that should be
     // the same as what we just copied over from the sidecar file, but you never know ...
-    dt_exif_xmp_read_data(xmpData, imgid);
+    // the previous comment is not ok. First for exportation tags (and metadata) can be different
+    // second we could save time not reading the xmp file, just using the database data
+    dt_exif_xmp_read_data_export(xmpData, imgid);
 
     img->writeMetadata();
     return 0;

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -48,7 +48,7 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
 int dt_exif_xmp_write(const int imgid, const char *filename);
 
 /** write xmp packet inside an image. */
-int dt_exif_xmp_attach(const int imgid, const char *filename);
+int dt_exif_xmp_attach_export(const int imgid, const char *filename);
 
 /** get the xmp blob for imgid. */
 char *dt_exif_xmp_read_string(const int imgid);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -899,7 +899,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   /* now write xmp into that container, if possible */
   if(copy_metadata && (format->flags(format_params) & FORMAT_FLAGS_SUPPORT_XMP))
   {
-    dt_exif_xmp_attach(imgid, filename);
+    dt_exif_xmp_attach_export(imgid, filename);
     // no need to cancel the export if this fail
   }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -2,6 +2,7 @@
     This file is part of darktable,
     copyright (c) 2010--2011 henrik andersson.
     copyright (c) 2012 James C. McPherson
+    copyright (c) 2019 Philippe Weyland
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -558,6 +559,14 @@ void _detach_tag(guint tagid, gint imgid, gboolean undo_actif)
 }
 
 void dt_tag_detach(guint tagid, gint imgid)
+{
+  _detach_tag(tagid, imgid, TRUE);
+
+  dt_tag_update_used_tags();
+
+}
+
+void dt_tag_detach_from_gui(guint tagid, gint imgid)
 {
   _detach_tag(tagid, imgid, TRUE);
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -790,6 +790,74 @@ GList *dt_tag_get_list(gint imgid)
   GList *tags = NULL;
 
   gboolean omit_tag_hierarchy = dt_conf_get_bool("omit_tag_hierarchy");
+
+  uint32_t count = dt_tag_get_attached(imgid, &taglist, TRUE);
+
+  if(count < 1) return NULL;
+
+  for(; taglist; taglist = g_list_next(taglist))
+  {
+    dt_tag_t *t = (dt_tag_t *)taglist->data;
+    gchar *value = t->tag;
+
+    size_t j = 0;
+    gchar **pch = g_strsplit(value, "|", -1);
+
+    if(pch != NULL)
+    {
+      if(omit_tag_hierarchy)
+      {
+        char **iter = pch;
+        for(; *iter && *(iter + 1); iter++);
+        if(*iter) tags = g_list_prepend(tags, g_strdup(*iter));
+      }
+      else
+      {
+        while(pch[j] != NULL)
+        {
+          tags = g_list_prepend(tags, g_strdup(pch[j]));
+          j++;
+        }
+      }
+      g_strfreev(pch);
+    }
+  }
+
+  g_list_free_full(taglist, g_free);
+
+  return dt_util_glist_uniq(tags);
+}
+
+GList *dt_tag_get_hierarchical(gint imgid)
+{
+  GList *taglist = NULL;
+  GList *tags = NULL;
+
+  int count = dt_tag_get_attached(imgid, &taglist, TRUE);
+
+  if(count < 1) return NULL;
+
+  while(taglist)
+  {
+    dt_tag_t *t = (dt_tag_t *)taglist->data;
+
+    tags = g_list_prepend(tags, t->tag);
+
+    taglist = g_list_next(taglist);
+  }
+
+  g_list_free_full(taglist, g_free);
+
+  tags = g_list_reverse(tags);
+  return tags;
+}
+
+GList *dt_tag_get_list_export(gint imgid)
+{
+  GList *taglist = NULL;
+  GList *tags = NULL;
+
+  gboolean omit_tag_hierarchy = dt_conf_get_bool("omit_tag_hierarchy");
   gboolean export_private_tags = dt_conf_get_bool("plugins/lighttable/export/export_private_tags");
   gboolean export_tag_synomyms = dt_conf_get_bool("plugins/lighttable/export/export_tag_synonyms");
 
@@ -834,7 +902,7 @@ GList *dt_tag_get_list(gint imgid)
   return dt_util_glist_uniq(tags);
 }
 
-GList *dt_tag_get_hierarchical(gint imgid)
+GList *dt_tag_get_hierarchical_export(gint imgid)
 {
   GList *taglist = NULL;
   GList *tags = NULL;

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -95,6 +95,8 @@ void dt_tag_attach_string_list(const gchar *tags, gint imgid);
 /** detach tag from images. \param[in] tagid if of tag to deattach. \param[in] imgid the image id to attach
  * tag from, if < 0 selected images are used. */
 void dt_tag_detach(guint tagid, gint imgid);
+/** same as above but raises a dt_collection_update_query() */
+void dt_tag_detach_from_gui(guint tagid, gint imgid);
 
 /** detach tags from images that matches name, it is valid to use % to match tag */
 void dt_tag_detach_by_string(const char *name, gint imgid);

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -112,9 +112,17 @@ GList *dt_sort_tag(GList *tags, gboolean byname);
  * tags. */
 GList *dt_tag_get_list(gint imgid);
 
+/** get a list of tags,
+ *  the difference to dt_tag_get_list() is that this one checks option for exportation */
+GList *dt_tag_get_list_export(gint imgid);
+
 /** get a flat list of only hierarchical tags,
  *  the difference to dt_tag_get_attached() is that this one filters out the "darktable|" tags. */
 GList *dt_tag_get_hierarchical(gint imgid);
+
+/** get a flat list of only hierarchical tags,
+ *  the difference to dt_tag_get_hierarchical() is that this one checks option for exportation */
+GList *dt_tag_get_hierarchical_export(gint imgid);
 
 /** get the subset of images from the selected ones that have a given tag attached */
 GList *dt_tag_get_images_from_selection(gint imgid, gint tagid);

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1262,7 +1262,7 @@ static int32_t dt_control_local_copy_images_job_run(dt_job_t *job)
     else
     {
       if (dt_image_local_copy_reset(imgid) == 0)
-        dt_tag_detach(tagid, imgid);
+        dt_tag_detach_from_gui(tagid, imgid);
     }
     t = g_list_delete_link(t, t);
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -386,6 +386,26 @@ void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h,
   cairo_restore(cr);
 }
 
+void dtgtk_cairo_paint_multiply_small(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  cairo_save(cr);
+  const gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+
+  cairo_set_line_width(cr, 0.1);
+  cairo_move_to(cr, 0.3, 0.3);
+  cairo_line_to(cr, 0.7, 0.7);
+  cairo_move_to(cr, 0.7, 0.3);
+  cairo_line_to(cr, 0.3, 0.7);
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+  cairo_restore(cr);
+}
+
 void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   cairo_save(cr);

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -75,6 +75,8 @@ void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a simple minus icon */
 void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a simple multiply icon */
+void dtgtk_cairo_paint_multiply_small(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a treelist icon */
 void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a invert icon */

--- a/src/imageio/storage/flickr.c
+++ b/src/imageio/storage/flickr.c
@@ -278,7 +278,7 @@ static flickcurl_upload_status *_flickr_api_upload_photo(dt_storage_flickr_param
 
   if(imgid)
   {
-    GList *tags_list = dt_tag_get_list(imgid);
+    GList *tags_list = dt_tag_get_list_export(imgid);
     params->tags = dt_util_glist_to_str(",", tags_list);
     g_list_free_full(tags_list, g_free);
   }

--- a/src/imageio/storage/piwigo.c
+++ b/src/imageio/storage/piwigo.c
@@ -984,7 +984,7 @@ int store(dt_imageio_module_storage_t *self, dt_imageio_module_data_t *sdata, co
 
     if(p->export_tags)
     {
-      GList *tags_list = dt_tag_get_list(imgid);
+      GList *tags_list = dt_tag_get_list_export(imgid);
       if(p->tags) g_free(p->tags);
       p->tags = dt_util_glist_to_str(",", tags_list);
       g_list_free_full(tags_list, g_free);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -588,7 +588,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       {
         const char *tagname = ((dt_tag_t *)taglist->data)->leave;
         length = length + strlen(tagname) + 2;
-        if(length < 40)
+        if(length < 50)
           tagstring = dt_util_dstrcat(tagstring, "%s, ", tagname);
         else
         {
@@ -596,9 +596,11 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
           length = strlen(tagname) + 2;
         }
       }
-      if(strlen(tagstring) > 2) tagstring[strlen(tagstring)-2] = '\0';
+      if(tagstring) tagstring[strlen(tagstring)-2] = '\0';
       _metadata_update_value(d->metadata[md_tag_names], tagstring);
     }
+    else _metadata_update_value(d->metadata[md_tag_names], NODATA_STRING);
+
     dt_tag_free_result(&tags);
 
     /* release img */

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -588,7 +588,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       {
         const char *tagname = ((dt_tag_t *)taglist->data)->leave;
         length = length + strlen(tagname) + 2;
-        if(length < 50)
+        if(length < 45)
           tagstring = dt_util_dstrcat(tagstring, "%s, ", tagname);
         else
         {

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -543,9 +543,16 @@ static void reset_sel_on_path_full(GtkTreeModel *model, GtkTreeIter *iter, gbool
   GtkTreeIter child, parent = *iter;
   do
   {
-    gtk_tree_store_set(GTK_TREE_STORE(model), &parent, DT_LIB_TAGGING_COL_SEL, 0, -1);
-    if (gtk_tree_model_iter_children(model, &child, &parent))
-      reset_sel_on_path_full(model, &child, FALSE);
+    if(GTK_IS_TREE_STORE(model))
+    {
+      gtk_tree_store_set(GTK_TREE_STORE(model), &parent, DT_LIB_TAGGING_COL_SEL, 0, -1);
+      if (gtk_tree_model_iter_children(model, &child, &parent))
+        reset_sel_on_path_full(model, &child, FALSE);
+    }
+    else
+    {
+      gtk_list_store_set(GTK_LIST_STORE(model), &parent, DT_LIB_TAGGING_COL_SEL, 0, -1);
+    }
   } while (!root && gtk_tree_model_iter_next(model, &parent));
 }
 
@@ -607,8 +614,15 @@ static void update_sel_on_tree(GtkTreeModel *model)
       GtkTreeIter iter = parent;
       if (find_tag_iter_tagid(model, &iter, ((dt_tag_t *)tag->data)->id))
       {
-        gtk_tree_store_set(GTK_TREE_STORE(model), &iter, DT_LIB_TAGGING_COL_SEL, ((dt_tag_t *)tag->data)->select, -1);
-        propagate_sel_to_parents(model, &iter);
+        if(GTK_IS_TREE_STORE(model))
+        {
+          gtk_tree_store_set(GTK_TREE_STORE(model), &iter, DT_LIB_TAGGING_COL_SEL, ((dt_tag_t *)tag->data)->select, -1);
+          propagate_sel_to_parents(model, &iter);
+        }
+        else
+        {
+          gtk_list_store_set(GTK_LIST_STORE(model), &iter, DT_LIB_TAGGING_COL_SEL, ((dt_tag_t *)tag->data)->select, -1);
+        }
       }
     }
   }
@@ -705,8 +719,9 @@ static void _lib_selection_changed_callback(gpointer instance, dt_lib_module_t *
   {
     init_treeview(self, 1);
   }
-  else if (d->tree_flag)
-    update_sel_on_tree(GTK_TREE_MODEL(d->dictionary_treestore));
+  else
+    update_sel_on_tree(d->tree_flag ? GTK_TREE_MODEL(d->dictionary_treestore)
+                                    : GTK_TREE_MODEL(d->dictionary_liststore));
 }
 
 static void set_keyword(dt_lib_module_t *self)

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -151,11 +151,9 @@ static gboolean set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *pa
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   gboolean visible;
-  gboolean initial = TRUE;
   gchar *tagname = NULL;
   gchar *synonyms = NULL;
-  gtk_tree_model_get(model, iter, DT_LIB_TAGGING_COL_PATH, &tagname, DT_LIB_TAGGING_COL_SYNONYM, &synonyms,
-      DT_LIB_TAGGING_COL_VISIBLE, &initial, -1);
+  gtk_tree_model_get(model, iter, DT_LIB_TAGGING_COL_PATH, &tagname, DT_LIB_TAGGING_COL_SYNONYM, &synonyms, -1);
   if (!d->keyword[0])
     visible = TRUE;
   else
@@ -167,13 +165,10 @@ static gboolean set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *pa
     g_free(haystack);
     g_free(needle);
   }
-  if (initial != visible)
-  {
-    if (d->tree_flag)
-      gtk_tree_store_set(GTK_TREE_STORE(model), iter, DT_LIB_TAGGING_COL_VISIBLE, visible, -1);
-    else
-      gtk_list_store_set(GTK_LIST_STORE(model), iter, DT_LIB_TAGGING_COL_VISIBLE, visible, -1);
-  }
+  if (d->tree_flag)
+    gtk_tree_store_set(GTK_TREE_STORE(model), iter, DT_LIB_TAGGING_COL_VISIBLE, visible, -1);
+  else
+    gtk_list_store_set(GTK_LIST_STORE(model), iter, DT_LIB_TAGGING_COL_VISIBLE, visible, -1);
   g_free(tagname);
   g_free(synonyms);
   return FALSE;
@@ -461,12 +456,27 @@ static void _lib_tagging_tags_changed_callback(gpointer instance, dt_lib_module_
   init_treeview(self, 1);
 }
 
+static void collection_updated_callback(gpointer instance, dt_lib_module_t *self)
+{
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+  d->collection[0] = '\0';
+}
+
 static void raise_signal_tag_changed(dt_lib_module_t *self)
 {
-  // raises change only for other modules
-  dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-  dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+  // when collection is on tag any attach & detach becomes very slow
+  // speeding up when jumping from tag collection to the other
+  // the cost is that tag collection doesn't reflect the tag changes real time
+  if (!d->collection[0])
+  {
+    // raises change only for other modules
+    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
+    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+  }
 }
 
 // find a tag on the tree
@@ -699,12 +709,6 @@ static void _lib_selection_changed_callback(gpointer instance, dt_lib_module_t *
     update_sel_on_tree(GTK_TREE_MODEL(d->dictionary_treestore));
 }
 
-static void collection_updated_callback(gpointer instance, dt_lib_module_t *self)
-{
-  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  d->collection[0] = '\0';
-}
-
 static void set_keyword(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
@@ -764,6 +768,81 @@ static gboolean update_tag_name_per_name(GtkTreeModel *model, GtkTreePath *path,
   }
   g_free(tagname);
   return FALSE;
+}
+
+void init_presets(dt_lib_module_t *self)
+{
+
+}
+
+void *get_params(dt_lib_module_t *self, int *size)
+{
+  char *params = NULL;
+  *size = 0;
+  GList *tags = NULL;
+  const guint count = dt_tag_get_attached(-1, &tags, TRUE);
+
+  if(count)
+  {
+    for(GList *taglist = tags; taglist; taglist = g_list_next(taglist))
+    {
+      params = dt_util_dstrcat(params, "%d,", ((dt_tag_t *)taglist->data)->id);
+    }
+    dt_tag_free_result(&tags);
+    *size = strlen(params);
+    params[*size-1]='\0';
+  }
+  return params;
+}
+
+int set_params(dt_lib_module_t *self, const void *params, int size)
+{
+  if(!params || !size) return 1;
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+
+  const char *buf = (char *)params;
+  if (buf && buf[0])
+  {
+    GtkTreeModel *model = gtk_tree_view_get_model(d->dictionary_view);
+    GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
+    GtkTreeIter iter;
+    const int imgsel = dt_view_get_image_to_act_on();
+    gchar **tokens = g_strsplit(buf, ",", 0);
+    if(tokens)
+    {
+      gchar **entry = tokens;
+      while(*entry)
+      {
+        guint tagid = strtoul(*entry, NULL, 0);
+
+        dt_tag_attach(tagid, imgsel);
+
+        const guint count = dt_tag_images_count(tagid);
+        gtk_tree_model_get_iter_first(store, &iter);
+        if (find_tag_iter_tagid(store, &iter, tagid))
+        {
+          if (d->tree_flag)
+          {
+            gtk_tree_store_set(GTK_TREE_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
+                                    DT_LIB_TAGGING_COL_SEL, 2, -1);
+            calculate_sel_on_tree(GTK_TREE_MODEL(store), &iter);
+          }
+          else
+          {
+            gtk_list_store_set(GTK_LIST_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
+                                    DT_LIB_TAGGING_COL_SEL, 2, -1);
+          }
+        }
+        entry++;
+      }
+    }
+    g_strfreev(tokens);
+    init_treeview(self, 0);
+
+    raise_signal_tag_changed(self);
+    dt_image_synch_xmp(imgsel);
+  }
+  return 0;
 }
 
 static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
@@ -826,7 +905,9 @@ static void detach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
   imgsel = dt_view_get_image_to_act_on();
   GList *affected_images = dt_tag_get_images_from_selection(imgsel, tagid);
 
+  // dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
   dt_tag_detach(tagid, imgsel);
+  // dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
 
   init_treeview(self, 0);
   if (d->tree_flag || !d->suggestion_flag)
@@ -1021,6 +1102,13 @@ static void entry_activated(GtkButton *button, dt_lib_module_t *self)
   new_button_clicked(NULL, self);
 }
 
+static void clear_entry_button_callback(GtkButton *button, dt_lib_module_t *self)
+{
+  dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+  /** clear input box */
+  gtk_entry_set_text(d->entry, "");
+}
+
 static void tag_name_changed(GtkEntry *entry, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
@@ -1030,7 +1118,7 @@ static void tag_name_changed(GtkEntry *entry, dt_lib_module_t *self)
   gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)set_matching_tag_visibility, self);
   if (d->tree_flag && d->keyword[0])
   {
-    gtk_tree_model_foreach(GTK_TREE_MODEL(store), (GtkTreeModelForeachFunc)tree_reveal_func, NULL);
+    gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)tree_reveal_func, NULL);
     gtk_tree_view_expand_all(d->dictionary_view);
   }
 }
@@ -1926,7 +2014,7 @@ static gboolean mouse_scroll_attached(GtkWidget *treeview, GdkEventScroll *event
     gint width, height;
     gtk_widget_get_size_request (GTK_WIDGET(d->attached_window), &width, &height);
     height = height + 10.0 * event->delta_y;
-    height = (height < 100.0) ? 100.0 : (height > 300.0) ? 300.0 : height;
+    height = (height < 100.0) ? 100.0 : (height > 500.0) ? 500.0 : height;
     gtk_widget_set_size_request(GTK_WIDGET(d->attached_window), -1, DT_PIXEL_APPLY_DPI((gint)height));
     dt_conf_set_int("plugins/lighttable/tagging/heightattachedwindow", (gint)height);
     return TRUE;
@@ -1942,7 +2030,7 @@ static gboolean mouse_scroll_dictionary(GtkWidget *treeview, GdkEventScroll *eve
     gint width, height;
     gtk_widget_get_size_request (GTK_WIDGET(d->dictionary_window), &width, &height);
     height = height + 10.0 * event->delta_y;
-    height = (height < 300.0) ? 300.0 : (height > 500.0) ? 500.0 : height;
+    height = (height < 100.0) ? 100.0 : (height > 1000.0) ? 1000.0 : height;
     gtk_widget_set_size_request(GTK_WIDGET(d->dictionary_window), -1, DT_PIXEL_APPLY_DPI((gint)height));
     dt_conf_set_int("plugins/lighttable/tagging/heightdictionarywindow", (gint)height);
     return TRUE;
@@ -2104,7 +2192,7 @@ static void update_layout(dt_lib_module_t *self)
       gtk_list_store_clear(GTK_LIST_STORE(store));
       gtk_tree_view_set_model(GTK_TREE_VIEW(d->dictionary_view), GTK_TREE_MODEL(d->dictionary_treefilter));
       g_object_unref(d->dictionary_treefilter);
-      if (d->completion) gtk_entry_completion_set_model(d->completion, NULL);
+      if (d->completion) gtk_entry_set_completion(d->entry, NULL);
     }
     gtk_widget_set_sensitive(GTK_WIDGET(d->toggle_suggestion_button), FALSE);
   }
@@ -2118,7 +2206,7 @@ static void update_layout(dt_lib_module_t *self)
       gtk_tree_store_clear(GTK_TREE_STORE(store));
       gtk_tree_view_set_model(GTK_TREE_VIEW(d->dictionary_view), GTK_TREE_MODEL(d->dictionary_listfilter));
       g_object_unref(d->dictionary_listfilter);
-      if (d->completion) gtk_entry_completion_set_model(d->completion, GTK_TREE_MODEL(d->dictionary_listfilter));
+      if (d->completion) gtk_entry_set_completion(d->entry, d->completion);
     }
     gtk_widget_set_sensitive(GTK_WIDGET(d->toggle_suggestion_button), TRUE);
   }
@@ -2476,17 +2564,25 @@ void gui_init(dt_lib_module_t *self)
   box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
 
-  // text entry and new button
+  hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+
+  // text entry
   w = gtk_entry_new();
   gtk_entry_set_text(GTK_ENTRY(w), "");
   gtk_widget_set_tooltip_text(w, _("enter tag name"));
   dt_gui_add_help_link(w, "tagging.html#tagging_usage");
-  gtk_box_pack_start(box, w, TRUE, TRUE, 0);
+  gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(tag_name_changed), (gpointer)self);
   g_signal_connect(G_OBJECT(w), "activate", G_CALLBACK(entry_activated), (gpointer)self);
   d->entry = GTK_ENTRY(w);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->entry));
+
+  button = dtgtk_button_new(dtgtk_cairo_paint_multiply_small, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_widget_set_tooltip_text(button, _("clear entry"));
+  gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(clear_entry_button_callback), (gpointer)self);
+  gtk_box_pack_start(box, GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
   // dictionary_view tree view
   w = gtk_scrolled_window_new(NULL, NULL);


### PR DESCRIPTION
Some fixed bugs:

- some records don't appear when filtering the tree view
- when entry completion enabled, gtk error message when entry is changed on tree view
- any attach or detach while jumping from tag collection to the other resets the "go to back work"
- any attach or detach while jumping from tag collection to the other is painfully slow. This is due to the tag collection refresh => The fix consists in not issuing "tag changed" signal as long as "go to back work" is active. This signal is always issued otherwise.
- dt_tag_detach calls collection refresh. Costly and not symmetric with dt_tag_attach. => created a new dt_tag_detach_from_gui (as for attach) not to change the behaviour of control_jobs.c. From my point of view it could be worth to check if this collection refresh is really useful there.

new:

- the user can now define tag presets
- added a button to clear the entry (for those who are not full keyboard ;-) )


