### PR TITLE
Revise the altivec wrapper to make the #undefs unneeded.

### DIFF
--- a/src/ppc64le/altivec.h
+++ b/src/ppc64le/altivec.h
@@ -1,10 +1,11 @@
 
-#include_next <altivec.h>
-
-#undef pixel
-
-#ifdef __cplusplus
-#undef bool // type/macro name collisions are bad.
+#ifndef __APPLE_ALTIVEC__
+/* Prevent gcc from defining the keywords as macros. Do not manually
+ * undef for c99 stdbool.h compat.
+ */
+  #define __APPLE_ALTIVEC__ 1
+  #include_next <altivec.h>
+  #undef __APPLE_ALTIVEC__
 #else
-#define bool _Bool // needed for some of the Lua headers, AFAICT.
+  #include_next <altivec.h>
 #endif


### PR DESCRIPTION
This is a revised, cleaner, wrapper with better behaviour.