### PR TITLE
Fake support for dual pixel dng files; fixes #4006

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1410,6 +1410,7 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[3] = NAN;
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
+  img->pixel_rawplanes = 1;
   img->cache_entry = 0;
 }
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -206,6 +206,10 @@ typedef struct dt_image_t
 
   /* DefaultUserCrop */
   float usercrop[4];
+
+  /* number of complete data planes as used by dual-pixel images and the size of one plane*/
+  uint32_t pixel_rawplanes;
+
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -240,14 +240,16 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
 
     const int cpp = r->getCpp();
 
-    // checking for corrupted info supports cpp to be either 1 or 2
+    // checking for corrupted info supports cpp to be either 1 or 2 for TYPE_USHORT16
+    // for TYPE_FLOAT32 only cpp==1 is accepted
     if((r->getDataType() != TYPE_USHORT16) && (r->getDataType() != TYPE_FLOAT32)) return DT_IMAGEIO_FILE_CORRUPTED;
 
-    if(((r->getBpp() / cpp) != sizeof(uint16_t)) && (r->getBpp() != sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
+    if((r->getBpp() != cpp * sizeof(uint16_t)) && (r->getBpp() != cpp * sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
 
-    if((r->getDataType() == TYPE_USHORT16) && ((r->getBpp() / cpp) != sizeof(uint16_t))) return DT_IMAGEIO_FILE_CORRUPTED;
+    if((r->getDataType() == TYPE_USHORT16) && (r->getBpp() != cpp * sizeof(uint16_t))) return DT_IMAGEIO_FILE_CORRUPTED;
 
-    if((r->getDataType() == TYPE_FLOAT32) && (r->getBpp() != sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
+    // this also assures cpp==1
+    if((r->getDataType() == TYPE_FLOAT32)  && (r->getBpp() != sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
 
     if((cpp < 1) || (cpp>2)) return DT_IMAGEIO_FILE_CORRUPTED;
 
@@ -369,6 +371,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
       }
       else
       { 
+        // This code should never be reached because of a test above
         fprintf(stderr,"\n[rawspeed] (%s) has unsupported dual pixel FLOAT",img->filename);
         return DT_IMAGEIO_FILE_CORRUPTED;
       }

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -237,6 +237,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
       dt_imageio_retval_t ret = dt_imageio_open_rawspeed_sraw(img, r, mbuf);
       return ret;
     }
+
     const int cpp = r->getCpp();
 
     // checking for corrupted info supports cpp to be either 1 or 2
@@ -363,7 +364,7 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
           const uint16_t *in = (uint16_t *) r->getDataUncropped(0, j);
           uint16_t *out = ((uint16_t *)buf) + (size_t) j * img->width;
           for(int i = 0; i < img->width; i++)
-            out[i] = (in[i*2] + in[i*2+1]) / 2;
+            out[i] = in[i*2];
         }
       }
       else

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -237,21 +237,22 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
       dt_imageio_retval_t ret = dt_imageio_open_rawspeed_sraw(img, r, mbuf);
       return ret;
     }
+    const int cpp = r->getCpp();
 
+    // checking for corrupted info supports cpp to be either 1 or 2
     if((r->getDataType() != TYPE_USHORT16) && (r->getDataType() != TYPE_FLOAT32)) return DT_IMAGEIO_FILE_CORRUPTED;
 
-    if((r->getBpp() != sizeof(uint16_t)) && (r->getBpp() != sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
+    if(((r->getBpp() / cpp) != sizeof(uint16_t)) && (r->getBpp() != sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
 
-    if((r->getDataType() == TYPE_USHORT16) && (r->getBpp() != sizeof(uint16_t))) return DT_IMAGEIO_FILE_CORRUPTED;
+    if((r->getDataType() == TYPE_USHORT16) && ((r->getBpp() / cpp) != sizeof(uint16_t))) return DT_IMAGEIO_FILE_CORRUPTED;
 
     if((r->getDataType() == TYPE_FLOAT32) && (r->getBpp() != sizeof(float))) return DT_IMAGEIO_FILE_CORRUPTED;
 
-    const float cpp = r->getCpp();
-    if(cpp != 1) return DT_IMAGEIO_FILE_CORRUPTED;
+    if((cpp < 1) || (cpp>2)) return DT_IMAGEIO_FILE_CORRUPTED;
 
     img->buf_dsc.channels = 1;
 
-    switch(r->getBpp())
+    switch(r->getBpp() / cpp)
     {
       case sizeof(uint16_t):
         img->buf_dsc.datatype = TYPE_UINT16;
@@ -333,16 +334,43 @@ dt_imageio_retval_t dt_imageio_open_rawspeed(dt_image_t *img, const char *filena
      * (from Klaus: r->pitch may differ from DT pitch (line to line spacing))
      * else fallback to generic dt_imageio_flip_buffers()
      */
-    const size_t bufSize_mipmap = (size_t)img->width * img->height * r->getBpp();
-    const size_t bufSize_rawspeed = (size_t)r->pitch * dimUncropped.y;
-    if(bufSize_mipmap == bufSize_rawspeed)
+
+    /*
+      For dual pixels we can't just copy or use the flip as data are interwoven.
+      Here we use the medium of both sub-pixels, not worth to use _OPENMP.
+      As there are no dual-float-pixel images we have them disabled.
+    */
+    if (cpp == 1)
     {
-      memcpy(buf, r->getDataUncropped(0, 0), bufSize_mipmap);
+      const size_t bufSize_mipmap = (size_t)img->width * img->height * r->getBpp();
+      const size_t bufSize_rawspeed = (size_t)r->pitch * dimUncropped.y;
+      if(bufSize_mipmap == bufSize_rawspeed)
+      {
+        memcpy(buf, r->getDataUncropped(0, 0), bufSize_mipmap);
+      }
+      else
+      {
+        dt_imageio_flip_buffers((char *)buf, (char *)r->getDataUncropped(0, 0), r->getBpp(), dimUncropped.x,
+                                dimUncropped.y, dimUncropped.x, dimUncropped.y, r->pitch, ORIENTATION_NONE);
+      }
     }
     else
     {
-      dt_imageio_flip_buffers((char *)buf, (char *)r->getDataUncropped(0, 0), r->getBpp(), dimUncropped.x,
-                              dimUncropped.y, dimUncropped.x, dimUncropped.y, r->pitch, ORIENTATION_NONE);
+      if(img->buf_dsc.datatype == TYPE_UINT16)
+      {
+        for(int j = 0; j < img->height; j++)
+        {
+          const uint16_t *in = (uint16_t *) r->getDataUncropped(0, j);
+          uint16_t *out = ((uint16_t *)buf) + (size_t) j * img->width;
+          for(int i = 0; i < img->width; i++)
+            out[i] = (in[i*2] + in[i*2+1]) / 2;
+        }
+      }
+      else
+      { 
+        fprintf(stderr,"\n[rawspeed] (%s) has unsupported dual pixel FLOAT",img->filename);
+        return DT_IMAGEIO_FILE_CORRUPTED;
+      }
     }
   }
   catch(const std::exception &exc)

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -257,7 +257,11 @@ void *dt_mipmap_cache_alloc(dt_mipmap_buffer_t *buf, const dt_image_t *img)
   const int ht = img->height;
 
   const size_t bpp = dt_iop_buffer_dsc_to_bpp(&img->buf_dsc);
-  const size_t buffer_size = (size_t)wd * ht * bpp + sizeof(*dsc);
+  // the standard size of the buffer is for one plane, this is used by rawprepare
+  size_t buffer_size = (size_t) dt_round_size_sse(wd * ht * bpp) + sizeof(*dsc);
+  // if there are more planes like for dual pixel images we allocate room for each plane to allow later preprocessing
+  if (bpp!=1)
+    buffer_size += (size_t) dt_round_size_sse(wd * ht * bpp) * (img->pixel_rawplanes+1);
 
   // buf might have been alloc'ed before,
   // so only check size and re-alloc if necessary:

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2542,6 +2542,9 @@ void enter(dt_view_t *self)
 
   dt_dev_load_image(darktable.develop, dev->image_storage.id);
 
+  // print a warning as long as we don't have proper dual pixel support in one of the modules
+  if (dev->image_storage.pixel_rawplanes > 1)
+    dt_control_log(_("`%s' is a dual pixel raw. No advanced processing implemented yet"),dev->image_storage.filename);
 
   /*
    * add IOP modules to plugin list


### PR DESCRIPTION
This pr handles the dt side of dual pixel raw files, besides this there are
two wrong checks in rawspeed code. One has already been fixed by @LebedevRI
in the develop branch, the second fix has been suggested.

Fixing issue #4006 