### PR TITLE
metadata update

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3221,13 +3221,16 @@ static void dt_set_xmp_dt_metadata(Exiv2::XmpData &xmpData, const int imgid, con
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
     int keyid = sqlite3_column_int(stmt, 0);
-    if(export_flag)
+    if(export_flag && (dt_metadata_get_type(keyid) != DT_METADATA_TYPE_INTERNAL))
     {
       const gchar *name = dt_metadata_get_name(keyid);
       gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_private", name);
       const gboolean private_flag =  dt_conf_get_bool(setting);
       g_free(setting);
-      if(!private_flag)
+      setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_hidden", name);
+      const gboolean hidden_flag =  dt_conf_get_bool(setting);
+      g_free(setting);
+      if(!private_flag && !hidden_flag)
         xmpData[dt_metadata_get_key(keyid)] = sqlite3_column_text(stmt, 1);
     }
     else

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -38,15 +38,16 @@ static const struct
 {
   char *key;
   char *name;
+  int type;
   uint32_t display_order;
 } dt_metadata_def[] = {
   // clang-format off
-  {"Xmp.dc.creator", N_("creator"), 2},
-  {"Xmp.dc.publisher", N_("publisher"), 3},
-  {"Xmp.dc.title", N_("title"), 0},
-  {"Xmp.dc.description", N_("description"), 1},
-  {"Xmp.dc.rights", N_("rights"), 4},
-  {"Xmp.acdsee.notes", N_("notes"), 5}
+  {"Xmp.dc.creator", N_("creator"), DT_METADATA_TYPE_USER, 2},
+  {"Xmp.dc.publisher", N_("publisher"), DT_METADATA_TYPE_USER, 3},
+  {"Xmp.dc.title", N_("title"), DT_METADATA_TYPE_USER, 0},
+  {"Xmp.dc.description", N_("description"), DT_METADATA_TYPE_USER, 1},
+  {"Xmp.dc.rights", N_("rights"), DT_METADATA_TYPE_USER, 4},
+  {"Xmp.acdsee.notes", N_("notes"), DT_METADATA_TYPE_USER, 5}
   // clang-format on
 };
 
@@ -76,6 +77,19 @@ const dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order)
   return -1;
 }
 
+const int dt_metadata_get_type_by_display_order(const uint32_t order)
+{
+  if(order < DT_METADATA_NUMBER)
+  {
+    for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+    {
+      if(order == dt_metadata_def[i].display_order)
+        return dt_metadata_def[i].type;
+    }
+  }
+  return 0;
+}
+
 const char *dt_metadata_get_name(const uint32_t keyid)
 {
   if(keyid < DT_METADATA_NUMBER)
@@ -100,6 +114,14 @@ const char *dt_metadata_get_key(const uint32_t keyid)
     return dt_metadata_def[keyid].key;
   else
     return NULL;
+}
+
+const int dt_metadata_get_type(const uint32_t keyid)
+{
+  if(keyid < DT_METADATA_NUMBER)
+    return dt_metadata_def[keyid].type;
+  else
+    return 0;
 }
 
 typedef struct dt_undo_metadata_t

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -35,11 +35,22 @@ typedef enum dt_metadata_t
 }
 dt_metadata_t;
 
+typedef enum dt_metadata_type_t
+{
+  DT_METADATA_TYPE_USER,     // metadata for users
+  DT_METADATA_TYPE_OPTIONAL, // metadata hidden by default
+  DT_METADATA_TYPE_INTERNAL  // metadata for dt internal usage - the user cannot see it
+}
+dt_metadata_type_t;
+
 /** return the metadata key by display order */
 const char *dt_metadata_get_name_by_display_order(const uint32_t order);
 
 /** return the metadata keyid by display order */
 const dt_metadata_t dt_metadata_get_keyid_by_display_order(const uint32_t order);
+
+/** return the metadata type by display order */
+const int dt_metadata_get_type_by_display_order(const uint32_t order);
 
 /** return the metadata name of the metadata keyid */
 const char *dt_metadata_get_name(const uint32_t keyid);
@@ -47,8 +58,11 @@ const char *dt_metadata_get_name(const uint32_t keyid);
 /** return the keyid of the metadata key */
 const dt_metadata_t dt_metadata_get_keyid(const char* key);
 
-/** retunr the key of the metadata keyid */
+/** return the key of the metadata keyid */
 const char *dt_metadata_get_key(const uint32_t keyid);
+
+/** return the type of the metadata keyid */
+const int dt_metadata_get_type(const uint32_t keyid);
 
 /** Set metadata for a specific image, or all selected for id == -1. */
 void dt_metadata_set(int id, const char *key, const char *value, const gboolean undo_on, const gboolean group_on); // exif.cc, ligthroom.c, duplicate.c, lua/image.c

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -551,12 +551,13 @@ static GtkWidget *_lib_import_get_extra_widget(dt_lib_module_t *self,dt_lib_impo
   gtk_grid_attach(GTK_GRID(grid), label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), presets, label, GTK_POS_RIGHT, 1, 1);
 
+  GtkWidget *metadata_label[DT_METADATA_NUMBER];
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
-    label = gtk_label_new(_(metadata_name[i]));
-    gtk_widget_set_halign(label, GTK_ALIGN_START);
-    gtk_grid_attach(GTK_GRID(grid), label, 0, line++, 1, 1);
-    gtk_grid_attach_next_to(GTK_GRID(grid), metadata[i], label, GTK_POS_RIGHT, 1, 1);
+    metadata_label[i] = gtk_label_new(_(metadata_name[i]));
+    gtk_widget_set_halign(metadata_label[i], GTK_ALIGN_START);
+    gtk_grid_attach(GTK_GRID(grid), metadata_label[i], 0, line++, 1, 1);
+    gtk_grid_attach_next_to(GTK_GRID(grid), metadata[i], metadata_label[i], GTK_POS_RIGHT, 1, 1);
   }
 
   label = gtk_label_new(_("tags"));
@@ -565,6 +566,19 @@ static GtkWidget *_lib_import_get_extra_widget(dt_lib_module_t *self,dt_lib_impo
   gtk_grid_attach_next_to(GTK_GRID(grid), tags, label, GTK_POS_RIGHT, 1, 1);
 
   gtk_widget_show_all(frame);
+
+  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+  {
+    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_hidden", metadata_name[i]);
+    const gboolean hidden = dt_conf_get_bool(setting);
+    g_free(setting);
+    const int meta_type = dt_metadata_get_type_by_display_order(i);
+    if(meta_type == DT_METADATA_TYPE_INTERNAL || hidden)
+    {
+      gtk_widget_hide(metadata_label[i]);
+      gtk_widget_hide(metadata[i]);
+    }
+  }
 
   if(data != NULL)
   {

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -509,7 +509,8 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       gchar *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_hidden", name);
       const gboolean hidden = dt_conf_get_bool(setting);
       g_free(setting);
-      if(hidden)
+      const int meta_type = dt_metadata_get_type(keyid);
+      if(meta_type == DT_METADATA_TYPE_INTERNAL || hidden)
       {
         gtk_widget_hide(GTK_WIDGET(d->name[md_xmp_metadata+i]));
         gtk_widget_hide(GTK_WIDGET(d->metadata[md_xmp_metadata+i]));


### PR DESCRIPTION
- add internal, optional and user metadata types
- add tooltips and fix some incoherences

Internal metadata allows dev to use metadata mechanisms (read/write <-> db & xmp) for internal information without interfering with user's metadata (today metadata). They are not visible to the user.

Optional metadata are per default hidden, but can be set visible by the user if he finds them useful.

Internal and hidden metadata are not visible in metadata editor, image information and import modules. They are not exported.

An example of this is the PR #4477 `version name` which belongs to duplicate module.
As it represents the duplicate name field, it should be internal. 
One can argue he wants to use it outside duplicate module (for images without duplicate). In this case it should be optional. To be decided.

NB: even if metadata `version name` is set as internal, and as such not exported with images, the corresponding variable `$(VERSION_NAME)` still allows the user to export the value.

