### PR TITLE
Change order of image info line

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -675,7 +675,7 @@
   <dtconfig prefs="gui" section="darkroom">
     <name>plugins/darkroom/image_infos_pattern</name>
     <type>string</type>
-    <default>$(EXIF_ISO) ISO • $(EXIF_EXPOSURE) s • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm</default>
+    <default>$(EXIF_EXPOSURE) s • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • ISO $(EXIF_ISO)</default>
     <shortdescription>pattern for the image infos line</shortdescription>
     <longdescription>see manual to know all the tags you can use.</longdescription>
   </dtconfig>


### PR DESCRIPTION
This is a very minor change. The image info line had a different order than the info line you get if you hover your mouse pointer over the image.

Before:
![image](https://user-images.githubusercontent.com/16699443/69014335-7bc68a00-0989-11ea-939a-abbecf3d4d9c.png)

After:
![image](https://user-images.githubusercontent.com/16699443/69014338-82ed9800-0989-11ea-9f25-3bb3ddd74daa.png)
