### PR TITLE
gui responsiveness: improve for contrast equalizer

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1317,7 +1317,13 @@ static void reset_mix(dt_iop_module_t *self)
 
 void gui_update(struct dt_iop_module_t *self)
 {
+  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
   reset_mix(self);
+  if(c->timeout_handle)
+  {
+    g_source_remove(c->timeout_handle);
+    c->timeout_handle = 0;
+  }
   gtk_widget_queue_draw(self->widget);
 }
 

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -280,6 +280,7 @@ typedef struct dt_iop_basecurve_gui_data_t
   GtkWidget *cmb_preserve_colors;
   double mouse_x, mouse_y;
   int selected;
+  int timeout_handle;
   double selected_offset, selected_y, selected_min, selected_max;
   float draw_xs[DT_IOP_TONECURVE_RES], draw_ys[DT_IOP_TONECURVE_RES];
   float draw_min_xs[DT_IOP_TONECURVE_RES], draw_min_ys[DT_IOP_TONECURVE_RES];
@@ -1951,6 +1952,17 @@ static gboolean area_resized(GtkWidget *widget, GdkEvent *event, gpointer user_d
   return TRUE;
 }
 
+static gboolean postponed_value_change(gpointer data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)data;
+  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  c->timeout_handle = 0;
+
+  return FALSE;
+}
+
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
@@ -1983,8 +1995,12 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   dt_iop_basecurve_sanity_check(self, widget);
 
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(widget);
+
+  const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
+
+  if(!c->timeout_handle)
+    c->timeout_handle = g_timeout_add(delay, postponed_value_change, self);
 
   return TRUE;
 }
@@ -2120,6 +2136,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = -1.0;
   c->selected = -1;
   c->loglogscale = 0;
+  c->timeout_handle = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
@@ -2200,6 +2217,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
   dt_draw_curve_destroy(c->minmax_curve);
+  if(c->timeout_handle) g_source_remove(c->timeout_handle);
   free(self->gui_data);
   self->gui_data = NULL;
 }

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1422,6 +1422,13 @@ void gui_update(struct dt_iop_module_t *self)
     gtk_widget_set_visible(g->exposure_bias, FALSE);
   }
 
+  if(g->timeout_handle)
+  {
+    g_source_remove(g->timeout_handle);
+    g->timeout_handle = 0;
+  }
+
+
   dt_bauhaus_slider_set(g->exposure_step, p->exposure_stops);
   dt_bauhaus_slider_set(g->exposure_bias, p->exposure_bias);
   // gui curve is read directly from params during expose event.

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2415,6 +2415,12 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->interpolator, p->curve_type[g->channel]);
   dt_bauhaus_combobox_set(g->mode, p->mode);
 
+  if(g->timeout_handle)
+  {
+    g_source_remove(g->timeout_handle);
+    g->timeout_handle = 0;
+  }
+
   gtk_widget_queue_draw(self->widget);
 }
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -289,6 +289,11 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_lowlight_gui_data_t *g = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
   dt_bauhaus_slider_set(g->scale_blueness, p->blueness);
+  if(g->timeout_handle)
+  {
+    g_source_remove(g->timeout_handle);
+    g->timeout_handle = 0;
+  }
   gtk_widget_queue_draw(self->widget);
 }
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -61,6 +61,7 @@ typedef struct dt_iop_lowlight_gui_data_t
   dt_iop_lowlight_params_t drag_params;
   int dragging;
   int x_move;
+  int timeout_handle;
   float draw_xs[DT_IOP_LOWLIGHT_RES], draw_ys[DT_IOP_LOWLIGHT_RES];
   float draw_min_xs[DT_IOP_LOWLIGHT_RES], draw_min_ys[DT_IOP_LOWLIGHT_RES];
   float draw_max_xs[DT_IOP_LOWLIGHT_RES], draw_max_ys[DT_IOP_LOWLIGHT_RES];
@@ -680,6 +681,17 @@ static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_dat
   return TRUE;
 }
 
+static gboolean postponed_value_change(gpointer data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)data;
+  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  c->timeout_handle = 0;
+
+  return FALSE;
+}
+
 static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -708,7 +720,11 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
     {
       dt_iop_lowlight_get_params(p, c->mouse_x, c->mouse_y + c->mouse_pick, c->mouse_radius);
     }
-    dt_dev_add_history_item(darktable.develop, self, TRUE);
+    gtk_widget_queue_draw(widget);
+    const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
+
+    if(!c->timeout_handle)
+      c->timeout_handle = g_timeout_add(delay, postponed_value_change, self);
   }
   else if(event->y > height)
   {
@@ -723,12 +739,13 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
         dist = d2;
       }
     }
+    gtk_widget_queue_draw(widget);
   }
   else
   {
     c->x_move = -1;
+    gtk_widget_queue_draw(widget);
   }
-  gtk_widget_queue_draw(widget);
   gint x, y;
 #if GTK_CHECK_VERSION(3, 20, 0)
   gdk_window_get_device_position(event->window,
@@ -840,6 +857,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
   c->x_move = -1;
+  c->timeout_handle = 0;
   c->mouse_radius = 1.0 / DT_IOP_LOWLIGHT_BANDS;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -873,6 +891,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_draw_curve_destroy(c->transition_curve);
+  if(c->timeout_handle) g_source_remove(c->timeout_handle);
   free(self->gui_data);
   self->gui_data = NULL;
 }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -634,7 +634,11 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_rawdenoise_gui_data_t *g = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
-
+  if(g->timeout_handle)
+  {
+    g_source_remove(g->timeout_handle);
+    g->timeout_handle = 0;
+  }
   dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "non_raw" : "raw");
   gtk_widget_queue_draw(self->widget);

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1672,6 +1672,12 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->chk_compensate_middle_grey), p->compensate_middle_grey);
   dt_bauhaus_combobox_set(g->cmb_preserve_colors, p->preserve_colors);
 
+  if(g->timeout_handle)
+  {
+    g_source_remove(g->timeout_handle);
+    g->timeout_handle = 0;
+  }
+
   _rgbcurve_show_hide_controls(p, g);
 
   // that's all, gui curve is read directly from params during expose event.

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -152,6 +152,7 @@ typedef struct dt_iop_tonecurve_gui_data_t
   tonecurve_channel_t channel;
   double mouse_x, mouse_y;
   int selected;
+  int timeout_handle;
   float draw_xs[DT_IOP_TONECURVE_RES], draw_ys[DT_IOP_TONECURVE_RES];
   float draw_min_xs[DT_IOP_TONECURVE_RES], draw_min_ys[DT_IOP_TONECURVE_RES];
   float draw_max_xs[DT_IOP_TONECURVE_RES], draw_max_ys[DT_IOP_TONECURVE_RES];
@@ -1173,6 +1174,17 @@ static void dt_iop_tonecurve_sanity_check(dt_iop_module_t *self, GtkWidget *widg
   }
 }
 
+static gboolean postponed_value_change(gpointer data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)data;
+  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  c->timeout_handle = 0;
+
+  return FALSE;
+}
+
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
@@ -1205,8 +1217,12 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   dt_iop_tonecurve_sanity_check(self, widget);
 
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(widget);
+
+  const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
+
+  if(!c->timeout_handle)
+    c->timeout_handle = g_timeout_add(delay, postponed_value_change, self);
 
   return TRUE;
 }
@@ -1302,6 +1318,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->selected = -1;
   c->loglogscale = 0;
   c->semilog = 0;
+  c->timeout_handle = 0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
@@ -1441,6 +1458,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_draw_curve_destroy(c->minmax_curve[ch_L]);
   dt_draw_curve_destroy(c->minmax_curve[ch_a]);
   dt_draw_curve_destroy(c->minmax_curve[ch_b]);
+  if(c->timeout_handle) g_source_remove(c->timeout_handle);
   free(self->gui_data);
   self->gui_data = NULL;
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -852,6 +852,12 @@ void gui_update(struct dt_iop_module_t *self)
     gtk_widget_set_visible(g->logbase, FALSE);
   }
 
+  if(g->timeout_handle)
+  {
+    g_source_remove(g->timeout_handle);
+    g->timeout_handle = 0;
+  }
+
   // that's all, gui curve is read directly from params during expose event.
   gtk_widget_queue_draw(self->widget);
 }


### PR DESCRIPTION
Delay dt_dev_add_history_item() when nodes are moved.

This works really well with a fast GPU and is a clear improvement on CPU.

Other candidates would be:
basecurve
colorzones
lowlight
rawdenoise
rgbcurve
tonecurve
