### PR TITLE
waveform histogram: ui improvements

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -110,6 +110,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_pre_tonecurve = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_levels = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
 
+    // FIXME: these are uint32_t, setting to -1 is confusing
     dev->histogram_max = -1;
     dev->histogram_pre_tonecurve_max = -1;
     dev->histogram_pre_levels_max = -1;

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -163,24 +163,22 @@ static inline void dt_draw_waveform_lines(cairo_t *cr, const int left, const int
                                           const int bottom)
 {
   //   float width = right - left;
-  float height = bottom - top;
-
-  int num = 9, middle = 5;
+  const float height = bottom - top;
+  const int num = 9, middle = 5, white = 1;
+  // FIXME: should this vary with ppd?
+  const double dashes = 4.0;
 
   cairo_save(cr);
 
+  // FIXME: should be using DT_PIXEL_APPLY_DPI()?
+  const double wd = cairo_get_line_width(cr);
   for(int k = 1; k < num; k++)
   {
-    if(k == middle) continue;
+    cairo_set_dash(cr, &dashes, k == white || k == middle, 0);
+    cairo_set_line_width(cr, k == white ? wd*3 : k == middle ? wd*2 : wd);
     dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
     cairo_stroke(cr);
   }
-
-  double dashes = 4.0;
-  cairo_set_dash(cr, &dashes, 1, 0);
-
-  dt_draw_line(cr, left, top + middle / (float)num * height, right, top + middle / (float)num * height);
-  cairo_stroke(cr);
 
   cairo_restore(cr);
 }

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -857,10 +857,11 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
   // draw grid
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(.4));
   cairo_set_source_rgb(cr, .1, .1, .1);
-  if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
-    dt_draw_waveform_lines(cr, 0, 0, width, height);
-  else
-    dt_draw_vertical_lines(cr, 4, 0, 0, width, height);
+  // NOTE: if we actually draw a waveform in the background, we might want this:
+  //if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+  //  dt_draw_waveform_lines(cr, 0, 0, width, height);
+  //else
+  dt_draw_vertical_lines(cr, 4, 0, 0, width, height);
 
   // Drawing the vertical line indicators
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -857,10 +857,6 @@ static gboolean dt_iop_levels_area_draw(GtkWidget *widget, cairo_t *crf, gpointe
   // draw grid
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(.4));
   cairo_set_source_rgb(cr, .1, .1, .1);
-  // NOTE: if we actually draw a waveform in the background, we might want this:
-  //if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
-  //  dt_draw_waveform_lines(cr, 0, 0, width, height);
-  //else
   dt_draw_vertical_lines(cr, 4, 0, 0, width, height);
 
   // Drawing the vertical line indicators

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -347,12 +347,12 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
                                                                        : allocation.width;
     if (d->highlight == 2)
     {
-      float exposure = d->exposure + diff * 4.0f / (float)range;
+      const float exposure = d->exposure + diff * 4.0f / (float)range;
       dt_dev_exposure_set_exposure(darktable.develop, exposure);
     }
     else if(d->highlight == 1)
     {
-      float black = d->black - diff * .1f / (float)range;
+      const float black = d->black - diff * .1f / (float)range;
       dt_dev_exposure_set_black(darktable.develop, black);
     }
   }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -186,8 +186,6 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
 
   dt_pthread_mutex_lock(&dev->preview_pipe_mutex);
 
-  const float hist_max = dev->histogram_type == DT_DEV_HISTOGRAM_LINEAR ? dev->histogram_max
-                                                                        : logf(1.0 + dev->histogram_max);
   const int waveform_width = dev->histogram_waveform_width;
   const int waveform_height = dev->histogram_waveform_height;
   const gint waveform_stride = dev->histogram_waveform_stride;
@@ -244,7 +242,7 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
     dt_draw_grid(cr, 4, 0, 0, width, height);
 
   // draw histogram
-  if(hist_max > 0.0f && dev->image_storage.id == dev->preview_pipe->output_imgid)
+  if(dev->image_storage.id == dev->preview_pipe->output_imgid)
   {
     cairo_save(cr);
     if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
@@ -263,17 +261,17 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
           = dt_cairo_image_surface_create_for_data(hist_wav, CAIRO_FORMAT_ARGB32,
                                                    waveform_width, waveform_height, waveform_stride);
 
-      cairo_save(cr);
       cairo_scale(cr, darktable.gui->ppd*width/waveform_width, darktable.gui->ppd*height/waveform_height);
       cairo_set_source_surface(cr, source, 0.0, 0.0);
       cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
       cairo_paint(cr);
       cairo_surface_destroy(source);
-      cairo_restore(cr);
     }
-    else
+    else if(dev->histogram_max)
     {
       uint32_t *hist = buf;
+      const float hist_max = dev->histogram_type == DT_DEV_HISTOGRAM_LINEAR ? dev->histogram_max
+                                                                            : logf(1.0 + dev->histogram_max);
       cairo_translate(cr, 0, height);
       cairo_scale(cr, width / 255.0, -(height - 10) / hist_max);
       cairo_set_operator(cr, CAIRO_OPERATOR_ADD);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -220,16 +220,23 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   cairo_fill(cr);
   cairo_restore(cr);
 
+  // exposure change regions
   if(d->highlight == 1)
   {
     cairo_set_source_rgb(cr, .5, .5, .5);
-    cairo_rectangle(cr, 0, 0, .2 * width, height);
+    if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+      cairo_rectangle(cr, 0, 7.0/9.0 * height, width, height);
+    else
+      cairo_rectangle(cr, 0, 0, 0.2 * width, height);
     cairo_fill(cr);
   }
   else if(d->highlight == 2)
   {
     cairo_set_source_rgb(cr, .5, .5, .5);
-    cairo_rectangle(cr, 0.2 * width, 0, width, height);
+    if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+      cairo_rectangle(cr, 0, 0, width, 7.0/9.0 * height);
+    else
+      cairo_rectangle(cr, 0.2 * width, 0, width, height);
     cairo_fill(cr);
   }
 
@@ -323,6 +330,7 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
+  dt_develop_t *dev = darktable.develop;
 
   /* check if exposure hooks are available */
   gboolean hooks_available = dt_dev_exposure_hooks_available(darktable.develop);
@@ -331,29 +339,36 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
 
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
-  if(d->dragging && d->highlight == 2)
+  if(d->dragging)
   {
-    float exposure = d->exposure + (event->x - d->button_down_x) * 4.0f / (float)allocation.width;
-    dt_dev_exposure_set_exposure(darktable.develop, exposure);
-  }
-  else if(d->dragging && d->highlight == 1)
-  {
-    float black = d->black - (event->x - d->button_down_x) * .1f / (float)allocation.width;
-    dt_dev_exposure_set_black(darktable.develop, black);
+    const float diff = dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM ? d->button_down_y - event->y
+                                                                        : event->x - d->button_down_x;
+    const int range = dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM ? allocation.height
+                                                                       : allocation.width;
+    if (d->highlight == 2)
+    {
+      float exposure = d->exposure + diff * 4.0f / (float)range;
+      dt_dev_exposure_set_exposure(darktable.develop, exposure);
+    }
+    else if(d->highlight == 1)
+    {
+      float black = d->black - diff * .1f / (float)range;
+      dt_dev_exposure_set_black(darktable.develop, black);
+    }
   }
   else
   {
     const float x = event->x;
     const float y = event->y;
-    const float pos = x / (float)(allocation.width);
+    const float posx = x / (float)(allocation.width);
+    const float posy = y / (float)(allocation.height);
 
-
-    if(pos < 0 || pos > 1.0)
+    if(posx < 0.0f || posx > 1.0f || posy < 0.0f || posy > 1.0f)
       ;
     else if(x > d->mode_x && x < d->mode_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
     {
       d->highlight = 3;
-      switch(darktable.develop->histogram_type)
+      switch(dev->histogram_type)
       {
         case DT_DEV_HISTOGRAM_LOGARITHMIC:
           gtk_widget_set_tooltip_text(widget, _("set histogram mode to linear"));
@@ -384,7 +399,8 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
       d->highlight = 6;
       gtk_widget_set_tooltip_text(widget, d->red ? _("click to hide blue channel") : _("click to show blue channel"));
     }
-    else if(pos < 0.2)
+    else if((posx < 0.2f && dev->histogram_type != DT_DEV_HISTOGRAM_WAVEFORM) ||
+            (posy > 7.0f/9.0f && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM))
     {
       d->highlight = 1;
       gtk_widget_set_tooltip_text(widget, _("drag to change black point,\ndoubleclick resets"));


### PR DESCRIPTION
- draw 50% grid line slightly thicker so it is legible, and draw 100% grid line thicker and dotted to call attention to it as a a reasonable upper limit
- when in waveform histogram, make the regions which adjust exposure via mouse drag/scroll be horizontal rather than vertical, to correspond to the waveform
- display waveform histogram even when image is totally black (previously it would disappear, which made sense for the regular histogram, but not for the waveform, for which we should see a horizontal line at the very bottom)
- remove vestigial code which sometimes displayed waveform grid lines if levels iop despite regular histogram always being show

These changes were originally in #4132 but are spun out into their own PR as they don't depend on the core and speed-up changes in the PR.

I made the changes which @TurboGit suggested on that PR in 305bae65c165b8f37fa76b37546d9e74856f3c65.

Here is how the waveform histogram looks after this PR on a hidpi display.

![waveform with UI changes hidpi low detail](https://user-images.githubusercontent.com/2311860/72669351-af13ac80-39fe-11ea-8526-73a7ea2463e7.png)

And this is the waveform histogram with the drag region for exposure highlighted via mouseover:

![waveform with drag region](https://user-images.githubusercontent.com/2311860/72669395-36612000-39ff-11ea-9949-f528e7086a6c.png)
