### PR TITLE
Made modules search case insensetive

### DIFF
--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -399,9 +399,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
         }
         else
         {
-          int is_match = (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_name(module->op), -1), -1,
-                                       g_utf8_casefold(text_entered, -1))
-                          != NULL);
+          const int is_match = (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_name(module->op), -1), -1,
+                                             g_utf8_casefold(text_entered, -1))
+                                != NULL);
 
           if(is_match)
             gtk_widget_show(w);

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -399,7 +399,9 @@ static void _lib_modulegroups_update_iop_visibility(dt_lib_module_t *self)
         }
         else
         {
-          int is_match = (g_strstr_len(dt_iop_get_localized_name(module->op), -1, text_entered) != NULL);
+          int is_match = (g_strstr_len(g_utf8_casefold(dt_iop_get_localized_name(module->op), -1), -1,
+                                       g_utf8_casefold(text_entered, -1))
+                          != NULL);
 
           if(is_match)
             gtk_widget_show(w);


### PR DESCRIPTION
Related to the issue #3424. It is really an issue for some languages, where the names of the modules contain capital letters.