### PR TITLE
Improve readability of preference window

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1135,9 +1135,18 @@ cell:selected
 
 #preferences_notebook scrolledwindow #pref_section > label
 {
-    font-size: 1.5em;
+    font-size: 1.2em;
     font-weight: bold;
+}
+
+#preferences_notebook scrolledwindow #pref_section
+{
     margin-top: 1.1em;
+}
+
+#preferences_notebook scrolledwindow #pref_section:first-child
+{
+    margin-top: 0;
 }
 
 /* Color picker */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1125,15 +1125,19 @@ cell:selected
     color: #FFFF00;
 }
 
-#pref_section
-{
-    border-bottom: 2px solid @fg_color;
+#preferences_notebook scrolledwindow viewport {
+  padding: 5px;
 }
-#pref_section *
+
+#preferences_notebook scrolledwindow label {
+  min-height: 1.5em;
+}
+
+#preferences_notebook scrolledwindow #pref_section > label
 {
-    font-size: 1.3em;
-    margin-left: 10em;
-    margin-right: 10em;
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-top: 1.1em;
 }
 
 /* Color picker */

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -213,6 +213,15 @@ static gboolean reset_language_widget(GtkWidget *label, GdkEventButton *event, G
 
 static void hardcoded_gui(GtkWidget *grid, int *line)
 {
+
+  GtkWidget *seclabel = gtk_label_new(_("general"));
+  GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+  gtk_widget_set_hexpand(lbox, TRUE);
+  gtk_widget_set_name(lbox, "pref_section");
+  gtk_grid_attach(GTK_GRID(grid), lbox, 0, (*line)++, 2, 1);
+
+
   // language
 
   GtkWidget *label = gtk_label_new(_("interface language"));

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -11,7 +11,6 @@
   GtkWidget *grid = gtk_grid_new();
   gtk_grid_set_row_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
   gtk_grid_set_column_spacing(GTK_GRID(grid), DT_PIXEL_APPLY_DPI(5));
-  gtk_grid_set_row_homogeneous(GTK_GRID(grid), TRUE);
   gtk_widget_set_valign(grid, GTK_ALIGN_START);
   int line = 0;
   char tooltip[1024];
@@ -85,8 +84,6 @@
       GtkWidget *seclabel = gtk_label_new(_("import"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -102,8 +99,6 @@
       GtkWidget *seclabel = gtk_label_new(_("lighttable"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -119,8 +114,6 @@
       GtkWidget *seclabel = gtk_label_new(_("darkroom"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -136,8 +129,6 @@
       GtkWidget *seclabel = gtk_label_new(_("map / geolocalisation"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -153,8 +144,6 @@
       GtkWidget *seclabel = gtk_label_new(_("security"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -170,8 +159,6 @@
       GtkWidget *seclabel = gtk_label_new(_("miscellaneous"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -192,8 +179,6 @@
       GtkWidget *seclabel = gtk_label_new(_("quality"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -209,8 +194,6 @@
       GtkWidget *seclabel = gtk_label_new(_("xmp"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -226,8 +209,6 @@
       GtkWidget *seclabel = gtk_label_new(_("cpu / gpu / memory"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
@@ -245,8 +226,6 @@
       GtkWidget *seclabel = gtk_label_new(_("miscellaneous"));
       GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
       gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
-      gtk_widget_set_halign(seclabel, GTK_ALIGN_CENTER);
-      gtk_widget_set_halign(lbox, GTK_ALIGN_CENTER);
       gtk_widget_set_hexpand(lbox, TRUE);
       gtk_widget_set_name(lbox, "pref_section");
       gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);


### PR DESCRIPTION
The idea is to make the preference window more consistent with the rest of the interface, and a bit more dense.

* Add a "General" section for language and theme for consistency
* Make the preferences a bit more dense (especially as their number continues growing) (this is achieved by replacing the homogeneity of row height by a min-height, which is not perfect, but prevents the language field which is bigger than others to be used as a minimum)
* Make the section title style more consistent with rest of the interface (left align and no underlining)
* Add some space between widgets and scrollbar

![comp2](https://user-images.githubusercontent.com/329388/65830461-30540180-e29f-11e9-9ee9-8a44998c9324.png)
