### PR TITLE
Minor change for dt 3.0 string freeze

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2569,8 +2569,8 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 
 
     bd->showmask = dtgtk_button_new(dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-    gtk_widget_set_tooltip_text(bd->showmask, _("display mask and/or color channel. ctrl-click to display mask, "
-                                                "shift-click to display channel. hover over parametric mask slider to "
+    gtk_widget_set_tooltip_text(bd->showmask, _("display mask and/or color channel. ctrl+click to display mask, "
+                                                "shift+click to display channel. hover over parametric mask slider to "
                                                 "select channel for display"));
     g_signal_connect(G_OBJECT(bd->showmask), "button-press-event", G_CALLBACK(_blendop_blendif_showmask_clicked), module);
     gtk_widget_set_name(bd->showmask, "show_mask_button");

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4984,21 +4984,21 @@ void gui_init(struct dt_iop_module_t *self)
                                               "set to zero for the generic case"));
   gtk_widget_set_tooltip_text(g->aspect, _("adjust aspect ratio of image by horizontal and vertical scaling"));
   gtk_widget_set_tooltip_text(g->fit_v, _("automatically correct for vertical perspective distortion\n"
-                                          "ctrl-click to only fit rotation\n"
-                                          "shift-click to only fit lens shift"));
+                                          "ctrl+click to only fit rotation\n"
+                                          "shift+click to only fit lens shift"));
   gtk_widget_set_tooltip_text(g->fit_h, _("automatically correct for horizontal perspective distortion\n"
-                                          "ctrl-click to only fit rotation\n"
-                                          "shift-click to only fit lens shift"));
+                                          "ctrl+click to only fit rotation\n"
+                                          "shift+click to only fit lens shift"));
   gtk_widget_set_tooltip_text(g->fit_both, _("automatically correct for vertical and "
                                              "horizontal perspective distortions; fitting rotation,"
                                              "lens shift in both directions, and shear\n"
-                                             "ctrl-click to only fit rotation\n"
-                                             "shift-click to only fit lens shift\n"
-                                             "ctrl-shift-click to only fit rotation and lens shift"));
+                                             "ctrl+click to only fit rotation\n"
+                                             "shift+click to only fit lens shift\n"
+                                             "ctrl+shift+click to only fit rotation and lens shift"));
   gtk_widget_set_tooltip_text(g->structure, _("analyse line structure in image\n"
-                                              "ctrl-click for an additional edge enhancement\n"
-                                              "shift-click for an additional detail enhancement\n"
-                                              "ctrl-shift-click for a combination of both methods"));
+                                              "ctrl+click for an additional edge enhancement\n"
+                                              "shift+click for an additional detail enhancement\n"
+                                              "ctrl+shift+click for a combination of both methods"));
   gtk_widget_set_tooltip_text(g->clean, _("remove line structure information"));
   gtk_widget_set_tooltip_text(g->eye, _("toggle visibility of structure lines"));
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1233,7 +1233,7 @@ static gboolean checker_motion_notify(GtkWidget *widget, GdkEventMotion *event,
         "click to select\n"
         "double click to reset\n"
         "right click to delete patch\n"
-        "shift-click while color picking to replace patch"),
+        "shift+click while color picking to replace patch"),
       p->source_L[patch], p->source_a[patch], p->source_b[patch]);
   gtk_widget_set_tooltip_text(g->area, tooltip);
   return TRUE;

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3490,15 +3490,15 @@ static void btn_make_radio_callback (GtkToggleButton *btn, dt_iop_module_t *modu
     if (btn == g->btn_point_tool)
       dt_control_hinter_message
         (darktable.control, _("click and drag to add point\nscroll to change size\n"
-                              "shift-scroll to change strength - ctrl-scroll to change direction"));
+                              "shift+scroll to change strength - ctrl+scroll to change direction"));
     else if (btn == g->btn_line_tool)
       dt_control_hinter_message
         (darktable.control, _("click to add line\nscroll to change size\n"
-                              "shift-scroll to change strength - ctrl-scroll to change direction"));
+                              "shift+scroll to change strength - ctrl+scroll to change direction"));
     else if (btn == g->btn_curve_tool)
       dt_control_hinter_message
         (darktable.control, _("click to add curve\nscroll to change size\n"
-                              "shift-scroll to change strength - ctrl-scroll to change direction"));
+                              "shift+scroll to change strength - ctrl+scroll to change direction"));
     else if (btn == g->btn_node_tool)
       dt_control_hinter_message (darktable.control, _("click to edit nodes"));
 
@@ -3604,10 +3604,10 @@ void gui_init (dt_iop_module_t *module)
   gtk_toggle_button_set_active(g->btn_node_tool, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->btn_node_tool), FALSE, FALSE, 0);
 
-  dt_liquify_layers[DT_LIQUIFY_LAYER_PATH].hint           = _("ctrl-click: add node - right click: remove path\n"
-                                                              "ctrl-alt-click: toggle line/curve");
+  dt_liquify_layers[DT_LIQUIFY_LAYER_PATH].hint           = _("ctrl+click: add node - right click: remove path\n"
+                                                              "ctrl+alt+click: toggle line/curve");
   dt_liquify_layers[DT_LIQUIFY_LAYER_CENTERPOINT].hint    = _("click and drag to move - click: show/hide feathering controls\n"
-                                                              "ctrl-click: autosmooth, cusp, smooth, symmetrical"
+                                                              "ctrl+click: autosmooth, cusp, smooth, symmetrical"
                                                               " - right click to remove");
   dt_liquify_layers[DT_LIQUIFY_LAYER_CTRLPOINT1].hint     = _("drag to change shape of path");
   dt_liquify_layers[DT_LIQUIFY_LAYER_CTRLPOINT2].hint     = _("drag to change shape of path");
@@ -3615,7 +3615,7 @@ void gui_init (dt_iop_module_t *module)
   dt_liquify_layers[DT_LIQUIFY_LAYER_HARDNESSPOINT1].hint = _("drag to adjust hardness (center)");
   dt_liquify_layers[DT_LIQUIFY_LAYER_HARDNESSPOINT2].hint = _("drag to adjust hardness (feather)");
   dt_liquify_layers[DT_LIQUIFY_LAYER_STRENGTHPOINT].hint  = _("drag to adjust warp strength\n"
-                                                              "ctrl-click: linear, grow, and shrink");
+                                                              "ctrl+click: linear, grow, and shrink");
 }
 
 void gui_cleanup (dt_iop_module_t *module)


### PR DESCRIPTION
Minor adjustments in the keyboard shortcuts so that they are uniformly written within darktable (e.g ctrl-click --> ctrl+click).

Sorry I'm a bit late, but I noticed the errors when translating into German.

Ideally, the spelling within darktable and the manual should be the same. After this convention e.g. ctrl should be capitalized --> Ctrl. Can be changed to the next version!

https://www.mail-archive.com/darktable-dev@lists.darktable.org/msg04818.html