### PR TITLE
Set image aspect ratio on import or update

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -514,7 +514,7 @@ static void _collection_update_aspect_ratio(const dt_collection_t *collection)
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       const int imgid = sqlite3_column_int(stmt, 0);
-      dt_image_set_aspect_ratio(imgid);
+      dt_image_set_raw_aspect_ratio(imgid);
 
       if(dt_get_wtime() - start > MAX_TIME)
       {

--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -500,7 +500,7 @@ static void _collection_update_aspect_ratio(const dt_collection_t *collection)
 
   if (params->sort == DT_COLLECTION_SORT_ASPECT_RATIO)
   {
-    const float MAX_TIME = 5.0;
+    const float MAX_TIME = 7.0;
     const gchar *where_ext = dt_collection_get_extended_where(collection, -1);
     gchar *query = NULL;
     sqlite3_stmt *stmt = NULL;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1249,6 +1249,7 @@ void dt_image_init(dt_image_t *img)
 {
   img->width = img->height = img->verified_size = 0;
   img->final_width = img->final_height = 0;
+  img->aspect_ratio = 0.0;
   img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
   img->orientation = ORIENTATION_NULL;
   img->legacy_flip.legacy = 0;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -594,9 +594,6 @@ void dt_image_set_raw_aspect_ratio(const int32_t imgid)
 
   /* store */
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
-
-  if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
 }
 
 void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -581,30 +581,12 @@ void dt_image_flip(const int32_t imgid, const int32_t cw)
   dt_image_set_flip(imgid, orientation);
 }
 
-void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio)
-{
-  if (aspect_ratio > .0f)
-  {
-    /* fetch image from cache */
-    dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
-
-    /* set image aspect_ratio */
-    image->aspect_ratio = aspect_ratio;
-
-    /* store */
-    dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
-
-
-    if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
-      dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
-  }
-}
-
 void dt_image_set_raw_aspect_ratio(const int32_t imgid)
 {
+  /* fetch image from cache */
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
-  /* set image aspect_ratio */
+  /* set image aspect ratio */
   if(image->orientation < ORIENTATION_SWAP_XY)
     image->aspect_ratio = (float )image->width / (float )image->height;
   else
@@ -613,6 +595,49 @@ void dt_image_set_raw_aspect_ratio(const int32_t imgid)
   /* store */
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
 
+  if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
+}
+
+void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio)
+{
+  if (aspect_ratio > .0f)
+  {
+    /* fetch image from cache */
+    dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+
+    /* set image aspect ratio */
+    image->aspect_ratio = aspect_ratio;
+
+    /* store */
+    dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+
+    if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+      dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
+  }
+}
+
+void dt_image_set_aspect_ratio_if_different(const int32_t imgid, double aspect_ratio)
+{
+  if (aspect_ratio > .0f)
+  {
+    /* fetch image from cache */
+    dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'r');
+
+    /* set image aspect ratio */
+    if(fabs(image->aspect_ratio - aspect_ratio) > 0.1)
+    {
+      dt_image_cache_read_release(darktable.image_cache, image);
+      dt_image_t *wimage = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+      wimage->aspect_ratio = aspect_ratio;
+      dt_image_cache_write_release(darktable.image_cache, wimage, DT_IMAGE_CACHE_SAFE);
+    }
+    else
+      dt_image_cache_read_release(darktable.image_cache, image);
+
+    if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
+      dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
+  }
 }
 
 void dt_image_reset_aspect_ratio(const int32_t imgid)
@@ -620,8 +645,8 @@ void dt_image_reset_aspect_ratio(const int32_t imgid)
   /* fetch image from cache */
   dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
-  /* set image aspect_ratio */
-  image->aspect_ratio = 0.0;
+  /* set image aspect ratio */
+  image->aspect_ratio = 0.f;
 
   /* store */
   dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
@@ -1264,7 +1289,7 @@ void dt_image_init(dt_image_t *img)
 {
   img->width = img->height = img->verified_size = 0;
   img->final_width = img->final_height = 0;
-  img->aspect_ratio = 0.0;
+  img->aspect_ratio = 0.f;
   img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
   img->orientation = ORIENTATION_NULL;
   img->legacy_flip.legacy = 0;

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -585,31 +585,46 @@ void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio)
 {
   if (aspect_ratio > .0f)
   {
-    sqlite3_stmt *stmt;
+    /* fetch image from cache */
+    dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE images SET aspect_ratio=ROUND(?1,1) WHERE id=?2",
-                                -1, &stmt, NULL);
+    /* set image aspect_ratio */
+    image->aspect_ratio = aspect_ratio;
 
-    DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 1, aspect_ratio);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
+    /* store */
+    dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+
 
     if (darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
       dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);
   }
 }
 
+void dt_image_set_raw_aspect_ratio(const int32_t imgid)
+{
+  dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+
+  /* set image aspect_ratio */
+  if(image->orientation < ORIENTATION_SWAP_XY)
+    image->aspect_ratio = (float )image->width / (float )image->height;
+  else
+    image->aspect_ratio = (float )image->height / (float )image->width;
+
+  /* store */
+  dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+
+}
+
 void dt_image_reset_aspect_ratio(const int32_t imgid)
 {
-  sqlite3_stmt *stmt;
+  /* fetch image from cache */
+  dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
 
-  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "UPDATE images SET aspect_ratio=0.0 WHERE id=?1", -1,
-                              &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
-  sqlite3_step(stmt);
-  sqlite3_finalize(stmt);
+  /* set image aspect_ratio */
+  image->aspect_ratio = 0.0;
+
+  /* store */
+  dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
 
   if(darktable.collection->params.sort == DT_COLLECTION_SORT_ASPECT_RATIO)
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -264,6 +264,8 @@ void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
 void dt_image_set_location_and_elevation(const int32_t imgid, dt_image_geoloc_t *geoloc);
 /** returns 1 if there is history data found for this image, 0 else. */
 int dt_image_altered(const uint32_t imgid);
+/** set the raw image aspect ratio */
+void dt_image_set_raw_aspect_ratio(const int32_t imgid);
 /** set the image final/cropped aspect ratio */
 double dt_image_set_aspect_ratio(const int32_t imgid);
 /** set the image final/cropped aspect ratio */

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -264,12 +264,14 @@ void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
 void dt_image_set_location_and_elevation(const int32_t imgid, dt_image_geoloc_t *geoloc);
 /** returns 1 if there is history data found for this image, 0 else. */
 int dt_image_altered(const uint32_t imgid);
-/** set the raw image aspect ratio */
-void dt_image_set_raw_aspect_ratio(const int32_t imgid);
 /** set the image final/cropped aspect ratio */
 double dt_image_set_aspect_ratio(const int32_t imgid);
+/** set the image raw aspect ratio */
+void dt_image_set_raw_aspect_ratio(const int32_t imgid);
 /** set the image final/cropped aspect ratio */
 void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio);
+/** set the image final/cropped aspect ratio if different from stored*/
+void dt_image_set_aspect_ratio_if_different(const int32_t imgid, double aspect_ratio);
 /** reset the image final/cropped aspect ratio to 0.0 */
 void dt_image_reset_aspect_ratio(const int32_t imgid);
 /** returns the orientation bits of the image from exif. */

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -171,6 +171,7 @@ typedef struct dt_image_t
   // to understand this, look at comment for dt_histogram_roi_t
   int32_t width, height, verified_size, final_width, final_height;
   int32_t crop_x, crop_y, crop_width, crop_height;
+  float aspect_ratio;
 
   // used by library
   int32_t num, flags, film_id, id, group_id, version;

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -219,43 +219,51 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
       uint32_t u;
   } flip;
   if(img->id <= 0) return;
+  if(!img->aspect_ratio || img->aspect_ratio < .0001)
+  {
+    if(img->orientation < ORIENTATION_SWAP_XY)
+      img->aspect_ratio = (float )img->width / (float )img->height;
+    else
+      img->aspect_ratio = (float )img->height / (float )img->width;
+  }
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get(darktable.db),
-      "UPDATE main.images SET width = ?1, height = ?2, filename = ?3, maker = ?4, model = ?5, "
-      "lens = ?6, exposure = ?7, aperture = ?8, iso = ?9, focal_length = ?10, "
-      "focus_distance = ?11, film_id = ?12, datetime_taken = ?13, flags = ?14, "
-      "crop = ?15, orientation = ?16, raw_parameters = ?17, group_id = ?18, longitude = ?19, "
-      "latitude = ?20, altitude = ?21, color_matrix = ?22, colorspace = ?23, raw_black = ?24, "
-      "raw_maximum = ?25 WHERE id = ?26",
+      "UPDATE main.images SET width = ?1, height = ?2, aspect_ratio = ROUND(?3,1), filename = ?4, maker = ?5, model = ?6, "
+      "lens = ?7, exposure = ?8, aperture = ?9, iso = ?10, focal_length = ?11, "
+      "focus_distance = ?12, film_id = ?13, datetime_taken = ?14, flags = ?15, "
+      "crop = ?16, orientation = ?17, raw_parameters = ?18, group_id = ?19, longitude = ?20, "
+      "latitude = ?21, altitude = ?22, color_matrix = ?23, colorspace = ?24, raw_black = ?25, "
+      "raw_maximum = ?26 WHERE id = ?27",
       -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, img->width);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, img->height);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, img->filename, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, img->exif_maker, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, img->exif_model, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, img->exif_lens, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, img->exif_exposure);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, img->exif_aperture);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, img->exif_iso);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, img->exif_focal_length);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 11, img->exif_focus_distance);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 12, img->film_id);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 13, img->exif_datetime_taken, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 14, img->flags);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 15, img->exif_crop);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 16, img->orientation);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 3, img->aspect_ratio);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, img->filename, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, img->exif_maker, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, img->exif_model, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 7, img->exif_lens, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, img->exif_exposure);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, img->exif_aperture);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, img->exif_iso);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 11, img->exif_focal_length);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 12, img->exif_focus_distance);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 13, img->film_id);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 14, img->exif_datetime_taken, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 15, img->flags);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 16, img->exif_crop);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 17, img->orientation);
   flip.s = img->legacy_flip;
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 17, flip.u);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 18, img->group_id);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 19, img->geoloc.longitude);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 20, img->geoloc.latitude);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 21, img->geoloc.elevation);
-  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 22, &img->d65_color_matrix, sizeof(img->d65_color_matrix), SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 23, img->colorspace);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 24, img->raw_black_level);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 25, img->raw_white_point);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 26, img->id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 18, flip.u);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 19, img->group_id);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 20, img->geoloc.longitude);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 21, img->geoloc.latitude);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 22, img->geoloc.elevation);
+  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 23, &img->d65_color_matrix, sizeof(img->d65_color_matrix), SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 24, img->colorspace);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 25, img->raw_black_level);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 26, img->raw_white_point);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 27, img->id);
   const int rc = sqlite3_step(stmt);
   if(rc != SQLITE_DONE) fprintf(stderr, "[image_cache_write_release] sqlite3 error %d\n", rc);
   sqlite3_finalize(stmt);

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -41,7 +41,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
       "SELECT id, group_id, film_id, width, height, filename, maker, model, lens, exposure, "
       "aperture, iso, focal_length, datetime_taken, flags, crop, orientation, focus_distance, "
       "raw_parameters, longitude, latitude, altitude, color_matrix, colorspace, version, raw_black, "
-      "raw_maximum FROM main.images WHERE id = ?1",
+      "raw_maximum, aspect_ratio FROM main.images WHERE id = ?1",
       -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, entry->key);
   if(sqlite3_step(stmt) == SQLITE_ROW)
@@ -101,6 +101,10 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
     img->raw_black_level = sqlite3_column_int(stmt, 25);
     for(uint8_t i = 0; i < 4; i++) img->raw_black_level_separate[i] = 0;
     img->raw_white_point = sqlite3_column_int(stmt, 26);
+    if(sqlite3_column_type(stmt, 27) == SQLITE_FLOAT)
+      img->aspect_ratio = sqlite3_column_double(stmt, 27);
+    else
+      img->aspect_ratio = 0.0;
 
     // buffer size? colorspace?
     if(img->flags & DT_IMAGE_LDR)

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -222,7 +222,6 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
       struct dt_image_raw_parameters_t s;
       uint32_t u;
   } flip;
-  if(img->id <= 0) return;
   if(!img->aspect_ratio || img->aspect_ratio < .0001)
   {
     if(img->orientation < ORIENTATION_SWAP_XY)
@@ -230,43 +229,44 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
     else
       img->aspect_ratio = (float )img->height / (float )img->width;
   }
+  if(img->id <= 0) return;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(
       dt_database_get(darktable.db),
-      "UPDATE main.images SET width = ?1, height = ?2, aspect_ratio = ROUND(?3,1), filename = ?4, maker = ?5, model = ?6, "
-      "lens = ?7, exposure = ?8, aperture = ?9, iso = ?10, focal_length = ?11, "
-      "focus_distance = ?12, film_id = ?13, datetime_taken = ?14, flags = ?15, "
-      "crop = ?16, orientation = ?17, raw_parameters = ?18, group_id = ?19, longitude = ?20, "
-      "latitude = ?21, altitude = ?22, color_matrix = ?23, colorspace = ?24, raw_black = ?25, "
-      "raw_maximum = ?26 WHERE id = ?27",
+      "UPDATE main.images SET width = ?1, height = ?2, filename = ?3, maker = ?4, model = ?5, "
+      "lens = ?6, exposure = ?7, aperture = ?8, iso = ?9, focal_length = ?10, "
+      "focus_distance = ?11, film_id = ?12, datetime_taken = ?13, flags = ?14, "
+      "crop = ?15, orientation = ?16, raw_parameters = ?17, group_id = ?18, longitude = ?19, "
+      "latitude = ?20, altitude = ?21, color_matrix = ?22, colorspace = ?23, raw_black = ?24, "
+      "raw_maximum = ?25, aspect_ratio = ROUND(?26,1) WHERE id = ?27",
       -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, img->width);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, img->height);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 3, img->aspect_ratio);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, img->filename, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, img->exif_maker, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, img->exif_model, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 7, img->exif_lens, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, img->exif_exposure);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, img->exif_aperture);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, img->exif_iso);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 11, img->exif_focal_length);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 12, img->exif_focus_distance);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 13, img->film_id);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 14, img->exif_datetime_taken, -1, SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 15, img->flags);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 16, img->exif_crop);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 17, img->orientation);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 3, img->filename, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 4, img->exif_maker, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 5, img->exif_model, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 6, img->exif_lens, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 7, img->exif_exposure);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 8, img->exif_aperture);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 9, img->exif_iso);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 10, img->exif_focal_length);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 11, img->exif_focus_distance);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 12, img->film_id);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 13, img->exif_datetime_taken, -1, SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 14, img->flags);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 15, img->exif_crop);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 16, img->orientation);
   flip.s = img->legacy_flip;
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 18, flip.u);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 19, img->group_id);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 20, img->geoloc.longitude);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 21, img->geoloc.latitude);
-  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 22, img->geoloc.elevation);
-  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 23, &img->d65_color_matrix, sizeof(img->d65_color_matrix), SQLITE_STATIC);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 24, img->colorspace);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 25, img->raw_black_level);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 26, img->raw_white_point);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 17, flip.u);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 18, img->group_id);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 19, img->geoloc.longitude);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 20, img->geoloc.latitude);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 21, img->geoloc.elevation);
+  DT_DEBUG_SQLITE3_BIND_BLOB(stmt, 22, &img->d65_color_matrix, sizeof(img->d65_color_matrix), SQLITE_STATIC);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 23, img->colorspace);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 24, img->raw_black_level);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 25, img->raw_white_point);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 26, img->aspect_ratio);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 27, img->id);
   const int rc = sqlite3_step(stmt);
   if(rc != SQLITE_DONE) fprintf(stderr, "[image_cache_write_release] sqlite3 error %d\n", rc);

--- a/src/control/jobs/image_jobs.c
+++ b/src/control/jobs/image_jobs.c
@@ -34,14 +34,15 @@ static int32_t dt_image_load_job_run(dt_job_t *job)
   dt_mipmap_buffer_t buf;
   dt_mipmap_cache_get(darktable.mipmap_cache, &buf, params->imgid, params->mip, DT_MIPMAP_BLOCKING, 'r');
 
-  // drop read lock, as this is only speculative async loading.
-  dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
-
   if (buf.buf && buf.height && buf.width)
   {
     const double aspect_ratio = (double)buf.width / (double)buf.height;
-    dt_image_set_aspect_ratio_to(params->imgid, aspect_ratio);
+    dt_image_set_aspect_ratio_if_different(params->imgid, aspect_ratio);
   }
+
+  // drop read lock, as this is only speculative async loading.
+  // moved this after the if, because the if never worked because the cache was released.
+  dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
   return 0;
 }
 


### PR DESCRIPTION
Added check aspect_ratio to dt_image_t.  Set aspect_ratio = 0.0 in image init.  Added check to see if aspect_raio exists and if not calculate it so that it's saved in dt_image_cache_write_release().

Fixes #3724