### PR TITLE
UI: make modules labels a bit smaller

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -477,7 +477,7 @@ entry selection
   padding: 0 2pt 2pt 0.5em;
   font-weight: normal;
   font-family: sans-serif;
-  font-size: larger;
+  font-size: 1.1em;
 }
 
 /* Labels of controls sections in modules */


### PR DESCRIPTION
The purpose of the condensed font was to reduce the width footprint of the modules labels, which is defeated by the increased font size. Since these labels are isolated (not lost in a full block of text), I find they stay legible even at relatively small sizes. To be discussed…