### PR TITLE
Fixing the regression introduced by pr #2949

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1212,20 +1212,18 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
   GList *history = dev->history;
-  // the history size is NOT defined by current history_end but by the number actually written
-  int hist_size = 0;
+
   for(int i = 0; history; i++)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);
     (void)dt_dev_write_history_item(imgid, hist, i);
     history = g_list_next(history);
-    hist_size++;
   }
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "UPDATE main.images SET history_end = ?1, iop_order_version = ?3 WHERE id = ?2", -1,
                               &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, hist_size);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dev->history_end);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, dev->iop_order_version);
   sqlite3_step(stmt);


### PR DESCRIPTION
I commented in that pr
   dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
   Should write all available data on the history stack to the database.
   Also it should write the correct history_end to main.images for the
   specified image.
   This end was dev->history_end, it must be the number of written items
   instead.

As @TurboGit detected this was wrong.