### PR TITLE
thumbs/export: prevent reading outside of the input image's dimensions

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -753,8 +753,8 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   const double scaley = height > 0 ? fminf(height / (double)pipe.processed_height, max_scale) : max_scale;
   const double scale = fminf(scalex, scaley);
 
-  const int processed_width = scale * pipe.processed_width + .5f;
-  const int processed_height = scale * pipe.processed_height + .5f;
+  const int processed_width = floor(scale * pipe.processed_width);
+  const int processed_height = floor(scale * pipe.processed_height);
 
   const int bpp = format->bpp(format_params);
 


### PR DESCRIPTION
this fix corrects for possible problems with the roi calculations. under
certain conditions (mainly thumbnail processing) the pixelpipe would request
input image dimensions higher than available thus reading outside of the
input image buffer and leading to artifacts - typically (a) column(s) of pixels
on the rightmost image border.

this is a fix for #3646