### PR TITLE
simplest way to fix #4381

### DIFF
--- a/src/views/knight.c
+++ b/src/views/knight.c
@@ -934,7 +934,7 @@ static gboolean _event_loop_animation(dt_knight_t *d)
 static gboolean _event_loop(gpointer user_data)
 {
   dt_knight_t *d = (dt_knight_t *)user_data;
-  gboolean res;
+  gboolean res = FALSE;  // silence warning about unitialized res
   switch(d->game_state)
   {
     case INTRO:


### PR DESCRIPTION
Variable `res` in `knight.c` `_event_loop` is not initialized. This is IMO simplest fix for it.

My 2nd idea was to also conditionally disable compilation of `knight` view module, but I don't yet know how to get from CMake to c code, so the konami code (I haven't managed to make it work for me) or aprill fools day easter egg code paths would be totally disabled from compilation.

If somebody could guide me, I'd like to also introduce `USE_KNIGHT` or `USE_FUN` or `USE_EGG/EASTEREGG`. :wink: 

So - this fixes #4381 :)