### PR TITLE
Migrate clip parameter of basicadj

### DIFF
--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -107,7 +107,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     new->middle_grey = old->middle_grey;
     new->brightness = old->brightness;
     new->saturation = old->saturation;
-    new->clip = old->clip;
+    // version 2 vibrance field added before clip
+    new->clip = old->vibrance;
     new->vibrance = 0;
     return 0;
   }


### PR DESCRIPTION
The vibrance parameter has been added before clip in the v2 parameters struct of basicadj. If I understood correctly how the migration works, the legacy_params function should then take the vibrance value of v1 as clip parameter of v2. Is this correct?

Should it be better to rewrite the legacy_params function to define the v1 struct as dt_iop_basicadj_params_v1_t (as in other modules, e.g. src/iop/borders.c)?