### PR TITLE
blend gui: fix handling of mask display and mask suppress when module…

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -477,6 +477,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module);
 void dt_iop_gui_update_blendif(dt_iop_module_t *module);
 void dt_iop_gui_update_masks(dt_iop_module_t *module);
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
+void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
 
 /** routine to translate from mode id to sequence in option list */
 int dt_iop_gui_blending_mode_seq(dt_iop_gui_blend_data_t *bd, int mode);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2068,6 +2068,25 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   darktable.gui->reset = reset;
 }
 
+void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
+{
+  if(darktable.gui->reset) return;
+  if(!module) return;
+
+  const int has_mask_display = module->request_mask_display & (DT_DEV_PIXELPIPE_DISPLAY_MASK | DT_DEV_PIXELPIPE_DISPLAY_CHANNEL);
+  const int suppress = module->suppress_mask;
+
+  if((module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) && module->blend_data && (has_mask_display || suppress))
+  {
+    dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)module->blend_data;
+    dtgtk_button_set_active(DTGTK_BUTTON(bd->showmask), 0);
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->suppress), 0);
+    module->request_mask_display = DT_DEV_PIXELPIPE_DISPLAY_NONE;
+    module->suppress_mask = 0;
+    dt_dev_reprocess_all(module->dev);
+  }
+}
+
 static void _collect_blend_modes(GList **list, const char *name, unsigned int mode)
 {
   dt_iop_blend_mode_t *bm;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1729,6 +1729,9 @@ void dt_iop_request_focus(dt_iop_module_t *module)
 
     /*reset mask view */
     dt_masks_reset_form_gui();
+
+    /* do stuff needed in the blending gui */
+    dt_iop_gui_blending_lose_focus(darktable.develop->gui_module);
   }
 
   darktable.develop->gui_module = module;


### PR DESCRIPTION
… loses focus

* turn off mask display and mask suppress when focus is switched to other module
* de-activate the corresponding buttons