### PR TITLE
Updating windows build instructions

### DIFF
--- a/packaging/windows/BUILD.txt
+++ b/packaging/windows/BUILD.txt
@@ -14,7 +14,7 @@ A) Native compile using MSYS2:  How to make a darktable windows installer (64 bi
 	$ pacman -S git
 
     Install required libraries and dependencies:
-	$ pacman -S mingw-w64-x86_64-{exiv2,lcms2,lensfun,dbus-glib,openexr,sqlite3,libxslt,libsoup,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes,python3-jsonschema,python3-setuptools}
+	$ pacman -S mingw-w64-x86_64-{exiv2,lcms2,lensfun,dbus-glib,openexr,sqlite3,libxslt,libsoup,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes,python3-jsonschema,python3-setuptools,python3-importlib-metadata}
 
     For gphoto2:
     You need to restart the MINGW64 or MSYS terminal to have CAMLIBS and IOLIBS environment variables  properly set for LIBGPHOTO are available. You can check them with:


### PR DESCRIPTION
After update of MSYS2 installation, which include Python upgrade to 3.8, I got the following build error

``
[ 93%] Checking validity of noiseprofiles.json
Traceback (most recent call last):
  File "C:\msys64\mingw64\bin\jsonschema-script.py", line 6, in <module>
    from pkg_resources import load_entry_point
  File "C:/msys64/mingw64/lib/python3.8/site-packages\pkg_resources\__init__.py", line 3251, in <module>
    def _initialize_master_working_set():
  File "C:/msys64/mingw64/lib/python3.8/site-packages\pkg_resources\__init__.py", line 3234, in _call_aside
    f(*args, **kwargs)
  File "C:/msys64/mingw64/lib/python3.8/site-packages\pkg_resources\__init__.py", line 3263, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "C:/msys64/mingw64/lib/python3.8/site-packages\pkg_resources\__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "C:/msys64/mingw64/lib/python3.8/site-packages\pkg_resources\__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "C:/msys64/mingw64/lib/python3.8/site-packages\pkg_resources\__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'importlib_metadata' distribution was not found and is required by jsonschema
make[2]: *** [data/CMakeFiles/validate_noiseprofiles_json.dir/build.make:59: data/CMakeFiles/validate_noiseprofiles_json] Error 1
make[1]: *** [CMakeFiles/Makefile2:7325: data/CMakeFiles/validate_noiseprofiles_json.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
``

I found that there is a missing dependency 

`pacman -S mingw-w64-x86_64-python3-importlib-metadata`

so adding that to the build instructions