### PR TITLE
Improve tools menu consistency

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -632,6 +632,10 @@ dialog combobox window
   color: @section_label;
 }
 
+#view_label {
+  margin: 0.5em 0;
+}
+
 menuitem button,
 popover button,
 tooltip button


### PR DESCRIPTION
Use the same height for buttons.

Before:
![dt-gauche](https://user-images.githubusercontent.com/329388/66272325-e0091080-e857-11e9-80ae-6085d9494e7f.png)
![dt-droite](https://user-images.githubusercontent.com/329388/66272326-e26b6a80-e857-11e9-9bd6-ea861fa2da40.png)

After:
![dt5g](https://user-images.githubusercontent.com/329388/66273103-6e819000-e860-11e9-9be6-7f367fa9036b.png)
![dt5d](https://user-images.githubusercontent.com/329388/66273104-75100780-e860-11e9-9756-cad992f17fe5.png)
