### PR TITLE
Fix header bar & background import options on folder/image import

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1248,7 +1248,7 @@ filechooser *:checked
     color: @field_selected_fg;
 }
 
-filechooser *:checked
+filechooser checkbutton:checked
 {
     background-color: transparent;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1248,6 +1248,11 @@ filechooser *:checked
     color: @field_selected_fg;
 }
 
+filechooser *:checked
+{
+    background-color: transparent;
+}
+
 #view_dropdown *:selected,
 #view_label:selected
 {

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -366,8 +366,8 @@ button
 #footer-toolbar #dt-button
 {
   padding: 0.9em;
-  min-height: 1em; /* Align toolbox button height on comboboxe's one */
-  min-width: 1em;
+  min-height: 0.9em; /* Align toolbox button height on comboboxe's one */
+  min-width: 0.9em;
   border: 0;
   font-size: .7em;
 }
@@ -628,9 +628,9 @@ dialog combobox window
   border-radius: 2pt;
   border: 0;
   outline-style: none;
-  min-height: 0.5em;
-  min-width: 0.5em;
-  padding: 0.5em;
+  min-height: 0.4em;
+  min-width: 0.4em;
+  padding: 0.4em;
 }
 
 #view_dropdown,
@@ -639,12 +639,12 @@ dialog combobox window
   background-color: transparent;
   outline-style:none;
   border-radius: 2px;
-  padding: 0.5em;
+  padding: 0.4em;
   color: @section_label;
 }
 
 #view_label {
-  margin: 0.5em 0;
+  margin: 0.1em 0;
 }
 
 menuitem button,


### PR DESCRIPTION
As we now have a lighter UI, these last times I frequently find the header bar quite too big (and also the group, favs, help and prefs icons) regardless of the rest of the UI. The goal of this new UI is also to let the most possible place to images.
I finally improve that and reduce particularly the header bar height and cited icons. I also reduce also some padding label text on the right (shortcuts to views).

Before :

![Capture-20191204211932-1919x110](https://user-images.githubusercontent.com/45535283/70178990-800adb00-16dd-11ea-9ec9-07a5a55994ec.png)

And after this PR :

![Capture-20191204211846-1919x88](https://user-images.githubusercontent.com/45535283/70179017-8d27ca00-16dd-11ea-8cfb-c3b0879bd0bc.png)

This also fix a not wanted background on check import options of import image/folder dialog box.

As this is related to UI and no string change, it's of course for 3.0 milestone.
