### PR TITLE
opencl: increase opencl_memory_headroom to 400MB

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -86,7 +86,7 @@
   <dtconfig>
     <name>opencl_memory_headroom</name>
     <type>int</type>
-    <default>300</default>
+    <default>400</default>
     <shortdescription>amount of OpenCL memory (in MB) which we assume as being reserved for the driver</shortdescription>
     <longdescription>this amount of memory (in MB) will be subtracted from total GPU memory in order to calculate the available OpenCL memory. too low values will lead to out-of-memory situations in OpenCL processing. too high values will lead to unnecessary tiling (needs a restart).</longdescription>
   </dtconfig>


### PR DESCRIPTION
The original setting of 300MB comes from a time when typical
graphic cards had 1-2GB of memory. Modern GPUs are equipped with 4GB
or more. Over the years drivers seem to need more and more memory
for their own tasks. I have experienced situations during export
when some modules (e.g. contrast equalizer) needed to fall back
to CPU as available memory on the GPU was lower than expected
(output is fine then but takes much longer). With a memory headroom
of 400MB we make things a bit less tight.
Note: This affects the default setting when installing darktable anew.
On existing systems users will need to manually adjust darktablerc.