### PR TITLE
fixes parsing when comma in exif

### DIFF
--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1678,34 +1678,13 @@ static void camera_menu_fill(dt_iop_module_t *self, const lfCamera *const *camli
   g_ptr_array_free(makers, TRUE);
 }
 
-static void parse_maker_model(const char *txt, char *make, size_t sz_make, char *model, size_t sz_model)
+static void parse_model(const char *txt, char *model, size_t sz_model)
 {
-  const gchar *sep;
-
   while(txt[0] && isspace(txt[0])) txt++;
-  sep = strchr(txt, ',');
-  if(sep)
-  {
-    size_t len = sep - txt;
-    if(len > sz_make - 1) len = sz_make - 1;
-    memcpy(make, txt, len);
-    make[len] = 0;
-
-    while(*++sep && isspace(sep[0]))
-      ;
-    len = strlen(sep);
-    if(len > sz_model - 1) len = sz_model - 1;
-    memcpy(model, sep, len);
-    model[len] = 0;
-  }
-  else
-  {
-    size_t len = strlen(txt);
-    if(len > sz_model - 1) len = sz_model - 1;
-    memcpy(model, txt, len);
-    model[len] = 0;
-    make[0] = 0;
-  }
+  size_t len = strlen(txt);
+  if(len > sz_model - 1) len = sz_model - 1;
+  memcpy(model, txt, len);
+  model[len] = 0;
 }
 
 static void camera_menusearch_clicked(GtkWidget *button, gpointer user_data)
@@ -1753,7 +1732,7 @@ static void camera_autosearch_clicked(GtkWidget *button, gpointer user_data)
   }
   else
   {
-    parse_maker_model(txt, make, sizeof(make), model, sizeof(model));
+    parse_model(txt, model, sizeof(model));
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfCamera **camlist = dt_iop_lensfun_db->FindCamerasExt(make, model, 0);
     dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
@@ -2103,14 +2082,14 @@ static void lens_autosearch_clicked(GtkWidget *button, gpointer user_data)
   lfDatabase *dt_iop_lensfun_db = (lfDatabase *)gd->db;
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
   const lfLens **lenslist;
-  char make[200], model[200];
+  char model[200];
   const gchar *txt = ((dt_iop_lensfun_params_t *)self->default_params)->lens;
 
   (void)button;
 
-  parse_maker_model(txt, make, sizeof(make), model, sizeof(model));
+  parse_model(txt, model, sizeof(model));
   dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
-  lenslist = dt_iop_lensfun_db->FindLenses(g->camera, make[0] ? make : NULL,
+  lenslist = dt_iop_lensfun_db->FindLenses(g->camera, NULL,
                                            model[0] ? model : NULL, LF_SEARCH_SORT_AND_UNIQUIFY);
   dt_pthread_mutex_unlock(&darktable.plugin_threadsafe);
   if(!lenslist) return;
@@ -2563,10 +2542,10 @@ void gui_update(struct dt_iop_module_t *self)
   }
   if(g->camera && p->lens[0])
   {
-    char make[200], model[200];
-    parse_maker_model(p->lens, make, sizeof(make), model, sizeof(model));
+    char model[200];
+    parse_model(p->lens, model, sizeof(model));
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
-    const lfLens **lenslist = dt_iop_lensfun_db->FindLenses(g->camera, make[0] ? make : NULL,
+    const lfLens **lenslist = dt_iop_lensfun_db->FindLenses(g->camera, NULL,
                                                             model[0] ? model : NULL, 0);
     if(lenslist)
       lens_set(self, lenslist[0]);


### PR DESCRIPTION
fixes issues when exiv2 lens metadata contains comma:

The function `parse_maker_model` uses the comma in the input string to
separate the maker from the model. This does not work when the input
already contains a comma, as it is e.g. in "Sigma 24-70mm F2,8 DG OS HSM
Art".

This PR removes the special case in which the comma separates maker from model (and removes maker). (The function was supporting someting like parsing "Nikon, Sigma someLens F2.8" into maker="Nikon" model="Sigma someLens F2.8" and I must question its validity looking at the exiv2 database: I did not find any lens metadata that contains the maker and the model.)

* renames parse_maker_model to parse_model
* removes code to parse the maker

You can test that by adding the file ~/.exiv2 that contains something
like this:

cat ~/.exiv2
[nikon]
201=Sigma 24-70mm F2,8 DG OS HSM Art

replace "nikon" with your body and "201" with your lensID. Then
import images into darktable (it will not affect images already in your
database).

At the same time I have created a PR (https://github.com/Exiv2/exiv2/pull/1055) on exiv2 to fix the comma.
replace it by a dot.