### PR TITLE
panels enhancements

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -29,6 +29,20 @@
     <shortdescription>maximum width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>min_panel_height</name>
+    <type>int</type>
+    <default>64</default>
+    <shortdescription>minimum width of the side panels in pixels</shortdescription>
+    <longdescription>(needs a restart)</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>max_panel_height</name>
+    <type>int</type>
+    <default>400</default>
+    <shortdescription>maximum width of the side panels in pixels</shortdescription>
+    <longdescription>(needs a restart)</longdescription>
+  </dtconfig>
   <dtconfig prefs="gui">
     <name>slideshow_delay</name>
     <type>int</type>
@@ -577,26 +591,12 @@
     <shortdescription>enable filmstrip</shortdescription>
     <longdescription>enable the filmstrip in darkroom, tethering and map modes.</longdescription>
   </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/filmstrip/height</name>
-    <type>int</type>
-    <default>120</default>
-    <shortdescription>height of filmstrip</shortdescription>
-    <longdescription>height of the filmstrip in pixels</longdescription>
-  </dtconfig>
   <dtconfig prefs="gui">
     <name>plugins/lighttable/timeline/visible</name>
     <type>bool</type>
     <default>true</default>
     <shortdescription>enable timeline</shortdescription>
     <longdescription>enable the timeline in lighttable mode.</longdescription>
-  </dtconfig>
-  <dtconfig>
-    <name>plugins/lighttable/timeline/height</name>
-    <type>int</type>
-    <default>72</default>
-    <shortdescription>height of timeline</shortdescription>
-    <longdescription>height of the timeline in pixels</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/timeline/last_zoom</name>

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -155,7 +155,7 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky);
   dt_accel_path_view(path, sizeof(path), "lighttable", "sticky preview with focus detection");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_focus);
-  dt_accel_path_view(path, sizeof(path), "lighttable", "toggle timeline");
+  dt_accel_path_view(path, sizeof(path), "lighttable", "toggle filmstrip/timeline");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_timeline);
   dt_accel_path_view(path, sizeof(path), "lighttable", "preview zoom 100%");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_zoom_100);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1685,8 +1685,8 @@ void dt_ui_restore_panels(dt_ui_t *ui)
   g_free(key);
   if(state)
   {
-    /* hide all panels */
-    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(ui, k, FALSE, TRUE);
+    /* hide all panels (we let saved state as it is, to recover them when pressing TAB)*/
+    for(int k = 0; k < DT_UI_PANEL_SIZE; k++) dt_ui_panel_show(ui, k, FALSE, FALSE);
   }
   else
   {

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1102,26 +1102,6 @@ void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible)
   }
 }
 
-void dt_lib_toggle_filmstrip_visibility(void)
-{
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  if(!m) return;
-  const gboolean vs = dt_lib_is_visible(m);
-  const gboolean ps = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
-
-  if(ps) // bottom panel is visible, just hide/show filmstrip
-  {
-    dt_lib_set_visible(m, !vs);
-  }
-  else // bottom panel is not visible
-  {
-    // show it
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, TRUE, TRUE);
-    // and display filstrip only if it was not activated
-    if(!vs) dt_lib_set_visible(m, !vs);
-  }
-}
-
 void dt_lib_connect_common_accels(dt_lib_module_t *module)
 {
   if(module->reset_button)

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1071,21 +1071,42 @@ void dt_lib_presets_add(const char *name, const char *plugin_name, const int32_t
   sqlite3_finalize(stmt);
 }
 
+static gchar *_get_lib_view_path(dt_lib_module_t *module, char *suffix)
+{
+  if(!darktable.view_manager) return NULL;
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  // in lighttable, we store panels states per layout
+  char lay[32] = "";
+  if(g_strcmp0(cv->module_name, "lighttable") == 0)
+  {
+    if(dt_view_lighttable_preview_state(darktable.view_manager))
+      g_snprintf(lay, sizeof(lay), "preview/");
+    else
+      g_snprintf(lay, sizeof(lay), "%d/", dt_view_lighttable_get_layout(darktable.view_manager));
+  }
+  else if(g_strcmp0(cv->module_name, "darkroom") == 0)
+  {
+    g_snprintf(lay, sizeof(lay), "%d/", dt_view_darkroom_get_layout(darktable.view_manager));
+  }
+
+  return dt_util_dstrcat(NULL, "plugins/%s/%s%s%s", cv->module_name, lay, module->plugin_name, suffix);
+}
+
 gboolean dt_lib_is_visible(dt_lib_module_t *module)
 {
-  char key[512];
-  g_snprintf(key, sizeof(key), "plugins/lighttable/%s/visible", module->plugin_name);
-  if(dt_conf_key_exists(key)) return dt_conf_get_bool(key);
+  gchar *key = _get_lib_view_path(module, "_visible");
+  gboolean ret = TRUE; /* if not key found, always make module visible */
+  if(key && dt_conf_key_exists(key)) ret = dt_conf_get_bool(key);
+  g_free(key);
 
-  /* if not key found, always make module visible */
-  return TRUE;
+  return ret;
 }
 
 void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible)
 {
-  char key[512];
-  g_snprintf(key, sizeof(key), "plugins/lighttable/%s/visible", module->plugin_name);
+  gchar *key = _get_lib_view_path(module, "_visible");
   dt_conf_set_bool(key, visible);
+  g_free(key);
   if(module->widget)
   {
     if(module->expander)

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -158,8 +158,6 @@ void dt_lib_connect_common_accels(dt_lib_module_t *module);
 gboolean dt_lib_is_visible(dt_lib_module_t *module);
 /** set the visible state of a plugin */
 void dt_lib_set_visible(dt_lib_module_t *module, gboolean visible);
-/** toggle filmstrip visibility */
-void dt_lib_toggle_filmstrip_visibility(void);
 /** check if a plugin is to be shown in a given view */
 gboolean dt_lib_is_visible_in_view(dt_lib_module_t *module, const dt_view_t *view);
 

--- a/src/libs/tools/filmstrip.c
+++ b/src/libs/tools/filmstrip.c
@@ -77,6 +77,7 @@ typedef struct dt_lib_filmstrip_t
   cairo_surface_t *surface;
   GHashTable *thumbs_table;
   int32_t panel_width;
+  int32_t panel_height;
 
   dt_gui_hist_dialog_t dg;
 } dt_lib_filmstrip_t;
@@ -86,13 +87,6 @@ static void _lib_filmstrip_scroll_to_image(dt_lib_module_t *self, gint imgid, gb
 /* proxy function for retrieving last activate request image id */
 static int32_t _lib_filmstrip_get_activated_imgid(dt_lib_module_t *self);
 static GtkWidget *_lib_filmstrip_get_widget(dt_lib_module_t *self);
-
-static gboolean _lib_filmstrip_size_handle_button_callback(GtkWidget *w, GdkEventButton *e,
-                                                           gpointer user_data);
-static gboolean _lib_filmstrip_size_handle_motion_notify_callback(GtkWidget *w, GdkEventButton *e,
-                                                                  gpointer user_data);
-static gboolean _lib_filmstrip_size_handle_cursor_callback(GtkWidget *w, GdkEventCrossing *e,
-                                                           gpointer user_data);
 
 /* motion notify event handler */
 static gboolean _lib_filmstrip_motion_notify_callback(GtkWidget *w, GdkEventMotion *e, gpointer user_data);
@@ -303,6 +297,7 @@ void gui_init(dt_lib_module_t *self)
   d->offset_x = 0;
   d->surface = NULL;
   d->panel_width = -1;
+  d->panel_height = -1;
   d->thumbs_table = g_hash_table_new(g_int_hash, g_int_equal);
   dt_gui_hist_dialog_init(&d->dg);
 
@@ -340,30 +335,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->filmstrip), "leave-notify-event",
                    G_CALLBACK(_lib_filmstrip_mouse_leave_callback), self);
 
-  /* set size of filmstrip */
-  int32_t height = dt_conf_get_int("plugins/lighttable/filmstrip/height");
-  gtk_widget_set_size_request(d->filmstrip, -1,
-                              CLAMP(height, DT_PIXEL_APPLY_DPI(64), DT_PIXEL_APPLY_DPI(400)));
-
-  /* create the resize handle */
-  GtkWidget *size_handle = gtk_event_box_new();
-  gtk_widget_set_size_request(size_handle, -1, DT_PIXEL_APPLY_DPI(5));
-  gtk_widget_add_events(size_handle, GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
-                                     | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK
-                                     | GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(G_OBJECT(size_handle), "button-press-event",
-                   G_CALLBACK(_lib_filmstrip_size_handle_button_callback), self);
-  g_signal_connect(G_OBJECT(size_handle), "button-release-event",
-                   G_CALLBACK(_lib_filmstrip_size_handle_button_callback), self);
-  g_signal_connect(G_OBJECT(size_handle), "motion-notify-event",
-                   G_CALLBACK(_lib_filmstrip_size_handle_motion_notify_callback), self);
-  g_signal_connect(G_OBJECT(size_handle), "leave-notify-event",
-                   G_CALLBACK(_lib_filmstrip_size_handle_cursor_callback), self);
-  g_signal_connect(G_OBJECT(size_handle), "enter-notify-event",
-                   G_CALLBACK(_lib_filmstrip_size_handle_cursor_callback), self);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), size_handle, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->filmstrip, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->filmstrip, TRUE, TRUE, 0);
 
   /* initialize view manager proxy */
   darktable.view_manager->proxy.filmstrip.module = self;
@@ -416,84 +388,6 @@ static inline gboolean _is_on_lighttable()
   // on lighttable, does nothing and report that it has not been handled
   const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   return cv->view((dt_view_t *)cv) == DT_VIEW_LIGHTTABLE;
-}
-
-static gboolean _lib_filmstrip_size_handle_cursor_callback(GtkWidget *w, GdkEventCrossing *e,
-                                                           gpointer user_data)
-{
-  dt_control_change_cursor((e->type == GDK_ENTER_NOTIFY) ? GDK_SB_V_DOUBLE_ARROW : GDK_LEFT_PTR);
-  return TRUE;
-}
-
-static gboolean _lib_filmstrip_size_handle_button_callback(GtkWidget *w, GdkEventButton *e, gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_filmstrip_t *d = (dt_lib_filmstrip_t *)self->data;
-
-  if(e->button == 1)
-  {
-    if(e->type == GDK_BUTTON_PRESS)
-    {
-      /* store current  mousepointer position */
-#if GTK_CHECK_VERSION(3, 20, 0)
-      gdk_window_get_device_position(e->window,
-                                     gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_window_get_display(
-                                         gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui))))),
-                                     &d->size_handle_x, &d->size_handle_y, 0);
-#else
-      gdk_window_get_device_position(
-          gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)),
-          gdk_device_manager_get_client_pointer(gdk_display_get_device_manager(
-              gdk_window_get_display(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui))))),
-          &d->size_handle_x, &d->size_handle_y, NULL);
-#endif
-
-      gtk_widget_get_size_request(d->filmstrip, NULL, &d->size_handle_height);
-      d->size_handle_is_dragging = TRUE;
-      cairo_surface_destroy(d->surface);
-      d->surface = NULL;
-    }
-    else if(e->type == GDK_BUTTON_RELEASE)
-      d->size_handle_is_dragging = FALSE;
-  }
-  return TRUE;
-}
-
-static gboolean _lib_filmstrip_size_handle_motion_notify_callback(GtkWidget *w, GdkEventButton *e,
-                                                                  gpointer user_data)
-{
-  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  dt_lib_filmstrip_t *d = (dt_lib_filmstrip_t *)self->data;
-  if(d->size_handle_is_dragging)
-  {
-    gint x, y, sx, sy;
-#if GTK_CHECK_VERSION(3, 20, 0)
-    gdk_window_get_device_position(e->window,
-        gdk_seat_get_pointer(gdk_display_get_default_seat(
-            gdk_window_get_display(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui))))),
-        &x, &y, 0);
-#else
-    gdk_window_get_device_position(
-        gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui)),
-        gdk_device_manager_get_client_pointer(gdk_display_get_device_manager(
-            gdk_window_get_display(gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui))))),
-        &x, &y, NULL);
-#endif
-
-    gtk_widget_get_size_request(d->filmstrip, &sx, &sy);
-    sy = CLAMP(d->size_handle_height + (d->size_handle_y - y), DT_PIXEL_APPLY_DPI(64),
-               DT_PIXEL_APPLY_DPI(400));
-
-    dt_conf_set_int("plugins/lighttable/filmstrip/height", sy);
-
-    cairo_surface_destroy(d->surface);
-    d->surface = NULL;
-    gtk_widget_set_size_request(d->filmstrip, -1, sy);
-
-    return TRUE;
-  }
-
-  return FALSE;
 }
 
 static gboolean _lib_filmstrip_motion_notify_callback(GtkWidget *w, GdkEventMotion *e, gpointer user_data)
@@ -710,7 +604,7 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
   const float line_width = DT_PIXEL_APPLY_DPI(2.0);
 
   // windows could have been expanded for example, we need to create a new surface of the good size and redraw
-  if(strip->surface && width != strip->panel_width)
+  if(strip->surface && (width != strip->panel_width || height != strip->panel_height))
   {
     cairo_surface_destroy(strip->surface);
     strip->surface = NULL;
@@ -724,6 +618,7 @@ static gboolean _lib_filmstrip_draw_callback(GtkWidget *widget, cairo_t *wcr, gp
       = dt_cairo_image_surface_create(CAIRO_FORMAT_ARGB32, allocation.width, allocation.height);
     strip->force_expose_all = TRUE;
     strip->panel_width = width;
+    strip->panel_height = height;
   }
 
   // get cairo drawing handle

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1030,7 +1030,11 @@ static gboolean zoom_key_accel(GtkAccelGroup *accel_group, GObject *acceleratabl
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_toggle_filmstrip_visibility();
+  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
+  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
+  // if we show the panel, ensure that filmstrip is visible
+  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
   return TRUE;
 }
 

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -383,20 +383,18 @@ static void check_layout(dt_view_t *self)
   // make sure we reset culling layout
   _culling_destroy_slots(self);
 
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *timeline = darktable.view_manager->proxy.timeline.module;
-  gboolean vs = dt_lib_is_visible(timeline);
-
+  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
+  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
   if(layout == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
   {
-    gtk_widget_hide(GTK_WIDGET(timeline->widget));
-    gtk_widget_show(GTK_WIDGET(m->widget));
+    dt_lib_set_visible(mf, dt_lib_is_visible(mf));
+    dt_lib_set_visible(mt, dt_lib_is_visible(mt));
     dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
   }
   else
   {
-    gtk_widget_hide(GTK_WIDGET(m->widget));
-    if(vs) gtk_widget_show(GTK_WIDGET(timeline->widget));
+    dt_lib_set_visible(mf, FALSE); // not available in this layouts
+    dt_lib_set_visible(mt, TRUE);  // always on, visibility is driven by panel state
     g_timeout_add(200, _expose_again_full, self);
     _scrollbars_restore();
   }
@@ -3312,22 +3310,6 @@ void enter(dt_view_t *self)
   // clean the undo list
   dt_undo_clear(darktable.undo, DT_UNDO_LIGHTTABLE);
 
-  // show/hide filmstrip when entering the view
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *timeline = darktable.view_manager->proxy.timeline.module;
-  gboolean vs = dt_lib_is_visible(timeline);
-
-  if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
-  {
-    gtk_widget_hide(GTK_WIDGET(timeline->widget));
-    gtk_widget_show(GTK_WIDGET(m->widget));
-  }
-  else
-  {
-    gtk_widget_hide(GTK_WIDGET(m->widget));
-    if(vs) gtk_widget_show(GTK_WIDGET(timeline->widget));
-  }
-
   gtk_drag_dest_set(dt_ui_center(darktable.gui->ui), GTK_DEST_DEFAULT_ALL, target_list_all, n_targets_all,
                     GDK_ACTION_COPY);
 
@@ -3350,6 +3332,20 @@ void enter(dt_view_t *self)
   lib->force_expose_all = TRUE;
   lib->activate_on_release = DT_VIEW_ERR;
   dt_collection_hint_message(darktable.collection);
+
+  // show/hide filmstrip && timeline when entering the view
+  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
+  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
+  if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
+  {
+    dt_lib_set_visible(mf, dt_lib_is_visible(mf));
+    dt_lib_set_visible(mt, dt_lib_is_visible(mt));
+  }
+  else
+  {
+    dt_lib_set_visible(mf, FALSE); // not available in this layouts
+    dt_lib_set_visible(mt, TRUE);  // always on, visibility is driven by panel state
+  }
 
   // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
@@ -3436,12 +3432,13 @@ static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int
   else
     lib->full_preview_follow_sel = FALSE;
 
-  // restore panels
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *timeline = darktable.view_manager->proxy.timeline.module;
-  gtk_widget_hide(GTK_WIDGET(timeline->widget));
-  gtk_widget_show(GTK_WIDGET(m->widget));
+  // show/hide filmstrip && timeline when entering the view
+  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
+  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
+  dt_lib_set_visible(mf, dt_lib_is_visible(mf));
+  dt_lib_set_visible(mt, dt_lib_is_visible(mt));
   dt_view_filmstrip_scroll_to_image(darktable.view_manager, lib->full_preview_id, FALSE);
+  // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
 
   // we don't need the scrollbars
@@ -3480,10 +3477,9 @@ static void _preview_quit(dt_view_t *self)
   lib->full_y = 0.0f;
 
   // restore panels
-  dt_lib_module_t *m = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *timeline = darktable.view_manager->proxy.timeline.module;
-  gboolean vs = dt_lib_is_visible(timeline);
-
+  // show/hide filmstrip && timeline when entering the view
+  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
+  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
   if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     // retrieve saved slots
@@ -3493,13 +3489,13 @@ static void _preview_quit(dt_view_t *self)
     lib->slots_old = NULL;
     lib->slots_count_old = 0;
 
-    gtk_widget_hide(GTK_WIDGET(timeline->widget));
-    gtk_widget_show(GTK_WIDGET(m->widget));
+    dt_lib_set_visible(mf, dt_lib_is_visible(mf));
+    dt_lib_set_visible(mt, dt_lib_is_visible(mt));
   }
   else
   {
-    gtk_widget_hide(GTK_WIDGET(m->widget));
-    if(vs) gtk_widget_show(GTK_WIDGET(timeline->widget));
+    dt_lib_set_visible(mf, FALSE); // not available in this layouts
+    dt_lib_set_visible(mt, TRUE);  // always on, visibility is driven by panel state
     g_timeout_add(200, _expose_again_full, self);
   }
   dt_ui_restore_panels(darktable.gui->ui);
@@ -4381,15 +4377,53 @@ int key_pressed(dt_view_t *self, guint key, guint state)
 static gboolean timeline_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                             GdkModifierType modifier, gpointer data)
 {
-  dt_lib_module_t *m = darktable.view_manager->proxy.timeline.module;
-  if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING)
+  dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+
+  if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
   {
-    gtk_widget_hide(GTK_WIDGET(m->widget)); // to be sure
+    // we can have both timeline and filmstrip, let's toggle them circulary :
+    // nothing => filmstrip => filmstrip + timeline => timeline => nothing
+    dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
+    dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
+    const gboolean mtv = dt_lib_is_visible(mt);
+    const gboolean mfv = dt_lib_is_visible(mf);
+
+    if(!pb) // nothing shown (panel hidden)
+    {
+      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, TRUE, TRUE);
+      // we ensure that we have at least one lib visible
+      if(!mtv && !mfv) dt_lib_set_visible(mt, FALSE);
+    }
+    else
+    {
+      if(mtv && mfv)
+      {
+        dt_lib_set_visible(mf, FALSE);
+      }
+      else if(mtv)
+      {
+        // we prepare for next step
+        dt_lib_set_visible(mt, FALSE);
+        dt_lib_set_visible(mf, TRUE);
+        // and we hide the panel
+        dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, FALSE, TRUE);
+      }
+      else
+      {
+        dt_lib_set_visible(mt, TRUE);
+        dt_lib_set_visible(mf, TRUE);
+      }
+    }
   }
   else
   {
-    gboolean vs = dt_lib_is_visible(m);
-    dt_lib_set_visible(m, !vs);
+    // there's only timeline in bottom panel, so better hide/show it instead of timeline lib
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
+    // if we show the panel, ensure that timeline is visible
+    if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, TRUE);
   }
   return TRUE;
 }
@@ -4447,7 +4481,7 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "preview zoom fit"), 0, 0);
 
   // timeline
-  dt_accel_register_view(self, NC_("accel", "toggle timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
+  dt_accel_register_view(self, NC_("accel", "toggle filmstrip/timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
 }
 
 static gboolean _lighttable_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -4562,7 +4596,7 @@ void connect_key_accels(dt_view_t *self)
 
   // timeline
   closure = g_cclosure_new(G_CALLBACK(timeline_key_accel_callback), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle timeline", closure);
+  dt_accel_connect_view(self, "toggle filmstrip/timeline", closure);
 }
 
 GSList *mouse_actions(const dt_view_t *self)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -383,18 +383,18 @@ static void check_layout(dt_view_t *self)
   // make sure we reset culling layout
   _culling_destroy_slots(self);
 
-  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
   if(layout == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
   {
-    dt_lib_set_visible(mf, dt_lib_is_visible(mf));
-    dt_lib_set_visible(mt, dt_lib_is_visible(mt));
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE); // not available in this layouts
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module,
+                       TRUE); // always on, visibility is driven by panel state
     dt_ui_scrollbars_show(darktable.gui->ui, FALSE);
   }
   else
   {
-    dt_lib_set_visible(mf, FALSE); // not available in this layouts
-    dt_lib_set_visible(mt, TRUE);  // always on, visibility is driven by panel state
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, FALSE); // not available in this layouts
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module,
+                       TRUE); // always on, visibility is driven by panel state
     g_timeout_add(200, _expose_again_full, self);
     _scrollbars_restore();
   }
@@ -3333,18 +3333,18 @@ void enter(dt_view_t *self)
   lib->activate_on_release = DT_VIEW_ERR;
   dt_collection_hint_message(darktable.collection);
 
-  // show/hide filmstrip && timeline when entering the view
-  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
+  // show/hide filmstrip & timeline when entering the view
   if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
   {
-    dt_lib_set_visible(mf, dt_lib_is_visible(mf));
-    dt_lib_set_visible(mt, dt_lib_is_visible(mt));
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE); // not available in this layouts
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module,
+                       TRUE); // always on, visibility is driven by panel state
   }
   else
   {
-    dt_lib_set_visible(mf, FALSE); // not available in this layouts
-    dt_lib_set_visible(mt, TRUE);  // always on, visibility is driven by panel state
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, FALSE); // not available in this layouts
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module,
+                       TRUE); // always on, visibility is driven by panel state
   }
 
   // restore panels
@@ -3432,11 +3432,10 @@ static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int
   else
     lib->full_preview_follow_sel = FALSE;
 
-  // show/hide filmstrip && timeline when entering the view
-  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
-  dt_lib_set_visible(mf, dt_lib_is_visible(mf));
-  dt_lib_set_visible(mt, dt_lib_is_visible(mt));
+  // show/hide filmstrip & timeline when entering the view
+  dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE); // not available in this layouts
+  dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module,
+                     TRUE); // always on, visibility is driven by panel state
   dt_view_filmstrip_scroll_to_image(darktable.view_manager, lib->full_preview_id, FALSE);
   // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
@@ -3476,10 +3475,7 @@ static void _preview_quit(dt_view_t *self)
   lib->full_x = 0.0f;
   lib->full_y = 0.0f;
 
-  // restore panels
-  // show/hide filmstrip && timeline when entering the view
-  dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
-  dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
+  // show/hide filmstrip & timeline when entering the view
   if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     // retrieve saved slots
@@ -3489,15 +3485,18 @@ static void _preview_quit(dt_view_t *self)
     lib->slots_old = NULL;
     lib->slots_count_old = 0;
 
-    dt_lib_set_visible(mf, dt_lib_is_visible(mf));
-    dt_lib_set_visible(mt, dt_lib_is_visible(mt));
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE); // not available in this layouts
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module,
+                       TRUE); // always on, visibility is driven by panel state
   }
   else
   {
-    dt_lib_set_visible(mf, FALSE); // not available in this layouts
-    dt_lib_set_visible(mt, TRUE);  // always on, visibility is driven by panel state
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, FALSE); // not available in this layouts
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module,
+                       TRUE); // always on, visibility is driven by panel state
     g_timeout_add(200, _expose_again_full, self);
   }
+  // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
 
   // restore scrollbars
@@ -4384,46 +4383,19 @@ static gboolean timeline_key_accel_callback(GtkAccelGroup *accel_group, GObject 
 
   if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
   {
-    // we can have both timeline and filmstrip, let's toggle them circulary :
-    // nothing => filmstrip => filmstrip + timeline => timeline => nothing
-    dt_lib_module_t *mt = darktable.view_manager->proxy.timeline.module;
-    dt_lib_module_t *mf = darktable.view_manager->proxy.filmstrip.module;
-    const gboolean mtv = dt_lib_is_visible(mt);
-    const gboolean mfv = dt_lib_is_visible(mf);
-
-    if(!pb) // nothing shown (panel hidden)
-    {
-      dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, TRUE, TRUE);
-      // we ensure that we have at least one lib visible
-      if(!mtv && !mfv) dt_lib_set_visible(mt, FALSE);
-    }
-    else
-    {
-      if(mtv && mfv)
-      {
-        dt_lib_set_visible(mf, FALSE);
-      }
-      else if(mtv)
-      {
-        // we prepare for next step
-        dt_lib_set_visible(mt, FALSE);
-        dt_lib_set_visible(mf, TRUE);
-        // and we hide the panel
-        dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, FALSE, TRUE);
-      }
-      else
-      {
-        dt_lib_set_visible(mt, TRUE);
-        dt_lib_set_visible(mf, TRUE);
-      }
-    }
+    // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
+    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
+    // we want to be sure that lib visibility are ok for this view
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE);
   }
   else
   {
     // there's only timeline in bottom panel, so better hide/show it instead of timeline lib
     dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-    // if we show the panel, ensure that timeline is visible
-    if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, TRUE);
+    // we want to be sure that lib visibility are ok for this view
+    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, FALSE);
+    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, TRUE);
   }
   return TRUE;
 }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -909,7 +909,11 @@ static gboolean _view_map_redo_callback(GtkAccelGroup *accel_group, GObject *acc
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_toggle_filmstrip_visibility();
+  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
+  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
+  // if we show the panel, ensure that filmstrip is visible
+  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
   return TRUE;
 }
 

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -316,7 +316,11 @@ void leave(dt_view_t *self)
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_toggle_filmstrip_visibility();
+  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
+  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
+  // if we show the panel, ensure that filmstrip is visible
+  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
   return TRUE;
 }
 

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -106,7 +106,11 @@ static void _view_capture_filmstrip_activate_callback(gpointer instance, gpointe
 static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  dt_lib_toggle_filmstrip_visibility();
+  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
+  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
+  // if we show the panel, ensure that filmstrip is visible
+  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
   return TRUE;
 }
 


### PR DESCRIPTION
This PR is intended to be merged to 'next' branch. It include following change/additions : 
### rework/enhance filmstrip hide/show : 
- save filmstrip/timeline state per view/layouts
- for all view except lighttable, show/hide filmstrip by toggling bottom panel visibility (bottom panel contains only filmstrip there). This avoid strange behavior when clicking on border button if filmstrip has been hidden (I've removed the routine in lib.c/h as this is as 2 lines code, and it's not universal)
- for all lighttable layouts except culling and preview : same as other views, but with timeline
- for lighttable culling and preview, it's a bit more tricky, as we can have both timeline and filmstrip. So consecutive CTRL-F show : filmstrip+timeline => timeline => bottom panel hidden => filmstrip => filmstrip+timeline
- due to this last change, rename lighttable CTRL-F shortcut to show that it act on filmstrip and timeline.
- fix some part of of code where timeline or filmstrip has been forgotten.

### rework filmstrip/timeline resizing : 
- refactor to use same routine as for left/right panels resizing
- this allow to set heights per view/layouts
- ensure that timeline and filmstrip keep same sizes when used together

### partially revert commit 048971a06f506639d2a0b2f4d7f11eb78dfbe0f4
- when restoring panels in "all collapsed" state, we want to keep old panel state values to recover them after exiting this state (by another TAB)
- with the commit, if you have all panels shown, you press TAB, exiting dt and relaunch, if you click another time on TAB, you don't recover your panels state...