### PR TITLE
Fix frame module crash (#3473)

### DIFF
--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -399,12 +399,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     // ... if 100% frame_offset we ensure frame_line "stick" the out border
     const int frame_br_out_x
         = (d->frame_offset == 1.0f && (border_min_size == MIN(border_size_l, border_size_r)))
-              ? (roi_out->width)
-              : CLAMP(image_lx - frame_offset - frame_size + frame_out_width - 1, 0, roi_out->width);
+              ? (roi_out->width - 1)
+              : CLAMP(image_lx - frame_offset - frame_size + frame_out_width - 1, 0, roi_out->width - 1);
     const int frame_br_out_y
         = (d->frame_offset == 1.0f && (border_min_size == MIN(border_size_t, border_size_b)))
-              ? (roi_out->height)
-              : CLAMP(image_ty - frame_offset - frame_size + frame_out_height - 1, 0, roi_out->height);
+              ? (roi_out->height - 1)
+              : CLAMP(image_ty - frame_offset - frame_size + frame_out_height - 1, 0, roi_out->height - 1);
 
     for(int r = frame_tl_out_y; r <= frame_br_out_y; r++)
     {


### PR DESCRIPTION
Fix for https://github.com/darktable-org/darktable/issues/3473
Tested on Linux and Windows 10.