### PR TITLE
Update OpenMP to 4.5 and improve performance in compute_log_histogram

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,13 @@ if (USE_OPENMP)
 
         # Clang has an option to specify the OpenMP standard to use. Specify it.
         # FIXME: Implement this in FindOpenMP.cmake
-        set(OPENMP_VERSION_SPECIFIER "-fopenmp-version=40")
+        set(OPENMP_VERSION_SPECIFIER "-fopenmp-version=45")
 
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OPENMP_VERSION_SPECIFIER}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPENMP_VERSION_SPECIFIER}")
     endif()
 
-    find_package(OpenMP 4.0 REQUIRED)
+    find_package(OpenMP 4.5 REQUIRED)
 endif()
 
 # Check for base threading library

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1261,15 +1261,12 @@ static inline void compute_log_histogram(const float *const restrict luminance,
 #ifdef _OPENMP
 #pragma omp parallel for default(none) schedule(simd:static) \
   dt_omp_firstprivate(luminance, num_elem) \
-  shared(histogram)
+  reduction(+:histogram[:UI_SAMPLES])
 #endif
   for(size_t k = 0; k < num_elem; k++)
   {
     // the histogram shows bins between [-14; +2] EV remapped between [0 ; UI_SAMPLES[
     const int index = CLAMP((int)(((log2f(luminance[k]) + 8.0f) / 8.0f) * (float)UI_SAMPLES), 0, UI_SAMPLES - 1);
-#ifdef _OPENMP
-    #pragma omp atomic
-#endif
     histogram[index] += 1;
   }
 


### PR DESCRIPTION
Spawned by #4309, which got fixed by 7ef8429158f935303e87916ebc6e92051e31b584.

The fix in 7ef8429158f935303e87916ebc6e92051e31b584 can be improved a lot by avoiding atomic access with the reduction clause in OpenMP, which shaves off at least 10 ms on my machine. See also the discussion in 7ef8429158f935303e87916ebc6e92051e31b584.

Unfortunately, element wise array reduction is only supported from OpenMP 4.5 and up, so this does require a change in the required OpenMP version also. However, this version has been supported for a long time now, since GCC 6.1 and Clang 7.0 (?), so this should not pose serious issues. If it does, in principle the performance increase can be achieved with some other tricks as well, but the reduction clause is much easier to work with and simpler to follow.

Perhaps array reduction can be used in other cases in the existing code base as well, but I haven't looked much into other OpenMP usages yet.