### PR TITLE
FIx source comment typos

### DIFF
--- a/src/common/cups_print.c
+++ b/src/common/cups_print.c
@@ -75,7 +75,7 @@ void dt_get_printer_info(const char *printer_name, dt_printer_info_t *pinfo)
       cupsMarkOptions(ppd, dest->num_options, dest->options);
 
       // first check if this is turboprint drived printer, two solutions:
-      // 1. ModelName constains TurboPrint
+      // 1. ModelName contains TurboPrint
       // 2. zedoPrinterDriver exists
       ppd_attr_t *attr = ppdFindAttr(ppd, "ModelName", NULL);
 

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2688,7 +2688,7 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
     }
     sqlite3_finalize(stmt);
 
-    // if masks have been readed create a mask manager entry in history
+    // if masks have been read, create a mask manager entry in history
     if(version < 3)
     {
       DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT COUNT(*) FROM main.masks_history WHERE imgid = ?1", -1,

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -190,7 +190,7 @@ void dt_ioppr_get_profile_info_cl(const dt_iop_order_iccprofile_info_t *const pr
  */
 cl_float *dt_ioppr_get_trc_cl(const dt_iop_order_iccprofile_info_t *const profile_info);
 
-/** build the required parameters for a kernell that uses a profile info */
+/** build the required parameters for a kernel that uses a profile info */
 cl_int dt_ioppr_build_iccprofile_params_cl(const dt_iop_order_iccprofile_info_t *const profile_info,
                                            const int devid, dt_colorspaces_iccprofile_info_cl_t **_profile_info_cl,
                                            cl_float **_profile_lut_cl, cl_mem *_dev_profile_info,

--- a/src/common/pdf.c
+++ b/src/common/pdf.c
@@ -558,7 +558,7 @@ dt_pdf_page_t *dt_pdf_add_page(dt_pdf_t *pdf, dt_pdf_image_t **images, int n_ima
       translate_x += scale_y;
     }
 
-    // unfortunately regular fprintf honours the decimal separator as set by the current locale,
+    // unfortunately regular fprintf honors the decimal separator as set by the current locale,
     // we want '.' in all cases though.
     char translate_x_str[G_ASCII_DTOSTR_BUF_SIZE];
     char translate_y_str[G_ASCII_DTOSTR_BUF_SIZE];

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -167,7 +167,7 @@ void dt_tag_free_result(GList **result);
 /** reorganize tags */
 void dt_tag_reorganize(const gchar *source, const gchar *dest);
 
-/** get number of seleted images */
+/** get number of selected images */
 uint32_t dt_selected_images_count();
 
 /** get number of images affected with that tag */


### PR DESCRIPTION
Found using `codespell`