### PR TITLE
watermark: update watermark text to 512 characters max.

### DIFF
--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -46,7 +46,7 @@
 #include "common/utility.h"
 
 #define CLIP(x) ((x < 0) ? 0.0 : (x > 1.0) ? 1.0 : x)
-DT_MODULE_INTROSPECTION(4, dt_iop_watermark_params_t)
+DT_MODULE_INTROSPECTION(5, dt_iop_watermark_params_t)
 
 // gchar *checksum = g_compute_checksum_for_data(G_CHECKSUM_MD5,data,length);
 
@@ -74,7 +74,7 @@ typedef struct dt_iop_watermark_params_t
   dt_iop_watermark_base_scale_t sizeto;
   char filename[64];
   /* simple text */
-  char text[64];
+  char text[512];
   /* text color */
   float color[3];
   /* text font */
@@ -91,7 +91,7 @@ typedef struct dt_iop_watermark_data_t
   float rotate;
   dt_iop_watermark_base_scale_t sizeto;
   char filename[64];
-  char text[64];
+  char text[512];
   float color[3];
   char font[64];
 } dt_iop_watermark_data_t;
@@ -115,7 +115,7 @@ typedef struct dt_iop_watermark_gui_data_t
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {
-  if(old_version == 1 && new_version == 4)
+  if(old_version == 1 && new_version == 5)
   {
     typedef struct dt_iop_watermark_params_v1_t
     {
@@ -151,7 +151,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->color[0] = n->color[1] = n->color[2] = 0;
     return 0;
   }
-  else if(old_version == 2 && new_version == 4)
+  else if(old_version == 2 && new_version == 5)
   {
     typedef struct dt_iop_watermark_params_v2_t
     {
@@ -188,7 +188,7 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->color[0] = n->color[1] = n->color[2] = 0;
     return 0;
   }
-  else if(old_version == 3 && new_version == 4)
+  else if(old_version == 3 && new_version == 5)
   {
     typedef struct dt_iop_watermark_params_v3_t
     {
@@ -225,6 +225,53 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     g_strlcpy(n->text, "", sizeof(n->text));
     g_strlcpy(n->font, "DejaVu Sans 10", sizeof(n->font));
     n->color[0] = n->color[1] = n->color[2] = 0;
+    return 0;
+  }
+  else if(old_version == 4 && new_version == 5)
+  {
+    typedef struct dt_iop_watermark_params_v4_t
+    {
+      /** opacity value of rendering watermark */
+      float opacity;
+      /** scale value of rendering watermark */
+      float scale;
+      /** Pixel independent xoffset, 0 to 1 */
+      float xoffset;
+      /** Pixel independent yoffset, 0 to 1 */
+      float yoffset;
+      /** Alignment value 0-8 3x3 */
+      int alignment;
+      /** Rotation **/
+      float rotate;
+      dt_iop_watermark_base_scale_t sizeto;
+      char filename[64];
+      /* simple text */
+      char text[64];
+      /* text color */
+      float color[3];
+      /* text font */
+      char font[64];
+    } dt_iop_watermark_params_v4_t;
+
+    dt_iop_watermark_params_v4_t *o = (dt_iop_watermark_params_v4_t *)old_params;
+    dt_iop_watermark_params_t *n = (dt_iop_watermark_params_t *)new_params;
+    dt_iop_watermark_params_t *d = (dt_iop_watermark_params_t *)self->default_params;
+
+    *n = *d; // start with a fresh copy of default parameters
+
+    n->opacity = o->opacity;
+    n->scale = o->scale;
+    n->xoffset = o->xoffset;
+    n->yoffset = o->yoffset;
+    n->alignment = o->alignment;
+    n->rotate = o->rotate;
+    n->sizeto = o->sizeto;
+    g_strlcpy(n->filename, o->filename, sizeof(n->filename));
+    g_strlcpy(n->text, o->text, sizeof(n->text));
+    g_strlcpy(n->font, o->font, sizeof(n->font));
+    n->color[0] = o->color[0];
+    n->color[1] = o->color[1];
+    n->color[2] = o->color[2];
     return 0;
   }
   return 1;


### PR DESCRIPTION
This is important as we can now have variables in the simple text entry
and so a limit of 64 was quickly reached.

Fixes #3840.