### PR TITLE
thumb : add configurable tooltip

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -648,6 +648,13 @@
     <shortdescription>enable extended thumb overlay</shortdescription>
     <longdescription>if set to true, thumb overlay shows filename and some exif data.</longdescription>
   </dtconfig>
+  <dtconfig prefs="gui" section="lighttable">
+    <name>plugins/lighttable/thumbnail_tooltip_pattern</name>
+    <type>string</type>
+    <default>&lt;b&gt;$(FILE_NAME).$(FILE_EXTENSION)&lt;/b&gt;$(NL)$(EXIF_DAY)/$(EXIF_MONTH)/$(EXIF_YEAR) $(EXIF_HOUR):$(EXIF_MINUTE):$(EXIF_SECOND)$(NL)$(EXIF_EXPOSURE) s • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • ISO $(EXIF_ISO)</default>
+    <shortdescription>pattern for the thumbnail tooltip (empty to disable)</shortdescription>
+    <longdescription>see manual to know all the tags you can use.</longdescription>
+  </dtconfig>
   <dtconfig prefs="gui" section="darkroom">
     <name>pressure_sensitivity</name>
     <type>

--- a/src/common/usermanual_url.c
+++ b/src/common/usermanual_url.c
@@ -52,6 +52,8 @@ char *dt_get_help_url(char *name)
   if(!strcmp(name, "global_toolbox_preferences")) return "preferences.html#preferences";
   if(!strcmp(name, "global_toolbox_help")) return "contextual_help.html#contextual_help";
   if(!strcmp(name, "lighttable_mode")) return "lighttable_chapter.html#lighttable_overview";
+  if(!strcmp(name, "lighttable_filemanager")) return "lighttable_chapter.html#lighttable_filemanager";
+  if(!strcmp(name, "lighttable_zoomable")) return "lighttable_chapter.html#lighttable_zoomable";
   if(!strcmp(name, "module_toolbox")) return NULL;
   if(!strcmp(name, "view_toolbox")) return NULL;
   if(!strcmp(name, "backgroundjobs")) return NULL;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -389,6 +389,38 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   _set_flag(thumb->w_group, GTK_STATE_FLAG_ACTIVE, (thumb->imgid == thumb->groupid));
 
   _set_flag(thumb->w_main, GTK_STATE_FLAG_SELECTED, thumb->selected);
+
+  // and the tooltip
+  gchar *pattern = dt_conf_get_string("plugins/lighttable/thumbnail_tooltip_pattern");
+  if(strcmp(pattern, "") == 0)
+  {
+    gtk_widget_set_has_tooltip(thumb->w_main, FALSE);
+  }
+  else
+  {
+    // we compute the info line (we reuse the function used in export to disk)
+    char input_dir[1024] = { 0 };
+    gboolean from_cache = TRUE;
+    dt_image_full_path(thumb->imgid, input_dir, sizeof(input_dir), &from_cache);
+
+    dt_variables_params_t *vp;
+    dt_variables_params_init(&vp);
+
+    vp->filename = input_dir;
+    vp->jobcode = "infos";
+    vp->imgid = thumb->imgid;
+    vp->sequence = 0;
+
+    gchar *msg = dt_variables_expand(vp, pattern, TRUE);
+
+    dt_variables_params_destroy(vp);
+
+    // we change the label
+    gtk_widget_set_tooltip_markup(thumb->w_main, msg);
+
+    g_free(msg);
+  }
+  g_free(pattern);
 }
 
 static void _dt_selection_changed_callback(gpointer instance, gpointer user_data)

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -858,7 +858,7 @@ static void _thumbtable_restore_scrollbars(dt_thumbtable_t *table)
     if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
     {
       if(strcmp(scrollbars_conf, "no scrollbars")) table->scrollbars = TRUE;
-    } 
+    }
 
     g_free(scrollbars_conf);
   }
@@ -1307,6 +1307,7 @@ dt_thumbtable_t *dt_thumbtable_new()
 {
   dt_thumbtable_t *table = (dt_thumbtable_t *)calloc(1, sizeof(dt_thumbtable_t));
   table->widget = gtk_layout_new(NULL, NULL);
+  dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
 
   // set css name and class
   gtk_widget_set_name(table->widget, "thumbtable_filemanager");
@@ -1580,11 +1581,20 @@ void dt_thumbtable_set_parent(dt_thumbtable_t *table, GtkWidget *new_parent, dt_
   {
     // we change the widget name
     if(mode == DT_THUMBTABLE_MODE_FILEMANAGER)
+    {
       gtk_widget_set_name(table->widget, "thumbtable_filemanager");
+      dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_filemanager"));
+    }
     else if(mode == DT_THUMBTABLE_MODE_FILMSTRIP)
+    {
       gtk_widget_set_name(table->widget, "thumbtable_filmstrip");
+      dt_gui_add_help_link(table->widget, dt_get_help_url("filmstrip"));
+    }
     else if(mode == DT_THUMBTABLE_MODE_ZOOM)
+    {
       gtk_widget_set_name(table->widget, "thumbtable_zoom");
+      dt_gui_add_help_link(table->widget, dt_get_help_url("lighttable_zoomable"));
+    }
 
     // if needed, we block/unblock drag and drop
     if(mode == DT_THUMBTABLE_MODE_ZOOM)


### PR DESCRIPTION
this fix #4441 
tooltip content can be set in preference dialog. It use same tags as the info line tool.
If set to empty string, no tooltip is shown