### PR TITLE
thumb/export: better finetuning of output dimensions

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -753,8 +753,24 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   const double scaley = height > 0 ? fminf(height / (double)pipe.processed_height, max_scale) : max_scale;
   const double scale = fminf(scalex, scaley);
 
-  const int processed_width = floor(scale * pipe.processed_width);
-  const int processed_height = floor(scale * pipe.processed_height);
+  int processed_width;
+  int processed_height;
+
+  float origin[] = { 0.0f, 0.0f };
+
+  if(dt_dev_distort_backtransform_plus(&dev, &pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, origin, 1))
+  {
+    processed_width = scale * pipe.processed_width + 0.5f;
+    processed_height = scale * pipe.processed_height + 0.5f;
+
+    if(ceilf(processed_width / scale) + origin[0] > pipe.iwidth) processed_width--;
+    if(ceilf(processed_height / scale) + origin[1] > pipe.iheight) processed_height--;
+  }
+  else
+  {
+    processed_width = floor(scale * pipe.processed_width);
+    processed_height = floor(scale * pipe.processed_height);
+  }
 
   const int bpp = format->bpp(format_params);
 


### PR DESCRIPTION
this tries to compromise between #3757 (make output dimensions exactly as user
requests) and #3646 (do not read outside of input/raw image buffer).