### PR TITLE
fix some casts

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2169,7 +2169,7 @@ static inline void _transform_rgb_to_lab_matrix(const float *const restrict imag
                                                 const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   const int ch = 4;
-  const size_t stride = (size_t)(width * height * ch);
+  const size_t stride = (size_t)width * height * ch;
   const float *const restrict matrix = profile_info->matrix_in;
 
   if(profile_info->nonlinearlut)
@@ -2252,7 +2252,7 @@ static inline void _transform_matrix_rgb(const float *const restrict image_in, f
                                   const dt_iop_order_iccprofile_info_t *const profile_info_to)
 {
   const int ch = 4;
-  const size_t stride = (size_t)(width * height * ch);
+  const size_t stride = (size_t)width * height * ch;
   const float *const restrict matrix_in = profile_info_from->matrix_in;
   const float *const restrict matrix_out = profile_info_to->matrix_out;
 
@@ -2755,7 +2755,7 @@ static __m128 _ioppr_xyz_to_linear_rgb_matrix_sse(const __m128 xyz, const dt_iop
 static void _transform_rgb_to_lab_matrix_sse(float *const image, const int width, const int height, const dt_iop_order_iccprofile_info_t *const profile_info)
 {
   const int ch = 4;
-  const size_t stride = (size_t)(width * height);
+  const size_t stride = (size_t)width * height;
 
   _apply_tonecurves(image, width, height, profile_info->lut_in[0], profile_info->lut_in[1], profile_info->lut_in[2],
       profile_info->unbounded_coeffs_in[0], profile_info->unbounded_coeffs_in[1], profile_info->unbounded_coeffs_in[2], profile_info->lutsize);
@@ -2837,7 +2837,7 @@ static void _transform_matrix_rgb_sse(float *const image, const int width, const
                                       const dt_iop_order_iccprofile_info_t *const profile_info_to)
 {
   const int ch = 4;
-  const size_t stride = (size_t)(width * height);
+  const size_t stride = (size_t)width * height;
 
   _apply_tonecurves(image, width, height, profile_info_from->lut_in[0], profile_info_from->lut_in[1],
                     profile_info_from->lut_in[2], profile_info_from->unbounded_coeffs_in[0],


### PR DESCRIPTION
Casting to `size_t` after (rather than before) multiplication might lead to integer overflow.