### PR TITLE
Toneequalizer: fix GUI glitches

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2594,6 +2594,13 @@ static gboolean area_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
   //if(!g->graph_valid)
   if(!_init_drawing(self->widget, g)) return FALSE; // this can be cached and drawn just once, but too lazy to debug a cache invalidation for Cairo objects
 
+  // since the widget sizes are not cached and invalidated properly above (yet…)
+  // force the invalidation of the nodes coordinates to account for possible widget resizing
+  dt_pthread_mutex_lock(&g->lock);
+  g->valid_nodes_x = FALSE;
+  g->valid_nodes_y = FALSE;
+  dt_pthread_mutex_unlock(&g->lock);
+
   // Refresh cached UI elements
   update_histogram(g);
   update_curve_lut(self);


### PR DESCRIPTION
* force the nodes to be recomputed at every redrawing of the equalizer view in case the module got resized since previous drawing (useful when the sliding bar is enabled on-the-fly, otherwise nodes keep their original coordinates and overflow the graph)
* fix #3202 by forcing tabs and graph interactions to give the focus to the module, and consequently enable the interactive cursor.