### PR TITLE
history: rework history entries, cleaner and closer to the iop modules.

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -326,6 +326,7 @@ button
 
 #recent-collection-button,
 #history-button,
+#history-button-enabled,
 #history-button-always-enabled,
 #history-button-default-enabled
 {
@@ -339,7 +340,7 @@ button
 
 #history-number
 {
-   padding: 2px;
+   padding-right: 4px;
    font-family: monospace;
 }
 
@@ -920,7 +921,9 @@ checkbutton check
 }
 
 #left #history-button, /* choose here spacing between history items in darkroom */
+#left #history-button-enabled,
 #left #history-switch,
+#left #history-button-enabled,
 #left #history-button-always-enabled,
 #left #history-switch-always-enabled,
 #left #history-button-default-enabled,
@@ -928,6 +931,12 @@ checkbutton check
 {
   padding: 1px 2px 2px 2px;
   margin: 0px 1px 1px 1px;
+}
+
+#left #history-switch-always-enabled,
+#left #history-switch-deprecated
+{
+  font-size: 0.6em;
 }
 
 #iop-bottom-bar
@@ -1081,14 +1090,17 @@ menuitem:active,
 combobox window *:active,
 #recent-collection-button:selected,
 #history-button:selected,
+#history-button-enabled:selected,
 #history-button-always-enabled:selected,
 #history-button-default-enabled:selected,
 #recent-collection-button:active,
 #history-button:active,
+#history-button-enabled:active,
 #history-button-always-enabled:active,
 #history-button-default-enabled:active,
 #recent-collection-button:checked,
 #history-button:checked,
+#history-button-enabled:checked,
 #history-button-always-enabled:checked,
 #history-button-default-enabled:checked,
 #iop-plugin-ui button:active,
@@ -1101,17 +1113,21 @@ combobox window *:active,
   color: @button_checked_fg;
 }
 
+/* currently selected button */
 #history-button:selected *,
+#history-button-enabled:selected *,
 #history-button-always-enabled:selected *,
 #history-button-default-enabled:selected *,
 #history-button:active *,
+#history-button-enabled:active *,
 #history-button-always-enabled:active *,
 #history-button-default-enabled:active *,
 #history-button:checked *,
+#history-button-enabled:checked *,
 #history-button-always-enabled:checked *,
 #history-button-default-enabled:checked *
 {
-  color: @button_checked_fg;
+    color: @button_checked_fg;
 }
 
 * button:hover,
@@ -1121,6 +1137,7 @@ menuitem:hover arrow,
 combobox window *:hover,
 #recent-collection-button:hover,
 #history-button:hover,
+#history-button-enabled:hover,
 #history-button-always-enabled:hover,
 #history-button-default-enabled:hover,
 #iop-plugin-ui button:hover,
@@ -1147,6 +1164,7 @@ notebook tab:hover label,
 #preferences_notebook menuitem:hover *,
 #recent-collection-button:hover,
 #history-button:hover *,
+#history-button-enabled:hover *,
 #history-button-always-enabled:hover *,
 #history-button-default-enabled:hover *,
 #iop-plugin-ui button:hover,
@@ -1162,10 +1180,17 @@ notebook tab:hover label,
   color: @button_hover_fg;
 }
 
-#history-button *
+#history-button-enabled *
 {
   color: @plugin_fg_color;
   background-color: transparent;
+}
+
+#history-button *
+{
+  color: shade(@plugin_fg_color, 0.7);
+  background-color: transparent;
+  font-family: italic;
 }
 
 button:disabled,
@@ -1175,21 +1200,24 @@ button:disabled,
   background-color: transparent;
 }
 
-/* disabled switch buttons in history, make them well visible */
+/* invisible switch buttons */
 #history-switch:disabled,
-#history-switch-always-enabled:disabled,
+#history-switch-enabled:disabled,
 #history-switch-default-enabled:disabled
 {
-  color: @plugin_label_color;
+    color: transparent;
+    background-color: transparent;
+    /* for some reasons we still have a color on those icons,
+       to avoid seeing them too much we make them very small */
+    min-width: .1em;
+    min-height: .1em;
 }
 
-/* switch button on the left of the history entry */
-#history-switch,
-#history-switch-default-enabled,
-#history-switch-always-enabled
+/* deprecated/always-on switch are visible */
+#history-switch-deprecated:disabled,
+#history-switch-always-enabled:disabled
 {
-    min-width: .6em;
-    min-height: .6em;
+    color: @plugin_label_color;
 }
 
 treeview *:hover,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -337,10 +337,10 @@ button
   font-weight: normal;
 }
 
-#history-button-always-enabled *,
-#history-button-default-enabled *
+#history-number
 {
-  color: shade(@plugin_label_color, 0.9);
+   padding: 2px;
+   font-family: monospace;
 }
 
 #dt-button button,
@@ -919,7 +919,12 @@ checkbutton check
   padding: 2px;
 }
 
-#left #history-button /* choose here spacing between history items in darkroom */
+#left #history-button, /* choose here spacing between history items in darkroom */
+#left #history-switch,
+#left #history-button-always-enabled,
+#left #history-switch-always-enabled,
+#left #history-button-default-enabled,
+#left #history-switch-default-enabled
 {
   padding: 1px 2px 2px 2px;
   margin: 0px 1px 1px 1px;
@@ -1157,14 +1162,34 @@ notebook tab:hover label,
   color: @button_hover_fg;
 }
 
+#history-button *
+{
+  color: @plugin_fg_color;
+  background-color: transparent;
+}
+
 button:disabled,
-#recent-collection-button:disabled,
-#history-button:disabled,
-#history-button-always-enabled:disabled,
-#history-button-default-enabled:disabled
+#recent-collection-button:disabled
 {
   color: @disabled_fg_color;
   background-color: transparent;
+}
+
+/* disabled switch buttons in history, make them well visible */
+#history-switch:disabled,
+#history-switch-always-enabled:disabled,
+#history-switch-default-enabled:disabled
+{
+  color: @plugin_label_color;
+}
+
+/* switch button on the left of the history entry */
+#history-switch,
+#history-switch-default-enabled,
+#history-switch-always-enabled
+{
+    min-width: .6em;
+    min-height: .6em;
 }
 
 treeview *:hover,

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -303,6 +303,21 @@ void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_identity_matrix(cr);
 }
 
+void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  const gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, 0.3);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_move_to(cr, 0.5, -0.5);
+  cairo_line_to(cr, 0.5, 0.5);
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+}
+
 void dtgtk_cairo_paint_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   dtgtk_cairo_paint_plusminus(cr, x, y, w, h, flags | CPF_ACTIVE, data);

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -66,6 +66,8 @@ void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an always-on switch icon */
 void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a deprecated switch icon */
+void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a plusminus icon */
 void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Same as dtgtk_cairo_paint_plusminus, but render as a plus even

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -176,6 +176,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
     gtk_widget_set_name(onoff, "history-switch-always-enabled");
     gtk_widget_set_name(widget, "history-button-always-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), TRUE);
+    // gtk_widget_set_tooltip_text(onoff, _("always-on module"));
   }
   else if(default_enabled)
   {
@@ -184,6 +185,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
     gtk_widget_set_name(onoff, "history-switch-default-enabled");
     gtk_widget_set_name(widget, "history-button-default-enabled");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
+    // gtk_widget_set_tooltip_text(onoff, _("default enabled module"));
   }
   else
   {
@@ -191,15 +193,17 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
     {
       onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_deprecated,
                                CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
+      gtk_widget_set_name(onoff, "history-switch-deprecated");
       // for after 3.0 as it breaks translation
-      // gtk_widget_set_tooltip_text(onoff, _("this is a deprecated module"));
+      // gtk_widget_set_tooltip_text(onoff, _("deprecated module"));
     }
     else
+    {
       onoff = dtgtk_button_new(dtgtk_cairo_paint_switch,
                                CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
-
-    gtk_widget_set_name(onoff, "history-switch");
-    gtk_widget_set_name(widget, "history-button");
+      gtk_widget_set_name(onoff, enabled ? "history-switch-enabled" : "history-switch");
+    }
+    gtk_widget_set_name(widget, enabled ? "history-button-enabled" : "history-button");
     dtgtk_button_set_active(DTGTK_BUTTON(onoff), enabled);
   }
 


### PR DESCRIPTION
Something else that was itching me since long time. It looks like this now:

![image](https://user-images.githubusercontent.com/467069/68800976-6553c200-065b-11ea-9363-b0d6e13f440b.png)
