### PR TITLE
fix #4021

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1009,9 +1009,9 @@ blendop_mask_tone_curve(__read_only image2d_t mask_in, __write_only image2d_t ma
   float opacity = read_imagef(mask_in, sampleri, (int2)(x, y)).x;
   float scaled_opacity = (2.f * opacity / gopacity - 1.f);
   if (1.f - brightness <= 0.f)
-    scaled_opacity = opacity <= FLT_EPSILON ? -1.f : 1.f;
+    scaled_opacity = opacity <= 16 * FLT_EPSILON ? -1.f : 1.f;
   else if (1.f + brightness <= 0.f)
-    scaled_opacity = opacity >= 1.f - FLT_EPSILON ? 1.f : -1.f;
+    scaled_opacity = opacity >= 1.f - 16 * FLT_EPSILON ? 1.f : -1.f;
   else if (brightness > 0.f)
   {
     scaled_opacity = (scaled_opacity + brightness) / (1.f - brightness);

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -83,33 +83,43 @@ static inline int max_i(int a, int b)
   return a > b ? a : b;
 }
 
+// Kahan summation algorithm
+static inline float Kahan_sum(const float m, float *c, const float add)
+{
+   const float t1 = add - (*c);
+   const float t2 = m + t1;
+   *c = (t2 - m) - t1;
+   return t2;
+}
+
 // calculate the one-dimensional moving average over a window of size 2*w+1
 // input array x has stride 1, output array y has stride stride_y
 static inline void box_mean_1d(int N, const float *x, float *y, size_t stride_y, int w)
 {
-  float m = 0.f, n_box = 0.f;
+  float m = 0.f, n_box = 0.f, c = 0.f;
   if(N > 2 * w)
   {
     for(int i = 0, i_end = w + 1; i < i_end; i++)
     {
-      m += x[i];
+      m = Kahan_sum(m, &c, x[i]);
       n_box++;
     }
     for(int i = 0, i_end = w; i < i_end; i++)
     {
       y[i * stride_y] = m / n_box;
-      m += x[i + w + 1];
+      m = Kahan_sum(m, &c, x[i + w + 1]);
       n_box++;
     }
     for(int i = w, i_end = N - w - 1; i < i_end; i++)
     {
       y[i * stride_y] = m / n_box;
-      m += x[i + w + 1] - x[i - w];
+      m = Kahan_sum(m, &c, x[i + w + 1]),
+      m = Kahan_sum(m, &c, -x[i - w]);
     }
     for(int i = N - w - 1, i_end = N; i < i_end; i++)
     {
       y[i * stride_y] = m / n_box;
-      m -= x[i - w];
+      m = Kahan_sum(m, &c, -x[i - w]);
       n_box--;
     }
   }
@@ -117,7 +127,7 @@ static inline void box_mean_1d(int N, const float *x, float *y, size_t stride_y,
   {
     for(int i = 0, i_end = min_i(w + 1, N); i < i_end; i++)
     {
-      m += x[i];
+      m = Kahan_sum(m, &c, x[i]);
       n_box++;
     }
     for(int i = 0; i < N; i++)
@@ -125,12 +135,12 @@ static inline void box_mean_1d(int N, const float *x, float *y, size_t stride_y,
       y[i * stride_y] = m / n_box;
       if(i - w >= 0)
       {
-        m -= x[i - w];
+        m = Kahan_sum(m, &c, -x[i - w]);
         n_box--;
       }
       if(i + w + 1 < N)
       {
-        m += x[i + w + 1];
+        m = Kahan_sum(m, &c, x[i + w + 1]);
         n_box++;
       }
     }

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2827,9 +2827,9 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
         float x = mask[k] / opacity;
         x = 2.f * x - 1.f;
         if (1.f - brightness <= 0.f)
-          x = mask[k] <= FLT_EPSILON ? -1.f : 1.f;
+          x = mask[k] <= 16 * FLT_EPSILON ? -1.f : 1.f;
         else if (1.f + brightness <= 0.f)
-          x = mask[k] >= 1.f - FLT_EPSILON ? 1.f : -1.f;
+          x = mask[k] >= 1.f - 16 * FLT_EPSILON ? 1.f : -1.f;
         else if (brightness > 0.f)
         {
           x = (x + brightness) / (1.f - brightness);


### PR DESCRIPTION
Addresses the same issue as pull request #4226. This change, however, is more appropriate in my view.

Context: Mask opacity equal to 1 means that all mask values become 1 (fully opaque) except those which where zero (fully transparent) before mask refinement via _mask opacity_ and _mask contrast_ sliders. In practice, however, we have to account for finite precision floating point arithmetics. The application of the guided filter to the image mask can change mask values which are equal to zero to some tiny non-zero values due to finite precision floating point arithmetics. We have to account for these possible rounding errors later in the mask refinement, in particular if _mask opacity_ is +/-1.

Furthermore, numerical accuracy of the guided filter is enhanced by using `double` for accumulation in the calculation of the sliding-box mean.