### PR TITLE
Fix various typos

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -206,7 +206,7 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>disable the entry completion</shortdescription>
-    <longdescription>the entry completion is useful for those who enter tags from keybord only. for others the entry completion can be embarassing. need to restart darktable.</longdescription>
+    <longdescription>the entry completion is useful for those who enter tags from keyboard only. for others the entry completion can be embarrassing. need to restart darktable.</longdescription>
   </dtconfig>
   <dtconfig prefs="core" capability="opencl" section="cpugpu">
     <name>opencl</name>

--- a/doc/usermanual/lighttable/lighttable.xml
+++ b/doc/usermanual/lighttable/lighttable.xml
@@ -260,8 +260,8 @@
         </para>
 
         <para>
-          In this mode, you'll navigate throught all selected images. If no selection is set
-          (or if only 1 image is selected), you'll navigate throught all images.
+          In this mode, you'll navigate through all selected images. If no selection is set
+          (or if only 1 image is selected), you'll navigate through all images.
         </para>
 
         <para>

--- a/doc/usermanual/preferences/core_options.xml
+++ b/doc/usermanual/preferences/core_options.xml
@@ -234,8 +234,8 @@
     <bridgehead renderas="sect5">disable the entry completion</bridgehead>
 
     <para>
-      The entry completion is useful for those who enter tags from keybord only.
-      For others the entry completion can be embarassing (default off). (need a restart)
+      The entry completion is useful for those who enter tags from keyboard only.
+      For others the entry completion can be embarrassing (default off). (need a restart)
     </para>
 
     <bridgehead renderas="sect5">password storage backend to use</bridgehead>

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -798,7 +798,7 @@ gint dt_sort_iop_by_order(gconstpointer a, gconstpointer b)
 // if module can be placed before than module_next on the pipe
 // it returns the new iop_order
 // if it cannot be placed it returns -1.0
-// this assums that the order is always positive
+// this assumes that the order is always positive
 double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *module, dt_iop_module_t *module_next,
                                   const int validate_order, const int log_error)
 {
@@ -838,7 +838,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
 
-        // if we reach module_next everithing is OK
+        // if we reach module_next everything is OK
         if(mod == module_next)
         {
           mod2 = mod;
@@ -935,7 +935,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
       {
         dt_iop_module_t *mod = (dt_iop_module_t *)modules->data;
 
-        // we reach the module next to module_next, everithing is OK
+        // we reach the module next to module_next, everything is OK
         if(mod2 != NULL)
         {
           mod1 = mod;
@@ -1018,7 +1018,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
 // if module can be placed after than module_prev on the pipe
 // it returns the new iop_order
 // if it cannot be placed it returns -1.0
-// this assums that the order is always positive
+// this assumes that the order is always positive
 double dt_ioppr_get_iop_order_after_iop(GList *iop_list, dt_iop_module_t *module, dt_iop_module_t *module_prev,
                                  const int validate_order, const int log_error)
 {

--- a/src/common/luminance_mask.h
+++ b/src/common/luminance_mask.h
@@ -181,7 +181,7 @@ static void pixel_rgb_norm_2(const float *const restrict image,
                              const float exposure_boost,
                              const float fulcrum, const float contrast_boost)
 {
-  // vector norm L2 : euclidian norm
+  // vector norm L2 : euclidean norm
 
   float result = 0.0f;
 

--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -276,7 +276,7 @@ void dt_conf_cleanup(dt_conf_t *cf)
   dt_pthread_mutex_destroy(&darktable.conf->mutex);
 }
 
-/** check if key exists, return 1 if lookup successed, 0 if failed..*/
+/** check if key exists, return 1 if lookup succeeded, 0 if failed..*/
 int dt_conf_key_exists(const char *key)
 {
   dt_pthread_mutex_lock(&darktable.conf->mutex);

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -115,7 +115,7 @@ typedef enum dt_signal_t
     */
   DT_SIGNAL_DEVELOP_PREVIEW2_PIPE_FINISHED,
 
-  /** \brief This signal is rasied when pipe is finished and the gui is attached
+  /** \brief This signal is raised when pipe is finished and the gui is attached
   no param, no returned value
     */
   DT_SIGNAL_DEVELOP_UI_PIPE_FINISHED,
@@ -131,7 +131,7 @@ typedef enum dt_signal_t
     */
   DT_SIGNAL_DEVELOP_MODULE_REMOVE,
 
-  /** \brief This signal is rasied when image is changed in darkroom */
+  /** \brief This signal is raised when image is changed in darkroom */
   DT_SIGNAL_DEVELOP_IMAGE_CHANGED,
 
   /** \brief This signal is raised when the screen profile has changed

--- a/src/gui/presets.h
+++ b/src/gui/presets.h
@@ -33,7 +33,7 @@ void dt_gui_presets_update_tv(const char *name, dt_dev_operation_t op, const int
                               const float max);
 void dt_gui_presets_update_fl(const char *name, dt_dev_operation_t op, const int32_t version, const float min,
                               const float max);
-/** update ldr flag: 0-dont care, 1-low dynamic range, 2-raw */
+/** update ldr flag: 0-don't care, 1-low dynamic range, 2-raw */
 void dt_gui_presets_update_ldr(const char *name, dt_dev_operation_t op, const int32_t version,
                                const int ldrflag);
 /** set auto apply property of preset. */

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -1655,7 +1655,7 @@ static int fact(const int n)
 // original RANSAC works on linear optimization problems. Our model is nonlinear. We
 // take advantage of the fact that lines interesting for our model are vantage lines
 // that meet in one vantage point for each subset of lines (vertical/horizontal).
-// Stragegy: we construct a model by (random) sampling within the subset of lines and
+// Strategy: we construct a model by (random) sampling within the subset of lines and
 // calculate the vantage point. Then we check the "distance" of all other lines to the
 // vantage point. The model that gives highest number of lines combined with the highest
 // total weight and lowest overall "distance" wins.
@@ -1753,7 +1753,7 @@ static void ransac(const dt_iop_ashift_line_t *lines, int *index_set, int *inout
         const float *L3 = lines[index_set[n]].L;
 
         // we take the absolute value of the dot product of V and L as a measure
-        // of the "distance" between point and line. Note that this is not the real euclidian
+        // of the "distance" between point and line. Note that this is not the real euclidean
         // distance but - with the given normalization - just a pragmatically selected number
         // that goes to zero if V lies on L and increases the more V and L are apart
         const float d = fabs(vec3scalar(V, L3));

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -1258,7 +1258,7 @@ static void _get_auto_exp(const uint32_t *const histogram, const unsigned int hi
   if(black < gavg)
   {
     const int maxwhiteclip = (gavg - black) * 4 / 3
-                             + black; // dont let whiteclip be such large that the histogram average goes above 3/4
+                             + black; // don't let whiteclip be so large that the histogram average goes above 3/4
 
     if(whiteclipg < maxwhiteclip)
     {
@@ -1269,7 +1269,7 @@ static void _get_auto_exp(const uint32_t *const histogram, const unsigned int hi
   whiteclipg
       = igamma2(whiteclipg); // need to inverse gamma transform to get correct exposure compensation parameter
 
-  // corection with gamma
+  // correction with gamma
   black = (black / whiteclipg);
 
   expcomp = CLAMP(expcomp, -5.0f, 12.0f);

--- a/src/iop/choleski.h
+++ b/src/iop/choleski.h
@@ -78,7 +78,7 @@
  *
  * We didn't bother to parallelize the code nor to make it use double floating point precision
  * because it's already fast enough (2 to 45 ms for 16×16 matrix on Xeon) and used for properly
- * conditionned matrices.
+ * conditioned matrices.
  *
  * Vectorization leads to slow-downs here since we access matrices row-wise and column-wise,
  * in a non-contiguous fashion.
@@ -282,7 +282,7 @@ static inline int solve_hermitian(const float *const restrict A,
   // Solve A x = y where A an hermitian positive definite matrix n × n
   // x and y are n vectors. Output the result in y
 
-  // A and y need to be 64-bits aligned, which is darktable's default memory alignement
+  // A and y need to be 64-bits aligned, which is darktable's default memory alignment
   // if you used DT_ALIGNED_ARRAY and dt_alloc_sse_ps(...) to declare arrays and pointers
 
   // If you are sure about the properties of the matrix A (symmetrical square definite positive)

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -360,7 +360,7 @@ void process(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, cons
           norm += weight;
         }
         // here we could try using a "balance" between original and changed value, this could be used to
-        // reduce artifcats
+        // reduce artifacts
         // but on first tries, results weren't very convincing, and there are blend settings available anyway
         // in dt
         // float balance = (out[v*width*ch +t*ch +3]-thresh)/out[v*width*ch +t*ch +3];

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2820,7 +2820,7 @@ static int demosaic_qual_flags(const dt_dev_pixelpipe_iop_t *const piece,
       break;
   }
 
-  // For suficiently small scaling, one or more repetitition of the
+  // For sufficiently small scaling, one or more repetitition of the
   // CFA pattern can be merged into a single pixel, hence it is
   // possible to skip the full demosaic and perform a quick downscale.
   // Note even though the X-Trans CFA is 6x6, for this purposes we can

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -634,7 +634,7 @@ static inline void backtransform(float *const buf, const int wd, const int ht, c
 // anscombe transform.
 // In the generalized anscombe transform, the profiles gives a and b such as:
 // V(X) = a * E[X] + b
-// In this new transform, we have an additionnal parameter, p, such as:
+// In this new transform, we have an additional parameter, p, such as:
 // V(X) = a * (E[X] + b) ^ p
 // When p == 1, we get back the equation of generalized anscombe transform.
 // Now, let's see how we derive the precondition.
@@ -645,7 +645,7 @@ static inline void backtransform(float *const buf, const int wd, const int ht, c
 //          = f'(X)^2 * V(X-E[X])
 //          = f'(X)^2 * V(X)
 // So the condition V(f(X)) = constant gives us the following condition:
-// V(X) = contant / f'(X)^2
+// V(X) = constant / f'(X)^2
 // Usually, we take constant = 1
 // If we have V(X) = a * (E[X] + b) ^ p
 // then: f'(X) = 1 / sqrt(a) * (E[X] + b) ^ (-p / 2)
@@ -735,7 +735,7 @@ static inline void precondition_v2(const float *const in, float *const buf, cons
 // That's why we introduce a user-controled bias parameter to be able to
 // control the bias:
 // we replace the 2 * p * constant / (2 - p) part of delta by user
-// defined bias controler.
+// defined bias controller.
 static inline void backtransform_v2(float *const buf, const int wd, const int ht, const float a, const float p[3],
                                     const float b, const float bias, const float wb[3])
 {

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1541,7 +1541,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
                                  { 215.0f/255.0f, 182.0f/255.0f, 0.0f}};// b = 128 @ L = 75, a = 0
 
    // since Cairo paints with sRGB at gamma 2.4, linear gradients are not linear and, at 50%,
-   // we dont see the neutral grey we would expect in the middle of a linear gradient between
+   // we don't see the neutral grey we would expect in the middle of a linear gradient between
    // 2 complimentary colors. So we add it artificially, but that will break the smoothness
    // of the transition.
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -31,8 +31,8 @@
  * Because it works before camera RGB -> XYZ conversion, the exposure cannot be computed from
  * any human-based perceptual colour model (Y channel), hence why several RGB norms are provided as estimators of
  * the pixel energy to compute a luminance map. None of them is perfect, and I'm still
- * looking forward to a real spectral energy estimator. The best physically-accurate norm should be the euclidian
- * norm, but the best looking is often the power norm, which has no theoritical background.
+ * looking forward to a real spectral energy estimator. The best physically-accurate norm should be the euclidean
+ * norm, but the best looking is often the power norm, which has no theoretical background.
  * The geometric mean also display interesting properties as it interprets saturated colours
  * as low-lights, allowing to lighten and desaturate them in a realistic way.
  *
@@ -843,8 +843,8 @@ void toneeq_process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
   if(in == NULL || out == NULL)
   {
     // Pointers are not 64-bits aligned, and SSE code will segfault
-    dt_control_log(_("tone equalizer in/out buffer are ill-aligned, please report the bug to the developpers"));
-    fprintf(stdout, "tone equalizer in/out buffer are ill-aligned, please report the bug to the developpers\n");
+    dt_control_log(_("tone equalizer in/out buffer are ill-aligned, please report the bug to the developers"));
+    fprintf(stdout, "tone equalizer in/out buffer are ill-aligned, please report the bug to the developers\n");
     return;
   }
 
@@ -1066,7 +1066,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
  * and y are the desired exposure compensation for each channel.
  *
  * This (x, y) set is interpolated by radial-basis function using a series of 8 gaussians.
- * Loosing 1 degree of freedom makes it an approximation rather than an interpolation but
+ * Losing 1 degree of freedom makes it an approximation rather than an interpolation but
  * helps reducing a bit the oscillations and fills a full AVX vector.
  *
  * The coefficients/factors used in the interpolation/approximation are linear, but keep in
@@ -1074,7 +1074,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
  * flip/flop between both.
  *
  * User params of exposure compensation are expected between [-2 ; +2] EV for practical UI reasons
- * and probably numerical stability reasons, but there is no theoritical obstacle to enlarge
+ * and probably numerical stability reasons, but there is no theoretical obstacle to enlarge
  * this range. The main reason for not allowing it is tone equalizer is mostly intended
  * to do local changes, and these don't look so well if you are too harsh on the changes.
  * For heavier tonemapping, it should be used in combination with a tone curve or filmic.
@@ -3136,7 +3136,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->method, "HSL lightness");
   dt_bauhaus_combobox_add(g->method, "HSV value / RGB max");
   dt_bauhaus_combobox_add(g->method, "RGB sum");
-  dt_bauhaus_combobox_add(g->method, "RGB euclidian norm");
+  dt_bauhaus_combobox_add(g->method, "RGB euclidean norm");
   dt_bauhaus_combobox_add(g->method, "RGB power norm");
   dt_bauhaus_combobox_add(g->method, "RGB geometric mean");
   g_signal_connect(G_OBJECT(g->method), "value-changed", G_CALLBACK(method_changed), self);

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -168,7 +168,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   // Plus :
   //  Before compressing the base intensity , we remove average base intensity in order to not have
   //  variable average intensity when varying compression factor.
-  //  after compression we substract 2.0 to have an average intensity at middle tone.
+  //  after compression we subtract 2.0 to have an average intensity at middle tone.
   //
 
   const float contr = 1. / data->contrast;

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -263,7 +263,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
     gtk_box_pack_start(GTK_BOX(vbox2), box, FALSE, TRUE, 0);
     GtkWidget *vbox3 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_pack_start(GTK_BOX(box), vbox3, FALSE, TRUE, 10); 
-    calculated = gtk_check_button_new_with_label(_("only embbeded"));
+    calculated = gtk_check_button_new_with_label(_("only embedded"));
     gtk_widget_set_tooltip_text(calculated, _("per default the interface sends some (limited) metadata beside the image to remote storage.\n"
         "to avoid this and let only image embedded dt xmp metadata, check this flag.\n"
         "if remote storage doesn't understand dt xmp metadata, you can use calculated metadata instead"));
@@ -378,7 +378,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_box_pack_start(GTK_BOX(vbox), box, FALSE, TRUE, 0);
 
   GtkWidget *button = dtgtk_button_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_tooltip_text(button, _("add an ouput metadata tag"));
+  gtk_widget_set_tooltip_text(button, _("add an output metadata tag"));
   gtk_box_pack_end(GTK_BOX(box), button, FALSE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(add_tag_button_clicked), (gpointer)d);
 

--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -701,7 +701,7 @@ static dt_lib_timeline_time_t _selection_scroll_to(dt_lib_timeline_time_t t, dt_
     // we ensure that we are not before the strip bound
     if(_time_compare(tt, strip->time_mini) <= 0) return strip->time_mini;
 
-    // and we dont want to display blocks after the bounds too
+    // and we don't want to display blocks after the bounds too
     dt_lib_timeline_time_t ttt = tt;
     _time_add(&ttt, nb - 1, strip->zoom);
     if(_time_compare(ttt, strip->time_maxi) <= 0) return tt;

--- a/src/lua/types.h
+++ b/src/lua/types.h
@@ -77,17 +77,17 @@ luaA_Type dt_lua_init_type_type(lua_State *L, luaA_Type type_id);
 /*********************************/
 /* MEMBER REGISTRATION FUNCTIONS */
 /*********************************/
-/// register a read-only member, the member function is poped from the stack
+/// register a read-only member, the member function is popped from the stack
 #define dt_lua_type_register_const(L, type_name, name)                                                       \
   dt_lua_type_register_const_type(L, luaA_type_find(L, #type_name), name)
 void dt_lua_type_register_const_type(lua_State *L, luaA_Type type_id, const char *name);
 
-/// register a read-write member, the member function is poped from the stack
+/// register a read-write member, the member function is popped from the stack
 #define dt_lua_type_register(L, type_name, name)                                                             \
   dt_lua_type_register_type(L, luaA_type_find(L, #type_name), name)
 void dt_lua_type_register_type(lua_State *L, luaA_Type type_id, const char *name);
 
-/// register a function for all fields of luaautoc struct, the member function is poped from the stack
+/// register a function for all fields of luaautoc struct, the member function is popped from the stack
 /// detects red-only vs read-write automatically
 #define dt_lua_type_register_struct(L, type_name)                                                            \
   dt_lua_type_register_struct_type(L, luaA_type_find(L, #type_name))
@@ -162,7 +162,7 @@ void dt_lua_type_gpointer_drop(lua_State*L, void* pointer);
 luaA_Type dt_lua_init_singleton(lua_State *L, const char *unique_name, void *data);
 
 /**
- * similar to dt_lua_init_singleton but the singleton has push and pop functions to save/restor
+ * similar to dt_lua_init_singleton but the singleton has push and pop functions to save/restore
  * the lua object called on
  */
 luaA_Type dt_lua_init_wrapped_singleton(lua_State *L, lua_CFunction pusher, lua_CFunction getter,

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -353,7 +353,7 @@ void expose(
     g_assert(darktable.develop->proxy.snapshot.filename != NULL);
 
     /* Store current image surface to snapshot file.
-       FIXME: add checks so that we dont make snapshots of preview pipe image surface.
+       FIXME: add checks so that we don't make snapshots of preview pipe image surface.
     */
     int fd = g_open(darktable.develop->proxy.snapshot.filename, O_CREAT | O_WRONLY | O_BINARY, 0600);
     cairo_surface_write_to_png_stream(image_surface, write_snapshot_data, GINT_TO_POINTER(fd));
@@ -2625,7 +2625,7 @@ void leave(dt_view_t *self)
   dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
 
   darktable.develop->image_storage.id = -1;
-  // darkroom development could have changed a collection, so update that before beeing back in lightroom 
+  // darkroom development could have changed a collection, so update that before being back in lightroom 
   dt_collection_update_query(darktable.collection);
   dt_print(DT_DEBUG_CONTROL, "[run_job-] 11 %f in darkroom mode\n", dt_get_wtime());
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -2050,7 +2050,7 @@ static gboolean _culling_recreate_slots(dt_view_t *self)
   dt_library_t *lib = (dt_library_t *)self->data;
 
   int display_first_image = -1;
-  // special if we start dt in culling + fxed + selection
+  // special if we start dt in culling + fixed + selection
   if(!lib->already_started && lib->culling_use_selection
      && dt_view_lighttable_get_culling_zoom_mode(darktable.view_manager) == DT_LIGHTTABLE_ZOOM_FIXED)
   {

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -296,7 +296,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
 
   // destroy old module list
 
-  /*  clear the undo list, for now we do this inconditionally. At some point we will probably want to clear
+  /*  clear the undo list, for now we do this unconditionally. At some point we will probably want to clear
      only part
       of the undo list. This should probably done with a view proxy routine returning the type of undo to
      remove. */
@@ -2358,7 +2358,7 @@ void dt_view_accels_refresh(dt_view_manager_t *vm)
         gchar **elems = g_strsplit(da->translated_path, "/", -1);
         if(elems[0] && elems[1] && elems[2])
         {
-          // do we already have a categorie ?
+          // do we already have a category ?
           bl = blocs;
           _bloc_t *b = NULL;
           while(bl)


### PR DESCRIPTION
Typos found using `codespell` (v1.17.0.dev0)