### PR TITLE
toneequalizer: default params to make people shut up

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1513,13 +1513,13 @@ void init(dt_iop_module_t *module)
                                                                       .speculars = 0.0f,
                                                                       .quantization = 0.0f,
                                                                       .smoothing = sqrtf(2.0f),
-                                                                      .iterations = 2,
+                                                                      .iterations = 1,
                                                                       .method = DT_TONEEQ_NORM_2,
                                                                       .details = DT_TONEEQ_GUIDED,
                                                                       .blending = 25.0f,
                                                                       .feathering = 10.0f,
-                                                                      .contrast_boost = 3.0f,
-                                                                      .exposure_boost = -3.0f };
+                                                                      .contrast_boost = 0.0f,
+                                                                      .exposure_boost = 0.0f };
   memcpy(module->params, &tmp, sizeof(dt_iop_toneequalizer_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_toneequalizer_params_t));
 }


### PR DESCRIPTION
Disable exposure and contrast compensations in default params, and use only one iteration of guided filter. 

This will give so-so masking results for everybody, instead of the current defaults that give good results in maybe 60% of use cases and are completely unpredictable in the remaining 40%. I'm getting married in 10 days, at that point I'm tired of hearing people whining about defaults params.