### PR TITLE
Accelerators for filmstrip don't conflict with lighttable

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -183,7 +183,7 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
   const gchar **views = self->views(self);
   while (views[i])
   {
-    if (strcmp(views[i], "lighttable") == 0) accel->views |= DT_VIEW_LIGHTTABLE;
+    if (strcmp(views[i], "lighttable") == 0 && strcmp(accel->module, "filmstrip") != 0) accel->views |= DT_VIEW_LIGHTTABLE;
     else if (strcmp(views[i], "darkroom") == 0) accel->views |= DT_VIEW_DARKROOM;
     else if (strcmp(views[i], "print") == 0) accel->views |= DT_VIEW_PRINT;
     else if (strcmp(views[i], "slideshow") == 0) accel->views |= DT_VIEW_SLIDESHOW;

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -183,7 +183,7 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
   const gchar **views = self->views(self);
   while (views[i])
   {
-    if (strcmp(views[i], "lighttable") == 0 && strcmp(accel->module, "filmstrip") != 0) accel->views |= DT_VIEW_LIGHTTABLE;
+    if (strcmp(views[i], "lighttable") == 0) accel->views |= DT_VIEW_LIGHTTABLE;
     else if (strcmp(views[i], "darkroom") == 0) accel->views |= DT_VIEW_DARKROOM;
     else if (strcmp(views[i], "print") == 0) accel->views |= DT_VIEW_PRINT;
     else if (strcmp(views[i], "slideshow") == 0) accel->views |= DT_VIEW_SLIDESHOW;

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -154,8 +154,12 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
-  return v;
+  static const char *v1[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
+  static const char *v2[] = {"darkroom", "tethering", "map", "print", NULL};
+  if(self->data)
+    return v1;
+  else
+    return v2; // We are registering accelerators; don't conflict with overlapping lighttable versions
 }
 
 uint32_t container(dt_lib_module_t *self)

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -212,6 +212,10 @@ void init_key_accels(dt_lib_module_t *self)
 
 void connect_key_accels(dt_lib_module_t *self)
 {
+  // on lighttable, does nothing and report that it has not been handled
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if (cv->view((dt_view_t *)cv) == DT_VIEW_LIGHTTABLE) return;
+
   // Rating accels
   dt_accel_connect_lib(self, "rate 0", g_cclosure_new(G_CALLBACK(_lib_filmstrip_ratings_key_accel_callback),
                                                       GINT_TO_POINTER(DT_VIEW_DESERT), NULL));
@@ -409,13 +413,6 @@ static gboolean _lib_filmstrip_mouse_leave_callback(GtkWidget *w, GdkEventCrossi
   gtk_widget_queue_draw(strip->filmstrip);
 
   return TRUE;
-}
-
-static inline gboolean _is_on_lighttable()
-{
-  // on lighttable, does nothing and report that it has not been handled
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  return cv->view((dt_view_t *)cv) == DT_VIEW_LIGHTTABLE;
 }
 
 static gboolean _lib_filmstrip_size_handle_cursor_callback(GtkWidget *w, GdkEventCrossing *e,
@@ -945,8 +942,6 @@ static gboolean _lib_filmstrip_copy_history_key_accel_callback(GtkAccelGroup *ac
                                                                GObject *aceeleratable, guint keyval,
                                                                GdkModifierType modifier, gpointer data)
 {
-  if(_is_on_lighttable()) return FALSE;
-
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
   const int32_t mouse_over_id = dt_control_get_mouse_over_id();
   if(mouse_over_id <= 0) return FALSE;
@@ -962,8 +957,6 @@ static gboolean _lib_filmstrip_copy_history_parts_key_accel_callback(GtkAccelGro
                                                                      GObject *aceeleratable, guint keyval,
                                                                      GdkModifierType modifier, gpointer data)
 {
-  if(_is_on_lighttable()) return FALSE;
-
   if(_lib_filmstrip_copy_history_key_accel_callback(accel_group, aceeleratable, keyval, modifier, data))
   {
     dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
@@ -979,8 +972,6 @@ static gboolean _lib_filmstrip_paste_history_key_accel_callback(GtkAccelGroup *a
                                                                 GObject *aceeleratable, guint keyval,
                                                                 GdkModifierType modifier, gpointer data)
 {
-  if(_is_on_lighttable()) return FALSE;
-
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
   const int mode = dt_conf_get_int("plugins/lighttable/copy_history/pastemode");
 
@@ -1001,8 +992,6 @@ static gboolean _lib_filmstrip_paste_history_parts_key_accel_callback(GtkAccelGr
                                                                       GObject *aceeleratable, guint keyval,
                                                                       GdkModifierType modifier, gpointer data)
 {
-  if(_is_on_lighttable()) return FALSE;
-
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
   const int mode = dt_conf_get_int("plugins/lighttable/copy_history/pastemode");
 
@@ -1027,8 +1016,6 @@ static gboolean _lib_filmstrip_discard_history_key_accel_callback(GtkAccelGroup 
                                                                   GObject *aceeleratable, guint keyval,
                                                                   GdkModifierType modifier, gpointer data)
 {
-  if(_is_on_lighttable()) return FALSE;
-
   const int32_t mouse_over_id = dt_control_get_mouse_over_id();
   if(mouse_over_id <= 0) return FALSE;
 
@@ -1044,15 +1031,13 @@ static gboolean _lib_filmstrip_duplicate_image_key_accel_callback(GtkAccelGroup 
 {
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)data;
 
-  if(_is_on_lighttable()) return FALSE;
-
   strip->force_expose_all = TRUE;
 
   const int32_t mouse_over_id = dt_control_get_mouse_over_id();
   if(mouse_over_id <= 0) return FALSE;
 
   /* check if images is currently loaded in darkroom */
-  if(!_is_on_lighttable() && dt_dev_is_current_image(darktable.develop, mouse_over_id)) dt_dev_write_history(darktable.develop);
+  if(dt_dev_is_current_image(darktable.develop, mouse_over_id)) dt_dev_write_history(darktable.develop);
 
   const int32_t newimgid = dt_image_duplicate(mouse_over_id);
   if(newimgid != -1)
@@ -1071,8 +1056,6 @@ static gboolean _lib_filmstrip_ratings_key_accel_callback(GtkAccelGroup *accel_g
 {
   dt_lib_module_t *self = (dt_lib_module_t *)darktable.view_manager->proxy.filmstrip.module;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
-
-  if(_is_on_lighttable()) return FALSE;
 
   const int num = GPOINTER_TO_INT(data);
   strip->force_expose_all = TRUE;
@@ -1125,8 +1108,6 @@ static gboolean _lib_filmstrip_colorlabels_key_accel_callback(GtkAccelGroup *acc
   dt_lib_module_t *self = (dt_lib_module_t *)darktable.view_manager->proxy.filmstrip.module;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
 
-  if(_is_on_lighttable()) return FALSE;
-
   strip->force_expose_all = TRUE;
 
   dt_colorlabels_key_accel_callback(NULL, NULL, 0, 0, data);
@@ -1141,8 +1122,6 @@ static gboolean _lib_filmstrip_select_key_accel_callback(GtkAccelGroup *accel_gr
 {
   dt_lib_module_t *self = (dt_lib_module_t *)darktable.view_manager->proxy.filmstrip.module;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
-
-  if(_is_on_lighttable()) return FALSE;
 
   strip->force_expose_all = TRUE;
 
@@ -1174,8 +1153,6 @@ static void _lib_filmstrip_dnd_get_callback(GtkWidget *widget, GdkDragContext *c
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
-
-  if(_is_on_lighttable()) return;
 
   g_assert(selection_data != NULL);
 
@@ -1236,8 +1213,6 @@ static void _lib_filmstrip_dnd_begin_callback(GtkWidget *widget, GdkDragContext 
 
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_filmstrip_t *strip = (dt_lib_filmstrip_t *)self->data;
-
-  if(_is_on_lighttable()) return;
 
   int imgid = strip->mouse_over_id;
 

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -152,10 +152,16 @@ const char *name(dt_lib_module_t *self)
   return _("filmstrip");
 }
 
+static gboolean initialising_accels = FALSE;
+
 const char **views(dt_lib_module_t *self)
 {
   static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
-  return v;
+  static const char *v_accels[] = {"darkroom", "tethering", "map", "print", NULL};
+  if (initialising_accels)
+    return v_accels;
+  else
+    return v;
 }
 
 uint32_t container(dt_lib_module_t *self)
@@ -175,6 +181,12 @@ int position()
 
 void init_key_accels(dt_lib_module_t *self)
 {
+//  First add accelerators that should not be disabled in lighttable
+//  dt_accel_register_lib(self, NC_("accel", "active in lighttable"), 0, 0);
+
+  initialising_accels = TRUE;
+//  The accelerators below will not be active in lighttable
+
   /* setup rating key accelerators */
   dt_accel_register_lib(self, NC_("accel", "rate 0"), GDK_KEY_0, 0);
   dt_accel_register_lib(self, NC_("accel", "rate 1"), GDK_KEY_1, 0);
@@ -208,11 +220,16 @@ void init_key_accels(dt_lib_module_t *self)
   dt_accel_register_lib(self, NC_("accel", "invert selection"), GDK_KEY_i, GDK_CONTROL_MASK);
   dt_accel_register_lib(self, NC_("accel", "select film roll"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "select untouched"), 0, 0);
+
+  initialising_accels = FALSE;
 }
 
 void connect_key_accels(dt_lib_module_t *self)
 {
-  // on lighttable, does nothing and report that it has not been handled
+//  dt_accel_connect_lib(self, "active in lighttable",
+//                       g_cclosure_new(G_CALLBACK(_lib_filmstrip_active_in_lighttable_key_accel_callback),
+//                                      (gpointer)self->data, NULL));
+
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if (cv->view((dt_view_t *)cv) == DT_VIEW_LIGHTTABLE) return;
 

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -154,12 +154,8 @@ const char *name(dt_lib_module_t *self)
 
 const char **views(dt_lib_module_t *self)
 {
-  static const char *v1[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
-  static const char *v2[] = {"darkroom", "tethering", "map", "print", NULL};
-  if(self->data)
-    return v1;
-  else
-    return v2; // We are registering accelerators; don't conflict with overlapping lighttable versions
+  static const char *v[] = {"lighttable", "darkroom", "tethering", "map", "print", NULL};
+  return v;
 }
 
 uint32_t container(dt_lib_module_t *self)


### PR DESCRIPTION
Change #2604 made sure that any accelerators defined for filmstrip are ignored in the context of lighttable.

This change lets preferences/shortcuts allow the same keys in both.

Closes #3562 