### PR TITLE
avoid variable length array syntax

### DIFF
--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -59,6 +59,8 @@ DT_MODULE_INTROSPECTION(1, dt_iop_colormapping_params_t)
 #define HISTN (1 << 11)
 #define MAXN 5
 
+typedef float float2[2];
+
 typedef enum dt_iop_colormapping_flags_t
 {
   NEUTRAL = 0,
@@ -73,8 +75,8 @@ typedef struct dt_iop_colormapping_flowback_t
 {
   float hist[HISTN];
   // n-means (max 5?) with mean/variance
-  float mean[MAXN][2];
-  float var[MAXN][2];
+  float2 mean[MAXN];
+  float2 var[MAXN];
   float weight[MAXN];
   // number of gaussians used.
   int n;
@@ -95,15 +97,15 @@ typedef struct dt_iop_colormapping_params_t
   // hist matching table for source image
   float source_ihist[HISTN];
   // n-means (max 5) with mean/variance for source image
-  float source_mean[MAXN][2];
-  float source_var[MAXN][2];
+  float2 source_mean[MAXN];
+  float2 source_var[MAXN];
   float source_weight[MAXN];
 
   // hist matching table for destination image
   int target_hist[HISTN];
   // n-means (max 5) with mean/variance for source image
-  float target_mean[MAXN][2];
-  float target_var[MAXN][2];
+  float2 target_mean[MAXN];
+  float2 target_var[MAXN];
   float target_weight[MAXN];
 } dt_iop_colormapping_params_t;
 
@@ -233,11 +235,8 @@ static void invert_histogram(const int *hist, float *inv_hist)
   // HISTN-1)]);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wvla"
-
-static void get_cluster_mapping(const int n, float mi[n][2], const float wi[n], float mo[n][2], const float wo[n],
-                                const float dominance, int mapio[n])
+static void get_cluster_mapping(const int n, float2 *mi, const float *wi, float2 *mo, const float *wo,
+                                const float dominance, int *mapio)
 {
   const float weightscale = 10000.0f;
 
@@ -268,7 +267,7 @@ static void get_cluster_mapping(const int n, float mi[n][2], const float wi[n], 
 
 
 // inverse distant weighting according to D. Shepard's method; with power parameter 2.0
-static void get_clusters(const float *col, const int n, float mean[n][2], float *weight)
+static void get_clusters(const float *col, const int n, float2 *mean, float *weight)
 {
   float mdist = FLT_MAX;
   for(int k = 0; k < n; k++)
@@ -288,7 +287,7 @@ static void get_clusters(const float *col, const int n, float mean[n][2], float 
 }
 
 
-static int get_cluster(const float *col, const int n, float mean[n][2])
+static int get_cluster(const float *col, const int n, float2 *mean)
 {
   float mdist = FLT_MAX;
   int cluster = 0;
@@ -305,14 +304,14 @@ static int get_cluster(const float *col, const int n, float mean[n][2])
   return cluster;
 }
 
-static void kmeans(const float *col, const int width, const int height, const int n, float mean_out[n][2],
-                   float var_out[n][2], float weight_out[n])
+static void kmeans(const float *col, const int width, const int height, const int n, float2 *mean_out,
+                   float2 *var_out, float *weight_out)
 {
   const int nit = 40;                       // number of iterations
   const int samples = width * height * 0.2; // samples: only a fraction of the buffer.
 
-  float(*const mean)[2] = malloc(2 * n * sizeof(float));
-  float(*const var)[2] = malloc(2 * n * sizeof(float));
+  float2 *const mean = malloc(n * sizeof(float2));
+  float2 *const var = malloc(n * sizeof(float2));
   int *const cnt = malloc(n * sizeof(int));
   int count;
 
@@ -428,8 +427,8 @@ static void kmeans(const float *col, const int width, const int height, const in
     {
       if(weight_out[j] > weight_out[j + 1])
       {
-        float temp_mean[2] = { mean_out[j + 1][0], mean_out[j + 1][1] };
-        float temp_var[2] = { var_out[j + 1][0], var_out[j + 1][1] };
+        float2 temp_mean = { mean_out[j + 1][0], mean_out[j + 1][1] };
+        float2 temp_var = { var_out[j + 1][0], var_out[j + 1][1] };
         float temp_weight = weight_out[j + 1];
 
         mean_out[j + 1][0] = mean_out[j][0];
@@ -447,8 +446,6 @@ static void kmeans(const float *col, const int width, const int height, const in
     }
   }
 }
-
-#pragma GCC diagnostic pop
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,
              void *const ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
@@ -496,7 +493,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     get_cluster_mapping(data->n, data->target_mean, data->target_weight, data->source_mean,
                         data->source_weight, dominance, mapio);
 
-    float(*const var_ratio)[2] = malloc(2 * data->n * sizeof(float));
+    float2 *const var_ratio = malloc(data->n * sizeof(float2));
 
     for(int i = 0; i < data->n; i++)
     {
@@ -650,7 +647,7 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
     get_cluster_mapping(data->n, data->target_mean, data->target_weight, data->source_mean,
                         data->source_weight, dominance, mapio);
 
-    float var_ratio[MAXN][2];
+    float2 var_ratio[MAXN];
     for(int i = 0; i < data->n; i++)
     {
       var_ratio[i][0]
@@ -956,8 +953,8 @@ static gboolean cluster_preview_draw(GtkWidget *widget, cairo_t *crf, dt_iop_mod
   dt_iop_colormapping_params_t *p = (dt_iop_colormapping_params_t *)self->params;
   dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
 
-  float(*mean)[2];
-  float(*var)[2];
+  float2 *mean;
+  float2 *var;
 
   if(widget == g->source_area)
   {


### PR DESCRIPTION
There is really no benefit here in using variable length arrays. Expressions as 

    float(*const mean)[2] = malloc(2 * n * sizeof(float));

are somewhat intricate. Introducing 

    typedef float float2[2];

may enhance readability. Contains also some minor clean-up.