### PR TITLE
histogram: waveform banding fix

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -114,11 +114,17 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_pre_tonecurve_max = -1;
     dev->histogram_pre_levels_max = -1;
 
-    // _init_f() of mosaiced image may be twice the dimensions of DT_MIPMAP_F
-    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] * 2;
-    // really needs to be the height of the histogram widget in device
-    // pixels (currently either 175 or 350)
-    dev->histogram_waveform_height = darktable.mipmap_cache->max_height[DT_MIPMAP_F];
+    // mosaiced image may be twice the dimensions of DT_MIPMAP_F but
+    // half width still gives sufficient data and is reasonably fast
+    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] / 2;
+    //  GUI-indepdent way
+    //dev->histogram_waveform_height = darktable.mipmap_cache->max_height[DT_MIPMAP_F] / 2;  // 225 px
+    // height of the histogram widget in device pixels (gui-dependent hack)
+    //dev->histogram_waveform_height = 175 * darktable.gui->ppd;
+    // this is sufficient visual information though the waveform
+    // widget will probably be either 175 or 350 pixels high depending
+    // on hidpi
+    dev->histogram_waveform_height = 128;
     dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
     dev->histogram_waveform = (uint32_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -113,6 +113,14 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_max = -1;
     dev->histogram_pre_tonecurve_max = -1;
     dev->histogram_pre_levels_max = -1;
+
+    // _init_f() of mosaiced image may be twice the dimensions of DT_MIPMAP_F
+    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] * 2;
+    // really needs to be the height of the histogram widget in device
+    // pixels (currently either 175 or 350)
+    dev->histogram_waveform_height = darktable.mipmap_cache->max_height[DT_MIPMAP_F];
+    dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
+    dev->histogram_waveform = (uint32_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }
 
   dev->iop_instance = 0;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -117,16 +117,12 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     // mosaiced image may be twice the dimensions of DT_MIPMAP_F but
     // half width still gives sufficient data and is reasonably fast
     dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] / 2;
-    //  GUI-indepdent way
-    //dev->histogram_waveform_height = darktable.mipmap_cache->max_height[DT_MIPMAP_F] / 2;  // 225 px
-    // height of the histogram widget in device pixels (gui-dependent hack)
-    //dev->histogram_waveform_height = 175 * darktable.gui->ppd;
     // this is sufficient visual information though the waveform
     // widget will probably be either 175 or 350 pixels high depending
     // on hidpi
     dev->histogram_waveform_height = 128;
     dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
-    dev->histogram_waveform = (uint32_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
+    dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }
 
   dev->iop_instance = 0;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -205,6 +205,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
   free(dev->histogram);
   free(dev->histogram_pre_tonecurve);
   free(dev->histogram_pre_levels);
+  free(dev->histogram_waveform);
 
   g_list_free_full(dev->forms, (void (*)(void *))dt_masks_free_form);
   g_list_free_full(dev->allforms, (void (*)(void *))dt_masks_free_form);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -180,6 +180,7 @@ typedef struct dt_develop_t
   // histogram for display.
   uint32_t *histogram, *histogram_pre_tonecurve, *histogram_pre_levels;
   uint32_t histogram_max, histogram_pre_tonecurve_max, histogram_pre_levels_max;
+  // FIXME: no longer true if Cairo is rescaling it
   // we should process the waveform histogram in the correct size to make it not look like crap
   uint32_t *histogram_waveform, histogram_waveform_width, histogram_waveform_height,
       histogram_waveform_stride;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -180,10 +180,8 @@ typedef struct dt_develop_t
   // histogram for display.
   uint32_t *histogram, *histogram_pre_tonecurve, *histogram_pre_levels;
   uint32_t histogram_max, histogram_pre_tonecurve_max, histogram_pre_levels_max;
-  // FIXME: no longer true if Cairo is rescaling it
-  // we should process the waveform histogram in the correct size to make it not look like crap
-  uint32_t *histogram_waveform, histogram_waveform_width, histogram_waveform_height,
-      histogram_waveform_stride;
+  uint8_t *histogram_waveform;
+  uint32_t histogram_waveform_width, histogram_waveform_height, histogram_waveform_stride;
   dt_dev_histogram_type_t histogram_type;
 
   // list of forms iop can use for masks or whatever

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2535,10 +2535,9 @@ post_process_collect_info:
       else
         _pixelpipe_final_histogram(dev, (const float *const)input, &roi_in);
 
-      // calculate the waveform histogram. since this is drawn pixel by pixel we have to do it in the correct
-      // size (thus the weird gui stuff :().
       // this HAS to be done on the float input data, otherwise we get really ugly artifacts due to rounding
       // issues when putting colors into the bins.
+      // FIXME: is above comment true now that waveform is scaled via Cairo?
       if(dev->histogram_waveform_width != 0 && input && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
       {
         _pixelpipe_final_histogram_waveform(dev, (const float *const )input, &roi_in);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1000,7 +1000,7 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   // Use integral sized bins for columns, as otherwise they will be
   // unequal and have banding. Rely on GUI to smoothly do horizontal
   // scaling.
-  const int bin_width = ceilf((float)(roi_in->width) / (float)dev->histogram_waveform_width);
+  const int bin_width = ceilf((float)(roi_in->width) / (float)(dev->histogram_waveform_stride/4));
   dev->histogram_waveform_width = roi_in->width / bin_width;
 
   uint16_t *buf = (uint16_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_width * 3,
@@ -2541,7 +2541,7 @@ post_process_collect_info:
       // this HAS to be done on the float input data, otherwise we get really ugly artifacts due to rounding
       // issues when putting colors into the bins.
       // FIXME: is above comment true now that waveform is scaled via Cairo?
-      if(dev->histogram_waveform_width != 0 && input && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+      if(input && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
       {
         _pixelpipe_final_histogram_waveform(dev, (const float *const )input, &roi_in);
       }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -997,40 +997,30 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   dt_times_t start_time = { 0 };
   if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
 
+  dev->histogram_waveform_width = roi_in->width;
   uint32_t *buf = (uint32_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_width * 3,
                                      sizeof(uint32_t));
-  uint8_t *weight = (uint8_t *)calloc(dev->histogram_waveform_width, sizeof(uint8_t));
   memset(dev->histogram_waveform, 0,
          sizeof(uint32_t) * dev->histogram_waveform_height * dev->histogram_waveform_stride / 4);
 
   // 1.0 is at 8/9 of the height!
-  const double bin_width = (double)(roi_in->width) / (double)dev->histogram_waveform_width,
-               _height = (double)(dev->histogram_waveform_height - 1);
+  const double _height = (double)(dev->histogram_waveform_height - 1);
   const float *const pixel = (const float *const )input;
   //         uint32_t mincol[3] = {UINT32_MAX,UINT32_MAX,UINT32_MAX}, maxcol[3] = {0,0,0};
 
-  // count # of horizontal pixels in bin to eliminate banding
-  for(int x = 0; x < roi_in->width; x++)
-  {
-    const int out_x = MIN(x / bin_width, dev->histogram_waveform_width - 1);
-    weight[out_x]++;
-  }
 
   // count the colors into buf ...
   for(int y = 0; y < roi_in->height; y++)
   {
     for(int x = 0; x < roi_in->width; x++)
     {
-      float rgb[3];
-      for(int k = 0; k < 3; k++) rgb[k] = pixel[4 * y * roi_in->width + 4 * x + 2 - k];
-
-      const int out_x = MIN(x / bin_width, dev->histogram_waveform_width - 1);
       for(int k = 0; k < 3; k++)
       {
-        const float v = isnan(rgb[k]) ? 0.0f
-                                      : rgb[k]; // catch NaNs as they don't convert well to integers
+        const float c = pixel[4 * y * roi_in->width + 4 * x + 2 - k];
+        // catch NaNs as they don't convert well to integers
+        const float v = isnan(c) ? 0.0f : c;
         const int out_y = CLAMP(1.0 - (8.0 / 9.0) * v, 0.0, 1.0) * _height;
-        uint32_t *const out = buf + (out_y * dev->histogram_waveform_width * 3 + out_x * 3 + k);
+        uint32_t *const out = buf + (out_y * dev->histogram_waveform_width + x) * 3 + k;
         (*out)++;
         //               mincol[k] = MIN(mincol[k], *out);
         //               maxcol[k] = MAX(maxcol[k], *out);
@@ -1046,6 +1036,7 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   // ... and scale that into a nice image. putting the pixels into the image directly gets too
   // saturated/clips.
   // new scale factor to do about the same as the old one for 1MP views, but scale to hidpi
+  // FIXME: can simplify if roi_in->width == dev->histogram_waveform_width
   const float scale = 0.5 * 1e6f/(roi_in->height*roi_in->width) *
     (dev->histogram_waveform_width*dev->histogram_waveform_height) / (350.0f*233.)
     / 255.0f; // normalization to 0..1 for gamma correction
@@ -1056,11 +1047,11 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
     {
       uint32_t *const in = buf + (y * dev->histogram_waveform_width + x) * 3;
       uint8_t *const out
-          = (uint8_t *)(dev->histogram_waveform + (y * dev->histogram_waveform_width + x));
+          = ((uint8_t *)dev->histogram_waveform) + (y * dev->histogram_waveform_stride + x * 4);
       for(int k = 0; k < 3; k++)
       {
         if(in[k] == 0) continue;
-        out[k] = CLAMP(powf(in[k] * (bin_width / weight[x]) * scale, gamma) * 255.0, 0, 255);
+        out[k] = CLAMP(powf(in[k] * scale, gamma) * 255.0, 0, 255);
         //               if(in[k] == 0)
         //                 out[k] = 0;
         //               else
@@ -1070,7 +1061,6 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   }
 
   free(buf);
-  free(weight);
 
   if(darktable.unmuted & DT_DEBUG_PERF)
   {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -997,11 +997,16 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   dt_times_t start_time = { 0 };
   if(darktable.unmuted & DT_DEBUG_PERF) dt_get_times(&start_time);
 
-  dev->histogram_waveform_width = roi_in->width;
+  // Use integral sized bins for columns, as otherwise they will be
+  // unequal and have banding. Rely on GUI to smoothly do horizontal
+  // scaling.
+  const int bin_width = ceilf((float)(roi_in->width) / (float)dev->histogram_waveform_width);
+
+  dev->histogram_waveform_width = roi_in->width / bin_width;
   uint32_t *buf = (uint32_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_width * 3,
                                      sizeof(uint32_t));
   memset(dev->histogram_waveform, 0,
-         sizeof(uint32_t) * dev->histogram_waveform_height * dev->histogram_waveform_stride / 4);
+         sizeof(uint8_t) * dev->histogram_waveform_height * dev->histogram_waveform_stride);
 
   // 1.0 is at 8/9 of the height!
   const double _height = (double)(dev->histogram_waveform_height - 1);
@@ -1014,13 +1019,15 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   {
     for(int x = 0; x < roi_in->width; x++)
     {
+      // FIXME: do we need the MIN()?
+      const int out_x = MIN(x / bin_width, dev->histogram_waveform_width - 1);
       for(int k = 0; k < 3; k++)
       {
         const float c = pixel[4 * y * roi_in->width + 4 * x + 2 - k];
         // catch NaNs as they don't convert well to integers
         const float v = isnan(c) ? 0.0f : c;
         const int out_y = CLAMP(1.0 - (8.0 / 9.0) * v, 0.0, 1.0) * _height;
-        uint32_t *const out = buf + (out_y * dev->histogram_waveform_width + x) * 3 + k;
+        uint32_t *const out = buf + (out_y * dev->histogram_waveform_width + out_x) * 3 + k;
         (*out)++;
         //               mincol[k] = MIN(mincol[k], *out);
         //               maxcol[k] = MAX(maxcol[k], *out);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -591,14 +591,6 @@ void gui_cleanup(dt_lib_module_t *self)
   /* disconnect callback from  signal */
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_histogram_change_callback), self);
 
-  dt_develop_t *dev = darktable.develop;
-
-  free(dev->histogram_waveform);
-  dev->histogram_waveform = NULL;
-  dev->histogram_waveform_stride = 0;
-  dev->histogram_waveform_height = 0;
-  dev->histogram_waveform_width = 0;
-
   g_free(self->data);
   self->data = NULL;
 }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -155,26 +155,21 @@ static void _draw_mode_toggle(cairo_t *cr, float x, float y, float width, float 
 
 static gboolean _lib_histogram_configure_callback(GtkWidget *widget, GdkEventConfigure *event, gpointer user_data)
 {
-  static int oldw = 0;
-
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
 
   const int width = event->width;
-  if(oldw != width)
-  {
-    // mode and color buttons position on first expose or widget size change
-    d->button_spacing = 0.02 * width;
-    d->button_w = 0.06 * width;
-    d->button_h = 0.06 * width;
-    d->button_y = d->button_spacing;
-    const float offset = d->button_w + d->button_spacing;
-    d->blue_x = width - offset;
-    d->green_x = d->blue_x - offset;
-    d->red_x = d->green_x - offset;
-    d->mode_x = d->red_x - offset;
-  }
-  oldw = event->width;
+  // mode and color buttons position on first expose or widget size change
+  // FIXME: should the button size depend on histogram width or just be set to something reasonable
+  d->button_spacing = 0.02 * width;
+  d->button_w = 0.06 * width;
+  d->button_h = 0.06 * width;
+  d->button_y = d->button_spacing;
+  const float offset = d->button_w + d->button_spacing;
+  d->blue_x = width - offset;
+  d->green_x = d->blue_x - offset;
+  d->red_x = d->green_x - offset;
+  d->mode_x = d->red_x - offset;
 
   return TRUE;
 }
@@ -256,13 +251,13 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
     {
       uint8_t *hist_wav = buf;
       // make the color channel selector work:
+      // FIXME: prior code had no conditional and just multiplied by mask[k] -- test to see if that is faster
       uint8_t mask[3] = { d->blue, d->green, d->red };
-      for(int y = 0; y < waveform_height; y++)
-        for(int x = 0; x < waveform_width; x++)
-          for(int k = 0; k < 3; k++)
-          {
-            hist_wav[y * waveform_stride + x * 4 + k] *= mask[k];
-          }
+      for(int k = 0; k < 3; k++)
+        if(!mask[k])
+          for(int y = 0; y < waveform_height; y++)
+            for(int x = 0; x < waveform_width; x++)
+              hist_wav[y * waveform_stride + x * 4 + k] = 0;
 
       cairo_surface_t *source
           = dt_cairo_image_surface_create_for_data(hist_wav, CAIRO_FORMAT_ARGB32,
@@ -442,6 +437,7 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
       dt_conf_set_string("plugins/darkroom/histogram/mode",
                          dt_dev_histogram_type_names[darktable.develop->histogram_type]);
       // we need to reprocess the preview pipe
+      // FIXME: can we only make the regular histogram if we're drawing it? if so then reprocess the preview pipe when switch to that as well
       if(darktable.develop->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
       {
         dt_dev_process_preview(darktable.develop);


### PR DESCRIPTION
This fixes banding identified by @groutr in #4065. The banding happens because columns were integrally binned, but not weighted by columns/bin. As only a few columns were in each bin, this produced large differences in brightness, and hence vertical striations in the waveform.

As an improvement which also fixes this, the waveform histogram is now created in a buffer with dimensions independent of the GUI, removing some pixelpipe/GUI interaction. The buffer dimensions are currently set so that the quality/speed is comparable to before this PR.

@groutr has tested this and reports that the waveform histogram is now cropped at the bottom. I haven't been able to replicate this.