### PR TITLE
Various UI fixes

### DIFF
--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -229,7 +229,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
 
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkWidget *dialog = gtk_dialog_new_with_buttons(_("edit metadata exportation"), GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
-                                       _("save"), GTK_RESPONSE_YES, _("cancel"), GTK_RESPONSE_NONE, NULL);
+                                       _("cancel"), GTK_RESPONSE_NONE, _("save"), GTK_RESPONSE_YES, NULL);
   d->dialog = dialog;
   gtk_window_set_default_size(GTK_WINDOW(dialog), 300, -1);
   GtkWidget *area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -320,7 +320,7 @@ void connect_key_accels(dt_lib_module_t *self)
 
 void gui_init(dt_lib_module_t *self)
 {
-  GtkBox *hbox;
+  GtkGrid *grid;
   GtkWidget *button;
   GtkWidget *label;
   GtkEntryCompletion *completion;
@@ -379,25 +379,24 @@ void gui_init(dt_lib_module_t *self)
     gtk_grid_attach_next_to(GTK_GRID(self->widget), combobox, label, GTK_POS_RIGHT, 1, 1);
   }
 
-  // reset/apply buttons
-  hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+  // clear/apply buttons
+
+  grid = GTK_GRID(gtk_grid_new());
+  gtk_grid_set_column_homogeneous(grid, TRUE);
 
   button = gtk_button_new_with_label(_("clear"));
   d->clear_button = button;
-  gtk_widget_set_hexpand(GTK_WIDGET(button), TRUE);
   gtk_widget_set_tooltip_text(button, _("remove metadata from selected images"));
+  gtk_grid_attach(grid, button, 0, 0, 1, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(clear_button_clicked), (gpointer)self);
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
 
   button = gtk_button_new_with_label(_("apply"));
   d->apply_button = button;
-  gtk_widget_set_hexpand(GTK_WIDGET(button), TRUE);
   gtk_widget_set_tooltip_text(button, _("write metadata for selected images"));
+  gtk_grid_attach(grid, button, 1, 0, 1, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(apply_button_clicked), (gpointer)self);
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  gtk_widget_set_margin_top(GTK_WIDGET(hbox), 0);
 
-  gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(hbox), 0, line, 2, 1);
+  gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(grid), 0, line, 2, 1);
 
   /* lets signup for mouse over image change signals */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -132,7 +132,7 @@ void gui_init(dt_lib_module_t *self)
   ellipsize_button(button);
   d->select_untouched_button = button;
   gtk_widget_set_tooltip_text(button, _("select untouched images in\ncurrent collection"));
-  gtk_grid_attach(grid, button, 0, line, 1, 1);
+  gtk_grid_attach(grid, button, 0, line, 2, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(4));
 }
 #undef ellipsize_button

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -3165,7 +3165,7 @@ static gboolean rating_key_accel_callback(GtkAccelGroup *accel_group, GObject *a
 
   dt_collection_update_query(darktable.collection); // update the counter
 
-  if(layout != DT_LIGHTTABLE_LAYOUT_CULLING && lib->collection_count != _culling_get_selection_count())
+  if(layout != DT_LIGHTTABLE_LAYOUT_CULLING && lib->collection_count != dt_collection_get_count(darktable.collection))
   {
     // some images disappeared from collection. Selection is now invisible.
     // lib->collection_count  --> before the rating


### PR DESCRIPTION
Reverted a change made in dc173920d9bfa63ae8003b8b483474bf33fe565c which meant the selection was being cleared every time ratings were applied via a keyboard shortcut. Partially fixes #3090.