### PR TITLE
left & right panels resizing

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -15,11 +15,18 @@
     <shortdescription>database location</shortdescription>
     <longdescription>filename relative to ~/.config/darktable or starting with a slash (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui">
-    <name>panel_width</name>
+  <dtconfig>
+    <name>min_panel_width</name>
     <type>int</type>
-    <default>350</default>
-    <shortdescription>width of the side panels in pixels</shortdescription>
+    <default>150</default>
+    <shortdescription>minimum width of the side panels in pixels</shortdescription>
+    <longdescription>(needs a restart)</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>max_panel_width</name>
+    <type>int</type>
+    <default>500</default>
+    <shortdescription>maximum width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
   <dtconfig prefs="gui">

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1211,7 +1211,7 @@
   <dtconfig>
     <name>lighttable/ui/preview/bottom_visible</name>
     <type>bool</type>
-    <default>false</default>
+    <default>true</default>
     <shortdescription>show bottom panel in preview mode</shortdescription>
     <longdescription/>
   </dtconfig>
@@ -1248,6 +1248,20 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>show toolbar top panel in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/panels_collapse_controls</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>show borders arrows in preview mode</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>lighttable/ui/preview/panel_collaps_state</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>panels collapsing state in preview mode</shortdescription>
     <longdescription/>
   </dtconfig>
   <dtconfig prefs="gui" section="darkroom">

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -252,7 +252,10 @@ box *
   background-color: @border_color;
   min-width: 20px;
 }
-
+#resize-border
+{
+  background-color: #ff0000;
+}
 #left
 {
   /* left sidebar */

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -704,27 +704,8 @@ int dt_control_key_pressed_override(guint key, guint state)
   }
   else if(key == accels->global_header.accel_key && state == accels->global_header.accel_mods)
   {
-    char param[512];
-    const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-    // in lighttable, we store panels states per layout
-    char lay[32] = "";
-    if(g_strcmp0(cv->module_name, "lighttable") == 0)
-    {
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-    }
-
-    /* do nothing if in collapse panel state
-       TODO: reconsider adding this check to ui api */
-    g_snprintf(param, sizeof(param), "%s/ui/%spanel_collaps_state", cv->module_name, lay);
-    if(dt_conf_get_int(param)) return 0;
-
-    /* toggle the header visibility state */
-    g_snprintf(param, sizeof(param), "%s/ui/%sshow_header", cv->module_name, lay);
-    const gboolean header = !dt_conf_get_bool(param);
-    dt_conf_set_bool(param, header);
-
-    /* show/hide the actual header panel */
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, header, TRUE);
+    /* toggle panel viewstate */
+    dt_ui_toggle_header(darktable.gui->ui);
     gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
     return 1;
   }

--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -36,7 +36,8 @@ static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
 
   widget_class->get_preferred_width = dtgtk_side_panel_get_preferred_width;
 
-  class->width = 150; // this is the miminum width, real size has to be applied after
+  class->width
+      = dt_conf_get_int("min_panel_width"); // this is the miminum width, real size has to be applied after
 }
 
 static void dtgtk_side_panel_init(GtkDarktableSidePanel *panel)

--- a/src/dtgtk/sidepanel.c
+++ b/src/dtgtk/sidepanel.c
@@ -36,7 +36,7 @@ static void dtgtk_side_panel_class_init(GtkDarktableSidePanelClass *class)
 
   widget_class->get_preferred_width = dtgtk_side_panel_get_preferred_width;
 
-  class->width = dt_conf_get_int("panel_width");
+  class->width = 150; // this is the miminum width, real size has to be applied after
 }
 
 static void dtgtk_side_panel_init(GtkDarktableSidePanel *panel)

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1866,10 +1866,20 @@ void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t p, gboolean show, gboolea
     dt_conf_set_bool(key, show);
   }
 
+  // for left and right sides, panels are onside a gtkoverlay
+  GtkWidget *over_panel = NULL;
+  if(p == DT_UI_PANEL_LEFT || p == DT_UI_PANEL_RIGHT) over_panel = gtk_widget_get_parent(ui->panels[p]);
+
   if(show)
+  {
     gtk_widget_show(ui->panels[p]);
+    if(over_panel) gtk_widget_show(over_panel);
+  }
   else
+  {
     gtk_widget_hide(ui->panels[p]);
+    gtk_widget_hide(over_panel);
+  }
 
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 }
@@ -2010,7 +2020,19 @@ static gboolean _panel_handle_button_callback(GtkWidget *w, GdkEventButton *e, g
       darktable.gui->widgets.panel_handle_dragging = TRUE;
     }
     else if(e->type == GDK_BUTTON_RELEASE)
+    {
       darktable.gui->widgets.panel_handle_dragging = FALSE;
+    }
+    else if(e->type == GDK_2BUTTON_PRESS)
+    {
+      darktable.gui->widgets.panel_handle_dragging = FALSE;
+      // we hide the panel
+      if(strcmp(gtk_widget_get_name(w), "panel-handle-right") == 0)
+        dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE, TRUE);
+      else
+        dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE, TRUE);
+      gtk_widget_queue_draw(w);
+    }
   }
   return TRUE;
 }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -81,9 +81,6 @@ typedef struct dt_ui_t
   /* container widgets */
   GtkWidget *containers[DT_UI_CONTAINER_SIZE];
 
-  /* border widgets */
-  GtkWidget *borders[DT_UI_BORDER_SIZE];
-
   /* panel widgets */
   GtkWidget *panels[DT_UI_PANEL_SIZE];
 
@@ -231,24 +228,41 @@ static gboolean view_switch_key_accel_callback(GtkAccelGroup *accel_group, GObje
   return TRUE;
 }
 
-static gboolean _panels_controls_accel_callback(GtkAccelGroup *accel_group,
-                                                GObject *acceleratable, guint keyval,
+static gchar *_panels_get_view_path(char *suffixe)
+{
+  if(!darktable.view_manager) return NULL;
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  // in lighttable, we store panels states per layout
+  char lay[32] = "";
+  if(g_strcmp0(cv->module_name, "lighttable") == 0)
+  {
+    if(dt_view_lighttable_preview_state(darktable.view_manager))
+      g_snprintf(lay, sizeof(lay), "preview/");
+    else
+      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+  }
+
+  return dt_util_dstrcat(NULL, "%s/ui/%s%s", cv->module_name, lay, suffixe);
+}
+
+static gchar *_panels_get_panel_path(dt_ui_panel_t panel, char *suffixe)
+{
+  gchar *v = _panels_get_view_path("");
+  if(!v) return NULL;
+  return dt_util_dstrcat(v, "%s%s", _ui_panel_config_names[panel], suffixe);
+}
+
+static gboolean _panels_controls_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                                 GdkModifierType modifier, gpointer data)
 {
-
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-
-  // Set the controls accel visible by default
-  gint visible = TRUE;
-
-  // Get the current parameter if defined
-  char key[512];
-  g_snprintf(key, sizeof(key), "%s/ui/panels_collapse_controls", cv->module_name);
+  gchar *key = _panels_get_view_path("panels_collapse_controls");
+  gboolean visible = TRUE;
   if(dt_conf_key_exists(key)) visible = dt_conf_get_bool(key);
 
   // Inverse the current parameter and save it
   visible = !visible;
   dt_conf_set_bool(key, visible);
+  g_free(key);
 
   // Show/hide the collapsing controls in the borders
   gtk_widget_set_visible(GTK_WIDGET(darktable.gui->widgets.right_border), visible);
@@ -263,43 +277,30 @@ static gboolean _panels_controls_accel_callback(GtkAccelGroup *accel_group,
 
 static void _panel_toggle(dt_ui_border_t border, dt_ui_t *ui)
 {
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-  // in lighttable, we store panels states per layout
-  char lay[32] = "";
-  if(g_strcmp0(cv->module_name, "lighttable") == 0)
-  {
-    if(dt_view_lighttable_preview_state(darktable.view_manager))
-      g_snprintf(lay, sizeof(lay), "preview/");
-    else
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-  }
+  gchar *key = NULL;
 
   switch(border)
   {
     case DT_UI_BORDER_LEFT: // left border
     {
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
-                 _ui_panel_config_names[DT_UI_PANEL_LEFT]);
+      key = _panels_get_panel_path(DT_UI_PANEL_LEFT, "_visible");
       dt_ui_panel_show(ui, DT_UI_PANEL_LEFT, !dt_conf_get_bool(key), TRUE);
     }
     break;
 
     case DT_UI_BORDER_RIGHT: // right border
     {
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
-                 _ui_panel_config_names[DT_UI_PANEL_RIGHT]);
+      key = _panels_get_panel_path(DT_UI_PANEL_RIGHT, "_visible");
       dt_ui_panel_show(ui, DT_UI_PANEL_RIGHT, !dt_conf_get_bool(key), TRUE);
     }
     break;
 
     case DT_UI_BORDER_TOP: // top border
     {
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
-                 _ui_panel_config_names[DT_UI_PANEL_CENTER_TOP]);
+      key = _panels_get_panel_path(DT_UI_PANEL_CENTER_TOP, "_visible");
       const gboolean show_ct = dt_conf_get_bool(key);
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
-                 _ui_panel_config_names[DT_UI_PANEL_TOP]);
+      g_free(key);
+      key = _panels_get_panel_path(DT_UI_PANEL_TOP, "_visible");
       const gboolean show_t = dt_conf_get_bool(key);
       // all visible => toolbar hidden => all hidden => toolbar visible => all visible
       if(show_ct && show_t)
@@ -316,11 +317,10 @@ static void _panel_toggle(dt_ui_border_t border, dt_ui_t *ui)
     case DT_UI_BORDER_BOTTOM: // bottom border
     default:
     {
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
-                 _ui_panel_config_names[DT_UI_PANEL_CENTER_BOTTOM]);
+      key = _panels_get_panel_path(DT_UI_PANEL_CENTER_BOTTOM, "_visible");
       const gboolean show_cb = dt_conf_get_bool(key);
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay,
-                 _ui_panel_config_names[DT_UI_PANEL_BOTTOM]);
+      g_free(key);
+      key = _panels_get_panel_path(DT_UI_PANEL_BOTTOM, "_visible");
       const gboolean show_b = dt_conf_get_bool(key);
       // all visible => toolbar hidden => all hidden => toolbar visible => all visible
       if(show_cb && show_b)
@@ -334,6 +334,7 @@ static void _panel_toggle(dt_ui_border_t border, dt_ui_t *ui)
     }
     break;
   }
+  g_free(key);
 }
 
 static gboolean _toggle_panel_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -586,7 +587,7 @@ static gboolean draw_borders(GtkWidget *widget, cairo_t *crf, gpointer user_data
       }
       break;
     case 2: // top
-      if(dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP))
+      if(dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_TOP))
       {
         cairo_move_to(cr, width / 2 - height, height);
         cairo_rel_line_to(cr, 2 * height, 0.0);
@@ -600,8 +601,7 @@ static gboolean draw_borders(GtkWidget *widget, cairo_t *crf, gpointer user_data
       }
       break;
     default: // bottom
-      if(dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM)
-         || dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM))
+      if(dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM))
       {
         cairo_move_to(cr, width / 2 - height, 0.0);
         cairo_rel_line_to(cr, 2 * height, 0.0);
@@ -1440,22 +1440,6 @@ static void init_widgets(dt_gui_gtk_t *gui)
   // Showing everything
   gtk_widget_show_all(dt_ui_main_window(gui->ui));
 
-  /* hide panels depending on last ui state */
-  for(int k = 0; k < DT_UI_PANEL_SIZE; k++)
-  {
-    /* prevent show all */
-    gtk_widget_set_no_show_all(GTK_WIDGET(gui->ui->containers[k]), TRUE);
-
-    /* check last visible state of panel */
-    char key[512];
-    g_snprintf(key, sizeof(key), "ui_last/%s/visible", _ui_panel_config_names[k]);
-
-    /* if no key, lets default to TRUE*/
-    if(!dt_conf_key_exists(key)) dt_conf_set_bool(key, TRUE);
-
-    if(!dt_conf_get_bool(key)) gtk_widget_set_visible(gui->ui->panels[k], FALSE);
-  }
-
   gtk_widget_set_visible(gui->scrollbars.hscrollbar, FALSE);
   gtk_widget_set_visible(gui->scrollbars.vscrollbar, FALSE);
 }
@@ -1613,58 +1597,27 @@ void dt_ui_container_destroy_children(struct dt_ui_t *ui, const dt_ui_container_
 
 void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui)
 {
-  char key[512];
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  // in lighttable, we store panels states per layout
-  char lay[32] = "";
-  if(g_strcmp0(cv->module_name, "lighttable") == 0)
-  {
-    if(dt_view_lighttable_preview_state(darktable.view_manager))
-      g_snprintf(lay, sizeof(lay), "preview/");
-    else
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-  }
-
-  g_snprintf(key, sizeof(key), "%s/ui/%spanel_collaps_state", cv->module_name, lay);
+  gchar *key = _panels_get_view_path("panel_collaps_state");
   uint32_t state = dt_conf_get_int(key);
 
   if(state)
   {
-    /* restore previous panel view states */
-    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(ui, k, (state >> k) & 1, TRUE);
-
-    /* reset state */
-    state = 0;
+    dt_conf_set_int(key, 0);
   }
   else
   {
-    /* store current panel view state */
-    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) state |= (uint32_t)(dt_ui_panel_visible(ui, k)) << k;
-
-    /* hide all panels */
-    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(ui, k, FALSE, TRUE);
+    dt_conf_set_int(key, 1);
   }
 
-  /* store new state */
-  dt_conf_set_int(key, state);
+  dt_ui_restore_panels(ui);
+  g_free(key);
 }
 
 void dt_ui_toggle_header(struct dt_ui_t *ui)
 {
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-  // in lighttable, we store panels states per layout
-  char lay[32] = "";
-  if(g_strcmp0(cv->module_name, "lighttable") == 0)
-  {
-    if(dt_view_lighttable_preview_state(darktable.view_manager))
-      g_snprintf(lay, sizeof(lay), "preview/");
-    else
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-  }
-
-  g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay, _ui_panel_config_names[DT_UI_PANEL_TOP]);
+  gchar *key = _panels_get_panel_path(DT_UI_PANEL_TOP, "_visible");
   dt_ui_panel_show(ui, DT_UI_PANEL_TOP, !dt_conf_get_bool(key), TRUE);
+  g_free(key);
 }
 
 void dt_ui_notify_user()
@@ -1684,81 +1637,63 @@ void dt_ui_notify_user()
 
 static void _ui_init_panel_size(GtkWidget *widget)
 {
-  if(!darktable.view_manager) return;
-  // conf entry to store the new size
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-  // in lighttable, we store panels width per layout
-  char lay[32] = "";
-  if(g_strcmp0(cv->module_name, "lighttable") == 0)
-  {
-    if(dt_view_lighttable_preview_state(darktable.view_manager))
-      g_snprintf(lay, sizeof(lay), "preview/");
-    else
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-  }
+  gchar *key = NULL;
 
   if(strcmp(gtk_widget_get_name(widget), "right") == 0)
   {
-    g_snprintf(key, sizeof(key), "%s/ui/%sright_panel_size", cv->module_name, lay);
+    key = _panels_get_panel_path(DT_UI_PANEL_RIGHT, "_size");
   }
   else
   {
-    g_snprintf(key, sizeof(key), "%s/ui/%sleft_panel_size", cv->module_name, lay);
+    key = _panels_get_panel_path(DT_UI_PANEL_LEFT, "_size");
   }
+
+  if(!key) return;
 
   // we store and apply the new value
   int s = 350; // default panel size
   if(dt_conf_key_exists(key))
     s = CLAMP(dt_conf_get_int(key), dt_conf_get_int("min_panel_width"), dt_conf_get_int("max_panel_width"));
   gtk_widget_set_size_request(widget, s, -1);
+  g_free(key);
 }
 
 void dt_ui_restore_panels(dt_ui_t *ui)
 {
-  /* restore visible state of panels for current view */
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-  // in lighttable, we store panels states per layout
-  char lay[32] = "";
-  if(g_strcmp0(cv->module_name, "lighttable") == 0)
-  {
-    if(dt_view_lighttable_preview_state(darktable.view_manager))
-      g_snprintf(lay, sizeof(lay), "preview/");
-    else
-      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-  }
-
   /* restore left & right panel size */
   _ui_init_panel_size(ui->panels[DT_UI_PANEL_LEFT]);
   _ui_init_panel_size(ui->panels[DT_UI_PANEL_RIGHT]);
 
   /* restore from a previous collapse all panel state if enabled */
-  g_snprintf(key, sizeof(key), "%s/ui/%spanel_collaps_state", cv->module_name, lay);
+  gchar *key = _panels_get_view_path("panel_collaps_state");
   uint32_t state = dt_conf_get_int(key);
+  g_free(key);
   if(state)
   {
     /* hide all panels */
-    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(ui, k, FALSE, TRUE);
+    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(ui, k, FALSE, FALSE);
   }
   else
   {
     /* restore the visible state of panels */
     for(int k = 0; k < DT_UI_PANEL_SIZE; k++)
     {
-      g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay, _ui_panel_config_names[k]);
-      if(dt_conf_key_exists(key) || g_strcmp0(lay, "preview/") == 0)
-        gtk_widget_set_visible(ui->panels[k], dt_conf_get_bool(key));
+      key = _panels_get_panel_path(k, "_visible");
+      if(dt_conf_key_exists(key))
+        dt_ui_panel_show(ui, k, dt_conf_get_bool(key), FALSE);
       else
-        gtk_widget_set_visible(ui->panels[k], 1);
+        dt_ui_panel_show(ui, k, TRUE, FALSE);
+
+      g_free(key);
     }
   }
 
   // restore the visible state of the collapsing controls
   gint visible = TRUE;
-  g_snprintf(key, sizeof(key), "%s/ui/panels_collapse_controls", cv->module_name);
+  key = _panels_get_view_path("panels_collapse_controls");
   if(dt_conf_key_exists(key)) visible = dt_conf_get_bool(key);
   dt_conf_set_bool(key, visible);
+  g_free(key);
 
   gtk_widget_set_visible(GTK_WIDGET(darktable.gui->widgets.right_border), visible);
   gtk_widget_set_visible(GTK_WIDGET(darktable.gui->widgets.left_border), visible);
@@ -1806,27 +1741,51 @@ void dt_ui_scrollbars_show(dt_ui_t *ui, gboolean show)
 
 void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t p, gboolean show, gboolean write)
 {
-  // if(!GTK_IS_WIDGET(ui->panels[p])) return;
   g_return_if_fail(GTK_IS_WIDGET(ui->panels[p]));
 
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(write)
   {
-    // in lighttable, we store panels states per layout
-    char lay[32] = "";
-    if(g_strcmp0(cv->module_name, "lighttable") == 0)
+    gchar *key;
+    if(show)
     {
-      if(dt_view_lighttable_preview_state(darktable.view_manager))
-        g_snprintf(lay, sizeof(lay), "preview/");
-      else
-        g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+      // we reset the collaps_panel value if we show a panel
+      key = _panels_get_view_path("panel_collaps_state");
+      dt_conf_set_int(key, 0);
+      g_free(key);
+      key = _panels_get_panel_path(p, "_visible");
+      dt_conf_set_bool(key, show);
+      g_free(key);
     }
-    char key[512];
-    g_snprintf(key, sizeof(key), "%s/ui/%s%s_visible", cv->module_name, lay, _ui_panel_config_names[p]);
-    dt_conf_set_bool(key, show);
+    else
+    {
+      // if it was the last visible panel, we set collaps_panel value instead
+      // so collapsing panels after will have an effect
+      gboolean collapse = TRUE;
+      for(int k = 0; k < DT_UI_PANEL_SIZE; k++)
+      {
+        if(k != p && dt_ui_panel_visible(ui, k))
+        {
+          collapse = FALSE;
+          break;
+        }
+      }
+
+      if(collapse)
+      {
+        key = _panels_get_view_path("panel_collaps_state");
+        dt_conf_set_int(key, 1);
+        g_free(key);
+      }
+      else
+      {
+        key = _panels_get_panel_path(p, "_visible");
+        dt_conf_set_bool(key, show);
+        g_free(key);
+      }
+    }
   }
 
-  // for left and right sides, panels are onside a gtkoverlay
+  // for left and right sides, panels are inside a gtkoverlay
   GtkWidget *over_panel = NULL;
   if(p == DT_UI_PANEL_LEFT || p == DT_UI_PANEL_RIGHT) over_panel = gtk_widget_get_parent(ui->panels[p]);
 
@@ -1838,25 +1797,24 @@ void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t p, gboolean show, gboolea
   else
   {
     gtk_widget_hide(ui->panels[p]);
-    gtk_widget_hide(over_panel);
+    if(over_panel) gtk_widget_hide(over_panel);
   }
 
   // force redraw of the border (to be sure the arrow in the right direction)
   if(p == DT_UI_PANEL_TOP || p == DT_UI_PANEL_CENTER_TOP)
-    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_TOP]);
+    gtk_widget_queue_draw(darktable.gui->widgets.top_border);
   else if(p == DT_UI_PANEL_BOTTOM || p == DT_UI_PANEL_CENTER_BOTTOM)
-    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_BOTTOM]);
+    gtk_widget_queue_draw(darktable.gui->widgets.bottom_border);
   else if(p == DT_UI_PANEL_LEFT)
-    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_LEFT]);
+    gtk_widget_queue_draw(darktable.gui->widgets.left_border);
   else if(p == DT_UI_PANEL_RIGHT)
-    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_RIGHT]);
+    gtk_widget_queue_draw(darktable.gui->widgets.right_border);
 
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 }
 
 gboolean dt_ui_panel_visible(dt_ui_t *ui, const dt_ui_panel_t p)
 {
-  // if(!GTK_IS_WIDGET(ui->panels[p])) return FALSE;
   g_return_val_if_fail(GTK_IS_WIDGET(ui->panels[p]), FALSE);
   return gtk_widget_get_visible(ui->panels[p]);
 }
@@ -2032,33 +1990,23 @@ static gboolean _panel_handle_motion_callback(GtkWidget *w, GdkEventButton *e, g
     gtk_widget_get_size_request(widget, &sx, &sy);
 
     // conf entry to store the new size
-    const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-    char key[512];
-    // in lighttable, we store panels width per layout
-    char lay[32] = "";
-    if(g_strcmp0(cv->module_name, "lighttable") == 0)
-    {
-      if(dt_view_lighttable_preview_state(darktable.view_manager))
-        g_snprintf(lay, sizeof(lay), "preview/");
-      else
-        g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
-    }
-
+    gchar *key = NULL;
     if(strcmp(gtk_widget_get_name(w), "panel-handle-right") == 0)
     {
       sx = CLAMP((sx + darktable.gui->widgets.panel_handle_x - x), dt_conf_get_int("min_panel_width"),
                  dt_conf_get_int("max_panel_width"));
-      g_snprintf(key, sizeof(key), "%s/ui/%sright_panel_size", cv->module_name, lay);
+      key = _panels_get_panel_path(DT_UI_PANEL_RIGHT, "_size");
     }
     else
     {
       sx = CLAMP((sx - darktable.gui->widgets.panel_handle_x + x), dt_conf_get_int("min_panel_width"),
                  dt_conf_get_int("max_panel_width"));
-      g_snprintf(key, sizeof(key), "%s/ui/%sleft_panel_size", cv->module_name, lay);
+      key = _panels_get_panel_path(DT_UI_PANEL_LEFT, "_size");
     }
 
     // we store and apply the new value
     dt_conf_set_int(key, sx);
+    g_free(key);
     gtk_widget_set_size_request(widget, sx, -1);
 
     return TRUE;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1749,7 +1749,8 @@ static void _ui_init_panel_size(GtkWidget *widget)
 
   // we store and apply the new value
   int s = 350; // default panel size
-  if(dt_conf_key_exists(key)) s = CLAMP(dt_conf_get_int(key), DT_PIXEL_APPLY_DPI(150), DT_PIXEL_APPLY_DPI(500));
+  if(dt_conf_key_exists(key))
+    s = CLAMP(dt_conf_get_int(key), dt_conf_get_int("min_panel_width"), dt_conf_get_int("max_panel_width"));
   gtk_widget_set_size_request(widget, s, -1);
 }
 
@@ -2054,14 +2055,14 @@ static gboolean _panel_handle_motion_callback(GtkWidget *w, GdkEventButton *e, g
 
     if(strcmp(gtk_widget_get_name(w), "panel-handle-right") == 0)
     {
-      sx = CLAMP((sx + darktable.gui->widgets.panel_handle_x - x), DT_PIXEL_APPLY_DPI(150),
-                 DT_PIXEL_APPLY_DPI(500));
+      sx = CLAMP((sx + darktable.gui->widgets.panel_handle_x - x), dt_conf_get_int("min_panel_width"),
+                 dt_conf_get_int("max_panel_width"));
       g_snprintf(key, sizeof(key), "%s/ui/%sright_panel_size", cv->module_name, lay);
     }
     else
     {
-      sx = CLAMP((sx - darktable.gui->widgets.panel_handle_x + x), DT_PIXEL_APPLY_DPI(150),
-                 DT_PIXEL_APPLY_DPI(500));
+      sx = CLAMP((sx - darktable.gui->widgets.panel_handle_x + x), dt_conf_get_int("min_panel_width"),
+                 dt_conf_get_int("max_panel_width"));
       g_snprintf(key, sizeof(key), "%s/ui/%sleft_panel_size", cv->module_name, lay);
     }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -266,14 +266,8 @@ static gboolean _toggle_left_panel_accel_callback(GtkAccelGroup *accel_group,
                                                 GdkModifierType modifier, gpointer data)
 {
   dt_ui_t *ui = (dt_ui_t *)darktable.gui->ui;
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-
-  g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name,
-           _ui_panel_config_names[DT_UI_PANEL_LEFT]);
-  const gboolean state = dt_conf_get_bool(key);
+  const gboolean state = dt_ui_panel_visible(ui, DT_UI_PANEL_LEFT);
   dt_ui_panel_show(ui, DT_UI_PANEL_LEFT, !state, TRUE);
-  dt_conf_set_bool(key, !state);
 
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 
@@ -285,14 +279,8 @@ static gboolean _toggle_right_panel_accel_callback(GtkAccelGroup *accel_group,
                                                 GdkModifierType modifier, gpointer data)
 {
   dt_ui_t *ui = (dt_ui_t *)darktable.gui->ui;
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-
-  g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name,
-             _ui_panel_config_names[DT_UI_PANEL_RIGHT]);
-  const gboolean state = dt_conf_get_bool(key);
+  const gboolean state = dt_ui_panel_visible(ui, DT_UI_PANEL_RIGHT);
   dt_ui_panel_show(ui, DT_UI_PANEL_RIGHT, !state, TRUE);
-  dt_conf_set_bool(key, !state);
 
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 
@@ -304,14 +292,8 @@ static gboolean _toggle_top_panel_accel_callback(GtkAccelGroup *accel_group,
                                                 GdkModifierType modifier, gpointer data)
 {
   dt_ui_t *ui = (dt_ui_t *)darktable.gui->ui;
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-
-  g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name,
-             _ui_panel_config_names[DT_UI_PANEL_CENTER_TOP]);
-  const gboolean state = dt_conf_get_bool(key);
+  const gboolean state = dt_ui_panel_visible(ui, DT_UI_PANEL_TOP);
   dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_TOP, !state, TRUE);
-  dt_conf_set_bool(key, !state);
 
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 
@@ -323,14 +305,8 @@ static gboolean _toggle_bottom_panel_accel_callback(GtkAccelGroup *accel_group,
                                                 GdkModifierType modifier, gpointer data)
 {
   dt_ui_t *ui = (dt_ui_t *)darktable.gui->ui;
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
-  char key[512];
-
-  g_snprintf(key, sizeof(key), "%s/ui/%s_visible", cv->module_name,
-             _ui_panel_config_names[DT_UI_PANEL_CENTER_BOTTOM]);
-  const gboolean state = dt_conf_get_bool(key);
+  const gboolean state = dt_ui_panel_visible(ui, DT_UI_PANEL_BOTTOM);
   dt_ui_panel_show(ui, DT_UI_PANEL_CENTER_BOTTOM, !state, TRUE);
-  dt_conf_set_bool(key, !state);
 
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 
@@ -407,8 +383,6 @@ static gboolean borders_button_pressed(GtkWidget *w, GdkEventButton *event, gpoi
     }
     break;
   }
-
-  gtk_widget_queue_draw(w);
 
   return TRUE;
 }
@@ -1881,6 +1855,16 @@ void dt_ui_panel_show(dt_ui_t *ui, const dt_ui_panel_t p, gboolean show, gboolea
     gtk_widget_hide(over_panel);
   }
 
+  // force redraw of the border (to be sure the arrow in the right direction)
+  if(p == DT_UI_PANEL_TOP || p == DT_UI_PANEL_CENTER_TOP)
+    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_TOP]);
+  else if(p == DT_UI_PANEL_BOTTOM || p == DT_UI_PANEL_CENTER_BOTTOM)
+    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_BOTTOM]);
+  else if(p == DT_UI_PANEL_LEFT)
+    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_LEFT]);
+  else if(p == DT_UI_PANEL_RIGHT)
+    gtk_widget_queue_draw(ui->borders[DT_UI_BORDER_RIGHT]);
+
   dt_view_lighttable_force_expose_all(darktable.view_manager);
 }
 
@@ -2031,7 +2015,6 @@ static gboolean _panel_handle_button_callback(GtkWidget *w, GdkEventButton *e, g
         dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_RIGHT, FALSE, TRUE);
       else
         dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_LEFT, FALSE, TRUE);
-      gtk_widget_queue_draw(w);
     }
   }
   return TRUE;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -42,6 +42,9 @@ typedef struct dt_gui_widgets_t
   GtkGrid *panel_left; // panel grid 3 rows, top,center,bottom and file on center
   GtkGrid *panel_right;
 
+  /* resize of left/right panels */
+  gboolean panel_handle_dragging;
+  int panel_handle_x, panel_handle_y;
 } dt_gui_widgets_t;
 
 typedef struct dt_gui_scrollbars_t

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -304,6 +304,8 @@ void dt_ui_update_scrollbars(struct dt_ui_t *ui);
 void dt_ui_scrollbars_show(struct dt_ui_t *ui, gboolean show);
 /** \brief toggle view of panels eg. collaps/expands to previous view state */
 void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
+/** \brief toggle view of header */
+void dt_ui_toggle_header(struct dt_ui_t *ui);
 /** \brief draw user's attention */
 void dt_ui_notify_user();
 /** \brief get visible state of panel */


### PR DESCRIPTION
This fix #3710 
- this allow user to change the width of left & right panels with the mouse.
- there's no change to the ui.
- sizes are store per panel, views & layout, like panels state.
- default size is set in the code to 350.