### PR TITLE
Minimal (faking) support for dual pixel dng files, second attempt

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1434,6 +1434,7 @@ void dt_image_init(dt_image_t *img)
   img->wb_coeffs[3] = NAN;
   img->usercrop[0] = img->usercrop[1] = 0;
   img->usercrop[2] = img->usercrop[3] = 1;
+  img->planes = 1;
   img->cache_entry = 0;
 }
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -206,6 +206,9 @@ typedef struct dt_image_t
 
   /* DefaultUserCrop */
   float usercrop[4];
+
+  /* Keep the number of cpp for dualpixel images */
+  uint32_t planes; 
   /* convenience pointer back into the image cache, so we can return dt_image_t* there directly. */
   struct dt_cache_entry_t *cache_entry;
 } dt_image_t;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2537,7 +2537,9 @@ void enter(dt_view_t *self)
 
   dt_dev_load_image(darktable.develop, dev->image_storage.id);
 
-
+  // print a warning as we only support first of dual pixels
+  if (dev->image_storage.planes > 1)
+    dt_control_log(_("Using first part of dual pixel image '%s'"),dev->image_storage.filename);
   /*
    * add IOP modules to plugin list
    */


### PR DESCRIPTION
A second attempt to give minimal support for dual pixel dng files.
Ref #4032 was first attempt, see discussion there
Ref #4006 as first issue

I am well aware that dual pixel images allow more functionality than what is handled
here. (And what can be done right now as the whole dt workflow is not aware of such images)

BUT: we could support basic reading and working on the image by just using the first of two pixels
so at least those images are somewhat usable in dt.

To make the user aware of this minimalistic approach there is a warning displayed every time
you open the image in darkroom.

There is one (minor) problem remaining atm, @LebedevRI is not convinced the 4 blacklevels are
always correct for dual pixel images so right now those have to be set by hand or camera
specific style. (They can be read via exiv2 of course)