### PR TITLE
tone equalizer: better default settings

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1515,9 +1515,9 @@ void init(dt_iop_module_t *module)
                                                                       .method = DT_TONEEQ_NORM_2,
                                                                       .details = DT_TONEEQ_GUIDED,
                                                                       .blending = 25.0f,
-                                                                      .feathering = 25.0f,
-                                                                      .contrast_boost = 0.0f,
-                                                                      .exposure_boost = 0.0f };
+                                                                      .feathering = 10.0f,
+                                                                      .contrast_boost = 3.0f,
+                                                                      .exposure_boost = -3.0f };
   memcpy(module->params, &tmp, sizeof(dt_iop_toneequalizer_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_toneequalizer_params_t));
 }


### PR DESCRIPTION
This is another attempt to provide more general masking settings so users may not need to bother at all with the masking tab in tone equalizer for at least 80% of their pictures.