### PR TITLE
collect module - remove configuration hidden module

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1263,25 +1263,8 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     break;
 
     case DT_COLLECTION_PROP_HISTORY: // history
-      {
-        int i = 0;
-        for(i = 0; i < DT_IOP_ORDER_LAST; i++)
-        {
-          char *hist_text = dt_util_dstrcat(NULL, "%s - %s", _("altered"),
-                                            _(dt_iop_order_string(i)));
-          if(strcmp(escaped_text, hist_text) == 0)
-          {
-            g_free(hist_text);
-            break;
-          }
-          g_free(hist_text);
-        }
-        if(i < DT_IOP_ORDER_LAST)
-          query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.module_order "
-                                         "WHERE version = %d))", i);
-        else
-          query = dt_util_dstrcat(query, "(id NOT IN (SELECT imgid FROM main.module_order))");
-      }
+      query = dt_util_dstrcat(query, "(id %s IN (SELECT DISTINCT(imgid) FROM main.history)) ",
+                              (strcmp(escaped_text, _("altered")) == 0) ? "" : "not");
       break;
 
     case DT_COLLECTION_PROP_GEOTAGGING: // geotagging
@@ -1524,6 +1507,21 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
         query = dt_util_dstrcat(query, "(id IN (SELECT imgid AS id FROM main.history AS h "
                                        "JOIN memory.darktable_iop_names AS m ON m.operation = h.operation "
                                        "WHERE h.enabled = 1 AND m.name LIKE '%s'))", escaped_text);
+      }
+      break;
+
+    case DT_COLLECTION_PROP_ORDER: // module order
+      {
+        int i = 0;
+        for(i = 0; i < DT_IOP_ORDER_LAST; i++)
+        {
+          if(strcmp(escaped_text, _(dt_iop_order_string(i))) == 0) break;
+        }
+        if(i < DT_IOP_ORDER_LAST)
+          query = dt_util_dstrcat(query, "(id IN (SELECT imgid FROM main.module_order "
+                                         "WHERE version = %d))", i);
+        else
+          query = dt_util_dstrcat(query, "(id NOT IN (SELECT imgid FROM main.module_order))");
       }
       break;
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1304,19 +1304,25 @@ static void list_view(dt_lib_collect_rule_t *dr)
         break;
 
       case DT_COLLECTION_PROP_HISTORY: // History, 2 hardcoded alternatives
-        g_snprintf(query, sizeof(query),
-                   "SELECT CASE altered"
-                   "         WHEN 1 THEN '%s'"
-                   "         ELSE '%s'"
-                   "       END as altered, 1, COUNT(*) AS count"
+        {
+          char *orders = NULL;
+          for(int i = 0; i < DT_IOP_ORDER_LAST; i++)
+          {
+            orders = dt_util_dstrcat(orders, "WHEN mo.version = %d THEN '%s - %s' ",
+                                     i, _("altered"), _(dt_iop_order_string(i)));
+          }
+          orders = dt_util_dstrcat(orders, "ELSE '%s' ", _("not altered"));
+          snprintf(query, sizeof(query),
+                   "SELECT CASE %s END as ver, 1, COUNT(*) AS count"
                    " FROM main.images AS mi"
-                   " LEFT JOIN (SELECT DISTINCT imgid AS history_id, 1 AS altered"
-                   "            FROM main.history)"
-                   "   ON id = history_id"
+                   " LEFT JOIN (SELECT imgid, version FROM main.module_order) mo"
+                   "  ON mo.imgid = mi.id"
                    " WHERE %s"
-                   " GROUP BY altered"
-                   " ORDER BY altered ASC",
-                   _("altered"),  _("not altered"), where_ext);
+                   " GROUP BY ver"
+                   " ORDER BY ver",
+                   orders, where_ext);
+          g_free(orders);
+        }
         break;
 
       case DT_COLLECTION_PROP_GEOTAGGING: // Geotagging, 2 hardcoded alternatives
@@ -1522,27 +1528,6 @@ static void list_view(dt_lib_collect_rule_t *dr)
                  where_ext);
         break;
 
-      case DT_COLLECTION_PROP_ORDER: // modules order
-        {
-          char *orders = NULL;
-          for(int i = 0; i < DT_IOP_ORDER_LAST; i++)
-          {
-            orders = dt_util_dstrcat(orders, "WHEN mo.version = %d THEN '%s' ", i, _(dt_iop_order_string(i)));
-          }
-          orders = dt_util_dstrcat(orders, "ELSE '%s' ", _("none"));
-          snprintf(query, sizeof(query),
-                   "SELECT CASE %s END as ver, 1, COUNT(*) AS count"
-                   " FROM main.images AS mi"
-                   " LEFT JOIN (SELECT imgid, version FROM main.module_order) mo"
-                   "  ON mo.imgid = mi.id"
-                   " WHERE %s"
-                   " GROUP BY ver"
-                   " ORDER BY ver",
-                   orders, where_ext);
-          g_free(orders);
-        }
-        break;
-
       default: // filmroll
         g_snprintf(query, sizeof(query),
                    "SELECT folder, film_rolls_id, COUNT(*) AS count"
@@ -1624,7 +1609,7 @@ static void list_view(dt_lib_collect_rule_t *dr)
                     || property == DT_COLLECTION_PROP_PUBLISHER || property == DT_COLLECTION_PROP_RIGHTS
                     || property == DT_COLLECTION_PROP_TITLE || property == DT_COLLECTION_PROP_APERTURE
                     || property == DT_COLLECTION_PROP_FOCAL_LENGTH || property == DT_COLLECTION_PROP_ISO
-                    || property == DT_COLLECTION_PROP_MODULE || property == DT_COLLECTION_PROP_ORDER))
+                    || property == DT_COLLECTION_PROP_MODULE))
     gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc)list_match_string, dr);
   // we update list selection
   gtk_tree_selection_unselect_all(gtk_tree_view_get_selection(d->view));
@@ -2205,8 +2190,6 @@ void gui_init(dt_lib_module_t *self)
   GtkBox *box;
   GtkWidget *w;
 
-  const gboolean hide_module = dt_conf_get_bool("plugins/lighttable/collect/hidemodule");
-
   for(int i = 0; i < MAX_RULES; i++)
   {
     d->rule[i].num = i;
@@ -2216,9 +2199,8 @@ void gui_init(dt_lib_module_t *self)
     gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
     w = gtk_combo_box_text_new();
     d->rule[i].combo = GTK_COMBO_BOX(w);
-    // skip module and order if hidden
-    const int count = hide_module ? dt_lib_collect_string_cnt - 2 : dt_lib_collect_string_cnt;
-    for(int k = 0; k < count; k++)
+
+    for(int k = 0; k < dt_lib_collect_string_cnt; k++)
       gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(w), _(dt_lib_collect_string[k]));
     g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(combo_changed), d->rule + i);
     gtk_box_pack_start(box, w, FALSE, FALSE, 0);
@@ -2296,12 +2278,9 @@ void gui_init(dt_lib_module_t *self)
 
   _lib_collect_gui_update(self);
 
-  if(!hide_module)
-  {
-    // force redraw collection images because of late update of the table memory.darktable_iop_names
-    dt_collection_update_query(darktable.collection);
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_QUERY_CHANGED);
-  }
+  // force redraw collection images because of late update of the table memory.darktable_iop_names
+  dt_collection_update_query(darktable.collection);
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_COLLECTION_QUERY_CHANGED);
 
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED, G_CALLBACK(collection_updated),
                             self);
@@ -2499,7 +2478,6 @@ void init(struct dt_lib_module_t *self)
   luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_LOCAL_COPY);
   luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_GROUPING);
   luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_MODULE);
-  luaA_enum_value(L,dt_collection_properties_t,DT_COLLECTION_PROP_ORDER);
 
 }
 #endif

--- a/src/libs/collect.h
+++ b/src/libs/collect.h
@@ -36,7 +36,8 @@ const char *dt_lib_collect_string[] = { N_("film roll"),    N_("folders"),     N
                                         N_("rights"),       N_("lens"),        N_("focal length"),
                                         N_("ISO"),          N_("aperture"),    N_("exposure"),
                                         N_("aspect ratio"), N_("filename"),    N_("geotagging"),
-                                        N_("grouping"),     N_("local copy"),  N_("module")};
+                                        N_("grouping"),     N_("local copy"),  N_("module"),
+                                        N_("module order")};
 const int dt_lib_collect_string_cnt = sizeof(dt_lib_collect_string) / sizeof(dt_lib_collect_string[0]);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/collect.h
+++ b/src/libs/collect.h
@@ -36,9 +36,7 @@ const char *dt_lib_collect_string[] = { N_("film roll"),    N_("folders"),     N
                                         N_("rights"),       N_("lens"),        N_("focal length"),
                                         N_("ISO"),          N_("aperture"),    N_("exposure"),
                                         N_("aspect ratio"), N_("filename"),    N_("geotagging"),
-                                        N_("grouping"),     N_("local copy"),
-                                        // last two ones - skipped if set hidden in darktablerc
-                                        N_("module"),       N_("order")};
+                                        N_("grouping"),     N_("local copy"),  N_("module")};
 const int dt_lib_collect_string_cnt = sizeof(dt_lib_collect_string) / sizeof(dt_lib_collect_string[0]);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
some fixes discussed on #4291.
- only enabled modules
- 'order' renamed to 'module order'
- 'none' entry renamed to 'not altered'
- removed configuration 'hidden module'

I haven't removed collection history entry (redundant with module order). Do I do it ?