### PR TITLE
Use O_BINARY flag for g_open() Fixes #2842

### DIFF
--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -34,6 +34,11 @@
 #include "win/win.h"
 #endif
 
+#if !defined(O_BINARY)
+// To have portable g_open() on *nix and on Windows
+#define O_BINARY 0
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -355,7 +355,7 @@ void expose(
     /* Store current image surface to snapshot file.
        FIXME: add checks so that we dont make snapshots of preview pipe image surface.
     */
-    int fd = g_open(darktable.develop->proxy.snapshot.filename, O_CREAT | O_WRONLY, 0600);
+    int fd = g_open(darktable.develop->proxy.snapshot.filename, O_CREAT | O_WRONLY | O_BINARY, 0600);
     cairo_surface_write_to_png_stream(image_surface, write_snapshot_data, GINT_TO_POINTER(fd));
     close(fd);
   }


### PR DESCRIPTION
Otherwise g_open() will create the image files in text mode in Windows, which results currupted PNGs