### PR TITLE
BUG: toneeq/fast guided filter

### DIFF
--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -468,7 +468,7 @@ static inline void fast_surface_blur(float *const restrict image,
 
     // Perform the patch-wise variance analyse to get
     // the a and b parameters for the linear blending s.t. mask = a * I + b
-    variance_analyse(ds_image, ds_mask, ds_ab, ds_width, ds_height, ds_radius, feathering);
+    variance_analyse(ds_mask, ds_image, ds_ab, ds_width, ds_height, ds_radius, feathering);
 
     // Compute the patch-wise average of parameters a and b
     box_average(ds_ab, ds_width, ds_height, 2, ds_radius);


### PR DESCRIPTION
Fix a bug in the guided filter where the guided and guiding images were inverted in function arguments, so the quantization parameter had to be compensated with exposure, which was not intuitive. This will slightly break previous edits using non-zero quantization, but will be easily corrected by adjusting the mask exposure compensation.