### PR TITLE
fix #3780 live samples position

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -495,6 +495,7 @@ void expose(
         cairo_rectangle(cri, box[0] * wd + 1.0 / zoom_scale, box[1] * ht,
                         (box[2] - box[0]) * wd - 3. / zoom_scale, (box[3] - box[1]) * ht - 2. / zoom_scale);
         cairo_stroke(cri);
+        cairo_translate(cri, -1.0 / zoom_scale, -1.0 / zoom_scale); // revert the translation for next sample
       }
       else
       {


### PR DESCRIPTION
Fixing "UI: color picker sample areas positions displayed incorrectly" #3780 
There was a cairo translation (used to reinforce the line width, I guess) that was not reverted and was accumulating across live samples, producing a progressive shift