### PR TITLE
Fix an issue with a memove() of static const

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@ tools/iop_deps.pdf
 cscope.out
 .*.swp
 .vscode/
-
+.clangd/
+tags
+cscope.*
+compile_commands.json

--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -293,8 +293,14 @@ static cmsHPROFILE _create_lcms_profile(const char *desc, const char *dmdd,
   {
     cmsSetProfileVersion(profile, 2.1);
     cmsCIEXYZ black = { 0, 0, 0 };
+    /* cmsWriteTag does a memmove(), we can't pass a global const */
+    cmsCIExyY wp = {
+        .x = whitepoint->x,
+        .y = whitepoint->y,
+        .Y = whitepoint->Y,
+    };
     cmsWriteTag(profile, cmsSigMediaBlackPointTag, &black);
-    cmsWriteTag(profile, cmsSigMediaWhitePointTag, &whitepoint);
+    cmsWriteTag(profile, cmsSigMediaWhitePointTag, &wp);
     cmsSetDeviceClass(profile, cmsSigDisplayClass);
   }
 


### PR DESCRIPTION
An issue found by address sanitizer when debugging an darktable issue.

 ``` 
    READ of size 24 at 0x7fffffffa2b8 thread T0
        #0 0x7ffff761162d in memmove (/usr/lib64/libasan.so.5+0x9f62d)
        #1 0x7ffff4a72a46 in memmove /usr/include/bits/string_fortified.h:40
        #2 0x7ffff4a72a46 in _cmsDupDefaultFn /usr/src/debug/lcms2-2.9-2.5.x86_64/src/cmserr.c:174
        #3 0x7ffff4a6efba in cmsWriteTag /usr/src/debug/lcms2-2.9-2.5.x86_64/src/cmsio0.c:1733
        #4 0x7ffff4a6efba in cmsWriteTag /usr/src/debug/lcms2-2.9-2.5.x86_64/src/cmsio0.c:1639
        #5 0x7ffff6c18c06 in _create_lcms_profile /home/asn/workspace/projects/darktable/src/common/colorspaces.c:299
        #6 0x7ffff6c1900b in _colorspaces_create_srgb_profile /home/asn/workspace/projects/darktable/src/common/colorspaces.c:330
        #7 0x7ffff6c1908e in dt_colorspaces_create_srgb_profile /home/asn/workspace/projects/darktable/src/common/colorspaces.c:340
        #8 0x7ffff6c221f5 in dt_colorspaces_init /home/asn/workspace/projects/darktable/src/common/colorspaces.c:1270
        #9 0x7ffff6c34a5a in dt_init /home/asn/workspace/projects/darktable/src/common/darktable.c:821
        #10 0x4009be in main /home/asn/workspace/projects/darktable/src/main.c:92
        #11 0x7ffff67bee0a in __libc_start_main (/lib64/libc.so.6+0x26e0a)
        #12 0x4008e9 in _start (/home/asn/workspace/projects/darktable/obj-asan/src/darktable+0x4008e9)
```