### PR TITLE
Update CSS on @AlicVB lighttable rewrite

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -41,13 +41,14 @@
 @define-color plugin_label_color @grey_75;
 
 /* Modules controls (sliders and comboboxes) */
-@define-color bauhaus_fg @grey_85;
+@define-color bauhaus_fg @grey_80;
 @define-color bauhaus_border shade(@plugin_bg_color, 0.5);
 @define-color bauhaus_indicator_border @grey_35;
 @define-color bauhaus_fill @grey_55;
 @define-color bauhaus_bg @grey_30;
-@define-color bauhaus_fg_hover @grey_100;
-@define-color bauhaus_fg_selected @grey_95;
+@define-color bauhaus_fg_hover @grey_90;
+@define-color bauhaus_fg_selected @grey_85;
+@define-color bauhaus_fg_disabled @grey_80;
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.5);
 
 /* GTK Buttons and tabs */
@@ -78,20 +79,21 @@
 /* Views */
 @define-color darkroom_bg_color @grey_60;
 @define-color darkroom_preview_bg_color @grey_50;
-@define-color lighttable_bg_color @grey_60;
+@define-color print_bg_color @grey_60;
+@define-color lighttable_bg_color @print_bg_color;
 @define-color lighttable_preview_bg_color @grey_50;
 @define-color lighttable_bg_font_color @grey_85;
-@define-color print_bg_color @grey_60;
 
 /* Lighttable and film-strip */
 @define-color thumbnail_font_color @grey_65;
-@define-color thumbnail_bg_color @grey_55; /* area between border and outline */
-@define-color thumbnail_outline_color @grey_65; /* square around image+metadata */
+@define-color thumbnail_bg_color @grey_55;
+@define-color thumbnail_outline_color @grey_65;
 @define-color thumbnail_selected_font_color @grey_65;
 @define-color thumbnail_selected_bg_color @grey_75;
 @define-color thumbnail_selected_outline_color @grey_65;
-@define-color thumbnail_hover_font_color @grey_65;
-@define-color thumbnail_hover_bg_color @grey_95;
+@define-color thumbnail_hover_font_color @grey_60;
+@define-color thumbnail_hover_bg_color @grey_90;
+@define-color thumbnail_hover_fg_color @grey_75;
 @define-color thumbnail_hover_outline_color @grey_65;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -48,8 +48,9 @@
 @define-color bauhaus_indicator_border @grey_50;
 @define-color bauhaus_fill @grey_70;
 @define-color bauhaus_bg @grey_45;
-@define-color bauhaus_fg_hover @grey_100;
-@define-color bauhaus_fg_selected @grey_95;
+@define-color bauhaus_fg_hover @grey_90;
+@define-color bauhaus_fg_selected @grey_85;
+@define-color bauhaus_fg_disabled @grey_80;
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.5);
 
 /* GTK Buttons and tabs */
@@ -80,21 +81,22 @@
 /* Views */
 @define-color darkroom_bg_color @grey_75;
 @define-color darkroom_preview_bg_color @grey_65;
-@define-color lighttable_bg_color @grey_75;
+@define-color print_bg_color @grey_75;
+@define-color lighttable_bg_color @print_bg_color;
 @define-color lighttable_preview_bg_color @grey_65;
 @define-color lighttable_bg_font_color @grey_95;
-@define-color print_bg_color @grey_75;
 
 /* Lighttable and film-strip */
 @define-color thumbnail_font_color @grey_80;
-@define-color thumbnail_bg_color @grey_70; /* area between border and outline */
-@define-color thumbnail_outline_color @grey_80; /* square around image+metadata */
+@define-color thumbnail_bg_color @grey_70;
+@define-color thumbnail_outline_color @grey_80;
 @define-color thumbnail_selected_font_color @grey_80;
 @define-color thumbnail_selected_bg_color @grey_90;
-@define-color thumbnail_selected_outline_color @grey_80;
-@define-color thumbnail_hover_font_color @grey_80;
-@define-color thumbnail_hover_bg_color @grey_100;
-@define-color thumbnail_hover_outline_color @grey_80;
+@define-color thumbnail_selected_outline_color @grey_60;
+@define-color thumbnail_hover_font_color @grey_55;
+@define-color thumbnail_hover_bg_color @grey_85;
+@define-color thumbnail_hover_fg_color @grey_70;
+@define-color thumbnail_hover_outline_color @grey_60;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -122,28 +122,30 @@
 /* Views */
 @define-color darkroom_bg_color @grey_45;
 @define-color darkroom_preview_bg_color @grey_35;
-@define-color lighttable_bg_color @grey_45;
+@define-color print_bg_color @grey_45;
+@define-color lighttable_bg_color @print_bg_color;
 @define-color lighttable_preview_bg_color @grey_35;
 @define-color lighttable_bg_font_color @grey_75;
-@define-color print_bg_color @grey_45;
-
-/* Brushes */
-@define-color brush_cursor alpha(white, .9);
-@define-color brush_trace alpha(black, .8);
 
 /* Lighttable and film-strip */
 @define-color thumbnail_font_color @grey_50;
-@define-color thumbnail_bg_color @grey_40; /* area between border and outline */
-@define-color thumbnail_outline_color @grey_50; /* square around image+metadata */
+@define-color thumbnail_bg_color @grey_40;
+@define-color thumbnail_bg50_color @grey_100;
+@define-color thumbnail_outline_color @grey_50;
 @define-color thumbnail_selected_font_color @grey_50;
 @define-color thumbnail_selected_bg_color @grey_60;
 @define-color thumbnail_selected_outline_color @grey_50;
 @define-color thumbnail_hover_font_color @grey_50;
 @define-color thumbnail_hover_bg_color @grey_80;
+@define-color thumbnail_hover_fg_color @grey_70;
 @define-color thumbnail_hover_outline_color @grey_50;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 @define-color culling_selected_border_color @grey_10;
 @define-color culling_filmstrip_selected_border_color @grey_10;
+
+/* Brushes */
+@define-color brush_cursor alpha(white, .9);
+@define-color brush_trace alpha(black, .8);
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
 @define-color graph_bg @grey_10;
@@ -1444,7 +1446,7 @@ Details :
 @keyframes lastactive
 {
   0% {border-color: @lighttable_bg_color; border-width : 2px;}
-  50% {border-color: @grey_100; border-width : 6px;}
+  50% {border-color: @thumbnail_bg50_color; border-width : 6px;}
   100% {border-color: @lighttable_bg_color; border-width : 2px;}
 }
 #thumb_back
@@ -1513,7 +1515,7 @@ Details :
 }
 #thumb_main:active #thumb_image
 {
-  border: 2px solid @grey_20;
+  border: 2px solid @plugin_bg_color;
 }
 
 /* bottom area */
@@ -1582,13 +1584,13 @@ Details :
 #thumb_main:hover #thumb_star:active,
 .dt_show_overlays #thumb_star:active
 {
-  color: @grey_90;
+  color: @bauhaus_fg_hover;
   background-color: @thumbnail_hover_outline_color;
 }
 #thumb_main:hover #thumb_star:hover
 {
-  color: @grey_90;
-  background-color: @grey_70;
+  color: @bauhaus_fg_hover;
+  background-color: @thumbnail_hover_fg_color;
 }
 
 /* local copy */
@@ -1629,7 +1631,7 @@ Details :
 .dt_show_overlays #thumb_group:active,
 .dt_show_overlays #thumb_audio:hover
 {
-  color: @grey_70;
+  color: @thumbnail_hover_fg_color;
 }
 
 #log-msg


### PR DESCRIPTION
Update of the themes since lighttable rewrite by @AlicVB.

I have fix text over thumbnail and make stars and icons (group, altered...) consistent between them and between themes. I have also just move some lines to just order them (lighttable ones near them, easier to update files). See #4487 

Before merging, please check all things I've change and especially minor updates this work made on bauhaus parts (I've checked many modules on darkroom and all is good but I could have forgot something).

Of course, review by @aurelienpierre and @AlicVB as they had work respectively on GUI and lighttable are especially requested. All others reviews are of course welcomed.