### PR TITLE
proof of concept: delayed reprocessing on parameter change

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -139,6 +139,7 @@ typedef struct dt_develop_t
   uint32_t average_delay;
   uint32_t preview_average_delay;
   uint32_t preview2_average_delay;
+  uint32_t timeout_handle;
   struct dt_iop_module_t *gui_module; // this module claims gui expose/event callbacks.
   float preview_downsampling;         // < 1.0: optionally downsample preview
 


### PR DESCRIPTION
do not trigger reprocessing more frequently than the pixelpipe can handle.
this is an idea how to tackle issues like #3674

t.b.d.