### PR TITLE
keyboard shortcuts to better handle multiple instances

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -2,7 +2,7 @@
 <!ELEMENT dtconfig (name,type,default,capability?,shortdescription?,longdescription?)>
 <!ATTLIST dtconfig
 	prefs (import|lighttable|darkroom|otherviews|processing|security|cpugpu|storage|misc) #IMPLIED
-        section (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp) #IMPLIED
+        section (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp|accel) #IMPLIED
         capability CDATA #IMPLIED
 >
 <!ELEMENT name (#PCDATA)>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1,6 +1,39 @@
 <?xml version="1.0"?>
 <!DOCTYPE dtconfiglist SYSTEM "darktableconfig.dtd">
 <dtconfiglist>
+  <dtconfig prefs="misc" section="accel">
+    <name>accel/prefer_expanded</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>prefer expanded instances</shortdescription>
+    <longdescription>if instances of the module are expanded, ignore collapsed instances</longdescription>
+  </dtconfig>
+  <dtconfig prefs="misc" section="accel">
+    <name>accel/prefer_enabled</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>prefer enabled instances</shortdescription>
+    <longdescription>after applying the above rule, if instances of the module are active, ignore inactive instances</longdescription>
+  </dtconfig>
+  <dtconfig prefs="misc" section="accel">
+    <name>accel/prefer_unmasked</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>prefer unmasked instances</shortdescription>
+    <longdescription>after applying the above rules, if instances of the module are unmasked, ignore masked instances</longdescription>
+  </dtconfig>
+  <dtconfig prefs="misc" section="accel">
+    <name>accel/select_order</name>
+    <type>
+      <enum>
+        <option>first instance</option>
+        <option>last instance</option>
+      </enum>
+    </type>
+    <default>last instance</default>
+    <shortdescription>selection order</shortdescription>
+    <longdescription>after applying the above rules, apply the shortcut based on its position in the pixelpipe</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>bauhaus/scale</name>
     <type>float</type>

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -21,6 +21,7 @@
 #include "common/darktable.h"
 #include "control/conf.h"
 #include "develop/develop.h"
+#include "develop/imageop.h"
 #include "gui/gtk.h"
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -28,6 +28,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/imageop.h"
 #include "gui/accelerators.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
@@ -712,9 +713,11 @@ int dt_control_key_pressed_override(guint key, guint state)
   if(darktable.view_manager->current_view->dynamic_accel_current)
   {
     gchar **vals = g_strsplit_set(darktable.view_manager->current_view->dynamic_accel_current->translated_path, "/", -1);
+    dt_iop_module_so_t *mod_so = darktable.view_manager->current_view->dynamic_accel_current->mod_so;
+    dt_iop_module_t *mod = dt_iop_get_module_accel_curr(mod_so);
     if(vals[0] && vals[1] && vals[2] && vals[3])
     {
-      gchar *txt = dt_util_dstrcat(NULL, _("scroll to change <b>%s</b> of %s module"), vals[3], vals[2]);
+      gchar *txt = dt_util_dstrcat(NULL, _("scroll to change <b>%s</b> of %s %s module"), vals[3], vals[2], mod->multi_name);
       dt_control_hinter_message(darktable.control, txt);
       g_free(txt);
     }

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -382,6 +382,12 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
   }
 
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
+
+  if(dt_conf_get_bool("accel/prefer_unmasked"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(data->module->so);
+  }
 }
 
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2057,8 +2057,7 @@ static dt_dev_proxy_exposure_t *find_last_exposure_instance(dt_develop_t *dev)
 {
   if(!dev->proxy.exposure) return NULL;
 
-  dev->proxy.exposure = g_list_sort(dev->proxy.exposure, dt_dev_exposure_hooks_sort);
-  dt_dev_proxy_exposure_t *instance = (dt_dev_proxy_exposure_t *)(g_list_last(dev->proxy.exposure)->data);
+  dt_dev_proxy_exposure_t *instance = (dt_dev_proxy_exposure_t *)(g_list_first(dev->proxy.exposure)->data);
 
   return instance;
 };

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -626,8 +626,9 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
   }
 
-  // we cleanup the module
-  dt_accel_disconnect_list(module->accel_closures);
+  // rebuild the accelerators (to point to an extant module)
+  dt_iop_connect_accels_multi(module->so);
+
   dt_accel_cleanup_locals_iop(module);
   module->accel_closures = NULL;
   // don't delete the module, a pipe may still need it
@@ -740,6 +741,8 @@ static void dt_iop_gui_movedown_callback(GtkButton *button, dt_iop_module_t *mod
   prev->dev->preview_pipe->cache_obsolete = 1;
   prev->dev->preview2_pipe->cache_obsolete = 1;
 
+  // rebuild the accelerators
+  dt_iop_connect_accels_multi(module->so);
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED);
 
   // invalidate buffers and force redraw of darkroom
@@ -781,7 +784,9 @@ static void dt_iop_gui_moveup_callback(GtkButton *button, dt_iop_module_t *modul
   next->dev->pipe->cache_obsolete = 1;
   next->dev->preview_pipe->cache_obsolete = 1;
   next->dev->preview2_pipe->cache_obsolete = 1;
-
+  
+  // rebuild the accelerators
+  dt_iop_connect_accels_multi(module->so);
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MODULE_MOVED);
 
   // invalidate buffers and force redraw of darkroom
@@ -858,11 +863,6 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
     dt_iop_gui_set_expanded(module, TRUE, TRUE);
   }
 
-  /* setup key accelerators */
-  module->accel_closures = NULL;
-  if(module->connect_key_accels) module->connect_key_accels(module);
-  dt_iop_connect_common_accels(module);
-
   // we want to stay on the same group
   dt_dev_modulegroups_set(darktable.develop, module_group);
 
@@ -894,11 +894,17 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
 static void dt_iop_gui_copy_callback(GtkButton *button, gpointer user_data)
 {
   dt_iop_gui_duplicate(user_data, FALSE);
+
+  /* setup key accelerators */
+  dt_iop_connect_accels_multi(((dt_iop_module_t *)user_data)->so);
 }
 
 static void dt_iop_gui_duplicate_callback(GtkButton *button, gpointer user_data)
 {
   dt_iop_gui_duplicate(user_data, TRUE);
+
+  /* setup key accelerators */
+  dt_iop_connect_accels_multi(((dt_iop_module_t *)user_data)->so);
 }
 
 typedef struct dt_iop_gui_rename_module_t
@@ -1102,6 +1108,12 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
   g_free(module_label);
   gtk_widget_set_tooltip_text(GTK_WIDGET(togglebutton), tooltip);
   gtk_widget_queue_draw(GTK_WIDGET(togglebutton));
+
+  if(dt_conf_get_bool("accel/prefer_enabled"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(module->so);
+  }
 }
 
 gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module)
@@ -1681,6 +1693,12 @@ static void dt_iop_gui_reset_callback(GtkButton *button, dt_iop_module_t *module
   dt_iop_gui_update(module);
 
   dt_dev_add_history_item(module->dev, module, TRUE);
+  
+  if(dt_conf_get_bool("accel/prefer_expanded") || dt_conf_get_bool("accel/prefer_enabled") || dt_conf_get_bool("accel/prefer_unmasked"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(module->so);
+  }
 }
 
 #if !GTK_CHECK_VERSION(3, 22, 0)
@@ -1924,6 +1942,12 @@ static gboolean _iop_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
       const gboolean collapse_others = !dt_conf_get_bool("darkroom/ui/single_module") != !(e->state & GDK_SHIFT_MASK);
       dt_iop_gui_set_expanded(module, !module->expanded, collapse_others);
 
+      if (dt_conf_get_bool("accel/prefer_expanded"))
+      {
+        // rebuild the accelerators
+        dt_iop_connect_accels_multi(module->so);
+      }
+
       //used to take focus away from module search text input box when module selected
       gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
 
@@ -2166,6 +2190,13 @@ static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *accele
   {
     dt_iop_request_focus(module);
   }
+
+  if(dt_conf_get_bool("accel/prefer_expanded"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(module->so);
+  }
+
   return TRUE;
 }
 
@@ -2193,6 +2224,12 @@ static gboolean enable_module_callback(GtkAccelGroup *accel_group, GObject *acce
     dt_iop_gui_set_expanded(module, !active, dt_conf_get_bool("darkroom/ui/single_module"));
 
   dt_iop_request_focus(module);
+
+  if(dt_conf_get_bool("accel/prefer_enabled"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(module->so);
+  }
 
   return TRUE;
 }
@@ -2289,7 +2326,6 @@ gchar *dt_iop_get_localized_name(const gchar *op)
 
 void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t state)
 {
-  const dt_iop_module_state_t old_state = module->state;
   module->state = state;
 
   char option[1024];
@@ -2353,41 +2389,6 @@ void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t s
     dt_conf_set_bool(option, TRUE);
     snprintf(option, sizeof(option), "plugins/darkroom/%s/favorite", module->op);
     dt_conf_set_bool(option, TRUE);
-  }
-
-  // (dis)connect key accels
-  if(old_state == dt_iop_state_HIDDEN && state != dt_iop_state_HIDDEN)
-  {
-    // connect
-    mods = g_list_first(darktable.develop->iop);
-    while(mods)
-    {
-      dt_iop_module_t *mod = (dt_iop_module_t *)mods->data;
-      if(mod->so == module)
-      {
-        if(mod->connect_key_accels) mod->connect_key_accels(mod);
-        dt_iop_connect_common_accels(mod);
-      }
-      mods = g_list_next(mods);
-    }
-    dt_dynamic_accel_get_valid_list();
-  }
-  else if(state == dt_iop_state_HIDDEN && old_state != dt_iop_state_HIDDEN)
-  {
-    // disconnect
-    mods = g_list_first(darktable.develop->iop);
-    while(mods)
-    {
-      dt_iop_module_t *mod = (dt_iop_module_t *)mods->data;
-      if(mod->so == module)
-      {
-        dt_accel_disconnect_list(mod->accel_closures);
-        dt_accel_cleanup_locals_iop(mod);
-        mod->accel_closures = NULL;
-      }
-      mods = g_list_next(mods);
-    }
-    dt_dynamic_accel_get_valid_list();
   }
 
   dt_view_manager_t *vm = darktable.view_manager;
@@ -2459,6 +2460,173 @@ dt_iop_module_t *dt_iop_get_module_by_op_priority(GList *modules, const char *op
   return mod_ret;
 }
 
+/** get the module that accelerators are attached to for the current so */
+dt_iop_module_t *dt_iop_get_module_accel_curr(dt_iop_module_so_t *module)
+{
+  GList *iop_mods = NULL;                 //All modules in iop
+  dt_iop_module_t *mod = NULL;            //Used while iterating module lists
+
+  iop_mods = g_list_last(darktable.develop->iop);
+  while(iop_mods)
+  {
+    mod = (dt_iop_module_t *)iop_mods->data;
+    if(mod->so == module && mod->accel_closures)
+    {
+      break;
+    }
+    iop_mods = g_list_previous(iop_mods);
+  }
+  return mod;
+}
+
+/** adds keyboard accels to the first module in the pipe to handle where there are multiple instances */
+void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
+{
+  /*
+   decide which module instance keyboard shortcuts will be applied to based on user preferences, as follows
+    - prefer expanded instances (when selected and instances of the module are expanded on the RHS of the screen, collapsed instances will be ignored)
+    - prefer enabled instances (when selected, after applying the above rule, if instances of the module are active, inactive instances will be ignored)
+    - prefer unmasked instances (when selected, after applying the above rules, if instances of the module are unmasked, masked instances will be ignored)
+    - selection order (after applying the above rules, apply the shortcut to the first or last instance remaining)
+  */
+  dt_iop_module_t *accel_mod_curr = NULL; //The module to which accelerators are currently attached
+  dt_iop_module_t *accel_mod_new = NULL;  //The module to which accelerators are to be attached
+  dt_iop_module_t *mod = NULL;            //Used while iterating module lists
+
+  GList *iop_mods = NULL;                 //All modules in iop
+  GList *all_instances = NULL;            //matching instances
+  GList *filtered_expanded = NULL;        //modules after applying 'expanded' filter
+  GList *filtered_enabled = NULL;         //modules after applying 'enabled' filter
+  GList *final_matches = NULL;            //final matching modules
+
+  int count_all = 0;
+  int count_expanded = 0;
+  int count_enabled = 0;
+  int count_unmasked = 0;
+
+  int prefer_expanded = dt_conf_get_bool("accel/prefer_expanded");
+  int prefer_enabled = dt_conf_get_bool("accel/prefer_enabled");
+  int prefer_unmasked = dt_conf_get_bool("accel/prefer_unmasked");
+  gchar *select_order = dt_conf_get_string("accel/select_order");
+
+  if(darktable.develop->gui_attached)
+  {
+    if(module->state != dt_iop_state_HIDDEN)
+    {
+      //filter out only matching modules
+      //count expanded instances
+      iop_mods = g_list_last(darktable.develop->iop);
+      while(iop_mods)
+      {
+        mod = (dt_iop_module_t *)iop_mods->data;
+        //modules with iop_order of INT_MAX are outside of the current pipe
+        if(mod->so == module && mod->iop_order != INT_MAX)
+        {
+          all_instances = g_list_prepend(all_instances, mod);
+          count_all++;
+          if(prefer_expanded && mod->expanded) count_expanded++;
+        }
+        iop_mods = g_list_previous(iop_mods);
+      }
+
+      if(count_all == 1)
+        final_matches = g_list_first(all_instances);
+      else
+      {
+        //filter out expanded if necessary
+        //count enabled instances
+        all_instances = g_list_last(all_instances);
+        while(all_instances)
+        {
+          mod = (dt_iop_module_t *)all_instances->data;
+          if(!prefer_expanded || count_expanded == 0 ||  mod->expanded)
+          {
+            filtered_expanded = g_list_prepend(filtered_expanded, mod);
+            if(prefer_enabled && mod->enabled) count_enabled++;
+          }
+          all_instances = g_list_previous(all_instances);
+        }
+
+        if(count_expanded == 1)
+          final_matches = g_list_first(filtered_expanded);
+        else
+        {
+          //filter out enabled if necessary
+          //count masked instances
+          filtered_expanded = g_list_last(filtered_expanded);
+          while(filtered_expanded)
+          {
+            mod = (dt_iop_module_t *)filtered_expanded->data;
+            if(!prefer_enabled || count_enabled == 0 ||  mod->enabled)
+            {
+              filtered_enabled = g_list_prepend(filtered_enabled, mod);
+              if(prefer_unmasked && (mod->blend_params->mask_mode == DEVELOP_MASK_DISABLED
+                                     || mod->blend_params->mask_mode == DEVELOP_MASK_ENABLED)) count_unmasked++;
+            }
+            filtered_expanded = g_list_previous(filtered_expanded);
+          }
+
+          if(count_enabled == 1)
+            final_matches = g_list_first(filtered_enabled);
+          else
+          {
+            //filter out masked if necessary
+            //to generate final matches list
+            filtered_enabled = g_list_last(filtered_enabled);
+            while(filtered_enabled)
+            {
+              mod = (dt_iop_module_t *)filtered_enabled->data;
+              //n.b. DISABLED and ENABLED below represent blend modes 'off' and 'uniformly'
+              if(!prefer_unmasked || count_unmasked == 0 || mod->blend_params->mask_mode == DEVELOP_MASK_ENABLED
+                                                         || mod->blend_params->mask_mode == DEVELOP_MASK_DISABLED)
+                final_matches = g_list_prepend(final_matches, mod);
+              filtered_enabled = g_list_previous(filtered_enabled);
+            }
+          }
+        }
+      }
+
+      if(strcmp(select_order, "first instance") == 0 && final_matches)
+        accel_mod_new = (dt_iop_module_t *)(g_list_first(final_matches)->data);
+      else if(final_matches)
+        accel_mod_new = (dt_iop_module_t *)(g_list_last(final_matches)->data);
+    }
+
+    accel_mod_curr = dt_iop_get_module_accel_curr(module);
+
+    //no need to change anything
+    if(accel_mod_curr == accel_mod_new) return;
+
+    //remove accelerators from current module
+    if(accel_mod_curr)
+    {
+      dt_accel_disconnect_list(accel_mod_curr->accel_closures);
+      accel_mod_curr->accel_closures = NULL;
+    }
+
+    //attach accelerators to new module
+    if(accel_mod_new)
+    {
+      //add accelerators to new module
+      if(accel_mod_new->connect_key_accels) accel_mod_new->connect_key_accels(accel_mod_new);
+      dt_iop_connect_common_accels(accel_mod_new);
+    }
+
+    dt_dynamic_accel_get_valid_list();
+  }
+}
+
+void dt_iop_connect_accels_all()
+{
+  GList *iop_mods = g_list_last(darktable.develop->iop);
+  while(iop_mods)
+  {
+    dt_iop_module_t *mod = (dt_iop_module_t *)iop_mods->data;
+    dt_iop_connect_accels_multi(mod->so);
+    iop_mods = g_list_previous(iop_mods);
+  }
+}
+
 dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules, const char *operation, const char *multi_name)
 {
   dt_iop_module_t *mod_ret = NULL;
@@ -2478,6 +2646,26 @@ dt_iop_module_t *dt_iop_get_module_by_instance_name(GList *modules, const char *
     m = g_list_next(m);
   }
   return mod_ret;
+}
+
+/** count instances of a module **/
+int dt_iop_count_instances(dt_iop_module_so_t *module)
+{
+  int inst_count = 0;
+  GList *iop_mods = NULL;                 //All modules in iop
+  dt_iop_module_t *mod = NULL;            //Used while iterating module lists
+
+  iop_mods = g_list_last(darktable.develop->iop);
+  while(iop_mods)
+  {
+    mod = (dt_iop_module_t *)iop_mods->data;
+    if(mod->so == module && mod->iop_order != INT_MAX)
+    {
+      inst_count++;
+    }
+    iop_mods = g_list_previous(iop_mods);
+  }
+  return inst_count;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -650,6 +650,18 @@ dt_iop_module_t *dt_iop_gui_get_next_visible_module(dt_iop_module_t *module);
 // initializes memory.darktable_iop_names
 void dt_iop_set_darktable_iop_table();
 
+/** adds keyboard accels to the first module in the pipe to handle where there are multiple instances */
+void dt_iop_connect_accels_multi(dt_iop_module_so_t *module);
+
+/** adds keyboard accels for all modules in the pipe */
+void dt_iop_connect_accels_all();
+
+/** get the module that accelerators are attached to for the current so */
+dt_iop_module_t *dt_iop_get_module_accel_curr(dt_iop_module_so_t *module);
+
+/** count instances of a module **/
+int dt_iop_count_instances(dt_iop_module_so_t *module);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -696,6 +696,12 @@ static void menuitem_pick_preset(GtkMenuItem *menuitem, dt_iop_module_t *module)
   dt_iop_gui_update(module);
   dt_dev_add_history_item(darktable.develop, module, FALSE);
   gtk_widget_queue_draw(module->widget);
+
+  if(dt_conf_get_bool("accel/prefer_enabled") || dt_conf_get_bool("accel/prefer_unmasked"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(module->so);
+  }
 }
 
 static gboolean menuitem_button_released_preset(GtkMenuItem *menuitem, GdkEventButton *event, dt_iop_module_t *module)
@@ -710,6 +716,13 @@ static gboolean menuitem_button_released_preset(GtkMenuItem *menuitem, GdkEventB
     if (new_module)
       menuitem_pick_preset(menuitem, new_module);
   }
+
+  if(dt_conf_get_bool("accel/prefer_enabled") || dt_conf_get_bool("accel/prefer_unmasked"))
+  {
+    // rebuild the accelerators
+    dt_iop_connect_accels_multi(module->so);
+  }
+
   return FALSE;
 }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -807,6 +807,7 @@ static void _lib_history_button_clicked_callback(GtkWidget *widget, gpointer use
   /* signal history changed */
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE);
   dt_dev_modulegroups_set(darktable.develop, dt_dev_modulegroups_get(darktable.develop));
+  dt_iop_connect_accels_all() ;
 }
 
 static void _lib_history_create_style_button_clicked_callback(GtkWidget *widget, gpointer user_data)

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -23,6 +23,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "develop/imageop.h"
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "libs/lib.h"
@@ -319,10 +320,14 @@ static void _lib_modulelist_row_changed_callback(GtkTreeView *treeview, gpointer
     gtk_tree_model_get(model, &iter, COL_MODULE, &module, -1);
 
     dt_iop_so_gui_set_state(module, (module->state + 1) % dt_iop_state_LAST);
+
     if(module->state == dt_iop_state_FAVORITE)
       dt_dev_modulegroups_set(darktable.develop, DT_MODULEGROUP_FAVORITES);
 
     update_selection(self);
+
+    // rebuild the accelerators 
+    dt_iop_connect_accels_multi(module);
   }
 }
 

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -216,6 +216,23 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
   <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='tags']">
     <xsl:apply-templates select="." mode="tab_block"/>
   </xsl:for-each>
+
+<xsl:text>
+   {
+      GtkWidget *seclabel = gtk_label_new(_("keyboard shortcuts with multiple instances"));
+      GtkWidget *lbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+      gtk_box_pack_start(GTK_BOX(lbox), seclabel, FALSE, FALSE, 0);
+      gtk_widget_set_hexpand(lbox, TRUE);
+      gtk_widget_set_name(lbox, "pref_section");
+      gtk_grid_attach(GTK_GRID(grid), lbox, 0, line++, 2, 1);
+      g_object_set(lbox,  "tooltip-text", _("Where multiple module instances are present, these preferences control rules that are applied (in order) to decide which module instance keyboard shortcuts will be applied to"), (gchar *)0);
+   }
+</xsl:text>
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs='misc' and @section='accel']">
+    <xsl:apply-templates select="." mode="tab_block"/>
+  </xsl:for-each>
+
 <xsl:text>
    {
       GtkWidget *seclabel = gtk_label_new(_("other"));


### PR DESCRIPTION
Resolves #4285. Resolves #3769. Resolves #2760.

In order to make keyboard shortcuts within the darkroom more consistent where multiple module instances are present, some additional parameters have been introduced to the Preferences dialog (under the Miscellaneous tab) in a new section 'keyboard shortcuts with multiple instances'. These preferences control rules that are applied (in order) to decide which module instance keyboard shortcuts will be applied to.

1. **prefer expanded instances** default FALSE (if instances of the module are expanded, ignore collapsed instances)
2. **prefer enabled instances** default FALSE (after applying the above rule, if instances of the module are active, ignore inactive instances)
3. **prefer unmasked instances** default FALSE (after applying the above rules, if instances of the module are unmasked, ignore masked instances)
4. **selection order** default "last instance" (after applying the above rules, apply the shortcut to the first or last instance remaining)

These rules also apply when mouse-dragging on the histogram to change exposure.

Darktable will reattach the keyboard shortcuts (using the above rules) to a different instance, if required, in the following scenarios:

- When opening a new image in the darkroom (when initially loading the image and when navigating to previous/next image)
- When selecting a history item in the 'history' module
- (if prefer expanded instances is set) when expanding/collapsing an instance (via the gui or a keyboard shortcut)
- (if prefer enabled instances is set) when enabling/disabling an instance (via the gui or a keyboard shortcut)
- (if prefer unmasked instances is set) when changing the masking behaviour of an instance
- (if prefer active/enabled/unmasked instances is set) when choosing a preset (via the module or darkroom menus)
- (if prefer active/enabled/unmasked instances is set) when resetting module parameters
- When choosing a style (via the module or darkroom menus)
- When duplicating, cloning, deleting or moving a module
- When hiding/unhiding a module in the 'more modules' module