### PR TITLE
bugfix: prevent extra duplicate image on import

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -998,8 +998,7 @@ GList* dt_image_find_duplicates(const char* filename)
 #endif 
 }
 
-
-int dt_image_read_duplicates(const uint32_t id, const char *filename)
+static int _image_read_duplicates(const uint32_t id, const char *filename)
 {
   int count_xmps_processed = 0;
   // Search for duplicate's sidecar files and import them if found and not in DB yet
@@ -1040,9 +1039,28 @@ int dt_image_read_duplicates(const uint32_t id, const char *filename)
       g_free(idfield);
     }
 
-    const int newid = dt_image_duplicate_with_version(id, version);
+    int newid = id;
+
+    if(!count_xmps_processed)
+    {
+      //this is the first xmp processed, just update the passed-in id
+      sqlite3_stmt *stmt;
+      DT_DEBUG_SQLITE3_PREPARE_V2
+        (dt_database_get(darktable.db),
+         "UPDATE main.images SET version=?1, max_version = ?1 WHERE id = ?2", -1, &stmt, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, version);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, id);
+      sqlite3_step(stmt);
+      sqlite3_finalize(stmt);
+    }
+    else
+    {
+      //create a new duplicate based on the passed-in id
+      newid = dt_image_duplicate_with_version(id, version);
+    }
     dt_image_t *img = dt_image_cache_get(darktable.image_cache, newid, 'w');
     (void)dt_exif_xmp_read(img, xmpfilename, 0);
+    img->version = version;
     dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
 
     count_xmps_processed++;
@@ -1115,7 +1133,7 @@ static uint32_t dt_image_import_internal(const int32_t film_id, const char *file
     dt_image_t *img = dt_image_cache_get(darktable.image_cache, id, 'w');
     img->flags &= ~DT_IMAGE_REMOVE;
     dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
-    dt_image_read_duplicates(id, normalized_filename);
+    _image_read_duplicates(id, normalized_filename);
     dt_image_synch_all_xmp(normalized_filename);
     g_free(ext);
     g_free(normalized_filename);
@@ -1160,12 +1178,12 @@ static uint32_t dt_image_import_internal(const int32_t film_id, const char *file
    * 0000 0003 0000 0000
    */
 
-  //insert a dummy record (which will be used to load xmp files and may later be removed)
+  //insert a v0 record (which may be updated later if no v0 xmp exists)
   DT_DEBUG_SQLITE3_PREPARE_V2
     (dt_database_get(darktable.db),
      "INSERT INTO main.images (id, film_id, filename, caption, description, license, sha1sum, flags, version, "
      "                         max_version, history_end, position)"
-     " SELECT NULL, ?1, ?2, '', '', '', '', ?3, -1, -1, 0, (IFNULL(MAX(position),0) & (4294967295 << 32))  + (1 << 32) "
+     " SELECT NULL, ?1, ?2, '', '', '', '', ?3, 0, 0, 0, (IFNULL(MAX(position),0) & (4294967295 << 32))  + (1 << 32) "
      " FROM images",
      -1, &stmt, NULL);
 
@@ -1312,48 +1330,8 @@ static uint32_t dt_image_import_internal(const int32_t film_id, const char *file
   dt_mipmap_cache_remove(darktable.mipmap_cache, id);
 
   // read all sidecar files
-  if(dt_image_read_duplicates(id, normalized_filename))
-  {
-    //duplicates were loaded from sidecar files
-    //dummy record no longer required
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), 
-                                "DELETE FROM main.images WHERE film_id = ?1 AND filename = ?2 AND version = -1",
-                                -1, &stmt,
-                                NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, film_id);
-    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, imgfname, -1, SQLITE_STATIC);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
-  else
-  {
-    //no sidecar files were loaded
-    //the dummy record now represents v0
-    DT_DEBUG_SQLITE3_PREPARE_V2
-      (dt_database_get(darktable.db),
-       "UPDATE main.images SET version = 0, max_version = 0 WHERE film_id = ?1 AND filename = ?2 AND version = -1",
-       -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, film_id);
-    DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, imgfname, -1, SQLITE_STATIC);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
+  _image_read_duplicates(id, normalized_filename);
 
-  //get the minimum id
-  // returned to calling function
-  DT_DEBUG_SQLITE3_PREPARE_V2
-    (dt_database_get(darktable.db),
-     "SELECT id FROM main.images i1 WHERE film_id = ?1 AND filename = ?2 AND "
-        "version = (SELECT MIN(version) FROM main.images i2 WHERE i2.film_id = i1.film_id "
-        "AND i2.filename = i1.filename)", -1, &stmt, NULL);
-  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, film_id);
-  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 2, imgfname, -1, SQLITE_STATIC);
-  if(sqlite3_step(stmt) == SQLITE_ROW)
-  {
-    id = sqlite3_column_int(stmt, 0);
-  }
-  sqlite3_finalize(stmt);
-  
   //synch database entries to xmp
   dt_image_synch_all_xmp(normalized_filename);
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -244,8 +244,6 @@ void dt_image_path_append_version(int imgid, char *pathname, size_t pathname_len
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len);
 /** finds all xmp duplicates for the given image in the database. */
 GList* dt_image_find_duplicates(const char* filename);
-/** look for duplicate's xmp files and read them, return the number of xmp files processed */
-int dt_image_read_duplicates(uint32_t id, const char *filename);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from threads other than lua.*/
 uint32_t dt_image_import(int32_t film_id, const char *filename, gboolean override_ignore_jpegs);
 /** imports a new image from raw/etc file and adds it to the data base and image cache. Use from lua thread.*/


### PR DESCRIPTION
second attempt to resolve issue with extra duplicate appearing on import
of files/folders where the minimum xmp version number is greater than
zero.

this replaces the previous solution delivered in #4393 while also
resolving some issues with group id not being set correctly and with
refresh of the lighttable.

Resolves #4385. Resolves #4562. Resolves #4568.