### PR TITLE
copy metadata feature

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2009--2011 johannes hanika.
+    copyright (c) 2019 philippe weyland
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,6 +22,7 @@
 #include "common/debug.h"
 #include "common/image_cache.h"
 #include "common/undo.h"
+#include "common/grouping.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "gui/gtk.h"
@@ -38,6 +40,33 @@ typedef struct dt_undo_colorlabels_t
   uint8_t after;
 } dt_undo_colorlabels_t;
 
+int dt_colorlabels_get_labels(const int imgid)
+{
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "SELECT color FROM main.color_labels WHERE imgid = ?1", -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+  int colors = 0;
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+    colors |= (1<<sqlite3_column_int(stmt, 0));
+  sqlite3_finalize(stmt);
+  return colors;
+}
+
+static void _pop_undo_execute(const int imgid, const uint8_t before, const uint8_t after)
+{
+  for(int color=0; color<5; color++)
+  {
+    if(after & (1<<color))
+    {
+      if (!(before & (1<<color)))
+        dt_colorlabels_set_label(imgid, color);
+    }
+    else if (before & (1<<color))
+      dt_colorlabels_remove_label(imgid, color);
+  }
+}
+
 static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_COLORLABELS)
@@ -46,80 +75,22 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
 
     while(list)
     {
-      dt_undo_colorlabels_t *clabels = (dt_undo_colorlabels_t *)list->data;
-      uint8_t labels;
-      dt_colorlabels_remove_labels(clabels->imgid);
+      dt_undo_colorlabels_t *undocolorlabels = (dt_undo_colorlabels_t *)list->data;
 
-      if(action == DT_ACTION_UNDO)
-        labels = clabels->before;
-      else
-        labels = clabels->after;
-
-      for(int color=0; color<5; color++)
-        if(labels & (1<<color))
-          dt_colorlabels_set_label(clabels->imgid, color);
-
+      const uint8_t before = (action == DT_ACTION_UNDO) ? undocolorlabels->after : undocolorlabels->before;
+      const uint8_t after = (action == DT_ACTION_UNDO) ? undocolorlabels->before : undocolorlabels->after;
+      _pop_undo_execute(undocolorlabels->imgid, before, after);
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(clabels->imgid));
       list = g_list_next(list);
     }
+    dt_collection_hint_message(darktable.collection);
   }
-}
-
-static dt_undo_colorlabels_t *_get_labels(int imgid, uint8_t label, gboolean add)
-{
-  dt_undo_colorlabels_t *result = (dt_undo_colorlabels_t *)malloc(sizeof(dt_undo_colorlabels_t));
-  result->before = 0;
-  result->imgid = imgid;
-  sqlite3_stmt *stmt;
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT color FROM main.color_labels WHERE imgid=?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-
-  while(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    const int color = sqlite3_column_int(stmt, 0);
-    result->before |= (1 << color);
-  }
-  sqlite3_finalize(stmt);
-
-  if(add)
-    result->after = result->before | label;
-  else
-    result->after = result->before & (~label);
-
-  return result;
-}
-
-GList *_get_labels_selection(uint8_t label, gboolean add)
-{
-  GList *result = NULL;
-
-  sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt, NULL);
-
-  while(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    const int imgid = sqlite3_column_int(stmt, 0);
-    result = g_list_append(result, _get_labels(imgid, label, add));
-  }
-
-  sqlite3_finalize(stmt);
-
-  return result;
 }
 
 static void _colorlabels_undo_data_free(gpointer data)
 {
   GList *l = (GList *)data;
   g_list_free(l);
-}
-
-void dt_colorlabels_remove_labels_selection()
-{
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db),
-                        "DELETE FROM main.color_labels WHERE imgid IN (SELECT imgid FROM main.selected_images)",
-                        NULL, NULL, NULL);
 }
 
 void dt_colorlabels_remove_labels(const int imgid)
@@ -154,92 +125,101 @@ void dt_colorlabels_remove_label(const int imgid, const int color)
   sqlite3_finalize(stmt);
 }
 
-void dt_colorlabels_toggle_label_selection(const int color)
+typedef enum dt_colorlabels_actions_t
 {
-  sqlite3_stmt *stmt, *stmt2;
+  DT_CA_SET = 0,
+  DT_CA_TOGGLE
+} dt_colorlabels_actions_t;
 
-  GList *undo = NULL;
 
-  dt_undo_start_group(darktable.undo, DT_UNDO_COLORLABELS);
 
-  // check if all images in selection have that color label, i.e. try to get those which do not have the label
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images WHERE imgid "
-                                                             "NOT IN (SELECT a.imgid FROM main.selected_images AS "
-                                                             "a JOIN main.color_labels AS b ON a.imgid = b.imgid "
-                                                             "WHERE b.color = ?1)",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, color);
-  if(sqlite3_step(stmt) == SQLITE_ROW)
+static void _colorlabels_execute(GList *imgs, const int labels, GList **undo, const gboolean undo_on, const int action)
+{
+  GList *images = imgs;
+  while(images)
   {
-    undo = _get_labels_selection(1 << color, TRUE);
-    // none or only part of images have that color label, so label them all
-    DT_DEBUG_SQLITE3_PREPARE_V2(
-        dt_database_get(darktable.db),
-        "INSERT OR IGNORE INTO main.color_labels (imgid, color) SELECT imgid, ?1 FROM main.selected_images",
-        -1, &stmt2, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, color);
-    sqlite3_step(stmt2);
-    sqlite3_finalize(stmt2);
-  }
-  else
-  {
-    undo = _get_labels_selection(1 << color, FALSE);
-    // none of the selected images without that color label, so delete them all
-    DT_DEBUG_SQLITE3_PREPARE_V2(
-        dt_database_get(darktable.db),
-        "DELETE FROM main.color_labels WHERE imgid IN (SELECT imgid FROM main.selected_images) AND color=?1", -1,
-        &stmt2, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, color);
-    sqlite3_step(stmt2);
-    sqlite3_finalize(stmt2);
-  }
-  sqlite3_finalize(stmt);
+    const int image_id = GPOINTER_TO_INT(images->data);
+    const uint8_t before = dt_colorlabels_get_labels(image_id);
+    uint8_t after = 0;
+    switch(action)
+    {
+      case DT_CA_SET:
+        after = labels;
+        break;
+      case DT_CA_TOGGLE:
+        after = (before & labels) ? before & (~labels) : before | labels;
+        break;
+      default:
+        after = before;
+        break;
+    }
 
-  dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, (dt_undo_data_t)undo, _pop_undo, _colorlabels_undo_data_free);
-  dt_undo_end_group(darktable.undo);
+    if(undo_on)
+    {
+      dt_undo_colorlabels_t *undocolorlabels = (dt_undo_colorlabels_t *)malloc(sizeof(dt_undo_colorlabels_t));
+      undocolorlabels->imgid = image_id;
+      undocolorlabels->before = before;
+      undocolorlabels->after = after;
+      *undo = g_list_append(*undo, undocolorlabels);
+    }
 
-  dt_collection_hint_message(darktable.collection);
+    _pop_undo_execute(image_id, before, after);
+
+    images = g_list_next(images);
+  }
 }
 
-void dt_colorlabels_toggle_label(const int imgid, const int color)
+void dt_colorlabels_set_labels(const int imgid, const int labels, const gboolean undo_on, const gboolean group_on)
 {
-  if(imgid <= 0) return;
-  sqlite3_stmt *stmt, *stmt2;
-  GList *undo = NULL;
-
-  dt_undo_start_group(darktable.undo, DT_UNDO_COLORLABELS);
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT * FROM main.color_labels WHERE imgid=?1 AND color=?2 LIMIT 1",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, color);
-  if(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    undo = g_list_append(undo, _get_labels(imgid, 1 << color, FALSE));
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "DELETE FROM main.color_labels WHERE imgid=?1 AND color=?2", -1, &stmt2, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, imgid);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt2, 2, color);
-    sqlite3_step(stmt2);
-    sqlite3_finalize(stmt2);
-  }
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
   else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
   {
-    undo = g_list_append(undo, _get_labels(imgid, 1 << color, TRUE));
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "INSERT INTO main.color_labels (imgid, color) VALUES (?1, ?2)", -1, &stmt2, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt2, 1, imgid);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt2, 2, color);
-    sqlite3_step(stmt2);
-    sqlite3_finalize(stmt2);
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_COLORLABELS);
+
+    _colorlabels_execute(imgs, labels, &undo, undo_on, DT_CA_SET);
+
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, undo, _pop_undo, _colorlabels_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+    dt_collection_hint_message(darktable.collection);
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
-  sqlite3_finalize(stmt);
+}
 
-  dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, (dt_undo_data_t)undo, _pop_undo, _colorlabels_undo_data_free);
-  dt_undo_end_group(darktable.undo);
+void dt_colorlabels_toggle_label(const int imgid, const int color, const gboolean undo_on, const gboolean group_on)
+{
+  const int label = 1<<color;
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
+  {
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_COLORLABELS);
 
-  dt_collection_hint_message(darktable.collection);
+    _colorlabels_execute(imgs, label, &undo, undo_on, DT_CA_TOGGLE);
+
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_COLORLABELS, undo, _pop_undo, _colorlabels_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+    dt_collection_hint_message(darktable.collection);
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  }
 }
 
 int dt_colorlabels_check_label(const int imgid, const int color)
@@ -266,45 +246,24 @@ int dt_colorlabels_check_label(const int imgid, const int color)
 gboolean dt_colorlabels_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                            GdkModifierType modifier, gpointer data)
 {
-  const int mode = GPOINTER_TO_INT(data);
-  int32_t selected;
+  const int color = GPOINTER_TO_INT(data);
+  const int32_t selected = dt_view_get_image_to_act_on();
 
-  selected = dt_view_get_image_to_act_on();
-
-  if(selected <= 0)
-  {
-    switch(mode)
+    switch(color)
     {
       case 0:
       case 1:
       case 2:
       case 3:
       case 4: // colors red, yellow, green, blue, purple
-        dt_colorlabels_toggle_label_selection(mode);
+        dt_colorlabels_toggle_label(selected, color, TRUE, TRUE);
         break;
       case 5:
       default: // remove all selected
-        dt_colorlabels_remove_labels_selection();
+        dt_colorlabels_set_labels(selected, 0, TRUE, TRUE);
         break;
     }
-  }
-  else
-  {
-    switch(mode)
-    {
-      case 0:
-      case 1:
-      case 2:
-      case 3:
-      case 4: // colors red, yellow, green, blue, purple
-        dt_colorlabels_toggle_label(selected, mode);
-        break;
-      case 5:
-      default: // remove all selected
-        dt_colorlabels_remove_labels(selected);
-        break;
-    }
-  }
+
   // synch to file:
   // TODO: move color labels to image_t cache and sync via write_get!
   dt_image_synch_xmp(selected);

--- a/src/common/colorlabels.h
+++ b/src/common/colorlabels.h
@@ -15,16 +15,14 @@ typedef enum dt_colorlables_enum
 /** array with all names as strings, terminated by a NULL entry */
 extern const char *dt_colorlabels_name[];
 
-/** remove assigned colorlabels of selected images*/
-void dt_colorlabels_remove_labels_selection();
+/** get the assigned colorlabels of imgid*/
+int dt_colorlabels_get_labels(const int imgid);
 /** remove labels associated to imgid */
 void dt_colorlabels_remove_labels(const int imgid);
-/** toggle color label of selection of images */
-void dt_colorlabels_toggle_label_selection(const int color);
-/** toggle color of imgid */
-void dt_colorlabels_toggle_label(const int imgid, const int color);
-/** assign a color label to imgid */
+/** assign a color label to imgid - no undo no image group*/
 void dt_colorlabels_set_label(const int imgid, const int color);
+/** assign a color label to image imgid or all selected for imgid == -1*/
+void dt_colorlabels_set_labels(const int imgid, const int color, const gboolean undo_on, const gboolean group_on);
 /** remove a color label from imgid */
 void dt_colorlabels_remove_label(const int imgid, const int color);
 /** get the name of the color for a given number (could be replaced by an array) */

--- a/src/common/colorlabels.h
+++ b/src/common/colorlabels.h
@@ -22,7 +22,7 @@ void dt_colorlabels_remove_labels(const int imgid);
 /** assign a color label to imgid - no undo no image group*/
 void dt_colorlabels_set_label(const int imgid, const int color);
 /** assign a color label to image imgid or all selected for imgid == -1*/
-void dt_colorlabels_set_labels(const int imgid, const int color, const gboolean undo_on, const gboolean group_on);
+void dt_colorlabels_set_labels(const int imgid, const int color, const gboolean clear_on, const gboolean undo_on, const gboolean group_on);
 /** remove a color label from imgid */
 void dt_colorlabels_remove_label(const int imgid, const int color);
 /** get the name of the color for a given number (could be replaced by an array) */

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -229,7 +229,7 @@ static bool dt_exif_read_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
           rights = strchr(rights, ' ');
           if(rights != NULL) rights++;
         }
-        dt_metadata_set(img->id, "Xmp.dc.rights", rights);
+        dt_metadata_set(img->id, "Xmp.dc.rights", rights, FALSE, FALSE);
         free(adr);
       }
       if(FIND_XMP_TAG("Xmp.dc.description"))
@@ -242,7 +242,7 @@ static bool dt_exif_read_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
           description = strchr(description, ' ');
           if(description != NULL) description++;
         }
-        dt_metadata_set(img->id, "Xmp.dc.description", description);
+        dt_metadata_set(img->id, "Xmp.dc.description", description, FALSE, FALSE);
         free(adr);
       }
       if(FIND_XMP_TAG("Xmp.dc.title"))
@@ -255,7 +255,7 @@ static bool dt_exif_read_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
           title = strchr(title, ' ');
           if(title != NULL) title++;
         }
-        dt_metadata_set(img->id, "Xmp.dc.title", title);
+        dt_metadata_set(img->id, "Xmp.dc.title", title, FALSE, FALSE);
         free(adr);
       }
       if(FIND_XMP_TAG("Xmp.dc.creator"))
@@ -268,7 +268,7 @@ static bool dt_exif_read_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
           creator = strchr(creator, ' ');
           if(creator != NULL) creator++;
         }
-        dt_metadata_set(img->id, "Xmp.dc.creator", creator);
+        dt_metadata_set(img->id, "Xmp.dc.creator", creator, FALSE, FALSE);
         free(adr);
       }
       if(FIND_XMP_TAG("Xmp.dc.publisher"))
@@ -281,7 +281,7 @@ static bool dt_exif_read_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
           publisher = strchr(publisher, ' ');
           if(publisher != NULL) publisher++;
         }
-        dt_metadata_set(img->id, "Xmp.dc.publisher", publisher);
+        dt_metadata_set(img->id, "Xmp.dc.publisher", publisher, FALSE, FALSE);
         free(adr);
       }
     }
@@ -437,7 +437,7 @@ static bool dt_exif_read_iptc_data(dt_image_t *img, Exiv2::IptcData &iptcData)
         char *tag = dt_util_foo_to_utf8(str.c_str());
         guint tagid = 0;
         dt_tag_new(tag, &tagid);
-        dt_tag_attach_from_gui(tagid, img->id);
+        dt_tag_attach_from_gui(tagid, img->id, FALSE, FALSE);
         g_free(tag);
         ++pos;
       }
@@ -445,22 +445,22 @@ static bool dt_exif_read_iptc_data(dt_image_t *img, Exiv2::IptcData &iptcData)
     if(FIND_IPTC_TAG("Iptc.Application2.Caption"))
     {
       std::string str = pos->print(/*&iptcData*/);
-      dt_metadata_set(img->id, "Xmp.dc.description", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.description", str.c_str(), FALSE, FALSE);
     }
     if(FIND_IPTC_TAG("Iptc.Application2.Copyright"))
     {
       std::string str = pos->print(/*&iptcData*/);
-      dt_metadata_set(img->id, "Xmp.dc.rights", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.rights", str.c_str(), FALSE, FALSE);
     }
     if(FIND_IPTC_TAG("Iptc.Application2.Writer"))
     {
       std::string str = pos->print(/*&iptcData*/);
-      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str(), FALSE, FALSE);
     }
     else if(FIND_IPTC_TAG("Iptc.Application2.Contact"))
     {
       std::string str = pos->print(/*&iptcData*/);
-      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str(), FALSE, FALSE);
     }
 
     return true;
@@ -678,7 +678,7 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         char tagname[64];
         snprintf(tagname, sizeof(tagname), "darktable|mode|exif-crop");
         dt_tag_new(tagname, &tagid);
-        dt_tag_attach(tagid, img->id);
+        dt_tag_attach(tagid, img->id, FALSE, FALSE);
       }
     /*
      * Get the focus distance in meters.
@@ -880,25 +880,25 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
     if(FIND_EXIF_TAG("Exif.Image.Artist"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str(), FALSE, FALSE);
     }
     else if(FIND_EXIF_TAG("Exif.Canon.OwnerName"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.creator", str.c_str(), FALSE, FALSE);
     }
 
     // FIXME: Should the UserComment go into the description? Or do we need an extra field for this?
     if(FIND_EXIF_TAG("Exif.Photo.UserComment"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set(img->id, "Xmp.dc.description", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.description", str.c_str(), FALSE, FALSE);
     }
 
     if(FIND_EXIF_TAG("Exif.Image.Copyright"))
     {
       std::string str = pos->print(&exifData);
-      dt_metadata_set(img->id, "Xmp.dc.rights", str.c_str());
+      dt_metadata_set(img->id, "Xmp.dc.rights", str.c_str(), FALSE, FALSE);
     }
 
     if(FIND_EXIF_TAG("Exif.Image.Rating"))
@@ -1102,19 +1102,19 @@ static void dt_exif_apply_global_overwrites(dt_image_t *img)
     char *str;
 
     str = dt_conf_get_string("ui_last/import_last_creator");
-    if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, "Xmp.dc.creator", str);
+    if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, "Xmp.dc.creator", str, FALSE, FALSE);
     g_free(str);
 
     str = dt_conf_get_string("ui_last/import_last_rights");
-    if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, "Xmp.dc.rights", str);
+    if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, "Xmp.dc.rights", str, FALSE, FALSE);
     g_free(str);
 
     str = dt_conf_get_string("ui_last/import_last_publisher");
-    if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, "Xmp.dc.publisher", str);
+    if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, "Xmp.dc.publisher", str, FALSE, FALSE);
     g_free(str);
 
     str = dt_conf_get_string("ui_last/import_last_tags");
-    if(str != NULL && str[0] != '\0') dt_tag_attach_string_list(str, img->id);
+    if(str != NULL && str[0] != '\0') dt_tag_attach_string_list(str, img->id, FALSE, FALSE);
     g_free(str);
   }
 }
@@ -1301,6 +1301,22 @@ int dt_exif_write_blob(uint8_t *blob, uint32_t size, const char *path, const int
     return 0;
   }
   return 1;
+}
+
+static void dt_remove_exif_geotag(Exiv2::ExifData &exifData)
+{
+  static const char *keys[] =
+  {
+    "Exif.GPSInfo.GPSLatitude",
+    "Exif.GPSInfo.GPSLongitude",
+    "Exif.GPSInfo.GPSAltitude",
+    "Exif.GPSInfo.GPSLatitudeRef",
+    "Exif.GPSInfo.GPSLongitudeRef",
+    "Exif.GPSInfo.GPSAltitudeRef",
+    "Exif.GPSInfo.GPSVersionID"
+  };
+  static const guint n_keys = G_N_ELEMENTS(keys);
+  dt_remove_exif_keys(exifData, keys, n_keys);
 }
 
 int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const int sRGB, const int out_width,
@@ -1551,6 +1567,7 @@ int dt_exif_read_blob(uint8_t **buf, const char *path, const int imgid, const in
       }
 
       // GPS data
+      dt_remove_exif_geotag(exifData);
       const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, imgid, 'r');
       if(!std::isnan(cimg->geoloc.longitude) && !std::isnan(cimg->geoloc.latitude))
       {
@@ -1846,9 +1863,6 @@ static void _exif_import_tags(dt_image_t *img, Exiv2::XmpData::iterator &pos)
   sqlite3_finalize(stmt_sel_id);
   sqlite3_finalize(stmt_ins_tags);
   sqlite3_finalize(stmt_ins_tagged);
-
-  // update used_tags
-  dt_tag_update_used_tags();
 }
 
 typedef struct history_entry_t
@@ -3001,8 +3015,23 @@ static void dt_set_xmp_dt_history(Exiv2::XmpData &xmpData, const int imgid, int 
   xmpData["Xmp.darktable.history_end"] = history_end;
 }
 
+static void dt_remove_xmp_exif_geotag(Exiv2::XmpData &xmpData)
+{
+  static const char *keys[] =
+  {
+    "Xmp.exif.GPSVersionID",
+    "Xmp.exif.GPSLongitude",
+    "Xmp.exif.GPSLatitude",
+    "Xmp.exif.GPSAltitudeRef",
+    "Xmp.exif.GPSAltitude"
+  };
+  static const guint n_keys = G_N_ELEMENTS(keys);
+  dt_remove_xmp_keys(xmpData, keys, n_keys);
+}
+
 static void dt_set_xmp_exif_geotag(Exiv2::XmpData &xmpData, double longitude, double latitude, double altitude)
 {
+  dt_remove_xmp_exif_geotag(xmpData);
   if(!std::isnan(longitude) && !std::isnan(latitude))
   {
     char long_dir = 'E', lat_dir = 'N';
@@ -3040,36 +3069,6 @@ static void dt_set_xmp_exif_geotag(Exiv2::XmpData &xmpData, double longitude, do
     xmpData["Xmp.exif.GPSAltitude"] = ele_str;
     g_free(ele_str);
   }
-}
-
-static void dt_remove_xmp_exif_geotag(Exiv2::XmpData &xmpData)
-{
-  static const char *keys[] =
-  {
-    "Xmp.exif.GPSVersionID",
-    "Xmp.exif.GPSLongitude",
-    "Xmp.exif.GPSLatitude",
-    "Xmp.exif.GPSAltitudeRef",
-    "Xmp.exif.GPSAltitude"
-  };
-  static const guint n_keys = G_N_ELEMENTS(keys);
-  dt_remove_xmp_keys(xmpData, keys, n_keys);
-}
-
-static void dt_remove_exif_geotag(Exiv2::ExifData &exifData)
-{
-  static const char *keys[] =
-  {
-    "Exif.GPSInfo.GPSLatitude",
-    "Exif.GPSInfo.GPSLongitude",
-    "Exif.GPSInfo.GPSAltitude",
-    "Exif.GPSInfo.GPSLatitudeRef",
-    "Exif.GPSInfo.GPSLongitudeRef",
-    "Exif.GPSInfo.GPSAltitudeRef",
-    "Exif.GPSInfo.GPSVersionID"
-  };
-  static const guint n_keys = G_N_ELEMENTS(keys);
-  dt_remove_exif_keys(exifData, keys, n_keys);
 }
 
 static void dt_set_xmp_dt_metadata(Exiv2::XmpData &xmpData, const int imgid)

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -499,8 +499,6 @@ void dt_film_remove(const int id)
   sqlite3_finalize(stmt);
   // dt_control_update_recent_films();
 
-  dt_tag_update_used_tags();
-
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_CHANGED);
 }
 

--- a/src/common/grouping.h
+++ b/src/common/grouping.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <glib.h>
+
 /** add an image to a group */
 void dt_grouping_add_to_group(int group_id, int image_id);
 
@@ -26,6 +28,12 @@ int dt_grouping_remove_from_group(int image_id);
 
 /** make an image the representative of the group it is in. returns the new group_id. */
 int dt_grouping_change_representative(int image_id);
+
+/** get images of the group */
+GList *dt_grouping_get_group_images(const int imgid);
+
+/** add grouped images to images list */
+void dt_grouping_add_grouped_images(GList **images);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -101,8 +101,8 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
   dt_image_reset_final_size(imgid);
 
   /* remove darktable|style|* tags */
-  dt_tag_detach_by_string("darktable|style%", imgid);
-  dt_tag_detach_by_string("darktable|changed", imgid);
+  dt_tag_detach_by_string("darktable|style%", imgid, FALSE, FALSE);
+  dt_tag_detach_by_string("darktable|changed", imgid, FALSE, FALSE);
 
   dt_unlock_image(imgid);
 
@@ -791,7 +791,7 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
   /* attach changed tag reflecting actual change */
   guint tagid = 0;
   dt_tag_new("darktable|changed", &tagid);
-  dt_tag_attach(tagid, dest_imgid);
+  dt_tag_attach(tagid, dest_imgid, FALSE, FALSE);
 
   /* if current image in develop reload history */
   if(dt_dev_is_current_image(darktable.develop, dest_imgid))
@@ -939,9 +939,9 @@ void dt_history_set_compress_problem(int32_t imgid, gboolean set)
   snprintf(tagname, sizeof(tagname), "darktable|problem|history-compress");
   dt_tag_new(tagname, &tagid);
   if (set)
-    dt_tag_attach(tagid, imgid);
+    dt_tag_attach(tagid, imgid, FALSE, FALSE);
   else
-    dt_tag_detach(tagid, imgid);
+    dt_tag_detach(tagid, imgid, FALSE, FALSE);
 }
 
 static int dt_history_end_attop(int32_t imgid)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -126,7 +126,7 @@ int dt_image_is_monochrome(const dt_image_t *img)
 int dt_image_is_matrix_correction_supported(const dt_image_t *img)
 {
    return ((img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW )) && !(img->flags & DT_IMAGE_MONOCHROME) );
-} 
+}
 
 int dt_image_is_rawprepare_supported(const dt_image_t *img)
 {
@@ -362,7 +362,7 @@ static void _set_location(const int imgid, const dt_image_geoloc_t *geoloc)
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
 }
 
-static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action)
+void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_LT_GEOTAG)
   {
@@ -375,6 +375,7 @@ static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_dat
 
       _set_location(undogeotag->imgid, geoloc);
 
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undogeotag->imgid));
       list = g_list_next(list);
     }
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -29,6 +29,7 @@
 #include "common/imageio_rawspeed.h"
 #include "common/mipmap_cache.h"
 #include "common/tags.h"
+#include "common/undo.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "control/jobs.h"
@@ -344,31 +345,97 @@ void dt_image_get_location(int imgid, dt_image_geoloc_t *geoloc)
   dt_image_cache_read_release(darktable.image_cache, img);
 }
 
-void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc)
+typedef struct dt_undo_geotag_t
+{
+  int imgid;
+  dt_image_geoloc_t before;
+  dt_image_geoloc_t after;
+} dt_undo_geotag_t;
+
+static void _set_location(const int imgid, const dt_image_geoloc_t *geoloc)
 {
   /* fetch image from cache */
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
-  /* set image location */
-  image->geoloc.longitude = geoloc->longitude;
-  image->geoloc.latitude = geoloc->latitude;
+  memcpy(&image->geoloc, geoloc, sizeof(dt_image_geoloc_t));
 
-  /* store */
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
 }
 
-void dt_image_set_location_and_elevation(const int32_t imgid, dt_image_geoloc_t *geoloc)
+static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action)
 {
-  /* fetch image from cache */
-  dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+  if(type == DT_UNDO_LT_GEOTAG)
+  {
+    GList *list = (GList *)data;
 
-  /* set image location and elevation */
-  image->geoloc.longitude = geoloc->longitude;
-  image->geoloc.latitude = geoloc->latitude;
-  image->geoloc.elevation = geoloc->elevation;
+    while(list)
+    {
+      dt_undo_geotag_t *undogeotag = (dt_undo_geotag_t *)list->data;
+      const dt_image_geoloc_t *geoloc = (action == DT_ACTION_UNDO) ? &undogeotag->before : &undogeotag->after;
 
-  /* store */
-  dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+      _set_location(undogeotag->imgid, geoloc);
+
+      list = g_list_next(list);
+    }
+
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  }
+}
+
+static void _geotag_undo_data_free(gpointer data)
+{
+  GList *l = (GList *)data;
+  g_list_free_full(l, g_free);
+}
+
+void _image_set_location(GList *imgs, const dt_image_geoloc_t *geoloc, GList **undo, const gboolean undo_on)
+{
+  GList *images = imgs;
+  while(images)
+  {
+    const int imgid = GPOINTER_TO_INT(images->data);
+
+    if(undo_on)
+    {
+      dt_undo_geotag_t *undogeotag = (dt_undo_geotag_t *)malloc(sizeof(dt_undo_geotag_t));
+      undogeotag->imgid = imgid;
+      dt_image_get_location(imgid, &undogeotag->before);
+
+      memcpy(&undogeotag->after, geoloc, sizeof(dt_image_geoloc_t));
+
+      *undo = g_list_append(*undo, undogeotag);
+    }
+
+    _set_location(imgid, geoloc);
+
+    images = g_list_next(images);
+  }
+}
+
+void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on)
+{
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
+  {
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_LT_GEOTAG);
+
+    _image_set_location(imgs, geoloc, &undo, undo_on);
+
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_LT_GEOTAG, undo, _pop_undo, _geotag_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+
+    g_list_free(imgs);
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  }
 }
 
 void dt_image_reset_final_size(const int32_t imgid)
@@ -769,8 +836,8 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
     sqlite3_finalize(stmt);
 
     // make sure that the duplicate doesn't have some magic darktable| tags
-    dt_tag_detach_by_string("darktable|changed", newid);
-    dt_tag_detach_by_string("darktable|exported", newid);
+    dt_tag_detach_by_string("darktable|changed", newid, FALSE, FALSE);
+    dt_tag_detach_by_string("darktable|exported", newid, FALSE, FALSE);
 
     // set version of new entry and max_version of all involved duplicates (with same film_id and filename)
     int32_t version = (newversion != -1) ? newversion : max_version + 1;
@@ -860,8 +927,6 @@ void dt_image_remove(const int32_t imgid)
   sqlite3_finalize(stmt);
   // also clear all thumbnails in mipmap_cache.
   dt_mipmap_cache_remove(darktable.mipmap_cache, imgid);
-
-  dt_tag_update_used_tags();
 }
 
 int dt_image_altered(const uint32_t imgid)
@@ -1236,7 +1301,7 @@ static uint32_t dt_image_import_internal(const int32_t film_id, const char *file
   snprintf(tagname, sizeof(tagname), "darktable|format|%s", ext);
   g_free(ext);
   dt_tag_new(tagname, &tagid);
-  dt_tag_attach(tagid, id);
+  dt_tag_attach(tagid, id, FALSE, FALSE);
 
   // make sure that there are no stale thumbnails left
   dt_mipmap_cache_remove(darktable.mipmap_cache, id);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -264,11 +264,9 @@ dt_image_orientation_t dt_image_get_orientation(const int imgid);
 gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height);
 void dt_image_reset_final_size(const int32_t imgid);
 /** set image location lon/lat */
-void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
+void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on);
 /** get image location lon/lat */
 void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
-/** set image location lon/lat/ele */
-void dt_image_set_location_and_elevation(const int32_t imgid, dt_image_geoloc_t *geoloc);
 /** returns 1 if there is history data found for this image, 0 else. */
 int dt_image_altered(const uint32_t imgid);
 /** set the image final/cropped aspect ratio */

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -383,15 +383,15 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
   // if buf is NULL, we quit the fct here
   if(!mbuf) return DT_IMAGEIO_OK;
 
-  // We test for monochrome before allocating the mipmap cache 
-  // We set the flag and add the tag only once. 
+  // We test for monochrome before allocating the mipmap cache
+  // We set the flag and add the tag only once.
   if((cpp == 1) && !(img->flags & DT_IMAGE_MONOCHROME))
     {
       guint tagid = 0;
       char tagname[64];
       snprintf(tagname, sizeof(tagname), "darktable|mode|monochrome");
       dt_tag_new(tagname, &tagid);
-      dt_tag_attach(tagid, img->id);
+      dt_tag_attach(tagid, img->id, FALSE, FALSE);
       img->flags |= DT_IMAGE_MONOCHROME;
     }
   void *buf = dt_mipmap_cache_alloc(mbuf, img);

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -146,7 +146,7 @@ static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_dat
       GList *before = (action == DT_ACTION_UNDO) ? undometadata->after : undometadata->before;
       GList *after = (action == DT_ACTION_UNDO) ? undometadata->before : undometadata->after;
       _pop_undo_execute(undometadata->imgid, before, after);
-      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(metadata->imgid));
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undometadata->imgid));
       list = g_list_next(list);
     }
 

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2010 tobias ellinghaus.
+    copyright (c) 2019 philippe weyland
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,7 +19,10 @@
 
 #include "common/metadata.h"
 #include "common/debug.h"
+#include "common/collection.h"
 #include "common/undo.h"
+#include "common/grouping.h"
+#include "views/view.h"
 #include "control/signal.h"
 
 #include <stdlib.h>
@@ -27,11 +31,107 @@ typedef struct dt_undo_metadata_t
 {
   int imgid;
   GList *before;      // list of key/value before
-  gint keyid;         // new value (key, value)
-  gchar *value;
+  GList *after;       // list of key/value after
 } dt_undo_metadata_t;
 
-static void _metadata_set_xmp(int id, const gint keyid, const char *value, gboolean undo_actif);
+static gboolean _compare_metadata(gconstpointer a, gconstpointer b)
+{
+  return g_strcmp0(a, b);
+}
+
+static gchar *_get_tb_removed_metadata_string_values(GList *before, GList *after)
+{
+  GList *b = before;
+  GList *a = after;
+  gchar *metadata_list = NULL;
+
+  while(b)
+  {
+    GList *same = g_list_find_custom(a, b->data, _compare_metadata);
+    GList *b2 = g_list_next(b);
+    gboolean different = FALSE;
+    if(same)
+    {
+      GList *same2 = g_list_next(same);
+      different = g_strcmp0(same2->data, b2->data);
+    }
+    if(!same || different)
+    {
+      metadata_list = dt_util_dstrcat(metadata_list, "%d,", atoi(b->data));
+    }
+    b = g_list_next(b);
+    b = g_list_next(b);
+  }
+  if(metadata_list) metadata_list[strlen(metadata_list) - 1] = '\0';
+  return metadata_list;
+}
+
+static gchar *_get_tb_added_metadata_string_values(const int img, GList *before, GList *after)
+{
+  GList *b = before;
+  GList *a = after;
+  gchar *metadata_list = NULL;
+
+  while(a)
+  {
+    GList *same = g_list_find_custom(b, a->data, _compare_metadata);
+    GList *a2 = g_list_next(a);
+    gboolean different = FALSE;
+    if(same)
+    {
+      GList *same2 = g_list_next(same);
+      different = g_strcmp0(same2->data, a2->data);
+    }
+    if(!same || different)
+    {
+      metadata_list = dt_util_dstrcat(metadata_list, "(%d,%d,\'%s\'),", GPOINTER_TO_INT(img), atoi(a->data), (char *)a2->data);
+    }
+    a = g_list_next(a);
+    a = g_list_next(a);
+  }
+  if(metadata_list) metadata_list[strlen(metadata_list) - 1] = '\0';
+  return metadata_list;
+}
+
+static void _bulk_remove_metadata(const int img, const gchar *metadata_list)
+{
+  if(img > 0 && metadata_list)
+  {
+    char *query = NULL;
+    sqlite3_stmt *stmt;
+    query = dt_util_dstrcat(query, "DELETE FROM main.meta_data WHERE id = %d AND key IN (%s)", img, metadata_list);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    g_free(query);
+  }
+}
+
+static void _bulk_add_metadata(const gchar *metadata_list)
+{
+  if(metadata_list)
+  {
+    char *query = NULL;
+    sqlite3_stmt *stmt;
+    query = dt_util_dstrcat(query, "INSERT INTO main.meta_data (id, key, value) VALUES %s", metadata_list);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    g_free(query);
+  }
+}
+
+static void _pop_undo_execute(const int imgid, GList *before, GList *after)
+{
+  gchar *tobe_removed_list = _get_tb_removed_metadata_string_values(before, after);
+  gchar *tobe_added_list = _get_tb_added_metadata_string_values(imgid, before, after);
+
+  _bulk_remove_metadata(imgid, tobe_removed_list);
+  _bulk_add_metadata(tobe_added_list);
+
+  g_free(tobe_removed_list);
+  g_free(tobe_added_list);
+}
 
 static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action, GList **imgs)
 {
@@ -41,30 +141,11 @@ static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_dat
 
     while(list)
     {
-      dt_undo_metadata_t *metadata = (dt_undo_metadata_t *)list->data;
+      dt_undo_metadata_t *undometadata = (dt_undo_metadata_t *)list->data;
 
-      GList *tag_list = metadata->before;
-
-      // remove from meta_data
-      dt_metadata_clear(metadata->imgid);
-
-      // iterate over tag_list and attach tagid to imgid
-
-      while(tag_list)
-      {
-        const gchar *key = (gchar *)tag_list->data;
-        const gint keyid = atoi(key);
-        tag_list = g_list_next(tag_list);
-        const gchar *value = (gchar *)tag_list->data;
-        tag_list = g_list_next(tag_list);
-        _metadata_set_xmp(metadata->imgid, keyid, value, FALSE);
-      }
-
-      if(action == DT_ACTION_REDO)
-      {
-        _metadata_set_xmp(metadata->imgid, metadata->keyid, metadata->value, FALSE);
-      }
-
+      GList *before = (action == DT_ACTION_UNDO) ? undometadata->after : undometadata->before;
+      GList *after = (action == DT_ACTION_UNDO) ? undometadata->before : undometadata->after;
+      _pop_undo_execute(undometadata->imgid, before, after);
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(metadata->imgid));
       list = g_list_next(list);
     }
@@ -73,55 +154,30 @@ static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_dat
   }
 }
 
-static dt_undo_metadata_t *_get_metadata(const int imgid, const gint keyid, const gchar *value)
+GList *dt_metadata_get_list_id(const int id)
 {
-  dt_undo_metadata_t *result = (dt_undo_metadata_t *)malloc(sizeof(dt_undo_metadata_t));
-  result->imgid  = imgid;
-  result->before = NULL;
-  result->keyid  = keyid;
-  result->value  = g_strdup(value);
-
+  GList *metadata = NULL;
   sqlite3_stmt *stmt;
-
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "SELECT key, value FROM main.meta_data WHERE id=?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, id);
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     const gchar *ckey = dt_util_dstrcat(NULL, "%d", sqlite3_column_int(stmt, 0));
     const gchar *cvalue = g_strdup((const char *)sqlite3_column_text(stmt, 1));
-    result->before = g_list_append(result->before, (gpointer)ckey);
-    result->before = g_list_append(result->before, (gpointer)cvalue);
+    metadata = g_list_append(metadata, (gpointer)ckey);
+    metadata = g_list_append(metadata, (gpointer)cvalue);
   }
   sqlite3_finalize(stmt);
-
-  return result;
-}
-
-GList *_get_metadata_selection(const gint keyid, const gchar *value)
-{
-  GList *result = NULL;
-
-  sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt, NULL);
-
-  while(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    const int imgid = sqlite3_column_int(stmt, 0);
-    result = g_list_append(result, _get_metadata(imgid, keyid, value));
-  }
-
-  sqlite3_finalize(stmt);
-
-  return result;
+  return metadata;
 }
 
 static void _undo_metadata_free(gpointer data)
 {
   dt_undo_metadata_t *metadata = (dt_undo_metadata_t *)data;
   g_list_free_full(metadata->before, g_free);
-  g_free(metadata->value);
+  g_list_free_full(metadata->after, g_free);
+  g_free(metadata);
 }
 
 static void _metadata_undo_data_free(gpointer data)
@@ -130,82 +186,24 @@ static void _metadata_undo_data_free(gpointer data)
   g_list_free_full(l, _undo_metadata_free);
 }
 
-static void _metadata_set_xmp(const int id, const gint keyid, const char *value, gboolean undo_actif)
+gchar *_cleanup_metadata_value(const gchar *value)
 {
-  sqlite3_stmt *stmt;
-  GList *undo = NULL;
-
-  if(undo_actif) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
-
-  if(id == -1)
+  char *v = NULL;
+  char *c = NULL;
+  if (value && value[0])
   {
-    if(undo_actif) undo = _get_metadata_selection(keyid, value);
-
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "DELETE FROM main.meta_data WHERE id IN (SELECT imgid FROM main.selected_images) "
-                                "AND key = ?1",
-                                -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, keyid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-
-    if(value != NULL && value[0] != '\0')
-    {
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "INSERT INTO main.meta_data (id, key, value) SELECT imgid, ?1, ?2 FROM "
-                                  "main.selected_images",
-                                  -1, &stmt, NULL);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, keyid);
-      DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, value, -1, SQLITE_TRANSIENT);
-      sqlite3_step(stmt);
-      sqlite3_finalize(stmt);
-    }
+    v = g_strdup(value);
+    c = v + strlen(v) - 1;
+    while(c >= v && *c == ' ') *c-- = '\0';
+    c = v;
+    while(*c == ' ') c++;
   }
-  else
-  {
-    if(undo_actif) undo = g_list_append(undo, _get_metadata(id, keyid, value));
-
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "DELETE FROM main.meta_data WHERE id = ?1 AND key = ?2", -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, id);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, keyid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-
-    if(value != NULL && value[0] != '\0')
-    {
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "INSERT INTO main.meta_data (id, key, value) VALUES (?1, ?2, ?3)", -1, &stmt,
-                                  NULL);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, id);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, keyid);
-      DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, value, -1, SQLITE_TRANSIENT);
-      sqlite3_step(stmt);
-      sqlite3_finalize(stmt);
-    }
-  }
-
-  if(undo_actif)
-  {
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, (dt_undo_data_t)undo, _pop_undo, _metadata_undo_data_free);
-    dt_undo_end_group(darktable.undo);
-  }
+  c = g_strdup(c);
+  g_free(v);
+  return c;
 }
 
-static void dt_metadata_set_xmp(int id, const char *key, const char *value)
-{
-  int keyid = dt_metadata_get_keyid(key);
-  if(keyid == -1) // unknown key
-    return;
-
-  _metadata_set_xmp(id, keyid, value, TRUE);
-}
-
-static void dt_metadata_set_exif(int id, const char *key, const char *value)
-{
-} // TODO Is this useful at all?
-
-static GList *dt_metadata_get_xmp(int id, const char *key, uint32_t *count)
+static GList *dt_metadata_get_xmp(const int id, const char *key, uint32_t *count)
 {
   GList *result = NULL;
   sqlite3_stmt *stmt;
@@ -328,7 +326,7 @@ static GList *dt_metadata_get_xmp(int id, const char *key, uint32_t *count)
   See you in hell
   houz
 */
-static GList *dt_metadata_get_exif(int id, const char *key, uint32_t *count)
+static GList *dt_metadata_get_exif(const int id, const char *key, uint32_t *count)
 {
   GList *result = NULL;
   sqlite3_stmt *stmt;
@@ -475,7 +473,7 @@ END:
 }
 
 // for everything which doesn't fit anywhere else (our made up stuff)
-static GList *dt_metadata_get_dt(int id, const char *key, uint32_t *count)
+static GList *dt_metadata_get_dt(const int id, const char *key, uint32_t *count)
 {
   GList *result = NULL;
   sqlite3_stmt *stmt;
@@ -516,50 +514,164 @@ static GList *dt_metadata_get_dt(int id, const char *key, uint32_t *count)
   return result;
 }
 
-void dt_metadata_set(int id, const char *key, const char *value)
+static void _metadata_add_metadata_to_list(GList **list, GList *metadata)
+{
+  GList *m = metadata;
+  while(m)
+  {
+    GList *m2 = g_list_next(m);
+    GList *same = g_list_find_custom(*list, m->data, _compare_metadata);
+    GList *same2 = g_list_next(same);
+    gboolean different = FALSE;
+    if(same) different = g_strcmp0(same2->data, m2->data);
+    if(same && different)
+    {
+      // same key but different value - replace the old value by the new one
+      g_free(same2->data);
+      same2->data = g_strdup(m2->data);
+    }
+    else if(!same)
+    {
+      // new key for that image - append the new metadata item
+      *list = g_list_append(*list, g_strdup(m->data));
+      *list = g_list_append(*list, g_strdup(m2->data));
+    }
+    m = g_list_next(m);
+    m = g_list_next(m);
+  }
+}
+
+typedef enum dt_tag_actions_t
+{
+  DT_MA_SET = 0,
+  DT_MA_ADD
+} dt_tag_actions_t;
+
+static void _metadata_execute(GList *imgs, GList *metadata, GList **undo, const gboolean undo_on, const gint action)
+{
+  GList *images = imgs;
+  while(images)
+  {
+    const int image_id = GPOINTER_TO_INT(images->data);
+
+    dt_undo_metadata_t *undometadata = (dt_undo_metadata_t *)malloc(sizeof(dt_undo_metadata_t));
+    undometadata->imgid = image_id;
+    undometadata->before = dt_metadata_get_list_id(image_id);
+    switch(action)
+    {
+      case DT_MA_SET:
+        undometadata->after = metadata ? g_list_copy_deep(metadata, (GCopyFunc)g_strdup, NULL) : NULL;
+        break;
+      case DT_MA_ADD:
+        undometadata->after = g_list_copy_deep(undometadata->before, (GCopyFunc)g_strdup, NULL);
+        _metadata_add_metadata_to_list(&undometadata->after, metadata);
+        break;
+      default:
+        undometadata->after = g_list_copy_deep(undometadata->before, (GCopyFunc)g_strdup, NULL);
+        break;
+    }
+
+    _pop_undo_execute(image_id, undometadata->before, undometadata->after);
+
+    if(undo_on)
+      *undo = g_list_append(*undo, undometadata);
+    else
+      _undo_metadata_free(undometadata);
+    images = g_list_next(images);
+  }
+}
+
+void dt_metadata_set(const int imgid, const char *key, const char *value, const gboolean undo_on, const gboolean group_on)
 {
   if(!key) return;
 
-  char *v = NULL;
-  char *c = NULL;
-
-  // strip whitespace from start & end
-  if(value)
+  int keyid = dt_metadata_get_keyid(key);
+  if(keyid != -1) // known key
   {
-    v = g_strdup(value);
-    c = v + strlen(v) - 1;
-    while(c >= v && *c == ' ') *c-- = '\0';
-    c = v;
-    while(*c == ' ') c++;
+    GList *imgs = NULL;
+    if(imgid == -1)
+      imgs = dt_collection_get_selected(darktable.collection, -1);
+    else
+      imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    if(imgs)
+    {
+      GList *undo = NULL;
+      if(group_on) dt_grouping_add_grouped_images(&imgs);
+      if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
+
+      const gchar *ckey = dt_util_dstrcat(NULL, "%d", keyid);
+      const gchar *cvalue = _cleanup_metadata_value(value);
+      GList *metadata = NULL;
+      metadata = g_list_append(metadata, (gpointer)ckey);
+      metadata = g_list_append(metadata, (gpointer)cvalue);
+
+      _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_ADD);
+
+      g_list_free_full(metadata, g_free);
+      g_list_free(imgs);
+      if(undo_on)
+      {
+        dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
+        dt_undo_end_group(darktable.undo);
+      }
+      dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+    }
   }
-
-  if(strncmp(key, "Xmp.", 4) == 0)
-    dt_metadata_set_xmp(id, key, c);
-  else if(strncmp(key, "Exif.", 5) == 0)
-    dt_metadata_set_exif(id, key, c);
-
-  g_free(v);
 }
 
-void dt_metadata_set_list(int id, GList *key_value)
+void dt_metadata_set_list(const int imgid, GList *key_value, const gboolean undo_on, const gboolean group_on)
 {
-  dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
-
+  GList *metadata = NULL;
   GList *kv = key_value;
-
   while(kv)
   {
     const gchar *key = (const gchar *)kv->data;
-    kv = g_list_next(kv);
-    const gchar *value = (const gchar *)kv->data;
-    kv = g_list_next(kv);
-    dt_metadata_set(id, key, value);
+    int keyid = dt_metadata_get_keyid(key);
+    if(keyid != -1) // known key
+    {
+      const gchar *ckey = dt_util_dstrcat(NULL, "%d", keyid);
+      kv = g_list_next(kv);
+      const gchar *value = (const gchar *)kv->data;
+      kv = g_list_next(kv);
+      if(value && value[0])
+      {
+        metadata = g_list_append(metadata, (gchar *)ckey);
+        metadata = g_list_append(metadata, _cleanup_metadata_value(value));
+      }
+    }
+    else
+    {
+      kv = g_list_next(kv);
+      kv = g_list_next(kv);
+    }
   }
 
-  dt_undo_end_group(darktable.undo);
+  if(metadata)
+  {
+    GList *imgs = NULL;
+    if(imgid == -1)
+      imgs = dt_collection_get_selected(darktable.collection, -1);
+    else
+      imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    if(imgs)
+    {
+      GList *undo = NULL;
+      if(group_on) dt_grouping_add_grouped_images(&imgs);
+      if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
+
+      _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_SET);
+
+      g_list_free(imgs);
+      if(undo_on)
+      {
+        dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
+        dt_undo_end_group(darktable.undo);
+      }
+    }
+  }
 }
 
-GList *dt_metadata_get(int id, const char *key, uint32_t *count)
+GList *dt_metadata_get(const int id, const char *key, uint32_t *count)
 {
   if(strncmp(key, "Xmp.", 4) == 0) return dt_metadata_get_xmp(id, key, count);
   if(strncmp(key, "Exif.", 5) == 0) return dt_metadata_get_exif(id, key, count);
@@ -567,23 +679,53 @@ GList *dt_metadata_get(int id, const char *key, uint32_t *count)
   return NULL;
 }
 
-// TODO: Also clear exif data? I don't think it makes sense.
-void dt_metadata_clear(int id)
+void dt_metadata_clear(const int imgid, const gboolean undo_on, const gboolean group_on)
 {
-  if(id == -1)
-  {
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.meta_data WHERE id IN "
-                                                         "(SELECT imgid FROM main.selected_images)",
-                          NULL, NULL, NULL);
-  }
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
   else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
   {
-    sqlite3_stmt *stmt;
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.meta_data WHERE id = ?1", -1,
-                                &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, id);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
+
+    _metadata_execute(imgs, NULL, &undo, undo_on, DT_MA_SET);
+
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+  }
+}
+
+void dt_metadata_set_list_id(const int imgid, GList *metadata, const gboolean clear_on, const gboolean undo_on, const gboolean group_on)
+{
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
+  {
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
+
+    _metadata_execute(imgs, metadata, &undo, undo_on, clear_on ? DT_MA_SET : DT_MA_ADD);
+
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
 }
 

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -23,18 +23,27 @@
 #include "metadata_gen.h"
 
 /** Set metadata for a specific image, or all selected for id == -1. */
-void dt_metadata_set(int id, const char *key, const char *value);
+void dt_metadata_set(int id, const char *key, const char *value, const gboolean undo_on, const gboolean group_on); // exif.cc, ligthroom.c, duplicate.c, lua/image.c
 
-/** Set metadata for a specific image, or all selected for id == -1. */
+/** Set metadata (named keys) for a specific image, or all selected for id == -1. */
 /** list is a set of key, value */
-void dt_metadata_set_list(int id, GList *key_value);
+void dt_metadata_set_list(int id, GList *key_value, const gboolean undo_on, const gboolean group_on); // libs/metadata.c
 
-/** Get metadata for a specific image, or all selected for id == -1.
+/** Set metadata (id keys) for a specific image, or all selected for id == -1.
+    list is a set of keyid, value
+    if clear_on TRUE the image metadata are cleared before attaching the new ones*/
+void dt_metadata_set_list_id(const int id, GList *key_value, const gboolean clear_on, const gboolean undo_on, const gboolean group_on); // libs/image.c
+
+/** Get metadata (named keys) for a specific image, or all selected for id == -1.
     For keys which return a string, the caller has to make sure that it
     is freed after usage. */
-GList *dt_metadata_get(int id, const char *key, uint32_t *count);
+GList *dt_metadata_get(int id, const char *key, uint32_t *count); // exif.cc, variables.c, facebook.c, flicker.c, gallery.c, googlephoto.c, latex.c, piwigo.c, watermark.c, metadata_view.c, libs/metadata.c, print_settings.c, lua/image.c
+
+/** Get metadata (id keys) for a specific image. The caller has to free the list after usage. */
+GList *dt_metadata_get_list_id(int id); // libs/image.c
+
 /** Remove metadata from specific images, or all selected for id == -1. */
-void dt_metadata_clear(int id);
+void dt_metadata_clear(int id, const gboolean undo_on, const gboolean group_on); // libs/metadata.c
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -1,6 +1,7 @@
 /*
     This file is part of darktable,
     copyright (c) 2011 henrik andersson.
+    copyright (c) 2019 philippe weyland.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,6 +22,7 @@
 #include "common/image_cache.h"
 #include "common/ratings.h"
 #include "common/undo.h"
+#include "common/grouping.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include "gui/gtk.h"
@@ -28,52 +30,31 @@
 typedef struct dt_undo_ratings_t
 {
   int imgid;
-  int before_rating;
-  int after_rating;
+  int before;
+  int after;
 } dt_undo_ratings_t;
 
-static void _ratings_apply_to_image(int imgid, int rating, gboolean undo);
-
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
+int dt_ratings_get(const int imgid)
 {
-  if(type == DT_UNDO_RATINGS)
+  int stars = 0;
+  dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
+  if(image)
   {
-    dt_undo_ratings_t *ratings = (dt_undo_ratings_t *)data;
-
-    if(action == DT_ACTION_UNDO)
-      _ratings_apply_to_image(ratings->imgid, ratings->before_rating, FALSE);
-    else
-      _ratings_apply_to_image(ratings->imgid, ratings->after_rating, FALSE);
-    *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(ratings->imgid));
+    stars = 0x7 & image->flags;
+    dt_image_cache_read_release(darktable.image_cache, image);
   }
+  return stars;
 }
 
-static void _ratings_undo_data_free(gpointer data)
-{
-  free(data);
-}
-
-static void _ratings_apply_to_image(int imgid, int rating, gboolean undo)
+static void _ratings_apply_to_image(int imgid, int rating)
 {
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
   if(image)
   {
-    if(undo)
-    {
-      dt_undo_ratings_t *ratings = malloc(sizeof(dt_undo_ratings_t));
-      ratings->imgid = imgid;
-      ratings->before_rating = 0x7 & image->flags;
-      ratings->after_rating = rating;
-      dt_undo_record(darktable.undo, NULL, DT_UNDO_RATINGS, (dt_undo_data_t)ratings,
-                     _pop_undo, _ratings_undo_data_free);
-    }
-
     image->flags = (image->flags & ~0x7) | (0x7 & rating);
     // synch through:
     dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
-
-    dt_collection_hint_message(darktable.collection);
   }
   else
   {
@@ -81,117 +62,95 @@ static void _ratings_apply_to_image(int imgid, int rating, gboolean undo)
   }
 }
 
-void dt_ratings_apply_to_image(int imgid, int rating)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
-  _ratings_apply_to_image(imgid, rating, TRUE);
-}
-
-void dt_ratings_apply_to_image_or_group(int imgid, int rating)
-{
-  const dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
-  if(image)
+  if(type == DT_UNDO_RATINGS)
   {
-    int img_group_id = image->group_id;
+    GList *list = (GList *)data;
 
-    // one star is a toggle, so you can easily reject images by removing the last star:
-    if(((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap") && (rating == 1))
+    while(list)
     {
-      rating = 0;
+      dt_undo_ratings_t *ratings = (dt_undo_ratings_t *)list->data;
+      _ratings_apply_to_image(ratings->imgid, (action == DT_ACTION_UNDO) ? ratings->before : ratings->after);
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(ratings->imgid));
+      list = g_list_next(list);
     }
-    else if(((image->flags & 0x7) == 6) && (rating == 6))
-    {
-      rating = 0;
-    }
-
-    dt_image_cache_read_release(darktable.image_cache, image);
-
-    dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
-
-    // If we're clicking on a grouped image, apply the rating to all images in the group.
-    if(darktable.gui && darktable.gui->grouping && darktable.gui->expanded_group_id != img_group_id)
-    {
-      sqlite3_stmt *stmt;
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "SELECT id FROM main.images WHERE group_id = ?1", -1, &stmt, NULL);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, img_group_id);
-      int count = 0;
-
-      while(sqlite3_step(stmt) == SQLITE_ROW)
-      {
-        dt_ratings_apply_to_image(sqlite3_column_int(stmt, 0), rating);
-        count++;
-      }
-      sqlite3_finalize(stmt);
-
-      if(count > 1)
-      {
-        if(rating == 6)
-          dt_control_log(ngettext("rejecting %d image", "rejecting %d images", count), count);
-        else
-          dt_control_log(ngettext("applying rating %d to %d image", "applying rating %d to %d images", count),
-                         rating, count);
-      }
-    }
-    else
-    {
-      dt_ratings_apply_to_image(imgid, rating);
-    }
-
-    dt_undo_end_group(darktable.undo);
+    dt_collection_hint_message(darktable.collection);
   }
 }
 
-void dt_ratings_apply_to_selection(int rating)
+static void _ratings_undo_data_free(gpointer data)
 {
-  uint32_t count = dt_collection_get_selected_count(darktable.collection);
-  if(count)
+  GList *l = (GList *)data;
+  g_list_free(l);
+}
+
+static void _ratings_apply(GList *imgs, const int rating, GList **undo, const gboolean undo_on)
+{
+  GList *images = imgs;
+  while(images)
   {
+    const int image_id = GPOINTER_TO_INT(images->data);
+    if(undo_on)
+    {
+      dt_undo_ratings_t *undoratings = (dt_undo_ratings_t *)malloc(sizeof(dt_undo_ratings_t));
+      undoratings->imgid = image_id;
+      undoratings->before = dt_ratings_get(image_id);
+      undoratings->after = rating;
+      *undo = g_list_append(*undo, undoratings);
+    }
+
+    _ratings_apply_to_image(image_id, rating);
+
+    images = g_list_next(images);
+  }
+}
+
+void dt_ratings_apply(const int imgid, const int rating, const gboolean toggle_on, const gboolean undo_on, const gboolean group_on)
+{
+  GList *undo = NULL;
+  GList *imgs = NULL;
+  guint count = 0;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+
+  int new_rating = rating;
+  // one star is a toggle, so you can easily reject images by removing the last star:
+  // The ratings should be consistent for the whole selection, so this logic is only applied to the first image.
+  if(toggle_on && !dt_conf_get_bool("rating_one_double_tap") && (rating == 1))
+  {
+    if(dt_ratings_get(GPOINTER_TO_INT(imgs->data)) == 1)
+      new_rating = 0;
+  }
+
+  if(imgs)
+  {
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    count = g_list_length(imgs);
     if(rating == 6)
       dt_control_log(ngettext("rejecting %d image", "rejecting %d images", count), count);
     else
       dt_control_log(ngettext("applying rating %d to %d image", "applying rating %d to %d images", count),
                      rating, count);
-#if 0 // not updating cache
-    gchar query[1024]= {0};
-    g_snprintf(query,sizeof(query), "UPDATE main.images SET flags=(flags & ~7) | (7 & %d) WHERE id IN "
-                                    "(SELECT imgid FROM main.selected_images)", rating);
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), query, NULL, NULL, NULL);
-#endif
 
-    /* for each selected image update rating */
-    sqlite3_stmt *stmt;
-    gboolean first = TRUE;
-    dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
-                                NULL);
-    while(sqlite3_step(stmt) == SQLITE_ROW)
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
+    _ratings_apply(imgs, new_rating, &undo, undo_on);
+
+    g_list_free(imgs);
+    if(undo_on)
     {
-      if(first == TRUE)
-      {
-        first = FALSE;
-        const dt_image_t *image = dt_image_cache_get(darktable.image_cache, sqlite3_column_int(stmt, 0), 'r');
-
-        // one star is a toggle, so you can easily reject images by removing the last star:
-        // The ratings should be consistent for the whole selection, so this logic is only applied to the first image.
-        if(((image->flags & 0x7) == 1) && !dt_conf_get_bool("rating_one_double_tap") && (rating == 1))
-        {
-          rating = 0;
-        }
-
-        dt_image_cache_read_release(darktable.image_cache, image);
-      }
-
-      dt_ratings_apply_to_image(sqlite3_column_int(stmt, 0), rating);
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_RATINGS, undo, _pop_undo, _ratings_undo_data_free);
+      dt_undo_end_group(darktable.undo);
     }
-    sqlite3_finalize(stmt);
-    dt_undo_end_group(darktable.undo);
-
-    /* redraw view */
-    /* dt_control_queue_redraw_center() */
-    /* needs to be called in the caller function */
+    dt_collection_hint_message(darktable.collection);
   }
   else
     dt_control_log(_("no images selected to apply rating"));
+  /* redraw view */
+  /* dt_control_queue_redraw_center() */
+  /* needs to be called in the caller function */
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -21,14 +21,11 @@
 #include "common/darktable.h"
 #include <gtk/gtk.h>
 
-/** \brief applies specified rating to selected images */
-void dt_ratings_apply_to_selection(int rating);
+/** get rating tfor the specified image */
+int dt_ratings_get(const int imgid);
 
-/** apply rating to the specified image */
-void dt_ratings_apply_to_image(int imgid, int rating);
-
-/** apply rating to the specified image, or any image in a collapsed group */
-void dt_ratings_apply_to_image_or_group(int imgid, int rating);
+/** apply rating to the specified image, if -1 to selected images */
+void dt_ratings_apply(const int imgid, const int rating, const gboolean toggle_on, const gboolean undo_on, const gboolean group_on);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -763,8 +763,8 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
     guint tagid = 0;
     gchar ntag[512] = { 0 };
     g_snprintf(ntag, sizeof(ntag), "darktable|style|%s", name);
-    if(dt_tag_new(ntag, &tagid)) dt_tag_attach_from_gui(tagid, newimgid);
-    if(dt_tag_new("darktable|changed", &tagid)) dt_tag_attach_from_gui(tagid, newimgid);
+    if(dt_tag_new(ntag, &tagid)) dt_tag_attach_from_gui(tagid, newimgid, FALSE, FALSE);
+    if(dt_tag_new("darktable|changed", &tagid)) dt_tag_attach_from_gui(tagid, newimgid, FALSE, FALSE);
 
     /* if current image in develop reload history */
     if(dt_dev_is_current_image(darktable.develop, newimgid))

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -140,7 +140,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
       GList *before = (action == DT_ACTION_UNDO) ? undotags->after : undotags->before;
       GList *after = (action == DT_ACTION_UNDO) ? undotags->before : undotags->after;
       _pop_undo_execute(undotags->imgid, before, after);
-      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(tags->imgid));
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(undotags->imgid));
       list = g_list_next(list);
     }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -22,6 +22,7 @@
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/undo.h"
+#include "common/grouping.h"
 #include "control/conf.h"
 #include "control/control.h"
 #include <glib.h>
@@ -33,86 +34,139 @@ typedef struct dt_undo_tags_t
 {
   int imgid;
   GList *before; // list of tagid before
-  guint tagid;   // tag added or removed from before
-  gboolean add;
+  GList *after; // list of tagid after
 } dt_undo_tags_t;
 
-static void _attach_tag(guint tagid, gint imgid, gboolean undo_actif);
-static void _detach_tag(guint tagid, gint imgid, gboolean undo_actif);
+static void dt_set_darktable_tags();
+
+#if 0
+static gchar *_get_list_string_values(GList *list)
+{
+  GList *l = list;
+  gchar *sl = NULL;
+  while(l)
+  {
+    sl = dt_util_dstrcat(sl, "%d,", GPOINTER_TO_INT(l->data));
+    l = g_list_next(l);
+  }
+  return sl;
+}
+#endif // 0
+
+static gchar *_get_tb_removed_tag_string_values(GList *before, GList *after)
+{
+  GList *b = before;
+  GList *a = after;
+  gchar *tag_list = NULL;
+  while(b)
+  {
+    if(!g_list_find(a, b->data))
+    {
+      tag_list = dt_util_dstrcat(tag_list, "%d,", GPOINTER_TO_INT(b->data));
+    }
+    b = g_list_next(b);
+  }
+  if(tag_list) tag_list[strlen(tag_list) - 1] = '\0';
+  return tag_list;
+}
+
+static gchar *_get_tb_added_tag_string_values(const int img, GList *before, GList *after)
+{
+  GList *b = before;
+  GList *a = after;
+  gchar *tag_list = NULL;
+  while(a)
+  {
+    if(!g_list_find(b, a->data))
+    {
+      tag_list = dt_util_dstrcat(tag_list, "(%d,%d),", GPOINTER_TO_INT(img), GPOINTER_TO_INT(a->data));
+    }
+    a = g_list_next(a);
+  }
+  if(tag_list) tag_list[strlen(tag_list) - 1] = '\0';
+  return tag_list;
+}
+
+static void _bulk_remove_tags(const int img, const gchar *tag_list)
+{
+  if(img > 0 && tag_list)
+  {
+    char *query = NULL;
+    sqlite3_stmt *stmt;
+    query = dt_util_dstrcat(query, "DELETE FROM main.tagged_images WHERE imgid = %d AND tagid IN (%s)", img, tag_list);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    g_free(query);
+  }
+}
+
+static void _bulk_add_tags(const gchar *tag_list)
+{
+  if(tag_list)
+  {
+    char *query = NULL;
+    sqlite3_stmt *stmt;
+    query = dt_util_dstrcat(query, "INSERT INTO main.tagged_images (imgid, tagid) VALUES %s", tag_list);
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    g_free(query);
+  }
+}
+
+static void _pop_undo_execute(const int imgid, GList *before, GList *after)
+{
+  gchar *tobe_removed_list = _get_tb_removed_tag_string_values(before, after);
+  gchar *tobe_added_list = _get_tb_added_tag_string_values(imgid, before, after);
+
+  _bulk_remove_tags(imgid, tobe_removed_list);
+  _bulk_add_tags(tobe_added_list);
+
+  g_free(tobe_removed_list);
+  g_free(tobe_added_list);
+}
 
 static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_TAGS)
   {
-    sqlite3_stmt *stmt;
     GList *list = (GList *)data;
 
     while(list)
     {
-      dt_undo_tags_t *tags = (dt_undo_tags_t *)list->data;
+      dt_undo_tags_t *undotags = (dt_undo_tags_t *)list->data;
 
-      GList *tag_list = tags->before;
-
-      // remove from tagged_images
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "DELETE FROM main.tagged_images WHERE imgid = ?1", -1, &stmt, NULL);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tags->imgid);
-      sqlite3_step(stmt);
-      sqlite3_finalize(stmt);
-
-      // iterate over tag_list and attach tagid to imgid
-
-      while(tag_list)
-      {
-        const guint tagid = (guint)GPOINTER_TO_INT(tag_list->data);
-        _attach_tag(tagid, tags->imgid, FALSE);
-        tag_list = g_list_next(tag_list);
-      }
-
-      if(action == DT_ACTION_REDO)
-      {
-        if(tags->add)
-          _attach_tag(tags->tagid, tags->imgid, FALSE);
-        else
-          _detach_tag(tags->tagid, tags->imgid, FALSE);
-      }
-
-      dt_image_synch_xmp(tags->imgid);
-
+      GList *before = (action == DT_ACTION_UNDO) ? undotags->after : undotags->before;
+      GList *after = (action == DT_ACTION_UNDO) ? undotags->before : undotags->after;
+      _pop_undo_execute(undotags->imgid, before, after);
       *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(tags->imgid));
       list = g_list_next(list);
     }
 
-    dt_tag_update_used_tags();
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   }
 }
 
-static dt_undo_tags_t *_get_tags(int imgid, guint tagid, gboolean add)
+static dt_undo_tags_t *_get_tags(const int imgid, const guint tagid, gboolean add)
 {
-  dt_undo_tags_t *result = (dt_undo_tags_t *)malloc(sizeof(dt_undo_tags_t));
-  result->imgid  = imgid;
-  result->before = NULL;
-  result->tagid  = tagid;
-  result->add    = add;
-
-  sqlite3_stmt *stmt;
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT tagid FROM main.tagged_images WHERE imgid=?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-
-  while(sqlite3_step(stmt) == SQLITE_ROW)
+  dt_undo_tags_t *undotags = (dt_undo_tags_t *)malloc(sizeof(dt_undo_tags_t));
+  undotags->imgid  = imgid;
+  undotags->before = dt_tag_get_tags(imgid);
+  undotags->after = g_list_copy(undotags->before);
+  GList *tag = g_list_find(undotags->after, GINT_TO_POINTER(tagid));
+  if(tag)
   {
-    const guint tag = sqlite3_column_int(stmt, 0);
-    result->before = g_list_append(result->before, GINT_TO_POINTER(tag));
+    if(!add) undotags->after = g_list_remove(undotags->after, GINT_TO_POINTER(tagid));
   }
-  sqlite3_finalize(stmt);
-
-  return result;
+  else
+  {
+    if(add) undotags->after = g_list_prepend(undotags->after, GINT_TO_POINTER(tagid));
+  }
+  return undotags;
 }
 
-GList *_get_tags_selection(guint tagid, gboolean add)
+GList *_get_tags_selection(const guint tagid, const gboolean add)
 {
   GList *result = NULL;
 
@@ -132,8 +186,10 @@ GList *_get_tags_selection(guint tagid, gboolean add)
 
 static void _undo_tags_free(gpointer data)
 {
-  dt_undo_tags_t *tag = (dt_undo_tags_t *)data;
-  g_list_free(tag->before);
+  dt_undo_tags_t *undotags = (dt_undo_tags_t *)data;
+  g_list_free(undotags->before);
+  g_list_free(undotags->after);
+  g_free(undotags);
 }
 
 static void _tags_undo_data_free(gpointer data)
@@ -216,12 +272,6 @@ guint dt_tag_remove(const guint tagid, gboolean final)
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.used_tags WHERE id=?1", -1, &stmt,
-                                NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "DELETE FROM main.tagged_images WHERE tagid=?1",
                                 -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
@@ -241,13 +291,6 @@ void dt_tag_delete_tag_batch(const char *flatlist)
 
   char *query = NULL;
   query = dt_util_dstrcat(query, "DELETE FROM data.tags WHERE id IN (%s)", flatlist);
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-  g_free(query);
-
-  query = NULL;
-  query = dt_util_dstrcat(query, "DELETE FROM main.used_tags WHERE id IN (%s)", flatlist);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
@@ -310,50 +353,6 @@ gchar *dt_tag_get_name(const guint tagid)
   return name;
 }
 
-void dt_tag_reorganize(const gchar *source, const gchar *dest)
-{
-  sqlite3_stmt *stmt;
-
-  if(!strcmp(source, dest)) return;
-
-  gchar *tag = g_strrstr(source, "|");
-  gchar *tag_to_free = NULL;
-  if(tag == NULL) tag_to_free = tag = g_strconcat("|", source, NULL);
-
-  if(!strcmp(dest, " "))
-  {
-    tag++;
-    dest++;
-  }
-
-  gchar *new_expr = g_strconcat(dest, tag, NULL);
-  gchar *source_expr = g_strconcat(source, "%", NULL);
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "UPDATE data.tags SET name=REPLACE(name,?1,?2) WHERE name LIKE ?3", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, source, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, new_expr, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, source_expr, -1, SQLITE_TRANSIENT);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "UPDATE main.used_tags SET name=REPLACE(name,?1,?2) WHERE name LIKE ?3",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, source, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, new_expr, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, source_expr, -1, SQLITE_TRANSIENT);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
-
-  g_free(source_expr);
-  g_free(new_expr);
-  g_free(tag_to_free);
-
-  /* raise signal of tags change to refresh keywords module */
-  // dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-}
-
 void dt_tag_rename(const guint tagid, const gchar *new_tagname)
 {
   sqlite3_stmt *stmt;
@@ -368,12 +367,6 @@ void dt_tag_rename(const guint tagid, const gchar *new_tagname)
   sqlite3_step(stmt);
   sqlite3_finalize(stmt);
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "UPDATE main.used_tags SET name = ?2 WHERE id = ?1", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, new_tagname, -1, SQLITE_TRANSIENT);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
 }
 
 gboolean dt_tag_exists(const char *name, guint *tagid)
@@ -397,201 +390,230 @@ gboolean dt_tag_exists(const char *name, guint *tagid)
   return FALSE;
 }
 
-// we keep this separate so that updating the gui only happens once (and it's the caller's responsibility)
-static void _attach_tag(guint tagid, gint imgid, gboolean undo_actif)
+static void _tag_add_tags_to_list(GList **list, GList *tags)
 {
-  sqlite3_stmt *stmt;
-  GList *undo = NULL;
-
-  if(undo_actif) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
-
-  if(imgid > 0)
+  GList *t = tags;
+  while(t)
   {
-    if(undo_actif) undo = g_list_append(undo, _get_tags(imgid, tagid, TRUE));
-
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "INSERT OR REPLACE INTO main.tagged_images (imgid, tagid) VALUES (?1, ?2)", -1,
-                                &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, tagid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
-  else
-  {
-    if(undo_actif) undo = _get_tags_selection(tagid, TRUE);
-
-    // insert into tagged_images if not there already.
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "INSERT OR REPLACE INTO main.tagged_images SELECT imgid, ?1 "
-                                "FROM main.selected_images",
-                                -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
-
-  if(undo_actif)
-  {
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, (dt_undo_data_t)undo, _pop_undo, _tags_undo_data_free);
-    dt_undo_end_group(darktable.undo);
-  }
-}
-
-gboolean _tag_is_attached(guint tagid, gint imgid)
-{
-  gboolean result = FALSE;
-  sqlite3_stmt *stmt;
-
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "SELECT tagid FROM main.tagged_images WHERE imgid=?1 AND tagid=?2", -1,
-                              &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, tagid);
-
-  if(sqlite3_step(stmt) == SQLITE_ROW)
-    result = TRUE;
-
-  sqlite3_finalize(stmt);
-  return result;
-}
-
-gboolean dt_tag_attach(guint tagid, gint imgid)
-{
-  gboolean attached = FALSE;
-  if(!_tag_is_attached(tagid, imgid))
-  {
-    _attach_tag(tagid, imgid, TRUE);
-
-    dt_tag_update_used_tags();
-
-    attached = TRUE;
-  }
-  return attached;
-}
-
-void dt_tag_attach_from_gui(guint tagid, gint imgid)
-{
-  if(dt_tag_attach(tagid, imgid))
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
-}
-
-void dt_tag_attach_list(GList *tags, gint imgid)
-{
-  GList *child = NULL;
-  if((child = g_list_first(tags)) != NULL) do
+    if(!g_list_find(*list, t->data))
     {
-      _attach_tag(GPOINTER_TO_INT(child->data), imgid, TRUE);
-    } while((child = g_list_next(child)) != NULL);
+      *list = g_list_prepend(*list, t->data);
+    }
+    t = g_list_next(t);
+  }
+}
 
-  dt_tag_update_used_tags();
+static void _tag_remove_tags_from_list(GList **list, GList *tags)
+{
+  GList *t = tags;
+  while(t)
+  {
+    if(g_list_find(*list, t->data))
+    {
+      *list = g_list_remove(*list, t->data);
+    }
+    t = g_list_next(t);
+  }
+}
+
+typedef enum dt_tag_actions_t
+{
+  DT_TA_ATTACH = 0,
+  DT_TA_DETACH,
+  DT_TA_SET
+} dt_tag_actions_t;
+
+static void _tag_execute(GList *tags, GList *imgs, GList **undo, const gboolean undo_on, const gint action)
+{
+  GList *images = imgs;
+  while(images)
+  {
+    const int image_id = GPOINTER_TO_INT(images->data);
+    dt_undo_tags_t *undotags = (dt_undo_tags_t *)malloc(sizeof(dt_undo_tags_t));
+    undotags->imgid = image_id;
+    undotags->before = dt_tag_get_tags(image_id);
+    switch(action)
+    {
+      case DT_TA_ATTACH:
+        undotags->after = g_list_copy(undotags->before);
+        _tag_add_tags_to_list(&undotags->after, tags);
+        break;
+      case DT_TA_DETACH:
+        undotags->after = g_list_copy(undotags->before);
+        _tag_remove_tags_from_list(&undotags->after, tags);
+        break;
+      case DT_TA_SET:
+        undotags->after = g_list_copy(tags);
+        break;
+      default:
+        undotags->after = g_list_copy(undotags->before);
+        break;
+    }
+    _pop_undo_execute(image_id, undotags->before, undotags->after);
+    if(undo_on)
+      *undo = g_list_append(*undo, undotags);
+    else
+      _undo_tags_free(undotags);
+    images = g_list_next(images);
+  }
+}
+
+void dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on)
+{
+  GList *undo = NULL;
+  GList *tags = NULL;
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
+  {
+    tags = g_list_prepend(tags, GINT_TO_POINTER(tagid));
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
+
+    _tag_execute(tags, imgs, &undo, undo_on, DT_TA_ATTACH);
+
+    g_list_free(tags);
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+  }
+}
+
+void dt_tag_attach_from_gui(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on)
+{
+  dt_tag_attach(tagid, imgid, undo_on, group_on);
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 }
 
-void dt_tag_attach_string_list(const gchar *tags, gint imgid)
+void dt_tag_set_tags(GList *tags, const gint imgid, const gboolean clear_on, const gboolean undo_on, const gboolean group_on)
 {
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
+  {
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
+
+    _tag_execute(tags, imgs, &undo, undo_on, clear_on ? DT_TA_SET : DT_TA_ATTACH);
+
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  }
+}
+
+void dt_tag_attach_string_list(const gchar *tags, gint imgid, const gboolean undo_on, const gboolean group_on)
+{
+  // tags may not exist yet
+  // undo only undoes the tags attachments. it doesn't remove created tags.
   gchar **tokens = g_strsplit(tags, ",", 0);
   if(tokens)
   {
-    gchar **entry = tokens;
-    while(*entry)
+    GList *imgs = NULL;
+    if(imgid == -1)
+      imgs = dt_collection_get_selected(darktable.collection, -1);
+    else
+      imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    if(imgs)
     {
-      // remove leading and trailing spaces
-      char *e = *entry + strlen(*entry) - 1;
-      while(*e == ' ' && e > *entry)
-      {
-        *e = '\0';
-        e--;
-      }
-      e = *entry;
-      while(*e == ' ' && *e != '\0') e++;
-      if(*e)
-      {
-        // add the tag to the image
-        guint tagid = 0;
-        dt_tag_new(e, &tagid);
-        _attach_tag(tagid, imgid, TRUE);
-      }
-      entry++;
-    }
+      GList *undo = NULL;
+      if(group_on) dt_grouping_add_grouped_images(&imgs);
+      if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
+      GList *tagl = NULL;
 
-    dt_tag_update_used_tags();
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+      gchar **entry = tokens;
+      while(*entry)
+      {
+        // remove leading and trailing spaces
+        char *e = *entry + strlen(*entry) - 1;
+        while(*e == ' ' && e > *entry)
+        {
+          *e = '\0';
+          e--;
+        }
+        e = *entry;
+        while(*e == ' ' && *e != '\0') e++;
+        if(*e)
+        {
+          guint tagid = 0;
+          dt_tag_new(e, &tagid);
+          tagl = g_list_prepend(tagl, GINT_TO_POINTER(tagid));
+        }
+        entry++;
+      }
+
+      _tag_execute(tagl, imgs, &undo, undo_on, DT_TA_ATTACH);
+
+      g_list_free(tagl);
+      g_list_free(imgs);
+      if(undo_on)
+      {
+        dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
+        dt_undo_end_group(darktable.undo);
+      }
+
+      dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+    }
   }
   g_strfreev(tokens);
 }
 
-void _detach_tag(guint tagid, gint imgid, gboolean undo_actif)
+void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on)
 {
-  sqlite3_stmt *stmt;
-  GList *undo = NULL;
-
-  if(undo_actif) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
-
-  if(imgid > 0)
-  {
-    if(undo_actif) undo = g_list_append(undo, _get_tags(imgid, tagid, FALSE));
-
-    // remove from tagged_images
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "DELETE FROM main.tagged_images WHERE tagid = ?1 AND imgid = ?2", -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_collection_get_selected(darktable.collection, -1);
   else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(imgs)
   {
-    if(undo_actif) undo = _get_tags_selection(tagid, FALSE);
+    GList *tags = NULL;
+    tags = g_list_prepend(tags, GINT_TO_POINTER(tagid));
+    GList *undo = NULL;
+    if(group_on) dt_grouping_add_grouped_images(&imgs);
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
-    // remove from tagged_images
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "DELETE FROM main.tagged_images WHERE tagid = ?1 AND imgid IN "
-                                "(SELECT imgid FROM main.selected_images)",
-                                -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+    _tag_execute(tags, imgs, &undo, undo_on, DT_TA_DETACH);
+
+    g_list_free(tags);
+    g_list_free(imgs);
+    if(undo_on)
+    {
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
+      dt_undo_end_group(darktable.undo);
+    }
   }
-
-  if(undo_actif)
-  {
-    dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, (dt_undo_data_t)undo, _pop_undo, _tags_undo_data_free);
-    dt_undo_end_group(darktable.undo);
-  }
-
 }
 
-void dt_tag_detach(guint tagid, gint imgid)
+void dt_tag_detach_from_gui(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on)
 {
-  _detach_tag(tagid, imgid, TRUE);
-
-  dt_tag_update_used_tags();
-
-}
-
-void dt_tag_detach_from_gui(guint tagid, gint imgid)
-{
-  _detach_tag(tagid, imgid, TRUE);
-
-  dt_tag_update_used_tags();
+  dt_tag_detach(tagid, imgid, undo_on, group_on);
 
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 }
 
-void dt_tag_detach_by_string(const char *name, gint imgid)
+void dt_tag_detach_by_string(const char *name, const gint imgid, const gboolean undo_on, const gboolean group_on)
 {
-  sqlite3_stmt *stmt;
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "DELETE FROM main.tagged_images WHERE tagid IN (SELECT id FROM "
-                              "data.tags WHERE name LIKE ?1) AND imgid = ?2;",
-                              -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
+  if(!name || !name[0]) return;
+  guint tagid = 0;
+  if (!dt_tag_exists(name, &tagid)) return;
 
-  dt_tag_update_used_tags();
+  dt_tag_detach(tagid, imgid, undo_on, group_on);
+
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 }
 
@@ -846,15 +868,38 @@ GList *dt_tag_get_hierarchical(gint imgid)
   while(taglist)
   {
     dt_tag_t *t = (dt_tag_t *)taglist->data;
-
     tags = g_list_prepend(tags, t->tag);
-
     taglist = g_list_next(taglist);
   }
 
   dt_tag_free_result(&taglist);
 
   tags = g_list_reverse(tags);
+  return tags;
+}
+
+GList *dt_tag_get_tags(gint imgid)
+{
+  GList *tags = NULL;
+  if(imgid < 0) return tags;
+
+  sqlite3_stmt *stmt;
+  dt_set_darktable_tags();
+  char query[256] = { 0 };
+  snprintf(query, sizeof(query), "SELECT DISTINCT T.id "
+                                 "FROM main.tagged_images AS I "
+                                 "JOIN data.tags T on T.id = I.tagid "
+                                 "WHERE I.imgid = %d "
+                                 "AND T.id NOT IN memory.darktable_tags", imgid);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+
+  while(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    tags = g_list_prepend(tags, GINT_TO_POINTER(sqlite3_column_int(stmt, 0)));
+  }
+
+  sqlite3_finalize(stmt);
+
   return tags;
 }
 
@@ -1607,19 +1652,6 @@ ssize_t dt_tag_export(const char *filename)
   fclose(fd);
 
   return count;
-}
-
-void dt_tag_update_used_tags()
-{
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.used_tags WHERE id NOT IN "
-                                                       "(SELECT tagid FROM main.tagged_images GROUP BY tagid)",
-                        NULL, NULL, NULL);
-
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "INSERT OR IGNORE INTO main.used_tags (id, name) "
-                                                       "SELECT t.id, t.name "
-                                                       "FROM data.tags AS t, main.tagged_images AS i "
-                                                       "ON t.id = i.tagid GROUP BY t.id",
-                        NULL, NULL, NULL);
 }
 
 char *dt_tag_get_subtag(const gint imgid, const char *category, const int level)

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -77,29 +77,30 @@ void dt_tag_rename(const guint tagid, const gchar *new_tagname);
 /** checks if tag exists. \param[in] name of tag to check. \return the id of found tag or -1 i not found. */
 gboolean dt_tag_exists(const char *name, guint *tagid);
 
-/** attach a list of tags on selected images. \param[in] tagid id of tag to attach. \param[in] imgid the image
+/** attach a tag on selected images. tagid id of tag to attach. imgid the image
  * id to attach tag to, if < 0 selected images are used. */
-gboolean dt_tag_attach(guint tagid, gint imgid);
+void dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
 /** same as above but raises a DT_SIGNAL_TAG_CHANGED */
-void dt_tag_attach_from_gui(guint tagid, gint imgid);
+void dt_tag_attach_from_gui(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
 
 /** attach a list of tags on selected images. \param[in] tags a list of ids of tags. \param[in] imgid the
- * image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's created.*/
-void dt_tag_attach_list(GList *tags, gint imgid);
+ * image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's created
+ * if clear_on TRUE the image tags are cleared before attaching the new ones*/
+void dt_tag_set_tags(GList *tags, const gint imgid, const gboolean clear_on, const gboolean undo_on, const gboolean group_on);
 
 /** attach a list of tags on selected images. \param[in] tags a comma separated string of tags. \param[in]
  * imgid the image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's
  * created.*/
-void dt_tag_attach_string_list(const gchar *tags, gint imgid);
+void dt_tag_attach_string_list(const gchar *tags, const gint imgid, const gboolean undo_on, const gboolean group_on);
 
 /** detach tag from images. \param[in] tagid if of tag to deattach. \param[in] imgid the image id to attach
  * tag from, if < 0 selected images are used. */
-void dt_tag_detach(guint tagid, gint imgid);
+void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
 /** same as above but raises a DT_SIGNAL_TAG_CHANGED */
-void dt_tag_detach_from_gui(guint tagid, gint imgid);
+void dt_tag_detach_from_gui(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
 
 /** detach tags from images that matches name, it is valid to use % to match tag */
-void dt_tag_detach_by_string(const char *name, gint imgid);
+void dt_tag_detach_by_string(const char *name, const gint imgid, const gboolean undo_on, const gboolean group_on);
 
 /** retrieves a list of tags of specified imgid \param[out] result a list of dt_tag_t, sorted by tag. */
 uint32_t dt_tag_get_attached(gint imgid, GList **result, gboolean ignore_dt_tags);
@@ -123,6 +124,9 @@ GList *dt_tag_get_hierarchical(gint imgid);
 /** get a flat list of only hierarchical tags,
  *  the difference to dt_tag_get_hierarchical() is that this one checks option for exportation */
 GList *dt_tag_get_hierarchical_export(gint imgid, int32_t flags);
+
+/** get a flat list of tag id, without darktable tags*/
+GList *dt_tag_get_tags(gint imgid);
 
 /** get the subset of images from the selected ones that have a given tag attached */
 GList *dt_tag_get_images_from_selection(gint imgid, gint tagid);
@@ -164,17 +168,11 @@ uint32_t dt_tag_get_recent_used(GList **result);
 /** frees the memory of a result set. */
 void dt_tag_free_result(GList **result);
 
-/** reorganize tags */
-void dt_tag_reorganize(const gchar *source, const gchar *dest);
-
 /** get number of selected images */
 uint32_t dt_selected_images_count();
 
 /** get number of images affected with that tag */
 uint32_t dt_tag_images_count(gint tagid);
-
-/** make sure that main.used_tags has everything. to be used after changes to main.tagged_images */
-void dt_tag_update_used_tags();
 
 /** retrieves the subtag of requested level for the requested category */
 char *dt_tag_get_subtag(const gint imgid, const char *category, const int level);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -941,7 +941,7 @@ void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolea
   const int imgid = dev->image_storage.id;
   guint tagid = 0;
   dt_tag_new("darktable|changed", &tagid);
-  dt_tag_attach_from_gui(tagid, imgid);
+  dt_tag_attach_from_gui(tagid, imgid, FALSE, FALSE);
 
   // invalidate buffers and force redraw of darkroom
   dt_dev_invalidate_all(dev);

--- a/src/develop/lightroom.c
+++ b/src/develop/lightroom.c
@@ -853,7 +853,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const int imgid,
         guint tagid = 0;
         if(!dt_tag_exists((char *)cvalue, &tagid)) dt_tag_new((char *)cvalue, &tagid);
 
-        dt_tag_attach_from_gui(tagid, imgid);
+        dt_tag_attach_from_gui(tagid, imgid, FALSE, FALSE);
         data->has_tags = TRUE;
         xmlFree(cvalue);
       }
@@ -924,7 +924,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const int imgid,
       if(!xmlStrncmp(ttlNode->name, (const xmlChar *)"li", 2))
       {
         xmlChar *cvalue = xmlNodeListGetString(doc, ttlNode->xmlChildrenNode, 1);
-        dt_metadata_set(imgid, "Xmp.dc.title", (char *)cvalue);
+        dt_metadata_set(imgid, "Xmp.dc.title", (char *)cvalue, FALSE, FALSE);
         xmlFree(cvalue);
       }
       ttlNode = ttlNode->next;
@@ -938,7 +938,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const int imgid,
       if(!xmlStrncmp(desNode->name, (const xmlChar *)"li", 2))
       {
         xmlChar *cvalue = xmlNodeListGetString(doc, desNode->xmlChildrenNode, 1);
-        dt_metadata_set(imgid, "Xmp.dc.description", (char *)cvalue);
+        dt_metadata_set(imgid, "Xmp.dc.description", (char *)cvalue, FALSE, FALSE);
         xmlFree(cvalue);
       }
       desNode = desNode->next;
@@ -952,7 +952,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const int imgid,
       if(!xmlStrncmp(creNode->name, (const xmlChar *)"li", 2))
       {
         xmlChar *cvalue = xmlNodeListGetString(doc, creNode->xmlChildrenNode, 1);
-        dt_metadata_set(imgid, "Xmp.dc.creator", (char *)cvalue);
+        dt_metadata_set(imgid, "Xmp.dc.creator", (char *)cvalue, FALSE, FALSE);
         xmlFree(cvalue);
       }
       creNode = creNode->next;
@@ -966,7 +966,7 @@ static void _lrop(const dt_develop_t *dev, const xmlDocPtr doc, const int imgid,
       if(!xmlStrncmp(rigNode->name, (const xmlChar *)"li", 2))
       {
         xmlChar *cvalue = xmlNodeListGetString(doc, rigNode->xmlChildrenNode, 1);
-        dt_metadata_set(imgid, "Xmp.dc.rights", (char *)cvalue);
+        dt_metadata_set(imgid, "Xmp.dc.rights", (char *)cvalue, FALSE, FALSE);
         xmlFree(cvalue);
       }
       rigNode = rigNode->next;
@@ -1508,7 +1508,7 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
 
   if(dev == NULL && data.has_rating)
   {
-    dt_ratings_apply_to_image(imgid, data.rating);
+    dt_ratings_apply(imgid, data.rating, FALSE, FALSE, FALSE);
 
     if(imported[0]) g_strlcat(imported, ", ", sizeof(imported));
     g_strlcat(imported, _("rating"), sizeof(imported));
@@ -1520,7 +1520,8 @@ void dt_lightroom_import(int imgid, dt_develop_t *dev, gboolean iauto)
     dt_image_geoloc_t geoloc;
     geoloc.longitude = data.lon;
     geoloc.latitude = data.lat;
-    dt_image_set_location(imgid, &geoloc);
+    geoloc.elevation = NAN;
+    dt_image_set_location(imgid, &geoloc, FALSE, FALSE);
 
     if(imported[0]) g_strlcat(imported, ", ", sizeof(imported));
     g_strlcat(imported, _("geotagging"), sizeof(imported));

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -90,7 +90,7 @@ static gboolean _lib_duplicate_caption_out_callback(GtkWidget *widget, GdkEvent 
   int imgid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget),"imgid"));
 
   // we write the content of the textbox to the caption field
-  dt_metadata_set(imgid, "Xmp.dc.title", gtk_entry_get_text(GTK_ENTRY(widget)));
+  dt_metadata_set(imgid, "Xmp.dc.title", gtk_entry_get_text(GTK_ENTRY(widget)), FALSE, FALSE);
   dt_image_synch_xmp(imgid);
 
   return FALSE;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -2,6 +2,7 @@
     This file is part of darktable,
     copyright (c) 2009--2010 johannes hanika.
     copyright (c) 2011 henrik andersson.
+    copyright (c) 2019 philippe weyland.
 
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -19,7 +20,13 @@
 #include "common/collection.h"
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "common/image_cache.h"
+#include "common/ratings.h"
+#include "common/colorlabels.h"
 #include "common/grouping.h"
+#include "common/undo.h"
+#include "common/metadata.h"
+#include "common/tags.h"
 #include "control/control.h"
 #include "control/jobs.h"
 #include "control/jobs/control_jobs.h"
@@ -43,8 +50,21 @@ typedef struct dt_lib_image_t
 {
   GtkWidget *rotate_cw_button, *rotate_ccw_button, *remove_button, *delete_button, *create_hdr_button,
       *duplicate_button, *reset_button, *move_button, *copy_button, *group_button, *ungroup_button,
-      *cache_button, *uncache_button, *refresh_button;
+      *cache_button, *uncache_button, *refresh_button,
+      *copy_metadata_button, *paste_metadata_button, *add_metadata_button, *clear_metadata_button,
+      *ratings_flag, *colors_flag, *metadata_flag, *geotags_flag, *tags_flag;
+  int imageid;
 } dt_lib_image_t;
+
+typedef enum dt_lib_metadata_id
+{
+  DT_LIB_META_NONE = 0,
+  DT_LIB_META_RATING = 1 << 0,
+  DT_LIB_META_COLORS = 1 << 1,
+  DT_LIB_META_METADATA = 1 << 2,
+  DT_LIB_META_GEOTAG = 1 << 3,
+  DT_LIB_META_TAG = 1 << 4
+} dt_lib_metadata_id;
 
 const char *name(dt_lib_module_t *self)
 {
@@ -166,6 +186,154 @@ int position()
   return 700;
 }
 
+
+static int _get_source_image(void)
+{
+  // if the mouse is over an image, always choose this one
+  // otherwise, choose the first image selected
+  int imgid = dt_control_get_mouse_over_id();
+  if(imgid != -1) return imgid;
+
+  GList *l = dt_collection_get_selected(darktable.collection, 1);
+  if(l)
+  {
+    imgid = GPOINTER_TO_INT(l->data);
+    g_list_free(l);
+  }
+
+  return imgid;
+}
+
+typedef enum dt_metadata_actions_t
+{
+  DT_MA_PASTE = 0,
+  DT_MA_ADD,
+  DT_MA_CLEAR
+} dt_metadata_actions_t;
+
+
+static void _execute_metadata(dt_lib_module_t *self, const int action)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  const gboolean rating_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/rating");
+  const gboolean colors_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/colors");
+  const gboolean dtmetadata_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/metadata");
+  const gboolean geotag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags");
+  const gboolean dttag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/tags");
+  const int imageid = d->imageid;
+  const int img = dt_view_get_image_to_act_on();
+
+  const dt_undo_type_t undo_type = (rating_flag ? DT_UNDO_RATINGS : 0) |
+                                  (colors_flag ? DT_UNDO_COLORLABELS : 0) |
+                                  (dtmetadata_flag ? DT_UNDO_METADATA : 0) |
+                                  (geotag_flag ? DT_UNDO_LT_GEOTAG : 0) |
+                                  (dttag_flag ? DT_UNDO_TAGS : 0);
+  if(undo_type) dt_undo_start_group(darktable.undo, undo_type);
+
+  if(rating_flag)
+  {
+    const int stars = (action == DT_MA_CLEAR) ? 0 : dt_ratings_get(imageid);
+    dt_ratings_apply(img, stars, FALSE, TRUE, TRUE);
+  }
+  if(colors_flag)
+  {
+    const int colors = (action == DT_MA_CLEAR) ? 0 : dt_colorlabels_get_labels(imageid);
+    dt_colorlabels_set_labels(img, colors, TRUE, TRUE);
+  }
+  if(dtmetadata_flag)
+  {
+    GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
+    dt_metadata_set_list_id(img, metadata, action != DT_MA_ADD, TRUE, TRUE);
+    g_list_free_full(metadata, g_free);
+  }
+  if(geotag_flag)
+  {
+    dt_image_geoloc_t *geoloc = (dt_image_geoloc_t *)malloc(sizeof(dt_image_geoloc_t));
+    if(action == DT_MA_CLEAR)
+      geoloc->longitude = geoloc->latitude = geoloc->elevation = NAN;
+    else
+      dt_image_get_location(imageid, geoloc);
+    dt_image_set_location(img, geoloc, TRUE, TRUE);
+    g_free(geoloc);
+  }
+  if(dttag_flag)
+  {
+    GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid);
+    dt_tag_set_tags(tags, img, action != DT_MA_ADD, TRUE, TRUE);
+    g_list_free(tags);
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+  }
+
+  if(undo_type)
+  {
+    dt_undo_end_group(darktable.undo);
+    dt_collection_update_query(darktable.collection);
+    dt_control_queue_redraw_center();
+    dt_image_synch_xmp(img);
+  }
+}
+
+static void copy_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  d->imageid = _get_source_image();
+  if(d->imageid)
+  {
+    gtk_widget_set_sensitive(d->paste_metadata_button, TRUE);
+    gtk_widget_set_sensitive(d->add_metadata_button, TRUE);
+  }
+}
+
+static void paste_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  _execute_metadata(self, DT_MA_PASTE);
+}
+
+static void add_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  _execute_metadata(self, DT_MA_ADD);
+}
+
+static void clear_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  _execute_metadata(self, DT_MA_CLEAR);
+}
+
+static void ratings_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->ratings_flag));
+  dt_conf_set_bool("plugins/lighttable/copy_metadata/rating", flag);
+}
+
+static void colors_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->colors_flag));
+  dt_conf_set_bool("plugins/lighttable/copy_metadata/colors", flag);
+}
+
+static void metadata_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->metadata_flag));
+  dt_conf_set_bool("plugins/lighttable/copy_metadata/metadata", flag);
+}
+
+static void geotags_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->geotags_flag));
+  dt_conf_set_bool("plugins/lighttable/copy_metadata/geotags", flag);
+}
+
+static void tags_flag_callback(GtkWidget *widget, dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  const gboolean flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->tags_flag));
+  dt_conf_set_bool("plugins/lighttable/copy_metadata/tags", flag);
+}
+
 #define ellipsize_button(button) gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
 void gui_init(dt_lib_module_t *self)
 {
@@ -277,8 +445,75 @@ void gui_init(dt_lib_module_t *self)
   ellipsize_button(button);
   d->refresh_button = button;
   gtk_widget_set_tooltip_text(button, _("update image information to match changes to file"));
-  gtk_grid_attach(grid, button, 0, line, 4, 1);
+  gtk_grid_attach(grid, button, 0, line++, 4, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(14));
+
+
+  GtkWidget *label = dt_ui_section_label_new(_("metadata operations"));
+  gtk_widget_set_tooltip_text(label, _("metadata operations apply on selected metadata"));
+  gtk_grid_attach(grid, label, 0, line++, 4, 1);
+
+  button = gtk_button_new_with_label(_("copy"));
+  ellipsize_button(button);
+  d->copy_metadata_button = button;
+  d->imageid = 0;
+  gtk_widget_set_tooltip_text(button, _("set the (first) selected image as source of metadata"));
+  gtk_grid_attach(grid, button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(copy_metadata_callback), self);
+
+  button = gtk_button_new_with_label(_("paste"));
+  ellipsize_button(button);
+  d->paste_metadata_button = button;
+  gtk_widget_set_sensitive(button, FALSE);
+  gtk_widget_set_tooltip_text(button, _("paste selected metadata to selected images (clears previous dt metadata and tags on selected images)"));
+  gtk_grid_attach(grid, button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(paste_metadata_callback), self);
+
+  button = gtk_button_new_with_label(_("add"));
+  ellipsize_button(button);
+  d->add_metadata_button = button;
+  gtk_widget_set_sensitive(button, FALSE);
+  gtk_widget_set_tooltip_text(button, _("add selected metadata to selected images (doesn\'t clear previous dt metadata and tags on selected images)"));
+  gtk_grid_attach(grid, button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(add_metadata_callback), self);
+
+  button = gtk_button_new_with_label(_("clear"));
+  ellipsize_button(button);
+  d->clear_metadata_button = button;
+  gtk_widget_set_tooltip_text(button, _("clear selected metadata on selected images"));
+  gtk_grid_attach(grid, button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(clear_metadata_callback), self);
+
+  GtkWidget *flag = gtk_check_button_new_with_label(_("ratings"));
+  d->ratings_flag = flag;
+  gtk_widget_set_tooltip_text(flag, _("select ratings metadata"));
+  gtk_grid_attach(grid, flag, 0, line, 2, 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/rating"));
+  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(ratings_flag_callback), self);
+  flag = gtk_check_button_new_with_label(_("colors"));
+  d->colors_flag = flag;
+  gtk_widget_set_tooltip_text(flag, _("select colors metadata"));
+  gtk_grid_attach(grid, flag, 2, line++, 2, 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/colors"));
+  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(colors_flag_callback), self);
+  flag = gtk_check_button_new_with_label(_("metadata"));
+  d->metadata_flag = flag;
+  gtk_widget_set_tooltip_text(flag, _("select dt metadata (from metadata editor module)"));
+  gtk_grid_attach(grid, flag, 0, line, 2, 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/metadata"));
+  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(metadata_flag_callback), self);
+  flag = gtk_check_button_new_with_label(_("geo tags"));
+  d->geotags_flag = flag;
+  gtk_widget_set_tooltip_text(flag, _("select geo tags metadata"));
+  gtk_grid_attach(grid, flag, 2, line++, 2, 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags"));
+  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(geotags_flag_callback), self);
+  flag = gtk_check_button_new_with_label(_("tags"));
+  d->tags_flag = flag;
+  gtk_widget_set_tooltip_text(flag, _("select tags metadata"));
+  gtk_grid_attach(grid, flag, 0, line, 2, 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/tags"));
+  g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(tags_flag_callback), self);
 
   /* connect preference changed signal */
   dt_control_signal_connect(
@@ -288,6 +523,13 @@ void gui_init(dt_lib_module_t *self)
       (gpointer)self);
 }
 #undef ellipsize_button
+
+void gui_reset(dt_lib_module_t *self)
+{
+  dt_lib_image_t *d = (dt_lib_image_t *)self->data;
+  d->imageid = 0;
+  gtk_widget_set_sensitive(d->paste_metadata_button, FALSE);
+}
 
 void gui_cleanup(dt_lib_module_t *self)
 {
@@ -311,6 +553,10 @@ void init_key_accels(dt_lib_module_t *self)
   dt_accel_register_lib(self, NC_("accel", "copy the image locally"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "resync the local copy"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "refresh exif"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "copy metadata"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "paste metadata"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "add metadata"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "clear metadata"), 0, 0);
   // Grouping keys
   dt_accel_register_lib(self, NC_("accel", "group"), GDK_KEY_g, GDK_CONTROL_MASK);
   dt_accel_register_lib(self, NC_("accel", "ungroup"), GDK_KEY_g, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
@@ -332,6 +578,10 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_button_lib(self, "copy the image locally", d->cache_button);
   dt_accel_connect_button_lib(self, "resync the local copy", d->uncache_button);
   dt_accel_connect_button_lib(self, "refresh exif", d->refresh_button);
+  dt_accel_connect_button_lib(self, "copy metadata", d->copy_metadata_button);
+  dt_accel_connect_button_lib(self, "paste metadata", d->paste_metadata_button);
+  dt_accel_connect_button_lib(self, "add metadata", d->add_metadata_button);
+  dt_accel_connect_button_lib(self, "clear metadata", d->clear_metadata_button);
   // Grouping keys
   dt_accel_connect_button_lib(self, "group", d->group_button);
   dt_accel_connect_button_lib(self, "ungroup", d->ungroup_button);

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -200,7 +200,7 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 
 static void clear_button_clicked(GtkButton *button, gpointer user_data)
 {
-  dt_metadata_clear(-1);
+  dt_metadata_clear(-1, TRUE, TRUE);
   dt_image_synch_xmp(-1);
   update(user_data, FALSE);
 }
@@ -243,7 +243,7 @@ static void write_metadata(dt_lib_module_t *self)
      && (d->multi_publisher == FALSE || gtk_combo_box_get_active(GTK_COMBO_BOX(d->publisher)) != 0))
     _append_kv(&key_value, "Xmp.dc.publisher", publisher);
 
-  dt_metadata_set_list(mouse_over_id, key_value);
+  dt_metadata_set_list(mouse_over_id, key_value, TRUE, TRUE);
 
   g_list_free(key_value);
   g_free(title);
@@ -525,7 +525,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
   if(creator[0] != '\0') _append_kv(&key_value, "Xmp.dc.creator", creator);
   if(publisher[0] != '\0') _append_kv(&key_value, "Xmp.dc.publisher", publisher);
 
-  dt_metadata_set_list(-1, key_value);
+  dt_metadata_set_list(-1, key_value, TRUE, TRUE);
 
   g_list_free(key_value);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -754,6 +754,10 @@ void gui_init(dt_lib_module_t *self)
      image in darkroom when enter */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE,
                             G_CALLBACK(_mouse_over_image_callback), self);
+
+  /* signup for tags changes */
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_TAG_CHANGED,
+                            G_CALLBACK(_mouse_over_image_callback), self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -358,7 +358,7 @@ static int _print_job_run(dt_job_t *job)
   guint tagid = 0;
   snprintf (tag, sizeof(tag), "darktable|printed|%s", params->prt.printer.name);
   dt_tag_new(tag, &tagid);
-  dt_tag_attach_from_gui(tagid, params->imgid);
+  dt_tag_attach_from_gui(tagid, params->imgid, FALSE, FALSE);
 
   return 0;
 }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2834,7 +2834,7 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
   {
     const int imgsel = dt_control_get_mouse_over_id();
 
-    dt_tag_attach_string_list(d->last_tag, imgsel);
+    dt_tag_attach_string_list(d->last_tag, imgsel, TRUE, TRUE);
     dt_image_synch_xmp(imgsel);
     init_treeview(self, 0);
     init_treeview(self, 1);

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -836,7 +836,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
       {
         guint tagid = strtoul(*entry, NULL, 0);
 
-        dt_tag_attach(tagid, imgsel);
+        dt_tag_attach(tagid, imgsel, TRUE, TRUE);
 
         const guint count = dt_tag_images_count(tagid);
         gtk_tree_model_get_iter_first(store, &iter);
@@ -881,7 +881,7 @@ static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
   const int imgsel = dt_view_get_image_to_act_on();
   if(imgsel < 0 && dt_collection_get_selected_count(darktable.collection) == 0)
     return;
-  dt_tag_attach(tagid, imgsel);
+  dt_tag_attach(tagid, imgsel, TRUE, TRUE);
 
   /** record last tag used */
   g_free(d->last_tag);
@@ -930,7 +930,7 @@ static void detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_lib
     return;
   GList *affected_images = dt_tag_get_images_from_selection(imgsel, tagid);
 
-  dt_tag_detach(tagid, imgsel);
+  dt_tag_detach(tagid, imgsel, TRUE, TRUE);
 
   init_treeview(self, 0);
   if (d->tree_flag || !d->suggestion_flag)
@@ -997,7 +997,7 @@ static void pop_menu_attached_attach_to_all(GtkWidget *menuitem, dt_lib_module_t
   if(tagid <= 0) return;
 
   const int imgsel = dt_view_get_image_to_act_on();
-  dt_tag_attach(tagid, imgsel);
+  dt_tag_attach(tagid, imgsel, TRUE, TRUE);
 
   /** record last tag used */
   g_free(d->last_tag);
@@ -1111,7 +1111,7 @@ static void new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   if(!tag || tag[0] == '\0') return;
 
   /** attach tag to selected images  */
-  dt_tag_attach_string_list(tag, -1);
+  dt_tag_attach_string_list(tag, -1, TRUE, TRUE);
   dt_image_synch_xmp(-1);
 
   /** record last tag used */
@@ -1124,6 +1124,7 @@ static void new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   init_treeview(self, 0);
   init_treeview(self, 1);
   raise_signal_tag_changed(self);
+  gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
 }
 
 static void entry_activated(GtkButton *button, dt_lib_module_t *self)
@@ -2800,7 +2801,7 @@ static gboolean _lib_tagging_tag_key_press(GtkWidget *entry, GdkEventKey *event,
     {
       const gchar *tag = gtk_entry_get_text(GTK_ENTRY(entry));
       // both these functions can deal with -1 for all selected images. no need for extra code in here!
-      dt_tag_attach_string_list(tag, d->floating_tag_imgid);
+      dt_tag_attach_string_list(tag, d->floating_tag_imgid, TRUE, TRUE);
       dt_image_synch_xmp(d->floating_tag_imgid);
 
       /** record last tag used */

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -203,6 +203,7 @@ void init_key_accels(dt_lib_module_t *self)
   dt_accel_register_lib_for_views(self, views, NC_("accel", "color green"), GDK_KEY_F3, 0);
   dt_accel_register_lib_for_views(self, views, NC_("accel", "color blue"), GDK_KEY_F4, 0);
   dt_accel_register_lib_for_views(self, views, NC_("accel", "color purple"), GDK_KEY_F5, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "clear color labels"), 0, 0);
 
   /* setup selection accelerators */
   dt_accel_register_lib_for_views(self, views, NC_("accel", "select all"), GDK_KEY_a, GDK_CONTROL_MASK);
@@ -272,6 +273,9 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_lib(
       self, "color purple",
       g_cclosure_new(G_CALLBACK(_lib_filmstrip_colorlabels_key_accel_callback), GINT_TO_POINTER(4), NULL));
+  dt_accel_connect_lib(
+      self, "clear color labels",
+      g_cclosure_new(G_CALLBACK(_lib_filmstrip_colorlabels_key_accel_callback), GINT_TO_POINTER(5), NULL));
 
   // Selection accels
   dt_accel_connect_lib(self, "select all", g_cclosure_new(G_CALLBACK(_lib_filmstrip_select_key_accel_callback),
@@ -518,7 +522,7 @@ static gboolean _lib_filmstrip_button_press_callback(GtkWidget *w, GdkEventButto
           int offset = 0;
           if(mouse_over_id == strip->activated_image) offset = dt_collection_image_offset(mouse_over_id);
 
-          dt_ratings_apply_to_image_or_group(mouse_over_id, strip->image_over);
+          dt_ratings_apply(mouse_over_id, strip->image_over, TRUE, TRUE, TRUE);
 
           if(mouse_over_id == strip->activated_image)
             if(_lib_filmstrip_imgid_in_collection(darktable.collection, mouse_over_id) == 0)
@@ -982,7 +986,7 @@ static gboolean _lib_filmstrip_ratings_key_accel_callback(GtkAccelGroup *accel_g
       int offset = 0;
       if(mouse_over_id == activated_image) offset = dt_collection_image_offset(mouse_over_id);
 
-      dt_ratings_apply_to_image_or_group(image_id, num);
+      dt_ratings_apply(image_id, num, TRUE, TRUE, TRUE);
 
       dt_collection_update_query(darktable.collection); // update the counter and selection
       dt_collection_hint_message(darktable.collection); // More than this, we need to redraw all

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -195,20 +195,10 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   dt_lib_ratings_t *d = (dt_lib_ratings_t *)self->data;
   if(d->current > 0)
   {
-    int32_t mouse_over_id;
-
-    mouse_over_id = dt_view_get_image_to_act_on();
-
-    if(mouse_over_id <= 0)
-    {
-      dt_ratings_apply_to_selection(d->current);
-    }
-    else
-    {
-      dt_ratings_apply_to_image(mouse_over_id, d->current);
-      // dt_control_log(ngettext("applying rating %d to %d image", "applying rating %d to %d images", 1),
-      // d->current, 1); //FIXME: Change the message after release
-    }
+    const int32_t mouse_over_id = dt_view_get_image_to_act_on();
+    dt_ratings_apply(mouse_over_id, d->current, TRUE, TRUE, TRUE);
+    // dt_control_log(ngettext("applying rating %d to %d image", "applying rating %d to %d images", 1),
+    // d->current, 1); //FIXME: Change the message after release
 
     dt_control_queue_redraw_center();
   }

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -252,7 +252,7 @@ static int creator_member(lua_State *L)
   else
   {
     dt_image_t *my_image = checkwriteimage(L, 1);
-    dt_metadata_set(my_image->id, "Xmp.dc.creator", luaL_checkstring(L, 3));
+    dt_metadata_set(my_image->id, "Xmp.dc.creator", luaL_checkstring(L, 3), TRUE, TRUE);
     dt_image_synch_xmp(my_image->id);
     releasewriteimage(L, my_image);
     return 0;
@@ -276,7 +276,7 @@ static int publisher_member(lua_State *L)
   else
   {
     dt_image_t *my_image = checkwriteimage(L, 1);
-    dt_metadata_set(my_image->id, "Xmp.dc.publisher", luaL_checkstring(L, 3));
+    dt_metadata_set(my_image->id, "Xmp.dc.publisher", luaL_checkstring(L, 3), TRUE, TRUE);
     dt_image_synch_xmp(my_image->id);
     releasewriteimage(L, my_image);
     return 0;
@@ -300,7 +300,7 @@ static int title_member(lua_State *L)
   else
   {
     dt_image_t *my_image = checkwriteimage(L, 1);
-    dt_metadata_set(my_image->id, "Xmp.dc.title", luaL_checkstring(L, 3));
+    dt_metadata_set(my_image->id, "Xmp.dc.title", luaL_checkstring(L, 3), TRUE, TRUE);
     dt_image_synch_xmp(my_image->id);
     releasewriteimage(L, my_image);
     return 0;
@@ -324,7 +324,7 @@ static int description_member(lua_State *L)
   else
   {
     dt_image_t *my_image = checkwriteimage(L, 1);
-    dt_metadata_set(my_image->id, "Xmp.dc.description", luaL_checkstring(L, 3));
+    dt_metadata_set(my_image->id, "Xmp.dc.description", luaL_checkstring(L, 3), TRUE, TRUE);
     dt_image_synch_xmp(my_image->id);
     releasewriteimage(L, my_image);
     return 0;
@@ -348,7 +348,7 @@ static int rights_member(lua_State *L)
   else
   {
     dt_image_t *my_image = checkwriteimage(L, 1);
-    dt_metadata_set(my_image->id, "Xmp.dc.rights", luaL_checkstring(L, 3));
+    dt_metadata_set(my_image->id, "Xmp.dc.rights", luaL_checkstring(L, 3), TRUE, TRUE);
     dt_image_synch_xmp(my_image->id);
     releasewriteimage(L, my_image);
     return 0;

--- a/src/lua/tags.c
+++ b/src/lua/tags.c
@@ -190,7 +190,7 @@ int dt_lua_tag_attach(lua_State *L)
     luaA_to(L, dt_lua_tag_t, &tagid, 1);
     luaA_to(L, dt_lua_image_t, &imgid, 2);
   }
-  dt_tag_attach_from_gui(tagid, imgid);
+  dt_tag_attach_from_gui(tagid, imgid, TRUE, TRUE);
   dt_image_synch_xmp(imgid);
   return 0;
 }
@@ -209,7 +209,7 @@ int dt_lua_tag_detach(lua_State *L)
     luaA_to(L, dt_lua_tag_t, &tagid, 1);
     luaA_to(L, dt_lua_image_t, &imgid, 2);
   }
-  dt_tag_detach(tagid, imgid);
+  dt_tag_detach(tagid, imgid, TRUE, TRUE);
   dt_image_synch_xmp(imgid);
   return 0;
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -4468,7 +4468,6 @@ static gboolean _lighttable_undo_callback(GtkAccelGroup *accel_group, GObject *a
 static gboolean _lighttable_redo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                           GdkModifierType modifier, gpointer data)
 {
-  printf("_lighttable_redo_callback\n");
   dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
   dt_library_t *lib = (dt_library_t *)self->data;
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -3157,10 +3157,7 @@ static gboolean rating_key_accel_callback(GtkAccelGroup *accel_group, GObject *a
   }
 
   mouse_over_id = dt_view_get_image_to_act_on();
-  if(mouse_over_id <= 0)
-    dt_ratings_apply_to_selection(num);
-  else
-    dt_ratings_apply_to_image_or_group(mouse_over_id, num);
+  dt_ratings_apply(mouse_over_id, num, TRUE, TRUE, TRUE);
   _update_collected_images(self);
 
   dt_collection_update_query(darktable.collection); // update the counter
@@ -3787,7 +3784,7 @@ void activate_control_element(dt_view_t *self)
     case DT_VIEW_STAR_5:
     {
       const int32_t mouse_over_id = dt_control_get_mouse_over_id();
-      dt_ratings_apply_to_image_or_group(mouse_over_id, lib->image_over);
+      dt_ratings_apply(mouse_over_id, lib->image_over, TRUE, TRUE, TRUE);
       _update_collected_images(self);
       break;
     }
@@ -4471,6 +4468,7 @@ static gboolean _lighttable_undo_callback(GtkAccelGroup *accel_group, GObject *a
 static gboolean _lighttable_redo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                           GdkModifierType modifier, gpointer data)
 {
+  printf("_lighttable_redo_callback\n");
   dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
   dt_library_t *lib = (dt_library_t *)self->data;
 

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1198,7 +1198,6 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
 {
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
-
   if(type == DT_UNDO_GEOTAG)
   {
     dt_undo_geotag_t *geotag = (dt_undo_geotag_t *)data;
@@ -1217,10 +1216,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
 
 static void _set_image_location(dt_view_t *self, int imgid, dt_image_geoloc_t *geoloc, gboolean set_elevation)
 {
-  if(set_elevation)
-    dt_image_set_location_and_elevation(imgid, geoloc);
-  else
-    dt_image_set_location(imgid, geoloc);
+  dt_image_set_location(imgid, geoloc, FALSE, FALSE);
 
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
 }
@@ -1243,7 +1239,7 @@ static void _view_map_add_image_to_map(dt_view_t *self, int imgid, gint x, gint 
 
   geotag->after.longitude = longitude;
   geotag->after.latitude = latitude;
-  geotag->after.elevation = 0.0;
+  geotag->after.elevation = NAN;
 
   dt_undo_record(darktable.undo, self, DT_UNDO_GEOTAG, (dt_undo_data_t)geotag, _pop_undo, free);
 


### PR DESCRIPTION
Starting copy/paste feature for color & rate, metadata, geotags and tags.

![image](https://user-images.githubusercontent.com/23012047/68542173-1a5f5380-03aa-11ea-8572-e8abe98eb9b3.png)

![image](https://user-images.githubusercontent.com/23012047/68542177-29de9c80-03aa-11ea-8766-8031f78911fd.png)

There are two key points in there:
- undo/redo
- image groups

If I create a top level undo group for the 4 above features (dt_undo_start_group() ) and then call individual feature routines with undo already implemented (like dt_ratings_apply_to_image_or_group() ), should that work (i.e. a unique undo would undo the 4 features at once) ?

Advice, guidelines and comments are welcome.
