### PR TITLE
manual: update tag view resizing desc

### DIFF
--- a/doc/usermanual/lighttable/panels/tagging.xml
+++ b/doc/usermanual/lighttable/panels/tagging.xml
@@ -193,8 +193,8 @@
       </para>
 
       <para>
-        You can resize the height of attached view or dictionary view using Ctrl+wheel.
-        New sizes are kept for ulterior darktable sessions.
+        You can dynamically resize the height of attached tags and tag dictionary views using Ctrl+wheel. 
+        The updated view height is kept for new darktable sessions.
       </para>
 
     </sect4>

--- a/doc/usermanual/lighttable/panels/tagging.xml
+++ b/doc/usermanual/lighttable/panels/tagging.xml
@@ -193,8 +193,8 @@
       </para>
 
       <para>
-        You can dynamically resize the height of attached tags and tag dictionary views using Ctrl+wheel. 
-        The updated view height is kept for new darktable sessions.
+        You can adjust height of the attached tags and tag dictionary list views using Ctrl+wheel. 
+        The updated list view height is kept for new darktable sessions.
       </para>
 
     </sect4>


### PR DESCRIPTION
correct view names visible in tag overlay are "attached tags" and "tag dictionary"
"ulterior" was replaced with "new"