### PR TITLE
Prevented premature iteration of filenames

### DIFF
--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -250,7 +250,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
 
   /* verify that expanded path and filename yields a unique file */
   path = dt_import_session_path(self, TRUE);
-  gchar *result_fname = dt_variables_expand(self->vp, pattern, TRUE);
+  gchar *result_fname = dt_variables_expand(self->vp, pattern, FALSE);
   previous_fname = fname = g_build_path(G_DIR_SEPARATOR_S, path, result_fname, (char *)NULL);
   if(g_file_test(fname, G_FILE_TEST_EXISTS) == TRUE)
   {


### PR DESCRIPTION
This stops the filename generator from iterating on it's first attempt, which was stopping the grouping of RAW+JPG groups, fixing #3998.

However it will assume that the next file imported with a different file type should be grouped with the current file. This also starts the filenames at 0 instead of .

Ideally we would compare the actual filenames before import but there doesn't seem to be a way to access that information from import_session at the moment.