### PR TITLE
Again work on history.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1074,7 +1074,6 @@ static void _history_reorder(int32_t imgid)
 int dt_history_compress_on_selection()
 {
   int uncompressed=0;
-  int32_t imgid = -1;
 
   // Get the list of selected images
   sqlite3_stmt *stmt;
@@ -1082,7 +1081,7 @@ int dt_history_compress_on_selection()
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    imgid = sqlite3_column_int(stmt, 0);
+    int imgid = sqlite3_column_int(stmt, 0);
     const int test = dt_history_end_attop(imgid);
     if (test == 1) // we do a compression and we know for sure history_end is at the top!
     {

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -870,7 +870,7 @@ int dt_history_copy_and_paste_on_selection(int32_t imgid, gboolean merge, GList 
   return res;
 }
 
-void dt_set_history_compress_problem(int32_t imgid, gboolean set)
+void dt_history_set_compress_problem(int32_t imgid, gboolean set)
 {
   guint tagid = 0;
   char tagname[64];
@@ -955,7 +955,7 @@ void dt_history_compress_on_image(int32_t imgid)
   int masks_count = 0;
   char op_mask_manager[20] = { 0 };
 
-  bool manager_position = FALSE;
+  gboolean manager_position = FALSE;
   // do we already have a mask manager at the correct position? We don't want to increase history nums later
   g_strlcpy(op_mask_manager, "mask_manager", sizeof(op_mask_manager));
 
@@ -1047,11 +1047,11 @@ static void _history_reorder(int32_t imgid)
 
   if(no_forced_reordering)
   {
-    if (give_reorder_information) fprintf(stderr,", no action");
+    if (give_reorder_information) fprintf(stderr,", no action\n");
   }
   else
   {
-    if (give_reorder_information) fprintf(stderr,", reorder");
+    if (give_reorder_information) fprintf(stderr,", reorder\n");
 
     _history_copy_and_paste_on_image_overwrite(imgid, dummy, 0);
     _history_copy_and_paste_on_image_overwrite(dummy, imgid, 0);
@@ -1073,7 +1073,6 @@ static void _history_reorder(int32_t imgid)
 
 int dt_history_compress_on_selection()
 {
-  int test;
   int uncompressed=0;
   int32_t imgid = -1;
 
@@ -1084,10 +1083,10 @@ int dt_history_compress_on_selection()
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     imgid = sqlite3_column_int(stmt, 0);
-    test = dt_history_end_attop(imgid);
+    const int test = dt_history_end_attop(imgid);
     if (test == 1) // we do a compression and we know for sure history_end is at the top!
     {
-      dt_set_history_compress_problem(imgid, FALSE);
+      dt_history_set_compress_problem(imgid, FALSE);
       dt_history_compress_on_image(imgid);
       _history_reorder(imgid);
  
@@ -1153,10 +1152,10 @@ int dt_history_compress_on_selection()
     if (test == 0) // no compression as history_end is right in the middle of history
     {
       uncompressed++;
-      dt_set_history_compress_problem(imgid, TRUE);
+      dt_history_set_compress_problem(imgid, TRUE);
     }
     if (test == -1)
-      dt_set_history_compress_problem(imgid, FALSE);
+      dt_history_set_compress_problem(imgid, FALSE);
   }
 
   sqlite3_finalize(stmt);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -870,34 +870,77 @@ int dt_history_copy_and_paste_on_selection(int32_t imgid, gboolean merge, GList 
   return res;
 }
 
-
-static void _clear_history_stack()
+void dt_set_history_compress_problem(int32_t imgid, gboolean set)
 {
-  while(darktable.develop->history)
-  {
-    dt_dev_free_history_item(((dt_dev_history_item_t *)darktable.develop->history->data));
-    darktable.develop->history = g_list_delete_link(darktable.develop->history, darktable.develop->history);
-  }
+  guint tagid = 0;
+  char tagname[64];
+  snprintf(tagname, sizeof(tagname), "darktable|problem|history-compress");
+  dt_tag_new(tagname, &tagid);
+  if (set)
+    dt_tag_attach(tagid, imgid);
+  else
+    dt_tag_detach(tagid, imgid);
 }
+
+static int dt_history_end_attop(int32_t imgid)
+{
+  int size=0;
+  int end=0;
+  sqlite3_stmt *stmt;
+
+  // get highest num in history
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+    "SELECT MAX(num) FROM main.history WHERE imgid=?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    size = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+
+  // get history_end
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+    "SELECT history_end FROM main.images WHERE id=?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    end = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+
+  // fprintf(stderr,"\ndt_history_end_attop for image %i: size %i, end %i",imgid,size,end);
+
+  // a special case right after removing all history
+  // It must be absolutely fresh and untouched so history_end is always on top
+  if ((size==0) && (end==0)) return -1;
+
+  // return 1 if end is larger than size
+  if (end > size) return 1;
+
+  // no compression as history_end is right in the middle of stack
+  return 0;
+}
+
 
 /* Please note: dt_history_compress_on_image 
   - is used in lighttable and darkroom mode
-  - compresses history only in the database
-  - *must* not touch the history stack
+  - It compresses history *exclusively* in the database and does *not* touch anything on the history stack
 */
 void dt_history_compress_on_image(int32_t imgid)
 {
-  // We load the specific images history if necessary
-  if(!dt_dev_is_current_image(darktable.develop, imgid))
-  {
-    darktable.develop->iop = dt_iop_load_modules(darktable.develop);
-    dt_dev_read_history_ext(darktable.develop, imgid, FALSE);
-  }
-  else
-    dt_dev_write_history(darktable.develop);
+  sqlite3_stmt *stmt;
+
+  // get history_end for image
+  int my_history_end = 0;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+    "SELECT history_end FROM main.images WHERE id=?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+
+  if (sqlite3_step(stmt) == SQLITE_ROW)
+    my_history_end = sqlite3_column_int(stmt, 0);
+  sqlite3_finalize(stmt);
+ 
+  if (my_history_end == 0) return;
 
   // compress history, keep disabled modules as documented
-  sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "DELETE FROM main.history WHERE imgid = ?1 AND num "
                               "NOT IN (SELECT MAX(num) FROM main.history WHERE "
@@ -905,13 +948,28 @@ void dt_history_compress_on_image(int32_t imgid)
                               "multi_priority)",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, darktable.develop->history_end);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, my_history_end);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  // delete all mask_manager entries
   int masks_count = 0;
   char op_mask_manager[20] = { 0 };
+
+  bool manager_position = FALSE;
+  // do we already have a mask manager at the correct position? We don't want to increase history nums later
+  g_strlcpy(op_mask_manager, "mask_manager", sizeof(op_mask_manager));
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT num FROM main.history WHERE imgid = ?1 AND operation = ?2", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, op_mask_manager, -1, SQLITE_TRANSIENT);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      if (sqlite3_column_int(stmt, 0) == 0) manager_position = TRUE;
+    }
+  sqlite3_finalize(stmt);
+
+  // delete all mask_manager entries
   g_strlcpy(op_mask_manager, "mask_manager", sizeof(op_mask_manager));
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -922,12 +980,12 @@ void dt_history_compress_on_image(int32_t imgid)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  // compress masks history
+  // compress masks history, this keeps masks owned by the mask manager.
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.masks_history WHERE imgid = ?1 AND num "
                                                              "NOT IN (SELECT MAX(num) FROM main.masks_history WHERE "
                                                              "imgid = ?1 AND num < ?2)", -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, darktable.develop->history_end);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, my_history_end);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
@@ -940,28 +998,29 @@ void dt_history_compress_on_image(int32_t imgid)
 
   if(masks_count > 0)
   {
-    // set the masks history as first entry
+    // set the masks history as first entry. This means the mask is owned by the manager, is this really correct and desired?
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                 "UPDATE main.masks_history SET num = 0 WHERE imgid = ?1", -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 
-    // make room for mask manager history entry
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.history SET num=num+1 WHERE imgid = ?1", -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+    if (!manager_position)
+    {
+      // make room for mask manager history entry
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+        "UPDATE main.history SET num=num+1 WHERE imgid = ?1", -1, &stmt, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+      sqlite3_step(stmt);
+      sqlite3_finalize(stmt);
 
-    // update history end
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.images SET history_end = history_end+1 WHERE id = ?1", -1,
-                                &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-
+      // update history end
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+        "UPDATE main.images SET history_end = history_end+1 WHERE id = ?1", -1, &stmt, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+      sqlite3_step(stmt);
+      sqlite3_finalize(stmt);
+    }
     const double iop_order = dt_ioppr_get_iop_order(darktable.develop->iop_order_list, op_mask_manager);
 
     // create a mask manager entry in history as first entry
@@ -979,27 +1038,111 @@ void dt_history_compress_on_image(int32_t imgid)
 }
 
 
-void dt_history_compress_on_selection()
+int dt_history_compress_on_selection()
 {
+  int test;
+  int uncompressed=0;
   int32_t imgid = -1;
+  int32_t dummy = 0x7fffffff;
+
   // Get the list of selected images
   sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
-                              NULL);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt, NULL);
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     imgid = sqlite3_column_int(stmt, 0);
-    dt_history_compress_on_image(imgid);
-    // Now read the history again into the stack
-    _clear_history_stack();
-    dt_dev_read_history_ext(darktable.develop, imgid, FALSE);
-    // writing ensures we have no gaps
-    dt_dev_write_history_ext(darktable.develop, imgid);
-    dt_image_synch_xmp(imgid);
+    test = dt_history_end_attop(imgid);
+    if (test == 1) // we do a compression and we know for sure history_end is at the top!
+    {
+      dt_set_history_compress_problem(imgid, FALSE);
+      dt_history_compress_on_image(imgid);
+      _history_copy_and_paste_on_image_overwrite(imgid, dummy, 0);
+      _history_copy_and_paste_on_image_overwrite(dummy, imgid, 0);
+
+      // now the modules are in right order but need renumbering to remove leaks
+      int max=0;    // the maximum num in main_history for an image
+      int size=0;   // the number of items in main_history for an image
+      int done=0;   // used for renumbering index
+
+      sqlite3_stmt *stmt2;
+    
+      // get highest num in history
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+        "SELECT MAX(num) FROM main.history WHERE imgid=?1", -1, &stmt2, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, imgid);
+      if (sqlite3_step(stmt2) == SQLITE_ROW)
+        max = sqlite3_column_int(stmt2, 0);
+      sqlite3_finalize(stmt2);
+
+      // get number of items in main.history
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+        "SELECT COUNT(*) FROM main.history WHERE imgid = ?1", -1, &stmt2, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, imgid);
+      if(sqlite3_step(stmt2) == SQLITE_ROW)
+        size = sqlite3_column_int(stmt2, 0);
+      sqlite3_finalize(stmt2);
+
+      if ((size>0) && (max>0))
+      {
+        for (int index=0;index<(max+1);index++)
+        {
+          sqlite3_stmt *stmt3;
+          DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+            "SELECT num FROM main.history WHERE imgid=?1 AND num=?2", -1, &stmt3, NULL);
+          DT_DEBUG_SQLITE3_BIND_INT(stmt3, 1, imgid);
+          DT_DEBUG_SQLITE3_BIND_INT(stmt3, 2, index);
+          if (sqlite3_step(stmt3) == SQLITE_ROW)
+          {
+            sqlite3_stmt *stmt4;
+            // step by step set the correct num
+            DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+              "UPDATE main.history SET num = ?3 WHERE imgid = ?1 AND num = ?2", -1, &stmt4, NULL);
+            DT_DEBUG_SQLITE3_BIND_INT(stmt4, 1, imgid);
+            DT_DEBUG_SQLITE3_BIND_INT(stmt4, 2, index);
+            DT_DEBUG_SQLITE3_BIND_INT(stmt4, 3, done);
+            sqlite3_step(stmt4);
+            sqlite3_finalize(stmt4);
+
+            done++;
+          }
+          sqlite3_finalize(stmt3);
+        }
+      }
+      // update history end
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+        "UPDATE main.images SET history_end = ?2 WHERE id = ?1", -1, &stmt2, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, imgid);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 2, done);
+      sqlite3_step(stmt2);
+      sqlite3_finalize(stmt2);
+
+      dt_image_write_sidecar_file(imgid);
+
+      // make sure a cleanup
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.history WHERE imgid = ?1", -1,
+        &stmt2, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, dummy);
+      sqlite3_step(stmt2);
+      sqlite3_finalize(stmt2);
+
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.masks_history WHERE imgid = ?1", -1, &stmt2,
+        NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, dummy);
+      sqlite3_step(stmt2);
+      sqlite3_finalize(stmt2);
+    }
+    if (test == 0) // no compression as history_end is right in the middle of history
+    {
+      uncompressed++;
+      dt_set_history_compress_problem(imgid, TRUE);
+    }
+    if (test == -1)
+      dt_set_history_compress_problem(imgid, FALSE);
   }
+
   sqlite3_finalize(stmt);
-  _clear_history_stack();  
+  return uncompressed;
 }
 
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -53,8 +53,11 @@ int dt_history_load_and_apply(int imgid, gchar *filename, int history_only);
 void dt_history_delete_on_selection();
 
 /** compress history stack */
-void dt_history_compress_on_selection();
+int dt_history_compress_on_selection();
 void dt_history_compress_on_image(int32_t imgid);
+/* set or clear a tag representing an error state while compressing history */
+void dt_set_history_compress_problem(int32_t imgid, gboolean set);
+
 
 typedef struct dt_history_item_t
 {

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -56,7 +56,7 @@ void dt_history_delete_on_selection();
 int dt_history_compress_on_selection();
 void dt_history_compress_on_image(int32_t imgid);
 /* set or clear a tag representing an error state while compressing history */
-void dt_set_history_compress_problem(int32_t imgid, gboolean set);
+void dt_history_set_compress_problem(int32_t imgid, gboolean set);
 
 
 typedef struct dt_history_item_t

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -689,6 +689,9 @@ void dt_dev_load_image(dt_develop_t *dev, const uint32_t imgid)
   dt_dev_read_history(dev);
 
   dev->first_load = 0;
+
+  // Loading an image means we do some developing and so remove the darktable|problem|history-compress tag
+  dt_set_history_compress_problem(imgid, FALSE);
 }
 
 void dt_dev_configure(dt_develop_t *dev, int wd, int ht)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -691,7 +691,7 @@ void dt_dev_load_image(dt_develop_t *dev, const uint32_t imgid)
   dev->first_load = 0;
 
   // Loading an image means we do some developing and so remove the darktable|problem|history-compress tag
-  dt_set_history_compress_problem(imgid, FALSE);
+  dt_history_set_compress_problem(imgid, FALSE);
 }
 
 void dt_dev_configure(dt_develop_t *dev, int wd, int ht)

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -155,7 +155,7 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
   const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   if (dt_collection_get_selected_count(darktable.collection) < 1 ) return;
 
-  int missing = dt_history_compress_on_selection();
+  const int missing = dt_history_compress_on_selection();
 
   dt_collection_update_query(darktable.collection);
   dt_control_queue_redraw_center();
@@ -163,13 +163,13 @@ static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
   { 
     GtkWidget *dialog = gtk_message_dialog_new(
     GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_CLOSE,
-    ngettext("No history compression of an image.\nSee tag: darktable|problem|history-compress.",
-             "No history compression of %d images.\nSee tag: darktable|problem|history-compress.", missing ), missing);
+    ngettext("no history compression of 1 image.\nsee tag: darktable|problem|history-compress.",
+             "no history compression of %d images.\nsee tag: darktable|problem|history-compress.", missing ), missing);
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
 #endif
 
-    gtk_window_set_title(GTK_WINDOW(dialog), _("History compression warning"));
+    gtk_window_set_title(GTK_WINDOW(dialog), _("history compression warning"));
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
     }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -703,6 +703,10 @@ static void _lib_history_compress_clicked_callback(GtkWidget *widget, gpointer u
   const int32_t imgid = darktable.develop->image_storage.id;
   if(!imgid) return;
 
+  // As dt_history_compress_on_image does *not* use the history stack data at all
+  // make sure the current stack is in the database
+  dt_dev_write_history(darktable.develop);
+
   dt_history_compress_on_image(imgid);
 
   sqlite3_stmt *stmt;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2623,7 +2623,8 @@ void leave(dt_view_t *self)
   dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
 
   darktable.develop->image_storage.id = -1;
-
+  // darkroom development could have changed a collection, so update that before beeing back in lightroom 
+  dt_collection_update_query(darktable.collection);
   dt_print(DT_DEBUG_CONTROL, "[run_job-] 11 %f in darkroom mode\n", dt_get_wtime());
 }
 


### PR DESCRIPTION
1) The lighttable history compression makes sure that **only** the images with
   history_end at the top are really compressed for safety reasons.

2) What about images that had no history compression?
   - You will get a message box telling you there were problems.
   - Also these images have a tag attached "darktable|problem|history-compress"
     so you can take care about those in darkroom
   - Whenever you open a picture in darkroom this tag will be automatically removed

3) there is the public dt_set_history_compress_problem(int32_t imgid, gboolean set)

4) There has been more work on dt_history_compress_on_image(int32_t imgid)
   It does **not** touch the history_stack at all!
   When we have a mask manager already there at position 0 we don't have to
   change num in main.history and history_end in main.images any more possibly
   avoiding leaks.

5) Also the dt_history_compress_on_selection() has major rework.
   - it returns the number of images that were not compressed as a helper for the
     lighttable button message box.
   - it does **not** load any history stack any more!
   - it does proper reordering of the history items doing a double
        _history_copy_and_paste_on_image_overwrite
     as i assume this has been tested well.
     So we have a properly ordered and leak-free at the end.

@TurboGit and @MStraeten  
Again delicate stuff i would want you to test carefully.
Of course there is the security check for lighttable mode.

But more important are the internal changes done for history compression. They **never** touch the
current history stack any more and the lighttable side generates properly ordered data in history without leaks.

The darkroom history compression does this reordering on it's own. 

Also, if you accept and like the code for reordering done in lighttable mode, could it make darkrooms mode safer? Probably not but i'm not sure.