### PR TITLE
Improve navigation visibility

### DIFF
--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -209,7 +209,7 @@ static gboolean _lib_navigation_draw_callback(GtkWidget *widget, cairo_t *crf, g
     {
       // Add a dark overlay on the picture to make it fade
       cairo_rectangle(cr, 0, 0, wd, ht);
-      cairo_set_source_rgba(cr, 0, 0, 0, 0.33);
+      cairo_set_source_rgba(cr, 0, 0, 0, 0.5);
       cairo_fill(cr);
 
       float boxw = 1, boxh = 1;


### PR DESCRIPTION
Currently, the navigation's area of interest is not highlight enough. This PR makes the navigation overlay highlight the area of interest by increasing its opacity.

![darken_navigation_overlay](https://user-images.githubusercontent.com/13468636/71522426-ec37c380-28c4-11ea-997e-0f2bf125d3d0.png)
