### PR TITLE
resort and group blend modes

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -36,7 +36,7 @@ G_DEFINE_TYPE(DtBauhausWidget, dt_bh, GTK_TYPE_DRAWING_AREA)
 
 // INNER_PADDING is the horizontal space between slider and quad
 // and vertical space between labels and slider baseline
-#define INNER_PADDING 4.0
+static const double INNER_PADDING = 4.0;
 
 // fwd declare
 static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data);
@@ -1044,22 +1044,27 @@ void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidg
 
 void dt_bauhaus_combobox_add(GtkWidget *widget, const char *text)
 {
-  dt_bauhaus_combobox_add_full(widget, text, DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, NULL, NULL);
+  dt_bauhaus_combobox_add_full(widget, text, DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, NULL, NULL, TRUE);
+}
+
+void dt_bauhaus_combobox_add_section(GtkWidget *widget, const char *text)
+{
+  dt_bauhaus_combobox_add_full(widget, text, DT_BAUHAUS_COMBOBOX_ALIGN_LEFT, NULL, NULL, FALSE);
 }
 
 void dt_bauhaus_combobox_add_aligned(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align)
 {
-  dt_bauhaus_combobox_add_full(widget, text, align, NULL, NULL);
+  dt_bauhaus_combobox_add_full(widget, text, align, NULL, NULL, TRUE);
 }
 
 void dt_bauhaus_combobox_add_full(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align,
-                                  gpointer data, void (free_func)(void *data))
+                                  gpointer data, void (free_func)(void *data), gboolean sensitive)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_COMBOBOX) return;
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   d->num_labels++;
-  dt_bauhaus_combobox_entry_t *entry = new_combobox_entry(text, align, TRUE, data, free_func);
+  dt_bauhaus_combobox_entry_t *entry = new_combobox_entry(text, align, sensitive, data, free_func);
   d->entries = g_list_append(d->entries, entry);
   if(d->active < 0) d->active = 0;
 }
@@ -1659,6 +1664,7 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_save(cr);
       float first_label_width = 0.0;
       gboolean first_label = TRUE;
+      gboolean show_box_label = TRUE;
       int k = 0, i = 0;
       int hovered = darktable.bauhaus->mouse_y / ht;
       gchar *keys = g_utf8_casefold(darktable.bauhaus->keys, -1);
@@ -1682,13 +1688,16 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
             set_color(cr, text_color);
 
           if(entry->alignment == DT_BAUHAUS_COMBOBOX_ALIGN_LEFT)
-            label_width = show_pango_text(w, context, cr, entry->label, 0, ht * k, max_width, FALSE);
+            label_width = show_pango_text(w, context, cr, entry->label, INNER_PADDING, ht * k + INNER_PADDING, max_width, FALSE);
           else
-            label_width = show_pango_text(w, context, cr, entry->label, wd - INNER_PADDING - darktable.bauhaus->quad_width, ht * k, max_width, TRUE);
+            label_width
+                = show_pango_text(w, context, cr, entry->label, wd - INNER_PADDING - darktable.bauhaus->quad_width,
+                                  ht * k + INNER_PADDING, max_width, TRUE);
 
           // prefer the entry over the label wrt. ellipsization when expanded
           if(first_label)
           {
+            show_box_label = entry->alignment == DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT;
             first_label_width = label_width;
             first_label = FALSE;
           }
@@ -1701,9 +1710,12 @@ static gboolean dt_bauhaus_popup_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       cairo_restore(cr);
 
       // left aligned box label. add it to the gui after the entries so we can ellipsize it if needed
-      set_color(cr, text_color);
-      show_pango_text(w, context, cr, w->label, 0, 0, wd - INNER_PADDING - darktable.bauhaus->quad_width - first_label_width, FALSE);
-
+      if(show_box_label)
+      {
+        set_color(cr, text_color);
+        show_pango_text(w, context, cr, w->label, INNER_PADDING, INNER_PADDING,
+                        wd - INNER_PADDING - darktable.bauhaus->quad_width - first_label_width, FALSE);
+      }
       g_free(keys);
     }
     break;
@@ -1903,7 +1915,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
       // comboboxes change immediately
       darktable.bauhaus->change_active = 1;
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
-      tmp.height = tmp.height * d->num_labels;
+      tmp.height = inner_height(tmp) * d->num_labels + 2 * INNER_PADDING;
       GtkAllocation allocation_w;
       gtk_widget_get_allocation(GTK_WIDGET(w), &allocation_w);
       const int ht = allocation_w.height;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -294,9 +294,10 @@ void dt_bauhaus_combobox_from_widget(dt_bauhaus_widget_t* widget,dt_iop_module_t
 GtkWidget *dt_bauhaus_combobox_new(dt_iop_module_t *self);
 
 void dt_bauhaus_combobox_add(GtkWidget *widget, const char *text);
+void dt_bauhaus_combobox_add_section(GtkWidget *widget, const char *text);
 void dt_bauhaus_combobox_add_aligned(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align);
 void dt_bauhaus_combobox_add_full(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align,
-                                  gpointer data, void (*free_func)(void *data));
+                                  gpointer data, void (*free_func)(void *data), gboolean sensitive);
 void dt_bauhaus_combobox_set(GtkWidget *w, int pos);
 gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *w, const char *text);
 void dt_bauhaus_combobox_remove_at(GtkWidget *widget, int pos);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -2013,7 +2013,7 @@ static void _raster_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
   raster_combo_entry_t *entry = (raster_combo_entry_t *)malloc(sizeof(raster_combo_entry_t));
   entry->module = NULL;
   entry->id = 0;
-  dt_bauhaus_combobox_add_full(w, _("no mask used"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, entry, free);
+  dt_bauhaus_combobox_add_full(w, _("no mask used"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, entry, free, TRUE);
 
   int i = 1;
 
@@ -2034,7 +2034,7 @@ static void _raster_combo_populate(GtkWidget *w, struct dt_iop_module_t **m)
       entry = (raster_combo_entry_t *)malloc(sizeof(raster_combo_entry_t));
       entry->module = iop;
       entry->id = id;
-      dt_bauhaus_combobox_add_full(w, modulename, DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, entry, free);
+      dt_bauhaus_combobox_add_full(w, modulename, DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, entry, free, TRUE);
       if(iop == module->raster_mask.sink.source && module->raster_mask.sink.id == id)
         dt_bauhaus_combobox_set(w, i);
       i++;
@@ -2427,6 +2427,13 @@ static void _add_blendmode_combo(GList **list, GtkWidget *combobox, GList *compl
 }
 
 
+static void _add_section_combo(GList **list, GtkWidget *combobox, const char *const name)
+{
+  *list = g_list_append(*list, GUINT_TO_POINTER(DEVELOP_BLEND_DISABLED));
+  dt_bauhaus_combobox_add_section(combobox, name);
+}
+
+
 void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
 {
   /* create and add blend mode if module supports it */
@@ -2576,26 +2583,30 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
     switch(bd->csp)
     {
       case iop_cs_Lab:
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("normal & difference modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_NORMAL2);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_BOUNDED);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_LIGHTEN);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_DARKEN);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_MULTIPLY);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_AVERAGE);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_DIFFERENCE2);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("lighten modes"));
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_LIGHTEN);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_ADD);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_SCREEN);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("darken modes"));
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_DARKEN);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_SUBSTRACT);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_DIFFERENCE2);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_SCREEN);
+                             DEVELOP_BLEND_MULTIPLY);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("contrast enhancing modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_OVERLAY);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2608,6 +2619,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                              DEVELOP_BLEND_LINEARLIGHT);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_PINLIGHT);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("color channel modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_LAB_LIGHTNESS);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2629,26 +2641,30 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
         break;
 
       case iop_cs_rgb:
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("normal & difference modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_NORMAL2);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_BOUNDED);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_LIGHTEN);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_DARKEN);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_MULTIPLY);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_AVERAGE);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_DIFFERENCE2);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("lighten modes"));
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_LIGHTEN);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_ADD);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_SCREEN);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("darken modes"));
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_DARKEN);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_SUBSTRACT);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_DIFFERENCE2);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_SCREEN);
+                             DEVELOP_BLEND_MULTIPLY);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("contrast enhancing modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_OVERLAY);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2661,10 +2677,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
                              DEVELOP_BLEND_LINEARLIGHT);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_PINLIGHT);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_HSV_LIGHTNESS);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_HSV_COLOR);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("color channel modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_RGB_R);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2674,7 +2687,11 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_LIGHTNESS);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_HSV_LIGHTNESS);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_CHROMA);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_HSV_COLOR);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_HUE);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2684,26 +2701,30 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
         break;
 
       case iop_cs_RAW:
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("normal & difference modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_NORMAL2);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_BOUNDED);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_LIGHTEN);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_DARKEN);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_MULTIPLY);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_AVERAGE);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_DIFFERENCE2);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("lighten modes"));
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_LIGHTEN);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_ADD);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_SCREEN);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("darken modes"));
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
+                             DEVELOP_BLEND_DARKEN);
+        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_SUBSTRACT);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_DIFFERENCE2);
-        _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
-                             DEVELOP_BLEND_SCREEN);
+                             DEVELOP_BLEND_MULTIPLY);
+        _add_section_combo(&(bd->blend_modes), bd->blend_modes_combo, _("contrast enhancing modes"));
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_OVERLAY);
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
@@ -2717,6 +2738,7 @@ void dt_iop_gui_init_blending(GtkWidget *iopw, dt_iop_module_t *module)
         _add_blendmode_combo(&(bd->blend_modes), bd->blend_modes_combo, bd->blend_modes_all,
                              DEVELOP_BLEND_PINLIGHT);
         break;
+
       case iop_cs_LCh:
       case iop_cs_HSL:
       case iop_cs_NONE:


### PR DESCRIPTION
Darktable provides a large number of different blend modes. It might be useful to group them into groups of related blend modes to guide the user. 

There are probably several meaningful ways to group the blend modes. My choice was inspired to some degree by an [article about blend modes in photoshop](https://photoblogstop.com/photoshop/photoshop-blend-modes-explained). Some remarks

- _average_ is actually identical to _normal bounded_ with opacity reduced by a factor 1/2. One might consider to mark this mode as depreciated in the future.
- _difference_ does actually not fit into any group. I see its use mainly to visualize temporarily a module's effect while editing not to be used for blending. In order to have quick access to this mode I lumped it into the _normal & difference_ group.
- _subtract_ in darktable is equivalent to _linear burn_ in photo shop, not _subtract_.

Here is how the new blend mode combo box looks like:

![Bildschirmfoto von 2020-02-25 01-26-28](https://user-images.githubusercontent.com/1159508/75241519-84b7ca80-57c6-11ea-8c79-f0a8d25f7cca.png)
![Bildschirmfoto von 2020-02-25 01-25-27](https://user-images.githubusercontent.com/1159508/75241527-85e8f780-57c6-11ea-9dcb-74cd2e038fad.png)
