### PR TITLE
fix - GMIC not found message is now displayed

### DIFF
--- a/cmake/modules/FindGMIC.cmake
+++ b/cmake/modules/FindGMIC.cmake
@@ -59,4 +59,6 @@ if(GMIC_LIBRARY AND GMIC_INCLUDE_DIR)
     endif(GMIC_FOUND)
 
   endif(NOT GMIC_VERSION_OK)
+else()
+  message(STATUS "GMIC not found")
 endif(GMIC_LIBRARY AND GMIC_INCLUDE_DIR)


### PR DESCRIPTION
fix - GMIC not found message is now displayed when cmake does find the a GMIC library