### PR TITLE
correct place of filmicrgb in iop layout

### DIFF
--- a/tools/iop-layout-legacy.sh
+++ b/tools/iop-layout-legacy.sh
@@ -51,6 +51,7 @@ group_tone=(
     'bilat'
     'globaltonemap'
     'filmic'
+    'filmicrgb'
 )
 
 group_color=(

--- a/tools/iop-layout.sh
+++ b/tools/iop-layout.sh
@@ -43,6 +43,7 @@ group_basic=(
     'profile_gamma'
     'temperature'
     'filmic'
+    'filmicrgb'
     'basicadj'
 )
 


### PR DESCRIPTION
Now that #2938 is merged, configure it in `tools/iop-layout.sh` script to be at the same place at original filmic.