### PR TITLE
histogram: panel resize fix

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -80,7 +80,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dt_pthread_mutex_init(&dev->pipe_mutex, NULL);
   dt_pthread_mutex_init(&dev->preview_pipe_mutex, NULL);
   dt_pthread_mutex_init(&dev->preview2_pipe_mutex, NULL);
-  //   dt_pthread_mutex_init(&dev->histogram_waveform_mutex, NULL);
   dev->histogram = NULL;
   dev->histogram_pre_tonecurve = NULL;
   dev->histogram_pre_levels = NULL;
@@ -153,7 +152,6 @@ void dt_dev_cleanup(dt_develop_t *dev)
   dt_pthread_mutex_destroy(&dev->pipe_mutex);
   dt_pthread_mutex_destroy(&dev->preview_pipe_mutex);
   dt_pthread_mutex_destroy(&dev->preview2_pipe_mutex);
-  //   dt_pthread_mutex_destroy(&dev->histogram_waveform_mutex);
   if(dev->pipe)
   {
     dt_dev_pixelpipe_cleanup(dev->pipe);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -180,11 +180,9 @@ typedef struct dt_develop_t
   // histogram for display.
   uint32_t *histogram, *histogram_pre_tonecurve, *histogram_pre_levels;
   uint32_t histogram_max, histogram_pre_tonecurve_max, histogram_pre_levels_max;
+  // we should process the waveform histogram in the correct size to make it not look like crap
   uint32_t *histogram_waveform, histogram_waveform_width, histogram_waveform_height,
       histogram_waveform_stride;
-  // we should process the waveform histogram in the correct size to make it not look like crap. since this
-  // requires gui knowledge we need this mutex
-  //   dt_pthread_mutex_t histogram_waveform_mutex;
   dt_dev_histogram_type_t histogram_type;
 
   // list of forms iop can use for masks or whatever

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2540,12 +2540,10 @@ post_process_collect_info:
       // size (thus the weird gui stuff :().
       // this HAS to be done on the float input data, otherwise we get really ugly artifacts due to rounding
       // issues when putting colors into the bins.
-      //       dt_pthread_mutex_lock(&dev->histogram_waveform_mutex);
       if(dev->histogram_waveform_width != 0 && input && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
       {
         _pixelpipe_final_histogram_waveform(dev, (const float *const )input, &roi_in);
       }
-      //       dt_pthread_mutex_unlock(&dev->histogram_waveform_mutex);
 
       dt_pthread_mutex_unlock(&pipe->busy_mutex);
     }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -193,10 +193,7 @@ static gboolean _lib_histogram_configure_callback(GtkWidget *widget, GdkEventCon
     // reprocess the preview pipe if necessary
     if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
     {
-      dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
-      dev->preview_pipe->cache_obsolete = 1;
-      // FIXME; need this? only need to redraw center?
-      dt_control_queue_redraw();
+      dt_dev_process_preview(dev);
     }
   }
   oldw = event->width;
@@ -455,9 +452,7 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
       // we need to reprocess the preview pipe
       if(darktable.develop->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
       {
-        darktable.develop->preview_status = DT_DEV_PIXELPIPE_DIRTY;
-        darktable.develop->preview_pipe->cache_obsolete = 1;
-        dt_control_queue_redraw();
+        dt_dev_process_preview(darktable.develop);
       }
     }
     else if(d->highlight == 4) // red button


### PR DESCRIPTION
The buffer holding the waveform histogram needs to be re-allocated now that the right panel can resize (since #3726). Also, the buttons on the histogram need to be repositioned depending on panel width.

Without this PR, darkroom view will crash if you perform the following steps:

1. set histogram mode to waveform
2. resize the right panel

I wonder if this PR could be written better. It's a quick fix. Is it necessary to recalculate the preview to generate a new histogram on every resize of the right panel in waveform mode? Would it be better to just resize the waveform histogram data itself, and lazily/later recalculate the preview?

Also, would it be better to make the buttons on the histogram not depend on the widget width, but simply be right justified?