### PR TITLE
Folder levels code redundancy

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -358,7 +358,7 @@
   </dtconfig>
   <dtconfig prefs="gui">
     <name>show_folder_levels</name>
-    <type>int</type>
+    <type min="1" max="5">int</type>
     <default>1</default>
     <shortdescription>number of folder levels to show in lists</shortdescription>
     <longdescription>the number of folder levels to show in film roll names, starting from the right</longdescription>

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -141,7 +141,6 @@ const char *dt_image_film_roll_name(const char *path)
   int numparts = dt_conf_get_int("show_folder_levels");
   numparts = CLAMPS(numparts, 1, 5);
   int count = 0;
-  if(numparts < 1) numparts = 1;
   while(folder > path)
   {
     if(*folder == G_DIR_SEPARATOR)


### PR DESCRIPTION
While looking for something else I came across these rather surprising bits of redundant code:
CLAMPS followed by an if;
No bound on data entry but value bounded by the CLAMPS

They seem so obvious I wonder if there is a reason, but dt seems to be happy with the changes.