### PR TITLE
Fix undeclared side effect in src/common/cpuid.c

### DIFF
--- a/src/common/cpuid.c
+++ b/src/common/cpuid.c
@@ -79,7 +79,7 @@ dt_cpu_flags_t dt_detect_cpu_features()
                    "cmp     %0, %1\n"
                    "setne   %%al\n"
                    "movzb   %%al, %0\n"
-                   : "=r"(ax), "=r"(tmp));
+                   : "=r"(ax), "=r"(tmp) : : "al");
 
     if(ax)
     {


### PR DESCRIPTION
In inline assembly at line src/common/cpuid.c:80, the instruction setne will override register eax, this side effect may corrupt the normal data flow in certain context. For example, assume somebody incidently write a assignment expression which assigned from a function call, the return value of function call will use the register eax which will cause data flow corruption under some context:
```
  int val = printf("Hello world\n");
  __asm volatile(
      "pushf\n"
      "pop     %0\n"
      "mov     %0, %1\n"
      "xor     $0x00200000, %0\n"
      "push    %0\n"
      "popf\n"
      "pushf\n"
      "pop     %0\n"
      "cmp     %0, %1\n"
      "setne   %%al\n"
      "movzb   %%al, %0\n"
      : "=r"(ax), "=r"(tmp));
  printf("%d\n", val); // should be 12
```
The above code will produce output 1 when compiled with flag -O2 where
it should be 12.