### PR TITLE
keyboard shortcuts to cycle through iop module combobox options

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1204,9 +1204,9 @@ void dt_bauhaus_combobox_set(GtkWidget *widget, int pos)
     if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
     {
       if(w->module && w->module->multi_name[0] != '\0')
-        dt_control_log(_("%s %s/%s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(widget));
+        dt_control_log(_("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(widget));
       else if(w->module)
-        dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(widget));
+        dt_control_log(_("%s / %s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(widget));
       else
         dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(widget));
     }

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1197,7 +1197,20 @@ void dt_bauhaus_combobox_set(GtkWidget *widget, int pos)
   dt_bauhaus_combobox_data_t *d = &w->data.combobox;
   d->active = CLAMP(pos, -1, d->num_labels - 1);
   gtk_widget_queue_draw(GTK_WIDGET(w));
-  if(!darktable.gui->reset) g_signal_emit_by_name(G_OBJECT(w), "value-changed");
+  if(!darktable.gui->reset) 
+  {
+    g_signal_emit_by_name(G_OBJECT(w), "value-changed");
+
+    if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
+    {
+      if(w->module && w->module->multi_name[0] != '\0')
+        dt_control_log(_("%s %s/%s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(widget));
+      else if(w->module)
+        dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(widget));
+      else
+        dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(widget));
+    }
+  }
 }
 
 gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *widget, const char *text)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -949,6 +949,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
       fprintf(stderr, "ERROR: can't init gui, aborting.\n");
       return 1;
     }
+    darktable.gui->reset = 1;
     dt_bauhaus_init();
   }
   else
@@ -1017,6 +1018,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
 
     // initialize undo struct
     darktable.undo = dt_undo_init();
+    darktable.gui->reset = 0;
   }
 
   if(darktable.unmuted & DT_DEBUG_MEMORY)

--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -171,9 +171,7 @@ static int dt_imageio_load_modules_format(dt_imageio_t *iio)
       continue;
     }
     module->gui_data = NULL;
-    if(darktable.gui) darktable.gui->reset = 1;
     module->gui_init(module);
-    if(darktable.gui) darktable.gui->reset = 0;
     if(module->widget) g_object_ref(module->widget);
     g_free(libname);
     res = g_list_insert_sorted(res, module, dt_imageio_sort_modules_format);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -526,8 +526,6 @@ static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObje
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
 
-  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
-
   if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
   {
     if(w->module && w->module->multi_name[0] != '\0')
@@ -551,8 +549,6 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
   dt_bauhaus_combobox_set(combobox, prevval);
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
-
-  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
 
   if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
   {

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -510,8 +510,9 @@ static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObje
 {
   GtkWidget *combobox = GTK_WIDGET(data);
 
-  int currentval = dt_bauhaus_combobox_get(combobox);
-  dt_bauhaus_combobox_set(combobox, ++currentval);
+  const int currentval = dt_bauhaus_combobox_get(combobox);
+  const int nextval = currentval + 1 >= dt_bauhaus_combobox_length(combobox) ? 0 : currentval + 1;
+  dt_bauhaus_combobox_set(combobox, nextval);
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
 
@@ -534,8 +535,10 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
 {
   GtkWidget *combobox = GTK_WIDGET(data);
 
-  int currentval = dt_bauhaus_combobox_get(combobox);
-  dt_bauhaus_combobox_set(combobox, --currentval);
+  const int currentval = dt_bauhaus_combobox_get(combobox);
+  const int prevval = currentval - 1 < 0 ? dt_bauhaus_combobox_length(combobox) : currentval - 1;
+
+  dt_bauhaus_combobox_set(combobox, prevval);
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
 

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -512,7 +512,19 @@ static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObje
 
   int currentval = dt_bauhaus_combobox_get(combobox);
   dt_bauhaus_combobox_set(combobox, ++currentval);
-  dt_control_hinter_message(darktable.control, dt_bauhaus_combobox_get_text(combobox));
+
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
+
+  if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
+  {
+    if(w->module && w->module->multi_name[0] != '\0')
+      dt_control_log(_("%s %s/%s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(combobox));
+    else if(w->module)
+      dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(combobox));
+    else
+      dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(combobox));
+  }
+
   g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
   return TRUE;
 }
@@ -524,7 +536,19 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
 
   int currentval = dt_bauhaus_combobox_get(combobox);
   dt_bauhaus_combobox_set(combobox, --currentval);
-  dt_control_hinter_message(darktable.control, dt_bauhaus_combobox_get_text(combobox));
+
+  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
+
+  if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
+  {
+    if(w->module && w->module->multi_name[0] != '\0')
+      dt_control_log(_("%s %s/%s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(combobox));
+    else if(w->module)
+      dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(combobox));
+    else
+      dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(combobox));
+  }
+
   g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
   return TRUE;
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -537,7 +537,6 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
 
   const int currentval = dt_bauhaus_combobox_get(combobox);
   const int prevval = currentval - 1 < 0 ? dt_bauhaus_combobox_length(combobox) : currentval - 1;
-
   dt_bauhaus_combobox_set(combobox, prevval);
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -217,6 +217,39 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
   dt_accel_register_lib_for_views(self, v, path, accel_key, mods);
 }
 
+void dt_accel_register_combobox_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)
+{
+  gchar accel_next_path[256];
+  gchar accel_prev_path[256];
+
+  dt_accel_t *accel_next = (dt_accel_t *)g_malloc(sizeof(dt_accel_t));
+  dt_accel_t *accel_prev = (dt_accel_t *)g_malloc(sizeof(dt_accel_t));
+
+  //accel to select next value
+  snprintf(accel_next_path, 256, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), so->op, path,
+           NC_("accel", "next"));
+  gtk_accel_map_add_entry(accel_next_path, 0, 0);
+  g_strlcpy(accel_next->path, accel_next_path, sizeof(accel_next->path));
+  dt_accel_path_iop_translated(accel_next_path, sizeof(accel_next_path), so, path);
+  g_strlcpy(accel_next->translated_path, accel_next_path, sizeof(accel_next->translated_path));
+  g_strlcpy(accel_next->module, so->op, sizeof(accel_next->module));
+  accel_next->local = local;
+  accel_next->views = DT_VIEW_DARKROOM;
+  darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel_next);
+
+  //accel to select previous value
+  snprintf(accel_prev_path, 256, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), so->op, path,
+           NC_("accel", "previous"));
+  gtk_accel_map_add_entry(accel_prev_path, 0, 0);
+  g_strlcpy(accel_prev->path, accel_prev_path, sizeof(accel_prev->path));
+  dt_accel_path_iop_translated(accel_prev_path, sizeof(accel_prev_path), so, path);
+  g_strlcpy(accel_next->translated_path, accel_prev_path, sizeof(accel_prev->translated_path));
+  g_strlcpy(accel_prev->module, so->op, sizeof(accel_prev->module));
+  accel_prev->local = local;
+  accel_prev->views = DT_VIEW_DARKROOM;
+  darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel_prev);
+}
+
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)
 {
   gchar increase_path[256];
@@ -470,6 +503,58 @@ static gboolean bauhaus_slider_reset_callback(GtkAccelGroup *accel_group, GObjec
 
   g_signal_emit_by_name(G_OBJECT(slider), "value-changed");
   return TRUE;
+}
+
+static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
+                                                 guint keyval, GdkModifierType modifier, gpointer data)
+{
+  GtkWidget *combobox = GTK_WIDGET(data);
+
+  int currentval = dt_bauhaus_combobox_get(combobox);
+  dt_bauhaus_combobox_set(combobox, ++currentval);
+  dt_control_hinter_message(darktable.control, dt_bauhaus_combobox_get_text(combobox));
+  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
+  return TRUE;
+}
+
+static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
+                                                 guint keyval, GdkModifierType modifier, gpointer data)
+{
+  GtkWidget *combobox = GTK_WIDGET(data);
+
+  int currentval = dt_bauhaus_combobox_get(combobox);
+  dt_bauhaus_combobox_set(combobox, --currentval);
+  dt_control_hinter_message(darktable.control, dt_bauhaus_combobox_get_text(combobox));
+  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
+  return TRUE;
+}
+
+void dt_accel_connect_combobox_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *combobox)
+{
+  gchar accel_next_path[256];
+  gchar accel_prev_path[256];
+
+  assert(DT_IS_BAUHAUS_WIDGET(combobox));
+
+  GClosure *closure;
+
+  //accel to select next value
+  snprintf(accel_next_path, 256, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), module->so->op, path,
+           NC_("accel", "next"));
+  closure = g_cclosure_new(G_CALLBACK(bauhaus_combobox_next_callback), (gpointer)combobox, NULL);
+  dt_accel_t *accel = _lookup_accel(accel_next_path);
+  if(accel) accel->closure = closure;
+  gtk_accel_group_connect_by_path(darktable.control->accelerators, accel_next_path, closure);
+  module->accel_closures = g_slist_prepend(module->accel_closures, accel);
+
+  //accel to select previous value
+  snprintf(accel_prev_path, 256, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), module->so->op, path,
+           NC_("accel", "previous"));
+  closure = g_cclosure_new(G_CALLBACK(bauhaus_combobox_prev_callback), (gpointer)combobox, NULL);
+  accel = _lookup_accel(accel_prev_path);
+  if(accel) accel->closure = closure;
+  gtk_accel_group_connect_by_path(darktable.control->accelerators, accel_prev_path, closure);
+  module->accel_closures = g_slist_prepend(module->accel_closures, accel);
 }
 
 void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *slider)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -220,18 +220,24 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
 void dt_accel_register_combobox_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)
 {
   gchar accel_next_path[256];
+  gchar accel_next_path_trans[256];
   gchar accel_prev_path[256];
+  gchar accel_prev_path_trans[256];
 
   dt_accel_t *accel_next = (dt_accel_t *)g_malloc(sizeof(dt_accel_t));
   dt_accel_t *accel_prev = (dt_accel_t *)g_malloc(sizeof(dt_accel_t));
 
+  gchar *module_name_fixed = dt_util_str_replace(so->name(), "/", "-");
+
   //accel to select next value
   snprintf(accel_next_path, 256, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), so->op, path,
            NC_("accel", "next"));
+  snprintf(accel_next_path_trans, 256, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
+           g_dpgettext2(NULL, "accel", path), C_("accel", "next"));
   gtk_accel_map_add_entry(accel_next_path, 0, 0);
   g_strlcpy(accel_next->path, accel_next_path, sizeof(accel_next->path));
   dt_accel_path_iop_translated(accel_next_path, sizeof(accel_next_path), so, path);
-  g_strlcpy(accel_next->translated_path, accel_next_path, sizeof(accel_next->translated_path));
+  g_strlcpy(accel_next->translated_path, accel_next_path_trans, sizeof(accel_next->translated_path));
   g_strlcpy(accel_next->module, so->op, sizeof(accel_next->module));
   accel_next->local = local;
   accel_next->views = DT_VIEW_DARKROOM;
@@ -240,14 +246,18 @@ void dt_accel_register_combobox_iop(dt_iop_module_so_t *so, gboolean local, cons
   //accel to select previous value
   snprintf(accel_prev_path, 256, "<Darktable>/%s/%s/%s/%s", NC_("accel", "image operations"), so->op, path,
            NC_("accel", "previous"));
+  snprintf(accel_prev_path_trans, 256, "<Darktable>/%s/%s/%s/%s", C_("accel", "image operations"), module_name_fixed,
+           g_dpgettext2(NULL, "accel", path), C_("accel", "previous"));
   gtk_accel_map_add_entry(accel_prev_path, 0, 0);
   g_strlcpy(accel_prev->path, accel_prev_path, sizeof(accel_prev->path));
   dt_accel_path_iop_translated(accel_prev_path, sizeof(accel_prev_path), so, path);
-  g_strlcpy(accel_next->translated_path, accel_prev_path, sizeof(accel_prev->translated_path));
+  g_strlcpy(accel_prev->translated_path, accel_prev_path_trans, sizeof(accel_prev->translated_path));
   g_strlcpy(accel_prev->module, so->op, sizeof(accel_prev->module));
   accel_prev->local = local;
   accel_prev->views = DT_VIEW_DARKROOM;
   darktable.control->accelerator_list = g_slist_prepend(darktable.control->accelerator_list, accel_prev);
+
+  g_free(module_name_fixed);
 }
 
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path)

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -524,18 +524,6 @@ static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObje
   const int nextval = currentval + 1 >= dt_bauhaus_combobox_length(combobox) ? 0 : currentval + 1;
   dt_bauhaus_combobox_set(combobox, nextval);
 
-  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
-
-  if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
-  {
-    if(w->module && w->module->multi_name[0] != '\0')
-      dt_control_log(_("%s %s/%s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(combobox));
-    else if(w->module)
-      dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(combobox));
-    else
-      dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(combobox));
-  }
-
   return TRUE;
 }
 
@@ -547,18 +535,6 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
   const int currentval = dt_bauhaus_combobox_get(combobox);
   const int prevval = currentval - 1 < 0 ? dt_bauhaus_combobox_length(combobox) : currentval - 1;
   dt_bauhaus_combobox_set(combobox, prevval);
-
-  dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
-
-  if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
-  {
-    if(w->module && w->module->multi_name[0] != '\0')
-      dt_control_log(_("%s %s/%s: %s"), w->module->name(), w->module->multi_name, w->label, dt_bauhaus_combobox_get_text(combobox));
-    else if(w->module)
-      dt_control_log(_("%s/%s: %s"), w->module->name(), w->label, dt_bauhaus_combobox_get_text(combobox));
-    else
-      dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(combobox));
-  }
 
   return TRUE;
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -526,6 +526,8 @@ static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObje
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
 
+  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
+
   if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
   {
     if(w->module && w->module->multi_name[0] != '\0')
@@ -536,7 +538,6 @@ static gboolean bauhaus_combobox_next_callback(GtkAccelGroup *accel_group, GObje
       dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(combobox));
   }
 
-  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
   return TRUE;
 }
 
@@ -551,6 +552,8 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
 
   dt_bauhaus_widget_t *w = (dt_bauhaus_widget_t *)DT_BAUHAUS_WIDGET(combobox);
 
+  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
+
   if(!gtk_widget_is_visible(GTK_WIDGET(w)) && *w->label)
   {
     if(w->module && w->module->multi_name[0] != '\0')
@@ -561,7 +564,6 @@ static gboolean bauhaus_combobox_prev_callback(GtkAccelGroup *accel_group, GObje
       dt_control_log(_("%s"), dt_bauhaus_combobox_get_text(combobox));
   }
 
-  g_signal_emit_by_name(G_OBJECT(combobox), "value-changed");
   return TRUE;
 }
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -80,6 +80,7 @@ void dt_accel_register_lib(dt_lib_module_t *self, const gchar *path, guint accel
 void dt_accel_register_lib_for_views(dt_lib_module_t *self, dt_view_type_flags_t views, const gchar *path,
                                      guint accel_key, GdkModifierType mods);
 void dt_accel_register_slider_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path);
+void dt_accel_register_combobox_iop(dt_iop_module_so_t *so, gboolean local, const gchar *path);
 void dt_accel_register_lua(const gchar *path, guint accel_key, GdkModifierType mods);
 
 // Accelerator connection functions
@@ -90,6 +91,7 @@ dt_accel_t *dt_accel_connect_lib(dt_lib_module_t *module, const gchar *path, GCl
 void dt_accel_connect_button_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *button);
 void dt_accel_connect_button_lib(dt_lib_module_t *module, const gchar *path, GtkWidget *button);
 void dt_accel_connect_slider_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *slider);
+void dt_accel_connect_combobox_iop(dt_iop_module_t *module, const gchar *path, GtkWidget *combobox);
 void dt_accel_connect_locals_iop(dt_iop_module_t *module);
 void dt_accel_connect_preset_iop(dt_iop_module_t *so, const gchar *path);
 void dt_accel_connect_preset_lib(dt_lib_module_t *so, const gchar *path);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -523,6 +523,9 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "focal length"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop factor"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "aspect adjust"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "guides"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "automatic cropping"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "lens model"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -536,6 +539,9 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "focal length", GTK_WIDGET(g->f_length));
   dt_accel_connect_slider_iop(self, "crop factor", GTK_WIDGET(g->crop_factor));
   dt_accel_connect_slider_iop(self, "aspect adjust", GTK_WIDGET(g->aspect));
+  dt_accel_connect_combobox_iop(self, "guides", GTK_WIDGET(g->guide_lines));
+  dt_accel_connect_combobox_iop(self, "automatic cropping", GTK_WIDGET(g->cropmode));
+  dt_accel_connect_combobox_iop(self, "lens model", GTK_WIDGET(g->mode));
 }
 
 // multiply 3x3 matrix with 3x1 vector

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -32,6 +32,7 @@
 #include "gui/draw.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
+#include "gui/accelerators.h"
 #include "iop/iop_api.h"
 
 #include <assert.h>
@@ -175,6 +176,40 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
   return 1;
 }
 
+typedef struct dt_iop_basecurve_gui_data_t
+{
+  dt_draw_curve_t *minmax_curve; // curve for gui to draw
+  int minmax_curve_type, minmax_curve_nodes;
+  GtkBox *hbox;
+  GtkDrawingArea *area;
+  GtkWidget *scale, *fusion, *exposure_step, *exposure_bias;
+  GtkWidget *cmb_preserve_colors;
+  double mouse_x, mouse_y;
+  int selected;
+  int timeout_handle;
+  double selected_offset, selected_y, selected_min, selected_max;
+  float draw_xs[DT_IOP_TONECURVE_RES], draw_ys[DT_IOP_TONECURVE_RES];
+  float draw_min_xs[DT_IOP_TONECURVE_RES], draw_min_ys[DT_IOP_TONECURVE_RES];
+  float draw_max_xs[DT_IOP_TONECURVE_RES], draw_max_ys[DT_IOP_TONECURVE_RES];
+  int loglogscale;
+} dt_iop_basecurve_gui_data_t;
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "scale"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "exposure fusion"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_basecurve_gui_data_t *g = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "scale", GTK_WIDGET(g->scale));
+  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
+  dt_accel_connect_combobox_iop(self, "exposure fusion", GTK_WIDGET(g->fusion));
+}
+
 static const char neutral[] = N_("neutral");
 static const char canon_eos[] = N_("canon eos like");
 static const char canon_eos_alt[] = N_("canon eos like alternate");
@@ -269,24 +304,6 @@ static const basecurve_preset_t basecurve_presets[] = {
 };
 #undef m
 static const int basecurve_presets_cnt = sizeof(basecurve_presets) / sizeof(basecurve_preset_t);
-
-typedef struct dt_iop_basecurve_gui_data_t
-{
-  dt_draw_curve_t *minmax_curve; // curve for gui to draw
-  int minmax_curve_type, minmax_curve_nodes;
-  GtkBox *hbox;
-  GtkDrawingArea *area;
-  GtkWidget *scale, *fusion, *exposure_step, *exposure_bias;
-  GtkWidget *cmb_preserve_colors;
-  double mouse_x, mouse_y;
-  int selected;
-  int timeout_handle;
-  double selected_offset, selected_y, selected_min, selected_max;
-  float draw_xs[DT_IOP_TONECURVE_RES], draw_ys[DT_IOP_TONECURVE_RES];
-  float draw_min_xs[DT_IOP_TONECURVE_RES], draw_min_ys[DT_IOP_TONECURVE_RES];
-  float draw_max_xs[DT_IOP_TONECURVE_RES], draw_max_ys[DT_IOP_TONECURVE_RES];
-  int loglogscale;
-} dt_iop_basecurve_gui_data_t;
 
 typedef struct dt_iop_basecurve_data_t
 {

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -145,6 +145,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "vibrance"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clip"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -160,6 +161,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->sl_saturation));
   dt_accel_connect_slider_iop(self, "vibrance", GTK_WIDGET(g->sl_vibrance));
   dt_accel_connect_slider_iop(self, "clip", GTK_WIDGET(g->sl_clip));
+  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
 }
 
 static void _turn_select_region_off(struct dt_iop_module_t *self)

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -117,6 +117,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "midtone range"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -129,6 +130,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "highlights", GTK_WIDGET(g->highlights));
   dt_accel_connect_slider_iop(self, "shadows", GTK_WIDGET(g->shadows));
   dt_accel_connect_slider_iop(self, "midtone range", GTK_WIDGET(g->midtone));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
 }
 
 int legacy_params(

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -201,6 +201,10 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "frame line size"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "frame line offset"));
   dt_accel_register_iop(self, FALSE, NC_("accel", "pick frame line color from image"), 0, 0);
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "aspect"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "orientation"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "horizontal position"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "vertical position"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -211,6 +215,10 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_button_iop(self, "pick frame line color from image", GTK_WIDGET(g->frame_colorpick));
   dt_accel_connect_slider_iop(self, "frame line size", GTK_WIDGET(g->frame_size));
   dt_accel_connect_slider_iop(self, "frame line offset", GTK_WIDGET(g->frame_offset));
+  dt_accel_connect_combobox_iop(self, "aspect", GTK_WIDGET(g->aspect));
+  dt_accel_connect_combobox_iop(self, "orientation", GTK_WIDGET(g->aspect_orient));
+  dt_accel_connect_combobox_iop(self, "horizontal position", GTK_WIDGET(g->pos_h));
+  dt_accel_connect_combobox_iop(self, "vertical position", GTK_WIDGET(g->pos_v));
 }
 
 int distort_transform(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, float *points, size_t points_count)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -132,6 +132,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "red"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "destination"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -142,6 +143,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "red", GTK_WIDGET(g->scale_red));
   dt_accel_connect_slider_iop(self, "green", GTK_WIDGET(g->scale_green));
   dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->scale_blue));
+  dt_accel_connect_combobox_iop(self, "destination", GTK_WIDGET(g->output_channel));
 }
 
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const ivoid,

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3351,6 +3351,8 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "top"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "right"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bottom"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "aspect ratio"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "guide lines"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -3366,6 +3368,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "top", GTK_WIDGET(g->cy));
   dt_accel_connect_slider_iop(self, "right", GTK_WIDGET(g->cw));
   dt_accel_connect_slider_iop(self, "bottom", GTK_WIDGET(g->ch));
+  dt_accel_connect_combobox_iop(self, "guide lines", GTK_WIDGET(g->guide_lines));
+  dt_accel_connect_combobox_iop(self, "aspect ratio", GTK_WIDGET(g->aspect_presets));
 }
 
 GSList *mouse_actions(struct dt_iop_module_t *self)

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -3353,6 +3353,9 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bottom"));
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "aspect ratio"));
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "guide lines"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "flip"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "keystone"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "automatic cropping"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -3370,6 +3373,9 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "bottom", GTK_WIDGET(g->ch));
   dt_accel_connect_combobox_iop(self, "guide lines", GTK_WIDGET(g->guide_lines));
   dt_accel_connect_combobox_iop(self, "aspect ratio", GTK_WIDGET(g->aspect_presets));
+  dt_accel_connect_combobox_iop(self, "flip", GTK_WIDGET(g->hvflip));
+  dt_accel_connect_combobox_iop(self, "keystone", GTK_WIDGET(g->keystone_type));
+  dt_accel_connect_combobox_iop(self, "automatic cropping", GTK_WIDGET(g->crop_auto));
 }
 
 GSList *mouse_actions(struct dt_iop_module_t *self)

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -301,6 +301,8 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "output saturation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast fulcrum"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "contrast"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color control sliders"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -311,6 +313,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "output saturation", GTK_WIDGET(g->saturation_out));
   dt_accel_connect_slider_iop(self, "contrast fulcrum", GTK_WIDGET(g->grey));
   dt_accel_connect_slider_iop(self, "contrast", GTK_WIDGET(g->contrast));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
+  dt_accel_connect_combobox_iop(self, "color control sliders", GTK_WIDGET(g->controls));
 }
 
 static inline float CDL(float x, float slope, float offset, float power)

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -135,6 +135,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green-red"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue-yellow"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "saturation"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "target color"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -145,6 +146,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "green-red", GTK_WIDGET(g->scale_a));
   dt_accel_connect_slider_iop(self, "blue-yellow", GTK_WIDGET(g->scale_b));
   dt_accel_connect_slider_iop(self, "saturation", GTK_WIDGET(g->scale_C));
+  dt_accel_connect_combobox_iop(self, "target color", GTK_WIDGET(g->combobox_target));
 }
 
 

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -29,6 +29,7 @@
 #include "control/control.h"
 #include "develop/develop.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #ifdef HAVE_OPENJPEG
 #include "common/imageio_j2k.h"
 #endif
@@ -154,6 +155,22 @@ int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
                       dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_Lab;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "input profile"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "working profile"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "gamut clipping"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "input profile", GTK_WIDGET(g->profile_combobox));
+  dt_accel_connect_combobox_iop(self, "working profile", GTK_WIDGET(g->work_combobox));
+  dt_accel_connect_combobox_iop(self, "gamut clipping", GTK_WIDGET(g->clipping_combobox));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -118,6 +118,18 @@ int output_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe,
   return cst;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "export profile"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_colorout_gui_data_t *g = (dt_iop_colorout_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "export profile", GTK_WIDGET(g->output_profile));
+}
+
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -179,6 +179,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "spatial extent"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "range extent"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "hue"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "precedence"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -189,6 +190,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "spatial extent", GTK_WIDGET(g->spatial));
   dt_accel_connect_slider_iop(self, "range extent", GTK_WIDGET(g->range));
   dt_accel_connect_slider_iop(self, "hue", GTK_WIDGET(g->hue));
+  dt_accel_connect_combobox_iop(self, "precedence", GTK_WIDGET(g->precedence));
 }
 
 typedef struct dt_iop_colorreconstruct_bilateral_t

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -165,6 +165,9 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mix"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "select by"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "process mode"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation method"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -172,6 +175,9 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
 
   dt_accel_connect_slider_iop(self, "mix", GTK_WIDGET(g->strength));
+  dt_accel_connect_combobox_iop(self, "select by", GTK_WIDGET(g->select_by));
+  dt_accel_connect_combobox_iop(self, "process mode", GTK_WIDGET(g->mode));
+  dt_accel_connect_combobox_iop(self, "interpolation method", GTK_WIDGET(g->interpolator));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -114,6 +114,7 @@ void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edge detection radius"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "threshold"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "operation mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -122,6 +123,7 @@ void connect_key_accels(dt_iop_module_t *self)
 
   dt_accel_connect_slider_iop(self, "edge detection radius", GTK_WIDGET(g->radius_scale));
   dt_accel_connect_slider_iop(self, "threshold", GTK_WIDGET(g->thresh_scale));
+  dt_accel_connect_combobox_iop(self, "operation mode", GTK_WIDGET(g->mode_select));
 }
 
 // fibonacci lattice to select surrounding pixels for different cases

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -190,6 +190,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
 
   dt_accel_connect_slider_iop(self, "edge threshold", GTK_WIDGET(g->median_thrs));
+  dt_accel_connect_combobox_iop(self, "method (bayer)", GTK_WIDGET(g->demosaic_method_bayer));
   dt_accel_connect_combobox_iop(self, "method (xtrans)", GTK_WIDGET(g->demosaic_method_xtrans));
   dt_accel_connect_combobox_iop(self, "color smoothing", GTK_WIDGET(g->color_smoothing));
   dt_accel_connect_combobox_iop(self, "match greens", GTK_WIDGET(g->greeneq));

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -179,12 +179,20 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edge threshold"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method (bayer)"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method (xtrans)"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color smoothing"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "match greens"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
-  dt_accel_connect_slider_iop(self, "edge threshold",
-                              GTK_WIDGET(((dt_iop_demosaic_gui_data_t *)self->gui_data)->median_thrs));
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_slider_iop(self, "edge threshold", GTK_WIDGET(g->median_thrs));
+  dt_accel_connect_combobox_iop(self, "method (xtrans)", GTK_WIDGET(g->demosaic_method_xtrans));
+  dt_accel_connect_combobox_iop(self, "color smoothing", GTK_WIDGET(g->color_smoothing));
+  dt_accel_connect_combobox_iop(self, "match greens", GTK_WIDGET(g->greeneq));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -599,6 +599,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "search radius"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "scattering"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "central pixel weight"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -613,6 +614,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "search radius", GTK_WIDGET(g->nbhood));
   dt_accel_connect_slider_iop(self, "scattering", GTK_WIDGET(g->scattering));
   dt_accel_connect_slider_iop(self, "central pixel weight", GTK_WIDGET(g->central_pixel_weight));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
 }
 
 typedef union floatint_t

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -118,6 +118,17 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "method", GTK_WIDGET(g->dither_type));
+}
 
 void init_presets(dt_iop_module_so_t *self)
 {

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -123,24 +123,24 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mode"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "exposure"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "auto-exposure"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "percentile"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target level"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  dt_accel_connect_slider_iop(self, "mode", GTK_WIDGET(g->mode));
   dt_accel_connect_slider_iop(self, "black", GTK_WIDGET(g->black));
   dt_accel_connect_slider_iop(self, "exposure", GTK_WIDGET(g->exposure));
   dt_accel_connect_slider_iop(self, "auto-exposure", GTK_WIDGET(g->autoexpp));
   dt_accel_connect_slider_iop(self, "percentile", GTK_WIDGET(g->deflicker_percentile));
   dt_accel_connect_slider_iop(self, "target level", GTK_WIDGET(g->deflicker_target_level));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -277,6 +277,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target middle grey"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target white luminance"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target power transfer function"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve chrominance"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -295,6 +296,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "target middle grey", GTK_WIDGET(g->grey_point_target));
   dt_accel_connect_slider_iop(self, "target white luminance", GTK_WIDGET(g->white_point_target));
   dt_accel_connect_slider_iop(self, "target power transfer function", GTK_WIDGET(g->output_power));
+  dt_accel_connect_combobox_iop(self, "preserve chrominance", GTK_WIDGET(g->preserve_color));
 }
 
 

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -122,6 +122,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "bias"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "target"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "detail"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "operator"));
  }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -131,6 +132,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "bias", GTK_WIDGET(g->drago.bias));
   dt_accel_connect_slider_iop(self, "target", GTK_WIDGET(g->drago.max_light));
   dt_accel_connect_slider_iop(self, "detail", GTK_WIDGET(g->detail));
+  dt_accel_connect_combobox_iop(self, "operator", GTK_WIDGET(g->operator));
  }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -96,6 +96,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "clipping threshold"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -103,6 +104,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
 
   dt_accel_connect_slider_iop(self, "clipping threshold", GTK_WIDGET(g->clip));
+  dt_accel_connect_combobox_iop(self, "method", GTK_WIDGET(g->mode));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -177,6 +177,8 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_iop(self, FALSE, NC_("accel", "camera model"), 0, (GdkModifierType)0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "lens model"), 0, (GdkModifierType)0);
   dt_accel_register_iop(self, FALSE, NC_("accel", "select corrections"), 0, (GdkModifierType)0);
+
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "corrections"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -192,6 +194,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "scale", GTK_WIDGET(g->scale));
   dt_accel_connect_slider_iop(self, "TCA R", GTK_WIDGET(g->tca_r));
   dt_accel_connect_slider_iop(self, "TCA B", GTK_WIDGET(g->tca_b));
+
+  dt_accel_connect_combobox_iop(self, "corrections", GTK_WIDGET(g->modflags));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -179,6 +179,8 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_iop(self, FALSE, NC_("accel", "select corrections"), 0, (GdkModifierType)0);
 
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "corrections"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "geometry"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -196,6 +198,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "TCA B", GTK_WIDGET(g->tca_b));
 
   dt_accel_connect_combobox_iop(self, "corrections", GTK_WIDGET(g->modflags));
+  dt_accel_connect_combobox_iop(self, "geometry", GTK_WIDGET(g->target_geom));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->reverse));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -136,6 +136,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gray"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -145,6 +146,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "black", GTK_WIDGET(g->percentile_black));
   dt_accel_connect_slider_iop(self, "gray", GTK_WIDGET(g->percentile_grey));
   dt_accel_connect_slider_iop(self, "white", GTK_WIDGET(g->percentile_white));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -28,6 +28,7 @@
 #include "develop/imageop.h"
 #include "dtgtk/button.h"
 #include "gui/gtk.h"
+#include "gui/accelerators.h"
 #include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
@@ -143,6 +144,20 @@ int default_group()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_rgb;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "application color space"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation "));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "application color space", GTK_WIDGET(g->colorspace));
+  dt_accel_connect_combobox_iop(self, "interpolation ", GTK_WIDGET(g->interpolation ));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -121,26 +121,26 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
-//  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mode"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "linear"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "gamma"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "dynamic range"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "middle grey luma"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "black relative exposure"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "safety factor"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
 
-//  dt_accel_connect_slider_iop(self, "mode", GTK_WIDGET(g->mode));
   dt_accel_connect_slider_iop(self, "linear", GTK_WIDGET(g->linear));
   dt_accel_connect_slider_iop(self, "gamma", GTK_WIDGET(g->gamma));
   dt_accel_connect_slider_iop(self, "dynamic range", GTK_WIDGET(g->dynamic_range));
   dt_accel_connect_slider_iop(self, "middle grey luma", GTK_WIDGET(g->grey_point));
   dt_accel_connect_slider_iop(self, "black relative exposure", GTK_WIDGET(g->shadows_range));
   dt_accel_connect_slider_iop(self, "safety factor", GTK_WIDGET(g->security_factor));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->mode));
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -28,6 +28,7 @@
 #include "dtgtk/drawingarea.h"
 #include "gui/color_picker_proxy.h"
 #include "gui/presets.h"
+#include "gui/accelerators.h"
 #include "libs/colorpicker.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
@@ -140,6 +141,22 @@ int flags()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_rgb;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation method"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "mode"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "interpolation method", GTK_WIDGET(g->interpolator));
+  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
+  dt_accel_connect_combobox_iop(self, "mode", GTK_WIDGET(g->autoscale));
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -26,6 +26,7 @@
 #include "develop/imageop.h"
 #include "dtgtk/drawingarea.h"
 #include "gui/color_picker_proxy.h"
+#include "gui/accelerators.h"
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(5)
 
@@ -103,7 +104,6 @@ typedef struct dt_iop_rgblevels_global_data_t
   int kernel_levels;
 } dt_iop_rgblevels_global_data_t;
 
-
 const char *name()
 {
   return _("rgb levels");
@@ -122,6 +122,18 @@ int flags()
 int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   return iop_cs_rgb;
+}
+
+void init_key_accels(dt_iop_module_so_t *self)
+{
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
+}
+
+void connect_key_accels(dt_iop_module_t *self)
+{
+  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+
+  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->cmb_preserve_colors));
 }
 
 static void _turn_select_region_off(struct dt_iop_module_t *self)

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -280,6 +280,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "compress"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "shadows color correction"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "highlights color correction"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "soften with"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -293,6 +294,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "compress", GTK_WIDGET(g->compress));
   dt_accel_connect_slider_iop(self, "shadows color correction", GTK_WIDGET(g->shadows_ccorrect));
   dt_accel_connect_slider_iop(self, "highlights color correction", GTK_WIDGET(g->highlights_ccorrect));
+  dt_accel_connect_combobox_iop(self, "soften with", GTK_WIDGET(g->shadhi_algo));
 }
 
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -210,6 +210,7 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "red"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "green"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "blue"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "presets"));
 
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/camera"), 0, 0);
   dt_accel_register_iop(self, TRUE, NC_("accel", "preset/camera neutral"), 0, 0);
@@ -226,6 +227,7 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "green", GTK_WIDGET(g->scale_g));
   dt_accel_connect_slider_iop(self, "blue", GTK_WIDGET(g->scale_b));
   dt_accel_connect_slider_iop(self, "green2", GTK_WIDGET(g->scale_g2));
+  dt_accel_connect_combobox_iop(self, "presets", GTK_WIDGET(g->presets));
 
   GClosure *closure;
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -208,6 +208,10 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "base of the logarithm"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "interpolation method"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve colors"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "scale"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color space"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -215,6 +219,10 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
 
   dt_accel_connect_slider_iop(self, "base of the logarithm", GTK_WIDGET(g->logbase));
+  dt_accel_connect_combobox_iop(self, "interpolation method", GTK_WIDGET(g->interpolator));
+  dt_accel_connect_combobox_iop(self, "preserve colors", GTK_WIDGET(g->preserve_colors));
+  dt_accel_connect_combobox_iop(self, "scale", GTK_WIDGET(g->scale));
+  dt_accel_connect_combobox_iop(self, "color space", GTK_WIDGET(g->autoscale_ab));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -323,6 +323,8 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mask quantization"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mask exposure compensation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "mask contrast compensation"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "luminance estimator"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "preserve details"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -344,7 +346,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "mask quantization", GTK_WIDGET(g->quantization));
   dt_accel_connect_slider_iop(self, "mask exposure compensation", GTK_WIDGET(g->exposure_boost));
   dt_accel_connect_slider_iop(self, "mask contrast compensation", GTK_WIDGET(g->contrast_boost));
-
+  dt_accel_connect_combobox_iop(self, "luminance estimator", GTK_WIDGET(g->method));
+  dt_accel_connect_combobox_iop(self, "preserve details", GTK_WIDGET(g->details));
 }
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -312,6 +312,8 @@ void init_key_accels(dt_iop_module_so_t *self)
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "rotation"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "x offset"));
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "y offset"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "marker"));
+  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "scale on"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -324,6 +326,8 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_accel_connect_slider_iop(self, "rotation", GTK_WIDGET(g->rotate));
   dt_accel_connect_slider_iop(self, "x offset", GTK_WIDGET(g->x_offset));
   dt_accel_connect_slider_iop(self, "y offset", GTK_WIDGET(g->y_offset));
+  dt_accel_connect_combobox_iop(self, "marker", GTK_WIDGET(g->watermarks));
+  dt_accel_connect_combobox_iop(self, "scale on", GTK_WIDGET(g->sizeto));
 }
 
 static void _combo_box_set_active_text(dt_iop_watermark_gui_data_t *g, gchar *text)


### PR DESCRIPTION
This PR allow shortcuts to be assigned to previous and next values of a combobox in an iop module.

Each time the combobox value is changed through a keyboard shortcut its new value is displayed on an onscreen popup (similar to how changed slider values are displayed).

The following is a list of iop comboboxes included:

 basic group

- color reconstruction: "precedence"
- shadows & highlights: "soften with"
- base curve: "scale", "preserve colors", "fusion"
- basic adjustments: "preserve colors"
- tone equalizer: "luminance estimator", "preserve details"
- exposure: "mode"
- crop & rotate: "flip", "keystone", "automatic cropping", "aspect", "guides"
- demosaic: "method", "color smoothing", "match greens"
- highlight reconstruction: "method"
- white balance: "preset"

tone group

- local contrast: "mode"
- global tonemap: "operator"
- levels: "mode"
- tone curve: "color space", "interpolation method", "preserve colors", "scale"
- filmic rgb: "preserve chrominance"
- rgb levels: "preserve colors"
- rgb curve: "mode, "interpolation method", "preserve colors"

color group

- output color profile: "export profile"
- color zones: "select by", "process mode", "interpolation method"
- color balance: "mode", "color control sliders"
- channel mixer: "destination"
- lut 3D: "application color space", "interpolation"
- color look up table: "target color"
- input color profile: "input profile", "working profile", "gamut clipping"
- unbreak input profile: "mode"

correction group

- dithering: method
- defringe: operation mode
- perspective correction: "guides", "automatic cropping", "lens model"
- lens correction: "corrections", "geometry", "mode"
- denoise (profiled): "mode"

effects group

- watermark: "marker", "scale on"
- framing: "aspect", "orientation", "horizontal position", "vertical position"

Resolves #4356.