### PR TITLE
Make tools use same paths and options as main binary

### DIFF
--- a/tools/purge_from_cache.sh
+++ b/tools/purge_from_cache.sh
@@ -25,9 +25,11 @@
 . "$(dirname "$0")/common.sh"
 
 # default values
-library="${HOME}/.config/darktable/library.db"
+configdir="$HOME/.config/darktable"
 cache_base="${HOME}/.cache/darktable"
+library="$configdir/library.db"
 dryrun=1
+LIBDB=""
 
 # remember the command line to show it in the end when not purging
 commandline="$0 $*"
@@ -41,19 +43,25 @@ while [ "$#" -ge 1 ] ; do
     echo "Usage:   $0 [options]"
     echo ""
     echo "Options:"
-    echo "  -c|--cache_base <path>   path to the place where darktable's thumbnail caches are stored"
+    echo "  -c|--cachedir <path>   path to the place where darktable's thumbnail caches are stored"
     echo "                           (default: '${cache_base}')"
+    echo "  -d|--configdir <path>    path to the darktable config directory"
+    echo "                           (default: '${configdir}')"
     echo "  -l|--library <path>      path to the library.db"
     echo "                           (default: '${library}')"
     echo "  -p|--purge               actually delete the files instead of just finding them"
     exit 0
     ;;
   -l|--library)
-    library="$2"
+    LIBDB="$2"
     shift
     ;;
-  -c|--cache_base)
+  -c|--cachedir|--cache_base)
     cache_base="$2"
+    shift
+    ;;
+  -d|--configdir)
+    configdir="$2"
     shift
     ;;
   -p|--purge)
@@ -66,6 +74,12 @@ while [ "$#" -ge 1 ] ; do
     shift
 done
 
+library="$configdir/library.db"
+
+if [ "$LIBDB" != "" ]; then
+    library="$LIBDB"
+fi
+
 # set the command to run for each stale file
 action="echo found stale mipmap in "
 if [ ${dryrun} -eq 0 ]; then
@@ -76,7 +90,7 @@ fi
 library=$(ReadLink "${library}")
 
 if [ ! -f "${library}" ]; then
-  echo "library '${library}' doesn't exist"
+  echo "error: library db '${library}' doesn't exist"
   exit 1
 fi
 
@@ -84,7 +98,7 @@ fi
 cache_dir="${cache_base}/mipmaps-$(printf "%s" "${library}" | sha1sum | cut --delimiter=" " --fields=1).d"
 
 if [ ! -d "${cache_dir}" ]; then
-  echo "cache directory '${cache_dir}' doesn't exist"
+  echo "error: cache directory '${cache_dir}' doesn't exist"
   exit 1
 fi
 

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -1,24 +1,70 @@
 #!/bin/bash
 
-DRYRUN=yes
-
-if [ "$1" = "-p" ]; then
-    DRYRUN=no
-fi
-
-DBFILE=$HOME/.config/darktable/library.db
-TMPFILE=$(mktemp -t tmp.XXXXXXXXXX)
-QUERY="select A.id,B.folder,A.filename from images as A join film_rolls as B on A.film_id = B.id"
+#
+# Usage: purge_non_existing_images [-p]
+#        -p  do the purge, otherwise only display non existing images
+#
 
 if ! which sqlite3 > /dev/null; then
-    echo error: please install sqlite3 binary.
+    echo "error: please install sqlite3 binary".
     exit 1
+fi
+
+configdir="$HOME/.config/darktable"
+DBFILE="$configdir/library.db"
+dryrun=1
+library=""
+
+# remember the command line to show it in the end when not purging
+commandline="$0 $*"
+
+# handle command line arguments
+while [ "$#" -ge 1 ] ; do
+  option="$1"
+  case ${option} in
+  -h|--help)
+    echo "Delete non existing images from darktable's database"
+    echo "Usage:   $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  -c|--configdir <path>    path to the darktable config directory"
+    echo "                           (default: '${configdir}')"
+    echo "  -l|--library <path>      path to the library.db"
+    echo "                           (default: '${DBFILE}')"
+    echo "  -p|--purge               actually delete the tags instead of just finding them"
+    exit 0
+    ;;
+  -l|--library)
+    library="$2"
+    shift
+    ;;
+  -c|--configdir)
+    configdir="$2"
+    shift
+    ;;
+  -p|--purge)
+    dryrun=0
+    ;;
+  *)
+    echo "warning: ignoring unknown option $option"
+    ;;
+  esac
+    shift
+done
+
+DBFILE="$configdir/library.db"
+
+if [ "$library" != "" ]; then
+    DBFILE="$library"
 fi
 
 if [ ! -f "$DBFILE" ]; then
-    echo error: library.db not found \($DBFILE\).
+    echo "error: library db '${DBFILE}' doesn't exist"
     exit 1
 fi
+
+TMPFILE=$(mktemp -t tmp.XXXXXXXXXX)
+QUERY="select A.id,B.folder,A.filename from images as A join film_rolls as B on A.film_id = B.id"
 
 sqlite3 $DBFILE "$QUERY" > "$TMPFILE"
 
@@ -33,7 +79,7 @@ do
   then
     echo "  $FD/$FL with ID = $ID"
 
-    if [ $DRYRUN = no ]; then
+    if [ $dryrun -eq 0 ]; then
         for table in images meta_data; do
             sqlite3 "$DBFILE" "delete from $table where id=$ID"
         done
@@ -47,7 +93,7 @@ done
 rm "$TMPFILE"
 
 
-if [ $DRYRUN = no ]; then
+if [ $dryrun -eq 0 ]; then
     # delete now-empty filmrolls
     sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
     sqlite3 "$DBFILE" "VACUUM; ANALYZE"
@@ -55,10 +101,8 @@ else
     echo
     echo Remove following now-empty filmrolls:
     sqlite3 "$DBFILE" "SELECT folder FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
-fi
-
-if [ $DRYRUN = yes ]; then
+    
     echo
     echo to really remove non existing images from the database call:
-    echo "$0" -p
+    echo "${commandline} --purge"
 fi

--- a/tools/purge_unused_tags.sh
+++ b/tools/purge_unused_tags.sh
@@ -6,12 +6,68 @@
 #
 
 if ! which sqlite3 > /dev/null; then
-    echo error: please install sqlite3 binary.
+    echo "error: please install sqlite3 binary".
     exit 1
 fi
 
-LIBDB=$HOME/.config/darktable/library.db
-DATADB=$HOME/.config/darktable/data.db
+configdir="$HOME/.config/darktable"
+LIBDB="$configdir/library.db"
+dryrun=1
+library=""
+
+# remember the command line to show it in the end when not purging
+commandline="$0 $*"
+
+# handle command line arguments
+while [ "$#" -ge 1 ] ; do
+  option="$1"
+  case ${option} in
+  -h|--help)
+    echo "Delete unused tags from darktable's database"
+    echo "Usage:   $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  -c|--configdir <path>    path to the darktable config directory"
+    echo "                           (default: '${configdir}')"
+    echo "  -l|--library <path>      path to the library.db"
+    echo "                           (default: '${LIBDB}')"
+    echo "  -p|--purge               actually delete the tags instead of just finding them"
+    exit 0
+    ;;
+  -l|--library)
+    library="$2"
+    shift
+    ;;
+  -c|--configdir)
+    configdir="$2"
+    shift
+    ;;
+  -p|--purge)
+    dryrun=0
+    ;;
+  *)
+    echo "warning: ignoring unknown option $option"
+    ;;
+  esac
+    shift
+done
+
+LIBDB="$configdir/library.db"
+DATADB="$configdir/data.db"
+
+if [ "$library" != "" ]; then
+    LIBDB="$library"
+fi
+
+if [ ! -f "$LIBDB" ]; then
+    echo "error: library db '${LIBDB}' doesn't exist"
+    exit 1
+fi
+
+if [ ! -f "$DATADB" ]; then
+    echo "error: data db '${DATADB}' doesn't exist"
+    exit 1
+fi
 
 # tags not used
 Q1C="
@@ -26,17 +82,7 @@ ATTACH DATABASE \"$DATADB\" as data;
 DELETE FROM data.tags WHERE id NOT IN (SELECT tagid FROM tagged_images);
 "
 
-if [ ! -f "$LIBDB" ]; then
-    echo missing \""$LIBDB"\" file
-    exit 1
-fi
-
-if [ ! -f "$DATADB" ]; then
-    echo missing \""$DATADB"\" file
-    exit 1
-fi
-
-if [ "$1" = "-p" ]; then
+if [ ${dryrun} -eq 0 ]; then
     echo Purging tags...
     echo "$Q1C" | sqlite3
     echo "$Q1" | sqlite3
@@ -52,5 +98,5 @@ else
     echo "$Q1C" | sqlite3
     echo
     echo to really purge from the database call:
-    echo "$0" -p
+    echo "${commandline} --purge"
 fi


### PR DESCRIPTION
This path changes logic in scripts for locating `library.db` and `data.db` to match as closely as possible the code in main binary, based of on `database.c` locations searchnig.

This also makes sure that commandline params are identical as for binary for same options (so `--configdir`, `--cachedir`, `--library`)

I also made sure that changes do not break backwards compatibility with calling scripts, but may break "scripts that fix scripts" (inspired by @jade-nl)