### PR TITLE
Fix shortcut to hide navigation thumbnail

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -566,12 +566,12 @@ static gboolean _lib_navigation_leave_notify_callback(GtkWidget *widget, GdkEven
 
 void init_key_accels(dt_lib_module_t *self)
 {
-  dt_accel_register_lib(self, NC_("accel", "toggle navigation thumbnail visibility"), GDK_KEY_N, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+  dt_accel_register_lib(self, NC_("accel", "hide navigation thumbnail"), GDK_KEY_N, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
 }
 
 void connect_key_accels(dt_lib_module_t *self)
 {
-  dt_accel_connect_lib(self, "toggle navigation thumbnail visibility",
+  dt_accel_connect_lib(self, "hide navigation thumbnail",
                      g_cclosure_new(G_CALLBACK(_lib_navigation_collapse_callback), self, NULL));
 }
 

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -571,7 +571,7 @@ void init_key_accels(dt_lib_module_t *self)
 
 void connect_key_accels(dt_lib_module_t *self)
 {
-  dt_accel_connect_lib(self, "hide navigation thumbnail",
+  dt_accel_connect_lib(self, "toggle navigation thumbnail visibility",
                      g_cclosure_new(G_CALLBACK(_lib_navigation_collapse_callback), self, NULL));
 }
 


### PR DESCRIPTION
Fixes #2483

Keeping "hide navigation thumbnail" would maybe be more consistent (with histogram hiding shortcut) but it would break already customized shortcuts.