### PR TITLE
Speed up UI by fixing and enabling preview downsampling

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2040,4 +2040,11 @@
     <shortdescription>version of the last completed performance configuration</shortdescription>
     <longdescription>what was the last performance configuration which has been completed</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>preview_downsampling</name>
+    <type>float</type>
+    <default>1.0</default>
+    <shortdescription>resolution reduction of preview image</shortdescription>
+    <longdescription>decrease to 0.5 or 0.25 to speed up preview rendering</longdescription>
+  </dtconfig>
 </dtconfiglist>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2312,10 +2312,19 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
 
 int dt_dev_distort_transform(dt_develop_t *dev, float *points, size_t points_count)
 {
-  return dt_dev_distort_transform_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  int result = dt_dev_distort_transform_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  for(size_t idx=0; idx<points_count; idx++) {
+    points[idx*2] *= dev->preview_downsampling;
+    points[idx*2+1] *= dev->preview_downsampling;
+  }
+  return result;
 }
 int dt_dev_distort_backtransform(dt_develop_t *dev, float *points, size_t points_count)
 {
+  for(size_t idx=0; idx<points_count; idx++) {
+    points[idx*2] /= dev->preview_downsampling;
+    points[idx*2+1] /= dev->preview_downsampling;
+  }
   return dt_dev_distort_backtransform_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -54,7 +54,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
   memset(dev, 0, sizeof(dt_develop_t));
   dev->full_preview = FALSE;
-  dev->preview_downsampling = 1.0f;
+  dev->preview_downsampling = dt_conf_get_float("preview_downsampling");
   dev->gui_module = NULL;
   dev->timestamp = 0;
   dev->average_delay = DT_DEV_AVERAGE_DELAY_START;
@@ -681,6 +681,9 @@ float dt_dev_get_zoom_scale(dt_develop_t *dev, dt_dev_zoom_t zoom, int closeup_f
       if(preview) zoom_scale *= ps;
       break;
   }
+
+  if(preview) zoom_scale /= dev->preview_downsampling;
+
   return zoom_scale;
 }
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2093,8 +2093,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   // in creation mode
   if(gui->creation)
   {
-    const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;
+    const float wd = darktable.develop->preview_pipe->iwidth * darktable.develop->preview_downsampling;
+    const float ht = darktable.develop->preview_pipe->iheight * darktable.develop->preview_downsampling;
 
     if(gui->guipoints_count == 0)
     {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -253,6 +253,7 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }
+    circle->radius /= darktable.develop->preview_downsampling;
     form->points = g_list_append(form->points, circle);
     dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -253,7 +253,6 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }
-    circle->radius /= darktable.develop->preview_downsampling;
     form->points = g_list_append(form->points, circle);
     dt_masks_gui_form_save_creation(darktable.develop, crea_module, form, gui);
 
@@ -496,8 +495,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   // in creation mode
   if(gui->creation)
   {
-    float wd = darktable.develop->preview_pipe->iwidth;
-    float ht = darktable.develop->preview_pipe->iheight;
+    float wd = darktable.develop->preview_pipe->iwidth * darktable.develop->preview_downsampling;
+    float ht = darktable.develop->preview_pipe->iheight * darktable.develop->preview_downsampling;
 
     if(gui->guipoints_count == 0)
     {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -527,6 +527,11 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
                                      : DT_DEV_TRANSFORM_DIR_FORW_EXCL),
                                     fbox, 2);
 
+  // correct coordinates if preview is downsampled
+  if(!darktable.lib->proxy.colorpicker.size) {
+    for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
+  }
+
   fbox[0] -= roi->x;
   fbox[1] -= roi->y;
   fbox[2] -= roi->x;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -522,9 +522,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   }
 
   // correct coordinates if preview is downsampled
-  if(module->iop_order > 16) { // apply only *after* Crop and Rotate (module 16)
-    for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
-  }
+  for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
 
   // transform back to current module coordinates
   dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -522,7 +522,9 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   }
 
   // correct coordinates if preview is downsampled
-  for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
+  if(module->iop_order > 16) { // apply only *after* Crop and Rotate (module 16)
+    for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
+  }
 
   // transform back to current module coordinates
   dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -521,16 +521,16 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
     fbox[1] = fbox[3] = module->color_picker_point[1] * ht;
   }
 
+  // correct coordinates if preview is downsampled
+  if(module->iop_order > 16) { // apply only *after* Crop and Rotate (module 16)
+    for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
+  }
+
   // transform back to current module coordinates
   dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
                                     module->iop_order, ((picker_source == PIXELPIPE_PICKER_INPUT) ? DT_DEV_TRANSFORM_DIR_FORW_INCL
                                      : DT_DEV_TRANSFORM_DIR_FORW_EXCL),
                                     fbox, 2);
-
-  // correct coordinates if preview is downsampled
-  if(!darktable.lib->proxy.colorpicker.size) {
-    for(int idx=0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
-  }
 
   fbox[0] -= roi->x;
   fbox[1] -= roi->y;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -505,13 +505,6 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
     float pi[2], po[2];
-
-    // correct coordinates if preview is downsampled:
-    // this actually un-corrects coordinates, and somehow the following
-    // code re-applies the downsampling.
-    points[i] /= darktable.develop->preview_downsampling;
-    points[i+1] /= darktable.develop->preview_downsampling;
-
     pi[0] = -(d->enlarge_x - d->cix) / factor + points[i];
     pi[1] = -(d->enlarge_y - d->ciy) / factor + points[i + 1];
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -505,6 +505,13 @@ int distort_backtransform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, 
   for(size_t i = 0; i < points_count * 2; i += 2)
   {
     float pi[2], po[2];
+
+    // correct coordinates if preview is downsampled:
+    // this actually un-corrects coordinates, and somehow the following
+    // code re-applies the downsampling.
+    points[i] /= darktable.develop->preview_downsampling;
+    points[i+1] /= darktable.develop->preview_downsampling;
+
     pi[0] = -(d->enlarge_x - d->cix) / factor + points[i];
     pi[1] = -(d->enlarge_y - d->ciy) / factor + points[i + 1];
 


### PR DESCRIPTION
According to `darktable -d perf`, darktable spends roughly half its interactive rendering time on rendering the preview pipeline, and half on the image pipeline. From the performance log, it seems that both pipelines are rendered in parallel. For the sake of illustration, let's say they both take 500 ms for a particular rendering job and finish at the same time.

So whenever I move a slider, the main image updates about twice per second. This makes the UI feel rather sluggish.

Delving into the source code, I found there already is [an option for downsampling the preview](https://github.com/darktable-org/darktable/blob/master/src/develop/develop.c#L57). However, setting the option to 0.5 makes all previews look too small (when zooming or panning while the main view is not rendered yet). This is apparently caused by an incorrect zoom scale in `dt_dev_get_zoom_scale`, which doesn't take `preview_downsampling` into account. This PR fixes this bug.

Now, setting `preview_downsampling` to 0.25 makes the preview pipe rendering take only a tiny fraction of the original time, roughly 50 ms, and--more importantly--thereby reduces the image pipe rendering times by half, to 250 ms. Thus the Darktable UI updates twice as fast as before, which is highly noticeable!

This PR does not in fact reduce `preview_downsampling`, yet, but makes it a configurable parameter in the darktablerc.

Caveats:

- I suspect that my fix for `preview_downsampling` still has bugs. In particular, I don't understand the function of the `ps` variable in [develop.c:663](https://github.com/darktable-org/darktable/blob/master/src/develop/develop.c#L663), which seems to apply `preview_downsampling` sometimes. This needs review by someone who knows what these things do.

- Setting `preview_downsampling` to weird numbers (3.14, 0.23, even 0.0 and -1.5) seems to not cause crashes. Still, some form of validation might be a good idea. Any hints on how/where to implement that would be appreciated.

- I am running Darktable on Kubuntu Linux, on an Intel i7 8809G with a AMD Radeon RX Vega M GH with OpenCL enabled using ROCm. I am running on a 4K screen. It might be that `preview_downsampling` is less necessary on lower-resolution screens or more powerful GPUs or some such.