### PR TITLE
deprecate some modules

### DIFF
--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -398,7 +398,7 @@ dt_omp_firstprivate(image, out, num_elem, sampling, clip_min, clip_max) \
 schedule(static) aligned(image, out:64)
 #endif
     for(size_t k = 0; k < num_elem; k++)
-      out[k] = fast_clamp(image[k], clip_min, clip_max);
+      out[k] = image[k];
   }
   else if(sampling == 1.0f)
   {
@@ -477,12 +477,6 @@ static inline void fast_surface_blur(float *const restrict image,
     {
       // Process the intermediate filtered image
       apply_linear_blending(ds_image, ds_ab, num_elem_ds);
-    }
-    else
-    {
-      // Increase the radius for the next iteration
-      ds_radius *= 2.0f;
-      feathering /= 2.0f;
     }
   }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -419,38 +419,38 @@ void init_presets(dt_iop_module_so_t *self)
   p.details = DT_TONEEQ_GUIDED;
   p.method = DT_TONEEQ_NORM_2;
 
-  p.blending = 12.5f;
-  p.feathering = 5.0f;
-  p.iterations = 3;
-  p.quantization = 1.0f;
-  p.exposure_boost = -1.0f;
-  p.contrast_boost = 2.0f;
+  p.blending = 33.0f;
+  p.feathering = 10.0f;
+  p.iterations = 1;
+  p.quantization = 0.0f;
+  p.exposure_boost = 0.0f;
+  p.contrast_boost = 0.0f;
   dt_gui_presets_add_generic(_("mask blending : landscapes"), self->op, self->version(), &p, sizeof(p), 1);
 
   p.blending = 25.0f;
-  p.feathering = 5.0f;
+  p.feathering = 25.0f;
   p.iterations = 2;
-  p.quantization = 1.0f;
-  p.exposure_boost = -1.5f;
-  p.contrast_boost = 3.0f;
+  p.quantization = 0.0f;
+  p.exposure_boost = 0.0f;
+  p.contrast_boost = 0.0f;
   dt_gui_presets_add_generic(_("mask blending : all purposes"), self->op, self->version(), &p, sizeof(p), 1);
 
   p.blending = 25.0f;
   p.feathering = 25.0f;
   p.iterations = 4;
-  p.quantization = 1.0f;
-  p.exposure_boost = -1.5f;
-  p.contrast_boost = 3.0f;
+  p.quantization = 0.0f;
+  p.exposure_boost = -0.5f;
+  p.contrast_boost = 1.0f;
   dt_gui_presets_add_generic(_("mask blending : isolated subjects"), self->op, self->version(), &p, sizeof(p), 1);
 
   // Shadows/highlights presets
 
   p.blending = 25.0f;
-  p.feathering = 10.0f;
+  p.feathering = 25.0f;
   p.iterations = 2;
-  p.quantization = 1.0f;
-  p.exposure_boost = -1.5f;
-  p.contrast_boost = 3.0f;
+  p.quantization = 0.0f;
+  p.exposure_boost = -0.5f;
+  p.contrast_boost = 1.0f;
 
   p.noise = 0.05f;
   p.ultra_deep_blacks = 0.15f;
@@ -464,12 +464,12 @@ void init_presets(dt_iop_module_so_t *self)
 
   dt_gui_presets_add_generic(_("compress shadows/highlights : soft"), self->op, self->version(), &p, sizeof(p), 1);
 
-  p.blending = 12.5f;
-  p.feathering = 20.0f;
-  p.iterations = 3;
-  p.quantization = 1.0f;
-  p.exposure_boost = -1.0f;
-  p.contrast_boost = 2.0f;
+  p.blending = 25.0f;
+  p.feathering = 10.0f;
+  p.iterations = 2;
+  p.quantization = 0.0f;
+  p.exposure_boost = -0.5f;
+  p.contrast_boost = 1.0f;
 
   p.noise = 0.5f;
   p.ultra_deep_blacks = 0.9f;
@@ -484,11 +484,11 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("compress shadows/highlights : strong"), self->op, self->version(), &p, sizeof(p), 1);
 
   p.blending = 25.0f;
-  p.feathering = 10.0f;
+  p.feathering = 25.0f;
   p.iterations = 2;
-  p.quantization = 1.0f;
-  p.exposure_boost = -1.5f;
-  p.contrast_boost = 3.0f;
+  p.quantization = 0.0f;
+  p.exposure_boost = 0.0f;
+  p.contrast_boost = 0.0f;
 
   p.noise = 0.0f;
   p.ultra_deep_blacks = 0.15f;
@@ -660,7 +660,9 @@ static inline void compute_correction(const float *const restrict luminance,
     // build the correction for the current pixel
     // as the sum of the contribution of each luminance channelcorrection
     float result = 0.0f;
-    const float exposure = log2f(luminance[k]);
+
+    // The radial-basis interpolation is valid in [-8; 0] EV and can quickely diverge outside
+    const float exposure = fast_clamp(log2f(luminance[k]), -8.0f, 0.0f);
 
 #ifdef _OPENMP
 #pragma omp simd aligned(luminance, centers_ops, factors:64) safelen(PIXEL_CHAN) reduction(+:result)
@@ -668,7 +670,8 @@ static inline void compute_correction(const float *const restrict luminance,
     for(int i = 0; i < PIXEL_CHAN; ++i)
       result += gaussian_func(exposure - centers_ops[i], gauss_denom) * factors[i];
 
-    correction[k] = result;
+    // the user-set correction is expected in [-2;+2] EV, so is the interpolated one
+    correction[k] = fast_clamp(result, 0.25f, 4.0f);
   }
 }
 
@@ -712,7 +715,7 @@ static inline void compute_luminance_mask(const float *const restrict in, float 
       // Still no contrast boost
       luminance_mask(in, luminance, width, height, ch, d->method, d->exposure_boost, 0.0f, 1.0f);
       fast_surface_blur(luminance, width, height, d->radius, d->feathering, d->iterations,
-                    DT_GF_BLENDING_GEOMEAN, d->scale, d->quantization, exp2f(-8.0f), 1.0f);
+                    DT_GF_BLENDING_GEOMEAN, d->scale, d->quantization, exp2f(-14.0f), 4.0f);
       break;
     }
 
@@ -728,7 +731,7 @@ static inline void compute_luminance_mask(const float *const restrict in, float 
       luminance_mask(in, luminance, width, height, ch, d->method, d->exposure_boost,
                       CONTRAST_FULCRUM, d->contrast_boost);
       fast_surface_blur(luminance, width, height, d->radius, d->feathering, d->iterations,
-                    DT_GF_BLENDING_LINEAR, d->scale, d->quantization, exp2f(-8.0f), 1.0f);
+                    DT_GF_BLENDING_LINEAR, d->scale, d->quantization, exp2f(-14.0f), 4.0f);
       break;
     }
 
@@ -1505,15 +1508,15 @@ void init(dt_iop_module_t *module)
                                                                       .highlights = 0.0f,
                                                                       .whites = 0.0f,
                                                                       .speculars = 0.0f,
-                                                                      .quantization = 1.0f,
+                                                                      .quantization = 0.0f,
                                                                       .smoothing = sqrtf(2.0f),
                                                                       .iterations = 2,
                                                                       .method = DT_TONEEQ_NORM_2,
                                                                       .details = DT_TONEEQ_GUIDED,
                                                                       .blending = 25.0f,
-                                                                      .feathering = 10.0f,
-                                                                      .contrast_boost = 2.0f,
-                                                                      .exposure_boost = -1.0f };
+                                                                      .feathering = 25.0f,
+                                                                      .contrast_boost = 0.0f,
+                                                                      .exposure_boost = 0.0f };
   memcpy(module->params, &tmp, sizeof(dt_iop_toneequalizer_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_toneequalizer_params_t));
 }


### PR DESCRIPTION
1. rename "equalizer" into "contrast equalizer" to make the difference between tone equalizer clear
1. deprecate the `relight` IOP:
  its use case falls back to the "fill-in" preset in tone equalizer, and uses the same logic to blend the exposure change. Unfortunately, it works in Lab display-referred space, where the concept of exposure is void, and the exposure blending ends-up flattening the affected areas a lot. Results are really random.
1. deprecate the `zone system` IOP:
  its use case falls back to the tone equalizer module, but tone equal allows to affect every channel independantly, while zone system redistributes the zones (you can only push a zone by pulling another), so the tuning can be more challenging and, again, local contrast flattening is to be expected.
1. deprecate the `global tone mapping` IOP:
  the colour science behind this module is dead wrong from the fundamentals. First of all, the tone mapping operators used there were designed for RGB spaces, yet they are applied in Lab. Second, the Lab space is designed around the idea that 100 % L means 100 Cd/m² (nits) display-referred, so it is not suitable for any HDR work (Lab-HDR has been developed a couple of years ago by Mark Fairchild and al.). Third, the Drago operator works fairly (even if it heavily desaturates shadows), the filmic operator falls back to the specific filmic module use case, but the Reinhard operator is completely broken and its output depends on the image size (different results in lightness have been reported depending on the file export resolution).

Modules left available that should be deprecated at some point:

1. tone mapping (the local one): its algo, using a gaussian blur to tonemap locally, will always produce halos around hard edges and there is no solution to that (using mild settings to hide dust under carpets is not considered a solution). This algo will never be robust, its flaw is on its theoritical background.
1. shadows and highlights: again, it's very prone to halos and the practically usable setting range is quite small. This module also adds local contrast as a side effect, for some settings combinations (that people might find pleasing), yet it's not its purpose and overlaps on local contrast module use cases. Finally, this module, working in Lab, is not really suitable for HDR work.

On a side note, here, HDR means any image which dynamic range is larger than the one of the output medium. Modern screens still have no more than 8 to 10 EV of theoritical dynamic range, and prints range between 4-7 EV. Yet, even entry-level DSLR shooting at base ISO hit 12 EV easily, and high-end ones almost hit 14 EV. So, pretty much every picture shot at base ISO now should be considered HDR, and a good image processing pipeline should be ready for that (aka allow dramatic edits without screwing colour).