### PR TITLE
iop-order: invert order for multiple instances when importing.

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1007,6 +1007,8 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
   }
   else if(version == 17)
   {
+    sqlite3_exec(db->handle, "BEGIN TRANSACTION", NULL, NULL, NULL);
+
     ////////////////////////////// masks history
     TRY_EXEC("CREATE TABLE main.masks_history (imgid INTEGER, num INTEGER, formid INTEGER, form INTEGER, name VARCHAR(256), "
              "version INTEGER, points BLOB, points_count INTEGER, source BLOB)",
@@ -1121,6 +1123,8 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
   //   }
   else if(version == 18)
   {
+    sqlite3_exec(db->handle, "BEGIN TRANSACTION", NULL, NULL, NULL);
+
     TRY_EXEC("UPDATE images SET orientation=-2 WHERE orientation=1;",
              "[init] can't update images orientation 1 from database\n");
 
@@ -1250,6 +1254,8 @@ static int _upgrade_data_schema_step(dt_database_t *db, int version)
   }
   else if(version == 2)
   {
+    sqlite3_exec(db->handle, "BEGIN TRANSACTION", NULL, NULL, NULL);
+
     //    With sqlite above or equal to 3.25.0 RENAME COLUMN can be used instead of the following code
     //    TRY_EXEC("ALTER TABLE data.tags RENAME COLUMN description TO synonyms;",
     //             "[init] can't change tags column name from description to synonyms\n");

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -598,7 +598,8 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
         if (iop_order_version_src != iop_order_version_dest)
         {
           hist->module->iop_order =
-            dt_ioppr_get_iop_order(dest_iop_list, hist->module->op) + (double)hist->module->multi_priority / 100.0f;
+            dt_ioppr_get_iop_order(dest_iop_list, hist->module->op)
+            + (double)hist->module->iop_order / 100.0f;
         }
 
         if (!dt_iop_is_hidden(hist->module))
@@ -635,7 +636,7 @@ static int _history_copy_and_paste_on_image_merge(int32_t imgid, int32_t dest_im
         if (iop_order_version_src != iop_order_version_dest)
         {
           mod_src->iop_order =
-            dt_ioppr_get_iop_order(dest_iop_list, mod_src->op) + (double)mod_src->multi_priority / 100.0f;
+            dt_ioppr_get_iop_order(dest_iop_list, mod_src->op) + (double)mod_src->iop_order / 100.0f;
         }
 
         if (DT_IOP_ORDER_INFO)

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -723,7 +723,8 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
       style_item.blendop_params_size = sqlite3_column_bytes(stmt, 5);
 
       const double old_iop_order = sqlite3_column_double(stmt, 9);
-      style_item.iop_order = dt_ioppr_get_iop_order(current_iop_list, style_item.operation) + (double)style_item.multi_priority / 100.0f;
+      style_item.iop_order = dt_ioppr_get_iop_order(current_iop_list, style_item.operation)
+        + (double)old_iop_order / 100.0f;
 
       if (DT_IOP_ORDER_INFO)
       {

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -726,7 +726,7 @@ void dt_styles_apply_to_image(const char *name, gboolean duplicate, int32_t imgi
       style_item.iop_order = dt_ioppr_get_iop_order(current_iop_list, style_item.operation)
         + (double)old_iop_order / 100.0f;
 
-      if (DT_IOP_ORDER_INFO)
+      if(DT_IOP_ORDER_INFO)
       {
         fprintf(stderr,"\n  module %20s, order %9.5f->%9.5f, v(%i), multiprio %i",
                 style_item.operation, old_iop_order, style_item.iop_order, style_item.module_version, style_item.multi_priority);


### PR DESCRIPTION
When importing from version previous to 3.0 we do invert the
iop-order to ensure the same order as before.

Fixes #3477.