### PR TITLE
fix function parameter names in declaration

### DIFF
--- a/src/common/pdf.h
+++ b/src/common/pdf.h
@@ -116,7 +116,7 @@ static const int dt_pdf_paper_sizes_n = sizeof(dt_pdf_paper_sizes) / sizeof(dt_p
 dt_pdf_t *dt_pdf_start(const char *filename, float width, float height, float dpi, dt_pdf_stream_encoder_t default_encoder);
 int dt_pdf_add_icc(dt_pdf_t *pdf, const char *filename);
 int dt_pdf_add_icc_from_data(dt_pdf_t *pdf, const unsigned char *data, size_t size);
-dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf, const unsigned char *image, int bpp, int width, int height, int icc_id, float border);
+dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf, const unsigned char *image, int width, int height, int bpp, int icc_id, float border);
 dt_pdf_page_t *dt_pdf_add_page(dt_pdf_t *pdf, dt_pdf_image_t **images, int n_images);
 void dt_pdf_finish(dt_pdf_t *pdf, dt_pdf_page_t **pages, int n_pages);
 


### PR DESCRIPTION
The function declaration does not match the corresponding function implementation (and usage), which is 

    dt_pdf_image_t *dt_pdf_add_image(dt_pdf_t *pdf, const unsigned char *image, int width, int height, int bpp, int icc_id, float border)
    { ... }

This mismatch may lead to erroneous usage.
