### PR TITLE
Fixing build problems with camera_control.c (again)

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -1024,7 +1024,7 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
 
           if (cfi.preview.size > 0)   // we have valid preview data for this file
           {
-            size_t chunksize = cfi.preview.size;
+            uint64_t chunksize = cfi.preview.size;
             char *chunk = malloc(chunksize);
             if (chunk)
             {
@@ -1040,7 +1040,7 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
           // If there has been no preview we try to take a small file
           if (!gotit && (cfi.file.size > 0 && cfi.file.size < 512000))
           {
-            size_t chunksize = cfi.file.size;
+            uint64_t chunksize = cfi.file.size;
             char *chunk = malloc(chunksize);
             if (chunk)
             {
@@ -1084,7 +1084,7 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
         {
           gp_file_new(&exif);
 
-          size_t chunksize = 0x200000;
+          uint64_t chunksize = 0x200000;
           char *chunk = calloc(chunksize,sizeof(char));
           if (chunk)
           {


### PR DESCRIPTION
I did a stupid wrong attempt before.

As defined in gphoto2-camera.h

```
int gp_camera_file_read		(Camera *camera, const char *folder, const char *file,
		    		 CameraFileType type,
		    		 uint64_t offset, char *buf, uint64_t *size,
		    		 GPContext *context);
```
chunksize must be uint64_t
:-(((
