### PR TITLE
don't let toneequalizer capture the cursor if colour pickers are used

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -92,6 +92,7 @@
 #include "dtgtk/drawingarea.h"
 #include "dtgtk/expander.h"
 #include "gui/accelerators.h"
+#include "gui/color_picker_proxy.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
@@ -1620,6 +1621,9 @@ static void noise_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->noise = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1630,6 +1634,9 @@ static void ultra_deep_blacks_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->ultra_deep_blacks = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1640,6 +1647,9 @@ static void deep_blacks_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->deep_blacks = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1650,6 +1660,9 @@ static void blacks_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->blacks = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1660,6 +1673,9 @@ static void shadows_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->shadows = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1670,6 +1686,9 @@ static void midtones_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->midtones = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1680,6 +1699,9 @@ static void highlights_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->highlights = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1690,6 +1712,9 @@ static void whites_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->whites = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1700,6 +1725,9 @@ static void speculars_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_toneequalizer_params_t *p = (dt_iop_toneequalizer_params_t *)self->params;
   p->speculars = dt_bauhaus_slider_get(slider);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1712,6 +1740,9 @@ static void method_changed(GtkWidget *widget, gpointer user_data)
   p->method = dt_bauhaus_combobox_get(widget);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1725,6 +1756,9 @@ static void details_changed(GtkWidget *widget, gpointer user_data)
   invalidate_luminance_cache(self);
   show_guiding_controls(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void blending_callback(GtkWidget *slider, gpointer user_data)
@@ -1736,6 +1770,9 @@ static void blending_callback(GtkWidget *slider, gpointer user_data)
   p->blending = dt_bauhaus_slider_get(slider);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void feathering_callback(GtkWidget *slider, gpointer user_data)
@@ -1747,6 +1784,9 @@ static void feathering_callback(GtkWidget *slider, gpointer user_data)
   p->feathering = dt_bauhaus_slider_get(slider);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void smoothing_callback(GtkWidget *slider, gpointer user_data)
@@ -1769,6 +1809,9 @@ static void smoothing_callback(GtkWidget *slider, gpointer user_data)
   update_curve_lut(self);
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void iterations_callback(GtkWidget *slider, gpointer user_data)
@@ -1780,6 +1823,9 @@ static void iterations_callback(GtkWidget *slider, gpointer user_data)
   p->iterations = dt_bauhaus_slider_get(slider);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void quantization_callback(GtkWidget *slider, gpointer user_data)
@@ -1791,6 +1837,9 @@ static void quantization_callback(GtkWidget *slider, gpointer user_data)
   p->quantization = dt_bauhaus_slider_get(slider);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void contrast_boost_callback(GtkWidget *slider, gpointer user_data)
@@ -1802,6 +1851,9 @@ static void contrast_boost_callback(GtkWidget *slider, gpointer user_data)
   p->contrast_boost = dt_bauhaus_slider_get(slider);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void exposure_boost_callback(GtkWidget *slider, gpointer user_data)
@@ -1813,6 +1865,9 @@ static void exposure_boost_callback(GtkWidget *slider, gpointer user_data)
   p->exposure_boost = dt_bauhaus_slider_get(slider);
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
@@ -1872,6 +1927,9 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
   darktable.gui->reset = reset;
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1933,6 +1991,9 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
   darktable.gui->reset = reset;
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1963,6 +2024,9 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton, dt_iop_module_
 
   dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
   dt_dev_reprocess_center(self->dev);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 }
 
 
@@ -1979,7 +2043,7 @@ static void switch_cursors(struct dt_iop_module_t *self)
   GdkCursor *cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
 
   // if we are editing masks, do not display controls
-  if(!sanity_check(self) || in_mask_editing(self))
+  if(!sanity_check(self) || in_mask_editing(self) || (self->blend_picker->module->request_color_pick))
   {
     // display default cursor
     gdk_window_set_cursor(gtk_widget_get_window(widget), cursor);
@@ -2932,6 +2996,10 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
     }
     return TRUE;
   }
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
+
   return FALSE;
 }
 
@@ -3046,6 +3114,9 @@ static gboolean notebook_button_press(GtkWidget *widget, GdkEventButton *event, 
 
   // Give focus to module
   dt_iop_request_focus(self);
+
+  // Unlock the colour picker so we can display our own custom cursor
+  dt_iop_color_picker_reset(self, TRUE);
 
   return 0;
 }


### PR DESCRIPTION
fix #3729

Changes:
1. the cursor is not captured if colour pickers are in use
2. every UI interaction (except mouse over) with tone EQ module will disable the colour pickers