### PR TITLE
change "gamma" GUI name to "display encoding"

### DIFF
--- a/src/iop/gamma.c
+++ b/src/iop/gamma.c
@@ -40,7 +40,7 @@ typedef struct dt_iop_gamma_params_t
 
 const char *name()
 {
-  return C_("modulename", "gamma");
+  return C_("modulename", "display encoding");
 }
 
 int default_group()


### PR DESCRIPTION
gamma.c is a legacy from dt 0.9 or something and use to do what colorout.c does now. That name confuses people since it appears in GUI in dt 3.0. We rename it to what it actually does now : export `float32` pipeline to `uint8` image buffer to send to display.