### PR TITLE
Introduce database maintenance into purging scripts

### DIFF
--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -50,6 +50,7 @@ rm "$TMPFILE"
 if [ $DRYRUN = no ]; then
     # delete now-empty filmrolls
     sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
+    sqlite3 "$DBFILE" "VACUUM; ANALYZE"
 else
     echo
     echo Remove following now-empty filmrolls:

--- a/tools/purge_unused_tags.sh
+++ b/tools/purge_unused_tags.sh
@@ -40,6 +40,12 @@ if [ "$1" = "-p" ]; then
     echo Purging tags...
     echo "$Q1C" | sqlite3
     echo "$Q1" | sqlite3
+
+# since sqlite3 up untill version 3.15 didn't support vacuuming attached databases we'll do them separatelly
+
+   sqlite3 "$LIBDB" "VACUUM; ANALYZE;"
+   sqlite3 "$DATADB" "VACUUM; ANALYZE"
+
 else
     echo The following tags are not used:
     echo "$Q1C" | sqlite3


### PR DESCRIPTION
In [discuss.pixls.us thread](https://discuss.pixls.us/t/darktable-periodic-database-maintenance/16375), user _gadolf_ suggested having periodic database maintenance somewhere in darktable.

I figured out that 1st place to do so, would be in purging scripts.
Reasoning is simple: [VACUUM](https://www.sqlite.org/lang_vacuum.html) surelly helps with database overgrowth, and where's the better place if not right after purging unnecessary entries?

[ANALYZE](https://www.sqlite.org/lang_analyze.html) in those cases theorecitally should write stats tables for query scheduler and increase overall performance (although I believe the change seen will be minimal).