### PR TITLE
Added check for mouse wheel scroll option to profiled denoise

### DIFF
--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3852,6 +3852,7 @@ static gboolean denoiseprofile_scrolled(GtkWidget *widget, GdkEventScroll *event
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   dt_iop_denoiseprofile_gui_data_t *c = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
 
+  if(((event->state & gtk_accelerator_get_default_mod_mask()) == darktable.gui->sidebar_scroll_mask) != dt_conf_get_bool("darkroom/ui/sidebar_scroll_default")) return FALSE;
   gdouble delta_y;
   if(dt_gui_get_scroll_deltas(event, NULL, &delta_y))
   {


### PR DESCRIPTION
The check for the "mouse wheel scroll modules side panel by default" option was missing from the denoise (profiled) module, so I added it in. Fixes #3240.

I noticed #2576 added a bunch of these, and I searched for modules with a function named '*_scrolled' and everything that came up seems to work as intended.