### PR TITLE
Powerfull extract_wb for superior wb presets extraction and finetuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,15 @@ if(USE_XMLLINT)
   endif(${Xmllint_BIN} STREQUAL "Xmllint_BIN-NOTFOUND")
 endif(USE_XMLLINT)
 
+find_program(exiftool_BIN exiftool)
+if(${exiftool_BIN} STREQUAL "exiftool_BIN-NOTFOUND")
+  message(STATUS "Missing exiftool")
+  set(HAVE_EXIFTOOL 0)
+else()
+  message(STATUS "Found exiftool")
+  set(HAVE_EXIFTOOL 1)
+endif()
+
 # done with looking for programs
 if(NOT EXTERNAL_PROGRAMS_FOUND)
   message(FATAL_ERROR "Some external programs couldn't be found")

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ Optionally, you might need for special features:
  - `libcolord-dev` `libcolord-gtk-dev` for colour profile support
  - `webp` and `openjpeg` libraries for WebP and JPEG 2000 support
  - GraphicsMagick library for TIFF-encoded EXIF thumbnails and LDR image format support
+ - `exiftool` for creating whitebalance presets
 
 ### Build
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,11 +5,15 @@ if (BUILD_NOISE_TOOLS)
     add_subdirectory(noise)
 endif()
 
+set(TOOLS common.sh  purge_from_cache.sh  purge_non_existing_images.sh  purge_unused_tags.sh)
+
+if(HAVE_EXIFTOOL)
+    set(TOOLS ${TOOLS} extract_wb_from_images.sh)
+endif()
+
 install(
-  FILES
-      common.sh  purge_from_cache.sh  purge_non_existing_images.sh  purge_unused_tags.sh
+  PROGRAMS
+      ${TOOLS}
   DESTINATION
       ${CMAKE_INSTALL_DATAROOTDIR}/darktable/tools
-  PERMISSIONS
-      OWNER_READ OWNER_EXECUTE OWNER_WRITE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -77,7 +77,11 @@ ARGV.each do |filename|
   finetune = 0
   listed_presets = []
   fl_count = 0
-  IO.popen("exiftool \"-WB_*\" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model -WBShiftAB -WBShiftAB_GM -WhiteBalanceFineTune -WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\"") do |io|
+  command = "exiftool \"-WB_*\" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model -WBShiftAB -WBShiftAB_GM -WhiteBalanceFineTune -WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\""
+  if filename.end_with? ".txt"
+    command = "cat \"#{filename}\""
+  end
+  IO.popen(command) do |io|
     while !io.eof?
       lineparts = io.readline.split(":")
       tag = lineparts[0].strip

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -74,9 +74,10 @@ end
 found_presets = []
 ARGV.each do |filename|
   red = green = blue = maker = model = preset = nil
+  finetune = 0
   listed_presets = []
   fl_count = 0
-  IO.popen("exiftool \"-WB_*\" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model \"#{filename}\"") do |io|
+  IO.popen("exiftool \"-WB_*\" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model -WBShiftAB -WBShiftAB_GM -WhiteBalanceFineTune -WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\"") do |io|
     while !io.eof?
       lineparts = io.readline.split(":")
       tag = lineparts[0].strip
@@ -132,6 +133,10 @@ ARGV.each do |filename|
         fl_count += 1 if p[0..."Fluorescent".size] == "Fluorescent"
         p = "Unknown" if !p || p==""
         listed_presets << [p,r,g,b]
+      elsif tag == "WB Shift AB" #canon - positive is towards amber, panasonic/leica/pentax - positive is towards blue?
+        finetune = values[0]
+      elsif tag == "WBShiftAB_GM" #sony
+        finetune = values[0]
       end
     end
   end
@@ -150,13 +155,13 @@ ARGV.each do |filename|
     end
 
     preset = FL_PRESET_REPLACE[preset] if FL_PRESET_REPLACE[preset]
-    [maker, model, preset, red, green, blue]
+    [maker, model, preset, "0", red, green, blue]
   end
 
   # Print out the WB value that was used in the file
   preset = "\"#{ARGV[0]}\"" if !preset
   if red && green && blue
-    found_presets << [maker, model, preset, red, green, blue]
+    found_presets << [maker, model, preset, finetune, red, green, blue]
   end
 end
 
@@ -177,22 +182,22 @@ def convert_preset_to_sort(preset)
 end
 
 found_presets.sort! do |a, b|
-  convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2])
+  (convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2])) == 0 ? a[3].to_i <=> b[3].to_i : (convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2]))
 end
 
 min_padding = 0
-found_presets.each do |maker, model, preset, red, green, blue, acc|
+found_presets.each do |maker, model, preset, finetune, red, green, blue, acc|
   min_padding = preset.size if preset.size > min_padding
 end
 
 # Print out the presets if they exist
-found_presets.each do |maker, model, preset, red, green, blue|
+found_presets.each do |maker, model, preset, finetune, red, green, blue|
   if IGNORED_PRESETS.include? preset
     $stderr.puts "Ignoring preset '#{preset}'"
   else
     preset = '"'+preset+'"' if preset[-1] == "K"
     preset = preset + " "*(min_padding-preset.size)
-    puts "  { \"#{maker}\", \"#{model}\", #{preset}, 0, { #{red}, #{green}, #{blue}, 0 } },"
+    puts "  { \"#{maker}\", \"#{model}\", #{preset}, #{finetune}, { #{red}, #{green}, #{blue}, 0 } },"
   end
 end
 

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -144,33 +144,18 @@ ARGV.each do |filename|
         finetune = values[0]
       elsif tag == "WB Shift GM" # detect GM shift and warn about it
         gm_skew = gm_skew || (values[0].to_i != 0)
-        if values[0].to_i != 0
-          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
-        end
       elsif tag == "WB Shift AB GM" # sony
         finetune = values[0]
         gm_skew = gm_skew || (values[1].to_i != 0)
-        if values[1].to_i != 0
-          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
-        end
       elsif tag == "White Balance Fine Tune" && maker.start_with?("NIKON") # nikon
         finetune = 0-(values[0].to_i * 2) # nikon lies about half-steps (eg 6->6->5 instead of 6->5.5->5, need to address this later on, so rescalling this now)
         gm_skew = gm_skew || (values[1].to_i != 0)
-        if values[1].to_i != 0
-          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
-        end
       elsif tag == "White Balance Fine Tune" && maker == "FUJIFILM" # fuji
         finetune = values[3].to_i / 20 # Fuji has -180..180 but steps are every 20
         gm_skew = gm_skew || (values[1].to_i != 0)
-        if values[1].to_i != 0
-          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
-        end
       elsif tag == "White Balance Bracket" # olympus
         finetune = values[0]
         gm_skew = gm_skew || (values[1].to_i != 0)
-        if values[1].to_i != 0
-          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
-        end
       end
     end
   end
@@ -203,9 +188,17 @@ ARGV.each do |filename|
   end
 end
 
-puts found_presets.inspect.gsub("], ", "],\n")
+# $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
+ 
 # Get rid of duplicate presets
 found_presets = Hash[found_presets.sort.zip].keys
+
+#get rid of ignored presets (might speed up things later on?)
+found_presets.reject! do |maker, model, preset, finetune, red, green, blue|
+  IGNORED_PRESETS.include? preset
+end
+
+# $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
 
 def convert_preset_to_sort(preset)
   if IGNORED_PRESETS.include? preset
@@ -221,7 +214,10 @@ def convert_preset_to_sort(preset)
 end
 
 found_presets.sort! do |a, b|
-  (convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2])) == 0 ? a[3].to_i <=> b[3].to_i : (convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2]))
+  (convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2])) == 0 ? 
+    a[3].to_i <=> b[3].to_i 
+    : 
+    (convert_preset_to_sort(a[2]) <=> convert_preset_to_sort(b[2]))
 end
 
 min_padding = 0
@@ -229,16 +225,41 @@ found_presets.each do |maker, model, preset, finetune, red, green, blue|
   min_padding = preset.size if preset.size > min_padding
 end
 
+ #dealing with Nikon half-steps
 (found_presets.length - 1).times do |index|
-  #dealing with Nikon half-steps
-  if found_presets[index][0] == "Nikon" && found_presets[index+1][0] == found_presets[index][0] && found_presets[index+1][1] == found_presets[index][1] && found_presets[index+1][2] == found_presets[index][2] && found_presets[index+1][3] == found_presets[index][3] #case now translated
+  if found_presets[index][0] == "Nikon" && #case now translated
+      found_presets[index+1][0] == found_presets[index][0] && ##
+      found_presets[index+1][1] == found_presets[index][1] &&
+      found_presets[index+1][2] == found_presets[index][2] &&
+      found_presets[index+1][3] == found_presets[index][3]
+      
     curr_finetune = found_presets[index][3].to_i
-    if curr_finetune < 0 # finetune
+    if curr_finetune < 0 
       found_presets[index+1][3] = ((found_presets[index+1][3].to_i) + 1).to_s
     elsif curr_finetune > 0
-      found_presets[index][3] = ((found_presets[index][3].to_i) - 1).to_s
+      found_presets[index][3] = ((curr_finetune) - 1).to_s
     end
   end
+end
+
+lazy_finetuning = []
+(found_presets.length - 1).times do |index|
+  if found_presets[index+1][0] == found_presets[index][0] && ##
+      found_presets[index+1][1] == found_presets[index][1] &&
+      found_presets[index+1][2] == found_presets[index][2] &&
+      found_presets[index+1][3].to_i != ((found_presets[index][3].to_i)+1)
+    # found gap. complain about needing to interpolate
+    lazy_finetuning << [found_presets[index][0], found_presets[index][1], found_presets[index][2]]
+  end
+end
+
+# Get rid of duplicate lazy finetuning reports
+lazy_finetuning = Hash[lazy_finetuning.sort.zip].keys
+
+# $stderr.puts lazy_finetuning.inspect.gsub("], ", "],\n") # debug content
+
+lazy_finetuning.each do |maker, model, preset|
+  $stderr.puts "Gaps detected in finetuning for #{maker} #{model} preset #{preset}, dt will need to interpolate!"
 end
 
 # Print out the presets if they exist

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -24,6 +24,9 @@ FL_PRESET_REPLACE={
   "White Fluorescent" => "WhiteFluorescent",
   "Unknown (0x600)" => "Underwater",
   "Sunny" => "DirectSunlight",
+  "Fine Weather" => "DirectSunlight",
+  "Tungsten (Incandescent)" => "Tungsten",
+  "ISO Studio Tungsten" => "Tungsten",
   "Cool WHT FL" => "CoolWhiteFluorescent",
   "Daylight FL" => "DaylightFluorescent",
   "Warm WHT FL" => "WarmWhiteFluorescent",
@@ -39,10 +42,12 @@ FL_PRESET_REPLACE={
   "6000K (Cloudy)" => "Cloudy",
   "7500K (Fine Weather with Shade)" => "Shade",
 }
-PRESET_ORDER=["Unknown", "DirectSunlight", "Daylight","Shade","Cloudy","Tungsten","Incandescent","Fluorescent",
-              "WarmWhiteFluorescent","CoolWhiteFluorescent","DayWhiteFluorescent","DaylightFluorescent",
-              "DaylightFluorescent", "NeutralFluorescent", "WhiteFluorescent", "HighTempMercuryVaporFluorescent",
-              "HTMercury", "SodiumVaporFluorescent", "Underwater", "Flash"]
+PRESET_ORDER=["Unknown", "DirectSunlight", "Daylight", "D55", "Shade","Cloudy",
+              "Tungsten","Incandescent","Fluorescent", "WarmWhiteFluorescent",
+              "CoolWhiteFluorescent","DayWhiteFluorescent","DaylightFluorescent",
+              "DaylightFluorescent", "NeutralFluorescent", "WhiteFluorescent",
+              "HighTempMercuryVaporFluorescent", "HTMercury", 
+              "SodiumVaporFluorescent", "Underwater", "Flash"]
 
 PRESET_SORT_MAPPING={}
 PRESET_ORDER.each_with_index {|name, index| PRESET_SORT_MAPPING[name]=index+1}
@@ -76,20 +81,25 @@ ARGV.each do |filename|
   red = green = blue = maker = model = preset = nil
   finetune = 0
   listed_presets = []
+  preset_names = {}
   fl_count = 0
   gm_skew = false;
-  command = "exiftool -Make -Model \"-WB_*\" -WhiteBalance -WhiteBalance2 "\
-    "-WhitePoint -WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune "\
-    "-WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\""
+  command = "exiftool -Make -Model \"-WBType*\" \"-WB_*\" "\
+    "-WhiteBalance -WhiteBalance2 -WhitePoint "\
+    "-WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune "\
+    "-WBShiftIntelligentAuto -WBShiftCreativeControl "\
+    "-WBRedLevel -WBBlueLevel -WBGreenLevel "\
+    "\"#{filename}\""
   if filename.end_with? ".txt"
     command = "cat \"#{filename}\""
   end
   IO.popen(command) do |io|
+    rlevel = blevel = glevel = 0
     while !io.eof?
       lineparts = io.readline.split(":")
       tag = lineparts[0].strip
       values = lineparts[1].strip.split(" ")
-
+    
       if tag.split.include? "Make"
         maker = lineparts[1].strip
       elsif tag.split.include? "Model"
@@ -112,6 +122,11 @@ ARGV.each do |filename|
         red = values[1].to_f/green
         blue = values[2].to_f/green
         green = 1
+      # elsif tag == "WB GRB Levels Auto" && maker == "FUJIFILM" # fuji seems to use "WB GRB Levels Auto to describe manual finetuning
+      #  green = values[0].to_f
+      #  red = values[1].to_f/green
+      #  blue = values[2].to_f/green
+      #  green = 1
       elsif tag == "White Point" && values.length > 3
         green = (values[1].to_f+values[2].to_f)/2.0
         red = values[0].to_f/green
@@ -120,8 +135,14 @@ ARGV.each do |filename|
       elsif tag == "White Balance" || tag == "White Balance 2"
         preset = values.join(" ")
         preset = FL_PRESET_REPLACE[preset] if FL_PRESET_REPLACE[preset]
+      elsif tag.split[0..1].join(" ") == "WB Type"
+        preset_names[tag.split[2..-1].join] = values.join(" ");
       elsif ["WB RGB Levels", "WB RGGB Levels"].include? tag.split[0..2].join(" ")
         p = tag.split[3..-1].join
+        
+        if preset_names.has_key?(p)
+          p = preset_names[p];
+        end
 
         r=g=b=0
         if values.size == 4
@@ -140,6 +161,12 @@ ARGV.each do |filename|
         fl_count += 1 if p[0..."Fluorescent".size] == "Fluorescent"
         p = "Unknown" if !p || p==""
         listed_presets << [p,r,g,b]
+      elsif tag == "WB Red Level"
+        rlevel = values[0].to_f
+      elsif tag == "WB Blue Level"
+        blevel = values[0].to_f
+      elsif tag == "WB Green Level"
+        glevel = values[0].to_f
       elsif tag == "WB Shift AB" # canon - positive is towards amber, panasonic/leica/pentax - positive is towards blue?
         finetune = values[0]
       elsif tag == "WB Shift GM" # detect GM shift and warn about it
@@ -151,12 +178,18 @@ ARGV.each do |filename|
         finetune = 0-(values[0].to_i * 2) # nikon lies about half-steps (eg 6->6->5 instead of 6->5.5->5, need to address this later on, so rescalling this now)
         gm_skew = gm_skew || (values[1].to_i != 0)
       elsif tag == "White Balance Fine Tune" && maker == "FUJIFILM" # fuji
+        $stderr.puts "Warning: Fuji does not seem to produce any sensible data for finetuning! If all finetuned values are identical, use one with no finetuning (0)"
         finetune = values[3].to_i / 20 # Fuji has -180..180 but steps are every 20
         gm_skew = gm_skew || (values[1].to_i != 0)
       elsif tag == "White Balance Bracket" # olympus
         finetune = values[0]
         gm_skew = gm_skew || (values[1].to_i != 0)
       end
+    end
+    if rlevel > 0 && glevel > 0 && blevel > 0
+      red = rlevel/glevel
+      blue = blevel/glevel
+      green = 1
     end
   end
 

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -9,7 +9,8 @@ end
 IGNORED_PRESETS=["Auto","Kelvin","Measured","AsShot","Kelvin","Preset",
                  "Multi Auto", "Color Temperature Enhancement", "Custom",
                  "One Touch WB 1", "One Touch WB 2", "One Touch WB 3",
-                 "One Touch WB 4", "Custom WB 1", "Auto0", "Auto1", "Auto2"]
+                 "One Touch WB 4", "Custom WB 1", "Auto0", "Auto1", "Auto2",
+                 "CWB1", "CWB2", "CWB3", "CWB4"]
 # Preset names we adjust
 FL_PRESET_REPLACE={
   "Fluorescent" => "CoolWhiteFluorescent",
@@ -41,13 +42,13 @@ FL_PRESET_REPLACE={
   "6000K (Cloudy)" => "Cloudy",
   "7500K (Fine Weather with Shade)" => "Shade",
 }
-PRESET_ORDER=["Unknown", "DirectSunlight", "Daylight", "D55", "Shade","Cloudy",
+PRESET_ORDER=["DirectSunlight", "Daylight", "D55", "Shade","Cloudy",
               "Tungsten", "ISO Studio Tungsten", "Incandescent","Fluorescent", 
               "WarmWhiteFluorescent", "CoolWhiteFluorescent",
               "DayWhiteFluorescent","DaylightFluorescent",
               "DaylightFluorescent", "NeutralFluorescent", "WhiteFluorescent",
               "HighTempMercuryVaporFluorescent", "HTMercury", 
-              "SodiumVaporFluorescent", "Underwater", "Flash"]
+              "SodiumVaporFluorescent", "Underwater", "Flash", "Unknown"]
 
 PRESET_SORT_MAPPING={}
 PRESET_ORDER.each_with_index {|name, index| PRESET_SORT_MAPPING[name]=index+1}
@@ -159,7 +160,30 @@ ARGV.each do |filename|
           b = values[2].to_f/g
           g = 1
         else
-          $stderr.puts "Found tag '#{p}' with #{values.size} values instead of 3 or 4"
+          $stderr.puts "Found RGB tag '#{p}' with #{values.size} values instead of 3 or 4"
+        end
+        fl_count += 1 if p[0..."Fluorescent".size] == "Fluorescent"
+        p = "Unknown" if !p || p==""
+        listed_presets << [p,r,g,b]
+      elsif ["WB RB Levels"].include? tag.split[0..2].join(" ")
+        p = tag.split[3..-1].join
+        
+        if preset_names.has_key?(p)
+          p = preset_names[p];
+        end
+
+        r=g=b=0
+        if values.size == 4
+          g = (values[2].to_f+values[3].to_f)/2.0
+          r = values[0].to_f/g
+          b = values[1].to_f/g
+          g = 1
+        elsif values.size == 2
+          r = values[0].to_f
+          b = values[2].to_f
+          g = 1
+        else
+          $stderr.puts "Found RB tag '#{p}' with #{values.size} values instead of 2 or 4"
         end
         fl_count += 1 if p[0..."Fluorescent".size] == "Fluorescent"
         p = "Unknown" if !p || p==""

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -42,7 +42,7 @@ FL_PRESET_REPLACE={
 PRESET_ORDER=["Unknown", "DirectSunlight", "Daylight","Shade","Cloudy","Tungsten","Incandescent","Fluorescent",
               "WarmWhiteFluorescent","CoolWhiteFluorescent","DayWhiteFluorescent","DaylightFluorescent",
               "DaylightFluorescent", "NeutralFluorescent", "WhiteFluorescent", "HighTempMercuryVaporFluorescent",
-              "SodiumVaporFluorescent", "Underwater", "Flash"]
+              "HTMercury", "SodiumVaporFluorescent", "Underwater", "Flash"]
 
 PRESET_SORT_MAPPING={}
 PRESET_ORDER.each_with_index {|name, index| PRESET_SORT_MAPPING[name]=index+1}
@@ -188,15 +188,15 @@ ARGV.each do |filename|
   end
 end
 
-# $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
- 
-# Get rid of duplicate presets
-found_presets = Hash[found_presets.sort.zip].keys
-
 #get rid of ignored presets (might speed up things later on?)
 found_presets.reject! do |maker, model, preset, finetune, red, green, blue|
   IGNORED_PRESETS.include? preset
 end
+
+# $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
+ 
+# Get rid of duplicate presets
+found_presets = Hash[found_presets.sort.zip].keys
 
 # $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
 
@@ -242,12 +242,32 @@ end
   end
 end
 
+# $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
+
+# pack Nikon finetuning in case there were no half-steps 
+(found_presets.length - 1).times do |index|
+  if found_presets[index][0] == "Nikon" && #case now translated
+      found_presets[index+1][0] == found_presets[index][0] && ##
+      found_presets[index+1][1] == found_presets[index][1] &&
+      found_presets[index+1][2] == found_presets[index][2] &&
+      found_presets[index+1][3].to_i.even? && found_presets[index][3].to_i.even? &&
+      (found_presets[index+1][3].to_i) == (found_presets[index][3].to_i + 2)
+    
+    #detected gap eg -12 -> -10. slicing in half to undo multiplication done earlier
+    found_presets[index][3] = (found_presets[index][3].to_i / 2).to_s
+    found_presets[index+1][3] = (found_presets[index+1][3].to_i / 2).to_s
+  end
+end
+# $stderr.puts found_presets.inspect.gsub("], ", "],\n") # debug content
+
+#detect lazy finetuning (will not complain if there's no finetuning)
 lazy_finetuning = []
 (found_presets.length - 1).times do |index|
   if found_presets[index+1][0] == found_presets[index][0] && ##
       found_presets[index+1][1] == found_presets[index][1] &&
       found_presets[index+1][2] == found_presets[index][2] &&
       found_presets[index+1][3].to_i != ((found_presets[index][3].to_i)+1)
+      
     # found gap. complain about needing to interpolate
     lazy_finetuning << [found_presets[index][0], found_presets[index][1], found_presets[index][2]]
   end

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -77,6 +77,7 @@ ARGV.each do |filename|
   finetune = 0
   listed_presets = []
   fl_count = 0
+  gm_skew = false;
   command = "exiftool -Make -Model \"-WB_*\" -WhiteBalance -WhiteBalance2 "\
     "-WhitePoint -WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune "\
     "-WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\""
@@ -139,12 +140,43 @@ ARGV.each do |filename|
         fl_count += 1 if p[0..."Fluorescent".size] == "Fluorescent"
         p = "Unknown" if !p || p==""
         listed_presets << [p,r,g,b]
-      elsif tag == "WB Shift AB" #canon - positive is towards amber, panasonic/leica/pentax - positive is towards blue?
+      elsif tag == "WB Shift AB" # canon - positive is towards amber, panasonic/leica/pentax - positive is towards blue?
         finetune = values[0]
-      elsif tag == "WBShiftAB_GM" #sony
+      elsif tag == "WB Shift GM" # detect GM shift and warn about it
+        gm_skew = gm_skew || (values[0].to_i != 0)
+        if values[0].to_i != 0
+          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
+        end
+      elsif tag == "WBShiftAB_GM" # sony
         finetune = values[0]
+        gm_skew = gm_skew || (values[1].to_i != 0)
+        if values[1].to_i != 0
+          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
+        end
+      elsif tag == "White Balance Fine Tune" && make == "NIKON" # nikon
+        finetune = values[0] * 2 # nikon lies about half-steps (eg 6->6->5 instead of 6->5.5->5, need to address this later on, so rescalling this now)
+        gm_skew = gm_skew || (values[1].to_i != 0)
+        if values[1].to_i != 0
+          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
+        end
+      elsif tag == "White Balance Fine Tune" && make == "FUJIFILM" # fuji
+        finetune = values[3].to_i / 20 # Fuji has -180..180 but steps are every 20
+        gm_skew = gm_skew || (values[1].to_i != 0)
+        if values[1].to_i != 0
+          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
+        end
+      elseif tag == "White Balance Bracket" # olympus
+        finetune = values[0]
+        gm_skew = gm_skew || (values[1].to_i != 0)
+        if values[1].to_i != 0
+          $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
+        end
       end
     end
+  end
+
+  if gm_skew
+    $stderr.puts "WARNING: #{filename} has finetuning over GM axis! Data is skewed!"
   end
 
   # Adjust the maker/model we found with the map we generated before

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -147,25 +147,25 @@ ARGV.each do |filename|
         if values[0].to_i != 0
           $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
         end
-      elsif tag == "WBShiftAB_GM" # sony
+      elsif tag == "WB Shift AB GM" # sony
         finetune = values[0]
         gm_skew = gm_skew || (values[1].to_i != 0)
         if values[1].to_i != 0
           $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
         end
-      elsif tag == "White Balance Fine Tune" && make == "NIKON" # nikon
-        finetune = values[0] * 2 # nikon lies about half-steps (eg 6->6->5 instead of 6->5.5->5, need to address this later on, so rescalling this now)
+      elsif tag == "White Balance Fine Tune" && maker.start_with?("NIKON") # nikon
+        finetune = 0-(values[0].to_i * 2) # nikon lies about half-steps (eg 6->6->5 instead of 6->5.5->5, need to address this later on, so rescalling this now)
         gm_skew = gm_skew || (values[1].to_i != 0)
         if values[1].to_i != 0
           $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
         end
-      elsif tag == "White Balance Fine Tune" && make == "FUJIFILM" # fuji
+      elsif tag == "White Balance Fine Tune" && maker == "FUJIFILM" # fuji
         finetune = values[3].to_i / 20 # Fuji has -180..180 but steps are every 20
         gm_skew = gm_skew || (values[1].to_i != 0)
         if values[1].to_i != 0
           $stderr.puts "WARNING: finetuning over GM axis detected! data is skewed!"
         end
-      elseif tag == "White Balance Bracket" # olympus
+      elsif tag == "White Balance Bracket" # olympus
         finetune = values[0]
         gm_skew = gm_skew || (values[1].to_i != 0)
         if values[1].to_i != 0
@@ -199,10 +199,11 @@ ARGV.each do |filename|
   # Print out the WB value that was used in the file
   preset = "\"#{ARGV[0]}\"" if !preset
   if red && green && blue
-    found_presets << [maker, model, preset, finetune, red, green, blue]
+    found_presets << [maker, model, preset, finetune.to_s, red, green, blue]
   end
 end
 
+puts found_presets.inspect.gsub("], ", "],\n")
 # Get rid of duplicate presets
 found_presets = Hash[found_presets.sort.zip].keys
 
@@ -224,8 +225,20 @@ found_presets.sort! do |a, b|
 end
 
 min_padding = 0
-found_presets.each do |maker, model, preset, finetune, red, green, blue, acc|
+found_presets.each do |maker, model, preset, finetune, red, green, blue|
   min_padding = preset.size if preset.size > min_padding
+end
+
+(found_presets.length - 1).times do |index|
+  #dealing with Nikon half-steps
+  if found_presets[index][0] == "Nikon" && found_presets[index+1][0] == found_presets[index][0] && found_presets[index+1][1] == found_presets[index][1] && found_presets[index+1][2] == found_presets[index][2] && found_presets[index+1][3] == found_presets[index][3] #case now translated
+    curr_finetune = found_presets[index][3].to_i
+    if curr_finetune < 0 # finetune
+      found_presets[index+1][3] = ((found_presets[index+1][3].to_i) + 1).to_s
+    elsif curr_finetune > 0
+      found_presets[index][3] = ((found_presets[index][3].to_i) - 1).to_s
+    end
+  end
 end
 
 # Print out the presets if they exist

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -77,7 +77,9 @@ ARGV.each do |filename|
   finetune = 0
   listed_presets = []
   fl_count = 0
-  command = "exiftool \"-WB_*\" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model -WBShiftAB -WBShiftAB_GM -WhiteBalanceFineTune -WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\""
+  command = "exiftool -Make -Model \"-WB_*\" -WhiteBalance -WhiteBalance2 "\
+    "-WhitePoint -WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune "\
+    "-WBShiftIntelligentAuto -WBShiftCreativeControl \"#{filename}\""
   if filename.end_with? ".txt"
     command = "cat \"#{filename}\""
   end
@@ -87,7 +89,11 @@ ARGV.each do |filename|
       tag = lineparts[0].strip
       values = lineparts[1].strip.split(" ")
 
-      if tag == "WB RGGB Levels"
+      if tag.split.include? "Make"
+        maker = lineparts[1].strip
+      elsif tag.split.include? "Model"
+        model = lineparts[1].strip
+      elsif tag == "WB RGGB Levels"
         green = (values[1].to_f+values[2].to_f)/2.0
         red = values[0].to_f/green
         blue = values[3].to_f/green
@@ -110,10 +116,6 @@ ARGV.each do |filename|
         red = values[0].to_f/green
         blue = values[3].to_f/green
         green = 1
-      elsif tag.split.include? "Make"
-        maker = lineparts[1].strip
-      elsif tag.split.include? "Model"
-        model = lineparts[1].strip
       elsif tag == "White Balance" || tag == "White Balance 2"
         preset = values.join(" ")
         preset = FL_PRESET_REPLACE[preset] if FL_PRESET_REPLACE[preset]

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -10,7 +10,8 @@ IGNORED_PRESETS=["Auto","Kelvin","Measured","AsShot","Kelvin","Preset",
                  "Multi Auto", "Color Temperature Enhancement", "Custom",
                  "One Touch WB 1", "One Touch WB 2", "One Touch WB 3",
                  "One Touch WB 4", "Custom WB 1", "Auto0", "Auto1", "Auto2",
-                 "CWB1", "CWB2", "CWB3", "CWB4"]
+                 "CWB1", "CWB2", "CWB3", "CWB4", "Black", "Illuminator1",
+                 "Illuminator2", "Uncorrected"]
 # Preset names we adjust
 FL_PRESET_REPLACE={
   "Fluorescent" => "CoolWhiteFluorescent",

--- a/tools/extract_wb
+++ b/tools/extract_wb
@@ -26,7 +26,6 @@ FL_PRESET_REPLACE={
   "Sunny" => "DirectSunlight",
   "Fine Weather" => "DirectSunlight",
   "Tungsten (Incandescent)" => "Tungsten",
-  "ISO Studio Tungsten" => "Tungsten",
   "Cool WHT FL" => "CoolWhiteFluorescent",
   "Daylight FL" => "DaylightFluorescent",
   "Warm WHT FL" => "WarmWhiteFluorescent",
@@ -43,8 +42,9 @@ FL_PRESET_REPLACE={
   "7500K (Fine Weather with Shade)" => "Shade",
 }
 PRESET_ORDER=["Unknown", "DirectSunlight", "Daylight", "D55", "Shade","Cloudy",
-              "Tungsten","Incandescent","Fluorescent", "WarmWhiteFluorescent",
-              "CoolWhiteFluorescent","DayWhiteFluorescent","DaylightFluorescent",
+              "Tungsten", "ISO Studio Tungsten", "Incandescent","Fluorescent", 
+              "WarmWhiteFluorescent", "CoolWhiteFluorescent",
+              "DayWhiteFluorescent","DaylightFluorescent",
               "DaylightFluorescent", "NeutralFluorescent", "WhiteFluorescent",
               "HighTempMercuryVaporFluorescent", "HTMercury", 
               "SodiumVaporFluorescent", "Underwater", "Flash"]
@@ -84,11 +84,14 @@ ARGV.each do |filename|
   preset_names = {}
   fl_count = 0
   gm_skew = false;
-  command = "exiftool -Make -Model \"-WBType*\" \"-WB_*\" "\
-    "-WhiteBalance -WhiteBalance2 -WhitePoint "\
-    "-WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune "\
-    "-WBShiftIntelligentAuto -WBShiftCreativeControl "\
-    "-WBRedLevel -WBBlueLevel -WBGreenLevel "\
+  command = "exiftool -Make -Model \"-WBType*\" \"-WB_*\" \"-ColorTemp*\"    "\
+    "-WhiteBalance -WhiteBalance2 -WhitePoint -ColorCompensationFilter       "\
+    "-WBShiftAB -WBShiftAB_GM -WBShiftAB_GM_Precise -WBShiftGM -WBScale      "\
+    "-WhiteBalanceFineTune -WhiteBalanceComp -WhiteBalanceSetting            "\
+    "-WhiteBalanceBracket -WhiteBalanceBias -WBMode -WhiteBalanceMode        "\
+    "-WhiteBalanceTemperature -WhiteBalanceDetected -ColorTemperature        "\
+    "-WBShiftIntelligentAuto -WBShiftCreativeControl -WhiteBalanceSetup      "\
+    "-WBRedLevel -WBBlueLevel -WBGreenLevel -RedBalance -BlueBalance         "\
     "\"#{filename}\""
   if filename.end_with? ".txt"
     command = "cat \"#{filename}\""
@@ -184,6 +187,8 @@ ARGV.each do |filename|
       elsif tag == "White Balance Bracket" # olympus
         finetune = values[0]
         gm_skew = gm_skew || (values[1].to_i != 0)
+      elsif tag == "Color Compensation Filter" # minolta?
+        gm_skew = gm_skew || (values[0].to_i != 0)
       end
     end
     if rlevel > 0 && glevel > 0 && blevel > 0

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -27,11 +27,14 @@ echo "Extracting WB presets."
 for image in "$@"
 do
     echo -n "."
-    exiftool -Make -Model "-WBType*" "-WB_*" \
-      -WhiteBalance -WhiteBalance2 -WhitePoint \
-      -WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune \
-      -WhiteBalanceBracket -WBShiftIntelligentAuto -WBShiftCreativeControl \
-      -WBRedLevel -WBBlueLevel -WBGreenLevel \
+    exiftool -Make -Model "-WBType*" "-WB_*" "-ColorTemp*"                     \
+      -WhiteBalance -WhiteBalance2 -WhitePoint -ColorCompensationFilter        \
+      -WBShiftAB -WBShiftAB_GM -WBShiftAB_GM_Precise -WBShiftGM -WBScale       \
+      -WhiteBalanceFineTune -WhiteBalanceComp -WhiteBalanceSetting             \
+      -WhiteBalanceBracket -WhiteBalanceBias -WBMode -WhiteBalanceMode         \
+      -WhiteBalanceTemperature -WhiteBalanceDetected -ColorTemperature         \
+      -WBShiftIntelligentAuto -WBShiftCreativeControl -WhiteBalanceSetup       \
+      -WBRedLevel -WBBlueLevel -WBGreenLevel -RedBalance -BlueBalance          \
       "${image}" > "${tmp_dir}/${image}.txt"
 done
 

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -21,13 +21,16 @@ fi
 tmp_dir=$(mktemp -d -t dt-wb-XXXXXXXXXX)
 cur_dir=$(pwd)
 
-tarball="$cur_dir"/darktable-whitebalance-$(date +'%Y%m%d').tar.gz
+tarball="$cur_dir"/darktable-whitebalance-$(date +'%Y%m%d').tar.bz2
 
 echo "Extracting WB presets."
 for image in "$@"
 do
     echo -n "."
-    exiftool "-WB_*" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model -WBShiftAB -WBShiftAB_GM -WhiteBalanceFineTune -WBShiftIntelligentAuto -WBShiftCreativeControl -WhiteBalanceBracket "${image}" > "${tmp_dir}/${image}.txt"
+    exiftool -Make -Model "-WB_*" -WhiteBalance -WhiteBalance2 -WhitePoint \
+      -WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune \
+      -WhiteBalanceBracket -WBShiftIntelligentAuto -WBShiftCreativeControl \
+      "${image}" > "${tmp_dir}/${image}.txt"
 done
 
 echo

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -27,9 +27,11 @@ echo "Extracting WB presets."
 for image in "$@"
 do
     echo -n "."
-    exiftool -Make -Model "-WB_*" -WhiteBalance -WhiteBalance2 -WhitePoint \
+    exiftool -Make -Model "-WBType*" "-WB_*" \
+      -WhiteBalance -WhiteBalance2 -WhitePoint \
       -WBShiftAB -WBShiftAB_GM -WBShiftGM -WhiteBalanceFineTune \
       -WhiteBalanceBracket -WBShiftIntelligentAuto -WBShiftCreativeControl \
+      -WBRedLevel -WBBlueLevel -WBGreenLevel \
       "${image}" > "${tmp_dir}/${image}.txt"
 done
 

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -21,7 +21,7 @@ fi
 tmp_dir=$(mktemp -d -t dt-wb-XXXXXXXXXX)
 cur_dir=$(pwd)
 
-tarball="$cur_dir"/darktable-whitebalance-$(date +'%Y%m%d').tar.bz2
+tarball="$cur_dir"/darktable-whitebalance-$(date +'%Y%m%d').tar.gz
 
 echo "Extracting WB presets."
 for image in "$@"
@@ -41,7 +41,7 @@ done
 echo
 echo "preparing tarball..."
 
-tar -cjf "${tarball}" -C ${tmp_dir} .
+tar -czf "${tarball}" -C ${tmp_dir} .
 
 echo "cleaning up..."
 rm -rf $tmp_dir

--- a/tools/extract_wb_from_images.sh
+++ b/tools/extract_wb_from_images.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#
+# Usage: extract_wb_from_images [-p]
+#        -p  do the purge, otherwise only display unused tags
+#
+
+commandline="$0 $*"
+
+# handle command line arguments
+option="$1"
+if [ "${option}" = "-h" ] || [ "${option}" = "--help" ]; then
+  echo "Extract White Balance preset info from images"
+  echo "Usage:   $0 <file1> [file2] ..."
+  echo ""
+  echo "This tool will generate archive with wite balance"
+  echo "presets extracted from provided image files"
+  exit 0
+fi
+
+tmp_dir=$(mktemp -d -t dt-wb-XXXXXXXXXX)
+cur_dir=$(pwd)
+
+tarball="$cur_dir"/darktable-whitebalance-$(date +'%Y%m%d').tar.gz
+
+echo "Extracting WB presets."
+for image in "$@"
+do
+    echo -n "."
+    exiftool "-WB_*" -WhiteBalance -WhiteBalance2 -WhitePoint -Make -Model -WBShiftAB -WBShiftAB_GM -WhiteBalanceFineTune -WBShiftIntelligentAuto -WBShiftCreativeControl -WhiteBalanceBracket "${image}" > "${tmp_dir}/${image}.txt"
+done
+
+echo
+echo "preparing tarball..."
+
+tar -cjf "${tarball}" -C ${tmp_dir} .
+
+echo "cleaning up..."
+rm -rf $tmp_dir
+
+echo
+
+echo "Extracting wb presets done, post the following file to us:"
+echo $tarball


### PR DESCRIPTION
While working on `temperature.c` changes I noticed the need for easier tooling for WB extraction.

This is effect of over week's worth work although only partial.

First - this adds `extract_wb_from_images.sh` script that runs same `exiftool` command as `extract_wb` in order for users to avoid needing to install ruby, nekogiri & all that. This removes couple pain points in wb presets generation.

Next are changes in `extract_wb`:
- Detects finetuning used, so user won't need to manually edit generated data
- detects whether shift over Green-Magenta axis happened and complains about it
- support over 25 steps of WB finetuning (nikon)
- doesn't scream at user about ignored presets (:wink:)
- detects and mention if user didn't do finetuning over whole Amber-Blue axis in case finetuning was done

TODO:
- [x] write improved wiki entry for camera support, especially wb extraction - https://github.com/darktable-org/darktable/wiki/White-balance-presets
- [x] install `extract_wb_from_images.sh` in same step as other tools, so it's available for all users
- [x] test on more reallife data (ongoing)
- [x] integrate with `temperature.c` code (ongoing)

Currently tested with various Canon cameras and data provided selflessly by good members of pixls.us on https://discuss.pixls.us/t/call-for-white-balance-finetuning-samples/17137 thread.

thanks to them it's confirmed that the scripts work flawlessly on all cameras by:
- Canon 
- Nikon
- Sony
- Pentax
- Panasonic
- Olympus

Fuji probably doesn't have finetuning in exif

other cameras - need more samples but I'm sure it'll be fine