### PR TITLE
debug option ioporder

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -120,7 +120,7 @@ static int usage(const char *argv0)
   printf("  --conf <key>=<value>\n");
   printf("  --configdir <user config directory>\n");
   printf("  -d {all,cache,camctl,camsupport,control,dev,fswatch,input,lighttable,\n");
-  printf("      lua, masks,memory,nan,opencl,perf,pwstorage,print,sql}\n");
+  printf("      lua, masks,memory,nan,opencl,perf,pwstorage,print,sql,ioporder}\n");
   printf("  --datadir <data directory>\n");
 #ifdef HAVE_OPENCL
   printf("  --disable-opencl\n");
@@ -633,6 +633,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
           darktable.unmuted |= DT_DEBUG_PRINT; // print errors are reported on console
         else if(!strcmp(argv[k + 1], "camsupport"))
           darktable.unmuted |= DT_DEBUG_CAMERA_SUPPORT; // camera support warnings are reported on console
+        else if(!strcmp(argv[k + 1], "ioporder"))
+          darktable.unmuted |= DT_DEBUG_IOPORDER; // iop order information are reported on console
         else
           return usage(argv[0]);
         k++;

--- a/src/common/darktable.h
+++ b/src/common/darktable.h
@@ -218,6 +218,7 @@ typedef enum dt_debug_thread_t
   DT_DEBUG_INPUT = 1 << 14,
   DT_DEBUG_PRINT = 1 << 15,
   DT_DEBUG_CAMERA_SUPPORT = 1 << 16,
+  DT_DEBUG_IOPORDER = 1 << 17,
 } dt_debug_thread_t;
 
 typedef struct dt_codepath_t

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -33,8 +33,8 @@
 
 #define DT_IOP_ORDER_VERSION 5
 
-#define DT_IOP_ORDER_INFO FALSE  // used while debugging
-#define DT_ONTHEFLY_INFO FALSE   // while debugging on-the-fly conversion
+#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
+
 
 static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_previous, const int dont_move);
 static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_list, const char *op_new, const char *op_next, const int dont_move);
@@ -569,8 +569,9 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
       }
     }
     else
-      fprintf(stderr, "[_ioppr_insert_iop_before] module %s don't exists on iop order list\n", op_next);
-
+    {
+      if (DT_IOP_ORDER_INFO) fprintf(stderr, "[_ioppr_insert_iop_before] module %s don't exists on iop order list\n", op_next);
+    }
     if(found)
     {
       // set the iop_order
@@ -582,8 +583,9 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
     }
   }
   else
-    fprintf(stderr, "[_ioppr_insert_iop_before] module %s already exists on iop order list\n", op_new);
-
+  {
+     if (DT_IOP_ORDER_INFO) fprintf(stderr, "[_ioppr_insert_iop_before] module %s already exists on iop order list\n", op_new);
+  }
   *_iop_order_list = iop_order_list;
 }
 
@@ -607,8 +609,7 @@ static void _ioppr_insert_iop_after(GList **_iop_order_list, GList *history_list
   }
   if(prior_next == NULL)
   {
-    fprintf(
-        stderr,
+    if (DT_IOP_ORDER_INFO) fprintf(stderr,
         "[_ioppr_insert_iop_after] can't find module previous to %s while moving %s after it\n",
         op_prev, op_new);
   }
@@ -655,8 +656,9 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
     iop_order_list = g_list_remove_link(iop_order_list, iops_order_current);
   }
   else
-    fprintf(stderr, "[_ioppr_move_iop_before] current module %s don't exists on iop order list\n", op_current);
-
+  {
+    if (DT_IOP_ORDER_INFO) fprintf(stderr, "[_ioppr_move_iop_before] current module %s don't exists on iop order list\n", op_current);
+  }
   // search for the previous and next one
   if(found)
   {
@@ -688,8 +690,9 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
     if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_move_iop_before   %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_current,iop_order_current->iop_order,iop_order_current->iop_order,iop_order_prev->iop_order,iop_order_next->iop_order);
   }
   else
-    fprintf(stderr, "[_ioppr_move_iop_before] next module %s don't exists on iop order list\n", op_next);
-
+  {
+    if (DT_IOP_ORDER_INFO) fprintf(stderr, "[_ioppr_move_iop_before] next module %s don't exists on iop order list\n", op_next);
+  }
   *_iop_order_list = iop_order_list;
 }
 
@@ -714,8 +717,7 @@ static void _ioppr_move_iop_after(GList **_iop_order_list, const char *op_curren
   }
   if(prior_next == NULL)
   {
-    fprintf(
-        stderr,
+    if (DT_IOP_ORDER_INFO) fprintf(stderr,
         "[_ioppr_move_iop_after] can't find module previous to %s while moving %s after it\n",
         op_prev, op_current);
   }
@@ -740,7 +742,7 @@ GList *dt_ioppr_get_iop_order_list(int *_version)
 
   if(old_version != version)
   {
-    fprintf(stderr, "[dt_ioppr_get_iop_order_list] error building iop_order_list to version %i\n", version);
+    if (DT_IOP_ORDER_INFO) fprintf(stderr, "[dt_ioppr_get_iop_order_list] error building iop_order_list to version %i\n", version);
   }
 
   if(_version && *_version == 0 && old_version > 0) *_version = old_version;
@@ -867,7 +869,8 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
           else
           {
             can_move = 0;
-            fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%f) and %s %s(%f) have the same iop_order\n",
+            if (DT_IOP_ORDER_INFO) fprintf(stderr,
+                "[dt_ioppr_check_duplicate_iop_order 1] modules %s %s(%f) and %s %s(%f) have the same iop_order\n",
                 mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op, mod->multi_name, mod->iop_order);
           }
         }
@@ -879,7 +882,8 @@ void dt_ioppr_check_duplicate_iop_order(GList **_iop_list, GList *history_list)
 
       if(!can_move)
       {
-        fprintf(stderr, "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%f) and %s %s(%f) have the same iop_order\n",
+        if (DT_IOP_ORDER_INFO) fprintf(stderr,
+            "[dt_ioppr_check_duplicate_iop_order] modules %s %s(%f) and %s %s(%f) have the same iop_order\n",
             mod_prev->op, mod_prev->multi_name, mod_prev->iop_order, mod->op, mod->multi_name, mod->iop_order);
       }
     }
@@ -928,7 +932,7 @@ void dt_ioppr_legacy_iop_order(GList **_iop_list, GList **_iop_order_list, GList
     if(mod->multi_priority == 0 && mod->iop_order == DBL_MAX)
     {
       mod->iop_order = dt_ioppr_get_iop_order(iop_order_list, mod->op);
-      if(mod->iop_order == DBL_MAX)
+      if((mod->iop_order == DBL_MAX) && (DT_IOP_ORDER_INFO)) 
         fprintf(stderr, "[dt_ioppr_legacy_iop_order] can't find iop_order for module %s\n", mod->op);
     }
 
@@ -959,7 +963,7 @@ int dt_ioppr_check_so_iop_order(GList *iop_list, GList *iop_order_list)
     if(entry == NULL)
     {
       iop_order_missing = 1;
-      fprintf(stderr, "[dt_ioppr_check_so_iop_order] missing iop_order for module %s\n", mod->op);
+      if (DT_IOP_ORDER_INFO) fprintf(stderr, "[dt_ioppr_check_so_iop_order] missing iop_order for module %s\n", mod->op);
     }
     modules = g_list_next(modules);
   }
@@ -1576,7 +1580,7 @@ static int _ioppr_migrate_iop_order(const int imgid, const int current_iop_order
   // get the number of known iops
   const int valid_iops = g_list_length (current_iop_list);
 
-  if (DT_ONTHEFLY_INFO)
+  if (DT_IOP_ORDER_INFO)
   {
     fprintf(stderr,"\n*** checking for %i known iops ***\n",valid_iops);
 
@@ -3612,6 +3616,5 @@ cleanup:
 }
 #endif
 
-#undef DT_ONTHEFLY_WRITING
-#undef DT_ONTHEFLY_INFO
-#undef DT_IOP_ORDER_INFO // used while debugging
+#undef DT_IOP_ORDER_INFO
+

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1217,7 +1217,7 @@ void dt_dev_write_history_ext(dt_develop_t *dev, const int imgid)
   sqlite3_finalize(stmt);
   GList *history = dev->history;
   if (DT_IOP_ORDER_INFO)
-    fprintf(stderr,"\n^^^^ Writing history image: %i",imgid);
+    fprintf(stderr,"\n^^^^ Writing history image: %i, iop version: %i",imgid,dev->iop_order_version);
   for(int i = 0; history; i++)
   {
     dt_dev_history_item_t *hist = (dt_dev_history_item_t *)(history->data);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -30,6 +30,7 @@
 DT_MODULE(1)
 
 #define PADDING 2
+#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
 
 #include "modulegroups.h"
 
@@ -336,6 +337,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
                                   ? gtk_entry_get_text(GTK_ENTRY(d->text_entry))
                                   : NULL;
 
+  if (DT_IOP_ORDER_INFO)
+    fprintf(stderr,"\n^^^^^ modulegroups");
+
   GList *modules = darktable.develop->iop;
   if(modules)
   {
@@ -347,6 +351,12 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
     {
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
       GtkWidget *w = module->expander;
+
+      if ((DT_IOP_ORDER_INFO) && (module->enabled))
+      {
+        fprintf(stderr,"\n%20s %9.5f",module->op,module->iop_order);
+        if(dt_iop_is_hidden(module)) fprintf(stderr,", hidden");
+      }
 
       /* skip modules without an gui */
       if(dt_iop_is_hidden(module)) continue;
@@ -460,7 +470,7 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
       }
     } while((modules = g_list_next(modules)) != NULL);
   }
-
+  if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
   // now that visibility has been updated set multi-show
   dt_dev_modules_update_multishow(darktable.develop);
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2210,9 +2210,9 @@ static gboolean _on_drag_motion(GtkWidget *widget, GdkDragContext *dc, gint x, g
   {
     double iop_order = -1.0;
     if(module_src->iop_order < module_dest->iop_order)
-      iop_order = dt_ioppr_get_iop_order_after_iop(darktable.develop->iop, module_src, module_dest, 1, 0);
+      iop_order = dt_ioppr_get_iop_order_after_iop(darktable.develop->iop, module_src, module_dest, 1, (darktable.unmuted & DT_DEBUG_IOPORDER));
     else
-      iop_order = dt_ioppr_get_iop_order_before_iop(darktable.develop->iop, module_src, module_dest, 1, 0);
+      iop_order = dt_ioppr_get_iop_order_before_iop(darktable.develop->iop, module_src, module_dest, 1, (darktable.unmuted & DT_DEBUG_IOPORDER));
 
     if(iop_order > 0.0 && iop_order != module_src->iop_order)
       can_moved = TRUE;


### PR DESCRIPTION
There have been so many issues about problems, bugs and misunderstandings related to iop_order over the last weeks.
This pr

1. indroduces a debug option -d ioporder selectable as usual
2. all existing messages about iop_order are only printed to console if this option is active avoiding "pollution" of the console with sometimes debatable value of information. #3103 
3. tells about the iop orders visualized in the module tabs `_lib_modulegroups_update_iop_visibility` #3094 
4. tells what is written to history in `dt_dev_write_history_ext` 
5. Will allow us to better understand problems while debugging this part of dt
6. Will give better chances for support with this new feature or new users fiddling around with re-ordering.
