### PR TITLE
not so simple padding fix around spinbuttons

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1047,6 +1047,10 @@ spinbutton {
     margin-top: 0;
 }
 
+#preferences_notebook scrolledwindow spinbutton {
+    padding: 0px;
+}
+
 /* Color picker module in darkroom left panel */
 
 #color-picker-area

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1017,7 +1017,7 @@ cell:selected
     color: #ffff00;
 }
 
-spinbutton {
+#export-max-size spinbutton {
     padding: 0px 5px;
 }
 
@@ -1045,10 +1045,6 @@ spinbutton {
 #preferences_notebook scrolledwindow #pref_section:first-child
 {
     margin-top: 0;
-}
-
-#preferences_notebook scrolledwindow spinbutton {
-    padding: 0px;
 }
 
 /* Color picker module in darkroom left panel */

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -611,6 +611,7 @@ void gui_init(dt_lib_module_t *self)
 
 
   GtkBox *hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+  gtk_widget_set_name(GTK_WIDGET(hbox), "export-max-size");
   label = gtk_label_new(_("max size"));
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_MIDDLE);
   g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);


### PR DESCRIPTION
In PR #4416 @Nilvus introduced a padding fix for spin inputs that fixed export window spin input padding issue.

*Before #4416*
![bad export padding](https://user-images.githubusercontent.com/10687765/76207643-732ae580-61fe-11ea-8eba-41522ea9c975.png)
*After #4416*
![god export padding](https://user-images.githubusercontent.com/10687765/76207646-745c1280-61fe-11ea-9616-cba9aae35692.png)

That however introduced padding problem in preferences window.

*Before #4416*
![good preferences padding](https://user-images.githubusercontent.com/10687765/76207805-c0a75280-61fe-11ea-952a-2ebe7edab2af.png)

*After #4416*
![bad preferences padding](https://user-images.githubusercontent.com/10687765/76207812-c69d3380-61fe-11ea-9f0e-1596d7d4ce3a.png)


this PR fixes padding for spin input in preferences window without touching all other spin inputs.

![This PR: good padding](https://user-images.githubusercontent.com/10687765/76207868-dfa5e480-61fe-11ea-925e-b8fa5f593c00.png)
![This PR: godd padding](https://user-images.githubusercontent.com/10687765/76207874-e16fa800-61fe-11ea-8ab9-d9ce06dec34e.png)
