### PR TITLE
add Exif.Photo.ExposureBiasValue to variables and image info

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -44,7 +44,7 @@
 
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 25
+#define CURRENT_DATABASE_VERSION_LIBRARY 26
 #define CURRENT_DATABASE_VERSION_DATA     6
 
 typedef struct dt_database_t
@@ -1530,6 +1530,13 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
 
     new_version = 25;
   }
+  else if(version == 25)
+  {
+    TRY_EXEC("ALTER TABLE main.images ADD COLUMN exposure_bias REAL",
+             "[init] can't add `exposure_bias' column to images table in database\n");
+
+    new_version = 26;
+  }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop
 
@@ -1796,7 +1803,8 @@ static void _create_library_schema(dt_database_t *db)
       "caption VARCHAR, description VARCHAR, license VARCHAR, sha1sum CHAR(40), "
       "orientation INTEGER, histogram BLOB, lightmap BLOB, longitude REAL, "
       "latitude REAL, altitude REAL, color_matrix BLOB, colorspace INTEGER, version INTEGER, "
-      "max_version INTEGER, write_timestamp INTEGER, history_end INTEGER, position INTEGER, aspect_ratio REAL)",
+      "max_version INTEGER, write_timestamp INTEGER, history_end INTEGER, position INTEGER, aspect_ratio REAL,"
+      "exposure_bias REAL)",
       NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE INDEX main.images_group_id_index ON images (group_id)", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE INDEX main.images_film_id_index ON images (film_id)", NULL, NULL, NULL);

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -734,6 +734,13 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       // uf_strlcpy_to_utf8(uf->conf->shutterText, max_name, pos, exifData);
       img->exif_exposure = 1.0 / pos->toFloat();
     }
+
+    // Read exposure bias
+    if(FIND_EXIF_TAG("Exif.Photo.ExposureBiasValue"))
+    {
+      img->exif_exposure_bias = pos->toFloat();
+    }
+
     /* Read aperture */
     if(FIND_EXIF_TAG("Exif.Photo.FNumber"))
     {
@@ -1180,14 +1187,14 @@ static bool dt_exif_read_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
         phi = pos->toLong();
 
       if((format == 3) && (bps >= 16) && (((spp == 1) && (phi == 32803)) || ((spp == 3) && (phi == 34892)))) is_hdr = TRUE;
-      if((format == 1) && (bps == 16) && (spp == 1) && (phi == 34892)) is_monochrome = TRUE; 
+      if((format == 1) && (bps == 16) && (spp == 1) && (phi == 34892)) is_monochrome = TRUE;
     }
 
     if(is_hdr)
       dt_imageio_set_hdr_tag(img);
 
     if(is_monochrome)
-      dt_imageio_set_bw_tag(img); 
+      dt_imageio_set_bw_tag(img);
 
     // some files have the colorspace explicitly set. try to read that.
     // is_ldr -> none

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -771,13 +771,14 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
      "   raw_auto_bright_threshold, raw_black, raw_maximum,"
      "   caption, description, license, sha1sum, orientation, histogram, lightmap,"
      "   longitude, latitude, altitude, color_matrix, colorspace, version, max_version, history_end,"
-     "   position, aspect_ratio)"
+     "   position, aspect_ratio, exposure_bias)"
      " SELECT NULL, group_id, film_id, width, height, filename, maker, model, lens,"
      "       exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
      "       flags, width, height, crop, raw_parameters, raw_denoise_threshold,"
      "       raw_auto_bright_threshold, raw_black, raw_maximum,"
      "       caption, description, license, sha1sum, orientation, histogram, lightmap,"
-     "       longitude, latitude, altitude, color_matrix, colorspace, NULL, NULL, 0, ?1, aspect_ratio"
+     "       longitude, latitude, altitude, color_matrix, colorspace, NULL, NULL, 0, ?1,"
+     "       aspect_ratio, exposure_bias"
      " FROM main.images WHERE id = ?2",
      -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT64(stmt, 1, new_image_position);
@@ -1408,6 +1409,7 @@ void dt_image_init(dt_image_t *img)
   g_strlcpy(img->exif_datetime_taken, "0000:00:00 00:00:00", sizeof(img->exif_datetime_taken));
   img->exif_crop = 1.0;
   img->exif_exposure = 0;
+  img->exif_exposure_bias = NAN;
   img->exif_aperture = 0;
   img->exif_iso = 0;
   img->exif_focal_length = 0;
@@ -1718,14 +1720,14 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
          "   raw_auto_bright_threshold, raw_black, raw_maximum,"
          "   caption, description, license, sha1sum, orientation, histogram, lightmap,"
          "   longitude, latitude, altitude, color_matrix, colorspace, version, max_version,"
-         "   position, aspect_ratio)"
+         "   position, aspect_ratio, exposure_bias)"
          " SELECT NULL, group_id, ?1 as film_id, width, height, ?2 as filename, maker, model, lens,"
          "        exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
          "        flags, width, height, crop, raw_parameters, raw_denoise_threshold,"
          "        raw_auto_bright_threshold, raw_black, raw_maximum,"
          "        caption, description, license, sha1sum, orientation, histogram, lightmap,"
          "        longitude, latitude, altitude, color_matrix, colorspace, -1, -1,"
-         "        ?3, aspect_ratio"
+         "        ?3, aspect_ratio, exposure_bias"
          " FROM main.images"
          " WHERE id = ?4",
         -1, &stmt, NULL);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -151,6 +151,7 @@ typedef struct dt_image_t
   int32_t exif_inited;
   dt_image_orientation_t orientation;
   float exif_exposure;
+  float exif_exposure_bias;
   float exif_aperture;
   float exif_iso;
   float exif_focal_length;

--- a/src/common/image_cache.c
+++ b/src/common/image_cache.c
@@ -41,7 +41,7 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
       "SELECT id, group_id, film_id, width, height, filename, maker, model, lens, exposure, "
       "aperture, iso, focal_length, datetime_taken, flags, crop, orientation, focus_distance, "
       "raw_parameters, longitude, latitude, altitude, color_matrix, colorspace, version, raw_black, "
-      "raw_maximum, aspect_ratio FROM main.images WHERE id = ?1",
+      "raw_maximum, aspect_ratio, exposure_bias FROM main.images WHERE id = ?1",
       -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, entry->key);
   if(sqlite3_step(stmt) == SQLITE_ROW)
@@ -106,6 +106,10 @@ void dt_image_cache_allocate(void *data, dt_cache_entry_t *entry)
       img->aspect_ratio = sqlite3_column_double(stmt, 27);
     else
       img->aspect_ratio = 0.0;
+    if(sqlite3_column_type(stmt, 28) == SQLITE_FLOAT)
+      img->exif_exposure_bias = sqlite3_column_double(stmt, 28);
+    else
+      img->exif_exposure_bias = NAN;
 
     // buffer size? colorspace?
     if(img->flags & DT_IMAGE_LDR)
@@ -239,7 +243,7 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
       "focus_distance = ?11, film_id = ?12, datetime_taken = ?13, flags = ?14, "
       "crop = ?15, orientation = ?16, raw_parameters = ?17, group_id = ?18, longitude = ?19, "
       "latitude = ?20, altitude = ?21, color_matrix = ?22, colorspace = ?23, raw_black = ?24, "
-      "raw_maximum = ?25, aspect_ratio = ROUND(?26,1) WHERE id = ?27",
+      "raw_maximum = ?25, aspect_ratio = ROUND(?26,1), exposure_bias = ?28 WHERE id = ?27",
       -1, &stmt, NULL);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, img->width);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, img->height);
@@ -269,6 +273,7 @@ void dt_image_cache_write_release(dt_image_cache_t *cache, dt_image_t *img, dt_i
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 25, img->raw_white_point);
   DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 26, img->aspect_ratio);
   DT_DEBUG_SQLITE3_BIND_INT(stmt, 27, img->id);
+  DT_DEBUG_SQLITE3_BIND_DOUBLE(stmt, 28, img->exif_exposure_bias);
   const int rc = sqlite3_step(stmt);
   if(rc != SQLITE_DONE) fprintf(stderr, "[image_cache_write_release] sqlite3 error %d\n", rc);
   sqlite3_finalize(stmt);

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -55,6 +55,7 @@ typedef struct dt_variables_data_t
   struct tm exif_tm;
 
   float exif_exposure;
+  float exif_exposure_bias;
   float exif_aperture;
   float exif_focal_length;
   float exif_focus_distance;
@@ -96,6 +97,7 @@ static void init_expansion(dt_variables_params_t *params, gboolean iterate)
   params->data->version = 0;
   params->data->stars = 0;
   params->data->exif_exposure = 0.0f;
+  params->data->exif_exposure_bias = NAN;
   params->data->exif_aperture = 0.0f;
   params->data->exif_focal_length = 0.0f;
   params->data->exif_focus_distance = 0.0f;
@@ -120,6 +122,7 @@ static void init_expansion(dt_variables_params_t *params, gboolean iterate)
     if(params->data->stars == 6) params->data->stars = -1;
 
     params->data->exif_exposure = img->exif_exposure;
+    params->data->exif_exposure_bias = img->exif_exposure_bias;
     params->data->exif_aperture = img->exif_aperture;
     params->data->exif_focal_length = img->exif_focal_length;
     if(!isnan(img->exif_focus_distance) && fpclassify(img->exif_focus_distance) != FP_ZERO)
@@ -186,6 +189,11 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup_printf("%d", params->data->exif_iso);
   else if(has_prefix(variable, "NL") && g_strcmp0(params->jobcode, "infos") == 0)
     result = g_strdup_printf("\n");
+  else if(has_prefix(variable, "EXIF_EXPOSURE_BIAS"))
+  {
+    if(!isnan(params->data->exif_exposure_bias))
+      result = g_strdup_printf("%+.2f", params->data->exif_exposure_bias);
+  }
   else if(has_prefix(variable, "EXIF_EXPOSURE"))
   {
     /* no special chars for all jobs except infos */

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -61,6 +61,7 @@ enum
   md_exif_lens,
   md_exif_aperture,
   md_exif_exposure,
+  md_exif_exposure_bias,
   md_exif_focal_length,
   md_exif_focus_distance,
   md_exif_iso,
@@ -111,6 +112,7 @@ static void _lib_metatdata_view_init_labels()
   _md_labels[md_exif_lens] = _("lens");
   _md_labels[md_exif_aperture] = _("aperture");
   _md_labels[md_exif_exposure] = _("exposure");
+  _md_labels[md_exif_exposure_bias] = _("exposure bias");
   _md_labels[md_exif_focal_length] = _("focal length");
   _md_labels[md_exif_focus_distance] = _("focus distance");
   _md_labels[md_exif_iso] = _("ISO");
@@ -447,6 +449,16 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     else
       snprintf(value, sizeof(value), "%.1f''", img->exif_exposure);
     _metadata_update_value(d->metadata[md_exif_exposure], value);
+
+    if(isnan(img->exif_exposure_bias))
+    {
+      _metadata_update_value(d->metadata[md_exif_exposure_bias], NODATA_STRING);
+    }
+    else
+    {
+      snprintf(value, sizeof(value), _("%+.2f EV"), img->exif_exposure_bias);
+      _metadata_update_value(d->metadata[md_exif_exposure_bias], value);
+    }
 
     snprintf(value, sizeof(value), "%.0f mm", img->exif_focal_length);
     _metadata_update_value(d->metadata[md_exif_focal_length], value);

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -502,6 +502,7 @@ int dt_lua_init_image(lua_State *L)
 {
   luaA_struct(L, dt_image_t);
   luaA_struct_member(L, dt_image_t, exif_exposure, float);
+  luaA_struct_member(L, dt_image_t, exif_exposure_bias, float);
   luaA_struct_member(L, dt_image_t, exif_aperture, float);
   luaA_struct_member(L, dt_image_t, exif_iso, float);
   luaA_struct_member(L, dt_image_t, exif_focal_length, float);


### PR DESCRIPTION
Relay on #4463 started by @aurelienpierre 

Overlay using $(EXIF_EXPOSURE_BIAS) with existing bias
![image](https://user-images.githubusercontent.com/23012047/78187931-bcf59d00-7445-11ea-9ed4-3780bcd6852e.png)


Overlay when bias is missing in cache
![image](https://user-images.githubusercontent.com/23012047/78187843-9172b280-7445-11ea-8528-eada2ae92a61.png)


with this formula:
![image](https://user-images.githubusercontent.com/23012047/78187783-7011c680-7445-11ea-9929-1aec6c938388.png)

On image information
![image](https://user-images.githubusercontent.com/23012047/78188036-ec0c0e80-7445-11ea-9452-395316e27362.png)

Of course to get the value it is enough to select image(s) and `refresh exif`

