### PR TITLE
Improve UI for hdr and monochrome images

### DIFF
--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -21,6 +21,7 @@
 #include "common/image.h"
 #include "common/imageio_module.h"
 #include "common/mipmap_cache.h"
+#include "common/tags.h"
 #include <glib.h>
 #include <stdio.h>
 
@@ -52,6 +53,10 @@ typedef enum dt_imageio_levels_t
 
 // Checks that the image is indeed an ldr image
 gboolean dt_imageio_is_ldr(const char *filename);
+
+void dt_imageio_set_bw_tag(dt_image_t *img);
+
+void dt_imageio_set_hdr_tag(dt_image_t *img);
 
 // opens the file using pfm, hdr, exr.
 dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -53,9 +53,9 @@ typedef enum dt_imageio_levels_t
 
 // Checks that the image is indeed an ldr image
 gboolean dt_imageio_is_ldr(const char *filename);
-
+// Set te darktable/mode/monochrome tag
 void dt_imageio_set_bw_tag(dt_image_t *img);
-
+// Set te darktable/mode/hdr tag
 void dt_imageio_set_hdr_tag(dt_image_t *img);
 
 // opens the file using pfm, hdr, exr.

--- a/src/common/imageio_rawspeed.cc
+++ b/src/common/imageio_rawspeed.cc
@@ -384,17 +384,8 @@ dt_imageio_retval_t dt_imageio_open_rawspeed_sraw(dt_image_t *img, RawImage r, d
   // if buf is NULL, we quit the fct here
   if(!mbuf) return DT_IMAGEIO_OK;
 
-  // We test for monochrome before allocating the mipmap cache
-  // We set the flag and add the tag only once.
-  if((cpp == 1) && !(img->flags & DT_IMAGE_MONOCHROME))
-    {
-      guint tagid = 0;
-      char tagname[64];
-      snprintf(tagname, sizeof(tagname), "darktable|mode|monochrome");
-      dt_tag_new(tagname, &tagid);
-      dt_tag_attach(tagid, img->id, FALSE, FALSE);
-      img->flags |= DT_IMAGE_MONOCHROME;
-    }
+  if(cpp == 1) img->flags |= DT_IMAGE_MONOCHROME;
+
   void *buf = dt_mipmap_cache_alloc(mbuf, img);
   if(!buf) return DT_IMAGEIO_CACHE_FULL;
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -55,8 +55,9 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
   if(img)
   {
     thumb->has_localcopy = (img->flags & DT_IMAGE_LOCAL_COPY);
-
     thumb->rating = (img->flags & 0x7);
+    thumb->is_bw = dt_image_is_monochrome(img);
+    thumb->is_hdr = dt_image_is_hdr(img);
 
     thumb->groupid = img->group_id;
 
@@ -218,16 +219,18 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     gchar *ext2 = NULL;
     while(ext > thumb->filename && *ext != '.') ext--;
     ext++;
+    gchar *uext = dt_view_extend_modes_str(ext, thumb->is_hdr, thumb->is_bw);
+
     if(thumb->img_width < thumb->img_height)
     {
       // vertical disposition
-      for(int i = 0; i < strlen(ext); i++) ext2 = dt_util_dstrcat(ext2, "%.1s\n", &ext[i]);
+      for(int i = 0; i < strlen(uext); i++) ext2 = dt_util_dstrcat(ext2, "%.1s\n", &uext[i]);
     }
     else
-      ext2 = dt_util_dstrcat(ext2, "%s", ext);
-    gchar *upcase_ext = g_ascii_strup(ext2, -1); // extension in capital letters to avoid character descenders
-    gtk_label_set_text(GTK_LABEL(thumb->w_ext), upcase_ext);
-    g_free(upcase_ext);
+      ext2 = dt_util_dstrcat(ext2, "%s", uext);
+
+    gtk_label_set_text(GTK_LABEL(thumb->w_ext), ext2);
+    g_free(uext);
     g_free(ext2);
 
     return TRUE;

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -55,6 +55,8 @@ typedef struct
   gboolean is_altered;
   gboolean has_audio;
   gboolean is_grouped;
+  gboolean is_bw;
+  gboolean is_hdr;
   gboolean has_localcopy;
   int groupid;
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1276,6 +1276,26 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
   if(rgbbuf) free(rgbbuf);
   return 0;
 }
+
+char* dt_view_extend_modes_str(const char * name, const gboolean is_hdr, const gboolean is_bw)
+{
+  char* upcase = g_ascii_strup(name, -1);  // extension in capital letters to avoid character descenders
+
+  if(is_hdr)
+  {
+    gchar* fullname = g_strdup_printf("%s HDR",upcase);
+    g_free(upcase);
+    upcase = fullname;
+  }
+  if(is_bw)
+  {
+    gchar* fullname = g_strdup_printf("%s B&W",upcase);
+    g_free(upcase);
+    upcase = fullname;
+  }
+  return upcase;
+}
+
 int dt_view_image_expose(dt_view_image_expose_t *vals)
 {
   int missing = 0;
@@ -1463,7 +1483,7 @@ int dt_view_image_expose(dt_view_image_expose_t *vals)
       ext++;
       dt_gui_gtk_set_source_rgb(cr, fontcol);
 
-      char* upcase_ext = g_ascii_strup(ext, -1);  // extension in capital letters to avoid character descenders
+      char* upcase_ext = dt_view_extend_modes_str(ext, dt_image_is_hdr(img), dt_image_is_monochrome(img));
 
       if(buf_ht > buf_wd)
       {

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -232,6 +232,8 @@ typedef struct dt_view_image_expose_t
   int *full_surface_ht;
   int *full_surface_w_lock;
 } dt_view_image_expose_t;
+/** returns an uppercase string of file extension **plus** some flag information **/
+char* dt_view_extend_modes_str(const char * name, const int is_hdr, const int is_bw);
 /** expose an image, set image over flags. return != 0 if thumbnail wasn't loaded yet. */
 int dt_view_image_expose(dt_view_image_expose_t *vals);
 /** expose an image and return a cairi_surface. return != 0 if thumbnail wasn't loaded yet. */


### PR DESCRIPTION
Both image types often want a different workflow than usual, for hdr's there has been a short discussion on pixls.us about this.

It might be helpful to visualize the information about such an image in the lighttable window, i have opted for a simpe textual addition instead of another icon there.
![pic1](https://user-images.githubusercontent.com/50982232/77988674-3645a080-731d-11ea-90bc-4c43c7823484.png)


Also it is good to have a darktable tag also for hdr images, there is such already for monochromes.
![pic2](https://user-images.githubusercontent.com/50982232/77988694-3f367200-731d-11ea-979c-d7ec8f7ce615.png)


The detection of "image being a hdr or b&w" is normally done inside `dt_imageio_open`, this is
ok and should be kept but we can also do an early detection when reading exif data in
`dt_exif_read_exif_data`. At least for files tested via `dt_image_is_hdr` or for dng's this
is pretty easy.

Why is this good? We have the monochrome/hdr flags already correctly set while importing.

Any performance penalty? No

Is it complete? i guess so. The **collect images** list already seem pretty large and as this is a somewhat special workflow searching via tags seems to be ok/better.