### PR TITLE
remove unused code

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -19,8 +19,6 @@
 #include "colorspace.cl"
 #include "color_conversion.cl"
 
-#define BLEND_ONLY_LIGHTNESS     8
-
 typedef enum dt_develop_blend_mode_t
 {
   DEVELOP_BLEND_MASK_FLAG = 0x80,
@@ -356,7 +354,7 @@ blendop_mask_rgb (__read_only image2d_t in_a, __read_only image2d_t in_b, __read
 
 __kernel void
 blendop_Lab (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask, __write_only image2d_t out, const int width, const int height, 
-             const int blend_mode, const int blendflag, const int2 offs, const int mask_display)
+             const int blend_mode, const int2 offs, const int mask_display)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -370,10 +368,6 @@ blendop_Lab (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only
   float4 a = read_imagef(in_a, sampleri, (int2)(x, y) + offs); // see comment in blend.c:dt_develop_blend_process_cl()
   float4 b = read_imagef(in_b, sampleri, (int2)(x, y));
   float opacity = read_imagef(mask, sampleri, (int2)(x, y)).x;
-
-  /* save before scaling (for later use) */
-  float ay = a.y;
-  float az = a.z;
 
   /* scale L down to [0; 1] and a,b to [-1; 1] */
   const float4 scale = (float4)(100.0f, 128.0f, 128.0f, 1.0f);
@@ -640,13 +634,6 @@ blendop_Lab (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only
   /* we transfer alpha channel of input if mask_display is set, else we save opacity into alpha channel */
   o.w = mask_display ? a.w : opacity;
 
-  /* if module wants to blend only lightness, set a and b to values of input image (saved before scaling) */
-  if (blendflag & BLEND_ONLY_LIGHTNESS)
-  {
-    o.y = ay;
-    o.z = az;
-  }
-
   write_imagef(out, (int2)(x, y), o);
 }
 
@@ -654,7 +641,7 @@ blendop_Lab (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only
 
 __kernel void
 blendop_RAW (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask, __write_only image2d_t out, const int width, const int height, 
-             const int blend_mode, const int blendflag, const int2 offs, const int mask_display)
+             const int blend_mode, const int2 offs, const int mask_display)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);
@@ -799,7 +786,7 @@ blendop_RAW (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only
 
 __kernel void
 blendop_rgb (__read_only image2d_t in_a, __read_only image2d_t in_b, __read_only image2d_t mask, __write_only image2d_t out, const int width, const int height, 
-             const int blend_mode, const int blendflag, const int2 offs, const int mask_display)
+             const int blend_mode, const int2 offs, const int mask_display)
 {
   const int x = get_global_id(0);
   const int y = get_global_id(1);

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -37,8 +37,7 @@ typedef struct _blend_buffer_desc_t
   size_t bch;
 } _blend_buffer_desc_t;
 
-typedef void(_blend_row_func)(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                              int flag);
+typedef void(_blend_row_func)(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask);
 
 static inline float _Hue_2_RGB(float v1, float v2, float vH)
 {
@@ -386,8 +385,7 @@ static void _blend_make_mask(const _blend_buffer_desc_t *bd, const unsigned int 
 }
 
 /* normal blend with clamping */
-static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                                  int flag)
+static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -401,18 +399,9 @@ static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+tb[1]*local_opacity, min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+tb[2]*local_opacity, min[2], max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity, min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity, min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -442,8 +431,7 @@ static void _blend_normal_bounded(const _blend_buffer_desc_t *bd, const float *a
 }
 
 /* normal blend without any clamping */
-static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float *a, float *b,
-                                    const float *mask, int flag)
+static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -458,17 +446,8 @@ static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float 
       _blend_Lab_scale(&b[j], tb);
 
       tb[0] = ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity;
-
-      if(flag == 0)
-      {
-        tb[1] = ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity;
-        tb[2] = ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity;
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[1] = ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity;
+      tb[2] = ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity;
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -496,8 +475,7 @@ static void _blend_normal_unbounded(const _blend_buffer_desc_t *bd, const float 
 }
 
 /* lighten */
-static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -512,21 +490,12 @@ static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&b[j], tb);
 
       tbo = tb[0];
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]>tb[0] ? ta[0] : tb[0])*local_opacity,
-                           min[0], max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[1]+tb[1])*fabsf(tbo-tb[0]),
-                             min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[2]+tb[2])*fabsf(tbo-tb[0]),
-                             min[2], max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] > tb[0] ? ta[0] : tb[0]) * local_opacity,
+                            min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[1] + tb[1]) * fabsf(tbo - tb[0]),
+                            min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[2] + tb[2]) * fabsf(tbo - tb[0]),
+                            min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -556,8 +525,7 @@ static void _blend_lighten(const _blend_buffer_desc_t *bd, const float *a, float
 }
 
 /* darken */
-static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                          int flag)
+static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -572,21 +540,12 @@ static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float 
       _blend_Lab_scale(&b[j], tb);
 
       tbo = tb[0];
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]<tb[0] ? ta[0] : tb[0])*local_opacity,
-                           min[0], max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[1]+tb[1])*fabsf(tbo-tb[0]),
-                             min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-fabsf(tbo-tb[0]))+0.5f*(ta[2]+tb[2])*fabsf(tbo-tb[0]),
-                             min[2], max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] < tb[0] ? ta[0] : tb[0]) * local_opacity,
+                            min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[1] + tb[1]) * fabsf(tbo - tb[0]),
+                            min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2] * (1.0f - fabsf(tbo - tb[0])) + 0.5f * (ta[2] + tb[2]) * fabsf(tbo - tb[0]),
+                            min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -617,8 +576,7 @@ static void _blend_darken(const _blend_buffer_desc_t *bd, const float *a, float 
 }
 
 /* multiply */
-static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                            int flag)
+static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -634,37 +592,25 @@ static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, floa
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
       lmax = max[0] + fabsf(min[0]);
-      la =clamp_range_f(ta[0]+fabsf(min[0]), lmin, lmax);
-      lb =clamp_range_f(tb[0]+fabsf(min[0]), lmin, lmax);
+      la = clamp_range_f(ta[0] + fabsf(min[0]), lmin, lmax);
+      lb = clamp_range_f(tb[0] + fabsf(min[0]), lmin, lmax);
 
-      tb[0] =clamp_range_f((la*(1.0f-local_opacity))+((la*lb)*local_opacity), min[0], max[0])
+      tb[0] = clamp_range_f((la * (1.0f - local_opacity)) + ((la * lb) * local_opacity), min[0], max[0])
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1]
-              =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity,
-                             min[1], max[1]);
-          tb[2]
-              =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity,
-                             min[2], max[2]);
-        }
-        else
-        {
-          tb[1]
-              =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])*tb[0]/0.01f*local_opacity,
-                             min[1], max[1]);
-          tb[2]
-              =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])*tb[0]/0.01f*local_opacity,
-                             min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -697,8 +643,7 @@ static void _blend_multiply(const _blend_buffer_desc_t *bd, const float *a, floa
 }
 
 /* average */
-static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -712,21 +657,12 @@ static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]+tb[0])/2.0f*local_opacity, min[0],
-                           max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])/2.0f*local_opacity, min[1],
-                             max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])/2.0f*local_opacity, min[2],
-                             max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0]
+          = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] + tb[0]) / 2.0f * local_opacity, min[0], max[0]);
+      tb[1]
+          = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) / 2.0f * local_opacity, min[1], max[1]);
+      tb[2]
+          = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) / 2.0f * local_opacity, min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -758,7 +694,7 @@ static void _blend_average(const _blend_buffer_desc_t *bd, const float *a, float
 }
 
 /* add */
-static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
+static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -772,21 +708,9 @@ static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b,
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+(ta[0]+tb[0])*local_opacity, min[0],
-                           max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+(ta[1]+tb[1])*local_opacity, min[1],
-                             max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+(ta[2]+tb[2])*local_opacity, min[2],
-                             max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + (ta[0] + tb[0]) * local_opacity, min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + (ta[1] + tb[1]) * local_opacity, min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + (ta[2] + tb[2]) * local_opacity, min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -821,8 +745,7 @@ static void _blend_add(const _blend_buffer_desc_t *bd, const float *a, float *b,
 }
 
 /* substract */
-static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -836,24 +759,15 @@ static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, flo
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(
-          ta[0]*(1.0f-local_opacity)+((tb[0]+ta[0])-(fabsf(min[0]+max[0])))*local_opacity,
-          min[0], max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(
-            ta[1]*(1.0f-local_opacity)+((tb[1]+ta[1])-(fabsf(min[1]+max[1])))*local_opacity,
-            min[1], max[1]);
-        tb[2] =clamp_range_f(
-            ta[2]*(1.0f-local_opacity)+((tb[2]+ta[2])-(fabsf(min[2]+max[2])))*local_opacity,
-            min[2], max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity)
+                                + ((tb[0] + ta[0]) - (fabsf(min[0] + max[0]))) * local_opacity,
+                            min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity)
+                                + ((tb[1] + ta[1]) - (fabsf(min[1] + max[1]))) * local_opacity,
+                            min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity)
+                                + ((tb[2] + ta[2]) - (fabsf(min[2] + max[2]))) * local_opacity,
+                            min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -890,8 +804,7 @@ static void _blend_substract(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* difference (deprecated) */
-static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                              int flag)
+static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -912,24 +825,16 @@ static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, fl
       tb[0] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
-      {
-        lmax = max[1] + fabsf(min[1]);
-        la =clamp_range_f(ta[1]+fabsf(min[1]), lmin, lmax);
-        lb =clamp_range_f(tb[1]+fabsf(min[1]), lmin, lmax);
-        tb[1] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
-                - fabsf(min[1]);
-        lmax = max[2] + fabsf(min[2]);
-        la =clamp_range_f(ta[2]+fabsf(min[2]), lmin, lmax);
-        lb =clamp_range_f(tb[2]+fabsf(min[2]), lmin, lmax);
-        tb[2] =clamp_range_f(la*(1.0f-local_opacity)+fabsf(la-lb)*local_opacity, lmin, lmax)
-                - fabsf(min[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      lmax = max[1] + fabsf(min[1]);
+      la = clamp_range_f(ta[1] + fabsf(min[1]), lmin, lmax);
+      lb = clamp_range_f(tb[1] + fabsf(min[1]), lmin, lmax);
+      tb[1] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
+              - fabsf(min[1]);
+      lmax = max[2] + fabsf(min[2]);
+      la = clamp_range_f(ta[2] + fabsf(min[2]), lmin, lmax);
+      lb = clamp_range_f(tb[2] + fabsf(min[2]), lmin, lmax);
+      tb[2] = clamp_range_f(la * (1.0f - local_opacity) + fabsf(la - lb) * local_opacity, lmin, lmax)
+              - fabsf(min[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -974,8 +879,7 @@ static void _blend_difference(const _blend_buffer_desc_t *bd, const float *a, fl
 }
 
 /* difference 2 (new) */
-static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                               int flag)
+static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -994,18 +898,9 @@ static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, f
       tb[2] = fabsf(ta[2] - tb[2]) / fabsf(max[2] - min[2]);
       tb[0] = fmaxf(tb[0], fmaxf(tb[1], tb[2]));
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] = 0.0f;
-        tb[2] = 0.0f;
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
+      tb[1] = 0.0f;
+      tb[2] = 0.0f;
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -1051,8 +946,7 @@ static void _blend_difference2(const _blend_buffer_desc_t *bd, const float *a, f
 }
 
 /* screen */
-static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                          int flag)
+static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1074,31 +968,23 @@ static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float 
                            lmin, lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)
-                               +0.5f*(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)
-                               +0.5f*(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity,
-                               min[2], max[2]);
-        }
-        else
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)
-                               +0.5f*(ta[1]+tb[1])*tb[0]/0.01f*local_opacity,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)
-                               +0.5f*(ta[2]+tb[2])*tb[0]/0.01f*local_opacity,
-                               min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity)
+                                  + 0.5f * (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity)
+                                  + 0.5f * (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity)
+                                  + 0.5f * (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity)
+                                  + 0.5f * (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -1152,8 +1038,7 @@ static void _blend_screen(const _blend_buffer_desc_t *bd, const float *a, float 
 }
 
 /* overlay */
-static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1181,31 +1066,19 @@ static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float
                            lmin, lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
-        }
-        else
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -1272,8 +1145,7 @@ static void _blend_overlay(const _blend_buffer_desc_t *bd, const float *a, float
 }
 
 /* softlight */
-static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
 
   float max[4] = { 0 }, min[4] = { 0 };
@@ -1301,31 +1173,19 @@ static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, flo
           lmin, lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
-        }
-        else
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -1389,8 +1249,7 @@ static void _blend_softlight(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* hardlight */
-static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1418,31 +1277,19 @@ static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, flo
                            lmin, lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
-        }
-        else
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -1509,8 +1356,7 @@ static void _blend_hardlight(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* vividlight */
-static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                              int flag)
+static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1538,31 +1384,19 @@ static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, fl
                            lmin, lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
-        }
-        else
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -1628,8 +1462,7 @@ static void _blend_vividlight(const _blend_buffer_desc_t *bd, const float *a, fl
 }
 
 /* linearlight */
-static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                               int flag)
+static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1653,31 +1486,19 @@ static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, f
                            lmax)
               - fabsf(min[0]);
 
-      if(flag == 0)
+      if(ta[0] > 0.01f)
       {
-        if(ta[0] > 0.01f)
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/ta[0]*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/ta[0]*local_opacity2,
-                               min[2], max[2]);
-        }
-        else
-        {
-          tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity2)
-                               +(ta[1]+tb[1])*tb[0]/0.01f*local_opacity2,
-                               min[1], max[1]);
-          tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity2)
-                               +(ta[2]+tb[2])*tb[0]/0.01f*local_opacity2,
-                               min[2], max[2]);
-        }
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / ta[0] * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / ta[0] * local_opacity2,
+                              min[2], max[2]);
       }
       else
       {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
+        tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity2) + (ta[1] + tb[1]) * tb[0] / 0.01f * local_opacity2,
+                              min[1], max[1]);
+        tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity2) + (ta[2] + tb[2]) * tb[0] / 0.01f * local_opacity2,
+                              min[2], max[2]);
       }
 
       _blend_Lab_rescale(tb, &b[j]);
@@ -1735,8 +1556,7 @@ static void _blend_linearlight(const _blend_buffer_desc_t *bd, const float *a, f
 }
 
 /* pinlight */
-static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                            int flag)
+static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1830,8 +1650,7 @@ static void _blend_pinlight(const _blend_buffer_desc_t *bd, const float *a, floa
 }
 
 /* lightness blend */
-static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1884,8 +1703,7 @@ static void _blend_lightness(const _blend_buffer_desc_t *bd, const float *a, flo
 }
 
 /* chroma blend */
-static void _blend_chroma(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                          int flag)
+static void _blend_chroma(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -1945,7 +1763,7 @@ static void _blend_chroma(const _blend_buffer_desc_t *bd, const float *a, float 
 }
 
 /* hue blend */
-static void _blend_hue(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
+static void _blend_hue(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -2011,7 +1829,7 @@ static void _blend_hue(const _blend_buffer_desc_t *bd, const float *a, float *b,
 }
 
 /* color blend; blend hue and chroma, but not lightness */
-static void _blend_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask, int flag)
+static void _blend_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -2080,8 +1898,7 @@ static void _blend_color(const _blend_buffer_desc_t *bd, const float *a, float *
 }
 
 /* color adjustment; blend hue and chroma; take lightness from module output */
-static void _blend_coloradjust(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                               int flag)
+static void _blend_coloradjust(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -2149,8 +1966,7 @@ static void _blend_coloradjust(const _blend_buffer_desc_t *bd, const float *a, f
 }
 
 /* inverse blend */
-static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                           int flag)
+static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   float max[4] = { 0 }, min[4] = { 0 };
   _blend_colorspace_channel_range(bd->cst, min, max);
@@ -2164,18 +1980,9 @@ static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float
       _blend_Lab_scale(&a[j], ta);
       _blend_Lab_scale(&b[j], tb);
 
-      tb[0] =clamp_range_f(ta[0]*(1.0f-local_opacity)+tb[0]*local_opacity, min[0], max[0]);
-
-      if(flag == 0)
-      {
-        tb[1] =clamp_range_f(ta[1]*(1.0f-local_opacity)+tb[1]*local_opacity, min[1], max[1]);
-        tb[2] =clamp_range_f(ta[2]*(1.0f-local_opacity)+tb[2]*local_opacity, min[2], max[2]);
-      }
-      else
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
+      tb[0] = clamp_range_f(ta[0] * (1.0f - local_opacity) + tb[0] * local_opacity, min[0], max[0]);
+      tb[1] = clamp_range_f(ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity, min[1], max[1]);
+      tb[2] = clamp_range_f(ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity, min[2], max[2]);
 
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
@@ -2206,8 +2013,7 @@ static void _blend_inverse(const _blend_buffer_desc_t *bd, const float *a, float
 
 /* blend only lightness in Lab color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_Lab_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                                 int flag)
+static void _blend_Lab_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2232,8 +2038,7 @@ static void _blend_Lab_lightness(const _blend_buffer_desc_t *bd, const float *a,
 
 /* blend only a-channel in Lab color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_Lab_a(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_Lab_a(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2258,8 +2063,7 @@ static void _blend_Lab_a(const _blend_buffer_desc_t *bd, const float *a, float *
 
 /* blend only b-channel in Lab color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_Lab_b(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_Lab_b(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2285,8 +2089,7 @@ static void _blend_Lab_b(const _blend_buffer_desc_t *bd, const float *a, float *
 
 /* blend only color in Lab color space without any clamping (a noop for other
  * color spaces) */
-static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_Lab)
   {
@@ -2301,12 +2104,6 @@ static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, flo
       tb[1] = ta[1] * (1.0f - local_opacity) + tb[1] * local_opacity;
       tb[2] = ta[2] * (1.0f - local_opacity) + tb[2] * local_opacity;
 
-      if(flag != 0)
-      {
-        tb[1] = ta[1];
-        tb[2] = ta[2];
-      }
-
       _blend_Lab_rescale(tb, &b[j]);
       b[j + 3] = local_opacity;
     }
@@ -2317,8 +2114,7 @@ static void _blend_Lab_color(const _blend_buffer_desc_t *bd, const float *a, flo
 
 /* blend only lightness in HSV color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_HSV_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                                 int flag)
+static void _blend_HSV_lightness(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2346,8 +2142,7 @@ static void _blend_HSV_lightness(const _blend_buffer_desc_t *bd, const float *a,
 
 /* blend only color in HSV color space without any clamping (a noop for other
  * color spaces) */
-static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                             int flag)
+static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2385,8 +2180,7 @@ static void _blend_HSV_color(const _blend_buffer_desc_t *bd, const float *a, flo
 
 /* blend only R-channel in RGB color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_RGB_R(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_RGB_R(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2402,13 +2196,11 @@ static void _blend_RGB_R(const _blend_buffer_desc_t *bd, const float *a, float *
   }
   else /* if(bd->cst == iop_cs_Lab || bd->cst == iop_cs_RAW) */
     _blend_noop(bd, a, b, mask, NULL, NULL); // Noop for Lab and Raw (unclamped)
-
 }
 
 /* blend only R-channel in RGB color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_RGB_G(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_RGB_G(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2428,8 +2220,7 @@ static void _blend_RGB_G(const _blend_buffer_desc_t *bd, const float *a, float *
 
 /* blend only R-channel in RGB color space without any clamping (a noop for
  * other color spaces) */
-static void _blend_RGB_B(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask,
-                         int flag)
+static void _blend_RGB_B(const _blend_buffer_desc_t *bd, const float *a, float *b, const float *mask)
 {
   if(bd->cst == iop_cs_rgb)
   {
@@ -2837,9 +2628,6 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
         ? self->request_mask_display
         : DT_DEV_PIXELPIPE_DISPLAY_NONE;
 
-  // check if we only should blend lightness channel. will affect only Lab space
-  const int blendflag = self->flags() & IOP_FLAGS_BLEND_ONLY_LIGHTNESS;
-
   // get channel max values depending on colorspace
   const dt_iop_colorspace_type_t cst = self->blend_colorspace(self, piece->pipe, piece);
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
@@ -3061,10 +2849,10 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
   // select the blend operator
   _blend_row_func *const blend = dt_develop_choose_blend_func(d->blend_mode);
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(bch, blend, blendflag, ch, cst, ivoid, iwidth, mask, \
+#pragma omp parallel for default(none)                                                                            \
+  dt_omp_firstprivate(bch, blend, ch, cst, ivoid, iwidth, mask, \
                       mask_display, oheight, ovoid, owidth, \
-                      request_mask_display, work_profile, xoffs, yoffs)
+                        request_mask_display, work_profile, xoffs, yoffs)
 #endif
   for(size_t y = 0; y < oheight; y++)
   {
@@ -3078,7 +2866,7 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
     if(request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_ANY)
       display_channel(&bd, in, out, m, request_mask_display, work_profile);
     else
-      blend(&bd, in, out, m, blendflag);
+      blend(&bd, in, out, m);
 
     if((mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) && cst != iop_cs_RAW)
       for(size_t j = 0; j < bd.stride; j += 4) out[j + 3] = in[j + 3];
@@ -3152,9 +2940,6 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
          && (mask_mode & DEVELOP_MASK_MASK_CONDITIONAL))
             ? self->request_mask_display
             : DT_DEV_PIXELPIPE_DISPLAY_NONE;
-
-  // check if we only should blend lightness channel. will affect only Lab space
-  const int blendflag = self->flags() & IOP_FLAGS_BLEND_ONLY_LIGHTNESS;
 
   // get channel max values depending on colorspace
   const dt_iop_colorspace_type_t cst = self->blend_colorspace(self, piece->pipe, piece);
@@ -3501,9 +3286,8 @@ int dt_develop_blend_process_cl(struct dt_iop_module_t *self, struct dt_dev_pixe
     dt_opencl_set_kernel_arg(devid, kernel, 4, sizeof(int), (void *)&owidth);
     dt_opencl_set_kernel_arg(devid, kernel, 5, sizeof(int), (void *)&oheight);
     dt_opencl_set_kernel_arg(devid, kernel, 6, sizeof(unsigned), (void *)&blend_mode);
-    dt_opencl_set_kernel_arg(devid, kernel, 7, sizeof(int), (void *)&blendflag);
-    dt_opencl_set_kernel_arg(devid, kernel, 8, 2 * sizeof(int), (void *)&offs);
-    dt_opencl_set_kernel_arg(devid, kernel, 9, sizeof(int), (void *)&mask_display);
+    dt_opencl_set_kernel_arg(devid, kernel, 7, 2 * sizeof(int), (void *)&offs);
+    dt_opencl_set_kernel_arg(devid, kernel, 8, sizeof(int), (void *)&mask_display);
     err = dt_opencl_enqueue_kernel_2d(devid, kernel, sizes);
     if(err != CL_SUCCESS) goto error;
   }

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -93,8 +93,6 @@ typedef enum dt_iop_flags_t
   IOP_FLAGS_INCLUDE_IN_STYLES = 1 << 0,
   IOP_FLAGS_SUPPORTS_BLENDING = 1 << 1, // Does provide blending modes
   IOP_FLAGS_DEPRECATED = 1 << 2,
-  IOP_FLAGS_BLEND_ONLY_LIGHTNESS
-  = 1 << 3, // Does only blend with L-channel in Lab space. Keeps a, b of original image.
   IOP_FLAGS_ALLOW_TILING = 1 << 4, // Does allow tile-wise processing (valid for CPU and GPU processing)
   IOP_FLAGS_HIDDEN = 1 << 5,       // Hide the iop from userinterface
   IOP_FLAGS_TILING_FULL_ROI


### PR DESCRIPTION
Removes some old unused code related to the unused `IOP_FLAGS_BLEND_ONLY_LIGHTNESS` flag.