### PR TITLE
denoiseprofile: ensure pixel values are >= 0 before backtransform

### DIFF
--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -372,6 +372,7 @@ denoiseprofile_backtransform_v2(read_only image2d_t in, write_only image2d_t out
   float4 px = read_imagef(in, sampleri, (int2)(x, y));
   const float alpha = px.w;
 
+  px = fmax((float4)0.0f, px);
   float4 delta = px * px + (float4)bias;
   float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
   float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -817,7 +817,7 @@ static inline void backtransform_v2(float *const buf, const int wd, const int ht
     {
       for(int c = 0; c < 3; c++)
       {
-        const float x = buf2[c];
+        const float x = MAX(buf2[c], 0.0f);
         const float delta = x * x + bias;
         const float denominator = 4.0f / (sqrt(a) * (2.0f - p[c]));
         const float z1 = (x + sqrt(MAX(delta, 0.0f))) / denominator;


### PR DESCRIPTION
In some cases, in wavelets mode, some pixels may appear white after
backtransform instead of black if they are < 0:
before:
![Capture d’écran_2019-10-10_07-59-34](https://user-images.githubusercontent.com/34063828/66543521-e5a37680-eb35-11e9-963e-6efb9b9b6668.png)
after:
![Capture d’écran_2019-10-10_08-02-17](https://user-images.githubusercontent.com/34063828/66543528-e89e6700-eb35-11e9-9274-b2323eb9ac04.png)
