### PR TITLE
Fix hang in timeline due to infinite loop

### DIFF
--- a/src/libs/tools/timeline.c
+++ b/src/libs/tools/timeline.c
@@ -370,7 +370,7 @@ static void _time_add(dt_lib_timeline_time_t *t, int val, dt_lib_timeline_zooms_
     }
     while(t->minute < 0)
     {
-      t->hour += 60;
+      t->minute += 60;
       _time_add(t, -1, DT_LIB_TIMELINE_ZOOM_HOUR);
     }
   }


### PR DESCRIPTION
This PR fixes a darktable hang using the timeline with zoom level jour:

![Screenshot (2)](https://user-images.githubusercontent.com/51910609/72466027-74302f80-37d8-11ea-9b84-e2a0d52a146a.png)

If you move your mouse hovering over the timeline from right to left at the hour zoom level (see picture above), there is a chance that darktable hangs due to an infinite loop.