### PR TITLE
Fix invalid CMake syntax

### DIFF
--- a/data/kernels/CMakeLists.txt
+++ b/data/kernels/CMakeLists.txt
@@ -31,8 +31,8 @@ macro (testcompile_opencl_kernel IN)
 endmacro (testcompile_opencl_kernel)
 
 if (TESTBUILD_OPENCL_PROGRAMS)
-  foreach(IN ${DT_OPENCL_KERNELS})
-    testcompile_opencl_kernel(${IN})
+  foreach(KERNEL IN ITEMS ${DT_OPENCL_KERNELS})
+    testcompile_opencl_kernel(${KERNEL})
   endforeach()
 endif()
 


### PR DESCRIPTION
The syntax of the foreach statement in data/kernels/CMakeLists.txt
was invalid. This lead to errors when running cmake.

Use correct syntax to make the build work.