### PR TITLE
Fix OpenCL compile errors on Windows

### DIFF
--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1838,7 +1838,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
           //store has using a simple filerename
           char finalfilename[PATH_MAX] = { 0 };
           snprintf(finalfilename, sizeof(finalfilename), "%s" G_DIR_SEPARATOR_S "%s.%s", cachedir, bname, md5sum);
-          if(g_rename(link_dest, finalfilename) != 0) goto ret;
+          rename(link_dest, finalfilename);
 #else
           if(symlink(md5sum, bname) != 0) goto ret;
 #endif //!defined(_WIN32)

--- a/src/common/opencl.c
+++ b/src/common/opencl.c
@@ -1815,7 +1815,7 @@ int dt_opencl_build_program(const int dev, const int prog, const char *binname, 
           // save opencl compiled binary as md5sum-named file
           char link_dest[PATH_MAX] = { 0 };
           snprintf(link_dest, sizeof(link_dest), "%s" G_DIR_SEPARATOR_S "%s", cachedir, md5sum);
-          FILE *f = g_fopen(link_dest, "w");
+          FILE *f = g_fopen(link_dest, "wb");
           if(!f) goto ret;
           size_t bytes_written = fwrite(binaries[i], sizeof(char), binary_sizes[i], f);
           if(bytes_written != binary_sizes[i]) goto ret;


### PR DESCRIPTION
Fixes #3384 

This fix handles the following issues:
* Using binary flag for g_fopen() when producing OpenCL compiled/cached binaries
* Properly deleting the OpenCL compiled/cached binaries
* Also adding a bit more diagnostic