### PR TITLE
usermanual: add open-sans.css to html.stylesheet

### DIFF
--- a/doc/usermanual/xsl/darktable_html_dtorg.xsl
+++ b/doc/usermanual/xsl/darktable_html_dtorg.xsl
@@ -23,7 +23,7 @@
 <xsl:param name="html.cleanup" select="1"></xsl:param>
 <xsl:param name="make.clean.html" select="1"></xsl:param>
 <xsl:param name="html.stylesheet.type">text/css</xsl:param>
-<xsl:param name="html.stylesheet">/theme/css/normalize.css /theme/css/skeleton.css /theme/css/darktable.css /theme/css/usermanual.css</xsl:param>
+<xsl:param name="html.stylesheet">/theme/css/normalize.css /theme/css/skeleton.css /theme/css/open-sans.css /theme/css/darktable.css /theme/css/usermanual.css</xsl:param>
 <xsl:param name="docbook.css.source" />
 <xsl:param name="docbook.css.link" select="0"></xsl:param>
 <xsl:param name="generate.meta.abstract" select="1"></xsl:param>


### PR DESCRIPTION
Currently https://darktable.gitlab.io/doc/en/index.html triggers HTTP 404 for loading https://darktable.gitlab.io/doc/theme/css/open-sans.css

Relates to https://github.com/darktable-org/dtorg/commit/c150028656093fd1224c6fe63e0b037bb1b4a565