### PR TITLE
drawn masks: sigmoidal transition in gradient shape

### DIFF
--- a/src/develop/masks.h
+++ b/src/develop/masks.h
@@ -25,7 +25,7 @@
 
 #include <assert.h>
 
-#define DEVELOP_MASKS_VERSION (5)
+#define DEVELOP_MASKS_VERSION (6)
 
 /**forms types */
 typedef enum dt_masks_type_t
@@ -59,6 +59,12 @@ typedef enum dt_masks_points_states_t
   DT_MASKS_POINT_STATE_NORMAL = 1,
   DT_MASKS_POINT_STATE_USER = 2
 } dt_masks_points_states_t;
+
+typedef enum dt_masks_gradient_states_t
+{
+  DT_MASKS_GRADIENT_STATE_LINEAR = 1,
+  DT_MASKS_GRADIENT_STATE_SIGMOIDAL = 2
+} dt_masks_gradient_states_t;
 
 typedef enum dt_masks_edit_mode_t
 {
@@ -138,6 +144,7 @@ typedef struct dt_masks_point_gradient_t
   float compression;
   float steepness;
   float curvature;
+  dt_masks_gradient_states_t state;
 } dt_masks_point_gradient_t;
 
 /** structure used to store all forms's id for a group */
@@ -216,6 +223,7 @@ typedef struct dt_masks_form_gui_t
   gboolean source_dragging;
   gboolean form_rotating;
   gboolean border_toggling;
+  gboolean gradient_toggling;
   int point_dragging;
   int feather_dragging;
   int seg_dragging;

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -152,7 +152,6 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
     dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(g_list_first(form->points)->data);
 
     gradient->curvature = 0.0f;
-    gradient->state = DT_MASKS_GRADIENT_STATE_LINEAR;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     dt_masks_gui_form_remove(form, gui, index);

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -152,12 +152,22 @@ static int dt_gradient_events_button_pressed(struct dt_iop_module_t *module, flo
     dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(g_list_first(form->points)->data);
 
     gradient->curvature = 0.0f;
+    gradient->state = DT_MASKS_GRADIENT_STATE_LINEAR;
     dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
 
     dt_masks_gui_form_remove(form, gui, index);
     dt_masks_gui_form_create(form, gui, index);
 
     dt_masks_update_image(darktable.develop);
+
+    return 1;
+  }
+  else if(!gui->creation && ((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK))
+  {
+    dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
+    if(!gpt) return 0;
+
+    gui->gradient_toggling = TRUE;
 
     return 1;
   }
@@ -288,6 +298,31 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
 
     return 1;
   }
+  else if(gui->gradient_toggling)
+  {
+    // we get the gradient
+    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)(g_list_first(form->points)->data);
+
+    // we end the gradient toggling
+    gui->gradient_toggling = FALSE;
+
+    // toggle transition type of gradient
+    if(gradient->state == DT_MASKS_GRADIENT_STATE_LINEAR)
+      gradient->state = DT_MASKS_GRADIENT_STATE_SIGMOIDAL;
+    else
+      gradient->state = DT_MASKS_GRADIENT_STATE_LINEAR;
+
+    dt_dev_add_masks_history_item(darktable.develop, module, TRUE);
+
+    // we recreate the form points
+    dt_masks_gui_form_remove(form, gui, index);
+    dt_masks_gui_form_create(form, gui, index);
+
+    // we save the new parameters
+    dt_masks_update_image(darktable.develop);
+
+    return 1;
+  }
   else if(gui->creation)
   {
     const float wd = darktable.develop->preview_pipe->backbuf_width;
@@ -337,13 +372,12 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     }
 
     const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
-    const float steepness = 0.0f; // MIN(1.0f,dt_conf_get_float("plugins/darkroom/masks/gradient/steepness"));
-                                  // // currently not used
 
     gradient->rotation = -rotation / M_PI * 180.0f;
     gradient->compression = MAX(0.0f, compression);
-    gradient->steepness = MAX(0.0f, steepness);
+    gradient->steepness = 0.0f;
     gradient->curvature = 0.0f;
+    gradient->state = DT_MASKS_GRADIENT_STATE_SIGMOIDAL;
     // not used for masks
     form->source[0] = form->source[1] = 0.0f;
 
@@ -1018,6 +1052,14 @@ static int dt_gradient_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   return 1;
 }
 
+// caller needs to make sure that input remains within bounds
+static inline float dt_gradient_lookup(const float *lut, const float i)
+{
+  const int bin0 = i;
+  const int bin1 = i + 1;
+  const float f = i - bin0;
+  return lut[bin1] * f + lut[bin0] * (1.0f - f);
+}
 
 static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece, dt_masks_form_t *form,
                                 float **buffer, int *width, int *height, int *posx, int *posy)
@@ -1084,22 +1126,40 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
   const float wd = piece->pipe->iwidth;
   const float ht = piece->pipe->iheight;
   const float hwscale = 1.0f / sqrtf(wd * wd + ht * ht);
+  const float ihwscale = 1.0f / hwscale;
   const float v = (-gradient->rotation / 180.0f) * M_PI;
   const float sinv = sin(v);
   const float cosv = cos(v);
   const float xoffset = cosv * gradient->anchor[0] * wd + sinv * gradient->anchor[1] * ht;
   const float yoffset = sinv * gradient->anchor[0] * wd - cosv * gradient->anchor[1] * ht;
   const float compression = fmaxf(gradient->compression, 0.001f);
-  const float cs = powf(10.0f, gradient->steepness);
-  const float steepness = cs * cs - 1.0f;
-  const float normf = 0.5f * cs / compression;
+  const float normf = 1.0f / compression;
   const float curvature = gradient->curvature;
+  const dt_masks_gradient_states_t state = gradient->state;
+
+  const int lutmax = 2 * compression * ihwscale;
+  const int lutsize = 2 * lutmax + 2;
+  float *lut = dt_alloc_align(64, lutsize * sizeof(float));
+  if(lut == NULL)
+  {
+    dt_free_align(points);
+    return 0;
+  }
+
+  for(int n = 0; n < lutsize; n++)
+  {
+    const float distance = (n - lutmax) * hwscale;
+    const float value = 0.5f + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance: erff(distance / compression));
+    lut[n] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
+  }
+  float *clut = lut + lutmax;
+
 
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(gh, gw, sinv, cosv, xoffset, yoffset, hwscale, normf, steepness, curvature) \
-  shared(points)
+  dt_omp_firstprivate(gh, gw, sinv, cosv, xoffset, yoffset, hwscale, ihwscale, curvature) \
+  shared(points, clut)
 #else
 #pragma omp parallel for shared(points)
 #endif
@@ -1116,11 +1176,12 @@ static int dt_gradient_get_mask(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
 
       const float distance = y0 - curvature * x0 * x0;
 
-      float value = normf * distance / sqrtf(1.0f + steepness * distance * distance) + 0.5f;
-
-      points[(j * gw + i) * 2] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
+      points[(j * gw + i) * 2] = (distance < -2.0f * compression) ? 0.0f :
+                                    ((distance > 2.0f * compression) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
     }
   }
+
+  dt_free_align(lut);
 
   // we allocate the buffer
   *buffer = dt_alloc_align(64, w * h * sizeof(float));
@@ -1228,22 +1289,39 @@ static int dt_gradient_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_io
   const float wd = piece->pipe->iwidth;
   const float ht = piece->pipe->iheight;
   const float hwscale = 1.0f / sqrtf(wd * wd + ht * ht);
+  const float ihwscale = 1.0f / hwscale;
   const float v = (-gradient->rotation / 180.0f) * M_PI;
   const float sinv = sin(v);
   const float cosv = cos(v);
   const float xoffset = cosv * gradient->anchor[0] * wd + sinv * gradient->anchor[1] * ht;
   const float yoffset = sinv * gradient->anchor[0] * wd - cosv * gradient->anchor[1] * ht;
   const float compression = fmaxf(gradient->compression, 0.001f);
-  const float cs = powf(10.0f, gradient->steepness);
-  const float steepness = cs * cs - 1.0f;
-  const float normf = 0.5f * cs / compression;
+  const float normf = 1.0f / compression;
   const float curvature = gradient->curvature;
+  const dt_masks_gradient_states_t state = gradient->state;
+
+  const int lutmax = 2 * compression * ihwscale;
+  const int lutsize = 2 * lutmax + 2;
+  float *lut = dt_alloc_align(64, lutsize * sizeof(float));
+  if(lut == NULL)
+  {
+    dt_free_align(points);
+    return 0;
+  }
+
+  for(int n = 0; n < lutsize; n++)
+  {
+    const float distance = (n - lutmax) * hwscale;
+    const float value = 0.5f + 0.5f * ((state == DT_MASKS_GRADIENT_STATE_LINEAR) ? normf * distance: erff(distance / compression));
+    lut[n] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
+  }
+  float *clut = lut + lutmax;
 
 #ifdef _OPENMP
 #if !defined(__SUNOS__) && !defined(__NetBSD__)
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(gh, gw, sinv, cosv, xoffset, yoffset, hwscale, normf, steepness, curvature) \
-  shared(points)
+  dt_omp_firstprivate(gh, gw, sinv, cosv, xoffset, yoffset, hwscale, ihwscale, curvature, compression) \
+  shared(points, clut)
 #else
 #pragma omp parallel for shared(points)
 #endif
@@ -1261,11 +1339,11 @@ static int dt_gradient_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_io
 
       const float distance = y0 - curvature * x0 * x0;
 
-      const float value = normf * distance / sqrtf(1.0f + steepness * distance * distance) + 0.5f;
-
-      points[index * 2] = (value < 0.0f) ? 0.0f : ((value > 1.0f) ? 1.0f : value);
+      points[index * 2] = (distance < -2.0f * compression) ? 0.0f : ((distance > 2.0f * compression) ? 1.0f : dt_gradient_lookup(clut, distance * ihwscale));
     }
   }
+
+  dt_free_align(lut);
 
 // we fill the mask buffer by interpolation
 #ifdef _OPENMP

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1180,6 +1180,31 @@ static int dt_masks_legacy_params_v4_to_v5(dt_develop_t *dev, void *params)
   return 0;
 }
 
+static int dt_masks_legacy_params_v5_to_v6(dt_develop_t *dev, void *params)
+{
+  /*
+   * difference affecting gradient
+   * up to v5: linear transition
+   * after v5: linear or sigmoidal transition
+   */
+
+  dt_masks_form_t *m = (dt_masks_form_t *)params;
+
+  GList *p = g_list_first(m->points);
+
+  if(!p) return 1;
+
+  if(m->type & DT_MASKS_GRADIENT)
+  {
+    dt_masks_point_gradient_t *gradient = (dt_masks_point_gradient_t *)p->data;
+    gradient->state = DT_MASKS_GRADIENT_STATE_LINEAR;
+  }
+
+  m->version = 6;
+
+  return 0;
+}
+
 
 int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_version, const int new_version)
 {
@@ -1191,27 +1216,35 @@ int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_versio
   }
 #endif
 
-  if(old_version == 1 && new_version == 5)
+  if(old_version == 1 && new_version == 6)
   {
     res = dt_masks_legacy_params_v1_to_v2(dev, params);
     if(!res) res = dt_masks_legacy_params_v2_to_v3(dev, params);
     if(!res) res = dt_masks_legacy_params_v3_to_v4(dev, params);
     if(!res) res = dt_masks_legacy_params_v4_to_v5(dev, params);
+    if(!res) res = dt_masks_legacy_params_v5_to_v6(dev, params);
   }
-  else if(old_version == 2 && new_version == 5)
+  else if(old_version == 2 && new_version == 6)
   {
     res = dt_masks_legacy_params_v2_to_v3(dev, params);
     if(!res) res = dt_masks_legacy_params_v3_to_v4(dev, params);
     if(!res) res = dt_masks_legacy_params_v4_to_v5(dev, params);
+    if(!res) res = dt_masks_legacy_params_v5_to_v6(dev, params);
   }
-  else if(old_version == 3 && new_version == 5)
+  else if(old_version == 3 && new_version == 6)
   {
     res = dt_masks_legacy_params_v3_to_v4(dev, params);
     if(!res) res = dt_masks_legacy_params_v4_to_v5(dev, params);
+    if(!res) res = dt_masks_legacy_params_v5_to_v6(dev, params);
   }
-  else if(old_version == 4 && new_version == 5)
+  else if(old_version == 4 && new_version == 6)
   {
     res = dt_masks_legacy_params_v4_to_v5(dev, params);
+    if(!res) res = dt_masks_legacy_params_v5_to_v6(dev, params);
+  }
+  else if(old_version == 5 && new_version == 6)
+  {
+    res = dt_masks_legacy_params_v5_to_v6(dev, params);
   }
 
   return res;
@@ -1769,7 +1802,7 @@ void dt_masks_clear_form_gui(dt_develop_t *dev)
   dev->form_gui->dx = dev->form_gui->dy = 0.0f;
   dev->form_gui->scrollx = dev->form_gui->scrolly = 0.0f;
   dev->form_gui->form_selected = dev->form_gui->border_selected = dev->form_gui->form_dragging
-      = dev->form_gui->form_rotating = dev->form_gui->border_toggling = FALSE;
+      = dev->form_gui->form_rotating = dev->form_gui->border_toggling = dev->form_gui->gradient_toggling = FALSE;
   dev->form_gui->source_selected = dev->form_gui->source_dragging = FALSE;
   dev->form_gui->pivot_selected = FALSE;
   dev->form_gui->point_border_selected = dev->form_gui->seg_selected = dev->form_gui->point_selected


### PR DESCRIPTION
Make the transition in gradients sigmoidal rather than linear. Legacy
gradients still process as they did. If needed users can toggle between
the default sigmodial and linear transition by shift-click in the gradient.
This commit also gives up on the steepness parameter. That functionality
has always been broken. Fortunately that parameter has been set to zero
from day one and was never exposed to the user.

This fixes #4145