### PR TITLE
dt_image_cache_write_release should be locked per image.

### DIFF
--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -219,6 +219,7 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
       uint32_t u;
   } flip;
   if(img->id <= 0) return;
+  dt_lock_image(img->id);
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get(darktable.db),
@@ -268,6 +269,7 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
     dt_image_write_sidecar_file(img->id);
   }
   dt_cache_release(&cache->cache, img->cache_entry);
+  dt_unlock_image(img->id);
 }
 
 


### PR DESCRIPTION
Might be related to #3463