### PR TITLE
navigation : verify imgid before drawing

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -174,7 +174,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
   gtk_render_background(context, cr, 0, 0, allocation.width, allocation.height);
 
   /* draw navigation image if available */
-  if(dev->preview_pipe->output_backbuf)
+  if(dev->preview_pipe->output_backbuf && dev->image_storage.id == dev->preview_pipe->output_imgid)
   {
     dt_pthread_mutex_t *mutex = &dev->preview_pipe->backbuf_mutex;
     dt_pthread_mutex_lock(mutex);


### PR DESCRIPTION
this fix #3575
Same check is already applied for darkroom main view.

In a second time, we may want to draw some "waiting screen" when entering darkroom, to avoid keeping a "freezed" image of the previous view before the image is loaded.
This is especially visible if image has heavy settings (I usually use denoise profiled with search radius at maximum for testing)