### PR TITLE
Fix image information datetime field on Windows with Russian locale

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -472,7 +472,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       tt_exif.tm_isdst = -1;
       mktime(&tt_exif);
       // just %c is too long and includes a time zone that we don't know from exif
-      strftime(datetime, sizeof(datetime), "%a %x %X", &tt_exif);
+      strftime(datetime, sizeof(datetime), "%x %X", &tt_exif);
       _metadata_update_value(d->metadata[md_exif_datetime], datetime);
     }
     else


### PR DESCRIPTION
Issue is that datetime field shows '-' instead of date and time.

On Windows with Russian locale strftime does not produce valid UTF-8
string that is expected by _metadata_update_value.

Most likely same issue is present on other locales that do not use Latin characters.

Signed-off-by: Andrey Vostrikov <av.linux.dev@gmail.com>