### PR TITLE
Relaxing stress on iop_order

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: darktable 2.8\n"
+"Project-Id-Version: darktable 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-05 10:21-0500\n"
-"PO-Revision-Date: 2019-06-04 14:12-0500\n"
+"POT-Creation-Date: 2019-09-27 22:43-0500\n"
+"PO-Revision-Date: 2019-09-27 22:37-0500\n"
 "Last-Translator: Edgar Lux <edgarlux@disroot.org>\n"
 "Language-Team: Edgar Lux\n"
 "Language: es_ES\n"
@@ -12,74 +12,74 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-Bookmarks: -1,1170,-1,-1,-1,-1,-1,-1,-1,-1\n"
-"X-Generator: Poedit 2.2.1\n"
+"X-Generator: Poedit 2.2.3\n"
 
-#: ../build/src/preferences_gen.h:2080
+#: ../build/src/preferences_gen.h:2105
 msgid "GUI options"
 msgstr "Opciones de interfaz de usuario"
 
-#: ../build/src/preferences_gen.h:2083 ../src/libs/import.c:106
+#: ../build/src/preferences_gen.h:2108 ../src/libs/import.c:107
 msgid "import"
 msgstr "importar"
 
-#: ../build/src/preferences_gen.h:2094
+#: ../build/src/preferences_gen.h:2119
 msgid "ignore JPEG images when importing film rolls"
 msgstr "Ignorar imágenes JPEG al importar los carretes"
 
-#: ../build/src/preferences_gen.h:2103 ../build/src/preferences_gen.h:2123
-#: ../build/src/preferences_gen.h:2146 ../build/src/preferences_gen.h:2169
-#: ../build/src/preferences_gen.h:2192 ../build/src/preferences_gen.h:2215
-#: ../build/src/preferences_gen.h:2274 ../build/src/preferences_gen.h:2351
-#: ../build/src/preferences_gen.h:2371 ../build/src/preferences_gen.h:2391
-#: ../build/src/preferences_gen.h:2411 ../build/src/preferences_gen.h:2431
-#: ../build/src/preferences_gen.h:2451 ../build/src/preferences_gen.h:2524
-#: ../build/src/preferences_gen.h:2571 ../build/src/preferences_gen.h:2613
-#: ../build/src/preferences_gen.h:2637 ../build/src/preferences_gen.h:2694
-#: ../build/src/preferences_gen.h:2740 ../build/src/preferences_gen.h:2759
-#: ../build/src/preferences_gen.h:2779 ../build/src/preferences_gen.h:2799
-#: ../build/src/preferences_gen.h:2857 ../build/src/preferences_gen.h:2904
-#: ../build/src/preferences_gen.h:2935 ../build/src/preferences_gen.h:2955
-#: ../build/src/preferences_gen.h:2975 ../build/src/preferences_gen.h:2995
-#: ../build/src/preferences_gen.h:3015 ../build/src/preferences_gen.h:3035
-#: ../build/src/preferences_gen.h:3055 ../build/src/preferences_gen.h:3074
-#: ../build/src/preferences_gen.h:3157 ../build/src/preferences_gen.h:3203
-#: ../build/src/preferences_gen.h:3223 ../build/src/preferences_gen.h:3243
-#: ../build/src/preferences_gen.h:3263 ../build/src/preferences_gen.h:3310
-#: ../build/src/preferences_gen.h:3330 ../build/src/preferences_gen.h:3377
-#: ../build/src/preferences_gen.h:3433 ../build/src/preferences_gen.h:3453
-#: ../build/src/preferences_gen.h:3473 ../build/src/preferences_gen.h:3520
-#: ../build/src/preferences_gen.h:3572 ../build/src/preferences_gen.h:3592
-#: ../build/src/preferences_gen.h:3612 ../build/src/preferences_gen.h:3632
-#: ../build/src/preferences_gen.h:3663 ../build/src/preferences_gen.h:3710
-#: ../build/src/preferences_gen.h:3730 ../build/src/preferences_gen.h:3769
-#: ../build/src/preferences_gen.h:3789 ../build/src/preferences_gen.h:3809
-#: ../build/src/preferences_gen.h:3912 ../build/src/preferences_gen.h:3967
-#: ../build/src/preferences_gen.h:4006 ../build/src/preferences_gen.h:4060
-#: ../build/src/preferences_gen.h:4084 ../build/src/preferences_gen.h:4109
-#: ../build/src/preferences_gen.h:4158 ../build/src/preferences_gen.h:4182
-#: ../build/src/preferences_gen.h:4206 ../src/lua/preferences.c:619
-#: ../src/lua/preferences.c:634 ../src/lua/preferences.c:646
-#: ../src/lua/preferences.c:658 ../src/lua/preferences.c:674
-#: ../src/lua/preferences.c:738
+#: ../build/src/preferences_gen.h:2128 ../build/src/preferences_gen.h:2148
+#: ../build/src/preferences_gen.h:2171 ../build/src/preferences_gen.h:2194
+#: ../build/src/preferences_gen.h:2217 ../build/src/preferences_gen.h:2240
+#: ../build/src/preferences_gen.h:2299 ../build/src/preferences_gen.h:2376
+#: ../build/src/preferences_gen.h:2396 ../build/src/preferences_gen.h:2416
+#: ../build/src/preferences_gen.h:2436 ../build/src/preferences_gen.h:2456
+#: ../build/src/preferences_gen.h:2476 ../build/src/preferences_gen.h:2549
+#: ../build/src/preferences_gen.h:2596 ../build/src/preferences_gen.h:2638
+#: ../build/src/preferences_gen.h:2662 ../build/src/preferences_gen.h:2719
+#: ../build/src/preferences_gen.h:2765 ../build/src/preferences_gen.h:2784
+#: ../build/src/preferences_gen.h:2804 ../build/src/preferences_gen.h:2824
+#: ../build/src/preferences_gen.h:2882 ../build/src/preferences_gen.h:2929
+#: ../build/src/preferences_gen.h:2960 ../build/src/preferences_gen.h:2980
+#: ../build/src/preferences_gen.h:3000 ../build/src/preferences_gen.h:3020
+#: ../build/src/preferences_gen.h:3040 ../build/src/preferences_gen.h:3060
+#: ../build/src/preferences_gen.h:3080 ../build/src/preferences_gen.h:3099
+#: ../build/src/preferences_gen.h:3182 ../build/src/preferences_gen.h:3228
+#: ../build/src/preferences_gen.h:3248 ../build/src/preferences_gen.h:3268
+#: ../build/src/preferences_gen.h:3288 ../build/src/preferences_gen.h:3335
+#: ../build/src/preferences_gen.h:3355 ../build/src/preferences_gen.h:3402
+#: ../build/src/preferences_gen.h:3458 ../build/src/preferences_gen.h:3478
+#: ../build/src/preferences_gen.h:3498 ../build/src/preferences_gen.h:3545
+#: ../build/src/preferences_gen.h:3597 ../build/src/preferences_gen.h:3617
+#: ../build/src/preferences_gen.h:3637 ../build/src/preferences_gen.h:3657
+#: ../build/src/preferences_gen.h:3688 ../build/src/preferences_gen.h:3735
+#: ../build/src/preferences_gen.h:3755 ../build/src/preferences_gen.h:3794
+#: ../build/src/preferences_gen.h:3814 ../build/src/preferences_gen.h:3834
+#: ../build/src/preferences_gen.h:3937 ../build/src/preferences_gen.h:3992
+#: ../build/src/preferences_gen.h:4031 ../build/src/preferences_gen.h:4051
+#: ../build/src/preferences_gen.h:4105 ../build/src/preferences_gen.h:4129
+#: ../build/src/preferences_gen.h:4154 ../build/src/preferences_gen.h:4203
+#: ../build/src/preferences_gen.h:4227 ../build/src/preferences_gen.h:4251
+#: ../src/lua/preferences.c:619 ../src/lua/preferences.c:634
+#: ../src/lua/preferences.c:646 ../src/lua/preferences.c:658
+#: ../src/lua/preferences.c:674 ../src/lua/preferences.c:738
 #, c-format
 msgid "double click to reset to `%s'"
 msgstr "Doble clic para restablecer a `%s'"
 
-#: ../build/src/preferences_gen.h:2103 ../build/src/preferences_gen.h:2123
-#: ../build/src/preferences_gen.h:2274 ../build/src/preferences_gen.h:2371
-#: ../build/src/preferences_gen.h:2391 ../build/src/preferences_gen.h:2411
-#: ../build/src/preferences_gen.h:2431 ../build/src/preferences_gen.h:2451
-#: ../build/src/preferences_gen.h:2779 ../build/src/preferences_gen.h:2857
-#: ../build/src/preferences_gen.h:3035 ../build/src/preferences_gen.h:3243
-#: ../build/src/preferences_gen.h:3263 ../build/src/preferences_gen.h:3453
-#: ../build/src/preferences_gen.h:3612 ../build/src/preferences_gen.h:3632
-#: ../build/src/preferences_gen.h:3730 ../build/src/preferences_gen.h:3809
-#: ../build/src/preferences_gen.h:4006
+#: ../build/src/preferences_gen.h:2128 ../build/src/preferences_gen.h:2148
+#: ../build/src/preferences_gen.h:2299 ../build/src/preferences_gen.h:2396
+#: ../build/src/preferences_gen.h:2416 ../build/src/preferences_gen.h:2436
+#: ../build/src/preferences_gen.h:2456 ../build/src/preferences_gen.h:2476
+#: ../build/src/preferences_gen.h:2804 ../build/src/preferences_gen.h:2882
+#: ../build/src/preferences_gen.h:3060 ../build/src/preferences_gen.h:3268
+#: ../build/src/preferences_gen.h:3288 ../build/src/preferences_gen.h:3478
+#: ../build/src/preferences_gen.h:3637 ../build/src/preferences_gen.h:3657
+#: ../build/src/preferences_gen.h:3755 ../build/src/preferences_gen.h:3834
+#: ../build/src/preferences_gen.h:4031 ../build/src/preferences_gen.h:4051
 msgctxt "preferences"
 msgid "FALSE"
 msgstr "FALSO"
 
-#: ../build/src/preferences_gen.h:2106
+#: ../build/src/preferences_gen.h:2131
 msgid ""
 "when having raw+JPEG images together in one directory it makes no sense to "
 "import both. with this flag one can ignore all JPEGs found."
@@ -87,55 +87,55 @@ msgstr ""
 "Cuando se tienen imágenes RAW+JPEG juntas en un directorio no tiene sentido "
 "importar ambas. Con esta marca se pueden ignorar todos los JPEG encontrados."
 
-#: ../build/src/preferences_gen.h:2114
+#: ../build/src/preferences_gen.h:2139
 msgid "recursive directory traversal when importing filmrolls"
 msgstr "Hacer un recorrido recursivo de los directorios al importar carretes"
 
-#: ../build/src/preferences_gen.h:2133
+#: ../build/src/preferences_gen.h:2158
 msgid "creator to be applied when importing"
 msgstr "Establecer autor al importar"
 
-#: ../build/src/preferences_gen.h:2156
+#: ../build/src/preferences_gen.h:2181
 msgid "publisher to be applied when importing"
 msgstr "Establecer editor al importar"
 
-#: ../build/src/preferences_gen.h:2179
+#: ../build/src/preferences_gen.h:2204
 msgid "rights to be applied when importing"
 msgstr "Establecer derechos al importar"
 
-#: ../build/src/preferences_gen.h:2202
+#: ../build/src/preferences_gen.h:2227
 msgid "comma separated tags to be applied when importing"
 msgstr "Establecer etiquetas separadas por comas al importar"
 
-#: ../build/src/preferences_gen.h:2225
+#: ../build/src/preferences_gen.h:2250
 msgid "initial import rating"
 msgstr "Puntuación inicial"
 
-#: ../build/src/preferences_gen.h:2243 ../build/src/preferences_gen.h:2826
-#: ../build/src/preferences_gen.h:2884 ../build/src/preferences_gen.h:3111
-#: ../build/src/preferences_gen.h:3138 ../build/src/preferences_gen.h:3183
-#: ../build/src/preferences_gen.h:3836 ../build/src/preferences_gen.h:3863
-#: ../build/src/preferences_gen.h:3892 ../src/lua/preferences.c:697
+#: ../build/src/preferences_gen.h:2268 ../build/src/preferences_gen.h:2851
+#: ../build/src/preferences_gen.h:2909 ../build/src/preferences_gen.h:3136
+#: ../build/src/preferences_gen.h:3163 ../build/src/preferences_gen.h:3208
+#: ../build/src/preferences_gen.h:3861 ../build/src/preferences_gen.h:3888
+#: ../build/src/preferences_gen.h:3917 ../src/lua/preferences.c:697
 #, c-format
 msgid "double click to reset to `%d'"
 msgstr "Doble clic para restablecer a `%d'"
 
-#: ../build/src/preferences_gen.h:2246
+#: ../build/src/preferences_gen.h:2271
 msgid "initial star rating for all images when importing a filmroll"
 msgstr "Puntuación inicial para todas las imágenes al importar carretes"
 
-#: ../build/src/preferences_gen.h:2254 ../src/libs/tools/lighttable.c:89
-#: ../src/views/lighttable.c:248
+#: ../build/src/preferences_gen.h:2279 ../src/libs/tools/lighttable.c:89
+#: ../src/views/lighttable.c:249
 msgid "lighttable"
 msgstr "mesa de luz"
 
-#: ../build/src/preferences_gen.h:2265
+#: ../build/src/preferences_gen.h:2290
 msgid "don't use embedded preview JPEG but half-size raw"
 msgstr ""
 "Utilizar un RAW de tamaño medio como vista previa en lugar de una JPEG "
 "incrustada"
 
-#: ../build/src/preferences_gen.h:2277
+#: ../build/src/preferences_gen.h:2302
 msgid ""
 "check this option to not use the embedded JPEG from the raw file but process "
 "the raw data. this is slower but gives you color managed thumbnails."
@@ -144,56 +144,56 @@ msgstr ""
 "incrustado en el archivo RAW. Es más lento, pero proporciona miniaturas con "
 "manejo de color."
 
-#: ../build/src/preferences_gen.h:2285
+#: ../build/src/preferences_gen.h:2310
 msgid "high quality thumb processing from size"
 msgstr "Procesamiento de las miniaturas de alta calidad desde el tamaño"
 
-#: ../build/src/preferences_gen.h:2296 ../build/src/preferences_gen.h:3690
+#: ../build/src/preferences_gen.h:2321 ../build/src/preferences_gen.h:3715
 msgctxt "preferences"
 msgid "always"
 msgstr "Siempre"
 
-#: ../build/src/preferences_gen.h:2301
+#: ../build/src/preferences_gen.h:2326
 msgctxt "preferences"
 msgid "small"
 msgstr "Pequeño"
 
-#: ../build/src/preferences_gen.h:2306
+#: ../build/src/preferences_gen.h:2331
 msgctxt "preferences"
 msgid "VGA"
 msgstr "VGA"
 
-#: ../build/src/preferences_gen.h:2311 ../build/src/preferences_gen.h:2351
+#: ../build/src/preferences_gen.h:2336 ../build/src/preferences_gen.h:2376
 msgctxt "preferences"
 msgid "720p"
 msgstr "720p"
 
-#: ../build/src/preferences_gen.h:2316
+#: ../build/src/preferences_gen.h:2341
 msgctxt "preferences"
 msgid "1080p"
 msgstr "1080p"
 
-#: ../build/src/preferences_gen.h:2321
+#: ../build/src/preferences_gen.h:2346
 msgctxt "preferences"
 msgid "WQXGA"
 msgstr "WQXGA"
 
-#: ../build/src/preferences_gen.h:2326
+#: ../build/src/preferences_gen.h:2351
 msgctxt "preferences"
 msgid "4K"
 msgstr "4K"
 
-#: ../build/src/preferences_gen.h:2331
+#: ../build/src/preferences_gen.h:2356
 msgctxt "preferences"
 msgid "5K"
 msgstr "5K"
 
-#: ../build/src/preferences_gen.h:2336 ../build/src/preferences_gen.h:3685
+#: ../build/src/preferences_gen.h:2361 ../build/src/preferences_gen.h:3710
 msgctxt "preferences"
 msgid "never"
 msgstr "Nunca"
 
-#: ../build/src/preferences_gen.h:2354
+#: ../build/src/preferences_gen.h:2379
 msgid ""
 "if the thumbnail size is greater than this value, it will be processed using "
 "the full quality rendering path (better but slower)."
@@ -201,21 +201,21 @@ msgstr ""
 "Si el tamaño de la miniatura es mayor que este valor, se procesará "
 "utilizando la ruta de procesamiento de máxima calidad (mejor, pero más lento)"
 
-#: ../build/src/preferences_gen.h:2362
+#: ../build/src/preferences_gen.h:2387
 msgid "enable extended thumb overlay"
 msgstr "Habilitar superposición de miniatura extendida"
 
-#: ../build/src/preferences_gen.h:2374
+#: ../build/src/preferences_gen.h:2399
 msgid "if set to true, thumb overlay shows filename and some exif data."
 msgstr ""
 "Si se marca verdadero, la superposición de la miniatura mostrará el nombre "
 "del archivo y algunos datos Exif."
 
-#: ../build/src/preferences_gen.h:2382
+#: ../build/src/preferences_gen.h:2407
 msgid "use single-click in the collect panel"
 msgstr "Pulse un solo clic en el panel de colecciones"
 
-#: ../build/src/preferences_gen.h:2394
+#: ../build/src/preferences_gen.h:2419
 msgid ""
 "check this option to use single-click to select items in the collect panel. "
 "this will allow you to do range selections for date-time and numeric values."
@@ -224,21 +224,21 @@ msgstr ""
 "colección. Como consecuencia, puede hacer rangos de selecciones por tiempo "
 "y  con valores numéricos"
 
-#: ../build/src/preferences_gen.h:2402
+#: ../build/src/preferences_gen.h:2427
 msgid "expand a single lighttable module at a time"
 msgstr "Desplegar solo un módulo a la vez en la mesa de luz"
 
-#: ../build/src/preferences_gen.h:2414
+#: ../build/src/preferences_gen.h:2439
 msgid "this option toggles the behavior of shift clicking in lighttable mode"
 msgstr ""
 "Esta opción alterna el comportamiento del Máyus+clic en el modo de mesa de "
 "luz"
 
-#: ../build/src/preferences_gen.h:2422
+#: ../build/src/preferences_gen.h:2447
 msgid "scroll to lighttable modules when expanded/collapsed"
 msgstr "Desplazar los módulos al desplegarlos o contraerlos en la mesa de luz"
 
-#: ../build/src/preferences_gen.h:2434 ../build/src/preferences_gen.h:2802
+#: ../build/src/preferences_gen.h:2459 ../build/src/preferences_gen.h:2827
 msgid ""
 "when this option is enabled then darktable will try to scroll the module to "
 "the top of the visible list"
@@ -246,11 +246,11 @@ msgstr ""
 "Cuando esta opción está marcada, darktable intentará desplazar el módulo a "
 "la parte superior de la lista visible"
 
-#: ../build/src/preferences_gen.h:2442
+#: ../build/src/preferences_gen.h:2467
 msgid "rating an image one star twice will not zero out the rating"
 msgstr "Puntuar una imagen con una estrella dos veces no anulará el puntaje"
 
-#: ../build/src/preferences_gen.h:2454
+#: ../build/src/preferences_gen.h:2479
 msgid ""
 "do not have the rating of one star behave as documented in the manual--an "
 "image rated one star twice will result in a zero star rating."
@@ -259,45 +259,45 @@ msgstr ""
 "el manual: una imagen puntuada con una sola estrella dos veces anulará el "
 "puntaje."
 
-#: ../build/src/preferences_gen.h:2462 ../src/views/darkroom.c:106
+#: ../build/src/preferences_gen.h:2487 ../src/views/darkroom.c:107
 msgid "darkroom"
 msgstr "cuarto oscuro"
 
-#: ../build/src/preferences_gen.h:2473
+#: ../build/src/preferences_gen.h:2498
 msgid "pen pressure control for brush masks"
 msgstr "Control de presión de lápiz para pinceles de máscara"
 
-#: ../build/src/preferences_gen.h:2484 ../build/src/preferences_gen.h:2524
+#: ../build/src/preferences_gen.h:2509 ../build/src/preferences_gen.h:2549
 msgctxt "preferences"
 msgid "off"
 msgstr "Apagado"
 
-#: ../build/src/preferences_gen.h:2489
+#: ../build/src/preferences_gen.h:2514
 msgctxt "preferences"
 msgid "hardness (relative)"
 msgstr "Dureza (relativo)"
 
-#: ../build/src/preferences_gen.h:2494
+#: ../build/src/preferences_gen.h:2519
 msgctxt "preferences"
 msgid "hardness (absolute)"
 msgstr "Dureza (absoluta)"
 
-#: ../build/src/preferences_gen.h:2499
+#: ../build/src/preferences_gen.h:2524
 msgctxt "preferences"
 msgid "opacity (relative)"
 msgstr "Opacidad (relativa)"
 
-#: ../build/src/preferences_gen.h:2504
+#: ../build/src/preferences_gen.h:2529
 msgctxt "preferences"
 msgid "opacity (absolute)"
 msgstr "Opacidad (absoluta)"
 
-#: ../build/src/preferences_gen.h:2509
+#: ../build/src/preferences_gen.h:2534
 msgctxt "preferences"
 msgid "brush size (relative)"
 msgstr "Tamaño del pincel (relativo)"
 
-#: ../build/src/preferences_gen.h:2527
+#: ../build/src/preferences_gen.h:2552
 msgid ""
 "off - pressure reading ignored, hardness/opacity/brush size - pressure "
 "reading controls specified attribute, absolute/relative - pressure reading "
@@ -308,26 +308,26 @@ msgstr ""
 "relativo: la lectura de presión se toma directamente como valor de atributo "
 "o se multiplica con los ajustes predefinidos."
 
-#: ../build/src/preferences_gen.h:2535
+#: ../build/src/preferences_gen.h:2560
 msgid "smoothing of brush strokes"
 msgstr "Suavizado de pinceladas"
 
-#: ../build/src/preferences_gen.h:2546
+#: ../build/src/preferences_gen.h:2571
 msgctxt "preferences"
 msgid "low"
 msgstr "Bajo"
 
-#: ../build/src/preferences_gen.h:2551 ../build/src/preferences_gen.h:2571
+#: ../build/src/preferences_gen.h:2576 ../build/src/preferences_gen.h:2596
 msgctxt "preferences"
 msgid "medium"
 msgstr "Medio"
 
-#: ../build/src/preferences_gen.h:2556
+#: ../build/src/preferences_gen.h:2581
 msgctxt "preferences"
 msgid "high"
 msgstr "Alto"
 
-#: ../build/src/preferences_gen.h:2574
+#: ../build/src/preferences_gen.h:2599
 msgid ""
 "sets level for smoothing of brush strokes. stronger smoothing leads to less "
 "nodes and easier editing but with lower control of accuracy."
@@ -335,21 +335,21 @@ msgstr ""
 "Ajusta los niveles de suavizado de pinceladas. Un mayor suavizado conlleva "
 "menos nodos y una edición más fácil pero con un menor control de precisión."
 
-#: ../build/src/preferences_gen.h:2582
+#: ../build/src/preferences_gen.h:2607
 msgid "display of individual color channels"
 msgstr "Mostrar canales individuales de color"
 
-#: ../build/src/preferences_gen.h:2593 ../build/src/preferences_gen.h:2613
+#: ../build/src/preferences_gen.h:2618 ../build/src/preferences_gen.h:2638
 msgctxt "preferences"
 msgid "false color"
 msgstr "Color falso"
 
-#: ../build/src/preferences_gen.h:2598
+#: ../build/src/preferences_gen.h:2623
 msgctxt "preferences"
 msgid "grey scale"
 msgstr "Escala de gris"
 
-#: ../build/src/preferences_gen.h:2616
+#: ../build/src/preferences_gen.h:2641
 msgid ""
 "defines how color channels are displayed when activated in the parametric "
 "masks feature."
@@ -357,109 +357,109 @@ msgstr ""
 "Define cómo se muestran los canales de color al activar el módulo de "
 "máscaras paramétricas."
 
-#: ../build/src/preferences_gen.h:2624
+#: ../build/src/preferences_gen.h:2649
 msgid "pattern for the image infos line"
 msgstr "Modelo para la línea informativa de la imagen"
 
-#: ../build/src/preferences_gen.h:2640
+#: ../build/src/preferences_gen.h:2665
 msgid "see manual to know all the tags you can use."
 msgstr ""
 "Consulte el manual para conocer todas las etiquetas que puede utilizar."
 
-#: ../build/src/preferences_gen.h:2648
+#: ../build/src/preferences_gen.h:2673
 msgid "position of the image infos line"
 msgstr "Posición de la línea informativa de la imagen"
 
-#: ../build/src/preferences_gen.h:2659
+#: ../build/src/preferences_gen.h:2684
 msgctxt "preferences"
 msgid "top left"
 msgstr "Parte superior izquierda"
 
-#: ../build/src/preferences_gen.h:2664
+#: ../build/src/preferences_gen.h:2689
 msgctxt "preferences"
 msgid "top right"
 msgstr "Parte superior derecha"
 
-#: ../build/src/preferences_gen.h:2669
+#: ../build/src/preferences_gen.h:2694
 msgctxt "preferences"
 msgid "top center"
 msgstr "Parte superior central"
 
-#: ../build/src/preferences_gen.h:2674 ../build/src/preferences_gen.h:2694
+#: ../build/src/preferences_gen.h:2699 ../build/src/preferences_gen.h:2719
 msgctxt "preferences"
 msgid "bottom"
 msgstr "Parte inferior"
 
-#: ../build/src/preferences_gen.h:2679
+#: ../build/src/preferences_gen.h:2704
 msgctxt "preferences"
 msgid "hidden"
 msgstr "oculto"
 
-#: ../build/src/preferences_gen.h:2704
+#: ../build/src/preferences_gen.h:2729
 msgid "show search module text entry"
 msgstr "Muestra la entrada de texto del módulo de búsqueda"
 
-#: ../build/src/preferences_gen.h:2715
+#: ../build/src/preferences_gen.h:2740
 msgctxt "preferences"
 msgid "show search text"
 msgstr "mostrar búsqueda de texto"
 
-#: ../build/src/preferences_gen.h:2720
+#: ../build/src/preferences_gen.h:2745
 msgctxt "preferences"
 msgid "show groups"
 msgstr "mostrar grupos"
 
-#: ../build/src/preferences_gen.h:2725 ../build/src/preferences_gen.h:2740
+#: ../build/src/preferences_gen.h:2750 ../build/src/preferences_gen.h:2765
 msgctxt "preferences"
 msgid "show both"
 msgstr "mostrar ambos"
 
-#: ../build/src/preferences_gen.h:2750
+#: ../build/src/preferences_gen.h:2775
 msgid "expand a single darkroom module at a time"
 msgstr "Desplegar solo un módulo a la vez en el cuarto oscuro"
 
-#: ../build/src/preferences_gen.h:2759 ../build/src/preferences_gen.h:2799
-#: ../build/src/preferences_gen.h:2904 ../build/src/preferences_gen.h:2935
-#: ../build/src/preferences_gen.h:2955 ../build/src/preferences_gen.h:2975
-#: ../build/src/preferences_gen.h:2995 ../build/src/preferences_gen.h:3015
-#: ../build/src/preferences_gen.h:3055 ../build/src/preferences_gen.h:3074
-#: ../build/src/preferences_gen.h:3157 ../build/src/preferences_gen.h:3203
-#: ../build/src/preferences_gen.h:3223 ../build/src/preferences_gen.h:3330
-#: ../build/src/preferences_gen.h:3433 ../build/src/preferences_gen.h:3473
-#: ../build/src/preferences_gen.h:3592 ../build/src/preferences_gen.h:3663
-#: ../build/src/preferences_gen.h:3789 ../build/src/preferences_gen.h:3912
+#: ../build/src/preferences_gen.h:2784 ../build/src/preferences_gen.h:2824
+#: ../build/src/preferences_gen.h:2929 ../build/src/preferences_gen.h:2960
+#: ../build/src/preferences_gen.h:2980 ../build/src/preferences_gen.h:3000
+#: ../build/src/preferences_gen.h:3020 ../build/src/preferences_gen.h:3040
+#: ../build/src/preferences_gen.h:3080 ../build/src/preferences_gen.h:3099
+#: ../build/src/preferences_gen.h:3182 ../build/src/preferences_gen.h:3228
+#: ../build/src/preferences_gen.h:3248 ../build/src/preferences_gen.h:3355
+#: ../build/src/preferences_gen.h:3458 ../build/src/preferences_gen.h:3498
+#: ../build/src/preferences_gen.h:3617 ../build/src/preferences_gen.h:3688
+#: ../build/src/preferences_gen.h:3814 ../build/src/preferences_gen.h:3937
 msgctxt "preferences"
 msgid "TRUE"
 msgstr "VERDADERO"
 
-#: ../build/src/preferences_gen.h:2762
+#: ../build/src/preferences_gen.h:2787
 msgid "this option toggles the behavior of shift clicking in darkroom mode"
 msgstr ""
 "esta opción alterna el comportamiento del Mayús+clic en el modo de cuarto "
 "oscuro"
 
-#: ../build/src/preferences_gen.h:2770
+#: ../build/src/preferences_gen.h:2795
 msgid "expand the module when it is activated, and collapse it when disabled"
 msgstr ""
 "cuando está activado, se expande el módulo y cuando está desactivado, se "
 "contrae"
 
-#: ../build/src/preferences_gen.h:2782
+#: ../build/src/preferences_gen.h:2807
 msgid ""
 "this option allows to expand or collapse automatically the module when it is "
 "enabled or disabled."
 msgstr ""
 "esta opción habilita la expansión o la contracción automática del módulo"
 
-#: ../build/src/preferences_gen.h:2790
+#: ../build/src/preferences_gen.h:2815
 msgid "scroll to darkroom modules when expanded/collapsed"
 msgstr "Desplazar los módulos al desplegarlos o plegarlos en el cuarto oscuro"
 
-#: ../build/src/preferences_gen.h:2810
+#: ../build/src/preferences_gen.h:2835
 msgid "border around image in darkroom mode"
 msgstr "Ancho del borde alrededor de la imagen en el modo de cuarto oscuro"
 
-#: ../build/src/preferences_gen.h:2829
+#: ../build/src/preferences_gen.h:2854
 msgid ""
 "process the image in darkroom mode with a small border. set to 0 if you "
 "don't want any border."
@@ -467,16 +467,16 @@ msgstr ""
 "procesa la imagen en el modo de cuarto oscuro con un borde mas pequeño. "
 "ajuste a 0 si no quiere ningún borde."
 
-#: ../build/src/preferences_gen.h:2837
+#: ../build/src/preferences_gen.h:2862
 msgid "map / geolocalisation"
 msgstr "Mapa y geolocalización"
 
-#: ../build/src/preferences_gen.h:2848
+#: ../build/src/preferences_gen.h:2873
 msgid "only draw images on map that are currently collected and filtered"
 msgstr ""
 "Dibuje solo imágenes en el mapa que estén filtradas y en la colección actual"
 
-#: ../build/src/preferences_gen.h:2860
+#: ../build/src/preferences_gen.h:2885
 msgid ""
 "use the current filter settings to select the geotagged images drawn on the "
 "map, i.e. limit the images drawn to the current filmstrip. this limits the "
@@ -487,11 +487,11 @@ msgstr ""
 "dibujadas a la tira actual de imágenes. Esto restringe la cantidad de "
 "imágenes dibujadas y reduce el tiempo necesario para dibujarlas."
 
-#: ../build/src/preferences_gen.h:2868
+#: ../build/src/preferences_gen.h:2893
 msgid "maximum number of images drawn on map"
 msgstr "Cantidad máxima de imágenes mostradas en el mapa"
 
-#: ../build/src/preferences_gen.h:2887
+#: ../build/src/preferences_gen.h:2912
 msgid ""
 "the maximum number of geotagged images drawn on the map. increasing this "
 "number can slow drawing of the map down."
@@ -499,11 +499,11 @@ msgstr ""
 "La cantidad máxima de imágenes geoetiquetadas dibujadas en el mapa. "
 "Incrementar este número puede ralentizar el mapa."
 
-#: ../build/src/preferences_gen.h:2895
+#: ../build/src/preferences_gen.h:2920
 msgid "pretty print the image location"
 msgstr "Imprimir la ubicación de la imagen"
 
-#: ../build/src/preferences_gen.h:2907
+#: ../build/src/preferences_gen.h:2932
 msgid ""
 "show a more readable representation of the location in the image information "
 "module"
@@ -511,27 +511,27 @@ msgstr ""
 "Mostrar una representación más clara de la ubicación de la imagen en el "
 "módulo de información"
 
-#: ../build/src/preferences_gen.h:2915
+#: ../build/src/preferences_gen.h:2940
 msgid "security"
 msgstr "seguridad"
 
-#: ../build/src/preferences_gen.h:2926
+#: ../build/src/preferences_gen.h:2951
 msgid "ask before removing images from database"
 msgstr "Preguntar antes de eliminar imágenes de la base de datos"
 
-#: ../build/src/preferences_gen.h:2938
+#: ../build/src/preferences_gen.h:2963
 msgid "always ask the user before any image is removed from DB."
 msgstr ""
 "Preguntar siempre antes de eliminar cualquier imagen de la base de datos al "
 "usuario."
 
-#: ../build/src/preferences_gen.h:2946
+#: ../build/src/preferences_gen.h:2971
 msgid "ask before erasing images from disk / discarding history stack"
 msgstr ""
 "Preguntar antes de eliminar imágenes del disco o descartar el historial de "
 "acciones"
 
-#: ../build/src/preferences_gen.h:2958
+#: ../build/src/preferences_gen.h:2983
 msgid ""
 "always ask the user before any image file is deleted / history stack is "
 "discarded."
@@ -539,11 +539,11 @@ msgstr ""
 "Preguntar siempre antes de borrar cualquier archivo de imagen o descartar el "
 "historial de acciones."
 
-#: ../build/src/preferences_gen.h:2966
+#: ../build/src/preferences_gen.h:2991
 msgid "send files to trash when erasing images"
 msgstr "Enviar los archivos a la papelera al borrar las imágenes"
 
-#: ../build/src/preferences_gen.h:2978
+#: ../build/src/preferences_gen.h:3003
 msgid ""
 "send files to trash instead of permanently deleting files on system that "
 "supports it"
@@ -551,27 +551,27 @@ msgstr ""
 "Envía los archivos a la papelera en vez de borrarlos permanentemente en los "
 "sistemas que cuenten con esa opción"
 
-#: ../build/src/preferences_gen.h:2986
+#: ../build/src/preferences_gen.h:3011
 msgid "ask before moving images from film roll folder"
 msgstr "Preguntar antes de mover imágenes desde la carpeta del carrete"
 
-#: ../build/src/preferences_gen.h:2998
+#: ../build/src/preferences_gen.h:3023
 msgid "always ask the user before any image file is moved."
 msgstr "Preguntar siempre antes de mover cualquier archivo de imagen."
 
-#: ../build/src/preferences_gen.h:3006
+#: ../build/src/preferences_gen.h:3031
 msgid "ask before copying images to new film roll folder"
 msgstr "Preguntar antes de copiar imágenes a una nueva carpeta del carrete"
 
-#: ../build/src/preferences_gen.h:3018
+#: ../build/src/preferences_gen.h:3043
 msgid "always ask the user before any image file is copied."
 msgstr "Preguntar siempre antes de copiar cualquier archivo de imagen."
 
-#: ../build/src/preferences_gen.h:3026
+#: ../build/src/preferences_gen.h:3051
 msgid "ask before removing empty folders"
 msgstr "Preguntar antes de eliminar carpetas vacías"
 
-#: ../build/src/preferences_gen.h:3038
+#: ../build/src/preferences_gen.h:3063
 msgid ""
 "always ask the user before removing any empty folder. this can happen after "
 "moving or deleting images."
@@ -579,39 +579,39 @@ msgstr ""
 "Preguntar siempre antes de remover cualquier carpeta vacía. Esto puede pasar "
 "después de mover o eliminar imágenes."
 
-#: ../build/src/preferences_gen.h:3046
+#: ../build/src/preferences_gen.h:3071
 msgid "ask before deleting a tag"
 msgstr "Preguntar antes de borrar una etiqueta"
 
-#: ../build/src/preferences_gen.h:3065
+#: ../build/src/preferences_gen.h:3090
 msgid "ask before deleting a style"
 msgstr "Preguntar antes de borrar un estilo"
 
-#: ../build/src/preferences_gen.h:3084 ../build/src/preferences_gen.h:3986
+#: ../build/src/preferences_gen.h:3109 ../build/src/preferences_gen.h:4011
 msgid "miscellaneous"
 msgstr "miscelánea"
 
-#: ../build/src/preferences_gen.h:3095
+#: ../build/src/preferences_gen.h:3120
 msgid "width of the side panels in pixels"
 msgstr "Tamaño de los paneles laterales en pixeles"
 
-#: ../build/src/preferences_gen.h:3114
+#: ../build/src/preferences_gen.h:3139
 msgid "(needs a restart)"
 msgstr "(necesita reiniciarse)"
 
-#: ../build/src/preferences_gen.h:3122
+#: ../build/src/preferences_gen.h:3147
 msgid "waiting time between each picture in slideshow"
 msgstr "Tiempo de espera entre cada imagen en la presentación de diapositivas"
 
-#: ../build/src/preferences_gen.h:3148
+#: ../build/src/preferences_gen.h:3173
 msgid "do not show april 1st game"
 msgstr "No mostrar el juego del 1° de abril"
 
-#: ../build/src/preferences_gen.h:3167
+#: ../build/src/preferences_gen.h:3192
 msgid "number of folder levels to show in lists"
 msgstr "Número de niveles de carpetas que se muestran en listas"
 
-#: ../build/src/preferences_gen.h:3186
+#: ../build/src/preferences_gen.h:3211
 msgid ""
 "the number of folder levels to show in film roll names, starting from the "
 "right"
@@ -619,29 +619,29 @@ msgstr ""
 "Número de niveles de carpetas para mostrar en los nombres del carrete, "
 "comenzando por la derecha"
 
-#: ../build/src/preferences_gen.h:3194
+#: ../build/src/preferences_gen.h:3219
 msgid "enable filmstrip"
 msgstr "Activar tira de imágenes"
 
-#: ../build/src/preferences_gen.h:3206
+#: ../build/src/preferences_gen.h:3231
 msgid "enable the filmstrip in darkroom, tethering and map modes."
 msgstr ""
 "Activar tira de imágenes en el modo de cuarto oscuro, modo captura y modo "
 "mapa."
 
-#: ../build/src/preferences_gen.h:3214
+#: ../build/src/preferences_gen.h:3239
 msgid "enable timeline"
 msgstr "Activar línea de tiempo"
 
-#: ../build/src/preferences_gen.h:3226
+#: ../build/src/preferences_gen.h:3251
 msgid "enable the timeline in lighttable mode."
 msgstr "Activar línea de tiempo en la mesa de luz"
 
-#: ../build/src/preferences_gen.h:3234
+#: ../build/src/preferences_gen.h:3259
 msgid "overlay txt sidecar over zoomed images"
 msgstr "Solapar el txt asociado sobre las imágenes aumentadas"
 
-#: ../build/src/preferences_gen.h:3246
+#: ../build/src/preferences_gen.h:3271
 msgid ""
 "when there is a txt file next to an image it can be shown as an overlay over "
 "zoomed images on the lighttable. the txt file either has to be there at "
@@ -651,13 +651,13 @@ msgstr ""
 "sobre la imagen aumentada en la mesa de luz. El archivo txt tendrá que estar "
 "presente en el momento de importar o el rastreador tendrá que estar activado"
 
-#: ../build/src/preferences_gen.h:3254
+#: ../build/src/preferences_gen.h:3279
 msgid "mouse wheel scrolls modules side panel by default"
 msgstr ""
 "por defecto, con la rueda del ratón se desplaza por los módulos del panel "
 "lateral "
 
-#: ../build/src/preferences_gen.h:3266
+#: ../build/src/preferences_gen.h:3291
 msgid ""
 "when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to "
 "use mouse wheel for data entry.  when disabled, this behavior is reversed"
@@ -666,34 +666,34 @@ msgstr ""
 "módulos del panel lateral. Use Ctrl + Alt para que con la rueda del ratón se "
 "introduzcan datos. Cuando está desactivado, este comportamiento se invierte."
 
-#: ../build/src/preferences_gen.h:3274
+#: ../build/src/preferences_gen.h:3299
 msgid "show scrollbars for center view"
 msgstr "Mostrar barras de desplazamiento para la vista central"
 
-#: ../build/src/preferences_gen.h:3285
+#: ../build/src/preferences_gen.h:3310
 msgctxt "preferences"
 msgid "no scrollbars"
 msgstr "sin barras de desplazamiento"
 
-#: ../build/src/preferences_gen.h:3290 ../build/src/preferences_gen.h:3310
+#: ../build/src/preferences_gen.h:3315 ../build/src/preferences_gen.h:3335
 msgctxt "preferences"
 msgid "lighttable"
 msgstr "mesa de luz"
 
-#: ../build/src/preferences_gen.h:3295
+#: ../build/src/preferences_gen.h:3320
 msgctxt "preferences"
 msgid "lighttable + darkroom"
 msgstr "mesa de luz y cuarto oscuro"
 
-#: ../build/src/preferences_gen.h:3313
+#: ../build/src/preferences_gen.h:3338
 msgid "defines where scrollbars should be displayed"
 msgstr "Define dónde se deberían mostrar las barras de desplazamiento"
 
-#: ../build/src/preferences_gen.h:3321
+#: ../build/src/preferences_gen.h:3346
 msgid "always show panels' scrollbars"
 msgstr "Mostrar siempre las barras de desplazamiento de los paneles"
 
-#: ../build/src/preferences_gen.h:3333
+#: ../build/src/preferences_gen.h:3358
 msgid ""
 "defines whether the panel scrollbars should be always visible or activated "
 "only depending on the content.  (need a restart)"
@@ -701,26 +701,26 @@ msgstr ""
 "Establece si las barras de desplazamiento del panel son permanentes o se "
 "activan en función del contenido. (Necesita reiniciarse)"
 
-#: ../build/src/preferences_gen.h:3341
+#: ../build/src/preferences_gen.h:3366
 msgid "method to use for getting the display profile"
 msgstr "Método a usar para obtener el perfil del monitor"
 
-#: ../build/src/preferences_gen.h:3352 ../build/src/preferences_gen.h:3377
+#: ../build/src/preferences_gen.h:3377 ../build/src/preferences_gen.h:3402
 msgctxt "preferences"
 msgid "all"
 msgstr "todas"
 
-#: ../build/src/preferences_gen.h:3357
+#: ../build/src/preferences_gen.h:3382
 msgctxt "preferences"
 msgid "xatom"
 msgstr "xatom"
 
-#: ../build/src/preferences_gen.h:3362
+#: ../build/src/preferences_gen.h:3387
 msgctxt "preferences"
 msgid "colord"
 msgstr "colord"
 
-#: ../build/src/preferences_gen.h:3380
+#: ../build/src/preferences_gen.h:3405
 msgid ""
 "this option allows to force a specific means of getting the current display "
 "profile. this is useful when one alternative gives wrong results"
@@ -729,21 +729,21 @@ msgstr ""
 "actual del monitor. Es útil cuando una de las alternativas da un resultado "
 "erróneo"
 
-#: ../build/src/preferences_gen.h:3410
+#: ../build/src/preferences_gen.h:3435
 msgid "core options"
 msgstr "Opciones básicas"
 
-#: ../build/src/preferences_gen.h:3413 ../src/imageio/format/j2k.c:652
-#: ../src/imageio/format/jpeg.c:594 ../src/imageio/format/webp.c:326
+#: ../build/src/preferences_gen.h:3438 ../src/imageio/format/j2k.c:652
+#: ../src/imageio/format/jpeg.c:594 ../src/imageio/format/webp.c:329
 #: ../src/libs/camera.c:594
 msgid "quality"
 msgstr "calidad"
 
-#: ../build/src/preferences_gen.h:3424
+#: ../build/src/preferences_gen.h:3449
 msgid "color manage cached thumbnails"
 msgstr "Manejo de color de las miniaturas en caché"
 
-#: ../build/src/preferences_gen.h:3436
+#: ../build/src/preferences_gen.h:3461
 msgid ""
 "if enabled, cached thumbnails will be color managed so that lighttable and "
 "filmstrip can show correct colors. otherwise the results may look wrong once "
@@ -754,45 +754,45 @@ msgstr ""
 "de imágenes. En caso contrario, podrán mostrarse de forma errónea una vez "
 "que se cambie el perfil."
 
-#: ../build/src/preferences_gen.h:3444
+#: ../build/src/preferences_gen.h:3469
 msgid "always use LittleCMS 2 to apply output color profile"
 msgstr ""
 "Utilizar siempre LittleCMS 2 para establecer el perfil de color de salida"
 
-#: ../build/src/preferences_gen.h:3456
+#: ../build/src/preferences_gen.h:3481
 msgid "this is slower than the default."
 msgstr "Es más lento que el valor por defecto."
 
-#: ../build/src/preferences_gen.h:3464
+#: ../build/src/preferences_gen.h:3489
 msgid "do high quality processing for slideshow"
 msgstr "Procesamiento de alta calidad para las diapositivas"
 
-#: ../build/src/preferences_gen.h:3476
+#: ../build/src/preferences_gen.h:3501
 msgid "same option as for export, but applies to slideshow."
 msgstr ""
 "La misma opción que para exportar, pero se aplica a la presentación de "
 "diapositivas."
 
-#: ../build/src/preferences_gen.h:3484
+#: ../build/src/preferences_gen.h:3509
 msgid "demosaicing for zoomed out darkroom mode"
 msgstr "La interpolación cromática para alejar en el modo de cuarto oscuro"
 
-#: ../build/src/preferences_gen.h:3495
+#: ../build/src/preferences_gen.h:3520
 msgctxt "preferences"
 msgid "always bilinear (fast)"
 msgstr "siempre bilineal (rápido)"
 
-#: ../build/src/preferences_gen.h:3500 ../build/src/preferences_gen.h:3520
+#: ../build/src/preferences_gen.h:3525 ../build/src/preferences_gen.h:3545
 msgctxt "preferences"
 msgid "at most PPG (reasonable)"
 msgstr "la mayoría de PPG (razonable)"
 
-#: ../build/src/preferences_gen.h:3505
+#: ../build/src/preferences_gen.h:3530
 msgctxt "preferences"
 msgid "full (possibly slow)"
 msgstr "completo (posiblemente lento)"
 
-#: ../build/src/preferences_gen.h:3523
+#: ../build/src/preferences_gen.h:3548
 msgid ""
 "interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, "
 "but not as sharp. middle ground is using PPG + interpolation modes specified "
@@ -805,31 +805,31 @@ msgstr ""
 "propiedades exactas para exportar en tamaño completo. Los sensores X-trans "
 "usan VNG en vez de PPG."
 
-#: ../build/src/preferences_gen.h:3531
+#: ../build/src/preferences_gen.h:3556
 msgid "pixel interpolator"
 msgstr "Interpolador de píxel"
 
-#: ../build/src/preferences_gen.h:3542
+#: ../build/src/preferences_gen.h:3567
 msgctxt "preferences"
 msgid "bilinear"
 msgstr "bilineal"
 
-#: ../build/src/preferences_gen.h:3547
+#: ../build/src/preferences_gen.h:3572
 msgctxt "preferences"
 msgid "bicubic"
 msgstr "bicúbico"
 
-#: ../build/src/preferences_gen.h:3552
+#: ../build/src/preferences_gen.h:3577
 msgctxt "preferences"
 msgid "lanczos2"
 msgstr "lanczos2"
 
-#: ../build/src/preferences_gen.h:3557 ../build/src/preferences_gen.h:3572
+#: ../build/src/preferences_gen.h:3582 ../build/src/preferences_gen.h:3597
 msgctxt "preferences"
 msgid "lanczos3"
 msgstr "lanczos3"
 
-#: ../build/src/preferences_gen.h:3575
+#: ../build/src/preferences_gen.h:3600
 msgid ""
 "pixel interpolator used in rotation and lens correction (bilinear, bicubic, "
 "lanczos2, lanczos3)."
@@ -837,20 +837,20 @@ msgstr ""
 "El interpolador de píxel es usado para la rotación y corrección de lentes "
 "(bilineal, bicúbico, lanczos2, lanczos3)."
 
-#: ../build/src/preferences_gen.h:3583
+#: ../build/src/preferences_gen.h:3608
 msgid "auto-apply basecurve"
 msgstr "Establecer automáticamente la curva base de la cámara"
 
-#: ../build/src/preferences_gen.h:3595
+#: ../build/src/preferences_gen.h:3620
 msgid "use a basecurve by default (needs a restart)"
 msgstr "Usar una curva base por defecto (requiere reiniciar)"
 
-#: ../build/src/preferences_gen.h:3603
+#: ../build/src/preferences_gen.h:3628
 msgid "auto-apply per camera basecurve presets"
 msgstr ""
 "Establecer automáticamente los preajustes de la curva base de la cámara"
 
-#: ../build/src/preferences_gen.h:3615
+#: ../build/src/preferences_gen.h:3640
 msgid ""
 "use the per-camera basecurve by default instead of the generic manufacturer "
 "one if there is one available (needs a restart)"
@@ -859,11 +859,11 @@ msgstr ""
 "los genéricos de los fabricantes si es que hay uno disponible (necesita "
 "reiniciarse)"
 
-#: ../build/src/preferences_gen.h:3623
+#: ../build/src/preferences_gen.h:3648
 msgid "auto-apply sharpen"
 msgstr "Establecer enfoque automáticamente"
 
-#: ../build/src/preferences_gen.h:3635
+#: ../build/src/preferences_gen.h:3660
 msgid ""
 "this added sharpen is not recommended on cameras without a low-pass filter. "
 "the default is to not add any sharpening automatically as most recent "
@@ -873,15 +873,15 @@ msgstr ""
 "defecto, no se aplica ningún enfoque, dado que las cámaras más recientes no "
 "tienen filtro de paso bajo (requiere reinicirse)"
 
-#: ../build/src/preferences_gen.h:3643
+#: ../build/src/preferences_gen.h:3668
 msgid "xmp"
 msgstr "xmp"
 
-#: ../build/src/preferences_gen.h:3654
+#: ../build/src/preferences_gen.h:3679
 msgid "write sidecar file for each image"
 msgstr "Escribir un archivo asociado para cada imagen"
 
-#: ../build/src/preferences_gen.h:3666
+#: ../build/src/preferences_gen.h:3691
 msgid ""
 "these redundant files can later be re-imported into a different database, "
 "preserving your changes to the image."
@@ -889,16 +889,16 @@ msgstr ""
 "Estos ficheros redundantes pueden ser reimportados más tarde en una base de "
 "datos diferente, preservando sus cambios en la imagen."
 
-#: ../build/src/preferences_gen.h:3674
+#: ../build/src/preferences_gen.h:3699
 msgid "store xmp tags in compressed format"
 msgstr "Guarda las etiquetas xmp en formato comprimido"
 
-#: ../build/src/preferences_gen.h:3695 ../build/src/preferences_gen.h:3710
+#: ../build/src/preferences_gen.h:3720 ../build/src/preferences_gen.h:3735
 msgctxt "preferences"
 msgid "only large entries"
 msgstr "solo entradas largas"
 
-#: ../build/src/preferences_gen.h:3713
+#: ../build/src/preferences_gen.h:3738
 msgid ""
 "entries in xmp tags can get rather large and may exceed the available space "
 "to store the history stack in output files. this option allows xmp tags to "
@@ -908,11 +908,11 @@ msgstr ""
 "almacenamiento disponible en el historial de acciones de los archivos de "
 "salida. Esta opción permite comprimir las etiquetas xmp para ahorrar espacio."
 
-#: ../build/src/preferences_gen.h:3721
+#: ../build/src/preferences_gen.h:3746
 msgid "look for updated xmp files on startup"
 msgstr "Buscar archivos xmp actualizados al iniciar"
 
-#: ../build/src/preferences_gen.h:3733
+#: ../build/src/preferences_gen.h:3758
 msgid ""
 "check file modification times of all xmp files on startup to check if any "
 "got updated in the meantime"
@@ -920,15 +920,15 @@ msgstr ""
 "Revisar los tiempos de modificación de todos los archivos xmp al inicio para "
 "verificar si alguno fue actualizado durante el proceso"
 
-#: ../build/src/preferences_gen.h:3741
+#: ../build/src/preferences_gen.h:3766
 msgid "cpu / gpu / memory"
 msgstr "cpu/gpu/memoria"
 
-#: ../build/src/preferences_gen.h:3752
+#: ../build/src/preferences_gen.h:3777
 msgid "memory in megabytes to use for thumbnail cache"
 msgstr "Memoria en megabytes para usar en la caché de las miniaturas"
 
-#: ../build/src/preferences_gen.h:3772
+#: ../build/src/preferences_gen.h:3797
 msgid ""
 "this controls how much memory is going to be used for thumbnails and other "
 "buffers (needs a restart)."
@@ -937,11 +937,11 @@ msgstr ""
 "(necesita reiniciarse)."
 
 # backend - traducción
-#: ../build/src/preferences_gen.h:3780
+#: ../build/src/preferences_gen.h:3805
 msgid "enable disk backend for thumbnail cache"
 msgstr "Activa el segundo plano del disco para la caché de las miniaturas"
 
-#: ../build/src/preferences_gen.h:3792
+#: ../build/src/preferences_gen.h:3817
 msgid ""
 "if enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -958,11 +958,11 @@ msgstr ""
 "en gran medida cuando se navega mucho. Para generar todas las miniaturas de "
 "su colección fuera de línea, ejecute 'darktable-generate-cache'."
 
-#: ../build/src/preferences_gen.h:3800
+#: ../build/src/preferences_gen.h:3825
 msgid "enable disk backend for full preview cache"
 msgstr "Habilita el uso del disco para una vista previa completa"
 
-#: ../build/src/preferences_gen.h:3812
+#: ../build/src/preferences_gen.h:3837
 msgid ""
 "if enabled, write full preview to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -977,11 +977,11 @@ msgstr ""
 "manualmente. El rendimiento de la mesa de luz aumentará en gran medida al "
 "hacer zoom en la imagen en modo de vista previa completa."
 
-#: ../build/src/preferences_gen.h:3820
+#: ../build/src/preferences_gen.h:3845
 msgid "number of background threads"
 msgstr "Número de hilos en segundo plano"
 
-#: ../build/src/preferences_gen.h:3839
+#: ../build/src/preferences_gen.h:3864
 msgid ""
 "this controls for example how many threads are used to create thumbnails "
 "during import. the cache will grow to a maximum of twice this number of full "
@@ -992,11 +992,11 @@ msgstr ""
 "hasta un máximo de dos veces la resolución máxima de las imágenes (necesita "
 "reiniciarse)"
 
-#: ../build/src/preferences_gen.h:3847
+#: ../build/src/preferences_gen.h:3872
 msgid "host memory limit (in MB) for tiling"
 msgstr "Límite de memoria (en MB) para el proceso de bandas"
 
-#: ../build/src/preferences_gen.h:3866
+#: ../build/src/preferences_gen.h:3891
 msgid ""
 "this variable controls the maximum amount of memory (in MB) a module may use "
 "during image processing. lower values will force memory hungry modules to "
@@ -1009,11 +1009,11 @@ msgstr ""
 "creciente de bandas. Dejarlo en 0 ignorará cualquier límite. Un valor por "
 "debajo de 500 se tratará como 500 (necesita reiniciarse)."
 
-#: ../build/src/preferences_gen.h:3874
+#: ../build/src/preferences_gen.h:3899
 msgid "minimum amount of memory (in MB) for a single buffer in tiling"
 msgstr "Mínima cantidad de memoria para un único búfer de bandas (en MB)"
 
-#: ../build/src/preferences_gen.h:3895
+#: ../build/src/preferences_gen.h:3920
 msgid ""
 "if set to a positive, non-zero value this variable defines the minimum "
 "amount of memory (in MB) that tiling should take for a single image buffer. "
@@ -1024,11 +1024,11 @@ msgstr ""
 "para el búfer de una sola imagen. Tiene precedencia sobre los cálculos "
 "basados en la variable host_memory_limit (necesita reiniciarse)."
 
-#: ../build/src/preferences_gen.h:3903
+#: ../build/src/preferences_gen.h:3928
 msgid "activate OpenCL support"
 msgstr "Activar el soporte de OpenCL"
 
-#: ../build/src/preferences_gen.h:3915
+#: ../build/src/preferences_gen.h:3940
 msgid ""
 "if found, use OpenCL runtime on your system for improved processing speed. "
 "can be switched on and off at any time."
@@ -1036,43 +1036,43 @@ msgstr ""
 "Use OpenCL en su sistema para mejorar la velocidad de procesado, si está "
 "disponible. Puede apagarlo en cualquier momento."
 
-#: ../build/src/preferences_gen.h:3916 ../build/src/preferences_gen.h:3971
+#: ../build/src/preferences_gen.h:3941 ../build/src/preferences_gen.h:3996
 msgid "not available"
 msgstr "No disponible"
 
-#: ../build/src/preferences_gen.h:3919 ../build/src/preferences_gen.h:3923
-#: ../build/src/preferences_gen.h:3974 ../build/src/preferences_gen.h:3978
+#: ../build/src/preferences_gen.h:3944 ../build/src/preferences_gen.h:3948
+#: ../build/src/preferences_gen.h:3999 ../build/src/preferences_gen.h:4003
 msgid "not available on this system"
 msgstr "No disponible en este sistema"
 
-#: ../build/src/preferences_gen.h:3931
+#: ../build/src/preferences_gen.h:3956
 msgid "OpenCL scheduling profile"
 msgstr "Perfil de programación de OpenCL"
 
 #. Adding the restore defaults button
-#: ../build/src/preferences_gen.h:3942 ../build/src/preferences_gen.h:3967
-#: ../src/gui/preferences.c:619
+#: ../build/src/preferences_gen.h:3967 ../build/src/preferences_gen.h:3992
+#: ../src/gui/preferences.c:621
 msgctxt "preferences"
 msgid "default"
 msgstr "por defecto"
 
-#: ../build/src/preferences_gen.h:3947
+#: ../build/src/preferences_gen.h:3972
 msgctxt "preferences"
 msgid "multiple GPUs"
 msgstr "múltiples GPUs"
 
 # Ignorar advertencia: en el texto original GPU va en mayúsculas.
-#: ../build/src/preferences_gen.h:3952
+#: ../build/src/preferences_gen.h:3977
 msgctxt "preferences"
 msgid "very fast GPU"
 msgstr "GPU muy rápido"
 
-#: ../build/src/preferences_gen.h:3970
+#: ../build/src/preferences_gen.h:3995
 msgid ""
 "defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
 "systems. default - GPU processes full and CPU processes preview pipe "
 "(adaptable by config parameters); multiple GPUs - process both pixelpipes in "
-"parallel on two different GPUs; very fast GPU - process both pixelipes "
+"parallel on two different GPUs; very fast GPU - process both pixelpipes "
 "sequentially on the GPU."
 msgstr ""
 "define como las tareas de vista previa y pixelpipe completo son programadas "
@@ -1082,57 +1082,72 @@ msgstr ""
 "diferentes; GPU muy rápido - procesa ambos pixelpipes de forma secuencial en "
 "el GPU."
 
-#: ../build/src/preferences_gen.h:3997
+#: ../build/src/preferences_gen.h:4022
 msgid "omit hierarchy in simple tag lists"
 msgstr "Ignora la jerarquía en listas de etiquetas simples"
 
-#: ../build/src/preferences_gen.h:4009
+#: ../build/src/preferences_gen.h:4034
 msgid ""
-"when exporting images the hierarchical tags are also added as a simple list "
+"when creating XMP file the hierarchical tags are also added as a simple list "
 "of non-hierarchical ones to make them visible to some other programs. when "
 "this option is checked darktable will only include their last part and "
 "ignore the rest. so 'foo|bar|baz' will only add 'baz'."
 msgstr ""
-"al exportar imágenes las etiquetas jerárquicas también se agregan como una "
-"lista simple sin jerarquía para que sean visibles por otros programas. "
-"cuando esta opción esta marcada, darktable solo incluirá la última parte e "
-"ignorará el resto. por lo que 'foo|bar|baz' solo agregará 'baz'."
+"Cuando se crea el fichero XMP, las etiquetas jerárquicas se agregan también "
+"como una lista sencilla sin jerarquía para que sea visible por otros "
+"programas. Si está marcada esta opción, darktable solo incluirá la última "
+"parte de la lista e ignorará el resto, por lo que 'foo|bar|baz' solo añadirá "
+"'baz'."
 
-#: ../build/src/preferences_gen.h:4017
+#: ../build/src/preferences_gen.h:4042
+msgid "disable the entry completion"
+msgstr "Deshabilitar la compleción de texto"
+
+#: ../build/src/preferences_gen.h:4054
+msgid ""
+"the entry completion is useful for those who enter tags from keyboard only. "
+"for others the entry completion can be embarrassing. need to restart "
+"darktable."
+msgstr ""
+"La compleción del texto es útil solo para quienes ingresan las etiquetas con "
+"el teclado. Para otros casos, completar el ingreso de texto puede ser "
+"desconcertante. Es necesario reiniciar darktable."
+
+#: ../build/src/preferences_gen.h:4062
 msgid "password storage backend to use"
 msgstr "Respaldo de almacenamiento de contraseñas para usar"
 
-#: ../build/src/preferences_gen.h:4028 ../build/src/preferences_gen.h:4060
+#: ../build/src/preferences_gen.h:4073 ../build/src/preferences_gen.h:4105
 msgctxt "preferences"
 msgid "auto"
 msgstr "auto"
 
-#: ../build/src/preferences_gen.h:4033
+#: ../build/src/preferences_gen.h:4078
 msgctxt "preferences"
 msgid "none"
 msgstr "ninguna"
 
-#: ../build/src/preferences_gen.h:4038
+#: ../build/src/preferences_gen.h:4083
 msgctxt "preferences"
 msgid "libsecret"
 msgstr "libsecret"
 
-#: ../build/src/preferences_gen.h:4044
+#: ../build/src/preferences_gen.h:4089
 msgctxt "preferences"
 msgid "kwallet"
 msgstr "kwallet"
 
-#: ../build/src/preferences_gen.h:4063
+#: ../build/src/preferences_gen.h:4108
 msgid ""
 "the storage backend for password storage: auto, none, libsecret, kwallet"
 msgstr ""
 "la interfaz para almacenamiento de claves: auto, ninguno, libsecret, kwallet"
 
-#: ../build/src/preferences_gen.h:4071
+#: ../build/src/preferences_gen.h:4116
 msgid "executable for playing audio files"
 msgstr "Programa para reproducir archivos de audio"
 
-#: ../build/src/preferences_gen.h:4087
+#: ../build/src/preferences_gen.h:4132
 msgid ""
 "this external program is used to play audio files some cameras record to "
 "keep notes for images"
@@ -1140,46 +1155,48 @@ msgstr ""
 "Este programa externo es utilizado para reproducir archivos de audio que "
 "algunas cámaras graban para mantener notas de las imagenes"
 
-#: ../build/src/preferences_gen.h:4095
+#: ../build/src/preferences_gen.h:4140
 msgid "3D lut root folder"
 msgstr "Carpeta raíz del lut 3D"
 
-#: ../build/src/preferences_gen.h:4100 ../src/control/jobs/control_jobs.c:1581
-#: ../src/control/jobs/control_jobs.c:1641 ../src/gui/preferences.c:1553
+#: ../build/src/preferences_gen.h:4145 ../src/control/jobs/control_jobs.c:1629
+#: ../src/control/jobs/control_jobs.c:1689 ../src/gui/preferences.c:1607
 #: ../src/imageio/storage/disk.c:121 ../src/imageio/storage/disk.c:194
-#: ../src/imageio/storage/gallery.c:107 ../src/imageio/storage/gallery.c:178
-#: ../src/imageio/storage/latex.c:106 ../src/imageio/storage/latex.c:177
+#: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/gallery.c:179
+#: ../src/imageio/storage/latex.c:107 ../src/imageio/storage/latex.c:178
 #: ../src/libs/styles.c:300 ../src/lua/preferences.c:631
 msgid "select directory"
 msgstr "seleccionar directorio"
 
-#: ../build/src/preferences_gen.h:4112
-msgid "this folder (and sub-folders) contains Lut files used but lut3d modules"
+#: ../build/src/preferences_gen.h:4157
+msgid ""
+"this folder (and sub-folders) contains Lut files used by lut3d modules. need "
+"to restart darktable."
 msgstr ""
-"Esta carpeta (y subcarpetas) contiene los archivos Lut utilizados pero no "
-"los módulos lut3d"
+"Esta carpeta (y subcarpetas) contienen los archivos Lut utilizados por los "
+"módulos lut3d. Es necesario reiniciar darktable."
 
-#: ../build/src/preferences_gen.h:4142
+#: ../build/src/preferences_gen.h:4187
 msgid "session options"
 msgstr "Opciones de la sesión"
 
-#: ../build/src/preferences_gen.h:4145
+#: ../build/src/preferences_gen.h:4190
 msgid "base directory naming pattern"
 msgstr "Directorio base para el patrón de nombres"
 
-#: ../build/src/preferences_gen.h:4161 ../build/src/preferences_gen.h:4185
+#: ../build/src/preferences_gen.h:4206 ../build/src/preferences_gen.h:4230
 msgid "part of full import path for an import session"
 msgstr "parte de la ruta completa para importar una sesión"
 
-#: ../build/src/preferences_gen.h:4169
+#: ../build/src/preferences_gen.h:4214
 msgid "sub directory naming pattern"
 msgstr "Subdirectorio para el patrón de nombres"
 
-#: ../build/src/preferences_gen.h:4193
+#: ../build/src/preferences_gen.h:4238
 msgid "file naming pattern"
 msgstr "Patrón para nombrar archivos"
 
-#: ../build/src/preferences_gen.h:4209
+#: ../build/src/preferences_gen.h:4254
 msgid "file naming pattern used for a import session"
 msgstr "Patrón de nombres utilizado para importar una sesión"
 
@@ -1242,23 +1259,23 @@ msgstr "Mesa de Luz y Cuarto Oscuro Virtuales"
 msgid "graphics;photography;raw;"
 msgstr "gráficos;fotografía;raw;"
 
-#: ../src/chart/main.c:459 ../src/control/jobs/control_jobs.c:1581
-#: ../src/control/jobs/control_jobs.c:1641 ../src/gui/hist_dialog.c:140
-#: ../src/gui/preferences.c:1093 ../src/gui/preferences.c:1119
-#: ../src/gui/preferences.c:1203 ../src/gui/preferences.c:1325
-#: ../src/gui/preferences.c:1553 ../src/gui/presets.c:387
+#: ../src/chart/main.c:459 ../src/control/jobs/control_jobs.c:1629
+#: ../src/control/jobs/control_jobs.c:1689 ../src/gui/hist_dialog.c:171
+#: ../src/gui/preferences.c:1147 ../src/gui/preferences.c:1173
+#: ../src/gui/preferences.c:1257 ../src/gui/preferences.c:1379
+#: ../src/gui/preferences.c:1607 ../src/gui/presets.c:387
 #: ../src/gui/styles_dialog.c:283 ../src/imageio/storage/disk.c:121
-#: ../src/imageio/storage/gallery.c:107 ../src/imageio/storage/latex.c:106
-#: ../src/iop/lut3d.c:933 ../src/libs/collect.c:242
-#: ../src/libs/copy_history.c:78 ../src/libs/geotagging.c:472
-#: ../src/libs/import.c:758 ../src/libs/import.c:865 ../src/libs/lib.c:228
-#: ../src/libs/styles.c:300 ../src/libs/styles.c:323 ../src/libs/tagging.c:377
-#: ../src/libs/tagging.c:417
+#: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/latex.c:107
+#: ../src/iop/lut3d.c:1012 ../src/libs/collect.c:242
+#: ../src/libs/copy_history.c:78 ../src/libs/geotagging.c:473
+#: ../src/libs/import.c:759 ../src/libs/import.c:866 ../src/libs/lib.c:228
+#: ../src/libs/styles.c:300 ../src/libs/styles.c:323 ../src/libs/tagging.c:2120
+#: ../src/libs/tagging.c:2161
 msgid "_cancel"
 msgstr "_cancelar"
 
-#: ../src/chart/main.c:459 ../src/gui/preferences.c:1093
-#: ../src/gui/preferences.c:1324 ../src/gui/styles_dialog.c:284
+#: ../src/chart/main.c:459 ../src/gui/preferences.c:1147
+#: ../src/gui/preferences.c:1378 ../src/gui/styles_dialog.c:284
 #: ../src/libs/styles.c:301
 msgid "_save"
 msgstr "_guardar"
@@ -1351,213 +1368,217 @@ msgstr ""
 "demasiado tiempo para actualizar la relación de aspecto para la colección"
 
 #: ../src/common/collection.c:1241 ../src/develop/lightroom.c:824
-#: ../src/iop/bilateral.cc:371 ../src/iop/channelmixer.c:459
-#: ../src/iop/channelmixer.c:470 ../src/iop/colorbalance.c:2506
-#: ../src/iop/temperature.c:1376 ../src/libs/collect.c:1290
+#: ../src/iop/bilateral.cc:371 ../src/iop/channelmixer.c:456
+#: ../src/iop/channelmixer.c:467 ../src/iop/colorbalance.c:2525
+#: ../src/iop/temperature.c:1378 ../src/libs/collect.c:1284
 msgid "red"
 msgstr "rojo"
 
 #: ../src/common/collection.c:1243 ../src/develop/lightroom.c:826
-#: ../src/iop/temperature.c:1367 ../src/libs/collect.c:1290
+#: ../src/iop/temperature.c:1369 ../src/libs/collect.c:1284
 msgid "yellow"
 msgstr "amarillo"
 
 #: ../src/common/collection.c:1245 ../src/develop/lightroom.c:828
-#: ../src/iop/bilateral.cc:372 ../src/iop/channelmixer.c:460
-#: ../src/iop/channelmixer.c:476 ../src/iop/colorbalance.c:2513
-#: ../src/iop/temperature.c:1364 ../src/iop/temperature.c:1377
-#: ../src/libs/collect.c:1290
+#: ../src/iop/bilateral.cc:372 ../src/iop/channelmixer.c:457
+#: ../src/iop/channelmixer.c:473 ../src/iop/colorbalance.c:2532
+#: ../src/iop/temperature.c:1366 ../src/iop/temperature.c:1379
+#: ../src/libs/collect.c:1284
 msgid "green"
 msgstr "verde"
 
 #: ../src/common/collection.c:1247 ../src/develop/lightroom.c:830
-#: ../src/iop/bilateral.cc:373 ../src/iop/channelmixer.c:461
-#: ../src/iop/channelmixer.c:482 ../src/iop/colorbalance.c:2520
-#: ../src/iop/temperature.c:1378 ../src/libs/collect.c:1290
+#: ../src/iop/bilateral.cc:373 ../src/iop/channelmixer.c:458
+#: ../src/iop/channelmixer.c:479 ../src/iop/colorbalance.c:2539
+#: ../src/iop/temperature.c:1380 ../src/libs/collect.c:1284
 msgid "blue"
 msgstr "azul"
 
-#: ../src/common/collection.c:1249 ../src/libs/collect.c:1290
+#: ../src/common/collection.c:1249 ../src/libs/collect.c:1284
 msgid "purple"
 msgstr "púrpura"
 
-#: ../src/common/collection.c:1258 ../src/libs/collect.c:1257
+#: ../src/common/collection.c:1258 ../src/libs/collect.c:1251
 msgid "altered"
 msgstr "alterado"
 
-#: ../src/common/collection.c:1264 ../src/libs/collect.c:1266
+#: ../src/common/collection.c:1264 ../src/libs/collect.c:1260
 msgid "tagged"
 msgstr "etiquetado"
 
-#: ../src/common/collection.c:1270 ../src/libs/collect.c:1275
+#: ../src/common/collection.c:1270 ../src/libs/collect.c:1269
 msgid "not copied locally"
 msgstr "sin copia local"
 
 #. grouping
-#: ../src/common/collection.c:1483 ../src/libs/collect.c:1379
+#: ../src/common/collection.c:1483 ../src/libs/collect.c:1373
 msgid "group leaders"
 msgstr "líderes de grupo"
 
 #: ../src/common/collection.c:1681
 #, c-format
 msgid "%d image of %d (#%d) in current collection is selected"
-msgstr "seleccionada imagen %d de %d (#%d) en la colección actual"
+msgstr "%d imagen seleccionada de %d (#%d) de la colección actual"
 
 #: ../src/common/collection.c:1687
 #, c-format
 msgid "%d image of %d in current collection is selected"
 msgid_plural "%d images of %d in current collection are selected"
-msgstr[0] "seleccionada %d imagen de %d en la colección actual"
-msgstr[1] "seleccionadas %d imágenes de %d en la colección actual"
+msgstr[0] "%d imagen seleccionada de %d de la colección actual"
+msgstr[1] "%d imágenes seleccionadas de %d de la colección actual"
 
 #. 0th entry is a dummy for DT_COLORSPACE_FILE and not used
-#: ../src/common/colorspaces.c:947 ../src/iop/colorin.c:2106
-#: ../src/iop/lut3d.c:1045
+#: ../src/common/colorspaces.c:968 ../src/iop/colorin.c:2108
+#: ../src/iop/lut3d.c:1117
 msgid "sRGB"
 msgstr "sRGB"
 
 #. this is only used in error messages, no need for the (...) description
-#: ../src/common/colorspaces.c:948 ../src/common/colorspaces.c:1253
-#: ../src/iop/colorin.c:2107 ../src/libs/print_settings.c:1036
+#: ../src/common/colorspaces.c:969 ../src/common/colorspaces.c:1274
+#: ../src/iop/colorin.c:2109 ../src/libs/print_settings.c:1034
 msgid "Adobe RGB (compatible)"
 msgstr "Adobe RGB (compatible)"
 
-#: ../src/common/colorspaces.c:949 ../src/common/colorspaces.c:1258
-#: ../src/iop/colorin.c:2108
+#: ../src/common/colorspaces.c:970 ../src/common/colorspaces.c:1279
+#: ../src/iop/colorin.c:2110
 msgid "linear Rec709 RGB"
 msgstr "linear Rec709 RGB"
 
-#: ../src/common/colorspaces.c:950 ../src/common/colorspaces.c:1267
-#: ../src/iop/colorin.c:2109
+#: ../src/common/colorspaces.c:971 ../src/common/colorspaces.c:1288
+#: ../src/iop/colorin.c:2111
 msgid "linear Rec2020 RGB"
 msgstr "linear Rec2020 RGB"
 
-#: ../src/common/colorspaces.c:951 ../src/common/colorspaces.c:1272
+#: ../src/common/colorspaces.c:972 ../src/common/colorspaces.c:1298
 msgid "linear XYZ"
 msgstr "lineal XYZ"
 
-#: ../src/common/colorspaces.c:952 ../src/common/colorspaces.c:1276
-#: ../src/libs/colorpicker.c:581 ../src/libs/colorpicker.c:617
+#: ../src/common/colorspaces.c:973 ../src/common/colorspaces.c:1302
+#: ../src/libs/colorpicker.c:582 ../src/libs/colorpicker.c:619
 msgid "Lab"
 msgstr "Lab"
 
-#: ../src/common/colorspaces.c:953 ../src/common/colorspaces.c:1281
+#: ../src/common/colorspaces.c:974 ../src/common/colorspaces.c:1307
 msgid "linear infrared BGR"
 msgstr "infrarrojo lineal RGB"
 
-#: ../src/common/colorspaces.c:954 ../src/common/colorspaces.c:965
-#: ../src/common/colorspaces.c:1235 ../src/common/colorspaces.c:1238
+#: ../src/common/colorspaces.c:975 ../src/common/colorspaces.c:986
+#: ../src/common/colorspaces.c:1256 ../src/common/colorspaces.c:1259
 msgid "system display profile"
 msgstr "perfil de pantalla del s.o"
 
-#: ../src/common/colorspaces.c:955
+#: ../src/common/colorspaces.c:976
 msgid "embedded ICC profile"
 msgstr "perfil ICC incrustado"
 
-#: ../src/common/colorspaces.c:956
+#: ../src/common/colorspaces.c:977
 msgid "embedded matrix"
 msgstr "matriz incrustada"
 
-#: ../src/common/colorspaces.c:957
+#: ../src/common/colorspaces.c:978
 msgid "standard color matrix"
 msgstr "matriz de color standard"
 
-#: ../src/common/colorspaces.c:958
+#: ../src/common/colorspaces.c:979
 msgid "enhanced color matrix"
 msgstr "matriz de color mejorada"
 
-#: ../src/common/colorspaces.c:959
+#: ../src/common/colorspaces.c:980
 msgid "vendor color matrix"
 msgstr "matriz de color"
 
-#: ../src/common/colorspaces.c:960
+#: ../src/common/colorspaces.c:981
 msgid "alternate color matrix"
 msgstr "matriz de color alternativa"
 
-#: ../src/common/colorspaces.c:961
+#: ../src/common/colorspaces.c:982
 msgid "BRG (experimental)"
 msgstr "BRG (para pruebas)"
 
-#: ../src/common/colorspaces.c:962 ../src/common/colorspaces.c:1225
-#: ../src/iop/colorout.c:880
+#: ../src/common/colorspaces.c:983 ../src/common/colorspaces.c:1246
+#: ../src/iop/colorout.c:881
 msgid "export profile"
 msgstr "perfil de exportación"
 
-#: ../src/common/colorspaces.c:963 ../src/common/colorspaces.c:1229
-#: ../src/views/darkroom.c:1978
+#: ../src/common/colorspaces.c:984 ../src/common/colorspaces.c:1250
+#: ../src/views/darkroom.c:1998
 msgid "softproof profile"
 msgstr "perfil (impresión)"
 
 #. init the category profile with NULL profile, the actual profile must be retrieved dynamically by the caller
-#: ../src/common/colorspaces.c:964 ../src/common/colorspaces.c:1222
+#: ../src/common/colorspaces.c:985 ../src/common/colorspaces.c:1243
 msgid "work profile"
 msgstr "perfil de trabajo"
 
-#: ../src/common/colorspaces.c:1244
+#: ../src/common/colorspaces.c:1265
 msgid "sRGB (e.g. JPG)"
 msgstr "sRGB (p.ej. JPG)"
 
-#: ../src/common/colorspaces.c:1248 ../src/libs/print_settings.c:1029
+#: ../src/common/colorspaces.c:1269 ../src/libs/print_settings.c:1027
 msgid "sRGB (web-safe)"
 msgstr "sRGB (seguro para web)"
 
-#: ../src/common/colorspaces.c:1262
+#: ../src/common/colorspaces.c:1283
 msgid "gamma Rec709 RGB"
 msgstr "gamma Rec709 RGB"
 
-#: ../src/common/colorspaces.c:1285
+#: ../src/common/colorspaces.c:1293
+msgid "linear prophoto RGB"
+msgstr "RGB Profoto lineal"
+
+#: ../src/common/colorspaces.c:1311
 msgid "BRG (for testing)"
 msgstr "BRG (para pruebas)"
 
-#: ../src/common/cups_print.c:407
+#: ../src/common/cups_print.c:408
 #, c-format
 msgid "file `%s' to print not found for image %d on `%s'"
 msgstr "archivo `%s' a ser impreso no se encuentra para la imagen %d en `%s'"
 
-#: ../src/common/cups_print.c:426
+#: ../src/common/cups_print.c:427
 msgid "failed to create temporary file for printing options"
 msgstr "fallo al crear el fichero temporal de opciones de impresión"
 
-#: ../src/common/cups_print.c:494
+#: ../src/common/cups_print.c:495
 #, c-format
 msgid "printing on `%s' cancelled"
 msgstr "impresión en`%s' cancelada"
 
-#: ../src/common/cups_print.c:557
+#: ../src/common/cups_print.c:558
 #, c-format
 msgid "error while printing `%s' on `%s'"
 msgstr "error al imprimir `% s 'en`% s'"
 
-#: ../src/common/cups_print.c:559
+#: ../src/common/cups_print.c:560
 #, c-format
 msgid "printing `%s' on `%s'"
 msgstr "imprimiendo imágen `%s' en `%s'"
 
-#: ../src/common/darktable.c:229
+#: ../src/common/darktable.c:230
 #, c-format
 msgid "found strange path `%s'"
 msgstr "ruta extraña encontrada `%s'"
 
-#: ../src/common/darktable.c:246
+#: ../src/common/darktable.c:247
 #, c-format
 msgid "error loading directory `%s'"
 msgstr "error cargando directorio '%s'"
 
-#: ../src/common/darktable.c:269
+#: ../src/common/darktable.c:270
 #, c-format
 msgid "file `%s' has unknown format!"
 msgstr "el archivo `%s' tiene un formato desconocido!"
 
-#: ../src/common/darktable.c:282 ../src/libs/import.c:824
+#: ../src/common/darktable.c:283 ../src/libs/import.c:825
 #, c-format
 msgid "error loading file `%s'"
 msgstr "error cargando archivo '%s'"
 
-#: ../src/common/darktable.c:784
+#: ../src/common/darktable.c:786
 msgid "darktable - run performance configuration?"
 msgstr "darktable - ¿Ejecutando configuración de rendimiento?"
 
-#: ../src/common/darktable.c:785
+#: ../src/common/darktable.c:787
 msgid ""
 "we have an updated performance configuration logic - executing that might "
 "improve the performance of darktable.\n"
@@ -1572,23 +1593,22 @@ msgstr ""
 "personalizados.\n"
 "¿Acepta ejecutar la actualización de la configuración de rendimiento?\n"
 
-#: ../src/common/darktable.c:789 ../src/imageio/format/pdf.c:667
-#: ../src/imageio/format/pdf.c:692 ../src/imageio/storage/flickr.c:498
-#: ../src/imageio/storage/piwigo.c:822 ../src/iop/clipping.c:2003
-#: ../src/libs/export.c:610 ../src/libs/export.c:616
-#: ../src/libs/metadata_view.c:270
+#: ../src/common/darktable.c:791 ../src/common/variables.c:380
+#: ../src/imageio/format/pdf.c:669 ../src/imageio/format/pdf.c:694
+#: ../src/iop/clipping.c:2005 ../src/iop/filmicrgb.c:1436
+#: ../src/libs/export.c:626 ../src/libs/export.c:632
+#: ../src/libs/metadata_view.c:277
 msgid "no"
 msgstr "no"
 
-#: ../src/common/darktable.c:789 ../src/imageio/format/pdf.c:668
-#: ../src/imageio/format/pdf.c:693 ../src/imageio/storage/flickr.c:497
-#: ../src/imageio/storage/piwigo.c:821 ../src/iop/clipping.c:2004
-#: ../src/libs/export.c:611 ../src/libs/export.c:617
-#: ../src/libs/metadata_view.c:270
+#: ../src/common/darktable.c:791 ../src/common/variables.c:378
+#: ../src/imageio/format/pdf.c:670 ../src/imageio/format/pdf.c:695
+#: ../src/iop/clipping.c:2006 ../src/libs/export.c:627 ../src/libs/export.c:633
+#: ../src/libs/metadata_view.c:277
 msgid "yes"
 msgstr "sí"
 
-#: ../src/common/database.c:1578
+#: ../src/common/database.c:1605
 #, c-format
 msgid ""
 "an error has occurred while trying to open the database from\n"
@@ -1603,16 +1623,16 @@ msgstr ""
 "\n"
 "%s\n"
 
-#: ../src/common/database.c:1585
+#: ../src/common/database.c:1612
 msgid "darktable - error locking database"
 msgstr "Error en darktable al bloquear la base de datos"
 
-#: ../src/common/database.c:1585 ../src/common/database.c:1756
-#: ../src/common/database.c:1942 ../src/common/database.c:2020
+#: ../src/common/database.c:1612 ../src/common/database.c:1783
+#: ../src/common/database.c:1969 ../src/common/database.c:2047
 msgid "close darktable"
 msgstr "cerrar darktable"
 
-#: ../src/common/database.c:1696
+#: ../src/common/database.c:1723
 #, c-format
 msgid ""
 "the database lock file contains a pid that seems to be alive in your system: "
@@ -1621,19 +1641,19 @@ msgstr ""
 "El archivo de bloqueo de la base de datos contiene un pid que parece estar "
 "aun activo en su sistema: %d"
 
-#: ../src/common/database.c:1702
+#: ../src/common/database.c:1729
 #, c-format
 msgid "the database lock file seems to be empty"
 msgstr "El archivo de bloqueo de la base de datos parece estar vacío"
 
-#: ../src/common/database.c:1710
+#: ../src/common/database.c:1737
 #, c-format
 msgid "error opening the database lock file for reading: %s"
 msgstr ""
 "Error al abrir el archivo de bloqueo de la base de datos para su lectura: %s"
 
 #. the database has to be upgraded, let's ask user
-#: ../src/common/database.c:1747
+#: ../src/common/database.c:1774
 #, c-format
 msgid ""
 "the database schema has to be upgraded for\n"
@@ -1648,17 +1668,17 @@ msgstr ""
 "\n"
 "¿Desea continuar o salir ahora para hacer una copia de seguridad?\n"
 
-#: ../src/common/database.c:1755
+#: ../src/common/database.c:1782
 msgid "darktable - schema migration"
 msgstr "migración de esquemas de darktable"
 
-#: ../src/common/database.c:1756
+#: ../src/common/database.c:1783
 msgid "upgrade database"
 msgstr "actualizar la base de datos"
 
 #. oh, bad situation. the database is corrupt and can't be read!
 #. we inform the user here and let him decide what to do: exit or delete and try again.
-#: ../src/common/database.c:1931 ../src/common/database.c:2009
+#: ../src/common/database.c:1958 ../src/common/database.c:2036
 #, c-format
 msgid ""
 "an error has occurred while trying to open the database from\n"
@@ -1677,11 +1697,11 @@ msgstr ""
 "¿Desea cerrar manualmente darktable para reiniciar\n"
 "desde el respaldo la base de datos o comenzar con una nueva?"
 
-#: ../src/common/database.c:1941 ../src/common/database.c:2019
+#: ../src/common/database.c:1968 ../src/common/database.c:2046
 msgid "darktable - error opening database"
 msgstr "Error en darktable al abrir la base de datos"
 
-#: ../src/common/database.c:1942 ../src/common/database.c:2020
+#: ../src/common/database.c:1969 ../src/common/database.c:2047
 msgid "delete database"
 msgstr "borrar base de datos"
 
@@ -1697,7 +1717,8 @@ msgid_plural "remove empty directories?"
 msgstr[0] "¿Eliminar directorio vacío?"
 msgstr[1] "¿Eliminar directorios vacíos?"
 
-#: ../src/common/film.c:339 ../src/gui/preferences.c:491
+#: ../src/common/film.c:339 ../src/gui/preferences.c:493
+#: ../src/gui/styles_dialog.c:309
 msgid "name"
 msgstr "nombre"
 
@@ -1708,26 +1729,26 @@ msgstr ""
 "El carrete no se puede eliminar si tiene copias locales sin acceso a los "
 "originales"
 
-#: ../src/common/history.c:704
+#: ../src/common/history.c:707
 msgid "you need to copy history from an image before you paste it onto another"
 msgstr "Necesita copiar el historial de una imagen antes de pegarlo en otra"
 
-#: ../src/common/history.c:794 ../src/common/history.c:797
-#: ../src/common/history.c:813 ../src/common/styles.c:887
-#: ../src/common/styles.c:891 ../src/develop/blend_gui.c:2500
-#: ../src/develop/develop.c:1792 ../src/iop/ashift.c:4851
+#: ../src/common/history.c:798 ../src/common/history.c:801
+#: ../src/common/history.c:817 ../src/common/styles.c:894
+#: ../src/common/styles.c:898 ../src/develop/blend_gui.c:2501
+#: ../src/develop/develop.c:1861 ../src/iop/ashift.c:4856
 #: ../src/libs/live_view.c:437
 msgid "on"
 msgstr "encendido"
 
-#: ../src/common/history.c:794 ../src/common/history.c:797
-#: ../src/common/history.c:813 ../src/common/styles.c:887
-#: ../src/common/styles.c:891 ../src/develop/blend_gui.c:2247
-#: ../src/develop/blend_gui.c:2497 ../src/develop/develop.c:1792
+#: ../src/common/history.c:798 ../src/common/history.c:801
+#: ../src/common/history.c:817 ../src/common/styles.c:894
+#: ../src/common/styles.c:898 ../src/develop/blend_gui.c:2248
+#: ../src/develop/blend_gui.c:2498 ../src/develop/develop.c:1861
 #: ../src/imageio/format/exr.cc:357 ../src/imageio/format/j2k.c:660
-#: ../src/iop/ashift.c:4850 ../src/iop/ashift.c:4856 ../src/iop/colorin.c:2105
-#: ../src/iop/demosaic.c:5148 ../src/iop/vignette.c:1150
-#: ../src/libs/history.c:162 ../src/libs/live_view.c:436
+#: ../src/iop/ashift.c:4855 ../src/iop/ashift.c:4861 ../src/iop/colorin.c:2107
+#: ../src/iop/demosaic.c:5147 ../src/iop/vignette.c:1150
+#: ../src/libs/history.c:163 ../src/libs/live_view.c:436
 msgid "off"
 msgstr "inactivo"
 
@@ -1749,63 +1770,63 @@ msgstr ""
 "<h1>Gracias,</h1><p>todo debe funcionar, puede <b>cerrar</b> su navegador y "
 "<b>volver</b> a darktable.</p>"
 
-#: ../src/common/image.c:197
+#: ../src/common/image.c:191
 msgid "orphaned image"
 msgstr "imágenes huérfanas"
 
-#: ../src/common/image.c:1444
+#: ../src/common/image.c:1454
 #, c-format
 msgid "cannot access local copy `%s'"
 msgstr "No se puede acceder a la copia local `%s'"
 
-#: ../src/common/image.c:1450
+#: ../src/common/image.c:1460
 #, c-format
 msgid "cannot write local copy `%s'"
 msgstr "No se puede escribir la copia local `%s'"
 
-#: ../src/common/image.c:1457
+#: ../src/common/image.c:1467
 #, c-format
 msgid "error moving local copy `%s' -> `%s'"
 msgstr "Error al mover la copia local `%s' -> `%s'"
 
-#: ../src/common/image.c:1473
+#: ../src/common/image.c:1483
 #, c-format
 msgid "error moving `%s': file not found"
 msgstr "Error al mover `%s': no se encuentra el archivo"
 
-#: ../src/common/image.c:1477
+#: ../src/common/image.c:1487
 #, c-format
 msgid "error moving `%s' -> `%s': file exists"
 msgstr "Error al mover `%s' -> `%s': el archivo ya existe"
 
-#: ../src/common/image.c:1481
+#: ../src/common/image.c:1491
 #, c-format
 msgid "error moving `%s' -> `%s'"
 msgstr "Error al mover `%s' -> `%s'"
 
-#: ../src/common/image.c:1736
+#: ../src/common/image.c:1748
 msgid "cannot create local copy when the original file is not accessible."
 msgstr ""
 "la copia local no se puede crear cuando el archivo original no es accesible."
 
-#: ../src/common/image.c:1750
+#: ../src/common/image.c:1762
 msgid "cannot create local copy."
 msgstr "no se puede crear una copia local."
 
-#: ../src/common/image.c:1816 ../src/control/jobs/control_jobs.c:660
+#: ../src/common/image.c:1828 ../src/control/jobs/control_jobs.c:665
 msgid "cannot remove local copy when the original file is not accessible."
 msgstr ""
 "la copia local no se puede eliminar el archivo original cuando no es "
 "accesible."
 
-#: ../src/common/image.c:1985
+#: ../src/common/image.c:1997
 #, c-format
 msgid "%d local copy has been synchronized"
 msgid_plural "%d local copies have been synchronized"
 msgstr[0] "%d copia local ha sido sincronizada"
 msgstr[1] "%d copias locales han sido sincronizadas"
 
-#: ../src/common/imageio.c:637 ../src/common/mipmap_cache.c:1057
+#: ../src/common/imageio.c:637 ../src/common/mipmap_cache.c:1059
 #, c-format
 msgid "image `%s' is not available!"
 msgstr "la imagen `%s' no está disponible"
@@ -1852,12 +1873,12 @@ msgstr "distribución de poisson"
 msgid "noiseprofile file `%s' is not valid"
 msgstr "archivo de perfil de ruido `%s' no es válido"
 
-#: ../src/common/opencl.c:781
+#: ../src/common/opencl.c:783
 msgid ""
 "due to a slow GPU hardware acceleration via opencl has been de-activated."
 msgstr "desactivado debido a una aceleración lenta de GPU vía opencl."
 
-#: ../src/common/opencl.c:788
+#: ../src/common/opencl.c:790
 msgid ""
 "multiple GPUs detected - opencl scheduling profile has been set accordingly."
 msgstr ""
@@ -1865,27 +1886,27 @@ msgstr ""
 "configurado en consecuencia."
 
 # Ignorar advertencia: en el texto original GPU va en mayúsculas.
-#: ../src/common/opencl.c:795
+#: ../src/common/opencl.c:797
 msgid ""
 "very fast GPU detected - opencl scheduling profile has been set accordingly."
 msgstr ""
 "GPU muy rápido detectado - el perfil de control de opencl ha sido "
 "configurado en consecuencia."
 
-#: ../src/common/opencl.c:802
+#: ../src/common/opencl.c:804
 msgid "opencl scheduling profile set to default."
 msgstr "el perfil de control para opencl ha sido configurado a predeterminado."
 
-#: ../src/common/pdf.h:88 ../src/iop/lens.c:1845
-#: ../src/libs/print_settings.c:1288
+#: ../src/common/pdf.h:88 ../src/iop/lens.cc:1947
+#: ../src/libs/print_settings.c:1286
 msgid "mm"
 msgstr "mm"
 
-#: ../src/common/pdf.h:89 ../src/libs/print_settings.c:1289
+#: ../src/common/pdf.h:89 ../src/libs/print_settings.c:1287
 msgid "cm"
 msgstr "cm"
 
-#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:1290
+#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:1288
 msgid "inch"
 msgstr "pulgada"
 
@@ -1925,55 +1946,55 @@ msgstr[1] "rechazando %d imágenes"
 #, c-format
 msgid "applying rating %d to %d image"
 msgid_plural "applying rating %d to %d images"
-msgstr[0] "estableciendo puntuación %d a %d imagen"
-msgstr[1] "estableciendo puntuación %d a %d imágenes"
+msgstr[0] "estableciendo la puntuación de %d en %d imagen"
+msgstr[1] "estableciendo la puntuación de %d en %d imágenes"
 
 #: ../src/common/ratings.c:193
 msgid "no images selected to apply rating"
 msgstr "no se ha seleccionado ninguna imagen para puntuar"
 
-#: ../src/common/styles.c:185
+#: ../src/common/styles.c:186
 #, c-format
 msgid "style with name '%s' already exists"
 msgstr "el estilo con nombre '%s' ya existe"
 
 #. freed by _destroy_style_shortcut_callback
-#: ../src/common/styles.c:311 ../src/common/styles.c:315
-#: ../src/common/styles.c:395 ../src/common/styles.c:464
-#: ../src/common/styles.c:790 ../src/common/styles.c:1372
-#: ../src/common/styles.c:1391
+#: ../src/common/styles.c:312 ../src/common/styles.c:316
+#: ../src/common/styles.c:396 ../src/common/styles.c:465
+#: ../src/common/styles.c:797 ../src/common/styles.c:1379
+#: ../src/common/styles.c:1398
 #, c-format
 msgctxt "accel"
 msgid "styles/apply %s"
 msgstr "estilos/establecer %s"
 
-#: ../src/common/styles.c:401 ../src/gui/styles_dialog.c:144
+#: ../src/common/styles.c:402 ../src/gui/styles_dialog.c:144
 #, c-format
 msgid "style named '%s' successfully created"
 msgstr "el estilo nombrado '%s' ha sido creado correctamente"
 
 #. fail :(
-#: ../src/common/styles.c:500 ../src/common/styles.c:518
-#: ../src/views/darkroom.c:539 ../src/views/print.c:249
+#: ../src/common/styles.c:501 ../src/common/styles.c:519
+#: ../src/views/darkroom.c:539 ../src/views/print.c:248
 msgid "no image selected!"
 msgstr "no hay imagen seleccionada"
 
-#: ../src/common/styles.c:609
+#: ../src/common/styles.c:610
 #, c-format
 msgid "module `%s' version mismatch: %d != %d"
 msgstr "módulo '%s' la versión no coincide: %d != %d"
 
-#: ../src/common/styles.c:979
+#: ../src/common/styles.c:986
 #, c-format
 msgid "failed to overwrite style file for %s"
 msgstr "fallo al sobreescribir el archivo del estilo para %s"
 
-#: ../src/common/styles.c:985
+#: ../src/common/styles.c:992
 #, c-format
 msgid "style file for %s exists"
 msgstr "ya existe el archivo del estilo para %s"
 
-#: ../src/common/styles.c:1262
+#: ../src/common/styles.c:1269
 #, c-format
 msgid "style %s was successfully imported"
 msgstr "el estilo %s fue importado correctamente"
@@ -1987,7 +2008,7 @@ msgid "below sea level"
 msgstr "bajo el nivel del mar"
 
 #: ../src/common/utility.c:508 ../src/iop/watermark.c:775
-#: ../src/libs/metadata_view.c:569
+#: ../src/libs/metadata_view.c:576
 msgid "m"
 msgstr "m"
 
@@ -1995,7 +2016,7 @@ msgstr "m"
 msgid "working.."
 msgstr "trabajando.."
 
-#: ../src/control/control.c:680
+#: ../src/control/control.c:685
 #, c-format
 msgid "scroll to change <b>%s</b> of %s module"
 msgstr "Desplácese para cambiar <b>% s</b> del módulo %s"
@@ -2069,190 +2090,197 @@ msgid_plural "importing %d images from camera"
 msgstr[0] "importando %d imagen desde la cámara"
 msgstr[1] "importando %d imágenes desde la cámara"
 
-#: ../src/control/jobs/camera_jobs.c:391 ../src/gui/camera_import_dialog.c:209
+#: ../src/control/jobs/camera_jobs.c:391 ../src/gui/camera_import_dialog.c:287
 msgid "import images from camera"
 msgstr "importar imágenes desde la cámara"
 
-#: ../src/control/jobs/control_jobs.c:147
+#: ../src/control/jobs/control_jobs.c:148
 msgid "failed to create film roll for destination directory, aborting move.."
 msgstr "falló al crear el carrete para el directorio de destino, abortando..."
 
-#: ../src/control/jobs/control_jobs.c:345
+#: ../src/control/jobs/control_jobs.c:346
 msgid "exposure bracketing only works on raw images."
 msgstr "el ahorquillado de exposición solo funciona con imágenes raw."
 
-#: ../src/control/jobs/control_jobs.c:352
+#: ../src/control/jobs/control_jobs.c:353
 msgid "images have to be of same size and orientation!"
 msgstr "las imágenes deben tener el mismo tamaño y orientación"
 
-#: ../src/control/jobs/control_jobs.c:447
+#: ../src/control/jobs/control_jobs.c:448
 #, c-format
 msgid "merging %d image"
 msgid_plural "merging %d images"
 msgstr[0] "fusionando %d imagen"
 msgstr[1] "fusionando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:509
+#: ../src/control/jobs/control_jobs.c:510
 #, c-format
 msgid "wrote merged HDR `%s'"
 msgstr "escribir HDR fusionado `%s'"
 
-#: ../src/control/jobs/control_jobs.c:535
+#: ../src/control/jobs/control_jobs.c:536
 #, c-format
 msgid "duplicating %d image"
 msgid_plural "duplicating %d images"
 msgstr[0] "duplicando %d imagen"
 msgstr[1] "duplicando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:561
+#: ../src/control/jobs/control_jobs.c:566
 #, c-format
 msgid "flipping %d image"
 msgid_plural "flipping %d images"
 msgstr[0] "girando %d imagen"
 msgstr[1] "girando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:636
+#: ../src/control/jobs/control_jobs.c:641
 #, c-format
 msgid "removing %d image"
 msgid_plural "removing %d images"
 msgstr[0] "eliminando %d imagen"
 msgstr[1] "eliminando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:738
+#: ../src/control/jobs/control_jobs.c:743
 #, c-format
 msgid "could not send %s to trash%s%s"
 msgstr "no se pudo enviar %s a la papelera%s%s"
 
-#: ../src/control/jobs/control_jobs.c:739
+#: ../src/control/jobs/control_jobs.c:744
 #, c-format
 msgid "could not physically delete %s%s%s"
 msgstr "no se puede borrar físicamente del disco %s%s%s"
 
-#: ../src/control/jobs/control_jobs.c:749
+#: ../src/control/jobs/control_jobs.c:754
 msgid "physically delete"
 msgstr "borrar físicamente del disco"
 
-#: ../src/control/jobs/control_jobs.c:750
+#: ../src/control/jobs/control_jobs.c:755
 msgid "physically delete all files"
 msgstr "borrar físicamente todos los archivos del disco"
 
-#: ../src/control/jobs/control_jobs.c:752
+#: ../src/control/jobs/control_jobs.c:757
 msgid "only remove from the collection"
 msgstr "eliminar solo de la colección"
 
-#: ../src/control/jobs/control_jobs.c:753
+#: ../src/control/jobs/control_jobs.c:758
 msgid "skip to next file"
 msgstr "saltar al archivo siguiente"
 
-#: ../src/control/jobs/control_jobs.c:754
+#: ../src/control/jobs/control_jobs.c:759
 msgid "stop process"
 msgstr "detener el proceso"
 
-#: ../src/control/jobs/control_jobs.c:759
+#: ../src/control/jobs/control_jobs.c:764
 msgid "trashing error"
 msgstr "error eliminando"
 
-#: ../src/control/jobs/control_jobs.c:760
+#: ../src/control/jobs/control_jobs.c:765
 msgid "deletion error"
 msgstr "error de borrado"
 
-#: ../src/control/jobs/control_jobs.c:903
+#: ../src/control/jobs/control_jobs.c:908
 #, c-format
 msgid "trashing %d image"
 msgid_plural "trashing %d images"
 msgstr[0] "descartando %d imagen"
 msgstr[1] "descartando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:905
+#: ../src/control/jobs/control_jobs.c:910
 #, c-format
 msgid "deleting %d image"
 msgid_plural "deleting %d images"
 msgstr[0] "borrando %d imagen"
 msgstr[1] "borrando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1121
+#: ../src/control/jobs/control_jobs.c:1126
 msgid "failed to parse GPX file"
 msgstr "fallo al analizar el archivo GPX"
 
-#: ../src/control/jobs/control_jobs.c:1202
+#: ../src/control/jobs/control_jobs.c:1207
 #, c-format
 msgid "applied matched GPX location onto %d image"
 msgid_plural "applied matched GPX location onto %d images"
 msgstr[0] "asociación de ubicación GPX en %d imagen aplicada"
 msgstr[1] "asociación de ubicación GPX en %d imágenes aplicadas"
 
-#: ../src/control/jobs/control_jobs.c:1217
+#: ../src/control/jobs/control_jobs.c:1222
 #, c-format
 msgid "moving %d image"
 msgstr "moviendo %d imagen"
 
-#: ../src/control/jobs/control_jobs.c:1218
+#: ../src/control/jobs/control_jobs.c:1223
 #, c-format
 msgid "moving %d images"
 msgstr "moviendo %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1223
+#: ../src/control/jobs/control_jobs.c:1228
 #, c-format
 msgid "copying %d image"
 msgstr "copiando %d imagen"
 
-#: ../src/control/jobs/control_jobs.c:1224
+#: ../src/control/jobs/control_jobs.c:1229
 #, c-format
 msgid "copying %d images"
 msgstr "copiando %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1240
+#: ../src/control/jobs/control_jobs.c:1245
 #, c-format
 msgid "creating local copy of %d image"
 msgid_plural "creating local copies of %d images"
 msgstr[0] "creando copia local de %d imagen"
 msgstr[1] "creando copia local de %d imagenes"
 
-#: ../src/control/jobs/control_jobs.c:1243
+#: ../src/control/jobs/control_jobs.c:1248
 #, c-format
 msgid "removing local copy of %d image"
 msgid_plural "removing local copies of %d images"
 msgstr[0] "eliminando copia local de %d imagen"
 msgstr[1] "eliminando copia local de %d imagenes"
 
-#: ../src/control/jobs/control_jobs.c:1317
+#: ../src/control/jobs/control_jobs.c:1287
+#, c-format
+msgid "refreshing info for %d image"
+msgid_plural "refreshing info for %d images"
+msgstr[0] "Actualizando información para %d imagen"
+msgstr[1] "Actualizando información para %d imágenes"
+
+#: ../src/control/jobs/control_jobs.c:1354
 #, c-format
 msgid "exporting %d image.."
 msgid_plural "exporting %d images.."
 msgstr[0] "exportando %d imagen.."
 msgstr[1] "exportando %d imágenes.."
 
-#: ../src/control/jobs/control_jobs.c:1319
+#: ../src/control/jobs/control_jobs.c:1356
 #, c-format
 msgid "exporting %d image to %s"
 msgid_plural "exporting %d images to %s"
 msgstr[0] "exportando %d imagen a %s"
 msgstr[1] "exportando %d imágenes a %s"
 
-#: ../src/control/jobs/control_jobs.c:1362 ../src/views/darkroom.c:552
-#: ../src/views/print.c:262
+#: ../src/control/jobs/control_jobs.c:1408 ../src/views/darkroom.c:552
+#: ../src/views/print.c:261
 #, c-format
 msgid "image `%s' is currently unavailable"
 msgstr "imagen `%s' no esta disponible actualmente"
 
-#: ../src/control/jobs/control_jobs.c:1450
+#: ../src/control/jobs/control_jobs.c:1498
 msgid "merge hdr image"
 msgstr "fusionar imagen hdr"
 
-#: ../src/control/jobs/control_jobs.c:1464
+#: ../src/control/jobs/control_jobs.c:1512
 msgid "duplicate images"
 msgstr "duplicate images"
 
-#: ../src/control/jobs/control_jobs.c:1471
+#: ../src/control/jobs/control_jobs.c:1519
 msgid "flip images"
 msgstr "invertir imágenes"
 
 #. get all selected images now, to avoid the set changing during ui interaction
-#: ../src/control/jobs/control_jobs.c:1478
+#: ../src/control/jobs/control_jobs.c:1526
 msgid "remove images"
 msgstr "eliminar imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1500
+#: ../src/control/jobs/control_jobs.c:1548
 #, c-format
 msgid "do you really want to remove %d selected image from the collection?"
 msgid_plural ""
@@ -2260,23 +2288,23 @@ msgid_plural ""
 msgstr[0] "¿desea eliminar %d imagen seleccionada de la colección?"
 msgstr[1] "¿desea eliminar %d imágenes seleccionadas de la colección?"
 
-#: ../src/control/jobs/control_jobs.c:1507
+#: ../src/control/jobs/control_jobs.c:1555
 msgid "remove images?"
 msgstr "¿eliminar las imágenes?"
 
 #. first get all selected images, to avoid the set changing during ui interaction
-#: ../src/control/jobs/control_jobs.c:1523
+#: ../src/control/jobs/control_jobs.c:1571
 msgid "delete images"
 msgstr "borrar imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1547
+#: ../src/control/jobs/control_jobs.c:1595
 #, c-format
 msgid "do you really want to send %d selected image to trash?"
 msgid_plural "do you really want to send %d selected images to trash?"
 msgstr[0] "¿desea realmente enviar %d imagen seleccionada a la papelera?"
 msgstr[1] "¿desea realmente enviar %d imágenes seleccionadas a la papelera?"
 
-#: ../src/control/jobs/control_jobs.c:1549
+#: ../src/control/jobs/control_jobs.c:1597
 #, c-format
 msgid "do you really want to physically delete %d selected image from disk?"
 msgid_plural ""
@@ -2284,24 +2312,24 @@ msgid_plural ""
 msgstr[0] "¿desea borrar FISICAMENTE %d imagen seleccionada del disco?"
 msgstr[1] "¿desea borrar FISICAMENTE %d imágenes seleccionadas del disco?"
 
-#: ../src/control/jobs/control_jobs.c:1556
+#: ../src/control/jobs/control_jobs.c:1604
 msgid "trash images?"
 msgstr "¿eliminar imagenes?"
 
-#: ../src/control/jobs/control_jobs.c:1556
+#: ../src/control/jobs/control_jobs.c:1604
 msgid "delete images?"
 msgstr "¿borrar las imágenes?"
 
-#: ../src/control/jobs/control_jobs.c:1577
+#: ../src/control/jobs/control_jobs.c:1625
 msgid "move images"
 msgstr "mover imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1582
-#: ../src/control/jobs/control_jobs.c:1642
+#: ../src/control/jobs/control_jobs.c:1630
+#: ../src/control/jobs/control_jobs.c:1690
 msgid "_select as destination"
 msgstr "_seleccionar destino"
 
-#: ../src/control/jobs/control_jobs.c:1603
+#: ../src/control/jobs/control_jobs.c:1651
 #, c-format
 msgid ""
 "do you really want to physically move the %d selected image to %s?\n"
@@ -2316,17 +2344,17 @@ msgstr[1] ""
 "¿desea mover físicamente %d imagenes seleccionadas a %s?\n"
 " ?(todos los duplicados no seleccionados se moverán en conjunto)"
 
-#: ../src/control/jobs/control_jobs.c:1612
+#: ../src/control/jobs/control_jobs.c:1660
 msgid "move image?"
 msgid_plural "move images?"
 msgstr[0] "¿mover las imágenes?"
 msgstr[1] "¿mover las imágenes?"
 
-#: ../src/control/jobs/control_jobs.c:1637
+#: ../src/control/jobs/control_jobs.c:1685
 msgid "copy images"
 msgstr "copiar imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1663
+#: ../src/control/jobs/control_jobs.c:1711
 #, c-format
 msgid "do you really want to physically copy the %d selected image to %s?"
 msgid_plural "do you really want to physically copy %d selected images to %s?"
@@ -2334,47 +2362,51 @@ msgstr[0] "¿realmente desea copiar FISICAMENTE %d imagen seleccionada a %s ?"
 msgstr[1] ""
 "¿realmente desea copiar FISICAMENTE %d imagenes seleccionadas a %s ?"
 
-#: ../src/control/jobs/control_jobs.c:1669
+#: ../src/control/jobs/control_jobs.c:1717
 msgid "copy image?"
 msgid_plural "copy images?"
 msgstr[0] "¿copiar imagen?"
 msgstr[1] "¿copiar imagenes?"
 
-#: ../src/control/jobs/control_jobs.c:1689
-#: ../src/control/jobs/control_jobs.c:1696
+#: ../src/control/jobs/control_jobs.c:1737
+#: ../src/control/jobs/control_jobs.c:1744
 msgid "local copy images"
 msgstr "copia local de las imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1758
+#: ../src/control/jobs/control_jobs.c:1751 ../src/libs/image.c:276
+msgid "refresh exif"
+msgstr "Actualizar Exif"
+
+#: ../src/control/jobs/control_jobs.c:1814
 #, c-format
 msgid "failed to get parameters from storage module `%s', aborting export.."
 msgstr ""
 "fallo al obtener parámetros del modulo de almacenamiento`%s', abortando "
 "exportado..."
 
-#: ../src/control/jobs/control_jobs.c:1772
+#: ../src/control/jobs/control_jobs.c:1829
 msgid "export images"
 msgstr "exportar imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1797
+#: ../src/control/jobs/control_jobs.c:1854
 #, c-format
 msgid "adding time offset to %d image"
 msgid_plural "adding time offset to %d images"
 msgstr[0] "aplicando intervalo de tiempo a %d imagen"
 msgstr[1] "aplicando intervalo de tiempo a %d imagenes"
 
-#: ../src/control/jobs/control_jobs.c:1812
+#: ../src/control/jobs/control_jobs.c:1869
 #, c-format
 msgid "added time offset to %d image"
 msgid_plural "added time offset to %d images"
 msgstr[0] "agregado intervalo de tiempo a %d imagen"
 msgstr[1] "agregado intervalo de tiempo a %d imágenes"
 
-#: ../src/control/jobs/control_jobs.c:1851 ../src/libs/geotagging.c:780
+#: ../src/control/jobs/control_jobs.c:1908 ../src/libs/geotagging.c:781
 msgid "time offset"
 msgstr "compensación de hora"
 
-#: ../src/control/jobs/control_jobs.c:1875 ../src/libs/copy_history.c:441
+#: ../src/control/jobs/control_jobs.c:1932 ../src/libs/copy_history.c:366
 msgid "write sidecar files"
 msgstr "escribir archivos xmp"
 
@@ -2398,7 +2430,7 @@ msgstr[1] "importando %d imágenes"
 msgid "importing image %s"
 msgstr "importando imagen %s"
 
-#: ../src/control/jobs/image_jobs.c:109 ../src/libs/import.c:758
+#: ../src/control/jobs/image_jobs.c:109 ../src/libs/import.c:759
 msgid "import image"
 msgstr "importar imagen"
 
@@ -2411,85 +2443,85 @@ msgstr "mezclado omitido en módulo '%s': roi's no coincide"
 msgid "could not allocate buffer for blending"
 msgstr "No se pudo asignar el búfer para la mezcla"
 
-#: ../src/develop/blend_gui.c:1341
+#: ../src/develop/blend_gui.c:1342
 msgid "sliders for L channel"
 msgstr "deslizador para el canal L"
 
-#: ../src/develop/blend_gui.c:1341
+#: ../src/develop/blend_gui.c:1342
 msgid "sliders for a channel"
 msgstr "deslizador para el canal a"
 
-#: ../src/develop/blend_gui.c:1341
+#: ../src/develop/blend_gui.c:1342
 msgid "sliders for b channel"
 msgstr "deslizador para el canal b"
 
-#: ../src/develop/blend_gui.c:1342
+#: ../src/develop/blend_gui.c:1343
 msgid "sliders for chroma channel (of LCh)"
 msgstr "deslizador para canal crominancia (de LCh)"
 
-#: ../src/develop/blend_gui.c:1342
+#: ../src/develop/blend_gui.c:1343
 msgid "sliders for hue channel (of LCh)"
 msgstr "deslizador para canal de tono (de LCh)"
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " g "
 msgstr " g "
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " R "
 msgstr " R "
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " G "
 msgstr " G "
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " B "
 msgstr " B "
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " H "
 msgstr " H "
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " S "
 msgstr " S "
 
-#: ../src/develop/blend_gui.c:1343
+#: ../src/develop/blend_gui.c:1344
 msgid " L "
 msgstr " L "
 
-#: ../src/develop/blend_gui.c:1345
+#: ../src/develop/blend_gui.c:1346
 msgid "sliders for gray value"
 msgstr "deslizador para valor gris"
 
 # estaba puesto "L" se cambia por el correcto "R" en este caso
-#: ../src/develop/blend_gui.c:1345
+#: ../src/develop/blend_gui.c:1346
 msgid "sliders for red channel"
 msgstr "dezlidador para el canal R"
 
 # estaba puesto "L" se cambia por el correcto "G" en este caso
-#: ../src/develop/blend_gui.c:1345
+#: ../src/develop/blend_gui.c:1346
 msgid "sliders for green channel"
 msgstr "deslizador para el canal G"
 
-#: ../src/develop/blend_gui.c:1346
+#: ../src/develop/blend_gui.c:1347
 msgid "sliders for blue channel"
 msgstr "deslizador para el canal b"
 
-#: ../src/develop/blend_gui.c:1346
+#: ../src/develop/blend_gui.c:1347
 msgid "sliders for hue channel (of HSL)"
 msgstr "deslizador para canal de tono (de HSL)"
 
-#: ../src/develop/blend_gui.c:1347
+#: ../src/develop/blend_gui.c:1348
 msgid "sliders for chroma channel (of HSL)"
 msgstr "deslizador para canal crominancia (de HSL)"
 
-#: ../src/develop/blend_gui.c:1347
+#: ../src/develop/blend_gui.c:1348
 msgid "sliders for value channel (of HSL)"
 msgstr "deslizador para canal de valor (de HSL)"
 
-#: ../src/develop/blend_gui.c:1349
+#: ../src/develop/blend_gui.c:1350
 msgid ""
 "adjustment based on input received by this module:\n"
 "* range defined by upper markers: blend fully\n"
@@ -2502,7 +2534,7 @@ msgstr ""
 "* rango entre marcadores superiores/inferiores adyacentes: mezclar "
 "gradualmente"
 
-#: ../src/develop/blend_gui.c:1353
+#: ../src/develop/blend_gui.c:1354
 msgid ""
 "adjustment based on unblended output of this module:\n"
 "* range defined by upper markers: blend fully\n"
@@ -2515,16 +2547,16 @@ msgstr ""
 "* rango entre marcadores superiores/inferiores adyacentes: mezclar "
 "gradualmente"
 
-#: ../src/develop/blend_gui.c:1503 ../src/iop/colorzones.c:2290
-#: ../src/iop/tonecurve.c:1255
+#: ../src/develop/blend_gui.c:1504 ../src/iop/colorzones.c:2287
+#: ../src/iop/tonecurve.c:1340
 msgid ""
 "pick GUI color from image\n"
 "ctrl+click to select an area"
 msgstr ""
-"seleccionar el color de la interfaz gráfica desde la imagen\n"
+"Seleccionar el color de la interfaz gráfica desde la imagen\n"
 "Ctrl+clic para seleccionar un área"
 
-#: ../src/develop/blend_gui.c:1507
+#: ../src/develop/blend_gui.c:1508
 msgid ""
 "set the range based on an area from the image\n"
 "click+drag to use the input image\n"
@@ -2534,327 +2566,327 @@ msgstr ""
 "clic+arrastrar para usar la imagen de entrada\n"
 "Ctrl+clic+arrastrar para usar la imagen de salida"
 
-#: ../src/develop/blend_gui.c:1511
+#: ../src/develop/blend_gui.c:1512
 msgid "reset blend mask settings"
 msgstr "reiniciar opciones de mezcla de máscara"
 
-#: ../src/develop/blend_gui.c:1514
+#: ../src/develop/blend_gui.c:1515
 msgid "invert all channel's polarities"
 msgstr "invertir la polaridad de todos los canales"
 
-#: ../src/develop/blend_gui.c:1527 ../src/develop/blend_gui.c:1531
+#: ../src/develop/blend_gui.c:1528 ../src/develop/blend_gui.c:1532
 msgid "toggle polarity. best seen by enabling 'display mask'"
 msgstr "alternar polaridad. mejor visualización al activar 'mostrar máscara'"
 
-#: ../src/develop/blend_gui.c:1540
+#: ../src/develop/blend_gui.c:1541
 msgid "output"
 msgstr "salida"
 
-#: ../src/develop/blend_gui.c:1551
+#: ../src/develop/blend_gui.c:1552
 msgid "input"
 msgstr "entrada"
 
-#: ../src/develop/blend_gui.c:1562 ../src/develop/blend_gui.c:1563
+#: ../src/develop/blend_gui.c:1563 ../src/develop/blend_gui.c:1564
 msgid "double click to reset"
 msgstr "doble clic para reiniciar"
 
-#: ../src/develop/blend_gui.c:1601 ../src/develop/blend_gui.c:2271
+#: ../src/develop/blend_gui.c:1602 ../src/develop/blend_gui.c:2272
 msgid "parametric mask"
 msgstr "máscara paramétrica"
 
-#: ../src/develop/blend_gui.c:1635
+#: ../src/develop/blend_gui.c:1636
 #, c-format
 msgid "%d shape used"
 msgid_plural "%d shapes used"
 msgstr[0] "%d forma usada"
 msgstr[1] "%d formas usadas"
 
-#: ../src/develop/blend_gui.c:1640 ../src/develop/blend_gui.c:1695
-#: ../src/develop/blend_gui.c:1784 ../src/develop/blend_gui.c:1895
+#: ../src/develop/blend_gui.c:1641 ../src/develop/blend_gui.c:1696
+#: ../src/develop/blend_gui.c:1785 ../src/develop/blend_gui.c:1896
 msgid "no mask used"
 msgstr "máscaras no utilizadas"
 
-#: ../src/develop/blend_gui.c:1694 ../src/develop/blend_gui.c:1894
-#: ../src/develop/blend_gui.c:2304 ../src/develop/blend_gui.c:2465
-#: ../src/develop/blend_gui.c:2473 ../src/develop/blend_gui.c:2495
-#: ../src/develop/blend_gui.c:2528 ../src/develop/blend_gui.c:2536
-#: ../src/develop/blend_gui.c:2544 ../src/develop/blend_gui.c:2554
+#: ../src/develop/blend_gui.c:1695 ../src/develop/blend_gui.c:1895
+#: ../src/develop/blend_gui.c:2305 ../src/develop/blend_gui.c:2466
+#: ../src/develop/blend_gui.c:2474 ../src/develop/blend_gui.c:2496
+#: ../src/develop/blend_gui.c:2529 ../src/develop/blend_gui.c:2537
+#: ../src/develop/blend_gui.c:2545 ../src/develop/blend_gui.c:2555
 msgid "blend"
 msgstr "mezcla"
 
-#: ../src/develop/blend_gui.c:1694 ../src/develop/blend_gui.c:1759
-#: ../src/develop/blend_gui.c:2262
+#: ../src/develop/blend_gui.c:1695 ../src/develop/blend_gui.c:1760
+#: ../src/develop/blend_gui.c:2263
 msgid "drawn mask"
 msgstr "dibujar máscara"
 
-#: ../src/develop/blend_gui.c:1706
+#: ../src/develop/blend_gui.c:1707
 msgid "show and edit mask elements"
 msgstr "muestra y edita los elementos de la máscara"
 
 # se corrige la ortografía, le faltaba la tilde a máscara
-#: ../src/develop/blend_gui.c:1712
+#: ../src/develop/blend_gui.c:1713
 msgid "toggle polarity of drawn mask"
 msgstr "cambia la polaridad de la máscara dibujada"
 
-#: ../src/develop/blend_gui.c:1722 ../src/libs/masks.c:993
+#: ../src/develop/blend_gui.c:1723 ../src/libs/masks.c:993
 #: ../src/libs/masks.c:1032 ../src/libs/masks.c:1643
 msgid "add gradient"
 msgstr "agregar gradiente"
 
-#: ../src/develop/blend_gui.c:1730 ../src/iop/retouch.c:2673
+#: ../src/develop/blend_gui.c:1731 ../src/iop/retouch.c:2675
 #: ../src/iop/spots.c:664 ../src/libs/masks.c:989 ../src/libs/masks.c:1028
 #: ../src/libs/masks.c:1649
 msgid "add path"
 msgstr "agregar ruta"
 
-#: ../src/develop/blend_gui.c:1738 ../src/iop/retouch.c:2680
+#: ../src/develop/blend_gui.c:1739 ../src/iop/retouch.c:2682
 #: ../src/iop/spots.c:671 ../src/libs/masks.c:985 ../src/libs/masks.c:1024
 #: ../src/libs/masks.c:1656
 msgid "add ellipse"
 msgstr "agregar elipse"
 
-#: ../src/develop/blend_gui.c:1746 ../src/iop/retouch.c:2687
+#: ../src/develop/blend_gui.c:1747 ../src/iop/retouch.c:2689
 #: ../src/iop/spots.c:678 ../src/libs/masks.c:981 ../src/libs/masks.c:1020
 #: ../src/libs/masks.c:1663
 msgid "add circle"
 msgstr "agregar círculo"
 
-#: ../src/develop/blend_gui.c:1754 ../src/iop/retouch.c:2667
+#: ../src/develop/blend_gui.c:1755 ../src/iop/retouch.c:2669
 #: ../src/libs/masks.c:1016 ../src/libs/masks.c:1669
 msgid "add brush"
 msgstr "agregar pincel"
 
-#: ../src/develop/blend_gui.c:1894 ../src/develop/blend_gui.c:2292
+#: ../src/develop/blend_gui.c:1895 ../src/develop/blend_gui.c:2293
 msgid "raster mask"
 msgstr "máscara de matriz de píxeles"
 
-#: ../src/develop/blend_gui.c:1904
+#: ../src/develop/blend_gui.c:1905
 msgid "toggle polarity of raster mask"
 msgstr "cambiar polaridad de la máscara dibujada"
 
 #. * generate a list of all available blend modes
-#: ../src/develop/blend_gui.c:2192 ../src/libs/live_view.c:408
+#: ../src/develop/blend_gui.c:2193 ../src/libs/live_view.c:408
 msgctxt "blendmode"
 msgid "normal"
 msgstr "normal"
 
-#: ../src/develop/blend_gui.c:2193
+#: ../src/develop/blend_gui.c:2194
 msgctxt "blendmode"
 msgid "normal bounded"
 msgstr "normal limitado"
 
-#: ../src/develop/blend_gui.c:2194 ../src/libs/live_view.c:417
+#: ../src/develop/blend_gui.c:2195 ../src/libs/live_view.c:417
 msgctxt "blendmode"
 msgid "lighten"
 msgstr "aclarar"
 
-#: ../src/develop/blend_gui.c:2195 ../src/libs/live_view.c:416
+#: ../src/develop/blend_gui.c:2196 ../src/libs/live_view.c:416
 msgctxt "blendmode"
 msgid "darken"
 msgstr "oscurecer"
 
-#: ../src/develop/blend_gui.c:2196 ../src/libs/live_view.c:413
+#: ../src/develop/blend_gui.c:2197 ../src/libs/live_view.c:413
 msgctxt "blendmode"
 msgid "multiply"
 msgstr "multiplicar"
 
-#: ../src/develop/blend_gui.c:2197
+#: ../src/develop/blend_gui.c:2198
 msgctxt "blendmode"
 msgid "average"
 msgstr "media"
 
-#: ../src/develop/blend_gui.c:2198
+#: ../src/develop/blend_gui.c:2199
 msgctxt "blendmode"
 msgid "addition"
 msgstr "suma"
 
-#: ../src/develop/blend_gui.c:2199
+#: ../src/develop/blend_gui.c:2200
 msgctxt "blendmode"
 msgid "subtract"
 msgstr "sustraer"
 
-#: ../src/develop/blend_gui.c:2200 ../src/libs/live_view.c:422
+#: ../src/develop/blend_gui.c:2201 ../src/libs/live_view.c:422
 msgctxt "blendmode"
 msgid "difference"
 msgstr "diferencia"
 
-#: ../src/develop/blend_gui.c:2201 ../src/libs/live_view.c:414
+#: ../src/develop/blend_gui.c:2202 ../src/libs/live_view.c:414
 msgctxt "blendmode"
 msgid "screen"
 msgstr "pantalla"
 
-#: ../src/develop/blend_gui.c:2202 ../src/libs/live_view.c:415
+#: ../src/develop/blend_gui.c:2203 ../src/libs/live_view.c:415
 msgctxt "blendmode"
 msgid "overlay"
 msgstr "solapar"
 
-#: ../src/develop/blend_gui.c:2203
+#: ../src/develop/blend_gui.c:2204
 msgctxt "blendmode"
 msgid "softlight"
 msgstr "luz suave"
 
-#: ../src/develop/blend_gui.c:2204
+#: ../src/develop/blend_gui.c:2205
 msgctxt "blendmode"
 msgid "hardlight"
 msgstr "luz fuerte"
 
-#: ../src/develop/blend_gui.c:2205
+#: ../src/develop/blend_gui.c:2206
 msgctxt "blendmode"
 msgid "vividlight"
 msgstr "luz intensa"
 
-#: ../src/develop/blend_gui.c:2206
+#: ../src/develop/blend_gui.c:2207
 msgctxt "blendmode"
 msgid "linearlight"
 msgstr "claridad lineal"
 
-#: ../src/develop/blend_gui.c:2207
+#: ../src/develop/blend_gui.c:2208
 msgctxt "blendmode"
 msgid "pinlight"
 msgstr "luz focal"
 
-#: ../src/develop/blend_gui.c:2208
+#: ../src/develop/blend_gui.c:2209
 msgctxt "blendmode"
 msgid "lightness"
 msgstr "luminosidad"
 
-#: ../src/develop/blend_gui.c:2209
+#: ../src/develop/blend_gui.c:2210
 msgctxt "blendmode"
 msgid "chroma"
 msgstr "crominancia"
 
-#: ../src/develop/blend_gui.c:2210
+#: ../src/develop/blend_gui.c:2211
 msgctxt "blendmode"
 msgid "hue"
 msgstr "tono"
 
-#: ../src/develop/blend_gui.c:2211
+#: ../src/develop/blend_gui.c:2212
 msgctxt "blendmode"
 msgid "color"
 msgstr "color"
 
-#: ../src/develop/blend_gui.c:2212
+#: ../src/develop/blend_gui.c:2213
 msgctxt "blendmode"
 msgid "coloradjustment"
 msgstr "ajuste de color"
 
-#: ../src/develop/blend_gui.c:2214
+#: ../src/develop/blend_gui.c:2215
 msgctxt "blendmode"
 msgid "Lab lightness"
 msgstr "Luminosidad Lab"
 
-#: ../src/develop/blend_gui.c:2216
+#: ../src/develop/blend_gui.c:2217
 msgctxt "blendmode"
 msgid "Lab color"
 msgstr "Color Lab"
 
-#: ../src/develop/blend_gui.c:2217
+#: ../src/develop/blend_gui.c:2218
 msgctxt "blendmode"
 msgid "Lab L-channel"
 msgstr "Lab canal-L"
 
-#: ../src/develop/blend_gui.c:2219
+#: ../src/develop/blend_gui.c:2220
 msgctxt "blendmode"
 msgid "Lab a-channel"
 msgstr "Lab canal-a"
 
-#: ../src/develop/blend_gui.c:2221
+#: ../src/develop/blend_gui.c:2222
 msgctxt "blendmode"
 msgid "Lab b-channel"
 msgstr "Lab canal-b"
 
-#: ../src/develop/blend_gui.c:2223
+#: ../src/develop/blend_gui.c:2224
 msgctxt "blendmode"
 msgid "HSV lightness"
 msgstr "Luminosidad HSV"
 
-#: ../src/develop/blend_gui.c:2225
+#: ../src/develop/blend_gui.c:2226
 msgctxt "blendmode"
 msgid "HSV color"
 msgstr "Color HSV"
 
-#: ../src/develop/blend_gui.c:2226
+#: ../src/develop/blend_gui.c:2227
 msgctxt "blendmode"
 msgid "RGB red channel"
 msgstr "Canal RGB rojo"
 
-#: ../src/develop/blend_gui.c:2228
+#: ../src/develop/blend_gui.c:2229
 msgctxt "blendmode"
 msgid "RGB green channel"
 msgstr "Canal RGB verde"
 
-#: ../src/develop/blend_gui.c:2230
+#: ../src/develop/blend_gui.c:2231
 msgctxt "blendmode"
 msgid "RGB blue channel"
 msgstr "Canal RGB azul"
 
 #. * deprecated blend modes: make them available as legacy history stacks might want them
-#: ../src/develop/blend_gui.c:2234
+#: ../src/develop/blend_gui.c:2235
 msgctxt "blendmode"
 msgid "difference (deprecated)"
 msgstr "diferencia (obsoleto)"
 
-#: ../src/develop/blend_gui.c:2236
+#: ../src/develop/blend_gui.c:2237
 msgctxt "blendmode"
 msgid "inverse (deprecated)"
 msgstr "inverso  (obsoleto)"
 
-#: ../src/develop/blend_gui.c:2238
+#: ../src/develop/blend_gui.c:2239
 msgctxt "blendmode"
 msgid "normal (deprecated)"
 msgstr "normal  (obsoleto)"
 
-#: ../src/develop/blend_gui.c:2239
+#: ../src/develop/blend_gui.c:2240
 msgctxt "blendmode"
 msgid "unbounded (deprecated)"
 msgstr "ilimitado (obsoleto)"
 
-#: ../src/develop/blend_gui.c:2254
+#: ../src/develop/blend_gui.c:2255
 msgid "uniformly"
 msgstr "uniformemente"
 
 #. overlays and
-#: ../src/develop/blend_gui.c:2282
+#: ../src/develop/blend_gui.c:2283
 msgid "drawn & parametric mask"
 msgstr "dibujo y máscara paramétrica"
 
-#: ../src/develop/blend_gui.c:2304
+#: ../src/develop/blend_gui.c:2305
 msgid "blend mode"
 msgstr "modo de mezcla"
 
-#: ../src/develop/blend_gui.c:2305
+#: ../src/develop/blend_gui.c:2306
 msgid "choose blending mode"
 msgstr "elegir el modo de mezcla"
 
-#: ../src/develop/blend_gui.c:2465 ../src/iop/watermark.c:1430
+#: ../src/develop/blend_gui.c:2466 ../src/iop/watermark.c:1430
 msgid "opacity"
 msgstr "opacidad"
 
-#: ../src/develop/blend_gui.c:2468
+#: ../src/develop/blend_gui.c:2469
 msgid "set the opacity of the blending"
 msgstr "opacidad de la mezcla"
 
-#: ../src/develop/blend_gui.c:2473
+#: ../src/develop/blend_gui.c:2474
 msgid "combine masks"
 msgstr "combinar máscaras"
 
-#: ../src/develop/blend_gui.c:2475
+#: ../src/develop/blend_gui.c:2476
 msgid "exclusive"
 msgstr "exclusivo"
 
-#: ../src/develop/blend_gui.c:2478
+#: ../src/develop/blend_gui.c:2479
 msgid "inclusive"
 msgstr "inclusivo"
 
-#: ../src/develop/blend_gui.c:2481
+#: ../src/develop/blend_gui.c:2482
 msgid "exclusive & inverted"
 msgstr "exclusivo e invertido"
 
-#: ../src/develop/blend_gui.c:2484
+#: ../src/develop/blend_gui.c:2485
 msgid "inclusive & inverted"
 msgstr "inclusivo e invertido"
 
-#: ../src/develop/blend_gui.c:2489
+#: ../src/develop/blend_gui.c:2490
 msgid ""
 "how to combine individual drawn mask and different channels of parametric "
 "mask"
@@ -2862,54 +2894,54 @@ msgstr ""
 "cómo combinar máscaras individuales y diferentes canales de máscaras "
 "paramétricas"
 
-#: ../src/develop/blend_gui.c:2495
+#: ../src/develop/blend_gui.c:2496
 msgid "invert mask"
 msgstr "invertir máscara"
 
-#: ../src/develop/blend_gui.c:2504
+#: ../src/develop/blend_gui.c:2505
 msgid "apply mask in normal or inverted mode"
 msgstr "aplicar la máscara en modo normal o invertido"
 
-#: ../src/develop/blend_gui.c:2510
+#: ../src/develop/blend_gui.c:2511
 msgid "feathering guide"
 msgstr "guía de difuminado"
 
-#: ../src/develop/blend_gui.c:2512
+#: ../src/develop/blend_gui.c:2513
 msgid "output image"
 msgstr "imagen de salida"
 
-#: ../src/develop/blend_gui.c:2516
+#: ../src/develop/blend_gui.c:2517
 msgid "input image"
 msgstr "imagen de entrada"
 
-#: ../src/develop/blend_gui.c:2522
+#: ../src/develop/blend_gui.c:2523
 msgid "choose to guide mask by input or output image"
 msgstr "elegir máscara guía para imágen de entrada o salida"
 
-#: ../src/develop/blend_gui.c:2528
+#: ../src/develop/blend_gui.c:2529
 msgid "feathering radius"
 msgstr "radio de difuminado"
 
-#: ../src/develop/blend_gui.c:2530
+#: ../src/develop/blend_gui.c:2531
 msgid "spatial radius of feathering"
 msgstr "extensión espacial del difuminado"
 
-#: ../src/develop/blend_gui.c:2536
+#: ../src/develop/blend_gui.c:2537
 msgid "mask blur"
 msgstr "máscara de desenfoque"
 
 # se corrige la ortografía, le faltaba la tilde a máscara
-#: ../src/develop/blend_gui.c:2538
+#: ../src/develop/blend_gui.c:2539
 msgid "radius for gaussian blur of blend mask"
 msgstr "el radio del desenfoque gausiano de la máscara combinada"
 
-#: ../src/develop/blend_gui.c:2544 ../src/iop/retouch.c:2943
+#: ../src/develop/blend_gui.c:2545 ../src/iop/retouch.c:2951
 msgid "mask opacity"
 msgstr "opacidad de la máscara"
 
 # Se elimina la redundancia de la palabra "totalmente".
 # Se corrige ortografía, se añade la tilde a máscara
-#: ../src/develop/blend_gui.c:2546
+#: ../src/develop/blend_gui.c:2547
 msgid ""
 "shifts and tilts the tone curve of the blend mask to adjust its brightness "
 "without affecting fully transparent/fully opaque regions"
@@ -2917,18 +2949,18 @@ msgstr ""
 "desplaza e inclina la curva de tono de la mezcla de máscara, para ajustar su "
 "brillo, sin afectar a las regiones totalmente transparentes/opacas"
 
-#: ../src/develop/blend_gui.c:2554
+#: ../src/develop/blend_gui.c:2555
 msgid "mask contrast"
 msgstr "contraste de la máscara"
 
-#: ../src/develop/blend_gui.c:2556
+#: ../src/develop/blend_gui.c:2557
 msgid ""
 "gives the tone curve of the blend mask an s-like shape to adjust its contrast"
 msgstr ""
 "da a la curva de tono de la máscara un estilo S para ajustar su contraste"
 
 # se corrige ortografía, le falta la tilde a la segunda palabra de máscara
-#: ../src/develop/blend_gui.c:2563
+#: ../src/develop/blend_gui.c:2564
 msgid ""
 "display mask and/or color channel. ctrl-click to display mask, shift-click "
 "to display channel. hover over parametric mask slider to select channel for "
@@ -2938,115 +2970,117 @@ msgstr ""
 "Mayús+clic para mostrar el canal. Pase el puntero por encima del deslizador "
 "para seleccionar el canal a mostrar"
 
-#: ../src/develop/blend_gui.c:2571
+#: ../src/develop/blend_gui.c:2572
 msgid "temporarily switch off blend mask. only for module in focus"
 msgstr "apagar temporalmente la mezcla de máscara. solo para módulo enfocado"
 
-#: ../src/develop/blend_gui.c:2601
+#: ../src/develop/blend_gui.c:2602
 msgid "mask refinement"
 msgstr "afinar máscara"
 
-#: ../src/develop/develop.c:1574
+#: ../src/develop/develop.c:1648
 #, c-format
 msgid "%s: module `%s' version mismatch: %d != %d"
 msgstr "%s: módulo '%s' versión no coincidente: %d != %d"
 
-#: ../src/develop/imageop.c:1013
+#: ../src/develop/imageop.c:1017
 msgid "new instance"
 msgstr "nueva instancia"
 
-#: ../src/develop/imageop.c:1019
+#: ../src/develop/imageop.c:1023
 msgid "duplicate instance"
 msgstr "duplicar instancia"
 
-#: ../src/develop/imageop.c:1025 ../src/libs/masks.c:1153
+#: ../src/develop/imageop.c:1029 ../src/libs/masks.c:1153
 msgid "move up"
 msgstr "subir"
 
-#: ../src/develop/imageop.c:1031 ../src/libs/masks.c:1156
+#: ../src/develop/imageop.c:1035 ../src/libs/masks.c:1156
 msgid "move down"
 msgstr "bajar"
 
 #. delete
-#: ../src/develop/imageop.c:1037 ../src/libs/image.c:142
-#: ../src/libs/styles.c:458 ../src/libs/tagging.c:578
+#: ../src/develop/imageop.c:1041 ../src/libs/image.c:144
+#: ../src/libs/styles.c:458 ../src/libs/tagging.c:1164
+#: ../src/libs/tagging.c:1261
 msgid "delete"
 msgstr "borrar"
 
-#: ../src/develop/imageop.c:1044
+#: ../src/develop/imageop.c:1048 ../src/libs/tagging.c:1735
 msgid "rename"
 msgstr "renombrar"
 
-#: ../src/develop/imageop.c:1087 ../src/develop/imageop.c:1967
+#: ../src/develop/imageop.c:1091 ../src/develop/imageop.c:1975
 #, c-format
 msgid "%s is switched on"
 msgstr "%s está activado"
 
-#: ../src/develop/imageop.c:1087 ../src/develop/imageop.c:1967
+#: ../src/develop/imageop.c:1091 ../src/develop/imageop.c:1975
 #, c-format
 msgid "%s is switched off"
 msgstr "%s está desactivado"
 
-#: ../src/develop/imageop.c:1398 ../src/gui/accelerators.c:660
-#: ../src/gui/accelerators.c:745 ../src/gui/accelerators.c:927
-#: ../src/gui/accelerators.c:953 ../src/gui/presets.c:190
-#: ../src/gui/presets.c:303 ../src/gui/presets.c:644
-#: ../src/iop/temperature.c:1457 ../src/libs/import.c:559 ../src/libs/lib.c:320
+#: ../src/develop/imageop.c:1402 ../src/gui/accelerators.c:686
+#: ../src/gui/accelerators.c:771 ../src/gui/accelerators.c:953
+#: ../src/gui/accelerators.c:979 ../src/gui/camera_import_dialog.c:445
+#: ../src/gui/presets.c:190 ../src/gui/presets.c:303 ../src/gui/presets.c:644
+#: ../src/iop/temperature.c:1459 ../src/libs/import.c:560 ../src/libs/lib.c:320
 #: ../src/libs/lib.c:348 ../src/libs/lib.c:1125
 msgid "preset"
 msgstr "predefinido"
 
-#: ../src/develop/imageop.c:1418
+#: ../src/develop/imageop.c:1422
 msgctxt "accel"
 msgid "fusion"
 msgstr "fusión"
 
 #. Adding the optional show accelerator to the table (blank)
-#: ../src/develop/imageop.c:1423
+#: ../src/develop/imageop.c:1427
 msgctxt "accel"
 msgid "show module"
 msgstr "mostrar módulo"
 
-#: ../src/develop/imageop.c:1424
+#: ../src/develop/imageop.c:1428
 msgctxt "accel"
 msgid "enable module"
 msgstr "activar módulo"
 
-#: ../src/develop/imageop.c:1426 ../src/libs/lib.c:614
+#: ../src/develop/imageop.c:1430 ../src/libs/lib.c:614
 msgctxt "accel"
 msgid "reset module parameters"
 msgstr "reiniciar parámetros"
 
-#: ../src/develop/imageop.c:1427 ../src/libs/lib.c:618
+#: ../src/develop/imageop.c:1431 ../src/libs/lib.c:618
 msgctxt "accel"
 msgid "show preset menu"
 msgstr "mostrar menú de preajustes"
 
-#: ../src/develop/imageop.c:1939
+#: ../src/develop/imageop.c:1947
 msgid ""
 "multiple instances actions\n"
 "middle-click creates new instance"
 msgstr ""
-"acciones para múltiples instancias\n"
-"pulsación central crea nuevas instancias"
+"Acciones para múltiples instancias\n"
+"Pulse el botón central para crear instancias nuevas"
 
-#: ../src/develop/imageop.c:1950 ../src/libs/lib.c:987
+#: ../src/develop/imageop.c:1958 ../src/libs/lib.c:987
 msgid "reset parameters"
 msgstr "reiniciar parámetros"
 
 #. Adding the outer container
-#: ../src/develop/imageop.c:1958 ../src/gui/preferences.c:473
+#: ../src/develop/imageop.c:1966 ../src/gui/preferences.c:475
 #: ../src/libs/lib.c:996
 msgid "presets"
 msgstr "Preajustes"
 
-#: ../src/develop/imageop.c:1960
+#: ../src/develop/imageop.c:1968
 msgid ""
 "presets\n"
 "middle-click to apply on new instance"
 msgstr ""
-"preajustes\n"
-"pulsando el botón central lo configura en una nueva instancia nueva"
+"Preajustes\n"
+"Pulse el botón central sobre el preajuste para establecerlo en una instancia "
+"nueva"
 
 #: ../src/develop/lightroom.c:1034
 msgid "cannot find lightroom XMP!"
@@ -3058,7 +3092,9 @@ msgstr "No se encuentra mesa de luz XMP"
 msgid "`%s' not a lightroom XMP!"
 msgstr "`%s' no es una mesa de luz XMP"
 
-#: ../src/develop/lightroom.c:1568 ../src/libs/import.c:579
+#. tags
+#: ../src/develop/lightroom.c:1568 ../src/gui/camera_import_dialog.c:465
+#: ../src/libs/import.c:580 ../src/libs/metadata_view.c:136
 msgid "tags"
 msgstr "etiquetas"
 
@@ -3068,7 +3104,7 @@ msgid "rating"
 msgstr "valoración"
 
 #: ../src/develop/lightroom.c:1589 ../src/libs/collect.h:38
-#: ../src/libs/geotagging.c:62
+#: ../src/libs/geotagging.c:63
 msgid "geotagging"
 msgstr "geoetiquetado"
 
@@ -3085,23 +3121,127 @@ msgid_plural "%s have been imported"
 msgstr[0] "%s ha sido  importado"
 msgstr[1] "%s han sido importados"
 
-#: ../src/develop/masks/masks.c:145
+#: ../src/develop/masks/masks.c:157
+msgid "[SHAPE] remove shape"
+msgstr "[FIGURA] quitar figura"
+
+#: ../src/develop/masks/masks.c:164
+msgid "[PATH creation] add a smooth node"
+msgstr "[creación de RUTA] añadir un nodo de suavizado"
+
+#: ../src/develop/masks/masks.c:170
+msgid "[PATH creation] add a sharp node"
+msgstr "[creación de RUTA] agregar nodo de enfoque"
+
+#: ../src/develop/masks/masks.c:175
+msgid "[PATH creation] terminate path creation"
+msgstr "[creación de RUTA] finalizar la creación de la ruta"
+
+#: ../src/develop/masks/masks.c:181
+msgid "[PATH on node] switch between smooth/sharp node"
+msgstr "[RUTA en el nodo] alternar entre nodo de suavizado y de enfoque"
+
+#: ../src/develop/masks/masks.c:186
+msgid "[PATH on node] remove the node"
+msgstr "[RUTA en el nodo] quitar el nodo"
+
+#: ../src/develop/masks/masks.c:191
+msgid "[PATH on feather] reset curvature"
+msgstr "[RUTA en el suavizado] restablecer curvatura"
+
+#: ../src/develop/masks/masks.c:197
+msgid "[PATH on segment] add node"
+msgstr "[RUTA en el segmento] añadir nodo"
+
+#: ../src/develop/masks/masks.c:202
+msgid "[PATH] change size"
+msgstr "[RUTA] ajustar tamaño"
+
+#: ../src/develop/masks/masks.c:208
+msgid "[PATH] change opacity"
+msgstr "[RUTA] ajustar opacidad"
+
+#: ../src/develop/masks/masks.c:214
+msgid "[PATH] change feather size"
+msgstr "[RUTA] ajustar dureza"
+
+#: ../src/develop/masks/masks.c:221
+msgid "[GRADIENT on pivot] rotate shape"
+msgstr "[GRADIENTE en el pivote] rotar figura"
+
+#: ../src/develop/masks/masks.c:226
+msgid "[GRADIENT creation] set rotation"
+msgstr "[creación de GRADIENTE] fijar rotación"
+
+#: ../src/develop/masks/masks.c:231
+msgid "[GRADIENT] change compression"
+msgstr "[GRADIENTE] cambiar compresión"
+
+#: ../src/develop/masks/masks.c:237
+msgid "[GRADIENT] change opacity"
+msgstr "[GRADIENTE] cambiar opacidad"
+
+#: ../src/develop/masks/masks.c:244
+msgid "[ELLIPSE] change size"
+msgstr "[ELIPSE] cambiar tamaño"
+
+#: ../src/develop/masks/masks.c:250
+msgid "[ELLIPSE] change opacity"
+msgstr "[ELIPSE] cambiar opacidad"
+
+#: ../src/develop/masks/masks.c:256
+msgid "[ELLIPSE] switch feathering mode"
+msgstr "[ELIPSE] cambiar el modo de difuminado"
+
+#: ../src/develop/masks/masks.c:262
+msgid "[ELLIPSE] rotate shape"
+msgstr "[ELIPSE] rotar figura"
+
+#: ../src/develop/masks/masks.c:269
+msgid "[BRUSH creation] change size"
+msgstr "[creación de PINCEL] ajustar tamaño"
+
+#: ../src/develop/masks/masks.c:275
+msgid "[BRUSH creation] change hardness"
+msgstr "[creación de PINCEL] ajustar dureza"
+
+#: ../src/develop/masks/masks.c:281
+msgid "[BRUSH] change opacity"
+msgstr "[PINCEL] ajustar opacidad"
+
+#: ../src/develop/masks/masks.c:286
+msgid "[BRUSH] change hardness"
+msgstr "[PINCEL] ajustar dureza"
+
+#: ../src/develop/masks/masks.c:293
+msgid "[CIRCLE] change size"
+msgstr "[CÍRCULO] cambiar tamaño"
+
+#: ../src/develop/masks/masks.c:299
+msgid "[CIRCLE] change opacity"
+msgstr "[CÍRCULO] cambiar opacidad"
+
+#: ../src/develop/masks/masks.c:305
+msgid "[CIRCLE] change feather size"
+msgstr "[CÍRCULO] cambiar área de difuminado"
+
+#: ../src/develop/masks/masks.c:331
 msgid "ctrl+click to add a sharp node"
 msgstr "Ctrl+clic para agregar nodo de enfoque"
 
-#: ../src/develop/masks/masks.c:147
+#: ../src/develop/masks/masks.c:333
 msgid "ctrl+click to switch between smooth/sharp node"
 msgstr "Ctrl+clic para cambiar nodo de suavizado/enfoque"
 
-#: ../src/develop/masks/masks.c:149
+#: ../src/develop/masks/masks.c:335
 msgid "right-click to reset curvature"
 msgstr "pulsación derecha para reiniciar curvatura"
 
-#: ../src/develop/masks/masks.c:151
+#: ../src/develop/masks/masks.c:337
 msgid "ctrl+click to add a node"
 msgstr "Ctrl+clic para agregar un nodo"
 
-#: ../src/develop/masks/masks.c:153 ../src/develop/masks/masks.c:191
+#: ../src/develop/masks/masks.c:339 ../src/develop/masks/masks.c:377
 #, c-format
 msgid ""
 "shift+scroll to set feather size, ctrl+scroll to set shape opacity (%d%%)"
@@ -3109,16 +3249,16 @@ msgstr ""
 "Mayús+rueda del ratón ajusta difuminado, Ctrl+rueda del ratón ajusta "
 "opacidad (%d%%)"
 
-#: ../src/develop/masks/masks.c:158
+#: ../src/develop/masks/masks.c:344
 #, c-format
 msgid "ctrl+scroll to set shape opacity (%d%%)"
 msgstr "Ctrl+rueda del ratón para ajustar la opacidad de la forma (%d%%)"
 
-#: ../src/develop/masks/masks.c:160
+#: ../src/develop/masks/masks.c:346
 msgid "move to rotate shape"
 msgstr "mover para rotar figura"
 
-#: ../src/develop/masks/masks.c:166 ../src/develop/masks/masks.c:188
+#: ../src/develop/masks/masks.c:352 ../src/develop/masks/masks.c:374
 #, c-format
 msgid ""
 "scroll to set size, shift+scroll to set feather size\n"
@@ -3128,11 +3268,11 @@ msgstr ""
 "la dureza,\n"
 "Ctrl+rueda del ratón para ajustar la opacidad (%d%%)"
 
-#: ../src/develop/masks/masks.c:168
+#: ../src/develop/masks/masks.c:354
 msgid "ctrl+click to rotate"
 msgstr "Ctrl+clic para rotar"
 
-#: ../src/develop/masks/masks.c:171
+#: ../src/develop/masks/masks.c:357
 #, c-format
 msgid ""
 "shift+click to switch feathering mode, ctrl+click to rotate\n"
@@ -3142,7 +3282,7 @@ msgstr ""
 "Mayús+rueda del ratón cambia el área de difuminado,\n"
 "Ctrl+rueda del ratón cambia la opacidad de la figura (%d%%)"
 
-#: ../src/develop/masks/masks.c:177
+#: ../src/develop/masks/masks.c:363
 #, c-format
 msgid ""
 "scroll to set brush size, shift+scroll to set hardness,\n"
@@ -3152,65 +3292,65 @@ msgstr ""
 "para ajustar la dureza,\n"
 "Ctrl+rueda del ratón para ajustar la opacidad (%d%%)"
 
-#: ../src/develop/masks/masks.c:180
+#: ../src/develop/masks/masks.c:366
 #, c-format
 msgid "scroll to set hardness, ctrl+scroll to set shape opacity (%d%%)"
 msgstr ""
 "Rueda del ratón ajusta la dureza, Ctrl+rueda del ratón ajusta la opacidad de "
 "la forma (%d%%)"
 
-#: ../src/develop/masks/masks.c:182
+#: ../src/develop/masks/masks.c:368
 msgid "scroll to set brush size"
 msgstr "rueda del ratón para ajustar tamaño del pincel"
 
-#: ../src/develop/masks/masks.c:344
+#: ../src/develop/masks/masks.c:530
 #, c-format
 msgid "circle #%d"
 msgstr "círculo #%d"
 
-#: ../src/develop/masks/masks.c:346
+#: ../src/develop/masks/masks.c:532
 #, c-format
 msgid "path #%d"
 msgstr "ruta #%d"
 
-#: ../src/develop/masks/masks.c:348
+#: ../src/develop/masks/masks.c:534
 #, c-format
 msgid "gradient #%d"
 msgstr "gradiente #%d"
 
-#: ../src/develop/masks/masks.c:350
+#: ../src/develop/masks/masks.c:536
 #, c-format
 msgid "ellipse #%d"
 msgstr "elipse #%d"
 
-#: ../src/develop/masks/masks.c:352
+#: ../src/develop/masks/masks.c:538
 #, c-format
 msgid "brush #%d"
 msgstr "pincel #%d"
 
-#: ../src/develop/masks/masks.c:420
+#: ../src/develop/masks/masks.c:606
 #, c-format
 msgid "copy of %s"
 msgstr "copia de %s"
 
-#: ../src/develop/masks/masks.c:1130
+#: ../src/develop/masks/masks.c:1316
 #, c-format
 msgid "%s: mask version mismatch: %d != %d"
 msgstr "%s: no coincide la versión de máscara: %d != %d"
 
-#: ../src/develop/masks/masks.c:1862 ../src/libs/masks.c:1036
+#: ../src/develop/masks/masks.c:2051 ../src/libs/masks.c:1036
 msgid "add existing shape"
 msgstr "añadir figura existente"
 
-#: ../src/develop/masks/masks.c:1887
+#: ../src/develop/masks/masks.c:2076
 msgid "use same shapes as"
 msgstr "usar la misma figura como"
 
-#: ../src/develop/masks/masks.c:2200
+#: ../src/develop/masks/masks.c:2390
 msgid "masks can not contain themselves"
 msgstr "las mascaras no pueden contenerse a si mismas"
 
-#: ../src/develop/pixelpipe_hb.c:2704
+#: ../src/develop/pixelpipe_hb.c:2736
 msgid ""
 "darktable discovered problems with your OpenCL setup; disabling OpenCL for "
 "this session!"
@@ -3331,7 +3471,7 @@ msgstr "sol de tarde"
 msgid "underwater"
 msgstr "bajo el agua"
 
-#: ../src/external/wb_presets.c:73 ../src/views/darkroom.c:1875
+#: ../src/external/wb_presets.c:73 ../src/views/darkroom.c:1895
 msgid "black & white"
 msgstr "blanco y negro"
 
@@ -3456,57 +3596,60 @@ msgctxt "accel"
 msgid "lua"
 msgstr "lua"
 
-#: ../src/gui/accelerators.c:727 ../src/libs/lib.c:403
+#: ../src/gui/accelerators.c:753 ../src/libs/lib.c:403
 msgid "deleting preset for obsolete module"
 msgstr "borrando preajuste de módulo obsoleto"
 
-#: ../src/gui/camera_import_dialog.c:182
+#: ../src/gui/camera_import_dialog.c:262
 msgid "store value as default"
 msgstr "Guardar como valor por defecto"
 
-#: ../src/gui/camera_import_dialog.c:187
+#: ../src/gui/camera_import_dialog.c:267
 msgid "reset value to default"
 msgstr "Restablecer valor a predeterminado"
 
-#: ../src/gui/camera_import_dialog.c:210 ../src/libs/geotagging.c:418
+#: ../src/gui/camera_import_dialog.c:288 ../src/libs/geotagging.c:419
+#: ../src/libs/tagging.c:1164 ../src/libs/tagging.c:1261
+#: ../src/libs/tagging.c:1349 ../src/libs/tagging.c:1515
+#: ../src/libs/tagging.c:1735
 msgid "cancel"
 msgstr "cancelar"
 
-#: ../src/gui/camera_import_dialog.c:210
+#: ../src/gui/camera_import_dialog.c:288
 msgctxt "camera import"
 msgid "import"
 msgstr "importar"
 
 #. Top info
-#: ../src/gui/camera_import_dialog.c:226
+#: ../src/gui/camera_import_dialog.c:304
 msgid "please wait while prefetching thumbnails of images from camera..."
 msgstr ""
 "por favor espere mientras se cargan las miniaturas de imágenes desde "
 "cámara..."
 
-#: ../src/gui/camera_import_dialog.c:233 ../src/libs/session.c:100
+#: ../src/gui/camera_import_dialog.c:311 ../src/libs/session.c:100
 msgid "jobcode"
 msgstr "código de trabajo"
 
-#: ../src/gui/camera_import_dialog.c:247
+#: ../src/gui/camera_import_dialog.c:325
 msgid "thumbnail"
 msgstr "miniatura"
 
-#: ../src/gui/camera_import_dialog.c:251
+#: ../src/gui/camera_import_dialog.c:329
 msgid "storage file"
 msgstr "archivo de almacenamiento"
 
 #. general settings
-#: ../src/gui/camera_import_dialog.c:269
+#: ../src/gui/camera_import_dialog.c:347
 msgid "general"
 msgstr "General"
 
 #. ignoring of jpegs. hack while we don't handle raw+jpeg in the same directories.
-#: ../src/gui/camera_import_dialog.c:272 ../src/libs/import.c:454
+#: ../src/gui/camera_import_dialog.c:350 ../src/libs/import.c:455
 msgid "ignore JPEG files"
 msgstr "Ignorar archivos JPEG"
 
-#: ../src/gui/camera_import_dialog.c:274 ../src/libs/import.c:455
+#: ../src/gui/camera_import_dialog.c:352 ../src/libs/import.c:456
 msgid ""
 "do not load files with an extension of .jpg or .jpeg. this can be useful "
 "when there are raw+JPEG in a directory."
@@ -3514,11 +3657,40 @@ msgstr ""
 "No cargar archivos con extensión .JPG o .JPEG. Puede ser útil cuando en un "
 "directorio existen RAW+JPEG."
 
-#: ../src/gui/camera_import_dialog.c:283
+#. default metadata
+#: ../src/gui/camera_import_dialog.c:361 ../src/libs/import.c:468
+msgid "apply metadata on import"
+msgstr "establecer los metadatos al importar"
+
+#: ../src/gui/camera_import_dialog.c:362 ../src/libs/import.c:469
+msgid "apply some metadata to all newly imported images."
+msgstr "establecer ciertos metadatos a todas las imágenes importadas."
+
+#: ../src/gui/camera_import_dialog.c:396 ../src/libs/import.c:510
+msgid "comma separated list of tags"
+msgstr "lista de etiquetas separadas por coma"
+
+#: ../src/gui/camera_import_dialog.c:450 ../src/libs/collect.h:35
+#: ../src/libs/import.c:565 ../src/libs/metadata.c:349
+#: ../src/libs/metadata_view.c:127
+msgid "creator"
+msgstr "autor"
+
+#: ../src/gui/camera_import_dialog.c:455 ../src/libs/collect.h:35
+#: ../src/libs/import.c:570 ../src/libs/metadata.c:350
+msgid "publisher"
+msgstr "editor"
+
+#: ../src/gui/camera_import_dialog.c:460 ../src/libs/collect.h:36
+#: ../src/libs/import.c:575 ../src/libs/metadata.c:351
+msgid "rights"
+msgstr "derechos"
+
+#: ../src/gui/camera_import_dialog.c:489
 msgid "override today's date"
 msgstr "Anular la fecha de hoy"
 
-#: ../src/gui/camera_import_dialog.c:286
+#: ../src/gui/camera_import_dialog.c:492
 msgid ""
 "check this, if you want to override the timestamp used when expanding "
 "variables:\n"
@@ -3530,15 +3702,15 @@ msgstr ""
 "$(AÑO), $(MES), $(DIA),\n"
 "$(HORA), $(MINUTO), $(SEGUNDOS)"
 
-#: ../src/gui/camera_import_dialog.c:302
+#: ../src/gui/camera_import_dialog.c:508
 msgid "images"
 msgstr "Imágenes"
 
-#: ../src/gui/camera_import_dialog.c:303
+#: ../src/gui/camera_import_dialog.c:509
 msgid "settings"
 msgstr "Configuración"
 
-#: ../src/gui/camera_import_dialog.c:497
+#: ../src/gui/camera_import_dialog.c:703
 msgid ""
 "select the images from the list below that you want to import into a new "
 "filmroll"
@@ -3546,111 +3718,117 @@ msgstr ""
 "Seleccione las imágenes de la siguiente lista que desee importar a una nueva "
 "sesión"
 
-#: ../src/gui/camera_import_dialog.c:548
+#: ../src/gui/camera_import_dialog.c:754
 msgid "please use YYYY-MM-DD format for date override"
 msgstr "Use el formato AAAA-MM-DD para sobreescribir la fecha"
 
 #. register keys for view switching
-#: ../src/gui/gtk.c:1163
+#: ../src/gui/gtk.c:1167
 msgctxt "accel"
 msgid "tethering view"
 msgstr "vista de captura"
 
-#: ../src/gui/gtk.c:1164
+#: ../src/gui/gtk.c:1168
 msgctxt "accel"
 msgid "lighttable view"
 msgstr "vista de mesa de luz"
 
-#: ../src/gui/gtk.c:1165
+#: ../src/gui/gtk.c:1169
 msgctxt "accel"
 msgid "darkroom view"
 msgstr "vista de cuarto oscuro"
 
-#: ../src/gui/gtk.c:1166
+#: ../src/gui/gtk.c:1170
 msgctxt "accel"
 msgid "map view"
 msgstr "vista de mapa"
 
-#: ../src/gui/gtk.c:1167
+#: ../src/gui/gtk.c:1171
 msgctxt "accel"
 msgid "slideshow view"
 msgstr "vista de diapositivas"
 
-#: ../src/gui/gtk.c:1168
+#: ../src/gui/gtk.c:1172
 msgctxt "accel"
 msgid "print view"
 msgstr "vista de imprimir"
 
 #. register ctrl-q to quit:
-#: ../src/gui/gtk.c:1191
+#: ../src/gui/gtk.c:1195
 msgctxt "accel"
 msgid "quit"
 msgstr "salir"
 
 #. Full-screen accelerators
-#: ../src/gui/gtk.c:1196
+#: ../src/gui/gtk.c:1200
 msgctxt "accel"
 msgid "toggle fullscreen"
 msgstr "activar pantalla completa"
 
-#: ../src/gui/gtk.c:1197
+#: ../src/gui/gtk.c:1201
 msgctxt "accel"
 msgid "leave fullscreen"
 msgstr "salir de pantalla completa"
 
 #. Side-border hide/show
-#: ../src/gui/gtk.c:1205
+#: ../src/gui/gtk.c:1209
 msgctxt "accel"
 msgid "toggle side borders"
 msgstr "activar paneles laterales"
 
-#: ../src/gui/gtk.c:1207
+#: ../src/gui/gtk.c:1211
 msgctxt "accel"
 msgid "toggle panels collapsing controls"
 msgstr "activar paneles de control de plegado"
 
-#: ../src/gui/gtk.c:1211
+#: ../src/gui/gtk.c:1215
 msgctxt "accel"
 msgid "toggle left panel"
 msgstr "activar panel izquierdo"
 
-#: ../src/gui/gtk.c:1215
+#: ../src/gui/gtk.c:1219
 msgctxt "accel"
 msgid "toggle right panel"
 msgstr "activar panel derecho"
 
-#: ../src/gui/gtk.c:1219
+#: ../src/gui/gtk.c:1223
 msgctxt "accel"
 msgid "toggle top panel"
 msgstr "activar panel superior"
 
-#: ../src/gui/gtk.c:1223
+#: ../src/gui/gtk.c:1227
 msgctxt "accel"
 msgid "toggle bottom panel"
 msgstr "activar panel inferior"
 
 #. toggle view of header
-#: ../src/gui/gtk.c:1228
+#: ../src/gui/gtk.c:1232
 msgctxt "accel"
 msgid "toggle header"
 msgstr "activar cabecera"
 
 #. View-switch
-#: ../src/gui/gtk.c:1231
+#: ../src/gui/gtk.c:1235
 msgctxt "accel"
 msgid "switch view"
 msgstr "cambiar vista"
 
 #. Global zoom in & zoom out
-#: ../src/gui/gtk.c:1237 ../src/libs/tools/lighttable.c:213
+#: ../src/gui/gtk.c:1241 ../src/libs/tools/lighttable.c:213
 msgctxt "accel"
 msgid "zoom in"
 msgstr "acercar"
 
-#: ../src/gui/gtk.c:1238 ../src/libs/tools/lighttable.c:214
+#: ../src/gui/gtk.c:1242 ../src/libs/tools/lighttable.c:214
 msgctxt "accel"
 msgid "zoom out"
 msgstr "alejar"
+
+#. accels window
+#: ../src/gui/gtk.c:1245
+msgctxt "accel"
+msgid "show accels window"
+msgstr "Mostrar la ventana de atajos"
 
 #: ../src/gui/gtkentry.c:186
 msgid "$(ROLL_NAME) - roll of the input image"
@@ -3677,212 +3855,260 @@ msgid "$(SEQUENCE) - sequence number"
 msgstr "$(SEQUENCE) - número de secuencia"
 
 #: ../src/gui/gtkentry.c:192
+msgid "$(MAX_WIDTH) - maximum image export width"
+msgstr "$(MAX_WIDTH) - ancho máximo de exportación de la imagen"
+
+#: ../src/gui/gtkentry.c:193
+msgid "$(MAX_HEIGHT) - maximum image export height"
+msgstr "$(MAX_HEIGHT) - altura máxima de exportación de la imagen"
+
+#: ../src/gui/gtkentry.c:194
 msgid "$(YEAR) - year"
 msgstr "$(YEAR) - año"
 
-#: ../src/gui/gtkentry.c:193
+#: ../src/gui/gtkentry.c:195
 msgid "$(MONTH) - month"
 msgstr "$(MONTH) - mes"
 
-#: ../src/gui/gtkentry.c:194
+#: ../src/gui/gtkentry.c:196
 msgid "$(DAY) - day"
 msgstr "$(DAY) - día"
 
-#: ../src/gui/gtkentry.c:195
+#: ../src/gui/gtkentry.c:197
 msgid "$(HOUR) - hour"
 msgstr "$(HOUR) - hora"
 
-#: ../src/gui/gtkentry.c:196
+#: ../src/gui/gtkentry.c:198
 msgid "$(MINUTE) - minute"
 msgstr "$(MINUTE) - minuto"
 
-#: ../src/gui/gtkentry.c:197
+#: ../src/gui/gtkentry.c:199
 msgid "$(SECOND) - second"
 msgstr "$(SECOND) - segundo"
 
-#: ../src/gui/gtkentry.c:198
+#: ../src/gui/gtkentry.c:200
 msgid "$(EXIF_YEAR) - EXIF year"
 msgstr "$(EXIF_YEAR) - año Exif"
 
-#: ../src/gui/gtkentry.c:199
+#: ../src/gui/gtkentry.c:201
 msgid "$(EXIF_MONTH) - EXIF month"
 msgstr "$(EXIF_MONTH) - mes Exif"
 
-#: ../src/gui/gtkentry.c:200
+#: ../src/gui/gtkentry.c:202
 msgid "$(EXIF_DAY) - EXIF day"
 msgstr "$(EXIF_DAY) - día Exif"
 
-#: ../src/gui/gtkentry.c:201
+#: ../src/gui/gtkentry.c:203
 msgid "$(EXIF_HOUR) - EXIF hour"
 msgstr "$(EXIF_HOUR) - hora Exif"
 
-#: ../src/gui/gtkentry.c:202
+#: ../src/gui/gtkentry.c:204
 msgid "$(EXIF_MINUTE) - EXIF minute"
 msgstr "$(EXIF_MINUTE) - minuto Exif"
 
-#: ../src/gui/gtkentry.c:203
+#: ../src/gui/gtkentry.c:205
 msgid "$(EXIF_SECOND) - EXIF second"
 msgstr "$(EXIF_SECOND) - segundo Exif"
 
-#: ../src/gui/gtkentry.c:204
+#: ../src/gui/gtkentry.c:206
 msgid "$(EXIF_ISO) - ISO value"
 msgstr "$(EXIF_ISO) - valor ISO"
 
-#: ../src/gui/gtkentry.c:205
+#: ../src/gui/gtkentry.c:207
 msgid "$(MAKER) - camera maker"
 msgstr "$(MAKER) - fabricante de la cámara"
 
-#: ../src/gui/gtkentry.c:206
+#: ../src/gui/gtkentry.c:208
 msgid "$(MODEL) - camera model"
 msgstr "$(MODEL) - modelo de la cámara"
 
-#: ../src/gui/gtkentry.c:207
+#: ../src/gui/gtkentry.c:209
 msgid "$(STARS) - star rating"
 msgstr "$(STARS) - puntuación"
 
-#: ../src/gui/gtkentry.c:208
+#: ../src/gui/gtkentry.c:210
 msgid "$(LABELS) - colorlabels"
 msgstr "$(LABELS) - etiquetas de color"
 
-#: ../src/gui/gtkentry.c:209
+#: ../src/gui/gtkentry.c:211
 msgid "$(PICTURES_FOLDER) - pictures folder"
 msgstr "$(PICTURES_FOLDER) - carpeta de fotos"
 
-#: ../src/gui/gtkentry.c:210
+#: ../src/gui/gtkentry.c:212
 msgid "$(HOME) - home folder"
 msgstr "$(HOME) - carpeta home"
 
-#: ../src/gui/gtkentry.c:211
+#: ../src/gui/gtkentry.c:213
 msgid "$(DESKTOP) - desktop folder"
 msgstr "$(DESKTOP) - carpeta escritorio"
 
-#: ../src/gui/gtkentry.c:212
+#: ../src/gui/gtkentry.c:214
 msgid "$(TITLE) - title from metadata"
 msgstr "$(TITLE) - titulo de los metadatos"
 
-#: ../src/gui/gtkentry.c:213
+#: ../src/gui/gtkentry.c:215
+msgid "$(DESCRIPTION) - description from metadata"
+msgstr "$(DESCRIPTION) - descripción en los metadatos"
+
+#: ../src/gui/gtkentry.c:216
 msgid "$(CREATOR) - creator from metadata"
 msgstr "$(CREATOR) - autor de los metadatos"
 
-#: ../src/gui/gtkentry.c:214
+#: ../src/gui/gtkentry.c:217
 msgid "$(PUBLISHER) - publisher from metadata"
 msgstr "$(PUBLISHER) - editor de los metadatos"
 
-#: ../src/gui/gtkentry.c:215
+#: ../src/gui/gtkentry.c:218
 msgid "$(RIGHTS) - rights from metadata"
 msgstr "$(RIGHTS) - derechos de los metadatos"
 
-#: ../src/gui/guides.c:370
+#: ../src/gui/gtkentry.c:219
+msgid "$(OPENCL_ACTIVATED) - whether OpenCL is activated"
+msgstr "$(OPENCL_ACTIVATED) - determinar si OpenCL está activado"
+
+#: ../src/gui/gtkentry.c:220
+msgid "$(CATEGORY0(category)) - subtag of level 0 in hierarchical tags"
+msgstr ""
+"$(CATEGORY0(category)) - subetiqueta de nivel 0 en etiquetas jerárquicas"
+
+#: ../src/gui/gtkentry.c:221
+msgid "$(TAGS) - tags as set in metadata settings"
+msgstr "$(TAGS) - etiquetas establecidas en la configuración de metadatos"
+
+#: ../src/gui/guides.c:108
+msgid "horizontal lines"
+msgstr "líneas horizontales"
+
+#: ../src/gui/guides.c:109
+msgid "number of horizontal guide lines"
+msgstr "número de líneas guía horizontales"
+
+#: ../src/gui/guides.c:115
+msgid "vertical lines"
+msgstr "líneas verticales"
+
+#: ../src/gui/guides.c:116
+msgid "number of vertical guide lines"
+msgstr "número de líneas guía verticales"
+
+#: ../src/gui/guides.c:122
+msgid "subdivisions"
+msgstr "subdivisiones"
+
+#: ../src/gui/guides.c:123
+msgid "number of subdivisions per grid rectangle"
+msgstr "Cantidad de subdivisiones por cuadrícula"
+
+#: ../src/gui/guides.c:440
 msgid "extra"
 msgstr "extra"
 
-#: ../src/gui/guides.c:371
+#: ../src/gui/guides.c:441
 msgid "golden sections"
 msgstr "secciones áureas"
 
-#: ../src/gui/guides.c:372
+#: ../src/gui/guides.c:442
 msgid "golden spiral sections"
 msgstr "secciones espirales"
 
-#: ../src/gui/guides.c:373
+#: ../src/gui/guides.c:443
 msgid "golden spiral"
 msgstr "espiral áurea"
 
-#: ../src/gui/guides.c:374 ../src/imageio/format/pdf.c:679
-#: ../src/iop/denoiseprofile.c:3295 ../src/iop/lens.c:2191
+#: ../src/gui/guides.c:444 ../src/imageio/format/pdf.c:681
+#: ../src/iop/denoiseprofile.c:3921 ../src/iop/lens.cc:2326
 #: ../src/iop/rawdenoise.c:985 ../src/libs/tools/filter.c:125
 msgid "all"
 msgstr "todas"
 
-#: ../src/gui/guides.c:375
+#: ../src/gui/guides.c:445
 msgid "show some extra guides"
 msgstr "mostrar guías extra"
 
-#: ../src/gui/guides.c:407
+#: ../src/gui/guides.c:481
 msgid "grid"
 msgstr "rejilla"
 
-#. TODO: make the number of lines configurable with a slider?
-#: ../src/gui/guides.c:408
+#: ../src/gui/guides.c:483
 msgid "rules of thirds"
 msgstr "regla de los tercios"
 
-#: ../src/gui/guides.c:409
+#: ../src/gui/guides.c:484
 msgid "metering"
 msgstr "medida"
 
-#: ../src/gui/guides.c:410
+#: ../src/gui/guides.c:485
 msgid "perspective"
 msgstr "perspectiva"
 
 #. TODO: make the number of lines configurable with a slider?
-#: ../src/gui/guides.c:411
+#: ../src/gui/guides.c:486
 msgid "diagonal method"
 msgstr "método diagonal"
 
-#: ../src/gui/guides.c:412
+#: ../src/gui/guides.c:487
 msgid "harmonious triangles"
 msgstr "triángulos armónicos"
 
-#: ../src/gui/guides.c:416
+#: ../src/gui/guides.c:491
 msgid "golden mean"
 msgstr "proporción áurea"
 
-#: ../src/gui/hist_dialog.c:140
+#: ../src/gui/hist_dialog.c:171
 msgid "select parts"
-msgstr "seleccionar partes"
+msgstr "seleccionar ítems"
 
-#: ../src/gui/hist_dialog.c:141
+#: ../src/gui/hist_dialog.c:172
 msgid "select _all"
-msgstr "seleccionar _todo"
+msgstr "incluir _todos"
 
-#: ../src/gui/hist_dialog.c:141
+#: ../src/gui/hist_dialog.c:172
 msgid "select _none"
-msgstr "seleccionar _ninguno"
+msgstr "excluir _todos"
 
-#: ../src/gui/hist_dialog.c:141 ../src/gui/preferences.c:1326
+#: ../src/gui/hist_dialog.c:172 ../src/gui/preferences.c:1380
 #: ../src/gui/presets.c:386 ../src/libs/lib.c:227
 msgid "_ok"
 msgstr "_ok"
 
-#: ../src/gui/hist_dialog.c:167 ../src/gui/styles_dialog.c:347
-#: ../src/gui/styles_dialog.c:356
+#: ../src/gui/hist_dialog.c:198 ../src/gui/styles_dialog.c:349
+#: ../src/gui/styles_dialog.c:358
 msgid "include"
 msgstr "incluir"
 
-#: ../src/gui/hist_dialog.c:174 ../src/gui/styles_dialog.c:376
-#: ../src/gui/styles_dialog.c:379
+#: ../src/gui/hist_dialog.c:205 ../src/gui/styles_dialog.c:378
+#: ../src/gui/styles_dialog.c:381
 msgid "item"
 msgstr "ítem"
 
-#: ../src/gui/hist_dialog.c:200
+#: ../src/gui/hist_dialog.c:231
 msgid "can't copy history out of unaltered image"
 msgstr "no se puede copiar el historial de una imagen no modificada"
 
 #. format string and corresponding flag stored into the database
-#: ../src/gui/preferences.c:79 ../src/gui/presets.c:56
+#: ../src/gui/preferences.c:81 ../src/gui/presets.c:56
 msgid "normal images"
 msgstr "imagenes normales"
 
-#: ../src/gui/preferences.c:80 ../src/gui/presets.c:57
-#: ../src/libs/metadata_view.c:286
+#: ../src/gui/preferences.c:82 ../src/gui/presets.c:57
+#: ../src/libs/metadata_view.c:293
 msgid "raw"
 msgstr "raw"
 
-#: ../src/gui/preferences.c:81 ../src/gui/presets.c:58
+#: ../src/gui/preferences.c:83 ../src/gui/presets.c:58
 msgid "HDR"
 msgstr "HDR"
 
 #. language
-#: ../src/gui/preferences.c:216
+#: ../src/gui/preferences.c:218
 msgid "interface language"
 msgstr "Idioma de interfaz"
 
-#: ../src/gui/preferences.c:231
+#: ../src/gui/preferences.c:233
 msgid "double click to reset to the system language"
 msgstr "Doble clic para restablecer al idioma del sistema"
 
-#: ../src/gui/preferences.c:233
+#: ../src/gui/preferences.c:235
 msgid ""
 "set the language of the user interface. the system default is marked with an "
 "* (needs a restart)"
@@ -3890,234 +4116,251 @@ msgstr ""
 "Configurar el idioma de la interfaz de usuario. El predeterminado está "
 "marcado con un * (necesita reiniciarse)"
 
-#: ../src/gui/preferences.c:242
+#: ../src/gui/preferences.c:244
 msgid "theme"
 msgstr "Tema"
 
-#: ../src/gui/preferences.c:266
+#: ../src/gui/preferences.c:268
 msgid "set the theme for the user interface"
 msgstr "Establezca el tema de la interfaz de usuario"
 
-#: ../src/gui/preferences.c:277
+#: ../src/gui/preferences.c:279
 msgid "darktable preferences"
 msgstr "preferencias de darktable"
 
-#: ../src/gui/preferences.c:279
+#: ../src/gui/preferences.c:281
 msgid "close"
 msgstr "cerrar"
 
-#: ../src/gui/preferences.c:483
+#: ../src/gui/preferences.c:485
 msgid "module"
 msgstr "módulo"
 
 #. exif
-#: ../src/gui/preferences.c:495 ../src/gui/preferences.c:1367
-#: ../src/gui/presets.c:431 ../src/libs/metadata_view.c:106
+#: ../src/gui/preferences.c:497 ../src/gui/preferences.c:1421
+#: ../src/gui/presets.c:431 ../src/libs/metadata_view.c:110
 msgid "model"
 msgstr "modelo"
 
-#: ../src/gui/preferences.c:499 ../src/gui/preferences.c:1375
-#: ../src/gui/presets.c:438 ../src/libs/metadata_view.c:107
+#: ../src/gui/preferences.c:501 ../src/gui/preferences.c:1429
+#: ../src/gui/presets.c:438 ../src/libs/metadata_view.c:111
 msgid "maker"
 msgstr "fabricante"
 
-#: ../src/gui/preferences.c:503 ../src/gui/preferences.c:1383
+#: ../src/gui/preferences.c:505 ../src/gui/preferences.c:1437
 #: ../src/gui/presets.c:445 ../src/libs/collect.h:36
-#: ../src/libs/metadata_view.c:108
+#: ../src/libs/metadata_view.c:112
 msgid "lens"
 msgstr "lente"
 
 #. iso
-#: ../src/gui/preferences.c:507 ../src/gui/preferences.c:1389
+#: ../src/gui/preferences.c:509 ../src/gui/preferences.c:1443
 #: ../src/gui/presets.c:451 ../src/libs/camera.c:588 ../src/libs/collect.h:37
-#: ../src/libs/metadata_view.c:113
+#: ../src/libs/metadata_view.c:117
 msgid "ISO"
 msgstr "ISO"
 
 #. exposure
-#: ../src/gui/preferences.c:511 ../src/gui/preferences.c:1402
-#: ../src/gui/presets.c:464 ../src/iop/basicadj.c:684 ../src/iop/exposure.c:107
-#: ../src/iop/exposure.c:879 ../src/iop/relight.c:363 ../src/libs/collect.h:37
-#: ../src/libs/metadata_view.c:110
+#: ../src/gui/preferences.c:513 ../src/gui/preferences.c:1456
+#: ../src/gui/presets.c:464 ../src/iop/basicadj.c:680 ../src/iop/exposure.c:107
+#: ../src/iop/exposure.c:886 ../src/iop/relight.c:361 ../src/libs/collect.h:37
+#: ../src/libs/metadata_view.c:114
 msgid "exposure"
 msgstr "exposición"
 
 #. aperture
-#: ../src/gui/preferences.c:515 ../src/gui/preferences.c:1417
+#: ../src/gui/preferences.c:517 ../src/gui/preferences.c:1471
 #: ../src/gui/presets.c:479 ../src/libs/camera.c:575 ../src/libs/camera.c:577
-#: ../src/libs/collect.h:37 ../src/libs/metadata_view.c:109
+#: ../src/libs/collect.h:37 ../src/libs/metadata_view.c:113
 msgid "aperture"
 msgstr "apertura"
 
 #. focal length
-#: ../src/gui/preferences.c:519 ../src/gui/preferences.c:1432
-#: ../src/gui/presets.c:494 ../src/iop/ashift.c:4868 ../src/libs/camera.c:580
-#: ../src/libs/collect.h:36 ../src/libs/metadata_view.c:111
+#: ../src/gui/preferences.c:521 ../src/gui/preferences.c:1486
+#: ../src/gui/presets.c:494 ../src/iop/ashift.c:4873 ../src/libs/camera.c:580
+#: ../src/libs/collect.h:36 ../src/libs/metadata_view.c:115
 msgid "focal length"
 msgstr "longitud focal"
 
-#: ../src/gui/preferences.c:524 ../src/iop/basicadj.c:740
-#: ../src/iop/borders.c:1021 ../src/iop/levels.c:704
+#: ../src/gui/preferences.c:526 ../src/iop/basicadj.c:741
+#: ../src/iop/borders.c:1022 ../src/iop/levels.c:705
+#: ../src/iop/rgblevels.c:1089
 msgid "auto"
 msgstr "auto"
 
 #. Adding the import/export buttons
-#: ../src/gui/preferences.c:533 ../src/gui/preferences.c:626
+#: ../src/gui/preferences.c:535 ../src/gui/preferences.c:628
 msgctxt "preferences"
 msgid "import"
 msgstr "importar"
 
 #. Adding the outer container
-#: ../src/gui/preferences.c:573
+#: ../src/gui/preferences.c:575
 msgid "shortcuts"
 msgstr "Atajos de teclado"
 
-#: ../src/gui/preferences.c:584
+#: ../src/gui/preferences.c:586
 msgid "shortcut"
 msgstr "atajo de teclado"
 
-#: ../src/gui/preferences.c:588
+#: ../src/gui/preferences.c:590
 msgid "binding"
 msgstr "combinación"
 
 #. Export button
 #. export button
-#: ../src/gui/preferences.c:631 ../src/libs/export.c:696
+#: ../src/gui/preferences.c:633 ../src/libs/export.c:714
 #: ../src/libs/styles.c:472
 msgid "export"
 msgstr "exportar"
 
 #. Setting the notification text
-#: ../src/gui/preferences.c:907
+#: ../src/gui/preferences.c:910
 msgid "press key combination to remap..."
 msgstr "pulse combinación de teclas..."
 
-#: ../src/gui/preferences.c:1052 ../src/gui/presets.c:182 ../src/libs/lib.c:340
+#: ../src/gui/preferences.c:1011
+#, c-format
+msgid ""
+"%s accel is already mapped to\n"
+"%s.\n"
+"do you want to replace it ?"
+msgstr ""
+"El atajo `%s' ya está asignado a\n"
+"%s.\n"
+"¿Quiere reemplazarlo?"
+
+#: ../src/gui/preferences.c:1017
+msgid "accel conflict"
+msgstr "Atajo en conflicto"
+
+#: ../src/gui/preferences.c:1106 ../src/gui/presets.c:182 ../src/libs/lib.c:340
 #, c-format
 msgid "do you really want to delete the preset `%s'?"
-msgstr "¿desea borrar el ajuste predefinido `%s'?"
+msgstr "¿Desea borrar el ajuste predefinido `%s'?"
 
-#: ../src/gui/preferences.c:1056 ../src/gui/presets.c:186 ../src/libs/lib.c:344
+#: ../src/gui/preferences.c:1110 ../src/gui/presets.c:186 ../src/libs/lib.c:344
 msgid "delete preset?"
-msgstr "¿borrar este ajuste predefinido?"
+msgstr "¿Borrar este ajuste predefinido?"
 
 #. Non-zero value indicates export
-#: ../src/gui/preferences.c:1092
+#: ../src/gui/preferences.c:1146
 msgid "select file to export"
-msgstr "seleccione el archivo a exportar"
+msgstr "Seleccione el archivo a exportar"
 
 #. Zero value indicates import
-#: ../src/gui/preferences.c:1118
+#: ../src/gui/preferences.c:1172
 msgid "select file to import"
-msgstr "seleccionar el archivo a importar"
+msgstr "Seleccionar el archivo a importar"
 
-#: ../src/gui/preferences.c:1119 ../src/gui/preferences.c:1203
+#: ../src/gui/preferences.c:1173 ../src/gui/preferences.c:1257
 #: ../src/libs/collect.c:243 ../src/libs/copy_history.c:79
-#: ../src/libs/geotagging.c:473 ../src/libs/import.c:759
-#: ../src/libs/import.c:866 ../src/libs/styles.c:324
+#: ../src/libs/geotagging.c:474 ../src/libs/import.c:760
+#: ../src/libs/import.c:867 ../src/libs/styles.c:324
 msgid "_open"
 msgstr "_abrir"
 
-#: ../src/gui/preferences.c:1162
+#: ../src/gui/preferences.c:1216
 msgid ""
 "are you sure you want to restore the default keybindings?  this will erase "
 "any modifications you have made."
 msgstr ""
-"está seguro que desea restaurar los atajos de teclado por defecto? Esto "
-"borrará cualquier modificación que haya hecho."
+"¿Está seguro de que desea restablecer los atajos de teclado predeterminados?"
+"Borrará cualquier modificación previamente hecha."
 
 #. Zero value indicates import
-#: ../src/gui/preferences.c:1202
+#: ../src/gui/preferences.c:1256
 msgid "select preset to import"
-msgstr "seleccionar el prepreajuste al importar"
+msgstr "Seleccionar el preajuste al importar"
 
-#: ../src/gui/preferences.c:1221
+#: ../src/gui/preferences.c:1275
 msgid "failed to import preset"
-msgstr "falló ajuste preestablecido al importar"
+msgstr "No se pudo importar el preajuste"
 
-#: ../src/gui/preferences.c:1321 ../src/gui/presets.c:385
+#: ../src/gui/preferences.c:1375 ../src/gui/presets.c:385
 #, c-format
 msgid "edit `%s' for module `%s'"
-msgstr "editar `%s' para el módulo `%s'"
+msgstr "Editar `%s' para el módulo `%s'"
 
-#: ../src/gui/preferences.c:1344 ../src/gui/presets.c:408 ../src/libs/lib.c:252
+#: ../src/gui/preferences.c:1398 ../src/gui/presets.c:408 ../src/libs/lib.c:252
 msgid "description or further information"
-msgstr "descripción o información adicional"
+msgstr "Descripción o información adicional"
 
-#: ../src/gui/preferences.c:1347 ../src/gui/presets.c:411
+#: ../src/gui/preferences.c:1401 ../src/gui/presets.c:411
 msgid "auto apply this preset to matching images"
-msgstr "establecer automáticamente este preajuste en imágenes coincidentes"
+msgstr "Establecer automáticamente este preajuste en imágenes coincidentes"
 
-#: ../src/gui/preferences.c:1350 ../src/gui/presets.c:414
+#: ../src/gui/preferences.c:1404 ../src/gui/presets.c:414
 msgid "only show this preset for matching images"
-msgstr "mostrar sólo este preajuste para imágenes coincidentes"
+msgstr "Mostrar este preajuste sólo para imágenes coincidentes"
 
-#: ../src/gui/preferences.c:1352 ../src/gui/presets.c:415
+#: ../src/gui/preferences.c:1406 ../src/gui/presets.c:415
 msgid ""
 "be very careful with this option. this might be the last time you see your "
 "preset."
 msgstr ""
-"cuidado con esta opción. puediera ser la última vez que vea su preajuste."
+"Especial cuidado con esta opción. Puediera ser la última vez que vea el "
+"preajuste."
 
-#: ../src/gui/preferences.c:1366 ../src/gui/presets.c:430
+#: ../src/gui/preferences.c:1420 ../src/gui/presets.c:430
 #, no-c-format
 msgid "string to match model (use % as wildcard)"
 msgstr "cadena para coincidencia con modelo (use % como comodín)"
 
-#: ../src/gui/preferences.c:1374 ../src/gui/presets.c:437
+#: ../src/gui/preferences.c:1428 ../src/gui/presets.c:437
 #, no-c-format
 msgid "string to match maker (use % as wildcard)"
 msgstr "cadena para coincidencia con fabricante (use % como comodín)"
 
-#: ../src/gui/preferences.c:1382 ../src/gui/presets.c:444
+#: ../src/gui/preferences.c:1436 ../src/gui/presets.c:444
 #, no-c-format
 msgid "string to match lens (use % as wildcard)"
 msgstr "cadena para coincidencia de lente (use % as wildcard)"
 
-#: ../src/gui/preferences.c:1392 ../src/gui/presets.c:454
+#: ../src/gui/preferences.c:1446 ../src/gui/presets.c:454
 msgid "minimum ISO value"
 msgstr "valor Exif mínimo"
 
-#: ../src/gui/preferences.c:1395 ../src/gui/presets.c:457
+#: ../src/gui/preferences.c:1449 ../src/gui/presets.c:457
 msgid "maximum ISO value"
 msgstr "valor ISO máximo"
 
-#: ../src/gui/preferences.c:1406 ../src/gui/presets.c:468
+#: ../src/gui/preferences.c:1460 ../src/gui/presets.c:468
 msgid "minimum exposure time"
 msgstr "tiempo mínimo de exposición"
 
-#: ../src/gui/preferences.c:1407 ../src/gui/presets.c:469
+#: ../src/gui/preferences.c:1461 ../src/gui/presets.c:469
 msgid "maximum exposure time"
 msgstr "tiempo máximo de exposición"
 
-#: ../src/gui/preferences.c:1421 ../src/gui/presets.c:483
+#: ../src/gui/preferences.c:1475 ../src/gui/presets.c:483
 msgid "minimum aperture value"
 msgstr "valor de apertura mínimo"
 
-#: ../src/gui/preferences.c:1422 ../src/gui/presets.c:484
+#: ../src/gui/preferences.c:1476 ../src/gui/presets.c:484
 msgid "maximum aperture value"
 msgstr "valor de apertura máximo"
 
-#: ../src/gui/preferences.c:1437 ../src/gui/presets.c:500
+#: ../src/gui/preferences.c:1491 ../src/gui/presets.c:500
 msgid "minimum focal length"
 msgstr "mínima longitud focal"
 
-#: ../src/gui/preferences.c:1438 ../src/gui/presets.c:501
+#: ../src/gui/preferences.c:1492 ../src/gui/presets.c:501
 msgid "maximum focal length"
 msgstr "máxima longitud focal"
 
 #. raw/hdr/ldr
-#: ../src/gui/preferences.c:1447 ../src/gui/presets.c:507
+#: ../src/gui/preferences.c:1501 ../src/gui/presets.c:507
 #: ../src/imageio/format/j2k.c:644
 msgid "format"
 msgstr "formato"
 
-#: ../src/gui/preferences.c:1554 ../src/imageio/storage/disk.c:122
-#: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/latex.c:107
+#: ../src/gui/preferences.c:1608 ../src/imageio/storage/disk.c:122
+#: ../src/imageio/storage/gallery.c:109 ../src/imageio/storage/latex.c:108
 msgid "_select as output destination"
 msgstr "_seleccionar como destino de salida"
 
-#: ../src/gui/preferences.c:1565
+#: ../src/gui/preferences.c:1619
 #, c-format
 msgid "preset %s was successfully saved"
 msgstr "el ajuste preestablecido %s fue  guardado correctamente"
@@ -4155,31 +4398,31 @@ msgstr "¿sobreescribir el preajuste?"
 msgid "name of the preset"
 msgstr "nombre del preajuste"
 
-#: ../src/gui/presets.c:880 ../src/gui/presets.c:893
+#: ../src/gui/presets.c:878 ../src/gui/presets.c:891
 msgid "(default)"
 msgstr "(por defecto)"
 
-#: ../src/gui/presets.c:904
+#: ../src/gui/presets.c:902
 msgid "disabled: wrong module version"
 msgstr "desactivar: versión errónea del módulo"
 
-#: ../src/gui/presets.c:928 ../src/libs/lib.c:489
+#: ../src/gui/presets.c:926 ../src/libs/lib.c:489
 msgid "edit this preset.."
 msgstr "editar este preajuste.."
 
-#: ../src/gui/presets.c:932 ../src/libs/lib.c:493
+#: ../src/gui/presets.c:930 ../src/libs/lib.c:493
 msgid "delete this preset"
 msgstr "borrar este preajuste"
 
-#: ../src/gui/presets.c:938 ../src/libs/lib.c:500
+#: ../src/gui/presets.c:936 ../src/libs/lib.c:500
 msgid "store new preset.."
 msgstr "almacenar nuevo preajuste.."
 
-#: ../src/gui/presets.c:944 ../src/libs/lib.c:512
+#: ../src/gui/presets.c:942 ../src/libs/lib.c:512
 msgid "update preset"
 msgstr "actualizar preajuste"
 
-#: ../src/gui/presets.c:957
+#: ../src/gui/presets.c:955
 msgid "favourite"
 msgstr "favoritos"
 
@@ -4205,26 +4448,32 @@ msgstr "crea un duplicado del estilo antes de efectuar los cambios"
 msgid "create new style"
 msgstr "crear un estilo nuevo"
 
-#: ../src/gui/styles_dialog.c:309
+#: ../src/gui/styles_dialog.c:310
 msgid "enter a name for the new style"
 msgstr "introduzca un nombre para el nuevo estilo"
 
-#: ../src/gui/styles_dialog.c:313
+#. DT_COLLECTION_SORT_TITLE
+#: ../src/gui/styles_dialog.c:313 ../src/libs/collect.h:35
+#: ../src/libs/metadata.c:348 ../src/libs/tools/filter.c:156
+msgid "description"
+msgstr "descripción"
+
+#: ../src/gui/styles_dialog.c:315
 msgid "enter a description for the new style, this description is searchable"
 msgstr ""
 "introduzca una descripción para el nuevo estilo. es posible buscar esta "
 "descripción"
 
-#: ../src/gui/styles_dialog.c:368
+#: ../src/gui/styles_dialog.c:370
 msgid "update"
 msgstr "actualizar"
 
-#: ../src/gui/styles_dialog.c:463
+#: ../src/gui/styles_dialog.c:465
 msgid "can't create style out of unaltered image"
 msgstr "no se puede crear el estilo de una imagen sin alterar"
 
-#: ../src/imageio/format/copy.c:124 ../src/libs/copy_history.c:383
-#: ../src/libs/image.c:202
+#: ../src/imageio/format/copy.c:124 ../src/libs/copy_history.c:308
+#: ../src/libs/image.c:204
 msgid "copy"
 msgstr "copiar"
 
@@ -4308,35 +4557,35 @@ msgstr "Cinema4K, 24FPS"
 msgid "JPEG (8-bit)"
 msgstr "JPEG (8-bit)"
 
-#: ../src/imageio/format/pdf.c:77 ../src/imageio/format/png.c:527
+#: ../src/imageio/format/pdf.c:79 ../src/imageio/format/png.c:527
 #: ../src/imageio/format/tiff.c:467
 msgid "8 bit"
 msgstr "8 bit"
 
-#: ../src/imageio/format/pdf.c:78 ../src/imageio/format/png.c:528
+#: ../src/imageio/format/pdf.c:80 ../src/imageio/format/png.c:528
 #: ../src/imageio/format/tiff.c:468
 msgid "16 bit"
 msgstr "16 bit"
 
-#: ../src/imageio/format/pdf.c:200 ../src/imageio/format/pdf.c:486
+#: ../src/imageio/format/pdf.c:202 ../src/imageio/format/pdf.c:488
 msgid "invalid paper size"
 msgstr "formato de papel inválido"
 
-#: ../src/imageio/format/pdf.c:207
+#: ../src/imageio/format/pdf.c:209
 msgid "invalid border size, using 0"
 msgstr "tamaño de borde inválido, usando 0"
 
-#: ../src/imageio/format/pdf.c:256 ../src/imageio/storage/disk.c:330
-#: ../src/imageio/storage/email.c:135 ../src/imageio/storage/facebook.c:1307
-#: ../src/imageio/storage/flickr.c:655 ../src/imageio/storage/gallery.c:345
-#: ../src/imageio/storage/gallery.c:386
-#: ../src/imageio/storage/googlephoto.c:1376
-#: ../src/imageio/storage/piwigo.c:974
+#: ../src/imageio/format/pdf.c:258 ../src/imageio/storage/disk.c:332
+#: ../src/imageio/storage/email.c:136 ../src/imageio/storage/facebook.c:1311
+#: ../src/imageio/storage/flickr.c:650 ../src/imageio/storage/gallery.c:349
+#: ../src/imageio/storage/gallery.c:390
+#: ../src/imageio/storage/googlephoto.c:1380
+#: ../src/imageio/storage/piwigo.c:969
 #, c-format
 msgid "could not export to file `%s'!"
 msgstr "no se puede exportar el archivo %s"
 
-#: ../src/imageio/format/pdf.c:410
+#: ../src/imageio/format/pdf.c:412
 msgid "PDF"
 msgstr "PDF"
 
@@ -4345,25 +4594,25 @@ msgstr "PDF"
 #. clang-format off
 #. xmp
 #. DT_COLLECTION_SORT_CUSTOM_ORDER
-#: ../src/imageio/format/pdf.c:581 ../src/imageio/storage/facebook.c:1119
-#: ../src/imageio/storage/flickr.c:539 ../src/imageio/storage/gallery.c:184
-#: ../src/imageio/storage/googlephoto.c:1232 ../src/imageio/storage/latex.c:184
-#: ../src/imageio/storage/piwigo.c:864 ../src/libs/collect.h:34
-#: ../src/libs/metadata.c:347 ../src/libs/metadata_view.c:122
+#: ../src/imageio/format/pdf.c:583 ../src/imageio/storage/facebook.c:1120
+#: ../src/imageio/storage/flickr.c:530 ../src/imageio/storage/gallery.c:185
+#: ../src/imageio/storage/googlephoto.c:1233 ../src/imageio/storage/latex.c:185
+#: ../src/imageio/storage/piwigo.c:857 ../src/libs/collect.h:34
+#: ../src/libs/metadata.c:347 ../src/libs/metadata_view.c:126
 #: ../src/libs/tools/filter.c:155
 msgid "title"
 msgstr "título"
 
-#: ../src/imageio/format/pdf.c:591
+#: ../src/imageio/format/pdf.c:593
 msgid "enter the title of the pdf"
 msgstr "introduzca el título del pdf"
 
 #. // papers
-#: ../src/imageio/format/pdf.c:604 ../src/libs/print_settings.c:1273
+#: ../src/imageio/format/pdf.c:606 ../src/libs/print_settings.c:1271
 msgid "paper size"
 msgstr "formato de papel"
 
-#: ../src/imageio/format/pdf.c:609
+#: ../src/imageio/format/pdf.c:611
 msgid ""
 "paper size of the pdf\n"
 "either one from the list or \"<width> [unit] x <height> <unit>\n"
@@ -4373,30 +4622,30 @@ msgstr ""
 "bien sea uno de la lista o \"<width> [unit] x <height> <unit>\n"
 "ejemplo: 210 mm x 2.97 cm"
 
-#: ../src/imageio/format/pdf.c:619
+#: ../src/imageio/format/pdf.c:621
 msgid "page orientation"
 msgstr "orientación de la página"
 
-#: ../src/imageio/format/pdf.c:620 ../src/iop/borders.c:1022
-#: ../src/libs/print_settings.c:1282
+#: ../src/imageio/format/pdf.c:622 ../src/iop/borders.c:1023
+#: ../src/libs/print_settings.c:1280
 msgid "portrait"
 msgstr "retrato"
 
-#: ../src/imageio/format/pdf.c:621 ../src/iop/borders.c:1023
-#: ../src/libs/print_settings.c:1283
+#: ../src/imageio/format/pdf.c:623 ../src/iop/borders.c:1024
+#: ../src/libs/print_settings.c:1281
 msgid "landscape"
 msgstr "horizontal"
 
-#: ../src/imageio/format/pdf.c:624
+#: ../src/imageio/format/pdf.c:626
 msgid "paper orientation of the pdf"
 msgstr "orientación de la página del pdf"
 
 #. border
-#: ../src/imageio/format/pdf.c:629
+#: ../src/imageio/format/pdf.c:631
 msgid "border"
 msgstr "borde"
 
-#: ../src/imageio/format/pdf.c:639
+#: ../src/imageio/format/pdf.c:641
 msgid ""
 "empty space around the pdf\n"
 "format: size + unit\n"
@@ -4407,19 +4656,19 @@ msgstr ""
 "ejemplos: 10 mm, 1 in"
 
 #. dpi
-#: ../src/imageio/format/pdf.c:651
+#: ../src/imageio/format/pdf.c:653
 msgid "dpi"
 msgstr "ppp"
 
-#: ../src/imageio/format/pdf.c:659
+#: ../src/imageio/format/pdf.c:661
 msgid "dpi of the images inside the pdf"
 msgstr "ppp de las imágenes dentro del pdf"
 
-#: ../src/imageio/format/pdf.c:666
+#: ../src/imageio/format/pdf.c:668
 msgid "rotate images"
 msgstr "rotar imágenes"
 
-#: ../src/imageio/format/pdf.c:671
+#: ../src/imageio/format/pdf.c:673
 msgid ""
 "images can be rotated to match the pdf orientation to waste less space when "
 "printing"
@@ -4427,55 +4676,55 @@ msgstr ""
 "las imágenes pueden ser rotadas para igualar la orientación del pdf y así, "
 "desperdiciar menos espacio al imprimir"
 
-#: ../src/imageio/format/pdf.c:678
+#: ../src/imageio/format/pdf.c:680
 msgid "TODO: pages"
 msgstr "PENDIENTE: páginas"
 
-#: ../src/imageio/format/pdf.c:680
+#: ../src/imageio/format/pdf.c:682
 msgid "single images"
 msgstr "imágenes"
 
-#: ../src/imageio/format/pdf.c:681
+#: ../src/imageio/format/pdf.c:683
 msgid "contact sheet"
 msgstr "hoja de contactos"
 
 #. gtk_grid_attach(grid, GTK_WIDGET(d->pages), 0, ++line, 2, 1);
 #. g_signal_connect(G_OBJECT(d->pages), "value-changed", G_CALLBACK(pages_toggle_callback), self);
-#: ../src/imageio/format/pdf.c:684
+#: ../src/imageio/format/pdf.c:686
 msgid "what pages should be added to the pdf"
 msgstr "las páginas que deberían ser agregadas al pdf"
 
-#: ../src/imageio/format/pdf.c:691
+#: ../src/imageio/format/pdf.c:693
 msgid "embed icc profiles"
 msgstr "incrustar perfiles icc"
 
-#: ../src/imageio/format/pdf.c:696
+#: ../src/imageio/format/pdf.c:698
 msgid "images can be tagged with their icc profile"
 msgstr "las imágenes pueden ser etiquetadas con su perfil icc"
 
-#: ../src/imageio/format/pdf.c:702 ../src/imageio/format/png.c:526
+#: ../src/imageio/format/pdf.c:704 ../src/imageio/format/png.c:526
 #: ../src/imageio/format/tiff.c:466
 msgid "bit depth"
 msgstr "profundidad de bit"
 
-#: ../src/imageio/format/pdf.c:712
+#: ../src/imageio/format/pdf.c:714
 msgid "bits per channel of the embedded images"
 msgstr "bits por canal de las imágenes incrustadas"
 
-#: ../src/imageio/format/pdf.c:718 ../src/imageio/format/png.c:540
-#: ../src/imageio/format/tiff.c:481 ../src/iop/graduatednd.c:1223
+#: ../src/imageio/format/pdf.c:720 ../src/imageio/format/png.c:540
+#: ../src/imageio/format/tiff.c:481 ../src/iop/graduatednd.c:1224
 msgid "compression"
 msgstr "con compresión"
 
-#: ../src/imageio/format/pdf.c:719 ../src/imageio/format/tiff.c:482
+#: ../src/imageio/format/pdf.c:721 ../src/imageio/format/tiff.c:482
 msgid "uncompressed"
 msgstr "sin comprimir"
 
-#: ../src/imageio/format/pdf.c:720 ../src/imageio/format/tiff.c:483
+#: ../src/imageio/format/pdf.c:722 ../src/imageio/format/tiff.c:483
 msgid "deflate"
 msgstr "deflación"
 
-#: ../src/imageio/format/pdf.c:723
+#: ../src/imageio/format/pdf.c:725
 msgid ""
 "method used for image compression\n"
 "uncompressed -- fast but big files\n"
@@ -4485,23 +4734,23 @@ msgstr ""
 "sin compresión -- rápido con archivos grandes \n"
 "deflación -- más lento con archivos pequeños"
 
-#: ../src/imageio/format/pdf.c:731
+#: ../src/imageio/format/pdf.c:733
 msgid "image mode"
 msgstr "modo de imagen"
 
-#: ../src/imageio/format/pdf.c:732
+#: ../src/imageio/format/pdf.c:734
 msgid "normal"
 msgstr "normal"
 
-#: ../src/imageio/format/pdf.c:733
+#: ../src/imageio/format/pdf.c:735
 msgid "draft"
 msgstr "borrador"
 
-#: ../src/imageio/format/pdf.c:734
+#: ../src/imageio/format/pdf.c:736
 msgid "debug"
 msgstr "depurar"
 
-#: ../src/imageio/format/pdf.c:737
+#: ../src/imageio/format/pdf.c:739
 msgid ""
 "normal -- just put the images into the pdf\n"
 "draft -- images are replaced with boxes\n"
@@ -4543,31 +4792,31 @@ msgstr "deflación con predicción (flotante)"
 msgid "compression level"
 msgstr "nivel de compresión"
 
-#: ../src/imageio/format/webp.c:286
+#: ../src/imageio/format/webp.c:289
 msgid "WebP (8-bit)"
 msgstr "WebP (8-bit)"
 
-#: ../src/imageio/format/webp.c:318
+#: ../src/imageio/format/webp.c:321
 msgid "compression type"
 msgstr "tipo de compresión"
 
-#: ../src/imageio/format/webp.c:319
+#: ../src/imageio/format/webp.c:322
 msgid "lossy"
 msgstr "con pérdida"
 
-#: ../src/imageio/format/webp.c:320
+#: ../src/imageio/format/webp.c:323
 msgid "lossless"
 msgstr "sin pérdidas"
 
-#: ../src/imageio/format/webp.c:329
+#: ../src/imageio/format/webp.c:332
 msgid "applies only to lossy setting"
 msgstr "aplica solo a ajustes con pérdida"
 
-#: ../src/imageio/format/webp.c:336
+#: ../src/imageio/format/webp.c:339
 msgid "image hint"
 msgstr "indicio de imagen"
 
-#: ../src/imageio/format/webp.c:338
+#: ../src/imageio/format/webp.c:341
 msgid ""
 "image characteristics hint for the underlying encoder.\n"
 "picture : digital picture, like portrait, inner shot\n"
@@ -4579,28 +4828,28 @@ msgstr ""
 "foto      : fotografía de exteriores, con iluminación natural\n"
 "gráfico : tono discreto de la imagen (gráfico, patron, etc)"
 
-#: ../src/imageio/format/webp.c:342
+#: ../src/imageio/format/webp.c:345
 msgid "default"
 msgstr "por defecto"
 
-#: ../src/imageio/format/webp.c:343
+#: ../src/imageio/format/webp.c:346
 msgid "picture"
 msgstr "imagen"
 
-#: ../src/imageio/format/webp.c:344
+#: ../src/imageio/format/webp.c:347
 msgid "photo"
 msgstr "foto"
 
-#: ../src/imageio/format/webp.c:345
+#: ../src/imageio/format/webp.c:348
 msgid "graphic"
 msgstr "gráfico"
 
-#: ../src/imageio/storage/disk.c:70
+#: ../src/imageio/storage/disk.c:70 ../src/libs/export.c:535
 msgid "file on disk"
 msgstr "archivo en disco"
 
-#: ../src/imageio/storage/disk.c:183 ../src/imageio/storage/gallery.c:170
-#: ../src/imageio/storage/latex.c:169
+#: ../src/imageio/storage/disk.c:183 ../src/imageio/storage/gallery.c:171
+#: ../src/imageio/storage/latex.c:170
 msgid ""
 "enter the path where to put exported images\n"
 "variables support bash like string manipulation\n"
@@ -4618,7 +4867,7 @@ msgstr "en conflicto"
 msgid "create unique filename"
 msgstr "crear nombre único"
 
-#: ../src/imageio/storage/disk.c:201 ../src/libs/copy_history.c:427
+#: ../src/imageio/storage/disk.c:201 ../src/libs/copy_history.c:352
 msgid "overwrite"
 msgstr "sobreescribir"
 
@@ -4626,33 +4875,33 @@ msgstr "sobreescribir"
 msgid "skip"
 msgstr "omitir"
 
-#: ../src/imageio/storage/disk.c:279 ../src/imageio/storage/gallery.c:273
-#: ../src/imageio/storage/latex.c:272
+#: ../src/imageio/storage/disk.c:281 ../src/imageio/storage/gallery.c:274
+#: ../src/imageio/storage/latex.c:273
 #, c-format
 msgid "could not create directory `%s'!"
 msgstr "No se puede crear el directorio '%s'"
 
-#: ../src/imageio/storage/disk.c:286
+#: ../src/imageio/storage/disk.c:288
 #, c-format
 msgid "could not write to directory `%s'!"
 msgstr "No se puede escribir en el directorio '%s'"
 
-#: ../src/imageio/storage/disk.c:316
+#: ../src/imageio/storage/disk.c:318
 #, c-format
 msgid "%d/%d skipping `%s'"
 msgid_plural "%d/%d skipping `%s'"
 msgstr[0] "%d/%d omitiendo `%s'"
 msgstr[1] "%d/%d omitiendo `%s'"
 
-#: ../src/imageio/storage/disk.c:335 ../src/imageio/storage/email.c:142
-#: ../src/imageio/storage/gallery.c:394 ../src/imageio/storage/latex.c:361
+#: ../src/imageio/storage/disk.c:337 ../src/imageio/storage/email.c:143
+#: ../src/imageio/storage/gallery.c:398 ../src/imageio/storage/latex.c:362
 #, c-format
 msgid "%d/%d exported to `%s'"
 msgid_plural "%d/%d exported to `%s'"
 msgstr[0] "%d/%d exportado a `%s'"
 msgstr[1] "%d/%d exportados a `%s'"
 
-#: ../src/imageio/storage/disk.c:394
+#: ../src/imageio/storage/disk.c:396
 msgid ""
 "you are going to export on overwrite mode, this will overwrite any existing "
 "images\n"
@@ -4664,25 +4913,25 @@ msgstr ""
 "\n"
 "¿Realmente desea continuar?"
 
-#: ../src/imageio/storage/email.c:51
+#: ../src/imageio/storage/email.c:52
 msgid "send as email"
 msgstr "enviar como correo electrónico"
 
-#: ../src/imageio/storage/email.c:196
+#: ../src/imageio/storage/email.c:197
 msgid "images exported from darktable"
 msgstr "imágenes exportadas desde dartable"
 
-#: ../src/imageio/storage/email.c:249
+#: ../src/imageio/storage/email.c:250
 msgid "could not launch email client!"
 msgstr "no se pudo abrir el cliente de correo!"
 
-#: ../src/imageio/storage/facebook.c:255
+#: ../src/imageio/storage/facebook.c:256
 #, c-format
 msgid "[facebook] unexpected URL format\n"
 msgstr "[facebook] formato de url inesperado\n"
 
 #. //////////// build & show the validation dialog
-#: ../src/imageio/storage/facebook.c:620
+#: ../src/imageio/storage/facebook.c:621
 msgid ""
 "step 1: a new window or tab of your browser should have been loaded. you "
 "have to login into your facebook account there and authorize darktable to "
@@ -4692,38 +4941,38 @@ msgstr ""
 "entrar en su cuenta de facebook y autorizar a darktable a subir las fotos "
 "antes de continuar."
 
-#: ../src/imageio/storage/facebook.c:623
+#: ../src/imageio/storage/facebook.c:624
 msgid ""
 "step 2: paste your browser URL and click the OK button once you are done."
 msgstr ""
 "paso 2: pegue su url en el navegador y haga clic en el botón ok una vez "
 "listo."
 
-#: ../src/imageio/storage/facebook.c:629 ../src/imageio/storage/facebook.c:724
+#: ../src/imageio/storage/facebook.c:630 ../src/imageio/storage/facebook.c:725
 msgid "facebook authentication"
 msgstr "autenticación Facebook"
 
-#: ../src/imageio/storage/facebook.c:637
+#: ../src/imageio/storage/facebook.c:638
 msgid "URL:"
 msgstr "URL:"
 
-#: ../src/imageio/storage/facebook.c:659
+#: ../src/imageio/storage/facebook.c:660
 msgid "please enter the validation URL"
 msgstr "por favor, ingrese la url de validación"
 
-#: ../src/imageio/storage/facebook.c:669
+#: ../src/imageio/storage/facebook.c:670
 msgid "the given URL is not valid, it should look like: "
 msgstr "la url dada no es válida, debería ser similar a: "
 
-#: ../src/imageio/storage/facebook.c:700
+#: ../src/imageio/storage/facebook.c:701
 msgid "authentication successful"
 msgstr "autenticación exitosa"
 
-#: ../src/imageio/storage/facebook.c:704
+#: ../src/imageio/storage/facebook.c:705
 msgid "authentication failed"
 msgstr "fallo de autenticación"
 
-#: ../src/imageio/storage/facebook.c:717
+#: ../src/imageio/storage/facebook.c:718
 msgid ""
 "a new window or tab of your browser should have been loaded. you have to "
 "login into your facebook account there and authorize darktable to upload "
@@ -4733,92 +4982,92 @@ msgstr ""
 "cuenta de facebook y allí, autorizar a darktable a subir las fotos antes de "
 "continuar."
 
-#: ../src/imageio/storage/facebook.c:850
-#: ../src/imageio/storage/googlephoto.c:941
+#: ../src/imageio/storage/facebook.c:851
+#: ../src/imageio/storage/googlephoto.c:942
 msgid "new account"
 msgstr "nueva cuenta"
 
-#: ../src/imageio/storage/facebook.c:855
-#: ../src/imageio/storage/googlephoto.c:946
+#: ../src/imageio/storage/facebook.c:856
+#: ../src/imageio/storage/googlephoto.c:947
 msgid "other account"
 msgstr "otras cuentas"
 
-#: ../src/imageio/storage/facebook.c:884
-#: ../src/imageio/storage/googlephoto.c:974
+#: ../src/imageio/storage/facebook.c:885
+#: ../src/imageio/storage/googlephoto.c:975
 msgid "unable to retrieve the album list"
 msgstr "no se pudo obtener la lista de albums"
 
-#: ../src/imageio/storage/facebook.c:892 ../src/imageio/storage/flickr.c:393
-#: ../src/imageio/storage/flickr.c:420 ../src/imageio/storage/googlephoto.c:984
-#: ../src/imageio/storage/piwigo.c:523 ../src/imageio/storage/piwigo.c:587
+#: ../src/imageio/storage/facebook.c:893 ../src/imageio/storage/flickr.c:393
+#: ../src/imageio/storage/flickr.c:420 ../src/imageio/storage/googlephoto.c:985
+#: ../src/imageio/storage/piwigo.c:524 ../src/imageio/storage/piwigo.c:588
 msgid "create new album"
 msgstr "crear album nuevo"
 
-#: ../src/imageio/storage/facebook.c:964
-#: ../src/imageio/storage/googlephoto.c:1037
-#: ../src/imageio/storage/googlephoto.c:1187
+#: ../src/imageio/storage/facebook.c:965
+#: ../src/imageio/storage/googlephoto.c:1038
+#: ../src/imageio/storage/googlephoto.c:1188
 msgid "logout"
 msgstr "desconectarse"
 
 #. Set default permission to private
 #. login button
-#: ../src/imageio/storage/facebook.c:970 ../src/imageio/storage/facebook.c:990
-#: ../src/imageio/storage/facebook.c:1037
-#: ../src/imageio/storage/facebook.c:1063
-#: ../src/imageio/storage/facebook.c:1182 ../src/imageio/storage/flickr.c:481
-#: ../src/imageio/storage/googlephoto.c:1043
-#: ../src/imageio/storage/googlephoto.c:1191
-#: ../src/imageio/storage/googlephoto.c:1204
-#: ../src/imageio/storage/googlephoto.c:1271
-#: ../src/imageio/storage/piwigo.c:809
+#: ../src/imageio/storage/facebook.c:971 ../src/imageio/storage/facebook.c:991
+#: ../src/imageio/storage/facebook.c:1038
+#: ../src/imageio/storage/facebook.c:1064
+#: ../src/imageio/storage/facebook.c:1183 ../src/imageio/storage/flickr.c:481
+#: ../src/imageio/storage/googlephoto.c:1044
+#: ../src/imageio/storage/googlephoto.c:1192
+#: ../src/imageio/storage/googlephoto.c:1205
+#: ../src/imageio/storage/googlephoto.c:1272
+#: ../src/imageio/storage/piwigo.c:810
 msgid "login"
 msgstr "acceder"
 
-#: ../src/imageio/storage/facebook.c:1098
+#: ../src/imageio/storage/facebook.c:1099
 msgid "facebook webalbum"
 msgstr "álbum en facebook"
 
-#: ../src/imageio/storage/facebook.c:1120 ../src/imageio/storage/flickr.c:554
+#: ../src/imageio/storage/facebook.c:1121 ../src/imageio/storage/flickr.c:545
 msgid "summary"
 msgstr "sumario"
 
-#: ../src/imageio/storage/facebook.c:1121
+#: ../src/imageio/storage/facebook.c:1122
 msgid "privacy"
 msgstr "privacidad"
 
-#: ../src/imageio/storage/facebook.c:1167
+#: ../src/imageio/storage/facebook.c:1168
 msgid "only me"
 msgstr "solo yo"
 
-#: ../src/imageio/storage/facebook.c:1170 ../src/imageio/storage/flickr.c:507
-#: ../src/imageio/storage/piwigo.c:835
+#: ../src/imageio/storage/facebook.c:1171 ../src/imageio/storage/flickr.c:498
+#: ../src/imageio/storage/piwigo.c:828
 msgid "friends"
 msgstr "amigos"
 
-#: ../src/imageio/storage/facebook.c:1173
+#: ../src/imageio/storage/facebook.c:1174
 msgid "public"
 msgstr "público"
 
-#: ../src/imageio/storage/facebook.c:1176
+#: ../src/imageio/storage/facebook.c:1177
 msgid "friends of friends"
 msgstr "amigos de amigos"
 
-#: ../src/imageio/storage/facebook.c:1316
-#: ../src/imageio/storage/googlephoto.c:1385
+#: ../src/imageio/storage/facebook.c:1320
+#: ../src/imageio/storage/googlephoto.c:1389
 msgid "unable to create album, no title provided"
 msgstr "no se pudo crear el álbum, no se asignó un título"
 
-#: ../src/imageio/storage/facebook.c:1325
-#: ../src/imageio/storage/googlephoto.c:1392
+#: ../src/imageio/storage/facebook.c:1329
+#: ../src/imageio/storage/googlephoto.c:1396
 msgid "unable to create album"
 msgstr "no se pudo crear el álbum"
 
-#: ../src/imageio/storage/facebook.c:1335
+#: ../src/imageio/storage/facebook.c:1339
 msgid "unable to export photo to webalbum"
 msgstr "no se pudo exportar la foto al album web"
 
 #. this makes sense only if the export was successful
-#: ../src/imageio/storage/facebook.c:1347
+#: ../src/imageio/storage/facebook.c:1351
 #, c-format
 msgid "%d/%d exported to facebook webalbum"
 msgid_plural "%d/%d exported to facebook webalbum"
@@ -4853,14 +5102,14 @@ msgid "flickr webalbum"
 msgstr "álbum en flickr"
 
 #: ../src/imageio/storage/flickr.c:338 ../src/imageio/storage/flickr.c:378
-#: ../src/imageio/storage/flickr.c:832 ../src/imageio/storage/flickr.c:838
-#: ../src/imageio/storage/piwigo.c:471 ../src/imageio/storage/piwigo.c:486
-#: ../src/imageio/storage/piwigo.c:498
+#: ../src/imageio/storage/flickr.c:825 ../src/imageio/storage/flickr.c:831
+#: ../src/imageio/storage/piwigo.c:472 ../src/imageio/storage/piwigo.c:487
+#: ../src/imageio/storage/piwigo.c:499
 msgid "not authenticated"
 msgstr "no autenticado"
 
-#: ../src/imageio/storage/flickr.c:374 ../src/imageio/storage/flickr.c:828
-#: ../src/imageio/storage/piwigo.c:463
+#: ../src/imageio/storage/flickr.c:374 ../src/imageio/storage/flickr.c:821
+#: ../src/imageio/storage/piwigo.c:464
 msgid "authenticated"
 msgstr "autenticado"
 
@@ -4877,73 +5126,69 @@ msgstr "usuario"
 msgid "flickr login"
 msgstr "acceso a Flickr"
 
-#: ../src/imageio/storage/flickr.c:496 ../src/imageio/storage/piwigo.c:820
-msgid "export tags"
-msgstr "exportar etiquetas"
-
-#: ../src/imageio/storage/flickr.c:505 ../src/imageio/storage/piwigo.c:832
+#: ../src/imageio/storage/flickr.c:496 ../src/imageio/storage/piwigo.c:825
 msgid "visible to"
 msgstr "visible para"
 
-#: ../src/imageio/storage/flickr.c:506 ../src/imageio/storage/piwigo.c:837
+#: ../src/imageio/storage/flickr.c:497 ../src/imageio/storage/piwigo.c:830
 msgid "you"
 msgstr "usted"
 
-#: ../src/imageio/storage/flickr.c:508 ../src/imageio/storage/piwigo.c:836
+#: ../src/imageio/storage/flickr.c:499 ../src/imageio/storage/piwigo.c:829
 msgid "family"
 msgstr "familia"
 
-#: ../src/imageio/storage/flickr.c:509
+#: ../src/imageio/storage/flickr.c:500
 msgid "friends + family"
 msgstr "amigos + familia"
 
-#: ../src/imageio/storage/flickr.c:510 ../src/imageio/storage/piwigo.c:833
+#: ../src/imageio/storage/flickr.c:501 ../src/imageio/storage/piwigo.c:826
 msgid "everyone"
 msgstr "todos"
 
 #. Available albums
-#: ../src/imageio/storage/flickr.c:518
+#: ../src/imageio/storage/flickr.c:509
 msgid "photosets"
 msgstr "álbumes"
 
-#: ../src/imageio/storage/flickr.c:524 ../src/imageio/storage/piwigo.c:851
+#: ../src/imageio/storage/flickr.c:515 ../src/imageio/storage/piwigo.c:844
 msgid "refresh album list"
 msgstr "refrescar lista de album"
 
-#: ../src/imageio/storage/flickr.c:545
+#: ../src/imageio/storage/flickr.c:536
 msgid "my new photoset"
 msgstr "mi nuevo photoset"
 
-#: ../src/imageio/storage/flickr.c:560
+#: ../src/imageio/storage/flickr.c:551
 msgid "exported from darktable"
 msgstr "exportado desde darktable"
 
-#: ../src/imageio/storage/flickr.c:567 ../src/imageio/storage/piwigo.c:882
+#: ../src/imageio/storage/flickr.c:558 ../src/imageio/storage/piwigo.c:875
 msgid "click login button to start"
 msgstr "pulse el botón acceder para empezar"
 
-#: ../src/imageio/storage/flickr.c:675
+#: ../src/imageio/storage/flickr.c:670
 msgid "could not upload to flickr!"
 msgstr "no se puede subir a flickr!"
 
 #. this makes sense only if the export was successful
-#: ../src/imageio/storage/flickr.c:726
+#: ../src/imageio/storage/flickr.c:721
 #, c-format
 msgid "%d/%d exported to flickr webalbum"
 msgid_plural "%d/%d exported to flickr webalbum"
 msgstr[0] "%d/%d exportado al álbum web flickr"
 msgstr[1] "%d/%d exportados al álbum web flickr"
 
-#: ../src/imageio/storage/gallery.c:71
+#: ../src/imageio/storage/gallery.c:72
 msgid "website gallery"
 msgstr "galería web"
 
-#: ../src/imageio/storage/gallery.c:190
+#: ../src/imageio/storage/gallery.c:191
 msgid "enter the title of the website"
 msgstr "introduzca el título de la página web"
 
 #. //////////// build & show the validation dialog
-#: ../src/imageio/storage/googlephoto.c:760
+#: ../src/imageio/storage/googlephoto.c:761
 msgid ""
 "step 1: a new window or tab of your browser should have been loaded. you "
 "have to login into your google account there and authorize darktable to "
@@ -4953,7 +5198,7 @@ msgstr ""
 "entrar en su cuenta de google y autorizar a darktable a subir las fotos "
 "antes de continuar."
 
-#: ../src/imageio/storage/googlephoto.c:763
+#: ../src/imageio/storage/googlephoto.c:764
 msgid ""
 "step 2: paste the verification code shown to you in the browser and click "
 "the OK button once you are done."
@@ -4961,68 +5206,68 @@ msgstr ""
 "paso 2: copie el código de verificación mostrado en su navegador y haga clic "
 "en el botón OK una vez listo."
 
-#: ../src/imageio/storage/googlephoto.c:769
+#: ../src/imageio/storage/googlephoto.c:770
 msgid "google authentication"
 msgstr "autenticación google fotos"
 
-#: ../src/imageio/storage/googlephoto.c:777
+#: ../src/imageio/storage/googlephoto.c:778
 msgid "verification code:"
 msgstr "código de verificación:"
 
-#: ../src/imageio/storage/googlephoto.c:800
+#: ../src/imageio/storage/googlephoto.c:801
 msgid "please enter the verification code"
 msgstr "por favor, ingrese el código de verificación"
 
-#: ../src/imageio/storage/googlephoto.c:1219
+#: ../src/imageio/storage/googlephoto.c:1220
 msgid "google photos"
 msgstr "google fotos"
 
-#: ../src/imageio/storage/googlephoto.c:1402
+#: ../src/imageio/storage/googlephoto.c:1406
 msgid "unable to export to google photos album"
 msgstr "no se pudo exportar la foto al álbum google fotos"
 
 #. this makes sense only if the export was successful
-#: ../src/imageio/storage/googlephoto.c:1415
+#: ../src/imageio/storage/googlephoto.c:1419
 #, c-format
 msgid "%d/%d exported to google photos album"
 msgid_plural "%d/%d exported to google photos album"
 msgstr[0] "%d/%d exportado al álbum google photos"
 msgstr[1] "%d/%d exportados al álbum google+"
 
-#: ../src/imageio/storage/latex.c:70
+#: ../src/imageio/storage/latex.c:71
 msgid "LaTeX book template"
 msgstr "Plantilla de libro LaTeX"
 
 #. TODO: support title, author, subject, keywords (collect tags?)
-#: ../src/imageio/storage/latex.c:193
+#: ../src/imageio/storage/latex.c:194
 msgid "enter the title of the book"
 msgstr "introduzca el título del libro"
 
-#: ../src/imageio/storage/piwigo.c:477
+#: ../src/imageio/storage/piwigo.c:478
 msgid "not authenticated, cannot reach server"
 msgstr "no autenticado, no se pudo conectar con el servidor"
 
-#: ../src/imageio/storage/piwigo.c:588
+#: ../src/imageio/storage/piwigo.c:589
 msgid "---"
 msgstr "(---)"
 
-#: ../src/imageio/storage/piwigo.c:629
+#: ../src/imageio/storage/piwigo.c:630
 msgid "cannot refresh albums"
 msgstr "no se pudo refrescar lista de albums"
 
-#: ../src/imageio/storage/piwigo.c:722
+#: ../src/imageio/storage/piwigo.c:723
 msgid "piwigo"
 msgstr "piwigo"
 
-#: ../src/imageio/storage/piwigo.c:747
+#: ../src/imageio/storage/piwigo.c:748
 msgid "accounts"
 msgstr "cuentas"
 
-#: ../src/imageio/storage/piwigo.c:764
+#: ../src/imageio/storage/piwigo.c:765
 msgid "server"
 msgstr "servidor"
 
-#: ../src/imageio/storage/piwigo.c:768
+#: ../src/imageio/storage/piwigo.c:769
 msgid ""
 "the server name\n"
 "default protocol is https\n"
@@ -5032,48 +5277,48 @@ msgstr ""
 "el protocolo por defecto es https\n"
 "especificar http:// si no es un servidor seguro"
 
-#: ../src/imageio/storage/piwigo.c:781
+#: ../src/imageio/storage/piwigo.c:782
 msgid "user"
 msgstr "usuario"
 
-#: ../src/imageio/storage/piwigo.c:795
+#: ../src/imageio/storage/piwigo.c:796
 msgid "password"
 msgstr "contraseña"
 
-#: ../src/imageio/storage/piwigo.c:810
+#: ../src/imageio/storage/piwigo.c:811
 msgid "piwigo login"
 msgstr "loguearse en piiwigo"
 
-#: ../src/imageio/storage/piwigo.c:834
+#: ../src/imageio/storage/piwigo.c:827
 msgid "contacts"
 msgstr "hoja de contactos"
 
 #. Available albums
-#: ../src/imageio/storage/piwigo.c:845
-msgid "albums"
+#: ../src/imageio/storage/piwigo.c:838
+msgid "album"
 msgstr "álbum"
 
-#: ../src/imageio/storage/piwigo.c:870
+#: ../src/imageio/storage/piwigo.c:863
 msgid "new album"
 msgstr "álbum nuevo"
 
 #. parent album list
 #. Available albums
-#: ../src/imageio/storage/piwigo.c:878
+#: ../src/imageio/storage/piwigo.c:871
 msgid "parent album"
 msgstr "álbum principal"
 
-#: ../src/imageio/storage/piwigo.c:995
+#: ../src/imageio/storage/piwigo.c:988
 msgid "cannot create a new piwigo album!"
 msgstr "crear album nuevo!"
 
-#: ../src/imageio/storage/piwigo.c:1004
+#: ../src/imageio/storage/piwigo.c:997
 msgid "could not upload to piwigo!"
 msgstr "no se puede subir a piwigo!"
 
 # piwigo es un servicio web para crear galerias de fotos
 #. this makes sense only if the export was successful
-#: ../src/imageio/storage/piwigo.c:1028
+#: ../src/imageio/storage/piwigo.c:1026
 #, c-format
 msgid "%d/%d exported to piwigo webalbum"
 msgid_plural "%d/%d exported to piwigo webalbum"
@@ -5128,111 +5373,111 @@ msgstr "no hay suficiente estructura para la corrección automática"
 msgid "automatic correction failed, please correct manually"
 msgstr "fallo de corrección automática, por favor, corrija manualmente"
 
-#: ../src/iop/ashift.c:4619 ../src/iop/ashift.c:4620 ../src/iop/ashift.c:4723
-#: ../src/iop/ashift.c:4724
+#: ../src/iop/ashift.c:4623 ../src/iop/ashift.c:4624 ../src/iop/ashift.c:4727
+#: ../src/iop/ashift.c:4728
 #, c-format
 msgid "lens shift (%s)"
 msgstr "desplazamiento de lente (%s)"
 
-#: ../src/iop/ashift.c:4619 ../src/iop/ashift.c:4620 ../src/iop/ashift.c:4723
-#: ../src/iop/ashift.c:4724 ../src/iop/clipping.c:1691
-#: ../src/iop/clipping.c:1976 ../src/iop/clipping.c:1995
+#: ../src/iop/ashift.c:4623 ../src/iop/ashift.c:4624 ../src/iop/ashift.c:4727
+#: ../src/iop/ashift.c:4728 ../src/iop/clipping.c:1693
+#: ../src/iop/clipping.c:1978 ../src/iop/clipping.c:1997
 msgid "horizontal"
 msgstr "horizontal"
 
-#: ../src/iop/ashift.c:4619 ../src/iop/ashift.c:4620 ../src/iop/ashift.c:4723
-#: ../src/iop/ashift.c:4724 ../src/iop/clipping.c:1690
-#: ../src/iop/clipping.c:1977 ../src/iop/clipping.c:1994
+#: ../src/iop/ashift.c:4623 ../src/iop/ashift.c:4624 ../src/iop/ashift.c:4727
+#: ../src/iop/ashift.c:4728 ../src/iop/clipping.c:1692
+#: ../src/iop/clipping.c:1979 ../src/iop/clipping.c:1996
 msgid "vertical"
 msgstr "vertical"
 
-#: ../src/iop/ashift.c:4828 ../src/iop/graduatednd.c:1230
+#: ../src/iop/ashift.c:4833 ../src/iop/graduatednd.c:1231
 #: ../src/iop/watermark.c:1437
 msgid "rotation"
 msgstr "rotación"
 
-#: ../src/iop/ashift.c:4834
+#: ../src/iop/ashift.c:4839
 msgid "lens shift (vertical)"
 msgstr "desplazamiento de lente (vertical)"
 
-#: ../src/iop/ashift.c:4839
+#: ../src/iop/ashift.c:4844
 msgid "lens shift (horizontal)"
 msgstr "desplazamiento de lente (horizontal)"
 
-#: ../src/iop/ashift.c:4844
+#: ../src/iop/ashift.c:4849
 msgid "shear"
 msgstr "cortar"
 
-#: ../src/iop/ashift.c:4849 ../src/iop/clipping.c:2126
+#: ../src/iop/ashift.c:4854 ../src/iop/clipping.c:2128
 #: ../src/libs/live_view.c:343
 msgid "guides"
 msgstr "guías"
 
-#: ../src/iop/ashift.c:4855 ../src/iop/clipping.c:2002
+#: ../src/iop/ashift.c:4860 ../src/iop/clipping.c:2004
 msgid "automatic cropping"
 msgstr "corte automatico"
 
-#: ../src/iop/ashift.c:4857
+#: ../src/iop/ashift.c:4862
 msgid "largest area"
 msgstr "área mas larga"
 
-#: ../src/iop/ashift.c:4858
+#: ../src/iop/ashift.c:4863
 msgid "original format"
 msgstr "formato original"
 
-#: ../src/iop/ashift.c:4862
+#: ../src/iop/ashift.c:4867
 msgid "lens model"
 msgstr "modelo de lente"
 
-#: ../src/iop/ashift.c:4863
+#: ../src/iop/ashift.c:4868
 msgid "generic"
 msgstr "genérico"
 
-#: ../src/iop/ashift.c:4864
+#: ../src/iop/ashift.c:4869
 msgid "specific"
 msgstr "específico"
 
-#: ../src/iop/ashift.c:4877
+#: ../src/iop/ashift.c:4882
 msgid "crop factor"
 msgstr "factor de corte"
 
-#: ../src/iop/ashift.c:4882
+#: ../src/iop/ashift.c:4887
 msgid "lens dependence"
 msgstr "dependencia del lente"
 
-#: ../src/iop/ashift.c:4892
+#: ../src/iop/ashift.c:4897
 msgid "aspect adjust"
 msgstr "ajustar aspecto"
 
-#: ../src/iop/ashift.c:4902
+#: ../src/iop/ashift.c:4907
 msgid "automatic fit"
 msgstr "ajuste automático"
 
-#: ../src/iop/ashift.c:4918
+#: ../src/iop/ashift.c:4923
 msgid "get structure"
 msgstr "obtener estructura"
 
-#: ../src/iop/ashift.c:4963
+#: ../src/iop/ashift.c:4968
 msgid "rotate image"
 msgstr "rotar imagen"
 
-#: ../src/iop/ashift.c:4964 ../src/iop/ashift.c:4965
+#: ../src/iop/ashift.c:4969 ../src/iop/ashift.c:4970
 msgid "apply lens shift correction in one direction"
 msgstr "efectúa la corrección del desplazamiento de lente en una dirección"
 
-#: ../src/iop/ashift.c:4966
+#: ../src/iop/ashift.c:4971
 msgid "shear the image along one diagonal"
 msgstr "recortar la imagen de acuerdo a la diagonal"
 
-#: ../src/iop/ashift.c:4967
+#: ../src/iop/ashift.c:4972
 msgid "display guide lines overlay"
 msgstr "mostrar lineas guías superpuestas"
 
-#: ../src/iop/ashift.c:4968 ../src/iop/clipping.c:2005
+#: ../src/iop/ashift.c:4973 ../src/iop/clipping.c:2007
 msgid "automatically crop to avoid black edges"
 msgstr "cortar automáticamente para evitar bordes negros"
 
-#: ../src/iop/ashift.c:4969
+#: ../src/iop/ashift.c:4974
 msgid ""
 "lens model of the perspective correction: generic or according to the focal "
 "length"
@@ -5240,13 +5485,13 @@ msgstr ""
 "modelo del lente de la corrección de perspectiva: genérico o de acuerdo a la "
 "distancia focal"
 
-#: ../src/iop/ashift.c:4971
+#: ../src/iop/ashift.c:4976
 msgid "focal length of the lens, default value set from exif data if available"
 msgstr ""
 "distancia focal del lente, valor por defecto ajustado desde los datos Exif "
 "si están disponibles"
 
-#: ../src/iop/ashift.c:4973
+#: ../src/iop/ashift.c:4978
 msgid ""
 "crop factor of the camera sensor, default value set from exif data if "
 "available, manual setting is often required"
@@ -5254,7 +5499,7 @@ msgstr ""
 "factor de corte del sensor de la cámara, valor por defecto tomado de los "
 "datos Exif si están disponibles, ajustes manuales son requeridos usualmente"
 
-#: ../src/iop/ashift.c:4976
+#: ../src/iop/ashift.c:4981
 msgid ""
 "the level of lens dependent correction, set to maximum for full lens "
 "dependency, set to zero for the generic case"
@@ -5262,13 +5507,13 @@ msgstr ""
 "el nivel de la corrección dependiente del lente, ajuste al máximo para una "
 "dependencia completa del lente, ajuste a cero para casos genéricos"
 
-#: ../src/iop/ashift.c:4978
+#: ../src/iop/ashift.c:4983
 msgid "adjust aspect ratio of image by horizontal and vertical scaling"
 msgstr ""
 "Ajusta la relación de aspecto de la imagen mediante cambiar la escala "
 "horizontal y vertical"
 
-#: ../src/iop/ashift.c:4979
+#: ../src/iop/ashift.c:4984
 msgid ""
 "automatically correct for vertical perspective distortion\n"
 "ctrl-click to only fit rotation\n"
@@ -5278,7 +5523,7 @@ msgstr ""
 "Ctrl+clic para corregir solo la rotación\n"
 "Mayús+clic para corregir la desviación del lente"
 
-#: ../src/iop/ashift.c:4982
+#: ../src/iop/ashift.c:4987
 msgid ""
 "automatically correct for horizontal perspective distortion\n"
 "ctrl-click to only fit rotation\n"
@@ -5288,7 +5533,7 @@ msgstr ""
 "Ctrl+clic para solo corregir la rotación\n"
 "Mayús+clic para solo corregir la desviación del lente"
 
-#: ../src/iop/ashift.c:4985
+#: ../src/iop/ashift.c:4990
 msgid ""
 "automatically correct for vertical and horizontal perspective distortions; "
 "fitting rotation,lens shift in both directions, and shear\n"
@@ -5303,7 +5548,7 @@ msgstr ""
 "Mayús+clic para solo corregir la desviación del lente\n"
 "Ctrl+Mayús+clic para ajustar la rotación y el corte del lente"
 
-#: ../src/iop/ashift.c:4991
+#: ../src/iop/ashift.c:4996
 msgid ""
 "analyse line structure in image\n"
 "ctrl-click for an additional edge enhancement\n"
@@ -5315,17 +5560,37 @@ msgstr ""
 "Mayús+clic para mejoras adicionales en el detalle\n"
 "Ctrl+Mayús+clic para una combinación de ambos métodos"
 
-#: ../src/iop/ashift.c:4995
+#: ../src/iop/ashift.c:5000
 msgid "remove line structure information"
 msgstr "remover estructura de información lineal"
 
-#: ../src/iop/ashift.c:4996
+#: ../src/iop/ashift.c:5001
 msgid "toggle visibility of structure lines"
 msgstr "cambiar la visibilidad de las líneas estructurales"
 
+#: ../src/iop/ashift.c:5049
+#, c-format
+msgid "[%s on segment] select segment"
+msgstr "[%s en el segmento] seleccionar segmento"
+
+#: ../src/iop/ashift.c:5054
+#, c-format
+msgid "[%s on segment] unselect segment"
+msgstr "[%s en el segmento] anular selección de segmento"
+
+#: ../src/iop/ashift.c:5060
+#, c-format
+msgid "[%s] select all segments from zone"
+msgstr "[%s] seleccionar todos los segmentos de la zona"
+
+#: ../src/iop/ashift.c:5066
+#, c-format
+msgid "[%s] unselect all segments from zone"
+msgstr "[%s] anular la selección de todos los segmentos de la zona"
+
 #: ../src/iop/atrous.c:117
-msgid "equalizer"
-msgstr "ecualizador"
+msgid "contrast equalizer"
+msgstr "ecualizador de contraste"
 
 #: ../src/iop/atrous.c:137 ../src/iop/soften.c:108
 msgctxt "accel"
@@ -5402,12 +5667,12 @@ msgstr "deblur: difuminado medio, fuerza 1"
 msgid "deblur: fine blur, strength 1"
 msgstr "deblur: difuminado suave, fuerza 1"
 
-#: ../src/iop/atrous.c:1597 ../src/iop/denoiseprofile.c:3058
+#: ../src/iop/atrous.c:1597 ../src/iop/denoiseprofile.c:3667
 #: ../src/iop/rawdenoise.c:813
 msgid "coarse"
 msgstr "grueso"
 
-#: ../src/iop/atrous.c:1604 ../src/iop/denoiseprofile.c:3066
+#: ../src/iop/atrous.c:1604 ../src/iop/denoiseprofile.c:3675
 #: ../src/iop/rawdenoise.c:821
 msgid "fine"
 msgstr "fino"
@@ -5417,12 +5682,12 @@ msgid "contrasty"
 msgstr "contrastado"
 
 #: ../src/iop/atrous.c:1617 ../src/iop/atrous.c:1621
-#: ../src/iop/colorzones.c:2337 ../src/iop/denoiseprofile.c:3075
+#: ../src/iop/colorzones.c:2334 ../src/iop/denoiseprofile.c:3684
 #: ../src/iop/rawdenoise.c:830
 msgid "smooth"
 msgstr "suavizado"
 
-#: ../src/iop/atrous.c:1622 ../src/iop/denoiseprofile.c:3080
+#: ../src/iop/atrous.c:1622 ../src/iop/denoiseprofile.c:3689
 #: ../src/iop/rawdenoise.c:835
 msgid "noisy"
 msgstr "ruidoso"
@@ -5464,115 +5729,115 @@ msgstr ""
 "cambia el borde de los halos para cada tamaño\n"
 "solo cambia los resultados de las pestañas de luma y crominancia"
 
-#: ../src/iop/atrous.c:1877 ../src/iop/colorzones.c:2345
+#: ../src/iop/atrous.c:1877 ../src/iop/colorzones.c:2342
 #: ../src/iop/soften.c:756
 msgid "mix"
 msgstr "mezcla"
 
-#: ../src/iop/atrous.c:1878 ../src/iop/colorzones.c:2346
+#: ../src/iop/atrous.c:1878 ../src/iop/colorzones.c:2343
 msgid "make effect stronger or weaker"
 msgstr "hacer mas suave o fuerte el efecto"
 
-#: ../src/iop/basecurve.c:151
+#: ../src/iop/basecurve.c:178
 msgid "neutral"
 msgstr "neutral"
 
-#: ../src/iop/basecurve.c:152
+#: ../src/iop/basecurve.c:179
 msgid "canon eos like"
 msgstr "similar a canon EOS"
 
-#: ../src/iop/basecurve.c:153
+#: ../src/iop/basecurve.c:180
 msgid "canon eos like alternate"
 msgstr "similar a canon eos (alternativo)"
 
-#: ../src/iop/basecurve.c:154
+#: ../src/iop/basecurve.c:181
 msgid "nikon like"
 msgstr "similar a nikon"
 
-#: ../src/iop/basecurve.c:155
+#: ../src/iop/basecurve.c:182
 msgid "nikon like alternate"
 msgstr "similar a nikon (alternativo)"
 
-#: ../src/iop/basecurve.c:156
+#: ../src/iop/basecurve.c:183
 msgid "sony alpha like"
 msgstr "similar a sony alpha"
 
-#: ../src/iop/basecurve.c:157
+#: ../src/iop/basecurve.c:184
 msgid "pentax like"
 msgstr "similar a pentax"
 
-#: ../src/iop/basecurve.c:158
+#: ../src/iop/basecurve.c:185
 msgid "ricoh like"
 msgstr "similar a ricoh"
 
-#: ../src/iop/basecurve.c:159
+#: ../src/iop/basecurve.c:186
 msgid "olympus like"
 msgstr "similar a olympus"
 
-#: ../src/iop/basecurve.c:160
+#: ../src/iop/basecurve.c:187
 msgid "olympus like alternate"
 msgstr "similar a olympus (alternativo)"
 
-#: ../src/iop/basecurve.c:161
+#: ../src/iop/basecurve.c:188
 msgid "panasonic like"
 msgstr "similar a panasonic"
 
-#: ../src/iop/basecurve.c:162
+#: ../src/iop/basecurve.c:189
 msgid "leica like"
 msgstr "similar a leica"
 
-#: ../src/iop/basecurve.c:163
+#: ../src/iop/basecurve.c:190
 msgid "kodak easyshare like"
 msgstr "similar a kodak easyshare"
 
-#: ../src/iop/basecurve.c:164
+#: ../src/iop/basecurve.c:191
 msgid "konica minolta like"
 msgstr "similar a konica minolta"
 
-#: ../src/iop/basecurve.c:165
+#: ../src/iop/basecurve.c:192
 msgid "samsung like"
 msgstr "similar a samsung"
 
-#: ../src/iop/basecurve.c:166
+#: ../src/iop/basecurve.c:193
 msgid "fujifilm like"
 msgstr "similar a fujifilm"
 
-#: ../src/iop/basecurve.c:167
+#: ../src/iop/basecurve.c:194
 msgid "nokia like"
 msgstr "similar a nokia"
 
 #. clang-format off
 #. smoother cubic spline curve
-#: ../src/iop/basecurve.c:223 ../src/iop/colorzones.c:2377
-#: ../src/iop/rgbcurve.c:1574 ../src/iop/tonecurve.c:1296
+#: ../src/iop/basecurve.c:250 ../src/iop/colorzones.c:2374
+#: ../src/iop/rgbcurve.c:1564 ../src/iop/tonecurve.c:1381
 msgid "cubic spline"
 msgstr "curva segmentaria cúbica"
 
-#: ../src/iop/basecurve.c:297
+#: ../src/iop/basecurve.c:326
 msgid "base curve"
 msgstr "curva base"
 
-#: ../src/iop/basecurve.c:1966
+#: ../src/iop/basecurve.c:2125
 msgid "abscissa: input, ordinate: output. works on RGB channels"
 msgstr "abcisas: entrada, ordenadas: salida. trabaja en los canales RGB"
 
-#: ../src/iop/basecurve.c:1971 ../src/iop/lens.c:2326
-#: ../src/iop/tonecurve.c:1307 ../src/iop/vignette.c:1156
+#: ../src/iop/basecurve.c:2130 ../src/iop/lens.cc:2461
+#: ../src/iop/tonecurve.c:1405 ../src/iop/vignette.c:1156
 #: ../src/iop/watermark.c:1434
 msgid "scale"
 msgstr "escala"
 
 #. centripetal spline
-#: ../src/iop/basecurve.c:1972 ../src/iop/filmic.c:1802
-#: ../src/iop/profile_gamma.c:869 ../src/iop/tonecurve.c:1308
+#: ../src/iop/basecurve.c:2131 ../src/iop/filmic.c:1807
+#: ../src/iop/profile_gamma.c:874 ../src/iop/tonecurve.c:1406
 msgid "linear"
 msgstr "lineal"
 
-#: ../src/iop/basecurve.c:1973 ../src/iop/profile_gamma.c:853
+#: ../src/iop/basecurve.c:2132 ../src/iop/profile_gamma.c:858
 msgid "logarithmic"
 msgstr "logarítmico"
 
-#: ../src/iop/basecurve.c:1974 ../src/iop/tonecurve.c:1312
+#: ../src/iop/basecurve.c:2133 ../src/iop/tonecurve.c:1408
 msgid ""
 "scale to use in the graph. use logarithmic scale for more precise control "
 "near the blacks"
@@ -5580,30 +5845,80 @@ msgstr ""
 "escala a usar en el gráfico. use escala logarítmica para un control más "
 "preciso cerca de los negros"
 
-#: ../src/iop/basecurve.c:1980
-msgid "fusion"
-msgstr "fusión"
+#: ../src/iop/basecurve.c:2139 ../src/iop/basicadj.c:701
+#: ../src/iop/rgbcurve.c:1584 ../src/iop/rgblevels.c:1116
+#: ../src/iop/tonecurve.c:1392
+msgid "preserve colors"
+msgstr "preservar los colores"
 
-#: ../src/iop/basecurve.c:1981 ../src/iop/basicadj.c:706
-#: ../src/iop/clipping.c:1689 ../src/iop/clipping.c:1975
-#: ../src/iop/clipping.c:1993 ../src/iop/clipping.c:2133
-#: ../src/iop/clipping.c:2160 ../src/iop/colorreconstruction.c:1377
-#: ../src/iop/lens.c:2185 ../src/iop/retouch.c:582 ../src/iop/rgbcurve.c:1595
-#: ../src/libs/export.c:509 ../src/libs/live_view.c:350
+#: ../src/iop/basecurve.c:2140 ../src/iop/basecurve.c:2153
+#: ../src/iop/basicadj.c:702 ../src/iop/clipping.c:1691
+#: ../src/iop/clipping.c:1977 ../src/iop/clipping.c:1995
+#: ../src/iop/clipping.c:2135 ../src/iop/clipping.c:2162
+#: ../src/iop/colorreconstruction.c:1377 ../src/iop/lens.cc:2320
+#: ../src/iop/retouch.c:582 ../src/iop/rgbcurve.c:1585
+#: ../src/iop/rgblevels.c:1117 ../src/iop/tonecurve.c:1393
+#: ../src/libs/export.c:518 ../src/libs/live_view.c:350
 #: ../src/libs/live_view.c:375 ../src/libs/live_view.c:384
-#: ../src/libs/print_settings.c:1471
+#: ../src/libs/print_settings.c:1469
 msgid "none"
 msgstr "ninguna"
 
-#: ../src/iop/basecurve.c:1982
+#: ../src/iop/basecurve.c:2141 ../src/iop/basicadj.c:703
+#: ../src/iop/rgbcurve.c:1586 ../src/iop/rgblevels.c:1118
+#: ../src/iop/tonecurve.c:1394
+msgid "luminance"
+msgstr "luminancia"
+
+#: ../src/iop/basecurve.c:2142 ../src/iop/basicadj.c:704
+#: ../src/iop/rgbcurve.c:1587 ../src/iop/rgblevels.c:1119
+#: ../src/iop/tonecurve.c:1395
+msgid "max rgb"
+msgstr "rgb máx."
+
+#: ../src/iop/basecurve.c:2143 ../src/iop/basicadj.c:705
+#: ../src/iop/rgbcurve.c:1588 ../src/iop/rgblevels.c:1120
+#: ../src/iop/tonecurve.c:1396
+msgid "average rgb"
+msgstr "rgb media"
+
+#: ../src/iop/basecurve.c:2144 ../src/iop/basicadj.c:706
+#: ../src/iop/rgbcurve.c:1589 ../src/iop/rgblevels.c:1121
+#: ../src/iop/tonecurve.c:1397
+msgid "sum rgb"
+msgstr "rgb suma"
+
+#: ../src/iop/basecurve.c:2145 ../src/iop/basicadj.c:707
+#: ../src/iop/rgbcurve.c:1590 ../src/iop/rgblevels.c:1122
+#: ../src/iop/tonecurve.c:1398
+msgid "norm rgb"
+msgstr "rgb normal"
+
+#: ../src/iop/basecurve.c:2146 ../src/iop/basicadj.c:708
+#: ../src/iop/rgbcurve.c:1591 ../src/iop/rgblevels.c:1123
+#: ../src/iop/tonecurve.c:1399
+msgid "basic power"
+msgstr "poder básico"
+
+#: ../src/iop/basecurve.c:2148 ../src/iop/basicadj.c:710
+#: ../src/iop/rgbcurve.c:1593 ../src/iop/rgblevels.c:1125
+#: ../src/iop/tonecurve.c:1401
+msgid "method to preserve colors when applying contrast"
+msgstr "Método para preservar los colores al aplicar contraste"
+
+#: ../src/iop/basecurve.c:2152
+msgid "fusion"
+msgstr "fusión"
+
+#: ../src/iop/basecurve.c:2154
 msgid "two exposures"
 msgstr "doble exposición"
 
-#: ../src/iop/basecurve.c:1983
+#: ../src/iop/basecurve.c:2155
 msgid "three exposures"
 msgstr "triple exposición"
 
-#: ../src/iop/basecurve.c:1984
+#: ../src/iop/basecurve.c:2156
 msgid ""
 "fuse this image stopped up/down a couple of times with itself, to compress "
 "high dynamic range. expose for the highlights before use."
@@ -5612,15 +5927,15 @@ msgstr ""
 "para comprimir el rango dinámico alto. exponga las luces altas antes de "
 "usarlo."
 
-#: ../src/iop/basecurve.c:1990
+#: ../src/iop/basecurve.c:2162
 msgid "how many stops to shift the individual exposures apart"
 msgstr "cuantas paradas para distanciar la exposición individual"
 
-#: ../src/iop/basecurve.c:1991
+#: ../src/iop/basecurve.c:2163
 msgid "exposure shift"
 msgstr "ajuste de exposición"
 
-#: ../src/iop/basecurve.c:2001
+#: ../src/iop/basecurve.c:2173
 msgid ""
 "whether to shift exposure up or down (-1: reduce highlight, +1: reduce "
 "shadows)"
@@ -5628,19 +5943,19 @@ msgstr ""
 "si se ajustará a mayor o menor exposición (-1: reduce las luces altas, +1: "
 "reduce las sombras)"
 
-#: ../src/iop/basecurve.c:2003
+#: ../src/iop/basecurve.c:2175
 msgid "exposure bias"
 msgstr "desviación de exposición"
 
-#: ../src/iop/basicadj.c:97
+#: ../src/iop/basicadj.c:92
 msgid "basic adjustments"
 msgstr "ajustes básicos"
 
-#: ../src/iop/basicadj.c:672 ../src/iop/exposure.c:889
+#: ../src/iop/basicadj.c:668 ../src/iop/exposure.c:896
 msgid "black level correction"
 msgstr "corrección de nivel de negro"
 
-#: ../src/iop/basicadj.c:674
+#: ../src/iop/basicadj.c:670
 msgid ""
 "adjust the black level to unclip negative RGB values.\n"
 "you should never use it to add more density in blacks!\n"
@@ -5652,78 +5967,67 @@ msgstr ""
 "Si está mal configurado, recortará los colores casi negros de la gama\n"
 "forzando los valores RGB a los negativos."
 
-#: ../src/iop/basicadj.c:686 ../src/iop/exposure.c:877
+#: ../src/iop/basicadj.c:682 ../src/iop/exposure.c:884
 msgid "adjust the exposure correction"
 msgstr "ajusta la corrección de exposición"
 
-#: ../src/iop/basicadj.c:692
+#: ../src/iop/basicadj.c:688
 msgid "highlight compression"
 msgstr "compresión de luces altas"
 
-#: ../src/iop/basicadj.c:693
+#: ../src/iop/basicadj.c:689
 msgid "highlight compression adjustment"
 msgstr "ajuste de compresión de luces altas"
 
-#: ../src/iop/basicadj.c:699 ../src/iop/bilat.c:546 ../src/iop/colisa.c:379
-#: ../src/iop/colorbalance.c:2400 ../src/iop/colorbalance.c:2402
-#: ../src/iop/filmic.c:1747 ../src/iop/lowpass.c:685
+#: ../src/iop/basicadj.c:695 ../src/iop/bilat.c:546 ../src/iop/colisa.c:379
+#: ../src/iop/colorbalance.c:2419 ../src/iop/colorbalance.c:2421
+#: ../src/iop/filmic.c:1752 ../src/iop/filmicrgb.c:1396
+#: ../src/iop/lowpass.c:685
 msgid "contrast"
 msgstr "contraste"
 
-#: ../src/iop/basicadj.c:700 ../src/iop/colisa.c:387
+#: ../src/iop/basicadj.c:696 ../src/iop/colisa.c:387
 msgid "contrast adjustment"
 msgstr "ajuste de contraste"
 
-#: ../src/iop/basicadj.c:705 ../src/iop/rgbcurve.c:1594
-msgid "preserve colors"
-msgstr "preservar los colores"
-
-#: ../src/iop/basicadj.c:707 ../src/iop/rgbcurve.c:1596
-msgid "luminance"
-msgstr "luminancia"
-
-#: ../src/iop/basicadj.c:709 ../src/iop/rgbcurve.c:1603
-msgid "method to preserve colors when applying contrast"
-msgstr "Método para preservar los colores al aplicar contraste"
-
-#: ../src/iop/basicadj.c:713
+#: ../src/iop/basicadj.c:714
 msgid "middle grey"
 msgstr "gris medio"
 
-#: ../src/iop/basicadj.c:715
+#: ../src/iop/basicadj.c:716
 msgid "middle grey adjustment"
 msgstr "ajuste de gris medio"
 
-#: ../src/iop/basicadj.c:727 ../src/iop/colisa.c:380 ../src/iop/retouch.c:2910
+#: ../src/iop/basicadj.c:728 ../src/iop/colisa.c:380 ../src/iop/retouch.c:2918
 #: ../src/iop/soften.c:748 ../src/iop/vignette.c:1158
 msgid "brightness"
 msgstr "brillo"
 
-#: ../src/iop/basicadj.c:728 ../src/iop/colisa.c:388
+#: ../src/iop/basicadj.c:729 ../src/iop/colisa.c:388
 msgid "brightness adjustment"
 msgstr "ajuste de brillo"
 
 #. dt_bauhaus_slider_set_format(g->gslider2, "");
-#: ../src/iop/basicadj.c:733 ../src/iop/channelmixer.c:457
-#: ../src/iop/colisa.c:381 ../src/iop/colorbalance.c:2498
-#: ../src/iop/colorbalance.c:2548 ../src/iop/colorbalance.c:2597
-#: ../src/iop/colorchecker.c:1384 ../src/iop/colorcorrection.c:292
-#: ../src/iop/colorize.c:431 ../src/iop/colorzones.c:2266
-#: ../src/iop/colorzones.c:2330 ../src/iop/graduatednd.c:1259
+#: ../src/iop/basicadj.c:734 ../src/iop/channelmixer.c:454
+#: ../src/iop/colisa.c:381 ../src/iop/colorbalance.c:2517
+#: ../src/iop/colorbalance.c:2567 ../src/iop/colorbalance.c:2616
+#: ../src/iop/colorchecker.c:1385 ../src/iop/colorcorrection.c:292
+#: ../src/iop/colorize.c:431 ../src/iop/colorzones.c:2263
+#: ../src/iop/colorzones.c:2327 ../src/iop/graduatednd.c:1260
 #: ../src/iop/lowpass.c:687 ../src/iop/soften.c:741
-#: ../src/iop/splittoning.c:599 ../src/iop/vignette.c:1159
+#: ../src/iop/splittoning.c:626 ../src/iop/vignette.c:1159
 msgid "saturation"
 msgstr "saturación"
 
-#: ../src/iop/basicadj.c:734
+#: ../src/iop/basicadj.c:735
 msgid "saturation adjustment"
 msgstr "ajuste de saturación"
 
-#: ../src/iop/basicadj.c:741
+#: ../src/iop/basicadj.c:742
 msgid "apply auto exposure based on the entire image"
 msgstr "Aplica la exposición automática basada en toda la imagen"
 
-#: ../src/iop/basicadj.c:749
+#: ../src/iop/basicadj.c:750
 msgid ""
 "apply auto exposure based on a region defined by the user\n"
 "click and drag to draw the area\n"
@@ -5734,11 +6038,11 @@ msgstr ""
 "Pulse y arrastre para dibujar el área\n"
 "Pulse el botón derecho para cancelar"
 
-#: ../src/iop/basicadj.c:759
+#: ../src/iop/basicadj.c:760
 msgid "clip"
 msgstr "recortar"
 
-#: ../src/iop/basicadj.c:760
+#: ../src/iop/basicadj.c:761
 msgid "adjusts clipping value for auto exposure calculation"
 msgstr "Ajusta el valor de recorte para el cálculo de la exposición automática"
 
@@ -5751,12 +6055,13 @@ msgstr "contraste local"
 msgid "local laplacian: inconsistent output"
 msgstr "laplaciano local: salida inconsistente"
 
-#: ../src/iop/bilat.c:525 ../src/iop/colorbalance.c:2346
-#: ../src/iop/denoiseprofile.c:3373 ../src/iop/exposure.c:857
-#: ../src/iop/lens.c:2334 ../src/iop/levels.c:671
-#: ../src/iop/profile_gamma.c:852 ../src/iop/rgbcurve.c:1488
-#: ../src/libs/copy_history.c:425 ../src/libs/export.c:670
-#: ../src/libs/print_settings.c:1512 ../src/views/darkroom.c:1810
+#: ../src/iop/bilat.c:525 ../src/iop/colorbalance.c:2365
+#: ../src/iop/denoiseprofile.c:4010 ../src/iop/exposure.c:864
+#: ../src/iop/lens.cc:2469 ../src/iop/levels.c:672
+#: ../src/iop/profile_gamma.c:857 ../src/iop/rgbcurve.c:1478
+#: ../src/iop/rgblevels.c:1010 ../src/libs/copy_history.c:350
+#: ../src/libs/export.c:686 ../src/libs/print_settings.c:1510
+#: ../src/views/darkroom.c:1830
 msgid "mode"
 msgstr "modo"
 
@@ -5799,7 +6104,7 @@ msgid "L difference to detect edges (range sigma of bilateral filter)"
 msgstr "Diferencia L para detectar bordes (rango sigma del filtro bilateral)"
 
 #: ../src/iop/bilat.c:551 ../src/iop/monochrome.c:612 ../src/iop/shadhi.c:841
-#: ../src/iop/splittoning.c:637
+#: ../src/iop/splittoning.c:664
 msgid "highlights"
 msgstr "luces"
 
@@ -5807,7 +6112,7 @@ msgstr "luces"
 msgid "changes the local contrast of highlights"
 msgstr "cambios al contraste local de las luces altas"
 
-#: ../src/iop/bilat.c:557 ../src/iop/shadhi.c:840 ../src/iop/splittoning.c:632
+#: ../src/iop/bilat.c:557 ../src/iop/shadhi.c:840 ../src/iop/splittoning.c:659
 msgid "shadows"
 msgstr "sombras"
 
@@ -5839,19 +6144,19 @@ msgctxt "accel"
 msgid "radius"
 msgstr "radio"
 
-#: ../src/iop/bilateral.cc:90 ../src/iop/channelmixer.c:135
+#: ../src/iop/bilateral.cc:90 ../src/iop/channelmixer.c:133
 #: ../src/iop/temperature.c:212
 msgctxt "accel"
 msgid "red"
 msgstr "rojo"
 
-#: ../src/iop/bilateral.cc:91 ../src/iop/channelmixer.c:136
+#: ../src/iop/bilateral.cc:91 ../src/iop/channelmixer.c:134
 #: ../src/iop/temperature.c:213
 msgctxt "accel"
 msgid "green"
 msgstr "verde"
 
-#: ../src/iop/bilateral.cc:92 ../src/iop/channelmixer.c:137
+#: ../src/iop/bilateral.cc:92 ../src/iop/channelmixer.c:135
 #: ../src/iop/temperature.c:214
 msgctxt "accel"
 msgid "blue"
@@ -5903,7 +6208,7 @@ msgid "the size of bloom"
 msgstr "el tamaño del resplandor"
 
 #: ../src/iop/bloom.c:536 ../src/iop/colorreconstruction.c:1371
-#: ../src/iop/defringe.c:472 ../src/iop/hotpixels.c:467
+#: ../src/iop/defringe.c:472 ../src/iop/hotpixels.c:468
 #: ../src/iop/sharpen.c:794
 msgid "threshold"
 msgstr "umbral"
@@ -5912,9 +6217,9 @@ msgstr "umbral"
 msgid "the threshold of light"
 msgstr "el umbral de luz"
 
-#: ../src/iop/bloom.c:542 ../src/iop/denoiseprofile.c:3380
+#: ../src/iop/bloom.c:542 ../src/iop/denoiseprofile.c:4017
 #: ../src/iop/grain.c:636 ../src/iop/hazeremoval.c:233
-#: ../src/iop/hotpixels.c:475 ../src/iop/nlmeans.c:845 ../src/iop/velvia.c:389
+#: ../src/iop/hotpixels.c:476 ../src/iop/nlmeans.c:845 ../src/iop/velvia.c:389
 msgid "strength"
 msgstr "fuerza"
 
@@ -5955,106 +6260,106 @@ msgid "15:10 postcard black"
 msgstr "postal negra 10x15"
 
 #. add import single image buttons
-#: ../src/iop/borders.c:938 ../src/libs/import.c:980
+#: ../src/iop/borders.c:939 ../src/libs/import.c:982
 msgid "image"
 msgstr "imagen"
 
-#: ../src/iop/borders.c:939
+#: ../src/iop/borders.c:940
 msgid "3:1"
 msgstr "3:1"
 
-#: ../src/iop/borders.c:940
+#: ../src/iop/borders.c:941
 msgid "95:33"
 msgstr "95:33"
 
-#: ../src/iop/borders.c:941
+#: ../src/iop/borders.c:942
 msgid "2:1"
 msgstr "2:1"
 
-#: ../src/iop/borders.c:942
+#: ../src/iop/borders.c:943
 msgid "16:9"
 msgstr "16:9"
 
-#: ../src/iop/borders.c:943 ../src/iop/clipping.c:2021
+#: ../src/iop/borders.c:944 ../src/iop/clipping.c:2023
 msgid "golden cut"
 msgstr "proporción áurea"
 
-#: ../src/iop/borders.c:944
+#: ../src/iop/borders.c:945
 msgid "3:2"
 msgstr "3:2"
 
-#: ../src/iop/borders.c:945
+#: ../src/iop/borders.c:946
 msgid "A4"
 msgstr "A4"
 
-#: ../src/iop/borders.c:946
+#: ../src/iop/borders.c:947
 msgid "DIN"
 msgstr "DIN"
 
-#: ../src/iop/borders.c:947
+#: ../src/iop/borders.c:948
 msgid "4:3"
 msgstr "4:3"
 
-#: ../src/iop/borders.c:948 ../src/iop/clipping.c:2011
+#: ../src/iop/borders.c:949 ../src/iop/clipping.c:2013
 msgid "square"
 msgstr "cuadrado"
 
-#: ../src/iop/borders.c:949
+#: ../src/iop/borders.c:950
 msgid "constant border"
 msgstr "borde constante"
 
-#: ../src/iop/borders.c:970 ../src/iop/borders.c:975
+#: ../src/iop/borders.c:971 ../src/iop/borders.c:976
 msgid "center"
 msgstr "centro"
 
-#: ../src/iop/borders.c:971 ../src/iop/borders.c:976
+#: ../src/iop/borders.c:972 ../src/iop/borders.c:977
 msgid "1/3"
 msgstr "1/3"
 
-#: ../src/iop/borders.c:972 ../src/iop/borders.c:977
+#: ../src/iop/borders.c:973 ../src/iop/borders.c:978
 msgid "3/8"
 msgstr "3/8"
 
-#: ../src/iop/borders.c:973 ../src/iop/borders.c:978
+#: ../src/iop/borders.c:974 ../src/iop/borders.c:979
 msgid "5/8"
 msgstr "5/8"
 
-#: ../src/iop/borders.c:974 ../src/iop/borders.c:979
+#: ../src/iop/borders.c:975 ../src/iop/borders.c:980
 msgid "2/3"
 msgstr "2/3"
 
-#: ../src/iop/borders.c:1005
+#: ../src/iop/borders.c:1006
 msgid "border size"
 msgstr "tamaño del borde"
 
-#: ../src/iop/borders.c:1008
+#: ../src/iop/borders.c:1009
 msgid "size of the border in percent of the full image"
 msgstr "tamaño del borde en porcentaje de la imagen completa"
 
-#: ../src/iop/borders.c:1013 ../src/iop/clipping.c:2108
+#: ../src/iop/borders.c:1014 ../src/iop/clipping.c:2110
 msgid "aspect"
 msgstr "aspecto"
 
-#: ../src/iop/borders.c:1017
+#: ../src/iop/borders.c:1018
 msgid "select the aspect ratio or right click and type your own (w:h)"
 msgstr ""
 "seleccione la relación de aspecto o haga clic derecho para seleccionar su "
 "propio tipo (a:l)"
 
-#: ../src/iop/borders.c:1020 ../src/iop/flip.c:75
-#: ../src/libs/print_settings.c:1281
+#: ../src/iop/borders.c:1021 ../src/iop/flip.c:75
+#: ../src/libs/print_settings.c:1279
 msgid "orientation"
 msgstr "orientación"
 
-#: ../src/iop/borders.c:1024
+#: ../src/iop/borders.c:1025
 msgid "aspect ratio orientation of the image with border"
 msgstr "orientación de la relación de aspecto de la imagen con bordes"
 
-#: ../src/iop/borders.c:1030
+#: ../src/iop/borders.c:1031
 msgid "horizontal position"
 msgstr "posición horizontal"
 
-#: ../src/iop/borders.c:1033
+#: ../src/iop/borders.c:1034
 msgid ""
 "select the horizontal position ratio relative to top or right click and type "
 "your own (y:h)"
@@ -6062,11 +6367,11 @@ msgstr ""
 "seleccione la relación de posición horizontal superior relativa o haga clic "
 "derecho para seleccionar su propio tipo (a:l)"
 
-#: ../src/iop/borders.c:1037
+#: ../src/iop/borders.c:1038
 msgid "vertical position"
 msgstr "posición vertical"
 
-#: ../src/iop/borders.c:1040
+#: ../src/iop/borders.c:1041
 msgid ""
 "select the vertical position ratio relative to left or right click and type "
 "your own (x:w)"
@@ -6074,43 +6379,43 @@ msgstr ""
 "selecione la relación de posición vertical relativa a la izquierda o haga "
 "clic derecho para seleccionar su propio tipo (x:l)"
 
-#: ../src/iop/borders.c:1045
+#: ../src/iop/borders.c:1046
 msgid "frame line size"
 msgstr "tamaño del enmarcado"
 
-#: ../src/iop/borders.c:1048
+#: ../src/iop/borders.c:1049
 msgid "size of the frame line in percent of min border width"
 msgstr "tamaño porcentual del borde"
 
-#: ../src/iop/borders.c:1052
+#: ../src/iop/borders.c:1053
 msgid "frame line offset"
 msgstr "desplazamiento de enmarcado"
 
-#: ../src/iop/borders.c:1055
+#: ../src/iop/borders.c:1056
 msgid "offset of the frame line beginning on picture side"
 msgstr "desplazamiento de la línea de marco en el lateral de la foto"
 
-#: ../src/iop/borders.c:1063
+#: ../src/iop/borders.c:1064
 msgid "select border color"
 msgstr "seleccionar color del borde"
 
-#: ../src/iop/borders.c:1064
+#: ../src/iop/borders.c:1065
 msgid "border color"
 msgstr "color del borde"
 
-#: ../src/iop/borders.c:1068
+#: ../src/iop/borders.c:1069
 msgid "pick border color from image"
 msgstr "seleccionar color del borde de la imagen"
 
-#: ../src/iop/borders.c:1079
+#: ../src/iop/borders.c:1080
 msgid "select frame line color"
 msgstr "seleccionar color del marco"
 
-#: ../src/iop/borders.c:1080
+#: ../src/iop/borders.c:1081
 msgid "frame line color"
 msgstr "color del marco"
 
-#: ../src/iop/borders.c:1084
+#: ../src/iop/borders.c:1085
 msgid "pick frame line color from image"
 msgstr "seleccionar color del marco de la imagen"
 
@@ -6139,112 +6444,112 @@ msgstr ""
 "corrección automática de aberración cromática\n"
 "sólo funciona en imágenes raw."
 
-#: ../src/iop/channelmixer.c:114
+#: ../src/iop/channelmixer.c:112
 msgid "channel mixer"
 msgstr "mezclador de canal"
 
-#: ../src/iop/channelmixer.c:455
+#: ../src/iop/channelmixer.c:452
 msgid "destination"
 msgstr "destino"
 
 #. dt_bauhaus_slider_set_format(g->gslider1, "");
-#: ../src/iop/channelmixer.c:456 ../src/iop/colorbalance.c:2485
-#: ../src/iop/colorbalance.c:2535 ../src/iop/colorbalance.c:2584
+#: ../src/iop/channelmixer.c:453 ../src/iop/colorbalance.c:2504
+#: ../src/iop/colorbalance.c:2554 ../src/iop/colorbalance.c:2603
 #: ../src/iop/colorize.c:416 ../src/iop/colorreconstruction.c:1374
-#: ../src/iop/colorreconstruction.c:1379 ../src/iop/colorzones.c:2268
-#: ../src/iop/colorzones.c:2329 ../src/iop/graduatednd.c:1244
-#: ../src/iop/splittoning.c:584
+#: ../src/iop/colorreconstruction.c:1379 ../src/iop/colorzones.c:2265
+#: ../src/iop/colorzones.c:2326 ../src/iop/graduatednd.c:1245
+#: ../src/iop/splittoning.c:611
 msgid "hue"
 msgstr "tono"
 
-#: ../src/iop/channelmixer.c:458 ../src/iop/colorchecker.c:1366
-#: ../src/iop/colorize.c:442 ../src/iop/colorzones.c:2263
-#: ../src/iop/colorzones.c:2331
+#: ../src/iop/channelmixer.c:455 ../src/iop/colorchecker.c:1367
+#: ../src/iop/colorize.c:442 ../src/iop/colorzones.c:2260
+#: ../src/iop/colorzones.c:2328
 msgid "lightness"
 msgstr "luminosidad"
 
-#: ../src/iop/channelmixer.c:462
+#: ../src/iop/channelmixer.c:459
 msgctxt "channelmixer"
 msgid "gray"
 msgstr "gris"
 
-#: ../src/iop/channelmixer.c:469
+#: ../src/iop/channelmixer.c:466
 msgid "amount of red channel in the output channel"
 msgstr "cantidad de rojo en el canal de salida"
 
-#: ../src/iop/channelmixer.c:475
+#: ../src/iop/channelmixer.c:472
 msgid "amount of green channel in the output channel"
 msgstr "cantidad de verde en el canal de salida"
 
-#: ../src/iop/channelmixer.c:481
+#: ../src/iop/channelmixer.c:478
 msgid "amount of blue channel in the output channel"
 msgstr "cantidad de azul en el canal de salida"
 
-#: ../src/iop/channelmixer.c:497
+#: ../src/iop/channelmixer.c:494
 msgid "swap R and B"
 msgstr "intercambiar R y B"
 
-#: ../src/iop/channelmixer.c:502
+#: ../src/iop/channelmixer.c:499
 msgid "swap G and B"
 msgstr "intercambiar G y B"
 
-#: ../src/iop/channelmixer.c:507
+#: ../src/iop/channelmixer.c:504
 msgid "color contrast boost"
 msgstr "incremento de contraste de color"
 
-#: ../src/iop/channelmixer.c:512
+#: ../src/iop/channelmixer.c:509
 msgid "color details boost"
 msgstr "incremento de detalles de color"
 
-#: ../src/iop/channelmixer.c:517
+#: ../src/iop/channelmixer.c:514
 msgid "color artifacts boost"
 msgstr "incremento de irregularidades de color"
 
-#: ../src/iop/channelmixer.c:522
+#: ../src/iop/channelmixer.c:519
 msgid "B/W luminance-based"
 msgstr "B/N basado en luminosidad"
 
-#: ../src/iop/channelmixer.c:527
+#: ../src/iop/channelmixer.c:524
 msgid "B/W artifacts boost"
 msgstr "B/N destacar objetos"
 
-#: ../src/iop/channelmixer.c:532
+#: ../src/iop/channelmixer.c:529
 msgid "B/W smooth skin"
 msgstr "B/N piel suave"
 
-#: ../src/iop/channelmixer.c:537
+#: ../src/iop/channelmixer.c:534
 msgid "B/W blue artifacts reduce"
 msgstr "B/N reduce artefactos azules"
 
-#: ../src/iop/channelmixer.c:543
+#: ../src/iop/channelmixer.c:540
 msgid "B/W Ilford Delta 100-400"
 msgstr "B/N Ilford Delta 100-400"
 
-#: ../src/iop/channelmixer.c:549
+#: ../src/iop/channelmixer.c:546
 msgid "B/W Ilford Delta 3200"
 msgstr "B/N Ilford Delta 3200"
 
-#: ../src/iop/channelmixer.c:555
+#: ../src/iop/channelmixer.c:552
 msgid "B/W Ilford FP4"
 msgstr "B/N Ilford FP4"
 
-#: ../src/iop/channelmixer.c:561
+#: ../src/iop/channelmixer.c:558
 msgid "B/W Ilford HP5"
 msgstr "B/N Ilford HP5"
 
-#: ../src/iop/channelmixer.c:567
+#: ../src/iop/channelmixer.c:564
 msgid "B/W Ilford SFX"
 msgstr "B/N Ilford SFX"
 
-#: ../src/iop/channelmixer.c:573
+#: ../src/iop/channelmixer.c:570
 msgid "B/W Kodak T-Max 100"
 msgstr "B/N Kodak T-Max 100"
 
-#: ../src/iop/channelmixer.c:579
+#: ../src/iop/channelmixer.c:576
 msgid "B/W Kodak T-max 400"
 msgstr "B/N Kodak T-max 400"
 
-#: ../src/iop/channelmixer.c:585
+#: ../src/iop/channelmixer.c:582
 msgid "B/W Kodak Tri-X 400"
 msgstr "B/N Kodak Tri-X 400"
 
@@ -6264,129 +6569,129 @@ msgstr "fuerza del efecto"
 msgid "crop and rotate"
 msgstr "recortar y rotar"
 
-#: ../src/iop/clipping.c:1588
+#: ../src/iop/clipping.c:1590
 msgid "invalid ratio format. it should be \"number:number\""
 msgstr "formato de aspecto inválido. debería ser \"número:número\""
 
-#: ../src/iop/clipping.c:1692 ../src/iop/clipping.c:1996
+#: ../src/iop/clipping.c:1694 ../src/iop/clipping.c:1998
 msgid "full"
 msgstr "lleno"
 
-#: ../src/iop/clipping.c:1693
+#: ../src/iop/clipping.c:1695
 msgid "old system"
 msgstr "sistema antiguo"
 
-#: ../src/iop/clipping.c:1694
+#: ../src/iop/clipping.c:1696
 msgid "correction applied"
 msgstr "corrección hecha"
 
-#: ../src/iop/clipping.c:1974 ../src/libs/live_view.c:374
+#: ../src/iop/clipping.c:1976 ../src/libs/live_view.c:374
 msgid "flip"
 msgstr "voltear"
 
-#: ../src/iop/clipping.c:1978 ../src/iop/clipping.c:2163
-#: ../src/iop/colorbalance.c:2359 ../src/libs/live_view.c:378
+#: ../src/iop/clipping.c:1980 ../src/iop/clipping.c:2165
+#: ../src/iop/colorbalance.c:2378 ../src/libs/live_view.c:378
 msgid "both"
 msgstr "ambos"
 
-#: ../src/iop/clipping.c:1980
+#: ../src/iop/clipping.c:1982
 msgid "mirror image horizontally and/or vertically"
 msgstr "reflejar imagen horizontal/vertical"
 
-#: ../src/iop/clipping.c:1985
+#: ../src/iop/clipping.c:1987
 msgid "angle"
 msgstr "ángulo"
 
-#: ../src/iop/clipping.c:1988
+#: ../src/iop/clipping.c:1990
 msgid "right-click and drag a line on the image to drag a straight line"
 msgstr "clic derecho y arrastrar ratón en la imagen para crear una linea recta"
 
-#: ../src/iop/clipping.c:1992
+#: ../src/iop/clipping.c:1994
 msgid "keystone"
 msgstr "perspectiva"
 
-#: ../src/iop/clipping.c:1997
+#: ../src/iop/clipping.c:1999
 msgid "set perspective correction for your image"
 msgstr "seleccionar corrección de perspectiva para su imagen"
 
-#: ../src/iop/clipping.c:2009
+#: ../src/iop/clipping.c:2011
 msgid "freehand"
 msgstr "libre"
 
-#: ../src/iop/clipping.c:2010
+#: ../src/iop/clipping.c:2012
 msgid "original image"
 msgstr "imagen original"
 
-#: ../src/iop/clipping.c:2012
+#: ../src/iop/clipping.c:2014
 msgid "10:8 in print"
 msgstr "10:8 en impresión"
 
-#: ../src/iop/clipping.c:2013
+#: ../src/iop/clipping.c:2015
 msgid "5:4, 4x5, 8x10"
 msgstr "5:4, 4x5, 8x10"
 
-#: ../src/iop/clipping.c:2014
+#: ../src/iop/clipping.c:2016
 msgid "11x14"
 msgstr "11x14"
 
-#: ../src/iop/clipping.c:2015
+#: ../src/iop/clipping.c:2017
 msgid "8.5x11, letter"
 msgstr "8.5x11, carta"
 
-#: ../src/iop/clipping.c:2016
+#: ../src/iop/clipping.c:2018
 msgid "4:3, VGA, TV"
 msgstr "4:3, VGA, TV"
 
-#: ../src/iop/clipping.c:2017
+#: ../src/iop/clipping.c:2019
 msgid "5x7"
 msgstr "5x7"
 
-#: ../src/iop/clipping.c:2018
+#: ../src/iop/clipping.c:2020
 msgid "ISO 216, DIN 476, A4"
 msgstr "ISO 216, DIN 476, A4"
 
-#: ../src/iop/clipping.c:2019
+#: ../src/iop/clipping.c:2021
 msgid "3:2, 4x6, 35mm"
 msgstr "3:2, 4x6, 35mm"
 
-#: ../src/iop/clipping.c:2020
+#: ../src/iop/clipping.c:2022
 msgid "16:10, 8x5"
 msgstr "16:10, 8x5"
 
-#: ../src/iop/clipping.c:2022
+#: ../src/iop/clipping.c:2024
 msgid "16:9, HDTV"
 msgstr "16:9, HDTV"
 
-#: ../src/iop/clipping.c:2023
+#: ../src/iop/clipping.c:2025
 msgid "widescreen"
 msgstr "pantalla ancha"
 
-#: ../src/iop/clipping.c:2024
+#: ../src/iop/clipping.c:2026
 msgid "2:1, univisium"
 msgstr "2:1, univisium"
 
-#: ../src/iop/clipping.c:2025
+#: ../src/iop/clipping.c:2027
 msgid "cinemascope"
 msgstr "cinemascope"
 
-#: ../src/iop/clipping.c:2026
+#: ../src/iop/clipping.c:2028
 msgid "21:9"
 msgstr "21:9"
 
-#: ../src/iop/clipping.c:2027
+#: ../src/iop/clipping.c:2029
 msgid "anamorphic"
 msgstr "anamórfico"
 
-#: ../src/iop/clipping.c:2028
+#: ../src/iop/clipping.c:2030
 msgid "3:1, panorama"
 msgstr "3:1, panorámica"
 
-#: ../src/iop/clipping.c:2060 ../src/iop/clipping.c:2072
+#: ../src/iop/clipping.c:2062 ../src/iop/clipping.c:2074
 #, c-format
 msgid "invalid ratio format for `%s'. it should be \"number:number\""
 msgstr "formato de aspecto inválido para `%s'. debería ser \"número:número\""
 
-#: ../src/iop/clipping.c:2119
+#: ../src/iop/clipping.c:2121
 msgid ""
 "set the aspect ratio\n"
 "the list is sorted: from most square to least square"
@@ -6394,38 +6699,53 @@ msgstr ""
 "ajusta la relación de aspecto\n"
 "la lista está ordenada: desde el mas cuadrado hasta el menos cuadrado"
 
-#: ../src/iop/clipping.c:2155 ../src/libs/live_view.c:370
+#: ../src/iop/clipping.c:2157 ../src/libs/live_view.c:370
 msgid "display guide lines to help compose your photograph"
 msgstr "mostrar lineas guía para ayudar a componer su fotografía"
 
-#: ../src/iop/clipping.c:2159 ../src/iop/clipping.c:2164
+#: ../src/iop/clipping.c:2161 ../src/iop/clipping.c:2166
 #: ../src/libs/live_view.c:379
 msgid "flip guides"
 msgstr "invertir guías"
 
-#: ../src/iop/clipping.c:2161 ../src/libs/live_view.c:376
+#: ../src/iop/clipping.c:2163 ../src/libs/live_view.c:376
 msgid "horizontally"
 msgstr "horizontalmente"
 
-#: ../src/iop/clipping.c:2162 ../src/libs/live_view.c:377
+#: ../src/iop/clipping.c:2164 ../src/libs/live_view.c:377
 msgid "vertically"
 msgstr "verticalmente"
 
-#: ../src/iop/clipping.c:3215
+#: ../src/iop/clipping.c:3217
 msgctxt "accel"
 msgid "commit"
 msgstr "aceptar"
 
-#: ../src/iop/clipping.c:3216
+#: ../src/iop/clipping.c:3218
 msgctxt "accel"
 msgid "angle"
 msgstr "ángulo"
+
+#: ../src/iop/clipping.c:3239
+#, c-format
+msgid "[%s on borders] crop"
+msgstr "[%s en los bordes] recortar"
+
+#: ../src/iop/clipping.c:3245
+#, c-format
+msgid "[%s on borders] crop keeping ratio"
+msgstr "[%s en los bordes] recortar manteniendo la proporción"
+
+#: ../src/iop/clipping.c:3250
+#, c-format
+msgid "[%s] define/rotate horizon"
+msgstr "[%s] definir o rotar horizonte"
 
 #: ../src/iop/colisa.c:78
 msgid "contrast brightness saturation"
 msgstr "contraste brillo saturación"
 
-#: ../src/iop/colisa.c:99 ../src/iop/lowpass.c:197
+#: ../src/iop/colisa.c:99 ../src/iop/filmicrgb.c:273 ../src/iop/lowpass.c:197
 msgctxt "accel"
 msgid "contrast"
 msgstr "contraste"
@@ -6490,182 +6810,182 @@ msgctxt "accel"
 msgid "controls"
 msgstr "controles"
 
-#: ../src/iop/colorbalance.c:959
+#: ../src/iop/colorbalance.c:960
 msgid "optimize luma from patches"
 msgstr "optimizar la luminosidad a partir de parches"
 
-#: ../src/iop/colorbalance.c:961 ../src/iop/colorbalance.c:2632
+#: ../src/iop/colorbalance.c:962 ../src/iop/colorbalance.c:2651
 msgid "optimize luma"
 msgstr "optimizar luminosidad"
 
-#: ../src/iop/colorbalance.c:965
+#: ../src/iop/colorbalance.c:966
 msgid "neutralize colors from patches"
 msgstr "neutraliza los colores desde los parches"
 
-#: ../src/iop/colorbalance.c:967 ../src/iop/colorbalance.c:2641
+#: ../src/iop/colorbalance.c:968 ../src/iop/colorbalance.c:2660
 msgid "neutralize colors"
 msgstr "neutralizar los colores"
 
-#: ../src/iop/colorbalance.c:2347
+#: ../src/iop/colorbalance.c:2366
 msgid "lift, gamma, gain (ProPhotoRGB)"
 msgstr "realce, gamma, ganancia (ProPhotoRGB)"
 
-#: ../src/iop/colorbalance.c:2348
+#: ../src/iop/colorbalance.c:2367
 msgid "slope, offset, power (ProPhotoRGB)"
 msgstr "pendiente, desplazamiento, potencia (ProPhotoRGB)"
 
-#: ../src/iop/colorbalance.c:2349
+#: ../src/iop/colorbalance.c:2368
 msgid "lift, gamma, gain (sRGB)"
 msgstr "realce, gamma, ganancia (sRGB)"
 
-#: ../src/iop/colorbalance.c:2351 ../src/iop/colorbalance.c:2362
+#: ../src/iop/colorbalance.c:2370 ../src/iop/colorbalance.c:2381
 msgid "color-grading mapping method"
 msgstr "método de mapeo de gradación de color"
 
-#: ../src/iop/colorbalance.c:2356
+#: ../src/iop/colorbalance.c:2375
 msgid "color control sliders"
 msgstr "controles deslizantes de color"
 
-#: ../src/iop/colorbalance.c:2357
+#: ../src/iop/colorbalance.c:2376
 msgid "HSL"
 msgstr "HSL"
 
-#: ../src/iop/colorbalance.c:2358
+#: ../src/iop/colorbalance.c:2377
 msgid "RGBL"
 msgstr "RGBL"
 
-#: ../src/iop/colorbalance.c:2369
+#: ../src/iop/colorbalance.c:2388
 msgid "master"
 msgstr "máster"
 
-#: ../src/iop/colorbalance.c:2374
+#: ../src/iop/colorbalance.c:2393
 msgid "input saturation"
 msgstr "saturación de entrada"
 
-#: ../src/iop/colorbalance.c:2376
+#: ../src/iop/colorbalance.c:2395
 msgid "saturation correction before the color balance"
 msgstr "corrección de saturación antes del balance de color"
 
-#: ../src/iop/colorbalance.c:2382
+#: ../src/iop/colorbalance.c:2401
 msgid "output saturation"
 msgstr "saturación de salida"
 
-#: ../src/iop/colorbalance.c:2384
+#: ../src/iop/colorbalance.c:2403
 msgid "saturation correction after the color balance"
 msgstr "corrección de saturación despues del balance de color"
 
-#: ../src/iop/colorbalance.c:2388
+#: ../src/iop/colorbalance.c:2407
 msgid "contrast fulcrum"
 msgstr "punto de referencia de contraste"
 
-#: ../src/iop/colorbalance.c:2391
+#: ../src/iop/colorbalance.c:2410
 msgid "adjust to match a neutral tone"
 msgstr "ajustar para que coincida con un tono neutro"
 
-#: ../src/iop/colorbalance.c:2460 ../src/iop/colorbalance.c:2472
+#: ../src/iop/colorbalance.c:2479 ../src/iop/colorbalance.c:2491
 msgid "factor of "
 msgstr "factor de "
 
-#: ../src/iop/colorbalance.c:2461
+#: ../src/iop/colorbalance.c:2480
 msgid "factor"
 msgstr "factor"
 
 #. lift
-#: ../src/iop/colorbalance.c:2478
+#: ../src/iop/colorbalance.c:2497
 msgid "shadows : lift / offset"
 msgstr "sombras : levantar/desplazar"
 
-#: ../src/iop/colorbalance.c:2480
+#: ../src/iop/colorbalance.c:2499
 msgid "factor of lift"
 msgstr "factor de realce"
 
-#: ../src/iop/colorbalance.c:2480
+#: ../src/iop/colorbalance.c:2499
 msgid "lift"
 msgstr "realce"
 
-#: ../src/iop/colorbalance.c:2488 ../src/iop/colorbalance.c:2538
-#: ../src/iop/colorbalance.c:2587
+#: ../src/iop/colorbalance.c:2507 ../src/iop/colorbalance.c:2557
+#: ../src/iop/colorbalance.c:2606
 msgid "select the hue"
 msgstr "seleccionar el tono"
 
-#: ../src/iop/colorbalance.c:2501 ../src/iop/colorbalance.c:2551
-#: ../src/iop/colorbalance.c:2600
+#: ../src/iop/colorbalance.c:2520 ../src/iop/colorbalance.c:2570
+#: ../src/iop/colorbalance.c:2619
 msgid "select the saturation"
 msgstr "selecciona la saturación"
 
-#: ../src/iop/colorbalance.c:2506
+#: ../src/iop/colorbalance.c:2525
 msgid "factor of red for lift"
 msgstr "factor de rojo a realzar"
 
-#: ../src/iop/colorbalance.c:2513
+#: ../src/iop/colorbalance.c:2532
 msgid "factor of green for lift"
 msgstr "factor de verde a realzar"
 
-#: ../src/iop/colorbalance.c:2520
+#: ../src/iop/colorbalance.c:2539
 msgid "factor of blue for lift"
 msgstr "factor de azul a realzar"
 
 #. gamma
-#: ../src/iop/colorbalance.c:2528
+#: ../src/iop/colorbalance.c:2547
 msgid "mid-tones : gamma / power"
 msgstr "medios tonos: gamma / fuerza"
 
-#: ../src/iop/colorbalance.c:2530
+#: ../src/iop/colorbalance.c:2549
 msgid "factor of gamma"
 msgstr "factor de gamma"
 
-#: ../src/iop/colorbalance.c:2530 ../src/iop/profile_gamma.c:854
-#: ../src/iop/profile_gamma.c:876
+#: ../src/iop/colorbalance.c:2549 ../src/iop/profile_gamma.c:859
+#: ../src/iop/profile_gamma.c:881
 msgid "gamma"
 msgstr "gamma"
 
-#: ../src/iop/colorbalance.c:2555
+#: ../src/iop/colorbalance.c:2574
 msgid "factor of red for gamma"
 msgstr "factor rojo de gamma"
 
-#: ../src/iop/colorbalance.c:2562
+#: ../src/iop/colorbalance.c:2581
 msgid "factor of green for gamma"
 msgstr "factor verde de gamma"
 
-#: ../src/iop/colorbalance.c:2569
+#: ../src/iop/colorbalance.c:2588
 msgid "factor of blue for gamma"
 msgstr "factor azul de gamma"
 
 #. gain
-#: ../src/iop/colorbalance.c:2577
+#: ../src/iop/colorbalance.c:2596
 msgid "highlights : gain / slope"
 msgstr "altas luces: ganancia/perdida"
 
-#: ../src/iop/colorbalance.c:2579
+#: ../src/iop/colorbalance.c:2598
 msgid "factor of gain"
 msgstr "factor de ganancia"
 
-#: ../src/iop/colorbalance.c:2579
+#: ../src/iop/colorbalance.c:2598
 msgid "gain"
 msgstr "ganancia"
 
-#: ../src/iop/colorbalance.c:2604
+#: ../src/iop/colorbalance.c:2623
 msgid "factor of red for gain"
 msgstr "factor rojo de ganancia"
 
-#: ../src/iop/colorbalance.c:2611
+#: ../src/iop/colorbalance.c:2630
 msgid "factor of green for gain"
 msgstr "factor verde de ganancia"
 
-#: ../src/iop/colorbalance.c:2618
+#: ../src/iop/colorbalance.c:2637
 msgid "factor of blue for gain"
 msgstr "factor azul de ganancia"
 
-#: ../src/iop/colorbalance.c:2625
+#: ../src/iop/colorbalance.c:2644
 msgid "auto optimizers"
 msgstr "optimizadores automáticos"
 
 # Esta entrada estaba sin traducir
-#: ../src/iop/colorbalance.c:2637
+#: ../src/iop/colorbalance.c:2656
 msgid "fit the whole histogram and center the average luma"
 msgstr "ajustar todo el histograma y centrar la luz media"
 
-#: ../src/iop/colorbalance.c:2646
+#: ../src/iop/colorbalance.c:2665
 msgid "optimize the RGB curves to remove color casts"
 msgstr "optimizar las curvas RGB para eliminar los tonos de color"
 
@@ -6701,12 +7021,12 @@ msgstr "Fuji Provia  simulación"
 msgid "Fuji Velvia emulation"
 msgstr "Fuji Velvia simulación"
 
-#: ../src/iop/colorchecker.c:845 ../src/iop/colorchecker.c:1358
+#: ../src/iop/colorchecker.c:845 ../src/iop/colorchecker.c:1359
 #, c-format
 msgid "patch #%d"
 msgstr "parche #%d"
 
-#: ../src/iop/colorchecker.c:1228
+#: ../src/iop/colorchecker.c:1229
 #, c-format
 msgid ""
 "(%2.2f %2.2f %2.2f)\n"
@@ -6723,43 +7043,43 @@ msgstr ""
 "clic derecho para borrar parche\n"
 "Mayús+clic mientras seleccione color para reemplazar parche"
 
-#: ../src/iop/colorchecker.c:1353
+#: ../src/iop/colorchecker.c:1354
 msgid "patch"
 msgstr "parche"
 
-#: ../src/iop/colorchecker.c:1354
+#: ../src/iop/colorchecker.c:1355
 msgid "color checker patch"
 msgstr "parche del cuentagotas"
 
-#: ../src/iop/colorchecker.c:1365
+#: ../src/iop/colorchecker.c:1366
 msgid "lightness offset"
 msgstr "desplazamiento de luminosidad"
 
-#: ../src/iop/colorchecker.c:1369
+#: ../src/iop/colorchecker.c:1370
 msgid "chroma offset green/red"
 msgstr "desplazamiento de crominancia verde/rojo"
 
-#: ../src/iop/colorchecker.c:1370
+#: ../src/iop/colorchecker.c:1371
 msgid "green/red"
 msgstr "rojo/verde"
 
-#: ../src/iop/colorchecker.c:1376
+#: ../src/iop/colorchecker.c:1377
 msgid "chroma offset blue/yellow"
 msgstr "desplazamiento de crominancia azul/amarillo"
 
-#: ../src/iop/colorchecker.c:1377
+#: ../src/iop/colorchecker.c:1378
 msgid "blue/yellow"
 msgstr "azul/amarillo"
 
-#: ../src/iop/colorchecker.c:1383
+#: ../src/iop/colorchecker.c:1384
 msgid "saturation offset"
 msgstr "desplazamiento de saturación"
 
-#: ../src/iop/colorchecker.c:1388
+#: ../src/iop/colorchecker.c:1389
 msgid "target color"
 msgstr "color del objetivo"
 
-#: ../src/iop/colorchecker.c:1389
+#: ../src/iop/colorchecker.c:1390
 msgid ""
 "control target color of the patches via relative offsets or via absolute Lab "
 "values"
@@ -6767,11 +7087,11 @@ msgstr ""
 "control del objetivo de color para los parches vía desviaciones relativas o "
 "vía valores Lab absolutos"
 
-#: ../src/iop/colorchecker.c:1390
+#: ../src/iop/colorchecker.c:1391
 msgid "relative"
 msgstr "relativo"
 
-#: ../src/iop/colorchecker.c:1391
+#: ../src/iop/colorchecker.c:1392
 msgid "absolute"
 msgstr "absoluto"
 
@@ -6833,11 +7153,11 @@ msgstr ""
 msgid "set the global saturation"
 msgstr "establece la saturación global"
 
-#: ../src/iop/colorin.c:118
+#: ../src/iop/colorin.c:120
 msgid "input color profile"
 msgstr "perfil de color de entrada"
 
-#: ../src/iop/colorin.c:471
+#: ../src/iop/colorin.c:473
 #, c-format
 msgid ""
 "can't extract matrix from colorspace `%s', it will be replaced by Rec2020 "
@@ -6846,39 +7166,39 @@ msgstr ""
 "no se puede extraer la matriz del espacio de color `%s', por lo que será "
 "reemplazada por Rec2020 RGB"
 
-#: ../src/iop/colorin.c:1581
+#: ../src/iop/colorin.c:1583
 #, c-format
 msgid "`%s' color matrix not found!"
 msgstr "`%s' matriz de color no encontrada!"
 
-#: ../src/iop/colorin.c:1616
+#: ../src/iop/colorin.c:1618
 msgid "input profile could not be generated!"
 msgstr "el perfil de entrada no puede ser generado!"
 
-#: ../src/iop/colorin.c:1698
+#: ../src/iop/colorin.c:1700
 msgid "unsupported input profile has been replaced by linear Rec709 RGB!"
 msgstr ""
 "perfil de entrada no soportado ha sido remplazado por linear Rec709 RGB!"
 
-#: ../src/iop/colorin.c:2067
+#: ../src/iop/colorin.c:2069
 msgid "input profile"
 msgstr "perfil de entrada"
 
-#: ../src/iop/colorin.c:2071
+#: ../src/iop/colorin.c:2073
 msgid "working profile"
 msgstr "definir un perfil"
 
-#: ../src/iop/colorin.c:2081 ../src/iop/colorin.c:2092
-#: ../src/iop/colorout.c:891
+#: ../src/iop/colorin.c:2083 ../src/iop/colorin.c:2094
+#: ../src/iop/colorout.c:892
 #, c-format
 msgid "ICC profiles in %s or %s"
 msgstr "Perfiles ICC en %s o %s"
 
-#: ../src/iop/colorin.c:2103
+#: ../src/iop/colorin.c:2105
 msgid "gamut clipping"
 msgstr "recorte de gama"
 
-#: ../src/iop/colorin.c:2111
+#: ../src/iop/colorin.c:2113
 msgid "confine Lab values to gamut of RGB color space"
 msgstr "limitar los valores Lab al gama del espacio de color RGB"
 
@@ -6896,7 +7216,7 @@ msgctxt "accel"
 msgid "source mix"
 msgstr "mezcla fuente"
 
-#: ../src/iop/colorize.c:423 ../src/iop/splittoning.c:591
+#: ../src/iop/colorize.c:423 ../src/iop/splittoning.c:618
 msgid "select the hue tone"
 msgstr "seleccionar el tono"
 
@@ -6930,45 +7250,45 @@ msgctxt "accel"
 msgid "acquire as target"
 msgstr "obtener como objetivo"
 
-#: ../src/iop/colormapping.c:1107
+#: ../src/iop/colormapping.c:1113
 msgid "source clusters:"
 msgstr "grupos fuente:"
 
-#: ../src/iop/colormapping.c:1116
+#: ../src/iop/colormapping.c:1122
 msgid "target clusters:"
 msgstr "grupos objetivo:"
 
-#: ../src/iop/colormapping.c:1129
+#: ../src/iop/colormapping.c:1135
 msgid "acquire as source"
 msgstr "adquirir como fuente"
 
-#: ../src/iop/colormapping.c:1131
+#: ../src/iop/colormapping.c:1137
 msgid "analyze this image as a source image"
 msgstr "analizar esta imagen como imagen fuente"
 
-#: ../src/iop/colormapping.c:1135
+#: ../src/iop/colormapping.c:1141
 msgid "acquire as target"
 msgstr "adquirir como objetivo"
 
-#: ../src/iop/colormapping.c:1137
+#: ../src/iop/colormapping.c:1143
 msgid "analyze this image as a target image"
 msgstr "analizar esta imagen como objetivo"
 
-#: ../src/iop/colormapping.c:1142
+#: ../src/iop/colormapping.c:1148
 msgid "number of clusters"
 msgstr "número de grupos"
 
-#: ../src/iop/colormapping.c:1144
+#: ../src/iop/colormapping.c:1150
 msgid "number of clusters to find in image. value change resets all clusters"
 msgstr ""
 "numero de grupos a encontrar en una imagen. los cambios en los valores "
 "reinician todos los grupos"
 
-#: ../src/iop/colormapping.c:1149
+#: ../src/iop/colormapping.c:1155
 msgid "color dominance"
 msgstr "dominancia de color"
 
-#: ../src/iop/colormapping.c:1150
+#: ../src/iop/colormapping.c:1156
 msgid ""
 "how clusters are mapped. low values: based on color proximity, high values: "
 "based on color dominance"
@@ -6976,64 +7296,64 @@ msgstr ""
 "como son mapeados los grupos. valores bajos. basado en proximidad de color, "
 "valores altos: basados en dominancia de color"
 
-#: ../src/iop/colormapping.c:1157
+#: ../src/iop/colormapping.c:1163
 msgid "histogram equalization"
 msgstr "equalización del histograma"
 
-#: ../src/iop/colormapping.c:1158
+#: ../src/iop/colormapping.c:1164
 msgid "level of histogram equalization"
 msgstr "nivel de equalización del histograma"
 
-#: ../src/iop/colorout.c:80
+#: ../src/iop/colorout.c:81
 msgid "output color profile"
 msgstr "perfil de color de salida"
 
-#: ../src/iop/colorout.c:666
+#: ../src/iop/colorout.c:667
 msgid "missing output profile has been replaced by sRGB!"
 msgstr "perfil de salida no entontrado reemplazado por sRGB!"
 
-#: ../src/iop/colorout.c:685
+#: ../src/iop/colorout.c:686
 msgid "missing softproof profile has been replaced by sRGB!"
 msgstr "perfil de salida no encontrado ha sido reemplazado por sRGB!"
 
-#: ../src/iop/colorout.c:728
+#: ../src/iop/colorout.c:729
 msgid "unsupported output profile has been replaced by sRGB!"
 msgstr "perfil de salida no soportado reemplazado por sRGB!"
 
-#: ../src/iop/colorout.c:867
+#: ../src/iop/colorout.c:868
 msgid "output intent"
 msgstr "salida"
 
-#: ../src/iop/colorout.c:868 ../src/libs/export.c:653
-#: ../src/libs/print_settings.c:1241 ../src/libs/print_settings.c:1456
-#: ../src/views/darkroom.c:1953 ../src/views/darkroom.c:1961
-#: ../src/views/lighttable.c:4705 ../src/views/lighttable.c:4713
+#: ../src/iop/colorout.c:869 ../src/libs/export.c:669
+#: ../src/libs/print_settings.c:1239 ../src/libs/print_settings.c:1454
+#: ../src/views/darkroom.c:1973 ../src/views/darkroom.c:1981
+#: ../src/views/lighttable.c:4868 ../src/views/lighttable.c:4876
 msgid "perceptual"
 msgstr "perceptual"
 
-#: ../src/iop/colorout.c:869 ../src/libs/export.c:654
-#: ../src/libs/print_settings.c:1242 ../src/libs/print_settings.c:1457
-#: ../src/views/darkroom.c:1954 ../src/views/darkroom.c:1962
-#: ../src/views/lighttable.c:4706 ../src/views/lighttable.c:4714
+#: ../src/iop/colorout.c:870 ../src/libs/export.c:670
+#: ../src/libs/print_settings.c:1240 ../src/libs/print_settings.c:1455
+#: ../src/views/darkroom.c:1974 ../src/views/darkroom.c:1982
+#: ../src/views/lighttable.c:4869 ../src/views/lighttable.c:4877
 msgid "relative colorimetric"
 msgstr "relativo colorimétrico"
 
-#: ../src/iop/colorout.c:870 ../src/libs/export.c:655
-#: ../src/libs/print_settings.c:1243 ../src/libs/print_settings.c:1458
-#: ../src/views/darkroom.c:1955 ../src/views/darkroom.c:1963
-#: ../src/views/lighttable.c:4707 ../src/views/lighttable.c:4715
+#: ../src/iop/colorout.c:871 ../src/libs/export.c:671
+#: ../src/libs/print_settings.c:1241 ../src/libs/print_settings.c:1456
+#: ../src/views/darkroom.c:1975 ../src/views/darkroom.c:1983
+#: ../src/views/lighttable.c:4870 ../src/views/lighttable.c:4878
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "saturación"
 
-#: ../src/iop/colorout.c:871 ../src/libs/export.c:656
-#: ../src/libs/print_settings.c:1244 ../src/libs/print_settings.c:1459
-#: ../src/views/darkroom.c:1956 ../src/views/darkroom.c:1964
-#: ../src/views/lighttable.c:4708 ../src/views/lighttable.c:4716
+#: ../src/iop/colorout.c:872 ../src/libs/export.c:672
+#: ../src/libs/print_settings.c:1242 ../src/libs/print_settings.c:1457
+#: ../src/views/darkroom.c:1976 ../src/views/darkroom.c:1984
+#: ../src/views/lighttable.c:4871 ../src/views/lighttable.c:4879
 msgid "absolute colorimetric"
 msgstr "absoluto colorimétrico"
 
-#: ../src/iop/colorout.c:888
+#: ../src/iop/colorout.c:889
 msgid "rendering intent"
 msgstr "representación de color"
 
@@ -7059,7 +7379,7 @@ msgstr "tono"
 #: ../src/iop/colorreconstruction.c:635 ../src/iop/colorreconstruction.c:1088
 #: ../src/iop/globaltonemap.c:190 ../src/iop/globaltonemap.c:356
 #: ../src/iop/hazeremoval.c:708 ../src/iop/hazeremoval.c:960
-#: ../src/iop/levels.c:361
+#: ../src/iop/levels.c:362
 msgid "inconsistent output"
 msgstr "salida inconsistente"
 
@@ -7155,31 +7475,32 @@ msgstr "establecer en esta imagen el aspecto analizado previamente"
 msgid "color zones"
 msgstr "zonas de color"
 
-#: ../src/iop/colorzones.c:556
+#: ../src/iop/colorzones.c:553
 msgid "red black white"
 msgstr "rojo negro blanco"
 
-#: ../src/iop/colorzones.c:578
+#: ../src/iop/colorzones.c:575
 msgid "black white and skin tones"
 msgstr "byn y tonos de piel"
 
-#: ../src/iop/colorzones.c:600
+#: ../src/iop/colorzones.c:597
 msgid "polarizing filter"
 msgstr "filtro polarizador"
 
-#: ../src/iop/colorzones.c:620
+#: ../src/iop/colorzones.c:617
 msgid "natural skin tones"
 msgstr "tonos de piel naturales"
 
-#: ../src/iop/colorzones.c:652
+#: ../src/iop/colorzones.c:649
 msgid "black & white film"
 msgstr "película blanco y negro"
 
-#: ../src/iop/colorzones.c:2071 ../src/iop/retouch.c:2237
+#: ../src/iop/colorzones.c:2068 ../src/iop/retouch.c:2238
+#: ../src/iop/toneequal.c:1960
 msgid "cannot display masks when the blending mask is displayed"
 msgstr "no se puede mostrar máscaras cuando se muestra la máscara de mezcla"
 
-#: ../src/iop/colorzones.c:2278 ../src/iop/rgbcurve.c:1520
+#: ../src/iop/colorzones.c:2275 ../src/iop/rgbcurve.c:1510
 msgid ""
 "create a curve based on an area from the image\n"
 "click to create a flat curve\n"
@@ -7192,55 +7513,55 @@ msgstr ""
 "Use Mayús+clic para crear una curva negativa"
 
 #. edit by area
-#: ../src/iop/colorzones.c:2309
+#: ../src/iop/colorzones.c:2306
 msgid "edit by area"
 msgstr "editar por área"
 
-#: ../src/iop/colorzones.c:2311
+#: ../src/iop/colorzones.c:2308
 msgid "edit the curve nodes by area"
 msgstr "Editar los nodos de la curva por área"
 
-#: ../src/iop/colorzones.c:2318
+#: ../src/iop/colorzones.c:2315
 msgid "display selection"
 msgstr "selección de visualización"
 
-#: ../src/iop/colorzones.c:2327
+#: ../src/iop/colorzones.c:2324
 msgid "select by"
 msgstr "seleccionar por"
 
-#: ../src/iop/colorzones.c:2328
+#: ../src/iop/colorzones.c:2325
 msgid "choose selection criterion, will be the abscissa in the graph"
 msgstr "escoja criterio de selección, será la abscisa en el gráfico"
 
-#: ../src/iop/colorzones.c:2336
+#: ../src/iop/colorzones.c:2333
 msgid "process mode"
 msgstr "modo de proceso"
 
-#: ../src/iop/colorzones.c:2338
+#: ../src/iop/colorzones.c:2335
 msgid "strong"
 msgstr "fuerza"
 
-#: ../src/iop/colorzones.c:2340
+#: ../src/iop/colorzones.c:2337
 msgid "choose between a smoother or stronger effect"
 msgstr "Elija entre un efecto más suave o más marcado."
 
-#: ../src/iop/colorzones.c:2376 ../src/iop/rgbcurve.c:1573
-#: ../src/iop/tonecurve.c:1295
+#: ../src/iop/colorzones.c:2373 ../src/iop/rgbcurve.c:1563
+#: ../src/iop/tonecurve.c:1380
 msgid "interpolation method"
 msgstr "método de interpolación"
 
-#: ../src/iop/colorzones.c:2378 ../src/iop/rgbcurve.c:1575
-#: ../src/iop/tonecurve.c:1297
+#: ../src/iop/colorzones.c:2375 ../src/iop/rgbcurve.c:1565
+#: ../src/iop/tonecurve.c:1382
 msgid "centripetal spline"
 msgstr "curva segmentaria centrípeta"
 
-#: ../src/iop/colorzones.c:2379 ../src/iop/rgbcurve.c:1576
-#: ../src/iop/tonecurve.c:1298
+#: ../src/iop/colorzones.c:2376 ../src/iop/rgbcurve.c:1566
+#: ../src/iop/tonecurve.c:1383
 msgid "monotonic spline"
 msgstr "curva segmentaria monótona"
 
-#: ../src/iop/colorzones.c:2383 ../src/iop/rgbcurve.c:1580
-#: ../src/iop/tonecurve.c:1300
+#: ../src/iop/colorzones.c:2380 ../src/iop/rgbcurve.c:1570
+#: ../src/iop/tonecurve.c:1385
 msgid ""
 "change this method if you see oscillations or cusps in the curve\n"
 "- cubic spline is better to produce smooth curves but oscillates when nodes "
@@ -7321,54 +7642,54 @@ msgctxt "accel"
 msgid "edge threshold"
 msgstr "borde del umbral"
 
-#: ../src/iop/demosaic.c:4917
+#: ../src/iop/demosaic.c:4916
 #, c-format
 msgid "`%s' color matrix not found for 4bayer image!"
 msgstr "`%s' matriz de color no encontrada para la imagen 4bayer"
 
-#: ../src/iop/demosaic.c:5121 ../src/iop/demosaic.c:5130
+#: ../src/iop/demosaic.c:5120 ../src/iop/demosaic.c:5129
 #: ../src/iop/dither.c:801 ../src/iop/highlights.c:1078
 msgid "method"
 msgstr "método"
 
-#: ../src/iop/demosaic.c:5123
+#: ../src/iop/demosaic.c:5122
 msgid "PPG (fast)"
 msgstr "PPG (rápido)"
 
-#: ../src/iop/demosaic.c:5124
+#: ../src/iop/demosaic.c:5123
 msgid "AMaZE (slow)"
 msgstr "AMaZE (lento)"
 
-#: ../src/iop/demosaic.c:5125
+#: ../src/iop/demosaic.c:5124
 msgid "VNG4"
 msgstr "VNG4"
 
-#: ../src/iop/demosaic.c:5126 ../src/iop/demosaic.c:5135
+#: ../src/iop/demosaic.c:5125 ../src/iop/demosaic.c:5134
 msgid "passthrough (monochrome) (experimental)"
 msgstr "atravesar (monocromo) (experimental)"
 
 # Demosaicing -> Algoritmo de interpolación cromática.
-#: ../src/iop/demosaic.c:5127 ../src/iop/demosaic.c:5137
+#: ../src/iop/demosaic.c:5126 ../src/iop/demosaic.c:5136
 msgid "demosaicing raw data method"
 msgstr "método de interpolación cromática RAW"
 
-#: ../src/iop/demosaic.c:5132
+#: ../src/iop/demosaic.c:5131
 msgid "VNG"
 msgstr "VNG"
 
-#: ../src/iop/demosaic.c:5133
+#: ../src/iop/demosaic.c:5132
 msgid "Markesteijn 1-pass"
 msgstr "Markesteijn 1 pasada"
 
-#: ../src/iop/demosaic.c:5134
+#: ../src/iop/demosaic.c:5133
 msgid "Markesteijn 3-pass (slow)"
 msgstr "Markesteijn 3 pasadas (lento)"
 
-#: ../src/iop/demosaic.c:5136
+#: ../src/iop/demosaic.c:5135
 msgid "frequency domain chroma (slow)"
 msgstr "frecuencia y dominio crominancia (lento)"
 
-#: ../src/iop/demosaic.c:5140
+#: ../src/iop/demosaic.c:5139
 msgid ""
 "threshold for edge-aware median.\n"
 "set to 0.0 to switch off.\n"
@@ -7378,66 +7699,66 @@ msgstr ""
 "poner en 0.0 para desactivar.\n"
 "poner en 1.0 para ignorar bordes."
 
-#: ../src/iop/demosaic.c:5142
+#: ../src/iop/demosaic.c:5141
 msgid "edge threshold"
 msgstr "borde del umbral"
 
-#: ../src/iop/demosaic.c:5146
+#: ../src/iop/demosaic.c:5145
 msgid "color smoothing"
 msgstr "suavizado de color"
 
-#: ../src/iop/demosaic.c:5149
+#: ../src/iop/demosaic.c:5148
 msgid "one time"
 msgstr "una vez"
 
-#: ../src/iop/demosaic.c:5150
+#: ../src/iop/demosaic.c:5149
 msgid "two times"
 msgstr "dos veces"
 
-#: ../src/iop/demosaic.c:5151
+#: ../src/iop/demosaic.c:5150
 msgid "three times"
 msgstr "tres veces"
 
-#: ../src/iop/demosaic.c:5152
+#: ../src/iop/demosaic.c:5151
 msgid "four times"
 msgstr "cuatro veces"
 
-#: ../src/iop/demosaic.c:5153
+#: ../src/iop/demosaic.c:5152
 msgid "five times"
 msgstr "cinco veces"
 
 # Demosaicing -> Algoritmo de interpolación cromática.
-#: ../src/iop/demosaic.c:5154
+#: ../src/iop/demosaic.c:5153
 msgid "how many color smoothing median steps after demosaicing"
 msgstr ""
 "la cantidad de suavizado con medios pasos después de la interpolación "
 "cromática"
 
-#: ../src/iop/demosaic.c:5158
+#: ../src/iop/demosaic.c:5157
 msgid "match greens"
 msgstr "igualar verdes"
 
-#: ../src/iop/demosaic.c:5159
+#: ../src/iop/demosaic.c:5158
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ../src/iop/demosaic.c:5160
+#: ../src/iop/demosaic.c:5159
 msgid "local average"
 msgstr "promedio local"
 
-#: ../src/iop/demosaic.c:5161
+#: ../src/iop/demosaic.c:5160
 msgid "full average"
 msgstr "promedio total"
 
-#: ../src/iop/demosaic.c:5162
+#: ../src/iop/demosaic.c:5161
 msgid "full and local average"
 msgstr "promedio total y local"
 
-#: ../src/iop/demosaic.c:5163
+#: ../src/iop/demosaic.c:5162
 msgid "green channels matching method"
 msgstr "método de emparejamiento para el canal verde"
 
-#: ../src/iop/demosaic.c:5175
+#: ../src/iop/demosaic.c:5174
 msgid ""
 "demosaicing\n"
 "only needed for raw images."
@@ -7445,34 +7766,34 @@ msgstr ""
 "interpolación cromática\n"
 "solo es necesario en imágenes raw."
 
-#: ../src/iop/denoiseprofile.c:352
+#: ../src/iop/denoiseprofile.c:498
 msgid "denoise (profiled)"
 msgstr "reducción de ruido (perfilado)"
 
 #. these blobs were exported as dtstyle and copied from there:
-#: ../src/iop/denoiseprofile.c:407
+#: ../src/iop/denoiseprofile.c:553
 msgid "chroma (use on 1st instance)"
 msgstr "crominancia (uso en 1ª instancia)"
 
-#: ../src/iop/denoiseprofile.c:410
+#: ../src/iop/denoiseprofile.c:556
 msgid "luma (use on 2nd instance)"
 msgstr "luma (uso en 2ª instancia)"
 
-#: ../src/iop/denoiseprofile.c:2513
+#: ../src/iop/denoiseprofile.c:2964
 #, c-format
 msgid "found match for ISO %d"
 msgstr "se encontró coincidencia para el ISO %d"
 
-#: ../src/iop/denoiseprofile.c:2522
+#: ../src/iop/denoiseprofile.c:2973
 #, c-format
 msgid "interpolated from ISO %d and %d"
 msgstr "interpolación del ISO %d y %d"
 
-#: ../src/iop/denoiseprofile.c:2824 ../src/iop/denoiseprofile.c:3386
+#: ../src/iop/denoiseprofile.c:3404 ../src/iop/denoiseprofile.c:4028
 msgid "compute variance"
 msgstr "calcular varianza"
 
-#: ../src/iop/denoiseprofile.c:3260
+#: ../src/iop/denoiseprofile.c:3886
 msgid ""
 "use only with a perfectly\n"
 "uniform image if you want to\n"
@@ -7482,50 +7803,50 @@ msgstr ""
 "uniforme si desea estimar \n"
 "la varianza del ruido."
 
-#: ../src/iop/denoiseprofile.c:3267
+#: ../src/iop/denoiseprofile.c:3893
 msgid "variance red: "
 msgstr "varianza del rojo:"
 
 #. This gets filled in by process
-#: ../src/iop/denoiseprofile.c:3270
+#: ../src/iop/denoiseprofile.c:3896
 msgid "variance computed on the red channel"
 msgstr "varianza calculada para el canal rojo"
 
-#: ../src/iop/denoiseprofile.c:3275
+#: ../src/iop/denoiseprofile.c:3901
 msgid "variance green: "
 msgstr "varianza del verde:"
 
 #. This gets filled in by process
-#: ../src/iop/denoiseprofile.c:3278
+#: ../src/iop/denoiseprofile.c:3904
 msgid "variance computed on the green channel"
 msgstr "varianza calculada para el canal verde"
 
-#: ../src/iop/denoiseprofile.c:3283
+#: ../src/iop/denoiseprofile.c:3909
 msgid "variance blue: "
 msgstr "varianza del azul:"
 
 #. This gets filled in by process
-#: ../src/iop/denoiseprofile.c:3286
+#: ../src/iop/denoiseprofile.c:3912
 msgid "variance computed on the blue channel"
 msgstr "varianza calculada para el canal azul"
 
-#: ../src/iop/denoiseprofile.c:3297 ../src/iop/rawdenoise.c:987
+#: ../src/iop/denoiseprofile.c:3923 ../src/iop/rawdenoise.c:987
 msgid "R"
 msgstr "R"
 
-#: ../src/iop/denoiseprofile.c:3299 ../src/iop/rawdenoise.c:989
+#: ../src/iop/denoiseprofile.c:3925 ../src/iop/rawdenoise.c:989
 msgid "G"
 msgstr "G"
 
-#: ../src/iop/denoiseprofile.c:3301 ../src/iop/rawdenoise.c:991
+#: ../src/iop/denoiseprofile.c:3927 ../src/iop/rawdenoise.c:991
 msgid "B"
 msgstr "B"
 
-#: ../src/iop/denoiseprofile.c:3335
+#: ../src/iop/denoiseprofile.c:3961
 msgid "whitebalance-adaptive transform"
 msgstr "transformada adaptable al balance de blancos"
 
-#: ../src/iop/denoiseprofile.c:3337
+#: ../src/iop/denoiseprofile.c:3963
 msgid ""
 "adapt denoising according to the\n"
 "white balance coefficients.\n"
@@ -7541,11 +7862,11 @@ msgstr ""
 "Deshabilitar si en una instancia anterior\n"
 "se ha utilizado con el modo de mezcla de color."
 
-#: ../src/iop/denoiseprofile.c:3354
-msgid "migrate to fixed algorithm"
-msgstr "migrar a algoritmo fijo"
+#: ../src/iop/denoiseprofile.c:3983
+msgid "fix various bugs in algorithm"
+msgstr "Corrección de errores en el algoritmo"
 
-#: ../src/iop/denoiseprofile.c:3356
+#: ../src/iop/denoiseprofile.c:3985
 msgid ""
 "fix bugs in anscombe transform resulting\n"
 "in undersmoothing of the green channel in\n"
@@ -7567,40 +7888,76 @@ msgstr ""
 "Habilitar esta opción cambiará la eliminación de ruido que se tiene.\n"
 "Una vez habilitado, no podrá volver al algoritmo anterior."
 
-#: ../src/iop/denoiseprofile.c:3372 ../src/libs/export.c:629
-#: ../src/libs/print_settings.c:1185 ../src/libs/print_settings.c:1405
+#: ../src/iop/denoiseprofile.c:3996
+msgid "upgrade profiled transform"
+msgstr "Actualización del modelo"
+
+#: ../src/iop/denoiseprofile.c:3998
+msgid ""
+"upgrade the variance stabilizing algorithm.\n"
+"new algorithm extends the current one.\n"
+"it is more flexible but could give small\n"
+"differences in the images already processed."
+msgstr ""
+"Actualización del algoritmo de estabilización de varianza.\n"
+"El nuevo algoritmo amplía al actual.\n"
+"Es más flexible pero podría dar pequeñas\n"
+"diferencias en las imágenes ya procesadas."
+
+#: ../src/iop/denoiseprofile.c:4009 ../src/libs/export.c:645
+#: ../src/libs/print_settings.c:1183 ../src/libs/print_settings.c:1403
 msgid "profile"
 msgstr "perfil"
 
-#: ../src/iop/denoiseprofile.c:3374 ../src/iop/nlmeans.c:843
+#: ../src/iop/denoiseprofile.c:4011 ../src/iop/nlmeans.c:843
 msgid "patch size"
 msgstr "tamaño del cuadro"
 
-#: ../src/iop/denoiseprofile.c:3376
+#: ../src/iop/denoiseprofile.c:4013
 msgid "search radius"
 msgstr "buscar el radio"
 
-#: ../src/iop/denoiseprofile.c:3378
+#: ../src/iop/denoiseprofile.c:4015
 msgid "scattering (coarse-grain noise)"
 msgstr "diseminar (ruido con granularidad gruesa)"
 
-#: ../src/iop/denoiseprofile.c:3379
+#: ../src/iop/denoiseprofile.c:4016
 msgid "central pixel weight (details)"
 msgstr "peso del pixel central (detalles)"
 
-#: ../src/iop/denoiseprofile.c:3381
+#: ../src/iop/denoiseprofile.c:4018
+msgid "adjust autoset parameters"
+msgstr "ajustar los parámetros de configuración automática"
+
+#: ../src/iop/denoiseprofile.c:4019
+msgid "preserve shadows"
+msgstr "preservar las sombras"
+
+#: ../src/iop/denoiseprofile.c:4020
+msgid "bias correction"
+msgstr "corrección de sesgo"
+
+#: ../src/iop/denoiseprofile.c:4021
 msgid "non-local means"
 msgstr "medias no locales"
 
-#: ../src/iop/denoiseprofile.c:3382
+#: ../src/iop/denoiseprofile.c:4022
+msgid "non-local means auto"
+msgstr "medias no locales automático"
+
+#: ../src/iop/denoiseprofile.c:4023
 msgid "wavelets"
 msgstr "ondículas"
 
-#: ../src/iop/denoiseprofile.c:3388
+#: ../src/iop/denoiseprofile.c:4024
+msgid "wavelets auto"
+msgstr "ondículas automático"
+
+#: ../src/iop/denoiseprofile.c:4030
 msgid "profile used for variance stabilization"
 msgstr "perfil utilizado para estabilizar la varianza"
 
-#: ../src/iop/denoiseprofile.c:3389
+#: ../src/iop/denoiseprofile.c:4031
 msgid ""
 "method used in the denoising core. non-local means works best for "
 "`lightness' blending, wavelets work best for `color' blending"
@@ -7609,7 +7966,7 @@ msgstr ""
 "locales es mejor para la mezcla de luminosidad, el de ondículas funciona "
 "mejor para la mezcla de color"
 
-#: ../src/iop/denoiseprofile.c:3392
+#: ../src/iop/denoiseprofile.c:4034
 msgid ""
 "radius of the patches to match.\n"
 "increase for more sharpness on strong edges, and better denoising of smooth "
@@ -7623,7 +7980,7 @@ msgstr ""
 "Si los detalles están demasiado suavizados, reduzca este valor o aumente el "
 "control deslizante de detalles."
 
-#: ../src/iop/denoiseprofile.c:3395
+#: ../src/iop/denoiseprofile.c:4037
 msgid ""
 "emergency use only: radius of the neighbourhood to search patches in. "
 "increase for better denoising performance, but watch the long runtimes! "
@@ -7634,7 +7991,7 @@ msgstr ""
 "en la eliminación de ruido, pero con mayor tiempo de ejecución. los radios "
 "grandes pueden ser muy lentos. se le ha advertido"
 
-#: ../src/iop/denoiseprofile.c:3397
+#: ../src/iop/denoiseprofile.c:4039
 msgid ""
 "scattering of the neighbourhood to search patches in. increase for better "
 "coarse-grain noise reduction. does not affect execution time."
@@ -7642,7 +7999,7 @@ msgstr ""
 "dispersión en la proximidad para buscar coincidencias. aumente para una "
 "mejor reducción de ruido de grano grueso. no afecta el tiempo de ejecución."
 
-#: ../src/iop/denoiseprofile.c:3399
+#: ../src/iop/denoiseprofile.c:4041
 msgid ""
 "increase the weight of the central pixel\n"
 "of the patch in the patch comparison.\n"
@@ -7654,9 +8011,41 @@ msgstr ""
 "Útil para recuperar detalles cuando el tamaño del parche\n"
 "es bastante grande."
 
-#: ../src/iop/denoiseprofile.c:3403
+#: ../src/iop/denoiseprofile.c:4045
 msgid "finetune denoising strength"
 msgstr "fuerza de la corrección para reducir el ruido"
+
+#: ../src/iop/denoiseprofile.c:4046
+msgid ""
+"controls the way parameters are autoset\n"
+"increase if shadows are not denoised enough\n"
+"or if chroma noise remains.\n"
+"this can happen if your picture is underexposed."
+msgstr ""
+"Controla la forma en que los parámetros se configuran automáticamente\n"
+"Incrementar si la reducción de ruido no es suficiente en las sombras\n"
+"o si queda ruido de croma.\n"
+"Podría suceder si la imagen está subexpuesta."
+
+#: ../src/iop/denoiseprofile.c:4050
+msgid ""
+"finetune shadows denoising.\n"
+"decrease to denoise more aggressively\n"
+"dark areas of the image.\n"
+msgstr ""
+"Afinar la reducción de ruido en las sombras.\n"
+"Disminuir para reducir el ruido más intensamente en\n"
+"las áreas oscuras de la imagen.\n"
+
+#: ../src/iop/denoiseprofile.c:4053
+msgid ""
+"correct color cast in shadows.\n"
+"decrease if shadows are too purple.\n"
+"increase if shadows are too green."
+msgstr ""
+"Correccón de color en sombras.\n"
+"Disminuir si las sombras son demasiado púrpuras.\n"
+"Aumentar si las sombras son demasiado verdes."
 
 #: ../src/iop/dither.c:103 ../src/iop/vignette.c:1164
 msgid "dithering"
@@ -7778,16 +8167,16 @@ msgstr "propiedades de la linterna mágica"
 msgid "failed to get raw buffer from image `%s'"
 msgstr "No se pudo obtener el búfer en bruto de la imagen `%s'"
 
-#: ../src/iop/exposure.c:859 ../src/iop/levels.c:673
+#: ../src/iop/exposure.c:866 ../src/iop/levels.c:674
 msgctxt "mode"
 msgid "manual"
 msgstr "manual"
 
-#: ../src/iop/exposure.c:862 ../src/iop/levels.c:676 ../src/iop/vignette.c:1147
+#: ../src/iop/exposure.c:869 ../src/iop/levels.c:677 ../src/iop/vignette.c:1147
 msgid "automatic"
 msgstr "automático"
 
-#: ../src/iop/exposure.c:884
+#: ../src/iop/exposure.c:891
 msgid ""
 "adjust the black level to unclip negative RGB values.\n"
 "you should never use it to add more density in blacks!\n"
@@ -7799,46 +8188,46 @@ msgstr ""
 "si está mal configurado, recortará los colores casi negros de la gama \\ n\n"
 "empujando los valores RGB a negativos."
 
-#: ../src/iop/exposure.c:894
+#: ../src/iop/exposure.c:901
 msgid ""
 "percentage of bright values clipped out, toggle color picker to activate"
 msgstr ""
-"porcentaje del valor del brillo excluido, alternar selector de color para "
+"Porcentaje del valor del brillo excluido, pulsar en el cuentagotas para "
 "activar"
 
-#: ../src/iop/exposure.c:896 ../src/iop/highlights.c:1087
-#: ../src/views/darkroom.c:1838
+#: ../src/iop/exposure.c:903 ../src/iop/highlights.c:1087
+#: ../src/views/darkroom.c:1858
 msgid "clipping threshold"
 msgstr "umbral superior"
 
 # No existe porceptual
-#: ../src/iop/exposure.c:907
+#: ../src/iop/exposure.c:914
 msgid "percentile"
 msgstr "percentil"
 
-#: ../src/iop/exposure.c:911
+#: ../src/iop/exposure.c:918
 #, no-c-format
 msgid "where in the histogram to meter for deflicking. E.g. 50% is median"
 msgstr ""
 "Donde se medirá el histograma para remover el parpadeo (p.ej. 50% es mediano)"
 
-#: ../src/iop/exposure.c:916
+#: ../src/iop/exposure.c:923
 msgid "target level"
 msgstr "nivel de objetivo"
 
-#: ../src/iop/exposure.c:919
+#: ../src/iop/exposure.c:926
 msgid ""
 "where to place the exposure level for processed pics, EV below overexposure."
 msgstr ""
 "donde ubicar el nivel de exposición de las fotos procesadas, EV bajo la "
 "sobre-exposición."
 
-#: ../src/iop/exposure.c:923
+#: ../src/iop/exposure.c:930
 msgid "computed EC: "
 msgstr "computed EC: "
 
 #. This gets filled in by process
-#: ../src/iop/exposure.c:927
+#: ../src/iop/exposure.c:934
 msgid "what exposure correction has actually been used"
 msgstr "qué correcciones de exposición se han utilizado actualmente"
 
@@ -7854,7 +8243,7 @@ msgstr "09 EV (clave baja)"
 msgid "10 EV (indoors)"
 msgstr "10 EV (interiores)"
 
-#: ../src/iop/filmic.c:325
+#: ../src/iop/filmic.c:325 ../src/iop/filmicrgb.c:246
 msgid "11 EV (dim outdoors)"
 msgstr "11 EV (atenuación en exteriores)"
 
@@ -7882,21 +8271,21 @@ msgstr "16 EV (HDR)"
 msgid "18 EV (HDR++)"
 msgstr "18 EV (HDR++)"
 
-#: ../src/iop/filmic.c:1672
+#: ../src/iop/filmic.c:1679
 msgid "read-only graph, use the parameters below to set the nodes"
 msgstr ""
 "gráfico de solo lectura, utilice los siguientes parámetros para configurar "
 "los nodos"
 
-#: ../src/iop/filmic.c:1678
+#: ../src/iop/filmic.c:1683
 msgid "logarithmic shaper"
 msgstr "modelador logarítmico"
 
-#: ../src/iop/filmic.c:1683
+#: ../src/iop/filmic.c:1688 ../src/iop/filmicrgb.c:1332
 msgid "middle grey luminance"
 msgstr "luminancia gris media"
 
-#: ../src/iop/filmic.c:1686
+#: ../src/iop/filmic.c:1691 ../src/iop/filmicrgb.c:1335
 msgid ""
 "adjust to match the average luminance of the subject.\n"
 "except in back-lighting situations, this should be around 18%."
@@ -7905,14 +8294,14 @@ msgstr ""
 "Excepto en situaciones de retroiluminación, esto debería ser alrededor del "
 "18%."
 
-#: ../src/iop/filmic.c:1696
+#: ../src/iop/filmic.c:1701 ../src/iop/filmicrgb.c:1345
 msgid "white relative exposure"
 msgstr "exposición blanca relativa"
 
 # número de pasos entre el gris medio y el blanco puro.
 # esta es una lectura que un fotómetro te daría en la escena.
 # ajustar para evitar el recorte de altas luces
-#: ../src/iop/filmic.c:1699
+#: ../src/iop/filmic.c:1704 ../src/iop/filmicrgb.c:1348
 msgid ""
 "number of stops between middle grey and pure white.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
@@ -7922,11 +8311,12 @@ msgstr ""
 "Esta es una lectura que un fotómetro te daría en la escena.\n"
 "Ajustar para evitar el recorte de altas luces"
 
-#: ../src/iop/filmic.c:1710 ../src/iop/profile_gamma.c:903
+#: ../src/iop/filmic.c:1715 ../src/iop/filmicrgb.c:1359
+#: ../src/iop/profile_gamma.c:908
 msgid "black relative exposure"
 msgstr "exposición negra relativa"
 
-#: ../src/iop/filmic.c:1713
+#: ../src/iop/filmic.c:1718 ../src/iop/filmicrgb.c:1362
 msgid ""
 "number of stops between middle grey and pure black.\n"
 "this is a reading a lightmeter would give you on the scene.\n"
@@ -7938,11 +8328,11 @@ msgstr ""
 "Aumentar para obtener más contraste.\n"
 "Disminuir para recuperar más detalles en condiciones de poca luz."
 
-#: ../src/iop/filmic.c:1723 ../src/iop/profile_gamma.c:927
+#: ../src/iop/filmic.c:1728 ../src/iop/profile_gamma.c:932
 msgid "safety factor"
 msgstr "factor de seguridad"
 
-#: ../src/iop/filmic.c:1726
+#: ../src/iop/filmic.c:1731 ../src/iop/filmicrgb.c:1376
 msgid ""
 "enlarge or shrink the computed dynamic range.\n"
 "useful in conjunction with \"auto tune levels\"."
@@ -7950,11 +8340,12 @@ msgstr ""
 "Aumentar o reducir el rango dinámico calculado.\n"
 "Útil en combinación con \"niveles automáticos\"."
 
-#: ../src/iop/filmic.c:1732 ../src/iop/profile_gamma.c:935
+#: ../src/iop/filmic.c:1737 ../src/iop/filmicrgb.c:1382
+#: ../src/iop/profile_gamma.c:940
 msgid "auto tune levels"
 msgstr "niveles automáticos"
 
-#: ../src/iop/filmic.c:1737
+#: ../src/iop/filmic.c:1742 ../src/iop/filmicrgb.c:1387
 msgid ""
 "try to optimize the settings with some guessing.\n"
 "this will fit the luminance range inside the histogram bounds.\n"
@@ -7966,11 +8357,11 @@ msgstr ""
 "Funciona mejor para paisajes y fotos uniformemente iluminadas\n"
 "pero falla en las clave alta y clave baja."
 
-#: ../src/iop/filmic.c:1742
+#: ../src/iop/filmic.c:1747
 msgid "filmic S curve"
 msgstr "curva S de película"
 
-#: ../src/iop/filmic.c:1749
+#: ../src/iop/filmic.c:1754 ../src/iop/filmicrgb.c:1398
 msgid ""
 "slope of the linear part of the curve\n"
 "affects mostly the mid-tones"
@@ -7979,11 +8370,12 @@ msgstr ""
 "Afecta sobre todo a los tonos medios"
 
 #. geotagging
-#: ../src/iop/filmic.c:1756 ../src/libs/metadata_view.c:127
+#: ../src/iop/filmic.c:1761 ../src/iop/filmicrgb.c:1405
+#: ../src/libs/metadata_view.c:131
 msgid "latitude"
 msgstr "latitud"
 
-#: ../src/iop/filmic.c:1759
+#: ../src/iop/filmic.c:1764 ../src/iop/filmicrgb.c:1408
 msgid ""
 "width of the linear domain in the middle of the curve.\n"
 "increase to get more contrast at the extreme luminances.\n"
@@ -7993,11 +8385,11 @@ msgstr ""
 "Para obtener más contraste en las luminancias extremas.\n"
 "No tiene efecto en los tonos medios."
 
-#: ../src/iop/filmic.c:1766
+#: ../src/iop/filmic.c:1771 ../src/iop/filmicrgb.c:1415
 msgid "shadows/highlights balance"
 msgstr "equilibrio entre sombras y altas luces"
 
-#: ../src/iop/filmic.c:1769
+#: ../src/iop/filmic.c:1774 ../src/iop/filmicrgb.c:1418
 msgid ""
 "slides the latitude along the slope\n"
 "to give more room to shadows or highlights.\n"
@@ -8009,11 +8401,11 @@ msgstr ""
 "Usarlo en caso de querer proteger los detalles \n"
 "en un extremo del histograma."
 
-#: ../src/iop/filmic.c:1775
+#: ../src/iop/filmic.c:1780
 msgid "global saturation"
 msgstr "saturación global"
 
-#: ../src/iop/filmic.c:1779
+#: ../src/iop/filmic.c:1784
 msgid ""
 "desaturates the input of the module globally.\n"
 "you need to set this value below 100%\n"
@@ -8023,11 +8415,11 @@ msgstr ""
 "Es necesario establecer este valor por debajo del 100% \n"
 "si la preservación de la crominancia está habilitada."
 
-#: ../src/iop/filmic.c:1785
+#: ../src/iop/filmic.c:1790 ../src/iop/filmicrgb.c:1424
 msgid "extreme luminance saturation"
 msgstr "saturación de luminancia extrema"
 
-#: ../src/iop/filmic.c:1789
+#: ../src/iop/filmic.c:1794 ../src/iop/filmicrgb.c:1428
 msgid ""
 "desaturates the output of the module\n"
 "specifically at extreme luminances.\n"
@@ -8037,36 +8429,36 @@ msgstr ""
 "específicamente a luminancias extremas.\n"
 "Disminuir si las sombras o las altas luces o ambas están sobresaturadas."
 
-#: ../src/iop/filmic.c:1799 ../src/libs/export.c:651
-#: ../src/libs/print_settings.c:1240 ../src/libs/print_settings.c:1453
+#: ../src/iop/filmic.c:1804 ../src/libs/export.c:667
+#: ../src/libs/print_settings.c:1238 ../src/libs/print_settings.c:1451
 msgid "intent"
 msgstr "propósito"
 
-#: ../src/iop/filmic.c:1800
+#: ../src/iop/filmic.c:1805
 msgid "contrasted"
 msgstr "contrastado"
 
 #. cubic spline
-#: ../src/iop/filmic.c:1801
+#: ../src/iop/filmic.c:1806
 msgid "faded"
 msgstr "difuminado"
 
 #. monotonic spline
-#: ../src/iop/filmic.c:1803
+#: ../src/iop/filmic.c:1808
 msgid "optimized"
 msgstr "optimizado"
 
-#: ../src/iop/filmic.c:1805
+#: ../src/iop/filmic.c:1810
 msgid "change this method if you see reversed contrast or faded blacks"
 msgstr ""
 "Cambiar el método si aparecen contrastes invertidos o negros difuminados"
 
 #. Preserve color
-#: ../src/iop/filmic.c:1809
+#: ../src/iop/filmic.c:1814
 msgid "preserve the chrominance"
 msgstr "preservar la crominancia"
 
-#: ../src/iop/filmic.c:1811
+#: ../src/iop/filmic.c:1816 ../src/iop/filmicrgb.c:1440
 msgid ""
 "ensure the original color are preserved.\n"
 "may reinforce chromatic aberrations.\n"
@@ -8076,15 +8468,15 @@ msgstr ""
 "Puede acentuar las aberraciones cromáticas. \n"
 "Es necesario ajustar manualmente la saturación cuando se utiliza este modo."
 
-#: ../src/iop/filmic.c:1821
+#: ../src/iop/filmic.c:1826
 msgid "destination/display"
 msgstr "destino/visualización"
 
-#: ../src/iop/filmic.c:1837
+#: ../src/iop/filmic.c:1842 ../src/iop/filmicrgb.c:1448
 msgid "target black luminance"
 msgstr "objetivo luminancia negra"
 
-#: ../src/iop/filmic.c:1840
+#: ../src/iop/filmic.c:1845 ../src/iop/filmicrgb.c:1451
 msgid ""
 "luminance of output pure black, this should be 0%\n"
 "except if you want a faded look"
@@ -8092,11 +8484,11 @@ msgstr ""
 "La luminancia de salida negro puro, debería ser del 0%\n"
 "excepto si se desea lograr un aspecto difuminado"
 
-#: ../src/iop/filmic.c:1846
+#: ../src/iop/filmic.c:1851 ../src/iop/filmicrgb.c:1457
 msgid "target middle grey"
 msgstr "objetivo gris medio"
 
-#: ../src/iop/filmic.c:1849
+#: ../src/iop/filmic.c:1854 ../src/iop/filmicrgb.c:1460
 msgid ""
 "midde grey value of the target display or color space.\n"
 "you should never touch that unless you know what you are doing."
@@ -8104,11 +8496,11 @@ msgstr ""
 "Valor gris medio de la pantalla de destino o espacio de color.\n"
 "Evitar moverlo a menos que se sepa lo que se está haciendo."
 
-#: ../src/iop/filmic.c:1855
+#: ../src/iop/filmic.c:1860 ../src/iop/filmicrgb.c:1466
 msgid "target white luminance"
 msgstr "objetivo luminancia blanca"
 
-#: ../src/iop/filmic.c:1858
+#: ../src/iop/filmic.c:1863 ../src/iop/filmicrgb.c:1469
 msgid ""
 "luminance of output pure white, this should be 100%\n"
 "except if you want a faded look"
@@ -8116,11 +8508,11 @@ msgstr ""
 "La luminancia de salida blanco puro debería ser del 100%\n"
 "excepto si se desea lograr un aspecto difuminado"
 
-#: ../src/iop/filmic.c:1864
+#: ../src/iop/filmic.c:1869
 msgid "target gamma"
 msgstr "objetivo gamma"
 
-#: ../src/iop/filmic.c:1866
+#: ../src/iop/filmic.c:1871 ../src/iop/filmicrgb.c:1477
 msgid ""
 "power or gamma of the transfer function\n"
 "of the display or color space.\n"
@@ -8129,6 +8521,112 @@ msgstr ""
 "Potencia o gamma de la función de transferencia\n"
 "de la pantalla o del espacio de color.\n"
 "Evitar moverlo a menos que se sepa lo que se está haciendo."
+
+#: ../src/iop/filmicrgb.c:193
+msgid "filmic rgb"
+msgstr "rgb en película"
+
+#: ../src/iop/filmicrgb.c:234
+msgid "07 EV (studio)"
+msgstr "07 EV (estudio)"
+
+#: ../src/iop/filmicrgb.c:240
+msgid "09 EV (indoors)"
+msgstr "09 EV (interiores)"
+
+#: ../src/iop/filmicrgb.c:252
+msgid "13 EV (outdoors)"
+msgstr "13 EV (exteriores)"
+
+#: ../src/iop/filmicrgb.c:258
+msgid "15 EV (backlighting)"
+msgstr "15 EV (retroiluminación)"
+
+#: ../src/iop/filmicrgb.c:264
+msgid "17 EV (HDR)"
+msgstr "17 EV (HDR)"
+
+#: ../src/iop/filmicrgb.c:269
+msgctxt "accel"
+msgid "white exposure"
+msgstr "exposición de blanco"
+
+#: ../src/iop/filmicrgb.c:270
+msgctxt "accel"
+msgid "black exposure"
+msgstr "exposición de negro"
+
+#: ../src/iop/filmicrgb.c:271
+msgctxt "accel"
+msgid "middle grey luminance"
+msgstr "luminancia gris medio"
+
+#: ../src/iop/filmicrgb.c:272
+msgctxt "accel"
+msgid "dynamic range scaling"
+msgstr "escala de rango dinámico"
+
+#: ../src/iop/filmicrgb.c:274
+msgctxt "accel"
+msgid "latitude"
+msgstr "latitud"
+
+#: ../src/iop/filmicrgb.c:275
+msgctxt "accel"
+msgid "shadows/highlights balance"
+msgstr "equilibrio entre sombras y altas luces"
+
+#: ../src/iop/filmicrgb.c:276
+msgctxt "accel"
+msgid "extreme luminance saturation"
+msgstr "saturación de luminancia extrema"
+
+#: ../src/iop/filmicrgb.c:1307
+msgid ""
+"read-only graph, use the parameters below to set the nodes\n"
+"the bright curve is the filmic tone mapping curve\n"
+"the dark curve is the desaturation curve\n"
+msgstr ""
+"Gráfico no alterable, use los siguientes parámetros para configurar los "
+"nodos.\n"
+"La curva clara es la curva de mapeo de tono de película\n"
+"La curva oscura es la curva de desaturación\n"
+
+#: ../src/iop/filmicrgb.c:1319
+msgid "scene"
+msgstr "escena"
+
+#: ../src/iop/filmicrgb.c:1320
+msgid "look"
+msgstr "apariencia"
+
+#: ../src/iop/filmicrgb.c:1321
+msgid "display"
+msgstr "pantalla"
+
+#: ../src/iop/filmicrgb.c:1373
+msgid "dynamic range scaling"
+msgstr "escala de rango dinámico"
+
+#: ../src/iop/filmicrgb.c:1435
+msgid "preserve chroma"
+msgstr "preservar croma"
+
+#: ../src/iop/filmicrgb.c:1437
+msgid "max RGB"
+msgstr "RGB máximo"
+
+#: ../src/iop/filmicrgb.c:1438
+msgid "luminance Y"
+msgstr "luminancia Y"
+
+#: ../src/iop/filmicrgb.c:1439
+msgid "RGB power norm"
+msgstr "Norma de potencia RGB"
+
+#: ../src/iop/filmicrgb.c:1475
+msgid "target power transfer function"
+msgstr "función de transferencia de potencia objetivo"
 
 #: ../src/iop/finalscale.c:39
 msgctxt "modulename"
@@ -8288,15 +8786,15 @@ msgctxt "accel"
 msgid "compression"
 msgstr "compresión"
 
-#: ../src/iop/graduatednd.c:1216
+#: ../src/iop/graduatednd.c:1217
 msgid "density"
 msgstr "densidad"
 
-#: ../src/iop/graduatednd.c:1217
+#: ../src/iop/graduatednd.c:1218
 msgid "the density in EV for the filter"
 msgstr "la densidad en EV para el filtro"
 
-#: ../src/iop/graduatednd.c:1225
+#: ../src/iop/graduatednd.c:1226
 #, no-c-format
 msgid ""
 "compression of graduation:\n"
@@ -8305,17 +8803,37 @@ msgstr ""
 "compresión de la graduación:\n"
 "0% = suave, 100% = duro"
 
-#: ../src/iop/graduatednd.c:1232
+#: ../src/iop/graduatednd.c:1233
 msgid "rotation of filter -180 to 180 degrees"
 msgstr "rotación del filtro -180 a 180 grados"
 
-#: ../src/iop/graduatednd.c:1251
+#: ../src/iop/graduatednd.c:1252
 msgid "select the hue tone of filter"
 msgstr "seleccionar el tono del filtro"
 
-#: ../src/iop/graduatednd.c:1262
+#: ../src/iop/graduatednd.c:1263
 msgid "select the saturation of filter"
 msgstr "seleccionar la saturación del filtro"
+
+#: ../src/iop/graduatednd.c:1293
+#, c-format
+msgid "[%s on nodes] change line rotation"
+msgstr "[%s en nodos] cambiar la rotación de la línea"
+
+#: ../src/iop/graduatednd.c:1298
+#, c-format
+msgid "[%s on line] move line"
+msgstr "[%s sobre la línea] mover línea"
+
+#: ../src/iop/graduatednd.c:1304
+#, c-format
+msgid "[%s on line] change density"
+msgstr "[%s sobre la línea] cambiar densidad"
+
+#: ../src/iop/graduatednd.c:1310
+#, c-format
+msgid "[%s on line] change compression"
+msgstr "[%s sobre la línea] cambiar compresión"
 
 #: ../src/iop/grain.c:418
 msgid "grain"
@@ -8435,24 +8953,24 @@ msgid_plural "fixed %d pixels"
 msgstr[0] "corregido %d pixel"
 msgstr[1] "corregidos %d píxeles"
 
-#: ../src/iop/hotpixels.c:468
+#: ../src/iop/hotpixels.c:469
 msgid "lower threshold for hot pixel"
 msgstr "umbral inferior de los píxeles calientes"
 
-#: ../src/iop/hotpixels.c:476
+#: ../src/iop/hotpixels.c:477
 msgid "strength of hot pixel correction"
 msgstr "cantidad de corrección de píxeles calientes"
 
 #. 3 neighbours
-#: ../src/iop/hotpixels.c:481
+#: ../src/iop/hotpixels.c:482
 msgid "detect by 3 neighbors"
 msgstr "detección por 3 píxeles cercanos"
 
-#: ../src/iop/hotpixels.c:488
+#: ../src/iop/hotpixels.c:489
 msgid "mark fixed pixels"
 msgstr "marcar píxeles corregidos"
 
-#: ../src/iop/hotpixels.c:500
+#: ../src/iop/hotpixels.c:501
 msgid ""
 "hot pixel correction\n"
 "only works for raw images."
@@ -8460,7 +8978,7 @@ msgstr ""
 "corrección de píxeles calientes\n"
 "sólo funciona en imágenes raw."
 
-#: ../src/iop/invert.c:98 ../src/iop/invert.c:522
+#: ../src/iop/invert.c:98 ../src/iop/invert.c:530
 #, c-format
 msgid "`%s' color matrix not found for 4bayer image"
 msgstr "`%s' matriz de color no encontrada para imagen 4bayer"
@@ -8474,72 +8992,72 @@ msgctxt "accel"
 msgid "pick color of film material from image"
 msgstr "seleccionar color de la película desde la imagen"
 
-#: ../src/iop/invert.c:597
+#: ../src/iop/invert.c:605
 msgid "color of film material"
 msgstr "color de la película"
 
-#: ../src/iop/invert.c:603
-msgid "module disabled for monochrome image"
-msgstr "módulo deshabilitado para imagen monocromo"
+#: ../src/iop/invert.c:611
+msgid "brightness of film material"
+msgstr "brillo del material de la película"
 
-#: ../src/iop/invert.c:625
+#: ../src/iop/invert.c:635
 msgid "select color of film material"
 msgstr "seleccionar color de la película"
 
-#: ../src/iop/invert.c:630
+#: ../src/iop/invert.c:640
 msgid "pick color of film material from image"
 msgstr "seleccionar color de la película desde la imagen"
 
-#: ../src/iop/lens.c:133
+#: ../src/iop/lens.cc:147
 msgid "lens correction"
 msgstr "corrección de lente"
 
-#: ../src/iop/lens.c:158 ../src/iop/vignette.c:174 ../src/iop/watermark.c:263
+#: ../src/iop/lens.cc:172 ../src/iop/vignette.c:174 ../src/iop/watermark.c:263
 msgctxt "accel"
 msgid "scale"
 msgstr "escala"
 
-#: ../src/iop/lens.c:159
+#: ../src/iop/lens.cc:173
 msgctxt "accel"
 msgid "TCA R"
 msgstr "TCA R"
 
-#: ../src/iop/lens.c:160
+#: ../src/iop/lens.cc:174
 msgctxt "accel"
 msgid "TCA B"
 msgstr "TCA B"
 
-#: ../src/iop/lens.c:162
+#: ../src/iop/lens.cc:176
 msgctxt "accel"
 msgid "find camera"
 msgstr "encontrar cámara"
 
-#: ../src/iop/lens.c:163
+#: ../src/iop/lens.cc:177
 msgctxt "accel"
 msgid "find lens"
 msgstr "encontrar lente"
 
-#: ../src/iop/lens.c:164
+#: ../src/iop/lens.cc:178
 msgctxt "accel"
 msgid "auto scale"
 msgstr "auto redimensionar"
 
-#: ../src/iop/lens.c:165
+#: ../src/iop/lens.cc:179
 msgctxt "accel"
 msgid "camera model"
 msgstr "modelo de cámara"
 
-#: ../src/iop/lens.c:166
+#: ../src/iop/lens.cc:180
 msgctxt "accel"
 msgid "lens model"
 msgstr "modelo de lente"
 
-#: ../src/iop/lens.c:167
+#: ../src/iop/lens.cc:181
 msgctxt "accel"
 msgid "select corrections"
 msgstr "seleccionar correcciones"
 
-#: ../src/iop/lens.c:1515
+#: ../src/iop/lens.cc:1601
 #, c-format
 msgid ""
 "maker:\t\t%s\n"
@@ -8552,27 +9070,27 @@ msgstr ""
 "montura:\t\t%s\n"
 "factor de recorte:\t%.1f"
 
-#: ../src/iop/lens.c:1749
+#: ../src/iop/lens.cc:1835
 msgid "camera/lens not found - please select manually"
 msgstr ""
 "cámara/lente no encontrada -\n"
 "por favor, seleccionelo manualmente"
 
-#: ../src/iop/lens.c:1752
+#: ../src/iop/lens.cc:1838
 msgid "try to locate your camera/lens in the above two menus"
 msgstr ""
 "intente localizar su cámara/lente en alguno de los dos menús superiores"
 
-#: ../src/iop/lens.c:1806
+#: ../src/iop/lens.cc:1902
 #, c-format
 msgid ""
 "maker:\t\t%s\n"
 "model:\t\t%s\n"
 "focal range:\t%s\n"
-"aperture:\t\t%s\n"
+"aperture:\t%s\n"
 "crop factor:\t%.1f\n"
 "type:\t\t%s\n"
-"mounts:\t\t%s"
+"mounts:\t%s"
 msgstr ""
 "fabricante:\t\t%s\n"
 "modelo:\t\t%s\n"
@@ -8582,143 +9100,143 @@ msgstr ""
 "tipo:\t\t\t%s\n"
 "montura:\t\t%s"
 
-#: ../src/iop/lens.c:1846
+#: ../src/iop/lens.cc:1948
 msgid "focal length (mm)"
 msgstr "longitud focal (mm)"
 
-#: ../src/iop/lens.c:1870
+#: ../src/iop/lens.cc:1972
 msgid "f/"
 msgstr "f/"
 
-#: ../src/iop/lens.c:1871
+#: ../src/iop/lens.cc:1973
 msgid "f-number (aperture)"
 msgstr "número-f (apertura)"
 
-#: ../src/iop/lens.c:1885
+#: ../src/iop/lens.cc:1987
 msgid "d"
 msgstr "d"
 
-#: ../src/iop/lens.c:1886
+#: ../src/iop/lens.cc:1988
 msgid "distance to subject"
 msgstr "distancia al sujeto"
 
-#: ../src/iop/lens.c:2197
+#: ../src/iop/lens.cc:2332
 msgid "distortion & TCA"
 msgstr "distorsión y TCA"
 
-#: ../src/iop/lens.c:2203
+#: ../src/iop/lens.cc:2338
 msgid "distortion & vignetting"
 msgstr "distorsión y viñeteado"
 
-#: ../src/iop/lens.c:2209
+#: ../src/iop/lens.cc:2344
 msgid "TCA & vignetting"
 msgstr "TCA y viñeteado"
 
-#: ../src/iop/lens.c:2215
+#: ../src/iop/lens.cc:2350
 msgid "only distortion"
 msgstr "sólo distorsión"
 
-#: ../src/iop/lens.c:2221
+#: ../src/iop/lens.cc:2356
 msgid "only TCA"
 msgstr "sólo TCA"
 
-#: ../src/iop/lens.c:2227
+#: ../src/iop/lens.cc:2362
 msgid "only vignetting"
 msgstr "sólo viñeteado"
 
-#: ../src/iop/lens.c:2247
+#: ../src/iop/lens.cc:2382
 msgid "find camera"
 msgstr "encontrar cámara"
 
-#: ../src/iop/lens.c:2261
+#: ../src/iop/lens.cc:2396
 msgid "find lens"
 msgstr "encontrar lente"
 
-#: ../src/iop/lens.c:2292
+#: ../src/iop/lens.cc:2427
 msgid "corrections"
 msgstr "correcciones"
 
-#: ../src/iop/lens.c:2294
+#: ../src/iop/lens.cc:2429
 msgid "which corrections to apply"
 msgstr "corrección a aplicar"
 
-#: ../src/iop/lens.c:2307
+#: ../src/iop/lens.cc:2442
 msgid "geometry"
 msgstr "geometría"
 
-#: ../src/iop/lens.c:2309
+#: ../src/iop/lens.cc:2444
 msgid "target geometry"
 msgstr "geometría destino"
 
-#: ../src/iop/lens.c:2310
+#: ../src/iop/lens.cc:2445
 msgid "rectilinear"
 msgstr "rectilínea"
 
-#: ../src/iop/lens.c:2311
+#: ../src/iop/lens.cc:2446
 msgid "fish-eye"
 msgstr "ojo de pez"
 
-#: ../src/iop/lens.c:2312
+#: ../src/iop/lens.cc:2447
 msgid "panoramic"
 msgstr "panorámica"
 
-#: ../src/iop/lens.c:2313
+#: ../src/iop/lens.cc:2448
 msgid "equirectangular"
 msgstr "equirrectangular"
 
-#: ../src/iop/lens.c:2315
+#: ../src/iop/lens.cc:2450
 msgid "orthographic"
 msgstr "ortográfico"
 
-#: ../src/iop/lens.c:2316
+#: ../src/iop/lens.cc:2451
 msgid "stereographic"
 msgstr "estereográfico"
 
-#: ../src/iop/lens.c:2317
+#: ../src/iop/lens.cc:2452
 msgid "equisolid angle"
 msgstr "ángulo sólido constante"
 
-#: ../src/iop/lens.c:2318
+#: ../src/iop/lens.cc:2453
 msgid "thoby fish-eye"
 msgstr "ojo de pez thoby"
 
-#: ../src/iop/lens.c:2325
+#: ../src/iop/lens.cc:2460
 msgid "auto scale"
 msgstr "auto redimensionar"
 
-#: ../src/iop/lens.c:2336
+#: ../src/iop/lens.cc:2471
 msgid "correct distortions or apply them"
 msgstr "corrija la distorsión o establézcala"
 
-#: ../src/iop/lens.c:2337
+#: ../src/iop/lens.cc:2472
 msgid "correct"
 msgstr "corregir"
 
-#: ../src/iop/lens.c:2338
+#: ../src/iop/lens.cc:2473
 msgid "distort"
 msgstr "distorsión"
 
-#: ../src/iop/lens.c:2343
+#: ../src/iop/lens.cc:2478
 msgid "Transversal Chromatic Aberration red"
 msgstr "Aberración cromáticas trasversal roja"
 
-#: ../src/iop/lens.c:2344
+#: ../src/iop/lens.cc:2479
 msgid "TCA red"
 msgstr "TCA rojo"
 
-#: ../src/iop/lens.c:2349
+#: ../src/iop/lens.cc:2484
 msgid "Transversal Chromatic Aberration blue"
 msgstr "Aberración cromáticas trasversal azul"
 
-#: ../src/iop/lens.c:2350
+#: ../src/iop/lens.cc:2485
 msgid "TCA blue"
 msgstr "TCA azul"
 
-#: ../src/iop/lens.c:2357
+#: ../src/iop/lens.cc:2492
 msgid "corrections done: "
 msgstr "correcciones realizadas: "
 
-#: ../src/iop/lens.c:2358
+#: ../src/iop/lens.cc:2493
 msgid "which corrections have actually been done"
 msgstr "qué correcciones se han realizado actualmente"
 
@@ -8726,53 +9244,53 @@ msgstr "qué correcciones se han realizado actualmente"
 msgid "levels"
 msgstr "niveles"
 
-#: ../src/iop/levels.c:691
+#: ../src/iop/levels.c:692 ../src/iop/rgblevels.c:1052
 msgid ""
 "drag handles to set black, gray, and white points. operates on L channel."
 msgstr ""
 "arrastre las barras para establecer los puntos negro, gris y blanco. opera "
 "en el canal L."
 
-#: ../src/iop/levels.c:705
+#: ../src/iop/levels.c:706 ../src/iop/rgblevels.c:1090
 msgid "apply auto levels"
 msgstr "establecer niveles automáticos"
 
-#: ../src/iop/levels.c:708
+#: ../src/iop/levels.c:709 ../src/iop/rgblevels.c:1066
 msgid "pick black point from image"
 msgstr "seleccionar punto negro de la imagen"
 
-#: ../src/iop/levels.c:711
+#: ../src/iop/levels.c:712 ../src/iop/rgblevels.c:1069
 msgid "pick medium gray point from image"
 msgstr "seleccionar el punto gris medio de la imagen"
 
-#: ../src/iop/levels.c:714
+#: ../src/iop/levels.c:715 ../src/iop/rgblevels.c:1072
 msgid "pick white point from image"
 msgstr "seleccionar el punto blanco de la imagen"
 
 # Porcentaje no se emplea en lugar de percentil
-#: ../src/iop/levels.c:736
+#: ../src/iop/levels.c:737
 msgid "black percentile"
 msgstr "percentil negro"
 
-#: ../src/iop/levels.c:738
+#: ../src/iop/levels.c:739
 msgid "black"
 msgstr "negro"
 
 # Porcentaje no se emplea en lugar de percentil
-#: ../src/iop/levels.c:741
+#: ../src/iop/levels.c:742
 msgid "gray percentile"
 msgstr "percentil gris"
 
-#: ../src/iop/levels.c:743
+#: ../src/iop/levels.c:744
 msgid "gray"
 msgstr "gris"
 
 # Porcentaje no se emplea en lugar de percentil
-#: ../src/iop/levels.c:746
+#: ../src/iop/levels.c:747
 msgid "white percentile"
 msgstr "percentil blanco"
 
-#: ../src/iop/levels.c:748
+#: ../src/iop/levels.c:749
 msgid "white"
 msgstr "blanco"
 
@@ -8787,9 +9305,9 @@ msgid ""
 "scroll to change size\n"
 "shift-scroll to change strength - ctrl-scroll to change direction"
 msgstr ""
-"haga clic y arrastre para agregar el punto\n"
-"desplazamiento para cambiar el tamaño\n"
-"Mayús+rueda del ratón para cambiar la fuerza - Ctrl+rueda del ratón para "
+"Pulse y arrastre para agregar el punto\n"
+"Rueda del ratón para cambiar el tamaño\n"
+"Mayús+rueda del ratón para cambiar la fuerza. Ctrl+rueda del ratón para "
 "cambiar la dirección"
 
 #: ../src/iop/liquify.c:3494
@@ -8798,9 +9316,9 @@ msgid ""
 "scroll to change size\n"
 "shift-scroll to change strength - ctrl-scroll to change direction"
 msgstr ""
-"clic para agregar una línea\n"
-"rueda del ratón para cambiar el tamaño\n"
-"Mayús+rueda del ratón para cambiar la fuerza - Ctrl+rueda del ratón para "
+"Pulsar para agregar una línea\n"
+"Rueda del ratón para cambiar el tamaño\n"
+"Mayús+rueda del ratón para cambiar la fuerza. Ctrl+rueda del ratón para "
 "cambiar la dirección"
 
 #: ../src/iop/liquify.c:3498
@@ -8809,44 +9327,44 @@ msgid ""
 "scroll to change size\n"
 "shift-scroll to change strength - ctrl-scroll to change direction"
 msgstr ""
-"clic para añadir curva\n"
-"rueda del ratón para cambiar tamaño \n"
-"Mayús+rueda del ratón para cambiar intensidad Ctrl+rueda del ratón para "
+"Pulsar para añadir curva\n"
+"Rueda del ratón para cambiar tamaño \n"
+"Mayús+rueda del ratón para cambiar intensidad. Ctrl+rueda del ratón para "
 "cambiar dirección"
 
 #: ../src/iop/liquify.c:3501
 msgid "click to edit nodes"
-msgstr "clic para editar nodos"
+msgstr "Pulsar para editar nodos"
 
 #: ../src/iop/liquify.c:3567
 msgid ""
 "use a tool to add warps.\n"
 "right-click to remove a warp."
 msgstr ""
-"utilice una herramienta para agregar deformaciones.\n"
-"pulsación derecha para eliminar una deformación."
+"Utilice una herramienta para agregar deformaciones.\n"
+"Clic derecho para eliminar una deformación."
 
-#: ../src/iop/liquify.c:3569
+#: ../src/iop/liquify.c:3570
 msgid "warps|nodes count:"
-msgstr "deformaciones|cuenta de nodos:"
+msgstr "Deformaciones|cuenta de nodos:"
 
-#: ../src/iop/liquify.c:3576
-msgid "node tool: edit, add and delete nodes"
-msgstr "herramienta de nodo: agregar y eliminar nodos"
-
-#: ../src/iop/liquify.c:3583
-msgid "curve tool: draw curves"
-msgstr "herramienta de curva: dibujar curvas"
-
-#: ../src/iop/liquify.c:3590
-msgid "line tool: draw lines"
-msgstr "herramienta de linea: dibujar lineas"
-
-#: ../src/iop/liquify.c:3597
+#: ../src/iop/liquify.c:3580
 msgid "point tool: draw points"
-msgstr "herramienta de punto: dibujar puntos"
+msgstr "Herramienta de punto: dibujar puntos"
 
-#: ../src/iop/liquify.c:3603
+#: ../src/iop/liquify.c:3587
+msgid "line tool: draw lines"
+msgstr "Herramienta de linea: dibujar lineas"
+
+#: ../src/iop/liquify.c:3594
+msgid "curve tool: draw curves"
+msgstr "Herramienta de curva: dibujar curvas"
+
+#: ../src/iop/liquify.c:3601
+msgid "node tool: edit, add and delete nodes"
+msgstr "Herramienta de nodo: agregar y eliminar nodos"
+
+#: ../src/iop/liquify.c:3605
 msgid ""
 "ctrl-click: add node - right click: remove path\n"
 "ctrl-alt-click: toggle line/curve"
@@ -8854,55 +9372,55 @@ msgstr ""
 "Ctrl+clic: agregar nodo - clic derecho: eliminar ruta\n"
 "Ctrl+alt+clic: alternar línea/curva"
 
-#: ../src/iop/liquify.c:3605
+#: ../src/iop/liquify.c:3607
 msgid ""
 "click and drag to move - click: show/hide feathering controls\n"
 "ctrl-click: autosmooth, cusp, smooth, symmetrical - right click to remove"
 msgstr ""
-"clic y arrastrar para mover - clic: mostrar/ocultar control de difuminado\n"
-"Ctrl+clic: suavizado automático, cúspide, suavizado, simétrico - clic "
-"derecho para eliminar"
+"Clic + arrastrar para mover. Clic: mostrar/ocultar control de difuminado\n"
+"Ctrl+clic: suavizado automático, cúspide, suavizado, simétrico. Clic derecho "
+"para eliminar"
 
-#: ../src/iop/liquify.c:3608 ../src/iop/liquify.c:3609
+#: ../src/iop/liquify.c:3610 ../src/iop/liquify.c:3611
 msgid "drag to change shape of path"
-msgstr "arrastrar para cambiar la forma de la ruta"
-
-#: ../src/iop/liquify.c:3610
-msgid "drag to adjust warp radius"
-msgstr "arrastre para ajustar el radio de deformación"
-
-#: ../src/iop/liquify.c:3611
-msgid "drag to adjust hardness (center)"
-msgstr "arrastre para ajustar la dureza (centro)"
+msgstr "Arrastrar para cambiar la forma de la ruta"
 
 #: ../src/iop/liquify.c:3612
-msgid "drag to adjust hardness (feather)"
-msgstr "arrastre para ajustar la dureza (difuminado)"
+msgid "drag to adjust warp radius"
+msgstr "Arrastrar para ajustar el radio de deformación"
 
 #: ../src/iop/liquify.c:3613
+msgid "drag to adjust hardness (center)"
+msgstr "Arrastrar para ajustar la dureza (centro)"
+
+#: ../src/iop/liquify.c:3614
+msgid "drag to adjust hardness (feather)"
+msgstr "Arrastrar para ajustar la dureza (difuminado)"
+
+#: ../src/iop/liquify.c:3615
 msgid ""
 "drag to adjust warp strength\n"
 "ctrl-click: linear, grow, and shrink"
 msgstr ""
-"arrastre para ajustar la fuerza del deformado\n"
-"Ctrl+clic : lineal, crecer, y encoger"
+"Arrastre para ajustar la fuerza del deformado\n"
+"Ctrl+clic : lineal, aumentar y encoger"
 
-#: ../src/iop/liquify.c:3631
+#: ../src/iop/liquify.c:3633
 msgctxt "accel"
 msgid "point tool"
 msgstr "herramienta de punto"
 
-#: ../src/iop/liquify.c:3632
+#: ../src/iop/liquify.c:3634
 msgctxt "accel"
 msgid "line tool"
 msgstr "herramienta de línea"
 
-#: ../src/iop/liquify.c:3633
+#: ../src/iop/liquify.c:3635
 msgctxt "accel"
 msgid "curve tool"
 msgstr "herramienta de curva"
 
-#: ../src/iop/liquify.c:3634
+#: ../src/iop/liquify.c:3636
 msgctxt "accel"
 msgid "node tool"
 msgstr "herramienta de nodo"
@@ -9009,7 +9527,7 @@ msgstr "brillo"
 msgid "soften with"
 msgstr "suavizar con"
 
-#: ../src/iop/lowpass.c:691 ../src/iop/retouch.c:2927 ../src/iop/shadhi.c:834
+#: ../src/iop/lowpass.c:691 ../src/iop/retouch.c:2935 ../src/iop/shadhi.c:834
 msgid "gaussian"
 msgstr "gausiano"
 
@@ -9037,94 +9555,98 @@ msgstr "saturación del filtro de paso bajo"
 msgid "which filter to use for blurring"
 msgstr "que filtro usar para desenfoque"
 
-#: ../src/iop/lut3d.c:90
+#: ../src/iop/lut3d.c:91
 msgid "lut 3D"
 msgstr "lut 3D"
 
-#: ../src/iop/lut3d.c:354
+#: ../src/iop/lut3d.c:355
 #, c-format
 msgid "invalid png header from %s"
-msgstr "encabezado inválido de png de %s"
+msgstr "encabezado no válido de png de %s"
 
-#: ../src/iop/lut3d.c:362
+#: ../src/iop/lut3d.c:363
 #, c-format
 msgid "png bit-depth %d not supported"
 msgstr "la profundidad de bits %d png no es compatible"
 
-#: ../src/iop/lut3d.c:374
+#: ../src/iop/lut3d.c:375
 #, c-format
 msgid "invalid level in png file %d %d"
 msgstr "nivel inválido en el archivo png %d %d"
 
-#: ../src/iop/lut3d.c:389 ../src/iop/lut3d.c:406
+#: ../src/iop/lut3d.c:390 ../src/iop/lut3d.c:407
 msgid "error - allocating buffer for png lut"
 msgstr "Error: asignar búfer para png lut"
 
-#: ../src/iop/lut3d.c:396
+#: ../src/iop/lut3d.c:397
 #, c-format
 msgid "error - could not read png image %s"
 msgstr "Error: no se pudo leer la imagen png %s"
 
-#: ../src/iop/lut3d.c:572
+#: ../src/iop/lut3d.c:573
 #, c-format
 msgid "error - invalid cube file: %s"
 msgstr "Error: archivo de cubo inválido %s"
 
-#: ../src/iop/lut3d.c:588
+#: ../src/iop/lut3d.c:589
 msgid "DOMAIN MIN <> 0.0 is not supported"
 msgstr "DOMINIO MíN <> 0.0 no es compatible"
 
-#: ../src/iop/lut3d.c:599
+#: ../src/iop/lut3d.c:600
 msgid "DOMAIN MAX <> 1.0 is not supported"
 msgstr "DOMINIO MáX <> 0.0 no es compatible"
 
-#: ../src/iop/lut3d.c:608
+#: ../src/iop/lut3d.c:609
 msgid "1D cube lut is not supported"
 msgstr "el cubo lut 1D no es compatible"
 
-#: ../src/iop/lut3d.c:622
+#: ../src/iop/lut3d.c:623
 msgid "error - allocating buffer for cube lut"
 msgstr "Error: asignación de búfer para el cubo lut"
 
-#: ../src/iop/lut3d.c:633
+#: ../src/iop/lut3d.c:634
 msgid "error - cube lut size is not defined"
 msgstr "error: el tamaño del cubo LUT no está definido"
 
-#: ../src/iop/lut3d.c:650
+#: ../src/iop/lut3d.c:651
 msgid "error - cube lut lines number is not correct"
 msgstr "error: el número de líneas del cubo LUT no es correcto"
 
-#: ../src/iop/lut3d.c:927
+#: ../src/iop/lut3d.c:1006
 msgid "Lut root folder not defined"
 msgstr "Carpeta raíz de Lut no definida"
 
-#: ../src/iop/lut3d.c:933
+#: ../src/iop/lut3d.c:1012
 msgid "select lut file"
 msgstr "seleccionar archivo LUT"
 
-#: ../src/iop/lut3d.c:934
+#: ../src/iop/lut3d.c:1013
 msgid "_select"
 msgstr "seleccionar"
 
-#: ../src/iop/lut3d.c:951
+#: ../src/iop/lut3d.c:1030
 msgid "hald cluts (png)"
 msgstr "hald cluts (png)"
 
-#: ../src/iop/lut3d.c:958
+#: ../src/iop/lut3d.c:1037
 msgid "3D lut (cube)"
 msgstr "lut 3D (cubo)"
 
-#: ../src/iop/lut3d.c:964 ../src/libs/copy_history.c:93
-#: ../src/libs/geotagging.c:494 ../src/libs/import.c:789
+#: ../src/iop/lut3d.c:1043 ../src/libs/copy_history.c:93
+#: ../src/libs/geotagging.c:495 ../src/libs/import.c:790
 #: ../src/libs/styles.c:341
 msgid "all files"
 msgstr "todos los archivos"
 
-#: ../src/iop/lut3d.c:982
+#: ../src/iop/lut3d.c:1058
 msgid "Select file outside Lut root folder is not allowed"
 msgstr "No se permite seleccionar el archivo fuera de la carpeta raíz de Lut"
 
-#: ../src/iop/lut3d.c:1031
+#: ../src/iop/lut3d.c:1102
+msgid "select a png (haldclut) or a cube file"
+msgstr "Seleccione un png (HaldCLUT) o un archivo de cubo"
+
+#: ../src/iop/lut3d.c:1109
 msgid ""
 "the file path (relative to lut folder) is saved with image (and not the lut "
 "data themselves)\n"
@@ -9136,47 +9658,43 @@ msgstr ""
 "PRECAUCIÓN: la carpeta LUT se debe configurar en preferencias/Opciones "
 "básicas/miscelánea antes de elegir el archivo LUT"
 
-#: ../src/iop/lut3d.c:1037
-msgid "select a png (haldclut) or a cube file"
-msgstr "Seleccione un png (HaldCLUT) o un archivo de cubo"
-
-#: ../src/iop/lut3d.c:1044
+#: ../src/iop/lut3d.c:1116
 msgid "application color space"
 msgstr "espacio de color de la aplicación"
 
-#: ../src/iop/lut3d.c:1046
+#: ../src/iop/lut3d.c:1118
 msgid "REC.709"
 msgstr "REC.709"
 
-#: ../src/iop/lut3d.c:1047
+#: ../src/iop/lut3d.c:1119
 msgid "lin sRGB/REC.709"
 msgstr "sRGB/REC.709 lineal"
 
-#: ../src/iop/lut3d.c:1048
+#: ../src/iop/lut3d.c:1120
 msgid "lin prophoto RGB"
 msgstr "Profoto RGB lineal"
 
-#: ../src/iop/lut3d.c:1050
+#: ../src/iop/lut3d.c:1122
 msgid "select the color space in which the LUT has to be applied"
 msgstr "Seleccione el espacio de color en el que se debe aplicar el LUT"
 
-#: ../src/iop/lut3d.c:1054
+#: ../src/iop/lut3d.c:1126
 msgid "interpolation"
 msgstr "interpolación"
 
-#: ../src/iop/lut3d.c:1055
+#: ../src/iop/lut3d.c:1127
 msgid "tetrahedral"
 msgstr "tetahedro"
 
-#: ../src/iop/lut3d.c:1056
+#: ../src/iop/lut3d.c:1128
 msgid "trilinear"
 msgstr "trilineal"
 
-#: ../src/iop/lut3d.c:1057
+#: ../src/iop/lut3d.c:1129
 msgid "pyramid"
 msgstr "pirámide"
 
-#: ../src/iop/lut3d.c:1059
+#: ../src/iop/lut3d.c:1131
 msgid "select the interpolation method"
 msgstr "elija el método de interpolación"
 
@@ -9277,27 +9795,27 @@ msgstr "10 EV Rango dinámico (genérico)"
 msgid "08 EV dynamic range (generic)"
 msgstr "08 EV Rango dinámico (genérico)"
 
-#: ../src/iop/profile_gamma.c:856
+#: ../src/iop/profile_gamma.c:861
 msgid "tone mapping method"
 msgstr "método mapeo de tonos"
 
-#: ../src/iop/profile_gamma.c:871
+#: ../src/iop/profile_gamma.c:876
 msgid "linear part"
 msgstr "parte lineal"
 
-#: ../src/iop/profile_gamma.c:878
+#: ../src/iop/profile_gamma.c:883
 msgid "gamma exponential factor"
 msgstr "factor exponencial gamma"
 
-#: ../src/iop/profile_gamma.c:891
+#: ../src/iop/profile_gamma.c:896
 msgid "middle grey luma"
 msgstr "luma gris medio"
 
-#: ../src/iop/profile_gamma.c:894
+#: ../src/iop/profile_gamma.c:899
 msgid "adjust to match the average luma of the subject"
 msgstr "ajustar para que coincida con la luma media del sujeto"
 
-#: ../src/iop/profile_gamma.c:906
+#: ../src/iop/profile_gamma.c:911
 msgid ""
 "number of stops between middle grey and pure black\n"
 "this is a reading a posemeter would give you on the scene"
@@ -9305,11 +9823,11 @@ msgstr ""
 "número de pasos entre el gris medio y el negro puro\n"
 "esta es una lectura que un exposímetro te daría en la escena"
 
-#: ../src/iop/profile_gamma.c:915
+#: ../src/iop/profile_gamma.c:920
 msgid "dynamic range"
 msgstr "rango dinámico"
 
-#: ../src/iop/profile_gamma.c:918
+#: ../src/iop/profile_gamma.c:923
 msgid ""
 "number of stops between pure black and pure white\n"
 "this is a reading a posemeter would give you on the scene"
@@ -9318,11 +9836,11 @@ msgstr ""
 "esta es una lectura que un exposimetro te daría en la escena"
 
 #. Security factor
-#: ../src/iop/profile_gamma.c:925
+#: ../src/iop/profile_gamma.c:930
 msgid "optimize automatically"
 msgstr "optimizar automáticamente"
 
-#: ../src/iop/profile_gamma.c:930
+#: ../src/iop/profile_gamma.c:935
 msgid ""
 "enlarge or shrink the computed dynamic range\n"
 "this is useful when noise perturbates the measurements"
@@ -9330,7 +9848,7 @@ msgstr ""
 "ampliar o reducir el rango dinámico calculado.\n"
 "esto es útil cuando el ruido perturba las mediciones"
 
-#: ../src/iop/profile_gamma.c:940
+#: ../src/iop/profile_gamma.c:945
 msgid "make an optimization with some guessing"
 msgstr "hacer una optimización con algunas estimaciones"
 
@@ -9441,21 +9959,21 @@ msgctxt "accel"
 msgid "width"
 msgstr "ancho"
 
-#: ../src/iop/relight.c:364
+#: ../src/iop/relight.c:362
 msgid "the fill-light in EV"
 msgstr "la luz de relleno en EV"
 
-#: ../src/iop/relight.c:369 ../src/libs/metadata_view.c:115
-#: ../src/libs/print_settings.c:1306
+#: ../src/iop/relight.c:367 ../src/libs/metadata_view.c:119
+#: ../src/libs/print_settings.c:1304
 msgid "width"
 msgstr "ancho"
 
-#: ../src/iop/relight.c:371
+#: ../src/iop/relight.c:369
 #, no-c-format
 msgid "width of fill-light area defined in zones"
 msgstr "ancho del área de luz de relleno definida en zonas"
 
-#: ../src/iop/relight.c:382
+#: ../src/iop/relight.c:380
 msgid ""
 "select the center of fill-light\n"
 "ctrl+click to select an area"
@@ -9463,7 +9981,7 @@ msgstr ""
 "seleccionar el centro de la luz de relleno\n"
 "Ctrl+clic para seleccionar un área"
 
-#: ../src/iop/relight.c:397
+#: ../src/iop/relight.c:395
 msgid "toggle tool for picking median lightness in image"
 msgstr "activar herramienta para escoger la luz media en la imagen"
 
@@ -9475,11 +9993,11 @@ msgstr "retoque"
 msgid "cannot display scales when the blending mask is displayed"
 msgstr "no puede mostrar las escalas cuando se muestra la máscara de mezcla"
 
-#: ../src/iop/retouch.c:2648
+#: ../src/iop/retouch.c:2649
 msgid "# shapes:"
 msgstr "# formas:"
 
-#: ../src/iop/retouch.c:2652
+#: ../src/iop/retouch.c:2654
 msgid ""
 "to add a shape select an algorithm and a shape type and click on the image.\n"
 "shapes are added to the current scale"
@@ -9488,7 +10006,7 @@ msgstr ""
 "en la imagen.\n"
 "Las formas se añaden a la escala actual"
 
-#: ../src/iop/retouch.c:2659
+#: ../src/iop/retouch.c:2661
 msgid "show and edit shapes on the current scale"
 msgstr "muestra y edita las formas en la escala actual"
 
@@ -9512,19 +10030,19 @@ msgstr "activa la herramienta de saneado"
 msgid "activates cloning tool"
 msgstr "activa la herramienta de clonado"
 
-#: ../src/iop/retouch.c:2735
+#: ../src/iop/retouch.c:2736
 msgid "# scales:"
 msgstr "# escalas:"
 
-#: ../src/iop/retouch.c:2742
+#: ../src/iop/retouch.c:2745
 msgid "current:"
 msgstr "actual:"
 
-#: ../src/iop/retouch.c:2749
+#: ../src/iop/retouch.c:2754
 msgid "merge from:"
 msgstr "fusionar imagen hdr:"
 
-#: ../src/iop/retouch.c:2759
+#: ../src/iop/retouch.c:2767
 msgid ""
 "top slider adjusts where the merge scales start\n"
 "bottom slider adjusts the number of scales\n"
@@ -9536,43 +10054,43 @@ msgstr ""
 "El recuadro rojo indica la escala actual.\n"
 "La línea verde indica que la escala tiene formas"
 
-#: ../src/iop/retouch.c:2781
+#: ../src/iop/retouch.c:2789
 msgid "display masks"
 msgstr "mostrar máscaras"
 
-#: ../src/iop/retouch.c:2787
+#: ../src/iop/retouch.c:2795
 msgid "temporarily switch off shapes"
 msgstr "desactivar temporalmente las formas"
 
-#: ../src/iop/retouch.c:2794
+#: ../src/iop/retouch.c:2802
 msgid "display wavelet scale"
 msgstr "mostrar escala de la ondícula"
 
-#: ../src/iop/retouch.c:2802
+#: ../src/iop/retouch.c:2810
 msgid "cut shapes from current scale"
 msgstr "cortar formas desde la escala actual"
 
-#: ../src/iop/retouch.c:2808
+#: ../src/iop/retouch.c:2816
 msgid "paste cut shapes to current scale"
 msgstr "pegar las formas cortadas en la escala actual"
 
-#: ../src/iop/retouch.c:2832
+#: ../src/iop/retouch.c:2840
 msgid "preview single scale"
 msgstr "vista previa de una escala"
 
-#: ../src/iop/retouch.c:2839
+#: ../src/iop/retouch.c:2847
 msgid "adjust preview levels"
 msgstr "ajustar los niveles de vista previa"
 
-#: ../src/iop/retouch.c:2858
+#: ../src/iop/retouch.c:2866
 msgid "auto levels"
 msgstr "niveles automáticos"
 
-#: ../src/iop/retouch.c:2870
+#: ../src/iop/retouch.c:2878
 msgid "shape selected:"
 msgstr "forma seleccionada:"
 
-#: ../src/iop/retouch.c:2874
+#: ../src/iop/retouch.c:2882
 msgid ""
 "click on a shape to select it,\n"
 "to unselect click on an empty space"
@@ -9580,231 +10098,227 @@ msgstr ""
 "Pulse en una forma para seleccionarla.\n"
 "Para deseleccionar, pulse en un espacio vacío"
 
-#: ../src/iop/retouch.c:2881
+#: ../src/iop/retouch.c:2889
 msgid "fill mode"
 msgstr "modo de relleno"
 
-#: ../src/iop/retouch.c:2882
+#: ../src/iop/retouch.c:2890
 msgid "erase"
 msgstr "borrar"
 
-#: ../src/iop/retouch.c:2883 ../src/iop/watermark.c:1381
+#: ../src/iop/retouch.c:2891 ../src/iop/watermark.c:1381
 msgid "color"
 msgstr "color"
 
-#: ../src/iop/retouch.c:2884
+#: ../src/iop/retouch.c:2892
 msgid "erase the detail or fills with chosen color"
 msgstr "borrar el detalle o rellenar con el color elegido"
 
-#: ../src/iop/retouch.c:2896 ../src/iop/retouch.c:2897
+#: ../src/iop/retouch.c:2904 ../src/iop/retouch.c:2905
 msgid "select fill color"
 msgstr "seleccione el color de relleno"
 
-#: ../src/iop/retouch.c:2903
+#: ../src/iop/retouch.c:2911
 msgid "pick fill color from image"
 msgstr "elegir color de relleno de la imagen"
 
-#: ../src/iop/retouch.c:2907
+#: ../src/iop/retouch.c:2915
 msgid "fill color: "
 msgstr "color de relleno "
 
-#: ../src/iop/retouch.c:2912
+#: ../src/iop/retouch.c:2920
 msgid "adjusts color brightness to fine-tune it. works with erase as well"
 msgstr ""
 "ajustes del brillo del color para afinarlo. funciona también con borrado"
 
-#: ../src/iop/retouch.c:2926
+#: ../src/iop/retouch.c:2934
 msgid "blur type"
 msgstr "tipo de desenfoque"
 
-#: ../src/iop/retouch.c:2928
+#: ../src/iop/retouch.c:2936
 msgid "bilateral"
 msgstr "rejilla bilateral"
 
-#: ../src/iop/retouch.c:2929
+#: ../src/iop/retouch.c:2937
 msgid "type for the blur algorithm"
 msgstr "tipo de algoritmo de desenfoque"
 
-#: ../src/iop/retouch.c:2935
+#: ../src/iop/retouch.c:2943
 msgid "blur radius"
 msgstr "radio de desenfoque"
 
-#: ../src/iop/retouch.c:2936
+#: ../src/iop/retouch.c:2944
 msgid "radius of the selected blur type"
 msgstr "radio del tipo de desenfoque seleccionado"
 
-#: ../src/iop/retouch.c:2944
+#: ../src/iop/retouch.c:2952
 msgid "set the opacity on the selected shape"
 msgstr "seleccionar la opacidad en la forma seleccionada"
 
 #. add all the controls to the iop
-#: ../src/iop/retouch.c:2948
+#: ../src/iop/retouch.c:2956
 msgid "retouch tools"
 msgstr "herramienta de retoque"
 
 #. wavelet decompose
-#: ../src/iop/retouch.c:2957
+#: ../src/iop/retouch.c:2965
 msgid "wavelet decompose"
 msgstr "descomponer en ondículas"
 
 #. shapes
-#: ../src/iop/retouch.c:2971
+#: ../src/iop/retouch.c:2979
 msgid "shapes"
 msgstr "formas"
 
-#: ../src/iop/retouch.c:3325
+#: ../src/iop/retouch.c:3333
 msgctxt "accel"
 msgid "retouch tool circle"
 msgstr "herramienta de retoque círculo"
 
-#: ../src/iop/retouch.c:3326
+#: ../src/iop/retouch.c:3334
 msgctxt "accel"
 msgid "retouch tool ellipse"
 msgstr "herramienta de retoque elipse"
 
-#: ../src/iop/retouch.c:3327
+#: ../src/iop/retouch.c:3335
 msgctxt "accel"
 msgid "retouch tool path"
 msgstr "herramienta de retoque ruta"
 
-#: ../src/iop/retouch.c:3328
+#: ../src/iop/retouch.c:3336
 msgctxt "accel"
 msgid "retouch tool brush"
 msgstr "herramienta de retoque pincel"
 
-#: ../src/iop/retouch.c:3330
+#: ../src/iop/retouch.c:3338
 msgctxt "accel"
 msgid "continuous add circle"
 msgstr "agregar círculo"
 
-#: ../src/iop/retouch.c:3331
+#: ../src/iop/retouch.c:3339
 msgctxt "accel"
 msgid "continuous add ellipse"
 msgstr "agregar elipse"
 
-#: ../src/iop/retouch.c:3332
+#: ../src/iop/retouch.c:3340
 msgctxt "accel"
 msgid "continuous add path"
 msgstr "agregar ruta"
 
-#: ../src/iop/retouch.c:3333
+#: ../src/iop/retouch.c:3341
 msgctxt "accel"
 msgid "continuous add brush"
 msgstr "agregar pincel"
 
-#: ../src/iop/retouch.c:4417 ../src/iop/retouch.c:5273
+#: ../src/iop/retouch.c:4425 ../src/iop/retouch.c:5281
 #, c-format
 msgid "max scale is %i for this image size"
 msgstr "la escala máxima es %i para este tamaño de imagen"
 
-#: ../src/iop/rgbcurve.c:136
+#: ../src/iop/rgbcurve.c:126
 msgid "rgb curve"
 msgstr "curva rgb"
 
-#: ../src/iop/rgbcurve.c:218 ../src/iop/tonecurve.c:464
+#: ../src/iop/rgbcurve.c:208 ../src/iop/tonecurve.c:544
 #: ../src/iop/tonemap.cc:297
 msgid "contrast compression"
 msgstr "compresión del contraste"
 
-#: ../src/iop/rgbcurve.c:226 ../src/iop/tonecurve.c:472
+#: ../src/iop/rgbcurve.c:216 ../src/iop/tonecurve.c:552
 msgid "gamma 1.0 (linear)"
 msgstr "gamma 1.0 (linear)"
 
-#: ../src/iop/rgbcurve.c:235 ../src/iop/tonecurve.c:481
+#: ../src/iop/rgbcurve.c:225 ../src/iop/tonecurve.c:561
 msgid "contrast - med (linear)"
 msgstr "contraste medio (linear)"
 
-#: ../src/iop/rgbcurve.c:243 ../src/iop/tonecurve.c:489
+#: ../src/iop/rgbcurve.c:233 ../src/iop/tonecurve.c:569
 msgid "contrast - high (linear)"
 msgstr "contraste alto (linear)"
 
-#: ../src/iop/rgbcurve.c:256 ../src/iop/tonecurve.c:500
+#: ../src/iop/rgbcurve.c:246 ../src/iop/tonecurve.c:580
 msgid "contrast - med (gamma 2.2)"
 msgstr "contraste medio (gamma 2.2)"
 
-#: ../src/iop/rgbcurve.c:268 ../src/iop/tonecurve.c:510
+#: ../src/iop/rgbcurve.c:258 ../src/iop/tonecurve.c:590
 msgid "contrast - high (gamma 2.2)"
 msgstr "alto contraste (gamma 2.2)"
 
-#: ../src/iop/rgbcurve.c:279 ../src/iop/tonecurve.c:521
+#: ../src/iop/rgbcurve.c:269 ../src/iop/tonecurve.c:601
 msgid "gamma 2.0"
 msgstr "gamma 2.0"
 
-#: ../src/iop/rgbcurve.c:283 ../src/iop/tonecurve.c:525
+#: ../src/iop/rgbcurve.c:273 ../src/iop/tonecurve.c:605
 msgid "gamma 0.5"
 msgstr "gamma 0.5"
 
-#: ../src/iop/rgbcurve.c:287 ../src/iop/tonecurve.c:529
+#: ../src/iop/rgbcurve.c:277 ../src/iop/tonecurve.c:609
 msgid "logarithm (base 2)"
 msgstr "logarítmico (base 2)"
 
-#: ../src/iop/rgbcurve.c:291 ../src/iop/tonecurve.c:533
+#: ../src/iop/rgbcurve.c:281 ../src/iop/tonecurve.c:613
 msgid "exponential (base 2)"
 msgstr "exponencial (base 2)"
 
-#: ../src/iop/rgbcurve.c:1489 ../src/iop/tonecurve.c:1227
+#: ../src/iop/rgbcurve.c:1479 ../src/iop/rgblevels.c:1011
+#: ../src/iop/tonecurve.c:1312
 msgid "RGB, linked channels"
 msgstr "RGB  canales enlazados"
 
-#: ../src/iop/rgbcurve.c:1490
+#: ../src/iop/rgbcurve.c:1480 ../src/iop/rgblevels.c:1012
 msgid "RGB, independent channels"
 msgstr "canales independientes RGB"
 
-#: ../src/iop/rgbcurve.c:1492
+#: ../src/iop/rgbcurve.c:1482 ../src/iop/rgblevels.c:1014
 msgid "choose between linked and independent channels."
 msgstr "Elegir entre canales enlazados o independientes."
 
-#: ../src/iop/rgbcurve.c:1499
+#: ../src/iop/rgbcurve.c:1489 ../src/iop/rgblevels.c:1021
 msgid "  R  "
 msgstr "  R  "
 
-#: ../src/iop/rgbcurve.c:1502
-msgid "curve_nodes for r channel"
+#: ../src/iop/rgbcurve.c:1492 ../src/iop/rgblevels.c:1024
+msgid "curve nodes for r channel"
 msgstr "nodos de la curva para el canal R"
 
-#: ../src/iop/rgbcurve.c:1504
+#: ../src/iop/rgbcurve.c:1494 ../src/iop/rgblevels.c:1026
 msgid "  G  "
 msgstr "  G  "
 
-#: ../src/iop/rgbcurve.c:1507
-msgid "curve_nodes for g channel"
+#: ../src/iop/rgbcurve.c:1497 ../src/iop/rgblevels.c:1029
+msgid "curve nodes for g channel"
 msgstr "nodos de la curva para el canal G"
 
-#: ../src/iop/rgbcurve.c:1509
+#: ../src/iop/rgbcurve.c:1499 ../src/iop/rgblevels.c:1031
 msgid "  B  "
 msgstr "  B  "
 
-#: ../src/iop/rgbcurve.c:1512
-msgid "curve_nodes for b channel"
+#: ../src/iop/rgbcurve.c:1502 ../src/iop/rgblevels.c:1034
+msgid "curve nodes for b channel"
 msgstr "nodos de la curva para el canal B"
 
-#: ../src/iop/rgbcurve.c:1532
+#: ../src/iop/rgbcurve.c:1522
 msgid "pick GUI color from image"
 msgstr "seleccionar color de la imagen"
 
-#: ../src/iop/rgbcurve.c:1586 ../src/iop/rgbcurve.c:1588
+#: ../src/iop/rgbcurve.c:1576 ../src/iop/rgbcurve.c:1578
 msgid "compensate middle grey"
 msgstr "compensar gris medio"
 
-#: ../src/iop/rgbcurve.c:1597
-msgid "max rgb"
-msgstr "rgb máx."
+#: ../src/iop/rgblevels.c:108
+msgid "rgb levels"
+msgstr "niveles RGB"
 
-#: ../src/iop/rgbcurve.c:1598
-msgid "average rgb"
-msgstr "rgb media"
-
-#: ../src/iop/rgbcurve.c:1599
-msgid "sum rgb"
-msgstr "rgb suma"
-
-#: ../src/iop/rgbcurve.c:1600
-msgid "norm rgb"
-msgstr "rgb normal"
-
-#: ../src/iop/rgbcurve.c:1601
-msgid "basic power"
-msgstr "poder básico"
+#: ../src/iop/rgblevels.c:1094
+msgid ""
+"apply auto levels based on a region defined by the user\n"
+"click and drag to draw the area\n"
+"right click to cancel"
+msgstr ""
+"Establece los niveles automáticamente en función de una región definida por "
+"el usuario\n"
+"Pulse y arrastre para dibujar el área\n"
+"Pulse el botón derecho para cancelar"
 
 #: ../src/iop/rotatepixels.c:76
 msgctxt "modulename"
@@ -9815,13 +10329,11 @@ msgstr "rotar pixeles"
 msgid "automatic pixel rotation"
 msgstr "rotación automática de pixeles"
 
-#: ../src/iop/rotatepixels.c:359
-msgid ""
-"automatic pixel rotation\n"
-"only works for the sensors that need it."
+#: ../src/iop/rotatepixels.c:358
+msgid "automatic pixel rotation only works for the sensors that need it."
 msgstr ""
-"rotación automática de pixel\n"
-"solo funciona para los sensores que lo necesiten."
+"La rotación automática del píxel funciona solo para los sensores que lo "
+"necesiten."
 
 #: ../src/iop/scalepixels.c:56
 msgctxt "modulename"
@@ -9832,24 +10344,22 @@ msgstr "redimensionar pixeles"
 msgid "automatic pixel scaling"
 msgstr "escalado automático de pixeles"
 
-#: ../src/iop/scalepixels.c:276
-msgid ""
-"automatic pixel scaling\n"
-"only works for the sensors that need it."
+#: ../src/iop/scalepixels.c:275
+msgid "automatic pixel scaling only works for the sensors that need it."
 msgstr ""
-"escalado automático de pixel\n"
-"solo funciona para los sensores que lo necesiten."
+"La redimensión automática del píxel funciona solo para los sensores que lo "
+"necesiten."
 
 #: ../src/iop/shadhi.c:177
 msgid "shadows and highlights"
 msgstr "sombras y altas luces"
 
-#: ../src/iop/shadhi.c:276
+#: ../src/iop/shadhi.c:276 ../src/iop/toneequal.c:312
 msgctxt "accel"
 msgid "shadows"
 msgstr "sombras"
 
-#: ../src/iop/shadhi.c:277
+#: ../src/iop/shadhi.c:277 ../src/iop/toneequal.c:316
 msgctxt "accel"
 msgid "highlights"
 msgstr "altas luces"
@@ -9860,7 +10370,7 @@ msgid "white point adjustment"
 msgstr "ajuste de punto blanco"
 
 #: ../src/iop/shadhi.c:280 ../src/iop/splittoning.c:114
-#: ../src/libs/copy_history.c:471
+#: ../src/libs/copy_history.c:396
 msgctxt "accel"
 msgid "compress"
 msgstr "comprimir"
@@ -9879,7 +10389,7 @@ msgstr "reconstrucción de luces"
 msgid "white point adjustment"
 msgstr "ajuste de punto blanco"
 
-#: ../src/iop/shadhi.c:844 ../src/iop/splittoning.c:650
+#: ../src/iop/shadhi.c:844 ../src/iop/splittoning.c:678
 msgid "compress"
 msgstr "comprimir"
 
@@ -10006,23 +10516,23 @@ msgstr "platinotipo auténtico"
 msgid "chocolate brown"
 msgstr "marrón chocolate"
 
-#: ../src/iop/splittoning.c:578
+#: ../src/iop/splittoning.c:605
 msgid "select tone color"
 msgstr "seleccionar tono de color"
 
-#: ../src/iop/splittoning.c:602
+#: ../src/iop/splittoning.c:629
 msgid "select the saturation tone"
 msgstr "seleccionar el tono de saturación"
 
-#: ../src/iop/splittoning.c:644
+#: ../src/iop/splittoning.c:672
 msgid "balance"
 msgstr "balance"
 
-#: ../src/iop/splittoning.c:654
+#: ../src/iop/splittoning.c:682
 msgid "the balance of center of splittoning"
 msgstr "balance central de las variaciones tonales"
 
-#: ../src/iop/splittoning.c:655
+#: ../src/iop/splittoning.c:683
 msgid ""
 "compress the effect on highlights/shadows and\n"
 "preserve midtones"
@@ -10124,68 +10634,68 @@ msgid "failed to read camera white balance information from `%s'!"
 msgstr ""
 "fallo al leer la información del balance de blancos de la cámara desde `%s'!"
 
-#: ../src/iop/temperature.c:1365
+#: ../src/iop/temperature.c:1367
 msgid "magenta"
 msgstr "magenta"
 
-#: ../src/iop/temperature.c:1366
+#: ../src/iop/temperature.c:1368
 msgid "cyan"
 msgstr "cyan"
 
-#: ../src/iop/temperature.c:1379
+#: ../src/iop/temperature.c:1381
 msgid "emerald"
 msgstr "esmeralda"
 
-#: ../src/iop/temperature.c:1442
+#: ../src/iop/temperature.c:1444
 msgid "tint"
 msgstr "tinte"
 
-#: ../src/iop/temperature.c:1443
+#: ../src/iop/temperature.c:1445
 msgid "temperature"
 msgstr "temperatura"
 
-#: ../src/iop/temperature.c:1459
+#: ../src/iop/temperature.c:1461
 msgid "choose white balance preset from camera"
 msgstr "seleccione balance de blancos predefinido de la cámara"
 
-#: ../src/iop/temperature.c:1462
+#: ../src/iop/temperature.c:1464
 msgid "finetune"
 msgstr "afinar"
 
-#: ../src/iop/temperature.c:1463
+#: ../src/iop/temperature.c:1465
 #, c-format
 msgid "%.0f mired"
 msgstr "%.0f mired"
 
-#: ../src/iop/temperature.c:1467
+#: ../src/iop/temperature.c:1469
 msgid "fine tune white balance preset"
 msgstr "ajuste fino del balance de blancos predefinido"
 
-#: ../src/iop/temperature.c:1472
+#: ../src/iop/temperature.c:1474
 msgid "white balance disabled for camera"
 msgstr "balance de blancos deshabilitado para la cámara"
 
-#: ../src/iop/tonecurve.c:164
+#: ../src/iop/tonecurve.c:189
 msgid "tone curve"
 msgstr "curva de tono"
 
-#: ../src/iop/tonecurve.c:1223
+#: ../src/iop/tonecurve.c:1308
 msgid "color space"
 msgstr "esquema de color"
 
-#: ../src/iop/tonecurve.c:1224
+#: ../src/iop/tonecurve.c:1309
 msgid "Lab, linked channels"
 msgstr "Lab canales enlazados"
 
-#: ../src/iop/tonecurve.c:1225
+#: ../src/iop/tonecurve.c:1310
 msgid "Lab, independent channels"
 msgstr "canales independientes Lab"
 
-#: ../src/iop/tonecurve.c:1226
+#: ../src/iop/tonecurve.c:1311
 msgid "XYZ, linked channels"
 msgstr "XYZ, canales enlazados"
 
-#: ../src/iop/tonecurve.c:1229
+#: ../src/iop/tonecurve.c:1314
 msgid ""
 "if set to auto, a and b curves have no effect and are not displayed. chroma "
 "values (a and b) of each pixel are then adjusted based on L curve data. auto "
@@ -10196,45 +10706,358 @@ msgstr ""
 "curva L. auto XYZ es similar, pero establece los cambios de saturación en el "
 "espacio XYZ."
 
-#: ../src/iop/tonecurve.c:1239
+#: ../src/iop/tonecurve.c:1324
 msgid "  L  "
 msgstr "  L  "
 
-#: ../src/iop/tonecurve.c:1241
+#: ../src/iop/tonecurve.c:1326
 msgid "tonecurve for L channel"
 msgstr "curva para el canal L"
 
-#: ../src/iop/tonecurve.c:1243
+#: ../src/iop/tonecurve.c:1328
 msgid "  a  "
 msgstr "  a  "
 
-#: ../src/iop/tonecurve.c:1245
+#: ../src/iop/tonecurve.c:1330
 msgid "tonecurve for a channel"
 msgstr "curva para el canal a"
 
-#: ../src/iop/tonecurve.c:1247
+#: ../src/iop/tonecurve.c:1332
 msgid "  b  "
 msgstr "  b  "
 
-#: ../src/iop/tonecurve.c:1249
+#: ../src/iop/tonecurve.c:1334
 msgid "tonecurve for b channel"
 msgstr "curva para el canal b"
 
-#: ../src/iop/tonecurve.c:1309
-msgid "log-log (xy)"
-msgstr "log-log (xy)"
+#: ../src/iop/tonecurve.c:1407
+msgid "log"
+msgstr "registro"
 
-#: ../src/iop/tonecurve.c:1310
-msgid "semi-log (x)"
-msgstr "semi-log (x)"
-
-#: ../src/iop/tonecurve.c:1311
-msgid "semi-log (y)"
-msgstr "semi-log (y)"
-
-#: ../src/iop/tonecurve.c:1319
+#: ../src/iop/tonecurve.c:1415
 msgid "base of the logarithm"
 msgstr "base del logaritmo"
+
+#: ../src/iop/toneequal.c:290
+msgid "tone equalizer"
+msgstr "ecualizador de tono"
+
+#: ../src/iop/toneequal.c:310
+msgctxt "accel"
+msgid "blacks"
+msgstr "negros"
+
+#: ../src/iop/toneequal.c:311
+msgctxt "accel"
+msgid "deep shadows"
+msgstr "sombras profundas"
+
+#: ../src/iop/toneequal.c:313
+msgctxt "accel"
+msgid "light shadows"
+msgstr "sombras claras"
+
+#: ../src/iop/toneequal.c:314
+msgctxt "accel"
+msgid "midtones"
+msgstr "tonos medios"
+
+#: ../src/iop/toneequal.c:315
+msgctxt "accel"
+msgid "dark highlights"
+msgstr "reflejos oscuros"
+
+#: ../src/iop/toneequal.c:317
+msgctxt "accel"
+msgid "whites"
+msgstr "blancos"
+
+#: ../src/iop/toneequal.c:318
+msgctxt "accel"
+msgid "speculars"
+msgstr "especulares"
+
+#: ../src/iop/toneequal.c:319
+msgctxt "accel"
+msgid "filter diffusion"
+msgstr "difusión de filtro"
+
+#: ../src/iop/toneequal.c:320
+msgctxt "accel"
+msgid "smoothing diameter"
+msgstr "diámetro de suavizado"
+
+#: ../src/iop/toneequal.c:321
+msgctxt "accel"
+msgid "edges refinement/feathering"
+msgstr "afinar o difuminar bordes"
+
+#: ../src/iop/toneequal.c:322
+msgctxt "accel"
+msgid "mask quantization"
+msgstr "cuantificación de máscara"
+
+#: ../src/iop/toneequal.c:323
+msgctxt "accel"
+msgid "mask exposure compensation"
+msgstr "compensación de exposición de máscara"
+
+#: ../src/iop/toneequal.c:324
+msgctxt "accel"
+msgid "mask contrast compensation"
+msgstr "compensación de contraste de máscara"
+
+#. No blending
+#: ../src/iop/toneequal.c:416
+msgid "mask blending : none"
+msgstr "fusión de máscara : ninguno"
+
+#: ../src/iop/toneequal.c:428
+msgid "mask blending : landscapes"
+msgstr "fusión de máscara : panorama"
+
+#: ../src/iop/toneequal.c:436
+msgid "mask blending : all purposes"
+msgstr "fusión de máscara : multiuso"
+
+#: ../src/iop/toneequal.c:444
+msgid "mask blending : isolated subjects"
+msgstr "fusión de máscara : sujetos aislados"
+
+#: ../src/iop/toneequal.c:465
+msgid "compress shadows/highlights : soft"
+msgstr "compresión de sombras/altas luces : tenue"
+
+#: ../src/iop/toneequal.c:484
+msgid "compress shadows/highlights : strong"
+msgstr "compresión de sombras/altas luces : intenso"
+
+#: ../src/iop/toneequal.c:503
+msgid "relight : fill-in"
+msgstr "reencender : relleno"
+
+#: ../src/iop/toneequal.c:554
+msgid ""
+"tone equalizer needs to be after distorsion modules in the pipeline – "
+"disabled"
+msgstr ""
+"El ecualizador de tono debe estar después de los módulos de distorsión en el "
+"procesado: deshabilitado"
+
+#: ../src/iop/toneequal.c:824 ../src/iop/toneequal.c:945
+msgid "tone equalizer failed to allocate memory, check your RAM settings"
+msgstr ""
+"El ecualizador de tono no pudo asignar memoria, verifique la configuración "
+"de RAM"
+
+#. Pointers are not 64-bits aligned, and SSE code will segfault
+#: ../src/iop/toneequal.c:846
+msgid ""
+"tone equalizer in/out buffer are ill-aligned, please report the bug to the "
+"developers"
+msgstr ""
+"El búfer de entrada/salida del ecualizador de tono está mal alineado, "
+"informe el error a los desarrolladores"
+
+#: ../src/iop/toneequal.c:1770 ../src/iop/toneequal.c:2143
+msgid "the interpolation is unstable, decrease the curve smoothing"
+msgstr "La interpolación es inestable, disminuya el suavizado de la curva"
+
+#: ../src/iop/toneequal.c:1855 ../src/iop/toneequal.c:1915
+msgid "wait for the preview to finish recomputing"
+msgstr "Espere a que la vista previa termine de recalcular"
+
+#: ../src/iop/toneequal.c:2148
+msgid "some parameters are out-of-bounds"
+msgstr "Algunos parámetros están fuera de los límites"
+
+#: ../src/iop/toneequal.c:3035
+msgid "simple"
+msgstr "sencillo"
+
+#: ../src/iop/toneequal.c:3036
+msgid "advanced"
+msgstr "avanzado"
+
+#: ../src/iop/toneequal.c:3037
+msgid "masking"
+msgstr "máscaras"
+
+#: ../src/iop/toneequal.c:3051
+msgid "-8 EV : blacks"
+msgstr "-8 EV : negros"
+
+#: ../src/iop/toneequal.c:3057
+msgid "-7 EV : deep shadows"
+msgstr "-7 EV : sombras profundas"
+
+#: ../src/iop/toneequal.c:3063
+msgid "-6 EV : shadows"
+msgstr "-6 EV : sombras"
+
+#: ../src/iop/toneequal.c:3069
+msgid "-5 EV : light shadows"
+msgstr "-5 EV : sombras claras"
+
+#: ../src/iop/toneequal.c:3075
+msgid "-4 EV : midtones"
+msgstr "-4 EV : tonos medios"
+
+#: ../src/iop/toneequal.c:3081
+msgid "-3 EV : dark highlights"
+msgstr "-3 EV : reflejos oscuros"
+
+#: ../src/iop/toneequal.c:3087
+msgid "-2 EV : highlights"
+msgstr "-2 EV : altas luces"
+
+#: ../src/iop/toneequal.c:3093
+msgid "-1 EV : whites"
+msgstr "-1 EV : blancos"
+
+#: ../src/iop/toneequal.c:3099
+msgid "+0 EV : speculars"
+msgstr "+0 EV : especulares"
+
+#: ../src/iop/toneequal.c:3123
+msgid "curve smoothing"
+msgstr "suavizado de curva"
+
+#: ../src/iop/toneequal.c:3124
+msgid ""
+"positive values will produce more progressive tone transitions\n"
+"but the curve might become oscillatory in some settings.\n"
+"negative values will avoid oscillations and behave more robustly\n"
+"but may produce brutal tone transitions and damage local contrast."
+msgstr ""
+"Los valores positivos producirán transiciones de tono graduales\n"
+"pero la curva puede volverse oscilatoria con algunas configuraciones.\n"
+"Los valores negativos evitarán oscilaciones y se comportarán de manera más "
+"robusta\n"
+"pero puede producir transiciones de tonos abruptas y dañar el contraste "
+"local."
+
+#: ../src/iop/toneequal.c:3133
+msgid "luminance estimator"
+msgstr "estimador de luminancia"
+
+#: ../src/iop/toneequal.c:3145
+msgid "preserve details"
+msgstr "preservar los detalles"
+
+#: ../src/iop/toneequal.c:3150
+msgid ""
+"'no' affects global and local contrast (safe if you only add contrast)\n"
+"'guided filter' only affects global contrast and tries to preserve local "
+"contrast\n"
+"'averaged guided filter' is a geometric mean of both methods"
+msgstr ""
+"'no' afecta el contraste global y local (seguro si solo agrega contraste)\n"
+"'filtro guiado' solo afecta el contraste global tratando de preservar el "
+"contraste local\n"
+"'filtro guiado promediado' es una media geométrica de ambos métodos"
+
+#: ../src/iop/toneequal.c:3157
+msgid "filter diffusion"
+msgstr "difusión de filtro"
+
+#: ../src/iop/toneequal.c:3158
+msgid ""
+"number of passes of guided filter to apply\n"
+"helps diffusing the edges of the filter at the expense of speed"
+msgstr ""
+"Número de pasadas del filtro guiado para aplicar\n"
+"Ayuda a difuminar los bordes del filtro a expensas de la velocidad"
+
+#: ../src/iop/toneequal.c:3166
+msgid "smoothing diameter"
+msgstr "diámetro de suavizado"
+
+#: ../src/iop/toneequal.c:3167
+msgid "diameter of the blur in percent of the largest image size"
+msgstr "diámetro del desenfoque en porcentaje del tamaño de imagen más grande"
+
+#: ../src/iop/toneequal.c:3173
+msgid "edges refinement/feathering"
+msgstr "afinar o difuminar bordes"
+
+#: ../src/iop/toneequal.c:3174
+msgid ""
+"precision of the feathering :\n"
+"higher values force the mask to follow edges more closely\n"
+"but may void the effect of the smoothing\n"
+"lower values give smoother gradients and better smoothing\n"
+"but may lead to inaccurate edges taping"
+msgstr ""
+"Precisión del difuminado:\n"
+"Los valores más altos fuerzan a la máscara a seguir los bordes más de cerca\n"
+"pero pueden anular el efecto del suavizado\n"
+"Los valores más bajos dan gradientes más lisos y un mejor suavizado\n"
+"pero puede dar lugar a bordes imprecisos"
+
+#: ../src/iop/toneequal.c:3182
+msgid "mask post-processing"
+msgstr "postprocesado de máscara"
+
+#: ../src/iop/toneequal.c:3188
+msgid ""
+"mask histogram span between the first and last deciles.\n"
+"the central line shows the average. orange bars appear at extrema if "
+"clipping occurs."
+msgstr ""
+"El histograma de máscara se extiende entre el primer y el último decil.\n"
+"La línea central muestra el promedio. Aparecerán barras naranjas en los "
+"extremos si se produce un recorte."
+
+#: ../src/iop/toneequal.c:3193
+msgid "mask quantization"
+msgstr "cuantificación de máscara"
+
+#: ../src/iop/toneequal.c:3195
+msgid ""
+"0 disables the quantization.\n"
+"higher values posterize the luminance mask to help the guiding\n"
+"produce piece-wise smooth areas when using high feathering values"
+msgstr ""
+"0 deshabilita la cuantización.\n"
+"Los valores más altos posterizan la máscara de luminancia para ayudar a "
+"guiar\n"
+"Cuando se usan valores de difuminado altos, produce áreas lisas por "
+"segmentos "
+
+#: ../src/iop/toneequal.c:3203
+msgid "mask exposure compensation"
+msgstr "compensación de exposición de máscara"
+
+#: ../src/iop/toneequal.c:3205
+msgid ""
+"use this to slide the mask average exposure along channels\n"
+"for better control of the exposure corrections.\n"
+"the picker will auto-adjust the average exposure at -4EV."
+msgstr ""
+"Funciona para deslizar la exposición promedio de la máscara a lo largo de "
+"los canales\n"
+"para un mejor control de las correcciones de exposición.\n"
+"El cuentagotas ajustará automáticamente la exposición promedio a -4EV."
+
+#: ../src/iop/toneequal.c:3217
+msgid "mask contrast compensation"
+msgstr "compensación de contraste de máscara"
+
+#: ../src/iop/toneequal.c:3219
+msgid ""
+"use this to dilate the mask contrast around its average exposure\n"
+"this allows to spread the exposure histogram over more channels\n"
+"for better control of the exposure corrections."
+msgstr ""
+"Funciona para dilatar el contraste de la máscara alrededor de la exposición "
+"promedio\n"
+"Permite extender el histograma de exposición a más canales.\n"
+"Ofrece un mejor control de las correcciones de exposición."
+
+#: ../src/iop/toneequal.c:3231 ../src/iop/toneequal.c:3235
+msgid "display exposure mask"
+msgstr "mostrar la máscara de exposición"
 
 #: ../src/iop/tonemap.cc:73
 msgid "tone mapping"
@@ -10398,6 +11221,23 @@ msgstr "proporción ancho/alto"
 msgid "add some level of random noise to prevent banding"
 msgstr "agregar algun nivel de ruido aleatorio para prevenir bandas"
 
+#: ../src/iop/vignette.c:1220
+#, c-format
+msgid "[%s on node] change vignette/feather size"
+msgstr "[%s en el nodo] cambiar el tamaño de viñeta/difuminado"
+
+#: ../src/iop/vignette.c:1226
+#, c-format
+msgid "[%s on node] change vignette/feather size keeping ratio"
+msgstr ""
+"[%s en el nodo] cambiar el tamaño de viñeta/difuminado manteniendo la "
+"relación"
+
+#: ../src/iop/vignette.c:1232
+#, c-format
+msgid "[%s on center] move vignette"
+msgstr "[%s en el centro] mover viñeta"
+
 #: ../src/iop/watermark.c:236
 msgid "watermark"
 msgstr "marca de agua"
@@ -10512,7 +11352,7 @@ msgid "position"
 msgstr "posición"
 
 #. Create the 3x3 gtk table toggle button table...
-#: ../src/iop/watermark.c:1454 ../src/libs/print_settings.c:1391
+#: ../src/iop/watermark.c:1454 ../src/libs/print_settings.c:1389
 msgid "alignment"
 msgstr "alineación"
 
@@ -10715,36 +11555,36 @@ msgstr "eliminar..."
 msgid "uncategorized"
 msgstr "sin categoría"
 
-#: ../src/libs/collect.c:1257
+#: ../src/libs/collect.c:1251
 msgid "not altered"
 msgstr "no alterado"
 
-#: ../src/libs/collect.c:1266
+#: ../src/libs/collect.c:1260
 msgid "not tagged"
 msgstr "sin etiquetar"
 
-#: ../src/libs/collect.c:1275
+#: ../src/libs/collect.c:1269
 msgid "copied locally"
 msgstr "copiar localmente"
 
-#: ../src/libs/collect.c:1379
+#: ../src/libs/collect.c:1373
 msgid "group followers"
 msgstr "seguidores de grupo"
 
-#: ../src/libs/collect.c:1555 ../src/libs/collect.c:1570
-#: ../src/libs/collect.c:1953
+#: ../src/libs/collect.c:1549 ../src/libs/collect.c:1564
+#: ../src/libs/collect.c:1947
 msgid "clear this rule"
 msgstr "eliminar esta regla"
 
-#: ../src/libs/collect.c:1559
+#: ../src/libs/collect.c:1553
 msgid "clear this rule or add new rules"
 msgstr "eliminar esta regla o añadir nuevas reglas"
 
-#: ../src/libs/collect.c:1616
+#: ../src/libs/collect.c:1610
 msgid "type your query, use <, <=, >, >=, <>, =, [;] as operators"
 msgstr "escriba su búsqueda, utilice <, <=, >, >=, <>, =, [;] como operadores"
 
-#: ../src/libs/collect.c:1621
+#: ../src/libs/collect.c:1615
 msgid ""
 "type your query, use <, <=, >, >=, <>, =, [;] as operators, type dates in "
 "the form : YYYY:MM:DD HH:MM:SS (only the year is mandatory)"
@@ -10752,32 +11592,32 @@ msgstr ""
 "escriba su búsqueda, utilice <, <=, >, >=, <>, =, [;] como operadores, tipos "
 "de datos en forma de : YYYY:MM:DD HH:MM:SS (solo el año es obligatorio)"
 
-#: ../src/libs/collect.c:1627 ../src/libs/collect.c:2047
+#: ../src/libs/collect.c:1621 ../src/libs/collect.c:2041
 #, no-c-format
 msgid "type your query, use `%' as wildcard"
 msgstr "teclee su ruta, use '%'  como comodín"
 
-#: ../src/libs/collect.c:1959
+#: ../src/libs/collect.c:1953
 msgid "narrow down search"
 msgstr "reducir la búsqueda"
 
-#: ../src/libs/collect.c:1964
+#: ../src/libs/collect.c:1958
 msgid "add more images"
 msgstr "añadir más imágenes"
 
-#: ../src/libs/collect.c:1969
+#: ../src/libs/collect.c:1963
 msgid "exclude images"
 msgstr "excluir imágenes"
 
-#: ../src/libs/collect.c:1976
+#: ../src/libs/collect.c:1970
 msgid "change to: and"
 msgstr "cambiar a: y"
 
-#: ../src/libs/collect.c:1981
+#: ../src/libs/collect.c:1975
 msgid "change to: or"
 msgstr "cambiar a: o"
 
-#: ../src/libs/collect.c:1986
+#: ../src/libs/collect.c:1980
 msgid "change to: except"
 msgstr "cambiar a: excepto"
 
@@ -10806,35 +11646,16 @@ msgstr "fecha"
 msgid "time"
 msgstr "tiempo"
 
-#: ../src/libs/collect.h:34 ../src/libs/history.c:62
+#: ../src/libs/collect.h:34 ../src/libs/history.c:63
 msgid "history"
 msgstr "historial"
-
-#. DT_COLLECTION_SORT_TITLE
-#: ../src/libs/collect.h:35 ../src/libs/metadata.c:348
-#: ../src/libs/tools/filter.c:156
-msgid "description"
-msgstr "descripción"
-
-#: ../src/libs/collect.h:35 ../src/libs/import.c:564 ../src/libs/metadata.c:349
-#: ../src/libs/metadata_view.c:123
-msgid "creator"
-msgstr "autor"
-
-#: ../src/libs/collect.h:35 ../src/libs/import.c:569 ../src/libs/metadata.c:350
-msgid "publisher"
-msgstr "editor"
-
-#: ../src/libs/collect.h:36 ../src/libs/import.c:574 ../src/libs/metadata.c:351
-msgid "rights"
-msgstr "derechos"
 
 #. DT_COLLECTION_SORT_DESCRIPTION
 #: ../src/libs/collect.h:38 ../src/libs/tools/filter.c:157
 msgid "aspect ratio"
 msgstr "proporción de aspecto"
 
-#: ../src/libs/collect.h:38 ../src/libs/metadata_view.c:97
+#: ../src/libs/collect.h:38 ../src/libs/metadata_view.c:101
 #: ../src/libs/tools/filter.c:147
 msgid "filename"
 msgstr "nombre"
@@ -10843,8 +11664,8 @@ msgstr "nombre"
 msgid "grouping"
 msgstr "agrupadas"
 
-#: ../src/libs/collect.h:39 ../src/libs/metadata_view.c:100
-#: ../src/libs/metadata_view.c:291
+#: ../src/libs/collect.h:39 ../src/libs/metadata_view.c:104
+#: ../src/libs/metadata_view.c:298
 msgid "local copy"
 msgstr "copia local"
 
@@ -10862,53 +11683,53 @@ msgctxt "accel"
 msgid "add sample"
 msgstr "añadir muestra"
 
-#: ../src/libs/colorpicker.c:377
+#: ../src/libs/colorpicker.c:378
 msgid "hover to highlight sample on canvas, click to lock sample"
 msgstr ""
 "pasar por encima para resaltar la muestra sobre el lienzo, hacer clic para "
 "tomar"
 
-#: ../src/libs/colorpicker.c:393 ../src/libs/image.c:180
+#: ../src/libs/colorpicker.c:394 ../src/libs/image.c:182
 msgid "remove"
 msgstr "eliminar"
 
-#: ../src/libs/colorpicker.c:499
+#: ../src/libs/colorpicker.c:500
 msgid "live samples"
 msgstr "muestras ajustables"
 
-#: ../src/libs/colorpicker.c:553
+#: ../src/libs/colorpicker.c:554
 msgid "point"
 msgstr "punto"
 
-#: ../src/libs/colorpicker.c:554
+#: ../src/libs/colorpicker.c:555
 msgid "area"
 msgstr "área"
 
-#: ../src/libs/colorpicker.c:569 ../src/libs/colorpicker.c:605
+#: ../src/libs/colorpicker.c:570 ../src/libs/colorpicker.c:607
 msgid "mean"
 msgstr "promedio"
 
-#: ../src/libs/colorpicker.c:570 ../src/libs/colorpicker.c:606
+#: ../src/libs/colorpicker.c:571 ../src/libs/colorpicker.c:608
 msgid "min"
 msgstr "min"
 
-#: ../src/libs/colorpicker.c:571 ../src/libs/colorpicker.c:607
+#: ../src/libs/colorpicker.c:572 ../src/libs/colorpicker.c:609
 msgid "max"
 msgstr "max"
 
-#: ../src/libs/colorpicker.c:580 ../src/libs/colorpicker.c:616
+#: ../src/libs/colorpicker.c:581 ../src/libs/colorpicker.c:618
 msgid "RGB"
 msgstr "RGB"
 
-#: ../src/libs/colorpicker.c:592
+#: ../src/libs/colorpicker.c:593
 msgid "restrict histogram to selection"
 msgstr "restringir el histograma a la selección"
 
-#: ../src/libs/colorpicker.c:624
+#: ../src/libs/colorpicker.c:626
 msgid "add"
 msgstr "agregar"
 
-#: ../src/libs/colorpicker.c:633
+#: ../src/libs/colorpicker.c:635
 msgid "display sample areas on image"
 msgstr "mostrar sobre la imagen"
 
@@ -10929,18 +11750,37 @@ msgstr "Archivos asociados xmp"
 msgid "error loading file '%s'"
 msgstr "Error al cargar el archivo '%s'"
 
-#: ../src/libs/copy_history.c:299
+#: ../src/libs/copy_history.c:166
+#, c-format
+msgid ""
+"no history compression of 1 image.\n"
+"see tag: darktable|problem|history-compress."
+msgid_plural ""
+"no history compression of %d images.\n"
+"see tag: darktable|problem|history-compress."
+msgstr[0] ""
+"Una imagen sin compresión del historial.\n"
+"Ver etiqueta: darktable|problem|history-compress."
+msgstr[1] ""
+"%d imágenes sin compresión del historial.\n"
+"Ver etiqueta: darktable|problem|history-compress."
+
+#: ../src/libs/copy_history.c:172
+msgid "history compression warning"
+msgstr "Advertencia de compresión del historial"
+
+#: ../src/libs/copy_history.c:220
 #, c-format
 msgid "do you really want to clear history of %d selected image?"
 msgid_plural "do you really want to clear history of %d selected images?"
 msgstr[0] "¿Desea realmente limpiar el historial de %d imagen seleccionada?"
 msgstr[1] "¿Desea realmente limpiar el historial de %d imágenes seleccionadas?"
 
-#: ../src/libs/copy_history.c:305
+#: ../src/libs/copy_history.c:226
 msgid "delete images' history?"
 msgstr "¿Borrar el historial de las imágenes?"
 
-#: ../src/libs/copy_history.c:386
+#: ../src/libs/copy_history.c:311
 msgid ""
 "copy part history stack of\n"
 "first selected image"
@@ -10948,11 +11788,11 @@ msgstr ""
 "Copiar elementos del historial de acciones de la\n"
 "primera imagen seleccionada"
 
-#: ../src/libs/copy_history.c:390
+#: ../src/libs/copy_history.c:315
 msgid "copy all"
 msgstr "copiar todo"
 
-#: ../src/libs/copy_history.c:393
+#: ../src/libs/copy_history.c:318
 msgid ""
 "copy history stack of\n"
 "first selected image"
@@ -10960,11 +11800,11 @@ msgstr ""
 "Copiar el historial de acciones de\n"
 "la primera imagen seleccionada"
 
-#: ../src/libs/copy_history.c:398
+#: ../src/libs/copy_history.c:323
 msgid "paste"
 msgstr "pegar"
 
-#: ../src/libs/copy_history.c:400
+#: ../src/libs/copy_history.c:325
 msgid ""
 "paste part history stack to\n"
 "all selected images"
@@ -10972,11 +11812,11 @@ msgstr ""
 "Pegar elementos del historial de acciones en\n"
 "todas las imágenes seleccionadas"
 
-#: ../src/libs/copy_history.c:405
+#: ../src/libs/copy_history.c:330
 msgid "paste all"
 msgstr "pegar todo"
 
-#: ../src/libs/copy_history.c:407
+#: ../src/libs/copy_history.c:332
 msgid ""
 "paste history stack to\n"
 "all selected images"
@@ -10984,11 +11824,11 @@ msgstr ""
 "Pegar el historial de acciones en\n"
 "todas las imágenes seleccionadas"
 
-#: ../src/libs/copy_history.c:412
+#: ../src/libs/copy_history.c:337
 msgid "compress history"
 msgstr "comprimir historial de acciones"
 
-#: ../src/libs/copy_history.c:414
+#: ../src/libs/copy_history.c:339
 msgid ""
 "compress history stack of\n"
 "all selected images"
@@ -10996,11 +11836,11 @@ msgstr ""
 "Comprimir el historial de acciones de\n"
 "todas las imágenes seleccionadas"
 
-#: ../src/libs/copy_history.c:417
+#: ../src/libs/copy_history.c:342
 msgid "discard"
 msgstr "descartar"
 
-#: ../src/libs/copy_history.c:420
+#: ../src/libs/copy_history.c:345
 msgid ""
 "discard history stack of\n"
 "all selected images"
@@ -11008,19 +11848,19 @@ msgstr ""
 "Descartar el historial de acciones de\n"
 "todas las imágenes seleccionadas"
 
-#: ../src/libs/copy_history.c:426
+#: ../src/libs/copy_history.c:351
 msgid "append"
 msgstr "anexar"
 
-#: ../src/libs/copy_history.c:428
+#: ../src/libs/copy_history.c:353
 msgid "how to handle existing history"
 msgstr "Cómo tratar al historial existente"
 
-#: ../src/libs/copy_history.c:434
+#: ../src/libs/copy_history.c:359
 msgid "load sidecar file"
 msgstr "cargar archivo xmp"
 
-#: ../src/libs/copy_history.c:437
+#: ../src/libs/copy_history.c:362
 msgid ""
 "open an XMP sidecar file\n"
 "and apply it to selected images"
@@ -11028,92 +11868,92 @@ msgstr ""
 "Abrir un archivo XMP asociado\n"
 "y aplicarlo a las imágenes seleccionadas"
 
-#: ../src/libs/copy_history.c:444
+#: ../src/libs/copy_history.c:369
 msgid "write history stack and tags to XMP sidecar files"
 msgstr ""
 "Escribir el historial de acciones y las etiquetas\n"
 "en los archivos XMP asociados"
 
-#: ../src/libs/copy_history.c:469
+#: ../src/libs/copy_history.c:394
 msgctxt "accel"
 msgid "copy all"
 msgstr "copiar todo"
 
-#: ../src/libs/copy_history.c:470
+#: ../src/libs/copy_history.c:395
 msgctxt "accel"
 msgid "copy"
 msgstr "copiar"
 
-#: ../src/libs/copy_history.c:472
+#: ../src/libs/copy_history.c:397
 msgctxt "accel"
 msgid "discard"
 msgstr "descartar"
 
-#: ../src/libs/copy_history.c:473
+#: ../src/libs/copy_history.c:398
 msgctxt "accel"
 msgid "paste all"
 msgstr "pegar todo"
 
-#: ../src/libs/copy_history.c:474
+#: ../src/libs/copy_history.c:399
 msgctxt "accel"
 msgid "paste"
 msgstr "pegar"
 
-#: ../src/libs/copy_history.c:475
+#: ../src/libs/copy_history.c:400
 msgctxt "accel"
 msgid "load sidecar files"
 msgstr "carga archivos asociados"
 
-#: ../src/libs/copy_history.c:476
+#: ../src/libs/copy_history.c:401
 msgctxt "accel"
 msgid "write sidecar files"
 msgstr "escribir archivos xmp"
 
-#: ../src/libs/duplicate.c:66
+#: ../src/libs/duplicate.c:67
 msgid "duplicate manager"
 msgstr "administrador de duplicado"
 
-#: ../src/libs/duplicate.c:484
+#: ../src/libs/duplicate.c:487
 msgid "existing duplicates"
 msgstr "duplicados existentes"
 
-#: ../src/libs/duplicate.c:487
+#: ../src/libs/duplicate.c:490
 msgid "create a 'virgin' duplicate of the image without any development"
 msgstr "crear un duplicado 'virgen' de la imagen sin ningún revelado"
 
-#: ../src/libs/duplicate.c:491
+#: ../src/libs/duplicate.c:494
 msgid "create a duplicate of the image with same history stack"
 msgstr "crear un duplicado de la imagen con la misma  historia"
 
-#: ../src/libs/export.c:64
+#: ../src/libs/export.c:69
 msgid "export selected"
 msgstr "exportar selección"
 
-#: ../src/libs/export.c:122
+#: ../src/libs/export.c:127
 msgid "export to disk"
 msgstr "exportar al disco"
 
-#: ../src/libs/export.c:532
+#: ../src/libs/export.c:548
 msgid "storage options"
 msgstr "opciones de almacenamiento"
 
-#: ../src/libs/export.c:537
+#: ../src/libs/export.c:553
 msgid "target storage"
 msgstr "guardar en"
 
-#: ../src/libs/export.c:560
+#: ../src/libs/export.c:576
 msgid "format options"
 msgstr "opciones de formato"
 
-#: ../src/libs/export.c:565
+#: ../src/libs/export.c:581
 msgid "file format"
 msgstr "formato de archivo"
 
-#: ../src/libs/export.c:583
+#: ../src/libs/export.c:599
 msgid "global options"
 msgstr "opciones globales"
 
-#: ../src/libs/export.c:588
+#: ../src/libs/export.c:604
 msgid ""
 "maximum output width\n"
 "set to 0 for no scaling"
@@ -11121,7 +11961,7 @@ msgstr ""
 "anchura máxima\n"
 "use 0 para no redimensionar"
 
-#: ../src/libs/export.c:590
+#: ../src/libs/export.c:606
 msgid ""
 "maximum output height\n"
 "set to 0 for no scaling"
@@ -11129,69 +11969,73 @@ msgstr ""
 "altura máxima\n"
 "use 0 para no redimensionar"
 
-#: ../src/libs/export.c:597
+#: ../src/libs/export.c:613
 msgid "max size"
 msgstr "tamaño máx"
 
-#: ../src/libs/export.c:603
+#: ../src/libs/export.c:619
 msgid "x"
 msgstr "x"
 
-#: ../src/libs/export.c:609
+#: ../src/libs/export.c:625
 msgid "allow upscaling"
 msgstr "permitir redimensionado"
 
-#: ../src/libs/export.c:615
+#: ../src/libs/export.c:631
 msgid "high quality resampling"
 msgstr "remuestreo de alta calidad"
 
-#: ../src/libs/export.c:618
+#: ../src/libs/export.c:634
 msgid "do high quality resampling during export"
 msgstr "Hacer un remuestreo de alta calidad durante la exportación"
 
-#: ../src/libs/export.c:631 ../src/libs/export.c:652
-#: ../src/libs/print_settings.c:1408 ../src/libs/print_settings.c:1455
+#: ../src/libs/export.c:647 ../src/libs/export.c:668
+#: ../src/libs/print_settings.c:1406 ../src/libs/print_settings.c:1453
 msgid "image settings"
 msgstr "configuración de la imagen"
 
-#: ../src/libs/export.c:642 ../src/libs/print_settings.c:1444
+#: ../src/libs/export.c:658 ../src/libs/print_settings.c:1442
 #, c-format
 msgid "output ICC profiles in %s or %s"
 msgstr "perfiles de salida ICC en %s o %s"
 
-#: ../src/libs/export.c:662 ../src/libs/print_settings.c:1469
+#: ../src/libs/export.c:678 ../src/libs/print_settings.c:1467
 msgid "style"
 msgstr "estilo"
 
-#: ../src/libs/export.c:665
+#: ../src/libs/export.c:681
 msgid "temporary style to use while exporting"
 msgstr "estilo temporal para ser aplicado al exportar"
 
-#: ../src/libs/export.c:674 ../src/libs/print_settings.c:1514
+#: ../src/libs/export.c:690 ../src/libs/print_settings.c:1512
 msgid "replace history"
 msgstr "reemplazar al historial"
 
-#: ../src/libs/export.c:675 ../src/libs/print_settings.c:1515
+#: ../src/libs/export.c:691 ../src/libs/print_settings.c:1513
 msgid "append history"
 msgstr "incorporar al historial"
 
-#: ../src/libs/export.c:680 ../src/libs/print_settings.c:1522
+#: ../src/libs/export.c:696 ../src/libs/print_settings.c:1520
 msgid ""
 "whether the style items are appended to the history or replacing the history"
 msgstr "los elementos del estilo se anexan al historial o los reemplazan"
 
-#: ../src/libs/export.c:698
+#: ../src/libs/export.c:716
 msgid "export with current settings"
 msgstr "exportar con la configuración actual"
 
+#: ../src/libs/export.c:722
+msgid "edit metadata exportation details"
+msgstr "editar los detalles de exportación de metadatos"
+
 #. enable shortcut to export with current export settings:
-#: ../src/libs/export.c:1249 ../src/libs/styles.c:71
-#: ../src/views/darkroom.c:3121
+#: ../src/libs/export.c:1308 ../src/libs/styles.c:71
+#: ../src/views/darkroom.c:3168
 msgctxt "accel"
 msgid "export"
 msgstr "exportar"
 
-#: ../src/libs/geotagging.c:410
+#: ../src/libs/geotagging.c:411
 msgid ""
 "enter the time shown on the selected picture\n"
 "format: hh:mm:ss"
@@ -11199,23 +12043,23 @@ msgstr ""
 "introduzca el tiempo mostrado en la imagen seleccionada\n"
 "formato: hh:mm:ss"
 
-#: ../src/libs/geotagging.c:419
+#: ../src/libs/geotagging.c:420
 msgid "ok"
 msgstr "ok"
 
-#: ../src/libs/geotagging.c:472
+#: ../src/libs/geotagging.c:473
 msgid "open GPX file"
 msgstr "abrir archivo gpx"
 
-#: ../src/libs/geotagging.c:489
+#: ../src/libs/geotagging.c:490
 msgid "GPS data exchange format"
 msgstr "Formato de intercambio de datos GPS"
 
-#: ../src/libs/geotagging.c:499
+#: ../src/libs/geotagging.c:500
 msgid "camera time zone"
 msgstr "zona horaria de la camara"
 
-#: ../src/libs/geotagging.c:500
+#: ../src/libs/geotagging.c:501
 msgid ""
 "most cameras don't store the time zone in EXIF. give the correct time zone "
 "so the GPX data can be correctly matched"
@@ -11224,7 +12068,7 @@ msgstr ""
 "la zona horaria correcta para que los datos gpx puedan ser procesados "
 "correctamente"
 
-#: ../src/libs/geotagging.c:791
+#: ../src/libs/geotagging.c:792
 msgid ""
 "time offset\n"
 "format: [+-]?[[hh:]mm:]ss"
@@ -11232,20 +12076,20 @@ msgstr ""
 "compensación horaria\n"
 "formato: [+-]?[[hh:]mm:]ss"
 
-#: ../src/libs/geotagging.c:801
+#: ../src/libs/geotagging.c:802
 msgid "calculate the time offset from an image"
 msgstr "calcular la compensación horaria desde una imagen"
 
-#: ../src/libs/geotagging.c:806
+#: ../src/libs/geotagging.c:807
 msgid "apply time offset to selected images"
 msgstr "establecer la compensación horaria en las imágenes seleccionadas"
 
 #. gpx
-#: ../src/libs/geotagging.c:814
+#: ../src/libs/geotagging.c:815
 msgid "apply GPX track file"
 msgstr "adjuntar archivo gpx de seguimiento"
 
-#: ../src/libs/geotagging.c:815
+#: ../src/libs/geotagging.c:816
 msgid "parses a GPX file and updates location of selected images"
 msgstr ""
 "abrir archivo gpx y actualizar la ubicación de las imágenes seleccionadas"
@@ -11302,7 +12146,7 @@ msgstr ""
 
 # El original es "doble click reinicializa", lo cambio por este otro que creo que es más entendible"doble click para reiniciar"
 #. connect callbacks
-#: ../src/libs/histogram.c:377 ../src/libs/histogram.c:539
+#: ../src/libs/histogram.c:377 ../src/libs/histogram.c:546
 msgid ""
 "drag to change exposure,\n"
 "doubleclick resets"
@@ -11310,35 +12154,35 @@ msgstr ""
 "arrastrar para cambiar exposición,\n"
 "doble clic para reiniciar"
 
-#: ../src/libs/histogram.c:581
+#: ../src/libs/histogram.c:588
 msgctxt "accel"
 msgid "hide histogram"
 msgstr "ocultar histograma"
 
-#: ../src/libs/history.c:83
+#: ../src/libs/history.c:84
 msgctxt "accel"
 msgid "create style from history"
 msgstr "crear un estilo desde el historial"
 
 #. dt_accel_register_lib(self, NC_("accel", "apply style from popup menu"), 0, 0);
-#: ../src/libs/history.c:85
+#: ../src/libs/history.c:86
 msgctxt "accel"
 msgid "compress history stack"
 msgstr "comprimir historial de acciones"
 
-#: ../src/libs/history.c:112
+#: ../src/libs/history.c:113
 msgid "compress history stack"
 msgstr "comprimir historial de acciones"
 
-#: ../src/libs/history.c:114
+#: ../src/libs/history.c:115
 msgid "create a minimal history stack which produces the same image"
 msgstr "generar un historial de acciones mínimo que produzca la misma imagen"
 
-#: ../src/libs/history.c:121
+#: ../src/libs/history.c:122
 msgid "create a style from the current history stack"
 msgstr "crear un estilo del historial de acciones actual"
 
-#: ../src/libs/history.c:651 ../src/libs/snapshots.c:345
+#: ../src/libs/history.c:652 ../src/libs/snapshots.c:346
 msgid "original"
 msgstr "original"
 
@@ -11346,268 +12190,267 @@ msgstr "original"
 msgid "selected image[s]"
 msgstr "imagen(es) seleccionada(s)"
 
-#: ../src/libs/image.c:140
+#: ../src/libs/image.c:142
 msgid "trash"
 msgstr "borrar"
 
-#: ../src/libs/image.c:148
+#: ../src/libs/image.c:150
 msgid "send file to trash"
 msgstr "enviar el archivo a la papelera"
 
-#: ../src/libs/image.c:150
+#: ../src/libs/image.c:152
 msgid "physically delete from disk"
 msgstr "borrar físicamente del disco"
 
-#: ../src/libs/image.c:183
+#: ../src/libs/image.c:185
 msgid "remove from the collection"
 msgstr "eliminar de la colección"
 
-#: ../src/libs/image.c:195
+#: ../src/libs/image.c:197
 msgid "move"
 msgstr "mover"
 
-#: ../src/libs/image.c:198
+#: ../src/libs/image.c:200
 msgid "move to other folder"
 msgstr "mover a otra carpeta"
 
-#: ../src/libs/image.c:205
+#: ../src/libs/image.c:207
 msgid "copy to other folder"
 msgstr "copiar a otra carpeta"
 
-#: ../src/libs/image.c:210
+#: ../src/libs/image.c:212
 msgid "create HDR"
 msgstr "crear HDR"
 
-#: ../src/libs/image.c:215
+#: ../src/libs/image.c:217
 msgid "create a high dynamic range image from selected shots"
 msgstr "crear una imagen de alto rango dinámico de las imágenes seleccionadas"
 
-#: ../src/libs/image.c:217
+#: ../src/libs/image.c:219
 msgid "duplicate"
 msgstr "duplicar"
 
-#: ../src/libs/image.c:220
+#: ../src/libs/image.c:222
 msgid "add a duplicate to the collection, including its history stack"
 msgstr ""
 "añadir un duplicado a la colección, incluyendo el historial de acciones"
 
-#: ../src/libs/image.c:227
+#: ../src/libs/image.c:229
 msgid "rotate selected images 90 degrees CCW"
 msgstr "rotar imágenes seleccionadas 90 grados en sentido antihorario"
 
-#: ../src/libs/image.c:233
+#: ../src/libs/image.c:235
 msgid "rotate selected images 90 degrees CW"
 msgstr "rotar imágenes seleccionadas 90 grados en sentido horario"
 
-#: ../src/libs/image.c:237
+#: ../src/libs/image.c:239
 msgid "reset rotation"
 msgstr "restaurar rotación"
 
-#: ../src/libs/image.c:240
+#: ../src/libs/image.c:242
 msgid "reset rotation to EXIF data"
 msgstr "restaurar rotación según los datos Exif"
 
-#: ../src/libs/image.c:245
+#: ../src/libs/image.c:247
 msgid "copy locally"
 msgstr "copiar localmente"
 
-#: ../src/libs/image.c:248
+#: ../src/libs/image.c:250
 msgid "copy the image locally"
 msgstr "copiar imagen localmente"
 
-#: ../src/libs/image.c:252
+#: ../src/libs/image.c:254
 msgid "resync local copy"
 msgstr "sincronizar copia local"
 
-#: ../src/libs/image.c:255
+#: ../src/libs/image.c:257
 msgid "synchronize the image's XMP and remove the local copy"
 msgstr "sincronizar el XMP de la imagen y remover la copia local"
 
 #. DT_COLLECTION_SORT_COLOR
-#: ../src/libs/image.c:260 ../src/libs/tools/filter.c:152
+#: ../src/libs/image.c:262 ../src/libs/tools/filter.c:152
 msgid "group"
 msgstr "agrupar"
 
-#: ../src/libs/image.c:263
+#: ../src/libs/image.c:265
 msgid "add selected images to expanded group or create a new one"
 msgstr "agregue las imagenes seleccionadas al grupo expandido o cree uno nuevo"
 
-#: ../src/libs/image.c:267
+#: ../src/libs/image.c:269
 msgid "ungroup"
 msgstr "desagrupar"
 
-#: ../src/libs/image.c:270
+#: ../src/libs/image.c:272
 msgid "remove selected images from the group"
 msgstr "eliminar imagenes seleccionadas del grupo"
 
-#: ../src/libs/image.c:293
+#: ../src/libs/image.c:279
+msgid "update image information to match changes to file"
+msgstr ""
+"actualizar la información de la imagen para que coincida con los cambios del "
+"archivo"
+
+#: ../src/libs/image.c:302
 msgctxt "accel"
 msgid "remove from collection"
 msgstr "eliminar de la colección"
 
-#: ../src/libs/image.c:294
+#: ../src/libs/image.c:303
 msgctxt "accel"
 msgid "delete from disk or send to trash"
 msgstr "borrar físicamente del disco o enviar a la papelera"
 
-#: ../src/libs/image.c:295
+#: ../src/libs/image.c:304
 msgctxt "accel"
 msgid "move to other folder"
 msgstr "Mover a otra carpeta"
 
-#: ../src/libs/image.c:296
+#: ../src/libs/image.c:305
 msgctxt "accel"
 msgid "copy to other folder"
 msgstr "Copiar a otra carpeta"
 
-#: ../src/libs/image.c:297
+#: ../src/libs/image.c:306
 msgctxt "accel"
 msgid "rotate selected images 90 degrees CW"
 msgstr "rotar imágenes seleccionadas 90 grados en sentido horario"
 
-#: ../src/libs/image.c:298
+#: ../src/libs/image.c:307
 msgctxt "accel"
 msgid "rotate selected images 90 degrees CCW"
 msgstr "rotar imágenes seleccionadas 90 grados en sentido antihorario"
 
-#: ../src/libs/image.c:299
+#: ../src/libs/image.c:308
 msgctxt "accel"
 msgid "create HDR"
 msgstr "crear HDR"
 
-#: ../src/libs/image.c:300
+#: ../src/libs/image.c:309
 msgctxt "accel"
 msgid "duplicate"
 msgstr "duplicar"
 
-#: ../src/libs/image.c:301
+#: ../src/libs/image.c:310
 msgctxt "accel"
 msgid "reset rotation"
 msgstr "restablecer rotación"
 
-#: ../src/libs/image.c:302
+#: ../src/libs/image.c:311
 msgctxt "accel"
 msgid "copy the image locally"
 msgstr "Copiar imagen localmente"
 
-#: ../src/libs/image.c:303
+#: ../src/libs/image.c:312
 msgctxt "accel"
 msgid "resync the local copy"
 msgstr "Resincronizar copia local"
 
+#: ../src/libs/image.c:313
+msgctxt "accel"
+msgid "refresh exif"
+msgstr "actualizar Exif"
+
 #. Grouping keys
-#: ../src/libs/image.c:305
+#: ../src/libs/image.c:315
 msgctxt "accel"
 msgid "group"
 msgstr "agrupar"
 
-#: ../src/libs/image.c:306
+#: ../src/libs/image.c:316
 msgctxt "accel"
 msgid "ungroup"
 msgstr "desagrupar"
 
-#: ../src/libs/import.c:128
+#: ../src/libs/import.c:129
 msgctxt "accel"
 msgid "scan for devices"
 msgstr "buscar dispositivos"
 
-#: ../src/libs/import.c:129
+#: ../src/libs/import.c:130
 msgctxt "accel"
 msgid "import from camera"
 msgstr "importar desde cámara"
 
-#: ../src/libs/import.c:130
+#: ../src/libs/import.c:131
 msgctxt "accel"
 msgid "tethered shoot"
 msgstr "captura"
 
-#: ../src/libs/import.c:131
+#: ../src/libs/import.c:132
 msgctxt "accel"
 msgid "import image"
 msgstr "importar imagen"
 
-#: ../src/libs/import.c:132
+#: ../src/libs/import.c:133
 msgctxt "accel"
 msgid "import folder"
 msgstr "importar carpeta"
 
-#: ../src/libs/import.c:225
+#: ../src/libs/import.c:226
 #, c-format
 msgid "device \"%s\" connected on port \"%s\"."
 msgstr "dispositivo \"%s\" conectado en puerto \"%s\"."
 
-#: ../src/libs/import.c:235
+#: ../src/libs/import.c:236
 msgid "import from camera"
 msgstr "importar desde cámara"
 
-#: ../src/libs/import.c:241
+#: ../src/libs/import.c:242
 msgid "tethered shoot"
 msgstr "captura"
 
 #. No supported devices is detected lets notice user..
-#: ../src/libs/import.c:265
+#: ../src/libs/import.c:266
 msgid "no supported devices found"
 msgstr "no se encuentran dispositivos soportados"
 
 #. add extra lines to 'extra'. don't forget to destroy the widgets later.
-#: ../src/libs/import.c:429
+#: ../src/libs/import.c:430
 msgid "import options"
 msgstr "opciones al importar"
 
 #. recursive opening.
-#: ../src/libs/import.c:447
+#: ../src/libs/import.c:448
 msgid "import directories recursively"
 msgstr "importar directorios recursivamente"
 
-#: ../src/libs/import.c:449
+#: ../src/libs/import.c:450
 msgid ""
 "recursively import subdirectories. each directory goes into a new film roll."
 msgstr ""
 "importar directorios recursivamente. cada directorio crea un nuevo carrete."
 
-#: ../src/libs/import.c:467
-msgid "apply metadata on import"
-msgstr "establecer los metadatos al importar"
-
-#: ../src/libs/import.c:468
-msgid "apply some metadata to all newly imported images."
-msgstr "establecer ciertos metadatos a todas las imágenes importadas."
-
-#: ../src/libs/import.c:509
-msgid "comma separated list of tags"
-msgstr "lista de etiquetas separadas por coma"
-
-#: ../src/libs/import.c:784
+#: ../src/libs/import.c:785
 msgid "supported images"
 msgstr "imágenes admitidas"
 
-#: ../src/libs/import.c:840
+#: ../src/libs/import.c:841
 msgid "file has unknown format!"
 msgstr "El archivo tiene un formato desconocido"
 
-#: ../src/libs/import.c:865
+#: ../src/libs/import.c:866
 msgid "import film"
 msgstr "importar sesión"
 
-#: ../src/libs/import.c:984
+#: ../src/libs/import.c:986
 msgid "select one or more images to import"
 msgstr "seleccionar una o más imágenes a importar"
 
 #. adding the import folder button
-#: ../src/libs/import.c:991
+#: ../src/libs/import.c:993
 msgid "folder"
 msgstr "carpeta"
 
-#: ../src/libs/import.c:995
+#: ../src/libs/import.c:997
 msgid "select a folder to import as film roll"
 msgstr "seleccionar una carpeta para importar como carrete"
 
 #. add the rescan button
-#: ../src/libs/import.c:1003
+#: ../src/libs/import.c:1006
 msgid "scan for devices"
 msgstr "buscar dispositivos"
 
-#: ../src/libs/import.c:1007
+#: ../src/libs/import.c:1010
 msgid "scan for newly attached devices"
 msgstr "buscar nuevos dispositivos conectados"
 
@@ -11712,7 +12555,7 @@ msgstr "id"
 msgid "overlay another image over the live view"
 msgstr "superponer otra imagen sobre el live view"
 
-#: ../src/libs/live_view.c:392 ../src/libs/metadata_view.c:95
+#: ../src/libs/live_view.c:392 ../src/libs/metadata_view.c:99
 msgid "image id"
 msgstr "imagen"
 
@@ -11956,65 +12799,65 @@ msgid "all rights reserved."
 msgstr "todos los derechos reservados."
 
 #. internal
-#: ../src/libs/metadata_view.c:94
+#: ../src/libs/metadata_view.c:98
 msgid "filmroll"
 msgstr "sesión"
 
 # Cámbio el orden de las palagras "grupo id" por la siguiente "id. grupo", ya que la primera proviene de "group id", en Español se pondría en el segundo caso, también le pongo "." a la abreviatura "id" para no confundirla con la acción de ir a un lugar
-#: ../src/libs/metadata_view.c:96
+#: ../src/libs/metadata_view.c:100
 msgid "group id"
 msgstr "id. grupo"
 
-#: ../src/libs/metadata_view.c:98
+#: ../src/libs/metadata_view.c:102
 msgid "version"
 msgstr "versión"
 
 #. DT_COLLECTION_SORT_GROUP
-#: ../src/libs/metadata_view.c:99 ../src/libs/tools/filter.c:153
+#: ../src/libs/metadata_view.c:103 ../src/libs/tools/filter.c:153
 msgid "full path"
 msgstr "ruta completa"
 
-#: ../src/libs/metadata_view.c:102
+#: ../src/libs/metadata_view.c:106
 msgid "flags"
 msgstr "banderas"
 
-#: ../src/libs/metadata_view.c:112
+#: ../src/libs/metadata_view.c:116
 msgid "focus distance"
 msgstr "distancia focal"
 
-#: ../src/libs/metadata_view.c:114
+#: ../src/libs/metadata_view.c:118
 msgid "datetime"
 msgstr "fecha/hora"
 
-#: ../src/libs/metadata_view.c:116 ../src/libs/print_settings.c:1310
+#: ../src/libs/metadata_view.c:120 ../src/libs/print_settings.c:1308
 msgid "height"
 msgstr "alto"
 
-#: ../src/libs/metadata_view.c:118
+#: ../src/libs/metadata_view.c:122
 msgid "export width"
 msgstr "ancho de exportación"
 
-#: ../src/libs/metadata_view.c:119
+#: ../src/libs/metadata_view.c:123
 msgid "export height"
 msgstr "altura de exportación"
 
-#: ../src/libs/metadata_view.c:124
+#: ../src/libs/metadata_view.c:128
 msgid "copyright"
 msgstr "derechos"
 
-#: ../src/libs/metadata_view.c:128
+#: ../src/libs/metadata_view.c:132
 msgid "longitude"
 msgstr "longitud"
 
-#: ../src/libs/metadata_view.c:129
+#: ../src/libs/metadata_view.c:133
 msgid "elevation"
 msgstr "elevación"
 
-#: ../src/libs/metadata_view.c:140
+#: ../src/libs/metadata_view.c:147
 msgid "image information"
 msgstr "información de la imagen"
 
-#: ../src/libs/metadata_view.c:252
+#: ../src/libs/metadata_view.c:259
 #, c-format
 msgid ""
 "double click to jump to film roll\n"
@@ -12023,103 +12866,103 @@ msgstr ""
 "doble clic para saltar al carrete\n"
 "%s"
 
-#: ../src/libs/metadata_view.c:283
+#: ../src/libs/metadata_view.c:290
 msgid "unused"
 msgstr "sin usar"
 
-#: ../src/libs/metadata_view.c:284
+#: ../src/libs/metadata_view.c:291
 msgid "unused/deprecated"
 msgstr "sin usar/obsoleto"
 
-#: ../src/libs/metadata_view.c:285
+#: ../src/libs/metadata_view.c:292
 msgid "ldr"
 msgstr "ldr"
 
-#: ../src/libs/metadata_view.c:287
+#: ../src/libs/metadata_view.c:294
 msgid "hdr"
 msgstr "hdr"
 
-#: ../src/libs/metadata_view.c:288
+#: ../src/libs/metadata_view.c:295
 msgid "marked for deletion"
 msgstr "marcado para ser eliminado"
 
-#: ../src/libs/metadata_view.c:289
+#: ../src/libs/metadata_view.c:296
 msgid "auto-applying presets applied"
 msgstr "ajustes automáticos establecidos"
 
-#: ../src/libs/metadata_view.c:290
+#: ../src/libs/metadata_view.c:297
 msgid "legacy flag. set for all new images"
 msgstr "banderas (antiguo). asignadas a todas las imágenes nuevas"
 
-#: ../src/libs/metadata_view.c:292
+#: ../src/libs/metadata_view.c:299
 msgid "has .txt"
 msgstr "tiene .txt"
 
-#: ../src/libs/metadata_view.c:293
+#: ../src/libs/metadata_view.c:300
 msgid "has .wav"
 msgstr "tiene .wav"
 
-#: ../src/libs/metadata_view.c:305
+#: ../src/libs/metadata_view.c:312
 msgid "image rejected"
 msgstr "imagen rechazada"
 
-#: ../src/libs/metadata_view.c:310
+#: ../src/libs/metadata_view.c:317
 #, c-format
 msgid "image has %d star"
 msgid_plural "image has %d stars"
 msgstr[0] "la imagen tiene %d estrella"
 msgstr[1] "la imagen tiene %d estrellas"
 
-#: ../src/libs/metadata_view.c:390 ../src/libs/snapshots.c:353
+#: ../src/libs/metadata_view.c:397 ../src/libs/snapshots.c:354
 msgid "unknown"
 msgstr "desconocido"
 
-#: ../src/libs/metadata_view.c:391
+#: ../src/libs/metadata_view.c:398
 msgid "tiff"
 msgstr "tiff"
 
-#: ../src/libs/metadata_view.c:392
+#: ../src/libs/metadata_view.c:399
 msgid "png"
 msgstr "png"
 
-#: ../src/libs/metadata_view.c:393
+#: ../src/libs/metadata_view.c:400
 msgid "j2k"
 msgstr "j2k"
 
-#: ../src/libs/metadata_view.c:394
+#: ../src/libs/metadata_view.c:401
 msgid "jpeg"
 msgstr "jpeg"
 
-#: ../src/libs/metadata_view.c:395
+#: ../src/libs/metadata_view.c:402
 msgid "exr"
 msgstr "exr"
 
-#: ../src/libs/metadata_view.c:396
+#: ../src/libs/metadata_view.c:403
 msgid "rgbe"
 msgstr "rgbe"
 
-#: ../src/libs/metadata_view.c:397
+#: ../src/libs/metadata_view.c:404
 msgid "pfm"
 msgstr "pfm"
 
-#: ../src/libs/metadata_view.c:398
+#: ../src/libs/metadata_view.c:405
 msgid "GraphicsMagick"
 msgstr "GraphicsMagick"
 
-#: ../src/libs/metadata_view.c:399
+#: ../src/libs/metadata_view.c:406
 msgid "rawspeed"
 msgstr "velocidad de disparo"
 
-#: ../src/libs/metadata_view.c:400
+#: ../src/libs/metadata_view.c:407
 msgid "netpnm"
 msgstr "netpnm"
 
-#: ../src/libs/metadata_view.c:405
+#: ../src/libs/metadata_view.c:412
 #, c-format
 msgid "loader: %s"
 msgstr "cargando: %s"
 
-#: ../src/libs/metadata_view.c:646
+#: ../src/libs/metadata_view.c:678
 msgctxt "accel"
 msgid "jump to film roll"
 msgstr "saltar al carrete"
@@ -12171,20 +13014,20 @@ msgstr "buscar módulos por nombre o etiqueta"
 msgid "clear text"
 msgstr "borrar texto"
 
-#: ../src/libs/modulelist.c:57
+#: ../src/libs/modulelist.c:58
 msgid "more modules"
 msgstr "más módulos"
 
-#: ../src/libs/modulelist.c:365
+#: ../src/libs/modulelist.c:366
 msgid "subset: no module"
 msgstr "subconjunto: ningún módulo"
 
-#: ../src/libs/modulelist.c:366
+#: ../src/libs/modulelist.c:367
 msgid "subset: all modules"
 msgstr "subconjunto: todos los modulos"
 
 #. the modules that are activated by default in the initial configuration
-#: ../src/libs/modulelist.c:369
+#: ../src/libs/modulelist.c:370
 msgid "subset: default modules"
 msgstr "subconjunto: módulos por defecto"
 
@@ -12193,7 +13036,7 @@ msgstr "subconjunto: módulos por defecto"
 #. colors
 #. sharpness
 #. image reconstruction
-#: ../src/libs/modulelist.c:379
+#: ../src/libs/modulelist.c:380
 msgid "workspace: all-purpose"
 msgstr "espacio de trabajo: polivalente / todo uso"
 
@@ -12204,11 +13047,11 @@ msgstr "espacio de trabajo: polivalente / todo uso"
 #. image reconstruction
 #. HDR reconstruction - tones
 #. HDR reconstruction - colors
-#: ../src/libs/modulelist.c:391
+#: ../src/libs/modulelist.c:392
 msgid "workspace: landscape & HDR"
 msgstr "espacio de trabajo: paisaje y HDR"
 
-#: ../src/libs/modulelist.c:403
+#: ../src/libs/modulelist.c:404
 msgid "workspace: architecture & streets"
 msgstr "espacio de trabajo: arquitectura y calles"
 
@@ -12218,7 +13061,7 @@ msgstr "espacio de trabajo: arquitectura y calles"
 #. sharpness
 #. image reconstruction
 #. retouch
-#: ../src/libs/modulelist.c:414
+#: ../src/libs/modulelist.c:415
 msgid "workspace: portrait & beauty"
 msgstr "espacio de trabajo: retrato y belleza"
 
@@ -12228,156 +13071,156 @@ msgstr "espacio de trabajo: retrato y belleza"
 #. sharpness
 #. image reconstruction
 #. denoising
-#: ../src/libs/modulelist.c:425
+#: ../src/libs/modulelist.c:426
 msgid "workspace: lowlight & high ISO"
 msgstr "espacio de trabajo: baja luminosidad e ISO alto"
 
-#: ../src/libs/modulelist.c:433
+#: ../src/libs/modulelist.c:434
 msgid "subset: creative modules only"
 msgstr "subconjunto: sólo módulos creativos"
 
-#: ../src/libs/modulelist.c:443
+#: ../src/libs/modulelist.c:444
 msgid "subset: technical modules only"
 msgstr "subconjunto: sólo módulos técnicos"
 
-#: ../src/libs/navigation.c:66
+#: ../src/libs/navigation.c:62
 msgid "navigation"
 msgstr "navegación"
 
-#: ../src/libs/navigation.c:534
+#: ../src/libs/navigation.c:504
 msgid "small"
 msgstr "pequeño"
 
-#: ../src/libs/navigation.c:538
+#: ../src/libs/navigation.c:508
 msgid "fit to screen"
 msgstr "ajustar a la pantalla"
 
-#: ../src/libs/navigation.c:542
+#: ../src/libs/navigation.c:512
 msgid "50%"
 msgstr "50%"
 
-#: ../src/libs/navigation.c:546
+#: ../src/libs/navigation.c:516
 msgid "100%"
 msgstr "100%"
 
-#: ../src/libs/navigation.c:550
+#: ../src/libs/navigation.c:520
 msgid "200%"
 msgstr "200%"
 
-#: ../src/libs/navigation.c:554
+#: ../src/libs/navigation.c:524
 msgid "400%"
 msgstr "400%"
 
-#: ../src/libs/navigation.c:558
+#: ../src/libs/navigation.c:528
 msgid "800%"
 msgstr "800%"
 
-#: ../src/libs/navigation.c:562
+#: ../src/libs/navigation.c:532
 msgid "1600%"
 msgstr "1600%"
 
-#: ../src/libs/navigation.c:599
+#: ../src/libs/navigation.c:569
 msgctxt "accel"
-msgid "toggle navigation thumbnail visibility"
-msgstr "alternar visibilidad de navegación de miniaturas"
+msgid "hide navigation thumbnail"
+msgstr "ocultar navegación de miniaturas"
 
 #. //////////////////////// PRINT SETTINGS
-#: ../src/libs/print_settings.c:43 ../src/libs/print_settings.c:1398
+#: ../src/libs/print_settings.c:44 ../src/libs/print_settings.c:1396
 msgid "print settings"
 msgstr "ajustes de impresión"
 
 #. FIXME: ellipsize title/printer as the export completed message is ellipsized
-#: ../src/libs/print_settings.c:239 ../src/libs/print_settings.c:437
+#: ../src/libs/print_settings.c:237 ../src/libs/print_settings.c:435
 #, c-format
 msgid "processing `%s' for `%s'"
 msgstr "procesando `%s' para el módulo `%s'"
 
-#: ../src/libs/print_settings.c:281
+#: ../src/libs/print_settings.c:279
 #, c-format
 msgid "cannot open printer profile `%s'"
 msgstr "no se puede abrir el perfil de la impresora `%s'"
 
-#: ../src/libs/print_settings.c:290
+#: ../src/libs/print_settings.c:288
 #, c-format
 msgid "error getting output profile for image %d"
 msgstr "error obteniendo el perfil de salida para la imagen %d"
 
-#: ../src/libs/print_settings.c:298
+#: ../src/libs/print_settings.c:296
 #, c-format
 msgid "cannot apply printer profile `%s'"
 msgstr "no se puede establecer el perfil de la impresora `%s'"
 
-#: ../src/libs/print_settings.c:318
+#: ../src/libs/print_settings.c:316
 msgid "failed to create temporary pdf for printing"
 msgstr "fallo al crear carpeta %s, de importado, abortada importación"
 
-#: ../src/libs/print_settings.c:392
+#: ../src/libs/print_settings.c:390
 msgid "cannot print until a picture is selected"
 msgstr "no se puede imprimir hasta que una imagen sea seleccionada"
 
-#: ../src/libs/print_settings.c:397
+#: ../src/libs/print_settings.c:395
 msgid "cannot print until a printer is selected"
 msgstr "no se puede imprimir hasta que una impresora sea seleccionada"
 
-#: ../src/libs/print_settings.c:402
+#: ../src/libs/print_settings.c:400
 msgid "cannot print until a paper is selected"
 msgstr "no se puede imprimir hasta que un papel sea seleccionado"
 
 #. in this case no need to release from cache what we couldn't get
-#: ../src/libs/print_settings.c:429
+#: ../src/libs/print_settings.c:427
 #, c-format
 msgid "cannot get image %d for printing"
 msgstr "no se puede obtener la imagen %d para imprimirla"
 
-#: ../src/libs/print_settings.c:696
+#: ../src/libs/print_settings.c:694
 #, c-format
 msgid "%3.2f (dpi:%d)"
 msgstr "%3.2f (ppp:%d)"
 
-#: ../src/libs/print_settings.c:1165
+#: ../src/libs/print_settings.c:1163
 msgid "printer"
 msgstr "impresora"
 
-#: ../src/libs/print_settings.c:1177
+#: ../src/libs/print_settings.c:1175
 msgid "media"
 msgstr "tipos de papel"
 
-#: ../src/libs/print_settings.c:1196
+#: ../src/libs/print_settings.c:1194
 msgid "color management in printer driver"
 msgstr "gestión de color en el controlador de la impresora"
 
-#: ../src/libs/print_settings.c:1231
+#: ../src/libs/print_settings.c:1229
 #, c-format
 msgid "printer ICC profiles in %s or %s"
 msgstr "perfiles ICC de impresora en %s o %s"
 
-#: ../src/libs/print_settings.c:1253
+#: ../src/libs/print_settings.c:1251
 msgid "black point compensation"
 msgstr "compensación de punto negro"
 
-#: ../src/libs/print_settings.c:1261
+#: ../src/libs/print_settings.c:1259
 msgid "activate black point compensation when applying the printer profile"
 msgstr ""
 "activa la compensación de punto negro al establecer el perfil de la impresora"
 
 #. //////////////////////// PAGE SETTINGS
-#: ../src/libs/print_settings.c:1267
+#: ../src/libs/print_settings.c:1265
 msgid "page"
 msgstr "página"
 
-#: ../src/libs/print_settings.c:1304
+#: ../src/libs/print_settings.c:1302
 msgid "image width/height"
 msgstr "ancho/alto de imagen"
 
-#: ../src/libs/print_settings.c:1308
+#: ../src/libs/print_settings.c:1306
 msgid " x "
 msgstr " x "
 
-#: ../src/libs/print_settings.c:1316
+#: ../src/libs/print_settings.c:1314
 msgid "scale factor"
 msgstr "factor de escala"
 
-#: ../src/libs/print_settings.c:1321
+#: ../src/libs/print_settings.c:1319
 msgid ""
 "image scale factor from native printer DPI:\n"
 " < 1 means that it is downscaled (best quality)\n"
@@ -12391,47 +13234,47 @@ msgstr ""
 "un valor muy grande puede resultar en una calidad de impresión pobre"
 
 #. d->b_top  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1335
+#: ../src/libs/print_settings.c:1333
 msgid "top margin"
 msgstr "margen superior"
 
 #. d->b_left  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1339
+#: ../src/libs/print_settings.c:1337
 msgid "left margin"
 msgstr "margen izquierdo"
 
-#: ../src/libs/print_settings.c:1342
+#: ../src/libs/print_settings.c:1340
 msgid "lock"
 msgstr "bloquear"
 
-#: ../src/libs/print_settings.c:1343
+#: ../src/libs/print_settings.c:1341
 msgid "change all margins uniformly"
 msgstr "cambiar los margenes uniformemente"
 
 #. d->b_right  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1347
+#: ../src/libs/print_settings.c:1345
 msgid "right margin"
 msgstr "margen derecho"
 
 #. d->b_bottom  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1351
+#: ../src/libs/print_settings.c:1349
 msgid "bottom margin"
 msgstr "margen inferior"
 
-#: ../src/libs/print_settings.c:1493
+#: ../src/libs/print_settings.c:1491
 msgid "temporary style to use while printing"
 msgstr "estilo temporal para ser aplicado al imprimir"
 
 #. Print button
-#: ../src/libs/print_settings.c:1530
+#: ../src/libs/print_settings.c:1528
 msgid "print"
 msgstr "imprimir"
 
-#: ../src/libs/print_settings.c:1532
+#: ../src/libs/print_settings.c:1530
 msgid "print with current settings"
 msgstr "imprimir con la configuración actual"
 
-#: ../src/libs/print_settings.c:1999
+#: ../src/libs/print_settings.c:1997
 msgctxt "accel"
 msgid "print"
 msgstr "imprimir"
@@ -12541,21 +13384,21 @@ msgstr "sesión"
 msgid "create"
 msgstr "crear"
 
-#: ../src/libs/snapshots.c:79
+#: ../src/libs/snapshots.c:80
 msgid "snapshots"
 msgstr "instantáneas"
 
-#: ../src/libs/snapshots.c:100
+#: ../src/libs/snapshots.c:101
 msgctxt "accel"
 msgid "take snapshot"
 msgstr "tomar una instantánea"
 
 #. create take snapshot button
-#: ../src/libs/snapshots.c:270
+#: ../src/libs/snapshots.c:271
 msgid "take snapshot"
 msgstr "tomar una instantánea"
 
-#: ../src/libs/snapshots.c:273
+#: ../src/libs/snapshots.c:274
 msgid ""
 "take snapshot to compare with another image or the same image at another "
 "stage of development"
@@ -12567,7 +13410,7 @@ msgstr ""
 msgid "styles"
 msgstr "estilos"
 
-#: ../src/libs/styles.c:70 ../src/libs/tagging.c:94
+#: ../src/libs/styles.c:70
 msgctxt "accel"
 msgid "delete"
 msgstr "borrar"
@@ -12647,31 +13490,49 @@ msgstr "importar el estilo desde un fichero"
 msgid "export the selected style into a style file"
 msgstr "exportar el estilo seleccionado a un fichero"
 
-#: ../src/libs/tagging.c:66
+#: ../src/libs/tagging.c:96
 msgid "tagging"
 msgstr "etiquetado"
 
-#: ../src/libs/tagging.c:91
+#: ../src/libs/tagging.c:121
 msgctxt "accel"
 msgid "attach"
 msgstr "añadir"
 
-#: ../src/libs/tagging.c:92
+#: ../src/libs/tagging.c:122
 msgctxt "accel"
 msgid "detach"
 msgstr "quitar"
 
-#: ../src/libs/tagging.c:93
+#: ../src/libs/tagging.c:123
 msgctxt "accel"
 msgid "new"
 msgstr "nueva"
 
-#: ../src/libs/tagging.c:95
+#: ../src/libs/tagging.c:124
 msgctxt "accel"
 msgid "tag"
 msgstr "etiqueta"
 
-#: ../src/libs/tagging.c:323
+#: ../src/libs/tagging.c:1040
+msgid "attach tag to all"
+msgstr "añadir etiqueta a todas las imágenes"
+
+#: ../src/libs/tagging.c:1048 ../src/libs/tagging.c:1913
+msgid "detach tag"
+msgstr "quitar etiqueta"
+
+#: ../src/libs/tagging.c:1163
+msgid "delete tag?"
+msgstr "¿borrar etiqueta?"
+
+#: ../src/libs/tagging.c:1170 ../src/libs/tagging.c:1267
+#: ../src/libs/tagging.c:1521
+#, c-format
+msgid "tag: %s "
+msgstr "etiqueta: %s "
+
+#: ../src/libs/tagging.c:1177
 #, c-format
 msgid ""
 "do you really want to delete the tag `%s'?\n"
@@ -12686,85 +13547,259 @@ msgstr[1] ""
 "¿desea borrar las etiqueta `%s'?\n"
 "%d imágenes tienen asignada esta etiqueta!"
 
-#: ../src/libs/tagging.c:329
-msgid "delete tag?"
+#: ../src/libs/tagging.c:1213
+#, c-format
+msgid "tag %s removed"
+msgstr "etiqueta %s eliminada"
+
+#: ../src/libs/tagging.c:1260 ../src/libs/tagging.c:1925
+msgid "delete branch"
+msgstr "Borrar rama"
+
+#: ../src/libs/tagging.c:1274
+#, c-format
+msgid "<u>%d</u> tag will be deleted."
+msgid_plural "<u>%d</u> tags will be deleted."
+msgstr[0] "<u>%d</u> etiqueta se eliminará."
+msgstr[1] "<u>%d</u> etiqueta se eliminarán."
+
+#: ../src/libs/tagging.c:1279 ../src/libs/tagging.c:1533
+#: ../src/libs/tagging.c:1753
+#, c-format
+msgid "<u>%d</u> image will be updated"
+msgid_plural "<u>%d</u> images will be updated "
+msgstr[0] "<u>%d</u> imagen se actualizará."
+msgstr[1] "<u>%d</u> imágenes se actualizarán."
+
+#: ../src/libs/tagging.c:1305
+#, c-format
+msgid "%d tags removed"
+msgstr "%d etiquetas eliminadas"
+
+#: ../src/libs/tagging.c:1348
+msgid "create tag"
+msgstr "Crear etiqueta"
+
+#: ../src/libs/tagging.c:1349 ../src/libs/tagging.c:1515
+msgid "save"
+msgstr "guardar"
+
+#: ../src/libs/tagging.c:1358 ../src/libs/tagging.c:1541
+msgid "name: "
+msgstr "nombre:"
+
+#: ../src/libs/tagging.c:1371
+#, c-format
+msgid "add to: \"%s\" "
+msgstr "añadir a: \"%s\" "
+
+#: ../src/libs/tagging.c:1377 ../src/libs/tagging.c:1556
+msgid "category"
+msgstr "categoría"
+
+#: ../src/libs/tagging.c:1380 ../src/libs/tagging.c:1559
+msgid "private"
+msgstr "privado"
+
+#: ../src/libs/tagging.c:1386 ../src/libs/tagging.c:1565
+msgid "synonyms: "
+msgstr "sinónimos:"
+
+#: ../src/libs/tagging.c:1403 ../src/libs/tagging.c:1586
+#: ../src/libs/tagging.c:1775
+msgid "empty tag is not allowed, aborting"
+msgstr "No se permite una etiqueta en blanco, abortando"
+
+#: ../src/libs/tagging.c:1405
+msgid "'|' character is not allowed to create a tag. aborting."
+msgstr "El caracter '|' no se puede usar para crear una etiqueta. Abortando."
+
+#: ../src/libs/tagging.c:1420
+msgid "tag name already exists. aborting."
+msgstr "El nombre de la etiqueta ya existe. Abortando."
+
+#: ../src/libs/tagging.c:1514
+msgid "edit tag"
+msgstr "editar etiqueta"
+
+#: ../src/libs/tagging.c:1528 ../src/libs/tagging.c:1748
+#, c-format
+msgid "<u>%d</u> tag will be updated."
+msgid_plural "<u>%d</u> tags will be updated."
+msgstr[0] "<u>%d</u> etiqueta se actualizará."
+msgstr[1] "<u>%d</u> etiquetas se actualizarán."
+
+#: ../src/libs/tagging.c:1588
+msgid ""
+"'|' character is not allowed for renaming tag.\n"
+"to modify the hierachy use rename path instead. Aborting."
+msgstr ""
+"El caracter '|' no se puede usar para renombrar una etiqueta.\n"
+"Use cambiar ruta para modificar la jerarquía. Abortando."
+
+#: ../src/libs/tagging.c:1626
+#, c-format
+msgid "at least one new tag name (%s) already exists, aborting"
+msgstr "Al menos un nuevo nombre de etiqueta (% s) ya existe... abortando"
+
+#: ../src/libs/tagging.c:1734
+msgid "rename path?"
+msgstr "¿confirma cambiar la ruta?"
+
+#: ../src/libs/tagging.c:1741
+#, c-format
+msgid "selected path: %s "
+msgstr "Ruta seleccionada: %s "
+
+#: ../src/libs/tagging.c:1777
+msgid "'|' misplaced, empty tag is not allowed, aborting"
+msgstr "'|' fuera de lugar. No se permite una etiqueta en blanco... abortando"
+
+#: ../src/libs/tagging.c:1803
+#, c-format
+msgid "at least one new tagname (%s) already exists, aborting."
+msgstr "Al menos un nombre de etiqueta nuevo (% s) ya existe... abortando."
+
+#: ../src/libs/tagging.c:1909
+msgid "attach tag"
+msgstr "añadir etiqueta"
+
+#: ../src/libs/tagging.c:1921
+msgid "delete tag"
 msgstr "¿borrar etiqueta?"
 
-#: ../src/libs/tagging.c:375
+#: ../src/libs/tagging.c:1931
+msgid "create tag..."
+msgstr "crear etiqueta..."
+
+#: ../src/libs/tagging.c:1935
+msgid "edit tag..."
+msgstr "editar etiqueta..."
+
+#: ../src/libs/tagging.c:1944
+msgid "rename path..."
+msgstr "cambiar la ruta..."
+
+#: ../src/libs/tagging.c:1951
+msgid "copy to entry"
+msgstr "copiar al campo de texto"
+
+#: ../src/libs/tagging.c:1975
+msgid "go to tag collection"
+msgstr "ir a la colección de etiquetas"
+
+#: ../src/libs/tagging.c:1981
+msgid "go back to work"
+msgstr "regresar al trabajo"
+
+#: ../src/libs/tagging.c:2091
+#, c-format
+msgid "%s"
+msgstr "%s"
+
+#: ../src/libs/tagging.c:2092
+msgid "(private)"
+msgstr "(privado)"
+
+#: ../src/libs/tagging.c:2118
 msgid "Select a keyword file"
 msgstr "Selecciona un archivo de palabras clave"
 
-#: ../src/libs/tagging.c:378
+#: ../src/libs/tagging.c:2121
 msgid "_import"
 msgstr "_import"
 
-#: ../src/libs/tagging.c:392
+#: ../src/libs/tagging.c:2135
 msgid "error importing tags"
 msgstr "error importando etiquetas"
 
-#: ../src/libs/tagging.c:394
+#: ../src/libs/tagging.c:2137
 #, c-format
 msgid "%zd tags imported"
 msgstr "%zd etiquetas importadas"
 
-#: ../src/libs/tagging.c:415
+#: ../src/libs/tagging.c:2159
 msgid "Select file to export to"
 msgstr "Seleccione el archivo a exportar"
 
-#: ../src/libs/tagging.c:418
+#: ../src/libs/tagging.c:2162
 msgid "_export"
 msgstr "_export"
 
-#: ../src/libs/tagging.c:433
+#: ../src/libs/tagging.c:2177
 msgid "error exporting tags"
 msgstr "error exportando etiquetas"
 
-#: ../src/libs/tagging.c:435
+#: ../src/libs/tagging.c:2179
 #, c-format
 msgid "%zd tags exported"
 msgstr "%zd etiquetas exportadas"
 
-#: ../src/libs/tagging.c:507
+#: ../src/libs/tagging.c:2537
 msgid ""
 "attached tags,\n"
-"doubleclick to detach"
+"double-click to detach\n"
+"right-click for other actions on attached tag,\n"
+"ctrl-wheel scroll to resize the window"
 msgstr ""
-"etiquetas adjuntas,\n"
-"doble clic para separar"
+"etiquetas adjuntas, \n"
+"para añadir pulse dos veces\n"
+"pulse clic derecho para mostrar más opciones\n"
+"Ctrl+rueda del ratón para cambiar el tamaño de la ventana"
 
-#: ../src/libs/tagging.c:515
+#: ../src/libs/tagging.c:2548
 msgid "attach"
 msgstr "añadir"
 
-#: ../src/libs/tagging.c:517
+#: ../src/libs/tagging.c:2551
 msgid "attach tag to all selected images"
 msgstr "añadir etiqueta a todas las imágenes seleccionadas"
 
-#: ../src/libs/tagging.c:522
+#: ../src/libs/tagging.c:2556
 msgid "detach"
 msgstr "quitar"
 
-#: ../src/libs/tagging.c:524
+#: ../src/libs/tagging.c:2559
 msgid "detach tag from all selected images"
 msgstr "quitar etiquetas de todas las imágenes seleccionadas"
 
-#: ../src/libs/tagging.c:537
+#: ../src/libs/tagging.c:2566
+msgid "toggle list with / without hierarchy"
+msgstr "alternar lista (con jerarquía o sin jerarquía)"
+
+#: ../src/libs/tagging.c:2574
+msgid "toggle sort by name or by count"
+msgstr "Alternar entre ordenar por nombre u ordenar por recuento"
+
+#: ../src/libs/tagging.c:2584
+msgid "toggle show or not darktable tags"
+msgstr "Alternar entre mostrar u ocultar etiquetas de darktable"
+
+#: ../src/libs/tagging.c:2600
 msgid "enter tag name"
 msgstr "introducir nombre de etiqueta"
 
-#: ../src/libs/tagging.c:563
-msgid ""
-"related tags,\n"
-"doubleclick to attach"
-msgstr ""
-"etiquetas relacionadas, \n"
-"doble clic para añadir"
+#: ../src/libs/tagging.c:2610
+msgid "clear entry"
+msgstr "borrar texto"
 
-#: ../src/libs/tagging.c:571
+#: ../src/libs/tagging.c:2662
+msgid ""
+"tag dictionary,\n"
+"double-click to attach,\n"
+"right-click for other actions on selected tag,\n"
+"ctrl-wheel scroll to resize the window"
+msgstr ""
+"Diccionario de etiquetas,\n"
+"para añadir con doble pulsación,\n"
+"para más opciones con clic derecho en la etiqueta seleccionada,\n"
+"Ctrl+rueda del ratón para redimensionar la ventana"
+
+#: ../src/libs/tagging.c:2677
 msgid "new"
 msgstr "nueva"
 
-#: ../src/libs/tagging.c:573
+#: ../src/libs/tagging.c:2680
 msgid ""
 "create a new tag with the\n"
 "name you entered"
@@ -12772,30 +13807,41 @@ msgstr ""
 "crea una nueva etiqueta con el\n"
 "nombre designado"
 
-#: ../src/libs/tagging.c:580
-msgid "delete selected tag"
-msgstr "borrar etiqueta seleccionada"
-
-#: ../src/libs/tagging.c:585
+#: ../src/libs/tagging.c:2685
 msgctxt "verb"
 msgid "import"
 msgstr "importar"
 
-#: ../src/libs/tagging.c:587
+#: ../src/libs/tagging.c:2688
 msgid "import tags from a Lightroom keyword file"
 msgstr "importar etiquetas desde el archivo Lightroom"
 
-#: ../src/libs/tagging.c:592
+#: ../src/libs/tagging.c:2693
 msgctxt "verb"
 msgid "export"
 msgstr "exportar"
 
-#: ../src/libs/tagging.c:594
+#: ../src/libs/tagging.c:2696
 msgid "export all tags to a Lightroom keyword file"
 msgstr "exportar todas las etiquetas al archivo Lightroom"
 
+#: ../src/libs/tagging.c:2703
+msgid "toggle list / tree view"
+msgstr "alternar vista (de lista o de árbol)"
+
+#: ../src/libs/tagging.c:2711
+msgid "toggle list with / without suggestion"
+msgstr "Alternar entre lista con o sin sugerencia"
+
+#: ../src/libs/tagging.c:2816
+msgid ""
+"tag shortcut is not active with tag tree view. please switch to list view"
+msgstr ""
+"El acceso directo de la etiqueta no está activo con vista de árbol. Cambiar "
+"la vista de la lista"
+
 #: ../src/libs/tools/battery_indicator.c:38
-#: ../src/libs/tools/battery_indicator.c:70
+#: ../src/libs/tools/battery_indicator.c:71
 msgid "battery indicator"
 msgstr "indicador de batería"
 
@@ -12848,20 +13894,20 @@ msgstr ""
 msgid "clear all labels of selected images"
 msgstr "quitar todas las marcas de las imágenes seleccionadas"
 
-#: ../src/libs/tools/darktable.c:59
+#: ../src/libs/tools/darktable.c:60
 msgid "darktable"
 msgstr "darktable"
 
-#: ../src/libs/tools/darktable.c:252
+#: ../src/libs/tools/darktable.c:253
 #, c-format
 msgid "copyright (c) the authors 2009-%s"
 msgstr "derechos reservados a (c) los autores 2009-%s"
 
-#: ../src/libs/tools/darktable.c:256
+#: ../src/libs/tools/darktable.c:257
 msgid "organize and develop images from digital cameras"
 msgstr "Revele y organice las imágenes de cámaras digitales"
 
-#: ../src/libs/tools/darktable.c:271
+#: ../src/libs/tools/darktable.c:272
 msgid "translator-credits"
 msgstr ""
 "Tatica Leandro\n"
@@ -12878,37 +13924,37 @@ msgstr "tira de imágenes"
 
 #. setup rating key accelerators
 #. Rating keys
-#: ../src/libs/tools/filmstrip.c:179 ../src/views/lighttable.c:4308
+#: ../src/libs/tools/filmstrip.c:179 ../src/views/lighttable.c:4378
 msgctxt "accel"
 msgid "rate 0"
 msgstr "0 estrellas"
 
-#: ../src/libs/tools/filmstrip.c:180 ../src/views/lighttable.c:4309
+#: ../src/libs/tools/filmstrip.c:180 ../src/views/lighttable.c:4379
 msgctxt "accel"
 msgid "rate 1"
 msgstr "1 estrella"
 
-#: ../src/libs/tools/filmstrip.c:181 ../src/views/lighttable.c:4310
+#: ../src/libs/tools/filmstrip.c:181 ../src/views/lighttable.c:4380
 msgctxt "accel"
 msgid "rate 2"
 msgstr "2 estrellas"
 
-#: ../src/libs/tools/filmstrip.c:182 ../src/views/lighttable.c:4311
+#: ../src/libs/tools/filmstrip.c:182 ../src/views/lighttable.c:4381
 msgctxt "accel"
 msgid "rate 3"
 msgstr "3 estrellas"
 
-#: ../src/libs/tools/filmstrip.c:183 ../src/views/lighttable.c:4312
+#: ../src/libs/tools/filmstrip.c:183 ../src/views/lighttable.c:4382
 msgctxt "accel"
 msgid "rate 4"
 msgstr "4 estrellas"
 
-#: ../src/libs/tools/filmstrip.c:184 ../src/views/lighttable.c:4313
+#: ../src/libs/tools/filmstrip.c:184 ../src/views/lighttable.c:4383
 msgctxt "accel"
 msgid "rate 5"
 msgstr "5 estrellas"
 
-#: ../src/libs/tools/filmstrip.c:185 ../src/views/lighttable.c:4314
+#: ../src/libs/tools/filmstrip.c:185 ../src/views/lighttable.c:4384
 msgctxt "accel"
 msgid "rate reject"
 msgstr "rechazar"
@@ -12947,27 +13993,27 @@ msgstr "duplicar imagen"
 #. setup color label accelerators
 #. Initializing accelerators
 #. Color labels keys
-#: ../src/libs/tools/filmstrip.c:199 ../src/views/lighttable.c:4300
+#: ../src/libs/tools/filmstrip.c:199 ../src/views/lighttable.c:4370
 msgctxt "accel"
 msgid "color red"
 msgstr "etiqueta roja"
 
-#: ../src/libs/tools/filmstrip.c:200 ../src/views/lighttable.c:4301
+#: ../src/libs/tools/filmstrip.c:200 ../src/views/lighttable.c:4371
 msgctxt "accel"
 msgid "color yellow"
 msgstr "etiqueta amarilla"
 
-#: ../src/libs/tools/filmstrip.c:201 ../src/views/lighttable.c:4302
+#: ../src/libs/tools/filmstrip.c:201 ../src/views/lighttable.c:4372
 msgctxt "accel"
 msgid "color green"
 msgstr "etiqueta verde"
 
-#: ../src/libs/tools/filmstrip.c:202 ../src/views/lighttable.c:4303
+#: ../src/libs/tools/filmstrip.c:202 ../src/views/lighttable.c:4373
 msgctxt "accel"
 msgid "color blue"
 msgstr "etiqueta azul"
 
-#: ../src/libs/tools/filmstrip.c:203 ../src/views/lighttable.c:4304
+#: ../src/libs/tools/filmstrip.c:203 ../src/views/lighttable.c:4374
 msgctxt "accel"
 msgid "color purple"
 msgstr "etiqueta morada"
@@ -13182,32 +14228,32 @@ msgstr "revisión de gama"
 msgid "soft proof"
 msgstr "prueba de impresión"
 
-#: ../src/views/darkroom.c:1010
+#: ../src/views/darkroom.c:1030
 msgid "no userdefined presets for favorite modules were found"
 msgstr "los módulos favoritos no tienen ajustes predefinidos por el usuario"
 
-#: ../src/views/darkroom.c:1015
+#: ../src/views/darkroom.c:1035
 #, c-format
 msgid "applied style `%s' on current image"
 msgstr "estilo aplicado '%s' en la imagen actual"
 
-#: ../src/views/darkroom.c:1127
+#: ../src/views/darkroom.c:1147
 msgid "no styles have been created yet"
 msgstr "no se han creado estilos todavia"
 
-#: ../src/views/darkroom.c:1754
+#: ../src/views/darkroom.c:1774
 msgid "quick access to presets of your favorites"
 msgstr "acceso rápido a los preajustes de tus módulos favoritos"
 
-#: ../src/views/darkroom.c:1763
+#: ../src/views/darkroom.c:1783
 msgid "quick access for applying any of your styles"
 msgstr "acceso rápido para aplicar cualquiera de tus estilos"
 
-#: ../src/views/darkroom.c:1776
+#: ../src/views/darkroom.c:1796
 msgid "display a second darkroom image window"
 msgstr "mostrar la imagen en cuarto oscuro en una segunda"
 
-#: ../src/views/darkroom.c:1787
+#: ../src/views/darkroom.c:1807
 msgid ""
 "toggle raw over exposed indication\n"
 "right click for options"
@@ -13215,47 +14261,47 @@ msgstr ""
 "activar el indicador de sobre exposición\n"
 "clic derecho para opciones"
 
-#: ../src/views/darkroom.c:1811
+#: ../src/views/darkroom.c:1831
 msgid "mark with CFA color"
 msgstr "marcar con color CFA"
 
-#: ../src/views/darkroom.c:1812
+#: ../src/views/darkroom.c:1832
 msgid "mark with solid color"
 msgstr "marcar con color sólido"
 
-#: ../src/views/darkroom.c:1813
+#: ../src/views/darkroom.c:1833
 msgid "false color"
 msgstr "color falso"
 
-#: ../src/views/darkroom.c:1815
+#: ../src/views/darkroom.c:1835
 msgid "select how to mark the clipped pixels"
 msgstr "seleccione como marcar los pixeles cortados"
 
-#: ../src/views/darkroom.c:1822 ../src/views/darkroom.c:1874
+#: ../src/views/darkroom.c:1842 ../src/views/darkroom.c:1894
 msgid "color scheme"
 msgstr "esquema de color"
 
-#: ../src/views/darkroom.c:1823
+#: ../src/views/darkroom.c:1843
 msgctxt "solidcolor"
 msgid "red"
 msgstr "rojo"
 
-#: ../src/views/darkroom.c:1824
+#: ../src/views/darkroom.c:1844
 msgctxt "solidcolor"
 msgid "green"
 msgstr "verde"
 
-#: ../src/views/darkroom.c:1825
+#: ../src/views/darkroom.c:1845
 msgctxt "solidcolor"
 msgid "blue"
 msgstr "azul"
 
-#: ../src/views/darkroom.c:1826
+#: ../src/views/darkroom.c:1846
 msgctxt "solidcolor"
 msgid "black"
 msgstr "negro"
 
-#: ../src/views/darkroom.c:1830
+#: ../src/views/darkroom.c:1850
 msgid ""
 "select the solid color to indicate over exposure.\n"
 "will only be used if mode = mark with solid color"
@@ -13263,7 +14309,7 @@ msgstr ""
 "seleccione el color sólido para indicar sobre-exposición.\n"
 "solo será utilizado si el modo = esta marcado con un color sólido"
 
-#: ../src/views/darkroom.c:1840
+#: ../src/views/darkroom.c:1860
 msgid ""
 "threshold of what shall be considered overexposed\n"
 "1.0 - white level\n"
@@ -13273,7 +14319,7 @@ msgstr ""
 "1.0 - nivel blanco\n"
 "0.0 - nivel negro"
 
-#: ../src/views/darkroom.c:1851
+#: ../src/views/darkroom.c:1871
 msgid ""
 "toggle over/under exposed indication\n"
 "right click for options"
@@ -13281,35 +14327,35 @@ msgstr ""
 "activar el indicador de exposición\n"
 "clic derecho para opciones"
 
-#: ../src/views/darkroom.c:1876
+#: ../src/views/darkroom.c:1896
 msgid "red & blue"
 msgstr "rojo y azul"
 
-#: ../src/views/darkroom.c:1877
+#: ../src/views/darkroom.c:1897
 msgid "purple & green"
 msgstr "púrpura y verde"
 
-#: ../src/views/darkroom.c:1879
+#: ../src/views/darkroom.c:1899
 msgid "select colors to indicate over/under exposure"
 msgstr "seleccionar los colores para indicar sobreexposición o subexposición"
 
-#: ../src/views/darkroom.c:1888
+#: ../src/views/darkroom.c:1908
 msgid "lower threshold"
 msgstr "umbral inferior"
 
-#: ../src/views/darkroom.c:1889
+#: ../src/views/darkroom.c:1909
 msgid "threshold of what shall be considered underexposed"
 msgstr "umbral bajo el que se considerará subexpuesto"
 
-#: ../src/views/darkroom.c:1897
+#: ../src/views/darkroom.c:1917
 msgid "upper threshold"
 msgstr "umbral superior"
 
-#: ../src/views/darkroom.c:1898
+#: ../src/views/darkroom.c:1918
 msgid "threshold of what shall be considered overexposed"
 msgstr "umbral sobre el que se considerará sobreexpuesto"
 
-#: ../src/views/darkroom.c:1909
+#: ../src/views/darkroom.c:1929
 msgid ""
 "toggle softproofing\n"
 "right click for profile options"
@@ -13317,7 +14363,7 @@ msgstr ""
 "activar pruebas en pantalla\n"
 "clic derecho para opciones de perfil"
 
-#: ../src/views/darkroom.c:1923
+#: ../src/views/darkroom.c:1943
 msgid ""
 "toggle gamut checking\n"
 "right click for profile options"
@@ -13325,331 +14371,399 @@ msgstr ""
 "activar la revisión de gama\n"
 "clic derecho para opciones del perfil"
 
-#: ../src/views/darkroom.c:1951 ../src/views/lighttable.c:4703
+#: ../src/views/darkroom.c:1971 ../src/views/lighttable.c:4866
 msgid "display intent"
 msgstr "salida en pantalla"
 
-#: ../src/views/darkroom.c:1959 ../src/views/lighttable.c:4711
+#: ../src/views/darkroom.c:1979 ../src/views/lighttable.c:4874
 msgid "preview display intent"
 msgstr "vista previa de salida en pantalla"
 
-#: ../src/views/darkroom.c:1979 ../src/views/lighttable.c:4719
+#: ../src/views/darkroom.c:1999 ../src/views/lighttable.c:4882
 msgid "display profile"
 msgstr "perfil (pantalla)"
 
-#: ../src/views/darkroom.c:1980 ../src/views/lighttable.c:4723
+#: ../src/views/darkroom.c:2000 ../src/views/lighttable.c:4886
 msgid "preview display profile"
 msgstr "vista previa del perfil (pantalla)"
 
-#: ../src/views/darkroom.c:1981
+#: ../src/views/darkroom.c:2001
 msgid "histogram profile"
 msgstr "perfil del histograma"
 
-#: ../src/views/darkroom.c:2035 ../src/views/lighttable.c:4753
+#: ../src/views/darkroom.c:2055 ../src/views/lighttable.c:4916
 #, c-format
 msgid "display ICC profiles in %s or %s"
 msgstr "mostrar perfiles ICC en %s o %s"
 
-#: ../src/views/darkroom.c:2038 ../src/views/lighttable.c:4756
+#: ../src/views/darkroom.c:2058 ../src/views/lighttable.c:4919
 #, c-format
 msgid "preview display ICC profiles in %s or %s"
 msgstr "vista previa: mostrar perfiles ICC en %s o %s"
 
-#: ../src/views/darkroom.c:2041
+#: ../src/views/darkroom.c:2061
 #, c-format
 msgid "softproof ICC profiles in %s or %s"
 msgstr "prueba de perfiles ICC en %s o %s"
 
-#: ../src/views/darkroom.c:2044
+#: ../src/views/darkroom.c:2064
 #, c-format
 msgid "histogram and color picker ICC profiles in %s or %s"
 msgstr "histograma y selector de color de perfiles ICC en %s o %s"
 
 #. Film strip shortcuts
 #. Setup key accelerators in capture view...
-#: ../src/views/darkroom.c:3113 ../src/views/map.c:892 ../src/views/print.c:329
+#: ../src/views/darkroom.c:3160 ../src/views/map.c:892 ../src/views/print.c:328
 #: ../src/views/tethering.c:396
 msgctxt "accel"
 msgid "toggle film strip"
 msgstr "activar o desactivar la tira de imágenes"
 
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:3116
+#: ../src/views/darkroom.c:3163
 msgctxt "accel"
 msgid "zoom close-up"
 msgstr "zoom acercar"
 
-#: ../src/views/darkroom.c:3117
+#: ../src/views/darkroom.c:3164
 msgctxt "accel"
 msgid "zoom fill"
 msgstr "zoom rellenar"
 
-#: ../src/views/darkroom.c:3118
+#: ../src/views/darkroom.c:3165
 msgctxt "accel"
 msgid "zoom fit"
 msgstr "zoom ajustar"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:3124
+#: ../src/views/darkroom.c:3171
 msgctxt "accel"
 msgid "image forward"
 msgstr "imagen siguiente"
 
-#: ../src/views/darkroom.c:3125
+#: ../src/views/darkroom.c:3172
 msgctxt "accel"
 msgid "image back"
 msgstr "imagen anterior"
 
 #. toggle raw overexposure indication
-#: ../src/views/darkroom.c:3128
+#: ../src/views/darkroom.c:3175
 msgctxt "accel"
 msgid "raw overexposed"
 msgstr "raw sobre-expuesto"
 
 #. toggle overexposure indication
-#: ../src/views/darkroom.c:3131
+#: ../src/views/darkroom.c:3178
 msgctxt "accel"
 msgid "overexposed"
 msgstr "sobreexpuesto"
 
 #. toggle softproofing
-#: ../src/views/darkroom.c:3134
+#: ../src/views/darkroom.c:3181
 msgctxt "accel"
 msgid "softproof"
 msgstr "prueba en pantalla"
 
 #. toggle gamut check
-#: ../src/views/darkroom.c:3137
+#: ../src/views/darkroom.c:3184
 msgctxt "accel"
 msgid "gamut check"
 msgstr "revisión de gama"
 
 #. brush size +/-
-#: ../src/views/darkroom.c:3140
+#: ../src/views/darkroom.c:3187
 msgctxt "accel"
 msgid "increase brush size"
 msgstr "aumentar tamaño del pincel"
 
-#: ../src/views/darkroom.c:3141
+#: ../src/views/darkroom.c:3188
 msgctxt "accel"
 msgid "decrease brush size"
 msgstr "reducir tamaño del pincel"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:3144
+#: ../src/views/darkroom.c:3191
 msgctxt "accel"
 msgid "increase brush hardness"
 msgstr "incrementar dureza del pincel"
 
-#: ../src/views/darkroom.c:3145
+#: ../src/views/darkroom.c:3192
 msgctxt "accel"
 msgid "decrease brush hardness"
 msgstr "reducir dureza del pincel"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:3148
+#: ../src/views/darkroom.c:3195
 msgctxt "accel"
 msgid "increase brush opacity"
 msgstr "incrementar opacidad del pincel"
 
-#: ../src/views/darkroom.c:3149
+#: ../src/views/darkroom.c:3196
 msgctxt "accel"
 msgid "decrease brush opacity"
 msgstr "reducir opacidad del pincel"
 
 #. fullscreen view
-#: ../src/views/darkroom.c:3152
+#: ../src/views/darkroom.c:3199
 msgctxt "accel"
 msgid "full preview"
 msgstr "vista previa completa"
 
 #. undo/redo
-#: ../src/views/darkroom.c:3155 ../src/views/lighttable.c:4339
+#: ../src/views/darkroom.c:3202 ../src/views/lighttable.c:4410
 #: ../src/views/map.c:889
 msgctxt "accel"
 msgid "undo"
 msgstr "deshacer"
 
-#: ../src/views/darkroom.c:3156 ../src/views/lighttable.c:4340
+#: ../src/views/darkroom.c:3203 ../src/views/lighttable.c:4411
 #: ../src/views/map.c:890
 msgctxt "accel"
 msgid "redo"
 msgstr "rehacer"
 
 #. add an option to allow skip mouse events while editing masks
-#: ../src/views/darkroom.c:3159
+#: ../src/views/darkroom.c:3206
 msgctxt "accel"
 msgid "allow to pan & zoom while editing masks"
-msgstr "permitir paneo y zoom mientras se editan máscaras"
+msgstr "Habilitar panoramización y ampliación mientras se editan las máscaras"
 
 #. set focus to the search modules text box
-#: ../src/views/darkroom.c:3162
+#: ../src/views/darkroom.c:3209
 msgctxt "accel"
 msgid "search modules"
 msgstr "buscar módulos"
 
+#: ../src/views/darkroom.c:3308
+msgid "switch to lighttable"
+msgstr "cambiar a mesa de luz"
+
+#: ../src/views/darkroom.c:3313 ../src/views/lighttable.c:4557
+msgid "zoom in the image"
+msgstr "acercamiento en la imagen"
+
+#: ../src/views/darkroom.c:3319
+msgid "unbounded zoom in the image"
+msgstr "Zoom ilimitado en la imagen"
+
+#: ../src/views/darkroom.c:3324
+msgid "zoom to 100% 200% and back"
+msgstr "Amplía de 100% a 200% y viceversa"
+
+#: ../src/views/darkroom.c:3330
+msgid "[modules] expand module without closing others"
+msgstr "[módulos] desplegar el módulo sin cerrar los otros"
+
+#: ../src/views/darkroom.c:3336
+msgid "[modules] change module position in pipe"
+msgstr "[módulos] reordenar módulos"
+
 #. workaround for GTK Quartz backend bug
-#: ../src/views/darkroom.c:3937 ../src/views/darkroom.c:3955
+#: ../src/views/darkroom.c:4038 ../src/views/darkroom.c:4056
 msgid "darktable - darkroom preview"
 msgstr "darktable: vista previa del cuarto oscuro"
 
 #: ../src/views/knight.c:334
 msgid "good knight"
-msgstr "buenas noche"
+msgstr "buen caballero"
 
-#: ../src/views/lighttable.c:1055 ../src/views/slideshow.c:348
+#: ../src/views/lighttable.c:1105 ../src/views/slideshow.c:352
 msgid "there are no images in this collection"
 msgstr "no hay imágenes en esta colección"
 
-#: ../src/views/lighttable.c:1059
+#: ../src/views/lighttable.c:1109
 msgid "if you have not imported any images yet"
 msgstr "si no ha importado ninguna imagen aún"
 
-#: ../src/views/lighttable.c:1063
+#: ../src/views/lighttable.c:1113
 msgid "you can do so in the import module"
 msgstr "puede hacerlo en el módulo importar"
 
-#: ../src/views/lighttable.c:1071
+#: ../src/views/lighttable.c:1121
 msgid "try to relax the filter settings in the top panel"
 msgstr "intente relajar las condiciones del filtro en el panel superior"
 
-#: ../src/views/lighttable.c:1080
+#: ../src/views/lighttable.c:1130
 msgid "or add images in the collection module in the left panel"
 msgstr "o agregue imágenes en el módulo de colección en el panel izquierdo"
 
-#: ../src/views/lighttable.c:3191
+#: ../src/views/lighttable.c:3245
 #, c-format
 msgid "you have reached the start of your selection (%d image)"
 msgid_plural "you have reached the start of your selection (%d images)"
 msgstr[0] "Se ha llegado al inicio de la selección (%d imagen)"
 msgstr[1] "Se ha llegado al inicio de la selección (%d imágenes)"
 
-#: ../src/views/lighttable.c:3196
+#: ../src/views/lighttable.c:3250
 msgid "you have reached the start of your collection"
 msgstr "Se ha llegado al inicio de la colección."
 
-#: ../src/views/lighttable.c:3220
+#: ../src/views/lighttable.c:3274
 #, c-format
 msgid "you have reached the end of your selection (%d image)"
 msgid_plural "you have reached the end of your selection (%d images)"
 msgstr[0] "Se ha llegado al final de la selección (%d imagen)"
 msgstr[1] "Se ha llegado al final de la selección (%d imágenes)"
 
-#: ../src/views/lighttable.c:3225
+#: ../src/views/lighttable.c:3279
 msgid "you have reached the end of your collection"
 msgstr "Se ha llegado al final de la colección"
 
-#: ../src/views/lighttable.c:3545
+#: ../src/views/lighttable.c:3599
 #, c-format
 msgid "zooming is limited to %d images"
 msgstr "El zoom está limitado a %d imágenes"
 
-#: ../src/views/lighttable.c:4305
+#: ../src/views/lighttable.c:4375
 msgctxt "accel"
 msgid "clear color labels"
 msgstr "limpiar marcas de color"
 
 #. Navigation keys
-#: ../src/views/lighttable.c:4317
+#: ../src/views/lighttable.c:4387
 msgctxt "accel"
 msgid "navigate up"
 msgstr "subir"
 
-#: ../src/views/lighttable.c:4318
+#: ../src/views/lighttable.c:4388
 msgctxt "accel"
 msgid "navigate down"
 msgstr "bajar"
 
-#: ../src/views/lighttable.c:4319
+#: ../src/views/lighttable.c:4389
 msgctxt "accel"
 msgid "navigate page up"
 msgstr "avanzar página"
 
-#: ../src/views/lighttable.c:4320
+#: ../src/views/lighttable.c:4390
 msgctxt "accel"
 msgid "navigate page down"
 msgstr "retroceder página"
 
 #. Scroll keys
-#: ../src/views/lighttable.c:4323
+#: ../src/views/lighttable.c:4393
 msgctxt "accel"
 msgid "scroll up"
 msgstr "desplazar arriba"
 
-#: ../src/views/lighttable.c:4324
+#: ../src/views/lighttable.c:4394
 msgctxt "accel"
 msgid "scroll down"
 msgstr "desplazar abajo"
 
-#: ../src/views/lighttable.c:4325
+#: ../src/views/lighttable.c:4395
 msgctxt "accel"
 msgid "scroll left"
 msgstr "desplazar izquierda"
 
-#: ../src/views/lighttable.c:4326
+#: ../src/views/lighttable.c:4396
 msgctxt "accel"
 msgid "scroll right"
 msgstr "deplazar derecha"
 
-#: ../src/views/lighttable.c:4327
+#: ../src/views/lighttable.c:4397
 msgctxt "accel"
 msgid "scroll center"
 msgstr "desplazar al centro"
 
-#: ../src/views/lighttable.c:4328
+#: ../src/views/lighttable.c:4398
 msgctxt "accel"
 msgid "realign images to grid"
 msgstr "realinear imagenes a la cuadrícula"
 
-#: ../src/views/lighttable.c:4329
+#: ../src/views/lighttable.c:4399
 msgctxt "accel"
 msgid "select toggle image"
 msgstr "seleccionar imagen activa"
 
-#: ../src/views/lighttable.c:4330
+#: ../src/views/lighttable.c:4400
 msgctxt "accel"
 msgid "select single image"
 msgstr "seleccionar imagen única"
 
 #. Preview key
-#: ../src/views/lighttable.c:4333
+#: ../src/views/lighttable.c:4403
 msgctxt "accel"
 msgid "preview"
 msgstr "vista previa rápida"
 
-#: ../src/views/lighttable.c:4334
+#: ../src/views/lighttable.c:4404
 msgctxt "accel"
 msgid "preview with focus detection"
 msgstr "vista previa rápida con detección de foco"
 
-#: ../src/views/lighttable.c:4335
+#: ../src/views/lighttable.c:4405
 msgctxt "accel"
 msgid "sticky preview"
 msgstr "vista previa"
 
-#: ../src/views/lighttable.c:4336
+#: ../src/views/lighttable.c:4406
 msgctxt "accel"
 msgid "sticky preview with focus detection"
 msgstr "vista previa con detección de foco"
 
 #. zoom for full preview
-#: ../src/views/lighttable.c:4343
+#: ../src/views/lighttable.c:4414
 msgctxt "accel"
 msgid "preview zoom 100%"
 msgstr "vista previa al 100%"
 
-#: ../src/views/lighttable.c:4344
+#: ../src/views/lighttable.c:4415
 msgctxt "accel"
 msgid "preview zoom fit"
 msgstr "vista previa del ajuste del zoom"
 
 #. timeline
-#: ../src/views/lighttable.c:4347
+#: ../src/views/lighttable.c:4418
 msgctxt "accel"
 msgid "toggle timeline"
 msgstr "alternar línea de tiempo"
 
-#: ../src/views/lighttable.c:4679
+#: ../src/views/lighttable.c:4544
+msgid "open image in darkroom"
+msgstr "Abrir imagen en el cuarto oscuro"
+
+#: ../src/views/lighttable.c:4551
+msgid "switch to next/previous image"
+msgstr "cambiar a la imagen siguiente/anterior"
+
+#: ../src/views/lighttable.c:4564 ../src/views/lighttable.c:4586
+msgid "scroll the collection"
+msgstr "desplazarse por la colección"
+
+#: ../src/views/lighttable.c:4570
+msgid "change number of images per row"
+msgstr "Cambiar el número de imágenes por fila"
+
+#: ../src/views/lighttable.c:4578
+msgid "change image order"
+msgstr "cambiar el orden de las imágenes"
+
+#: ../src/views/lighttable.c:4592
+msgid "zoom all the images"
+msgstr "Ampliar todas las imágenes"
+
+#: ../src/views/lighttable.c:4597
+msgid "pan inside all the images"
+msgstr "Desplazarse dentro de todas las imágenes"
+
+#: ../src/views/lighttable.c:4603
+msgid "zoom current image"
+msgstr "ampliar la imagen actual"
+
+#: ../src/views/lighttable.c:4609
+msgid "pan inside current image"
+msgstr "desplazarse dentro de la imagen actual"
+
+#: ../src/views/lighttable.c:4616
+msgid "zoom the main view"
+msgstr "ampliar la vista principal"
+
+#: ../src/views/lighttable.c:4621
+msgid "pan inside the main view"
+msgstr "Panorámica dentro de la vista principal"
+
+#: ../src/views/lighttable.c:4842
 msgid "set display profile"
 msgstr "ajustar perfil de pantalla"
 
@@ -13657,40 +14771,61 @@ msgstr "ajustar perfil de pantalla"
 msgid "map"
 msgstr "mapa"
 
-#: ../src/views/print.c:51
+#: ../src/views/map.c:1405
+msgid "[on image] open in darkroom"
+msgstr "[en la imagen] Abrir en el cuarto oscuro"
+
+#: ../src/views/map.c:1410
+msgid "[on map] zoom map"
+msgstr "[en el mapa] mapa de zoom"
+
+#: ../src/views/map.c:1415
+msgid "move image location"
+msgstr "cambiar la ubicación de la imagen"
+
+#: ../src/views/print.c:50
 msgctxt "view"
 msgid "print"
 msgstr "imprimir"
 
-#: ../src/views/slideshow.c:286 ../src/views/slideshow.c:302
+#: ../src/views/slideshow.c:290 ../src/views/slideshow.c:306
 msgid "end of images. press any key to return to lighttable mode"
 msgstr ""
 "Ha llegado al final. Presione cualquier tecla para volver al modo de mesa de "
 "luz"
 
-#: ../src/views/slideshow.c:316
+#: ../src/views/slideshow.c:320
 msgid "slideshow"
 msgstr "diapositivas"
 
-#: ../src/views/slideshow.c:438
+#: ../src/views/slideshow.c:441
 msgid "waiting to start slideshow"
 msgstr "Esperando para empezar la presentación de diapositivas"
 
-#: ../src/views/slideshow.c:556
+#: ../src/views/slideshow.c:559 ../src/views/slideshow.c:577
+#: ../src/views/slideshow.c:583
 msgid "slideshow paused"
 msgstr "Presentación de diapositivas pausado"
 
-#: ../src/views/slideshow.c:563 ../src/views/slideshow.c:570
+#: ../src/views/slideshow.c:566 ../src/views/slideshow.c:572
 #, c-format
 msgid "slideshow delay set to %d second"
 msgid_plural "slideshow delay set to %d seconds"
 msgstr[0] "Intervalo entre diapositivas establecido en% d segundo"
 msgstr[1] "Intervalo entre diapositivas establecido en% d segundos"
 
-#: ../src/views/slideshow.c:592
+#: ../src/views/slideshow.c:599
 msgctxt "accel"
 msgid "start and stop"
 msgstr "inicio y detención"
+
+#: ../src/views/slideshow.c:613
+msgid "go to next image"
+msgstr "pasar a la siguiente imagen"
+
+#: ../src/views/slideshow.c:618
+msgid "go to previous image"
+msgstr "retroceder a la imagen anterior"
 
 #: ../src/views/tethering.c:93
 msgid "tethering"
@@ -13704,6 +14839,114 @@ msgstr "Nueva sesión iniciada '%s'"
 #: ../src/views/tethering.c:251
 msgid "no camera with tethering support available for use..."
 msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
+
+#: ../src/views/view.c:2130
+msgid "Left click"
+msgstr "Clic izquierdo"
+
+#: ../src/views/view.c:2133
+msgid "Right click"
+msgstr "Clic derecho"
+
+#: ../src/views/view.c:2136
+msgid "Middle click"
+msgstr "Clic medio"
+
+#: ../src/views/view.c:2139
+msgid "Scroll"
+msgstr "Desplazar"
+
+#: ../src/views/view.c:2142
+msgid "Left double-click"
+msgstr "doble clic izquierdo"
+
+#: ../src/views/view.c:2145
+msgid "Right double-click"
+msgstr "doble clic derecho"
+
+#: ../src/views/view.c:2148
+msgid "Drag and drop"
+msgstr "Arrastrar y soltar"
+
+#: ../src/views/view.c:2151
+msgid "Left click+Drag"
+msgstr "Clic izquierdo+arrastrar"
+
+#: ../src/views/view.c:2154
+msgid "Right click+Drag"
+msgstr "Clic derecho+arrastrar"
+
+#: ../src/views/view.c:2178
+msgid "darktable - accels window"
+msgstr "darktable: ventana de atajos"
+
+#: ../src/views/view.c:2234
+msgid "switch to a classic window which will stay open after key release."
+msgstr ""
+"Cambiar a la ventana clásica que permanecerá abierta después de soltar la "
+"tecla."
+
+#: ../src/views/view.c:2347
+msgid "+Scroll"
+msgstr "+Desplazamiento"
+
+#: ../src/views/view.c:2362
+msgid "mouse actions"
+msgstr "acciones con el ratón"
+
+#: ../src/views/view.c:2400
+msgid "Accel"
+msgstr "Atajos del teclado"
+
+#: ../src/views/view.c:2402
+msgid "Action"
+msgstr "Acción"
+
+#, fuzzy
+#~ msgid "force exportation of private tags"
+#~ msgstr "error exportando etiquetas"
+
+#~ msgid "request exportation of synonyms"
+#~ msgstr "Solicitar la exportación de sinónimos"
+
+#~ msgid ""
+#~ "darktable doesn't export the synonyms per default. this option allows to "
+#~ "export them along with tags to XMP-dc Subject."
+#~ msgstr ""
+#~ "darktable no exporta los sinónimos por defecto. Esta opción permite "
+#~ "exportarlos junto con las etiquetas a Asunto XMP-dc."
+
+#~ msgid "export tags"
+#~ msgstr "exportar etiquetas"
+
+#~ msgid "migrate to fixed algorithm"
+#~ msgstr "migrar a algoritmo fijo"
+
+#~ msgid "albums"
+#~ msgstr "álbum"
+
+#, fuzzy
+#~ msgid ""
+#~ "attached tags,\n"
+#~ "double-click to detach"
+#~ msgstr ""
+#~ "etiquetas adjuntas,\n"
+#~ "doble clic para separar"
+
+#~ msgid "module disabled for monochrome image"
+#~ msgstr "módulo deshabilitado para imagen monocromo"
+
+#~ msgid "delete selected tag"
+#~ msgstr "borrar etiqueta seleccionada"
+
+#~ msgid "log-log (xy)"
+#~ msgstr "log-log (xy)"
+
+#~ msgid "semi-log (x)"
+#~ msgstr "semi-log (x)"
+
+#~ msgid "semi-log (y)"
+#~ msgstr "semi-log (y)"
 
 #~ msgid "display mask is currently disabled by another module"
 #~ msgstr ""
@@ -13797,9 +15040,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 
 #~ msgid "adjust the black level"
 #~ msgstr "ajusta el nivel de negro"
-
-#~ msgid "balance shadows-highlights"
-#~ msgstr "balance de sombras/altas altas"
 
 #~ msgid "gives more room to shadows or highlights, to protect the details"
 #~ msgstr ""
@@ -14000,9 +15240,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 #~ "(rápido). alta calidad - DXT1, misma memoria que la variante de baja "
 #~ "calidad pero más lento."
 
-#~ msgid "switch to %s mode"
-#~ msgstr "cambiar a %s modo"
-
 #~ msgctxt "accel"
 #~ msgid "capture view"
 #~ msgstr "vista de captura"
@@ -14113,9 +15350,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 #~ msgctxt "accel"
 #~ msgid "deflicker-level"
 #~ msgstr "deflicker-nivel"
-
-#~ msgid "deflicker"
-#~ msgstr "deflicker"
 
 #~ msgid "rotate by -90"
 #~ msgstr "rotar -90"
@@ -14283,9 +15517,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 #~ "debe entrar en su cuenta picasa y autorizar a darktable a subir las fotos "
 #~ "antes de continuar."
 
-#~ msgid "picasa authentication"
-#~ msgstr "autenticación picasa"
-
 #~ msgid "Adobe RGB"
 #~ msgstr "Adobe RGB"
 
@@ -14341,9 +15572,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 
 #~ msgid "picasa webalbum"
 #~ msgstr "album web picasa"
-
-#~ msgid "private"
-#~ msgstr "privado"
 
 #~ msgid "b/w"
 #~ msgstr "b/w"
@@ -14446,9 +15674,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 #~ msgid "inverse"
 #~ msgstr "invertir"
 
-#~ msgid "masks"
-#~ msgstr "máscaras"
-
 #~ msgid "Flickr account not authenticated"
 #~ msgstr "cuenta flickr no autenticada"
 
@@ -14522,9 +15747,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 
 #~ msgid "float hdr"
 #~ msgstr "hdr (float)"
-
-#~ msgid "album"
-#~ msgstr "álbum"
 
 #~ msgid "similar images"
 #~ msgstr "imagenes similares"
@@ -14909,9 +16131,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 
 #~ msgid "do that from the top left expander."
 #~ msgstr "hágalo desde el panel superior izquierdo."
-
-#~ msgid "lighten shadows"
-#~ msgstr "iluminar sombras"
 
 #~ msgid "local contrast 2"
 #~ msgstr "contraste local 2"
@@ -15571,10 +16790,6 @@ msgstr "No hay ninguna cámara con soporte de captura disponible para su uso..."
 
 #~ msgid "no module selected"
 #~ msgstr "sin seleccionar modulo"
-
-#~ msgctxt "color picker module"
-#~ msgid "`%s'"
-#~ msgstr "«%s»,"
 
 #~ msgid "load dt file"
 #~ msgstr "cargar archivo dt"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3850,7 +3850,7 @@ msgstr "$(SEQUENCE) - nombre séquentiel"
 
 #: ../src/gui/gtkentry.c:192
 msgid "$(MAX_WIDTH) - maximum image export width"
-msgstr "$(MAX_HEIGHT) - largeur maximum de l'image exportée"
+msgstr "$(MAX_WIDTH) - largeur maximum de l'image exportée"
 
 #: ../src/gui/gtkentry.c:193
 msgid "$(MAX_HEIGHT) - maximum image export height"

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2115,7 +2115,12 @@ static GList *read_history_v2(Exiv2::XmpData &xmpData, const char *filename)
       }
       else if(g_str_has_prefix(key_iter, "darktable:iop_order"))
       {
-        current_entry->iop_order = history->value().toFloat();  // This is a problem ??
+        // we ensure reading the iop_order as a high precision float
+        string str = g_strdup(history->value().toString().c_str());
+
+        // don't want to modify the locale so we do a simple test and maybe replace a dot by a comma
+        if ( 0.5f > stod("0.6")) replace(str.begin(), str.end(), '.', ',');
+        current_entry->iop_order = std::strtod(str.c_str(), NULL);
       }
       else if(g_str_has_prefix(key_iter, "darktable:blendop_version"))
       {

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2117,10 +2117,10 @@ static GList *read_history_v2(Exiv2::XmpData &xmpData, const char *filename)
       {
         // we ensure reading the iop_order as a high precision float
         string str = g_strdup(history->value().toString().c_str());
-
-        // don't want to modify the locale so we do a simple test and maybe replace a dot by a comma
-        if ( 0.5f > stod("0.6")) replace(str.begin(), str.end(), '.', ',');
-        current_entry->iop_order = std::strtod(str.c_str(), NULL);
+        static const std::locale& c_locale = std::locale("C");
+        std::istringstream istring(str);
+        istring.imbue(c_locale);
+        istring >> current_entry->iop_order;
       }
       else if(g_str_has_prefix(key_iter, "darktable:blendop_version"))
       {

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -920,7 +920,7 @@ static int dt_history_end_attop(int32_t imgid)
 }
 
 
-/* Please note: dt_history_compress_on_image 
+/* Please note: dt_history_compress_on_image
   - is used in lighttable and darkroom mode
   - It compresses history *exclusively* in the database and does *not* touch anything on the history stack
 */
@@ -937,7 +937,7 @@ void dt_history_compress_on_image(int32_t imgid)
   if (sqlite3_step(stmt) == SQLITE_ROW)
     my_history_end = sqlite3_column_int(stmt, 0);
   sqlite3_finalize(stmt);
- 
+
   if (my_history_end == 0) return;
 
   // compress history, keep disabled modules as documented
@@ -1067,7 +1067,7 @@ static void _history_reorder(int32_t imgid)
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
   }
-}  
+}
 #undef give_reorder_information
 #undef no_forced_reordering
 
@@ -1088,14 +1088,14 @@ int dt_history_compress_on_selection()
       dt_history_set_compress_problem(imgid, FALSE);
       dt_history_compress_on_image(imgid);
       _history_reorder(imgid);
- 
+
       // now the modules are in right order but need renumbering to remove leaks
       int max=0;    // the maximum num in main_history for an image
       int size=0;   // the number of items in main_history for an image
       int done=0;   // used for renumbering index
 
       sqlite3_stmt *stmt2;
-    
+
       // get highest num in history
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
         "SELECT MAX(num) FROM main.history WHERE imgid=?1", -1, &stmt2, NULL);

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -386,7 +386,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
       }
     }
     else
-      fprintf(stderr, "[_ioppr_insert_iop_before] module %s don't exists on iop order list\n", op_next);
+      fprintf(stderr, "[_ioppr_insert_iop_before] module %s does not exist in iop order list\n", op_next);
 
     if(found)
     {
@@ -399,7 +399,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
     }
   }
   else
-    fprintf(stderr, "[_ioppr_insert_iop_before] module %s already exists on iop order list\n", op_new);
+    fprintf(stderr, "[_ioppr_insert_iop_before] module %s already exists in iop order list\n", op_new);
 
   *_iop_order_list = iop_order_list;
 }
@@ -472,7 +472,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
     iop_order_list = g_list_remove_link(iop_order_list, iops_order_current);
   }
   else
-    fprintf(stderr, "[_ioppr_move_iop_before] current module %s don't exists on iop order list\n", op_current);
+    fprintf(stderr, "[_ioppr_move_iop_before] current module %s does not exist in iop order list\n", op_current);
 
   // search for the previous and next one
   if(found)
@@ -505,7 +505,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
     if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_move_iop_before   %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_current,iop_order_current->iop_order,iop_order_current->iop_order,iop_order_prev->iop_order,iop_order_next->iop_order);
   }
   else
-    fprintf(stderr, "[_ioppr_move_iop_before] next module %s don't exists on iop order list\n", op_next);
+    fprintf(stderr, "[_ioppr_move_iop_before] next module %s does not exist in iop order list\n", op_next);
 
   *_iop_order_list = iop_order_list;
 }
@@ -913,9 +913,10 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         else
         {
           // calculate new iop_order
-          iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 8.0;
-          /* fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] 2-calculated new iop_order=%f for %s(%f) between %s(%f) and %s(%f)\n",
-                 iop_order, module->op, module->iop_order, module_next->op, module_next->iop_order, mod->op, mod->iop_order); */
+          const double new_iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 8.0;
+          if (DT_IOP_ORDER_INFO) fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] 8-calculated new iop_order=%f for %s(%f) between %s(%f) and %s(%f)\n",
+                 new_iop_order, module->op, module->iop_order, mod1->op, mod1->iop_order, mod2->op, mod2->iop_order);
+          iop_order = new_iop_order;
         }
       }
     }
@@ -1010,9 +1011,10 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         else
         {
           // calculate new iop_order
-          iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 8.0;
-          /* fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] 2-calculated new iop_order=%f for %s(%f) between %s(%f) and %s(%f)\n",
-                 iop_order, module->op, module->iop_order, module_next->op, module_next->iop_order, mod->op, mod->iop_order); */
+          const double new_iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 8.0;
+          if (DT_IOP_ORDER_INFO) fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] 8-calculated new iop_order=%f for %s(%f) between %s(%f) and %s(%f)\n",
+                 new_iop_order, module->op, module->iop_order, mod1->op, mod1->iop_order, mod2->op, mod2->iop_order);
+          iop_order = new_iop_order;
         }
       }
     }

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -33,7 +33,7 @@
 
 #define DT_IOP_ORDER_VERSION 3
 
-#define DT_IOP_ORDER_INFO FALSE	// used while debugging
+#define DT_IOP_ORDER_INFO TRUE	// used while debugging
 
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_previous, const int dont_move);
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int dont_move);
@@ -391,7 +391,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
     if(found)
     {
       // set the iop_order
-      iop_order_new->iop_order = iop_order_prev + (iop_order_next - iop_order_prev) / 2.0;
+      iop_order_new->iop_order = iop_order_prev + (iop_order_next - iop_order_prev) / 8.0;
       if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_insert_iop_before %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_new,iop_order_new->iop_order,iop_order_new->iop_order,iop_order_prev,iop_order_next);
 
       // insert it on the proper order
@@ -498,7 +498,7 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
   if(found)
   {
     // set the iop_order
-    iop_order_current->iop_order = iop_order_prev->iop_order + (iop_order_next->iop_order - iop_order_prev->iop_order) / 2.0;
+    iop_order_current->iop_order = iop_order_prev->iop_order + (iop_order_next->iop_order - iop_order_prev->iop_order) / 8.0;
 
     // insert it on the proper order
     iop_order_list = g_list_insert(iop_order_list, iop_order_current, position);
@@ -655,7 +655,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
           dt_iop_module_t *mod_next = (dt_iop_module_t *)(modules1->data);
           if(mod->iop_order != mod_next->iop_order)
           {
-            mod->iop_order += (mod_next->iop_order - mod->iop_order) / 2.0;
+            mod->iop_order += (mod_next->iop_order - mod->iop_order) / 8.0;
           }
           else
           {
@@ -679,7 +679,7 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
           dt_iop_module_t *mod_next = (dt_iop_module_t *)(modules1->data);
           if(mod_prev->iop_order != mod_next->iop_order)
           {
-            mod_prev->iop_order -= (mod_prev->iop_order - mod_next->iop_order) / 2.0;
+            mod_prev->iop_order -= (mod_prev->iop_order - mod_next->iop_order) / 8.0;
           }
           else
           {
@@ -913,7 +913,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         else
         {
           // calculate new iop_order
-          iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 2.0;
+          iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 8.0;
           /* fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] 2-calculated new iop_order=%f for %s(%f) between %s(%f) and %s(%f)\n",
                  iop_order, module->op, module->iop_order, module_next->op, module_next->iop_order, mod->op, mod->iop_order); */
         }
@@ -1010,7 +1010,7 @@ double dt_ioppr_get_iop_order_before_iop(GList *iop_list, dt_iop_module_t *modul
         else
         {
           // calculate new iop_order
-          iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 2.0;
+          iop_order = mod1->iop_order + (mod2->iop_order - mod1->iop_order) / 8.0;
           /* fprintf(stderr, "[dt_ioppr_get_iop_order_before_iop] 2-calculated new iop_order=%f for %s(%f) between %s(%f) and %s(%f)\n",
                  iop_order, module->op, module->iop_order, module_next->op, module_next->iop_order, mod->op, mod->iop_order); */
         }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1325,22 +1325,12 @@ void _dev_insert_module(dt_develop_t *dev, dt_iop_module_t *module, const int im
 
 static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
 {
-  const int is_raw = dt_image_is_raw(&dev->image_storage);
-  const int is_monochrome = dt_image_is_monochrome(&(dev->image_storage));
-
   for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
-    // Note that we special case temperature & highlights as both modules are not
-    // enabled by default. They get enabled depending on the image kind.
-
     if(!dt_history_check_module_exists(imgid, module->op)
-       && (module->enabled == 1
-           // add temperature into history for non monochrome RAW
-           || (!strcmp(module->op, "temperature") && is_raw && !is_monochrome)
-           // and highlights into history for RAW
-           || (!strcmp(module->op, "highlights") && is_raw))
+       && module->default_enabled == 1
        && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
     {
       _dev_insert_module(dev, module, imgid);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1325,12 +1325,22 @@ void _dev_insert_module(dt_develop_t *dev, dt_iop_module_t *module, const int im
 
 static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
 {
+  const int is_raw = dt_image_is_raw(&dev->image_storage);
+  const int is_monochrome = dt_image_is_monochrome(&(dev->image_storage));
+
   for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
+
+    // Note that we special case temperature & highlights as both modules are not
+    // enabled by default. They get enabled depending on the image kind.
+
     if(!dt_history_check_module_exists(imgid, module->op)
-       && module->enabled == 1
-       && module->hide_enable_button == 1
+       && (module->enabled == 1
+           // add temperature into history for non monochrome RAW
+           || (!strcmp(module->op, "temperature") && is_raw && !is_monochrome)
+           // and highlights into history for RAW
+           || (!strcmp(module->op, "highlights") && is_raw))
        && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
     {
       _dev_insert_module(dev, module, imgid);

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1053,7 +1053,6 @@ void init(dt_iop_module_t *module)
   // module->data = malloc(sizeof(dt_iop_highlights_data_t));
   module->params = calloc(1, sizeof(dt_iop_highlights_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_highlights_params_t));
-  module->default_enabled = 1;
   module->params_size = sizeof(dt_iop_highlights_params_t);
   module->gui_data = NULL;
 }


### PR DESCRIPTION
 When inserting a new iop_order we always insert to the middle of two already existing numbers.
This populates the iop_numbers densely (in a very special way) and stresses the representation in double floats.

What could we do avoiding any sort of runtime reordering? Two ideas, both based on
the idea "**we** know better how  and where to insert than a simple divide-by-2"

1) before inserting we could always give a hint like jump to the middle (as we did before), jump to the far right, jump to slightly left ...

2) Or we could look at the code and find out what we do while populating:
We jump mostly to the right so we could not jump to middle-right but
only 'slightly' right. In maths that would mean, divide by a larger number
than two - i picked 8. If the analysis is right when inserting 20 iop_orders
we would not lose 6 decimal digits but a bit more than 2.

I have this working here proving the algorithm works and reduces stress in the order that was expected.

@TurboGit and @aurelienpierre as you seem to have worked on the new order most.

1. What did i miss?
2. Do we need a new version?

