### PR TITLE
Changes permitting preview_downsampling.

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1462,6 +1462,19 @@
     <longdescription>interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, but not as sharp. middle ground is using PPG + interpolation modes specified below, full will use exactly the settings for full-size export. X-Trans sensors use VNG rather than PPG as middle ground.</longdescription>
   </dtconfig>
   <dtconfig prefs="core" section="quality">
+    <name>preview_downsampling</name>
+    <type>
+      <enum>
+        <option>1.0 (none)</option>
+        <option>0.5</option>
+        <option>0.25</option>
+      </enum>
+    </type>
+    <default>1.0 (none)</default>
+    <shortdescription>reduce resolution of preview image</shortdescription>
+    <longdescription>decrease to speed up preview rendering, may hinder accurate masking</longdescription>
+  </dtconfig>
+  <dtconfig prefs="core" section="quality">                                 
     <name>plugins/lighttable/export/pixel_interpolator</name>
     <type>
       <enum>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -53,7 +53,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
   memset(dev, 0, sizeof(dt_develop_t));
   dev->full_preview = FALSE;
-  dev->preview_downsampling = 1.0f;
   dev->gui_module = NULL;
   dev->timestamp = 0;
   dev->average_delay = DT_DEV_AVERAGE_DELAY_START;
@@ -90,7 +89,9 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(mode, "waveform") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_WAVEFORM;
   g_free(mode);
-
+  char *preview_downsample = dt_conf_get_string("preview_downsampling");
+  dev->preview_downsampling = 
+      (g_strcmp0(preview_downsample, "1.0 (none)") ? 1.0f : atoi(preview_downsample));                                                                      
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -680,6 +681,7 @@ float dt_dev_get_zoom_scale(dt_develop_t *dev, dt_dev_zoom_t zoom, int closeup_f
       if(preview) zoom_scale *= ps;
       break;
   }
+  
   return zoom_scale;
 }
 
@@ -2401,11 +2403,26 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, c
     pieces = g_list_next(pieces);
   }
   dt_pthread_mutex_unlock(&dev->history_mutex);
+  if (transf_direction == DT_DEV_TRANSFORM_DIR_ALL 
+                        || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
+                        || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL)
+  {
+    for(size_t idx=0; idx < 2 * points_count; idx++) points[idx] *= dev->preview_downsampling;
+  }
+
   return 1;
 }
+
 int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, const double iop_order, const int transf_direction,
                                       float *points, size_t points_count)
 {
+  if (transf_direction == DT_DEV_TRANSFORM_DIR_ALL
+    || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
+    || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL) 
+  {
+    for(size_t idx=0; idx < 2 * points_count; idx++) points[idx] /= dev->preview_downsampling;
+  }
+  
   dt_pthread_mutex_lock(&dev->history_mutex);
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2082,7 +2082,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
 
-  float dx = 0, dy = 0, dxs = 0, dys = 0;
+  float dx = 0.f, dy = 0.f, dxs = 0.f, dys = 0.f;
   if((gui->group_selected == index) && gui->form_dragging)
   {
     dx = gui->posx + gui->dx - gpt->points[2];
@@ -2097,30 +2097,34 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   // in creation mode
   if(gui->creation)
   {
-    const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;
-
+    float preview_scale = MIN(darktable.develop->preview_pipe->iwidth,
+            darktable.develop->preview_pipe->iheight);
+    float radius[2] = { 0.f, 0.f };  
+    float radius_hardness = 0.f, radius_border = 0.f;
     if(gui->guipoints_count == 0)
     {
+      float masks_border = 0.f, masks_hardness = 0.f;
       dt_masks_form_t *form = darktable.develop->form_visible;
       if(!form) return;
-
-      float masks_border;
+                               
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
       else
         masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
-
-      float masks_hardness;
+                           
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_hardness"), HARDNESS_MAX);
       else
         masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/hardness"), HARDNESS_MAX);
 
       const float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
-
-      const float radius1 = masks_border * masks_hardness * MIN(wd, ht);
-      const float radius2 = masks_border * MIN(wd, ht);
+      
+      radius[0] = masks_border * masks_hardness;
+      radius[1] = masks_border;
+      
+      dt_dev_distort_backtransform(darktable.develop, radius, 1);
+      radius_hardness = radius[0] * preview_scale / darktable.develop->preview_pipe->iwidth;
+      radius_border = radius[1] * preview_scale / darktable.develop->preview_pipe->iheight;
 
       float xpos, ypos;
       if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
@@ -2137,12 +2141,12 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_save(cr);
       dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_CURSOR, opacity);
       cairo_set_line_width(cr, 3.0 / zoom_scale);
-      cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
+      cairo_arc(cr, xpos, ypos, radius_hardness, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
       cairo_stroke(cr);
       cairo_set_dash(cr, dashed, len, 0);
-      cairo_arc(cr, xpos, ypos, radius2, 0, 2.0 * M_PI);
+      cairo_arc(cr, xpos, ypos, radius_border, 0, 2.0 * M_PI);
       cairo_stroke(cr);
 
       if(form->type & DT_MASKS_CLONE)
@@ -2157,7 +2161,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     else
     {
       float masks_border, masks_hardness, masks_density;
-      float radius, oldradius, opacity, oldopacity, pressure;
+      float opacity, oldopacity, pressure;
+      float oldradius_hardness = 0;
       int stroked = 1;
 
       const float *guipoints = dt_masks_dynbuf_buffer(gui->guipoints);
@@ -2193,11 +2198,17 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
           // ignore pressure value
           break;
       }
-
-      radius = oldradius = masks_border * masks_hardness * MIN(wd, ht);
+      
+      radius[0] = masks_border * masks_hardness; 
+      radius[1] = masks_border;
+      dt_dev_distort_backtransform(darktable.develop, radius, 1);
+      radius_hardness = oldradius_hardness = radius[0] * preview_scale 
+            / darktable.develop->preview_pipe->iwidth;
+      radius_border = radius[1] * preview_scale 
+            / darktable.develop->preview_pipe->iwidth;
       opacity = oldopacity = masks_density;
 
-      cairo_set_line_width(cr, 2 * radius);
+      cairo_set_line_width(cr, 2 * radius_hardness);
       dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_TRACE, opacity);
 
       cairo_move_to(cr, guipoints[0], guipoints[1]);
@@ -2232,17 +2243,20 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
             // ignore pressure value
             break;
         }
-
-        radius = masks_border * masks_hardness * MIN(wd, ht);
+        
+        radius[0] = masks_border * masks_hardness; 
+        radius[1] = masks_border;
+        dt_dev_distort_backtransform(darktable.develop, radius, 1);
+        radius_hardness = radius[0] * preview_scale / darktable.develop->preview_pipe->iwidth;
         opacity = masks_density;
 
-        if(radius != oldradius || opacity != oldopacity)
+        if(radius_hardness != oldradius_hardness || opacity != oldopacity)
         {
           cairo_stroke(cr);
           stroked = 1;
-          cairo_set_line_width(cr, 2 * radius);
+          cairo_set_line_width(cr, 2 * radius_hardness);
           dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_TRACE, opacity);
-          oldradius = radius;
+          oldradius_hardness = radius_hardness;
           oldopacity = opacity;
           cairo_move_to(cr, guipoints[i * 2], guipoints[i * 2 + 1]);
         }
@@ -2252,13 +2266,13 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 3.0 / zoom_scale);
       dt_gui_gtk_set_source_rgba(cr, DT_GUI_COLOR_BRUSH_CURSOR, opacity);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
-                guipoints[2 * (gui->guipoints_count - 1) + 1], radius, 0, 2.0 * M_PI);
+                guipoints[2 * (gui->guipoints_count - 1) + 1], radius_hardness, 0, 2.0 * M_PI);
       cairo_fill_preserve(cr);
       cairo_set_source_rgba(cr, .8, .8, .8, .8);
       cairo_stroke(cr);
       cairo_set_dash(cr, dashed, len, 0);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
-                guipoints[2 * (gui->guipoints_count - 1) + 1], masks_border * MIN(wd, ht), 0,
+                guipoints[2 * (gui->guipoints_count - 1) + 1], radius_border, 0,
                 2.0 * M_PI);
       cairo_stroke(cr);
 


### PR DESCRIPTION
This builds on work started by @bastibe in PR #4233. He noticed that a significant amount of computation was being done on the preview image, which could be reduced by downsampling. In fact the variable dev->preview_downsampling already existed, but was fixed to 1.f

Unfortunately Bastian got caught up in some other bugs, and his code had some self-cancelling features. I didn't like the fact that it was necessary to make use of the preview_downsampling variable directly in circle.c and brush.c, but not in ellipse.c or other masks.

So I re-wrote parts of one function in each of circle.c and brush.c borrowing from ellipse.c so that these now call the transform/backtransform functions in develop.c (as they do already for a bunch of other things). The only other changes are a a few lines in each of those functions, taken from Bastian's code, plus a few lines to extract the variable from darktablerc; and finally making the variable visible in darktablerc.

It's available as a choice of 1.0 (no change), 0.5 or 0.25. With 0.25 you have 1/16 the pixels, so there is in principle 44% less processing being done when you make a change in darkraoom.

On the other hand, this might hinder you if you use the preview for precise masking... In that case I'd suggest you leave the value at 1.0