### PR TITLE
Respect scrollbar option while in filestrip mode

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -846,15 +846,21 @@ static gboolean _event_button_release(GtkWidget *widget, GdkEventButton *event, 
 static void _thumbtable_restore_scrollbars(dt_thumbtable_t *table)
 {
   table->scrollbars = FALSE;
-  if(table->mode != DT_THUMBTABLE_MODE_FILMSTRIP)
-  {
-    char *scrollbars_conf = dt_conf_get_string("scrollbars");
 
-    if(scrollbars_conf)
+  char *scrollbars_conf = dt_conf_get_string("scrollbars");
+  if(scrollbars_conf)
+  {
+    if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
+    {
+      if(!strcmp(scrollbars_conf, "lighttable + darkroom")) table->scrollbars = TRUE;
+    }
+
+    if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
     {
       if(strcmp(scrollbars_conf, "no scrollbars")) table->scrollbars = TRUE;
-      g_free(scrollbars_conf);
-    }
+    } 
+
+    g_free(scrollbars_conf);
   }
   dt_ui_scrollbars_show(darktable.gui->ui, table->scrollbars);
 }


### PR DESCRIPTION
In `src/dtgtk/thumbtable.c` `_thumbtable_restore_scrollbars` there seem to be a wrong
checking for the configure option "scrollbars" depending on table->mode.

While in `DT_THUMBTABLE_MODE_ZOOM` mode the scrollbars should be off, in `DT_THUMBTABLE_MODE_FILMSTRIP` mode we should check for the "also darkroom" option.
