### PR TITLE
filmic: fix OpenCL subscripted vector access

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -21,7 +21,7 @@
 // In case the OpenCL driver doesn't have a dot method
 inline float vdot(const float4 vec1, const float4 vec2)
 {
-  return vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2] + vec1[3] * vec2[3];
+    return vec1.x * vec2.x + vec1.y * vec2.y + vec1.z * vec2.z;
 }
 
 typedef enum dt_iop_filmicrgb_methods_type_t


### PR DESCRIPTION
fix `error: subscripted access is not allowed for OpenCL vectors` by taking .xyz members of the float4 vector, and don't use the 4th channel (alpha) which might not be set to 0 all the time.