### PR TITLE
Add four new timestamps columns in library.db

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -259,6 +259,7 @@ public:
 }
 
 static void _exif_import_tags(dt_image_t *img, Exiv2::XmpData::iterator &pos);
+static gboolean read_xmp_timestamps(Exiv2::XmpData &xmpData, const int imgid);
 
 // this array should contain all XmpBag and XmpSeq keys used by dt
 const char *dt_xmp_keys[]
@@ -273,7 +274,9 @@ const char *dt_xmp_keys[]
         "Xmp.darktable.masks_history", "Xmp.darktable.mask_num", "Xmp.darktable.mask_points",
         "Xmp.darktable.mask_version", "Xmp.darktable.mask", "Xmp.darktable.mask_nb", "Xmp.darktable.mask_src",
         "Xmp.darktable.history_basic_hash", "Xmp.darktable.history_auto_hash", "Xmp.darktable.history_current_hash",
-        "Xmp.acdsee.notes","Xmp.darktable.version_name",
+        "Xmp.darktable.import_timestamp", "Xmp.darktable.change_timestamp",
+        "Xmp.darktable.export_timestamp", "Xmp.darktable.print_timestamp",
+        "Xmp.acdsee.notes", "Xmp.darktable.version_name",
         "Xmp.dc.creator", "Xmp.dc.publisher", "Xmp.dc.title", "Xmp.dc.description", "Xmp.dc.rights",
         "Xmp.xmpMM.DerivedFrom" };
 
@@ -2702,7 +2705,7 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
     }
 
     int32_t preset_applied = 0;
-    
+
     if((pos = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.auto_presets_applied"))) != xmpData.end())
     {
       preset_applied = pos->toLong();
@@ -3018,7 +3021,10 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
       goto end;
     }
 
-end:
+  end:
+
+    all_ok = read_xmp_timestamps(xmpData, img->id);
+
     sqlite3_finalize(stmt);
 
     // set or clear bit in image struct. ONLY set if the Xmp.darktable.auto_presets_applied was 1
@@ -3231,6 +3237,76 @@ static void dt_set_xmp_dt_history(Exiv2::XmpData &xmpData, const int imgid, int 
   xmpData["Xmp.darktable.history_end"] = history_end;
 }
 
+// add timestamps to XmpData.
+static void set_xmp_timestamps(Exiv2::XmpData &xmpData, const int imgid)
+{
+  sqlite3_stmt *stmt;
+
+  DT_DEBUG_SQLITE3_PREPARE_V2(
+      dt_database_get(darktable.db),
+      "SELECT id, import_timestamp, change_timestamp, export_timestamp, print_timestamp"
+      " FROM main.images"
+      " WHERE id = ?1",
+      -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, imgid);
+
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    xmpData["Xmp.darktable.import_timestamp"] = sqlite3_column_int(stmt, 1);
+    xmpData["Xmp.darktable.change_timestamp"] = sqlite3_column_int(stmt, 2);
+    xmpData["Xmp.darktable.export_timestamp"] = sqlite3_column_int(stmt, 3);
+    xmpData["Xmp.darktable.print_timestamp"] = sqlite3_column_int(stmt, 4);
+  }
+  else
+  {
+    xmpData["Xmp.darktable.import_timestamp"] = -1;
+    xmpData["Xmp.darktable.change_timestamp"] = -1;
+    xmpData["Xmp.darktable.export_timestamp"] = -1;
+    xmpData["Xmp.darktable.print_timestamp"] = -1;
+  }
+  sqlite3_finalize(stmt);
+}
+
+// read timestamps from XmpData
+gboolean read_xmp_timestamps(Exiv2::XmpData &xmpData, const int imgid)
+{
+  gboolean all_ok = TRUE;
+  sqlite3_stmt *stmt;
+  Exiv2::XmpData::iterator pos;
+
+  const char *timestamps[] = { "change_timestamp", "export_timestamp", "print_timestamp" };
+  // Do not read for import_ts. It must be updated at each import.
+
+  const int nb_timestamps = sizeof(timestamps) / sizeof(char *);
+  int i;
+  char xmpkey[1024];
+  char query[1024];
+  char values[1024];
+  char tmp[64];
+
+  for (i = 0 ; i < nb_timestamps ; i++)
+  {
+    snprintf(xmpkey, sizeof(xmpkey), "Xmp.darktable.%s", timestamps[i]);
+    if((pos = xmpData.findKey(Exiv2::XmpKey(xmpkey))) != xmpData.end())
+    {
+      snprintf(tmp, sizeof(tmp), " %s = %ld,", timestamps[i], pos->toLong());
+      g_strlcat(values, tmp, sizeof(values));
+    }
+	}
+  values[strlen(values) - 1] = '\0'; /* remove last comma */
+  snprintf(query, sizeof(query), "UPDATE main.images SET %s WHERE id = %d", values, imgid);
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
+    if(sqlite3_step(stmt) != SQLITE_DONE)
+    {
+      fprintf(stderr, "[exif] error writing timestamps entry for image %d\n", imgid);
+      fprintf(stderr, "[exif]   %s\n", sqlite3_errmsg(dt_database_get(darktable.db)));
+      all_ok = FALSE;
+    }
+  sqlite3_finalize(stmt);
+
+  return all_ok;
+}
+
 static void dt_remove_xmp_exif_geotag(Exiv2::XmpData &xmpData)
 {
   static const char *keys[] =
@@ -3379,6 +3455,9 @@ static void _exif_xmp_read_data(Exiv2::XmpData &xmpData, const int imgid)
 
   // The original file name
   if(filename) xmpData["Xmp.xmpMM.DerivedFrom"] = filename;
+
+  // timestamps
+  set_xmp_timestamps(xmpData, imgid);
 
   // GPS data
   dt_set_xmp_exif_geotag(xmpData, longitude, latitude, altitude);

--- a/src/common/history.c
+++ b/src/common/history.c
@@ -121,6 +121,9 @@ void dt_history_delete_on_image_ext(int32_t imgid, gboolean undo)
   dt_tag_detach_by_string("darktable|style%", imgid, FALSE, FALSE);
   dt_tag_detach_by_string("darktable|changed", imgid, FALSE, FALSE);
 
+  /* unset change timestamp */
+  dt_image_cache_unset_change_timestamp(darktable.image_cache, imgid);
+
   // signal that the mipmap need to be updated
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 
@@ -756,6 +759,8 @@ int dt_history_copy_and_paste_on_image(int32_t imgid, int32_t dest_imgid, gboole
   guint tagid = 0;
   dt_tag_new("darktable|changed", &tagid);
   dt_tag_attach(tagid, dest_imgid, FALSE, FALSE);
+  /* set change_timestamp */
+  dt_image_cache_set_change_timestamp(darktable.image_cache, dest_imgid);
 
   /* if current image in develop reload history */
   if(dt_dev_is_current_image(darktable.develop, dest_imgid))

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -179,6 +179,10 @@ typedef struct dt_image_t
 
   // used by library
   int32_t num, flags, film_id, id, group_id, version;
+
+  //timestamps
+  time_t import_timestamp, change_timestamp, export_timestamp, print_timestamp;
+
   dt_image_loader_t loader;
 
   dt_iop_buffer_dsc_t buf_dsc;

--- a/src/common/image_cache.h
+++ b/src/common/image_cache.h
@@ -66,6 +66,12 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
 // remove the image from the cache
 void dt_image_cache_remove(dt_image_cache_t *cache, const uint32_t imgid);
 
+// register timestamps in cache
+void dt_image_cache_set_change_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
+void dt_image_cache_unset_change_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
+void dt_image_cache_set_export_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
+void dt_image_cache_set_print_timestamp(dt_image_cache_t *cache, const uint32_t imgid);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -827,7 +827,11 @@ void dt_styles_apply_to_image(const char *name, const gboolean duplicate, const 
     gchar ntag[512] = { 0 };
     g_snprintf(ntag, sizeof(ntag), "darktable|style|%s", name);
     if(dt_tag_new(ntag, &tagid)) dt_tag_attach_from_gui(tagid, newimgid, FALSE, FALSE);
-    if(dt_tag_new("darktable|changed", &tagid)) dt_tag_attach_from_gui(tagid, newimgid, FALSE, FALSE);
+    if(dt_tag_new("darktable|changed", &tagid))
+    {
+      dt_tag_attach_from_gui(tagid, newimgid, FALSE, FALSE);
+      dt_image_cache_set_change_timestamp(darktable.image_cache, imgid);
+    }
 
     /* if current image in develop reload history */
     if(dt_dev_is_current_image(darktable.develop, newimgid))

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -1281,6 +1281,10 @@ static int32_t dt_control_export_job_run(dt_job_t *job)
     dt_tag_detach(tagid, imgid, FALSE, FALSE);
     // make sure the 'exported' tag is set on the image
     dt_tag_attach_from_gui(etagid, imgid, FALSE, FALSE);
+
+    /* register export timestamp in cache */
+    dt_image_cache_set_export_timestamp(darktable.image_cache, imgid);
+
     // check if image still exists:
     const dt_image_t *image = dt_image_cache_get(darktable.image_cache, (int32_t)imgid, 'r');
     if(image)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -961,6 +961,9 @@ void dt_dev_add_history_item(dt_develop_t *dev, dt_iop_module_t *module, gboolea
   dt_tag_new("darktable|changed", &tagid);
   dt_tag_attach_from_gui(tagid, imgid, FALSE, FALSE);
 
+  /* register export timestamp in cache */
+  dt_image_cache_set_change_timestamp(darktable.image_cache, imgid);
+
   // invalidate buffers and force redraw of darkroom
   dt_dev_invalidate_all(dev);
   dt_pthread_mutex_unlock(&dev->history_mutex);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -51,6 +51,10 @@ enum
   md_internal_version,
   md_internal_fullpath,
   md_internal_local_copy,
+  md_internal_import_timestamp,
+  md_internal_change_timestamp,
+  md_internal_export_timestamp,
+  md_internal_print_timestamp,
 #if SHOW_FLAGS
   md_internal_flags,
 #endif
@@ -102,6 +106,10 @@ static void _lib_metatdata_view_init_labels()
   _md_labels[md_internal_version] = _("version");
   _md_labels[md_internal_fullpath] = _("full path");
   _md_labels[md_internal_local_copy] = _("local copy");
+  _md_labels[md_internal_import_timestamp] = _("import timestamp");
+  _md_labels[md_internal_change_timestamp] = _("change timestamp");
+  _md_labels[md_internal_export_timestamp] = _("export timestamp");
+  _md_labels[md_internal_print_timestamp] = _("print timestamp");
 #if SHOW_FLAGS
   _md_labels[md_internal_flags] = _("flags");
 #endif
@@ -282,6 +290,43 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
     g_strlcpy(value, (img->flags & DT_IMAGE_LOCAL_COPY) ? _("yes") : _("no"), sizeof(value));
     _metadata_update_value(d->metadata[md_internal_local_copy], value);
+
+    if (img->import_timestamp >=0)
+    {
+      char datetime[200];
+      // just %c is too long and includes a time zone that we don't know from exif
+      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->import_timestamp));
+      _metadata_update_value(d->metadata[md_internal_import_timestamp], datetime);
+    }
+    else
+      _metadata_update_value(d->metadata[md_internal_import_timestamp], "-");
+
+    if (img->change_timestamp >=0)
+    {
+      char datetime[200];
+      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->change_timestamp));
+      _metadata_update_value(d->metadata[md_internal_change_timestamp], datetime);
+    }
+    else
+      _metadata_update_value(d->metadata[md_internal_change_timestamp], "-");
+
+    if (img->export_timestamp >=0)
+    {
+      char datetime[200];
+      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->export_timestamp));
+      _metadata_update_value(d->metadata[md_internal_export_timestamp], datetime);
+    }
+    else
+      _metadata_update_value(d->metadata[md_internal_export_timestamp], "-");
+
+    if (img->print_timestamp >=0)
+    {
+      char datetime[200];
+      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->print_timestamp));
+      _metadata_update_value(d->metadata[md_internal_print_timestamp], datetime);
+    }
+    else
+      _metadata_update_value(d->metadata[md_internal_print_timestamp], "-");
 
     // TODO: decide if this should be removed for a release. maybe #ifdef'ing to only add it to git compiles?
 

--- a/src/libs/print_settings.c
+++ b/src/libs/print_settings.c
@@ -362,6 +362,9 @@ static int _print_job_run(dt_job_t *job)
   dt_tag_new(tag, &tagid);
   dt_tag_attach_from_gui(tagid, params->imgid, FALSE, FALSE);
 
+  /* register print timestamp in cache */
+  dt_image_cache_set_print_timestamp(darktable.image_cache, params->imgid);
+
   return 0;
 }
 


### PR DESCRIPTION
This is my first "pull request". I have therefore included only a very simple first part of my project, in order to better understand the PR mechanism.

The project is described in issue #4205.
This first part concerns only the modification of the database which consists in adding 4 new columns to the images table; one per timestamp.

To not make the images table too heavy. In return, I planned to remove the caption, description and license columns that are not used (I checked throughout the code). I will do this when I will have finished my current project.