### PR TITLE
Fix issue on focus peaking in culling mode #4156

### DIFF
--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1413,10 +1413,15 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
       cairo_fill(cr);
 
       if(darktable.gui->show_focus_peaking)
+      {
+        cairo_save(cr);
+        cairo_rectangle(cr, rectx, recty, rectw, recth);
+        cairo_clip(cr);
         dt_focuspeaking(cr, width, height, cairo_image_surface_get_data(surface),
                                            cairo_image_surface_get_width(surface),
                                            cairo_image_surface_get_height(surface));
-
+        cairo_restore(cr);
+      }
       if(!vals->full_surface || !*(vals->full_surface)) cairo_surface_destroy(surface);
     }
 


### PR DESCRIPTION
The issue #4156 describes the problem in a perfect way, also the analysis of @AlicVB
seems to be fully correct.

As we know the position & size of the image immediately before adding the peakings
we can restrict that to a clipped cairo region.

@aurelienpierre & @AlicVB ; any objections?