### PR TITLE
Allow more than 500 images for timelapse

### DIFF
--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -464,7 +464,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach_next_to(GTK_GRID(self->widget), GTK_WIDGET(hbox), GTK_WIDGET(modes_label), GTK_POS_RIGHT, 1, 1);
 
   lib->gui.timer = gtk_spin_button_new_with_range(1, 60, 1);
-  lib->gui.count = gtk_spin_button_new_with_range(1, 5000, 1);
+  lib->gui.count = gtk_spin_button_new_with_range(1, 9999, 1);
   lib->gui.brackets = gtk_spin_button_new_with_range(1, 5, 1);
   lib->gui.steps = gtk_spin_button_new_with_range(1, 9, 1);
   gtk_grid_attach_next_to(GTK_GRID(self->widget), GTK_WIDGET(lib->gui.timer), GTK_WIDGET(timer_label), GTK_POS_RIGHT, 1, 1);

--- a/src/libs/camera.c
+++ b/src/libs/camera.c
@@ -464,7 +464,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach_next_to(GTK_GRID(self->widget), GTK_WIDGET(hbox), GTK_WIDGET(modes_label), GTK_POS_RIGHT, 1, 1);
 
   lib->gui.timer = gtk_spin_button_new_with_range(1, 60, 1);
-  lib->gui.count = gtk_spin_button_new_with_range(1, 500, 1);
+  lib->gui.count = gtk_spin_button_new_with_range(1, 5000, 1);
   lib->gui.brackets = gtk_spin_button_new_with_range(1, 5, 1);
   lib->gui.steps = gtk_spin_button_new_with_range(1, 9, 1);
   gtk_grid_attach_next_to(GTK_GRID(self->widget), GTK_WIDGET(lib->gui.timer), GTK_WIDGET(timer_label), GTK_POS_RIGHT, 1, 1);


### PR DESCRIPTION
The current 500 limit is quite restrictive especially for lengthy timelapse sessions. It would be very helpful if the limit is greatly increased (or removed altogether)