### PR TITLE
move dt_simd_memcpy() outside of sse.h 

### DIFF
--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -24,8 +24,6 @@
 #include <time.h>
 
 #include "common/darktable.h"
-#include "common/sse.h"
-
 
 /** Note :
  * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code

--- a/src/common/luminance_mask.h
+++ b/src/common/luminance_mask.h
@@ -25,6 +25,7 @@
 #include <time.h>
 
 #include "common/darktable.h"
+#include "develop/imageop_math.h"
 
 
 /** Note :

--- a/src/common/sse.h
+++ b/src/common/sse.h
@@ -18,27 +18,6 @@
 
 #include "common/darktable.h"
 
-#if defined(__clang__)
-#undef _OPENMP
-#endif
-
-__DT_CLONE_TARGETS__
-static inline void dt_simd_memcpy(const float *const restrict in,
-                                  float *const restrict out,
-                                  const size_t num_elem)
-{
-  // Perform a parallel vectorized memcpy on 64-bits aligned
-  // contiguous buffers. This is several times faster than the original memcpy
-
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(in, out, num_elem) \
-schedule(static) aligned(in, out:64)
-#endif
-  for(size_t k = 0; k < num_elem; k++)
-    out[k] = in[k];
-}
-
 
 /**
  * Fast SSE2 implementation of special math functions.

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -148,6 +148,25 @@ static inline void dt_iop_estimate_exp(const float *const x, const float *const 
   coeff[2] = g;
 }
 
+
+__DT_CLONE_TARGETS__
+static inline void dt_simd_memcpy(const float *const __restrict__ in,
+                                  float *const __restrict__ out,
+                                  const size_t num_elem)
+{
+  // Perform a parallel vectorized memcpy on 64-bits aligned
+  // contiguous buffers. This is several times faster than the original memcpy
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+dt_omp_firstprivate(in, out, num_elem) \
+schedule(simd:static) aligned(in, out:64)
+#endif
+  for(size_t k = 0; k < num_elem; k++)
+    out[k] = in[k];
+}
+
+
 /** evaluates the exp fit. */
 static inline float dt_iop_eval_exp(const float *const coeff, const float x)
 {

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -174,7 +174,9 @@ static inline float dt_iop_eval_exp(const float *const coeff, const float x)
 }
 
 /** Copy alpha channel 1:1 from input to output */
-static inline void dt_iop_alpha_copy(const void *ivoid, void *ovoid, const int width, const int height)
+static inline void dt_iop_alpha_copy(const void *const __restrict__ ivoid,
+                                     void *const __restrict__ ovoid,
+                                     const int width, const int height)
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -23,7 +23,7 @@
 #include <time.h>
 
 #include "common/darktable.h"
-#include "common/sse.h"
+#include "develop/imageop_math.h"
 
 /** Note :
  * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code


### PR DESCRIPTION
Users compiling on non-sse systems get crashes when sse.h is loaded inconditionaly in C files. dt_simd_memcpy is moved to imageop_math.h

Take this opportunity to perform minor optimization in alpha_copy