### PR TITLE
use exclusively bash in all shell scripts

### DIFF
--- a/.ci/ci-script.sh
+++ b/.ci/ci-script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #    This file is part of darktable.
 #    copyright (c) 2016 Roman Lebedev.

--- a/build-doc.sh
+++ b/build-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This script is a quick hack to make it easier to build the darktable documetation
 # in PDF, html-multi and html-single formats, for the user manual and LUA API.
@@ -127,7 +127,7 @@ num_cpu()
                         ncpu=$(grep -c "^processor" /proc/cpuinfo)
                 elif [ -x /sbin/sysctl ]; then
                         ncpu=$(/sbin/sysctl -n hw.ncpu 2>/dev/null)
-                        if [ $? -neq 0 ]; then
+                        if [ $? -ne 0 ]; then
                                 ncpu=-1
                         fi
                 fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tools/authors_h.sh
+++ b/tools/authors_h.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # MIT License
 #

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Partly stolen from http://imagejdocu.tudor.lu/doku.php?id=diverse:commandline:imagej
 # Detect readlink or realpath version

--- a/tools/create_control_svg.sh
+++ b/tools/create_control_svg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #   This file is part of darktable,
 #   copyright (c) 2009--2010 johannes hanika.

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DT_SRC_DIR=$(dirname "$0")
 DT_SRC_DIR=$(cd "$DT_SRC_DIR/../" && pwd -P)

--- a/tools/create_version_c.sh
+++ b/tools/create_version_c.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tools/generate-authors.sh
+++ b/tools/generate-authors.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #
 #   This file is part of darktable,
 #   copyright (c) 2019 pascal obry

--- a/tools/get_git_version_string.sh
+++ b/tools/get_git_version_string.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 VERSION="$(git describe --tags --dirty)"
 

--- a/tools/get_last_commit_year.sh
+++ b/tools/get_last_commit_year.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DT_SRC_DIR=$(dirname "$0")
 DT_SRC_DIR=$(cd "$DT_SRC_DIR/../" && pwd -P)

--- a/tools/iop-layout-legacy.sh
+++ b/tools/iop-layout-legacy.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # do not touch the following 5 definitions
 

--- a/tools/iop-layout.sh
+++ b/tools/iop-layout.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 # do not touch the following 5 definitions
 

--- a/tools/keybinding2docbook.sh
+++ b/tools/keybinding2docbook.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Run from darktable root directory
 git grep -A 2 -h gtk_accel_map_add_entry | tr -d '\n' | \
 sed 's/gtk_accel_map_add_entry *( *\(\"[^\"]\+\"\) *, *\([^ ,]\+\) *, *\([^,)]\+\)) *;/%~\1;\2;\3%~/g' | \

--- a/tools/listcams.sh
+++ b/tools/listcams.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # TODO: extract basecurves, color matrices etc and create a complete html table for the web:
 echo "cameras with profiled presets for denoising:"

--- a/tools/makeman.sh
+++ b/tools/makeman.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e;
 

--- a/tools/noise/benchmark.sh
+++ b/tools/noise/benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 REF="reference.pfm"
 

--- a/tools/noise/graph.sh
+++ b/tools/noise/graph.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 isolist="200 400 800 1600"
 

--- a/tools/noise/graph2.sh
+++ b/tools/noise/graph2.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # remove whitespace and braces,
 # filter out panasonic and powershot etc because they usually blow up the plot ranges

--- a/tools/parse_version_c.sh
+++ b/tools/parse_version_c.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tools/purge_from_cache.sh
+++ b/tools/purge_from_cache.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # MIT License
 #

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DRYRUN=yes
 

--- a/tools/purge_unused_tags.sh
+++ b/tools/purge_unused_tags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Usage: purge_unused_tags [-p]

--- a/tools/update_modelines.sh
+++ b/tools/update_modelines.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # this appends modelines to all source and header files to make sure kate and
 # vim know how to format their stuff.

--- a/tools/update_wb_presets_from_ufraw.sh
+++ b/tools/update_wb_presets_from_ufraw.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Script updates our wb_presets which we regularly steal from UFRaw.
 #

--- a/tools/update_web_usermanual.sh
+++ b/tools/update_web_usermanual.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd build || exit
 rm -r doc/usermanual
 make darktable-usermanual-html

--- a/tools/watch_folder.sh
+++ b/tools/watch_folder.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # MIT License
 #


### PR DESCRIPTION
Darktable shell script files use shebang `#!/bin/sh` as well as `#!/bin/bash`. Many of the sh-scripts use features not available in a POSIX shell. In my view, only a single shell flavor should be utilized.

In stead of replacing `#!/bin/sh` by `#!/bin/bash` one could alternatively aim for full POSIX compliance  and use `#!/bin/sh`. This, however, would require considerably more rework.