### PR TITLE
cmake: Only look for avif cmake configs and not find modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,7 +321,7 @@ if(USE_WEBP)
 endif(USE_WEBP)
 
 if (USE_AVIF)
-    find_package(libavif 0.5.2)
+    find_package(libavif 0.5.2 CONFIG)
     if (TARGET avif)
         list(APPEND LIBS avif)
         add_definitions(-DHAVE_LIBAVIF=1)


### PR DESCRIPTION
Should reduce output of cmake when not available.