### PR TITLE
Ensure a single definition is controling the max zoom level.

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -28,8 +28,6 @@
 #include "gui/drag_and_drop.h"
 #include "views/view.h"
 
-#define ZOOM_MAX 13
-
 // specials functions for GList globals actions
 static gint _list_compare_by_imgid(gconstpointer a, gconstpointer b)
 {
@@ -234,7 +232,7 @@ static gboolean _compute_sizes(dt_thumbtable_t *table, gboolean force)
 
     if(force || allocation.width != table->view_width || allocation.height != table->view_height)
     {
-      table->thumbs_per_row = ZOOM_MAX;
+      table->thumbs_per_row = DT_LIGHTTABLE_MAX_ZOOM;
       table->view_width = allocation.width;
       table->view_height = allocation.height;
       table->thumb_size = table->view_width / npr;
@@ -287,7 +285,8 @@ static gboolean _thumbtable_update_scrollbars(dt_thumbtable_t *table)
     const int pos_h
         = lbefore * table->thumb_size + table->view_height - table->thumb_size * 0.5 - table->thumbs_area.y;
 
-    const int total_width = ZOOM_MAX * table->thumb_size + 2 * (table->view_width - table->thumb_size * 0.5);
+    const int total_width = DT_LIGHTTABLE_MAX_ZOOM * table->thumb_size
+      + 2 * (table->view_width - table->thumb_size * 0.5);
     const int pos_w = table->view_width - table->thumb_size * 0.5 - table->thumbs_area.x;
 
     dt_view_set_scrollbar(darktable.view_manager->current_view, pos_w, 0, total_width, table->view_width, pos_h, 0,
@@ -712,7 +711,7 @@ static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_
       const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
       int new = old;
       if(delta > 0)
-        new = MIN(ZOOM_MAX, new + 1);
+        new = MIN(DT_LIGHTTABLE_MAX_ZOOM, new + 1);
       else
         new = MAX(1, new - 1);
 
@@ -736,7 +735,7 @@ static gboolean _event_scroll(GtkWidget *widget, GdkEvent *event, gpointer user_
       const int old = dt_view_lighttable_get_zoom(darktable.view_manager);
       int new = old;
       if(delta > 0)
-        new = MIN(ZOOM_MAX, new + 1);
+        new = MIN(DT_LIGHTTABLE_MAX_ZOOM, new + 1);
       else
         new = MAX(1, new - 1);
 

--- a/src/libs/tools/lighttable.c
+++ b/src/libs/tools/lighttable.c
@@ -120,12 +120,13 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   d->layout = MIN(DT_LIGHTTABLE_LAYOUT_LAST - 1, dt_conf_get_int("plugins/lighttable/layout"));
   d->base_layout = MIN(DT_LIGHTTABLE_LAYOUT_LAST - 1, dt_conf_get_int("plugins/lighttable/base_layout"));
+
   if(d->layout == DT_LIGHTTABLE_LAYOUT_CULLING)
   {
     d->zoom_mode = dt_conf_get_int("plugins/lighttable/culling_zoom_mode");
     if(d->zoom_mode == DT_LIGHTTABLE_ZOOM_DYNAMIC && darktable.collection)
     {
-      d->current_zoom = MAX(1, MIN(30, dt_collection_get_selected_count(darktable.collection)));
+      d->current_zoom = MAX(1, MIN(DT_LIGHTTABLE_MAX_ZOOM, dt_collection_get_selected_count(darktable.collection)));
       if(d->current_zoom == 1) d->current_zoom = dt_conf_get_int("plugins/lighttable/culling_num_images");
     }
     else
@@ -150,7 +151,7 @@ void gui_init(dt_lib_module_t *self)
 
 
   /* create horizontal zoom slider */
-  d->zoom = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 1, 21, 1);
+  d->zoom = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 1, DT_LIGHTTABLE_MAX_ZOOM, 1);
   gtk_widget_set_size_request(GTK_WIDGET(d->zoom), DT_PIXEL_APPLY_DPI(140), -1);
   gtk_scale_set_draw_value(GTK_SCALE(d->zoom), FALSE);
   gtk_range_set_increments(GTK_RANGE(d->zoom), 1, 1);
@@ -447,7 +448,6 @@ static dt_lighttable_layout_t _lib_lighttable_get_layout(dt_lib_module_t *self)
   return d->layout;
 }
 
-#define DT_LIBRARY_MAX_ZOOM 13
 static void _lib_lighttable_set_zoom(dt_lib_module_t *self, gint zoom)
 {
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
@@ -484,7 +484,7 @@ static gboolean _lib_lighttable_key_accel_zoom_min_callback(GtkAccelGroup *accel
 {
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
-  gtk_range_set_value(GTK_RANGE(d->zoom), DT_LIBRARY_MAX_ZOOM);
+  gtk_range_set_value(GTK_RANGE(d->zoom), DT_LIGHTTABLE_MAX_ZOOM);
   return TRUE;
 }
 
@@ -510,8 +510,8 @@ static gboolean _lib_lighttable_key_accel_zoom_out_callback(GtkAccelGroup *accel
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_tool_lighttable_t *d = (dt_lib_tool_lighttable_t *)self->data;
   int zoom = d->current_zoom;
-  if(zoom >= 2 * DT_LIBRARY_MAX_ZOOM)
-    zoom = 2 * DT_LIBRARY_MAX_ZOOM;
+  if(zoom >= 2 * DT_LIGHTTABLE_MAX_ZOOM)
+    zoom = 2 * DT_LIGHTTABLE_MAX_ZOOM;
   else
     zoom++;
   gtk_range_set_value(GTK_RANGE(d->zoom), zoom);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -59,10 +59,6 @@
 DT_MODULE(1)
 
 #define FULL_PREVIEW_IN_MEMORY_LIMIT 9
-// TODO: this is also defined in lib/tools/lighttable.c
-//       fix so this value is shared.. DT_CTL_SET maybe ?
-#define DT_LIBRARY_MAX_ZOOM 13
-
 
 /* returns TRUE if lighttable is using the custom order filter */
 static gboolean _is_custom_image_order_actif(const dt_view_t *self);
@@ -2426,9 +2422,9 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
   else if(lib->full_preview_id > -1)
   {
     if(up)
-      lib->track = -DT_LIBRARY_MAX_ZOOM;
+      lib->track = -DT_LIGHTTABLE_MAX_ZOOM;
     else
-      lib->track = +DT_LIBRARY_MAX_ZOOM;
+      lib->track = +DT_LIGHTTABLE_MAX_ZOOM;
 
     if(layout == DT_LIGHTTABLE_LAYOUT_CULLING && state == 0) _culling_scroll(lib, up);
   }
@@ -2954,7 +2950,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
   if(key == accels->global_zoom_out.accel_key && state == accels->global_zoom_out.accel_mods)
   {
     zoom++;
-    if(zoom > 2 * DT_LIBRARY_MAX_ZOOM) zoom = 2 * DT_LIBRARY_MAX_ZOOM;
+    if(zoom > 2 * DT_LIGHTTABLE_MAX_ZOOM) zoom = 2 * DT_LIGHTTABLE_MAX_ZOOM;
 
     dt_view_lighttable_set_zoom(darktable.view_manager, zoom);
     return 1;

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -112,6 +112,9 @@ typedef struct dt_mouse_action_t
   (DT_VIEW_LIGHTTABLE | DT_VIEW_DARKROOM | DT_VIEW_TETHERING | DT_VIEW_MAP | DT_VIEW_SLIDESHOW | \
    DT_VIEW_PRINT | DT_VIEW_KNIGHT)
 
+/* maximum zoom factor for the lighttable */
+#define DT_LIGHTTABLE_MAX_ZOOM 25
+
 /**
  * main dt view module (as lighttable or darkroom)
  */


### PR DESCRIPTION
This fixes issues where not the same value was used everywhere. It
will also ease the maintenance.

For #4555.