### PR TITLE
Fix the curve tool fit_curve initialization. (#2480)

### DIFF
--- a/tools/basecurve/darktable-curve-tool.c
+++ b/tools/basecurve/darktable-curve-tool.c
@@ -470,18 +470,16 @@ fit_curve(CurveData* best, int* nopt, float* minsqerr, CurveSample* csample, int
   {
     if(i == 0 || drand48() < p_large)
     { // large step
-      for(int k=0;k<tent.m_numAnchors;k++)
+      for(int k=0;k<tent.m_numAnchors-1;k++)
       {
         float x = k/(tent.m_numAnchors-1.0f);
         x *= x*x; // move closer to 0
-        uint32_t pos = 0;
-        if (x * CURVE_RESOLUTION > CURVE_RESOLUTION) {
-            pos = x * CURVE_RESOLUTION;
-        }
-        if(pos >= CURVE_RESOLUTION) pos = CURVE_RESOLUTION-1;
+        uint32_t pos = x * CURVE_RESOLUTION;
         tent.m_anchors[k].x = x;
         tent.m_anchors[k].y = curve[pos];
       }
+      tent.m_anchors[tent.m_numAnchors-1].x = 1.0f;
+      tent.m_anchors[tent.m_numAnchors-1].y = curve[CURVE_RESOLUTION-1];
     }
     else
     { // mutate


### PR DESCRIPTION
It seems that a bit over a year ago, a superfluous check for `pos < 0` was blindly fixed, which then ended up breaking this tool. The original code was a bit weird, since `pos` can't even be negative anyway, and then this "fix" made the code even stranger and entirely broken.

This PR fixes the initialization code so that it works again and removes all bounds checking in order to make the code more straightforward.