### PR TITLE
module name sizing moved from code to darktable.css

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -198,7 +198,7 @@ entry *,
 dialog,
 dialog *,
 colorswatch,
-colorswatch *
+colorswatch *,
 stack,
 stack *,
 scrollbar,
@@ -464,7 +464,7 @@ entry selection
   font-weight: normal;
   font-stretch: condensed;
   font-family: sans-serif;
-  font-size: 0.9em;
+  font-size: larger;
 }
 
 /* Labels of controls sections in modules */

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2236,9 +2236,9 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
   gchar *label;
   /* create a history button and add to box */
   if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
-    label = g_strdup_printf("<span size=\"larger\">%s</span>", module->name());
+    label = g_strdup_printf("%s", module->name());
   else
-    label = g_strdup_printf("<span size=\"larger\">%s</span> %s", module->name(), module->multi_name);
+    label = g_strdup_printf("%s <span size=\"smaller\">%s</span>", module->name(), module->multi_name);
   return label;
 }
 

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -972,11 +972,8 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
 
 
   /* add module label */
-  char label[128];
-  // TODO: figure out why the span larger size is needed here and CSS styling is uneffective
-  g_snprintf(label, sizeof(label), "<span size=\"larger\">%s</span>", module->name(module));
   hw[DT_MODULE_LABEL] = gtk_label_new("");
-  gtk_label_set_markup(GTK_LABEL(hw[DT_MODULE_LABEL]), label);
+  gtk_label_set_markup(GTK_LABEL(hw[DT_MODULE_LABEL]), module->name(module));
   gtk_widget_set_tooltip_text(hw[DT_MODULE_LABEL], module->name(module));
   gtk_label_set_ellipsize(GTK_LABEL(hw[DT_MODULE_LABEL]), PANGO_ELLIPSIZE_MIDDLE);
   gtk_widget_set_name(hw[DT_MODULE_LABEL], "lib-panel-label");


### PR DESCRIPTION
on windows sans-serif has no condensed counter part. 
If this is the same on other OS, removing the  `font-stretch: condensed;` option from darktable.css would avoid the console messages :

```
(darktable.exe:68480): Pango-WARNING **: 12:13:30.447: couldn't load font "sans-serif Condensed Not-Rotated 10.349609375", falling back to "Sans Condensed Not-Rotated 10.349609375", expect ugly output.
(darktable.exe:68480): Pango-WARNING **: 12:13:30.447: couldn't load font "Sans Condensed Not-Rotated 10.349609375", falling back to "Sans Not-Rotated 10.349609375", expect ugly output.
```
