### PR TITLE
tone equalizer: bugfix

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3053,7 +3053,7 @@ static void _develop_ui_pipe_started_callback(gpointer instance, gpointer user_d
   if(g == NULL) return;
   switch_cursors(self);
 
-  if(!dtgtk_expander_get_expanded(DTGTK_EXPANDER(self->expander)) || !self->enabled || !g->has_focus)
+  if(!dtgtk_expander_get_expanded(DTGTK_EXPANDER(self->expander)) || !self->enabled)
   {
     // if module is not active, disable mask preview
     dt_pthread_mutex_lock(&g->lock);


### PR DESCRIPTION
after enabling mask display, when the masking params were changed, the mask display was turned off.

keep mask display until module is collapsed or disabled instead.

Bug reported by @alcomposer in private.