### PR TITLE
Fixing history, easier to read than numerous commits in PR #2898

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -874,9 +874,12 @@ void dt_history_compress_on_image(int32_t imgid)
 {
   if (imgid < 0) return;
 
+  // As darktable.develop->image_storage.id changes while processing the history we have to remember now
+  const bool in_darkroom = (dt_dev_is_current_image(darktable.develop, imgid));
+
   // We use the global darktable.develop so if we want to use a specific images
   // history and masks in the database we have to load it.
-  if(!dt_dev_is_current_image(darktable.develop, imgid))
+  if(!in_darkroom)
   {
     darktable.develop->iop = dt_iop_load_modules(darktable.develop);
     dt_dev_read_history_ext(darktable.develop, imgid, FALSE);
@@ -968,7 +971,7 @@ void dt_history_compress_on_image(int32_t imgid)
   }
 
   // load new history and write it back to ensure that all history are properly numbered without a gap
-  if(dt_dev_is_current_image(darktable.develop, imgid))
+  if(in_darkroom)
     dt_dev_reload_history_items(darktable.develop);
 
   // then we can get the item to select in the new clean-up history retrieve the position of the module
@@ -990,11 +993,12 @@ void dt_history_compress_on_image(int32_t imgid)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  if(dt_dev_is_current_image(darktable.develop, imgid))
+  if(in_darkroom)
     dt_dev_reload_history_items(darktable.develop);
 
   dt_dev_write_history_ext(darktable.develop,imgid);
   dt_image_synch_xmp(imgid);
+
   // We don't have to do this here; it's done in darkroom mode only.
   // dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -55,7 +55,6 @@ void dt_history_delete_on_selection();
 /** compress history stack */
 void dt_history_compress_on_selection();
 void dt_history_compress_on_image(int32_t imgid);
-void dt_history_compress_on_image_and_reload(int32_t imgid);
 
 typedef struct dt_history_item_t
 {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -761,19 +761,35 @@ int dt_dev_write_history_item(const int imgid, dt_dev_history_item_t *h, int32_t
   return 0;
 }
 
-static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable, gboolean no_image, gboolean include_masks)
+// Fix leaks at the too of the history
+static void _dev_history_rm_topleaks(dt_develop_t *dev)
 {
+    // fprintf(stderr,"\n  Fixing history items: ");
     GList *history = g_list_nth(dev->history, dev->history_end);
+    // First step: dev->history_end might still point to now invalid history data, so we remove that
     while(history)
     {
       GList *next = g_list_next(history);
       dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-      // printf("removing obsoleted history item: %s\n", hist->module->op);
+      // fprintf(stderr,"removing obsolete: %s , ", hist->module->op);
       dt_dev_free_history_item(hist);
       dev->history = g_list_delete_link(dev->history, history);
       history = next;
     }
-    history = g_list_nth(dev->history, dev->history_end - 1);
+    // Second step: There might be a leak; dev->history_end - 1 might point to NIL so we remove that too!
+    while ((dev->history_end>0) && (! g_list_nth(dev->history, dev->history_end - 1)))
+    {
+      // fprintf(stderr,"removing NIL %i , ",dev->history_end - 1);
+      dev->history_end--;
+    }
+    // fprintf(stderr,"done");
+}
+
+static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module, gboolean enable, gboolean no_image, gboolean include_masks)
+{
+    _dev_history_rm_topleaks(dev);
+
+    GList *history = g_list_nth(dev->history, dev->history_end - 1);
     dt_dev_history_item_t *hist = history ? (dt_dev_history_item_t *)(history->data) : 0;
     if(!history // if no history yet, push new item for sure.
        || module != hist->module
@@ -996,15 +1012,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
   dt_dev_pop_history_items(dev, 0);
 
   // remove unused history items:
-  GList *history = g_list_nth(dev->history, dev->history_end);
-  while(history)
-  {
-    GList *next = g_list_next(history);
-    dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
-    dt_dev_free_history_item(hist);
-    dev->history = g_list_delete_link(dev->history, history);
-    history = next;
-  }
+  _dev_history_rm_topleaks(dev);
   dt_dev_read_history(dev);
 
   // we have to add new module instances first
@@ -1048,6 +1056,7 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
     }
     modules = g_list_next(modules);
   }
+  _dev_history_rm_topleaks(dev);
 
   dt_dev_pop_history_items(dev, dev->history_end);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -701,35 +701,13 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
 static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer user_data)
 {
   const int32_t imgid = darktable.develop->image_storage.id;
-  if(!imgid) return;
+  if(imgid<0) return;
 
   dt_history_compress_on_image(imgid);
 
-  sqlite3_stmt *stmt;
-
-  // load new history and write it back to ensure that all history are properly numbered without a gap
-  dt_dev_reload_history_items(darktable.develop);
-  dt_dev_write_history(darktable.develop);
-
-  // then we can get the item to select in the new clean-up history retrieve the position of the module
-  // corresponding to the history end.
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT IFNULL(MAX(num)+1, 0) FROM main.history "
-                                                             "WHERE imgid=?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-
-  if (sqlite3_step(stmt) == SQLITE_ROW)
-    darktable.develop->history_end = sqlite3_column_int(stmt, 0);
-  sqlite3_finalize(stmt);
-
-  // select the new history end corresponding to the one before the history compression
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE main.images SET history_end=?2 WHERE id=?1",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, darktable.develop->history_end);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-
-  dt_dev_reload_history_items(darktable.develop);
+  // We want to update the modules list and mark latest selected module
+  /* signal history changed */
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }
 


### PR DESCRIPTION
This pr is a replacement for #2898 to make testing and review easier.

Current history management has two significant bugs most obvious after compression in lighttable mode. There are several issues, see #2774, #2420, #2514, #2775

1. At several places there might be 'leaks' in the history stack, there can be invalid items above dev->history_end or NIL items at the top of stack.

2. The compression code is simply wrong for use within lighttable mode because it uses the global history stack with darktable.development->history_end without making sure the history for a specific image is used.

This pr 

1. takes care for the leaks in development.c
2. makes sure, the correct history stack for an image is used
3. uses code for compression in common/history.c for lighttable & darkroom history compression.
4. Adds a checkbox when compressing history for selections 

@TurboGit -- hope this helps for reviewing / testing.
