### PR TITLE
Fix selected text issue and improve dialog bar

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -675,8 +675,8 @@ menuitem check
 dialog,
 filechooserdialog
 {
-  background-color: @bg_color;
-  color: @fg_color;
+  background-color: @plugin_bg_color;
+  color: @plugin_fg_color;
 }
 
 dialog *,
@@ -1319,7 +1319,9 @@ entry:active
   background-color: @field_active_bg;
 }
 
-entry:selected
+entry:selected,
+label *,
+textview text *
 {
   color: @field_selected_fg;
   background-color: @field_selected_bg;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1320,8 +1320,8 @@ entry:active
 }
 
 entry:selected,
-label *,
-textview text *
+label selection,
+textview text selection
 {
   color: @field_selected_fg;
   background-color: @field_selected_bg;


### PR DESCRIPTION
This fix #3610 and improve dialog windows (especially to add missing contrast in import options fields).

@timur-davletshin, @blitzgneisserin and @GLLM : please test if that doesn't break any other label or textview I don't see. It's normally ok. If you find any other part missing, please precise it here.