### PR TITLE
Vibrance slider added to Basic adjustments module

### DIFF
--- a/data/kernels/basicadj.cl
+++ b/data/kernels/basicadj.cl
@@ -93,7 +93,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
            const float black_point, const float scale,
            const int process_gamma, const float gamma,
            const int plain_contrast, const int preserve_colors, const float contrast,
-           const int process_saturation, const float saturation,
+           const int process_saturation_vibrance, const float saturation, const float vibrance,
            const int process_hlcompr, const float hlcomp, const float hlrange,
            const float middle_grey, const float inv_middle_grey,
            constant dt_colorspaces_iccprofile_info_cl_t *profile_info, read_only image2d_t lut,
@@ -152,11 +152,12 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
   }
 
   // saturation
-  if(process_saturation)
+  if(process_saturation_vibrance)
   {
-    const float luminance = (use_work_profile == 0) ? dt_camera_rgb_luminance(pixel): get_rgb_matrix_luminance(pixel, profile_info, profile_info->matrix_in, lut);
-
-    pixel = luminance + saturation * (pixel - luminance);
+    const float average = (pixel.x + pixel.y + pixel.z) / 3;
+    const float delta = fast_length(pixel - average);
+    const float P = vibrance * (1 - native_powr(delta, abs(vibrance)));
+    pixel = average + (saturation + P) * (pixel - average);
   }
 
   pixel.w = w;


### PR DESCRIPTION
**This is a duplicate of https://github.com/darktable-org/darktable/pull/3121** (I messed up my repo, so I had to clean up everything....sorry. In the meantime I updated the code from upstream)

This commit adds a vibrance slider to the basic adjustments module.
![vibrance-slider](https://user-images.githubusercontent.com/26119925/69768721-f493c600-1181-11ea-97ec-943596f46b33.jpg)

This feature adds a Vibrance slider in the Basic adjustments tool, right below the saturation slider.

The vibrance allows to accentuate the colors of the image without adding unnatural colors, as it's often the case of the Saturation slider.

The slider allows to set negative vibrance - compared to the vibrance tool already included in darktable.

Combining the effects of the vibrance and saturation slider the user can change the more/less saturated areas of the image, resulting in interesting faded look.

This tool runs together with the saturation tool, so it adds very little computational complexity to the pipeline.

*Big thanks to Aurélien Pierre for suggestions on the formula to use!*

NOTE: as this slider works in the RGB color space, its results might be slightly different than the Vibrance tool.