### PR TITLE
fix:filmicrgb: fixed rgb power norm for dark areas

### DIFF
--- a/data/kernels/filmic.cl
+++ b/data/kernels/filmic.cl
@@ -209,7 +209,7 @@ inline float pixel_rgb_norm_power(const float4 pixel)
   const float4 RGB = fabs(pixel);
   const float4 RGB_square = RGB * RGB;
   const float4 RGB_cubic = RGB_square * RGB;
-  return (RGB_cubic.x + RGB_cubic.y + RGB_cubic.z) / fmax(RGB_square.x + RGB_square.y + RGB_square.z, 1e-6f);
+  return (RGB_cubic.x + RGB_cubic.y + RGB_cubic.z) / fmax(RGB_square.x + RGB_square.y + RGB_square.z, 1e-12f);
 }
 
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -313,6 +313,7 @@ static inline float clamp_simd(const float x)
 static inline float pixel_rgb_norm_power(const float pixel[4])
 {
   // weird norm sort of perceptual. This is black magic really, but it looks good.
+  // the full norm is (R^3 + G^3 + B^3) / (R^2 + G^2 + B^2) and it should be in ]0; +infinity[
 
   float numerator = 0.0f;
   float denominator = 0.0f;
@@ -329,7 +330,7 @@ static inline float pixel_rgb_norm_power(const float pixel[4])
     denominator += RGB_square;
   }
 
-  return numerator / fmaxf(denominator, 1e-6f);
+  return numerator / fmaxf(denominator, 1e-12f);  // prevent from division-by-0 (note: (1e-6)^2 = 1e-12
 }
 
 


### PR DESCRIPTION
The denominator in the function pixel_rgb_norm_power() was limited
to a minimum value of 1e-6 (which is about 20 EV stops below 1.0).

But the denominator is the square-sum of R, G and B and thus the norm
was computed wrongly for values at about 10 EV stops (and lower) below
1.0. The minimum denominator value should be (1e-6)^2 = 1e-12.

For the computation of the norm, such a small value should be fine
since the only purpose of this minimum limit is that there is no
division by 0. The norm is specified to be in ]0; +infinity[.