### PR TITLE
blend gui: addition of alternative display modes for parametric mask sliders

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -149,7 +149,7 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_HSL_H = 10 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_HSL_S = 11 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_HSL_l = 12 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_ANY = (~0) << 2
+  DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2
 } dt_dev_pixelpipe_display_mask_t;
 
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -393,6 +393,8 @@ typedef struct dt_iop_gui_blend_data_t
   GtkBox *raster_box;
   GtkDarktableGradientSlider *upper_slider;
   GtkDarktableGradientSlider *lower_slider;
+  GtkLabel *upper_head;
+  GtkLabel *lower_head;
   GtkLabel *upper_label[8];
   GtkLabel *lower_label[8];
   GtkLabel *upper_picker_label;
@@ -418,6 +420,8 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *brightness_slider;
   int tab;
   int channels[8][2];
+  int altmode[8][2];
+  int (*altdisplay[8])(GtkWidget *, dt_iop_module_t *, int);
   dt_dev_pixelpipe_display_mask_t display_channel[8][2];
   dt_dev_pixelpipe_display_mask_t save_for_leave;
   int timeout_handle;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -68,15 +68,24 @@ static const dt_iop_gui_blendif_colorstop_t _gradient_L[]
         { 0.5f, { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
         { 1.0f, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
 
+
 static const dt_iop_gui_blendif_colorstop_t _gradient_a[]
-    = { { 0.0f, { 0, 0.34 * NEUTRAL_GRAY * 2, 0.27 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.5f, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 1.0f, { 0.53 * NEUTRAL_GRAY * 2, 0.08 * NEUTRAL_GRAY * 2, 0.28 * NEUTRAL_GRAY * 2, 1.0 } } };
+    = { { 0.0f,   { 0, 0.34 * NEUTRAL_GRAY * 2, 0.27 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.25f,  { 0.25 * NEUTRAL_GRAY * 2, 0.34 * NEUTRAL_GRAY * 2, 0.39 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.375f, { 0.375 * NEUTRAL_GRAY * 2, 0.46 * NEUTRAL_GRAY * 2, 0.45 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.5f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
+        { 0.625f, { 0.51 * NEUTRAL_GRAY * 2, 0.4 * NEUTRAL_GRAY * 2, 0.45 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.75f,  { 0.52 * NEUTRAL_GRAY * 2, 0.29 * NEUTRAL_GRAY * 2, 0.39 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 1.0f,   { 0.53 * NEUTRAL_GRAY * 2, 0.08 * NEUTRAL_GRAY * 2, 0.28 * NEUTRAL_GRAY * 2, 1.0 } } };
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_b[]
-    = { { 0.0f, { 0, 0.27 * NEUTRAL_GRAY * 2, 0.58 * NEUTRAL_GRAY * 2, 1.0 } },
-        { 0.5f, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 1.0f, { 0.81 * NEUTRAL_GRAY * 2, 0.66 * NEUTRAL_GRAY * 2, 0, 1.0 } } };
+    = { { 0.0f,   { 0, 0.27 * NEUTRAL_GRAY * 2, 0.58 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.25f,  { 0.25 * NEUTRAL_GRAY * 2, 0.39 * NEUTRAL_GRAY * 2, 0.54 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.375f, { 0.38 * NEUTRAL_GRAY * 2, 0.45 * NEUTRAL_GRAY * 2, 0.52 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.5f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
+        { 0.625f, { 0.58 * NEUTRAL_GRAY * 2, 0.55 * NEUTRAL_GRAY * 2, 0.38 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 0.75f,  { 0.66 * NEUTRAL_GRAY * 2, 0.59 * NEUTRAL_GRAY * 2, 0.25 * NEUTRAL_GRAY * 2, 1.0 } },
+        { 1.0f,   { 0.81 * NEUTRAL_GRAY * 2, 0.66 * NEUTRAL_GRAY * 2, 0, 1.0 } } };
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_gray[]
     = { { 0.0f, { 0, 0, 0, 1.0 } },
@@ -198,20 +207,39 @@ static void _blendif_cook(dt_iop_colorspace_type_t cst, const float *in, float *
   }
 }
 
+static inline int _blendif_print_digits_default(float value)
+{
+  int digits;
+  if(value < 0.0001f) digits = 0;
+  else if(value < 0.01f) digits = 2;
+  else if(value < 0.1f) digits = 1;
+  else digits = 0;
+
+  return digits;
+}
+
+static inline int _blendif_print_digits_ab(float value)
+{
+  int digits;
+  if(fabs(value) < 10.0f) digits = 1;
+  else digits = 0;
+
+  return digits;
+}
 
 static void _blendif_scale_print_L(float value, char *string, int n)
 {
-  snprintf(string, n, "%-4.0f", value * 100.0f);
+  snprintf(string, n, "%-4.*f", _blendif_print_digits_default(value), value * 100.0f);
 }
 
 static void _blendif_scale_print_ab(float value, char *string, int n)
 {
-  snprintf(string, n, "%-4.0f", value * 256.0f - 128.0f);
+  snprintf(string, n, "%-4.*f", _blendif_print_digits_ab(value * 256.0f - 128.0f), value * 256.0f - 128.0f);
 }
 
 static void _blendif_scale_print_rgb(float value, char *string, int n)
 {
-  snprintf(string, n, "%-4.0f", value * 255.0f);
+  snprintf(string, n, "%-4.*f", _blendif_print_digits_default(value), value * 255.0f);
 }
 
 static void _blendif_scale_print_hue(float value, char *string, int n)
@@ -221,7 +249,7 @@ static void _blendif_scale_print_hue(float value, char *string, int n)
 
 static void _blendif_scale_print_default(float value, char *string, int n)
 {
-  snprintf(string, n, "%-4.0f", value * 100.0f);
+  snprintf(string, n, "%-4.*f", _blendif_print_digits_default(value), value * 100.0f);
 }
 
 static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gui_blend_data_t *data)
@@ -437,7 +465,9 @@ static void _blendop_blendif_upper_callback(GtkDarktableGradientSlider *slider, 
 
   _blendop_blendif_reset_picker_set_values(data);
 
+  dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++) parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+  dt_pthread_mutex_unlock(&data->lock);
 
   for(int k = 0; k < 4; k++)
   {
@@ -468,7 +498,9 @@ static void _blendop_blendif_lower_callback(GtkDarktableGradientSlider *slider, 
 
   _blendop_blendif_reset_picker_set_values(data);
 
+  dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++) parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+  dt_pthread_mutex_unlock(&data->lock);
 
   for(int k = 0; k < 4; k++)
   {
@@ -540,6 +572,15 @@ static dt_iop_colorspace_type_t _blendop_blendif_get_picker_colorspace(dt_iop_gu
   return picker_cst;
 }
 
+static inline int _blendif_print_digits_picker(float value)
+{
+  int digits;
+  if(value < 10.0f) digits = 2;
+  else digits = 1;
+
+  return digits;
+}
+
 static void _update_gradient_slider(GtkWidget *widget, dt_iop_module_t *module)
 {
   dt_iop_gui_blend_data_t *data = module->blend_data;
@@ -578,7 +619,7 @@ static void _update_gradient_slider(GtkWidget *widget, dt_iop_module_t *module)
     _blendif_scale(cst, raw_max, picker_max, work_profile);
     _blendif_cook(cst, raw_mean, cooked, work_profile);
 
-    snprintf(text, sizeof(text), "(%.1f)", cooked[data->tab]);
+    snprintf(text, sizeof(text), "(%.*f)", _blendif_print_digits_picker(cooked[data->tab]), cooked[data->tab]);
 
     dtgtk_gradient_slider_multivalue_set_picker_meanminmax(
         DTGTK_GRADIENT_SLIDER(widget), picker_mean[data->tab], picker_min[data->tab], picker_max[data->tab]);
@@ -974,8 +1015,10 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixel
     picker_values[0] = CLAMP(picker_values[0], 0.f, picker_values[1]);
     picker_values[3] = CLAMP(picker_values[3], picker_values[2], 1.f);
 
+    dt_pthread_mutex_lock(&data->lock);
     for(int k = 0; k < 4; k++)
       dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k);
+    dt_pthread_mutex_unlock(&data->lock);
 
     // update picked values
     _update_gradient_slider(GTK_WIDGET(data->lower_slider), module);
@@ -994,8 +1037,10 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixel
     darktable.gui->reset = reset;
 
     // save values to parameters
+    dt_pthread_mutex_lock(&data->lock);
     for(int k = 0; k < 4; k++)
       parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+    dt_pthread_mutex_unlock(&data->lock);
 
     // de-activate processing of this channel if maximum span is selected
     if(parameters[1] == 0.0f && parameters[2] == 1.0f)
@@ -1118,8 +1163,11 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget, GdkEventCrossing *even
     dt_dev_reprocess_all(module->dev);
   }
 
+  dt_control_key_accelerators_off(darktable.control);
+  gtk_widget_grab_focus(widget);
   return TRUE;
 }
+
 
 // handler for delayed mask/channel display mode switch-off
 static gboolean _blendop_blendif_leave_delayed(gpointer data)
@@ -1157,9 +1205,166 @@ static gboolean _blendop_blendif_leave(GtkWidget *widget, GdkEventCrossing *even
       data->timeout_handle = g_timeout_add(1000, _blendop_blendif_leave_delayed, module);
     dt_pthread_mutex_unlock(&data->lock);
   }
-
+  if(!darktable.control->key_accelerators_on) dt_control_key_accelerators_on(darktable.control);
   return TRUE;
 }
+
+static float log10_scale_callback(GtkWidget *self, float inval, int dir)
+{
+  float outval;
+  const float tiny = 1.0e-4f;
+  switch(dir)
+  {
+    case GRADIENT_SLIDER_SET:
+      outval = (log10(CLAMP_RANGE(inval, 0.0001f, 1.0f)) + 4.0f) / 4.0f;
+      break;
+    case GRADIENT_SLIDER_GET:
+      outval = CLAMP_RANGE(exp(M_LN10 * (4.0f * inval - 4.0f)), 0.0f, 1.0f);
+      if(outval <= tiny) outval = 0.0f;
+      if(outval >= 1.0f - tiny) outval = 1.0f;
+      break;
+    default:
+      outval = inval;
+  }
+  return outval;
+}
+
+
+
+static int _blendop_blendif_disp_alternative_log(GtkWidget *widget, dt_iop_module_t *module, int mode)
+{
+  dt_iop_gui_blend_data_t *data = module->blend_data;
+  GtkDarktableGradientSlider *slider = (GtkDarktableGradientSlider *)widget;
+  const int uplow = (slider == data->lower_slider) ? 0 : 1;
+  const int tab = data->tab;
+
+  GtkLabel *head = (uplow == 0) ? data->lower_head : data->upper_head;
+  const char *inout = (uplow == 0) ? _("input") : _("output");
+
+  char text[32];
+  float values[4];
+  float resetvalues[4];
+  int newmode = (mode == 1) ? 1 : 0;
+
+  for(int k = 0; k < 4; k++) values[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+  for(int k = 0; k < 4; k++) resetvalues[k] = dtgtk_gradient_slider_multivalue_get_resetvalue(slider, k);
+
+  if(newmode == 1)
+  {
+    dtgtk_gradient_slider_set_scale_callback(slider, log10_scale_callback);
+    snprintf(text, sizeof(text), "%s%s", inout, _(" (log)"));
+    gtk_label_set_text(head, text);
+  }
+  else
+  {
+    dtgtk_gradient_slider_set_scale_callback(slider, NULL);
+    snprintf(text, sizeof(text), "%s%s", inout, "");
+    gtk_label_set_text(head, text);
+  }
+
+  for(int k = 0; k < 4; k++) dtgtk_gradient_slider_multivalue_set_value(slider, values[k], k);
+  for(int k = 0; k < 4; k++) dtgtk_gradient_slider_multivalue_set_resetvalue(slider, resetvalues[k], k);
+  dtgtk_gradient_slider_multivalue_clear_stops(slider);
+  for(int k = 0; k < data->numberstops[tab]; k++)
+    dtgtk_gradient_slider_multivalue_set_stop(slider,
+                                              (data->colorstops[tab])[k].stoppoint,
+                                              (data->colorstops[tab])[k].color);
+
+  return newmode;
+}
+
+
+static float magnifier_scale_callback(GtkWidget *self, float inval, int dir)
+{
+  float outval;
+  const float range = 6.0f;
+  const float invrange = 1.0f/range;
+  const float scale = tanh(range * 0.5f);
+  const float invscale = 1.0f/scale;
+  const float eps = 1.0e-6f;
+  const float tiny = 1.0e-4f;
+  switch(dir)
+  {
+    case GRADIENT_SLIDER_SET:
+      outval = (invscale * tanh(range * (CLAMP_RANGE(inval, 0.0f, 1.0f) - 0.5f)) + 1.0f) * 0.5f;
+      if(outval <= tiny) outval = 0.0f;
+      if(outval >= 1.0f - tiny) outval = 1.0f;
+      break;
+    case GRADIENT_SLIDER_GET:
+      outval = invrange * atanh((2.0f * CLAMP_RANGE(inval, eps, 1.0f - eps) - 1.0f) * scale) + 0.5f;
+      if(outval <= tiny) outval = 0.0f;
+      if(outval >= 1.0f - tiny) outval = 1.0f;
+      break;
+    default:
+      outval = inval;
+  }
+  return outval;
+}
+
+static int _blendop_blendif_disp_alternative_mag(GtkWidget *widget, dt_iop_module_t *module, int mode)
+{
+  dt_iop_gui_blend_data_t *data = module->blend_data;
+  GtkDarktableGradientSlider *slider = (GtkDarktableGradientSlider *)widget;
+  const int uplow = (slider == data->lower_slider) ? 0 : 1;
+  const int tab = data->tab;
+
+  GtkLabel *head = (uplow == 0) ? data->lower_head : data->upper_head;
+  const char *inout = (uplow == 0) ? _("input") : _("output");
+
+  char text[32];
+  float values[4];
+  float resetvalues[4];
+  int newmode = (mode == 1) ? 1 : 0;
+
+  for(int k = 0; k < 4; k++) values[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+  for(int k = 0; k < 4; k++) resetvalues[k] = dtgtk_gradient_slider_multivalue_get_resetvalue(slider, k);
+
+  if(newmode == 1)
+  {
+    dtgtk_gradient_slider_set_scale_callback(slider, magnifier_scale_callback);
+    snprintf(text, sizeof(text), "%s%s", inout, _(" (zoom)"));
+    gtk_label_set_text(head, text);
+  }
+  else
+  {
+    dtgtk_gradient_slider_set_scale_callback(slider, NULL);
+    snprintf(text, sizeof(text), "%s%s", inout, "");
+    gtk_label_set_text(head, text);
+  }
+
+  for(int k = 0; k < 4; k++) dtgtk_gradient_slider_multivalue_set_value(slider, values[k], k);
+  for(int k = 0; k < 4; k++) dtgtk_gradient_slider_multivalue_set_resetvalue(slider, resetvalues[k], k);
+  dtgtk_gradient_slider_multivalue_clear_stops(slider);
+  for(int k = 0; k < data->numberstops[tab]; k++)
+    dtgtk_gradient_slider_multivalue_set_stop(slider,
+                                              (data->colorstops[tab])[k].stoppoint,
+                                              (data->colorstops[tab])[k].color);
+
+  return newmode;
+}
+
+
+static gboolean _blendop_blendif_key_press(GtkWidget *widget, GdkEventKey *event, dt_iop_module_t *module)
+{
+  if(darktable.gui->reset) return FALSE;
+
+  dt_iop_gui_blend_data_t *data = module->blend_data;
+  gboolean handled = FALSE;
+
+  const int tab = data->tab;
+  GtkDarktableGradientSlider *slider = (GtkDarktableGradientSlider *)widget;
+  const int uplow = (slider == data->lower_slider) ? 0 : 1;
+
+  if(event->keyval == GDK_KEY_a)
+  {
+    if(data->altdisplay[tab])
+      data->altmode[tab][uplow] = (data->altdisplay[tab])(widget, module, data->altmode[tab][uplow] + 1);
+    handled = TRUE;
+  }
+
+  return handled;
+}
+
 
 void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 {
@@ -1227,6 +1432,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
       data->upper_slider,
       opolarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 3);
 
+  dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++)
   {
     dtgtk_gradient_slider_multivalue_set_value(data->lower_slider, iparameters[k], k);
@@ -1234,6 +1440,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
     dtgtk_gradient_slider_multivalue_set_resetvalue(data->lower_slider, idefaults[k], k);
     dtgtk_gradient_slider_multivalue_set_resetvalue(data->upper_slider, odefaults[k], k);
   }
+  dt_pthread_mutex_unlock(&data->lock);
 
   for(int k = 0; k < 4; k++)
   {
@@ -1257,8 +1464,15 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
   dtgtk_gradient_slider_multivalue_set_increment(data->lower_slider, data->increments[tab]);
   dtgtk_gradient_slider_multivalue_set_increment(data->upper_slider, data->increments[tab]);
 
+
   _update_gradient_slider(GTK_WIDGET(data->upper_slider), module);
   _update_gradient_slider(GTK_WIDGET(data->lower_slider), module);
+
+  if(data->altdisplay[tab])
+  {
+    data->altmode[tab][0] = (data->altdisplay[tab])(GTK_WIDGET(data->lower_slider), module, data->altmode[tab][0]);
+    data->altmode[tab][1] = (data->altdisplay[tab])(GTK_WIDGET(data->upper_slider), module, data->altmode[tab][1]);
+  }
 
   darktable.gui->reset = reset;
 }
@@ -1347,6 +1561,10 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
         bd->numberstops[3] = sizeof(_gradient_chroma) / sizeof(dt_iop_gui_blendif_colorstop_t);
         bd->colorstops[4] = _gradient_hue;
         bd->numberstops[4] = sizeof(_gradient_hue) / sizeof(dt_iop_gui_blendif_colorstop_t);
+        bd->altdisplay[0] = _blendop_blendif_disp_alternative_log;
+        bd->altdisplay[1] = _blendop_blendif_disp_alternative_mag;
+        bd->altdisplay[2] = _blendop_blendif_disp_alternative_mag;
+        bd->altdisplay[3] = _blendop_blendif_disp_alternative_log;
         break;
       case iop_cs_rgb:
         maxchannels = 7;
@@ -1408,6 +1626,12 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
         bd->numberstops[5] = sizeof(_gradient_chroma) / sizeof(dt_iop_gui_blendif_colorstop_t);
         bd->colorstops[6] = _gradient_gray;
         bd->numberstops[6] = sizeof(_gradient_gray) / sizeof(dt_iop_gui_blendif_colorstop_t);
+        bd->altdisplay[0] = _blendop_blendif_disp_alternative_log;
+        bd->altdisplay[1] = _blendop_blendif_disp_alternative_log;
+        bd->altdisplay[2] = _blendop_blendif_disp_alternative_log;
+        bd->altdisplay[3] = _blendop_blendif_disp_alternative_log;
+        bd->altdisplay[5] = _blendop_blendif_disp_alternative_log;
+        bd->altdisplay[6] = _blendop_blendif_disp_alternative_log;
         break;
       default:
         assert(FALSE); // blendif not supported for RAW, which is already caught upstream; we should not get
@@ -1478,9 +1702,9 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     gtk_box_pack_end(GTK_BOX(lowslider), GTK_WIDGET(bd->lower_polarity), FALSE, FALSE, 0);
 
 
-    GtkWidget *output = gtk_label_new(_("output"));
+    bd->upper_head = GTK_LABEL(gtk_label_new(_("output")));
     bd->upper_picker_label = GTK_LABEL(gtk_label_new(""));
-    gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(output), FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(bd->upper_head), FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(bd->upper_picker_label), TRUE, TRUE, 0);
     for(int k = 0; k < 4; k++)
     {
@@ -1489,9 +1713,9 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(bd->upper_label[k]), FALSE, FALSE, 0);
     }
 
-    GtkWidget *input = gtk_label_new(_("input"));
+    bd->lower_head = GTK_LABEL(gtk_label_new(_("input")));
     bd->lower_picker_label = GTK_LABEL(gtk_label_new(""));
-    gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(input), FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(bd->lower_head), FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(bd->lower_picker_label), TRUE, TRUE, 0);
     for(int k = 0; k < 4; k++)
     {
@@ -1502,8 +1726,8 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
     gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_slider), _("double click to reset"));
     gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_slider), _("double click to reset"));
-    gtk_widget_set_tooltip_text(output, ttoutput);
-    gtk_widget_set_tooltip_text(input, ttinput);
+    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_head), ttinput);
+    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_head), ttoutput);
 
     g_signal_connect(G_OBJECT(bd->channel_tabs), "switch_page", G_CALLBACK(_blendop_blendif_tab_switch), bd);
 
@@ -1520,6 +1744,10 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     g_signal_connect(G_OBJECT(bd->lower_slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
 
     g_signal_connect(G_OBJECT(bd->upper_slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
+
+    g_signal_connect(G_OBJECT(bd->lower_slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);
+
+    g_signal_connect(G_OBJECT(bd->upper_slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);
 
     g_signal_connect(G_OBJECT(bd->colorpicker), "button-press-event", G_CALLBACK(_blendop_blendif_color_picker_callback_button_press), module);
 
@@ -1960,6 +2188,8 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   dt_bauhaus_slider_set(bd->brightness_slider, module->blend_params->brightness);
   dt_bauhaus_slider_set(bd->contrast_slider, module->blend_params->contrast);
 
+  /* reset all alternative display modes for blendif */
+  memset(bd->altmode, 0, sizeof(bd->altmode));
   dt_iop_gui_update_blendif(module);
   dt_iop_gui_update_masks(module);
   dt_iop_gui_update_raster(module);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1297,6 +1297,11 @@ static int _blendop_blendif_disp_alternative_log(GtkWidget *widget, dt_iop_modul
   return _blendop_blendif_disp_alternative_worker(widget, module, mode, log10_scale_callback, _(" (log)"));
 }
 
+static void _blendof_blendif_disp_alternative_reset(GtkWidget *widget, dt_iop_module_t *module)
+{
+  (void) _blendop_blendif_disp_alternative_worker(widget, module, 0, NULL, "");
+}
+
 
 static gboolean _blendop_blendif_key_press(GtkWidget *widget, GdkEventKey *event, dt_iop_module_t *module)
 {
@@ -1426,6 +1431,11 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
   {
     data->altmode[tab][0] = (data->altdisplay[tab])(GTK_WIDGET(data->lower_slider), module, data->altmode[tab][0]);
     data->altmode[tab][1] = (data->altdisplay[tab])(GTK_WIDGET(data->upper_slider), module, data->altmode[tab][1]);
+  }
+  else
+  {
+    _blendof_blendif_disp_alternative_reset(GTK_WIDGET(data->lower_slider), module);
+    _blendof_blendif_disp_alternative_reset(GTK_WIDGET(data->upper_slider), module);
   }
 
   darktable.gui->reset = reset;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1688,8 +1688,8 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
       gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(bd->lower_label[k]), FALSE, FALSE, 0);
     }
 
-    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_slider), _("double click to reset"));
-    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_slider), _("double click to reset"));
+    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_slider), _("double click to reset. press 'a' to toggle available view modes"));
+    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_slider), _("double click to reset. press 'a' to toggle available view modes"));
     gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_head), ttinput);
     gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_head), ttoutput);
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -64,9 +64,11 @@ typedef enum dt_gui_blendif_pickcolor_type_t
 
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_L[]
-    = { { 0.0f, { 0, 0, 0, 1.0 } },
-        { 0.5f, { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
-        { 1.0f, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
+    = { { 0.0f,   { 0, 0, 0, 1.0 } },
+        { 0.125f, { NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, 1.0 } },
+        { 0.25f,  { NEUTRAL_GRAY / 4, NEUTRAL_GRAY / 4, NEUTRAL_GRAY / 4, 1.0 } },
+        { 0.5f,   { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
+        { 1.0f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
 
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_a[]
@@ -88,26 +90,36 @@ static const dt_iop_gui_blendif_colorstop_t _gradient_b[]
         { 1.0f,   { 0.81 * NEUTRAL_GRAY * 2, 0.66 * NEUTRAL_GRAY * 2, 0, 1.0 } } };
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_gray[]
-    = { { 0.0f, { 0, 0, 0, 1.0 } },
-        { 0.5f, { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
-        { 1.0f, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
+    = { { 0.0f,   { 0, 0, 0, 1.0 } },
+        { 0.125f, { NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, 1.0 } },
+        { 0.25f,  { NEUTRAL_GRAY / 4, NEUTRAL_GRAY / 4, NEUTRAL_GRAY / 4, 1.0 } },
+        { 0.5f,   { NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, NEUTRAL_GRAY / 2, 1.0 } },
+        { 1.0f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } } };
 
-static const dt_iop_gui_blendif_colorstop_t _gradient_red[] = { { 0.0f, { 0, 0, 0, 1.0 } },
-                                                                { 0.5f, { NEUTRAL_GRAY / 2, 0, 0, 1.0 } },
-                                                                { 1.0f, { NEUTRAL_GRAY, 0, 0, 1.0 } } };
+static const dt_iop_gui_blendif_colorstop_t _gradient_red[] = { { 0.0f,   { 0, 0, 0, 1.0 } },
+                                                                { 0.125f, { NEUTRAL_GRAY / 8, 0, 0, 1.0 } },
+                                                                { 0.25f,  { NEUTRAL_GRAY / 4, 0, 0, 1.0 } },
+                                                                { 0.5f,   { NEUTRAL_GRAY / 2, 0, 0, 1.0 } },
+                                                                { 1.0f,   { NEUTRAL_GRAY, 0, 0, 1.0 } } };
 
-static const dt_iop_gui_blendif_colorstop_t _gradient_green[] = { { 0.0f, { 0, 0, 0, 1.0 } },
-                                                                  { 0.5f, { 0, NEUTRAL_GRAY / 2, 0, 1.0 } },
-                                                                  { 1.0f, { 0, NEUTRAL_GRAY, 0, 1.0 } } };
+static const dt_iop_gui_blendif_colorstop_t _gradient_green[] = { { 0.0f,   { 0, 0, 0, 1.0 } },
+                                                                  { 0.125f, { 0, NEUTRAL_GRAY / 8, 0, 1.0 } },
+                                                                  { 0.25f,  { 0, NEUTRAL_GRAY / 8, 0, 1.0 } },
+                                                                  { 0.5f,   { 0, NEUTRAL_GRAY / 2, 0, 1.0 } },
+                                                                  { 1.0f,   { 0, NEUTRAL_GRAY, 0, 1.0 } } };
 
-static const dt_iop_gui_blendif_colorstop_t _gradient_blue[] = { { 0.0f, { 0, 0, 0, 1.0 } },
-                                                                 { 0.5f, { 0, 0, NEUTRAL_GRAY / 2, 1.0 } },
-                                                                 { 1.0f, { 0, 0, NEUTRAL_GRAY, 1.0 } } };
+static const dt_iop_gui_blendif_colorstop_t _gradient_blue[] = { { 0.0f,   { 0, 0, 0, 1.0 } },
+                                                                 { 0.125f, { 0, 0, NEUTRAL_GRAY / 8, 1.0 } },
+                                                                 { 0.25f,  { 0, 0, NEUTRAL_GRAY / 4, 1.0 } },
+                                                                 { 0.5f,   { 0, 0, NEUTRAL_GRAY / 2, 1.0 } },
+                                                                 { 1.0f,   { 0, 0, NEUTRAL_GRAY, 1.0 } } };
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_chroma[]
-    = { { 0.0f, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
-        { 0.5f, { NEUTRAL_GRAY, NEUTRAL_GRAY / 2, NEUTRAL_GRAY, 1.0 } },
-        { 1.0f, { NEUTRAL_GRAY, 0, NEUTRAL_GRAY, 1.0 } } };
+    = { { 0.0f,   { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } },
+        { 0.125f, { NEUTRAL_GRAY, NEUTRAL_GRAY * 0.875, NEUTRAL_GRAY, 1.0 } },
+        { 0.25f,  { NEUTRAL_GRAY, NEUTRAL_GRAY * 0.75, NEUTRAL_GRAY, 1.0 } },
+        { 0.5f,   { NEUTRAL_GRAY, NEUTRAL_GRAY * 0.5, NEUTRAL_GRAY, 1.0 } },
+        { 1.0f,   { NEUTRAL_GRAY, 0, NEUTRAL_GRAY, 1.0 } } };
 
 static const dt_iop_gui_blendif_colorstop_t _gradient_hue[] = {
   { 0.0f, { 1.00f * 1.5f * NEUTRAL_GRAY, 0.68f * 1.5f * NEUTRAL_GRAY, 0.78f * 1.5f * NEUTRAL_GRAY, 1.0 } },

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -109,7 +109,8 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_HSL_H = 10 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_HSL_S = 11 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_HSL_l = 12 << 3,
-  DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2
+  DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
+  DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
 extern const gchar *dt_dev_histogram_type_names[];

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -920,6 +920,8 @@ void dtgtk_gradient_slider_set_scale_callback(GtkDarktableGradientSlider *gslide
   GtkWidget *self = (GtkWidget *)gslider;
   GList *current = NULL;
 
+  if(old_callback == new_callback) return;
+
   for(int k = 0; k < gslider->positions; k++)
   {
     gslider->position[k] = new_callback(self, old_callback(self, gslider->position[k], GRADIENT_SLIDER_GET), GRADIENT_SLIDER_SET);

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -225,6 +225,12 @@ static gboolean _gradient_slider_add_delta_internal(GtkWidget *widget, gdouble d
   return TRUE;
 }
 
+static float _default_linear_scale_callback(GtkWidget *self, float value, int dir)
+{
+  // regardless of dir: input <-> output
+  return value;
+}
+
 static gboolean _gradient_slider_enter_notify_event(GtkWidget *widget, GdkEventCrossing *event)
 {
   GtkDarktableGradientSlider *gslider = DTGTK_GRADIENT_SLIDER(widget);
@@ -427,6 +433,7 @@ static void _gradient_slider_init(GtkDarktableGradientSlider *slider)
   slider->timeout_handle = 0;
   slider->selected = slider->positions == 1 ? 0 : -1;
   slider->active = -1;
+  slider->scale_callback = _default_linear_scale_callback;
 }
 
 static void _gradient_slider_realize(GtkWidget *widget)
@@ -514,12 +521,12 @@ static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr)
   cairo_pattern_t *gradient = NULL;
   if((current = g_list_first(gslider->colors)) != NULL)
   {
-    gradient = cairo_pattern_create_linear(0, 0, gwidth, gheight);
+    gradient = cairo_pattern_create_linear(0, 0, gwidth, 0);
     do
     {
       _gradient_slider_stop_t *stop = (_gradient_slider_stop_t *)current->data;
-      cairo_pattern_add_color_stop_rgb(gradient, stop->position, stop->color.red, stop->color.green,
-                                       stop->color.blue);
+      cairo_pattern_add_color_stop_rgba(gradient, stop->position, stop->color.red, stop->color.green,
+                                       stop->color.blue, stop->color.alpha);
     } while((current = g_list_next(current)) != NULL);
   }
 
@@ -527,10 +534,13 @@ static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr)
   {
     cairo_set_line_width(cr, 0.1);
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+    cairo_save(cr);
+    cairo_translate(cr, margins, (height - gheight) / 2.0);
     cairo_set_source(cr, gradient);
-    cairo_rectangle(cr, margins, (height - gheight) / 2.0, gwidth, gheight);
+    cairo_rectangle(cr, 0, 0, gwidth, gheight);
     cairo_fill(cr);
     cairo_stroke(cr);
+    cairo_restore(cr);
     cairo_pattern_destroy(gradient);
   }
 
@@ -615,6 +625,8 @@ static gboolean _gradient_slider_draw(GtkWidget *widget, cairo_t *cr)
   return FALSE;
 }
 
+
+
 // Public functions for multivalue type
 GtkWidget *dtgtk_gradient_slider_multivalue_new(gint positions)
 {
@@ -682,8 +694,9 @@ gint _list_find_by_position(gconstpointer a, gconstpointer b)
 void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslider, gfloat position,
                                                GdkRGBA color)
 {
+  const gfloat rawposition = gslider->scale_callback((GtkWidget *)gslider, position, GRADIENT_SLIDER_SET);
   // First find color at position, if exists update color, otherwise create a new stop at position.
-  GList *current = g_list_find_custom(gslider->colors, (gpointer)&position, _list_find_by_position);
+  GList *current = g_list_find_custom(gslider->colors, (gpointer)&rawposition, _list_find_by_position);
   if(current != NULL)
   {
     memcpy(&((_gradient_slider_stop_t *)current->data)->color, &color, sizeof(GdkRGBA));
@@ -692,7 +705,7 @@ void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslid
   {
     // stop didn't exist lets add it
     _gradient_slider_stop_t *gc = (_gradient_slider_stop_t *)g_malloc(sizeof(_gradient_slider_stop_t));
-    gc->position = position;
+    gc->position = rawposition;
     memcpy(&gc->color, &color, sizeof(GdkRGBA));
     gslider->colors = g_list_append(gslider->colors, gc);
   }
@@ -726,14 +739,14 @@ gdouble dtgtk_gradient_slider_multivalue_get_value(GtkDarktableGradientSlider *g
 {
   assert(pos <= gslider->positions);
 
-  return gslider->position[pos];
+  return gslider->scale_callback((GtkWidget *)gslider, gslider->position[pos], GRADIENT_SLIDER_GET);
 }
 
 void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint pos)
 {
   assert(pos <= gslider->positions);
 
-  gslider->position[pos] = value;
+  gslider->position[pos] = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
   g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
@@ -741,7 +754,8 @@ void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gsli
 
 void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
-  for(int k = 0; k < gslider->positions; k++) gslider->position[k] = values[k];
+  for(int k = 0; k < gslider->positions; k++)
+    gslider->position[k] = gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
   g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
@@ -766,28 +780,37 @@ void dtgtk_gradient_slider_multivalue_set_resetvalue(GtkDarktableGradientSlider 
 {
   assert(pos <= gslider->positions);
 
-  gslider->resetvalue[pos] = value;
+  gslider->resetvalue[pos] = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gslider->is_resettable = TRUE;
+}
+
+gdouble dtgtk_gradient_slider_multivalue_get_resetvalue(GtkDarktableGradientSlider *gslider, gint pos)
+{
+  assert(pos <= gslider->positions);
+
+  return gslider->scale_callback((GtkWidget *)gslider, gslider->resetvalue[pos], GRADIENT_SLIDER_GET);
 }
 
 void dtgtk_gradient_slider_multivalue_set_resetvalues(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
-  for(int k = 0; k < gslider->positions; k++) gslider->resetvalue[k] = values[k];
+  for(int k = 0; k < gslider->positions; k++)
+    gslider->resetvalue[k] = gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET);
   gslider->is_resettable = TRUE;
 }
 
 void dtgtk_gradient_slider_multivalue_set_picker(GtkDarktableGradientSlider *gslider, gdouble value)
 {
-  gslider->picker[0] = gslider->picker[1] = gslider->picker[2] = value;
+  gslider->picker[0] = gslider->picker[1] = gslider->picker[2]
+    = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
 void dtgtk_gradient_slider_multivalue_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean,
                                                             gdouble min, gdouble max)
 {
-  gslider->picker[0] = mean;
-  gslider->picker[1] = min;
-  gslider->picker[2] = max;
+  gslider->picker[0] = gslider->scale_callback((GtkWidget *)gslider, mean, GRADIENT_SLIDER_SET);
+  gslider->picker[1] = gslider->scale_callback((GtkWidget *)gslider, min, GRADIENT_SLIDER_SET);
+  gslider->picker[2] = gslider->scale_callback((GtkWidget *)gslider, max, GRADIENT_SLIDER_SET);
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
@@ -835,7 +858,8 @@ gdouble dtgtk_gradient_slider_get_value(GtkDarktableGradientSlider *gslider)
 
 void dtgtk_gradient_slider_multivalue_get_values(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
-  for(int k = 0; k < gslider->positions; k++) values[k] = gslider->position[k];
+  for(int k = 0; k < gslider->positions; k++)
+    values[k] = gslider->scale_callback((GtkWidget *)gslider, gslider->position[k], GRADIENT_SLIDER_GET);
 }
 
 void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value)
@@ -853,18 +877,24 @@ void dtgtk_gradient_slider_set_resetvalue(GtkDarktableGradientSlider *gslider, g
   dtgtk_gradient_slider_multivalue_set_resetvalue(gslider, value, 0);
 }
 
+gdouble dtgtk_gradient_slider_get_resetvalue(GtkDarktableGradientSlider *gslider)
+{
+  return dtgtk_gradient_slider_multivalue_get_resetvalue(gslider, 0);
+}
+
 void dtgtk_gradient_slider_set_picker(GtkDarktableGradientSlider *gslider, gdouble value)
 {
-  gslider->picker[0] = gslider->picker[1] = gslider->picker[2] = value;
+  gslider->picker[0] = gslider->picker[1] = gslider->picker[2]
+    = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
 void dtgtk_gradient_slider_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean,
                                                  gdouble min, gdouble max)
 {
-  gslider->picker[0] = mean;
-  gslider->picker[1] = min;
-  gslider->picker[2] = max;
+  gslider->picker[0] = gslider->scale_callback((GtkWidget *)gslider, mean, GRADIENT_SLIDER_SET);
+  gslider->picker[1] = gslider->scale_callback((GtkWidget *)gslider, min, GRADIENT_SLIDER_SET);
+  gslider->picker[2] = gslider->scale_callback((GtkWidget *)gslider, max, GRADIENT_SLIDER_SET);
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
@@ -883,6 +913,10 @@ void dtgtk_gradient_slider_set_increment(GtkDarktableGradientSlider *gslider, gd
   gslider->increment = value;
 }
 
+void dtgtk_gradient_slider_set_scale_callback(GtkDarktableGradientSlider *gslider, float (*callback)(GtkWidget *self, float value, int dir))
+{
+  gslider->scale_callback = (callback == NULL ? _default_linear_scale_callback : callback);
+}
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/gradientslider.h
+++ b/src/dtgtk/gradientslider.h
@@ -78,6 +78,11 @@ enum
   GRADIENT_SLIDER_MARGINS_BIG = 6
 };
 
+enum
+{
+  GRADIENT_SLIDER_SET = 1,
+  GRADIENT_SLIDER_GET = 2
+};
 
 typedef struct _GtkDarktableGradientSlider
 {
@@ -98,6 +103,7 @@ typedef struct _GtkDarktableGradientSlider
   gboolean do_reset;
   gboolean is_entered;
   guint timeout_handle;
+  float (*scale_callback)(GtkWidget*, float, int); // scale callback function
 } GtkDarktableGradientSlider;
 
 typedef struct _GtkDarktableGradientSliderClass
@@ -168,10 +174,13 @@ gboolean dtgtk_gradient_slider_multivalue_is_dragging(GtkDarktableGradientSlider
 void dtgtk_gradient_slider_multivalue_set_marker(GtkDarktableGradientSlider *gslider, gint mark, gint pos);
 void dtgtk_gradient_slider_multivalue_set_markers(GtkDarktableGradientSlider *gslider, gint *markers);
 
-/** Set the slider reset values for multivalue control */
+/** Set/get the slider reset values for multivalue control */
 void dtgtk_gradient_slider_multivalue_set_resetvalue(GtkDarktableGradientSlider *gslider, gdouble value,
                                                      gint pos);
 void dtgtk_gradient_slider_multivalue_set_resetvalues(GtkDarktableGradientSlider *gslider, gdouble *values);
+gdouble dtgtk_gradient_slider_multivalue_get_resetvalue(GtkDarktableGradientSlider *gslider, gint pos);
+gdouble dtgtk_gradient_slider_multivalue_get_resetvalues(GtkDarktableGradientSlider *gslider);
+
 
 /** Set a picker for multivalue control */
 void dtgtk_gradient_slider_multivalue_set_picker(GtkDarktableGradientSlider *gslider, gdouble value);
@@ -184,6 +193,8 @@ void dtgtk_gradient_slider_multivalue_set_margins(GtkDarktableGradientSlider *gs
 /** set increment for scroll action */
 void dtgtk_gradient_slider_multivalue_set_increment(GtkDarktableGradientSlider *gslider, gdouble value);
 
+/** set scaling function callback */
+void dtgtk_gradient_slider_set_scale_callback(GtkDarktableGradientSlider *gslider, float (*callback)(GtkWidget *self, float value, int dir));
 
 G_END_DECLS
 


### PR DESCRIPTION
* logarithmic view for L, R, G, B, C and g sliders (=> better control for dark pixels)
* zoom view for a and b sliders (=> better control for low saturated pixels)

views are toggled by typing "a" when mouse is over the slider. note that view
is not part of the parameter set, so it is not saved when you leave darkroom.

this is an enhancement for post 3.0.