### PR TITLE
zoomable : ensure we always see some image on screen

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -769,8 +769,6 @@ static gboolean _event_leave_notify(GtkWidget *widget, GdkEventCrossing *event, 
   if(event->detail == GDK_NOTIFY_INFERIOR) return FALSE;
 
   table->mouse_inside = FALSE;
-  table->last_x = -1;
-  table->last_y = -1;
   dt_control_set_mouse_over_id(-1);
   return TRUE;
 }

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -614,6 +614,14 @@ static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
   table->thumb_size = new_size;
   _pos_compute_area(table);
 
+  // we ensure there's still some visible thumbnails
+  const int space = new_size * 0.5; // we want at least 1/2 thumb to stay visible
+  int posy = MIN(table->view_height - space - table->thumbs_area.y, 0);
+  posy = MAX(space - table->thumbs_area.y - table->thumbs_area.height, posy);
+  int posx = MIN(table->view_width - space - table->thumbs_area.x, 0);
+  posx = MAX(space - table->thumbs_area.x - table->thumbs_area.width, posx);
+  if(posx != 0 && posy != 0) _move(table, posx, posy, FALSE);
+
   // and we load/unload thumbs if needed
   int changed = _thumbs_load_needed(table);
   changed += _thumbs_remove_unneeded(table);


### PR DESCRIPTION
may fix #4529 

This fix 2 bugs for zoomable lighttable : 
- when you zoom in, ensure you always keep some part of images on screen, otherwise you may have no way to find them back, apart from exiting/reentering
- when panning, fix the jump if mouse go out of the center area