### PR TITLE
Fixing pixelpipe cache data buffers if allocation goes wrong.

### DIFF
--- a/src/develop/pixelpipe_cache.c
+++ b/src/develop/pixelpipe_cache.c
@@ -63,7 +63,17 @@ int dt_dev_pixelpipe_cache_init(dt_dev_pixelpipe_cache_t *cache, int entries, si
   return 1;
 
 alloc_memory_fail:
-  dt_dev_pixelpipe_cache_cleanup(cache);
+  //  dt_dev_pixelpipe_cache_cleanup(cache);
+  // The above code seems to be not correct as failing to allocate the cache->data buffers
+  // should not cleanup the whole pixelpipe cache but only reset the buffers to null.
+  // A warning about low memory will appear but the pipeline still has valid data so dt won't crash
+  // but will only fail to generate thumbnails for example.
+  for(int k = 0; k < cache->entries; k++)
+  {
+    dt_free_align(cache->data[k]);
+    cache->size[k] = 0;
+    cache->data[k] = NULL;
+  }
   return 0;
 }
 


### PR DESCRIPTION
There are the issues #4056 and #4043. From my understanding both are related to
the error handling in `dt_dev_pixelpipe_cache_init` if allocation for one of the
cache->data buffers goes wrong.

In such an error case we should not call `dt_dev_pixelpipe_cache_cleanup` but
only reset each cache->size and cache->data to 0/NULL so the pipeline data are
still valid (so avoiding the reported crash) and the report about the memory-stress
is still reported.

Unfortunately i don't have a windows machine to test but i tried with

```
cache->data[k] = (void *)dt_alloc_align(64, size*100);
if(!cache->data[k]) goto alloc_memory_fail;
```
and very-very large images and this pr fixed the crashes i could also observe
under such memory-stress.