### PR TITLE
tone equalizer interactive cursor : try to improve issue #3428

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2397,6 +2397,14 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_line_to(cr, x_pointer - setting_offset_x - 4.0 * g->inner_padding / zoom_scale, y_pointer);
   cairo_stroke(cr);
 
+  // setting cursor cross hair
+  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5 / zoom_scale));
+  cairo_move_to(cr, x_pointer, y_pointer + setting_offset_x);
+  cairo_line_to(cr, x_pointer, y_pointer + outer_radius / zoom_scale);
+  cairo_move_to(cr, x_pointer, y_pointer - outer_radius / zoom_scale);
+  cairo_line_to(cr, x_pointer, y_pointer - setting_offset_x);
+  cairo_stroke(cr);
+
   // don't display the setting bullets if we are waiting for a luminance computation to finish
   const double dx = setting_offset_x * cos(correction * M_PI / 4.0);
   const double dy = setting_offset_x * sin(correction * M_PI / 4.0);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2399,10 +2399,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
   // setting cursor cross hair
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5 / zoom_scale));
-  cairo_move_to(cr, x_pointer, y_pointer + setting_offset_x);
+  cairo_move_to(cr, x_pointer, y_pointer + setting_offset_x + DT_PIXEL_APPLY_DPI(3. / zoom_scale));
   cairo_line_to(cr, x_pointer, y_pointer + outer_radius / zoom_scale);
   cairo_move_to(cr, x_pointer, y_pointer - outer_radius / zoom_scale);
-  cairo_line_to(cr, x_pointer, y_pointer - setting_offset_x);
+  cairo_line_to(cr, x_pointer, y_pointer - setting_offset_x - DT_PIXEL_APPLY_DPI(3. / zoom_scale));
   cairo_stroke(cr);
 
   // draw exposure cursor

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2374,14 +2374,19 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // set custom cursor dimensions
   const double outer_radius = 16.;
   const double inner_radius = outer_radius / 2.0;
-  const double setting_scale = 2. * outer_radius / zoom_scale;
+  //const double setting_scale = 2. * outer_radius / zoom_scale;
   const double setting_offset_x = (outer_radius + 4. * g->inner_padding) / zoom_scale;
 
   // setting fill bars
   match_color_to_background(cr, exposure_out, 1.0);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(6. / zoom_scale));
   cairo_move_to(cr, x_pointer - setting_offset_x, y_pointer);
-  cairo_line_to(cr, x_pointer - setting_offset_x, y_pointer - correction * setting_scale);
+
+  if(correction > 0.0f)
+    cairo_arc(cr, x_pointer, y_pointer, setting_offset_x, M_PI, M_PI + correction * M_PI / 4.0);
+  else
+    cairo_arc_negative(cr, x_pointer, y_pointer, setting_offset_x, M_PI, M_PI + correction * M_PI / 4.0);
+
   cairo_stroke(cr);
 
   // setting ground level
@@ -2393,7 +2398,9 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_stroke(cr);
 
   // don't display the setting bullets if we are waiting for a luminance computation to finish
-  cairo_arc(cr, x_pointer - setting_offset_x, y_pointer - correction * setting_scale, DT_PIXEL_APPLY_DPI(7. / zoom_scale), 0, 2. * M_PI);
+  const double dx = setting_offset_x * cos(correction * M_PI / 4.0);
+  const double dy = setting_offset_x * sin(correction * M_PI / 4.0);
+  cairo_arc(cr, x_pointer - dx, y_pointer - dy, DT_PIXEL_APPLY_DPI(5. / zoom_scale), 0, 2. * M_PI);
   cairo_fill(cr);
 
   // draw exposure cursor

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2374,12 +2374,12 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   // set custom cursor dimensions
   const double outer_radius = 16.;
   const double inner_radius = outer_radius / 2.0;
-  //const double setting_scale = 2. * outer_radius / zoom_scale;
   const double setting_offset_x = (outer_radius + 4. * g->inner_padding) / zoom_scale;
+  const double fill_width = DT_PIXEL_APPLY_DPI(4. / zoom_scale);
 
   // setting fill bars
   match_color_to_background(cr, exposure_out, 1.0);
-  cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(6. / zoom_scale));
+  cairo_set_line_width(cr, 2.0 * fill_width);
   cairo_move_to(cr, x_pointer - setting_offset_x, y_pointer);
 
   if(correction > 0.0f)
@@ -2399,10 +2399,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
 
   // setting cursor cross hair
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.5 / zoom_scale));
-  cairo_move_to(cr, x_pointer, y_pointer + setting_offset_x + DT_PIXEL_APPLY_DPI(3. / zoom_scale));
+  cairo_move_to(cr, x_pointer, y_pointer + setting_offset_x + fill_width);
   cairo_line_to(cr, x_pointer, y_pointer + outer_radius / zoom_scale);
   cairo_move_to(cr, x_pointer, y_pointer - outer_radius / zoom_scale);
-  cairo_line_to(cr, x_pointer, y_pointer - setting_offset_x - DT_PIXEL_APPLY_DPI(3. / zoom_scale));
+  cairo_line_to(cr, x_pointer, y_pointer - setting_offset_x - fill_width);
   cairo_stroke(cr);
 
   // draw exposure cursor
@@ -3062,7 +3062,7 @@ static void _develop_ui_pipe_started_callback(gpointer instance, gpointer user_d
   if(g == NULL) return;
   switch_cursors(self);
 
-  if(!dtgtk_expander_get_expanded(DTGTK_EXPANDER(self->expander)) || !self->enabled || !g->has_focus)
+  if(!dtgtk_expander_get_expanded(DTGTK_EXPANDER(self->expander)) || !self->enabled)
   {
     // if module is not active, disable mask preview
     dt_pthread_mutex_lock(&g->lock);

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2405,12 +2405,6 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_line_to(cr, x_pointer, y_pointer - setting_offset_x);
   cairo_stroke(cr);
 
-  // don't display the setting bullets if we are waiting for a luminance computation to finish
-  const double dx = setting_offset_x * cos(correction * M_PI / 4.0);
-  const double dy = setting_offset_x * sin(correction * M_PI / 4.0);
-  cairo_arc(cr, x_pointer - dx, y_pointer - dy, DT_PIXEL_APPLY_DPI(5. / zoom_scale), 0, 2. * M_PI);
-  cairo_fill(cr);
-
   // draw exposure cursor
   draw_exposure_cursor(cr, x_pointer, y_pointer, outer_radius, luminance_in, zoom_scale, 6, .9);
   draw_exposure_cursor(cr, x_pointer, y_pointer, inner_radius, luminance_out, zoom_scale, 3, .9);


### PR DESCRIPTION
Make the "fill" setting round to avoid confusion between the parameter intensity feedback, and the actual cursor:
![Capture d’écran du 2019-11-14 15-44-09](https://user-images.githubusercontent.com/2779157/68886741-0acc6b80-0718-11ea-9f0b-52055230f601.png)
(note that mouse arrow is added on the screenshot, it's not there in darktable).