### PR TITLE
add standard variables to watermark

### DIFF
--- a/doc/usermanual/darkroom/modules/effect/watermark.xml
+++ b/doc/usermanual/darkroom/modules/effect/watermark.xml
@@ -53,7 +53,8 @@
 
     <para>
       Here follows a list of available variable strings that is supported for substitution
-      within the svg document.
+      within the svg document. Beside this list you can also use the variable strings defined
+      in export selected module.
       <informaltable frame="none" width="80%">
         <tgroup cols="2" colsep="0" rowsep="0">
           <tbody>

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -29,6 +29,14 @@ uint32_t dt_lib_export_metadata_default_flags()
 const char flags_keyword[] = "plugins/lighttable/export/metadata_flags";
 const char formula_keyword[] = "plugins/lighttable/export/metadata_formula";
 
+uint32_t dt_lib_export_metadata_get_conf_flags()
+{
+  char *metadata_flags = dt_conf_get_string(flags_keyword);
+  const int32_t flags = strtol(metadata_flags, NULL, 16);
+  g_free(metadata_flags);
+  return flags;
+}
+
 char *dt_lib_export_metadata_get_conf()
 {
   char *metadata_presets = NULL;

--- a/src/common/metadata_export.c
+++ b/src/common/metadata_export.c
@@ -20,7 +20,7 @@
 #include "control/conf.h"
 #include "common/metadata_export.h"
 
-uint32_t dt_lib_export_metadata_default_flags()
+uint32_t dt_lib_export_metadata_default_flags(void)
 {
   const uint32_t flags = DT_META_EXIF | DT_META_METADATA | DT_META_GEOTAG | DT_META_TAG | DT_META_DT_HISTORY;
   return flags;
@@ -29,7 +29,7 @@ uint32_t dt_lib_export_metadata_default_flags()
 const char flags_keyword[] = "plugins/lighttable/export/metadata_flags";
 const char formula_keyword[] = "plugins/lighttable/export/metadata_formula";
 
-uint32_t dt_lib_export_metadata_get_conf_flags()
+uint32_t dt_lib_export_metadata_get_conf_flags(void)
 {
   char *metadata_flags = dt_conf_get_string(flags_keyword);
   const int32_t flags = strtol(metadata_flags, NULL, 16);
@@ -37,7 +37,7 @@ uint32_t dt_lib_export_metadata_get_conf_flags()
   return flags;
 }
 
-char *dt_lib_export_metadata_get_conf()
+char *dt_lib_export_metadata_get_conf(void)
 {
   char *metadata_presets = NULL;
   if(dt_conf_key_exists(flags_keyword))

--- a/src/common/metadata_export.h
+++ b/src/common/metadata_export.h
@@ -38,6 +38,7 @@ typedef struct dt_export_metadata_t
 } dt_export_metadata_t;
 
 uint32_t dt_lib_export_metadata_default_flags();
+uint32_t dt_lib_export_metadata_get_conf_flags();
 char *dt_lib_export_metadata_get_conf();
 void dt_lib_export_metadata_set_conf(const char *metadata_presets);
 

--- a/src/common/metadata_export.h
+++ b/src/common/metadata_export.h
@@ -37,9 +37,9 @@ typedef struct dt_export_metadata_t
   GList *list;
 } dt_export_metadata_t;
 
-uint32_t dt_lib_export_metadata_default_flags();
-uint32_t dt_lib_export_metadata_get_conf_flags();
-char *dt_lib_export_metadata_get_conf();
+uint32_t dt_lib_export_metadata_default_flags(void);
+uint32_t dt_lib_export_metadata_get_conf_flags(void);
+char *dt_lib_export_metadata_get_conf(void);
 void dt_lib_export_metadata_set_conf(const char *metadata_presets);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -810,6 +810,22 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
     g_free(location);
 
   }
+
+  // standard calculation on the remaining variables
+  const int32_t flags = dt_lib_export_metadata_get_conf_flags();
+  dt_variables_params_t *params;
+  dt_variables_params_init(&params);
+  params->filename = image->filename;
+  params->jobcode = "watermark";
+  params->sequence = 0;
+  params->imgid = image->id;
+  dt_variables_set_tags_flags(params, flags);
+  svgdoc = dt_variables_expand(params, svgdata, FALSE);
+  if(svgdoc != svgdata)
+  {
+    g_free(svgdata);
+    svgdata = svgdoc;
+  }
   return svgdoc;
 }
 


### PR DESCRIPTION
Add standard variables calculation and in particular the missing tagging features (private, synonyms and especially categories) to watermark.
The first 2 ones (private and synonyms) use the export metadata configuration flags from darktablerc.
The last one (category) allows to extract from tagging one or several categories for watermarking:
Example "copyrights $(YEAR) $(CATEGORY0(creator))".

dt_variable_expand() is called after watermark specific keywords calculation, so the existing watermark settings should work as usual.

Answers issue #3112 
