### PR TITLE
Add all default modules that can't be disabled but are hidden into hi…

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -987,6 +987,22 @@ void dt_history_compress_on_selection()
   sqlite3_finalize(stmt);
 }
 
+gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
+{
+  gboolean result = FALSE;
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+    dt_database_get(darktable.db),
+    "SELECT imgid FROM main.history WHERE imgid= ?1 AND operation = ?2", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, operation, -1, SQLITE_TRANSIENT);
+  if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
+  sqlite3_finalize(stmt);
+
+  return result;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -70,6 +70,9 @@ GList *dt_history_get_items(int32_t imgid, gboolean enabled);
 /** get list of history items for image as a nice string */
 char *dt_history_get_items_as_string(int32_t imgid);
 
+/* check if a module exists in the history of corresponding image */
+gboolean dt_history_check_module_exists(int32_t imgid, const char *operation);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
…story.

This ensures that the corresponding module have an entry into the database
and into the XMP. This is needed to have proper handling of the reorder
of the modules.

Also, the corresponding entries are hidden from the history GUI.

Part of #2905.