### PR TITLE
Fix loading the tone equalizer module

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -828,7 +828,8 @@ static inline void apply_toneequalizer(const float *const restrict in,
 
 
 __DT_CLONE_TARGETS__
-void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+static
+void toneeq_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
              const void *const restrict ivoid, void *const restrict ovoid,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -1018,6 +1019,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
     dt_iop_alpha_copy(in, out, roi_out->width, roi_out->height);
 }
 
+void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
+             const void *const restrict ivoid, void *const restrict ovoid,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+    toneeq_process(self, piece, ivoid, ovoid, roi_in, roi_out);
+}
 
 
 void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,


### PR DESCRIPTION
Error:

```
[iop_load_module] failed to open operation `toneequal': 'process': /usr/lib64/darktable/plugins/libtoneequal.so: undefined symbol: process
```

The documentation for target_clones states:

> It also creates a resolver function (see the ifunc attribute above) that dynamically selects a clone suitable for current architecture. The resolver is created only if there is a usage of a function with target_clones attribute. 

Looking at the elf the lib only provides a process.resolver symbol. So the dynamic loader doesn't find a process symbol.