### PR TITLE
Fixing iop_order when applying a style

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -732,7 +732,7 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
       style_item.params_size = sqlite3_column_bytes(stmt, 3);
       style_item.blendop_params_size = sqlite3_column_bytes(stmt, 5);
 
-      double old_iop_order = sqlite3_column_double(stmt, 9);
+      const double old_iop_order = sqlite3_column_double(stmt, 9);
       style_item.iop_order = dt_ioppr_get_iop_order(current_iop_list, style_item.operation) + (double)style_item.multi_priority / 100.0f;
 
       if (DT_IOP_ORDER_INFO)


### PR DESCRIPTION
There is one thing fundamentally wrong (at least i think so) with styles and iop_order.
The style database simply does **not know** about the iop_order version!

When a style is applied to an image the iop_orders for each module are granted to be
correct and are copied to the history as is.

Of course this might be exactly what you want and i think it would be great to have styles
with specifically re-ordered modules but at the moment this is absolutely unsafe.

Iop_orders in old styles can be completely out-of-order and i observed multiple crashes after applying such styles.
These crashes left dt in deep trouble resulting in multiple crashes as long there were images with
thumbnails to be updated.

What can be done?

We need a new style database including iop_order version so we can test: Are the iop_orders
valid in this style or do we have to make safe assumtions? This means a code overhaul
at many places, certainly **not** for dt3.0

This pr is meant as a security fix. What is done:

1. When you apply a style the iop_order is **not** taken from the style database but is read from
the images iop_order list (depending on it's iop_order version). For multiple instances the iop_order is increased by 1/100 per multi_instance.

2. A minor fix, if we apply a style we also want the modules tab to be redisplayed.