### PR TITLE
darktable wrapper script disabling gnome nightlight

### DIFF
--- a/tools/darktable-gnome-nightlight-disabled.sh
+++ b/tools/darktable-gnome-nightlight-disabled.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# command line: put this file in path before darktable as: /usr/local/bin/darktable 
+# desktop icon: edit /usr/share/applications/darktable.desktop: Exec and TryExec pointing to /usr/local/bin/darktable  
+# (ubuntu18.04, dt from git)
+#
+
+[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -en "$0" "$0" "$@" || :
+
+gnomenightlight="org.gnome.settings-daemon.plugins.color night-light-enabled"
+
+trap "gsettings set ${gnomenightlight} $(gsettings get ${gnomenightlight})" EXIT
+
+gsettings set ${gnomenightlight} false
+
+/opt/darktable/bin/darktable "$@"


### PR DESCRIPTION
this is for disabling nightlight when darktable is running by commandline or desktop icon
much better for working on photos, 
i forget too often to disable or get trapped by smooth activation of nightlight

the file should be placed as 'darktable' in /usr/local/bin before the original executable (if in path...)
the /opt/.. location from git is hardcoded as original executable path
the desktop file should be edited pointing to this wrapper
the nightlight mode is restored when darktable finishes
the script is secured with flock (maybe not necessary, i feel better...)