### PR TITLE
drawn masks: let changes also take effect on the preview2 pipe

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2567,6 +2567,7 @@ void dt_masks_update_image(dt_develop_t *dev)
   // invalidate buffers and force redraw of darkroom
   dev->pipe->changed |= DT_DEV_PIPE_SYNCH;
   dev->preview_pipe->changed |= DT_DEV_PIPE_SYNCH;
+  dev->preview2_pipe->changed |= DT_DEV_PIPE_SYNCH;
   dt_dev_invalidate_all(dev);
 }
 


### PR DESCRIPTION
Obviously the update of the preview2 pipe was missing.

It would be interesting to further investigate if we really need DT_DEV_PIPE_SYNCH rather than DT_DEV_PIPE_TOP_CHANGED. A complete pipe synch is quite expensive as it needs a full parameter commit of all pixelpipes and an update of the complete history stack. Can take easily 40ms or even 200ms on images with a long history stack. In order to experience the slowness just change the radius of an existing circle shape.