### PR TITLE
iop-order: fix lut3d order (after colorin).

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1470,16 +1470,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
 
   dev->iop_order_version = 0;
 
-  dt_ioppr_convert_onthefly(imgid);
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT iop_order_version FROM main.images WHERE id = ?1",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  if(sqlite3_step(stmt) == SQLITE_ROW) // seriously, this should never fail
-  {
-    dev->iop_order_version = sqlite3_column_int(stmt, 0);
-  }
-  sqlite3_finalize(stmt);
+  dev->iop_order_version = dt_ioppr_convert_onthefly(imgid);
 
   // free iop_order if any
   if(dev->iop_order_list) g_list_free_full(dev->iop_order_list, free);


### PR DESCRIPTION
For #3062.

Another iop-order bug!

@aurelienpierre : I'd like to review the iop-order after this patch to ensure we are ok to avoid multiplying the iop-order version (already 5 of them just for a dev version :).

```
  db:  1,00000000000   xmp   1,0000         rawprepare
  db:  2,00000000000   xmp   2,0000             invert
  db:  3,00000000000   xmp   3,0000        temperature
  db:  4,00000000000   xmp   4,0000         highlights
  db:  5,00000000000   xmp   5,0000          cacorrect
  db:  6,00000000000   xmp   6,0000          hotpixels
  db:  7,00000000000   xmp   7,0000         rawdenoise
  db:  8,00000000000   xmp   8,0000           demosaic
  db:  9,00000000000   xmp   9,0000     denoiseprofile
  db: 10,00000000000   xmp  10,0000          bilateral
  db: 11,00000000000   xmp  11,0000       rotatepixels
  db: 12,00000000000   xmp  12,0000        scalepixels
  db: 13,00000000000   xmp  13,0000               lens
  db: 14,00000000000   xmp  14,0000        hazeremoval
  db: 15,00000000000   xmp  15,0000             ashift
  db: 16,00000000000   xmp  16,0000               flip
  db: 17,00000000000   xmp  17,0000           clipping
  db: 18,00000000000   xmp  18,0000            liquify
  db: 19,00000000000   xmp  19,0000              spots
  db: 20,00000000000   xmp  20,0000            retouch
  db: 21,00000000000   xmp  21,0000           exposure
  db: 22,00000000000   xmp  22,0000       mask_manager
  db: 23,00000000000   xmp  23,0000            tonemap
  db: 24,00000000000   xmp  24,0000          toneequal
  db: 25,00000000000   xmp  25,0000        graduatednd
  db: 26,00000000000   xmp  26,0000      profile_gamma
  db: 27,00000000000   xmp  27,0000          equalizer
  db: 28,00000000000   xmp  28,0000            colorin
  db: 29,00000000000   xmp  29,0000              lut3d
  db: 30,00000000000   xmp  30,0000            nlmeans
  db: 31,00000000000   xmp  31,0000           defringe
  db: 32,00000000000   xmp  32,0000             atrous
  db: 33,00000000000   xmp  33,0000            lowpass
  db: 34,00000000000   xmp  34,0000           highpass
  db: 35,00000000000   xmp  35,0000            sharpen
  db: 36,00000000000   xmp  36,0000       channelmixer
  db: 37,00000000000   xmp  37,0000       colorchecker
  db: 38,00000000000   xmp  38,0000      colortransfer
  db: 39,00000000000   xmp  39,0000       colormapping
  db: 40,00000000000   xmp  40,0000       colorbalance
  db: 41,00000000000   xmp  41,0000           basicadj
  db: 42,00000000000   xmp  42,0000           rgbcurve
  db: 43,00000000000   xmp  43,0000          rgblevels
  db: 44,00000000000   xmp  44,0000              bloom
  db: 45,00000000000   xmp  45,0000          basecurve
  db: 46,00000000000   xmp  46,0000             filmic
  db: 47,00000000000   xmp  47,0000          filmicrgb
  db: 48,00000000000   xmp  48,0000             colisa
  db: 49,00000000000   xmp  49,0000          tonecurve
  db: 50,00000000000   xmp  50,0000             levels
  db: 51,00000000000   xmp  51,0000             shadhi
  db: 52,00000000000   xmp  52,0000              bilat
  db: 53,00000000000   xmp  53,0000    colorcorrection
  db: 54,00000000000   xmp  54,0000         colorzones
  db: 55,00000000000   xmp  55,0000           vibrance
  db: 56,00000000000   xmp  56,0000             velvia
  db: 57,00000000000   xmp  57,0000           colorize
  db: 58,00000000000   xmp  58,0000      colorcontrast
  db: 59,00000000000   xmp  59,0000      globaltonemap
  db: 60,00000000000   xmp  60,0000           lowlight
  db: 61,00000000000   xmp  61,0000         monochrome
  db: 62,00000000000   xmp  62,0000         zonesystem
  db: 63,00000000000   xmp  63,0000            relight
  db: 64,00000000000   xmp  64,0000              grain
  db: 65,00000000000   xmp  65,0000             soften
  db: 66,00000000000   xmp  66,0000        splittoning
  db: 67,00000000000   xmp  67,0000           vignette
  db: 68,00000000000   xmp  68,0000   colorreconstruct
  db: 69,00000000000   xmp  69,0000           colorout
  db: 70,00000000000   xmp  70,0000              clahe
  db: 71,00000000000   xmp  71,0000         finalscale
  db: 72,00000000000   xmp  72,0000        overexposed
  db: 73,00000000000   xmp  73,0000     rawoverexposed
  db: 74,00000000000   xmp  74,0000             dither
  db: 75,00000000000   xmp  75,0000            borders
  db: 76,00000000000   xmp  76,0000          watermark
  db: 77,00000000000   xmp  77,0000              gamma
```
 