### PR TITLE
Bugfix: Windows fails to delete version-zero xmp files

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -960,19 +960,13 @@ gboolean dt_image_altered(const uint32_t imgid)
 GList* dt_image_find_duplicates(const char* filename)
 {
   // find all duplicates of an image
+#ifndef _WIN32
   gchar pattern[PATH_MAX] = { 0 };
   GList* files = NULL;
   gchar *imgpath = g_path_get_dirname(filename);
-
   // NULL terminated list of glob patterns; should include "" and can be extended if needed
-#ifdef _WIN32
-  // Windows only accepts generic wildcards for filename
-  static const gchar *glob_patterns[] = { "", "_????", NULL };
-#else
   static const gchar *glob_patterns[]
     = { "", "_[0-9][0-9]", "_[0-9][0-9][0-9]", "_[0-9][0-9][0-9][0-9]", NULL };
-#endif
-
   const gchar **glob_pattern = glob_patterns;
   files = NULL;
   while(*glob_pattern)
@@ -984,25 +978,6 @@ GList* dt_image_find_duplicates(const char* filename)
     const gchar *c2 = filename + strlen(filename);
     while(*c2 != '.' && c2 > filename) c2--;
     snprintf(c1 + strlen(*glob_pattern), pattern + sizeof(pattern) - c1 - strlen(*glob_pattern), "%s.xmp", c2);
-
-#ifdef _WIN32
-    wchar_t *wpattern = g_utf8_to_utf16(pattern, -1, NULL, NULL, NULL);
-    WIN32_FIND_DATAW data;
-    HANDLE handle = FindFirstFileW(wpattern, &data);
-    g_free(wpattern);
-    if(handle != INVALID_HANDLE_VALUE)
-    {
-      do
-      {
-        char *file = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
-        if(win_valid_duplicate_filename(file)) files =
-                                                 g_list_append(files, g_build_filename(imgpath, file, NULL));
-        g_free(file);
-      }
-      while(FindNextFileW(handle, &data));
-    }
-    FindClose(handle);
-#else
     glob_t globbuf;
     if(!glob(pattern, 0, NULL, &globbuf))
     {
@@ -1010,13 +985,15 @@ GList* dt_image_find_duplicates(const char* filename)
         files = g_list_append(files, g_strdup(globbuf.gl_pathv[i]));
       globfree(&globbuf);
     }
-#endif
 
     glob_pattern++;
   }
 
   g_free(imgpath);
   return files;
+#else
+  return win_image_find_duplicates(filename);
+#endif 
 }
 
 

--- a/src/win/filepath.c
+++ b/src/win/filepath.c
@@ -17,40 +17,71 @@
 
 #include "dtwin.h"
 
-gboolean win_valid_duplicate_filename(const char *filename)
+GList* win_image_find_duplicates(const char* filename)
 {
-  // Windows only accepts generic wildcards for filename search
-  // therefore we must filter out invalid duplicate filenames
-  // valid filenames must have from 2 to 4 decimal digits between 
-  // last "_" and second last "." (or no "_" for the primary version)
-
-  gboolean valid_filename = TRUE;
-
-  const gchar *c4 = filename + strlen(filename);
-  while(*c4 != '.') c4--;
-  c4--;
-  while(*c4 != '.') c4--;
-  const gchar *c3 = c4;
-  gboolean underscore_found = FALSE; 
-  while(!underscore_found && c3 > filename) 
+  // find all duplicates of an image
+  gchar pattern[PATH_MAX] = { 0 };
+  GList* files = NULL;
+  gchar *imgpath = g_path_get_dirname(filename);
+  // Windows only accepts generic wildcards for filename
+  static const gchar *glob_patterns[] = { "", "_????", NULL }; 
+  const gchar *c3 = filename + strlen(filename);
+  while(*c3 != '\\' && c3 > filename) c3--;
+  if(*c3 == '\\') c3++;
+  const gchar **glob_pattern = glob_patterns;
+  files = NULL;
+  while(*glob_pattern)
   {
-    c3--;
-    underscore_found = (*c3 == '_');
-  }
-  if(underscore_found)
-  {
-    c3++;
-    c4--;
-    valid_filename = (c3 != c4);
-
-    while((c3 <= c4) && valid_filename)
+    g_strlcpy(pattern, filename, sizeof(pattern));
+    gchar *c1 = pattern + strlen(pattern);
+    while(*c1 != '.' && c1 > pattern) c1--;
+    g_strlcpy(c1, *glob_pattern, pattern + sizeof(pattern) - c1);
+    const gchar *c2 = filename + strlen(filename);
+    while(*c2 != '.' && c2 > filename) c2--;
+    snprintf(c1 + strlen(*glob_pattern), pattern + sizeof(pattern) - c1 - strlen(*glob_pattern), "%s.xmp", c2);
+    wchar_t *wpattern = g_utf8_to_utf16(pattern, -1, NULL, NULL, NULL);
+    WIN32_FIND_DATAW data;
+    HANDLE handle = FindFirstFileW(wpattern, &data);
+    g_free(wpattern); 
+    gchar *imgfile_without_path=g_strndup(c3,c2-c3); /*Need to remove path from front of filename*/
+    if(handle != INVALID_HANDLE_VALUE)
     {
-      if(!( *c3 >= '0' && *c3 <= '9' )) valid_filename = FALSE;
-      c3++;
+      do
+      {
+        gchar *file = g_utf16_to_utf8(data.cFileName, -1, NULL, NULL, NULL);
+        gchar *short_file_name = g_strndup(file, strlen(file) - 4 + c2 - filename - strlen(filename));  
+        gboolean valid_xmp_name = FALSE;
+        if(!(valid_xmp_name = (strlen(short_file_name) == strlen(imgfile_without_path)))) 
+        {
+          // if not the same length, make sure the extra char are 2-4 digits preceded by '_'
+          gchar *c4 = short_file_name + strlen(short_file_name);   
+          int i=0;
+          do
+          {
+            c4--;
+            i++;
+          }
+          while(g_ascii_isdigit(*c4) && c4 > short_file_name && i <= 4);
+          valid_xmp_name = (*c4 == '_' && strlen(short_file_name) == strlen(imgfile_without_path) + i);
+        }
+        
+        if(valid_xmp_name)
+            files = g_list_append(files, g_build_filename(imgpath, file, NULL));
+        
+        g_free(short_file_name);
+        g_free(file);
+      }
+      while(FindNextFileW(handle, &data));
+
     }
-  
+
+    g_free(imgfile_without_path);
+    FindClose(handle);
+    glob_pattern++;
   }
-  return valid_filename;
+
+  g_free(imgpath);
+  return files;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/win/filepath.h
+++ b/src/win/filepath.h
@@ -18,7 +18,7 @@
 #pragma once
 
 
-gboolean win_valid_duplicate_filename(const char *filename);
+GList* win_image_find_duplicates(const char *filename);
 
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
There has been a problem on Windows systems for some weeks, where "version zero" xmp files are left behind when the image file is deleted (see #4241).

It also depends on the format of the image filename.

This is partly a result of Windows having imprecise wildcards: given a file \_IMG1234.DNG, the search used to find matching xmp files will return any \_IMG1234_abcd.DNG with arbitrary characters abcd (of which some or all may be ""). To prevent this, there is a function in win.filepath.c which attempts to detect the "real" duplicates from accidental catches. It does this by starting at the back, jumping the two extensions, then continuing until it finds "_". It then checks if the characters removed were digits.

This works for finding non-version-0 duplicates. However, the stopping criterion is reaching the start of the filename... where in the example above, you see there is another "_". Since that one is not followed by digits, it fails.
That could be easily patched, but what if the image file was 
A_really_long_silly_name.dng
Or worse, 
A12_34.DNG
which would have a version 0 which looks like a duplicate of A12.DNG.

In fact, without further constraints on the format of the image files, the only reliable way of detecting them is by comparison with the image file name. 
Since that requires some preparation (removing the preceding path) and need not be recalculated at each lap of the loop over possible duplicates, I moved everything out to filepath.c (with a change of function name and type).