### PR TITLE
common: Improve debug output if image support is missing

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -279,8 +279,10 @@ static int dt_opencl_device_init(dt_opencl_t *cl, const int dev, cl_device_id *d
 
   if(!image_support)
   {
-    dt_print(DT_DEBUG_OPENCL, "[opencl_init] discarding device %d `%s' due to missing image support.\n", k,
-             infostr);
+    dt_print(DT_DEBUG_OPENCL,
+             "[opencl_init] discarding device %d `%s' - The OpenCL driver "
+             "doesn't provide image support. See also 'clinfo' output.\n",
+             k, infostr);
     res = -1;
     goto end;
   }


### PR DESCRIPTION
It should make more clear what is actually wrong and point them to clinfo.

See https://discuss.pixls.us/t/no-opencl-darktable-2-7-0-build-and-installed-from-darktable-git/14508