### PR TITLE
keyboard shortcuts to show/hide lib modules

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -616,6 +616,10 @@ static int dt_lib_load_module(void *m, const char *libname, const char *plugin_n
   {
     dt_accel_register_lib(module, NC_("accel", "show preset menu"), 0, 0);
   }
+  if(module->expandable(module))
+  {
+    dt_accel_register_lib(module, NC_("accel", "show module"), 0, 0);
+  }
 #ifdef USE_LUA
   dt_lua_lib_register(darktable.lua_state.state, module);
 #endif
@@ -938,6 +942,30 @@ static gboolean _lib_plugin_header_button_press(GtkWidget *w, GdkEventButton *e,
   return FALSE;
 }
 
+static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                     GdkModifierType modifier, gpointer data)
+
+{
+  dt_lib_module_t *module = (dt_lib_module_t *)data;
+
+  /* bail out if module is static */
+  if(!module->expandable(module)) return FALSE;
+
+  // make gtk scroll to the module once it updated its allocation size
+  uint32_t container = module->container(module);
+  if(dt_conf_get_bool("lighttable/ui/scroll_to_module"))
+  {
+    if(container == DT_UI_CONTAINER_PANEL_LEFT_CENTER)
+      darktable.gui->scroll_to[0] = module->expander;
+    else if(container == DT_UI_CONTAINER_PANEL_RIGHT_CENTER)
+      darktable.gui->scroll_to[1] = module->expander;
+  }
+
+  dt_lib_gui_set_expanded(module, !dtgtk_expander_get_expanded(DTGTK_EXPANDER(module->expander)));
+
+  return TRUE;
+}
+
 GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
 {
   /* check if module is expandable */
@@ -1127,6 +1155,12 @@ void dt_lib_connect_common_accels(dt_lib_module_t *module)
   if(module->reset_button)
     dt_accel_connect_button_lib(module, "reset module parameters", module->reset_button);
   if(module->presets_button) dt_accel_connect_button_lib(module, "show preset menu", module->presets_button);
+  if(module->expandable(module)) 
+  {
+    GClosure *closure = NULL;
+    closure = g_cclosure_new(G_CALLBACK(show_module_callback), module, NULL);
+    dt_accel_connect_lib(module, "show module", closure);
+  }
   if(module->init_presets)
   {
     sqlite3_stmt *stmt;


### PR DESCRIPTION
adds a new keyboard shortcut "show module" to all lib modules, which
has the same action as clicking on the module header (i.e.
expands/collapses the module)

Resolves #4126