### PR TITLE
Filter exiv2 output in get_image_iso()

### DIFF
--- a/tools/noise/subr.sh
+++ b/tools/noise/subr.sh
@@ -275,7 +275,7 @@ get_image_iso() {
 
 	tool_installed exiv2
 
-	iso=$(get_exif_key "$file" Exif.Photo.ISOSpeedRatings)
+	iso=$(get_exif_key "$file" Exif.Photo.ISOSpeedRatings | grep -o '[[:digit:]]*')
 
 	if [ -z "$iso" -o "$iso" = "65535" ]; then
 		iso=$(get_exif_key "$file" Exif.Photo.RecommendedExposureIndex)


### PR DESCRIPTION
In at least some cases (including my current case of exiv2 0.26 and Olympus *.orf files) there is extra output ("IMAGE ORF") from exiv2 that seems impossible to suppress using any combination of options. Since this is expected to return a string of digits or nothing, use grep to explicitly filter for this.