### PR TITLE
Disable GTK client side decoration for Windows builds

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -84,9 +84,10 @@ int main(int argc, char *argv[])
     printf("start: %s\n", datetime);
     printf("\n");
 
-    // make sure GTK client side decoration is disabled, otherwise windows resizing issues can be oberved
-    g_setenv("GTK_CSD", "0", TRUE);
   }
+
+  // make sure GTK client side decoration is disabled, otherwise windows resizing issues can be observed
+  g_setenv("GTK_CSD", "0", TRUE);
 #endif
 
   if(dt_init(argc, argv, TRUE, TRUE, NULL)) exit(1);

--- a/src/main.c
+++ b/src/main.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
     printf("\n");
 
     // make sure GTK client side decoration is disabled, otherwise windows resizing issues can be oberved
-    putenv("GTK_CSD=0");
+    g_setenv("GTK_CSD", "0", TRUE);
   }
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -83,6 +83,9 @@ int main(int argc, char *argv[])
     printf("version: %s\n", darktable_package_string);
     printf("start: %s\n", datetime);
     printf("\n");
+
+    // make sure GTK client side decoration is disabled, otherwise windows resizing issues can be oberved
+    putenv("GTK_CSD=0");
   }
 #endif
 


### PR DESCRIPTION
Disable GTK client side decoration for Windows builds to prevent main window resizing issues on Windows OS.

Fixes #3307
