### PR TITLE
views: show hide bottom panel when changing filmstrip status.

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1102,6 +1102,26 @@ void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible)
   }
 }
 
+void dt_lib_toggle_filmstrip_visibility(void)
+{
+  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
+  if(!m) return;
+  const gboolean vs = dt_lib_is_visible(m);
+  const gboolean ps = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+
+  if(ps) // bottom panel is visible, just hide/show filmstrip
+  {
+    dt_lib_set_visible(m, !vs);
+  }
+  else // bottom panel is not visible
+  {
+    // show it
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, TRUE, TRUE);
+    // and display filstrip only if it was not activated
+    if(!vs) dt_lib_set_visible(m, !vs);
+  }
+}
+
 void dt_lib_connect_common_accels(dt_lib_module_t *module)
 {
   if(module->reset_button)

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -158,6 +158,8 @@ void dt_lib_connect_common_accels(dt_lib_module_t *module);
 gboolean dt_lib_is_visible(dt_lib_module_t *module);
 /** set the visible state of a plugin */
 void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible);
+/** toggle filmstrip visibility */
+void dt_lib_toggle_filmstrip_visibility(void);
 /** check if a plugin is to be shown in a given view */
 gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module, const dt_view_t *view);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -954,12 +954,9 @@ static gboolean zoom_key_accel(GtkAccelGroup *accel_group, GObject *acceleratabl
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  gboolean vs = dt_lib_is_visible(m);
-  dt_lib_set_visible(m, !vs);
+  dt_lib_toggle_filmstrip_visibility();
   return TRUE;
 }
-
 
 static gboolean export_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                           GdkModifierType modifier, gpointer data)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -909,9 +909,7 @@ static gboolean _view_map_redo_callback(GtkAccelGroup *accel_group, GObject *acc
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  gboolean vs = dt_lib_is_visible(m);
-  dt_lib_set_visible(m, !vs);
+  dt_lib_toggle_filmstrip_visibility();
   return TRUE;
 }
 

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -316,9 +316,7 @@ void leave(dt_view_t *self)
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  const gboolean vs = dt_lib_is_visible(m);
-  dt_lib_set_visible(m, !vs);
+  dt_lib_toggle_filmstrip_visibility();
   return TRUE;
 }
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -104,14 +104,11 @@ static void _view_capture_filmstrip_activate_callback(gpointer instance, gpointe
 }
 
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                              GdkModifierType modifier, gpointer data)
+                                     GdkModifierType modifier, gpointer data)
 {
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  gboolean vs = dt_lib_is_visible(m);
-  dt_lib_set_visible(m, !vs);
+  dt_lib_toggle_filmstrip_visibility();
   return TRUE;
 }
-
 
 void init(dt_view_t *self)
 {


### PR DESCRIPTION
This is needed as when the bottom panel is hidden, trying to show/hide
the filmstrip will do nothing. We also want to handle the visibility of
the bottom panel.