### PR TITLE
use OpenMP flags for entire build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,20 @@ if (USE_OPENMP)
     endif()
 
     find_package(OpenMP 4.0 REQUIRED)
+
+    if(OpenMP_C_FLAGS)
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    endif()
+
+    if(OpenMP_CXX_FLAGS)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    endif()
+
+    list(APPEND LIBS ${OpenMP_C_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
+
+    if(WIN32)
+      list(APPEND LIBS gomp)
+    endif(WIN32)
 endif()
 
 include(ConfigureChecks.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,22 +230,6 @@ list(APPEND LIBS "${CMAKE_THREAD_LIBS_INIT}")
 # Need to explicitly link against math library.
 list(APPEND LIBS "-lm")
 
-if(USE_OPENMP)
-  if(OpenMP_C_FLAGS)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  endif()
-
-  if(OpenMP_CXX_FLAGS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  endif()
-
-  list(APPEND LIBS ${OpenMP_C_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
-
-  if(WIN32)
-    list(APPEND LIBS gomp)
-  endif(WIN32)
-endif(USE_OPENMP)
-
 if(USE_DARKTABLE_PROFILING)
   add_definitions(-DUSE_DARKTABLE_PROFILING)
   set(SOURCES ${SOURCES} "common/profiling.c")


### PR DESCRIPTION
Some external libraries (e.g. rawspeed) require OpenMP flags to build.