### PR TITLE
update key bindings for preview for consistency

### DIFF
--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -164,7 +164,7 @@ int position()
 void init_key_accels(dt_lib_module_t *self)
 {
   dt_accel_register_lib(self, NC_("accel", "toggle live view"), GDK_KEY_v, 0);
-  dt_accel_register_lib(self, NC_("accel", "zoom live view"), GDK_KEY_z, 0);
+  dt_accel_register_lib(self, NC_("accel", "zoom live view"), GDK_KEY_w, 0);
   dt_accel_register_lib(self, NC_("accel", "rotate 90 degrees CCW"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "rotate 90 degrees CW"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "flip horizontally"), 0, 0);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3331,7 +3331,7 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "decrease brush opacity"), GDK_KEY_less, 0);
 
   // fullscreen view
-  dt_accel_register_view(self, NC_("accel", "full preview"), GDK_KEY_z, 0);
+  dt_accel_register_view(self, NC_("accel", "full preview"), GDK_KEY_w, 0);
 
   // undo/redo
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);


### PR DESCRIPTION
Key binding for preview in light table has been changed from "z" to "w". The corresponding key bindings in darkroom mode and live view mode should be changed too for a consistent user experience.