### PR TITLE
Only show "flip guides" dropdown for asymmetrical guides

### DIFF
--- a/src/gui/guides.c
+++ b/src/gui/guides.c
@@ -453,7 +453,8 @@ static GtkWidget *_guides_gui_golden_mean(dt_iop_module_t *self, void *user_data
 static void _guides_add_guide(GList **list, const char *name,
                               dt_guides_draw_callback draw,
                               dt_guides_widget_callback widget,
-                              void *user_data, GDestroyNotify free)
+                              void *user_data, GDestroyNotify free,
+                              gboolean support_flip)
 {
   dt_guides_t *guide = (dt_guides_t *)malloc(sizeof(dt_guides_t));
   g_strlcpy(guide->name, name, sizeof(guide->name));
@@ -461,12 +462,13 @@ static void _guides_add_guide(GList **list, const char *name,
   guide->widget = widget;
   guide->user_data = user_data;
   guide->free = free;
+  guide->support_flip = support_flip;
   *list = g_list_append(*list, guide);
 }
 
 void dt_guides_add_guide(const char *name, dt_guides_draw_callback draw, dt_guides_widget_callback widget, void *user_data, GDestroyNotify free)
 {
-  _guides_add_guide(&darktable.guides, name, draw, widget, user_data, free);
+  _guides_add_guide(&darktable.guides, name, draw, widget, user_data, free, TRUE);
 }
 
 GList *dt_guides_init()
@@ -478,17 +480,17 @@ GList *dt_guides_init()
     user_data->horizontal = dt_conf_key_exists("plugins/darkroom/clipping/grid_horizontal") ? dt_conf_get_int("plugins/darkroom/clipping/grid_horizontal") : 3;
     user_data->vertical = dt_conf_key_exists("plugins/darkroom/clipping/grid_vertical") ? dt_conf_get_int("plugins/darkroom/clipping/grid_vertical") : 3;
     user_data->subdiv = dt_conf_key_exists("plugins/darkroom/clipping/grid_subdiv") ? dt_conf_get_int("plugins/darkroom/clipping/grid_subdiv") : 3;
-    _guides_add_guide(&guides, _("grid"), _guides_draw_grid, _guides_gui_grid, user_data, free);
+    _guides_add_guide(&guides, _("grid"), _guides_draw_grid, _guides_gui_grid, user_data, free, FALSE);
   }
-  _guides_add_guide(&guides, _("rules of thirds"), _guides_draw_rules_of_thirds, NULL, NULL, NULL);
-  _guides_add_guide(&guides, _("metering"), _guides_draw_metering, NULL, NULL, NULL);
-  _guides_add_guide(&guides, _("perspective"), _guides_draw_perspective, NULL, NULL, NULL); // TODO: make the number of lines configurable with a slider?
-  _guides_add_guide(&guides, _("diagonal method"), _guides_draw_diagonal_method, NULL, NULL, NULL);
-  _guides_add_guide(&guides, _("harmonious triangles"), _guides_draw_harmonious_triangles, NULL, NULL, NULL);
+  _guides_add_guide(&guides, _("rules of thirds"), _guides_draw_rules_of_thirds, NULL, NULL, NULL, FALSE);
+  _guides_add_guide(&guides, _("metering"), _guides_draw_metering, NULL, NULL, NULL, FALSE);
+  _guides_add_guide(&guides, _("perspective"), _guides_draw_perspective, NULL, NULL, NULL, FALSE); // TODO: make the number of lines configurable with a slider?
+  _guides_add_guide(&guides, _("diagonal method"), _guides_draw_diagonal_method, NULL, NULL, NULL, FALSE);
+  _guides_add_guide(&guides, _("harmonious triangles"), _guides_draw_harmonious_triangles, NULL, NULL, NULL, TRUE);
   {
     _golden_mean_t *user_data = (_golden_mean_t *)malloc(sizeof(_golden_mean_t));
     _golden_mean_set_data(user_data, dt_conf_get_int("plugins/darkroom/clipping/golden_extras"));
-    _guides_add_guide(&guides, _("golden mean"), _guides_draw_golden_mean, _guides_gui_golden_mean, user_data, free);
+    _guides_add_guide(&guides, _("golden mean"), _guides_draw_golden_mean, _guides_gui_golden_mean, user_data, free, TRUE);
   }
 
   return guides;

--- a/src/gui/guides.h
+++ b/src/gui/guides.h
@@ -33,6 +33,7 @@ typedef struct dt_guides_t
   dt_guides_widget_callback widget;
   void *user_data;
   GDestroyNotify free;
+  gboolean support_flip;
 } dt_guides_t;
 
 GList *dt_guides_init();

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1913,14 +1913,12 @@ static void aspect_flip(GtkWidget *button, dt_iop_module_t *self)
 // TODO once we depend on GTK3 >= 3.12 use the name as in 2f491cf8355a81554b98de538fe862d6ad9b62e5
 static void guides_presets_set_visibility(dt_iop_clipping_gui_data_t *g, int which)
 {
-  if(which == 0)
-  {
     gtk_widget_set_no_show_all(g->guides_widgets, TRUE);
     gtk_widget_hide(g->guides_widgets);
     gtk_widget_set_no_show_all(g->flip_guides, TRUE);
     gtk_widget_hide(g->flip_guides);
-  }
-  else
+
+  if(which != 0)
   {
     GtkWidget *widget = g_list_nth_data(g->guides_widgets_list, which - 1);
     if(widget)
@@ -1929,16 +1927,13 @@ static void guides_presets_set_visibility(dt_iop_clipping_gui_data_t *g, int whi
       gtk_widget_show_all(g->guides_widgets);
       gtk_stack_set_visible_child(GTK_STACK(g->guides_widgets), widget);
     }
-    else
-    {
-      gtk_widget_set_no_show_all(g->guides_widgets, TRUE);
-      gtk_widget_hide(g->guides_widgets);
-    }
-    gtk_widget_set_no_show_all(g->flip_guides, FALSE);
-    gtk_widget_show_all(g->flip_guides);
-  }
 
-  // TODO: add a support_flip flag to guides to hide the flip gui?
+    if(((dt_guides_t *)g_list_nth_data(darktable.guides, which - 1))->support_flip)
+    {
+      gtk_widget_set_no_show_all(g->flip_guides, FALSE);
+      gtk_widget_show_all(g->flip_guides);
+    }
+  }
 }
 
 static void guides_presets_changed(GtkWidget *combo, dt_iop_module_t *self)


### PR DESCRIPTION
In the crop & rotate module, when selecting to show guidelines, there always appears a dropdown to allow to flip horizontally or vertically. This is not useful for symmetrical guides, like grid, but it does add another widget to an already crowded module.

This change allows guideline definitions to specify if a "flip" dropdown should be shown.

For now, this doesn't change the lua interface; a flip dropdown will still always be shown for those.