### PR TITLE
Fixing new iop_order for sidecar files.

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2918,9 +2918,7 @@ static void dt_set_xmp_dt_history(Exiv2::XmpData &xmpData, const int imgid, int 
     snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:multi_priority", num);
     xmpData[key] = multi_priority;
     snprintf(key, sizeof(key), "Xmp.darktable.history[%d]/darktable:iop_order", num);
-    // This code only writes iop_order as the default which is float, so it's wrong.
-    // We **must** ensure it's written with high precision instead.
-    // xmpData[key] = iop_order;
+    // we ensure writing the iop_order as high precision...
     char *str = (char *)g_malloc(G_ASCII_DTOSTR_BUF_SIZE);
     g_ascii_formatd(str, G_ASCII_DTOSTR_BUF_SIZE, "%.13f", iop_order);
     xmpData[key] = str;

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -33,6 +33,8 @@
 
 #define DT_IOP_ORDER_VERSION 3
 
+#define DT_IOP_ORDER_INFO FALSE	// used while debugging
+
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_previous, const int dont_move);
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int dont_move);
 static void _ioppr_move_iop_after(GList **_iop_order_list, const char *op_current, const char *op_prev, const int dont_move);
@@ -386,6 +388,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
     {
       // set the iop_order
       iop_order_new->iop_order = iop_order_prev + (iop_order_next - iop_order_prev) / 2.0;
+      if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_insert_iop_before %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_new,iop_order_new->iop_order,iop_order_new->iop_order,iop_order_prev,iop_order_next);
 
       // insert it on the proper order
       iop_order_list = g_list_insert(iop_order_list, iop_order_new, position);
@@ -495,6 +498,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
 
     // insert it on the proper order
     iop_order_list = g_list_insert(iop_order_list, iop_order_current, position);
+    if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_move_iop_before   %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_current,iop_order_current->iop_order,iop_order_current->iop_order,iop_order_prev->iop_order,iop_order_next->iop_order);
   }
   else
     fprintf(stderr, "[_ioppr_move_iop_before] next module %s don't exists on iop order list\n", op_next);
@@ -562,6 +566,7 @@ GList *dt_ioppr_get_iop_order_list(int *_version)
 // if a module do not exists on iop_order_list it is flagged as unused with DBL_MAX
 void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
 {
+  if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n\ndt_ioppr_set_default_iop_order "); // dt_iop_module_so_t in develop/imageop.h
   GList *iop_list = *_iop_list;
 
   GList *modules = g_list_first(iop_list);
@@ -579,12 +584,14 @@ void dt_ioppr_set_default_iop_order(GList **_iop_list, GList *iop_order_list)
       mod->iop_order = DBL_MAX;
     }
 
+    if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  db: %14.11f   xmp %8.4f   %16s",mod->iop_order,mod->iop_order,mod->op);
     modules = g_list_next(modules);
   }
   // we need to set the right order
   iop_list = g_list_sort(iop_list, dt_sort_iop_by_order);
 
   *_iop_list = iop_list;
+    if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n");
 }
 
 // returns the first dt_dev_history_item_t on history_list where hist->module == mod
@@ -3229,3 +3236,5 @@ cleanup:
   return (err == CL_SUCCESS) ? TRUE : FALSE;
 }
 #endif
+
+#undef DT_IOP_ORDER_INFO // used while debugging


### PR DESCRIPTION
Discussing and debugging the new iop_order sheme showed there might be a problem
with the insertion of modules into the iop_order list.

Further tests here showed the new v3 algorithm is ok and gives correct iop_order
defined as a double.

But these tests also demonstrated, the exiv2 writing a float/double key to the sidecar uses low precision
1. resulting in iop_order of 38.9991 to be the same as 38.9992 **and** 
2. numbers close to a 'full' as 38.9999 to be in fact written as 39.0.

This means the priority of modules in sidecars is definitely wrong.
You **can** observe this by deleting the image from history and reimport it or just compare existing sidecar files with the data in main.history

This commit
- helps to debug and understand the problem, there is now
  #define DT_IOP_ORDER_INFO FALSE in iop_order.c
  If set to TRUE you will see what is inserted and what iop_order is given.
- Writes the iop_order **not** by toFloat but instead as a converted string with a precision of %.13f

Is this really enough? I don't really know. Possible problems:
- Already iop_order_v3 developed images deleted from the database will give wrong iop_orders
  when reimported.
- Do we also have to make sure exiv2 reads the high-precision iop_order as a double? Reading exiv2 docs about this did not give a definite answer for me and by experiment i would say it's ok as now.