### PR TITLE
Include variables.h in iop/watermark.c

### DIFF
--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -18,6 +18,7 @@
 
 #include "bauhaus/bauhaus.h"
 #include "common/tags.h"
+#include "common/variables.h"
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop.h"


### PR DESCRIPTION
Without it, I am getting build failures for introspection_watermark.

fixes: #3932