### PR TITLE
fix no update xmp after undo/redo

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -38,7 +38,7 @@ typedef struct dt_undo_colorlabels_t
   uint8_t after;
 } dt_undo_colorlabels_t;
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_COLORLABELS)
   {
@@ -59,6 +59,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
         if(labels & (1<<color))
           dt_colorlabels_set_label(clabels->imgid, color);
 
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(clabels->imgid));
       list = g_list_next(list);
     }
   }

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -183,6 +183,7 @@ void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_un
     {
       _history_snapshot_undo_restore(hist->imgid, hist->after, hist->after_history_end);
     }
-    *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(hist->imgid));
+  // in principle undo() routine should add imgid to imgs list to make _undo_do_undo_redo() refresh XMP file for each of them
+  // in this case the update of XMP file is done by the normal image (re)development process.
   }
 }

--- a/src/common/history_snapshot.c
+++ b/src/common/history_snapshot.c
@@ -169,7 +169,7 @@ void dt_history_snapshot_undo_lt_history_data_free(gpointer data)
   g_free(hist);
 }
 
-void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
+void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_LT_HISTORY)
   {
@@ -183,5 +183,6 @@ void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_un
     {
       _history_snapshot_undo_restore(hist->imgid, hist->after, hist->after_history_end);
     }
+    *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(hist->imgid));
   }
 }

--- a/src/common/history_snapshot.h
+++ b/src/common/history_snapshot.h
@@ -33,7 +33,7 @@ dt_undo_lt_history_t *dt_history_snapshot_item_init(void);
 
 void dt_history_snapshot_undo_create(int32_t imgid, int *snap_id, int *history_end);
 
-void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action);
+void dt_history_snapshot_undo_pop(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs);
 
 void dt_history_snapshot_undo_lt_history_data_free(gpointer data);
 

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -33,7 +33,7 @@ typedef struct dt_undo_metadata_t
 
 static void _metadata_set_xmp(int id, const gint keyid, const char *value, gboolean undo_actif);
 
-static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_data_t data, const dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_METADATA)
   {
@@ -65,6 +65,7 @@ static void _pop_undo(gpointer user_data, const dt_undo_type_t type, dt_undo_dat
         _metadata_set_xmp(metadata->imgid, metadata->keyid, metadata->value, FALSE);
       }
 
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(metadata->imgid));
       list = g_list_next(list);
     }
 

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -34,7 +34,7 @@ typedef struct dt_undo_ratings_t
 
 static void _ratings_apply_to_image(int imgid, int rating, gboolean undo);
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_RATINGS)
   {
@@ -44,6 +44,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
       _ratings_apply_to_image(ratings->imgid, ratings->before_rating, FALSE);
     else
       _ratings_apply_to_image(ratings->imgid, ratings->after_rating, FALSE);
+    *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(ratings->imgid));
   }
 }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -40,7 +40,7 @@ typedef struct dt_undo_tags_t
 static void _attach_tag(guint tagid, gint imgid, gboolean undo_actif);
 static void _detach_tag(guint tagid, gint imgid, gboolean undo_actif);
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   if(type == DT_UNDO_TAGS)
   {
@@ -79,6 +79,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
 
       dt_image_synch_xmp(tags->imgid);
 
+      *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(tags->imgid));
       list = g_list_next(list);
     }
 

--- a/src/common/undo.c
+++ b/src/common/undo.c
@@ -18,6 +18,7 @@
 
 #include "common/darktable.h"
 #include "common/collection.h"
+#include "common/image.h"
 #include "common/undo.h"
 #include <glib.h>    // for GList, gpointer, g_list_first, g_list_prepend
 #include <stdlib.h>  // for NULL, malloc, free
@@ -32,7 +33,7 @@ typedef struct dt_undo_item_t
   dt_undo_data_t data;
   double ts;
   gboolean is_group;
-  void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action);
+  void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs);
   void (*free_data)(gpointer data);
 } dt_undo_item_t;
 
@@ -75,7 +76,7 @@ static void _free_undo_data(void *p)
 
 static void _undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t data,
                          gboolean is_group,
-                         void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action),
+                         void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action, GList **imgs),
                          void (*free_data)(gpointer data))
 {
   if(!self) return;
@@ -143,10 +144,15 @@ void dt_undo_end_group(dt_undo_t *self)
 }
 
 void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t data,
-                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action),
+                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action, GList **imgs),
                     void (*free_data)(gpointer data))
 {
   _undo_record(self, user_data, type, data, FALSE, undo, free_data);
+}
+
+gint _images_list_cmp(gconstpointer a, gconstpointer b)
+{
+  return GPOINTER_TO_INT(a) - GPOINTER_TO_INT(b);
 }
 
 static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_t action)
@@ -160,6 +166,7 @@ static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_
   GList **to   = action == DT_ACTION_UNDO ? &self->redo_list : &self->undo_list;
 
   GList *l = g_list_first(*from);
+  GList *imgs = NULL;
 
   // check for first item that is matching the given pattern
 
@@ -191,7 +198,7 @@ static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_
           if(item->is_group)
             is_group = TRUE;
           else
-            item->undo(item->user_data, item->type, item->data, action);
+            item->undo(item->user_data, item->type, item->data, action, &imgs);
 
           //  add old position back into the TO list
           *to = g_list_prepend(*to, item);
@@ -215,7 +222,7 @@ static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_
             in_group = !in_group;
           else
             //  callback with redo or redo data
-            item->undo(item->user_data, item->type, item->data, action);
+            item->undo(item->user_data, item->type, item->data, action, &imgs);
 
           //  add old position back into the TO list
           *to = g_list_prepend(*to, item);
@@ -230,6 +237,18 @@ static void _undo_do_undo_redo(dt_undo_t *self, uint32_t filter, dt_undo_action_
     l = g_list_next(l);
   }
   UNLOCK;
+  if(imgs)
+  {
+    imgs = g_list_sort(imgs, _images_list_cmp);
+    // remove duplicates
+    for(GList *img = imgs; img != NULL; img = img->next)
+      while(img->next && img->data == img->next->data)
+        imgs = g_list_delete_link(imgs, img->next);
+    // udpate xmp for updated images
+    for(GList *img = imgs; img != NULL; img = img->next)
+      dt_image_synch_xmp(GPOINTER_TO_INT(img->data));
+    g_list_free(imgs);
+  }
 
   dt_collection_update_query(darktable.collection);
 }

--- a/src/common/undo.h
+++ b/src/common/undo.h
@@ -68,7 +68,7 @@ void dt_undo_end_group(dt_undo_t *self);
 
 // record a change that will be insered into the undo list
 void dt_undo_record(dt_undo_t *self, gpointer user_data, dt_undo_type_t type, dt_undo_data_t data,
-                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action),
+                    void (*undo)(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action, GList **imgs),
                     void (*free_data)(gpointer data));
 
 //  undo an element which correspond to filter. filter here is expected to be

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1064,7 +1064,7 @@ delete_next_file:
   return 0;
 }
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t item, dt_undo_action_t action, GList **imgs)
 {
   dt_undo_geotag_t *geotags = (dt_undo_geotag_t *)item;
   GList *l;
@@ -1082,6 +1082,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t it
     dt_image_geoloc_t *geoloc = (dt_image_geoloc_t *)l->data;
     dt_image_set_location_and_elevation(imgid, geoloc);
 
+    *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(imgid));
     l = g_list_next(l);
   }
 }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -529,7 +529,7 @@ static int _create_deleted_modules(GList **_iop_list, GList *history_list)
   return changed;
 }
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
 

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1192,7 +1192,7 @@ static void _view_map_filmstrip_activate_callback(gpointer instance, gpointer us
   _view_map_center_on_image(self, imgid);
 }
 
-static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action)
+static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t data, dt_undo_action_t action, GList **imgs)
 {
   dt_view_t *self = (dt_view_t *)user_data;
   dt_map_t *lib = (dt_map_t *)self->data;
@@ -1209,6 +1209,7 @@ static void _pop_undo(gpointer user_data, dt_undo_type_t type, dt_undo_data_t da
 
     _set_image_location(self, geotag->imgid, pos, TRUE);
     g_signal_emit_by_name(lib->map, "changed");
+    *imgs = g_list_prepend(*imgs, GINT_TO_POINTER(geotag->imgid));
   }
 }
 


### PR DESCRIPTION
In dt_undo_do_undo() and dt_undo_do_redo() I've added the an image list filled in by undo routine.
At the end, if there are some images in the list, xmp is refreshed for them.

Exception: libs/history.c where there is no image id visible. And anyway the xmp file for dev is updated only when the user moves to another image (or on dt restart).

Doubt: common/history_snapshot.c. The undo routine adds the image to the list, but Ctrl-Z/Ctrl-Y don't update the xmp file. I don't know why.

