### PR TITLE
Change variance stabilization transform of denoiseprofile and add an auto mode to denoiseprofile

### DIFF
--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -324,11 +324,10 @@ denoiseprofile_finish_v2(read_only image2d_t in, global float4* U2, write_only i
 
   float4 px = ((float4)u2.w > (float4)0.0f ? u2/u2.w : (float4)0.0f);
 
-  float4 a0 = 2.0f / (sqrt(a) * (2.0f - p));
-  float4 a1 = (1.0f + p / 2.0f) / (2.0f * a0 * a0 * (1.0f - p / 2.0f) / a);
-  float4 delta = px * px + a * 2000.0f * (float4)bias + 15.0f * 4.0f * a0 * a1;
-  float4 z = (px + sqrt(fmax((float4)0.0f, delta))) / (2.0f * a0);
-  px = native_powr(z, 1.0f / (1.0f - p / 2.0f)) - b;
+  float4 delta = px * px + (float4)bias;
+  float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
+  float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
+  px = native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b;
   px = px * wb;
   px.w = alpha;
 
@@ -373,11 +372,10 @@ denoiseprofile_backtransform_v2(read_only image2d_t in, write_only image2d_t out
   float4 px = read_imagef(in, sampleri, (int2)(x, y));
   float alpha = px.w;
 
-  float4 a0 = 2.0f / (sqrt(a) * (2.0f - p));
-  float4 a1 = (1.0f + p / 2.0f) / (2.0f * a0 * a0 * (1.0f - p / 2.0f) / a);
-  float4 delta = px * px + a * 2000.0f * (float4)bias + 15.0f * 4.0f * a0 * a1;
-  float4 z = (px + sqrt(fmax((float4)0.0f, delta))) / (2.0f * a0);
-  px = native_powr(z, 1.0f / (1.0f - p / 2.0f)) - b;
+  float4 delta = px * px + (float4)bias;
+  float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
+  float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
+  px = native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b;
   px = px * wb;
   px.w = alpha;
 

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -327,8 +327,7 @@ denoiseprofile_finish_v2(read_only image2d_t in, global float4* U2, write_only i
   float4 a0 = 2.0f / (sqrt(a) * (2.0f - p));
   float4 a1 = (1.0f + p / 2.0f) / (2.0f * a0 * a0 * (1.0f - p / 2.0f) / a);
   float4 delta = px * px + a * 2000.0f * (float4)bias + 15.0f * 4.0f * a0 * a1;
-  float4 positive_delta = delta > 0.0f ? delta : (float4)0.0f;
-  float4 z = (px + sqrt(positive_delta)) / (2.0f * a0);
+  float4 z = (px + sqrt(fmax((float4)0.0f, delta))) / (2.0f * a0);
   px = native_powr(z, 1.0f / (1.0f - p / 2.0f)) - b;
   px = px * wb;
   px.w = alpha;
@@ -377,8 +376,7 @@ denoiseprofile_backtransform_v2(read_only image2d_t in, write_only image2d_t out
   float4 a0 = 2.0f / (sqrt(a) * (2.0f - p));
   float4 a1 = (1.0f + p / 2.0f) / (2.0f * a0 * a0 * (1.0f - p / 2.0f) / a);
   float4 delta = px * px + a * 2000.0f * (float4)bias + 15.0f * 4.0f * a0 * a1;
-  float4 positive_delta = delta > 0.0f ? delta : (float4)0.0f;
-  float4 z = (px + sqrt(positive_delta)) / (2.0f * a0);
+  float4 z = (px + sqrt(fmax((float4)0.0f, delta))) / (2.0f * a0);
   px = native_powr(z, 1.0f / (1.0f - p / 2.0f)) - b;
   px = px * wb;
   px.w = alpha;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2956,6 +2956,7 @@ void init(dt_iop_module_t *module)
   }
   tmp.fix_anscombe_and_nlmeans_norm = TRUE;
   tmp.wb_adaptive_anscombe = TRUE;
+  tmp.upgrade_vst = TRUE;
   memcpy(module->params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
 }
@@ -3145,6 +3146,9 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
       gtk_widget_hide(g->box_wavelets);
       gtk_widget_hide(g->box_variance);
       gtk_widget_show_all(g->box_nlm);
+      gtk_widget_set_visible(g->radius, FALSE);
+      gtk_widget_set_visible(g->nbhood, FALSE);
+      gtk_widget_set_visible(g->scattering, FALSE);
       break;
     case 2:
       p->mode = MODE_WAVELETS;
@@ -3165,7 +3169,10 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
       gtk_widget_show_all(g->box_variance);
       break;
   }
-  gtk_widget_set_visible(g->overshooting, (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO));
+  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  gtk_widget_set_visible(g->shadows, !auto_mode);
+  gtk_widget_set_visible(g->bias, !auto_mode);
+  gtk_widget_set_visible(g->overshooting, auto_mode);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -3253,6 +3260,9 @@ void gui_update(dt_iop_module_t *self)
       gtk_widget_hide(g->box_wavelets);
       gtk_widget_hide(g->box_variance);
       gtk_widget_show_all(g->box_nlm);
+      gtk_widget_set_visible(g->radius, FALSE);
+      gtk_widget_set_visible(g->nbhood, FALSE);
+      gtk_widget_set_visible(g->scattering, FALSE);
       break;
     case MODE_WAVELETS:
       combobox_index = 2;
@@ -3278,7 +3288,10 @@ void gui_update(dt_iop_module_t *self)
       break;
   }
   dt_bauhaus_combobox_set(g->mode, combobox_index);
-  gtk_widget_set_visible(g->overshooting, (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO));
+  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  gtk_widget_set_visible(g->shadows, !auto_mode);
+  gtk_widget_set_visible(g->bias, !auto_mode);
+  gtk_widget_set_visible(g->overshooting, auto_mode);
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -373,14 +373,35 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     dt_iop_denoiseprofile_params_v7_t v7;
     if(old_version < 7)
     {
-      // first update to v6
+      // first update to v7
       if(legacy_params(self, old_params, old_version, &v7, 7)) return 1;
     }
     else
-      memcpy(&v7, old_params, sizeof(v7)); // was v6 already
+      memcpy(&v7, old_params, sizeof(v7)); // was v7 already
     dt_iop_denoiseprofile_params_t *v8 = new_params;
+    v8->radius = v7.radius;
+    v8->strength = v7.strength;
+    v8->mode = v7.mode;
+    v8->nbhood = v7.nbhood;
+    for(int k = 0; k < 3; k++)
+    {
+      v8->a[k] = v7.a[k];
+      v8->b[k] = v7.b[k];
+    }
+    for(int b = 0; b < DT_IOP_DENOISE_PROFILE_BANDS; b++)
+    {
+      for(int c = 0; c < DT_DENOISE_PROFILE_NONE; c++)
+      {
+        v8->x[c][b] = v7.x[c][b];
+        v8->y[c][b] = v7.y[c][b];
+      }
+    }
+    v8->scattering = v7.scattering;
+    v8->central_pixel_weight = v7.central_pixel_weight;
+    v8->fix_anscombe_and_nlmeans_norm = v7.fix_anscombe_and_nlmeans_norm;
+    v8->wb_adaptive_anscombe = v7.wb_adaptive_anscombe;
     v8->shadows = 1.0f;
-    v8->bias = 15.0f;
+    v8->bias = 0.0f;
     v8->upgrade_vst = FALSE;
     return 0;
   }

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -579,12 +579,10 @@ static inline void precondition(const float *const in, float *const buf, const i
 }
 
 static inline void precondition_v2(const float *const in, float *const buf, const int wd, const int ht,
-                                const float a, const float p[3], const float b, const float wb[3])
+                                   const float a, const float p[3], const float b, const float wb[3])
 {
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, ht, in, wd, a, p, b, wb) \
-  schedule(static)
+#pragma omp parallel for default(none) dt_omp_firstprivate(buf, ht, in, wd, a, p, b, wb) schedule(static)
 #endif
   for(int j = 0; j < ht; j++)
   {
@@ -594,7 +592,7 @@ static inline void precondition_v2(const float *const in, float *const buf, cons
     {
       for(int c = 0; c < 3; c++)
       {
-        buf2[c] = 2.0f * powf(MAX(in2[c]/wb[c]+b,0.0f), -p[c]/2+1) / ((-p[c]+2) * sqrt(a));
+        buf2[c] = 2.0f * powf(MAX(in2[c] / wb[c] + b, 0.0f), -p[c] / 2 + 1) / ((-p[c] + 2) * sqrt(a));
       }
       buf2 += 4;
       in2 += 4;
@@ -639,8 +637,8 @@ static inline void backtransform(float *const buf, const int wd, const int ht, c
   }
 }
 
-static inline void backtransform_v2(float *const buf, const int wd, const int ht, const float a,
-                                 const float p[3], const float b, const float bias, const float wb[3])
+static inline void backtransform_v2(float *const buf, const int wd, const int ht, const float a, const float p[3],
+                                    const float b, const float bias, const float wb[3])
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
@@ -655,13 +653,13 @@ static inline void backtransform_v2(float *const buf, const int wd, const int ht
       for(int c = 0; c < 3; c++)
       {
         const float x = buf2[c];
-        float alpha = 2.0/(sqrt(a)*(2.0-p[c]));
-        float beta = 1.0-p[c]/2.0;
+        float alpha = 2.0 / (sqrt(a) * (2.0 - p[c]));
+        float beta = 1.0 - p[c] / 2.0;
         float a0 = alpha;
-        float a1 = (1.0-beta)/(2.0*alpha*beta*alpha/a);
-        float delta = MAX(x*x + a * 2000.0f * bias + 15.0f * 4.0*a0*a1, 0.0f);
-        float z1 = (x + sqrt(delta))/(2.0*a0);
-        buf2[c] = powf(z1, 1.0/beta) - b;
+        float a1 = (1.0 - beta) / (2.0 * alpha * beta * alpha / a);
+        float delta = MAX(x * x + a * 2000.0f * bias + 15.0f * 4.0 * a0 * a1, 0.0f);
+        float z1 = (x + sqrt(delta)) / (2.0 * a0);
+        buf2[c] = powf(z1, 1.0 / beta) - b;
         buf2[c] *= wb[c];
       }
       buf2 += 4;
@@ -2140,8 +2138,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 2, sizeof(int), (void *)&width);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 3, sizeof(int), (void *)&height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 4, 4 * sizeof(float), (void *)&aa);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 5, 4 * sizeof(float),
-                             (void *)&sigma2);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 5, 4 * sizeof(float), (void *)&sigma2);
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_denoiseprofile_precondition, sizes);
     if(err != CL_SUCCESS) goto error;
   }
@@ -2455,8 +2452,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 2, sizeof(int), (void *)&width);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 3, sizeof(int), (void *)&height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 4, 4 * sizeof(float), (void *)&aa);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 5, 4 * sizeof(float),
-                             (void *)&sigma2);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 5, 4 * sizeof(float), (void *)&sigma2);
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_denoiseprofile_precondition, sizes);
     if(err != CL_SUCCESS) goto error;
   }
@@ -2652,15 +2648,12 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   if(!d->upgrade_vst)
   {
-    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 0, sizeof(cl_mem),
-                             (void *)&dev_tmp);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 1, sizeof(cl_mem),
-                             (void *)&dev_out);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 0, sizeof(cl_mem), (void *)&dev_tmp);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 1, sizeof(cl_mem), (void *)&dev_out);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 2, sizeof(int), (void *)&width);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 3, sizeof(int), (void *)&height);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 4, 4 * sizeof(float), (void *)&aa);
-    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 5, 4 * sizeof(float),
-                             (void *)&sigma2);
+    dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 5, 4 * sizeof(float), (void *)&sigma2);
     err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_denoiseprofile_backtransform, sizes);
     if(err != CL_SUCCESS) goto error;
   }
@@ -2804,7 +2797,8 @@ void reload_defaults(dt_iop_module_t *module)
     }
     const float a = g->interpolated.a[1];
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->wb_adaptive_anscombe = TRUE;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius = MIN((unsigned)(1.0f + a * 15000.0f + a * a * 300000.0f), 8);
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius
+        = MIN((unsigned)(1.0f + a * 15000.0f + a * a * 300000.0f), 8);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->nbhood = 7.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->scattering = MIN(3000.0f * a, 1.0f);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->central_pixel_weight = 0.1f;
@@ -3691,9 +3685,9 @@ void gui_init(dt_iop_module_t *self)
   g->upgrade_vst = gtk_check_button_new_with_label(_("upgrade algorithm"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->upgrade_vst), p->upgrade_vst);
   gtk_widget_set_tooltip_text(g->upgrade_vst, _("upgrade the variance stabilizing algorithm.\n"
-                                                 "new algorithm extends the current one.\n"
-                                                 "it is more flexible but could give small\n"
-                                                 "differences in the images already processed."));
+                                                "new algorithm extends the current one.\n"
+                                                "it is more flexible but could give small\n"
+                                                "differences in the images already processed."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->upgrade_vst, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->upgrade_vst), "toggled", G_CALLBACK(upgrade_vst_callback), self);
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -485,10 +485,10 @@ void init_presets(dt_iop_module_so_t *self)
 {
   // these blobs were exported as dtstyle and copied from there:
   add_preset(self, _("chroma (use on 1st instance)"),
-             "gz03eJxjYGiwZ2B44MAApmGgYf+22P2WdQpGVtxijKbJe3lMs3bfNWFEyNsBCaB6B3uEPvLExKP+2XUv/2dnxslqf+Cdsb3skXp7iDx5GORGEAYAkHIf3g==", 7,
+             "gz03eJxjYGiwZ2B44MAApkEYGYDF9m+L3W9Zp2BkxS3GaJq8l8c0a/ddE0aEGjsgAVTngKSfPDHxqH923cv/2ZlxstofeGdsL3uk3h4iTx4GuRGGAWheIV0=", 8,
              "gz12eJxjZGBgEGYAgRNODESDBnsIHll8AM62GP8=", 7);
   add_preset(self, _("luma (use on 2nd instance)"),
-             "gz03eJxjYGiwZ2B44DBr5kw7Bjho2O9nGWDpPnef5SU9VdNEjucm4ZnWpowIeZBaoD4HIAbpJ1/M78Ef2xOq2na/yxfaGWb/sCtsXQqVJxszgNwJAATFIno=", 7,
+             "gz03eJxjYGiwZ2B44DBr5kw7BjAbGYD4Dfv9LAMs3efus7ykp2qayPHcJDzT2pQRoQaojwGozsEeoZ88Mb8Hf2xPqGrb/S5faGeY/cOusHUpVJ5szMAIxQD2liP5", 8,
              "gz12eJxjZGBgEGAAgR4nBqJBgz0Ejyw+AIdGGMA=", 7);
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3026,6 +3026,8 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm, !p->fix_anscombe_and_nlmeans_norm);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->upgrade_vst), p->upgrade_vst);
   gtk_widget_set_visible(g->upgrade_vst, !p->upgrade_vst);
+  gtk_widget_set_visible(g->shadows, p->upgrade_vst);
+  gtk_widget_set_visible(g->bias, p->upgrade_vst);
 }
 
 void gui_reset(dt_iop_module_t *self)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3264,7 +3264,7 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->radius, p->radius);
   dt_bauhaus_slider_set(g->nbhood, p->nbhood);
   dt_bauhaus_slider_set_soft(g->strength, p->strength);
-  dt_bauhaus_slider_set(g->overshooting, p->overshooting);
+  dt_bauhaus_slider_set_soft(g->overshooting, p->overshooting);
   dt_bauhaus_slider_set(g->shadows, p->shadows);
   dt_bauhaus_slider_set_soft(g->bias, p->bias);
   dt_bauhaus_slider_set_soft(g->scattering, p->scattering);
@@ -3326,10 +3326,6 @@ void gui_update(dt_iop_module_t *self)
     dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
   }
   dt_bauhaus_combobox_set(g->mode, combobox_index);
-  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
-  gtk_widget_set_visible(g->shadows, !auto_mode);
-  gtk_widget_set_visible(g->bias, !auto_mode);
-  gtk_widget_set_visible(g->overshooting, auto_mode);
   if(p->a[0] == -1.0)
   {
     dt_bauhaus_combobox_set(g->profile, 0);
@@ -3353,8 +3349,10 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm, !p->fix_anscombe_and_nlmeans_norm);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->upgrade_vst), p->upgrade_vst);
   gtk_widget_set_visible(g->upgrade_vst, !p->upgrade_vst);
-  gtk_widget_set_visible(g->shadows, p->upgrade_vst);
-  gtk_widget_set_visible(g->bias, p->upgrade_vst);
+  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  gtk_widget_set_visible(g->overshooting, auto_mode);
+  gtk_widget_set_visible(g->shadows, p->upgrade_vst && !auto_mode);
+  gtk_widget_set_visible(g->bias, p->upgrade_vst && !auto_mode);
 }
 
 void gui_reset(dt_iop_module_t *self)
@@ -3745,8 +3743,9 @@ static void upgrade_vst_callback(GtkWidget *widget, dt_iop_module_t *self)
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   p->upgrade_vst = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-  gtk_widget_set_visible(g->shadows, p->upgrade_vst);
-  gtk_widget_set_visible(g->bias, p->upgrade_vst);
+  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  gtk_widget_set_visible(g->shadows, p->upgrade_vst && !auto_mode);
+  gtk_widget_set_visible(g->bias, p->upgrade_vst && !auto_mode);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -3763,6 +3762,7 @@ void gui_init(dt_iop_module_t *self)
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
   dt_bauhaus_slider_enable_soft_boundaries(g->strength, 0.001f, 1000.0f);
   g->overshooting = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 2);
+  dt_bauhaus_slider_enable_soft_boundaries(g->overshooting, 0.001f, 1000.0f);
   g->shadows = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.8f, .05, 1.f, 2);
   g->bias = dt_bauhaus_slider_new_with_range(self, -10.0f, 10.0f, 1.0f, 0.f, 1);
   dt_bauhaus_slider_enable_soft_boundaries(g->bias, -1000.0f, 1000.0f);
@@ -3903,7 +3903,6 @@ void gui_init(dt_iop_module_t *self)
                                                 "differences in the images already processed."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->upgrade_vst, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->upgrade_vst), "toggled", G_CALLBACK(upgrade_vst_callback), self);
-
 
   gtk_widget_show_all(g->box_nlm);
   gtk_widget_show_all(g->box_wavelets);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3311,20 +3311,24 @@ void gui_update(dt_iop_module_t *self)
       }
       break;
   }
+  float a = p->a[1];
+  if(p->a[0] == -1.0)
+  {
+    dt_noiseprofile_t interpolated = dt_iop_denoiseprofile_get_auto_profile(self);
+    a = interpolated.a[1];
+  }
   if((p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO))
   {
     const float gain = p->overshooting;
-    float a = p->a[1];
-    if(p->a[0] == -1.0)
-    {
-      dt_noiseprofile_t interpolated = dt_iop_denoiseprofile_get_auto_profile(self);
-      a = interpolated.a[1];
-    }
     dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
     dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
     dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
     dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
   }
+  dt_bauhaus_slider_set_default(g->radius, infer_radius_from_profile(a));
+  dt_bauhaus_slider_set_default(g->scattering, infer_scattering_from_profile(a));
+  dt_bauhaus_slider_set_default(g->shadows, infer_shadows_from_profile(a));
+  dt_bauhaus_slider_set_default(g->bias, infer_bias_from_profile(a));
   dt_bauhaus_combobox_set(g->mode, combobox_index);
   if(p->a[0] == -1.0)
   {
@@ -3772,7 +3776,7 @@ void gui_init(dt_iop_module_t *self)
   g->nbhood = dt_bauhaus_slider_new_with_range(self, 1.0f, 30.0f, 1.f, 7.f, 0);
   g->scattering = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01, 0.0f, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->scattering, 0.0, 20.0);
-  g->central_pixel_weight = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01, 0.0f, 2);
+  g->central_pixel_weight = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01, 0.1f, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->central_pixel_weight, 0.0, 10.0);
   g->channel = dt_conf_get_int("plugins/darkroom/denoiseprofile/gui_channel");
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3235,10 +3235,22 @@ static void overshooting_callback(GtkWidget *w, dt_iop_module_t *self)
     dt_noiseprofile_t interpolated = dt_iop_denoiseprofile_get_auto_profile(self);
     a = interpolated.a[1];
   }
+  // set the sliders as visible while we are setting their values
+  // otherwise a log message appears
+  gtk_widget_set_visible(g->radius, TRUE);
+  gtk_widget_set_visible(g->scattering, TRUE);
+  gtk_widget_set_visible(g->shadows, TRUE);
+  gtk_widget_set_visible(g->bias, TRUE);
   dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
   dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
   dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
   dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
+  // set back the sliders to invisible
+  gtk_widget_set_visible(g->radius, FALSE);
+  gtk_widget_set_visible(g->scattering, FALSE);
+  gtk_widget_set_visible(g->shadows, FALSE);
+  gtk_widget_set_visible(g->bias, FALSE);
+
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2707,9 +2707,9 @@ void reload_defaults(dt_iop_module_t *module)
     }
     const float a = g->interpolated.a[1];
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->wb_adaptive_anscombe = TRUE;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius = MIN((unsigned)(1.0f + a * 15000.0f + a * a * 300000.0f), 10);
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius = MIN((unsigned)(1.0f + a * 15000.0f + a * a * 300000.0f), 8);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->nbhood = 7.0f;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->scattering = MIN(3000.0f * a, 1.5f);
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->scattering = MIN(3000.0f * a, 1.0f);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->central_pixel_weight = 0.1f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->strength = 1.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->shadows = MAX(0.1f - 0.1 * logf(a), 0.7f);
@@ -3454,7 +3454,7 @@ void gui_init(dt_iop_module_t *self)
   g->profile = dt_bauhaus_combobox_new(self);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
   dt_bauhaus_slider_enable_soft_boundaries(g->strength, 0.001f, 1000.0f);
-  g->shadows = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.8f, .01, 1.f, 3);
+  g->shadows = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.8f, .05, 1.f, 2);
   g->bias = dt_bauhaus_slider_new_with_range(self, -10.0f, 10.0f, 1.0f, 0.f, 1);
   dt_bauhaus_slider_enable_soft_boundaries(g->bias, -1000.0f, 1000.0f);
   g->mode = dt_bauhaus_combobox_new(self);
@@ -3633,7 +3633,9 @@ void gui_init(dt_iop_module_t *self)
                                                          "useful to recover details when patch size\n"
                                                          "is quite big."));
   gtk_widget_set_tooltip_text(g->strength, _("finetune denoising strength"));
-  gtk_widget_set_tooltip_text(g->shadows, _("finetune shadows denoising"));
+  gtk_widget_set_tooltip_text(g->shadows, _("finetune shadows denoising.\n"
+                                            "decrease to denoise more aggressively\n"
+                                            "dark areas of the image.\n"));
   gtk_widget_set_tooltip_text(g->bias, _("correct color cast in shadows.\n"
                                          "decrease if shadows are too purple.\n"
                                          "increase if shadows are too green."));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3237,17 +3237,28 @@ static void overshooting_callback(GtkWidget *w, dt_iop_module_t *self)
   }
   // set the sliders as visible while we are setting their values
   // otherwise a log message appears
-  gtk_widget_set_visible(g->radius, TRUE);
-  gtk_widget_set_visible(g->scattering, TRUE);
+  if(p->mode == MODE_NLMEANS_AUTO)
+  {
+    gtk_widget_set_visible(g->radius, TRUE);
+    gtk_widget_set_visible(g->scattering, TRUE);
+    dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
+    dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
+    gtk_widget_set_visible(g->radius, FALSE);
+    gtk_widget_set_visible(g->scattering, FALSE);
+  }
+  else
+  {
+    // we are in wavelets mode.
+    // we need to show the box_nlm, setting the sliders to visible is not enough
+    gtk_widget_show_all(g->box_nlm);
+    dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
+    dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
+    gtk_widget_hide(g->box_nlm);
+  }
   gtk_widget_set_visible(g->shadows, TRUE);
   gtk_widget_set_visible(g->bias, TRUE);
-  dt_bauhaus_slider_set_soft(g->radius, infer_radius_from_profile(a * gain));
-  dt_bauhaus_slider_set_soft(g->scattering, infer_scattering_from_profile(a * gain));
   dt_bauhaus_slider_set(g->shadows, infer_shadows_from_profile(a * gain));
   dt_bauhaus_slider_set(g->bias, infer_bias_from_profile(a * gain));
-  // set back the sliders to invisible
-  gtk_widget_set_visible(g->radius, FALSE);
-  gtk_widget_set_visible(g->scattering, FALSE);
   gtk_widget_set_visible(g->shadows, FALSE);
   gtk_widget_set_visible(g->bias, FALSE);
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3771,8 +3771,8 @@ void gui_init(dt_iop_module_t *self)
   g->bias = dt_bauhaus_slider_new_with_range(self, -10.0f, 10.0f, 1.0f, 0.f, 1);
   dt_bauhaus_slider_enable_soft_boundaries(g->bias, -1000.0f, 1000.0f);
   g->mode = dt_bauhaus_combobox_new(self);
-  g->radius = dt_bauhaus_slider_new_with_range(self, 0.0f, 4.0f, 1.f, 1.f, 0);
-  dt_bauhaus_slider_enable_soft_boundaries(g->radius, 0.0, 10.0);
+  g->radius = dt_bauhaus_slider_new_with_range(self, 0.0f, 8.0f, 1.f, 1.f, 0);
+  dt_bauhaus_slider_enable_soft_boundaries(g->radius, 0.0, 12.0);
   g->nbhood = dt_bauhaus_slider_new_with_range(self, 1.0f, 30.0f, 1.f, 7.f, 0);
   g->scattering = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01, 0.0f, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->scattering, 0.0, 20.0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -591,7 +591,7 @@ static inline void precondition_v2(const float *const in, float *const buf, cons
     {
       for(int c = 0; c < 3; c++)
       {
-        buf2[c] = 2.0f * powf(MAX(in2[c]/wb[c],0.0f)+b, -p/2+1) / ((-p+2) * sqrt(a));
+        buf2[c] = 2.0f * powf(MAX(in2[c]/wb[c]+b,0.0f), -p/2+1) / ((-p+2) * sqrt(a));
       }
       buf2 += 4;
       in2 += 4;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3948,8 +3948,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->overshooting, _("controls the way parameters are autoset\n"
                                                  "increase if shadows are not denoised enough\n"
                                                  "or if chroma noise remains.\n"
-                                                 "this can happen if your picture is underexposed.\n"
-                                                 "decreasing to get back some local contrast."));
+                                                 "this can happen if your picture is underexposed."));
   gtk_widget_set_tooltip_text(g->shadows, _("finetune shadows denoising.\n"
                                             "decrease to denoise more aggressively\n"
                                             "dark areas of the image.\n"));

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2686,12 +2686,12 @@ void reload_defaults(dt_iop_module_t *module)
       dt_noiseprofile_t *profile = (dt_noiseprofile_t *)iter->data;
       dt_bauhaus_combobox_add(g->profile, profile->name);
     }
-
+    const float a = g->interpolated.a[1];
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->wb_adaptive_anscombe = TRUE;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius = 1.0f;
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->radius = MIN((unsigned)(1.0f + a * 15000.0f + a * a * 300000.0f), 10);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->nbhood = 7.0f;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->scattering = 0.0f;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->central_pixel_weight = 0.0f;
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->scattering = MIN(3000.0f * a, 1.5f);
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->central_pixel_weight = 0.1f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->strength = 1.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->shadows = 1.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->bias = 0.0f;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3435,7 +3435,7 @@ void gui_init(dt_iop_module_t *self)
   g->profile = dt_bauhaus_combobox_new(self);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
   dt_bauhaus_slider_enable_soft_boundaries(g->strength, 0.001f, 1000.0f);
-  g->shadows = dt_bauhaus_slider_new_with_range(self, 0.4f, 1.6f, .01, 1.f, 3);
+  g->shadows = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.8f, .01, 1.f, 3);
   g->bias = dt_bauhaus_slider_new_with_range(self, -10.0f, 10.0f, 1.0f, 0.f, 1);
   dt_bauhaus_slider_enable_soft_boundaries(g->bias, -1000.0f, 1000.0f);
   g->mode = dt_bauhaus_combobox_new(self);
@@ -3589,8 +3589,8 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->scattering, NULL, _("scattering (coarse-grain noise)"));
   dt_bauhaus_widget_set_label(g->central_pixel_weight, NULL, _("central pixel weight (details)"));
   dt_bauhaus_widget_set_label(g->strength, NULL, _("strength"));
-  dt_bauhaus_widget_set_label(g->shadows, NULL, _("shadows"));
-  dt_bauhaus_widget_set_label(g->bias, NULL, _("bias"));
+  dt_bauhaus_widget_set_label(g->shadows, NULL, _("preserve shadows"));
+  dt_bauhaus_widget_set_label(g->bias, NULL, _("bias correction"));
   dt_bauhaus_combobox_add(g->mode, _("non-local means"));
   dt_bauhaus_combobox_add(g->mode, _("wavelets"));
   const gboolean compute_variance = dt_conf_get_bool("plugins/darkroom/denoiseprofile/show_compute_variance_mode");

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1204,9 +1204,9 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     wb[2] = 2.0f * piece->pipe->dsc.processed_maximum[2];
   }
   // adaptive p depending on white balance
-  const float p[3] = { d->shadows - 0.1 * logf(wb[0]),
-                       d->shadows - 0.1 * logf(wb[1]),
-                       d->shadows - 0.1 * logf(wb[2])};
+  const float p[3] = { MAX(d->shadows - 0.1 * logf(wb[0]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[1]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[2]), 0.0f)};
 
   // update the coeffs with strength and scale
   for(int i = 0; i < 3; i++) wb[i] *= d->strength * in_scale;
@@ -1408,9 +1408,9 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
     for(int i = 0; i < 3; i++) wb[i] = piece->pipe->dsc.processed_maximum[i];
   }
   // adaptive p depending on white balance
-  const float p[3] = { d->shadows - 0.1 * logf(wb[0]),
-                       d->shadows - 0.1 * logf(wb[1]),
-                       d->shadows - 0.1 * logf(wb[2])};
+  const float p[3] = { MAX(d->shadows - 0.1 * logf(wb[0]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[1]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[2]), 0.0f)};
 
   // update the coeffs with strength and scale
   for(int i = 0; i < 3; i++) wb[i] *= d->strength * scale;
@@ -1631,9 +1631,9 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
     for(int i = 0; i < 3; i++) wb[i] = piece->pipe->dsc.processed_maximum[i];
   }
   // adaptive p depending on white balance
-  const float p[3] = { d->shadows - 0.1 * logf(wb[0]),
-                       d->shadows - 0.1 * logf(wb[1]),
-                       d->shadows - 0.1 * logf(wb[2])};
+  const float p[3] = { MAX(d->shadows - 0.1 * logf(wb[0]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[1]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[2]), 0.0f)};
   // update the coeffs with strength and scale
   for(int i = 0; i < 3; i++) wb[i] *= d->strength * scale;
 
@@ -1959,9 +1959,9 @@ static void process_variance(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     for(int i = 0; i < 3; i++) wb[i] = piece->pipe->dsc.processed_maximum[i];
   }
   // adaptive p depending on white balance
-  const float p[3] = { d->shadows - 0.1 * logf(wb[0]),
-                       d->shadows - 0.1 * logf(wb[1]),
-                       d->shadows - 0.1 * logf(wb[2])};
+  const float p[3] = { MAX(d->shadows - 0.1 * logf(wb[0]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[1]), 0.0f),
+                       MAX(d->shadows - 0.1 * logf(wb[2]), 0.0f)};
 
   // update the coeffs with strength
   for(int i = 0; i < 3; i++) wb[i] *= d->strength;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -151,7 +151,7 @@ typedef struct dt_iop_denoiseprofile_params_t
   gboolean wb_adaptive_anscombe; // whether to adapt anscombe transform to wb coeffs
   // backward compatibility options
   gboolean fix_anscombe_and_nlmeans_norm;
-  gboolean upgrade_vst;
+  gboolean use_new_vst;
 } dt_iop_denoiseprofile_params_t;
 
 typedef struct dt_iop_denoiseprofile_gui_data_t
@@ -193,7 +193,7 @@ typedef struct dt_iop_denoiseprofile_gui_data_t
   GtkLabel *label_var_B;
   // backward compatibility options
   GtkWidget *fix_anscombe_and_nlmeans_norm;
-  GtkWidget *upgrade_vst;
+  GtkWidget *use_new_vst;
 } dt_iop_denoiseprofile_gui_data_t;
 
 typedef struct dt_iop_denoiseprofile_data_t
@@ -214,7 +214,7 @@ typedef struct dt_iop_denoiseprofile_data_t
   gboolean wb_adaptive_anscombe; // whether to adapt anscombe transform to wb coeffs
   // backward compatibility options
   gboolean fix_anscombe_and_nlmeans_norm;
-  gboolean upgrade_vst;
+  gboolean use_new_vst;
 } dt_iop_denoiseprofile_data_t;
 
 typedef struct dt_iop_denoiseprofile_global_data_t
@@ -419,7 +419,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     v8->wb_adaptive_anscombe = v7.wb_adaptive_anscombe;
     v8->shadows = 1.0f;
     v8->bias = 0.0f;
-    v8->upgrade_vst = FALSE;
+    v8->use_new_vst = FALSE;
     v8->overshooting = 1.0f;
     return 0;
   }
@@ -1312,7 +1312,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   const float bb[3] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2] };
 
   const float compensate_p = DT_IOP_DENOISE_PROFILE_P_FULCRUM / powf(DT_IOP_DENOISE_PROFILE_P_FULCRUM, d->shadows);
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     precondition((float *)ivoid, (float *)ovoid, width, height, aa, bb);
   }
@@ -1434,7 +1434,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     buf1 = buf3;
   }
 
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     backtransform((float *)ovoid, width, height, aa, bb);
   }
@@ -1514,7 +1514,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   const float aa[3] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2] };
   const float bb[3] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2] };
   const float compensate_p = DT_IOP_DENOISE_PROFILE_P_FULCRUM / powf(DT_IOP_DENOISE_PROFILE_P_FULCRUM, d->shadows);
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     precondition((float *)ivoid, in, roi_in->width, roi_in->height, aa, bb);
   }
@@ -1669,7 +1669,7 @@ static void process_nlmeans(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
   // free shared tmp memory:
   dt_free_align(Sa);
   dt_free_align(in);
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     backtransform((float *)ovoid, roi_in->width, roi_in->height, aa, bb);
   }
@@ -1737,7 +1737,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   const float aa[3] = { d->a[1] * wb[0], d->a[1] * wb[1], d->a[1] * wb[2] };
   const float bb[3] = { d->b[1] * wb[0], d->b[1] * wb[1], d->b[1] * wb[2] };
   const float compensate_p = DT_IOP_DENOISE_PROFILE_P_FULCRUM / powf(DT_IOP_DENOISE_PROFILE_P_FULCRUM, d->shadows);
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     precondition((float *)ivoid, in, roi_in->width, roi_in->height, aa, bb);
   }
@@ -1941,7 +1941,7 @@ static void process_nlmeans_sse(struct dt_iop_module_t *self, dt_dev_pixelpipe_i
   // free shared tmp memory:
   dt_free_align(Sa);
   dt_free_align(in);
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     backtransform((float *)ovoid, roi_in->width, roi_in->height, aa, bb);
   }
@@ -2176,7 +2176,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   const float sigma2[4] = { (bb[0] / aa[0]) * (bb[0] / aa[0]), (bb[1] / aa[1]) * (bb[1] / aa[1]),
                             (bb[2] / aa[2]) * (bb[2] / aa[2]), 0.0f };
   const float compensate_p = DT_IOP_DENOISE_PROFILE_P_FULCRUM / powf(DT_IOP_DENOISE_PROFILE_P_FULCRUM, d->shadows);
-  if(d->upgrade_vst)
+  if(d->use_new_vst)
   {
     for(int c = 0; c < 3; c++)
     {
@@ -2227,7 +2227,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
   size_t sizesl[3];
   size_t local[3];
 
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 0, sizeof(cl_mem), (void *)&dev_in);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 1, sizeof(cl_mem), (void *)&dev_tmp);
@@ -2338,7 +2338,7 @@ static int process_nlmeans_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop
     }
   }
 
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 0, sizeof(cl_mem), (void *)&dev_in);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_finish, 1, sizeof(cl_mem), (void *)&dev_U2);
@@ -2530,7 +2530,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   const float sigma2[4] = { (bb[0] / aa[0]) * (bb[0] / aa[0]), (bb[1] / aa[1]) * (bb[1] / aa[1]),
                             (bb[2] / aa[2]) * (bb[2] / aa[2]), 0.0f };
   const float compensate_p = DT_IOP_DENOISE_PROFILE_P_FULCRUM / powf(DT_IOP_DENOISE_PROFILE_P_FULCRUM, d->shadows);
-  if(d->upgrade_vst)
+  if(d->use_new_vst)
   {
     for(int c = 0; c < 3; c++)
     {
@@ -2541,7 +2541,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
 
   size_t sizes[] = { ROUNDUPWD(width), ROUNDUPHT(height), 1 };
 
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 0, sizeof(cl_mem), (void *)&dev_in);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_precondition, 1, sizeof(cl_mem), (void *)&dev_out);
@@ -2742,7 +2742,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
     if(err != CL_SUCCESS) goto error;
   }
 
-  if(!d->upgrade_vst)
+  if(!d->use_new_vst)
   {
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 0, sizeof(cl_mem), (void *)&dev_tmp);
     dt_opencl_set_kernel_arg(devid, gd->kernel_denoiseprofile_backtransform, 1, sizeof(cl_mem), (void *)&dev_out);
@@ -2926,7 +2926,7 @@ void reload_defaults(dt_iop_module_t *module)
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->bias = infer_bias_from_profile(a);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->mode = MODE_NLMEANS;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->fix_anscombe_and_nlmeans_norm = TRUE;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->upgrade_vst = TRUE;
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->use_new_vst = TRUE;
     for(int k = 0; k < 3; k++)
     {
       ((dt_iop_denoiseprofile_params_t *)module->default_params)->a[k] = g->interpolated.a[k];
@@ -2956,7 +2956,7 @@ void init(dt_iop_module_t *module)
   }
   tmp.fix_anscombe_and_nlmeans_norm = TRUE;
   tmp.wb_adaptive_anscombe = TRUE;
-  tmp.upgrade_vst = TRUE;
+  tmp.use_new_vst = TRUE;
   memcpy(module->params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_denoiseprofile_params_t));
 }
@@ -3099,7 +3099,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 
   d->wb_adaptive_anscombe = p->wb_adaptive_anscombe;
   d->fix_anscombe_and_nlmeans_norm = p->fix_anscombe_and_nlmeans_norm;
-  d->upgrade_vst = p->upgrade_vst;
+  d->use_new_vst = p->use_new_vst;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -3181,7 +3181,7 @@ static void mode_callback(GtkWidget *w, dt_iop_module_t *self)
       gtk_widget_show_all(g->box_variance);
       break;
   }
-  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  const gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
   gtk_widget_set_visible(g->shadows, !auto_mode);
   gtk_widget_set_visible(g->bias, !auto_mode);
   gtk_widget_set_visible(g->overshooting, auto_mode);
@@ -3374,12 +3374,12 @@ void gui_update(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->wb_adaptive_anscombe), p->wb_adaptive_anscombe);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe_and_nlmeans_norm), p->fix_anscombe_and_nlmeans_norm);
   gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm, !p->fix_anscombe_and_nlmeans_norm);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->upgrade_vst), p->upgrade_vst);
-  gtk_widget_set_visible(g->upgrade_vst, !p->upgrade_vst);
-  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->use_new_vst), p->use_new_vst);
+  gtk_widget_set_visible(g->use_new_vst, !p->use_new_vst);
+  const gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
   gtk_widget_set_visible(g->overshooting, auto_mode);
-  gtk_widget_set_visible(g->shadows, p->upgrade_vst && !auto_mode);
-  gtk_widget_set_visible(g->bias, p->upgrade_vst && !auto_mode);
+  gtk_widget_set_visible(g->shadows, p->use_new_vst && !auto_mode);
+  gtk_widget_set_visible(g->bias, p->use_new_vst && !auto_mode);
 }
 
 void gui_reset(dt_iop_module_t *self)
@@ -3387,7 +3387,7 @@ void gui_reset(dt_iop_module_t *self)
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   gtk_widget_set_visible(g->fix_anscombe_and_nlmeans_norm, !p->fix_anscombe_and_nlmeans_norm);
-  gtk_widget_set_visible(g->upgrade_vst, !p->upgrade_vst);
+  gtk_widget_set_visible(g->use_new_vst, !p->use_new_vst);
 }
 
 static void dt_iop_denoiseprofile_get_params(dt_iop_denoiseprofile_params_t *p, const int ch, const double mouse_x,
@@ -3764,15 +3764,15 @@ static void fix_anscombe_and_nlmeans_norm_callback(GtkWidget *widget, dt_iop_mod
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void upgrade_vst_callback(GtkWidget *widget, dt_iop_module_t *self)
+static void use_new_vst_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-  p->upgrade_vst = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-  gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
-  gtk_widget_set_visible(g->shadows, p->upgrade_vst && !auto_mode);
-  gtk_widget_set_visible(g->bias, p->upgrade_vst && !auto_mode);
+  p->use_new_vst = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  const gboolean auto_mode = (p->mode == MODE_NLMEANS_AUTO) || (p->mode == MODE_WAVELETS_AUTO);
+  gtk_widget_set_visible(g->shadows, p->use_new_vst && !auto_mode);
+  gtk_widget_set_visible(g->bias, p->use_new_vst && !auto_mode);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -3909,7 +3909,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->bias, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_variance, TRUE, TRUE, 0);
 
-  g->fix_anscombe_and_nlmeans_norm = gtk_check_button_new_with_label(_("migrate to fixed algorithm"));
+  g->fix_anscombe_and_nlmeans_norm = gtk_check_button_new_with_label(_("fix various bugs in algorithm"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->fix_anscombe_and_nlmeans_norm), p->fix_anscombe_and_nlmeans_norm);
   gtk_widget_set_tooltip_text(g->fix_anscombe_and_nlmeans_norm, _("fix bugs in anscombe transform resulting\n"
                                                  "in undersmoothing of the green channel in\n"
@@ -3922,14 +3922,14 @@ void gui_init(dt_iop_module_t *self)
                                                  "return back to old algorithm."));
   gtk_box_pack_start(GTK_BOX(self->widget), g->fix_anscombe_and_nlmeans_norm, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->fix_anscombe_and_nlmeans_norm), "toggled", G_CALLBACK(fix_anscombe_and_nlmeans_norm_callback), self);
-  g->upgrade_vst = gtk_check_button_new_with_label(_("upgrade algorithm"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->upgrade_vst), p->upgrade_vst);
-  gtk_widget_set_tooltip_text(g->upgrade_vst, _("upgrade the variance stabilizing algorithm.\n"
+  g->use_new_vst = gtk_check_button_new_with_label(_("upgrade profiled transform"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->use_new_vst), p->use_new_vst);
+  gtk_widget_set_tooltip_text(g->use_new_vst, _("upgrade the variance stabilizing algorithm.\n"
                                                 "new algorithm extends the current one.\n"
                                                 "it is more flexible but could give small\n"
                                                 "differences in the images already processed."));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->upgrade_vst, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->upgrade_vst), "toggled", G_CALLBACK(upgrade_vst_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->use_new_vst, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->use_new_vst), "toggled", G_CALLBACK(use_new_vst_callback), self);
 
   gtk_widget_show_all(g->box_nlm);
   gtk_widget_show_all(g->box_wavelets);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2693,7 +2693,7 @@ void reload_defaults(dt_iop_module_t *module)
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->scattering = MIN(3000.0f * a, 1.5f);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->central_pixel_weight = 0.1f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->strength = 1.0f;
-    ((dt_iop_denoiseprofile_params_t *)module->default_params)->shadows = 1.0f;
+    ((dt_iop_denoiseprofile_params_t *)module->default_params)->shadows = MAX(0.1f - 0.1 * logf(a), 0.7f);
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->bias = 0.0f;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->mode = MODE_NLMEANS;
     ((dt_iop_denoiseprofile_params_t *)module->default_params)->fix_anscombe_and_nlmeans_norm = TRUE;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -2976,7 +2976,7 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->nbhood, p->nbhood);
   dt_bauhaus_slider_set_soft(g->strength, p->strength);
   dt_bauhaus_slider_set(g->shadows, p->shadows);
-  dt_bauhaus_slider_set(g->bias, p->bias);
+  dt_bauhaus_slider_set_soft(g->bias, p->bias);
   dt_bauhaus_slider_set_soft(g->scattering, p->scattering);
   dt_bauhaus_slider_set_soft(g->central_pixel_weight, p->central_pixel_weight);
   dt_bauhaus_combobox_set(g->profile, -1);
@@ -3435,8 +3435,9 @@ void gui_init(dt_iop_module_t *self)
   g->profile = dt_bauhaus_combobox_new(self);
   g->strength = dt_bauhaus_slider_new_with_range(self, 0.001f, 4.0f, .05, 1.f, 3);
   dt_bauhaus_slider_enable_soft_boundaries(g->strength, 0.001f, 1000.0f);
-  g->shadows = dt_bauhaus_slider_new_with_range(self, 0.4f, 1.6f, .05, 1.f, 3);
-  g->bias = dt_bauhaus_slider_new_with_range(self, -10.0f, 10.0f, .1, 0.f, 1);
+  g->shadows = dt_bauhaus_slider_new_with_range(self, 0.4f, 1.6f, .01, 1.f, 3);
+  g->bias = dt_bauhaus_slider_new_with_range(self, -10.0f, 10.0f, 1.0f, 0.f, 1);
+  dt_bauhaus_slider_enable_soft_boundaries(g->bias, -1000.0f, 1000.0f);
   g->mode = dt_bauhaus_combobox_new(self);
   g->radius = dt_bauhaus_slider_new_with_range(self, 0.0f, 4.0f, 1.f, 1.f, 0);
   dt_bauhaus_slider_enable_soft_boundaries(g->radius, 0.0, 10.0);


### PR DESCRIPTION
This PR implements in denoiseprofile a different variance stabilization transform (VST): the one from #2364 
This VST is an extension of the old VST which was a generalized anscombe transform.
The new VST writes variance as V(X) = a(E[X]+b)^p
The old VST corresponds to the case where p = 1

This gives a new parameter, p, which allows to make denoising stronger on shadows than on highlights for instance.
I think this parameters helps a lot for high ISOs.

In addition to this, the default params of the modules are estimated automatically from the profile, so that the user has a good setting of the parameters to start with.
Basically, with these, the user only has to set the module on to get a good denoising result.

Compared to #2364 , this PR guesses the p parameter, whereas in #2364 the p parameter was found through profiling.

This is work in progress, the work remaining is:
- some code cleaning and comments
- port the opencl part

So you can start testing on CPU implementations if you want :-)