### PR TITLE
OpenCL: remove native functions calls

### DIFF
--- a/data/kernels/atrous.cl
+++ b/data/kernels/atrous.cl
@@ -24,8 +24,8 @@ float4
 weight(const float4 c1, const float4 c2, const float sharpen)
 {
   // native_exp is faster than the cpu floating point aliasing hack:
-  const float wc = native_exp(-((c1.y - c2.y)*(c1.y - c2.y) + (c1.z - c2.z)*(c1.z - c2.z)) * sharpen);
-  const float wl = native_exp(- (c1.x - c2.x)*(c1.x - c2.x) * sharpen);
+  const float wc = exp(-((c1.y - c2.y)*(c1.y - c2.y) + (c1.z - c2.z)*(c1.z - c2.z)) * sharpen);
+  const float wl = exp(- (c1.x - c2.x)*(c1.x - c2.x) * sharpen);
   return (float4)(wl, wc, wc, 1.0f);
 }
 

--- a/data/kernels/basic.cl
+++ b/data/kernels/basic.cl
@@ -447,7 +447,7 @@ lookup_unbounded_twosided(read_only image2d_t lut, const float x, constant float
       // two-sided extrapolation (with inverted x-axis for left side)
       const float xx = (x >= ar) ? x : 1.0f - x;
       constant float *aa = (x >= ar) ? a : a + 3;
-      return aa[1] * native_powr(xx*aa[0], aa[2]);
+      return aa[1] * powr(xx*aa[0], aa[2]);
     }
   }
   else return x;
@@ -471,7 +471,7 @@ lerp_lookup_unbounded0(read_only image2d_t lut, const float x, global const floa
       const float l2 = read_imagef(lut, sampleri, p2).x;
       return l1 * (1.0f - f) + l2 * f;
     }
-    else return a[1] * native_powr(x*a[0], a[2]);
+    else return a[1] * powr(x*a[0], a[2]);
   }
   else return x;
 }
@@ -751,7 +751,7 @@ interpolation_func_lanczos(float width, float t)
 {
   float ta = fabs(t);
 
-  float r = (ta > width) ? 0.0f : ((ta < DT_LANCZOS_EPSILON) ? 1.0f : width*native_sin(M_PI_F*t)*native_sin(M_PI_F*t/width)/(M_PI_F*M_PI_F*t*t));
+  float r = (ta > width) ? 0.0f : ((ta < DT_LANCZOS_EPSILON) ? 1.0f : width*sin(M_PI_F*t)*native_sin(M_PI_F*t/width)/(M_PI_F*M_PI_F*t*t));
 
   return r;
 }
@@ -1943,7 +1943,7 @@ colorzones (read_only image2d_t in, write_only image2d_t out, const int width, c
   }
   select = clamp(select, 0.f, 1.f);
 
-  LCh.x *= native_powr(2.0f, 4.0f * (lookup(table_L, select) - .5f));
+  LCh.x *= powr(2.0f, 4.0f * (lookup(table_L, select) - .5f));
   LCh.y *= 2.f * lookup(table_C, select);
   LCh.z += lookup(table_h, select) - .5f;
 

--- a/data/kernels/basicadj.cl
+++ b/data/kernels/basicadj.cl
@@ -21,7 +21,7 @@
 
 float get_gamma(const float x, const float gamma)
 {
-  return native_powr(x, gamma);
+  return powr(x, gamma);
 }
 
 float get_lut_gamma(const float x, const float gamma, read_only image2d_t lut)
@@ -40,7 +40,7 @@ float get_lut_gamma(const float x, const float gamma, read_only image2d_t lut)
 
 float get_contrast(const float x, const float contrast, const float middle_grey, const float inv_middle_grey)
 {
-  return native_powr(x * inv_middle_grey, contrast) * middle_grey;
+  return powr(x * inv_middle_grey, contrast) * middle_grey;
 }
 
 float get_lut_contrast(const float x, const float contrast, const float middle_grey, const float inv_middle_grey, read_only image2d_t lut)
@@ -144,7 +144,7 @@ basicadj(read_only image2d_t in, write_only image2d_t out, const int width, cons
     const float lum = dt_rgb_norm(pixel, preserve_colors, use_work_profile, profile_info, lut);
     if(lum > 0.f)
     {
-      const float contrast_lum = native_powr(lum / middle_grey, contrast) * middle_grey;
+      const float contrast_lum = powr(lum / middle_grey, contrast) * middle_grey;
       ratio = contrast_lum / lum;
     }
 

--- a/data/kernels/color_conversion.cl
+++ b/data/kernels/color_conversion.cl
@@ -58,7 +58,7 @@ inline float lerp_lookup_unbounded(const float x, read_only image2d_t lut, const
       const float l2 = read_imagef(lut, sampleri, p2).x;
       return l1 * (1.0f - f) + l2 * f;
     }
-    else return unbounded_coeffs[1] * native_powr(x*unbounded_coeffs[0], unbounded_coeffs[2]);
+    else return unbounded_coeffs[1] * powr(x*unbounded_coeffs[0], unbounded_coeffs[2]);
   }
   else return x;
 }
@@ -82,7 +82,7 @@ inline float lookup_unbounded(read_only image2d_t lut, const float x, constant f
       const int2 p = (int2)((xi & 0xff), (xi >> 8));
       return read_imagef(lut, sampleri, p).x;
     }
-    else return a[1] * native_powr(x*a[0], a[2]);
+    else return a[1] * powr(x*a[0], a[2]);
   }
   else return x;
 }

--- a/data/kernels/colorspace.cl
+++ b/data/kernels/colorspace.cl
@@ -44,7 +44,7 @@ inline float4 lab_f(float4 x)
 {
   const float4 epsilon = 216.0f / 24389.0f;
   const float4 kappa = 24389.0f / 27.0f;
-  return (x > epsilon) ? native_powr(x, (float4)(1.0f/3.0f)) : (kappa * x + (float4)16.0f) / ((float4)116.0f);
+  return (x > epsilon) ? powr(x, (float4)(1.0f/3.0f)) : (kappa * x + (float4)16.0f) / ((float4)116.0f);
 }
 
 

--- a/data/kernels/denoiseprofile.cl
+++ b/data/kernels/denoiseprofile.cl
@@ -77,7 +77,7 @@ denoiseprofile_precondition_v2(read_only image2d_t in, write_only image2d_t out,
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
   const float alpha = pixel.w;
 
-  float4 t = 2.0f * native_powr(fmax((float4)0.0f, pixel / wb + b), 1.0f - p / 2.0f) / ((-p + 2.0f) * sqrt(a));
+  float4 t = 2.0f * powr(fmax((float4)0.0f, pixel / wb + b), 1.0f - p / 2.0f) / ((-p + 2.0f) * sqrt(a));
 
   t.w = alpha;
 
@@ -327,7 +327,7 @@ denoiseprofile_finish_v2(read_only image2d_t in, global float4* U2, write_only i
   float4 delta = px * px + (float4)bias;
   float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
   float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
-  px = native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b;
+  px = powr(z1, 1.0f / (1.0f - p / 2.0f)) - b;
   px = px * wb;
   px.w = alpha;
 
@@ -376,7 +376,7 @@ denoiseprofile_backtransform_v2(read_only image2d_t in, write_only image2d_t out
   float4 delta = px * px + (float4)bias;
   float4 denominator = 4.0f / (sqrt(a) * (2.0f - p));
   float4 z1 = (px + sqrt(fmax((float4)0.0f, delta))) / denominator;
-  px = native_powr(z1, 1.0f / (1.0f - p / 2.0f)) - b;
+  px = powr(z1, 1.0f / (1.0f - p / 2.0f)) - b;
   px = px * wb;
   px.w = alpha;
 

--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -591,9 +591,9 @@ colorbalance (read_only image2d_t in, write_only image2d_t out, const int width,
   float4 sRGB = XYZ_to_sRGB(Lab_to_XYZ(Lab));
 
   // Lift gamma gain
-  sRGB = (sRGB <= (float4)0.0031308f) ? 12.92f * sRGB : (1.0f + 0.055f) * native_powr(sRGB, (float4)1.0f/2.4f) - (float4)0.055f;
-  sRGB = native_powr(fmax(((sRGB - (float4)1.0f) * lift + (float4)1.0f) * gain, (float4)0.0f), gamma_inv);
-  sRGB = (sRGB <= (float4)0.04045f) ? sRGB / 12.92f : native_powr((sRGB + (float4)0.055f) / (1.0f + 0.055f), (float4)2.4f);
+  sRGB = (sRGB <= (float4)0.0031308f) ? 12.92f * sRGB : (1.0f + 0.055f) * powr(sRGB, (float4)1.0f/2.4f) - (float4)0.055f;
+  sRGB = powr(fmax(((sRGB - (float4)1.0f) * lift + (float4)1.0f) * gain, (float4)0.0f), gamma_inv);
+  sRGB = (sRGB <= (float4)0.04045f) ? sRGB / 12.92f : powr((sRGB + (float4)0.055f) / (1.0f + 0.055f), (float4)2.4f);
   Lab.xyz = XYZ_to_Lab(sRGB_to_XYZ(sRGB)).xyz;
 
   write_imagef (out, (int2)(x, y), Lab);
@@ -621,9 +621,9 @@ colorbalance_lgg (read_only image2d_t in, write_only image2d_t out, const int wi
   }
 
   // Lift gamma gain
-  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : native_powr(RGB, (float4)1.0f/2.2f);
+  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : powr(RGB, (float4)1.0f/2.2f);
   RGB = ((RGB - (float4)1.0f) * lift + (float4)1.0f) * gain;
-  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : native_powr(RGB, gamma_inv * (float4)2.2f);
+  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : powr(RGB, gamma_inv * (float4)2.2f);
 
   // saturation output
   if (saturation_out != 1.0f)
@@ -669,7 +669,7 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
 
   // lift power slope
   RGB = RGB * gain + lift;
-  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : native_powr(RGB, gamma_inv);
+  RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : powr(RGB, gamma_inv);
 
   // saturation output
   if (saturation_out != 1.0f)
@@ -684,7 +684,7 @@ colorbalance_cdl (read_only image2d_t in, write_only image2d_t out, const int wi
   {
     const float4 contrast4 = contrast;
     const float4 grey4 = grey;
-    RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : native_powr(RGB / grey4, contrast4) * grey4;
+    RGB = (RGB <= (float4)0.0f) ? (float4)0.0f : powr(RGB / grey4, contrast4) * grey4;
   }
 
   Lab.xyz = prophotorgb_to_Lab(RGB).xyz;

--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -72,7 +72,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
     // Log profile
     maxRGB = maxRGB / grey;
     maxRGB = (maxRGB < noise) ? noise : maxRGB;
-    maxRGB = (native_log2(maxRGB) - shadows_range) / dynamic_range;
+    maxRGB = (log2(maxRGB) - shadows_range) / dynamic_range;
     maxRGB = clamp(maxRGB, 0.0f, 1.0f);
 
     const float index = maxRGB;
@@ -92,7 +92,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
     // Log profile
     o = o / grey;
     o = (o < noise) ? noise : o;
-    o = (native_log2(o) - shadows4) / dynamic4;
+    o = (log2(o) - shadows4) / dynamic4;
     o = clamp(o, (float4)0.0f, (float4)1.0f);
 
     const float index = prophotorgb_to_XYZ(o).y;
@@ -113,7 +113,7 @@ filmic (read_only image2d_t in, write_only image2d_t out, int width, int height,
 
   // Apply the transfer function of the display
   const float4 power4 = power;
-  o = native_powr(o, power4);
+  o = powr(o, power4);
 
   i.xyz = prophotorgb_to_Lab(o).xyz;
 
@@ -126,8 +126,8 @@ inline float filmic_desaturate(const float x, const float sigma_toe, const float
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
 
-  const float key_toe = native_exp(-0.5f * radius_toe * radius_toe / sigma_toe);
-  const float key_shoulder = native_exp(-0.5f * radius_shoulder * radius_shoulder / sigma_shoulder);
+  const float key_toe = exp(-0.5f * radius_toe * radius_toe / sigma_toe);
+  const float key_shoulder = exp(-0.5f * radius_shoulder * radius_shoulder / sigma_shoulder);
 
   return 1.0f - clamp((key_toe + key_shoulder) / saturation, 0.0f, 1.0f);
 }
@@ -174,14 +174,14 @@ filmicrgb_split (read_only image2d_t in, write_only image2d_t out,
   const float4 i = read_imagef(in, sampleri, (int2)(x, y));
   float4 o;
 
-  const float4 noise4 = native_powr(2.0f, -16.0f);
+  const float4 noise4 = powr(2.0f, -16.0f);
   const float4 dynamic4 = dynamic_range;
   const float4 blacks4 = black_exposure;
   const float4 grey4 = grey_value;
 
   // Log tonemapping
   o = (i < noise4) ? noise4 : i;
-  o = (native_log2(o / grey4) - blacks4) / dynamic4;
+  o = (log2(o / grey4) - blacks4) / dynamic4;
   o = clamp(o, noise4, (float4)1.0f);
 
   // Selective desaturation of extreme luminances
@@ -195,7 +195,7 @@ filmicrgb_split (read_only image2d_t in, write_only image2d_t out,
   o.z = filmic_spline(o.z, M1, M2, M3, M4, M5, latitude_min, latitude_max);
 
   // Output power
-  o = native_powr(clamp(o, (float4)0.0f, (float4)1.0f), output_power);
+  o = powr(clamp(o, (float4)0.0f, (float4)1.0f), output_power);
 
   // Copy alpha layer and save
   o.w = i.w;
@@ -255,7 +255,7 @@ filmicrgb_chroma (read_only image2d_t in, write_only image2d_t out,
 
   const float4 i = read_imagef(in, sampleri, (int2)(x, y));
 
-  const float noise = native_powr(2.0f, -16.0f);
+  const float noise = powr(2.0f, -16.0f);
 
   float norm = get_pixel_norm(i, variant, profile_info, lut, use_work_profile);
   norm =  (norm < noise) ? noise : norm;
@@ -268,7 +268,7 @@ filmicrgb_chroma (read_only image2d_t in, write_only image2d_t out,
   if(min_ratios < 0.0f) o -= (float4)min_ratios;
 
   // Log tonemapping
-  norm = (native_log2(norm / grey_value) - black_exposure) / dynamic_range;
+  norm = (log2(norm / grey_value) - black_exposure) / dynamic_range;
   norm = clamp(norm, noise, 1.0f);
 
   // Selective desaturation of extreme luminances
@@ -282,7 +282,7 @@ filmicrgb_chroma (read_only image2d_t in, write_only image2d_t out,
   norm = filmic_spline(norm, M1, M2, M3, M4, M5, latitude_min, latitude_max);
 
   // Output power
-  norm = native_powr(clamp(norm, 0.0f, 1.0f), output_power);
+  norm = powr(clamp(norm, 0.0f, 1.0f), output_power);
 
   // Copy alpha layer and save
   o *= norm;

--- a/data/kernels/gaussian.cl
+++ b/data/kernels/gaussian.cl
@@ -24,8 +24,8 @@
    is needed to have read-write access to some buffers which openCL does not offer for image object. */
 
 
-kernel void 
-gaussian_transpose_4c(global float4 *in, global float4 *out, unsigned int width, unsigned int height, 
+kernel void
+gaussian_transpose_4c(global float4 *in, global float4 *out, unsigned int width, unsigned int height,
                       unsigned int blocksize, local float4 *buffer)
 {
   unsigned int x = get_global_id(0);
@@ -50,8 +50,8 @@ gaussian_transpose_4c(global float4 *in, global float4 *out, unsigned int width,
 }
 
 
-kernel void 
-gaussian_transpose_1c(global float *in, global float *out, unsigned int width, unsigned int height, 
+kernel void
+gaussian_transpose_1c(global float *in, global float *out, unsigned int width, unsigned int height,
                       unsigned int blocksize, local float *buffer)
 {
   unsigned int x = get_global_id(0);
@@ -76,7 +76,7 @@ gaussian_transpose_1c(global float *in, global float *out, unsigned int width, u
 }
 
 
-kernel void 
+kernel void
 gaussian_column_4c(global float4 *in, global float4 *out, unsigned int width, unsigned int height,
                   const float a0, const float a1, const float a2, const float a3, const float b1, const float b2,
                   const float coefp, const float coefn, const float4 Labmax, const float4 Labmin)
@@ -100,7 +100,7 @@ gaussian_column_4c(global float4 *in, global float4 *out, unsigned int width, un
   yb = xp * coefp;
   yp = yb;
 
- 
+
   for(int y=0; y<height; y++)
   {
     const int idx = mad24((unsigned int)y, width, x);
@@ -130,9 +130,9 @@ gaussian_column_4c(global float4 *in, global float4 *out, unsigned int width, un
     xc = clamp(in[idx], Labmin, Labmax);
     yc = (a2 * xn) + (a3 * xa) - (b1 * yn) - (b2 * ya);
 
-    xa = xn; 
-    xn = xc; 
-    ya = yn; 
+    xa = xn;
+    xn = xc;
+    ya = yn;
     yn = yc;
 
     out[idx] += yc;
@@ -140,7 +140,7 @@ gaussian_column_4c(global float4 *in, global float4 *out, unsigned int width, un
   }
 }
 
-kernel void 
+kernel void
 gaussian_column_1c(global float *in, global float *out, unsigned int width, unsigned int height,
                   const float a0, const float a1, const float a2, const float a3, const float b1, const float b2,
                   const float coefp, const float coefn, const float Labmax, const float Labmin)
@@ -164,7 +164,7 @@ gaussian_column_1c(global float *in, global float *out, unsigned int width, unsi
   yb = xp * coefp;
   yp = yb;
 
- 
+
   for(int y=0; y<height; y++)
   {
     const int idx = mad24((unsigned int)y, width, x);
@@ -194,9 +194,9 @@ gaussian_column_1c(global float *in, global float *out, unsigned int width, unsi
     xc = clamp(in[idx], Labmin, Labmax);
     yc = (a2 * xn) + (a3 * xa) - (b1 * yn) - (b2 * ya);
 
-    xa = xn; 
-    xn = xc; 
-    ya = yn; 
+    xa = xn;
+    xn = xc;
+    ya = yn;
     yn = yc;
 
     out[idx] += yc;
@@ -219,14 +219,14 @@ lookup_unbounded(read_only image2d_t lut, const float x, global float *a)
       const int2 p = (int2)((xi & 0xff), (xi >> 8));
       return read_imagef(lut, sampleri, p).x;
     }
-    else return a[1] * native_powr(x*a[0], a[2]);
+    else return a[1] * powr(x*a[0], a[2]);
   }
   else return x;
 }
 
 
-kernel void 
-lowpass_mix(read_only image2d_t in, write_only image2d_t out, unsigned int width, unsigned int height, const float saturation, 
+kernel void
+lowpass_mix(read_only image2d_t in, write_only image2d_t out, unsigned int width, unsigned int height, const float saturation,
             read_only image2d_t ctable, global float *ca, read_only image2d_t ltable, global float *la, const int unbound)
 {
   const unsigned int x = get_global_id(0);
@@ -307,11 +307,11 @@ overlay(const float4 in_a, const float4 in_b, const float opacity, const float t
 #define UNBOUND_HIGHLIGHTS_A   (UNBOUND_A << 3)   /* 16 */
 #define UNBOUND_HIGHLIGHTS_B   (UNBOUND_B << 3)   /* 32 */
 
-kernel void 
-shadows_highlights_mix(read_only image2d_t in, read_only image2d_t mask, write_only image2d_t out, 
-                       unsigned int width, unsigned int height, 
+kernel void
+shadows_highlights_mix(read_only image2d_t in, read_only image2d_t mask, write_only image2d_t out,
+                       unsigned int width, unsigned int height,
                        const float shadows, const float highlights, const float compress,
-                       const float shadows_ccorrect, const float highlights_ccorrect, 
+                       const float shadows_ccorrect, const float highlights_ccorrect,
                        const unsigned int flags, const int unbound_mask, const float low_approximation,
                        const float whitepoint)
 {

--- a/data/kernels/locallaplacian.cl
+++ b/data/kernels/locallaplacian.cl
@@ -261,7 +261,7 @@ float curve(
     val = g + ssigma * 2.0f*mt*t + t2*(ssigma + ssigma*shadhi);
   }
   // midtone local contrast
-  val += clarity * c * native_exp(-c*c/(2.0f*sigma*sigma/3.0f));
+  val += clarity * c * exp(-c*c/(2.0f*sigma*sigma/3.0f));
   return val;
 }
 

--- a/data/kernels/rgb_norms.h
+++ b/data/kernels/rgb_norms.h
@@ -49,7 +49,7 @@ dt_rgb_norm(const float4 in, const int norm, const int work_profile,
   }
   else if (norm == DT_RGB_NORM_NORM)
   {
-    return native_powr(in.x * in.x + in.y * in.y + in.z * in.z, 0.5f);
+    return powr(in.x * in.x + in.y * in.y + in.z * in.z, 0.5f);
   }
   else if (norm == DT_RGB_NORM_POWER)
   {

--- a/data/kernels/rgblevels.cl
+++ b/data/kernels/rgblevels.cl
@@ -31,7 +31,7 @@ float rgblevels_1c(const float pixel, global const float *levels, const float in
   else if(pixel >= levels[2])
   {
     const float percentage = (pixel - levels[0]) / (levels[2] - levels[0]);
-    level = native_powr(percentage, inv_gamma);
+    level = powr(percentage, inv_gamma);
   }
   else
   {


### PR DESCRIPTION
replace native_exp, native_powr, native_log2, which are implementation-defined (depending on the driver and possibly faster) by standard OpenCL exp, powr, log2, to alleviate the inconsistencies between the 2 AMD, the 2 Intel and the Nvidia drivers.

Might be the second part to fix #3756