### PR TITLE
full preview : add keys for sticky preview + update doc

### DIFF
--- a/doc/usermanual/lighttable/lighttable.xml
+++ b/doc/usermanual/lighttable/lighttable.xml
@@ -316,7 +316,7 @@
       <title>Full preview</title>
 
       <para>
-        While holding down the <emphasis>z</emphasis> key a fully zoomed preview of the image
+        While holding down the <emphasis>w</emphasis> key a fully zoomed preview of the image
         under the mouse cursor is displayed. You can use this feature for a quick inspection of
         image quality while rating and selecting images.
       </para>
@@ -326,7 +326,7 @@
       </indexterm>
 
       <para>
-        Holding down the <emphasis>ctlr-z</emphasis> key fully zooms into the image and
+        Holding down the <emphasis>ctlr-w</emphasis> key fully zooms into the image and
         additionally activates an analysis for sharp regions, detecting those parts of the image
         that are in focus. Areas of high sharpness are indicated by a red border&nbsp;&ndash; the
         higher the color intensity the better the sharpness. In case that no area of
@@ -336,7 +336,7 @@
       </para>
 
       <para>
-        Sometimes pressing <emphasis>z</emphasis> or <emphasis>ctrl-z</emphasis> may not reveal an
+        Sometimes pressing <emphasis>w</emphasis> or <emphasis>ctrl-w</emphasis> may not reveal an
         immediate effect&nbsp;&ndash; in that case please click into the center area and press the
         corresponding key again.
       </para>
@@ -348,7 +348,7 @@
           <tbody>
             <row>
               <entry>
-                Fully zoomed-in image view while holding down the <emphasis>ctrl-z</emphasis> key
+                Fully zoomed-in image view while holding down the <emphasis>ctrl-w</emphasis> key
                 with indication of the sharp areas in focus. Sharpness detection is based on an
                 embedded JPEG thumbnail of the original raw file independent of any processing
                 steps within darktable.
@@ -362,9 +362,9 @@
       </informaltable>
 
       <para>
-        If you want the full preview to stay, without having to hold <emphasis>z</emphasis> key,
-        you will have to assign a shortcut for <quote>view/lighttable/sticky preview</quote>
-        (see <xref linkend="shortcuts"/>).
+        If you want the full preview to stay, without having to hold <emphasis>w</emphasis> key,
+        you can use sticky preview mode with <emphasis>alt-w</emphasis> key or
+        <emphasis>ctrl-alt-w</emphasis> if you want focus detection.
         In sticky preview mode, you can zoom and pan in the image, exactly like in culling layout
         (see <xref linkend="lighttable_culling_zoom"/>).
       </para>

--- a/doc/usermanual/preferences/keymappings.xml
+++ b/doc/usermanual/preferences/keymappings.xml
@@ -701,18 +701,18 @@
       </row>
       <row>
         <entry>
-          views/lighttable/preview with focus detection
+          views/lighttable/preview
         </entry>
         <entry>
-          &lt;Primary&gt;z
+          w
         </entry>
       </row>
       <row>
         <entry>
-          views/lighttable/preview
+          views/lighttable/preview with focus detection
         </entry>
         <entry>
-          z
+          &lt;Primary&gt;w
         </entry>
       </row>
       <row>
@@ -833,6 +833,22 @@
         </entry>
         <entry>
           space
+        </entry>
+      </row>
+      <row>
+        <entry>
+          views/lighttable/sticky preview
+        </entry>
+        <entry>
+          &lt;Alt&gt;w
+        </entry>
+      </row>
+      <row>
+        <entry>
+          views/lighttable/sticky preview with focus detection
+        </entry>
+        <entry>
+          &lt;Primary&gt;&lt;Alt&gt;w
         </entry>
       </row>
       <row>

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -4370,8 +4370,9 @@ void init_key_accels(dt_view_t *self)
   // Preview key
   dt_accel_register_view(self, NC_("accel", "preview"), GDK_KEY_w, 0);
   dt_accel_register_view(self, NC_("accel", "preview with focus detection"), GDK_KEY_w, GDK_CONTROL_MASK);
-  dt_accel_register_view(self, NC_("accel", "sticky preview"), 0, 0);
-  dt_accel_register_view(self, NC_("accel", "sticky preview with focus detection"), 0, 0);
+  dt_accel_register_view(self, NC_("accel", "sticky preview"), GDK_KEY_w, GDK_MOD1_MASK);
+  dt_accel_register_view(self, NC_("accel", "sticky preview with focus detection"), GDK_KEY_w,
+                         GDK_MOD1_MASK | GDK_CONTROL_MASK);
 
   // undo/redo
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);


### PR DESCRIPTION
default key are now same as for "classic" preview + alt key : 
sticky preview : alt+w
sticky preview with focus detection : ctrl+alt+w

I've also updated the doc accordingly (and correct preview default keys which were not 'z' anymore)