### PR TITLE
Re-introduce the new iop order as v3.

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define DT_IOP_ORDER_VERSION 2
+#define DT_IOP_ORDER_VERSION 3
 
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_previous, const int dont_move);
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int dont_move);
@@ -62,6 +62,90 @@ static int _ioppr_legacy_iop_order_step(GList **_iop_order_list, GList *history_
     _ioppr_insert_iop_after(_iop_order_list, history_list, "toneequal", "clipping", dont_move);
 
     new_version = 2;
+  }
+  // version 2 --> 3
+  else if(old_version == 2)
+  {
+    // GENERAL RULE FOR SIGNAL PROCESSING/RECONSTRUCTION
+    // pictures are formed through this path :
+    // scene/surfaces/shapes -> atmosphere -> lens -> sensor -> RAW file
+    // we then need to reconstruct/clean the signal the other way :
+    // RAW file -> sensor denoise -> lens profile / deblur -> atmosphere dehaze -> surfaces perspective correction
+
+    // correct exposure in camera RGB space (otherwise, it's not really exposure)
+    _ioppr_move_iop_before(_iop_order_list, "exposure", "colorin", dont_move);
+
+    // move local distorsions/pixel shifts after general distorsions
+    _ioppr_move_iop_before(_iop_order_list, "retouch", "exposure", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "spots", "retouch", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "liquify", "spots", dont_move);
+
+    // move general perspective/distorsions module after lens
+    _ioppr_move_iop_before(_iop_order_list, "clipping", "liquify", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "flip", "clipping", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "ashift", "flip", dont_move);
+
+    // dehaze
+    _ioppr_move_iop_before(_iop_order_list, "hazeremoval", "ashift", dont_move);
+
+    // lens profiles need a pure sensor reading with no correction
+    _ioppr_move_iop_before(_iop_order_list, "lens", "hazeremoval", dont_move);
+
+    // move denoising before any deformation to avoid anisotropic noise creation
+    _ioppr_move_iop_before(_iop_order_list, "bilateral", "lens", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "denoiseprofile", "bilateral", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "demosaic", "denoiseprofile", dont_move);
+
+    // move Lab denoising/reconstruction after input profile where signal is linear
+    // NB: denoising in non-linear spaces makes no sense
+    _ioppr_move_iop_before(_iop_order_list, "colorin", "nlmeans", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "defringe", "nlmeans", dont_move);
+
+    // move frequency filters right after input profile - convolutions need L2 spaces
+    // to respect Parseval's theorem and avoid halos at edges
+    // NB: again, frequency filter in Lab make no sense
+    _ioppr_move_iop_after(_iop_order_list, "atrous", "defringe", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "lowpass", "atrous", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "highpass", "lowpass", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "sharpen", "highpass", dont_move);
+
+    // color adjustments in scene-linear space : move right after colorin
+    _ioppr_move_iop_after(_iop_order_list, "channelmixer", "sharpen", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colorchecker", "channelmixer", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colorbalance", "colorchecker", dont_move);
+
+    _ioppr_move_iop_after(_iop_order_list, "lut3d", "colorchecker", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "basicadj", "colorbalance", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "rgbcurve", "basicadj", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "rgblevels", "rgbcurve", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "bloom", "rgblevels", dont_move);
+
+    // scene-linear to display-referred encoding
+    // !!! WALL OF THE NON-LINEARITY !!! There is no coming back for colour ratios
+    _ioppr_move_iop_after(_iop_order_list, "basecurve", "colorbalance", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "filmic", "basecurve", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colisa", "filmic", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "tonecurve", "colisa", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "levels", "tonecurve", dont_move);
+
+    _ioppr_move_iop_after(_iop_order_list, "shadhi", "levels", dont_move);
+
+    // recover local contrast after non-linear tone edits
+    _ioppr_move_iop_after(_iop_order_list, "bilat", "shadhi", dont_move);
+
+    // display-referred colour edits
+    _ioppr_move_iop_after(_iop_order_list, "colorcorrection", "bilat", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "velvia", "colorcorrection", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "vibrance", "velvia", dont_move);
+    _ioppr_move_iop_after(_iop_order_list, "colorzones", "vibrance", dont_move);
+
+    // fix clipping before going in colourout
+    _ioppr_move_iop_before(_iop_order_list, "colorreconstruct", "colorout", dont_move);
+    _ioppr_move_iop_before(_iop_order_list, "vignette", "colorreconstruct", dont_move);
+
+    _ioppr_move_iop_before(_iop_order_list, "dither", "borders", dont_move);
+
+    new_version = 3;
   }
 
   if(new_version <= 0)


### PR DESCRIPTION
This is properly using a migration path from v2 to v3. Note that only
new edits will use this new ordering. Old ones are kept on the original
iop_order to not break edits.