### PR TITLE
BUG: fix toneequalizer behaviour in overexposed area

### DIFF
--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -398,7 +398,7 @@ dt_omp_firstprivate(image, out, num_elem, sampling, clip_min, clip_max) \
 schedule(static) aligned(image, out:64)
 #endif
     for(size_t k = 0; k < num_elem; k++)
-      out[k] = fast_clamp(image[k], clip_min, clip_max);
+      out[k] = image[k];
   }
   else if(sampling == 1.0f)
   {
@@ -477,12 +477,6 @@ static inline void fast_surface_blur(float *const restrict image,
     {
       // Process the intermediate filtered image
       apply_linear_blending(ds_image, ds_ab, num_elem_ds);
-    }
-    else
-    {
-      // Increase the radius for the next iteration
-      ds_radius *= 2.0f;
-      feathering /= 2.0f;
     }
   }
 


### PR DESCRIPTION
* fix #3116 by avoiding to interpolate the settings out of [-8; 0] EV.
* clamp the interpolated exposure correction in [-2;+2] EV, as the user-input settings.
* propagate the change introduced in d3bbd260cecf11fb0026fc7c79abaa4c63c2c887 on default params and presets.
* set default mask compensations (exposure and contrast) to 0 by default.
* don't increase the window radius between iterations of guided filter (previous edits will be slightly affected) for a more intuitive behaviour.
* don't clamp mask values if quantization is set to 0.