### PR TITLE
Fixing copy&paste of history

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -612,10 +612,9 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
       dt_iop_module_t *mod_src = (dt_iop_module_t *)(modules_src->data);
 
       // copy from history only if
-      if((_search_history_by_module(dev_src, mod_src) != NULL) &&  // module is in history of source image
-         !(mod_src->default_enabled && !mod_src->enabled) &&       // it's not a disabled module normally enabled by default
-         !dt_iop_is_hidden(mod_src) &&                             // it's not a hidden module
-         !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size)
+      if((_search_history_by_module(dev_src, mod_src) != NULL) && // module is in history of source image
+         !(mod_src->default_enabled && mod_src->enabled && !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size) && // it's not a enabled by default module with unmodified settings
+         !dt_iop_is_hidden(mod_src)) 
         )
       {
         double old_iop_order = mod_src->iop_order;

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -611,9 +611,12 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
     {
       dt_iop_module_t *mod_src = (dt_iop_module_t *)(modules_src->data);
 
-      // only if module is in history of source image, not auto-enabled and not-hidden
-      if((_search_history_by_module(dev_src, mod_src) != NULL) &&
-         !mod_src->default_enabled && !dt_iop_is_hidden(mod_src))
+      // copy from history only if
+      if((_search_history_by_module(dev_src, mod_src) != NULL) &&  // module is in history of source image
+         !(mod_src->default_enabled && !mod_src->enabled) &&       // it's not a disabled module normally enabled by default
+         !dt_iop_is_hidden(mod_src) &&                             // it's not a hidden module
+         !memcmp(mod_src->params, mod_src->default_params, mod_src->params_size)
+        )
       {
         double old_iop_order = mod_src->iop_order;
         if (iop_order_version_src != iop_order_version_dest)

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -34,6 +34,8 @@
 #include "develop/blend.h"
 #include "develop/masks.h"
 
+#define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
+
 void dt_history_item_free(gpointer data)
 {
   dt_history_item_t *item = (dt_history_item_t *)data;
@@ -546,6 +548,8 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   dev_dest->iop = dt_iop_load_modules_ext(dev_dest, TRUE);
 
   dt_dev_read_history_ext(dev_src, imgid, TRUE);
+
+  // This prepends the default modules and converts just in case it's an empty history
   dt_dev_read_history_ext(dev_dest, dest_imgid, TRUE);
 
   dt_ioppr_check_iop_order(dev_src, imgid, "_history_copy_and_paste_on_image_merge ");
@@ -557,9 +561,19 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   dt_ioppr_check_iop_order(dev_src, imgid, "_history_copy_and_paste_on_image_merge 1");
   dt_ioppr_check_iop_order(dev_dest, imgid, "_history_copy_and_paste_on_image_merge 1");
 
+  const int iop_order_version_src = dt_image_get_iop_order_version(imgid);
+
+  int iop_order_version_dest = dt_image_get_iop_order_version(dest_imgid);
+  GList *dest_iop_list = dt_ioppr_get_iop_order_list(&iop_order_version_dest);
+
   // the user have selected some history entries
+  if (DT_IOP_ORDER_INFO)
+    fprintf(stderr,"\n ^^^^^ Merging history from image %i v(%i) --> %i v(%i), ",
+            imgid, iop_order_version_src, dest_imgid, iop_order_version_dest);
+
   if(ops)
   {
+    if (DT_IOP_ORDER_INFO) fprintf(stderr," selected ops");
     // copy only selected history entries
     GList *l = g_list_last(ops);
     while(l)
@@ -570,8 +584,19 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
 
       if(hist)
       {
-        // merge the entry
-        dt_history_merge_module_into_history(dev_dest, dev_src, hist->module, &modules_used, FALSE);
+        double old_iop_order = hist->module->iop_order;
+
+        if (iop_order_version_src != iop_order_version_dest)
+          hist->module->iop_order = dt_ioppr_get_iop_order(dest_iop_list, hist->module->op) + (double)hist->module->multi_priority / 100.0f;
+
+        if (!dt_iop_is_hidden(hist->module))
+        { if (DT_IOP_ORDER_INFO)
+          fprintf(stderr,"\n  module %20s, order %9.5f->%9.5f, multiprio %i",
+                hist->module->op, old_iop_order, hist->module->iop_order, hist->module->multi_priority);
+
+          // merge the entry
+          dt_history_merge_module_into_history(dev_dest, dev_src, hist->module, &modules_used, FALSE);
+        }
       }
 
       l = g_list_previous(l);
@@ -579,15 +604,25 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
   }
   else
   {
+    if (DT_IOP_ORDER_INFO) fprintf(stderr," all modules");
     // we will copy all modules
     GList *modules_src = g_list_first(dev_src->iop);
     while(modules_src)
     {
       dt_iop_module_t *mod_src = (dt_iop_module_t *)(modules_src->data);
 
-      // but only if module is in history in source image
-      if(_search_history_by_module(dev_src, mod_src) != NULL)
+      // only if module is in history of source image, not auto-enabled and not-hidden
+      if((_search_history_by_module(dev_src, mod_src) != NULL) &&
+         !mod_src->default_enabled && !dt_iop_is_hidden(mod_src))
       {
+        double old_iop_order = mod_src->iop_order;
+        if (iop_order_version_src != iop_order_version_dest)
+          mod_src->iop_order = dt_ioppr_get_iop_order(dest_iop_list, mod_src->op) + (double)mod_src->multi_priority / 100.0f;
+
+        if (DT_IOP_ORDER_INFO)
+          fprintf(stderr,"\n  module %20s, order %9.5f->%9.5f, multiprio %i",
+                mod_src->op, old_iop_order, mod_src->iop_order, mod_src->multi_priority);
+
         // merge the module into dest image
         dt_history_merge_module_into_history(dev_dest, dev_src, mod_src, &modules_used, FALSE);
       }
@@ -595,6 +630,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
       modules_src = g_list_next(modules_src);
     }
   }
+  if (DT_IOP_ORDER_INFO) fprintf(stderr,"\nvvvvv\n");
 
   dt_ioppr_check_iop_order(dev_src, imgid, "_history_copy_and_paste_on_image_merge 2");
   dt_ioppr_check_iop_order(dev_dest, imgid, "_history_copy_and_paste_on_image_merge 2");
@@ -708,6 +744,9 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
     return 1;
   }
 
+  // Just in case lock the database
+  dt_pthread_mutex_lock(&darktable.db_insert);
+
   // be sure the current history is written before pasting some other history data
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(cv->view((dt_view_t *)cv) == DT_VIEW_DARKROOM) dt_dev_write_history(darktable.develop);
@@ -751,6 +790,8 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
     dt_image_set_aspect_ratio(dest_imgid);
   else
     dt_image_reset_aspect_ratio(dest_imgid);
+
+  dt_pthread_mutex_unlock(&darktable.db_insert);
 
   return ret_val;
 }
@@ -1181,6 +1222,7 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
   return result;
 }
 
+#undef DT_IOP_ORDER_INFO
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -592,7 +592,7 @@ static void _ioppr_insert_iop_before(GList **_iop_order_list, GList *history_lis
     {
       // set the iop_order
       iop_order_new->iop_order = iop_order_prev + (iop_order_next - iop_order_prev) / 2.0;
-      if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_insert_iop_before %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_new,iop_order_new->iop_order,iop_order_new->iop_order,iop_order_prev,iop_order_next);
+//      if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_insert_iop_before %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_new,iop_order_new->iop_order,iop_order_new->iop_order,iop_order_prev,iop_order_next);
 
       // insert it on the proper order
       iop_order_list = g_list_insert(iop_order_list, iop_order_new, position);
@@ -703,7 +703,8 @@ static void _ioppr_move_iop_before(GList **_iop_order_list, const char *op_curre
 
     // insert it on the proper order
     iop_order_list = g_list_insert(iop_order_list, iop_order_current, position);
-    if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_move_iop_before   %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_current,iop_order_current->iop_order,iop_order_current->iop_order,iop_order_prev->iop_order,iop_order_next->iop_order);
+   // VERY noisy so disable now
+   //    if (DT_IOP_ORDER_INFO) fprintf(stderr,"\n  _ioppr_move_iop_before   %16s: %14.11f [xmp:%8.4f], prev %14.11f, next %14.11f",op_current,iop_order_current->iop_order,iop_order_current->iop_order,iop_order_prev->iop_order,iop_order_next->iop_order);
   }
   else
   {

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2061,6 +2061,18 @@ dt_iop_module_t *get_module_by_name(const char *op)
   return NULL;
 }
 
+int get_module_flags(const char *op)
+{
+  GList *modules = darktable.iop;
+  while(modules)
+  {
+    dt_iop_module_so_t *module = (dt_iop_module_so_t *)modules->data;
+    if(!strcmp(module->op, op)) return module->flags();
+    modules = g_list_next(modules);
+  }
+  return 0;
+}
+
 static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2046,11 +2046,16 @@ void dt_iop_nap(int32_t usec)
 
 dt_iop_module_t *get_colorout_module(void)
 {
+  return get_module_by_name("colorout");
+}
+
+dt_iop_module_t *get_module_by_name(const char *op)
+{
   GList *modules = darktable.develop->iop;
   while(modules)
   {
     dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-    if(!strcmp(module->op, "colorout")) return module;
+    if(!strcmp(module->op, op)) return module;
     modules = g_list_next(modules);
   }
   return NULL;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -619,6 +619,9 @@ void dt_iop_nap(int32_t usec);
 dt_iop_module_t *get_colorout_module(void);
 dt_iop_module_t *get_module_by_name(const char *op);
 
+/** get module flags, works in dev and lt mode */
+int get_module_flags(const char *op);
+
 /** returns the localized plugin name for a given op name. must not be freed. */
 gchar *dt_iop_get_localized_name(const gchar *op);
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -615,7 +615,9 @@ int dt_iop_breakpoint(struct dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe)
 /** allow plugins to relinquish CPU and go to sleep for some time */
 void dt_iop_nap(int32_t usec);
 
+/** get module by name and colorout, works only with a dev mode */
 dt_iop_module_t *get_colorout_module(void);
+dt_iop_module_t *get_module_by_name(const char *op);
 
 /** returns the localized plugin name for a given op name. must not be freed. */
 gchar *dt_iop_get_localized_name(const gchar *op);

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -217,12 +217,14 @@ int dt_gui_hist_dialog_new(dt_gui_hist_dialog_t *d, int imgid, gboolean iscopy)
     do
     {
       dt_history_item_t *item = (dt_history_item_t *)items->data;
-
-      gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
-      gtk_list_store_set(GTK_LIST_STORE(liststore), &iter, DT_HIST_ITEMS_COL_ENABLED,
+      // This is sort of a hack, any better solution?
+      if (strcmp(item->op,"gamma") != 0)
+      {
+        gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
+        gtk_list_store_set(GTK_LIST_STORE(liststore), &iter, DT_HIST_ITEMS_COL_ENABLED,
                          iscopy ? TRUE : _gui_is_set(d->selops, item->num), DT_HIST_ITEMS_COL_NAME,
                          item->name, DT_HIST_ITEMS_COL_NUM, (guint)item->num, -1);
-
+      }
     } while((items = g_list_next(items)));
     g_list_free_full(items, dt_history_item_free);
   }

--- a/src/gui/hist_dialog.c
+++ b/src/gui/hist_dialog.c
@@ -73,11 +73,6 @@ static void _gui_hist_set_items(dt_gui_hist_dialog_t *d, gboolean active)
   }
 }
 
-static gint _g_list_find_module_by_name(gconstpointer a, gconstpointer b)
-{
-  return strncmp(((dt_iop_module_t *)a)->op, b, strlen(((dt_iop_module_t *)a)->op));
-}
-
 static void _gui_hist_copy_response(GtkDialog *dialog, gint response_id, dt_gui_hist_dialog_t *g)
 {
   switch(response_id)
@@ -214,12 +209,6 @@ int dt_gui_hist_dialog_new(dt_gui_hist_dialog_t *d, int imgid, gboolean iscopy)
   gtk_tree_selection_set_mode(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->items)), GTK_SELECTION_SINGLE);
   gtk_tree_view_set_model(GTK_TREE_VIEW(d->items), GTK_TREE_MODEL(liststore));
 
-  // we need access to the modules flags so ...
-  dt_develop_t _dev_test = { 0 };
-  dt_develop_t *dev_test = &_dev_test;
-  dt_dev_init(dev_test, FALSE);
-  dev_test->iop = dt_iop_load_modules_ext(dev_test, TRUE);
-
   /* fill list with history items */
   GtkTreeIter iter;
   GList *items = dt_history_get_items(imgid, FALSE);
@@ -229,20 +218,7 @@ int dt_gui_hist_dialog_new(dt_gui_hist_dialog_t *d, int imgid, gboolean iscopy)
     {
       dt_history_item_t *item = (dt_history_item_t *)items->data;
 
-      /* lookup history item module */
-      gboolean enabled = TRUE;
-      dt_iop_module_t *module = NULL;
-      GList *modules = g_list_first(dev_test->iop);
-      if(modules)
-      {
-        GList *result = g_list_find_custom(modules, item->op, _g_list_find_module_by_name);
-        if(result)
-        {
-          module = (dt_iop_module_t *)(result->data);
-          if ((module->flags() & IOP_FLAGS_HIDDEN)) enabled = FALSE;
-        }
-      }
-      if (enabled)
+      if(!(get_module_flags(item->op) & IOP_FLAGS_HIDDEN))
       {
         gtk_list_store_append(GTK_LIST_STORE(liststore), &iter);
         gtk_list_store_set(GTK_LIST_STORE(liststore), &iter, DT_HIST_ITEMS_COL_ENABLED,
@@ -257,8 +233,6 @@ int dt_gui_hist_dialog_new(dt_gui_hist_dialog_t *d, int imgid, gboolean iscopy)
     dt_control_log(_("can't copy history out of unaltered image"));
     return GTK_RESPONSE_CANCEL;
   }
-
-  dt_dev_cleanup(dev_test);      
 
   g_signal_connect(GTK_TREE_VIEW(d->items), "row-activated", (GCallback) tree_on_row_activated, GTK_WIDGET(dialog));
   g_object_unref(liststore);


### PR DESCRIPTION
See discussion issue #3153

This is what i made of the discussion, it should fix #3153 #3123 #3164 .

- tests in history.c
- writes to console what is done when using -d ioporder
- commented a **very** noisy and now irrelevant iop_order information
- modified the hist_dialog disabling gamma. Any better solution?

Please review & test @TurboGit and @parafin 