### PR TITLE
lighttable.xml: correct keyboard shortcuts for fully zoom from Z to W

### DIFF
--- a/doc/usermanual/lighttable/lighttable.xml
+++ b/doc/usermanual/lighttable/lighttable.xml
@@ -113,7 +113,7 @@
             </row>
             <row>
               <entry>
-                <emphasis>Z</emphasis>
+                <emphasis>W</emphasis>
               </entry>
               <entry>
                 fully zoom into the image while the key is pressed
@@ -121,7 +121,7 @@
             </row>
             <row>
               <entry>
-                <emphasis>Ctrl+Z</emphasis>
+                <emphasis>Ctrl+W</emphasis>
               </entry>
               <entry>
                 fully zoom into the image and show areas in focus

--- a/doc/usermanual/lighttable/lighttable.xml
+++ b/doc/usermanual/lighttable/lighttable.xml
@@ -265,7 +265,7 @@
         </para>
 
         <para>
-          Default shortcut for entering culling in fixed mode is <emphasis>X</emphasis>.
+          Default keyboard shortcut for entering culling in fixed mode is <emphasis>X</emphasis>.
         </para>
 
       </sect3>
@@ -280,7 +280,7 @@
         </para>
 
         <para>
-          Default shortcut for entering culling in fixed mode is <emphasis>Ctrl+X</emphasis>.
+          Default keyboard shortcut for entering culling in dynamic mode is <emphasis>Ctrl+X</emphasis>.
         </para>
 
       </sect3>


### PR DESCRIPTION
In chapter 2.1.4 Full preview the keyboard shortcuts are defined as W and Ctrl+W.
In Chapter 2.1 Overview it was still described with the key combination Z.