### PR TITLE
Update bug report and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Bug Report
+about: Open a new bug report
 title: ''
 labels: ''
 assignees: ''
@@ -8,6 +8,7 @@ assignees: ''
 
 <!-- IMPORTANT
 Bug reports that do not make an effort to help the developers will be closed without notice.
+Make sure that this bug has not already been opened and/or closed by searching the issues on GitHub, as duplicate bug reports will be closed.
 A bug report simply stating that Darktable crashes is unhelpful, so please fill in most of the items below and provide detailed information.
 -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,8 @@ assignees: ''
 
 ---
 
-Bugs report just saying it crashes without filling most of the items
-below and making no effort to help developpers to reproduce will be
-closed without notice.
+Bug reports that do not make an effort to help the developers will be closed without notice.
+A bug report simply stating that Darktable crashes is unhelpful, so please fill in most of the items below and provide detailed information.
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -17,8 +16,8 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
 **Expected behavior**
@@ -28,16 +27,16 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Platform (please complete the following information):**
+ - Darktable Version [e.g. 2.6.0]
  - OS: [e.g. funtoo linux]
- - Version [e.g. 2.6.0]
  - OpenCL activated or no
- - which GFX-card and GFX-driver
+ - Which graphics card and driver version
 
 **Additional context**
 Add any other context about the problem here, for example:
- - Can you reproduce with another dt version?
+ - Can you reproduce with another Darktable version?
  - Can you reproduce with a RAW or Jpeg or both?
  - Are the steps above reproduce with a fresh edit (removing history)?
  - Attach an XMP if this is necessary
- - Is dt compiled by yourself? If so which compiler is used? Which options?
+ - Did you compile Darktable yourself? If so which compiler was used, with what options?
  - Is the issue still present using an empty/new config-dir

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,39 +4,48 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
+<!-- IMPORTANT
 Bug reports that do not make an effort to help the developers will be closed without notice.
 A bug report simply stating that Darktable crashes is unhelpful, so please fill in most of the items below and provide detailed information.
+-->
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
+
 
 **To Reproduce**
-Steps to reproduce the behavior:
+<!-- Provide detailed steps that can reproduce the behavior, such as:
 1. Go to '...'
 2. Click on '...'
 3. Scroll down to '...'
 4. See error
+-->
+
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
+
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
+
 
 **Platform (please complete the following information):**
- - Darktable Version [e.g. 2.6.0]
- - OS: [e.g. funtoo linux]
- - OpenCL activated or no
- - Which graphics card and driver version
+ - Darktable Version: <!-- [e.g. 2.6.0] -->
+ - OS: <!-- [e.g. Windows 8.1, Gentoo Linux] -->
+ - <!-- OpenCL activated or no? -->
+ - <!-- Which graphics card and driver version -->
+
 
 **Additional context**
-Add any other context about the problem here, for example:
+<!-- Add any other context about the problem here, for example:
  - Can you reproduce with another Darktable version?
  - Can you reproduce with a RAW or Jpeg or both?
  - Are the steps above reproduce with a fresh edit (removing history)?
  - Attach an XMP if this is necessary
  - Did you compile Darktable yourself? If so which compiler was used, with what options?
  - Is the issue still present using an empty/new config-dir
+-->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,23 @@
 ---
-name: Feature request
+name: Feature Request
 about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is, e.g. "I'm always frustrated when [...]" -->
+
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+
+**Alternatives**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->
+


### PR DESCRIPTION
I updated the GitHub templates for new bug report and feature requests.  
I moved descriptions into comments to make things easier and potentially keep them out of opened issues. I clarified and revised some wording for grammar and to make a little more sense to end-users who may not be versed in tech.