### PR TITLE
UX fix for XMP reload. fixes #4239

### DIFF
--- a/src/control/crawler.c
+++ b/src/control/crawler.c
@@ -384,7 +384,7 @@ void dt_control_crawler_show_image_list(GList *images)
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(content_box), box, FALSE, FALSE, 0);
-  GtkWidget *reload_button = gtk_button_new_with_label(_("reload selected xmp files"));
+  GtkWidget *reload_button = gtk_button_new_with_label(_("update database from selected xmp files"));
   GtkWidget *overwrite_button = gtk_button_new_with_label(_("overwrite selected xmp files"));
   gtk_box_pack_start(GTK_BOX(box), reload_button, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(box), overwrite_button, FALSE, FALSE, 0);


### PR DESCRIPTION
@elman22 rightfully mentions in #4239 that "reload xmp" might be confusing.

This PR changes wording to match wording found in manual.
Will need translation updates.