### PR TITLE
threadsafe rowids in history.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1052,6 +1052,9 @@ static void _history_reorder(int32_t imgid)
   else
   {
     if (give_reorder_information) fprintf(stderr,", reorder\n");
+    // make sure running jobs can't interfere here as the followiing code uses a fixed dummy id
+    // and also intends to have a "properly" orderered database
+    dt_pthread_mutex_lock(&darktable.db_insert);
 
     _history_copy_and_paste_on_image_overwrite(imgid, dummy, 0);
     _history_copy_and_paste_on_image_overwrite(dummy, imgid, 0);
@@ -1066,6 +1069,7 @@ static void _history_reorder(int32_t imgid)
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dummy);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
+    dt_pthread_mutex_unlock(&darktable.db_insert);
   }
 }
 #undef give_reorder_information

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1350,6 +1350,9 @@ static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
 static void _dev_merge_history(dt_develop_t *dev, const int imgid)
 {
   sqlite3_stmt *stmt;
+  // be extra sure that we don't mess up history in separate threads:
+  // the mutex locking here is necessary because of the later workaround a sqlite3 "feature".
+  dt_pthread_mutex_lock(&darktable.db_insert);
 
   // count what we found:
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT COUNT(*) FROM memory.history", -1,
@@ -1466,6 +1469,7 @@ static void _dev_merge_history(dt_develop_t *dev, const int imgid)
       }
     }
   }
+  dt_pthread_mutex_unlock(&darktable.db_insert);
 }
 
 void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_image)


### PR DESCRIPTION
I sometimes observed non-plausible history for images in situations where multiple threads were involved (importing lots of images or updating thumbnails) and i started development,  added styles or compressed history while these threads were still running.

The history database - as it is used - requires nums to be sorted by rowid
in certain cases. (See comment in develop.c L.~1365)

Although we use sqlite3 in serialized mode this does not absolutely ensure
database lines are written in a definite rowid order.

At lease these need &darktable.db_insert protection
`static void _dev_merge_history(dt_develop_t *dev, const int imgid)`
`static void _history_reorder(int32_t imgid)`