### PR TITLE
Revert "lock db at high level **per image** (#3201)"

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -435,10 +435,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   pthread_mutexattr_t recursive_locking;
   pthread_mutexattr_init(&recursive_locking);
   pthread_mutexattr_settype(&recursive_locking, PTHREAD_MUTEX_RECURSIVE);
-  for (int k=0; k<DT_IMAGE_DBLOCKS; k++)  
-  {
-    dt_pthread_mutex_init(&(darktable.db_image[k]),&(recursive_locking));
-  }
+
+  dt_pthread_mutex_init(&(darktable.db_insert), &recursive_locking);
   dt_pthread_mutex_init(&(darktable.plugin_threadsafe), NULL);
   dt_pthread_mutex_init(&(darktable.capabilities_threadsafe), NULL);
   dt_pthread_mutex_init(&(darktable.exiv2_threadsafe), NULL);
@@ -1145,10 +1143,7 @@ void dt_cleanup()
 
   dt_capabilities_cleanup();
 
-  for (int k=0; k<DT_IMAGE_DBLOCKS; k++)  
-  {
-    dt_pthread_mutex_destroy(&(darktable.db_image[k]));
-  }
+  dt_pthread_mutex_destroy(&(darktable.db_insert));
   dt_pthread_mutex_destroy(&(darktable.plugin_threadsafe));
   dt_pthread_mutex_destroy(&(darktable.capabilities_threadsafe));
   dt_pthread_mutex_destroy(&(darktable.exiv2_threadsafe));

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -200,6 +200,7 @@ int dt_film_new(dt_film_t *film, const char *directory)
                                 -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, datetime, -1, SQLITE_STATIC);
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, directory, -1, SQLITE_STATIC);
+    dt_pthread_mutex_lock(&darktable.db_insert);
     rc = sqlite3_step(stmt);
     if(rc != SQLITE_DONE)
       fprintf(stderr, "[film_new] failed to insert film roll! %s\n",
@@ -210,6 +211,7 @@ int dt_film_new(dt_film_t *film, const char *directory)
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, directory, -1, SQLITE_STATIC);
     if(sqlite3_step(stmt) == SQLITE_ROW) film->id = sqlite3_column_int(stmt, 0);
     sqlite3_finalize(stmt);
+    dt_pthread_mutex_unlock(&darktable.db_insert);
   }
 
   if(film->id <= 0) return 0;

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -67,7 +67,7 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
     dt_history_snapshot_undo_create(hist->imgid, &hist->before, &hist->before_history_end);
   }
 
-  dt_lock_image(imgid);
+  dt_pthread_mutex_lock(&darktable.db_insert);
 
   sqlite3_stmt *stmt;
 
@@ -104,7 +104,7 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
   dt_tag_detach_by_string("darktable|style%", imgid);
   dt_tag_detach_by_string("darktable|changed", imgid);
 
-  dt_unlock_image(imgid);
+  dt_pthread_mutex_unlock(&darktable.db_insert);
 
   if(undo)
   {
@@ -156,7 +156,6 @@ void dt_history_delete_on_selection()
 
 int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only)
 {
-  dt_lock_image(imgid);
   dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
   if(img)
   {
@@ -164,11 +163,8 @@ int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only
     hist->imgid = imgid;
     dt_history_snapshot_undo_create(hist->imgid, &hist->before, &hist->before_history_end);
 
-    if(dt_exif_xmp_read(img, filename, history_only))
-    {
-      dt_unlock_image(imgid);
-      return 1;
-    }
+    if(dt_exif_xmp_read(img, filename, history_only)) return 1;
+
     dt_history_snapshot_undo_create(hist->imgid, &hist->after, &hist->after_history_end);
     dt_undo_start_group(darktable.undo, DT_UNDO_LT_HISTORY);
     dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_HISTORY, (dt_undo_data_t)hist,
@@ -182,7 +178,6 @@ int dt_history_load_and_apply(const int imgid, gchar *filename, int history_only
     dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
     dt_image_reset_final_size(imgid);
   }
-  dt_unlock_image(imgid);
   return 0;
 }
 
@@ -765,7 +760,8 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
     return 1;
   }
 
-  dt_lock_image_pair(imgid,dest_imgid);
+  // Just in case lock the database
+  dt_pthread_mutex_lock(&darktable.db_insert);
 
   // be sure the current history is written before pasting some other history data
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
@@ -811,7 +807,7 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
   else
     dt_image_reset_aspect_ratio(dest_imgid);
 
-  dt_unlock_image_pair(imgid,dest_imgid);
+  dt_pthread_mutex_unlock(&darktable.db_insert);
 
   return ret_val;
 }
@@ -987,7 +983,6 @@ static int dt_history_end_attop(int32_t imgid)
 */
 void dt_history_compress_on_image(int32_t imgid)
 {
-  dt_lock_image(imgid);
   sqlite3_stmt *stmt;
 
   // get history_end for image
@@ -1003,7 +998,6 @@ void dt_history_compress_on_image(int32_t imgid)
   if (my_history_end == 0)
   {
     dt_history_delete_on_image(imgid);
-    dt_unlock_image(imgid);
     return;
   }
   // compress history, keep disabled modules as documented
@@ -1101,33 +1095,45 @@ void dt_history_compress_on_image(int32_t imgid)
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
   }
-  dt_unlock_image(imgid);
 }
 
+#define no_forced_reordering FALSE
+#define give_reorder_information FALSE
 static void _history_reorder(int32_t imgid)
 {
   int32_t dummy = 0x7fffffff;
   sqlite3_stmt *stmt;
+  if(give_reorder_information) fprintf(stderr,"\n\n_history reorder for image: %i",imgid);
 
-  // make sure running jobs can't interfere here as the followiing code uses a fixed dummy id
-  // and also intends to have a "properly" orderered database
-  dt_lock_image_pair(imgid,dummy);
+  if(no_forced_reordering)
+  {
+    if (give_reorder_information) fprintf(stderr,", no action\n");
+  }
+  else
+  {
+    if (give_reorder_information) fprintf(stderr,", reorder\n");
+    // make sure running jobs can't interfere here as the followiing code uses a fixed dummy id
+    // and also intends to have a "properly" orderered database
+    dt_pthread_mutex_lock(&darktable.db_insert);
 
-  _history_copy_and_paste_on_image_overwrite(imgid, dummy, 0);
-  _history_copy_and_paste_on_image_overwrite(dummy, imgid, 0);
+    _history_copy_and_paste_on_image_overwrite(imgid, dummy, 0);
+    _history_copy_and_paste_on_image_overwrite(dummy, imgid, 0);
 
-  // make sure a cleanup
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.history WHERE imgid = ?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dummy);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
+    // make sure a cleanup
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.history WHERE imgid = ?1", -1, &stmt, NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dummy);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.masks_history WHERE imgid = ?1", -1, &stmt,NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dummy);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-  dt_unlock_image_pair(imgid,dummy);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.masks_history WHERE imgid = ?1", -1, &stmt,NULL);
+    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, dummy);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    dt_pthread_mutex_unlock(&darktable.db_insert);
+  }
 }
+#undef give_reorder_information
+#undef no_forced_reordering
 
 int dt_history_compress_on_selection()
 {
@@ -1140,7 +1146,6 @@ int dt_history_compress_on_selection()
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     int imgid = sqlite3_column_int(stmt, 0);
-    dt_lock_image(imgid);
     const int test = dt_history_end_attop(imgid);
     if (test == 1) // we do a compression and we know for sure history_end is at the top!
     {
@@ -1214,9 +1219,6 @@ int dt_history_compress_on_selection()
     }
     if (test == -1)
       dt_history_set_compress_problem(imgid, FALSE);
-
-    dt_unlock_image(imgid);
-
   }
 
   sqlite3_finalize(stmt);
@@ -1225,7 +1227,6 @@ int dt_history_compress_on_selection()
 
 gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
 {
-  dt_lock_image(imgid);
   gboolean result = FALSE;
   sqlite3_stmt *stmt;
 
@@ -1237,7 +1238,6 @@ gboolean dt_history_check_module_exists(int32_t imgid, const char *operation)
   if (sqlite3_step(stmt) == SQLITE_ROW) result = TRUE;
   sqlite3_finalize(stmt);
 
-  dt_unlock_image(imgid);
   return result;
 }
 

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -32,8 +32,6 @@ void dt_history_snapshot_undo_create(int32_t imgid, int *snap_id, int *history_e
   sqlite3_stmt *stmt;
   gboolean all_ok = TRUE;
 
-  dt_lock_image(imgid);
-
   // get current history end
   *history_end = 0;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
@@ -82,8 +80,6 @@ void dt_history_snapshot_undo_create(int32_t imgid, int *snap_id, int *history_e
     sqlite3_exec(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
   else
     sqlite3_exec(dt_database_get(darktable.db), "ROLLBACK_TRANSACTION", NULL, NULL, NULL);
-
-  dt_unlock_image(imgid);
 }
 
 static void _history_snapshot_undo_restore(int32_t imgid, int snap_id, int history_end)
@@ -91,8 +87,6 @@ static void _history_snapshot_undo_restore(int32_t imgid, int snap_id, int histo
   // restore the given snapshot for imgid
   sqlite3_stmt *stmt;
   gboolean all_ok = TRUE;
-
-  dt_lock_image(imgid);
 
   sqlite3_exec(dt_database_get(darktable.db), "BEGIN TRANSACTION", NULL, NULL, NULL);
 
@@ -133,8 +127,6 @@ static void _history_snapshot_undo_restore(int32_t imgid, int snap_id, int histo
     sqlite3_exec(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
   else
     sqlite3_exec(dt_database_get(darktable.db), "ROLLBACK_TRANSACTION", NULL, NULL, NULL);
-
-  dt_unlock_image(imgid);
 }
 
 static void _clear_undo_snapshot(int32_t imgid, int snap_id)


### PR DESCRIPTION
This reverts commit 979787652e0106d15023c879271f498a20b2fa87.