### PR TITLE
Change the char type to use CHAR_MIN/MAX for it's limits

### DIFF
--- a/tools/introspection/ast.pm
+++ b/tools/introspection/ast.pm
@@ -373,7 +373,7 @@ sub new
   bless($reference, $self);
 
   $reference->{unsigned} = 0;
-  @{$reference->{limits}} = ("G_MININT8", "G_MAXINT8", "0", "0", "G_MAXUINT8", "0");
+  @{$reference->{limits}} = ("CHAR_MIN", "CHAR_MAX", "0", "0", "UCHAR_MAX", "0");
   $reference->{code_type} = "char";
 
   return $reference;


### PR DESCRIPTION
char on x86(_64) defaults to a signed 8-bit int type. On ppc64le it defaults to an unsigned 8-bit int type.

G_MININT8 and G_MAXINT8 are the limit values for gint8, which is a signed type on all platforms.