### PR TITLE
let users choose the cairo filter in pref

### DIFF
--- a/src/common/focus_peaking.h
+++ b/src/common/focus_peaking.h
@@ -288,7 +288,7 @@ schedule(static) collapse(2) aligned(focus_peaking:64)
                                                                  cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, buf_width));
   cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
   cairo_set_source_surface(cr, surface, 0.0, 0.0);
-  cairo_pattern_set_filter(cairo_get_source (cr), CAIRO_FILTER_BEST);
+  cairo_pattern_set_filter(cairo_get_source (cr), darktable.gui->filter_image);
   cairo_fill(cr);
   cairo_restore(cr);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1492,9 +1492,9 @@ static void init_widgets(dt_gui_gtk_t *gui)
 
   if(dt_conf_key_exists("ui/cairo_filter"))
   {
-    if(strcmp(dt_conf_get_string("ui/cairo_filter"), "best"))
+    if(strcmp(dt_conf_get_string("ui/cairo_filter"), "best") == 0)
       gui->filter_image = CAIRO_FILTER_BEST;
-    else if (strcmp(dt_conf_get_string("ui/cairo_filter"), "good"))
+    else if (strcmp(dt_conf_get_string("ui/cairo_filter"), "good") == 0)
       gui->filter_image = CAIRO_FILTER_GOOD;
   }
   else

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1486,6 +1486,19 @@ static void init_widgets(dt_gui_gtk_t *gui)
 
   gtk_widget_set_visible(gui->scrollbars.hscrollbar, FALSE);
   gtk_widget_set_visible(gui->scrollbars.vscrollbar, FALSE);
+
+  // Fetch the cairo filter to draw scaled surfaces where exact 1:1 buffer/viewport size is not guaranteed
+  gui->filter_image = CAIRO_FILTER_FAST;
+
+  if(dt_conf_key_exists("ui/cairo_filter"))
+  {
+    if(strcmp(dt_conf_get_string("ui/cairo_filter"), "best"))
+      gui->filter_image = CAIRO_FILTER_BEST;
+    else if (strcmp(dt_conf_get_string("ui/cairo_filter"), "good"))
+      gui->filter_image = CAIRO_FILTER_GOOD;
+  }
+  else
+    dt_conf_set_string("ui/cairo_filter", "fast");
 }
 
 static void init_main_table(GtkWidget *container)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -120,6 +120,8 @@ typedef struct dt_gui_gtk_t
 
   gint scroll_mask;
   guint sidebar_scroll_mask;
+
+  cairo_filter_t filter_image;
 } dt_gui_gtk_t;
 
 #if (CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 13, 1))

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -329,9 +329,9 @@ void expose(
     cairo_rectangle(cr, 0, 0, wd, ht);
     cairo_set_source_surface(cr, surface, 0, 0);
     if(closeup)
-      cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+      cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
     else
-      cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_BEST);
+      cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
 
     cairo_fill(cr);
 
@@ -390,7 +390,7 @@ void expose(
 
     cairo_rectangle(cr, 0, 0, wd, ht);
     cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_BEST);
+    cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
     cairo_fill(cr);
     cairo_surface_destroy(surface);
     dt_pthread_mutex_unlock(mutex);
@@ -3609,7 +3609,7 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
 
     cairo_rectangle(cr, 0, 0, wd, ht);
     cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+    cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
     cairo_fill(cr);
 
     if(darktable.gui->show_focus_peaking)
@@ -3648,7 +3648,7 @@ static void second_window_expose(GtkWidget *widget, dt_develop_t *dev, cairo_t *
     // avoid to draw the 1px garbage that sometimes shows up in the preview :(
     cairo_rectangle(cr, 0, 0, wd - 1, ht - 1);
     cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+    cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
     cairo_fill(cr);
     cairo_surface_destroy(surface);
     dt_pthread_mutex_unlock(mutex);

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -510,7 +510,7 @@ void expose(dt_view_t *self, cairo_t *cr, int32_t width, int32_t height, int32_t
     surface = dt_cairo_image_surface_create_for_data((uint8_t *)slot->buf, CAIRO_FORMAT_RGB24, slot->width,
                                                      slot->height, stride);
     cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
+    cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
     cairo_rectangle(cr, 0, 0, slot->width/darktable.gui->ppd, slot->height/darktable.gui->ppd);
     cairo_fill(cr);
     cairo_surface_destroy(surface);


### PR DESCRIPTION
Fix #4152
Set default cairo filter to fast (== nearest). Keep the nearest setting in parts of the code where exact buffer/display pixel sizes is ensured.
Default can be changed in darktablerc: "ui/cairo_filter = fast, good, best"