### PR TITLE
Perform database maintenance on db upgrade and dt closing time

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -16,6 +16,27 @@
     <longdescription>filename relative to ~/.config/darktable or starting with a slash (needs a restart).</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>database/maintenance_check</name>
+    <type>
+      <enum>
+        <option>never</option>
+        <option>on startup</option>
+        <option>on close</option>
+        <option>on both</option>
+      </enum>
+    </type>
+    <default>on close</default>
+    <shortdescription>when to check for database maintenance</shortdescription>
+    <longdescription>this will set when db size is checked for possible maintenance condition and ask user to confirm</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>database/maintenance_freepage_ratio</name>
+    <type>int</type>
+    <default>25</default>
+    <shortdescription>freepage for database maintenance in percentage</shortdescription>
+    <longdescription>once this ratio is reached (for either dbs) user is asked to confirm database maintenance</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>min_panel_width</name>
     <type>int</type>
     <default>150</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -15,7 +15,7 @@
     <shortdescription>database location</shortdescription>
     <longdescription>filename relative to ~/.config/darktable or starting with a slash (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig>
+  <dtconfig prefs="core">
     <name>database/maintenance_check</name>
     <type>
       <enum>
@@ -29,7 +29,7 @@
     <shortdescription>when to check for database maintenance</shortdescription>
     <longdescription>this will set when db size is checked for possible maintenance condition and ask user to confirm</longdescription>
   </dtconfig>
-  <dtconfig>
+  <dtconfig prefs="core">
     <name>database/maintenance_freepage_ratio</name>
     <type>int</type>
     <default>25</default>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -869,6 +869,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     return 1;
   }
 
+  //early vacuum on startup (if configured to do so
+  dt_database_maybe_vacuum(darktable.db, init_gui, FALSE);
+
   // Initialize the signal system
   darktable.signals = dt_control_signal_init();
 
@@ -1098,6 +1101,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 void dt_cleanup()
 {
   const int init_gui = (darktable.gui != NULL);
+
+  dt_database_maybe_vacuum(darktable.db, init_gui, TRUE);
 
 #ifdef HAVE_PRINT
   dt_printers_abort_discovery();

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1160,6 +1160,7 @@ void dt_cleanup()
 
   dt_guides_cleanup(darktable.guides);
 
+  dt_database_optimize(darktable.db);
   dt_database_destroy(darktable.db);
 
   if(init_gui)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -869,8 +869,8 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     return 1;
   }
 
-  //early vacuum on startup (if configured to do so
-  dt_database_maybe_vacuum(darktable.db, init_gui, FALSE);
+  //db maintenance on startup (if configured to do so)
+  dt_database_maybe_maintenance(darktable.db, init_gui, FALSE);
 
   // Initialize the signal system
   darktable.signals = dt_control_signal_init();
@@ -1102,7 +1102,7 @@ void dt_cleanup()
 {
   const int init_gui = (darktable.gui != NULL);
 
-  dt_database_maybe_vacuum(darktable.db, init_gui, TRUE);
+  dt_database_maybe_maintenance(darktable.db, init_gui, TRUE);
 
 #ifdef HAVE_PRINT
   dt_printers_abort_discovery();

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2252,6 +2252,11 @@ start:
           db = NULL;
           goto error;
         }
+        
+        // upgrade was successfull, time for some housekeeping
+        sqlite3_exec(db->handle, "VACUUM data", NULL, NULL, NULL);
+        sqlite3_exec(db->handle, "ANALYZE data", NULL, NULL, NULL);
+      
       }
       else if(db_version > CURRENT_DATABASE_VERSION_DATA)
       {
@@ -2330,6 +2335,10 @@ start:
         db = NULL;
         goto error;
       }
+      
+      // upgrade was successfull, time for some housekeeping
+      sqlite3_exec(db->handle, "VACUUM main", NULL, NULL, NULL);
+      sqlite3_exec(db->handle, "ANALYZE main", NULL, NULL, NULL);
     }
     else if(db_version > CURRENT_DATABASE_VERSION_LIBRARY)
     {
@@ -2523,6 +2532,17 @@ gboolean dt_database_get_lock_acquired(const dt_database_t *db)
 {
   return db->lock_acquired;
 }
+
+void dt_database_optimize(const struct dt_database_t *db)
+{
+  // TODO: We should do auto vacuuming on darktable exit in pre-deremined cases
+  // possible heuristics suggestions in https://blogs.gnome.org/jnelson/2015/01/06/sqlite-vacuum-and-auto_vacuum/
+  
+  // optimize should in most cases be no-op and have no noticeable downsides
+  // see: https://www.sqlite.org/pragma.html#pragma_optimize
+  sqlite3_exec(db->handle, "PRAGMA optimize", NULL, NULL, NULL);
+}
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2252,11 +2252,11 @@ start:
           db = NULL;
           goto error;
         }
-        
+
         // upgrade was successfull, time for some housekeeping
         sqlite3_exec(db->handle, "VACUUM data", NULL, NULL, NULL);
         sqlite3_exec(db->handle, "ANALYZE data", NULL, NULL, NULL);
-      
+
       }
       else if(db_version > CURRENT_DATABASE_VERSION_DATA)
       {
@@ -2335,7 +2335,7 @@ start:
         db = NULL;
         goto error;
       }
-      
+
       // upgrade was successfull, time for some housekeeping
       sqlite3_exec(db->handle, "VACUUM main", NULL, NULL, NULL);
       sqlite3_exec(db->handle, "ANALYZE main", NULL, NULL, NULL);
@@ -2533,12 +2533,117 @@ gboolean dt_database_get_lock_acquired(const dt_database_t *db)
   return db->lock_acquired;
 }
 
+void _dt_database_vacuum(const struct dt_database_t *db)
+{
+  sqlite3_exec(db->handle, "VACUUM data", NULL, NULL, NULL);
+  sqlite3_exec(db->handle, "VACUUM data", NULL, NULL, NULL);
+  sqlite3_exec(db->handle, "ANALYZE main", NULL, NULL, NULL);
+  sqlite3_exec(db->handle, "ANALYZE main", NULL, NULL, NULL);
+}
+
+gboolean _ask_for_vacuum(const gboolean has_gui, guint64 size)
+{
+  if(!has_gui)
+  {
+    return 0;
+  }
+
+  char *size_info = g_format_size(size);
+
+  char *label_text = g_markup_printf_escaped(_("the database could use some maintenance\n"
+                                                 "\n"
+                                                 "there's <span style=\"italic\">%s</span> to be freed"
+                                                 "\n"
+                                                 "do you want to proceed now\n"),
+                                                 size_info);
+
+    gboolean shall_perform_maintenance =
+      dt_gui_show_standalone_yes_no_dialog(_("darktable - schema maintenance"), label_text,
+                                           _("later"), _("yes"));
+
+    g_free(label_text);
+    g_free(size_info);
+
+    return shall_perform_maintenance;
+}
+
+int _get_pragma_val(const struct dt_database_t *db, const char* pragma)
+{
+  gchar* query= g_strdup_printf("PRAGMA %s", pragma);
+  int val = -1;
+  sqlite3_stmt *stmt;
+  int rc = sqlite3_prepare_v2(db->handle, query,-1, &stmt, NULL);
+  if(rc == SQLITE_OK && sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    val = sqlite3_column_int(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+  g_free(query);
+
+  return val;
+}
+
+void dt_database_maybe_vacuum(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time)
+{
+  gboolean check_for_vacuum = FALSE;
+
+  char *config = dt_conf_get_string("database/maintenance_check");
+
+  if(config)
+  {
+    if(
+        (!g_strcmp0(config, "on both"))
+        || (closing_time && !g_strcmp0(config, "on close"))
+        || (!closing_time && !g_strcmp0(config, "on startup"))
+        )
+    {
+      // we have "on both/on close/on startup" setting, so - checking!
+      check_for_vacuum = TRUE;
+    }
+    // if the config was "never", check_for_vacuum is false.
+    g_free(config);
+  }
+
+  if(!check_for_vacuum)
+  {
+    return;
+  }
+
+  // checking free pages
+  const int main_free_count = _get_pragma_val(db, "main.freelist_count");
+  const int main_page_count = _get_pragma_val(db, "main.page_count");
+  const int main_page_size = _get_pragma_val(db, "main.page_size");
+
+  const int data_free_count = _get_pragma_val(db, "data.freelist_count");
+  const int data_page_count = _get_pragma_val(db, "data.page_count");
+  const int data_page_size = _get_pragma_val(db, "data.page_size");
+
+  // we don't need fine-grained percentages, so let's do ints
+  const int main_free_percentage = (main_free_count * 100 ) / main_page_count;
+  const int data_free_percentage = (data_free_count * 100 ) / data_page_count;
+
+  const int freepage_ratio = dt_conf_get_int("database/maintenance_freepage_ratio");
+
+  if((main_free_percentage >= freepage_ratio)
+      || (data_free_percentage >= freepage_ratio)
+      )
+  {
+
+    const guint64 calc_size = (main_free_count*main_page_size) + (data_free_count*data_page_size);
+
+    if(_ask_for_vacuum(has_gui, calc_size))
+    {
+      _dt_database_vacuum(db);
+    }
+  }
+
+
+}
+
 void dt_database_optimize(const struct dt_database_t *db)
 {
-  // TODO: We should do auto vacuuming on darktable exit in pre-deremined cases
-  // possible heuristics suggestions in https://blogs.gnome.org/jnelson/2015/01/06/sqlite-vacuum-and-auto_vacuum/
-  
   // optimize should in most cases be no-op and have no noticeable downsides
+  // this should be ran on every exit
   // see: https://www.sqlite.org/pragma.html#pragma_optimize
   sqlite3_exec(db->handle, "PRAGMA optimize", NULL, NULL, NULL);
 }

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -36,8 +36,8 @@ gboolean dt_database_get_lock_acquired(const struct dt_database_t *db);
 void dt_database_show_error(const struct dt_database_t *db);
 /** perform pre-db-close optimizations (always call when quiting darktable) */
 void dt_database_optimize(const struct dt_database_t *);
-
-void dt_database_maybe_vacuum(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time);
+/** conditionally perfrom db maintenance */
+void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -34,6 +34,8 @@ const gchar *dt_database_get_path(const struct dt_database_t *db);
 gboolean dt_database_get_lock_acquired(const struct dt_database_t *db);
 /** show an error popup. this has to be postponed until after we tried using dbus to reach another instance */
 void dt_database_show_error(const struct dt_database_t *db);
+/** perform pre-db-close optimizations (call only when quiting darktable) */
+void dt_database_optimize(const struct dt_database_t *);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -34,8 +34,10 @@ const gchar *dt_database_get_path(const struct dt_database_t *db);
 gboolean dt_database_get_lock_acquired(const struct dt_database_t *db);
 /** show an error popup. this has to be postponed until after we tried using dbus to reach another instance */
 void dt_database_show_error(const struct dt_database_t *db);
-/** perform pre-db-close optimizations (call only when quiting darktable) */
+/** perform pre-db-close optimizations (always call when quiting darktable) */
 void dt_database_optimize(const struct dt_database_t *);
+
+void dt_database_maybe_vacuum(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
This continues work started in #4303

This time it should perform `VACUUM` and `ANALYZE` operations right after schema upgrades.

Another addition is `PRAGMA optimize` done, as recommended by sqlite manual, upon closing darktable. See - https://www.sqlite.org/pragma.html#pragma_optimize

I'd like to also do `VACUUM` and `ANALYZE` on dt closing, basing on some heuristic about theoretical DB fragmentation, based on suggestions from https://blogs.gnome.org/jnelson/2015/01/06/sqlite-vacuum-and-auto_vacuum/ however I don't know the best way around it - introduce config param(s) that would say "VACUUM db when free pages reach 25% of DB"?