### PR TITLE
watermark - GLib-ERROR fix

### DIFF
--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -930,6 +930,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   /* get the dimension of svg */
   RsvgDimensionData dimension;
   rsvg_handle_get_dimensions(svg, &dimension);
+  // if no text is given dimensions are null
+  if(!dimension.width) dimension.width = 1;
+  if(!dimension.height) dimension.height = 1;
 
   //  width/height of current (possibly cropped) image
   const float iw = piece->buf_in.width;


### PR DESCRIPTION
GLib-ERROR overflow allocating when no text is given.
When this error occurs dt terminates.

I've just avoided the calculation issue.
Alternatively we could escape the process and log an error. 
Let me know.