### PR TITLE
Fix instance menu initialization when no module groups are selected

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2464,6 +2464,9 @@ void enter(dt_view_t *self)
     g_free(active_plugin);
   }
 
+  // update module multishow state now modules are loaded
+  dt_dev_modules_update_multishow(dev);
+
   // image should be there now.
   float zoom_x, zoom_y;
   dt_dev_check_zoom_bounds(dev, &zoom_x, &zoom_y, DT_ZOOM_FIT, 0, NULL, NULL);


### PR DESCRIPTION
When no module groups selection was restored from previous start, nothing updates the instance menu, and all entries are disabled until a group is selected (see #2726). This commit forces module instance status refresh after entering the darkroom.

I was not sure where to put this, it may be better somewhere else.

Fixes #2726