### PR TITLE
colorspace profiles sinc between linux and windows work environments

### DIFF
--- a/src/common/colorspaces.c
+++ b/src/common/colorspaces.c
@@ -1940,7 +1940,7 @@ gboolean dt_colorspaces_is_profile_equal(const char *fullname, const char *filen
   // basename as recorded in an iop.
   return _colorspaces_is_base_name(filename)
     ? !strcmp(_colorspaces_get_base_name(fullname), filename)
-    : !strcmp(fullname, filename);
+    : !strcmp(_colorspaces_get_base_name(fullname), _colorspaces_get_base_name(filename));
 }
 
 static const dt_colorspaces_color_profile_t *_get_profile(dt_colorspaces_t *self,


### PR DESCRIPTION
Hi

I created an icc-profile for my camera and am trying to use it in  “input color profile”.
I can select it in the "input profile" list. And i created a new automatically applied preset “MyPreset”.
This works fine until i transfer the working directory to a computer with different OS (Windows or Linux).
All changes are transferred correctly except for “MyPreset”: the program cannot find  icc-profile of the camera, although it is present in “input profile” list. And i have to choose it manually for each shot.

I found this simple solution to this problem.

As far as I understand the correspondence of the profile found in the system to the profile specified in the editing history is checked here. And at the same time I suppose that there is no difference in which of  four directories the profile file is located.