### PR TITLE
Fix #4005 icons size for HiDPI displays

### DIFF
--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -49,9 +49,6 @@ static gboolean _button_draw(GtkWidget *widget, cairo_t *cr)
   /* update paint flags depending of states */
   int flags = DTGTK_BUTTON(widget)->icon_flags;
 
-  /* set inner border */
-  int border = DT_PIXEL_APPLY_DPI((flags & CPF_DO_NOT_USE_BORDER) ? 4 : 6);
-
   /* prelight */
   if(state & GTK_STATE_FLAG_PRELIGHT)
     flags |= CPF_PRELIGHT;
@@ -103,19 +100,15 @@ static gboolean _button_draw(GtkWidget *widget, cairo_t *cr)
   /* draw icon */
   if(DTGTK_BUTTON(widget)->icon)
   {
-    int icon_width = text ? height - (border * 2) : width - (border * 2);
-    int icon_height = height - (border * 2);
-    void *icon_data = DTGTK_BUTTON(widget)->icon_data;
+    /* set inner border and icon size */
+    float f_border = (1 + 0.66 * (darktable.gui->dpi_factor-1)) * ((flags & CPF_DO_NOT_USE_BORDER) ? 4.0 : 6.0);
+    int border = round(f_border);
+    int icon_width = round(text ? height - (f_border * 2) : width - (f_border * 2));
+    int icon_height = round(height - (f_border * 2));
 
+    void *icon_data = DTGTK_BUTTON(widget)->icon_data;
     if(icon_width > 0 && icon_height > 0)
-    {
-      if(text)
-        DTGTK_BUTTON(widget)
-            ->icon(cr, border, border, height - (border * 2), height - (border * 2), flags, icon_data);
-      else
-        DTGTK_BUTTON(widget)
-            ->icon(cr, border, border, width - (border * 2), height - (border * 2), flags, icon_data);
-    }
+      DTGTK_BUTTON(widget)->icon(cr, border, border, icon_width, icon_height, flags, icon_data);
   }
 
   /* draw label */

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -18,6 +18,7 @@
 
 #include "paint.h"
 #include "gui/draw.h"
+#include "gui/gtk.h"
 #include <math.h>
 
 #ifndef M_PI
@@ -1428,7 +1429,7 @@ void dtgtk_cairo_paint_help(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   PangoRectangle ink;
   // grow is needed because ink.* are int and everything gets rounded to 1 or so otherwise,
   // leading to imprecise positioning
-  static const float grow = 12.0;
+  float grow = 12.0 * (1 + 0.5 * (darktable.gui->dpi_factor - 1));
   layout = pango_cairo_create_layout(cr);
   const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
@@ -1448,7 +1449,7 @@ void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   PangoRectangle ink;
   // grow is needed because ink.* are int and everything gets rounded to 1 or so otherwise,
   // leading to imprecise positioning
-  static const float grow = 12.0;
+  float grow = 12.0 * (1 + 0.5 * (darktable.gui->dpi_factor - 1));
   layout = pango_cairo_create_layout(cr);
   const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -66,9 +66,6 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   /* fetch flags */
   int flags = DTGTK_TOGGLEBUTTON(widget)->icon_flags;
 
-  /* set inner border */
-  int border = DT_PIXEL_APPLY_DPI((flags & CPF_DO_NOT_USE_BORDER) ? 4 : 6);
-
   /* update active state paint flag */
   gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
   if(active)
@@ -137,19 +134,16 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   /* draw icon */
   if(DTGTK_TOGGLEBUTTON(widget)->icon)
   {
-    int icon_width = text ? height - (border * 2) : width - (border * 2);
-    int icon_height = height - (border * 2);
+    /* set inner border and icon size */
+    float f_border = (1 + 0.66 * (darktable.gui->dpi_factor-1)) * ((flags & CPF_DO_NOT_USE_BORDER) ? 4.0 : 6.0);
+    int border = round(f_border);
+    int icon_width = round(text ? height - (f_border * 2) : width - (f_border * 2));
+    int icon_height = round(height - (f_border * 2));
+
     void *icon_data = DTGTK_TOGGLEBUTTON(widget)->icon_data;
 
     if(icon_width > 0 && icon_height > 0)
-    {
-      if(text)
-        DTGTK_TOGGLEBUTTON(widget)
-            ->icon(cr, border, border, icon_width, icon_height, flags, icon_data);
-      else
-        DTGTK_TOGGLEBUTTON(widget)
-            ->icon(cr, border, border, icon_width, icon_height, flags, icon_data);
-    }
+        DTGTK_TOGGLEBUTTON(widget)->icon(cr, border, border, icon_width, icon_height, flags, icon_data);
   }
 
 


### PR DESCRIPTION
fix for #4005 and top right icons.
In 4k display, Windows 10:

before 
![Cattura22](https://user-images.githubusercontent.com/43290988/73064121-c7714480-3ea0-11ea-8e57-4076ebc26f0f.JPG)

after
![Cattura23](https://user-images.githubusercontent.com/43290988/73064151-d657f700-3ea0-11ea-8e6f-7983ce96545c.JPG)

before
![Cattura24](https://user-images.githubusercontent.com/43290988/73064171-e1128c00-3ea0-11ea-8ab4-fbdc3f4ca87a.JPG)

after
![Cattura27](https://user-images.githubusercontent.com/43290988/73064180-e7a10380-3ea0-11ea-888a-2ea230e622ac.JPG)

