### PR TITLE
filmicrgb : fix glitch in spline in middle zone

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1031,7 +1031,7 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
   // factors of x⁴
   spline->M5[0] = a;
   spline->M5[1] = h;
-  spline->M5[3] = 0.f;
+  spline->M5[2] = 0.f;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,


### PR DESCRIPTION
fix #2997
Note that it *seems* to fix the problem, and the code changed looks like stupid errors I often do... but I've absolutely no idea about all the maths behind. So @aurelienpierre **please double check** it's not breaking anything !