### PR TITLE
Use blendop params when style applied on export

### DIFF
--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -593,11 +593,13 @@ void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, 
               && dt_develop_blend_legacy_params(module, style_item->blendop_params, style_item->blendop_version,
                   module->blend_params, dt_develop_blend_version(), style_item->blendop_params_size) == 0)
       {
+        // legacy style
         // do nothing
       }
       else
       {
-        memcpy(module->blend_params, module->default_blendop_params, sizeof(dt_develop_blend_params_t));
+        // apply style on export
+        memcpy(module->blend_params, style_item->blendop_params, sizeof(dt_develop_blend_params_t));
       }
 
       if(module->version() != style_item->module_version || module->params_size != style_item->params_size


### PR DESCRIPTION
Changed module->default_blendop_params to style_item->blendop_params so that masks are applied to styles on export.  This makes option 1 and option 3 of the if statement the same, but option 3 is the one taken when the style is applied on export, so I left it that way in case some other processing needs to happen when a style is applied on export versus a style applied in darktable.

Fixes #3571.