### PR TITLE
Waveform histogram speed-up and resolution increase

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -115,15 +115,14 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_pre_levels_max = -1;
 
     // FIXME: allow setting these via dt_conf system?
-    // useless once it exceeds width of DT_MIPMAP_F, (which is
-    // darktable.mipmap_cache->max_width[DT_MIPMAP_F]*2 for mosaiced
-    // imaages)
-    //dev->histogram_waveform_width = 768;
-    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] * 2;
-    // this is sufficient visual information though the waveform
-    // widget will probably be either 175 or 350 pixels high depending
-    // on hidpi
-    dev->histogram_waveform_height = 512;
+    // Calculate more pixels for hidpi. Don't exceed width of
+    // DT_MIPMAP_F (darktable.mipmap_cache->max_width[DT_MIPMAP_F]*2
+    // for mosaiced images) or make it too slow to calculate
+    // (regardless of ppd)
+    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] * MAX(2, darktable.gui->ppd);
+    // Hardcoded hack: histogram widget will probably be either 175 or
+    // 350 pixels high depending on hidpi
+    dev->histogram_waveform_height = 175 * MAX(2, darktable.gui->ppd);
     dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
     dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -118,11 +118,12 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     // useless once it exceeds width of DT_MIPMAP_F, (which is
     // darktable.mipmap_cache->max_width[DT_MIPMAP_F]*2 for mosaiced
     // imaages)
-    dev->histogram_waveform_width = 512;
+    //dev->histogram_waveform_width = 768;
+    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] * 2;
     // this is sufficient visual information though the waveform
     // widget will probably be either 175 or 350 pixels high depending
     // on hidpi
-    dev->histogram_waveform_height = 192;
+    dev->histogram_waveform_height = 512;
     dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
     dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -115,14 +115,15 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_pre_levels_max = -1;
 
     // FIXME: allow setting these via dt_conf system?
-    // Calculate more pixels for hidpi. Don't exceed width of
-    // DT_MIPMAP_F (darktable.mipmap_cache->max_width[DT_MIPMAP_F]*2
-    // for mosaiced images) or make it too slow to calculate
-    // (regardless of ppd)
-    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] * MAX(2, darktable.gui->ppd);
+    // Don't use absurd amounts of memory, exceed width of DT_MIPMAP_F
+    // (which will be darktable.mipmap_cache->max_width[DT_MIPMAP_F]*2
+    // for mosaiced images), nor make it too slow to calculate
+    // (regardless of ppd). Try to get enough detail for a (default)
+    // 350px panel, possibly 2x that on hidpi.
+    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F]/2;
     // Hardcoded hack: histogram widget will probably be either 175 or
     // 350 pixels high depending on hidpi
-    dev->histogram_waveform_height = 175 * MAX(2, darktable.gui->ppd);
+    dev->histogram_waveform_height = 175;
     dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
     dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -114,13 +114,15 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_pre_tonecurve_max = -1;
     dev->histogram_pre_levels_max = -1;
 
-    // mosaiced image may be twice the dimensions of DT_MIPMAP_F but
-    // half width still gives sufficient data and is reasonably fast
-    dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F] / 2;
+    // FIXME: allow setting these via dt_conf system?
+    // useless once it exceeds width of DT_MIPMAP_F, (which is
+    // darktable.mipmap_cache->max_width[DT_MIPMAP_F]*2 for mosaiced
+    // imaages)
+    dev->histogram_waveform_width = 512;
     // this is sufficient visual information though the waveform
     // widget will probably be either 175 or 350 pixels high depending
     // on hidpi
-    dev->histogram_waveform_height = 128;
+    dev->histogram_waveform_height = 192;
     dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
     dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
   }

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1018,6 +1018,11 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   const double _height = (double)(waveform_height - 1);
 
   // count the colors into buf ...
+#ifdef _OPENMP
+#pragma omp parallel for SIMD() default(none) \
+  dt_omp_firstprivate(roi_in, bin_width, _height, waveform_width, input, buf) \
+  schedule(static)
+#endif
   for(int in_y = 0; in_y < roi_in->height; in_y++)
   {
     // FIXME: does this skip some final columns -- or use too many?
@@ -1054,6 +1059,12 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   const int cache_size = 4096;
   uint8_t *cache = (uint8_t *)calloc(cache_size, sizeof(uint8_t));
 
+  // FIXME: does each thread need its own cache?
+#ifdef _OPENMP
+#pragma omp parallel for SIMD() default(none) \
+  dt_omp_firstprivate(waveform_width, waveform_height, waveform_stride, buf, waveform, cache, scale, gamma) \
+  schedule(static)
+#endif
   for(int out_y = 0; out_y < waveform_height; out_y++)
   {
     for(int out_x = 0; out_x < waveform_width; out_x++)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1037,6 +1037,9 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
         // FIXME: skip NaN's rather than treating as 0?
         const float v = isnan(c) ? 0.0f : c;
         const int out_y = CLAMP(1.0 - (8.0 / 9.0) * v, 0.0, 1.0) * _height;
+#ifdef _OPENMP
+#pragma omp atomic update
+#endif
         buf[(out_x + waveform_width * out_y) * 3 + k]++;
       }
     }
@@ -1080,6 +1083,9 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
         // cache XORd resul so common casees cached and cache misses are quick to find
         if(!cache[v])
         {
+#ifdef _OPENMP
+#pragma omp atomic write
+#endif
           cache[v] = (uint8_t)(CLAMP(powf(v * scale, gamma) * 255.0, 0, 255)) ^ 1;
         }
         out[k] = cache[v] ^ 1;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1066,7 +1066,7 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
 
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
-  dt_omp_firstprivate(waveform_width, waveform_height, waveform_stride, buf, waveform, cache, scale) \
+  dt_omp_firstprivate(waveform_width, waveform_height, waveform_stride, buf, waveform, cache, scale, gamma) \
   schedule(static)
 #endif
   for(int out_y = 0; out_y < waveform_height; out_y++)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1010,7 +1010,6 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   const int waveform_width = roi_in->width / bin_width;
   dev->histogram_waveform_width = waveform_width;
 
-  // FIXME: better to pre-allocate this in dev?
   // max input size should be 1440x900, and with a bin_width of 1,
   // that makes a maximum possible count of 900 in buf, while even if
   // waveform buffer is 128 (about smallest possible), bin_width is
@@ -1028,7 +1027,6 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   dt_omp_firstprivate(roi_in, bin_width, _height, waveform_width, input, buf) \
   schedule(static,bin_width*64)
 #endif
-  // FIXME: does this skip some final columns -- or use too many?
   for(int in_x = 0; in_x < roi_in->width; in_x++)
   {
     const int out_x = in_x / bin_width;
@@ -1066,10 +1064,9 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   const int cache_size = (roi_in->height * bin_width) + 1;
   uint8_t *cache = (uint8_t *)calloc(cache_size, sizeof(uint8_t));
 
-  // FIXME: does each thread need its own cache?
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
-  dt_omp_firstprivate(waveform_width, waveform_height, waveform_stride, buf, waveform, cache, cache_size, scale, gamma) \
+  dt_omp_firstprivate(waveform_width, waveform_height, waveform_stride, buf, waveform, cache, scale) \
   schedule(static)
 #endif
   for(int out_y = 0; out_y < waveform_height; out_y++)

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1077,13 +1077,12 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
         //mincol[k] = MIN(mincol[k], in[k]);
         //maxcol[k] = MAX(maxcol[k], in[k]);
         const uint32_t v = in[k];
-        // cache result+1, so common case of 0 count giving 0 output gets cached and cache misses are quick to find
-        // NOTE: for result==255, integer math will wrap to 0, hence it'll always be a chache miss
+        // cache XORd resul so common casees cached and cache misses are quick to find
         if(!cache[v])
         {
-          cache[v] = (uint8_t)(CLAMP(powf(v * scale, gamma) * 255.0, 0, 255)) + 1;
+          cache[v] = (uint8_t)(CLAMP(powf(v * scale, gamma) * 255.0, 0, 255)) ^ 1;
         }
-        out[k] = cache[v] - 1;
+        out[k] = cache[v] ^ 1;
         //               if(in[k] == 0)
         //                 out[k] = 0;
         //               else

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1007,7 +1007,7 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   // but histogram_waveform_width varies, depending on preview image
   // width and # of bins.
   const int bin_width = ceilf((float)(roi_in->width) / (float)(waveform_stride/4));
-  const int waveform_width = roi_in->width / bin_width;
+  const int waveform_width = ceilf(roi_in->width / (float)bin_width);
   dev->histogram_waveform_width = waveform_width;
 
   // max input size should be 1440x900, and with a bin_width of 1,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1079,7 +1079,7 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
       {
         //mincol[k] = MIN(mincol[k], in[k]);
         //maxcol[k] = MAX(maxcol[k], in[k]);
-        const uint32_t v = in[k];
+        const uint16_t v = in[k];
         // cache XORd result so common casees cached and cache misses are quick to find
         if(!cache[v])
         {

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -425,7 +425,7 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
 
   if(!hooks_available) return TRUE;
 
-  if(event->type == GDK_2BUTTON_PRESS)
+  if(event->type == GDK_2BUTTON_PRESS && (d->highlight == 1 || d->highlight ==2))
   {
     dt_dev_exposure_reset_defaults(darktable.develop);
   }


### PR DESCRIPTION
Changes to calculation of waveform histogram:

- speed up waveform histogram calculation via OpenMP and caching the gamma calculation
- calculate a more detailed histogram (especially on hidpi displays) in equivalent time, thanks to this speedup

I tested this code on both a recent and an eight year old laptop. In both cases, the new code is either faster or just as fast as the prior code, while producing less blurry output. Note that if detailed waveform histograms are not considered a good in themselves, it would be easy to turn down the resolution in dt_dev_init() to make the histogram math happen faster.

This PR also contained changes to how the waveform histogram appears in the UI. I've moved these to #4140 and rebased.

Here is before/after for lodpi:

Before:
![waveform lodpi before](https://user-images.githubusercontent.com/2311860/72641340-f08d5480-3937-11ea-8746-26597882c95f.png)

After (includes new grid from #4140):
![waveform lodpi after](https://user-images.githubusercontent.com/2311860/72641353-f4b97200-3937-11ea-887b-2cd9b2692772.png)

And before/after for hidpi:

Before:
![waveform hidpi before](https://user-images.githubusercontent.com/2311860/72641360-fbe08000-3937-11ea-911d-0dc22b82d749.png)

After:
![image](https://user-images.githubusercontent.com/2311860/72669579-82ad5f80-3a01-11ea-8b2e-fcbfe126064c.png)

This is a follow-up to #4041 and #4075.
