### PR TITLE
Suppress [dt_ioppr_transform_image_colorspace] warning for monochromes

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2881,7 +2881,8 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
   }
   if(profile_info == NULL)
   {
-    fprintf(stderr, "[dt_ioppr_transform_image_colorspace] module %s must be between input color profile and output color profile\n", self->op);
+    if (!dt_image_is_monochrome(&self->dev->image_storage))
+      fprintf(stderr, "[dt_ioppr_transform_image_colorspace] module %s must be between input color profile and output color profile\n", self->op);
     *converted_cst = cst_from;
     return;
   }
@@ -3139,7 +3140,8 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   }
   if(profile_info == NULL)
   {
-    fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] module %s must be between input color profile and output color profile\n", self->op);
+    if (!dt_image_is_monochrome(&self->dev->image_storage))
+      fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] module %s must be between input color profile and output color profile\n", self->op);
     *converted_cst = cst_from;
     return FALSE;
   }


### PR DESCRIPTION
Monochrome images from scanners or a few Leicas don't want a
dt_ioppr_transform_image_colorspace but just set converted_cst = cst_from.

The warning: [dt_ioppr_transform_image_colorspace] module %s must be between input color profile and output color profile\n"
is simply misleading so it is suppressed now by checking by
dt_image_is_monochrome(&self->dev->image_storage)