### PR TITLE
fix live sample data text for more consistent UI

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1014,8 +1014,7 @@ cell:selected
 
 #live-sample-data
 {
-   font-family: courier;
-   font-weight: bold;
+   font-family: monospace;
 }
 
 /* Accels window reminder */


### PR DESCRIPTION
As suggested by @alcomposer in #3034 issue (even if he closed it), using monospace and normal font (instead of bold) made live sample part more consistent to the rest of the UI. There's after all no other place where a single part of text is bold. And monospace is more cross OS fonts.

See especially this comment from @alcomposer that explain the best why change that : https://github.com/darktable-org/darktable/issues/3034#issuecomment-537292222