### PR TITLE
fix format string errors

### DIFF
--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -25,6 +25,7 @@
 #include "develop/develop.h"
 
 #include <sqlite3.h>
+#include <inttypes.h>
 
 void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
 {
@@ -139,7 +140,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
   else
   {
     img->id = -1;
-    fprintf(stderr, "[image_cache_allocate] failed to open image %d from database: %s\n", entry->key,
+    fprintf(stderr, "[image_cache_allocate] failed to open image %" PRIu32 " from database: %s\n", entry->key,
             sqlite3_errmsg(dt_database_get(darktable.db)));
   }
   sqlite3_finalize(stmt);

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -374,7 +374,8 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
     {
       // try and load from disk, if successful set flag
       char filename[PATH_MAX] = {0};
-      snprintf(filename, sizeof(filename), "%s.d/%d/%d.jpg", cache->cachedir, mip, get_imgid(entry->key));
+      snprintf(filename, sizeof(filename), "%s.d/%d/%" PRIu32 ".jpg", cache->cachedir, (int)mip,
+               get_imgid(entry->key));
       FILE *f = g_fopen(filename, "rb");
       if(f)
       {
@@ -394,7 +395,8 @@ void dt_mipmap_cache_allocate_dynamic(void *data, dt_cache_entry_t *entry)
            || ((color_space = dt_imageio_jpeg_read_color_space(&jpg)) == DT_COLORSPACE_NONE) // pointless test to keep it in the if clause
            || dt_imageio_jpeg_decompress(&jpg, entry->data + sizeof(*dsc)))
         {
-          fprintf(stderr, "[mipmap_cache] failed to decompress thumbnail for image %d from `%s'!\n", get_imgid(entry->key), filename);
+          fprintf(stderr, "[mipmap_cache] failed to decompress thumbnail for image %" PRIu32 " from `%s'!\n",
+                  get_imgid(entry->key), filename);
           goto read_error;
         }
         dsc->width = jpg.width;
@@ -465,7 +467,8 @@ void dt_mipmap_cache_deallocate_dynamic(void *data, dt_cache_entry_t *entry)
         const int mkd = g_mkdir_with_parents(filename, 0750);
         if(!mkd)
         {
-          snprintf(filename, sizeof(filename), "%s.d/%d/%d.jpg", cache->cachedir, mip, get_imgid(entry->key));
+          snprintf(filename, sizeof(filename), "%s.d/%d/%" PRIu32 ".jpg", cache->cachedir, (int)mip,
+                   get_imgid(entry->key));
           // Don't write existing files as both performance and quality (lossy jpg) suffer
           FILE *f = NULL;
           if (!g_file_test(filename, G_FILE_TEST_EXISTS) && (f = g_fopen(filename, "wb")))


### PR DESCRIPTION
Just a format string fixes. Why does gcc/clang not complain? Are warning levels not sensitive enough?