### PR TITLE
image: extends the list of iop for non altered flag.

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -854,6 +854,12 @@ int dt_image_altered(const uint32_t imgid)
     if(!strcmp(op, "sharpen") && dt_conf_get_bool("plugins/darkroom/sharpen/auto_apply")) continue;
     if(!strcmp(op, "dither")) continue;
     if(!strcmp(op, "highlights")) continue;
+    if(!strcmp(op, "rawprepare")) continue;
+    if(!strcmp(op, "colorin")) continue;
+    if(!strcmp(op, "colorout")) continue;
+    if(!strcmp(op, "gamma")) continue;
+    if(!strcmp(op, "demosaic")) continue;
+    if(!strcmp(op, "temperature")) continue;
     altered = 1;
     break;
   }


### PR DESCRIPTION
Fixes #3815.