### PR TITLE
remove superfluous argument from function pointer call

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -106,25 +106,25 @@ static void dt_iop_modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pi
 }
 
 /* default group for modules which do not implement the default_group() function */
-static int default_group()
+static int default_group(void)
 {
   return IOP_GROUP_BASIC;
 }
 
 /* default flags for modules which does not implement the flags() function */
-static int default_flags()
+static int default_flags(void)
 {
   return 0;
 }
 
 /* default operation tags for modules which does not implement the flags() function */
-static int default_operation_tags()
+static int default_operation_tags(void)
 {
   return 0;
 }
 
 /* default operation tags filter for modules which does not implement the flags() function */
-static int default_operation_tags_filter()
+static int default_operation_tags_filter(void)
 {
   return 0;
 }
@@ -192,11 +192,11 @@ static void default_process(struct dt_iop_module_t *self, struct dt_dev_pixelpip
     dt_unreachable_codepath_with_desc(self->op);
 }
 
-static dt_introspection_field_t *default_get_introspection_linear()
+static dt_introspection_field_t *default_get_introspection_linear(void)
 {
   return NULL;
 }
-static dt_introspection_t *default_get_introspection()
+static dt_introspection_t *default_get_introspection(void)
 {
   return NULL;
 }
@@ -1433,7 +1433,7 @@ static void dt_iop_init_module_so(void *m)
   }
 }
 
-void dt_iop_load_modules_so()
+void dt_iop_load_modules_so(void)
 {
   darktable.iop = dt_module_load_modules("/plugins", sizeof(dt_iop_module_so_t), dt_iop_load_module_so,
                                          dt_iop_init_module_so, NULL);
@@ -2044,7 +2044,7 @@ void dt_iop_nap(int32_t usec)
   g_usleep(usec);
 }
 
-dt_iop_module_t *get_colorout_module()
+dt_iop_module_t *get_colorout_module(void)
 {
   GList *modules = darktable.develop->iop;
   while(modules)

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -171,15 +171,15 @@ typedef struct dt_iop_module_so_t
   int (*introspection_init)(struct dt_iop_module_so_t *self, int api_version);
 
   /** callbacks, loaded once, referenced by the instances. */
-  int (*version)();
-  const char *(*name)();
-  int (*default_group)();
-  int (*flags)();
+  int (*version)(void);
+  const char *(*name)(void);
+  int (*default_group)(void);
+  int (*flags)(void);
 
-  const char *(*description)();
+  const char *(*description)(void);
 
-  int (*operation_tags)();
-  int (*operation_tags_filter)();
+  int (*operation_tags)(void);
+  int (*operation_tags_filter)(void);
 
   /** what do the iop want as an input? */
   void (*input_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
@@ -276,8 +276,8 @@ typedef struct dt_iop_module_so_t
 
   // introspection related callbacks
   gboolean have_introspection;
-  dt_introspection_t *(*get_introspection)();
-  dt_introspection_field_t *(*get_introspection_linear)();
+  dt_introspection_t *(*get_introspection)(void);
+  dt_introspection_field_t *(*get_introspection_linear)(void);
   void *(*get_p)(const void *param, const char *name);
   dt_introspection_field_t *(*get_f)(const char *name);
 
@@ -396,20 +396,20 @@ typedef struct dt_iop_module_t
   GtkWidget *multimenu_button;
 
   /** version of the parameters in the database. */
-  int (*version)();
+  int (*version)(void);
   /** get name of the module, to be translated. */
-  const char *(*name)();
+  const char *(*name)(void);
   /** get the default group this module belongs to. */
-  int (*default_group)();
+  int (*default_group)(void);
   /** get the iop module flags. */
-  int (*flags)();
+  int (*flags)(void);
 
   /** get a descriptive text used for example in a tooltip in more modules */
-  const char *(*description)();
+  const char *(*description)(void);
 
-  int (*operation_tags)();
+  int (*operation_tags)(void);
 
-  int (*operation_tags_filter)();
+  int (*operation_tags_filter)(void);
   void (*input_format)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
                        struct dt_dev_pixelpipe_iop_t *piece, struct dt_iop_buffer_dsc_t *dsc);
   /** what will it output? */
@@ -537,17 +537,17 @@ typedef struct dt_iop_module_t
 
   // introspection related data
   gboolean have_introspection;
-  dt_introspection_t *(*get_introspection)();
-  dt_introspection_field_t *(*get_introspection_linear)();
+  dt_introspection_t *(*get_introspection)(void);
+  dt_introspection_field_t *(*get_introspection_linear)(void);
   void *(*get_p)(const void *param, const char *name);
   dt_introspection_field_t *(*get_f)(const char *name);
 
 } dt_iop_module_t;
 
 /** loads and inits the modules in the plugins/ directory. */
-void dt_iop_load_modules_so();
+void dt_iop_load_modules_so(void);
 /** cleans up the dlopen refs. */
-void dt_iop_unload_modules_so();
+void dt_iop_unload_modules_so(void);
 /** load a module for a given .so */
 int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, struct dt_develop_t *dev);
 /** returns a list of instances referencing stuff loaded in load_modules_so. */
@@ -615,7 +615,7 @@ int dt_iop_breakpoint(struct dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe)
 /** allow plugins to relinquish CPU and go to sleep for some time */
 void dt_iop_nap(int32_t usec);
 
-dt_iop_module_t *get_colorout_module();
+dt_iop_module_t *get_colorout_module(void);
 
 /** returns the localized plugin name for a given op name. must not be freed. */
 gchar *dt_iop_get_localized_name(const gchar *op);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -5046,24 +5046,24 @@ GSList *mouse_actions(struct dt_iop_module_t *self)
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_LEFT;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on segment] select segment"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on segment] select segment"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_RIGHT;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on segment] unselect segment"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on segment] unselect segment"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_SHIFT_MASK;
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s] select all segments from zone"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s] select all segments from zone"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_SHIFT_MASK;
   a->action = DT_MOUSE_ACTION_RIGHT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s] unselect all segments from zone"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s] unselect all segments from zone"), self->name());
   lm = g_slist_append(lm, a);
 
   return lm;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3236,18 +3236,18 @@ GSList *mouse_actions(struct dt_iop_module_t *self)
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on borders] crop"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on borders] crop"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_SHIFT_MASK;
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on borders] crop keeping ratio"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on borders] crop keeping ratio"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_RIGHT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s] define/rotate horizon"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s] define/rotate horizon"), self->name());
   lm = g_slist_append(lm, a);
 
   return lm;

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1290,24 +1290,24 @@ GSList *mouse_actions(struct dt_iop_module_t *self)
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on nodes] change line rotation"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on nodes] change line rotation"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on line] move line"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on line] move line"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_CONTROL_MASK;
   a->action = DT_MOUSE_ACTION_SCROLL;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on line] change density"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on line] change density"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_SHIFT_MASK;
   a->action = DT_MOUSE_ACTION_SCROLL;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on line] change compression"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on line] change compression"), self->name());
   lm = g_slist_append(lm, a);
 
   return lm;

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -62,19 +62,19 @@ void init_global(struct dt_iop_module_so_t *self);
 void cleanup_global(struct dt_iop_module_so_t *self);
 
 /** version of the parameters in the database. */
-int version();
+int version(void);
 /** get name of the module, to be translated. */
-const char *name();
+const char *name(void);
 /** get the default group this module belongs to. */
-int default_group();
+int default_group(void);
 /** get the iop module flags. */
-int flags();
+int flags(void);
 
 /** get a descriptive text used for example in a tooltip in more modules */
-const char *description();
+const char *description(void);
 
-int operation_tags();
-int operation_tags_filter();
+int operation_tags(void);
+int operation_tags_filter(void);
 
 /** what do the iop want as an input? */
 void input_format(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_t *pipe,
@@ -213,8 +213,8 @@ void distort_mask(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *p
 
 // introspection related callbacks, will be auto-implemented if DT_MODULE_INTROSPECTION() is used,
 int introspection_init(struct dt_iop_module_so_t *self, int api_version);
-dt_introspection_t *get_introspection();
-dt_introspection_field_t *get_introspection_linear();
+dt_introspection_t *get_introspection(void);
+dt_introspection_field_t *get_introspection_linear(void);
 void *get_p(const void *param, const char *name);
 dt_introspection_field_t *get_f(const char *name);
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1217,19 +1217,19 @@ GSList *mouse_actions(struct dt_iop_module_t *self)
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on node] change vignette/feather size"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on node] change vignette/feather size"), self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->key.accel_mods = GDK_CONTROL_MASK;
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
   g_snprintf(a->name, sizeof(a->name), _("[%s on node] change vignette/feather size keeping ratio"),
-             self->name(self));
+             self->name());
   lm = g_slist_append(lm, a);
 
   a = (dt_mouse_action_t *)calloc(1, sizeof(dt_mouse_action_t));
   a->action = DT_MOUSE_ACTION_LEFT_DRAG;
-  g_snprintf(a->name, sizeof(a->name), _("[%s on center] move vignette"), self->name(self));
+  g_snprintf(a->name, sizeof(a->name), _("[%s on center] move vignette"), self->name());
   lm = g_slist_append(lm, a);
 
   return lm;

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -688,7 +688,7 @@ void dt_lib_init_presets(dt_lib_module_t *module)
       size_t op_params_size = sqlite3_column_bytes(stmt, 2);
       const char *name = (char *)sqlite3_column_text(stmt, 3);
 
-      int version = module->version(module);
+      int version = module->version();
 
       if(op_version < version)
       {
@@ -789,7 +789,7 @@ static void popup_callback(GtkButton *button, GdkEventButton *event, dt_lib_modu
   dt_lib_module_info_t *mi = (dt_lib_module_info_t *)calloc(1, sizeof(dt_lib_module_info_t));
 
   mi->plugin_name = g_strdup(module->plugin_name);
-  mi->version = module->version(module);
+  mi->version = module->version();
   mi->module = module;
   mi->params = module->get_params(module, &mi->params_size);
 

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -86,7 +86,7 @@ typedef struct dt_lib_module_t
   GtkWidget *expander;
 
   /** version */
-  int (*version)();
+  int (*version)(void);
   /** get name of the module, to be translated. */
   const char *(*name)(struct dt_lib_module_t *self);
   /** get the views which the module should be loaded in. */

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -38,7 +38,7 @@ struct dt_view_t;
 #pragma GCC visibility push(default)
 
 /** version */
-int version();
+int version(void);
 /** get name of the module, to be translated. */
 const char *name(struct dt_lib_module_t *self);
 


### PR DESCRIPTION
Note version was defined as

    int (*version)();

which denotes a function pointer to a function that takes an _unspecified number_ of arguments. See also _Notes_ in https://en.cppreference.com/w/c/language/function_declaration