### PR TITLE
Fix build on PPC and ARM (cpuid)

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -1,8 +1,13 @@
 include(CheckCSourceCompiles)
 include(TestBigEndian)
 include(CheckIncludeFile)
+include(CheckSymbolExists)
 
 check_include_file(cpuid.h HAVE_CPUID_H)
+
+if (HAVE_CPUID_H)
+    check_symbol_exists(__get_cpuid "cpuid.h" HAVE___GET_CPUID)
+endif()
 
 if (OpenMP_FOUND)
 

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -1,5 +1,8 @@
 include(CheckCSourceCompiles)
 include(TestBigEndian)
+include(CheckIncludeFile)
+
+check_include_file(cpuid.h HAVE_CPUID_H)
 
 if (OpenMP_FOUND)
 

--- a/src/common/cpuid.c
+++ b/src/common/cpuid.c
@@ -34,7 +34,7 @@
 #include <cpuid.h>
 #endif
 
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(HAVE___GET_GPUID)
 dt_cpu_flags_t dt_detect_cpu_features()
 {
   guint32 ax, bx, cx, dx;

--- a/src/common/cpuid.c
+++ b/src/common/cpuid.c
@@ -25,9 +25,9 @@
         Anders Kvist <akv@lnxbx.dk> and Klaus Post <klauspost@gmail.com>
  */
 
+#include "config.h"
 #include "cpuid.h"
 #include "common/darktable.h"
-#include "config.h"
 #include <glib.h>
 
 #ifdef HAVE_CPUID_H

--- a/src/common/cpuid.c
+++ b/src/common/cpuid.c
@@ -26,10 +26,13 @@
  */
 
 #include "cpuid.h"
-#include <cpuid.h>
 #include "common/darktable.h"
 #include "config.h"
 #include <glib.h>
+
+#ifdef HAVE_CPUID_H
+#include <cpuid.h>
+#endif
 
 #if defined(__i386__) || defined(__x86_64__)
 dt_cpu_flags_t dt_detect_cpu_features()

--- a/src/config.cmake.h
+++ b/src/config.cmake.h
@@ -66,6 +66,8 @@ static const char *dt_supported_extensions[] __attribute__((unused)) = {"@DT_SUP
 #define ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
 #endif
 
+#cmakedefine HAVE_CPUID_H 1
+
 #cmakedefine HAVE_OMP_FIRSTPRIVATE_WITH_CONST 1
 
 /******************************************************************************

--- a/src/config.cmake.h
+++ b/src/config.cmake.h
@@ -67,6 +67,7 @@ static const char *dt_supported_extensions[] __attribute__((unused)) = {"@DT_SUP
 #endif
 
 #cmakedefine HAVE_CPUID_H 1
+#cmakedefine HAVE___GET_CPUID 1
 
 #cmakedefine HAVE_OMP_FIRSTPRIVATE_WITH_CONST 1
 


### PR DESCRIPTION
This fixes building on ARM and PPC and detects support for `__get_cpuid()` correctly.