### PR TITLE
fix #3203 (scroll) + #3206 (dt tags + default for hierarchical tags)

### DIFF
--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -162,6 +162,12 @@ gboolean dt_tag_new(const char *name, guint *tagid)
   }
   sqlite3_finalize(stmt);
 
+  if(g_strstr_len(name, -1, "darktable|") == name)
+  {
+    // clear darktable tags list
+    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.darktable_tags", NULL, NULL, NULL);
+  }
+
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "INSERT INTO data.tags (id, name) VALUES (NULL, ?1)",
                               -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
@@ -852,6 +858,13 @@ GList *dt_tag_get_hierarchical(gint imgid)
   return tags;
 }
 
+static gint is_tag_a_category(gconstpointer a, gconstpointer b)
+{
+  dt_tag_t *ta = (dt_tag_t *)a;
+  dt_tag_t *tb = (dt_tag_t *)b;
+  return ((g_strcmp0(ta->tag, tb->tag) == 0) && ((ta->flags | tb->flags) & DT_TF_CATEGORY)) ? 0 : -1;
+}
+
 GList *dt_tag_get_list_export(gint imgid, int32_t flags)
 {
   GList *taglist = NULL;
@@ -865,16 +878,36 @@ GList *dt_tag_get_list_export(gint imgid, int32_t flags)
 
   if(count < 1) return NULL;
   GList *sorted_tags = dt_sort_tag(taglist, 0);
+  sorted_tags = g_list_reverse(sorted_tags);
 
   for(; sorted_tags; sorted_tags = g_list_next(sorted_tags))
   {
     dt_tag_t *t = (dt_tag_t *)sorted_tags->data;
     if ((export_private_tags || !(t->flags & DT_TF_PRIVATE))
         && !(t->flags & DT_TF_CATEGORY)
-        && !(omit_tag_hierarchy && (t->flags & DT_TF_PATH)))
+        && !(t->flags & DT_TF_PATH))
     {
       gchar *tagname = t->leave;
       tags = g_list_prepend(tags, g_strdup(tagname));
+
+      // add path tag as necessary
+      if(!omit_tag_hierarchy)
+      {
+        GList *next = g_list_next(sorted_tags);
+        gchar *end = g_strrstr(t->tag, "|");
+        while (end)
+        {
+          end[0] = '\0';
+          end = g_strrstr(t->tag, "|");
+          if (!next || !g_list_find_custom(next, t, (GCompareFunc)is_tag_a_category))
+          {
+            const gchar *tag = end ? end + 1 : t->tag;
+            tags = g_list_prepend(tags, g_strdup(tag));
+          }
+        }
+      }
+
+      // add synonyms as necessary
       if (export_tag_synomyms)
       {
         gchar *synonyms = t->synonym;

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -382,18 +382,17 @@ void tree_tagname_show(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTre
 {
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  guint id;
   gchar *name;
   gchar *path;
   guint count;
   gchar *coltext;
   gint flags;
 
-  gtk_tree_model_get(model, iter, DT_LIB_TAGGING_COL_ID, &id, DT_LIB_TAGGING_COL_TAG, &name,
+  gtk_tree_model_get(model, iter, DT_LIB_TAGGING_COL_TAG, &name,
                   DT_LIB_TAGGING_COL_COUNT, &count, DT_LIB_TAGGING_COL_FLAGS, &flags,
                   DT_LIB_TAGGING_COL_PATH, &path, -1);
   const gboolean hide = dictionary_view ? (d->tree_flag ? TRUE : d->hide_path_flag) : d->hide_path_flag;
-  const gboolean istag = id && !(flags & DT_TF_CATEGORY);
+  const gboolean istag = !(flags & DT_TF_CATEGORY);
   if ((dictionary_view && !count) || (!dictionary_view && count <= 1))
   {
     coltext = g_markup_printf_escaped(istag ? "%s" : "<i>%s</i>", hide ? name : path);
@@ -2039,10 +2038,13 @@ static gboolean mouse_scroll_attached(GtkWidget *treeview, GdkEventScroll *event
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (event->state & GDK_CONTROL_MASK)
   {
+    const gint increment = DT_PIXEL_APPLY_DPI(10.0);
+    const gint min_height = DT_PIXEL_APPLY_DPI(100.0);
+    const gint max_height = DT_PIXEL_APPLY_DPI(500.0);
     gint width, height;
     gtk_widget_get_size_request (GTK_WIDGET(d->attached_window), &width, &height);
-    height = height + 10.0 * event->delta_y;
-    height = (height < 100.0) ? 100.0 : (height > 500.0) ? 500.0 : height;
+    height = height + increment * event->delta_y;
+    height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
     gtk_widget_set_size_request(GTK_WIDGET(d->attached_window), -1, DT_PIXEL_APPLY_DPI((gint)height));
     dt_conf_set_int("plugins/lighttable/tagging/heightattachedwindow", (gint)height);
     return TRUE;
@@ -2055,10 +2057,13 @@ static gboolean mouse_scroll_dictionary(GtkWidget *treeview, GdkEventScroll *eve
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (event->state & GDK_CONTROL_MASK)
   {
+    const gint increment = DT_PIXEL_APPLY_DPI(10.0);
+    const gint min_height = DT_PIXEL_APPLY_DPI(100.0);
+    const gint max_height = DT_PIXEL_APPLY_DPI(1000.0);
     gint width, height;
     gtk_widget_get_size_request (GTK_WIDGET(d->dictionary_window), &width, &height);
-    height = height + 10.0 * event->delta_y;
-    height = (height < 100.0) ? 100.0 : (height > 1000.0) ? 1000.0 : height;
+    height = height + increment * event->delta_y;
+    height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
     gtk_widget_set_size_request(GTK_WIDGET(d->dictionary_window), -1, DT_PIXEL_APPLY_DPI((gint)height));
     dt_conf_set_int("plugins/lighttable/tagging/heightdictionarywindow", (gint)height);
     return TRUE;


### PR DESCRIPTION
should fix 2 bugs:
- ctrl-scroll for 4k screen (as suggested in #3203)
- just created dt tags are exported (seen in #3206 3206)

comes back to previous logic about path elements in hierarchical tags: considered as keywords by default instead of category (#3206). If the leave tag is set as category, then all the path elements are also seen as category.
The flag "omit hierarchy" is also more logical with that change. 
This should avoid to break former habits about exported tags (Subject).

