### PR TITLE
avoid accels conflict with libs (filmstrip)

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -164,7 +164,8 @@ void dt_accel_register_iop(dt_iop_module_so_t *so, gboolean local, const gchar *
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
 }
 
-void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel_key, GdkModifierType mods)
+void dt_accel_register_lib_for_views(dt_lib_module_t *self, dt_view_type_flags_t views, const gchar *path,
+                                     guint accel_key, GdkModifierType mods)
 {
   gchar accel_path[256];
   dt_accel_t *accel = (dt_accel_t *)g_malloc(sizeof(dt_accel_t));
@@ -178,23 +179,34 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
   g_strlcpy(accel->module, self->plugin_name, sizeof(accel->module));
   accel->local = FALSE;
   // we get the views in which the lib will be displayed
-  accel->views = 0;
+  accel->views = views;
+  darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
+}
+void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel_key, GdkModifierType mods)
+{
+  dt_view_type_flags_t v = 0;
   int i=0;
   const gchar **views = self->views(self);
   while (views[i])
   {
-    if (strcmp(views[i], "lighttable") == 0) accel->views |= DT_VIEW_LIGHTTABLE;
-    else if (strcmp(views[i], "darkroom") == 0) accel->views |= DT_VIEW_DARKROOM;
-    else if (strcmp(views[i], "print") == 0) accel->views |= DT_VIEW_PRINT;
-    else if (strcmp(views[i], "slideshow") == 0) accel->views |= DT_VIEW_SLIDESHOW;
-    else if (strcmp(views[i], "map") == 0) accel->views |= DT_VIEW_MAP;
-    else if (strcmp(views[i], "tethering") == 0) accel->views |= DT_VIEW_TETHERING;
+    if(strcmp(views[i], "lighttable") == 0)
+      v |= DT_VIEW_LIGHTTABLE;
+    else if(strcmp(views[i], "darkroom") == 0)
+      v |= DT_VIEW_DARKROOM;
+    else if(strcmp(views[i], "print") == 0)
+      v |= DT_VIEW_PRINT;
+    else if(strcmp(views[i], "slideshow") == 0)
+      v |= DT_VIEW_SLIDESHOW;
+    else if(strcmp(views[i], "map") == 0)
+      v |= DT_VIEW_MAP;
+    else if(strcmp(views[i], "tethering") == 0)
+      v |= DT_VIEW_TETHERING;
     else if(strcmp(views[i], "*") == 0)
-      accel->views |= DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT
-                      | DT_VIEW_SLIDESHOW;
+      v |= DT_VIEW_DARKROOM | DT_VIEW_LIGHTTABLE | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT
+           | DT_VIEW_SLIDESHOW;
     i++;  
   }
-  darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel);
+  dt_accel_register_lib_for_views(self, v, path, accel_key, mods);
 }
 
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -77,6 +77,8 @@ void dt_accel_register_view(dt_view_t *self, const gchar *path, guint accel_key,
 void dt_accel_register_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path, guint accel_key,
                            GdkModifierType mods);
 void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel_key, GdkModifierType mods);
+void dt_accel_register_lib_for_views(dt_lib_module_t *self, dt_view_type_flags_t views, const gchar *path,
+                                     guint accel_key, GdkModifierType mods);
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path);
 void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType mods);
 

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -175,39 +175,41 @@ int position()
 
 void init_key_accels(dt_lib_module_t *self)
 {
+  dt_view_type_flags_t views = DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_PRINT;
   /* setup rating key accelerators */
-  dt_accel_register_lib(self, NC_("accel", "rate 0"), GDK_KEY_0, 0);
-  dt_accel_register_lib(self, NC_("accel", "rate 1"), GDK_KEY_1, 0);
-  dt_accel_register_lib(self, NC_("accel", "rate 2"), GDK_KEY_2, 0);
-  dt_accel_register_lib(self, NC_("accel", "rate 3"), GDK_KEY_3, 0);
-  dt_accel_register_lib(self, NC_("accel", "rate 4"), GDK_KEY_4, 0);
-  dt_accel_register_lib(self, NC_("accel", "rate 5"), GDK_KEY_5, 0);
-  dt_accel_register_lib(self, NC_("accel", "rate reject"), GDK_KEY_r, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate 0"), GDK_KEY_0, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate 1"), GDK_KEY_1, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate 2"), GDK_KEY_2, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate 3"), GDK_KEY_3, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate 4"), GDK_KEY_4, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate 5"), GDK_KEY_5, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "rate reject"), GDK_KEY_r, 0);
 
   /* setup history key accelerators */
-  dt_accel_register_lib(self, NC_("accel", "copy history"), GDK_KEY_c, GDK_CONTROL_MASK);
-  dt_accel_register_lib(self, NC_("accel", "copy history parts"), GDK_KEY_c,
-                        GDK_CONTROL_MASK | GDK_SHIFT_MASK);
-  dt_accel_register_lib(self, NC_("accel", "paste history"), GDK_KEY_v, GDK_CONTROL_MASK);
-  dt_accel_register_lib(self, NC_("accel", "paste history parts"), GDK_KEY_v,
-                        GDK_CONTROL_MASK | GDK_SHIFT_MASK);
-  dt_accel_register_lib(self, NC_("accel", "discard history"), 0, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "copy history"), GDK_KEY_c, GDK_CONTROL_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "copy history parts"), GDK_KEY_c,
+                                  GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "paste history"), GDK_KEY_v, GDK_CONTROL_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "paste history parts"), GDK_KEY_v,
+                                  GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "discard history"), 0, 0);
 
-  dt_accel_register_lib(self, NC_("accel", "duplicate image"), GDK_KEY_d, GDK_CONTROL_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "duplicate image"), GDK_KEY_d, GDK_CONTROL_MASK);
 
   /* setup color label accelerators */
-  dt_accel_register_lib(self, NC_("accel", "color red"), GDK_KEY_F1, 0);
-  dt_accel_register_lib(self, NC_("accel", "color yellow"), GDK_KEY_F2, 0);
-  dt_accel_register_lib(self, NC_("accel", "color green"), GDK_KEY_F3, 0);
-  dt_accel_register_lib(self, NC_("accel", "color blue"), GDK_KEY_F4, 0);
-  dt_accel_register_lib(self, NC_("accel", "color purple"), GDK_KEY_F5, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "color red"), GDK_KEY_F1, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "color yellow"), GDK_KEY_F2, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "color green"), GDK_KEY_F3, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "color blue"), GDK_KEY_F4, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "color purple"), GDK_KEY_F5, 0);
 
   /* setup selection accelerators */
-  dt_accel_register_lib(self, NC_("accel", "select all"), GDK_KEY_a, GDK_CONTROL_MASK);
-  dt_accel_register_lib(self, NC_("accel", "select none"), GDK_KEY_a, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
-  dt_accel_register_lib(self, NC_("accel", "invert selection"), GDK_KEY_i, GDK_CONTROL_MASK);
-  dt_accel_register_lib(self, NC_("accel", "select film roll"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "select untouched"), 0, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "select all"), GDK_KEY_a, GDK_CONTROL_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "select none"), GDK_KEY_a,
+                                  GDK_CONTROL_MASK | GDK_SHIFT_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "invert selection"), GDK_KEY_i, GDK_CONTROL_MASK);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "select film roll"), 0, 0);
+  dt_accel_register_lib_for_views(self, views, NC_("accel", "select untouched"), 0, 0);
 }
 
 void connect_key_accels(dt_lib_module_t *self)


### PR DESCRIPTION
this fix #3562 , close #3563 
lib can now init their accels for specific views. But it's up to them to not connect them (to avoid a general check which would take little time when changing views)
this is applied to filmstrip, to avoid conflict with ratings/etc which are handle direcly by the view code in lighttable and by filmstrip in other views

thanks to @dterrahe for report, ideas and tests