### PR TITLE
Add safeguard rules in iop_order to protect clipping iop

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -181,6 +181,10 @@ GList *dt_ioppr_get_iop_order_rules()
                                                 { "demosaic", "colorin" },
                                                 { "colorin", "colorout" },
                                                 { "colorout", "gamma" },
+						/* clipping GUI broken if flip is done on top */
+                                                { "flip", "clipping" },
+						/* clipping GUI broken if ashift is done on top */
+                                                { "ashift", "clipping" },
                                                 { "\0", "\0" } };
 
   int i = 0;


### PR DESCRIPTION
"clipping" iop GUI simply does not work when orientation ("flip") or "ashift" are moved after in pipe order.
This PR is enforcing the rules to forbid moving flip or ashift after clipping during edits.