### PR TITLE
accel window : default shortcut

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1288,7 +1288,7 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_accel_register_global(NC_("accel", "zoom out"), GDK_KEY_minus, GDK_CONTROL_MASK);
 
   // accels window
-  dt_accel_register_global(NC_("accel", "show accels window"), 0, 0);
+  dt_accel_register_global(NC_("accel", "show accels window"), GDK_KEY_h, 0);
 
   darktable.gui->reset = 0;
 


### PR DESCRIPTION
Map accels window to "H" by default.
There was currently no default shortcut for this feature (I've completely forgot that part in my first implementation) . This was too bad, as it's especially useful for newcomers.
Note that I've already mentioned H as default shortcut for this in the usermanual...