### PR TITLE
bilat (local contrast): improve slightly the default params

### DIFF
--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -394,7 +394,7 @@ void init(dt_iop_module_t *module)
   module->params_size = sizeof(dt_iop_bilat_params_t);
   module->gui_data = NULL;
   // init defaults:
-  dt_iop_bilat_params_t tmp = (dt_iop_bilat_params_t){ s_mode_local_laplacian, 1.0, 1.0, 0.2, 0.2 };
+  dt_iop_bilat_params_t tmp = (dt_iop_bilat_params_t){ s_mode_local_laplacian, 0.5, 0.5, 0.25, 0.5 };
 
   memcpy(module->params, &tmp, sizeof(dt_iop_bilat_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_bilat_params_t));


### PR DESCRIPTION
Taking into account that the local contrast module is placed after filmic (global tonemapping), modify the default params to restore the local contrast that might have been lost in the tone mapping.