### PR TITLE
Mask Manager / label - typo correction

### DIFF
--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1147,7 +1147,7 @@ static int _tree_button_pressed(GtkWidget *treeview, GdkEventButton *event, dt_l
     if(from_group && depth < 3)
     {
       gtk_menu_shell_append(menu, gtk_separator_menu_item_new());
-      item = gtk_menu_item_new_with_label(_("use inversed shape"));
+      item = gtk_menu_item_new_with_label(_("use inverted shape"));
       g_signal_connect(item, "activate", (GCallback)_tree_inverse, self);
       gtk_menu_shell_append(menu, item);
       if(nb == 1)


### PR DESCRIPTION
Use "inverted" instead of "inversed"
The meaning of "Inversed" does not apply in this context
Note: I am not clear if this small change has any impact on Translations - a search in the code showed that 4 translations files contains the wrong string ("use inversed shape") as well. 