### PR TITLE
wip: try to add Exif.Photo.ExposureBiasValue to variables + image info

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -505,11 +505,11 @@ static bool dt_exif_read_xmp_data(dt_image_t *img, Exiv2::XmpData &xmpData, int 
       char *c ;
       while ( ( c = strchr(datetime,'T') ) != NULL )
       {
-	*c = ' ';
+  *c = ' ';
       }
       // replace '-' by ':'
       while ( ( c = strchr(datetime,'-')) != NULL ) {
-	*c = ':';
+  *c = ':';
       }
 
       g_strlcpy(img->exif_datetime_taken, datetime, sizeof(img->exif_datetime_taken));
@@ -734,6 +734,13 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       // uf_strlcpy_to_utf8(uf->conf->shutterText, max_name, pos, exifData);
       img->exif_exposure = 1.0 / pos->toFloat();
     }
+
+    // Read exposure bias
+    if(FIND_EXIF_TAG("Exif.Photo.ExposureBiasValue"))
+    {
+      img->exif_exposure_bias = pos->toFloat();
+    }
+
     /* Read aperture */
     if(FIND_EXIF_TAG("Exif.Photo.FNumber"))
     {

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1400,6 +1400,7 @@ void dt_image_init(dt_image_t *img)
   g_strlcpy(img->exif_datetime_taken, "0000:00:00 00:00:00", sizeof(img->exif_datetime_taken));
   img->exif_crop = 1.0;
   img->exif_exposure = 0;
+  img->exif_exposure_bias = 0.0;
   img->exif_aperture = 0;
   img->exif_iso = 0;
   img->exif_focal_length = 0;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -151,6 +151,7 @@ typedef struct dt_image_t
   int32_t exif_inited;
   dt_image_orientation_t orientation;
   float exif_exposure;
+  float exif_exposure_bias;
   float exif_aperture;
   float exif_iso;
   float exif_focal_length;

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -55,6 +55,7 @@ typedef struct dt_variables_data_t
   struct tm exif_tm;
 
   float exif_exposure;
+  float exif_exposure_bias;
   float exif_aperture;
   float exif_focal_length;
   float exif_focus_distance;
@@ -96,6 +97,7 @@ static void init_expansion(dt_variables_params_t *params, gboolean iterate)
   params->data->version = 0;
   params->data->stars = 0;
   params->data->exif_exposure = 0.0f;
+  params->data->exif_exposure_bias = 0.0f;
   params->data->exif_aperture = 0.0f;
   params->data->exif_focal_length = 0.0f;
   params->data->exif_focus_distance = 0.0f;
@@ -120,6 +122,7 @@ static void init_expansion(dt_variables_params_t *params, gboolean iterate)
     if(params->data->stars == 6) params->data->stars = -1;
 
     params->data->exif_exposure = img->exif_exposure;
+    params->data->exif_exposure_bias = img->exif_exposure_bias;
     params->data->exif_aperture = img->exif_aperture;
     params->data->exif_focal_length = img->exif_focal_length;
     if(!isnan(img->exif_focus_distance) && fpclassify(img->exif_focus_distance) != FP_ZERO)
@@ -212,6 +215,8 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     else
       result = g_strdup_printf("%.1f″", params->data->exif_exposure);
   }
+  else if(has_prefix(variable, "EXIF_EXPOSURE_BIAS"))
+    result = g_strdup_printf("%+.1f", params->data->exif_exposure_bias);
   else if(has_prefix(variable, "EXIF_APERTURE"))
     result = g_strdup_printf("%.1f", params->data->exif_aperture);
   else if(has_prefix(variable, "EXIF_FOCAL_LENGTH"))

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -61,6 +61,7 @@ enum
   md_exif_lens,
   md_exif_aperture,
   md_exif_exposure,
+  md_exif_exposure_bias,
   md_exif_focal_length,
   md_exif_focus_distance,
   md_exif_iso,
@@ -111,6 +112,7 @@ static void _lib_metatdata_view_init_labels()
   _md_labels[md_exif_lens] = _("lens");
   _md_labels[md_exif_aperture] = _("aperture");
   _md_labels[md_exif_exposure] = _("exposure");
+  _md_labels[md_exif_exposure_bias] = _("exposure bias");
   _md_labels[md_exif_focal_length] = _("focal length");
   _md_labels[md_exif_focus_distance] = _("focus distance");
   _md_labels[md_exif_iso] = _("ISO");
@@ -447,6 +449,9 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     else
       snprintf(value, sizeof(value), "%.1f''", img->exif_exposure);
     _metadata_update_value(d->metadata[md_exif_exposure], value);
+
+    snprintf(value, sizeof(value), _("%+.0f EV"), img->exif_exposure_bias);
+    _metadata_update_value(d->metadata[md_exif_exposure_bias], value);
 
     snprintf(value, sizeof(value), "%.0f mm", img->exif_focal_length);
     _metadata_update_value(d->metadata[md_exif_focal_length], value);


### PR DESCRIPTION
Try to fix #2680 and https://forums.darktable.fr/showthread.php?tid=4483

Unfortunately, it turned out to be more complicated than I thought and I need some help to finish. (maybe @phweyland or @jenshannoschwalm since you have worked on these parts ?).

1. The variable `$(EXIF_EXPOSURE_BIAS)` is not replaced in the image info by the value (even the default one),
2. The `dt_image_t` member `exif_exposure_bias` seems to not be read from the file EXIF, does it need to be fetched from database ?

Context : the camera exposure bias is useful when working in bracketing mode, while doing HDR or looking for the best exposure.