### PR TITLE
Fix warning about missing cl target opencl version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,5 +489,7 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
     IMMEDIATE @ONLY)
 
+configure_file(tools/basecurve/README.md README.tools.basecurve.md)
+
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/src/common/bilateralcl.c
+++ b/src/common/bilateralcl.c
@@ -19,8 +19,6 @@
 #ifdef HAVE_OPENCL
 
 #include "common/bilateralcl.h"
-#include "CL/cl.h"            // for _cl_mem, cl_mem, CL_SUCCESS
-#include "CL/cl_platform.h"   // for cl_int
 #include "common/darktable.h" // for CLAMPS, dt_print, darktable, darktable_t
 #include "common/opencl.h"    // for dt_opencl_set_kernel_arg, dt_opencl_cr...
 #include <glib.h>             // for MAX

--- a/src/common/bilateralcl.h
+++ b/src/common/bilateralcl.h
@@ -19,9 +19,11 @@
 #pragma once
 
 #ifdef HAVE_OPENCL
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
-#include "CL/cl.h"          // for cl_mem, _cl_mem
-#include "CL/cl_platform.h" // for cl_int
+#include <CL/cl.h>          // for cl_mem, _cl_mem
 #include <stddef.h>         // for size_t
 
 typedef struct dt_bilateral_cl_global_t

--- a/src/common/iop_order.h
+++ b/src/common/iop_order.h
@@ -21,8 +21,12 @@
 
 #include "common/colorspaces_inline_conversions.h"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #ifdef HAVE_OPENCL
-#include "CL/cl.h"           // for cl_mem
+#include <CL/cl.h>           // for cl_mem
 #endif
 
 struct dt_iop_module_t;

--- a/src/config.cmake.h
+++ b/src/config.cmake.h
@@ -71,6 +71,20 @@ static const char *dt_supported_extensions[] __attribute__((unused)) = {"@DT_SUP
 // the default fallback is going for version 220 anyway.
 #define CL_TARGET_OPENCL_VERSION 220
 
+/******************************************************************************
+ * OpenCL target settings
+ *****************************************************************************/
+
+// OpenCL 1.2 is the highest version supported by Nvidia drivers as of end 2019
+// we force use it because we don't have time to support every (vendor driver × OpenCL version)
+#define CL_TARGET_OPENCL_VERSION 120
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#define CL_VERSION_1_2  1
+
+/******************************************************************************
+ * formerly in src/external/CL/cl.h
+ *****************************************************************************/
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/config.cmake.h
+++ b/src/config.cmake.h
@@ -68,9 +68,6 @@ static const char *dt_supported_extensions[] __attribute__((unused)) = {"@DT_SUP
 
 #cmakedefine HAVE_OMP_FIRSTPRIVATE_WITH_CONST 1
 
-// the default fallback is going for version 220 anyway.
-#define CL_TARGET_OPENCL_VERSION 220
-
 /******************************************************************************
  * OpenCL target settings
  *****************************************************************************/

--- a/src/config.cmake.h
+++ b/src/config.cmake.h
@@ -68,6 +68,9 @@ static const char *dt_supported_extensions[] __attribute__((unused)) = {"@DT_SUP
 
 #cmakedefine HAVE_OMP_FIRSTPRIVATE_WITH_CONST 1
 
+// the default fallback is going for version 220 anyway.
+#define CL_TARGET_OPENCL_VERSION 220
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/imageop_math.h
+++ b/src/develop/imageop_math.h
@@ -20,9 +20,12 @@
 */
 
 #pragma once
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #ifdef HAVE_OPENCL
-#include "CL/cl.h"           // for cl_mem
+#include <CL/cl.h>           // for cl_mem
 #endif
 
 #include "common/image.h"    // for dt_image_t, dt_image_orientation_t

--- a/src/external/CL/cl.h
+++ b/src/external/CL/cl.h
@@ -26,21 +26,6 @@
  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  ******************************************************************************/
 
-
-/******************************************************************************
- * Custom darktable stuff
- *****************************************************************************/
-
-// OpenCL 1.2 is the highest version supported by Nvidia drivers as of end 2019
-// we force use it because we don't have time to support every (vendor driver × OpenCL version)
-#define CL_TARGET_OPENCL_VERSION 120
-#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
-#define CL_VERSION_1_2  1
-
-/******************************************************************************
- * End of custom darktable stuff
- *****************************************************************************/
-
 #ifndef __OPENCL_CL_H
 #define __OPENCL_CL_H
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -31,6 +31,10 @@ extern "C" {
 #include <glib.h>
 #include <stdint.h>
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #ifdef HAVE_OPENCL
 #include <CL/cl.h>
 #endif

--- a/tools/basecurve/README.md
+++ b/tools/basecurve/README.md
@@ -1,10 +1,10 @@
-# dt-curve-tool
+# darktable-curve-tool
 
 
 ## About
 
 
-The _dt-curve-tool_ program will help you approximate more accurately the transfer
+The _darktable-curve-tool_ program will help you approximate more accurately the transfer
 curves used by your in-camera JPEG engine.
 
 This tool does so by analyzing both the RAW data and the resulting
@@ -44,40 +44,42 @@ You can build the tool using the following commands:
     $ cd "$DARKATBLE_SRC_ROOT/tools/basecurve"
     $ mkdir build
     $ cd build/
-    $ cmake -DCMAKE_INSTALL_PREFIX=$YOUR_INSTALL_PATH -DCMAKE_BUILD_TYPE=Release ..
+    $ cmake -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}" -DDCMAKE_INSTALL_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}" -DCMAKE_BUILD_TYPE=Release ..
     $ cmake --build . -- install
 
 You are invited to print the help message to get to know the tool's options:
 
-    $ "$YOUR_INSTALL_PATH/bin/dt-curve-tool" -h
+    $ "${CMAKE_INSTALL_LIBEXECDIR}/darktable/tools/darktable-curve-tool" -h
 
 It may help you better understand the following paragraphs.
 
 
-## Determining a basecurve/tonecurve using _dt-curve-tool-helper_ script
+## Determining a basecurve/tonecurve using _darktable-curve-tool-helper_ script
 
 
-An additional helper script called _dt-curve-tool-helper_ is provided. This
+An additional helper script called _darktable-curve-tool-helper_ is provided. This
 script should automate many steps of the curve determination process.
 
-It is assumed that `$YOUR_INSTALL_PATH` is in your `$PATH`.
+It is assumed that `$YOUR_INSTALL_PATH` is in your `$PATH`. If not you can run in bash/zsh:
+
+export PATH="$PATH:${CMAKE_INSTALL_LIBEXECDIR}/darktable/tools/"
 
 
 ### Gathering the statistics
 
 
-    $ for raw in ${my raw file list} ; do
-         dt-curve-tool-helper "$raw"
+    $ for raw in my raw file list ; do
+         darktable-curve-tool-helper "$raw"
       done
 
-_dt-curve-tool-helper_ will look for corresponding JPEG files by itself; if no
+_darktable-curve-tool-helper_ will look for corresponding JPEG files by itself; if no
 corresponding JPEG file is found, the embedded JPEG file from the raw is extracted.
  
 
 ### Computing the curves
 
 
-    $ dt-curve-tool -z -e <one of the RAW files> | tee mycameracurves.sh
+    $ darktable-curve-tool -z -e <one of the RAW files> | tee mycameracurves.sh
 
 At this point, you should have some console output explaining how to apply these
 curves, or submit them for final inclusion by the darktable developers
@@ -96,13 +98,13 @@ Now you can safely run the inject script:
     $ sh ./mycameracurves.sh
 
 
-## Determining a basecurve/tonecurve with _dt-curve-tool_ alone
+## Determining a basecurve/tonecurve with _darktable-curve-tool_ alone
 
 
-Using _dt-curve-tool-helper_ may not be sufficient and you need to either
+Using _darktable-curve-tool-helper_ may not be sufficient and you need to either
 have more control or understand what is done behind the hood by the script.
 The following chapters will explain in depth all the steps required for
-determining a curve with _dt-curve-tool_ alone
+determining a curve with _darktable-curve-tool_ alone
 
 
 ### Creating the PPM versions of your JPEG and raw files 
@@ -114,7 +116,7 @@ Let's say you have FILE.RAW (eg: .NEF/.CR2) and FILE.JPG
     $ mv FILE.ppm FILE-raw.ppm
 
 This creates a PPM file, named FILE.ppm, that we rename to FILE-raw.ppm. This
-file contains the data from your sensor in a convenient format for dt-curve-tool
+file contains the data from your sensor in a convenient format for darktable-curve-tool
 to read. This data represents the data used as input by your in camera JPEG
 engine.
 
@@ -130,12 +132,12 @@ image so that the PPM from the raw and the JPEG share the same orientation.
 ### Gathering a round of statistics
 
 
-It is now time to let _dt-curve-tool_ analyse these two files so that it can gather
+It is now time to let _darktable-curve-tool_ analyse these two files so that it can gather
 some statistical data for a later computation of the curves
 
-It is assumed _dt-curve-tool_ is in your `$PATH`.
+It is assumed _darktable-curve-tool_ is in your `$PATH`.
 
-    $ dt-curve-tool FILE-raw.ppm FILE-jpeg.ppm
+    $ darktable-curve-tool FILE-raw.ppm FILE-jpeg.ppm
 
 This command loads and analyses the corresponding pixels found in both images. It
 writes, to a state file, the correspondence found for each pixel value.
@@ -145,24 +147,24 @@ multiple times to cover the whole range of values that your camera is able to
 capture. There is no exact number of files to be analysed, this all depends on
 your camera tonal range, and the scenes being photographed.
 
-The only thing you have to take care, is to point _dt-curve-tool_ to the same save
+The only thing you have to take care, is to point _darktable-curve-tool_ to the same save
 state file with the option _-s_ (which stands for **s**tate file). Let's say you specify
 the _-s_ option even on first run like this
 
-    $ dt-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-raw.ppm FILE-jpeg.ppm
+    $ darktable-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-raw.ppm FILE-jpeg.ppm
 
 You are then able to accumulate more data for this camera doing something like this
 
-    $ dt-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-raw2.ppm FILE-jpeg2.ppm
-    $ dt-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-raw3.ppm FILE-jpeg3.ppm
+    $ darktable-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-raw2.ppm FILE-jpeg2.ppm
+    $ darktable-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-raw3.ppm FILE-jpeg3.ppm
     ...
-    $ dt-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-rawN.ppm FILE-jpegN.ppm
+    $ darktable-curve-tool -s "$HOME/tmp/mycamera.dat" FILE-rawN.ppm FILE-jpegN.ppm
 
-Beware that _dt-curve-tool_ uses 32bit counters internally to keep track of the number
+Beware that _darktable-curve-tool_ uses 32bit counters internally to keep track of the number
 of times a RGB/Lab sample has been encountered. As cameras these days do have many pixels
 a photo, do not be zealous; do not run the tool on your complete catalog. In the
 case too many pixels have been sampled already, an error is printed on the
-console and _dt-curve-tool_ refuses to process any further image.
+console and _darktable-curve-tool_ refuses to process any further image.
 
 It may be smart to pick from 20 to 50 pics covering the whole tonal range of your
 camera; there is no need for thousands of pictures, firstly, it'd be real slow, and
@@ -177,13 +179,13 @@ It is now time to analyse the data and output the curves.
 So you gathered data in `$HOME/tmp/mycamera.dat`, that's perfect. Let's compute the
 curves now.
 
-    $ dt-curve-tool -z -e <one of the RAW files> -s ~/tmp/mycamera.dat | tee mycameracurves.sh
+    $ darktable-curve-tool -z -e <one of the RAW files> -s ~/tmp/mycamera.dat | tee mycameracurves.sh
     [this will print you a script on screen and in the mycameracurves.sh file]
 
 Little explanation before trying out the computed curves.
 
-The _-z_ option tells the _dt-curve-tool_ program to read the save state and compute
-the curves. The _-e_ option is just a convenient option for pointing _dt-curve-tool_
+The _-z_ option tells the _darktable-curve-tool_ program to read the save state and compute
+the curves. The _-e_ option is just a convenient option for pointing _darktable-curve-tool_
 to a file containing EXIF data that can provide your camera Model name.
 
 You can generate curves with more or less points to approximate the values
@@ -206,7 +208,7 @@ Then go on, import the curves:
 
 Spawn _darktable_, and check you got a new curve in the tonecurve module presets
 and the basecurve module presets. If you provided the _-e_ option to the final
-_dt-curve-tool_ command run, the preset should be named as your camera Model name.
+_darktable-curve-tool_ command run, the preset should be named as your camera Model name.
 Otherwise, they will be named 'measured basecurve/tonecurve'
 
 ### Applying the curves automatically
@@ -220,14 +222,14 @@ or the module preset little tiny button once you selected that preset->Edit pres
 ### Plotting the data for checking validity of data and fit
 
 On the final tool invocation (with _-z_ option) you may be interested in looking at
-what _dt-curve-tool_ munged and analysed for you.
+what _darktable-curve-tool_ munged and analysed for you.
 
 Two [GNUPlot](http://gnuplot.info/) scripts are provided in the same source directory to do so.
 They require files `basecurve.dat` and `basecurve.fit.dat` resp. `tonecurve.dat`
 and `tonecurve.fit.dat` to be present in the `$DARKATBLE_SRC_ROOT/tools/basecurve` directory.
 
-    $ gnuplot -c "$DARKATBLE_SRC_ROOT/tools/basecurve/gnuplot.tonecurve"
-    $ gnuplot -c "$DARKATBLE_SRC_ROOT/tools/basecurve/gnuplot.basecurve"
+    $ gnuplot -c "${CMAKE_INSTALL_DATAROOTDIR}/darktable/tools/basecurve/gnuplot.tonecurve"
+    $ gnuplot -c "${CMAKE_INSTALL_DATAROOTDIR}/darktable/tools/basecurve/gnuplot.basecurve"
 
 This generates a `basecurve.pdf` resp. `tonecurve.pdf` file with a graph of
 the gathered data and the fitted curves. This can help you measuring how much of


### PR DESCRIPTION
Fix warning about missing CL_TARGET_OPENCL_VERSION.

As the default fallback seems to be 220 I use that as a default version

```
In file included from /usr/include/CL/cl.h:32,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/common/dlopencl.h:27,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/common/opencl.h:38,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/develop/imageop.h:37,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/develop/develop.h:30,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/control/jobs/develop_jobs.h:22,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/control/jobs.h:99,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/control/control.h:32,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/bauhaus/bauhaus.h:23,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/bauhaus/bauhaus.c:20:
/usr/include/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
   34 | #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
      |         ^~~~~~~
In file included from /usr/include/CL/cl.h:32,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/common/dlopencl.h:27,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/common/opencl.h:38,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/develop/imageop.h:37,
                 from /home/abuild/rpmbuild/BUILD/darktable-3.0.0rc0~git23.cb0aaf0c1/src/common/color_picker.c:23:
/usr/include/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
   34 | #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
      |         ^~~~~~~
```