### PR TITLE
darkroom : ensure we draw image at integer position

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -310,7 +310,7 @@ void expose(
     }
     cairo_paint(cr);
 
-    cairo_translate(cr, .5f * (width - wd), .5f * (height - ht));
+    cairo_translate(cr, ceilf(.5f * (width - wd)), ceilf(.5f * (height - ht)));
     if(closeup)
     {
       const double scale = 1<<closeup;
@@ -328,7 +328,11 @@ void expose(
 
     cairo_rectangle(cr, 0, 0, wd, ht);
     cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_BEST);
+    if(closeup)
+      cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+    else
+      cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_BEST);
+
     cairo_fill(cr);
 
     if(darktable.gui->show_focus_peaking)


### PR DESCRIPTION
this fix #3876

Now that we use CAIRO_FILTER_BEST, to draw image buffer, we need to be sure that we stay at an integral value for the initial drawing point, otherwise, that would trigger some time expensive cairo filtering.
I've fallen back to previous CAIRO_FILTER_FAST filter in case of closeup, as we have to scale the image in this case, and this will automatically trigger filtering...

@aurelienpierre : as it's your code, can you have a look, please ?