### PR TITLE
Only set DT_IMAGE_AUTO_PRESETS_APPLIED while in gui mode. Fixing #4586

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1342,7 +1342,8 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   // flag was already set? only apply presets once in the lifetime of a history stack.
   // (the flag will be cleared when removing it)
-  if(!run || image->id <= 0)
+  // Also make sure this is only done while in gui
+  if(!run || (image->id <= 0) || (!dev->gui_attached))
   {
     dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_RELAXED);
     return FALSE;


### PR DESCRIPTION
The reporting issue is misleading, when watching the video the sequence is:
1. develop an image
2. discard history
3. export the image
4. reimport the image

The point is, after discarding the flag is cleared, export sets the flag but leaves no history and reimporting does **not** apply presets ... because the flag is already set.

How to fix? The auto apply should only be done while in gui.