### PR TITLE
fix strip_semicolons_from_keymap

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -175,8 +175,6 @@ static void strip_semicolons_from_keymap(const char *path)
   char pathtmp[PATH_MAX] = { 0 };
   FILE *fin = g_fopen(path, "rb");
   FILE *fout;
-  int i;
-  int c = '\0';
 
   if(!fin) return;
 
@@ -189,22 +187,30 @@ static void strip_semicolons_from_keymap(const char *path)
     return;
   }
 
+  int c = '\0';
   // First ignoring the first three lines
-  for(i = 0; i < 3; i++)
+  for(int i = 0; i < 3; i++)
   {
     while(c != '\n' && c != '\r' && c != EOF) c = fgetc(fin);
     while(c == '\n' || c == '\r') c = fgetc(fin);
+    ungetc(c, fin);
   }
 
   // Then ignore the first two characters of each line, copying the rest out
   while(c != EOF)
   {
     fseek(fin, 2, SEEK_CUR);
-    do
+    while(c != '\n' && c != '\r' && c != EOF)
     {
       c = fgetc(fin);
-      if(c != EOF) fputc(c, fout);
-    } while(c != '\n' && c != '\r' && c != EOF);
+      if(c != '\n' && c != '\r' && c != EOF) fputc(c, fout);
+    }
+    while(c == '\n' || c == '\r')
+    {
+      fputc(c, fout);
+      c = fgetc(fin);
+    }
+    ungetc(c, fin);
   }
 
   fclose(fin);


### PR DESCRIPTION
Fixes the following bug that has been introduced in commit 89be55654ac16dcd8215992034c9eb81f812364c: 

The function `strip_semicolons_from_keymap` removes not only the first three lines from the input file but also the 1st character of the 4th line. Consequently the file `keyboradrc_default` is corrupted and resetting keyboard accelerators to defaults does not work.

I am not sure if the whole treatment for possible line endings different from pure new-line (introduced in in commit 89be55654ac16dcd8215992034c9eb81f812364c) is meaningful. `gtk_accel_map_save` writes new-lines only, thus `gtk_accel_map_load` may not be able to understand new-line carriage-return line endings anyway.