### PR TITLE
Fixing the masks history ownership while compressing history

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -941,8 +941,12 @@ void dt_history_compress_on_image(int32_t imgid)
   if(masks_count > 0)
   {
     // set the masks history as first entry
+    // I think the above old comment show the wrong intention. jhs
+    // num always reflects the ownership of this mask.
+    // As we later increase the num for every history stack item in main.history for this image
+    // we also have to increase the num in masks_history.
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.masks_history SET num = 0 WHERE imgid = ?1", -1, &stmt, NULL);
+                                "UPDATE main.masks_history SET num=num+1 WHERE imgid = ?1", -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);


### PR DESCRIPTION
You probably have observed this too. If you are using a mask for any module while developing and later remove that module from the history stack by clicking on a 'lower position' in the history stack and do a _compress history stack_ you can observe:

1. You still have an active mask manager module
2. You can still see the masks in mask manager overview.

When reading the code for
`void dt_masks_write_masks_history_item(const int imgid, const int num, dt_masks_form_t *form)` found in src/develop/masks/masks.c and it's only caller
`int dt_dev_write_history_item(const int imgid, dt_dev_history_item_t *h, int32_t num)` found in src/develop/develop.c

the intention for **num** in **main.masks_history** becomes obvious. It is the owner of this mask and should be kept also when reordering or compressing the history.

In master the history compression sets this to zero for every entry, maybe it was implemented that way to be sure the mask is always kept in history whatever you do due to unfixed leaks in the history database/stack (Only exception was _discard_ the history stack.)

This commit does: keep the ownership of a mask while compressing the history.

 