### PR TITLE
Better white balance ui/ux: buttons, sections, colored sliders!

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2346,17 +2346,16 @@
   </dtconfig>
   <dtconfig prefs="gui" section="darkroom">
     <name>plugins/darkroom/temperature/colored_sliders</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>use colored sliders for visual indication</shortdescription>
-    <longdescription>enable visual indication of temperature adjustments.</longdescription>
-  </dtconfig>
-  <dtconfig prefs="gui" section="darkroom">
-    <name>plugins/darkroom/temperature/blackbody_is_confusing</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>temperature slider effect color emulation</shortdescription>
-    <longdescription>by default on temperature slider we show color of light coming from blackbody heated to given temperature and then illuminating the scene. think of it as a scene light source. if you find it confusing, enable this option to show inverse gradient of color to show effect of adjustment.</longdescription>
+    <type>
+      <enum>
+        <option>no color</option>
+        <option>blackbody</option>
+        <option>effect emulation</option>
+      </enum>
+    </type>
+    <default>no color</default>
+    <shortdescription>white balance slider colors</shortdescription>
+    <longdescription>visual indication of temperature adjustments. in 'blackbody' mode shows light source color, in 'effect emulation' shows effect the adjustment would have</longdescription>
   </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2344,7 +2344,7 @@
     <shortdescription>Geotagging search URL</shortdescription>
     <longdescription>this can be changed when the default OpenStreetMap search URL is broken</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui" section="darkroom">
+  <dtconfig prefs="darkroom" section="interface">
     <name>plugins/darkroom/temperature/colored_sliders</name>
     <type>
       <enum>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2357,6 +2357,13 @@
     <shortdescription>white balance slider colors</shortdescription>
     <longdescription>visual indication of temperature adjustments. in 'blackbody' mode shows light source color, in 'effect emulation' shows effect the adjustment would have</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/temperature/expand_coefficients</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>whether to show coefficients</shortdescription>
+    <longdescription>this is just for remembering whether to show coefficients or not and remember it.</longdescription>
+  </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
 

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2344,6 +2344,20 @@
     <shortdescription>Geotagging search URL</shortdescription>
     <longdescription>this can be changed when the default OpenStreetMap search URL is broken</longdescription>
   </dtconfig>
+  <dtconfig prefs="gui" section="darkroom">
+    <name>plugins/darkroom/temperature/colored_sliders</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>use colored sliders for visual indication</shortdescription>
+    <longdescription>enable visual indication of temperature adjustments.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui" section="darkroom">
+    <name>plugins/darkroom/temperature/blackbody_is_confusing</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>temperature slider effect color emulation</shortdescription>
+    <longdescription>by default on temperature slider we show color of light coming from blackbody heated to given temperature and then illuminating the scene. think of it as a scene light source. if you find it confusing, enable this option to show inverse gradient of color to show effect of adjustment.</longdescription>
+  </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
 

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2349,13 +2349,13 @@
     <type>
       <enum>
         <option>no color</option>
-        <option>blackbody</option>
+        <option>illuminant color</option>
         <option>effect emulation</option>
       </enum>
     </type>
     <default>no color</default>
     <shortdescription>white balance slider colors</shortdescription>
-    <longdescription>visual indication of temperature adjustments. in 'blackbody' mode shows light source color, in 'effect emulation' shows effect the adjustment would have</longdescription>
+    <longdescription>visual indication of temperature adjustments. in 'illuminant color' mode slider colors correspond to light source color, in 'effect emulation' slider colors correspond to effect the adjustment would have on the scene</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/temperature/expand_coefficients</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2355,7 +2355,7 @@
     </type>
     <default>no color</default>
     <shortdescription>white balance slider colors</shortdescription>
-    <longdescription>visual indication of temperature adjustments. in 'illuminant color' mode slider colors correspond to light source color, in 'effect emulation' slider colors correspond to effect the adjustment would have on the scene</longdescription>
+    <longdescription>visual indication of temperature adjustments. in 'illuminant color' mode slider colors correspond to the color of the light source, in 'effect emulation' slider colors correspond to the effect the adjustment would have on the scene</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/temperature/expand_coefficients</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2347,7 +2347,7 @@
   <dtconfig prefs="gui" section="darkroom">
     <name>plugins/darkroom/temperature/colored_sliders</name>
     <type>bool</type>
-    <default>true</default>
+    <default>false</default>
     <shortdescription>use colored sliders for visual indication</shortdescription>
     <longdescription>enable visual indication of temperature adjustments.</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2355,7 +2355,7 @@
     </type>
     <default>no color</default>
     <shortdescription>white balance slider colors</shortdescription>
-    <longdescription>visual indication of temperature adjustments. in 'illuminant color' mode slider colors correspond to the color of the light source, in 'effect emulation' slider colors correspond to the effect the adjustment would have on the scene</longdescription>
+    <longdescription>visual indication of temperature adjustments.\nin 'illuminant color' mode slider colors represent the color of the light source,\nin 'effect emulation' slider colors represent the effect the adjustment would have on the scene</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/temperature/expand_coefficients</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2362,7 +2362,14 @@
     <type>bool</type>
     <default>false</default>
     <shortdescription>whether to show coefficients</shortdescription>
-    <longdescription>this is just for remembering whether to show coefficients or not and remember it.</longdescription>
+    <longdescription>this is just for remembering whether to show coefficients or not and remember it</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/temperature/button_bar</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>arange buttons as bar below temp/tint sliders</shortdescription>
+    <longdescription>if enabled, the buttons in white balance module will be aranged below temp/tint sliders, otherwise they'll be shown in a grid to the right of temp/tint sliders</longdescription>
   </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -818,7 +818,7 @@ float dt_bauhaus_slider_get_default(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  return d->callback(widget, d->defpos, DT_BAUHAUS_GET);
+  return d->defpos;
 }
 
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max)

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2305,6 +2305,30 @@ void dt_bauhaus_slider_set_feedback(GtkWidget *widget, int feedback)
   gtk_widget_queue_draw(widget);
 }
 
+void dt_bauhaus_slider_set_feedback(GtkWidget *widget, int feedback)
+{
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
+
+  if(w->type != DT_BAUHAUS_SLIDER) return;
+
+  dt_bauhaus_slider_data_t *d = &w->data.slider;
+
+  d->fill_feedback = feedback;
+
+  gtk_widget_queue_draw(widget);
+}
+
+int dt_bauhaus_slider_get_feedback(GtkWidget *widget)
+{
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
+
+  if(w->type != DT_BAUHAUS_SLIDER) return 0;
+
+  dt_bauhaus_slider_data_t *d = &w->data.slider;
+
+  return d->fill_feedback;
+}
+
 void dt_bauhaus_slider_reset(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2305,19 +2305,6 @@ void dt_bauhaus_slider_set_feedback(GtkWidget *widget, int feedback)
   gtk_widget_queue_draw(widget);
 }
 
-void dt_bauhaus_slider_set_feedback(GtkWidget *widget, int feedback)
-{
-  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);
-
-  if(w->type != DT_BAUHAUS_SLIDER) return;
-
-  dt_bauhaus_slider_data_t *d = &w->data.slider;
-
-  d->fill_feedback = feedback;
-
-  gtk_widget_queue_draw(widget);
-}
-
 int dt_bauhaus_slider_get_feedback(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(widget);

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -814,6 +814,13 @@ void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float s
   dt_bauhaus_slider_set_soft_max(widget,soft_max);
 }
 
+float dt_bauhaus_slider_get_default(GtkWidget *widget)
+{
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  dt_bauhaus_slider_data_t *d = &w->data.slider;
+  return d->callback(widget, d->defpos, DT_BAUHAUS_GET);
+}
+
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -296,6 +296,7 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
 void dt_bauhaus_slider_clear_stops(GtkWidget *widget);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
 void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max);
+float dt_bauhaus_slider_get_default(GtkWidget *widget);
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max);
 void dt_bauhaus_slider_set_curve(GtkWidget *widget, float (*curve)(GtkWidget *self, float value, dt_bauhaus_curve_t dir));
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -287,6 +287,7 @@ void dt_bauhaus_slider_set_step(GtkWidget *w, float val);
 float dt_bauhaus_slider_get_step(GtkWidget *w);
 
 void dt_bauhaus_slider_set_feedback(GtkWidget *w, int feedback);
+int dt_bauhaus_slider_get_feedback(GtkWidget *w);
 
 void dt_bauhaus_slider_reset(GtkWidget *widget);
 void dt_bauhaus_slider_set_format(GtkWidget *w, const char *format);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -978,6 +978,31 @@ void dtgtk_cairo_paint_focus_peaking(cairo_t *cr, gint x, gint y, gint w, gint h
   FINISH
 }
 
+void dtgtk_cairo_paint_camera(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // lens
+  cairo_arc(cr, 0.5, 0.5, 0.2, 0, 2. * M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.5, 0.5, 0.1, M_PI, M_PI+M_PI_2);
+  cairo_stroke(cr);
+
+  // body
+  
+  cairo_move_to(cr, 0, 0.25);
+  cairo_line_to(cr, 0, 0.85);
+  cairo_line_to(cr, 0.95, 0.85);
+  cairo_line_to(cr, 0.95, 0.25);
+  cairo_line_to(cr, 0.75, 0.25);
+  cairo_line_to(cr, 0.65, 0.15);
+  cairo_line_to(cr, 0.35, 0.15);
+  cairo_line_to(cr, 0.25, 0.25);
+  cairo_close_path(cr);
+  cairo_stroke(cr);
+
+  FINISH
+}
 
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -181,6 +181,8 @@ void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h
 void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint focus peaking icon */
 void dtgtk_cairo_paint_focus_peaking(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint camera icon */
+void dtgtk_cairo_paint_camera(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -344,10 +344,9 @@ void dt_ellipsize_combo(GtkComboBox *cbox);
 static inline void dt_ui_section_label_set(GtkWidget *label)
 {
   gtk_widget_set_halign(label, GTK_ALIGN_FILL); // make it span the whole available width
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END); // ellipsize labels
   g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);    // make the text left aligned
   gtk_widget_set_name(label, "section_label"); // make sure that we can style these easily
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END); // ellipsize labels
 }
 
 static inline GtkWidget *dt_ui_section_label_new(const gchar *str)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -347,6 +347,7 @@ static inline void dt_ui_section_label_set(GtkWidget *label)
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);    // make the text left aligned
   gtk_widget_set_name(label, "section_label"); // make sure that we can style these easily
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END); // ellipsize labels
 }
 
 static inline GtkWidget *dt_ui_section_label_new(const gchar *str)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1280,7 +1280,7 @@ void gui_update(struct dt_iop_module_t *self)
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle));
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), active);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
+                               CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
 
   gtk_widget_set_visible(GTK_WIDGET(g->finetune), (found && gtk_widget_get_sensitive(g->finetune)));
 
@@ -1833,7 +1833,7 @@ static void _coeffs_button_changed(GtkDarktableToggleButton *widget, gpointer us
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle));
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), active);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
+                               CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
   g->expand_coeffs = active;
   dt_conf_set_bool("plugins/darkroom/temperature/expand_coefficients", active);
 }
@@ -1992,9 +1992,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   // create color picker to be able to send its signal when spot selected
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
-  g->btn_asshot = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  g->btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_star, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  g->btn_d65 = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  g->btn_asshot = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+  g->btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_star, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+  g->btn_d65 = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   gtk_grid_attach(grid, g->colorpicker, 1, 1, 1, 1);
   gtk_grid_attach(grid, g->btn_asshot, 2, 1, 1, 1);
   gtk_grid_attach(grid, g->btn_user, 1, 2, 1, 1);
@@ -2017,7 +2017,7 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
   GtkWidget *destdisp = dt_ui_section_label_new(_("channels coefficients"));
 
-  g->coeffs_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
+  g->coeffs_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle), g->expand_coeffs);
   gtk_widget_set_name(GTK_WIDGET(g->coeffs_toggle), "control-button");
 
@@ -2100,7 +2100,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), g->expand_coeffs);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,
-                               CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | (g->expand_coeffs?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
+                               CPF_STYLE_BOX | (g->expand_coeffs?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle), g->expand_coeffs);
 
   gui_sliders_update(self);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1420,10 +1420,13 @@ void gui_init(struct dt_iop_module_t *self)
   g->box_enabled = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   for(int k = 0; k < 4; k++) g->daylight_wb[k] = 1.0;
+
+  //Match UI order: temp first, then tint (like every other app ever)
+  g->scale_k = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,
+                                                  10., 5000.0, 0, feedback);
   g->scale_tint
       = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TINT, DT_IOP_HIGHEST_TINT, .01, 1.0, 3, feedback);
-  g->scale_k = dt_bauhaus_slider_new_with_range_and_feedback(self, DT_IOP_LOWEST_TEMPERATURE, DT_IOP_HIGHEST_TEMPERATURE,
-                                                10., 5000.0, 0, feedback);
+
 
   g->coeff_widgets = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   g->scale_r = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0, 8.0, .001, p->coeffs[0], 3, feedback);
@@ -1475,8 +1478,9 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->scale_tint, NULL, _("tint"));
   gtk_widget_set_tooltip_text(g->scale_tint, _("color tint of the image, from magenta (value < 1) to green (value > 1)"));
 
-  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_tint, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_k, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_tint, TRUE, TRUE, 0);
+
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_r, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_g, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(g->coeff_widgets), g->scale_b, TRUE, TRUE, 0);
@@ -1515,12 +1519,14 @@ void gui_init(struct dt_iop_module_t *self)
   
   self->gui_update(self);
 
-  g_signal_connect(G_OBJECT(g->scale_tint), "value-changed", G_CALLBACK(tint_callback), self);
   g_signal_connect(G_OBJECT(g->scale_k), "value-changed", G_CALLBACK(temp_callback), self);
+  g_signal_connect(G_OBJECT(g->scale_tint), "value-changed", G_CALLBACK(tint_callback), self);
+
   g_signal_connect(G_OBJECT(g->scale_r), "value-changed", G_CALLBACK(rgb_callback), self);
   g_signal_connect(G_OBJECT(g->scale_g), "value-changed", G_CALLBACK(rgb_callback), self);
   g_signal_connect(G_OBJECT(g->scale_b), "value-changed", G_CALLBACK(rgb_callback), self);
   g_signal_connect(G_OBJECT(g->scale_g2), "value-changed", G_CALLBACK(rgb_callback), self);
+
   g_signal_connect(G_OBJECT(g->presets), "value-changed", G_CALLBACK(presets_changed), self);
   g_signal_connect(G_OBJECT(g->finetune), "value-changed", G_CALLBACK(finetune_changed), self);
 }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1948,6 +1948,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *temp_label_box = gtk_event_box_new();
   GtkWidget *temp_label = dt_ui_section_label_new(_("scene illuminant temp"));
+  gtk_widget_set_tooltip_text(temp_label, _("click to cycle color mode on sliders"));
   gtk_container_add(GTK_CONTAINER(temp_label_box), temp_label);
 
   g_signal_connect(G_OBJECT(temp_label_box), "button-release-event", G_CALLBACK(temp_label_click), self);
@@ -1987,6 +1988,11 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach(grid, g->btn_user, 1, 2, 1, 1);
   gtk_grid_attach(grid, g->btn_d65, 2, 2, 1, 1);
 
+  gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
+  gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance preset to as shot"));
+  gtk_widget_set_tooltip_text(g->btn_user, _("set white balance to user modified"));
+  gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance preset to D65"));
+
   g_signal_connect(G_OBJECT(g->colorpicker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
   g_signal_connect(G_OBJECT(g->btn_asshot), "toggled", G_CALLBACK(btn_asshot_toggled),  (gpointer)self);
   g_signal_connect(G_OBJECT(g->btn_user), "toggled", G_CALLBACK(btn_user_toggled),  (gpointer)self);
@@ -2003,7 +2009,7 @@ void gui_init(struct dt_iop_module_t *self)
   // collapsible section for coeffs that are generally not to be used
 
   GtkWidget *destdisp_head = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-  GtkWidget *destdisp = dt_ui_section_label_new(_("rgb coefficients"));
+  GtkWidget *destdisp = dt_ui_section_label_new(_("channels coefficients"));
 
   g->coeffs_toggle = dtgtk_togglebutton_new(dtgtk_cairo_paint_solid_arrow, CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | CPF_DIRECTION_LEFT, NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle), g->expand_coeffs);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1920,8 +1920,29 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_widget_set_label(g->scale_tint, NULL, _("tint"));
   gtk_widget_set_tooltip_text(g->scale_tint, _("color tint of the image, from magenta (value < 1) to green (value > 1)"));
 
-  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_k, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_tint, TRUE, TRUE, 0);
+  GtkWidget *gridw = gtk_grid_new();
+  GtkGrid *grid = GTK_GRID(gridw);
+  gtk_grid_set_row_spacing(grid, DT_BAUHAUS_SPACE);
+  gtk_grid_set_column_spacing(grid, DT_BAUHAUS_SPACE);
+  gtk_grid_set_column_homogeneous(grid, FALSE);
+
+  gtk_grid_attach(grid, g->scale_k, 0, 1, 1, 1);
+  gtk_widget_set_hexpand(g->scale_k, TRUE);
+  gtk_grid_attach(grid, g->scale_tint, 0, 2, 1, 1);
+  gtk_widget_set_hexpand(g->scale_tint, TRUE);
+
+  g->colorpicker = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_grid_attach(grid, g->colorpicker, 1, 1, 1, 1);
+  GtkWidget *btn_reset = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  GtkWidget *btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_star, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  GtkWidget *btn_d65 = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_grid_attach(grid, btn_reset, 2, 1, 1, 1);
+  gtk_grid_attach(grid, btn_user, 1, 2, 1, 1);
+  gtk_grid_attach(grid, btn_d65, 2, 2, 1, 1);
+
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), gridw, TRUE, TRUE, 0);
+  //gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_k, TRUE, TRUE, 0);
+  //gtk_box_pack_start(GTK_BOX(g->box_enabled), g->scale_tint, TRUE, TRUE, 0);
 
   // collapsible section for coeffs that are generally not to be used
 
@@ -1986,9 +2007,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "disabled" : "enabled");
 
-  g->colorpicker = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_size_request(GTK_WIDGET(g->colorpicker), DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
-  gtk_box_pack_start(GTK_BOX(g->box_enabled), GTK_WIDGET(g->colorpicker), FALSE, FALSE, 0);
+  //g->colorpicker = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  //gtk_widget_set_size_request(GTK_WIDGET(g->colorpicker), DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
+  //gtk_box_pack_start(GTK_BOX(g->box_enabled), GTK_WIDGET(g->colorpicker), FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->colorpicker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
   gtk_widget_show_all(g->colorpicker);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -904,6 +904,9 @@ void gui_update(struct dt_iop_module_t *self)
     if (!found)
       dt_bauhaus_combobox_set(g->presets, 3);
   }
+
+  gtk_widget_set_visible(GTK_WIDGET(g->finetune), (found && gtk_widget_get_sensitive(g->finetune)));
+
 }
 
 static int calculate_bogus_daylight_wb(dt_iop_module_t *module, double bwb[4])
@@ -1331,6 +1334,7 @@ static void presets_changed(GtkWidget *widget, gpointer user_data)
   const int pos = dt_bauhaus_combobox_get(widget);
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   gtk_widget_set_sensitive(g->finetune, pos >= DT_IOP_NUM_OF_STD_TEMP_PRESETS);
+  gtk_widget_set_visible(GTK_WIDGET(g->finetune), gtk_widget_get_sensitive(g->finetune));
 }
 
 static void finetune_changed(GtkWidget *widget, gpointer user_data)
@@ -1400,6 +1404,8 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
   }
 
   gtk_widget_set_visible(GTK_WIDGET(g->scale_g2), (img->flags & DT_IMAGE_4BAYER));
+
+  //TODO: hide finetuning if presets are not available
 }
 
 void gui_init(struct dt_iop_module_t *self)
@@ -1469,6 +1475,8 @@ void gui_init(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop(g->scale_b, 1.0, 0.0, 0.0, 1.0);
     dt_bauhaus_slider_set_stop(g->scale_g2, 0.0, 0.0, 0.0, 0.0);
     dt_bauhaus_slider_set_stop(g->scale_g2, 1.0, 0.0, 1.0, 0.0);
+
+    // TODO: color the finetune slider
   }
 
   dt_bauhaus_slider_set_format(g->scale_k, "%.0f K");
@@ -1498,6 +1506,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
   gtk_stack_add_named(GTK_STACK(g->stack), g->colorpicker, "hidden");
 
+  //TODO: hide finetune if there are no finetuning
   g->finetune = dt_bauhaus_slider_new_with_range(self, -9.0, 9.0, 1.0, 0.0, 0);
   dt_bauhaus_widget_set_label(g->finetune, NULL, _("finetune"));
   dt_bauhaus_slider_set_format(g->finetune, _("%.0f mired"));

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -880,14 +880,16 @@ void color_finetuning_slider(struct dt_iop_module_t *self)
     double min_tune[3] = {0.0};
     double no_tune[3] = {0.0};
     double max_tune[3] = {0.0};
-    if(!g->blackbody_is_confusing) {
+    if(!g->blackbody_is_confusing)
+    {
       //realistic
       const double neutral[3] = {
           1 / wb_preset[preset->no_ft_pos].channel[0],
           1 / wb_preset[preset->no_ft_pos].channel[1],
           1 / wb_preset[preset->no_ft_pos].channel[2],
       };
-      for(int ch=0; ch<3; ch++) {
+      for(int ch=0; ch<3; ch++)
+      {
         min_tune[ch] = neutral[ch] * wb_preset[preset->min_ft_pos].channel[ch];
         no_tune[ch]  = neutral[ch] * wb_preset[preset->no_ft_pos].channel[ch];
         max_tune[ch] = neutral[ch] * wb_preset[preset->max_ft_pos].channel[ch];
@@ -896,27 +898,34 @@ void color_finetuning_slider(struct dt_iop_module_t *self)
       const float maxsRGBmin_tune = fmaxf(fmaxf(min_tune[0], min_tune[1]), min_tune[2]);
       const float maxsRGBmax_tune = fmaxf(fmaxf(max_tune[0], max_tune[1]), max_tune[2]);
 
-      for(int ch=0; ch<3; ch++) {
+      for(int ch=0; ch<3; ch++)
+      {
         min_tune[ch] = min_tune[ch] / maxsRGBmin_tune;
         no_tune[ch]  = 1.0;
         max_tune[ch] = max_tune[ch] / maxsRGBmax_tune;
       }
-    } else {
+    }
+    else
+    {
       //exagerated
 
-      for(int ch=0; ch<3; ch++) {
+      for(int ch=0; ch<3; ch++)
+      {
         min_tune[ch] = 0.5;
         no_tune[ch]  = 0.9;
         max_tune[ch] = 0.5;
       }
 
-      if(wb_preset[preset->min_ft_pos].channel[0] < wb_preset[preset->max_ft_pos].channel[0]) {
+      if(wb_preset[preset->min_ft_pos].channel[0] < wb_preset[preset->max_ft_pos].channel[0])
+      {
         // from blue to red
         min_tune[0] = 0.1;
         min_tune[2] = 0.9;
         max_tune[0] = 0.9;
         max_tune[2] = 0.1;
-      } else {
+      }
+      else
+      {
         //from red to blue
         min_tune[0] = 0.9;
         min_tune[2] = 0.1;
@@ -931,7 +940,8 @@ void color_finetuning_slider(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop(g->finetune, 0.5, no_tune[0],  no_tune[1],  no_tune[2]);
     dt_bauhaus_slider_set_stop(g->finetune, 1.0, max_tune[0], max_tune[1], max_tune[2]);
   }
-  if(gtk_widget_get_visible(GTK_WIDGET(g->finetune))) {
+  if(gtk_widget_get_visible(GTK_WIDGET(g->finetune)))
+  {
     gtk_widget_queue_draw(GTK_WIDGET(g->finetune));
   }
 }
@@ -979,7 +989,9 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
 
     dt_bauhaus_slider_set_stop(g->scale_b, 0.0, rchan, gchan, 0.0);
     dt_bauhaus_slider_set_stop(g->scale_b, 1.0, rchan, gchan, 1.0);
-  } else {
+  }
+  else
+  {
     //real (ish)
     //we consider dalight wb to be "reference white"
     const double white[3] = {
@@ -1008,7 +1020,8 @@ void color_rgb_sliders(struct dt_iop_module_t *self)
     dt_bauhaus_slider_set_stop(g->scale_b, 1.0, white[0]*(rchanmul/rchanmulmax), white[1]*(gchanmul/gchanmulmax), white[2]*1.0);
   }
 
-  if(gtk_widget_get_visible(GTK_WIDGET(g->scale_r))) {
+  if(gtk_widget_get_visible(GTK_WIDGET(g->scale_r)))
+  {
     gtk_widget_queue_draw(GTK_WIDGET(g->scale_r));
     gtk_widget_queue_draw(GTK_WIDGET(g->scale_g));
     gtk_widget_queue_draw(GTK_WIDGET(g->scale_b));
@@ -1073,13 +1086,17 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       const float maxsRGB_K = fmaxf(fmaxf(sRGB_K[0], sRGB_K[1]), sRGB_K[2]);
       const float maxsRGB_tint = fmaxf(fmaxf(sRGB_tint[0], sRGB_tint[1]),sRGB_tint[2]);
 
-      if(maxsRGB_K > 1.f) {
-        for(int ch=0; ch<3; ch++){
+      if(maxsRGB_K > 1.f)
+      {
+        for(int ch=0; ch<3; ch++)
+        {
           sRGB_K[ch] = fmaxf(sRGB_K[ch] / maxsRGB_K, 0.f);
         }
       }
-      if(maxsRGB_tint > 1.f) {
-        for(int ch=0; ch<3; ch++){
+      if(maxsRGB_tint > 1.f)
+      {
+        for(int ch=0; ch<3; ch++)
+        {
           sRGB_tint[ch] = fmaxf(sRGB_tint[ch] / maxsRGB_tint, 0.f);
         }
       }
@@ -1107,14 +1124,18 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       const float maxsRGB_temp = fmaxf(fmaxf(sRGB_temp[0], sRGB_temp[1]), sRGB_temp[2]);
       const float maxsRGB_tint = fmaxf(fmaxf(sRGB_tint[0], sRGB_tint[1]), sRGB_tint[2]);
 
-      if(maxsRGB_temp > 1.f) {
-        for(int ch=0; ch<3; ch++){
+      if(maxsRGB_temp > 1.f) 
+      {
+        for(int ch=0; ch<3; ch++)
+        {
           sRGB_temp[ch] = fmaxf(sRGB_temp[ch] / maxsRGB_temp, 0.f);
         }
       }
 
-      if(maxsRGB_tint > 1.f) {
-        for(int ch=0; ch<3; ch++){
+      if(maxsRGB_tint > 1.f)
+      {
+        for(int ch=0; ch<3; ch++)
+        {
           sRGB_tint[ch] = fmaxf(sRGB_tint[ch] / maxsRGB_tint, 0.f);
         }
       }
@@ -1780,7 +1801,9 @@ static void presets_changed(GtkWidget *widget, gpointer user_data)
     dt_bauhaus_slider_set_hard_max(g->finetune, wb_preset[preset->max_ft_pos].tuning);
     dt_bauhaus_slider_set_default(g->finetune, wb_preset[preset->no_ft_pos].tuning);
     --darktable.gui->reset;
-  } else {
+  }
+  else
+  {
     gtk_widget_set_sensitive(g->finetune, FALSE);
   }
   gtk_widget_set_visible(GTK_WIDGET(g->finetune), gtk_widget_get_sensitive(g->finetune));
@@ -1903,17 +1926,20 @@ static void temp_label_click(GtkWidget *label, GdkEventButton *event, gpointer u
   gchar *old_config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
   gboolean reset_feedback = FALSE;
 
-  if(!g_strcmp0(old_config, "no color")) {
+  if(!g_strcmp0(old_config, "no color"))
+  {
     dt_conf_set_string("plugins/darkroom/temperature/colored_sliders", "blackbody");
     reset_feedback = TRUE;
     g->colored_sliders = TRUE;
     g->blackbody_is_confusing = FALSE;
-  } else if (!g_strcmp0(old_config, "blackbody"))
+  } 
+  else if (!g_strcmp0(old_config, "blackbody"))
   {
     dt_conf_set_string("plugins/darkroom/temperature/colored_sliders", "effect emulation");
     g->colored_sliders = TRUE;
     g->blackbody_is_confusing = TRUE;
-  } else
+  }
+  else
   {
     dt_conf_set_string("plugins/darkroom/temperature/colored_sliders", "no color");
     reset_feedback = TRUE;
@@ -1925,7 +1951,8 @@ static void temp_label_click(GtkWidget *label, GdkEventButton *event, gpointer u
 
   if(reset_feedback)
   {
-    if(!g->colored_sliders){
+    if(!g->colored_sliders)
+    {
       dt_bauhaus_slider_clear_stops(g->scale_k);
       dt_bauhaus_slider_clear_stops(g->scale_tint);
       dt_bauhaus_slider_clear_stops(g->scale_r);
@@ -1944,6 +1971,44 @@ static void temp_label_click(GtkWidget *label, GdkEventButton *event, gpointer u
     dt_bauhaus_slider_set_feedback(g->scale_g2, feedback);
     dt_bauhaus_slider_set_feedback(g->finetune, feedback);
   }
+
+  color_temptint_sliders(self);
+  color_rgb_sliders(self);
+  color_finetuning_slider(self);
+}
+
+static void _preference_changed(gpointer instance, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+
+  gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
+  g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
+  g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "blackbody"); // true if config != "blackbody"
+  g_free(config);
+
+  g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
+  gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
+
+  if(!g->colored_sliders)
+  {
+    dt_bauhaus_slider_clear_stops(g->scale_k);
+    dt_bauhaus_slider_clear_stops(g->scale_tint);
+    dt_bauhaus_slider_clear_stops(g->scale_r);
+    dt_bauhaus_slider_clear_stops(g->scale_g);
+    dt_bauhaus_slider_clear_stops(g->scale_b);
+    dt_bauhaus_slider_clear_stops(g->scale_g2);
+    dt_bauhaus_slider_clear_stops(g->finetune);
+  }
+
+  const int feedback = g->colored_sliders ? 0 : 1;
+  dt_bauhaus_slider_set_feedback(g->scale_k, feedback);
+  dt_bauhaus_slider_set_feedback(g->scale_tint, feedback);
+  dt_bauhaus_slider_set_feedback(g->scale_r, feedback);
+  dt_bauhaus_slider_set_feedback(g->scale_g, feedback);
+  dt_bauhaus_slider_set_feedback(g->scale_b, feedback);
+  dt_bauhaus_slider_set_feedback(g->scale_g2, feedback);
+  dt_bauhaus_slider_set_feedback(g->finetune, feedback);
 
   color_temptint_sliders(self);
   color_rgb_sliders(self);
@@ -2106,6 +2171,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   g_signal_connect(G_OBJECT(g->presets), "value-changed", G_CALLBACK(presets_changed), self);
   g_signal_connect(G_OBJECT(g->finetune), "value-changed", G_CALLBACK(finetune_changed), self);
+
+  // update the gui when the preferences changed (i.e. colored sliders stuff)
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                            G_CALLBACK(_preference_changed), (gpointer)self);
 }
 
 void gui_reset(struct dt_iop_module_t *self)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1156,7 +1156,8 @@ void reload_defaults(dt_iop_module_t *module)
       {
         if(!strcmp(wb_preset[i].make, module->dev->image_storage.camera_maker)
            && !strcmp(wb_preset[i].model, module->dev->image_storage.camera_model)
-           && !strcmp(wb_preset[i].name, Daylight) && wb_preset[i].tuning == 0)
+           && (!strcmp(wb_preset[i].name, Daylight) || !strcmp(wb_preset[i].name, DirectSunlight))
+           && wb_preset[i].tuning == 0)
         {
 
           for(int k = 0; k < 4; k++) g->daylight_wb[k] = wb_preset[i].channel[k];

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -989,9 +989,9 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
 
   //we consider dalight wb to be "reference white"
   const double white[3] = {
-    1/g->daylight_wb[0],
-    1/g->daylight_wb[1],
-    1/g->daylight_wb[2],
+    1.0/g->daylight_wb[0],
+    1.0/g->daylight_wb[1],
+    1.0/g->daylight_wb[2],
   };
   // reflect actual black body colors for the temperature slider (or not)
   for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
@@ -1005,7 +1005,15 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       // TODO: this SHOULD take tint into account!
       const cmsCIEXYZ cmsXYZ = temperature_to_XYZ(K);
       float sRGB[3], XYZ[3] = {cmsXYZ.X, cmsXYZ.Y, cmsXYZ.Z};
-      dt_XYZ_to_sRGB_clipped(XYZ, sRGB);
+      //dt_XYZ_to_sRGB_clipped(XYZ, sRGB);
+      dt_XYZ_to_sRGB(XYZ, sRGB);
+
+      const float maxsRGB = sRGB[0] > sRGB[1] ? (sRGB[0] > sRGB[2] ? sRGB[0]:sRGB[2]) : (sRGB[1]>sRGB[2]?sRGB[1]:sRGB[2]);
+
+      for(int ch=0; ch<3; ch++){
+        sRGB[ch] = sRGB[ch] > 0? sRGB[ch] / maxsRGB : 0.0;
+      }
+
       dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB[0], sRGB[1], sRGB[2]);
     }
     else
@@ -1019,7 +1027,14 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       coeffs[3] /= coeffs[1];
       coeffs[1] = 1.0;
 
-      dt_bauhaus_slider_set_stop(g->scale_k, stop, white[0]*coeffs[0], white[1]*coeffs[1], white[2]*coeffs[2]);
+      float sRGB[3] = { white[0]*coeffs[0], white[1]*coeffs[1], white[2]*coeffs[2] };
+      const float maxsRGB = sRGB[0] > sRGB[1] ? (sRGB[0] > sRGB[2] ? sRGB[0]:sRGB[2]) : (sRGB[1]>sRGB[2]?sRGB[1]:sRGB[2]);
+
+      for(int ch=0; ch<3; ch++){
+        sRGB[ch] = sRGB[ch] > 0? sRGB[ch] / maxsRGB : 0.0;
+      }
+
+      dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB[0], sRGB[1], sRGB[2]);
     }
   }
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -213,6 +213,15 @@ static gboolean _set_preset_spot(GtkAccelGroup *accel_group, GObject *accelerata
   return TRUE;
 }
 
+static gboolean _set_preset_user(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                 GdkModifierType modifier, gpointer data)
+{
+  dt_iop_module_t *self = data;
+  dt_iop_temperature_gui_data_t *g = self->gui_data;
+  dt_bauhaus_combobox_set(g->presets, 3);
+  return TRUE;
+}
+
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "tint"));
@@ -225,6 +234,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/as shot"), 0, 0);
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/camera standard D65"), 0, 0);
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/from image area"), 0, 0);
+  dt_accel_register_iop(self, TRUE, NC_("accel", "preset/user modified"), 0, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -249,6 +259,9 @@ void connect_key_accels(dt_iop_module_t *self)
 
   closure = g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL);
   dt_accel_connect_iop(self, "preset/from image area", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_set_preset_user), (gpointer)self, NULL);
+  dt_accel_connect_iop(self, "preset/user modified", closure);
 }
 
 /*

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -846,14 +846,23 @@ void color_finetuning_slider(struct dt_iop_module_t *self)
     if(!g->blackbody_is_confusing) {
       //realistic
       const double neutral[3] = {
-          0.5 / wb_preset[preset->no_ft_pos].channel[0],
-          0.5 / wb_preset[preset->no_ft_pos].channel[1],
-          0.5 / wb_preset[preset->no_ft_pos].channel[2],
+          1 / wb_preset[preset->no_ft_pos].channel[0],
+          1 / wb_preset[preset->no_ft_pos].channel[1],
+          1 / wb_preset[preset->no_ft_pos].channel[2],
       };
       for(int ch=0; ch<3; ch++) {
         min_tune[ch] = neutral[ch] * wb_preset[preset->min_ft_pos].channel[ch];
         no_tune[ch]  = neutral[ch] * wb_preset[preset->no_ft_pos].channel[ch];
         max_tune[ch] = neutral[ch] * wb_preset[preset->max_ft_pos].channel[ch];
+      }
+
+      const float maxsRGBmin_tune = MAX(MAX(min_tune[0], min_tune[1]), min_tune[2]);
+      const float maxsRGBmax_tune = MAX(MAX(max_tune[0], max_tune[1]), max_tune[2]);
+
+      for(int ch=0; ch<3; ch++) {
+        min_tune[ch] = min_tune[ch] / maxsRGBmin_tune;
+        no_tune[ch]  = 1.0;
+        max_tune[ch] = max_tune[ch] / maxsRGBmax_tune;
       }
     } else {
       //exagerated
@@ -1010,8 +1019,10 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
 
       const float maxsRGB = sRGB[0] > sRGB[1] ? (sRGB[0] > sRGB[2] ? sRGB[0]:sRGB[2]) : (sRGB[1]>sRGB[2]?sRGB[1]:sRGB[2]);
 
-      for(int ch=0; ch<3; ch++){
-        sRGB[ch] = sRGB[ch] > 0? sRGB[ch] / maxsRGB : 0.0;
+      if(maxsRGB > 0.99999999) {
+        for(int ch=0; ch<3; ch++){
+          sRGB[ch] = sRGB[ch] > 0? sRGB[ch] / maxsRGB : 0.0;
+        }
       }
 
       dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB[0], sRGB[1], sRGB[2]);
@@ -1030,10 +1041,11 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       float sRGB[3] = { white[0]*coeffs[0], white[1]*coeffs[1], white[2]*coeffs[2] };
       const float maxsRGB = sRGB[0] > sRGB[1] ? (sRGB[0] > sRGB[2] ? sRGB[0]:sRGB[2]) : (sRGB[1]>sRGB[2]?sRGB[1]:sRGB[2]);
 
-      for(int ch=0; ch<3; ch++){
-        sRGB[ch] = sRGB[ch] > 0? sRGB[ch] / maxsRGB : 0.0;
+      if(maxsRGB > 0.99999999) {
+        for(int ch=0; ch<3; ch++){
+          sRGB[ch] = sRGB[ch] > 0? sRGB[ch] / maxsRGB : 0.0;
+        }
       }
-
       dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB[0], sRGB[1], sRGB[2]);
     }
   }

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1435,7 +1435,7 @@ void gui_init(struct dt_iop_module_t *self)
   {
   
     const double temp_step = (double)(DT_IOP_HIGHEST_TEMPERATURE - DT_IOP_LOWEST_TEMPERATURE) / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
-    const int blackbody_is_confusing = dt_conf_get_int("plugins/darkroom/temperature/blackbody_is_confusing");
+    const int blackbody_is_confusing = dt_conf_get_bool("plugins/darkroom/temperature/blackbody_is_confusing");
     // reflect actual black body colors for the temperature slider (or not)
     for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
     {

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1928,12 +1928,12 @@ static void temp_label_click(GtkWidget *label, GdkEventButton *event, gpointer u
 
   if(!g_strcmp0(old_config, "no color"))
   {
-    dt_conf_set_string("plugins/darkroom/temperature/colored_sliders", "blackbody");
+    dt_conf_set_string("plugins/darkroom/temperature/colored_sliders", "illuminant color");
     reset_feedback = TRUE;
     g->colored_sliders = TRUE;
     g->blackbody_is_confusing = FALSE;
   } 
-  else if (!g_strcmp0(old_config, "blackbody"))
+  else if (!g_strcmp0(old_config, "illuminant color"))
   {
     dt_conf_set_string("plugins/darkroom/temperature/colored_sliders", "effect emulation");
     g->colored_sliders = TRUE;
@@ -1984,7 +1984,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
 
   gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
-  g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "blackbody"); // true if config != "blackbody"
+  g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
   g_free(config);
 
   g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
@@ -2023,7 +2023,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
-  g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "blackbody"); // true if config != "blackbody"
+  g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "illuminant color"); // true if config != "illuminant color"
   g->expand_coeffs = dt_conf_get_bool("plugins/darkroom/temperature/expand_coefficients");
   g_free(config);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1995,7 +1995,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // create color picker to be able to send its signal when spot selected
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
-  g->btn_asshot = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+  g->btn_asshot = dtgtk_togglebutton_new(dtgtk_cairo_paint_camera, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   g->btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   g->btn_d65 = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -211,9 +211,9 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue"));
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "presets"));
 
-  dt_accel_register_iop(self, FALSE, NC_("accel", "preset/camera"), 0, 0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "preset/camera neutral"), 0, 0);
-  dt_accel_register_iop(self, FALSE, NC_("accel", "preset/spot"), 0, 0);
+  dt_accel_register_iop(self, TRUE, NC_("accel", "preset/as shot"), 0, 0);
+  dt_accel_register_iop(self, TRUE, NC_("accel", "preset/neutral daylight"), 0, 0);
+  dt_accel_register_iop(self, TRUE, NC_("accel", "preset/from image area"), 0, 0);
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -231,13 +231,13 @@ void connect_key_accels(dt_iop_module_t *self)
   GClosure *closure;
 
   closure = g_cclosure_new(G_CALLBACK(_set_preset_camera), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "preset/camera", closure);
+  dt_accel_connect_iop(self, "preset/as shot", closure);
 
   closure = g_cclosure_new(G_CALLBACK(_set_preset_camera_neutral), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "preset/camera neutral", closure);
+  dt_accel_connect_iop(self, "preset/neutral daylight", closure);
 
   closure = g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "preset/spot", closure);
+  dt_accel_connect_iop(self, "preset/from image area", closure);
 }
 
 /*
@@ -781,9 +781,9 @@ void gui_update(struct dt_iop_module_t *self)
   for(int k = 0; k < 4; k++) g->mod_coeff[k] = p->coeffs[k];
 
   dt_bauhaus_combobox_clear(g->presets);
-  dt_bauhaus_combobox_add(g->presets, C_("white balance", "camera"));
-  dt_bauhaus_combobox_add(g->presets, C_("white balance", "camera neutral"));
-  dt_bauhaus_combobox_add(g->presets, C_("white balance", "spot"));
+  dt_bauhaus_combobox_add(g->presets, C_("white balance", "as shot")); // old "camera". reason for change: all other RAW development tools use "As Shot" or "shot"
+  dt_bauhaus_combobox_add(g->presets, C_("white balance", "neutral daylight")); // old "camera neutral", reason: better matches intent
+  dt_bauhaus_combobox_add(g->presets, C_("white balance", "from image area")); // old "spot", reason: describes exactly what'll happen
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "user modified"));
   g->preset_cnt = DT_IOP_NUM_OF_STD_TEMP_PRESETS;
   memset(g->preset_num, 0, sizeof(g->preset_num));
@@ -1499,7 +1499,7 @@ void gui_init(struct dt_iop_module_t *self)
   gui_sliders_update(self);
 
   g->presets = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->presets, NULL, _("preset"));
+  dt_bauhaus_widget_set_label(g->presets, NULL, _("setting")); // relabel to setting to remove confusion between module presets and white balance settings
   gtk_box_pack_start(GTK_BOX(g->box_enabled), g->presets, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->presets, _("choose white balance preset from camera"));
   // create hidden color picker to be able to send its signal when spot selected

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -83,6 +83,7 @@ typedef struct dt_iop_temperature_gui_data_t
   GtkWidget *box_enabled;
   GtkWidget *label_disabled;
   GtkWidget *stack;
+  GtkWidget *buttonbar;
   GtkWidget *colorpicker;
   GtkWidget *btn_asshot; //As Shot
   GtkWidget *btn_user;
@@ -97,6 +98,7 @@ typedef struct dt_iop_temperature_gui_data_t
   int colored_sliders;
   int blackbody_is_confusing;
   int expand_coeffs;
+  gboolean button_bar_visible;
 } dt_iop_temperature_gui_data_t;
 
 typedef struct dt_iop_temperature_data_t
@@ -1289,6 +1291,7 @@ void gui_update(struct dt_iop_module_t *self)
                                CPF_STYLE_BOX | (active?CPF_DIRECTION_DOWN:CPF_DIRECTION_LEFT), NULL);
 
   gtk_widget_set_visible(GTK_WIDGET(g->finetune), (found && gtk_widget_get_sensitive(g->finetune)));
+  gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
 
   const int preset = dt_bauhaus_combobox_get(g->presets);
 
@@ -1960,7 +1963,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_free(config);
 
   const int feedback = g->colored_sliders ? 0 : 1;
-  const int button_bar = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
+  g->button_bar_visible = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -2055,19 +2058,16 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->btn_asshot), "toggled", G_CALLBACK(btn_asshot_toggled),  (gpointer)self);
   g_signal_connect(G_OBJECT(g->btn_user), "toggled", G_CALLBACK(btn_user_toggled),  (gpointer)self);
   g_signal_connect(G_OBJECT(g->btn_d65), "toggled", G_CALLBACK(btn_d65_toggled),  (gpointer)self);
+  
+  g->buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  if(button_bar)
-  {
-    GtkWidget* buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_d65, TRUE, TRUE, 0);
+  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_user, TRUE, TRUE, 0);
+  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->colorpicker, TRUE, TRUE, 0);
+  gtk_box_pack_end(GTK_BOX(g->buttonbar), g->btn_asshot, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->box_enabled), g->buttonbar, TRUE, TRUE, 0);
 
-    gtk_box_pack_end(GTK_BOX(buttonbar), g->btn_d65, TRUE, TRUE, 0);
-    gtk_box_pack_end(GTK_BOX(buttonbar), g->btn_user, TRUE, TRUE, 0);
-    gtk_box_pack_end(GTK_BOX(buttonbar), g->colorpicker, TRUE, TRUE, 0);
-    gtk_box_pack_end(GTK_BOX(buttonbar), g->btn_asshot, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(g->box_enabled), buttonbar, TRUE, TRUE, 0);
-
-    //in case we don't have enabled button bar, no need to show buttons and all buttons are simply hidden!
-  }
+  gtk_widget_set_visible(g->buttonbar, g->button_bar_visible);
 
   g->presets = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->presets, NULL, _("setting")); // relabel to setting to remove confusion between module presets and white balance settings

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -236,7 +236,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "presets"));
 
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/as shot"), 0, 0);
-  dt_accel_register_iop(self, TRUE, NC_("accel", "preset/camera standard D65"), 0, 0);
+  dt_accel_register_iop(self, TRUE, NC_("accel", "preset/camera reference"), 0, 0);
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/from image area"), 0, 0);
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/user modified"), 0, 0);
 }
@@ -259,7 +259,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_iop(self, "preset/as shot", closure);
 
   closure = g_cclosure_new(G_CALLBACK(_set_preset_camera_neutral), (gpointer)self, NULL);
-  dt_accel_connect_iop(self, "preset/camera standard D65", closure);
+  dt_accel_connect_iop(self, "preset/camera reference", closure);
 
   closure = g_cclosure_new(G_CALLBACK(_set_preset_spot), (gpointer)self, NULL);
   dt_accel_connect_iop(self, "preset/from image area", closure);
@@ -1154,7 +1154,7 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_bauhaus_combobox_clear(g->presets);
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "as shot")); // old "camera". reason for change: all other RAW development tools use "As Shot" or "shot"
-  dt_bauhaus_combobox_add(g->presets, C_("white balance", "camera standard D65")); // old "camera neutral", reason: better matches intent
+  dt_bauhaus_combobox_add(g->presets, C_("white balance", "camera reference")); // old "camera neutral", reason: better matches intent
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "from image area")); // old "spot", reason: describes exactly what'll happen
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "user modified"));
 
@@ -2045,7 +2045,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
   gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance preset to as shot"));
   gtk_widget_set_tooltip_text(g->btn_user, _("set white balance to user modified"));
-  gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance preset to D65"));
+  gtk_widget_set_tooltip_text(g->btn_d65, _("set white balance preset to camera reference point\nin most cases it should be D65"));
 
   //g_signal_connect(G_OBJECT(g->colorpicker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
   g_signal_connect(G_OBJECT(g->btn_asshot), "toggled", G_CALLBACK(btn_asshot_toggled),  (gpointer)self);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1946,6 +1946,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_free(config);
 
   const int feedback = g->colored_sliders ? 0 : 1;
+  const int button_bar = dt_conf_get_bool("plugins/darkroom/temperature/button_bar");
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
@@ -1960,6 +1961,8 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *temp_label_box = gtk_event_box_new();
   GtkWidget *temp_label = dt_ui_section_label_new(_("scene illuminant temp"));
   gtk_widget_set_tooltip_text(temp_label, _("click to cycle color mode on sliders"));
+  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(temp_label));
+  gtk_style_context_add_class(context, "section_label_top");
   gtk_container_add(GTK_CONTAINER(temp_label_box), temp_label);
 
   g_signal_connect(G_OBJECT(temp_label_box), "button-release-event", G_CALLBACK(temp_label_click), self);
@@ -1995,10 +1998,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->btn_asshot = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   g->btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   g->btn_d65 = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-  gtk_grid_attach(grid, g->colorpicker, 1, 1, 1, 1);
-  gtk_grid_attach(grid, g->btn_asshot, 2, 1, 1, 1);
-  gtk_grid_attach(grid, g->btn_user, 1, 2, 1, 1);
-  gtk_grid_attach(grid, g->btn_d65, 2, 2, 1, 1);
 
   gtk_widget_set_tooltip_text(g->colorpicker, _("set white balance to detected from area"));
   gtk_widget_set_tooltip_text(g->btn_asshot, _("set white balance preset to as shot"));
@@ -2009,6 +2008,25 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->btn_asshot), "toggled", G_CALLBACK(btn_asshot_toggled),  (gpointer)self);
   g_signal_connect(G_OBJECT(g->btn_user), "toggled", G_CALLBACK(btn_user_toggled),  (gpointer)self);
   g_signal_connect(G_OBJECT(g->btn_d65), "toggled", G_CALLBACK(btn_d65_toggled),  (gpointer)self);
+
+  if(button_bar)
+  {
+    GtkWidget* buttonbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+    gtk_box_pack_end(GTK_BOX(buttonbar), g->btn_d65, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(buttonbar), g->btn_user, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(buttonbar), g->colorpicker, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(buttonbar), g->btn_asshot, FALSE, FALSE, 0);
+
+    gtk_grid_attach(grid, buttonbar, 0, 3, 1, 1);
+  } 
+  else 
+  {
+    gtk_grid_attach(grid, g->btn_asshot, 1, 1, 1, 1);
+    gtk_grid_attach(grid, g->colorpicker, 2, 1, 1, 1);
+    gtk_grid_attach(grid, g->btn_user, 1, 2, 1, 1);
+    gtk_grid_attach(grid, g->btn_d65, 2, 2, 1, 1);
+  }
 
   gtk_box_pack_start(GTK_BOX(g->box_enabled), gridw, TRUE, TRUE, 0);
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1370,13 +1370,13 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
   if(FILTERS_ARE_CYGM(img->buf_dsc.filters))
   {
     dt_bauhaus_widget_set_label(g->scale_r, NULL, _("green"));
-    gtk_widget_set_tooltip_text(g->scale_r, _("green channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_r, _("green channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_g, NULL, _("magenta"));
-    gtk_widget_set_tooltip_text(g->scale_g, _("magenta channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_g, _("magenta channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_b, NULL, _("cyan"));
-    gtk_widget_set_tooltip_text(g->scale_b, _("cyan channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_b, _("cyan channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_g2, NULL, _("yellow"));
-    gtk_widget_set_tooltip_text(g->scale_g2, _("yellow channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_g2, _("yellow channel coefficient"));
 
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_b, 0);
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_g2, 1);
@@ -1386,13 +1386,13 @@ static void gui_sliders_update(struct dt_iop_module_t *self)
   else
   {
     dt_bauhaus_widget_set_label(g->scale_r, NULL, _("red"));
-    gtk_widget_set_tooltip_text(g->scale_r, _("red channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_r, _("red channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_g, NULL, _("green"));
-    gtk_widget_set_tooltip_text(g->scale_g, _("green channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_g, _("green channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_b, NULL, _("blue"));
-    gtk_widget_set_tooltip_text(g->scale_b, _("blue channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_b, _("blue channel coefficient"));
     dt_bauhaus_widget_set_label(g->scale_g2, NULL, _("emerald"));
-    gtk_widget_set_tooltip_text(g->scale_g2, _("emerald channel value on a scale from 0 to 8"));
+    gtk_widget_set_tooltip_text(g->scale_g2, _("emerald channel coefficient"));
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_r, 0);
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_g, 1);
     gtk_box_reorder_child(GTK_BOX(g->coeff_widgets), g->scale_b, 2);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -59,6 +59,12 @@ DT_MODULE_INTROSPECTION(3, dt_iop_temperature_params_t)
 
 #define DT_IOP_NUM_OF_STD_TEMP_PRESETS 4
 
+// If you reorder presets combo, change this consts
+#define DT_IOP_TEMP_AS_SHOT 0
+#define DT_IOP_TEMP_SPOT 1
+#define DT_IOP_TEMP_USER 2
+#define DT_IOP_TEMP_D65 3
+
 //storing the last picked color (if any)
 static float old[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
@@ -195,7 +201,7 @@ static gboolean _set_preset_camera(GtkAccelGroup *accel_group, GObject *accelera
 {
   dt_iop_module_t *self = data;
   dt_iop_temperature_gui_data_t *g = self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 0);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
   return TRUE;
 }
 
@@ -204,7 +210,7 @@ static gboolean _set_preset_camera_neutral(GtkAccelGroup *accel_group, GObject *
 {
   dt_iop_module_t *self = data;
   dt_iop_temperature_gui_data_t *g = self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 1);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
   return TRUE;
 }
 
@@ -213,7 +219,7 @@ static gboolean _set_preset_spot(GtkAccelGroup *accel_group, GObject *accelerata
 {
   dt_iop_module_t *self = data;
   dt_iop_temperature_gui_data_t *g = self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 2);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_SPOT);
   return TRUE;
 }
 
@@ -222,7 +228,7 @@ static gboolean _set_preset_user(GtkAccelGroup *accel_group, GObject *accelerata
 {
   dt_iop_module_t *self = data;
   dt_iop_temperature_gui_data_t *g = self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 3);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
   return TRUE;
 }
 
@@ -844,7 +850,7 @@ int generate_preset_combo(struct dt_iop_module_t *self)
               }
               ft_pos++;
             }
-            
+
           }
           dt_bauhaus_combobox_add_full(g->presets, _(wb_preset[i].name), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, preset, free, TRUE);
           g->preset_num[g->preset_cnt] = i;
@@ -1046,7 +1052,7 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       const float stop = i / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
       const double K = DT_IOP_LOWEST_TEMPERATURE + i * temp_step;
       const double tint = DT_IOP_LOWEST_TINT + i * tint_step;
-      
+
       double coeffs_K[4];
       double coeffs_tint[4];
       temp2mul(self, K, cur_tint, coeffs_K);
@@ -1079,7 +1085,7 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
       dt_bauhaus_slider_set_stop(g->scale_tint, stop, sRGB_tint[0], sRGB_tint[1], sRGB_tint[2]);
     }
   }
-  else 
+  else
   {
     // reflect actual black body colors for the temperature slider
     for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
@@ -1116,7 +1122,7 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
     }
   }
 
-  if(gtk_widget_get_visible(GTK_WIDGET(g->scale_k))) 
+  if(gtk_widget_get_visible(GTK_WIDGET(g->scale_k)))
   {
     gtk_widget_queue_draw(GTK_WIDGET(g->scale_k));
     gtk_widget_queue_draw(GTK_WIDGET(g->scale_tint));
@@ -1154,9 +1160,9 @@ void gui_update(struct dt_iop_module_t *self)
 
   dt_bauhaus_combobox_clear(g->presets);
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "as shot")); // old "camera". reason for change: all other RAW development tools use "As Shot" or "shot"
-  dt_bauhaus_combobox_add(g->presets, C_("white balance", "camera reference")); // old "camera neutral", reason: better matches intent
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "from image area")); // old "spot", reason: describes exactly what'll happen
   dt_bauhaus_combobox_add(g->presets, C_("white balance", "user modified"));
+  dt_bauhaus_combobox_add(g->presets, C_("white balance", "camera reference")); // old "camera neutral", reason: better matches intent
 
   g->preset_cnt = DT_IOP_NUM_OF_STD_TEMP_PRESETS;
   memset(g->preset_num, 0, sizeof(g->preset_num));
@@ -1171,7 +1177,7 @@ void gui_update(struct dt_iop_module_t *self)
   // is this a "as shot" white balance?
   if(memcmp(p->coeffs, fp->coeffs, 3 * sizeof(float)) == 0)
   {
-    dt_bauhaus_combobox_set(g->presets, 0);
+    dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
     found = TRUE;
   }
   else
@@ -1180,7 +1186,7 @@ void gui_update(struct dt_iop_module_t *self)
     if((p->coeffs[0] == (float)g->daylight_wb[0]) && (p->coeffs[1] == (float)g->daylight_wb[1])
        && (p->coeffs[2] == (float)g->daylight_wb[2]))
     {
-      dt_bauhaus_combobox_set(g->presets, 1);
+      dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
       found = TRUE;
     }
   }
@@ -1212,7 +1218,7 @@ void gui_update(struct dt_iop_module_t *self)
             dt_bauhaus_slider_set_hard_max(g->finetune, wb_preset[preset->max_ft_pos].tuning);
             dt_bauhaus_slider_set_default(g->finetune, wb_preset[preset->no_ft_pos].tuning);
           }
-          
+
           dt_bauhaus_slider_set(g->finetune, wb_preset[i].tuning);
           found = TRUE;
           break;
@@ -1274,7 +1280,7 @@ void gui_update(struct dt_iop_module_t *self)
       }
     }
     if (!found) //since we haven't got a match - it's user-set
-      dt_bauhaus_combobox_set(g->presets, 3);
+      dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
   }
 
   const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(g->coeffs_toggle));
@@ -1286,9 +1292,9 @@ void gui_update(struct dt_iop_module_t *self)
 
   const int preset = dt_bauhaus_combobox_get(g->presets);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), preset == 0);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), preset == 3);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), preset == 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), preset == DT_IOP_TEMP_AS_SHOT);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), preset == DT_IOP_TEMP_USER);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), preset == DT_IOP_TEMP_D65);
 
   color_temptint_sliders(self);
   color_rgb_sliders(self);
@@ -1595,7 +1601,7 @@ static void tint_callback(GtkWidget *slider, gpointer user_data)
   if(darktable.gui->reset) return;
   temp_changed(self);
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 3);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
 }
 
 static void temp_callback(GtkWidget *slider, gpointer user_data)
@@ -1604,7 +1610,7 @@ static void temp_callback(GtkWidget *slider, gpointer user_data)
   if(darktable.gui->reset) return;
   temp_changed(self);
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 3);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
 }
 
 static void rgb_callback(GtkWidget *slider, gpointer user_data)
@@ -1626,7 +1632,7 @@ static void rgb_callback(GtkWidget *slider, gpointer user_data)
 
   gui_update_from_coeffs(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
-  dt_bauhaus_combobox_set(g->presets, 3);
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
 }
 
 static void btn_asshot_toggled(GtkToggleButton *togglebutton, gpointer user_data)
@@ -1636,8 +1642,8 @@ static void btn_asshot_toggled(GtkToggleButton *togglebutton, gpointer user_data
 
   dt_iop_temperature_gui_data_t *g = self->gui_data;
 
-  if(gtk_toggle_button_get_active(togglebutton) && dt_bauhaus_combobox_get(g->presets) != 0)
-    dt_bauhaus_combobox_set(g->presets, 0);
+  if(gtk_toggle_button_get_active(togglebutton) && dt_bauhaus_combobox_get(g->presets) != DT_IOP_TEMP_AS_SHOT)
+    dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_AS_SHOT);
 }
 
 static void btn_d65_toggled(GtkToggleButton *togglebutton, gpointer user_data)
@@ -1647,8 +1653,8 @@ static void btn_d65_toggled(GtkToggleButton *togglebutton, gpointer user_data)
 
   dt_iop_temperature_gui_data_t *g = self->gui_data;
 
-  if(gtk_toggle_button_get_active(togglebutton) && dt_bauhaus_combobox_get(g->presets) != 1)
-    dt_bauhaus_combobox_set(g->presets, 1);
+  if(gtk_toggle_button_get_active(togglebutton) && dt_bauhaus_combobox_get(g->presets) != DT_IOP_TEMP_D65)
+    dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_D65);
 }
 
 static void btn_user_toggled(GtkToggleButton *togglebutton, gpointer user_data)
@@ -1658,8 +1664,8 @@ static void btn_user_toggled(GtkToggleButton *togglebutton, gpointer user_data)
 
   dt_iop_temperature_gui_data_t *g = self->gui_data;
 
-  if(gtk_toggle_button_get_active(togglebutton) && dt_bauhaus_combobox_get(g->presets) != 3)
-    dt_bauhaus_combobox_set(g->presets, 3);
+  if(gtk_toggle_button_get_active(togglebutton) && dt_bauhaus_combobox_get(g->presets) != DT_IOP_TEMP_USER)
+    dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_USER);
 }
 
 static void apply_preset(dt_iop_module_t *self)
@@ -1679,24 +1685,24 @@ static void apply_preset(dt_iop_module_t *self)
   {
     case -1: // just un-setting.
       return;
-    case 0: // as shot wb
+    case DT_IOP_TEMP_AS_SHOT: // as shot wb
       for(int k = 0; k < 4; k++) p->coeffs[k] = fp->coeffs[k];
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), TRUE);
       break;
-    case 1: // camera reference d65
-      for(int k = 0; k < 4; k++) p->coeffs[k] = g->daylight_wb[k];
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), TRUE);
-      break;
-    case 2: // from image area wb, expose callback will set p->coeffs.
+    case DT_IOP_TEMP_SPOT: // from image area wb, expose callback will set p->coeffs.
       //reset previously stored color picker information
       for(int k = 0; k < 4; k++) old[k] = 0.0f;
       gboolean ret_val;
       g_signal_emit_by_name(G_OBJECT(g->colorpicker), "button-press-event", NULL, &ret_val);
       break;
-    case 3: // directly changing one of the coeff sliders also changes the mod_coeff so it can be read here
+    case DT_IOP_TEMP_USER: // directly changing one of the coeff sliders also changes the mod_coeff so it can be read here
       for(int k = 0; k < 4; k++) p->coeffs[k] = g->mod_coeff[k];
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), TRUE);
-      break;      
+      break;
+    case DT_IOP_TEMP_D65: // camera reference d65
+      for(int k = 0; k < 4; k++) p->coeffs[k] = g->daylight_wb[k];
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), TRUE);
+      break;
     default: // camera WB presets
     {
       gboolean found = FALSE;
@@ -1765,13 +1771,12 @@ static void presets_changed(GtkWidget *widget, gpointer user_data)
   const dt_iop_temperature_preset_data_t *const preset = dt_bauhaus_combobox_get_data(widget);
   if(preset != NULL)
   {
-    const int32_t old_reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_widget_set_sensitive(g->finetune, (preset->min_ft_pos != preset->max_ft_pos));
     dt_bauhaus_slider_set_hard_min(g->finetune, wb_preset[preset->min_ft_pos].tuning);
     dt_bauhaus_slider_set_hard_max(g->finetune, wb_preset[preset->max_ft_pos].tuning);
     dt_bauhaus_slider_set_default(g->finetune, wb_preset[preset->no_ft_pos].tuning);
-    darktable.gui->reset = old_reset;
+    --darktable.gui->reset;
   } else {
     gtk_widget_set_sensitive(g->finetune, FALSE);
   }
@@ -1817,13 +1822,12 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   color_temptint_sliders(self);
 
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  const int32_t old_reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), FALSE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), FALSE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), FALSE);
-  dt_bauhaus_combobox_set(g->presets, 2);
-  darktable.gui->reset = old_reset;
+  dt_bauhaus_combobox_set(g->presets, DT_IOP_TEMP_SPOT);
+  --darktable.gui->reset;
 }
 
 static void _coeffs_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
@@ -1948,7 +1952,7 @@ void gui_init(struct dt_iop_module_t *self)
   self->gui_data = calloc(1, sizeof(dt_iop_temperature_gui_data_t));
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->default_params;
-  
+
   gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
   g->blackbody_is_confusing = g->colored_sliders && g_strcmp0(config, "blackbody"); // true if config != "blackbody"
@@ -2111,9 +2115,9 @@ void gui_reset(struct dt_iop_module_t *self)
   const int preset = dt_bauhaus_combobox_get(g->presets);
   dt_iop_color_picker_reset(self, TRUE);
 
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), preset == 0);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), preset == 3);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), preset == 1);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_asshot), preset == DT_IOP_TEMP_AS_SHOT);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_user), preset == DT_IOP_TEMP_USER);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->btn_d65), preset == DT_IOP_TEMP_D65);
 
   dtgtk_expander_set_expanded(DTGTK_EXPANDER(g->coeffs_expander), g->expand_coeffs);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->coeffs_toggle), dtgtk_cairo_paint_solid_arrow,

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1993,7 +1993,7 @@ void gui_init(struct dt_iop_module_t *self)
   // create color picker to be able to send its signal when spot selected
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, NULL);
   g->btn_asshot = dtgtk_togglebutton_new(dtgtk_cairo_paint_eye, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
-  g->btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_star, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
+  g->btn_user = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_drawn, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   g->btn_d65 = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
   gtk_grid_attach(grid, g->colorpicker, 1, 1, 1, 1);
   gtk_grid_attach(grid, g->btn_asshot, 2, 1, 1, 1);

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1038,46 +1038,15 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
     1.0/cur_coeffs[2],
   };
 
-  // reflect actual black body colors for the temperature slider (or not)
-  for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+  if(blackbody_is_confusing)
   {
-    const float stop = i / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
-    const double K = DT_IOP_LOWEST_TEMPERATURE + i * temp_step;
-    const double tint = DT_IOP_LOWEST_TINT + i * tint_step;
-
-    if(!blackbody_is_confusing)
+    // show effect of adjustment on temp/tint sliders
+    for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
     {
-      // it isn't!
-      const cmsCIEXYZ cmsXYZ_temp = temperature_tint_to_XYZ(K,cur_tint);
-      const cmsCIEXYZ cmsXYZ_tint = temperature_tint_to_XYZ(cur_temp, tint);
-      float sRGB_temp[3], XYZ_temp[3] = {cmsXYZ_temp.X, cmsXYZ_temp.Y, cmsXYZ_temp.Z};
-      float sRGB_tint[3], XYZ_tint[3] = {cmsXYZ_tint.X, cmsXYZ_tint.Y, cmsXYZ_tint.Z};
-
-      dt_XYZ_to_sRGB(XYZ_temp, sRGB_temp);
-      dt_XYZ_to_sRGB(XYZ_tint, sRGB_tint);
-
-      const float maxsRGB_temp = fmaxf(fmaxf(sRGB_temp[0], sRGB_temp[1]), sRGB_temp[2]);
-      const float maxsRGB_tint = fmaxf(fmaxf(sRGB_tint[0], sRGB_tint[1]), sRGB_tint[2]);
-
-      if(maxsRGB_temp > 1.f) {
-        for(int ch=0; ch<3; ch++){
-          sRGB_temp[ch] = fmaxf(sRGB_temp[ch] / maxsRGB_temp, 0.f);
-        }
-      }
-
-      if(maxsRGB_tint > 1.f) {
-        for(int ch=0; ch<3; ch++){
-          sRGB_tint[ch] = fmaxf(sRGB_tint[ch] / maxsRGB_tint, 0.f);
-        }
-      }
-
-      dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB_temp[0], sRGB_temp[1], sRGB_temp[2]);
-      dt_bauhaus_slider_set_stop(g->scale_tint, stop, sRGB_tint[0], sRGB_tint[1], sRGB_tint[2]);
-    }
-    else
-    {
-      // i think lightroom-ish look is ok-ish
-      //dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB[2], sRGB[1], sRGB[0]);
+      const float stop = i / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
+      const double K = DT_IOP_LOWEST_TEMPERATURE + i * temp_step;
+      const double tint = DT_IOP_LOWEST_TINT + i * tint_step;
+      
       double coeffs_K[4];
       double coeffs_tint[4];
       temp2mul(self, K, cur_tint, coeffs_K);
@@ -1107,6 +1076,42 @@ void color_temptint_sliders(struct dt_iop_module_t *self)
         }
       }
       dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB_K[0], sRGB_K[1], sRGB_K[2]);
+      dt_bauhaus_slider_set_stop(g->scale_tint, stop, sRGB_tint[0], sRGB_tint[1], sRGB_tint[2]);
+    }
+  }
+  else 
+  {
+    // reflect actual black body colors for the temperature slider
+    for(int i = 0; i < DT_BAUHAUS_SLIDER_MAX_STOPS; i++)
+    {
+      const float stop = i / (DT_BAUHAUS_SLIDER_MAX_STOPS - 1.0);
+      const double K = DT_IOP_LOWEST_TEMPERATURE + i * temp_step;
+      const double tint = DT_IOP_LOWEST_TINT + i * tint_step;
+
+      const cmsCIEXYZ cmsXYZ_temp = temperature_tint_to_XYZ(K,cur_tint);
+      const cmsCIEXYZ cmsXYZ_tint = temperature_tint_to_XYZ(cur_temp, tint);
+      float sRGB_temp[3], XYZ_temp[3] = {cmsXYZ_temp.X, cmsXYZ_temp.Y, cmsXYZ_temp.Z};
+      float sRGB_tint[3], XYZ_tint[3] = {cmsXYZ_tint.X, cmsXYZ_tint.Y, cmsXYZ_tint.Z};
+
+      dt_XYZ_to_sRGB(XYZ_temp, sRGB_temp);
+      dt_XYZ_to_sRGB(XYZ_tint, sRGB_tint);
+
+      const float maxsRGB_temp = fmaxf(fmaxf(sRGB_temp[0], sRGB_temp[1]), sRGB_temp[2]);
+      const float maxsRGB_tint = fmaxf(fmaxf(sRGB_tint[0], sRGB_tint[1]), sRGB_tint[2]);
+
+      if(maxsRGB_temp > 1.f) {
+        for(int ch=0; ch<3; ch++){
+          sRGB_temp[ch] = fmaxf(sRGB_temp[ch] / maxsRGB_temp, 0.f);
+        }
+      }
+
+      if(maxsRGB_tint > 1.f) {
+        for(int ch=0; ch<3; ch++){
+          sRGB_tint[ch] = fmaxf(sRGB_tint[ch] / maxsRGB_tint, 0.f);
+        }
+      }
+
+      dt_bauhaus_slider_set_stop(g->scale_k, stop, sRGB_temp[0], sRGB_temp[1], sRGB_temp[2]);
       dt_bauhaus_slider_set_stop(g->scale_tint, stop, sRGB_tint[0], sRGB_tint[1], sRGB_tint[2]);
     }
   }


### PR DESCRIPTION
Loads of work went here, so to sum up this PR:

- [x] sections of wb ui to show important things in nice structure
- [x] hides coefficients since most people won't use them (but still are easily accessible)
- [x] adds possibility to enable colored sliders (3 modes: no color, blackbody and effect emulation. users will love effect emulation one!) (fixes #4479)
- [x] hides finetuning slider for internal functions and camera presets which don't have finetuning
- [x] makes finetuning slider obey preset finetuning ranges (no constant -9..9 mired, it now accepts whatever's in wb_coeffs.c so -12..12 if fine as well as -3..3)
- [x] sections off settings combo so app functions/camera presets are distinctly separated
- [x] adds buttons for even easier access to internal presets/functions (#2459)
- [x] renames/relabels/moves several terms/items to match what they are called in other apps
- [x] adds tooltips for better discoverability
- [x] adds posibility to use accel for user setting (ref #4676)

This is how "previously" white balance module looked:
![obraz](https://user-images.githubusercontent.com/10687765/75237405-92b61d00-57bf-11ea-9aa2-0a0f8fdb6ca4.png)

with this PR default look is:
![default_look](https://user-images.githubusercontent.com/10687765/83355667-35eb7500-a361-11ea-8974-3a96254ab1d5.png)

however the recommended (image effect mode) is:
![02_recommended_view](https://user-images.githubusercontent.com/10687765/83355677-456abe00-a361-11ea-8b70-ba3dcc829e39.png)

with everything expanded and camera preset with finetuning active, this is how it looks:
![04_kitchensink](https://user-images.githubusercontent.com/10687765/83355693-64695000-a361-11ea-9a06-d265c508decb.png)

And here's how wb setting combo looks:
![setting menu](https://user-images.githubusercontent.com/10687765/83355753-b6aa7100-a361-11ea-86bd-b8a70808cbd8.png)

This is fully usage ready so I invite you all to test and comment :)

I'll try to keep it up to date with master, rebasing as needed

<details><summary>older info</summary>
This introduces option for enabling colored sliders in white balance module.
(previously disabled via compile flag)

Also introduces option for temperature slider color gradient: default is "black body radiation", so technically color of scene light. If user finds it confusing, one can enable "inverse", that makes it similar to other tools with colored temperature slider (eg. Lightroom)

Additionally - enables tooltips which apparently everybody loves.

//Edit!
This is how "normally" white balance module looks:
![obraz](https://user-images.githubusercontent.com/10687765/75237405-92b61d00-57bf-11ea-9aa2-0a0f8fdb6ca4.png)

This is after enabling colored sliders with temperature slider being default blackbody radiation color:
![obraz](https://user-images.githubusercontent.com/10687765/75237504-bb3e1700-57bf-11ea-89fe-23d567cb8fa6.png)

And for those that find blackbody radiation confusing - there's opposite (sorta Lightroom-like) look:
![obraz](https://user-images.githubusercontent.com/10687765/75237555-da3ca900-57bf-11ea-9e74-29298d882802.png)

//EDIT:
Fixes #4479
</details>