### PR TITLE
History v3->v4 on-the-fly-conversion

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1507,7 +1507,12 @@ void dt_ioppr_convert_onthefly(const int imgid)
   }
 
   // process history
-
+  // read in the history
+  for (int i=0;i<history_size;i++)
+  {
+    struct dt_onthefly_history_t *this = &myhistory[i];
+    this->new_iop_order = dt_ioppr_get_iop_order(current_iop_list, this->operation) + (double)this->multi_priority / 100.0;
+  }
 
   // print complete history information 
   fprintf(stderr,"\n\n ***** On-the-fly history V[%i]->V[%i], imageid: %i ****************",my_iop_order_version,DT_IOP_ORDER_VERSION,imgid);  

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -35,7 +35,7 @@
 
 #define DT_IOP_ORDER_INFO FALSE	// used while debugging
 #define DT_ONTHEFLY_INFO FALSE   // while debugging on-the-fly conversion
-#define DT_ONTHEFLY_WRITING FALSE // If TRUE will do history update
+#define DT_ONTHEFLY_WRITING TRUE // If TRUE will do history update
 
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_previous, const int dont_move);
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int dont_move);

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1416,7 +1416,8 @@ static void _ioppr_check_rules(GList *iop_list, const int imgid, const char *msg
 
 // how is on-the-fly conversion done
 // Currently a hack to support v3 history to later
-void dt_ioppr_convert_onthefly(const int imgid)
+// returns the history version of imgid
+int dt_ioppr_convert_onthefly(const int imgid)
 {
   int my_iop_order_version = 0;
 
@@ -1430,9 +1431,9 @@ void dt_ioppr_convert_onthefly(const int imgid)
   }
   sqlite3_finalize(stmt);
 
-  if (my_iop_order_version == DT_IOP_ORDER_VERSION) return;
+  if (my_iop_order_version == DT_IOP_ORDER_VERSION) return my_iop_order_version;
 
-  if (my_iop_order_version != 3) return; // this keeps other edit as they are
+  if (my_iop_order_version != 3) return my_iop_order_version; // this keeps other edit as they are
 
   // ************** from here on we deal only with the v3 history problems; although *******************************
 
@@ -1451,7 +1452,7 @@ void dt_ioppr_convert_onthefly(const int imgid)
   if (history_size <1)
   {
     fprintf(stderr,"\n[dt_ioppr_convert_onthefly] for image %i has no valid history\n",imgid);
-    return;
+    return my_iop_order_version;
   }
 
   GList *current_iop_list = dt_ioppr_get_iop_order_list(NULL);
@@ -1514,6 +1515,8 @@ void dt_ioppr_convert_onthefly(const int imgid)
     this->new_iop_order = dt_ioppr_get_iop_order(current_iop_list, this->operation) + (double)this->multi_priority / 100.0;
   }
 
+  // process some more checks possibly; any sort data that can't be correct?
+
   // print complete history information 
   fprintf(stderr,"\n\n ***** On-the-fly history V[%i]->V[%i], imageid: %i ****************",my_iop_order_version,DT_IOP_ORDER_VERSION,imgid);  
   for (int i=0;i<history_size;i++)
@@ -1549,6 +1552,7 @@ void dt_ioppr_convert_onthefly(const int imgid)
   }
 
   free(myhistory);
+  return DT_IOP_ORDER_VERSION;
 }
 
 int dt_ioppr_check_iop_order(dt_develop_t *dev, const int imgid, const char *msg)

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1458,24 +1458,15 @@ int dt_ioppr_convert_onthefly(const int imgid)
   GList *current_iop_list = dt_ioppr_get_iop_order_list(NULL);
 
   // get the number of known iops
-  int valid_iops = 0;
+  const int valid_iops = g_list_length (current_iop_list);
+
+  if (DT_ONTHEFLY_INFO) fprintf(stderr,"\n*** checking for %i known iops ***\n",valid_iops);
 
   GList *iops_order = g_list_last(current_iop_list);
   while(iops_order)
   {
-    valid_iops++; 
-    iops_order = g_list_previous(iops_order);
-  }
-
-  if (DT_ONTHEFLY_INFO) fprintf(stderr,"\n*** checking for known iops ***\n");
-
-  valid_iops = 0; // reuse it as an index  
-  iops_order = g_list_last(current_iop_list);
-  while(iops_order)
-  {
     dt_iop_order_entry_t *order_entry = (dt_iop_order_entry_t *)iops_order->data;
     if (DT_ONTHEFLY_INFO) fprintf(stderr,"  %s, %f\n",order_entry->operation,order_entry->iop_order);
-    valid_iops++; 
     iops_order = g_list_previous(iops_order);
   }
 

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -66,6 +66,9 @@ GList *dt_ioppr_iop_order_copy_deep(GList *iop_order_list);
 /** sort two modules by iop_order */
 gint dt_sort_iop_by_order(gconstpointer a, gconstpointer b);
 
+/** convert images history on the fly; returns images history version, needs further work  */
+void dt_ioppr_convert_onthefly(int imgid);
+
 /** returns the iop_order before module_next if module can be moved */
 double dt_ioppr_get_iop_order_before_iop(GList *iop_list, struct dt_iop_module_t *module, struct dt_iop_module_t *module_next,
                                   const int validate_order, const int log_error);

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -66,8 +66,8 @@ GList *dt_ioppr_iop_order_copy_deep(GList *iop_order_list);
 /** sort two modules by iop_order */
 gint dt_sort_iop_by_order(gconstpointer a, gconstpointer b);
 
-/** convert images history on the fly; returns images history version, needs further work  */
-void dt_ioppr_convert_onthefly(int imgid);
+/** convert images history v3->v4 on the fly; returns images history version */
+int dt_ioppr_convert_onthefly(int imgid);
 
 /** returns the iop_order before module_next if module can be moved */
 double dt_ioppr_get_iop_order_before_iop(GList *iop_list, struct dt_iop_module_t *module, struct dt_iop_module_t *module_next,

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1470,6 +1470,8 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
 
   dev->iop_order_version = 0;
 
+  dt_ioppr_convert_onthefly(imgid);
+
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT iop_order_version FROM main.images WHERE id = ?1",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);


### PR DESCRIPTION
After all the mess with history v3 #3053 introduced history v4

That pr didn't fix images already developed with a current history version 3. See discussion there.

This pr prepares for an _on-the-fly_ history conversion.

Basically there is just one new function in iop_order.c  `void dt_ioppr_convert_onthefly(const int imgid)`. It checks for proper versioning (currently **only** v3->v4) itself.

It is called when we have to read the images history, done in `void dt_dev_read_history_ext` to do that conversion soon enough to leave the lighttable safe.

Please review and look for correct results.

After comments and testing there will be 2 more - hopefully short - review phases 
1. Prepare the database changing code without making it ready-to-shoot
2. Make it ready-to-go

@TurboGit @parafin go ahead
