### PR TITLE
Recent sort

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -451,8 +451,8 @@
     <name>plugins/collect/descending</name>
     <type>bool</type>
     <default>true</default>
-    <shortdescription>sort collection recent to early</shortdescription>
-    <longdescription>changes the default collections-list order for folders, times and dates to run from recent to early</longdescription>
+    <shortdescription>sort collection recent to older</shortdescription>
+    <longdescription>changes the default collections-list order for folders, times and dates to run from recent to older</longdescription>
   </dtconfig> 
   <dtconfig>
     <name>ui_last/colorpicker_mean</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -447,6 +447,13 @@
     <shortdescription>jobcode of import job</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig prefs="gui">
+    <name>plugins/collect/descending</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>sort collection recent to early</shortdescription>
+    <longdescription>changes the default collections-list order for folders, times and dates to run from recent to early</longdescription>
+  </dtconfig> 
   <dtconfig>
     <name>ui_last/colorpicker_mean</name>
     <type>int</type>

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1112,7 +1112,6 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       sorted_names = g_list_prepend(sorted_names, tuple);
     }
     sqlite3_finalize(stmt);
-    g_free(query);
 
     sorted_names = g_list_sort(sorted_names,(sort_descend && (folders || days || times)) 
         ? neg_sort_folder_tag : sort_folder_tag);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1074,9 +1074,8 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       NULL,
       where_ext);
 
-    prequery = (sort_descend && g_str_has_suffix(prequery,"ASC")) 
+    gchar *query = (sort_descend && g_str_has_suffix(prequery,"ASC")) 
           ? strcat(g_strndup(prequery,strlen(prequery) - 3),"DESC") : prequery;
-    gchar *query=g_strndup(prequery,strlen(prequery));
     g_free(where_ext);
     g_free(prequery);       
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -1112,7 +1111,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       sorted_names = g_list_prepend(sorted_names, tuple);
     }
     sqlite3_finalize(stmt);
-
+    g_free(query);
     sorted_names = g_list_sort(sorted_names,(sort_descend && (folders || days || times)) 
         ? neg_sort_folder_tag : sort_folder_tag);
         

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1042,7 +1042,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
     /* query construction */
     gchar *where_ext = dt_collection_get_extended_where(darktable.collection, dr->num);
-    gchar *prequery = g_strdup_printf(
+    gchar *query = g_strdup_printf(
       folders ?
         "SELECT folder, film_rolls_id, COUNT(*) AS count"
         " FROM main.images AS mi"
@@ -1074,10 +1074,8 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       NULL,
       where_ext);
 
-    gchar *query = (sort_descend && g_str_has_suffix(prequery,"ASC")) 
-          ? strcat(g_strndup(prequery,strlen(prequery) - 3),"DESC") : prequery;
     g_free(where_ext);
-    g_free(prequery);       
+      
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
 
     char **last_tokens = NULL;

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1101,7 +1101,6 @@ static void tree_view(dt_lib_collect_rule_t *dr)
         char *name_folded_slash = g_strconcat(name_folded, G_DIR_SEPARATOR_S, NULL);
         collate_key = g_utf8_collate_key_for_filename(name_folded_slash, -1);
         g_free(name_folded_slash);
-        g_free(name_folded);
       }
       else
         collate_key = tag_collate_key(name_folded);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1112,7 +1112,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       sorted_names = g_list_prepend(sorted_names, tuple);
     }
     sqlite3_finalize(stmt);
-    free(query);
+    g_free(query);
 
     sorted_names = g_list_sort(sorted_names,(sort_descend && (folders || days || times)) 
         ? neg_sort_folder_tag : sort_folder_tag);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1063,14 +1063,12 @@ static void tree_view(dt_lib_collect_rule_t *dr)
         "SELECT SUBSTR(datetime_taken, 1, 10) AS date, 1, COUNT(*) AS count"
         " FROM main.images AS mi"
         " WHERE %s"
-        " GROUP BY date"
-        " ORDER BY datetime_taken ASC" :
+        " GROUP BY date" :
       times ?
         "SELECT datetime_taken AS date, 1, COUNT(*) AS count"
         " FROM main.images AS mi"
         " WHERE %s"
-        " GROUP BY date"
-        " ORDER BY datetime_taken ASC" :
+        " GROUP BY date" :
       NULL,
       where_ext);
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1076,7 +1076,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
     prequery = (sort_descend && g_str_has_suffix(prequery,"ASC")) 
           ? strcat(g_strndup(prequery,strlen(prequery) - 3),"DESC") : prequery;
-    const gchar *query=g_strndup(prequery,strlen(prequery));
+    gchar *query=g_strndup(prequery,strlen(prequery));
     g_free(where_ext);
     g_free(prequery);       
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
@@ -1112,6 +1112,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       sorted_names = g_list_prepend(sorted_names, tuple);
     }
     sqlite3_finalize(stmt);
+    free(query);
 
     sorted_names = g_list_sort(sorted_names,(sort_descend && (folders || days || times)) 
         ? neg_sort_folder_tag : sort_folder_tag);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -963,6 +963,14 @@ static gint sort_folder_tag(gconstpointer a, gconstpointer b)
   return g_strcmp0(tuple_a->collate_key, tuple_b->collate_key);
 }
 
+static gint neg_sort_folder_tag(gconstpointer a, gconstpointer b)
+{
+  const name_key_tuple_t *tuple_a = (const name_key_tuple_t *)a;
+  const name_key_tuple_t *tuple_b = (const name_key_tuple_t *)b;
+
+  return -g_strcmp0(tuple_a->collate_key, tuple_b->collate_key); 
+}  
+
 // create a key such that "darktable|" is coming first, and the rest is ordered such that sub tags are coming directly
 // behind their parent
 static char *tag_collate_key(char *tag)
@@ -1011,8 +1019,8 @@ static void tree_view(dt_lib_collect_rule_t *dr)
   const gboolean tags = (property == DT_COLLECTION_PROP_TAG);
   const gboolean days = (property == DT_COLLECTION_PROP_DAY);
   const gboolean times = (property == DT_COLLECTION_PROP_TIME);
-  const char *format_separator = folders ? "%s" G_DIR_SEPARATOR_S :
-  days || times ? "%s:" : "%s|";
+  const char *format_separator = folders ? "%s" G_DIR_SEPARATOR_S : days || times ? "%s:" : "%s|";
+  const gint sort_descend = dt_conf_get_bool("plugins/collect/descending");
 
   set_properties(dr);
 
@@ -1034,7 +1042,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
     /* query construction */
     gchar *where_ext = dt_collection_get_extended_where(darktable.collection, dr->num);
-    const char *query = g_strdup_printf(
+    gchar *prequery = g_strdup_printf(
       folders ?
         "SELECT folder, film_rolls_id, COUNT(*) AS count"
         " FROM main.images AS mi"
@@ -1066,7 +1074,11 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       NULL,
       where_ext);
 
+    prequery = (sort_descend && g_str_has_suffix(prequery,"ASC")) 
+          ? strcat(g_strndup(prequery,strlen(prequery) - 3),"DESC") : prequery;
+    const gchar *query=g_strndup(prequery,strlen(prequery));
     g_free(where_ext);
+    g_free(prequery);       
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
 
     char **last_tokens = NULL;
@@ -1079,21 +1091,21 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     while(sqlite3_step(stmt) == SQLITE_ROW)
     {
       char *name = g_strdup((const char *)sqlite3_column_text(stmt, 0));
+      char *name_folded = g_utf8_casefold(name, -1);                                              
       gchar *collate_key = NULL;
 
       const int count = sqlite3_column_int(stmt, 2);
 
       if(folders)
       {
-        char *name_folded = g_utf8_casefold(name, -1);
         char *name_folded_slash = g_strconcat(name_folded, G_DIR_SEPARATOR_S, NULL);
         collate_key = g_utf8_collate_key_for_filename(name_folded_slash, -1);
         g_free(name_folded_slash);
         g_free(name_folded);
       }
-      else if(tags)
-        collate_key = tag_collate_key(name);
-
+      else
+        collate_key = tag_collate_key(name_folded);
+      g_free(name_folded);
       name_key_tuple_t *tuple = (name_key_tuple_t *)malloc(sizeof(name_key_tuple_t));
       tuple->name = name;
       tuple->collate_key = collate_key;
@@ -1102,9 +1114,9 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     }
     sqlite3_finalize(stmt);
 
-    if(folders || tags)
-      sorted_names = g_list_sort(sorted_names, sort_folder_tag);
-
+    sorted_names = g_list_sort(sorted_names,(sort_descend && (folders || days || times)) 
+        ? neg_sort_folder_tag : sort_folder_tag);
+        
     for(GList *names = sorted_names; names; names = g_list_next(names))
     {
       name_key_tuple_t *tuple = (name_key_tuple_t *)names->data;
@@ -1220,7 +1232,6 @@ static void tree_view(dt_lib_collect_rule_t *dr)
     }
     g_list_free_full(sorted_names, free_tuple);
 
-
     gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(d->view), DT_LIB_COLLECT_COL_TOOLTIP);
 
     d->treefilter = _create_filtered_model(model, dr);
@@ -1241,7 +1252,6 @@ static void tree_view(dt_lib_collect_rule_t *dr)
 
     g_object_unref(model);
     g_strfreev(last_tokens);
-
     d->view_rule = property;
   }
 


### PR DESCRIPTION
This replaces #4553 because I suck at git.

In brief, it allows the display of folders, filmrolls, times and dates to sort from recent to distant in the collect module. There is a new variable under gui/miscellaneous to select this.

It also removes the case sensitivity from tags, but does not change the ordering of these or other data.