### PR TITLE
Add db maintenance options, change wording and add maintenance debug messages for better maintenance UX

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -25,7 +25,7 @@
         <option>on both</option>
       </enum>
     </type>
-    <default>on close</default>
+    <default>on startup</default>
     <shortdescription>when to check for database maintenance</shortdescription>
     <longdescription>this will set when db size is checked for possible maintenance condition and ask user to confirm</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -28,7 +28,7 @@
         <option>on both (don't ask)</option>
       </enum>
     </type>
-    <default>on startup</default>
+    <default>on close</default>
     <shortdescription>check for database maintenance</shortdescription>
     <longdescription>this will set when db size is checked for possible maintenance condition and whether to ask user to confirm</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -30,14 +30,14 @@
     </type>
     <default>on close</default>
     <shortdescription>check for database maintenance</shortdescription>
-    <longdescription>this will set when db size is checked for possible maintenance condition and whether to ask user to confirm</longdescription>
+    <longdescription>this option indicates when to check database fragmentation and perform maintenance</longdescription>
   </dtconfig>
   <dtconfig prefs="core">
     <name>database/maintenance_freepage_ratio</name>
     <type>int</type>
     <default>25</default>
-    <shortdescription>freepage for database maintenance in percentage</shortdescription>
-    <longdescription>once this ratio is reached (for either dbs) user is asked to confirm database maintenance</longdescription>
+    <shortdescription>database fragmentation ratio threshold</shortdescription>
+    <longdescription>fragmentation ratio above which to ask or carry out automatically database maintenance</longdescription>
   </dtconfig>
   <dtconfig>
     <name>min_panel_width</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -23,11 +23,14 @@
         <option>on startup</option>
         <option>on close</option>
         <option>on both</option>
+        <option>on startup (don't ask)</option>
+        <option>on close (don't ask)</option>
+        <option>on both (don't ask)</option>
       </enum>
     </type>
     <default>on startup</default>
-    <shortdescription>when to check for database maintenance</shortdescription>
-    <longdescription>this will set when db size is checked for possible maintenance condition and ask user to confirm</longdescription>
+    <shortdescription>check for database maintenance</shortdescription>
+    <longdescription>this will set when db size is checked for possible maintenance condition and whether to ask user to confirm</longdescription>
   </dtconfig>
   <dtconfig prefs="core">
     <name>database/maintenance_freepage_ratio</name>

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2684,11 +2684,11 @@ void _dt_database_maintenance(const struct dt_database_t *db)
   sqlite3_exec(db->handle, "ANALYZE main", NULL, NULL, NULL);
 }
 
-gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_time, guint64 size)
+gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_time, const guint64 size)
 {
   if(!has_gui)
   {
-    return 0;
+    return FALSE;
   }
 
   char *later_info = NULL;
@@ -2717,7 +2717,7 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
                                                  "you can always change maintenance preferences in core options"),
                                                  size_info, later_info);
 
-    gboolean shall_perform_maintenance =
+    const gboolean shall_perform_maintenance =
       dt_gui_show_standalone_yes_no_dialog(_("darktable - schema maintenance"), label_text,
                                            _("later"), _("yes"));
 
@@ -2732,7 +2732,7 @@ int _get_pragma_val(const struct dt_database_t *db, const char* pragma)
   gchar* query= g_strdup_printf("PRAGMA %s", pragma);
   int val = -1;
   sqlite3_stmt *stmt;
-  int rc = sqlite3_prepare_v2(db->handle, query,-1, &stmt, NULL);
+  const int rc = sqlite3_prepare_v2(db->handle, query,-1, &stmt, NULL);
   if(rc == SQLITE_OK && sqlite3_step(stmt) == SQLITE_ROW)
   {
     val = sqlite3_column_int(stmt, 0);
@@ -2747,14 +2747,15 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
 {
   char *config = dt_conf_get_string("database/maintenance_check");
 
-  if(!g_strcmp0(config, "never")){
+  if(!g_strcmp0(config, "never"))
+  {
     // early bail out on "never"
-    fprintf(stderr, "[db maintenance] please consider enabling database maintenance.\n");
+    dt_print(DT_DEBUG_SQL, "[db maintenance] please consider enabling database maintenance.\n");
     return;
   }
 
   gboolean check_for_maintenance = FALSE;
-  gboolean force_maintenance = g_str_has_suffix (config, "(don't ask)");
+  const gboolean force_maintenance = g_str_has_suffix (config, "(don't ask)");
 
   if(config)
   {
@@ -2763,7 +2764,7 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
         || (!closing_time && (strstr(config, "on startup"))))
     {
       // we have "on both/on close/on startup" setting, so - checking!
-      fprintf(stderr, "[db maintenance] checking for maintenance, due to rule: '%s'.\n", config);
+      dt_print(DT_DEBUG_SQL, "[db maintenance] checking for maintenance, due to rule: '%s'.\n", config);
       check_for_maintenance = TRUE;
     }
     // if the config was "never", check_for_vacuum is false.
@@ -2784,12 +2785,16 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
   const int data_page_count = _get_pragma_val(db, "data.page_count");
   const int data_page_size = _get_pragma_val(db, "data.page_size");
 
-  fprintf(stderr,
+  dt_print(DT_DEBUG_SQL,
       "[db maintenance] main: [%d/%d pages], data: [%d/%d pages].\n",
       main_free_count, main_page_count, data_free_count, data_page_count);
 
-  if(main_page_count <= 0 || data_page_count <= 0){
+  if(main_page_count <= 0 || data_page_count <= 0)
+  {
     //something's wrong with PRAGMA page_size returns. early bail.
+    dt_print(DT_DEBUG_SQL,
+        "[db maintenance] page_count <= 0 : main.page_count: %d, data.page_count: %d \n",
+        main_page_count, data_page_count);
     return;
   }
 
@@ -2803,12 +2808,12 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
       || (data_free_percentage >= freepage_ratio))
   {
     const guint64 calc_size = (main_free_count*main_page_size) + (data_free_count*data_page_size);
-    fprintf(stderr, "[db maintenance] maintenance suggested, %" PRId64 " bytes to free.\n", calc_size);
+    dt_print(DT_DEBUG_SQL, "[db maintenance] maintenance suggested, %" PRId64 " bytes to free.\n", calc_size);
 
     if(force_maintenance || _ask_for_maintenance(has_gui, closing_time, calc_size))
     {
       _dt_database_maintenance(db);
-      fprintf(stderr, "[db maintenance] maintenance done, %" PRId64 " bytes freed.\n", calc_size);
+      dt_print(DT_DEBUG_SQL, "[db maintenance] maintenance done, %" PRId64 " bytes freed.\n", calc_size);
     }
   }
 }

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2758,9 +2758,9 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
 
   if(config)
   {
-    if((g_strstr_len(config, -1, "on both")) // should cover "(don't ask) suffix
-        || (closing_time && (g_strstr_len(config, -1, "on close")))
-        || (!closing_time && (g_strstr_len(config, -1, "on startup"))))
+    if((strstr(config, "on both")) // should cover "(don't ask) suffix
+        || (closing_time && (strstr(config, "on close")))
+        || (!closing_time && (strstr(config, "on startup"))))
     {
       // we have "on both/on close/on startup" setting, so - checking!
       fprintf(stderr, "[db maintenance] checking for maintenance, due to rule: '%s'.\n", config);

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2684,21 +2684,38 @@ void _dt_database_maintenance(const struct dt_database_t *db)
   sqlite3_exec(db->handle, "ANALYZE main", NULL, NULL, NULL);
 }
 
-gboolean _ask_for_maintenance(const gboolean has_gui, guint64 size)
+gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_time, guint64 size)
 {
   if(!has_gui)
   {
     return 0;
   }
 
+  char *later_info = NULL;
   char *size_info = g_format_size(size);
+  char *config = dt_conf_get_string("database/maintenance_check");
+  if((closing_time && (!g_strcmp0(config, "on both"))) || !g_strcmp0(config, "on startup"))
+  {
+    later_info = _("click later to be asked on next startup");
+  }
+  else if (!closing_time && (!g_strcmp0(config, "on both")))
+  {
+    later_info = _("click later to be asked when closing darktable");
+  }
+  else if (!g_strcmp0(config, "on close"))
+  {
+    later_info = _("click later to be asked next time when closing darktable");
+  }
+
 
   char *label_text = g_markup_printf_escaped(_("the database could use some maintenance\n"
                                                  "\n"
                                                  "there's <span style=\"italic\">%s</span> to be freed"
-                                                 "\n"
-                                                 "do you want to proceed now\n"),
-                                                 size_info);
+                                                 "\n\n"
+                                                 "do you want to proceed now?\n\n"
+                                                 "%s\n"
+                                                 "you can always change maintenance preferences in core options"),
+                                                 size_info, later_info);
 
     gboolean shall_perform_maintenance =
       dt_gui_show_standalone_yes_no_dialog(_("darktable - schema maintenance"), label_text,
@@ -2729,17 +2746,24 @@ int _get_pragma_val(const struct dt_database_t *db, const char* pragma)
 void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time)
 {
   gboolean check_for_maintenance = FALSE;
+  gboolean force_maintenance = FALSE;
 
   char *config = dt_conf_get_string("database/maintenance_check");
 
   if(config)
   {
     if((!g_strcmp0(config, "on both"))
-        || (closing_time && !g_strcmp0(config, "on close"))
-        || (!closing_time && !g_strcmp0(config, "on startup")))
+        || (!g_strcmp0(config, "on both (don't ask)"))
+        || (closing_time
+            && (!g_strcmp0(config, "on close")
+                || !g_strcmp0(config, "on close (don't ask)")))
+        || (!closing_time
+            && (!g_strcmp0(config, "on startup")
+                || !g_strcmp0(config, "on startup (don't ask)"))))
     {
       // we have "on both/on close/on startup" setting, so - checking!
       check_for_maintenance = TRUE;
+      force_maintenance = g_str_has_suffix (config, "(don't ask)");
     }
     // if the config was "never", check_for_vacuum is false.
     g_free(config);
@@ -2775,7 +2799,7 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
   {
     const guint64 calc_size = (main_free_count*main_page_size) + (data_free_count*data_page_size);
 
-    if(_ask_for_maintenance(has_gui, calc_size))
+    if(force_maintenance || _ask_for_maintenance(has_gui, closing_time, calc_size))
     {
       _dt_database_maintenance(db);
     }


### PR DESCRIPTION
As evidenced by #4376 and recent comments in https://discuss.pixls.us/t/darktable-periodic-database-maintenance/16375 it seems that `on startup` default for db maintenance makes more sense from UX standpoint.

This PR makes several changes:
- adds 3 new options to perform maintenance without asking (received several requests for that)
- changes default option to `on startup`, since clicking `later` is no-op always
- better explains what'll happen when clicking `later`
- assures user of possibility to change option easily