### PR TITLE
Fixing history compression and closely related stuff in development.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -870,10 +870,31 @@ int dt_history_copy_and_paste_on_selection(int32_t imgid, gboolean merge, GList 
   return res;
 }
 
+
+static void _clear_history_stack()
+{
+  while(darktable.develop->history)
+  {
+    dt_dev_free_history_item(((dt_dev_history_item_t *)darktable.develop->history->data));
+    darktable.develop->history = g_list_delete_link(darktable.develop->history, darktable.develop->history);
+  }
+}
+
+/* Please note: dt_history_compress_on_image 
+  - is used in lighttable and darkroom mode
+  - compresses history only in the database
+  - *must* not touch the history stack
+*/
 void dt_history_compress_on_image(int32_t imgid)
 {
-  // make sure the right history is in there:
-  dt_dev_write_history(darktable.develop);
+  // We load the specific images history if necessary
+  if(!dt_dev_is_current_image(darktable.develop, imgid))
+  {
+    darktable.develop->iop = dt_iop_load_modules(darktable.develop);
+    dt_dev_read_history_ext(darktable.develop, imgid, FALSE);
+  }
+  else
+    dt_dev_write_history(darktable.develop);
 
   // compress history, keep disabled modules as documented
   sqlite3_stmt *stmt;
@@ -955,26 +976,12 @@ void dt_history_compress_on_image(int32_t imgid)
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
   }
-
-  // Update XMP files
-  dt_image_synch_xmp(imgid);
 }
 
-void dt_history_compress_on_image_and_reload(int32_t imgid)
-{
-  dt_history_compress_on_image(imgid);
-
-  /* if current image in develop reload history */
-  if(dt_dev_is_current_image(darktable.develop, imgid))
-  {
-    dt_dev_reload_history_items(darktable.develop);
-    dt_dev_write_history(darktable.develop);
-    dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
-  }
-}
 
 void dt_history_compress_on_selection()
 {
+  int32_t imgid = -1;
   // Get the list of selected images
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
@@ -982,9 +989,17 @@ void dt_history_compress_on_selection()
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    dt_history_compress_on_image_and_reload(sqlite3_column_int(stmt, 0));
+    imgid = sqlite3_column_int(stmt, 0);
+    dt_history_compress_on_image(imgid);
+    // Now read the history again into the stack
+    _clear_history_stack();
+    dt_dev_read_history_ext(darktable.develop, imgid, FALSE);
+    // writing ensures we have no gaps
+    dt_dev_write_history_ext(darktable.develop, imgid);
+    dt_image_synch_xmp(imgid);
   }
   sqlite3_finalize(stmt);
+  _clear_history_stack();  
 }
 
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -55,7 +55,6 @@ void dt_history_delete_on_selection();
 /** compress history stack */
 void dt_history_compress_on_selection();
 void dt_history_compress_on_image(int32_t imgid);
-void dt_history_compress_on_image_and_reload(int32_t imgid);
 
 typedef struct dt_history_item_t
 {

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -157,8 +157,24 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
   if(img < 0)
     dt_history_compress_on_selection();
   else
+  { 
     dt_history_compress_on_image(img);
-
+    // Now read the history again into the stack
+    while(darktable.develop->history)
+    {
+      dt_dev_free_history_item(((dt_dev_history_item_t *)darktable.develop->history->data));
+      darktable.develop->history = g_list_delete_link(darktable.develop->history, darktable.develop->history);
+    }
+    dt_dev_read_history_ext(darktable.develop, img, FALSE);
+    // writing ensures we have no gaps
+    dt_dev_write_history_ext(darktable.develop, img);
+    dt_image_synch_xmp(img);
+    while(darktable.develop->history)
+    {
+      dt_dev_free_history_item(((dt_dev_history_item_t *)darktable.develop->history->data));
+      darktable.develop->history = g_list_delete_link(darktable.develop->history, darktable.develop->history);
+    }
+  }
   dt_control_queue_redraw_center();
 }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -710,6 +710,7 @@ static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer u
   // load new history and write it back to ensure that all history are properly numbered without a gap
   dt_dev_reload_history_items(darktable.develop);
   dt_dev_write_history(darktable.develop);
+  dt_image_synch_xmp(imgid);
 
   // then we can get the item to select in the new clean-up history retrieve the position of the module
   // corresponding to the history end.
@@ -730,6 +731,7 @@ static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer u
   sqlite3_finalize(stmt);
 
   dt_dev_reload_history_items(darktable.develop);
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
 }
 


### PR DESCRIPTION
What does this include?
----------------------------------------------------------------------------------

** Fixing two leaks when writing history or adding an item to the history stack **

1) dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
   Should write all available data on the history stack to the database.
   Also it should write the correct history_end to main.images for the specified image.
   This end was dev->history_end, it must be the number of written items instead.

2) _dev_add_history_item_ext puts an item on top of the history stack.
   It only adds a *new* item if necessary, if appropriate it *replaces* the top item.
   We check for push-or-replace but before that check we must remove
     a) items above history_end
     b) NIL items.

** Managing the history database and stack **
1) dt_history_compress_on_image
   MUST ONLY use the database itself.
   No touch on the history stack like reloading or writing!
   There is only one exception, we *load* the history stack for the image at start

2) dt_history_compress_on_selection
   Does the database compression
   After that it re-reads the history stack and writes it back to ensure a proper size.

3) dt_image_synch_xmp(imgid);
   Is *not* done in the common compression code but seperately in the darkroom callback
   and for every image in the selection.

4) _lib_history_compress_clicked_callback
   Is allowed so and *must* reload the history stack as this happens in darkroom
   and we want the changes to be valid at once.
   It also rises a DT_SIGNAL_DEVELOP_HISTORY_CHANGE and sets the module groups.

5) The extra compress_and_reload funtion did not help at all.

6) The lightroom button for only one image needs extra care.