### PR TITLE
add a colour assessment mode in darkroom (white frame on middle grey …

### DIFF
--- a/src/common/focus.h
+++ b/src/common/focus.h
@@ -278,7 +278,7 @@ static void dt_focus_draw_clusters(cairo_t *cr, int width, int height, int imgid
     dt_dev_cleanup(&dev);
   }
 
-  const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+  const int32_t tb = darktable.develop->border_size;
   const float scale = fminf((width - 2 * tb) / (float)wd, (height - 2 * tb) / (float)ht) * full_zoom;
   cairo_scale(cr, scale, scale);
   float fx = 0.0f;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -127,6 +127,8 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 
   dev->proxy.exposure = NULL;
 
+  dev->border_size = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+
   dev->rawoverexposed.enabled = FALSE;
   dev->rawoverexposed.mode = dt_conf_get_int("darkroom/ui/rawoverexposed/mode");
   dev->rawoverexposed.colorscheme = dt_conf_get_int("darkroom/ui/rawoverexposed/colorscheme");
@@ -136,6 +138,8 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dev->overexposed.colorscheme = dt_conf_get_int("darkroom/ui/overexposed/colorscheme");
   dev->overexposed.lower = dt_conf_get_float("darkroom/ui/overexposed/lower");
   dev->overexposed.upper = dt_conf_get_float("darkroom/ui/overexposed/upper");
+
+  dev->iso_12646.enabled = FALSE;
 
   dev->second_window.zoom = DT_ZOOM_FIT;
   dev->second_window.closeup = 0;
@@ -704,7 +708,7 @@ void dt_dev_load_image(dt_develop_t *dev, const uint32_t imgid)
 void dt_dev_configure(dt_develop_t *dev, int wd, int ht)
 {
   // fixed border on every side
-  const int tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+  const int32_t tb = dev->border_size;
   wd -= 2*tb;
   ht -= 2*tb;
   if(dev->width != wd || dev->height != ht)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -200,6 +200,9 @@ typedef struct dt_develop_t
   struct dt_iop_module_t *full_preview_last_module;
   int full_preview_masks_state;
 
+  // darkroom border size
+  int32_t border_size;
+
   /* proxy for communication between plugins and develop/darkroom */
   struct
   {
@@ -269,6 +272,13 @@ typedef struct dt_develop_t
     dt_dev_rawoverexposed_colorscheme_t colorscheme;
     float threshold;
   } rawoverexposed;
+
+  // ISO 12646-compliant colour assessment conditions
+  struct
+  {
+    GtkWidget *button; // yes, ugliness is the norm. what did you expect ?
+    gboolean enabled;
+  } iso_12646;
 
   // the display profile related things (softproof, gamut check, profiles ...)
   struct

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1655,6 +1655,45 @@ void dtgtk_cairo_paint_overexposed(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_stroke(cr);
 }
 
+
+void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  const gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+
+  float line_width = 0.1;
+
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_set_line_width(cr, line_width);
+
+  // glass
+  cairo_arc_negative(cr, 0.5, 0.33, 0.4, 1., M_PI - 1.);
+  cairo_close_path(cr);
+
+  if(flags & CPF_ACTIVE)
+  {
+    cairo_stroke_preserve(cr);
+    cairo_fill(cr);
+  }
+  else
+  {
+    cairo_stroke(cr);
+    cairo_arc(cr, 0.5, 0.33, 0.2, -M_PI / 3., -M_PI / 6.);
+    cairo_stroke(cr);
+  }
+
+  // screw
+  cairo_move_to(cr, 0.33, 0.33 + 0.36 + 1.5 * line_width);
+  cairo_line_to(cr, 0.67, 0.33 + 0.36 + 1.5 * line_width);
+  cairo_stroke(cr);
+
+  // nib
+  cairo_arc(cr, 0.5, 0.33 + 0.36 + 1.5 * 1.75 * line_width, 2.0 * line_width, 0, M_PI);
+  cairo_fill(cr);
+}
+
+
 void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   const float alpha = (flags & CPF_ACTIVE ? 1.0 : 0.4);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1660,7 +1660,7 @@ void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 {
   const gint s = w < h ? w : h;
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  cairo_scale(cr, 0.9 * s, 0.9 * s);
 
   float line_width = 0.1;
 
@@ -1668,7 +1668,7 @@ void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   cairo_set_line_width(cr, line_width);
 
   // glass
-  cairo_arc_negative(cr, 0.5, 0.33, 0.4, 1., M_PI - 1.);
+  cairo_arc_negative(cr, 0.5, 0.38, 0.4, 1., M_PI - 1.);
   cairo_close_path(cr);
 
   if(flags & CPF_ACTIVE)
@@ -1679,17 +1679,17 @@ void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   else
   {
     cairo_stroke(cr);
-    cairo_arc(cr, 0.5, 0.33, 0.2, -M_PI / 3., -M_PI / 6.);
+    cairo_arc(cr, 0.5, 0.38, 0.2, -M_PI / 3., -M_PI / 6.);
     cairo_stroke(cr);
   }
 
   // screw
-  cairo_move_to(cr, 0.33, 0.33 + 0.36 + 1.5 * line_width);
-  cairo_line_to(cr, 0.67, 0.33 + 0.36 + 1.5 * line_width);
+  cairo_move_to(cr, 0.33, 0.38 + 0.36 + 1.5 * line_width);
+  cairo_line_to(cr, 0.67, 0.38 + 0.36 + 1.5 * line_width);
   cairo_stroke(cr);
 
   // nib
-  cairo_arc(cr, 0.5, 0.33 + 0.36 + 1.5 * 1.75 * line_width, 2.0 * line_width, 0, M_PI);
+  cairo_arc(cr, 0.5, 0.38 + 0.36 + 1.5 * 1.75 * line_width, 2.0 * line_width, 0, M_PI);
   cairo_fill(cr);
 }
 

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -147,6 +147,8 @@ void dtgtk_cairo_paint_check_mark(cairo_t *cr, gint x, gint y, gint w, gint h, g
 void dtgtk_cairo_paint_overexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint an raw over exposure icon */
 void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a light bulb **/
+void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a gamut check icon */
 void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a soft proofing icon */

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -198,7 +198,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
 
   if (d->imgid == 0) return;
 
-  const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+  const int32_t tb = darktable.develop->border_size;
   int nw = width-2*tb;
   int nh = height-2*tb;
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1333,7 +1333,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
     {
       if(zoom == 1 && !image_only)
       {
-        const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+        const int32_t tb = darktable.develop->border_size;
         scale = fminf((width - 2 * tb) / (float)buf_wd, (height - 2 * tb) / (float)buf_ht) * fz;
       }
       else
@@ -1370,7 +1370,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
         int h = height;
         if(zoom == 1 && !image_only)
         {
-          const int32_t tb = DT_PIXEL_APPLY_DPI(dt_conf_get_int("plugins/darkroom/ui/border_size"));
+          const int32_t tb = darktable.develop->border_size;
           w -= 2 * tb;
           h -= 2 * tb;
         }


### PR DESCRIPTION
…background)

fix #3686 

Add a toggle button in darkroom (the light bulb):
![toolkit](https://user-images.githubusercontent.com/2779157/70764098-bd630e80-1d56-11ea-89ca-b5dba7bd6aea.png)

Before, the image might look ok because of the dark background:
![Capture d’écran du 2019-12-13 03-09-12](https://user-images.githubusercontent.com/2779157/70764127-de2b6400-1d56-11ea-997d-6915e5bd9226.png)

Toogle the ISO 12646 colour assessment conditions, and you immediately see that your whites are actually grey:
![Capture d’écran du 2019-12-13 03-09-46](https://user-images.githubusercontent.com/2779157/70764161-f8fdd880-1d56-11ea-9e0c-ddb85d65f70c.png)

The feature is only adding a white frame and forcing the background colour of the darkroom to middle grey. The frame persists while zooming. This overcomes the Hunt and Bartleson–Breneman effects that affect colour and contrast perception in dim lit surrounds.

Example on grey theme:
![Capture d’écran du 2019-12-13 03-22-50](https://user-images.githubusercontent.com/2779157/70764436-e7690080-1d57-11ea-8729-56bd612f5cab.png)

Zoomed-in:
![Capture d’écran du 2019-12-13 03-25-07](https://user-images.githubusercontent.com/2779157/70764561-357e0400-1d58-11ea-9b80-56a5cc3177dc.png)


