### PR TITLE
Fix pipe order

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -131,6 +131,9 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
     _ioppr_move_iop_before(_iop_order_list, "colorreconstruct", "colorout", dont_move);
     _ioppr_move_iop_before(_iop_order_list, "vignette", "colorreconstruct", dont_move);
 
+
+    _ioppr_move_iop_before(_iop_order_list, "dither", "borders", dont_move);
+
     new_version = 2;
   }
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -54,11 +54,82 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
   {
     _ioppr_move_iop_after(_iop_order_list, "colorin", "demosaic", dont_move);
     _ioppr_move_iop_before(_iop_order_list, "colorout", "clahe", dont_move);
-    _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorin", dont_move);
-    _ioppr_insert_iop_after(_iop_order_list, history_list, "rgbcurve", "levels", dont_move);
-    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "grain", dont_move);
-    _ioppr_insert_iop_before(_iop_order_list, history_list, "rgblevels", "rgbcurve", dont_move);
-    _ioppr_move_iop_before(_iop_order_list, "dither", "borders", dont_move);
+
+    // GENERAL RULE FOR SIGNAL PROCESSING/RECONSTRUCTION
+    // pictures are formed through this path :
+    // scene/surfaces/shapes -> atmosphere -> lens -> sensor -> RAW file
+    // we then need to reconstruct/clean the signal the other way :
+    // RAW file -> sensor denoise -> lens profile / deblur -> atmosphere dehaze -> surfaces perspective correction
+
+    // correct exposure in camera RGB space (otherwise, it's not really exposure)
+    _ioppr_move_iop_before(_iop_order_list, "exposure", "colorin", dont_move);
+
+    // move local distorsions/pixel shifts after general distorsions
+    _ioppr_move_iop_before(_iop_order_list, "retouch", "exposure", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "spots", "retouch", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "liquify", "spots", dont_move);
+
+    // move general perspective/distorsions module after lens
+    _ioppr_move_iop_before(_iop_order_list, "clipping", "liquify", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "flip", "clipping", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "ashift", "flip", dont_move);
+
+    // dehaze
+    _ioppr_move_iop_before(_iop_order_list, "hazeremoval", "ashift", dont_move);
+
+    // lens profiles need a pure sensor reading with no correction
+    _ioppr_move_iop_before(_iop_order_list, "lens", "hazeremoval", dont_move);
+
+    // move denoising before any deformation to avoid anisotropic noise creation
+    _ioppr_move_iop_before(_iop_order_list, "bilateral", "lens", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "denoiseprofile", "bilateral", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "demosaic", "denoiseprofile", dont_move);
+
+    // move Lab denoising/reconstruction after input profile where signal is linear
+    // NB: denoising in non-linear spaces makes no sense
+    _ioppr_move_iop_before(_iop_order_list, "colorin", "nlmeans", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "defringe", "nlmeans", dont_move);
+
+    // move frequency filters right after input profile - convolutions need L2 spaces
+    // to respect Parseval's theorem and avoid halos at edges
+    // NB: again, frequency filter in Lab make no sense
+    _ioppr_move_iop_after(_iop_order_list, "atrous", "defringe", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "lowpass", "atrous", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "highpass", "lowpass", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "sharpen", "highpass", dont_move);
+
+    // color adjustments in scene-linear space : move right after colorin
+    _ioppr_move_iop_after(_iop_order_list, "channelmixer", "sharpen", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colorchecker", "channelmixer", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colorbalance", "colorchecker", dont_move);
+
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "colorchecker", dont_move);
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorzones", dont_move);
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "rgbcurve", "basicadj", dont_move);
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "rgblevels", "rgbcurve", dont_move);
+
+    // scene-linear to display-referred encoding
+    // !!! WALL OF THE NON-LINEARITY !!! There is no coming back for colour ratios
+    _ioppr_move_iop_after(_iop_order_list, "basecurve", "colorzones", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "filmic", "basecurve", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colisa", "filmic", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "tonecurve", "colisa", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "levels", "tonecurve", dont_move);
+
+    _ioppr_move_iop_after(_iop_order_list, "shadhi", "levels", dont_move);
+
+    // recover local contrast after non-linear tone edits
+    _ioppr_move_iop_after(_iop_order_list, "bilat", "shadhi", dont_move);
+
+    // display-referred colour edits
+    _ioppr_move_iop_after(_iop_order_list, "colorcorrection", "bilat", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "velvia", "colorcorrection", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "vibrance", "velvia", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colorzones", "vibrance", dont_move);
+
+    // fix clipping before going in colourout
+    _ioppr_move_iop_before(_iop_order_list, "colorreconstruct", "colorout", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "vignette", "colorreconstruct", dont_move);
 
     new_version = 2;
   }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -104,13 +104,13 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
     _ioppr_move_iop_after(_iop_order_list, "colorbalance", "colorchecker", dont_move);
 
     _ioppr_insert_iop_after(_iop_order_list, history_list, "lut3d", "colorchecker", dont_move);
-    _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorzones", dont_move);
+    _ioppr_insert_iop_after(_iop_order_list, history_list, "basicadj", "colorbalance", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "rgbcurve", "basicadj", dont_move);
     _ioppr_insert_iop_after(_iop_order_list, history_list, "rgblevels", "rgbcurve", dont_move);
 
     // scene-linear to display-referred encoding
     // !!! WALL OF THE NON-LINEARITY !!! There is no coming back for colour ratios
-    _ioppr_move_iop_after(_iop_order_list, "basecurve", "colorzones", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "basecurve", "colorbalance", dont_move);
     _ioppr_move_iop_after(_iop_order_list, "filmic", "basecurve", dont_move);
     _ioppr_move_iop_after(_iop_order_list, "colisa", "filmic", dont_move);
     _ioppr_move_iop_after(_iop_order_list, "tonecurve", "colisa", dont_move);


### PR DESCRIPTION
Rewrite the default pipe order to be more compliant with signal processing, with no care for working colour spaces (Lab or RGB).

## Explanations

Let us split the pixelpipe into 4 subsets :

> **camera RGB** -> [input color profile] -> **scene-referred colour pipe** -> [camera transform] -> **display-referred pipe** - > [output colour profile] -> **display RGB**

The subsets will be detailed below. [input color profile] and [output color profile] are stopping points defined by the `colorin` and `colourout` IOPs. [camera transform] is a stopping point defined by `basecurve` or `filmic` IOPs, aka transfer functions that aim at raising mid-tones while adding non-linear contrast, similarly to what film emulsions are doing.

### Camera RGB

Pictures are formed through this path:

> **emitted light** -> [scene/surfaces/shapes (reflection) ] -> [atmosphere (diffusion)] -> [lens (refraction)] -> [sensor (discrete sampling)] -> **RAW file**.

Each step adds errors and defects, so we need to revert them in the opposite order:

> **RAW file** -> [mosaiced denoise] -> [demosaic] -> [demosaiced denoise] -> [lens profile / deblur] -> [atmosphere dehaze] -> [surfaces perspective straigthen] -> **reconstructed light emission signal**.

On this reconstructed light emission, we then apply cropping (`clip`), pixel moving (`liquify`, `spot`, `retouch`), amplification (`exposure`), and finally go to [input color profile] where camera RGB is matched to human colour sensitivity through XYZ profiles.

Notice that, before input colour profiles, camera RGB is not to be confused with a colour signal since camera spectral sensitivity and metamerism has nothing to do with human ones. Only filters treating the RGB layers as gradient fields should be there, no operation decoupling luminance and chrominance should ever happen there, because luminance and chrominance are meaningful only from an human perceptual perspective, and the camera -> human mapping has not yet been performed.

### Scene-referred colour pipe

Here go the Lab and RGB ops that need linearly encoded colours to perform and can work on pixels values outside of [0; 1] range: 

- denoising: `nlmeans` 
- colour reconstruction: `defringe`
- spectral operations: `highpass`, `lowpass`, `sharpen`, `atrous`
- further colour calibration/profiling: `colorchecker`, `lut3d`, `channelmixer`
- colour adjustement working in RGB (whether they expect linear RGB or not): `colorbalance`, `rgbcurve`, `rgblevels`, `basicadj`

### Display-referred pipe

These are the colour adjustments belonging to the legacy image processing workflow, expecting non-linear encodings raising mid-tones and pixels values clamped between [0; 1], so mostly the Lab colour adjustments:

- global contrast enhancement: `colisa`, `tonecurve`, `levels`, `shadhi`, 
- local contrast enhancement: `bilat`,
- Lab colour adjustments: `colorcorrection`, `velvia`, `vibrance`, `colorzones`
- clipped highlights reconstruction: `colorreconstruct`, just before going in `colorout` 

### Display RGB

Arguably, no module should ever be there, because their colour would be unmanaged (possibly an issue for borders and watermark raster inputs), but I haven't touched at this part.