### PR TITLE
wavelet decompose: fix out of bounds problem with very small images

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -706,7 +706,7 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   float boost[MAX_NUM_SCALES][4];
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
-  const int max_mult = 1u << max_scale;
+  const int max_mult = 1u << (max_scale - 1);
 
   const int width = roi_out->width;
   const int height = roi_out->height;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -706,6 +706,10 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
   float boost[MAX_NUM_SCALES][4];
   float sharp[MAX_NUM_SCALES];
   const int max_scale = get_scales(thrs, boost, sharp, d, roi_in, piece);
+  const int max_mult = 1u << max_scale;
+
+  const int width = roi_out->width;
+  const int height = roi_out->height;
 
   if(self->dev->gui_attached && piece->pipe->type == DT_DEV_PIXELPIPE_FULL)
   {
@@ -715,13 +719,18 @@ static void process_wavelets(struct dt_iop_module_t *self, struct dt_dev_pixelpi
     // dt_control_queue_draw(GTK_WIDGET(g->area));
   }
 
+  // corner case of extremely small image. this is not really likely to happen but would
+  // lead to out of bounds memory access
+  if(width < 2 * max_mult || height < 2 * max_mult)
+  {
+    memcpy(o, i, width * height * 4 * sizeof(float));
+    return;
+  }
+
   float *detail[MAX_NUM_SCALES] = { NULL };
   float *tmp = NULL;
   float *buf2 = NULL;
   float *buf1 = NULL;
-
-  const int width = roi_out->width;
-  const int height = roi_out->height;
 
   tmp = (float *)dt_alloc_align(64, (size_t)sizeof(float) * 4 * width * height);
   if(tmp == NULL)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1347,12 +1347,13 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     if(t < 0.0f) break;
   }
 
+  const int max_mult = 1u << max_scale;
   const int width = roi_in->width, height = roi_in->height;
   const size_t npixels = (size_t)width*height;
 
-  // corner case of extremely small image. this is not really likely to happen but would cause issues later
-  // when we divide by (n-1). so let's be prepared
-  if(npixels < 2)
+  // corner case of extremely small image. this is not really likely to happen but would
+  // lead to out of bounds memory access
+  if(width < 2 * max_mult || height < 2 * max_mult)
   {
     memcpy(ovoid, ivoid, npixels * 4 * sizeof(float));
     return;

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1347,7 +1347,7 @@ static void process_wavelets(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     if(t < 0.0f) break;
   }
 
-  const int max_mult = 1u << max_scale;
+  const int max_mult = 1u << (max_scale - 1);
   const int width = roi_in->width, height = roi_in->height;
   const size_t npixels = (size_t)width*height;
 


### PR DESCRIPTION
wavelet decomposition in contrast equalizer and profiled denoise
can generate out of bounds problems on images with very small
dimensions. As a simple fix we just copy input->output in these
cases as in any case no useful module effect is expected.

This fixes #4047