### PR TITLE
more top/bottom panels accels

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -663,13 +663,6 @@ int dt_control_key_pressed_override(guint key, guint state)
     gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
     return 1;
   }
-  else if(key == accels->global_header.accel_key && state == accels->global_header.accel_mods)
-  {
-    /* toggle panel viewstate */
-    dt_ui_toggle_header(darktable.gui->ui);
-    gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
-    return 1;
-  }
   // add an option to allow skip mouse events while editing masks
   else if(key == accels->darkroom_skip_mouse_events.accel_key && state == accels->darkroom_skip_mouse_events.accel_mods)
   {

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -120,7 +120,7 @@ typedef struct dt_control_accels_t
       lighttable_sel_down, lighttable_sel_right, lighttable_sel_left, lighttable_sel_pageup,
       lighttable_sel_pagedown, lighttable_sel_start, lighttable_sel_end, lighttable_center, lighttable_preview,
       lighttable_preview_display_focus, lighttable_timeline, lighttable_preview_zoom_100,
-      lighttable_preview_zoom_fit, global_focus_peaking, global_sideborders, global_header, global_accels_window,
+      lighttable_preview_zoom_fit, global_focus_peaking, global_sideborders, global_accels_window,
       darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out, darkroom_skip_mouse_events,
       darkroom_search_modules_focus;
 } dt_control_accels_t;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -431,8 +431,42 @@ static gboolean _toggle_panel_accel_callback(GtkAccelGroup *accel_group, GObject
 static gboolean _toggle_header_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                               GdkModifierType modifier, gpointer data)
 {
-  dt_ui_toggle_header(darktable.gui->ui);
-  gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, !_panel_is_visible(DT_UI_PANEL_TOP), TRUE);
+  return TRUE;
+}
+static gboolean _toggle_filmstrip_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                                 GdkModifierType modifier, gpointer data)
+{
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !_panel_is_visible(DT_UI_PANEL_BOTTOM), TRUE);
+  return TRUE;
+}
+static gboolean _toggle_top_tool_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                                GdkModifierType modifier, gpointer data)
+{
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, !_panel_is_visible(DT_UI_PANEL_CENTER_TOP), TRUE);
+  return TRUE;
+}
+static gboolean _toggle_bottom_tool_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
+                                                   guint keyval, GdkModifierType modifier, gpointer data)
+{
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, !_panel_is_visible(DT_UI_PANEL_CENTER_BOTTOM),
+                   TRUE);
+  return TRUE;
+}
+static gboolean _toggle_top_all_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                               GdkModifierType modifier, gpointer data)
+{
+  const gboolean v = (_panel_is_visible(DT_UI_PANEL_CENTER_TOP) || _panel_is_visible(DT_UI_PANEL_TOP));
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_TOP, !v, TRUE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_TOP, !v, TRUE);
+  return TRUE;
+}
+static gboolean _toggle_bottom_all_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                                  GdkModifierType modifier, gpointer data)
+{
+  const gboolean v = (_panel_is_visible(DT_UI_PANEL_CENTER_BOTTOM) || _panel_is_visible(DT_UI_PANEL_BOTTOM));
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !v, TRUE);
+  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_CENTER_BOTTOM, !v, TRUE);
   return TRUE;
 }
 
@@ -1314,6 +1348,26 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_accel_register_global(NC_("accel", "toggle header"), GDK_KEY_h, GDK_CONTROL_MASK);
   dt_accel_connect_global("toggle header", g_cclosure_new(G_CALLBACK(_toggle_header_accel_callback), NULL, NULL));
 
+  dt_accel_register_global(NC_("accel", "toggle filmstrip and timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
+  dt_accel_connect_global("toggle filmstrip and timeline",
+                          g_cclosure_new(G_CALLBACK(_toggle_filmstrip_accel_callback), NULL, NULL));
+
+  dt_accel_register_global(NC_("accel", "toggle top toolbar"), 0, 0);
+  dt_accel_connect_global("toggle top toolbar",
+                          g_cclosure_new(G_CALLBACK(_toggle_top_tool_accel_callback), NULL, NULL));
+
+  dt_accel_register_global(NC_("accel", "toggle bottom toolbar"), 0, 0);
+  dt_accel_connect_global("toggle bottom toolbar",
+                          g_cclosure_new(G_CALLBACK(_toggle_bottom_tool_accel_callback), NULL, NULL));
+
+  dt_accel_register_global(NC_("accel", "toggle all top panels"), 0, 0);
+  dt_accel_connect_global("toggle all top panels",
+                          g_cclosure_new(G_CALLBACK(_toggle_top_all_accel_callback), NULL, NULL));
+
+  dt_accel_register_global(NC_("accel", "toggle all bottom panels"), 0, 0);
+  dt_accel_connect_global("toggle all bottom panels",
+                          g_cclosure_new(G_CALLBACK(_toggle_bottom_all_accel_callback), NULL, NULL));
+
   // toggle focus peaking everywhere
   dt_accel_register_global(NC_("accel", "toggle focus peaking"), GDK_KEY_f, GDK_CONTROL_MASK | GDK_SHIFT_MASK);
   dt_accel_connect_global("toggle focus peaking",
@@ -1747,13 +1801,6 @@ void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui)
   }
 
   dt_ui_restore_panels(ui);
-  g_free(key);
-}
-
-void dt_ui_toggle_header(struct dt_ui_t *ui)
-{
-  gchar *key = _panels_get_panel_path(DT_UI_PANEL_TOP, "_visible");
-  dt_ui_panel_show(ui, DT_UI_PANEL_TOP, !dt_conf_get_bool(key), TRUE);
   g_free(key);
 }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -232,9 +232,6 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   dt_accel_path_global(path, sizeof(path), "toggle side borders");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_sideborders);
 
-  dt_accel_path_global(path, sizeof(path), "toggle header");
-  gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_header);
-
   dt_accel_path_global(path, sizeof(path), "zoom in");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_zoom_in);
 
@@ -431,6 +428,14 @@ static gboolean _toggle_panel_accel_callback(GtkAccelGroup *accel_group, GObject
 
   return TRUE;
 }
+static gboolean _toggle_header_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                              GdkModifierType modifier, gpointer data)
+{
+  dt_ui_toggle_header(darktable.gui->ui);
+  gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
+  return TRUE;
+}
+
 
 static gboolean borders_button_pressed(GtkWidget *w, GdkEventButton *event, gpointer user_data)
 {
@@ -1305,8 +1310,9 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
   dt_accel_connect_global("toggle bottom panel", g_cclosure_new(G_CALLBACK(_toggle_panel_accel_callback),
                                                                 GINT_TO_POINTER(DT_UI_BORDER_BOTTOM), NULL));
 
-  // toggle view of header
+  // specific top/bottom toggles
   dt_accel_register_global(NC_("accel", "toggle header"), GDK_KEY_h, GDK_CONTROL_MASK);
+  dt_accel_connect_global("toggle header", g_cclosure_new(G_CALLBACK(_toggle_header_accel_callback), NULL, NULL));
 
   // toggle focus peaking everywhere
   dt_accel_register_global(NC_("accel", "toggle focus peaking"), GDK_KEY_f, GDK_CONTROL_MASK | GDK_SHIFT_MASK);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -310,8 +310,6 @@ void dt_ui_update_scrollbars(struct dt_ui_t *ui);
 void dt_ui_scrollbars_show(struct dt_ui_t *ui, gboolean show);
 /** \brief toggle view of panels eg. collaps/expands to previous view state */
 void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
-/** \brief toggle view of header */
-void dt_ui_toggle_header(struct dt_ui_t *ui);
 /** \brief draw user's attention */
 void dt_ui_notify_user();
 /** \brief get visible state of panel */

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -69,9 +69,6 @@
 
 DT_MODULE(1)
 
-static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data);
-
 static gboolean zoom_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                GdkModifierType modifier, gpointer data);
 
@@ -1048,17 +1045,6 @@ static gboolean zoom_key_accel(GtkAccelGroup *accel_group, GObject *acceleratabl
   dt_dev_invalidate(dev);
   dt_control_queue_redraw_center();
   dt_control_navigation_redraw();
-  return TRUE;
-}
-
-static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data)
-{
-  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
-  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-  // if we show the panel, ensure that filmstrip is visible
-  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
   return TRUE;
 }
 
@@ -2577,7 +2563,6 @@ void enter(dt_view_t *self)
         dt_iop_gui_set_expanded(module, TRUE, dt_conf_get_bool("darkroom/ui/single_module"));
       else
         dt_iop_gui_set_expanded(module, FALSE, FALSE);
-        
     }
 
     /* setup key accelerators (only if not hidden) */
@@ -2871,7 +2856,7 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     // module requested a color box
     if(mouse_in_imagearea(self, x, y))
     {
-      // Make sure a minimal width/height 
+      // Make sure a minimal width/height
       float delta_x = 1 / (float) dev->pipe->processed_width;
       float delta_y = 1 / (float) dev->pipe->processed_height;
 
@@ -3372,9 +3357,6 @@ void configure(dt_view_t *self, int wd, int ht)
 
 void init_key_accels(dt_view_t *self)
 {
-  // Film strip shortcuts
-  dt_accel_register_view(self, NC_("accel", "toggle film strip"), GDK_KEY_f, GDK_CONTROL_MASK);
-
   // Zoom shortcuts
   dt_accel_register_view(self, NC_("accel", "zoom close-up"), GDK_KEY_1, GDK_MOD1_MASK);
   dt_accel_register_view(self, NC_("accel", "zoom fill"), GDK_KEY_2, GDK_MOD1_MASK);
@@ -3446,10 +3428,6 @@ void connect_key_accels(dt_view_t *self)
 {
   GClosure *closure;
   dt_develop_t *data = (dt_develop_t *)self->data;
-
-  // Film strip shortcuts
-  closure = g_cclosure_new(G_CALLBACK(film_strip_key_accel), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle film strip", closure);
 
   // Zoom shortcuts
   closure = g_cclosure_new(G_CALLBACK(zoom_key_accel), GINT_TO_POINTER(1), NULL);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -839,7 +839,7 @@ static int expose_empty(dt_view_t *self, cairo_t *cr, int32_t width, int32_t hei
   const float offy = height * 0.2f;
   const float offx = DT_PIXEL_APPLY_DPI(60);
   const float at = 0.3f;
-  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG); 
+  dt_gui_gtk_set_source_rgb(cr, DT_GUI_COLOR_LIGHTTABLE_BG);
   cairo_rectangle(cr, 0, 0, width, height);
   cairo_fill(cr);
 
@@ -2963,33 +2963,6 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   return 0;
 }
 
-static gboolean timeline_key_accel_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                            GdkModifierType modifier, gpointer data)
-{
-  dt_view_t *self = darktable.view_manager->proxy.lighttable.view;
-  dt_library_t *lib = (dt_library_t *)self->data;
-
-  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
-
-  if(get_layout() == DT_LIGHTTABLE_LAYOUT_CULLING || lib->full_preview_id != -1)
-  {
-    // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-    // we want to be sure that lib visibility are ok for this view
-    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
-    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE);
-  }
-  else
-  {
-    // there's only timeline in bottom panel, so better hide/show it instead of timeline lib
-    dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-    // we want to be sure that lib visibility are ok for this view
-    dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, FALSE);
-    dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, TRUE);
-  }
-  return TRUE;
-}
-
 void init_key_accels(dt_view_t *self)
 {
   // movement keys
@@ -3031,9 +3004,6 @@ void init_key_accels(dt_view_t *self)
   // zoom for full preview
   dt_accel_register_view(self, NC_("accel", "preview zoom 100%"), 0, 0);
   dt_accel_register_view(self, NC_("accel", "preview zoom fit"), 0, 0);
-
-  // timeline
-  dt_accel_register_view(self, NC_("accel", "toggle filmstrip or timeline"), GDK_KEY_f, GDK_CONTROL_MASK);
 }
 
 static gboolean _lighttable_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -3149,10 +3119,6 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "preview zoom 100%", closure);
   closure = g_cclosure_new(G_CALLBACK(_lighttable_preview_zoom_fit), (gpointer)self, NULL);
   dt_accel_connect_view(self, "preview zoom fit", closure);
-
-  // timeline
-  closure = g_cclosure_new(G_CALLBACK(timeline_key_accel_callback), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle filmstrip or timeline", closure);
 }
 
 GSList *mouse_actions(const dt_view_t *self)

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -899,8 +899,6 @@ void init_key_accels(dt_view_t *self)
 {
   dt_accel_register_view(self, NC_("accel", "undo"), GDK_KEY_z, GDK_CONTROL_MASK);
   dt_accel_register_view(self, NC_("accel", "redo"), GDK_KEY_y, GDK_CONTROL_MASK);
-  // Film strip shortcuts
-  dt_accel_register_view(self, NC_("accel", "toggle film strip"), GDK_KEY_f, GDK_CONTROL_MASK);
 }
 
 static gboolean _view_map_undo_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -917,17 +915,6 @@ static gboolean _view_map_redo_callback(GtkAccelGroup *accel_group, GObject *acc
   return TRUE;
 }
 
-static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data)
-{
-  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
-  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-  // if we show the panel, ensure that filmstrip is visible
-  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
-  return TRUE;
-}
-
 void connect_key_accels(dt_view_t *self)
 {
   // undo/redo
@@ -935,9 +922,6 @@ void connect_key_accels(dt_view_t *self)
   dt_accel_connect_view(self, "undo", closure);
   closure = g_cclosure_new(G_CALLBACK(_view_map_redo_callback), (gpointer)self, NULL);
   dt_accel_connect_view(self, "redo", closure);
-  // Film strip shortcuts
-  closure = g_cclosure_new(G_CALLBACK(film_strip_key_accel), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle film strip", closure);
 }
 
 

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -332,32 +332,6 @@ void leave(dt_view_t *self)
                                (gpointer)self);
 }
 
-static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data)
-{
-  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
-  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-  // if we show the panel, ensure that filmstrip is visible
-  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
-  return TRUE;
-}
-
-void init_key_accels(dt_view_t *self)
-{
-  // Film strip shortcuts
-  dt_accel_register_view(self, NC_("accel", "toggle film strip"), GDK_KEY_f, GDK_CONTROL_MASK);
-}
-
-void connect_key_accels(dt_view_t *self)
-{
-  GClosure *closure;
-
-  // Film strip shortcuts
-  closure = g_cclosure_new(G_CALLBACK(film_strip_key_accel), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle film strip", closure);
-}
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -104,17 +104,6 @@ static void _view_capture_filmstrip_activate_callback(gpointer instance, int img
   if(imgid >= 0) dt_control_queue_redraw_center();
 }
 
-static gboolean film_strip_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
-                                     GdkModifierType modifier, gpointer data)
-{
-  // there's only filmstrip in bottom panel, so better hide/show it instead of filmstrip lib
-  const gboolean pb = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
-  dt_ui_panel_show(darktable.gui->ui, DT_UI_PANEL_BOTTOM, !pb, TRUE);
-  // if we show the panel, ensure that filmstrip is visible
-  if(!pb) dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module, TRUE);
-  return TRUE;
-}
-
 void init(dt_view_t *self)
 {
   self->data = calloc(1, sizeof(dt_capture_t));
@@ -396,18 +385,6 @@ void mouse_moved(dt_view_t *self, double x, double y, double pressure, int which
     dt_camctl_camera_set_property_string(darktable.camctl, NULL, "eoszoomposition", str);
   }
   dt_control_queue_redraw_center();
-}
-
-void init_key_accels(dt_view_t *self)
-{
-  // Setup key accelerators in capture view...
-  dt_accel_register_view(self, NC_("accel", "toggle film strip"), GDK_KEY_f, GDK_CONTROL_MASK);
-}
-
-void connect_key_accels(dt_view_t *self)
-{
-  GClosure *closure = g_cclosure_new(G_CALLBACK(film_strip_key_accel), (gpointer)self, NULL);
-  dt_accel_connect_view(self, "toggle film strip", closure);
 }
 
 int button_pressed(dt_view_t *self, double x, double y, double pressure, int which, int type, uint32_t state)


### PR DESCRIPTION
this fix #4484 

- this refactor header/filmstrip/timeline accels, so they are all handled globally in the same place.
- this add accels (with no default keys) for top toolbar, bottom toolbar, all top panels, all bottom panels