### PR TITLE
Lighttable

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1204,26 +1204,26 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   switch((flags & 7))
   {
     case 0:
-      cairo_set_source_rgba(cr, 1, 0.0, 0.0, alpha);
+      cairo_set_source_rgba(cr, 0.9, 0.0, 0.0, alpha);
       break; // red
     case 1:
-      cairo_set_source_rgba(cr, 1, 1.0, 0.0, alpha);
+      cairo_set_source_rgba(cr, 0.9, 0.9, 0.0, alpha);
       break; // yellow
     case 2:
-      cairo_set_source_rgba(cr, 0.0, 1, 0.0, alpha);
+      cairo_set_source_rgba(cr, 0.0, 0.9, 0.0, alpha);
       break; // green
     case 3:
-      cairo_set_source_rgba(cr, 0.0, 0.0, 1, alpha);
+      cairo_set_source_rgba(cr, 0.0, 0.0, 0.9, alpha);
       break; // blue
     case 4:
-      cairo_set_source_rgba(cr, 1, 0.0, 1.0, alpha);
-      break; // purple
+      cairo_set_source_rgba(cr, 0.9, 0.0, 0.9, alpha);
+      break; // magenta
     case 7:
       // don't fill
       cairo_set_source_rgba(cr, 0, 0, 0, 0);
       break;
     default:
-      cairo_set_source_rgba(cr, 1, 1, 1, alpha);
+      cairo_set_source_rgba(cr, 0.75, 0.75, 0.75, alpha);
       def = TRUE;
       break; // gray
   }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1418,6 +1418,8 @@ escape_image_loop:
     if(sqlite3_step(lib->statements.is_grouped) != SQLITE_ROW) mouse_over_group = -1;
   }
 
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+
   for(int row = 0; row < max_rows; row++)
   {
     for(int col = 0; col < max_cols; col++)

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1154,7 +1154,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
       PangoRectangle ink;
       PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
       pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
-      const int fontsize = 0.20 * width;
+      const int fontsize = DT_PIXEL_APPLY_DPI(22.0);
       pango_font_description_set_absolute_size(desc, fontsize * PANGO_SCALE);
       layout = pango_cairo_create_layout(cr);
       pango_layout_set_font_description(layout, desc);
@@ -1179,7 +1179,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
         {
           pango_layout_set_text(layout, &upcase_ext[i], 1);
           pango_layout_get_pixel_extents(layout, &ink, NULL);
-          cairo_move_to(cr, .025 * width - ink.x + (max_chr_width - ink.width) / 2, .2 * height - yoffs);
+          cairo_move_to(cr, .045 * width - ink.x + (max_chr_width - ink.width) / 2, .09 * height - yoffs + fontsize / 2.0);
           pango_cairo_show_layout(cr, layout);
         }
       }
@@ -1187,7 +1187,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
       {
         pango_layout_set_text(layout, upcase_ext, -1);
         pango_layout_get_pixel_extents(layout, &ink, NULL);
-        cairo_move_to(cr, .025 * width - ink.x, .2 * height - fontsize);
+        cairo_move_to(cr, .045 * width - ink.x, .09 * height - fontsize / 2.0);
         pango_cairo_show_layout(cr, layout);
       }
       g_free(upcase_ext);


### PR DESCRIPTION
1. Refactor the lighttable to the general theme by removing rounded corners, dropped shadows and unnecessary borders.
1. Fix #2998 by making 20px × DPI the max size for text and icons in lighttable thumbnails, no matter the zoom size (for small zoom sizes, icons and text are still proportional : we just ensure they don't get oversized at large zoom levels).
1. Add a dark overlay background on thumbnail to help legibility of overlays stars and stuff.

All this is to focus on pictures and avoid distractions around them.

this PR:
![Screenshot_20190926_011326](https://user-images.githubusercontent.com/2779157/65646543-aafcf280-dffb-11e9-817c-01854317b2e6.png)

darktable master:
![Screenshot_20190926_012314](https://user-images.githubusercontent.com/2779157/65646714-42fadc00-dffc-11e9-8843-5438459e3cb1.png)

this PR:
![Screenshot_20190926_012500](https://user-images.githubusercontent.com/2779157/65646777-7fc6d300-dffc-11e9-98b9-25c88f4cc6ec.png)

darktable master:
![Screenshot_20190926_012012](https://user-images.githubusercontent.com/2779157/65646615-e7c8e980-dffb-11e9-9c1c-4052f25ec18c.png)

@AlicVB could you take over for the culling view ? I'm not sure what happens here with the `zoom == 1`, exif info display does not behave in culling like file manager.