### PR TITLE
imageio: Fix a compiler warning

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -177,7 +177,7 @@ int write_image(struct dt_imageio_module_data_t *data,
 {
   dt_imageio_avif_t *d = (dt_imageio_avif_t *)data;
 
-  avifPixelFormat format;
+  avifPixelFormat format = AVIF_PIXEL_FORMAT_NONE;
   avifImage *image = NULL;
   avifEncoder *encoder = NULL;
   uint8_t *icc_profile_data = NULL;


### PR DESCRIPTION
src/imageio/format/avif.c:207:11: error: ‘format’ may be used
    uninitialized in this function [-Werror=maybe-uninitialized]

Fixes #4052