### PR TITLE
Change open preference button style from toggle button to button

### DIFF
--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -113,7 +113,7 @@ void gui_init(dt_lib_module_t *self)
   // that's done so that buttons added via Lua will come first.
 
   /* create the preference button */
-  d->preferences_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  d->preferences_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_box_pack_end(GTK_BOX(self->widget), d->preferences_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->preferences_button, _("show global preferences"));
   g_signal_connect(G_OBJECT(d->preferences_button), "clicked", G_CALLBACK(_lib_preferences_button_clicked),


### PR DESCRIPTION
In current 2.7 master the open preference button has toggle button style, which means, after closing the preference dialog, the open preference button is shown as active:
![PreferenceButton](https://user-images.githubusercontent.com/51910609/64427266-1b75bb00-d0b1-11e9-9907-70b37465d4e1.png)
This PR changes the button to a standard button, as in version 2.6.2
