### PR TITLE
bugfix: set/lose focus when expanding/collapsing modules

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2127,8 +2127,11 @@ static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *accele
     dt_dev_modulegroups_switch(darktable.develop, module);
   }
 
-  dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
-  dt_iop_request_focus(module);
+  dt_iop_gui_set_expanded(module, !module->expanded, dt_conf_get_bool("darkroom/ui/single_module"));
+  if(module->expanded)
+  {
+    dt_iop_request_focus(module);
+  }
   return TRUE;
 }
 


### PR DESCRIPTION
Ensure focus is set correctly when expanding/collapsing modules using keyboard shortcut.

Resolves issues around crop/rotate guides remaining on screen when module collapsed and not reappearing when expanded.