### PR TITLE
Fixing lighttables history compression.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -872,9 +872,15 @@ int dt_history_copy_and_paste_on_selection(int32_t imgid, gboolean merge, GList 
 
 void dt_history_compress_on_image(int32_t imgid)
 {
-  // make sure the right history is in there:
+  // ok, just make sure the current history is written!
   dt_dev_write_history(darktable.develop);
 
+  // We use the global darktable.develop so when we want to use a specific image
+  // for history and masks in the database we have to load it in case it's not there
+  if(!dt_dev_is_current_image(darktable.develop, imgid))
+  {
+    dt_dev_load_image(darktable.develop, imgid); 
+  }
   // compress history, keep disabled modules as documented
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -975,7 +981,8 @@ void dt_history_compress_on_image_and_reload(int32_t imgid)
 
 void dt_history_compress_on_selection()
 {
-  // Get the list of selected images
+
+// Get the list of selected images
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
                               NULL);
@@ -985,6 +992,7 @@ void dt_history_compress_on_selection()
     dt_history_compress_on_image_and_reload(sqlite3_column_int(stmt, 0));
   }
   sqlite3_finalize(stmt);
+
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -993,6 +993,7 @@ void dt_history_compress_on_image(int32_t imgid)
   dt_dev_reload_history_items(darktable.develop);
   dt_dev_write_history(darktable.develop);
   dt_image_synch_xmp(imgid);
+  dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }
 
 void dt_history_compress_on_selection()

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -55,7 +55,6 @@ void dt_history_delete_on_selection();
 /** compress history stack */
 void dt_history_compress_on_selection();
 void dt_history_compress_on_image(int32_t imgid);
-void dt_history_compress_on_image_and_reload(int32_t imgid);
 
 typedef struct dt_history_item_t
 {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -764,6 +764,8 @@ int dt_dev_write_history_item(const int imgid, dt_dev_history_item_t *h, int32_t
 static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable, gboolean no_image, gboolean include_masks)
 {
     GList *history = g_list_nth(dev->history, dev->history_end);
+    // This is the central point where we add some history information
+    // First step: dev->history_end might still point to now invalid history data, so we remove that
     while(history)
     {
       GList *next = g_list_next(history);
@@ -772,6 +774,12 @@ static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module
       dt_dev_free_history_item(hist);
       dev->history = g_list_delete_link(dev->history, history);
       history = next;
+    }
+    // Second step: There might be a leak; dev->history_end - 1 might point to NIL so we remove that too!
+    while ((dev->history_end>0) && (! g_list_nth(dev->history, dev->history_end - 1)))
+    {
+      fprintf(stderr,"\n Leak detected in _dev_add_history_item_ext for %i",dev->history_end - 1);
+      dev->history_end--;
     }
     history = g_list_nth(dev->history, dev->history_end - 1);
     dt_dev_history_item_t *hist = history ? (dt_dev_history_item_t *)(history->data) : 0;

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -182,7 +182,7 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
     if(img < 0)
       dt_history_compress_on_selection();
     else
-      dt_history_compress_on_image_and_reload(img);
+      dt_history_compress_on_image(img);
 
     dt_collection_update_query(darktable.collection);
     dt_control_queue_redraw_center();

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -152,14 +152,41 @@ static void copy_button_clicked(GtkWidget *widget, gpointer user_data)
 
 static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 {
+  gint res = GTK_RESPONSE_YES;
   const int img = dt_view_get_image_to_act_on();
 
-  if(img < 0)
-    dt_history_compress_on_selection();
-  else
-    dt_history_compress_on_image(img);
+  const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-  dt_control_queue_redraw_center();
+  int number;
+  if(img != -1)
+    number = 1;
+  else
+    number = dt_collection_get_selected_count(darktable.collection);
+
+  if (number == 0) return;
+
+  GtkWidget *dialog = gtk_message_dialog_new(
+  GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+    ngettext("do you really want to compress history of %d selected image?",
+             "do you really want to compress history of %d selected images?", number), number);
+#ifdef GDK_WINDOWING_QUARTZ
+  dt_osx_disallow_fullscreen(dialog);
+#endif
+
+  gtk_window_set_title(GTK_WINDOW(dialog), _("compress images' history?"));
+  res = gtk_dialog_run(GTK_DIALOG(dialog));
+  gtk_widget_destroy(dialog);
+
+  if(res == GTK_RESPONSE_YES)
+  {
+    if(img < 0)
+      dt_history_compress_on_selection();
+    else
+      dt_history_compress_on_image_and_reload(img);
+
+    dt_collection_update_query(darktable.collection);
+    dt_control_queue_redraw_center();
+  }
 }
 
 static void copy_parts_button_clicked(GtkWidget *widget, gpointer user_data)

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -704,29 +704,9 @@ static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer u
   if(imgid<0) return;
 
   dt_history_compress_on_image(imgid);
-
-/*  sqlite3_stmt *stmt;
-
-  // then we can get the item to select in the new clean-up history retrieve the position of the module
-  // corresponding to the history end.
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT IFNULL(MAX(num)+1, 0) FROM main.history "
-                                                             "WHERE imgid=?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-
-  if (sqlite3_step(stmt) == SQLITE_ROW)
-    darktable.develop->history_end = sqlite3_column_int(stmt, 0);
-  sqlite3_finalize(stmt);
-
-  // select the new history end corresponding to the one before the history compression
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE main.images SET history_end=?2 WHERE id=?1",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, darktable.develop->history_end);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-
-  dt_dev_reload_history_items(darktable.develop);
-*/
+  // We want to update the modules list and mark latest selected module
+  /* signal history changed */
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -701,11 +701,11 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
 static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer user_data)
 {
   const int32_t imgid = darktable.develop->image_storage.id;
-  if(!imgid) return;
+  if(imgid<0) return;
 
   dt_history_compress_on_image(imgid);
 
-  sqlite3_stmt *stmt;
+/*  sqlite3_stmt *stmt;
 
   // then we can get the item to select in the new clean-up history retrieve the position of the module
   // corresponding to the history end.
@@ -726,6 +726,7 @@ static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer u
   sqlite3_finalize(stmt);
 
   dt_dev_reload_history_items(darktable.develop);
+*/
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -707,10 +707,6 @@ static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer u
 
   sqlite3_stmt *stmt;
 
-  // load new history and write it back to ensure that all history are properly numbered without a gap
-  dt_dev_reload_history_items(darktable.develop);
-  dt_dev_write_history(darktable.develop);
-
   // then we can get the item to select in the new clean-up history retrieve the position of the module
   // corresponding to the history end.
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT IFNULL(MAX(num)+1, 0) FROM main.history "


### PR DESCRIPTION
As the common function for history compression uses the global
darktable.develop we must load the image for every compression.
Before this commit we had these problems

1. compressing history on a selection of images could lead to complete loss of history for the selected images
2. Problems with the masks history have been existing before #2870 

@TurboGit , could you review please?

This is one of the problems with history i am currently aware of, there are probably more things left

1. There might be a history "pollution" like described in #2774. I observed this too, although i could not find a definite way to trigger but ended in a history stack of several hundred entries for a single module easily. (Still hunting this bug.) BTW, I did **not** observe the described num-leak 
2. @aurelienpierre reported situations where compression of history was not possible and he even was not able to load an image with problematic history. See discussion of #2870. I observed it can take quite long to compress a very large history. Also i was not able to load the image as he described when such a large history was existing.
3. As the history compression of many pictures might take a while we could have some progress information?

Anything more to tackle?