### PR TITLE
Updated export targets

### DIFF
--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -85,8 +85,7 @@
     </para></listitem>
 
     <listitem><para>
-      The powerful export system supports local disk storage, popular web albums (flickr,
-      Google Photos, Facebook webalbum, Piwigo), LaTeX book template,
+      darktable supports export of developer images to local disk storage, some web albums, LaTeX book template,
       email attachments and can generate a simple html-based web gallery. darktable allows
       you to export to low dynamic range (JPEG, JPEG2000, PNG, TIFF, PDF), 16-bit (PPM, TIFF),
       or linear high dynamic range (PFM, EXR) images.

--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -86,8 +86,8 @@
 
     <listitem><para>
       darktable can export developed images as low or high dynamic range files (JPEG, PNG, TIFF, 
-      PDF, PFM, EXR) to local disk storage, some web albums, LaTeX book template,
-      email attachments and can generate a simple html-based web gallery.
+      PDF, PFM, EXR) to local disk storage, web albums, LaTeX book template,
+      email attachments, and can generate a simple html-based web gallery.
     </para></listitem>
 
     <listitem><para>

--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -85,8 +85,9 @@
     </para></listitem>
 
     <listitem><para>
-      The powerful export system supports Google+ webalbum, flickr upload, disk storage, 1:1
-      copy, email attachments and can generate a simple html-based web gallery. darktable allows
+      The powerful export system supports local disk storage, popular web albums (flickr,
+      Google Photos, Facebook webalbum, Piwigo), LaTeX book template,
+      email attachments and can generate a simple html-based web gallery. darktable allows
       you to export to low dynamic range (JPEG, JPEG2000, PNG, TIFF, PDF), 16-bit (PPM, TIFF),
       or linear high dynamic range (PFM, EXR) images.
     </para></listitem>

--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -85,10 +85,9 @@
     </para></listitem>
 
     <listitem><para>
-      darktable supports export of developer images to local disk storage, some web albums, LaTeX book template,
-      email attachments and can generate a simple html-based web gallery. darktable allows
-      you to export to low dynamic range (JPEG, JPEG2000, PNG, TIFF, PDF), 16-bit (PPM, TIFF),
-      or linear high dynamic range (PFM, EXR) images.
+      darktable can export developed images as low or high dynamic range files (JPEG, PNG, TIFF, 
+      PDF, PFM, EXR) to local disk storage, some web albums, LaTeX book template,
+      email attachments and can generate a simple html-based web gallery.
     </para></listitem>
 
     <listitem><para>


### PR DESCRIPTION
Google+ is long gone, other web album platforms were missing as well as LaTex book, removed 1:1 copy