### PR TITLE
fix xmp.Subject and lr.Hierarchical Subject tag type (xmpBag) in xmp …

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3336,9 +3336,9 @@ static void dt_exif_xmp_read_data(Exiv2::XmpData &xmpData, const int imgid)
   dt_set_xmp_dt_metadata(xmpData, imgid);
 
   // get tags from db, store in dublin core
-  std::unique_ptr<Exiv2::Value> v1(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+  std::unique_ptr<Exiv2::Value> v1(Exiv2::Value::create(Exiv2::xmpBag));
 
-  std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+  std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpBag));
 
   GList *tags = dt_tag_get_list(imgid);
   while(tags)
@@ -3427,7 +3427,7 @@ static void dt_exif_xmp_read_data_export(Exiv2::XmpData &xmpData, const int imgi
   if (metadata->flags & DT_META_TAG)
   {
     // get tags from db, store in dublin core
-    std::unique_ptr<Exiv2::Value> v1(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+    std::unique_ptr<Exiv2::Value> v1(Exiv2::Value::create(Exiv2::xmpBag));
     GList *tags = dt_tag_get_list_export(imgid, metadata->flags);
     while(tags)
     {
@@ -3440,7 +3440,7 @@ static void dt_exif_xmp_read_data_export(Exiv2::XmpData &xmpData, const int imgi
 
   if (metadata->flags & DT_META_HIERARCHICAL_TAG)
   {
-    std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpSeq)); // or xmpBag or xmpAlt.
+    std::unique_ptr<Exiv2::Value> v2(Exiv2::Value::create(Exiv2::xmpBag));
     GList *hierarchical = dt_tag_get_hierarchical_export(imgid, metadata->flags);
     while(hierarchical)
     {


### PR DESCRIPTION
fix for #4095 
Xmp.lr.hierachical subject have now the type xmpBag.

Idem for Xmp.dc.subject to follow Exiv2 documentation.