### PR TITLE
fix rating discard issue

### DIFF
--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -136,12 +136,15 @@ void dt_ratings_apply(const int imgid, const int rating, const gboolean toggle_o
 
     if(group_on) dt_grouping_add_grouped_images(&imgs);
     count = g_list_length(imgs);
-    if(new_rating == DT_VIEW_REJECT)
-      dt_control_log(ngettext("rejecting %d image", "rejecting %d images", count), count);
-    else
-      dt_control_log(ngettext("applying rating %d to %d image", "applying rating %d to %d images", count),
-                     new_rating, count);
-
+    if(count > 1)
+    {
+      if(new_rating == DT_VIEW_REJECT)
+        dt_control_log(ngettext("rejecting %d image", "rejecting %d images", count), count);
+      else
+        dt_control_log(ngettext("applying rating %d to %d image", "applying rating %d to %d images", count),
+                       new_rating, count);
+    }
+    
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
     _ratings_apply(imgs, new_rating, &undo, undo_on);
 


### PR DESCRIPTION
Should fix #3972 .
Note: on 3.0.0 the message was only displayed for selection. Now it's displayed both when hovering or for selection, which is more consistent.
Note2: Discard symbol is absent from the bottom view:
![image](https://user-images.githubusercontent.com/23012047/71676462-98bfec80-2d80-11ea-8316-b8222d1cc134.png)
Is that intentional ?

