### PR TITLE
Increased visibility when the mouse goes over the buttons

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -160,7 +160,6 @@
   background-image: none;
   font-family: sans-serif;
   font-size: 1em;
-  color: @fg_color;
   text-shadow:none;
   box-shadow:none;
   padding: 0;


### PR DESCRIPTION
Hi, 
When the mouse is above the buttons, the label takes the value specified in the themes. It becomes darker to increase visibility (see image attached).

PS : In the photo, my mouse is on the button, it is only my screenshot software that removed it.

Have a good day,

Julian
![Screenshot from 2019-11-10 00-33-20](https://user-images.githubusercontent.com/15966645/68536361-f5d78d00-0351-11ea-91df-0f2722a24936.png)
 fixes #3343 