### PR TITLE
Collect only based on enabled module in dev history

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1506,7 +1506,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
       {
         query = dt_util_dstrcat(query, "(id IN (SELECT imgid AS id FROM main.history AS h "
                                        "JOIN memory.darktable_iop_names AS m ON m.operation = h.operation "
-                                       "WHERE m.name LIKE '%s'))", escaped_text);
+                                       "WHERE h.enabled = 1 AND m.name LIKE '%s'))", escaped_text);
       }
       break;
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1512,7 +1512,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
         snprintf(query, sizeof(query),
                  "SELECT m.name AS module_name, 1, COUNT(*) AS count"
                  " FROM main.images AS mi"
-                 " JOIN (SELECT DISTINCT imgid, operation FROM main.history) AS h"
+                 " JOIN (SELECT DISTINCT imgid, operation FROM main.history WHERE enabled = 1) AS h"
                  "  ON h.imgid = mi.id"
                  " JOIN memory.darktable_iop_names AS m"
                  "  ON m.operation = h.operation"


### PR DESCRIPTION
This small change makes sure that module collection from PR #4291 is only based off on enabled modules as suggested by @Nilvus 

