### PR TITLE
Fix compile error with gcc 7.4

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -375,9 +375,8 @@ static double _PQ_fct(double x)
 static double _HLG_fct(double x)
 {
   static const double Beta  = 0.04;
-  static const double A     = 0.17883277;
-  static const double RA    = 1.0 / A;
-  static const double B     = 1.0 - 4.0 * A;
+  static const double RA    = 5.591816309728916; // 1.0 / A where A = 0.17883277
+  static const double B     = 0.28466892; // 1.0 - 4.0 * A
   static const double C     = 0.5599107295; // 0,5 –aln(4a)
 
   double e = MAX(x * (1.0 - Beta) + Beta, 0.0);


### PR DESCRIPTION
Since in C a `static const` identifier is not considered a compile-time constant expression, gcc (at least 7.4 does) barks at using A when initializing RA and B:

    /home/matthias/dev/darktable/src/common/colorspaces.c: In function ‘_HLG_fct’:
    /home/matthias/dev/darktable/src/common/colorspaces.c:379:31: error: initializer element is not constant

This change replaces the expressions with explicit value assignments.