### PR TITLE
filmstrip : keep mouseover in sync with mouse position

### DIFF
--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -792,7 +792,7 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
   {
     if(col < col_start)
     {
-      cairo_translate(cr, wd + line_width, 0);
+      cairo_translate(cr, wd, 0);
       continue;
     }
 


### PR DESCRIPTION
this fix #3312
some margin count error...
@aurelienpierre can you double check, please ? git blame says it's your code... and to be honest, it works, but I would have say that the correct fix would be to **add** the margin also when we draw image (line 857) instead of removing it when we don't draw thumb... (but this don't work...)