### PR TITLE
Enable accelerators for sliders in iop modules

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -19,6 +19,7 @@
 #include "gui/accelerators.h"
 #include "common/darktable.h"
 #include "common/debug.h"
+#include "common/utility.h"
 #include "control/control.h"
 #include "develop/blend.h"
 
@@ -79,8 +80,10 @@ static void dt_accel_path_view_translated(char *s, size_t n, dt_view_t *module, 
 
 static void dt_accel_path_iop_translated(char *s, size_t n, dt_iop_module_so_t *module, const char *path)
 {
-  snprintf(s, n, "<Darktable>/%s/%s/%s", C_("accel", "image operations"), module->name(),
+  gchar *module_name_fixed = dt_util_str_replace(module->name(), "/", "-");
+  snprintf(s, n, "<Darktable>/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
            g_dpgettext2(NULL, "accel", path));
+  g_free(module_name_fixed);
 }
 
 static void dt_accel_path_lib_translated(char *s, size_t n, dt_lib_module_t *module, const char *path)
@@ -92,16 +95,18 @@ static void dt_accel_path_lib_translated(char *s, size_t n, dt_lib_module_t *mod
 static void dt_accel_paths_slider_iop_translated(char *s[], size_t n, dt_iop_module_so_t *module,
                                                  const char *path)
 {
-  snprintf(s[0], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
+  gchar *module_name_fixed = dt_util_str_replace(module->name(), "/", "-");
+  snprintf(s[0], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
            g_dpgettext2(NULL, "accel", path), C_("accel", "increase"));
-  snprintf(s[1], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
+  snprintf(s[1], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
            g_dpgettext2(NULL, "accel", path), C_("accel", "decrease"));
-  snprintf(s[2], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
+  snprintf(s[2], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
            g_dpgettext2(NULL, "accel", path), C_("accel", "reset"));
-  snprintf(s[3], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
+  snprintf(s[3], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
            g_dpgettext2(NULL, "accel", path), C_("accel", "edit"));
-  snprintf(s[4], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module->name(),
+  snprintf(s[4], n, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
            g_dpgettext2(NULL, "accel", path), C_("accel", "dynamic"));
+  g_free(module_name_fixed);
 }
 
 static void dt_accel_path_lua_translated(char *s, size_t n, const char *path)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -520,6 +520,9 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lens shift (v)"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lens shift (h)"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shear"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "focal length"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop factor"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "aspect adjust"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -530,6 +533,9 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "lens shift (v)", GTK_WIDGET(g->lensshift_v));
   dt_accel_connect_slider_iop(self, "lens shift (h)", GTK_WIDGET(g->lensshift_h));
   dt_accel_connect_slider_iop(self, "shear", GTK_WIDGET(g->shear));
+  dt_accel_connect_slider_iop(self, "focal length", GTK_WIDGET(g->f_length));
+  dt_accel_connect_slider_iop(self, "crop factor", GTK_WIDGET(g->crop_factor));
+  dt_accel_connect_slider_iop(self, "aspect adjust", GTK_WIDGET(g->aspect));
 }
 
 // multiply 3x3 matrix with 3x1 vector

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -28,6 +28,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "common/rgb_norms.h"
 #include "develop/imageop.h"
+#include "gui/accelerators.h"
 #include "gui/color_picker_proxy.h"
 
 DT_MODULE_INTROSPECTION(2, dt_iop_basicadj_params_t)
@@ -107,6 +108,32 @@ int flags()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_rgb;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black level correction"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "exposure"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlight compression"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clip"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "black level correction", GTK_WIDGET(g->sl_black_point));
+  dt_accel_connect_slider_iop(self, "exposure", GTK_WIDGET(g->sl_exposure));
+  dt_accel_connect_slider_iop(self, "highlight compression", GTK_WIDGET(g->sl_hlcompr));
+  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->sl_contrast));
+  dt_accel_connect_slider_iop(self, "middle grey", GTK_WIDGET(g->sl_middle_grey));
+  dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->sl_brightness));
+  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->sl_saturation));
+  dt_accel_connect_slider_iop(self, "clip", GTK_WIDGET(g->sl_clip));
 }
 
 static void _turn_select_region_off(struct dt_iop_module_t *self)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -119,6 +119,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "brightness"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vibrance"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clip"));
 }
 
@@ -133,6 +134,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "middle grey", GTK_WIDGET(g->sl_middle_grey));
   dt_accel_connect_slider_iop(self, "brightness", GTK_WIDGET(g->sl_brightness));
   dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->sl_saturation));
+  dt_accel_connect_slider_iop(self, "vibrance", GTK_WIDGET(g->sl_vibrance));
   dt_accel_connect_slider_iop(self, "clip", GTK_WIDGET(g->sl_clip));
 }
 

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -32,6 +32,7 @@
 
 #include <gtk/gtk.h>
 #include <stdlib.h>
+#include "gui/accelerators.h"
 
 // this is the version of the modules parameters,
 // and includes version information about compile-time dt
@@ -110,6 +111,28 @@ int default_group()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "detail"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "coarseness"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "midtone range"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "detail", GTK_WIDGET(g->detail));
+  dt_accel_connect_slider_iop(self, "coarseness", GTK_WIDGET(g->spatial));
+  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->range));
+  dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
+  dt_accel_connect_slider_iop(self, "shadows", GTK_WIDGET(g->shadows));
+  dt_accel_connect_slider_iop(self, "midtone range", GTK_WIDGET(g->midtone));
 }
 
 int legacy_params(

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -199,6 +199,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "border size"));
   dt_accel_register_iop(self, FALSE, NC_("accel", "pick border color from image"), 0, 0);
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "frame line size"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "frame line offset"));
   dt_accel_register_iop(self, FALSE, NC_("accel", "pick frame line color from image"), 0, 0);
 }
 
@@ -209,6 +210,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "border size", GTK_WIDGET(g->size));
   dt_accel_connect_button_iop(self, "pick frame line color from image", GTK_WIDGET(g->frame_colorpick));
   dt_accel_connect_slider_iop(self, "frame line size", GTK_WIDGET(g->frame_size));
+  dt_accel_connect_slider_iop(self, "frame line offset", GTK_WIDGET(g->frame_offset));
 }
 
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -127,7 +127,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-#if 0 // BAUHAUS doesn't support keyaccels yet...
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "red"));
@@ -144,7 +143,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "green", GTK_WIDGET(g->scale_green));
   dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->scale_blue));
 }
-#endif
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -298,16 +298,20 @@ void init_presets(dt_iop_module_so_t *self)
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mode"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "controls"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "input saturation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "output saturation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast fulcrum"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  dt_accel_connect_slider_iop(self, "mode", GTK_WIDGET(g->mode));
-  dt_accel_connect_slider_iop(self, "controls", GTK_WIDGET(g->controls));
+  dt_accel_connect_slider_iop(self, "input saturation", GTK_WIDGET(g->saturation));
+  dt_accel_connect_slider_iop(self, "output saturation", GTK_WIDGET(g->saturation_out));
+  dt_accel_connect_slider_iop(self, "contrast fulcrum", GTK_WIDGET(g->grey));
+  dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->contrast));
 }
 
 static inline float CDL(float x, float slope, float offset, float power)

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -130,6 +130,25 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lightness"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green-red"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue-yellow"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "lightness", GTK_WIDGET(g->scale_L));
+  dt_accel_connect_slider_iop(self, "green-red", GTK_WIDGET(g->scale_a));
+  dt_accel_connect_slider_iop(self, "blue-yellow", GTK_WIDGET(g->scale_b));
+  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->scale_C));
+}
+
+
 int legacy_params(
     dt_iop_module_t  *self,
     const void *const old_params,

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -124,6 +124,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hue"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "lightness"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "source mix"));
 }
@@ -132,6 +134,8 @@ void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
 
+  dt_accel_connect_slider_iop(self, "hue", GTK_WIDGET(g->gslider1));
+  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->gslider2));
   dt_accel_connect_slider_iop(self, "lightness", GTK_WIDGET(g->scale1));
   dt_accel_connect_slider_iop(self, "source mix", GTK_WIDGET(g->scale2));
 }

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -161,6 +161,10 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "number of clusters"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "color dominance"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "histogram equalization"));
+  
   dt_accel_register_iop(self, FALSE, NC_("accel", "acquire as source"), 0, 0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "acquire as target"), 0, 0);
 }
@@ -168,6 +172,10 @@ void init_key_accels(dt_iop_module_so_t *self)
 void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "number of clusters", GTK_WIDGET(g->clusters));
+  dt_accel_connect_slider_iop(self, "color dominance", GTK_WIDGET(g->dominance));
+  dt_accel_connect_slider_iop(self, "histogram equalization", GTK_WIDGET(g->equalization));
 
   dt_accel_connect_button_iop(self, "acquire as source", g->acquire_source_button);
   dt_accel_connect_button_iop(self, "acquire as target", g->acquire_target_button);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -27,6 +27,7 @@
 #include "dtgtk/drawingarea.h"
 #include "gui/color_picker_proxy.h"
 #include "gui/presets.h"
+#include "gui/accelerators.h"
 #include "libs/colorpicker.h"
 
 DT_MODULE_INTROSPECTION(4, dt_iop_colorzones_params_t)
@@ -151,6 +152,18 @@ int default_group()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mix"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "mix", GTK_WIDGET(g->strength));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -24,6 +24,7 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "iop/iop_api.h"
 #include <gtk/gtk.h>
 #include <math.h>
@@ -108,6 +109,20 @@ const dt_iop_roi_t *roi_out, dt_develop_tiling_t *tiling)
   return;
 }
 */
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edge detection radius"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_defringe_gui_data_t *g = (dt_iop_defringe_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "edge detection radius", GTK_WIDGET(g->radius_scale));
+  dt_accel_connect_slider_iop(self, "threshold", GTK_WIDGET(g->thresh_scale));
+}
 
 // fibonacci lattice to select surrounding pixels for different cases
 static const float fib[] = { 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233 };

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -513,6 +513,32 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "adjust autoset parameters"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "preserve shadows"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bias correction"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "patch size"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "search radius"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scattering"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "central pixel weight"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
+  dt_accel_connect_slider_iop(self, "adjust autoset parameters", GTK_WIDGET(g->overshooting));
+  dt_accel_connect_slider_iop(self, "preserve shadows", GTK_WIDGET(g->shadows));
+  dt_accel_connect_slider_iop(self, "bias correction", GTK_WIDGET(g->bias));
+  dt_accel_connect_slider_iop(self, "patch size", GTK_WIDGET(g->radius));
+  dt_accel_connect_slider_iop(self, "search radius", GTK_WIDGET(g->nbhood));
+  dt_accel_connect_slider_iop(self, "scattering", GTK_WIDGET(g->scattering));
+  dt_accel_connect_slider_iop(self, "central pixel weight", GTK_WIDGET(g->central_pixel_weight));
+}
+
 static void add_preset(
     dt_iop_module_so_t *self, const char *name,
     const char *pi,  const int version,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -273,6 +273,10 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "latitude"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows highlights balance"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "extreme luminance saturation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target black luminance"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target middle grey"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target white luminance"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target power transfer function"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -287,6 +291,10 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "latitude", GTK_WIDGET(g->latitude));
   dt_accel_connect_slider_iop(self, "shadows highlights balance", GTK_WIDGET(g->balance));
   dt_accel_connect_slider_iop(self, "extreme luminance saturation", GTK_WIDGET(g->saturation));
+  dt_accel_connect_slider_iop(self, "target black luminance", GTK_WIDGET(g->black_point_target));
+  dt_accel_connect_slider_iop(self, "target middle grey", GTK_WIDGET(g->grey_point_target));
+  dt_accel_connect_slider_iop(self, "target white luminance", GTK_WIDGET(g->white_point_target));
+  dt_accel_connect_slider_iop(self, "target power transfer function", GTK_WIDGET(g->output_power));
 }
 
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -117,6 +117,22 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bias"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "detail"));
+ }
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "bias", GTK_WIDGET(g->drago.bias));
+  dt_accel_connect_slider_iop(self, "target", GTK_WIDGET(g->drago.max_light));
+  dt_accel_connect_slider_iop(self, "detail", GTK_WIDGET(g->detail));
+ }
+
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -163,6 +163,9 @@ void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "density"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "compression"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "rotation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hue"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -171,6 +174,9 @@ void connect_key_accels(dt_iop_module_t *self)
 
   dt_accel_connect_slider_iop(self, "density", GTK_WIDGET(g->scale1));
   dt_accel_connect_slider_iop(self, "compression", GTK_WIDGET(g->scale2));
+  dt_accel_connect_slider_iop(self, "rotation", GTK_WIDGET(g->scale3));
+  dt_accel_connect_slider_iop(self, "hue", GTK_WIDGET(g->gslider1));
+  dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->gslider2));
 }
 
 static inline float f(const float t, const float c, const float x)

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -433,11 +433,12 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-#if 0 // BAUHAUS doesn't support keyaccels yet...
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "coarseness"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "midtones bias"));
+  
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -446,9 +447,8 @@ void connect_key_accels(dt_iop_module_t *self)
 
   dt_accel_connect_slider_iop(self, "coarseness", GTK_WIDGET(g->scale1));
   dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->scale2));
+  dt_accel_connect_slider_iop(self, "midtones bias", GTK_WIDGET(g->scale3));
 }
-
-#endif
 
 // see: http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
 // this is the modified bernstein

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -41,6 +41,7 @@
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "iop/iop_api.h"
 
 #ifdef HAVE_OPENCL
@@ -115,6 +116,19 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "distance"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
+  dt_accel_connect_slider_iop(self, "distance", GTK_WIDGET(g->distance));
+}
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -93,6 +93,18 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_RAW;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clipping threshold"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "clipping threshold", GTK_WIDGET(g->clip));
+}
+
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -91,7 +91,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-#if 0 // BAUHAUS doesn't support keyaccels yet...
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "sharpness"));
@@ -106,7 +105,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "sharpness", GTK_WIDGET(g->scale1));
   dt_accel_connect_slider_iop(self, "contrast boost", GTK_WIDGET(g->scale2));
 }
-#endif
 
 void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece,
                      const dt_iop_roi_t *roi_in, const dt_iop_roi_t *roi_out,

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -175,7 +175,6 @@ void init_key_accels(dt_iop_module_so_t *self)
 
   dt_accel_register_iop(self, FALSE, NC_("accel", "find camera"), 0, (GdkModifierType)0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "find lens"), 0, (GdkModifierType)0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "auto scale"), 0, (GdkModifierType)0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "camera model"), 0, (GdkModifierType)0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "lens model"), 0, (GdkModifierType)0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "select corrections"), 0, (GdkModifierType)0);
@@ -185,15 +184,15 @@ void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
 
-  dt_accel_connect_button_iop(self, "find lens", GTK_WIDGET(g->find_lens_button));
-  dt_accel_connect_button_iop(self, "lens model", GTK_WIDGET(g->lens_model));
-  dt_accel_connect_button_iop(self, "camera model", GTK_WIDGET(g->camera_model));
   dt_accel_connect_button_iop(self, "find camera", GTK_WIDGET(g->find_camera_button));
+  dt_accel_connect_button_iop(self, "find lens", GTK_WIDGET(g->find_lens_button));
+  dt_accel_connect_button_iop(self, "camera model", GTK_WIDGET(g->camera_model));
+  dt_accel_connect_button_iop(self, "lens model", GTK_WIDGET(g->lens_model));
   dt_accel_connect_button_iop(self, "select corrections", GTK_WIDGET(g->modflags));
 
   dt_accel_connect_slider_iop(self, "scale", GTK_WIDGET(g->scale));
-  dt_accel_connect_slider_iop(self, "tca R", GTK_WIDGET(g->tca_r));
-  dt_accel_connect_slider_iop(self, "tca B", GTK_WIDGET(g->tca_b));
+  dt_accel_connect_slider_iop(self, "TCA R", GTK_WIDGET(g->tca_r));
+  dt_accel_connect_slider_iop(self, "TCA B", GTK_WIDGET(g->tca_b));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -36,6 +36,7 @@
 #include "gui/draw.h"
 #include "gui/color_picker_proxy.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "gui/presets.h"
 #include "iop/iop_api.h"
 
@@ -129,6 +130,22 @@ int flags()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gray"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_levels_gui_data_t *g = (dt_iop_levels_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "black", GTK_WIDGET(g->percentile_black));
+  dt_accel_connect_slider_iop(self, "gray", GTK_WIDGET(g->percentile_grey));
+  dt_accel_connect_slider_iop(self, "white", GTK_WIDGET(g->percentile_white));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -31,6 +31,7 @@
 #include "gui/color_picker_proxy.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "gui/accelerators.h"
 #include "iop/iop_api.h"
 #include <assert.h>
 #include <math.h>
@@ -87,6 +88,18 @@ int flags()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -114,6 +114,8 @@ int flags()
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "patch size"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "luma"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "chroma"));
 }
@@ -122,6 +124,8 @@ void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
 
+  dt_accel_connect_slider_iop(self, "patch size", GTK_WIDGET(g->radius));
+  dt_accel_connect_slider_iop(self, "strength", GTK_WIDGET(g->strength));
   dt_accel_connect_slider_iop(self, "luma", GTK_WIDGET(g->luma));
   dt_accel_connect_slider_iop(self, "chroma", GTK_WIDGET(g->chroma));
 }

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -123,24 +123,26 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mode"));
+//  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mode"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "linear"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gamma"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dynamic range"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "grey point"));
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows range"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey luma"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black relative exposure"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "safety factor"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
 
-  dt_accel_connect_slider_iop(self, "mode", GTK_WIDGET(g->mode));
+//  dt_accel_connect_slider_iop(self, "mode", GTK_WIDGET(g->mode));
   dt_accel_connect_slider_iop(self, "linear", GTK_WIDGET(g->linear));
   dt_accel_connect_slider_iop(self, "gamma", GTK_WIDGET(g->gamma));
   dt_accel_connect_slider_iop(self, "dynamic range", GTK_WIDGET(g->dynamic_range));
-  dt_accel_connect_slider_iop(self, "grey point", GTK_WIDGET(g->grey_point));
-  dt_accel_connect_slider_iop(self, "shadows range", GTK_WIDGET(g->shadows_range));
+  dt_accel_connect_slider_iop(self, "middle grey luma", GTK_WIDGET(g->grey_point));
+  dt_accel_connect_slider_iop(self, "black relative exposure", GTK_WIDGET(g->shadows_range));
+  dt_accel_connect_slider_iop(self, "safety factor", GTK_WIDGET(g->security_factor));
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -110,6 +110,10 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_iop(self, FALSE, NC_("accel", "pick primary color"), 0, 0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "pick secondary color"), 0, 0);
 
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows-hue"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows-saturation"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights-hue"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights-saturation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "balance"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "compress"));
 }
@@ -121,6 +125,10 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_button_iop(self, "pick primary color", GTK_WIDGET(g->shadow_colorpick));
   dt_accel_connect_button_iop(self, "pick secondary color", GTK_WIDGET(g->highlight_colorpick));
 
+  dt_accel_connect_slider_iop(self, "shadows-hue", GTK_WIDGET(g->shadow_hue_gslider));
+  dt_accel_connect_slider_iop(self, "shadows-saturation", GTK_WIDGET(g->shadow_sat_gslider));
+  dt_accel_connect_slider_iop(self, "highlights-hue", GTK_WIDGET(g->highlight_hue_gslider));
+  dt_accel_connect_slider_iop(self, "highlights-saturation", GTK_WIDGET(g->highlight_sat_gslider));
   dt_accel_connect_slider_iop(self, "balance", GTK_WIDGET(g->balance_scale));
   dt_accel_connect_slider_iop(self, "compress", GTK_WIDGET(g->compress_scale));
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -39,6 +39,7 @@
 #include "gui/gtk.h"
 #include "gui/presets.h"
 #include "gui/color_picker_proxy.h"
+#include "gui/accelerators.h"
 #include "iop/iop_api.h"
 #include "libs/colorpicker.h"
 
@@ -203,6 +204,18 @@ int flags()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "base of the logarithm"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "base of the logarithm", GTK_WIDGET(g->logbase));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -98,10 +98,9 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-#if 0 // BAUHAUS doesn't support keyaccels yet...
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vibrance"));
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "strength"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mid-tones bias"));
 }
 
@@ -109,12 +108,11 @@ void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_velvia_gui_data_t *g = (dt_iop_velvia_gui_data_t*)self->gui_data;
 
-  dt_accel_connect_slider_iop(self, "vibrance",
+  dt_accel_connect_slider_iop(self, "strength",
                               GTK_WIDGET(g->strength_scale));
   dt_accel_connect_slider_iop(self, "mid-tones bias",
                               GTK_WIDGET(g->bias_scale));
 }
-#endif
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -79,7 +79,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
-#if 0 // BAUHAUS doesn't support keyaccels yet...
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vibrance"));
@@ -92,7 +91,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "vibrance",
                               GTK_WIDGET(g->amount_scale));
 }
-#endif
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)


### PR DESCRIPTION
Closes #3482 (which is specifically for the basic adjustments module.

I've defined accelerators for all other modules that didn't have them, but often they don't seem to work (haze removal, global tonemap, denoiseprofile, defringe, colorzones, colorchecker, bilat). 

There were also modules where the definitions were already there, but deactived with a "#if 0 // BAUHAUS doesn't support keyaccels yet..." line. And indeed, after removing the line, the accelerators didn't work (channel mixer, highpass, velvia, vibrance). 

Except in the case of "grain" which had deactivated accelerators that worked fine after they were reenabled.

I have tried to find out what the difference between working and non-working modules is, but have not yet been able to spot it. Any help on what "BAUHAUS doesn't support keyaccels yet..." refers to (since sometimes it clearly does work) would be welcome. Otherwise a deep debug will be needed.