### PR TITLE
bugfix: ensure correct handling of darkroom/ui/single_module

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -848,8 +848,8 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
 
   if(dt_conf_get_bool("darkroom/ui/single_module"))
   {
-    dt_iop_gui_set_expanded(base, FALSE, FALSE);
-    dt_iop_gui_set_expanded(module, TRUE, FALSE);
+    dt_iop_gui_set_expanded(base, FALSE, TRUE);
+    dt_iop_gui_set_expanded(module, TRUE, TRUE);
   }
 
   /* setup key accelerators */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -887,7 +887,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
         /* add module to right panel */
         GtkWidget *expander = dt_iop_gui_get_expander(module);
         dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
-        dt_iop_gui_set_expanded(module, FALSE, FALSE);
+        dt_iop_gui_set_expanded(module, FALSE, dt_conf_get_bool("darkroom/ui/single_module"));
         dt_iop_gui_update_blending(module);
       }
 
@@ -2573,7 +2573,11 @@ void enter(dt_view_t *self)
       dt_ui_container_add_widget(darktable.gui->ui, DT_UI_CONTAINER_PANEL_RIGHT_CENTER, expander);
 
       snprintf(option, sizeof(option), "plugins/darkroom/%s/expanded", module->op);
-      dt_iop_gui_set_expanded(module, dt_conf_get_bool(option), FALSE);
+      if(dt_conf_get_bool(option))
+        dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
+      else
+        dt_iop_gui_set_expanded(module, FALSE, FALSE);
+        
     }
 
     /* setup key accelerators (only if not hidden) */


### PR DESCRIPTION
option to ensure that only one darkroom module is expanded at a time is now
correctly observed in the following scenarios:

 - when creating a new module instance
 - when opening a new image from the lighttable

Resolves #3584