### PR TITLE
fix #3978: importing all duplicates in Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,9 @@ if(WIN32)
   list(APPEND SOURCE_FILES "win/dtwin.c")
   list(APPEND HEADER_FILES "win/dtwin.h")
 
+  list(APPEND SOURCE_FILES "win/filepath.c")
+  list(APPEND HEADER_FILES "win/filepath.h")
+
   # Use mingw's sprintf instead of windows's
   ADD_DEFINITIONS( -D__USE_MINGW_ANSI_STDIO=1 )
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -34,6 +34,7 @@
 #include "control/control.h"
 #include "control/jobs.h"
 #include "develop/lightroom.h"
+#include "win/filepath.h"
 #ifdef USE_LUA
 #include "lua/image.h"
 #endif
@@ -47,6 +48,7 @@
 #include <glob.h>
 #endif
 #include <glib/gstdio.h>
+
 
 static int64_t max_image_position()
 {
@@ -1005,38 +1007,7 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
       do
       {
         char *file = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-
-				// Windows only accepts generic wildcards for filename
-				// therefore we must filter out filenames that do not match the patterns
-				// valid filenames must have from 2 to 4 decimal digits between "-" and "."
-				// or no "_" for the primary version
-				bool valid_filename = true;
-
-				gchar *c4 = file + strlen(file);
-				while(*c4 != '.') c4--;
-				c4--;
-				while(*c4 != '.') c4--;
-				gchar *c3 = c4;
-				bool underscore_found = false; 
-				while(!underscore_found && c3 > file) 
-				{
-					c3--;
-					underscore_found = (*c3 == '_');
-				}
-				if (underscore_found)
-				{
-					c3++;
-					c4--;
-					valid_filename = (c3 != c4);
-			
-					while ((c3 <= c4) && valid_filename)
-					{
-						if (!( *c3 >= '0' && *c3 <= '9' )) valid_filename = false;
-						c3++;
-					}
-				
-				}
-				if (valid_filename) files = g_list_append(files, g_build_filename(imgpath, file, NULL));
+				if(win_valid_duplicate_filename(file)) files = g_list_append(files, g_build_filename(imgpath, file, NULL));
 				g_free(file);
       }
       while(FindNextFileW(handle, &data));

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -49,7 +49,6 @@
 #endif
 #include <glib/gstdio.h>
 
-
 static int64_t max_image_position()
 {
   sqlite3_stmt *stmt = NULL;
@@ -976,10 +975,9 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
   gchar pattern[PATH_MAX] = { 0 };
 
   // NULL terminated list of glob patterns; should include "" and can be extended if needed
-
 #ifdef _WIN32
-  static const gchar *glob_patterns[] // Windows only accepts generic wildcards for filename
-      = { "", "_????", NULL };
+  // Windows only accepts generic wildcards for filename
+  static const gchar *glob_patterns[] = { "", "_????", NULL };
 #else
   static const gchar *glob_patterns[]
       = { "", "_[0-9][0-9]", "_[0-9][0-9][0-9]", "_[0-9][0-9][0-9][0-9]", NULL };
@@ -1007,8 +1005,9 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
       do
       {
         char *file = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-				if(win_valid_duplicate_filename(file)) files = g_list_append(files, g_build_filename(imgpath, file, NULL));
-				g_free(file);
+        if(win_valid_duplicate_filename(file)) files = 
+          g_list_append(files, g_build_filename(imgpath, file, NULL));
+        g_free(file);
       }
       while(FindNextFileW(handle, &data));
     }
@@ -1518,7 +1517,7 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
         GFile *goldxmp = g_file_new_for_path(oldxmp);
         GFile *gnewxmp = g_file_new_for_path(newxmp);
 
-	g_file_move(goldxmp, gnewxmp, 0, NULL, NULL, NULL, NULL);
+  g_file_move(goldxmp, gnewxmp, 0, NULL, NULL, NULL, NULL);
 
         g_object_unref(goldxmp);
         g_object_unref(gnewxmp);
@@ -1556,32 +1555,32 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
         GFile *cnew = g_file_new_for_path(copydestpath);
 
         g_clear_error(&moveError);
-	moveStatus = g_file_move(cold, cnew, 0, NULL, NULL, NULL, &moveError);
+  moveStatus = g_file_move(cold, cnew, 0, NULL, NULL, NULL, &moveError);
         if(!moveStatus)
         {
           fprintf(stderr, "[dt_image_rename] error moving local copy `%s' -> `%s'\n", copysrcpath, copydestpath);
 
-	  if(g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+    if(g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
           {
-	    gchar *oldBasename = g_path_get_basename(copysrcpath);
-	    dt_control_log(_("cannot access local copy `%s'"), oldBasename);
-	    g_free(oldBasename);
+      gchar *oldBasename = g_path_get_basename(copysrcpath);
+      dt_control_log(_("cannot access local copy `%s'"), oldBasename);
+      g_free(oldBasename);
           }
           else if(g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_EXISTS) || g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_IS_DIRECTORY))
           {
-	    gchar *newBasename = g_path_get_basename(copydestpath);
-	    dt_control_log(_("cannot write local copy `%s'"), newBasename);
-	    g_free(newBasename);
-	  }
+      gchar *newBasename = g_path_get_basename(copydestpath);
+      dt_control_log(_("cannot write local copy `%s'"), newBasename);
+      g_free(newBasename);
+    }
           else
           {
-	    gchar *oldBasename = g_path_get_basename(copysrcpath);
-	    gchar *newBasename = g_path_get_basename(copydestpath);
-	    dt_control_log(_("error moving local copy `%s' -> `%s'"), oldBasename, newBasename);
-	    g_free(oldBasename);
-	    g_free(newBasename);
-	  }
-	}
+      gchar *oldBasename = g_path_get_basename(copysrcpath);
+      gchar *newBasename = g_path_get_basename(copydestpath);
+      dt_control_log(_("error moving local copy `%s' -> `%s'"), oldBasename, newBasename);
+      g_free(oldBasename);
+      g_free(newBasename);
+    }
+  }
 
         g_object_unref(cold);
         g_object_unref(cnew);
@@ -1593,7 +1592,7 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
     {
       if(g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
       {
-	dt_control_log(_("error moving `%s': file not found"), oldimg);
+  dt_control_log(_("error moving `%s': file not found"), oldimg);
       }
       // only display error message if newname is set (renaming and
       // not moving) as when moving it can be the case where a
@@ -1603,11 +1602,11 @@ int32_t dt_image_rename(const int32_t imgid, const int32_t filmid, const gchar *
               && (g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_EXISTS)
                   || g_error_matches(moveError, G_IO_ERROR, G_IO_ERROR_IS_DIRECTORY)))
       {
-	dt_control_log(_("error moving `%s' -> `%s': file exists"), oldimg, newimg);
+  dt_control_log(_("error moving `%s' -> `%s': file exists"), oldimg, newimg);
       }
       else if(newname)
       {
-	dt_control_log(_("error moving `%s' -> `%s'"), oldimg, newimg);
+  dt_control_log(_("error moving `%s' -> `%s'"), oldimg, newimg);
       }
     }
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -974,8 +974,14 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
   gchar pattern[PATH_MAX] = { 0 };
 
   // NULL terminated list of glob patterns; should include "" and can be extended if needed
+
+#ifdef _WIN32
+  static const gchar *glob_patterns[] // Windows only accepts generic wildcards for filename
+      = { "", "_????", NULL };
+#else
   static const gchar *glob_patterns[]
       = { "", "_[0-9][0-9]", "_[0-9][0-9][0-9]", "_[0-9][0-9][0-9][0-9]", NULL };
+#endif
 
   const gchar **glob_pattern = glob_patterns;
   GList *files = NULL;
@@ -999,8 +1005,39 @@ void dt_image_read_duplicates(const uint32_t id, const char *filename)
       do
       {
         char *file = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-        files = g_list_append(files, g_build_filename(imgpath, file, NULL));
-        g_free(file);
+
+				// Windows only accepts generic wildcards for filename
+				// therefore we must filter out filenames that do not match the patterns
+				// valid filenames must have from 2 to 4 decimal digits between "-" and "."
+				// or no "_" for the primary version
+				bool valid_filename = true;
+
+				gchar *c4 = file + strlen(file);
+				while(*c4 != '.') c4--;
+				c4--;
+				while(*c4 != '.') c4--;
+				gchar *c3 = c4;
+				bool underscore_found = false; 
+				while(!underscore_found && c3 > file) 
+				{
+					c3--;
+					underscore_found = (*c3 == '_');
+				}
+				if (underscore_found)
+				{
+					c3++;
+					c4--;
+					valid_filename = (c3 != c4);
+			
+					while ((c3 <= c4) && valid_filename)
+					{
+						if (!( *c3 >= '0' && *c3 <= '9' )) valid_filename = false;
+						c3++;
+					}
+				
+				}
+				if (valid_filename) files = g_list_append(files, g_build_filename(imgpath, file, NULL));
+				g_free(file);
       }
       while(FindNextFileW(handle, &data));
     }

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -34,6 +34,7 @@
 #include "common/undo.h"
 #include "control/conf.h"
 #include "develop/imageop_math.h"
+#include "win/filepath.h"
 
 #include "gui/gtk.h"
 
@@ -989,38 +990,7 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
           do
           {
             char *xmp_filename = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-						
-						// Windows only accepts generic wildcards for filename
-						// therefore we must filter out filenames that do not match the patterns
-						// valid filenames must have from 2 to 4 decimal digits between "-" and "."
-						// or no "_" for the primary version
-						bool valid_filename = true;
-
-						gchar *c4 = xmp_filename + strlen(xmp_filename);
-						while(*c4 != '.') c4--;
-						c4--;
-						while(*c4 != '.') c4--;
-						gchar *c3 = c4;
-						bool underscore_found = false; 
-						while(!underscore_found && c3 > xmp_filename) 
-						{
-							c3--;
-							underscore_found = (*c3 == '_');
-						}
-						if (underscore_found)
-						{
-							c3++;
-							c4--;
-							valid_filename = (c3 != c4);
-					
-							while ((c3 <= c4) && valid_filename)
-							{
-								if (!( *c3 >= '0' && *c3 <= '9' )) valid_filename = false;
-								c3++;
-							}
-						
-						}
-						if (valid_filename) files = g_list_append(files, g_build_filename(dirname, xmp_filename, NULL));
+						if (win_valid_duplicate_filename(xmp_filename)) files = g_list_append(files, g_build_filename(dirname, xmp_filename, NULL));
             g_free(xmp_filename);
           }
           while(FindNextFileW(handle, &data));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -960,8 +960,8 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
       // NULL terminated list of glob patterns; should include "" and can be extended if needed
 
 #ifdef _WIN32
-			static const gchar *glob_patterns[] // Windows only accepts generic wildcards for filename
-					= { "", "_????", NULL };
+      // Windows only accepts generic wildcards for filename
+			static const gchar *glob_patterns[]	= { "", "_????", NULL };
 #else
 			static const gchar *glob_patterns[]
 					= { "", "_[0-9][0-9]", "_[0-9][0-9][0-9]", "_[0-9][0-9][0-9][0-9]", NULL };
@@ -990,7 +990,8 @@ static int32_t dt_control_delete_images_job_run(dt_job_t *job)
           do
           {
             char *xmp_filename = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-						if (win_valid_duplicate_filename(xmp_filename)) files = g_list_append(files, g_build_filename(dirname, xmp_filename, NULL));
+						if (win_valid_duplicate_filename(xmp_filename)) 
+                files = g_list_append(files, g_build_filename(dirname, xmp_filename, NULL));
             g_free(xmp_filename);
           }
           while(FindNextFileW(handle, &data));

--- a/src/win/filepath.c
+++ b/src/win/filepath.c
@@ -1,8 +1,5 @@
 /*
     This file is part of darktable,
-    copyright (c) 2009--2012 johannes hanika.
-    copyright (c) 2010--2012 tobias ellinghaus.
-
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -19,13 +16,12 @@
 
 #include "dtwin.h"
 
-
 gboolean win_valid_duplicate_filename(const char *filename)
 {
   // Windows only accepts generic wildcards for filename search
   // therefore we must filter out invalid duplicate filenames
-  // valid filenames must have from 2 to 4 decimal digits between "-" and "."
-  // or no "_" for the primary version
+  // valid filenames must have from 2 to 4 decimal digits between 
+  // last "_" and second last "." (or no "_" for the primary version)
 
   gboolean valid_filename = TRUE;
 
@@ -55,7 +51,6 @@ gboolean win_valid_duplicate_filename(const char *filename)
   }
   return valid_filename;
 }
-
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/win/filepath.c
+++ b/src/win/filepath.c
@@ -1,0 +1,62 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2009--2012 johannes hanika.
+    copyright (c) 2010--2012 tobias ellinghaus.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dtwin.h"
+
+
+gboolean win_valid_duplicate_filename(const char *filename)
+{
+  // Windows only accepts generic wildcards for filename search
+  // therefore we must filter out invalid duplicate filenames
+  // valid filenames must have from 2 to 4 decimal digits between "-" and "."
+  // or no "_" for the primary version
+
+  gboolean valid_filename = TRUE;
+
+  const gchar *c4 = filename + strlen(filename);
+  while(*c4 != '.') c4--;
+  c4--;
+  while(*c4 != '.') c4--;
+  const gchar *c3 = c4;
+  gboolean underscore_found = FALSE; 
+  while(!underscore_found && c3 > filename) 
+  {
+    c3--;
+    underscore_found = (*c3 == '_');
+  }
+  if(underscore_found)
+  {
+    c3++;
+    c4--;
+    valid_filename = (c3 != c4);
+
+    while((c3 <= c4) && valid_filename)
+    {
+      if(!( *c3 >= '0' && *c3 <= '9' )) valid_filename = FALSE;
+      c3++;
+    }
+  
+  }
+  return valid_filename;
+}
+
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/win/filepath.h
+++ b/src/win/filepath.h
@@ -1,0 +1,28 @@
+/*
+    This file is part of darktable,
+    copyright (c) 2009--2012 johannes hanika.
+    copyright (c) 2010--2012 tobias ellinghaus.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+
+gboolean win_valid_duplicate_filename(const char *filename);
+
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/win/filepath.h
+++ b/src/win/filepath.h
@@ -1,8 +1,5 @@
 /*
     This file is part of darktable,
-    copyright (c) 2009--2012 johannes hanika.
-    copyright (c) 2010--2012 tobias ellinghaus.
-
     darktable is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
Fix for #3978 
Also fixed a related bug, leaving .xmp files behind when trashing images