### PR TITLE
proper test for raw & dng files.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -107,35 +107,29 @@ int dt_image_is_hdr(const dt_image_t *img)
     return 0;
 }
 
+// NULL terminated list of supported non-RAW extensions
+//  const char *dt_non_raw_extensions[]
+//    = { ".jpeg", ".jpg",  ".pfm", ".hdr", ".exr", ".pxn", ".tif", ".tiff", ".png",
+//        ".j2c",  ".j2k",  ".jp2", ".jpc", ".gif", ".jpc", ".jp2", ".bmp",  ".dcm",
+//        ".jng",  ".miff", ".mng", ".pbm", ".pnm", ".ppm", ".pgm", NULL };
 int dt_image_is_raw(const dt_image_t *img)
 {
-  // NULL terminated list of supported non-RAW extensions
-  const char *dt_non_raw_extensions[]
-      = { ".jpeg", ".jpg",  ".pfm", ".hdr", ".exr", ".pxn", ".tif", ".tiff", ".png",
-          ".j2c",  ".j2k",  ".jp2", ".jpc", ".gif", ".jpc", ".jp2", ".bmp",  ".dcm",
-          ".jng",  ".miff", ".mng", ".pbm", ".pnm", ".ppm", ".pgm", NULL };
-
-  if(img->flags & DT_IMAGE_RAW) return TRUE;
-
-  const char *c = img->filename + strlen(img->filename);
-  while(*c != '.' && c > img->filename) c--;
-
-  gboolean isnonraw = FALSE;
-  for(const char **i = dt_non_raw_extensions; *i != NULL; i++)
-  {
-    if(!g_ascii_strncasecmp(c, *i, strlen(*i)))
-    {
-      isnonraw = TRUE;
-      break;
-    }
-  }
-
-  return !isnonraw;
+   return (img->flags & DT_IMAGE_RAW);
 }
 
 int dt_image_is_monochrome(const dt_image_t *img)
 {
    return (img->flags & DT_IMAGE_MONOCHROME);
+}
+
+int dt_image_is_matrix_correction_supported(const dt_image_t *img)
+{
+   return ((img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW )) && !(img->flags & DT_IMAGE_MONOCHROME) );
+} 
+
+int dt_image_is_rawprepare_supported(const dt_image_t *img)
+{
+   return (img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW));
 }
 
 const char *dt_image_film_roll_name(const char *path)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -74,6 +74,8 @@ typedef enum
   DT_IMAGE_MONOCHROME = 32768,
   // image has usercrop information
   DT_IMAGE_HAS_USERCROP = 65536,
+  // image is an sraw
+  DT_IMAGE_S_RAW = 1 << 17,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t
@@ -219,6 +221,10 @@ int dt_image_is_raw(const dt_image_t *img);
 int dt_image_is_hdr(const dt_image_t *img);
 /** returns non-zero if this image was taken using a monochrome camera */
 int dt_image_is_monochrome(const dt_image_t *img);
+/** returns non-zero if the image supports a color correction matrix */
+int dt_image_is_matrix_correction_supported(const dt_image_t *img);
+/** returns non-zero if the image supports the rawprepare module */
+int dt_image_is_rawprepare_supported(const dt_image_t *img);
 /** returns the full path name where the image was imported from. from_cache=TRUE check and return local
  * cached filename if any. */
 void dt_image_full_path(const int imgid, char *pathname, size_t pathname_len, gboolean *from_cache);

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -382,6 +382,7 @@ return_label:
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_LDR;
     img->flags &= ~DT_IMAGE_RAW;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->flags |= DT_IMAGE_HDR;
     img->loader = loader;
   }
@@ -527,6 +528,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->flags |= DT_IMAGE_LDR;
     img->loader = LOADER_TIFF;
     return ret;
@@ -538,6 +540,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
     img->buf_dsc.cst = iop_cs_rgb; // png is always RGB
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
     img->loader = LOADER_PNG;
@@ -552,6 +555,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
     img->flags &= ~DT_IMAGE_HDR;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->flags |= DT_IMAGE_LDR;
     img->loader = LOADER_J2K;
     return ret;
@@ -564,6 +568,7 @@ dt_imageio_retval_t dt_imageio_open_ldr(dt_image_t *img, const char *filename, d
     img->buf_dsc.cst = iop_cs_rgb; // pnm is always RGB
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
     img->loader = LOADER_PNM;
@@ -966,6 +971,7 @@ dt_imageio_retval_t dt_imageio_open_exotic(dt_image_t *img, const char *filename
     img->buf_dsc.cst = iop_cs_rgb;
     img->buf_dsc.filters = 0u;
     img->flags &= ~DT_IMAGE_RAW;
+    img->flags &= ~DT_IMAGE_S_RAW;
     img->flags &= ~DT_IMAGE_HDR;
     img->flags |= DT_IMAGE_LDR;
     img->loader = LOADER_GM;

--- a/src/common/imageio_gm.c
+++ b/src/common/imageio_gm.c
@@ -119,6 +119,7 @@ dt_imageio_retval_t dt_imageio_open_gm(dt_image_t *img, const char *filename, dt
   img->buf_dsc.filters = 0u;
   img->flags &= ~DT_IMAGE_RAW;
   img->flags &= ~DT_IMAGE_HDR;
+  img->flags &= ~DT_IMAGE_S_RAW;
   img->flags |= DT_IMAGE_LDR;
 
   return DT_IMAGEIO_OK;

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -367,7 +367,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
   // sraw aren't real raw, but not ldr either (need white balance and stuff)
   img->flags &= ~DT_IMAGE_LDR;
   img->flags &= ~DT_IMAGE_RAW;
-
+  img->flags |= DT_IMAGE_S_RAW;
   img->width = r->dim.x;
   img->height = r->dim.y;
 

--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -2879,7 +2879,8 @@ void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const flo
   }
   if(profile_info == NULL)
   {
-    if (!dt_image_is_monochrome(&self->dev->image_storage))
+    // The range information below is not informative in case it's the colorin module itself.
+    if (strcmp(self->op,"colorin"))
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace] module %s must be between input color profile and output color profile\n", self->op);
     *converted_cst = cst_from;
     return;
@@ -3138,7 +3139,8 @@ int dt_ioppr_transform_image_colorspace_cl(struct dt_iop_module_t *self, const i
   }
   if(profile_info == NULL)
   {
-    if (!dt_image_is_monochrome(&self->dev->image_storage))
+    // The range information below is not informative in case it's the colorin module itself.
+    if (strcmp(self->op,"colorin"))
       fprintf(stderr, "[dt_ioppr_transform_image_colorspace_cl] module %s must be between input color profile and output color profile\n", self->op);
     *converted_cst = cst_from;
     return FALSE;

--- a/src/develop/format.c
+++ b/src/develop/format.c
@@ -48,7 +48,7 @@ void default_input_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_de
 
   if(dsc->cst != iop_cs_RAW) return;
 
-  if(pipe->image.flags & DT_IMAGE_RAW) dsc->channels = 1;
+  if(dt_image_is_raw(&pipe->image)) dsc->channels = 1;
 
   if(dt_ioppr_get_iop_order(pipe->iop_order_list, self->op) > dt_ioppr_get_iop_order(pipe->iop_order_list, "rawprepare")) return;
 
@@ -65,7 +65,7 @@ void default_output_format(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_d
 
   if(dsc->cst != iop_cs_RAW) return;
 
-  if(pipe->image.flags & DT_IMAGE_RAW) dsc->channels = 1;
+  if(dt_image_is_raw(&pipe->image)) dsc->channels = 1;
 
   if(dt_ioppr_get_iop_order(pipe->iop_order_list, self->op) >= dt_ioppr_get_iop_order(pipe->iop_order_list, "rawprepare")) return;
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -292,7 +292,7 @@ void dt_dev_pixelpipe_create_nodes(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
     piece->histogram_stats.bins_count = 0;
     piece->histogram_stats.pixels = 0;
     piece->colors
-        = ((module->default_colorspace(module, pipe, NULL) == iop_cs_RAW) && (pipe->image.flags & DT_IMAGE_RAW))
+        = ((module->default_colorspace(module, pipe, NULL) == iop_cs_RAW) && (dt_image_is_raw(&pipe->image)))
               ? 1
               : 4;
     piece->iscale = pipe->iscale;
@@ -409,7 +409,7 @@ static void get_output_format(dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe,
   // first input.
   *dsc = pipe->image.buf_dsc;
 
-  if(!(pipe->image.flags & DT_IMAGE_RAW))
+  if(!(dt_image_is_raw(&pipe->image)))
   {
     // image max is normalized before
     for(int k = 0; k < 4; k++) dsc->processed_maximum[k] = 1.0f;

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1503,7 +1503,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   dt_image_t *img = &module->dev->image_storage;
   // can't be switched on for non-raw or x-trans images:
-  if((img->flags & DT_IMAGE_RAW) && (img->buf_dsc.filters != 9u) && !dt_image_is_monochrome(img))
+  if(dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !dt_image_is_monochrome(img))
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
@@ -1545,7 +1545,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_image_t *img = &pipe->image;
-  if(!(img->flags & DT_IMAGE_RAW) || dt_image_is_monochrome(img)) piece->enabled = 0;
+  if(!dt_image_is_raw(img) || dt_image_is_monochrome(img)) piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -1560,7 +1560,7 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 
 void gui_update(dt_iop_module_t *self)
 {
-  if(self->dev->image_storage.flags & DT_IMAGE_RAW)
+  if(dt_image_is_raw(&self->dev->image_storage))
     if(self->dev->image_storage.buf_dsc.filters != 9u && !dt_image_is_monochrome(&self->dev->image_storage))
       gtk_label_set_text(GTK_LABEL(self->widget), _("automatic chromatic aberration correction"));
     else

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -4851,7 +4851,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
 {
   dt_iop_demosaic_params_t *p = (dt_iop_demosaic_params_t *)params;
   dt_iop_demosaic_data_t *d = (dt_iop_demosaic_data_t *)piece->data;
-  if(!(pipe->image.flags & DT_IMAGE_RAW)) piece->enabled = 0;
+  if(!(dt_image_is_raw(&pipe->image))) piece->enabled = 0;
   d->green_eq = p->green_eq;
   d->color_smoothing = p->color_smoothing;
   d->median_thrs = p->median_thrs;
@@ -4998,7 +4998,7 @@ void reload_defaults(dt_iop_module_t *module)
     tmp.demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
 
   // only on for raw images:
-  if(module->dev->image_storage.flags & DT_IMAGE_RAW)
+  if(dt_image_is_raw(&module->dev->image_storage))
     module->default_enabled = 1;
   else
     {

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -982,6 +982,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
 
   // no OpenCL for DT_IOP_HIGHLIGHTS_INPAINT yet.
   if(d->mode == DT_IOP_HIGHLIGHTS_INPAINT) piece->process_cl_ready = 0;
+  if(self->hide_enable_button)
+    piece->enabled = 0;
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1038,7 +1038,7 @@ void reload_defaults(dt_iop_module_t *module)
   if(!module->dev) goto end;
 
   // only on for raw images:
-  if(module->dev->image_storage.flags & DT_IMAGE_RAW)
+  if(dt_image_is_raw(&(module->dev->image_storage)))
     module->default_enabled = 1;
   else
     {

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -316,7 +316,7 @@ void reload_defaults(dt_iop_module_t *module)
   if(!module->dev) goto end;
 
   // can't be switched on for non-raw images:
-  if(module->dev->image_storage.flags & DT_IMAGE_RAW)
+  if(dt_image_is_raw(&module->dev->image_storage))
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
@@ -357,7 +357,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
   d->permissive = p->permissive;
   d->markfixed = p->markfixed && (pipe->type != DT_DEV_PIXELPIPE_EXPORT)
                  && (pipe->type != DT_DEV_PIXELPIPE_THUMBNAIL);
-  if(!(pipe->image.flags & DT_IMAGE_RAW) || p->strength == 0.0) piece->enabled = 0;
+  if(!(dt_image_is_raw(&pipe->image)) || p->strength == 0.0) piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -539,7 +539,7 @@ void reload_defaults(dt_iop_module_t *module)
   if(!module->dev) goto end;
 
   // can't be switched on for non-raw images:
-  if(module->dev->image_storage.flags & DT_IMAGE_RAW)
+  if(dt_image_is_raw(&module->dev->image_storage))
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
@@ -602,7 +602,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
     dt_draw_curve_calc_values(d->curve[ch], 0.0, 1.0, DT_IOP_RAWDENOISE_BANDS, NULL, d->force[ch]);
   }
 
-  if (!(pipe->image.flags & DT_IMAGE_RAW))
+  if (!(dt_image_is_raw(&pipe->image)))
     piece->enabled = 0;
 }
 

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -687,7 +687,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   d->rawprepare.raw_black_level = (uint16_t)(black / 4.0f);
   d->rawprepare.raw_white_point = p->raw_white_point;
 
-  if(!dt_image_is_raw(&piece->pipe->image) || image_is_normalized(&piece->pipe->image)) piece->enabled = 0;
+  if(!(dt_image_is_rawprepare_supported(&piece->pipe->image)) || image_is_normalized(&piece->pipe->image)) piece->enabled = 0;
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -721,7 +721,7 @@ void reload_defaults(dt_iop_module_t *self)
                                      .raw_black_level_separate[3] = image->raw_black_level_separate[3],
                                      .raw_white_point = image->raw_white_point };
 
-  self->default_enabled = dt_image_is_raw(image) && !image_is_normalized(image);
+  self->default_enabled = dt_image_is_rawprepare_supported(image) && !image_is_normalized(image);
 
 end:
   memcpy(self->params, &tmp, sizeof(dt_iop_rawprepare_params_t));
@@ -751,7 +751,7 @@ void init(dt_iop_module_t *self)
     // are upgraded and temporary modules are constructed for this, with a 0x0 dev
     // pointer. i suppose the can be solved more elegantly on the other side.
     const dt_image_t *const image = &(self->dev->image_storage);
-    self->default_enabled = dt_image_is_raw(image) && !image_is_normalized(image);
+    self->default_enabled = dt_image_is_rawprepare_supported(image) && !image_is_normalized(image);
   }
   self->params_size = sizeof(dt_iop_rawprepare_params_t);
   self->gui_data = NULL;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1025,7 +1025,7 @@ void reload_defaults(dt_iop_module_t *module)
   // we might be called from presets update infrastructure => there is no image
   if(!module->dev || module->dev->image_storage.id == -1) goto end;
 
-  const int is_raw = dt_image_is_raw(&module->dev->image_storage);
+  const int is_raw = dt_image_is_matrix_correction_supported(&module->dev->image_storage);
 
   module->default_enabled = 0;
   module->hide_enable_button = 0;
@@ -1033,7 +1033,7 @@ void reload_defaults(dt_iop_module_t *module)
   // White balance module doesn't need to be enabled for monochrome raws (like
   // for leica monochrom cameras). prepare_matrices is a noop as well, as there
   // isn't a color matrix, so we can skip that as well.
-  if(is_raw && dt_image_is_monochrome(&(module->dev->image_storage)))
+  if(dt_image_is_monochrome(&(module->dev->image_storage)))
   {
     module->hide_enable_button = 1;
   }


### PR DESCRIPTION
Work on issue #3591

To make sure a proper raw/dng testing we have to distinguish between raw/sraw.
So introduced DT_IMAGE_S_RAW set&reset by all loaders.

Also direct testing for bits in img->flags is prone to errors so there are a
few tests available.

int dt_image_is_raw(const dt_image_t *img) now only tests the raw flag
and these two are new
int dt_image_is_matrix_correction_supported(const dt_image_t *img);
int dt_image_is_rawprepare_supported(const dt_image_t *img);

Existing modules use these functions now.