### PR TITLE
remove refs to "panel_width" setting

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1427,15 +1427,6 @@ static void init_widgets(dt_gui_gtk_t *gui)
 
   configure_ppd_dpi(gui);
 
-  // set constant width from conf key
-  int panel_width = dt_conf_get_int("panel_width");
-  if(panel_width < 20 || panel_width > 1000)
-  {
-    // fix for unset/insane values.
-    panel_width = 300 * gui->dpi_factor;
-    dt_conf_set_int("panel_width", panel_width);
-  }
-
   gtk_window_set_default_size(GTK_WINDOW(widget), DT_PIXEL_APPLY_DPI(900), DT_PIXEL_APPLY_DPI(500));
 
   gtk_window_set_icon_name(GTK_WINDOW(widget), "darktable");

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -568,8 +568,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(self->widget), "scroll-event", G_CALLBACK(_lib_histogram_scroll_callback), self);
 
   /* set size of navigation draw area */
-  const int panel_width = dt_conf_get_int("panel_width");
-  gtk_widget_set_size_request(self->widget, -1, panel_width * 0.5f);
+  gtk_widget_set_size_request(self->widget, -1, 175);
 
   /* connect to preview pipe finished  signal */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,

--- a/src/libs/navigation.c
+++ b/src/libs/navigation.c
@@ -133,8 +133,7 @@ void gui_init(dt_lib_module_t *self)
                    G_CALLBACK(_lib_navigation_leave_notify_callback), self);
 
   /* set size of navigation draw area */
-  int panel_width = dt_conf_get_int("panel_width");
-  gtk_widget_set_size_request(self->widget, -1, panel_width * .5);
+  gtk_widget_set_size_request(self->widget, -1, 175);
   gtk_widget_set_name(GTK_WIDGET(self->widget), "navigation-module");
 
   /* connect a redraw callback to control draw all and preview pipe finish signals */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1928,8 +1928,7 @@ void gui_init(dt_view_t *self)
   gtk_widget_set_tooltip_text(dev->second_window.button, _("display a second darkroom image window"));
   dt_view_manager_view_toolbox_add(darktable.view_manager, dev->second_window.button, DT_VIEW_DARKROOM);
 
-  const int panel_width = dt_conf_get_int("panel_width");
-  const int dialog_width = panel_width > 350 ? panel_width : 350;
+  const int dialog_width = 350;
 
   /* Enable ISO 12646-compliant colour assessment conditions */
   dev->iso_12646.button

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -4881,10 +4881,9 @@ void gui_init(dt_view_t *self)
   dt_view_manager_module_toolbox_add(darktable.view_manager, profile_button, DT_VIEW_LIGHTTABLE);
 
   // and the popup window
-  const int panel_width = dt_conf_get_int("panel_width");
   lib->profile_floating_window = gtk_popover_new(profile_button);
 
-  gtk_widget_set_size_request(GTK_WIDGET(lib->profile_floating_window), panel_width, -1);
+  gtk_widget_set_size_request(GTK_WIDGET(lib->profile_floating_window), 350, -1);
 #if GTK_CHECK_VERSION(3, 16, 0)
   g_object_set(G_OBJECT(lib->profile_floating_window), "transitions-enabled", FALSE, NULL);
 #endif


### PR DESCRIPTION
there's no more setting like that, as panels are resizable...
What I've done : 
1. fix popup dialog that depends from panel_width to 350 (last value)
2. fix histogram and navigation height to 175 (1/2 of last value) libs height are not dependent from lib width anymore, but I find that more pleasant, otherwise, setting panel size to low or height values, result in unusable sizes (not to say that we keep some uniformity for left and right panels)

Note that I've used "raw" values, for sizes, like it was before, but I wonder if we should apply some dpi/ppd/... transformation here...