### PR TITLE
Added low dynamic range image format support

### DIFF
--- a/doc/usermanual/overview/overview.xml
+++ b/doc/usermanual/overview/overview.xml
@@ -71,8 +71,8 @@
     </para></listitem>
 
     <listitem><para>
-      Import a variety of standard, raw and high dynamic range image formats (e.g. JPEG, CR2,
-      DNG, OpenEXR, PFM, ...).
+      Import a variety of standard raw, low and high dynamic range image formats (e.g. CR2,
+      DNG, JPEG, OpenEXR, PFM).
     </para></listitem>
 
     <listitem><para>


### PR DESCRIPTION
Arguably, JPEG is neither raw nor HDR.
Reordered image format examples in line with the format group order and removed three dots at the end as those are only examples (no one expects an exhaustive list).