### PR TITLE
fix accel window glitch

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -712,8 +712,7 @@ filechooserdialog scrolledwindow
 /* Tree view (lists and tables) */
 
 treeview,
-filechooserwidget treeview,
-treeview.view *
+filechooserwidget treeview
 {
   background-color: @field_bg;
   color: @field_fg;


### PR DESCRIPTION
Fix a glitch on accel window (see below). I've made multiple tests/checks to be sure removing this line doesn't affect any part. Other lists on lighttable and darkroom seen (many of them) remain the same with or without this line, except the glitch that this PR solve.

Without this PR :
![Capture-20191104204454-1119x70](https://user-images.githubusercontent.com/45535283/68153497-e1f0ed00-ff45-11e9-817a-b1099affe2a4.png)

With this PR :
![Capture-20191104210022-1075x74](https://user-images.githubusercontent.com/45535283/68153684-3f853980-ff46-11e9-81e2-ece78d9d86f8.png)
