### PR TITLE
Minor fix on collect.c

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1764,6 +1764,7 @@ static void combo_changed(GtkComboBox *combo, dt_lib_collect_rule_t *d)
   }
   else if(property == DT_COLLECTION_PROP_FILENAME)
   {
+    /* xgettext:no-c-format */
     gtk_widget_set_tooltip_text(d->text, _("type your query, use `%' as wildcard and `,' to separate values"));
   }
   else


### PR DESCRIPTION
Adding line with _"no-c-format"_ to avoid error **"msgtr is not a valid C string format, unlike msgid"** when translating