### PR TITLE
lighttable : don't reset offset if it has just been changed

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -593,7 +593,7 @@ static void _view_lighttable_query_listener_callback(gpointer instance, gpointer
   // in filemanager, we want to reset the offset to the beginning
   const dt_lighttable_layout_t layout = get_layout();
   if(layout == lib->current_layout && layout == DT_LIGHTTABLE_LAYOUT_FILEMANAGER && lib->offset > 0
-     && lib->first_visible_filemanager > 0)
+     && lib->first_visible_filemanager > 0 && !lib->offset_changed)
   {
     lib->offset = lib->first_visible_filemanager = 0;
     lib->offset_changed = TRUE;


### PR DESCRIPTION
fix #3461

I just hope I've not broken another use case...