### PR TITLE
filmicrgb bugfix

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -511,6 +511,8 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
       // Get the desaturation value based on the log value
       const float desaturation = filmic_desaturate(norm, data->sigma_toe, data->sigma_shoulder, data->saturation);
+       
+      for(int c = 0; c < 3; c++) ratios[c] *= norm;
 
       const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(ratios,
                                                                            work_profile->matrix_in,
@@ -521,7 +523,7 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
                                         : dt_camera_rgb_luminance(ratios);
 
       // Desaturate on the non-linear parts of the curve and save ratios
-      for(int c = 0; c < 3; c++) ratios[c] = linear_saturation(ratios[c] * norm, lum, desaturation) / norm;
+      for(int c = 0; c < 3; c++) ratios[c] = linear_saturation(ratios[c], lum, desaturation) / norm;
 
       // Filmic S curve on the max RGB
       // Apply the transfer function of the display


### PR DESCRIPTION
Fix #3381.

Explanation of the bug: the ratios sent to the luminance computations were not multiplied back by the norm, so the luminance computation didn't got proper RGB values but RGB/norm, giving a wrong luminance and therefore a wrong desaturation right after, which produced white shadows. This was done properly in the OpenCL code though.