### PR TITLE
Save/restore collect module height

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -464,6 +464,7 @@ static gboolean view_onMouseScroll(GtkWidget *treeview, GdkEventScroll *event, d
     height = height + increment*event->delta_y;
     height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
     gtk_widget_set_size_request(GTK_WIDGET(d->scrolledwindow), -1, height);
+    dt_conf_set_int("plugins/lighttable/collect/windowheight", height);
 
     return TRUE;
   }
@@ -2075,7 +2076,9 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
   d->scrolledwindow = GTK_SCROLLED_WINDOW(sw);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(d->scrolledwindow), DT_PIXEL_APPLY_DPI(300));
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), DT_PIXEL_APPLY_DPI(200));
+  gint height = dt_conf_get_int("plugins/lighttable/collect/windowheight");
+  gtk_widget_set_size_request(sw, -1, DT_PIXEL_APPLY_DPI(height));
   GtkTreeView *view = GTK_TREE_VIEW(gtk_tree_view_new());
   d->view_rule = -1;
   d->view = view;


### PR DESCRIPTION
Follow-up for #4046, the height of the collect window is now saved in darktablerc and restored on restart.