### PR TITLE
Fix #3556 Disable demosaic for non-raw dng files.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -113,7 +113,7 @@ int dt_image_is_raw(const dt_image_t *img)
   const char *dt_non_raw_extensions[]
       = { ".jpeg", ".jpg",  ".pfm", ".hdr", ".exr", ".pxn", ".tif", ".tiff", ".png",
           ".j2c",  ".j2k",  ".jp2", ".jpc", ".gif", ".jpc", ".jp2", ".bmp",  ".dcm",
-          ".jng",  ".miff", ".mng", ".pbm", ".pnm", ".ppm", ".pgm", NULL };
+          ".jng",  ".miff", ".mng", ".pbm", ".pnm", ".ppm", ".pgm", ".dng", NULL };
 
   if(img->flags & DT_IMAGE_RAW) return TRUE;
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -110,6 +110,8 @@ int dt_image_is_hdr(const dt_image_t *img)
 int dt_image_is_raw(const dt_image_t *img)
 {
   // NULL terminated list of supported non-RAW extensions
+  // rawspeed takes care of RAW dng files by setting the DT_IMAGE_RAW flag
+  // so NON-RAW dng files are tested correctly.  
   const char *dt_non_raw_extensions[]
       = { ".jpeg", ".jpg",  ".pfm", ".hdr", ".exr", ".pxn", ".tif", ".tiff", ".png",
           ".j2c",  ".j2k",  ".jp2", ".jpc", ".gif", ".jpc", ".jp2", ".bmp",  ".dcm",


### PR DESCRIPTION
Fixes issue #3556.

DNG files can have both types of data
1. raw      demosaic module enabled
2. non-raw  demosaic should be disabled

As dng files are tested in rawspeed for a bayer matrix they have the DT_IMAGE_RAW set and
will return true in dt_image_is_raw(const dt_image_t *img).
Including a test for the .dng file extension is therefore possible.