### PR TITLE
Fix accelerator name for timeline

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -166,7 +166,7 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   dt_accel_path_view(path, sizeof(path), "lighttable", "sticky preview with focus detection");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_preview_sticky_focus);
 
-  dt_accel_path_view(path, sizeof(path), "lighttable", "toggle filmstrip/timeline");
+  dt_accel_path_view(path, sizeof(path), "lighttable", "toggle filmstrip or timeline");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.lighttable_timeline);
 
   dt_accel_path_view(path, sizeof(path), "lighttable", "preview zoom 100%");

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -4453,7 +4453,7 @@ void init_key_accels(dt_view_t *self)
   dt_accel_register_view(self, NC_("accel", "preview zoom fit"), 0, 0);
 
   // timeline
-  dt_accel_register_view(self, NC_("accel", "toggle filmstrip/timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
+  dt_accel_register_view(self, NC_("accel", "toggle filmstrip or timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
 }
 
 static gboolean _lighttable_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -4568,7 +4568,7 @@ void connect_key_accels(dt_view_t *self)
 
   // timeline
   closure = g_cclosure_new(G_CALLBACK(timeline_key_accel_callback), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle filmstrip/timeline", closure);
+  dt_accel_connect_view(self, "toggle filmstrip or timeline", closure);
 }
 
 GSList *mouse_actions(const dt_view_t *self)


### PR DESCRIPTION
The "/" in the accelerator name causes it to be split over two levels in the shortcuts dialog