### PR TITLE
tagging update

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1287,7 +1287,13 @@ void dt_exif_apply_default_metadata(dt_image_t *img)
     }
 
     str = dt_conf_get_string("ui_last/import_last_tags");
-    if(str != NULL && str[0] != '\0') dt_tag_attach_string_list(str, img->id, FALSE, FALSE);
+    if(img->id > 0 && str != NULL && str[0] != '\0')
+    {
+      GList *imgs = NULL;
+      imgs = g_list_append(imgs, GINT_TO_POINTER(img->id));
+      dt_tag_attach_string_list(str, imgs, FALSE, FALSE);
+      g_list_free(imgs);
+    }
     g_free(str);
   }
 }

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2066,6 +2066,19 @@ void dt_image_write_sidecar_file(int imgid)
   }
 }
 
+void dt_image_synch_xmps(const GList *img)
+{
+  if(!img) return;
+  if(dt_conf_get_bool("write_sidecar_files"))
+  {
+    const GList *imgs = img;
+    while(imgs)
+    {
+      dt_image_write_sidecar_file(GPOINTER_TO_INT(imgs->data));
+      imgs = g_list_next(imgs);
+    }
+  }
+}
 
 void dt_image_synch_xmp(const int selected)
 {
@@ -2073,17 +2086,11 @@ void dt_image_synch_xmp(const int selected)
   {
     dt_image_write_sidecar_file(selected);
   }
-  else if(dt_conf_get_bool("write_sidecar_files"))
+  else
   {
-    sqlite3_stmt *stmt;
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
-                                NULL);
-    while(sqlite3_step(stmt) == SQLITE_ROW)
-    {
-      const int imgid = sqlite3_column_int(stmt, 0);
-      dt_image_write_sidecar_file(imgid);
-    }
-    sqlite3_finalize(stmt);
+    GList *imgs = dt_view_get_images_to_act_on();
+    dt_image_synch_xmps(imgs);
+    g_list_free(imgs);
   }
 }
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -334,6 +334,7 @@ void dt_image_local_copy_synch(void);
 // xmp functions:
 void dt_image_write_sidecar_file(int imgid);
 void dt_image_synch_xmp(const int selected);
+void dt_image_synch_xmps(const GList *img);
 void dt_image_synch_all_xmp(const gchar *pathname);
 
 // add an offset to the exif_datetime_taken field

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -77,8 +77,11 @@ void dt_tag_rename(const guint tagid, const gchar *new_tagname);
 /** checks if tag exists. \param[in] name of tag to check. \return the id of found tag or -1 i not found. */
 gboolean dt_tag_exists(const char *name, guint *tagid);
 
-/** attach a tag on selected images. tagid id of tag to attach. imgid the image
- * id to attach tag to, if < 0 selected images are used. */
+/** attach a tag on images list. tagid id of tag to attach. img the list of image
+ * id to attach tag to */
+gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolean undo_on, const gboolean group_on);
+/** attach a tag on images. tagid id of tag to attach. imgid the image
+ * id to attach tag to, if < 0 images to act on are used. */
 gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
 /** same as above but raises a DT_SIGNAL_TAG_CHANGED */
 void dt_tag_attach_from_gui(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
@@ -91,13 +94,15 @@ gboolean dt_is_tag_attached(const guint tagid, const gint imgid);
  * if clear_on TRUE the image tags are cleared before attaching the new ones*/
 void dt_tag_set_tags(GList *tags, const gint imgid, const gboolean clear_on, const gboolean undo_on, const gboolean group_on);
 
-/** attach a list of tags on selected images. \param[in] tags a comma separated string of tags. \param[in]
- * imgid the image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's
- * created.*/
-void dt_tag_attach_string_list(const gchar *tags, const gint imgid, const gboolean undo_on, const gboolean group_on);
+/** attach a list of tags on list of images. \param[in] tags a comma separated string of tags. \param[in]
+ * img the list of images to attach tag to. \note If tag not exists it's created.*/
+void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboolean undo_on, const gboolean group_on);
 
-/** detach tag from images. \param[in] tagid if of tag to deattach. \param[in] imgid the image id to attach
- * tag from, if < 0 selected images are used. */
+/** detach tag from images. \param[in] tagid if of tag to deattach. \param[in] img the list of image id to detach
+ * tag from */
+void dt_tag_detach_images(const guint tagid, const GList *img, const gboolean undo_on, const gboolean group_on);
+/** detach tag from images. \param[in] tagid if of tag to dettach. \param[in] imgid the image id to detach
+ * tag from, if < 0 images to act on are used. */
 void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
 /** same as above but raises a DT_SIGNAL_TAG_CHANGED */
 void dt_tag_detach_from_gui(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
@@ -131,8 +136,8 @@ GList *dt_tag_get_hierarchical_export(gint imgid, int32_t flags);
 /** get a flat list of tag id, without darktable tags*/
 GList *dt_tag_get_tags(gint imgid);
 
-/** get the subset of images from the selected ones that have a given tag attached */
-GList *dt_tag_get_images_from_selection(gint imgid, gint tagid);
+/** get the subset of images from the given list that have a given tag attached */
+GList *dt_tag_get_images_from_list(const GList *img, gint tagid);
 
 /** retrieves a list of suggested tags matching keyword. \param[in] keyword the keyword to search \param[out]
  * result a pointer to list populated with result. \return the count \note the limit of result is decided by

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -55,7 +55,7 @@ typedef struct dt_lib_tagging_t
   GtkTreeStore *dictionary_treestore;
   GtkTreeModelFilter *dictionary_listfilter, *dictionary_treefilter;
   GtkWidget *floating_tag_window;
-  int floating_tag_imgid;
+  GList *floating_tag_imgs;
   gboolean tree_flag, suggestion_flag, sort_count_flag, hide_path_flag, dttags_flag;
   char *collection;
   GtkEntryCompletion *completion;
@@ -135,7 +135,7 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_lib(self, "redo last tag", g_cclosure_new(G_CALLBACK(_lib_tagging_tag_redo), self, NULL));
 }
 
-static void propagate_sel_to_parents(GtkTreeModel *model, GtkTreeIter *iter)
+static void _propagate_sel_to_parents(GtkTreeModel *model, GtkTreeIter *iter)
 {
   guint sel;
   GtkTreeIter parent, child = *iter;
@@ -148,7 +148,7 @@ static void propagate_sel_to_parents(GtkTreeModel *model, GtkTreeIter *iter)
   }
 }
 
-static gboolean set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, dt_lib_module_t *self)
+static gboolean _set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   gboolean visible;
@@ -175,7 +175,7 @@ static gboolean set_matching_tag_visibility(GtkTreeModel *model, GtkTreePath *pa
   return FALSE;
 }
 
-static gboolean tree_reveal_func(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
+static gboolean _tree_reveal_func(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
 {
   gboolean state;
   GtkTreeIter parent, child = *iter;
@@ -192,7 +192,7 @@ static gboolean tree_reveal_func(GtkTreeModel *model, GtkTreePath *path, GtkTree
   return FALSE;
 }
 
-static void sort_attached_list(dt_lib_module_t *self, gboolean force)
+static void _sort_attached_list(dt_lib_module_t *self, gboolean force)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (force && d->sort_count_flag)
@@ -204,7 +204,7 @@ static void sort_attached_list(dt_lib_module_t *self, gboolean force)
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(d->attached_liststore), sort, GTK_SORT_ASCENDING);
 }
 
-static void sort_dictionary_list(dt_lib_module_t *self, gboolean force)
+static void _sort_dictionary_list(dt_lib_module_t *self, gboolean force)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (!d->tree_flag)
@@ -221,7 +221,7 @@ static void sort_dictionary_list(dt_lib_module_t *self, gboolean force)
     gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(d->dictionary_treestore), DT_TAG_SORT_PATH_ID, GTK_SORT_ASCENDING);
 }
 
-static void init_treeview(dt_lib_module_t *self, int which)
+static void _init_treeview(dt_lib_module_t *self, int which)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GList *tags = NULL;
@@ -316,7 +316,7 @@ static void init_treeview(dt_lib_module_t *self, int which)
                               DT_LIB_TAGGING_COL_VISIBLE, TRUE,
                               -1);
             if (((dt_tag_t *)taglist->data)->select)
-              propagate_sel_to_parents(GTK_TREE_MODEL(store), &iter);
+              _propagate_sel_to_parents(GTK_TREE_MODEL(store), &iter);
             common_length++;
             parent = iter;
             g_free(pth2);
@@ -334,8 +334,8 @@ static void init_treeview(dt_lib_module_t *self, int which)
     }
     if (d->keyword[0])
     {
-      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)set_matching_tag_visibility, self);
-      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)tree_reveal_func, NULL);
+      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)_set_matching_tag_visibility, self);
+      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)_tree_reveal_func, NULL);
       gtk_tree_view_set_model(GTK_TREE_VIEW(view), model);
       gtk_tree_view_expand_all(d->dictionary_view);
     }
@@ -365,15 +365,15 @@ static void init_treeview(dt_lib_module_t *self, int which)
     }
     if (which && d->keyword[0])
     {
-      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)set_matching_tag_visibility, self);
+      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)_set_matching_tag_visibility, self);
     }
     gtk_tree_view_set_model(GTK_TREE_VIEW(view), model);
     g_object_unref(model);
   }
   if (which)
-    sort_dictionary_list(self, FALSE);
+    _sort_dictionary_list(self, FALSE);
   else
-    sort_attached_list(self, FALSE);
+    _sort_attached_list(self, FALSE);
   // Free result...
   dt_tag_free_result(&tags);
 }
@@ -450,24 +450,24 @@ static void _lib_tagging_redraw_callback(gpointer instance, dt_lib_module_t *sel
   const int imgsel = dt_control_get_mouse_over_id();
   if(imgsel != d->imgsel)
   {
-    init_treeview(self, 0);
+    _init_treeview(self, 0);
   }
 }
 
 static void _lib_tagging_tags_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
-  init_treeview(self, 0);
-  init_treeview(self, 1);
+  _init_treeview(self, 0);
+  _init_treeview(self, 1);
 }
 
-static void collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
+static void _collection_updated_callback(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
                                         int next, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   d->collection[0] = '\0';
 }
 
-static void raise_signal_tag_changed(dt_lib_module_t *self)
+static void _raise_signal_tag_changed(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   // when collection is on tag any attach & detach becomes very slow
@@ -476,16 +476,16 @@ static void raise_signal_tag_changed(dt_lib_module_t *self)
   if (!d->collection[0])
   {
     // raises change only for other modules
-    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
     dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
     dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
-    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
   }
 }
 
 // find a tag on the tree
-static gboolean find_tag_iter_tagid(GtkTreeModel *model, GtkTreeIter *iter, gint tagid)
+static gboolean _find_tag_iter_tagid(GtkTreeModel *model, GtkTreeIter *iter, gint tagid)
 {
   gint tag;
   do
@@ -497,7 +497,7 @@ static gboolean find_tag_iter_tagid(GtkTreeModel *model, GtkTreeIter *iter, gint
     }
     GtkTreeIter child, parent = *iter;
     if (gtk_tree_model_iter_children(model, &child, &parent))
-      if (find_tag_iter_tagid(model, &child, tagid))
+      if (_find_tag_iter_tagid(model, &child, tagid))
       {
         *iter = child;
         return TRUE;
@@ -507,7 +507,7 @@ static gboolean find_tag_iter_tagid(GtkTreeModel *model, GtkTreeIter *iter, gint
 }
 
 // check if the tag has any child
-static gboolean find_child_tagname(GtkTreeModel *model, GtkTreeIter *iter, const gchar *tagname)
+static gboolean _find_child_tagname(GtkTreeModel *model, GtkTreeIter *iter, const gchar *tagname)
 {
   gchar *path;
   do
@@ -519,7 +519,7 @@ static gboolean find_child_tagname(GtkTreeModel *model, GtkTreeIter *iter, const
     }
     GtkTreeIter child, parent = *iter;
     if (gtk_tree_model_iter_children(model, &child, &parent))
-      if (find_child_tagname(model, &child, tagname))
+      if (_find_child_tagname(model, &child, tagname))
       {
         *iter = child;
         return TRUE;
@@ -529,7 +529,7 @@ static gboolean find_child_tagname(GtkTreeModel *model, GtkTreeIter *iter, const
 }
 
 // calculate the indeterminated state (1) where needed on the tree
-static void calculate_sel_on_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean root)
+static void _calculate_sel_on_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean root)
 {
   GtkTreeIter child, parent = *iter;
   do
@@ -538,15 +538,15 @@ static void calculate_sel_on_path(GtkTreeModel *model, GtkTreeIter *iter, gboole
     gtk_tree_model_get(model, &parent, DT_LIB_TAGGING_COL_SEL, &sel, -1);
     if (sel == 2)
     {
-      propagate_sel_to_parents(model, &parent);
+      _propagate_sel_to_parents(model, &parent);
     }
     if (gtk_tree_model_iter_children(model, &child, &parent))
-      calculate_sel_on_path(model, &child, FALSE);
+      _calculate_sel_on_path(model, &child, FALSE);
   } while (!root && gtk_tree_model_iter_next(model, &parent));
 }
 
 // reset the indeterminated selection (1) on the tree
-static void reset_sel_on_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean root)
+static void _reset_sel_on_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean root)
 {
   GtkTreeIter child, parent = *iter;
   do
@@ -559,13 +559,13 @@ static void reset_sel_on_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean r
       {
         gtk_tree_store_set(GTK_TREE_STORE(model), &parent, DT_LIB_TAGGING_COL_SEL, 0, -1);
       }
-      reset_sel_on_path(model, &child, FALSE);
+      _reset_sel_on_path(model, &child, FALSE);
     }
   } while (!root && gtk_tree_model_iter_next(model, &parent));
 }
 
 // reset all selection (1 & 2) on the tree
-static void reset_sel_on_path_full(GtkTreeModel *model, GtkTreeIter *iter, gboolean root)
+static void _reset_sel_on_path_full(GtkTreeModel *model, GtkTreeIter *iter, gboolean root)
 {
   GtkTreeIter child, parent = *iter;
   do
@@ -574,7 +574,7 @@ static void reset_sel_on_path_full(GtkTreeModel *model, GtkTreeIter *iter, gbool
     {
       gtk_tree_store_set(GTK_TREE_STORE(model), &parent, DT_LIB_TAGGING_COL_SEL, 0, -1);
       if (gtk_tree_model_iter_children(model, &child, &parent))
-        reset_sel_on_path_full(model, &child, FALSE);
+        _reset_sel_on_path_full(model, &child, FALSE);
     }
     else
     {
@@ -584,7 +584,7 @@ static void reset_sel_on_path_full(GtkTreeModel *model, GtkTreeIter *iter, gbool
 }
 
 //  try to find a node fully attached (2) which is the root of the update loop. If not the full tree will be used
-static void find_root_iter_iter(GtkTreeModel *model, GtkTreeIter *iter, GtkTreeIter *parent)
+static void _find_root_iter_iter(GtkTreeModel *model, GtkTreeIter *iter, GtkTreeIter *parent)
 {
   guint sel;
   GtkTreeIter child = *iter;
@@ -607,27 +607,27 @@ static void find_root_iter_iter(GtkTreeModel *model, GtkTreeIter *iter, GtkTreeI
 }
 
 // with tag detach update the tree selection
-static void calculate_sel_on_tree(GtkTreeModel *model, GtkTreeIter *iter)
+static void _calculate_sel_on_tree(GtkTreeModel *model, GtkTreeIter *iter)
 {
   GtkTreeIter parent;
   if (iter)
   {
     // only on sub-tree
-    find_root_iter_iter(model, iter, &parent);
-    reset_sel_on_path(model, &parent, TRUE);
-    calculate_sel_on_path(model, &parent, TRUE);
+    _find_root_iter_iter(model, iter, &parent);
+    _reset_sel_on_path(model, &parent, TRUE);
+    _calculate_sel_on_path(model, &parent, TRUE);
   }
   else
   {
     // on full tree
     gtk_tree_model_get_iter_first(model, &parent);
-    reset_sel_on_path(model, &parent, FALSE);
-    calculate_sel_on_path(model, &parent, FALSE);
+    _reset_sel_on_path(model, &parent, FALSE);
+    _calculate_sel_on_path(model, &parent, FALSE);
   }
 }
 
 // get the new selected images and update the tree selection
-static void update_sel_on_tree(GtkTreeModel *model)
+static void _update_sel_on_tree(GtkTreeModel *model)
 {
   GList *tags = NULL;
   const guint count = dt_tag_get_attached(-1, &tags, TRUE);
@@ -635,16 +635,16 @@ static void update_sel_on_tree(GtkTreeModel *model)
   {
     GtkTreeIter parent;
     gtk_tree_model_get_iter_first(model, &parent);
-    reset_sel_on_path_full(model, &parent, FALSE);
+    _reset_sel_on_path_full(model, &parent, FALSE);
     for (GList *tag = tags; tag; tag = g_list_next(tag))
     {
       GtkTreeIter iter = parent;
-      if (find_tag_iter_tagid(model, &iter, ((dt_tag_t *)tag->data)->id))
+      if (_find_tag_iter_tagid(model, &iter, ((dt_tag_t *)tag->data)->id))
       {
         if(GTK_IS_TREE_STORE(model))
         {
           gtk_tree_store_set(GTK_TREE_STORE(model), &iter, DT_LIB_TAGGING_COL_SEL, ((dt_tag_t *)tag->data)->select, -1);
-          propagate_sel_to_parents(model, &iter);
+          _propagate_sel_to_parents(model, &iter);
         }
         else
         {
@@ -657,7 +657,7 @@ static void update_sel_on_tree(GtkTreeModel *model)
 }
 
 // delete a tag in the tree (tree or list)
-static void delete_tree_tag(GtkTreeModel *model, GtkTreeIter *iter, gboolean tree)
+static void _delete_tree_tag(GtkTreeModel *model, GtkTreeIter *iter, gboolean tree)
 {
   guint tagid = 0;
   gtk_tree_model_get(model, iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
@@ -667,7 +667,7 @@ static void delete_tree_tag(GtkTreeModel *model, GtkTreeIter *iter, gboolean tre
     {
       gtk_tree_store_set(GTK_TREE_STORE(model), iter, DT_LIB_TAGGING_COL_SEL, 0,
           DT_LIB_TAGGING_COL_ID, 0, DT_LIB_TAGGING_COL_COUNT, 0, -1);
-      calculate_sel_on_tree(model, iter);
+      _calculate_sel_on_tree(model, iter);
       GtkTreeIter child, parent = *iter;
       if (!gtk_tree_model_iter_children(model, &child, &parent))
         gtk_tree_store_remove(GTK_TREE_STORE(model), iter);
@@ -680,7 +680,7 @@ static void delete_tree_tag(GtkTreeModel *model, GtkTreeIter *iter, gboolean tre
 }
 
 // delete a branch of the tag tree
-static void delete_tree_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean root, gboolean tree)
+static void _delete_tree_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean root, gboolean tree)
 {
   if (tree) // the treeview is tree. It handles the hierarchy itself (parent / child)
   {
@@ -689,7 +689,7 @@ static void delete_tree_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean ro
     do
     {
       if (gtk_tree_model_iter_children(model, &child, &parent))
-        delete_tree_path(model, &child, FALSE, tree);
+        _delete_tree_path(model, &child, FALSE, tree);
       GtkTreeIter tobedel = parent;
       valid = gtk_tree_model_iter_next(model, &parent);
       if (root)
@@ -701,7 +701,7 @@ static void delete_tree_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean ro
         gtk_tree_model_get(model, &tobedel, DT_LIB_TAGGING_COL_PATH, &path2, -1);
         g_free(path2);
 
-        calculate_sel_on_tree(model, &tobedel);
+        _calculate_sel_on_tree(model, &tobedel);
       }
       char *path = NULL;
       gtk_tree_model_get(model, &tobedel, DT_LIB_TAGGING_COL_PATH, &path, -1);
@@ -741,17 +741,17 @@ static void delete_tree_path(GtkTreeModel *model, GtkTreeIter *iter, gboolean ro
 static void _lib_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  init_treeview(self, 0);
+  _init_treeview(self, 0);
   if (!d->tree_flag && d->suggestion_flag)
   {
-    init_treeview(self, 1);
+    _init_treeview(self, 1);
   }
   else
-    update_sel_on_tree(d->tree_flag ? GTK_TREE_MODEL(d->dictionary_treestore)
+    _update_sel_on_tree(d->tree_flag ? GTK_TREE_MODEL(d->dictionary_treestore)
                                     : GTK_TREE_MODEL(d->dictionary_liststore));
 }
 
-static void set_keyword(dt_lib_module_t *self)
+static void _set_keyword(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   const gchar *beg = g_strrstr(gtk_entry_get_text(d->entry), ",");
@@ -766,7 +766,7 @@ static void set_keyword(dt_lib_module_t *self)
   g_strlcpy(d->keyword, beg, sizeof(d->keyword));
 }
 
-static gboolean update_tag_name_per_name(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, dt_tag_op_t *to)
+static gboolean _update_tag_name_per_name(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, dt_tag_op_t *to)
 {
   char *tagname;
   char *newtagname = to->newtagname;
@@ -847,9 +847,6 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
     GtkTreeModel *model = gtk_tree_view_get_model(d->dictionary_view);
     GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
     GtkTreeIter iter;
-    const int imgsel = dt_view_get_image_to_act_on();
-    if(imgsel < 0 && dt_collection_get_selected_count(darktable.collection) == 0)
-      return 0;
     gchar **tokens = g_strsplit(buf, ",", 0);
     if(tokens)
     {
@@ -857,18 +854,18 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
       while(*entry)
       {
         guint tagid = strtoul(*entry, NULL, 0);
-
-        dt_tag_attach(tagid, imgsel, TRUE, TRUE);
+        // attach tag on images to act on
+        dt_tag_attach(tagid, -1, TRUE, TRUE);
 
         const guint count = dt_tag_images_count(tagid);
         gtk_tree_model_get_iter_first(store, &iter);
-        if (find_tag_iter_tagid(store, &iter, tagid))
+        if (_find_tag_iter_tagid(store, &iter, tagid))
         {
           if (d->tree_flag)
           {
             gtk_tree_store_set(GTK_TREE_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
                                     DT_LIB_TAGGING_COL_SEL, 2, -1);
-            calculate_sel_on_tree(GTK_TREE_MODEL(store), &iter);
+            _calculate_sel_on_tree(GTK_TREE_MODEL(store), &iter);
           }
           else
           {
@@ -880,15 +877,15 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
       }
     }
     g_strfreev(tokens);
-    init_treeview(self, 0);
+    _init_treeview(self, 0);
 
-    raise_signal_tag_changed(self);
-    dt_image_synch_xmp(imgsel);
+    _raise_signal_tag_changed(self);
+    dt_image_synch_xmp(-1);
   }
   return 0;
 }
 
-static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
+static void _attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
 {
   GtkTreeIter iter;
   GtkTreeModel *model = NULL;
@@ -900,16 +897,14 @@ static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  const int imgsel = dt_view_get_image_to_act_on();
-  if(imgsel < 0 && dt_collection_get_selected_count(darktable.collection) == 0)
-    return;
-  dt_tag_attach(tagid, imgsel, TRUE, TRUE);
+  // attach tag on images to act on
+  dt_tag_attach(tagid, -1, TRUE, TRUE);
 
   /** record last tag used */
   g_free(d->last_tag);
   d->last_tag = g_strdup(dt_tag_get_name(tagid));
 
-  init_treeview(self, 0);
+  _init_treeview(self, 0);
   if (d->tree_flag || !d->suggestion_flag)
   {
     const uint32_t count = dt_tag_images_count(tagid);
@@ -921,7 +916,7 @@ static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
     {
       gtk_tree_store_set(GTK_TREE_STORE(store), &store_iter, DT_LIB_TAGGING_COL_COUNT, count,
                 DT_LIB_TAGGING_COL_SEL, 2, -1);
-      propagate_sel_to_parents(GTK_TREE_MODEL(store), &store_iter);
+      _propagate_sel_to_parents(GTK_TREE_MODEL(store), &store_iter);
     }
     else
     {
@@ -931,13 +926,13 @@ static void attach_selected_tag(dt_lib_module_t *self, dt_lib_tagging_t *d)
   }
   else
   {
-    init_treeview(self, 1);
+    _init_treeview(self, 1);
   }
-  raise_signal_tag_changed(self);
-  dt_image_synch_xmp(imgsel);
+  _raise_signal_tag_changed(self);
+  dt_image_synch_xmp(-1);
 }
 
-static void detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_lib_tagging_t *d)
+static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_lib_tagging_t *d)
 {
   GtkTreeIter iter;
   GtkTreeModel *model = NULL;
@@ -947,66 +942,61 @@ static void detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_lib
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  const int imgsel = dt_view_get_image_to_act_on();
-  if(imgsel < 0 && dt_collection_get_selected_count(darktable.collection) == 0)
-    return;
-  GList *affected_images = dt_tag_get_images_from_selection(imgsel, tagid);
+  GList *imgs = dt_view_get_images_to_act_on();
+  if(!imgs) return;
 
-  dt_tag_detach(tagid, imgsel, TRUE, TRUE);
-
-  init_treeview(self, 0);
-  if (d->tree_flag || !d->suggestion_flag)
+  GList *affected_images = dt_tag_get_images_from_list(imgs, tagid);
+  g_list_free(imgs);
+  if(affected_images)
   {
-    const guint count = dt_tag_images_count(tagid);
-    model = gtk_tree_view_get_model(d->dictionary_view);
-    GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
-    gtk_tree_model_get_iter_first(store, &iter);
-    if (find_tag_iter_tagid(store, &iter, tagid))
+    dt_tag_detach_images(tagid, affected_images, TRUE, TRUE);
+
+    _init_treeview(self, 0);
+    if (d->tree_flag || !d->suggestion_flag)
     {
-      if (d->tree_flag)
+      const guint count = dt_tag_images_count(tagid);
+      model = gtk_tree_view_get_model(d->dictionary_view);
+      GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
+      gtk_tree_model_get_iter_first(store, &iter);
+      if (_find_tag_iter_tagid(store, &iter, tagid))
       {
-        gtk_tree_store_set(GTK_TREE_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
-                                DT_LIB_TAGGING_COL_SEL, 0, -1);
-        calculate_sel_on_tree(GTK_TREE_MODEL(store), &iter);
-      }
-      else
-      {
-        gtk_list_store_set(GTK_LIST_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
-                                DT_LIB_TAGGING_COL_SEL, 0, -1);
+        if (d->tree_flag)
+        {
+          gtk_tree_store_set(GTK_TREE_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
+                                  DT_LIB_TAGGING_COL_SEL, 0, -1);
+          _calculate_sel_on_tree(GTK_TREE_MODEL(store), &iter);
+        }
+        else
+        {
+          gtk_list_store_set(GTK_LIST_STORE(store), &iter, DT_LIB_TAGGING_COL_COUNT, count,
+                                  DT_LIB_TAGGING_COL_SEL, 0, -1);
+        }
       }
     }
-  }
-  else
-  {
-    init_treeview(self, 1);
-  }
-  raise_signal_tag_changed(self);
-
-  // we have to check the conf option as dt_image_synch_xmp() doesn't when called for a single image
-  if(dt_conf_get_bool("write_sidecar_files"))
-  {
-    for(GList *image_iter = affected_images; image_iter; image_iter = g_list_next(image_iter))
+    else
     {
-      int imgid = GPOINTER_TO_INT(image_iter->data);
-      dt_image_synch_xmp(imgid);
+      _init_treeview(self, 1);
     }
+    _raise_signal_tag_changed(self);
+
+    dt_image_synch_xmps(affected_images);
+    g_list_free(affected_images);
   }
-  g_list_free(affected_images);
 }
 
-static void attach_button_clicked(GtkButton *button, dt_lib_module_t *self)
+static void _attach_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  attach_selected_tag(self, d);
+  _attach_selected_tag(self, d);
 }
 
-static void detach_button_clicked(GtkButton *button, dt_lib_module_t *self)
+static void _detach_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  detach_selected_tag(d->attached_view, self, d);
+  _detach_selected_tag(d->attached_view, self, d);
 }
 
-static void pop_menu_attached_attach_to_all(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_attached_attach_to_all(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkTreeIter iter;
@@ -1018,19 +1008,19 @@ static void pop_menu_attached_attach_to_all(GtkWidget *menuitem, dt_lib_module_t
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  const int imgsel = dt_view_get_image_to_act_on();
-  dt_tag_attach(tagid, imgsel, TRUE, TRUE);
+  // attach tag on images to act on
+  dt_tag_attach(tagid, -1, TRUE, TRUE);
 
   /** record last tag used */
   g_free(d->last_tag);
   d->last_tag = g_strdup(dt_tag_get_name(tagid));
 
-  init_treeview(self, 0);
+  _init_treeview(self, 0);
 
   const uint32_t count = dt_tag_images_count(tagid);
   model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->dictionary_view));
   gtk_tree_model_get_iter_first(model, &iter);
-  if(find_tag_iter_tagid(model, &iter, tagid))
+  if(_find_tag_iter_tagid(model, &iter, tagid))
   {
     GtkTreeIter store_iter;
     GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
@@ -1046,17 +1036,17 @@ static void pop_menu_attached_attach_to_all(GtkWidget *menuitem, dt_lib_module_t
     }
   }
 
-  raise_signal_tag_changed(self);
-  dt_image_synch_xmp(imgsel);
+  _raise_signal_tag_changed(self);
+  dt_image_synch_xmp(-1);
 }
 
-static void pop_menu_attached_detach(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_attached_detach(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  detach_selected_tag(d->attached_view, self, d);
+  _detach_selected_tag(d->attached_view, self, d);
 }
 
-static void pop_menu_attached(GtkWidget *treeview, GdkEventButton *event, dt_lib_module_t *self)
+static void _pop_menu_attached(GtkWidget *treeview, GdkEventButton *event, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkWidget *menu, *menuitem;
@@ -1072,7 +1062,7 @@ static void pop_menu_attached(GtkWidget *treeview, GdkEventButton *event, dt_lib
     if (sel == 1)
     {
       menuitem = gtk_menu_item_new_with_label(_("attach tag to all"));
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_attached_attach_to_all, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_attached_attach_to_all, self);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       menuitem = gtk_separator_menu_item_new();
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
@@ -1081,7 +1071,7 @@ static void pop_menu_attached(GtkWidget *treeview, GdkEventButton *event, dt_lib
 
   menuitem = gtk_menu_item_new_with_label(_("detach tag"));
   gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-  g_signal_connect(menuitem, "activate", (GCallback)pop_menu_attached_detach, self);
+  g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_attached_detach, self);
 
   gtk_widget_show_all(GTK_WIDGET(menu));
 
@@ -1095,7 +1085,7 @@ static void pop_menu_attached(GtkWidget *treeview, GdkEventButton *event, dt_lib
 #endif
 }
 
-static gboolean click_on_view_attached(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)
+static gboolean _click_on_view_attached(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -1110,13 +1100,13 @@ static gboolean click_on_view_attached(GtkWidget *view, GdkEventButton *event, d
       gtk_tree_selection_select_path(selection, path);
       if(event->type == GDK_BUTTON_PRESS && event->button == 3)
       {
-        pop_menu_attached(view, event, self);
+        _pop_menu_attached(view, event, self);
         gtk_tree_path_free(path);
         return TRUE;
       }
       else if(event->type == GDK_2BUTTON_PRESS && event->button == 1)
       {
-        detach_selected_tag(d->attached_view, self, d);
+        _detach_selected_tag(d->attached_view, self, d);
         gtk_tree_path_free(path);
         return TRUE;
       }
@@ -1126,15 +1116,16 @@ static gboolean click_on_view_attached(GtkWidget *view, GdkEventButton *event, d
   return FALSE;
 }
 
-static void new_button_clicked(GtkButton *button, dt_lib_module_t *self)
+static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   const gchar *tag = gtk_entry_get_text(d->entry);
   if(!tag || tag[0] == '\0') return;
 
-  /** attach tag to selected images  */
-  dt_tag_attach_string_list(tag, -1, TRUE, TRUE);
-  dt_image_synch_xmp(-1);
+  GList *imgs = dt_view_get_images_to_act_on();
+  dt_tag_attach_string_list(tag, imgs, TRUE, TRUE);
+  dt_image_synch_xmps(imgs);
+  g_list_free(imgs);
 
   /** record last tag used */
   g_free(d->last_tag);
@@ -1143,39 +1134,39 @@ static void new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   /** clear input box */
   gtk_entry_set_text(d->entry, "");
 
-  init_treeview(self, 0);
-  init_treeview(self, 1);
-  raise_signal_tag_changed(self);
+  _init_treeview(self, 0);
+  _init_treeview(self, 1);
+  _raise_signal_tag_changed(self);
   gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
 }
 
-static void entry_activated(GtkButton *button, dt_lib_module_t *self)
+static void _entry_activated(GtkButton *button, dt_lib_module_t *self)
 {
-  new_button_clicked(NULL, self);
+  _new_button_clicked(NULL, self);
 }
 
-static void clear_entry_button_callback(GtkButton *button, dt_lib_module_t *self)
+static void _clear_entry_button_callback(GtkButton *button, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   /** clear input box */
   gtk_entry_set_text(d->entry, "");
 }
 
-static void tag_name_changed(GtkEntry *entry, dt_lib_module_t *self)
+static void _tag_name_changed(GtkEntry *entry, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  set_keyword(self);
+  _set_keyword(self);
   GtkTreeModel *model = gtk_tree_view_get_model(d->dictionary_view);
   GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
-  gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)set_matching_tag_visibility, self);
+  gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)_set_matching_tag_visibility, self);
   if (d->tree_flag && d->keyword[0])
   {
-    gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)tree_reveal_func, NULL);
+    gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)_tree_reveal_func, NULL);
     gtk_tree_view_expand_all(d->dictionary_view);
   }
 }
 
-static void pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t *self, gboolean branch)
+static void _pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t *self, gboolean branch)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -1255,23 +1246,16 @@ static void pop_menu_dictionary_delete_tag(GtkWidget *menuitem, dt_lib_module_t 
   GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
   gtk_tree_model_filter_convert_iter_to_child_iter(GTK_TREE_MODEL_FILTER(model),
                             &store_iter, &iter);
-  delete_tree_tag(GTK_TREE_MODEL(store), &store_iter, d->tree_flag);
-  init_treeview(self, 0);
+  _delete_tree_tag(GTK_TREE_MODEL(store), &store_iter, d->tree_flag);
+  _init_treeview(self, 0);
 
-  GList *list_iter;
-  if((list_iter = g_list_first(tagged_images)) != NULL)
-  {
-    do
-    {
-      dt_image_synch_xmp(GPOINTER_TO_INT(list_iter->data));
-    } while((list_iter = g_list_next(list_iter)) != NULL);
-  }
+  dt_image_synch_xmps(tagged_images);
   g_list_free(tagged_images);
   g_free(tagname);
-  raise_signal_tag_changed(self);
+  _raise_signal_tag_changed(self);
 }
 
-static void pop_menu_dictionary_delete_path(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_delete_path(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -1347,25 +1331,18 @@ static void pop_menu_dictionary_delete_path(GtkWidget *menuitem, dt_lib_module_t
   GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
   gtk_tree_model_filter_convert_iter_to_child_iter(GTK_TREE_MODEL_FILTER(model),
                             &store_iter, &iter);
-  delete_tree_path(GTK_TREE_MODEL(store), &store_iter, TRUE, d->tree_flag);
-  init_treeview(self, 0);
+  _delete_tree_path(GTK_TREE_MODEL(store), &store_iter, TRUE, d->tree_flag);
+  _init_treeview(self, 0);
 
-  GList *list_iter;
-  if((list_iter = g_list_first(tagged_images)) != NULL)
-  {
-    do
-    {
-      dt_image_synch_xmp(GPOINTER_TO_INT(list_iter->data));
-    } while((list_iter = g_list_next(list_iter)) != NULL);
-  }
   dt_tag_free_result(&tag_family);
+  dt_image_synch_xmps(tagged_images);
   g_list_free(tagged_images);
-  raise_signal_tag_changed(self);
+  _raise_signal_tag_changed(self);
   g_free(tagname);
 }
 
 // create tag allows the user to create a single tag, which can be an element of the hierarchy or not
-static void pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -1493,7 +1470,7 @@ static void pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t 
       {
         GtkTreeIter iter2;
         gtk_tree_model_get_iter_first(store, &iter2);
-        if(!find_child_tagname(store, &iter2, new_tagname))
+        if(!_find_child_tagname(store, &iter2, new_tagname))
         {
           if (root)
           {
@@ -1519,20 +1496,20 @@ static void pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t 
         else
         {
           // hierarchy display must be updated
-          init_treeview(self, 1);
+          _init_treeview(self, 1);
         }
       }
       g_free(new_synonyms_list);
     }
     g_free(new_tagname);
   }
-  init_treeview(self, 0);
+  _init_treeview(self, 0);
   gtk_widget_destroy(dialog);
   g_free(tagname);
 }
 
 // edit tag allows the user to rename a single tag, which can be an element of the hierarchy and change other parameters
-static void pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -1701,21 +1678,14 @@ static void pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *s
       GtkSortType sort_order;
       gtk_tree_sortable_get_sort_column_id(GTK_TREE_SORTABLE(store), &sort_column, &sort_order);
       gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(store), GTK_TREE_SORTABLE_UNSORTED_SORT_COLUMN_ID, GTK_SORT_ASCENDING);
-      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)update_tag_name_per_name, to);
+      gtk_tree_model_foreach(store, (GtkTreeModelForeachFunc)_update_tag_name_per_name, to);
       gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(store), sort_column, sort_order);
       g_free(to);
       if (subtag) g_free(new_prefix_tag);
 
-      // update sidecar files
-      if(dt_conf_get_bool("write_sidecar_files"))
-      {
-        for (GList *imagelist = tagged_images; imagelist; imagelist = g_list_next(imagelist))
-        {
-          dt_image_synch_xmp(GPOINTER_TO_INT(imagelist->data));
-        }
-      }
-      raise_signal_tag_changed(self);
+      _raise_signal_tag_changed(self);
       dt_tag_free_result(&tag_family);
+      dt_image_synch_xmps(tagged_images);
       g_list_free(tagged_images);
     }
 
@@ -1752,13 +1722,13 @@ static void pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *s
       g_free(new_synonyms_list);
     }
   }
-  init_treeview(self, 0);
+  _init_treeview(self, 0);
   gtk_widget_destroy(dialog);
   g_free(tagname);
 }
 
 // rename path allows the user to redefine a hierarchy
-static void pop_menu_dictionary_rename_path(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_rename_path(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -1866,17 +1836,11 @@ static void pop_menu_dictionary_rename_path(GtkWidget *menuitem, dt_lib_module_t
         g_free(new_tagname);
       }
       // TODO see if we could update without reinit
-      init_treeview(self, 0);
-      init_treeview(self, 1);
+      _init_treeview(self, 0);
+      _init_treeview(self, 1);
 
-      if(dt_conf_get_bool("write_sidecar_files"))
-      {
-        for (GList *imagelist = tagged_images; imagelist; imagelist = g_list_next(imagelist))
-        {
-          dt_image_synch_xmp(GPOINTER_TO_INT(imagelist->data));
-        }
-      }
-      raise_signal_tag_changed(self);
+      dt_image_synch_xmps(tagged_images);
+      _raise_signal_tag_changed(self);
     }
     dt_tag_free_result(&tag_family);
     g_list_free(tagged_images);
@@ -1885,7 +1849,7 @@ static void pop_menu_dictionary_rename_path(GtkWidget *menuitem, dt_lib_module_t
   g_free(tagname);
 }
 
-static void pop_menu_dictionary_goto_tag_collection(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_goto_tag_collection(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkTreeIter iter;
@@ -1901,28 +1865,28 @@ static void pop_menu_dictionary_goto_tag_collection(GtkWidget *menuitem, dt_lib_
       if (!d->collection[0]) dt_collection_serialize(d->collection, 4096);
       char *tag_collection = NULL;
       tag_collection = dt_util_dstrcat(tag_collection, "1:0:%d:%s$", DT_COLLECTION_PROP_TAG, path);
-      dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+      dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
       dt_collection_deserialize(tag_collection);
-      dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+      dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
       g_free(tag_collection);
     }
     g_free(path);
   }
 }
 
-static void pop_menu_dictionary_goto_collection_back(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_goto_collection_back(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (d->collection[0])
   {
-    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+    dt_control_signal_block_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
     dt_collection_deserialize(d->collection);
-    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+    dt_control_signal_unblock_by_func(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
     d->collection[0] = '\0';
   }
 }
 
-static void pop_menu_dictionary_copy_tag(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_copy_tag(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkTreeIter iter;
@@ -1938,19 +1902,19 @@ static void pop_menu_dictionary_copy_tag(GtkWidget *menuitem, dt_lib_module_t *s
   }
 }
 
-static void pop_menu_dictionary_attach_tag(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_attach_tag(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  attach_selected_tag(self, d);
+  _attach_selected_tag(self, d);
 }
 
-static void pop_menu_dictionary_detach_tag(GtkWidget *menuitem, dt_lib_module_t *self)
+static void _pop_menu_dictionary_detach_tag(GtkWidget *menuitem, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
-  detach_selected_tag(d->dictionary_view, self, d);
+  _detach_selected_tag(d->dictionary_view, self, d);
 }
 
-static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_lib_module_t *self)
+static void _pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkTreeIter iter;
@@ -1970,11 +1934,11 @@ static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_l
     if (tagid)
     {
       menuitem = gtk_menu_item_new_with_label(_("attach tag"));
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_attach_tag, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_attach_tag, self);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
       menuitem = gtk_menu_item_new_with_label(_("detach tag"));
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_detach_tag, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_detach_tag, self);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
     }
     if (d->tree_flag || !d->suggestion_flag)
@@ -1986,22 +1950,22 @@ static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_l
       {
         menuitem = gtk_menu_item_new_with_label(_("delete tag"));
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-        g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_delete_tag, self);
+        g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_delete_tag, self);
       }
 
       menuitem = gtk_menu_item_new_with_label(_("delete branch"));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_delete_path, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_delete_path, self);
 
       menuitem = gtk_separator_menu_item_new();
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       menuitem = gtk_menu_item_new_with_label(_("create tag..."));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_create_tag, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_create_tag, self);
 
       menuitem = gtk_menu_item_new_with_label(_("edit tag..."));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_edit_tag, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_edit_tag, self);
     }
 
     if (d->tree_flag)
@@ -2010,13 +1974,13 @@ static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_l
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       menuitem = gtk_menu_item_new_with_label(_("rename path..."));
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
-      g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_rename_path, self);
+      g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_rename_path, self);
     }
 
     menuitem = gtk_separator_menu_item_new();
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
     menuitem = gtk_menu_item_new_with_label(_("copy to entry"));
-    g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_copy_tag, self);
+    g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_copy_tag, self);
     gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 
     if (d->collection[0])
@@ -2033,13 +1997,13 @@ static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_l
       if (count)
       {
         menuitem = gtk_menu_item_new_with_label(_("go to tag collection"));
-        g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_goto_tag_collection, self);
+        g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_goto_tag_collection, self);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       }
       if (d->collection[0])
       {
         menuitem = gtk_menu_item_new_with_label(_("go back to work"));
-        g_signal_connect(menuitem, "activate", (GCallback)pop_menu_dictionary_goto_collection_back, self);
+        g_signal_connect(menuitem, "activate", (GCallback)_pop_menu_dictionary_goto_collection_back, self);
         gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
       }
     }
@@ -2056,7 +2020,7 @@ static void pop_menu_dictionary(GtkWidget *treeview, GdkEventButton *event, dt_l
   }
 }
 
-static gboolean click_on_view_dictionary(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)
+static gboolean _click_on_view_dictionary(GtkWidget *view, GdkEventButton *event, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
@@ -2072,7 +2036,7 @@ static gboolean click_on_view_dictionary(GtkWidget *view, GdkEventButton *event,
       gtk_tree_selection_select_path(selection, path);
       if(event->type == GDK_BUTTON_PRESS && event->button == 3)
       {
-        pop_menu_dictionary(view, event, self);
+        _pop_menu_dictionary(view, event, self);
         gtk_tree_path_free(path);
         return TRUE;
       }
@@ -2083,7 +2047,7 @@ static gboolean click_on_view_dictionary(GtkWidget *view, GdkEventButton *event,
       }
       else if(event->type == GDK_2BUTTON_PRESS && event->button == 1)
       {
-        attach_selected_tag(self, d);
+        _attach_selected_tag(self, d);
         gtk_tree_path_free(path);
         return TRUE;
       }
@@ -2093,7 +2057,7 @@ static gboolean click_on_view_dictionary(GtkWidget *view, GdkEventButton *event,
   return FALSE;
 }
 
-static gboolean mouse_scroll_attached(GtkWidget *treeview, GdkEventScroll *event, dt_lib_module_t *self)
+static gboolean _mouse_scroll_attached(GtkWidget *treeview, GdkEventScroll *event, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (event->state & GDK_CONTROL_MASK)
@@ -2112,7 +2076,7 @@ static gboolean mouse_scroll_attached(GtkWidget *treeview, GdkEventScroll *event
   return FALSE;
 }
 
-static gboolean mouse_scroll_dictionary(GtkWidget *treeview, GdkEventScroll *event, dt_lib_module_t *self)
+static gboolean _mouse_scroll_dictionary(GtkWidget *treeview, GdkEventScroll *event, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (event->state & GDK_CONTROL_MASK)
@@ -2131,7 +2095,7 @@ static gboolean mouse_scroll_dictionary(GtkWidget *treeview, GdkEventScroll *eve
   return FALSE;
 }
 
-static gboolean row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean kb_mode,
+static gboolean _row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean kb_mode,
       GtkTooltip* tooltip, dt_lib_module_t *self)
 {
   gboolean res = FALSE;
@@ -2170,7 +2134,7 @@ static gboolean row_tooltip_setup(GtkWidget *treeview, gint x, gint y, gboolean 
   return res;
 }
 
-static void import_button_clicked(GtkButton *button, dt_lib_module_t *self)
+static void _import_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   char *last_dirname = dt_conf_get_string("plugins/lighttable/tagging/last_import_export_location");
   if(!last_dirname || !*last_dirname)
@@ -2206,10 +2170,10 @@ static void import_button_clicked(GtkButton *button, dt_lib_module_t *self)
 
   g_free(last_dirname);
   gtk_widget_destroy(filechooser);
-  init_treeview(self, 1);
+  _init_treeview(self, 1);
 }
 
-static void export_button_clicked(GtkButton *button, dt_lib_module_t *self)
+static void _export_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
   GDateTime *now = g_date_time_new_now_local();
   char *export_filename = g_date_time_format(now, "darktable_tags_%F_%R.txt");
@@ -2252,7 +2216,7 @@ static void export_button_clicked(GtkButton *button, dt_lib_module_t *self)
   gtk_widget_destroy(filechooser);
 }
 
-static void update_layout(dt_lib_module_t *self)
+static void _update_layout(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   GtkTreeModel *model = gtk_tree_view_get_model(GTK_TREE_VIEW(d->dictionary_view));
@@ -2324,7 +2288,7 @@ static void update_layout(dt_lib_module_t *self)
   }
 }
 
-static void toggle_suggestion_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
+static void _toggle_suggestion_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
 {
   if (dt_conf_get_bool("plugins/lighttable/tagging/nosuggestion"))
   {
@@ -2334,11 +2298,11 @@ static void toggle_suggestion_button_callback(GtkToggleButton *source, dt_lib_mo
   {
     dt_conf_set_bool("plugins/lighttable/tagging/nosuggestion", TRUE);
   }
-  update_layout(self);
-  init_treeview(self, 1);
+  _update_layout(self);
+  _init_treeview(self, 1);
 }
 
-static void toggle_tree_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
+static void _toggle_tree_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
 {
   if (dt_conf_get_bool("plugins/lighttable/tagging/treeview"))
   {
@@ -2348,11 +2312,11 @@ static void toggle_tree_button_callback(GtkToggleButton *source, dt_lib_module_t
   {
     dt_conf_set_bool("plugins/lighttable/tagging/treeview", TRUE);
   }
-  update_layout(self);
-  init_treeview(self, 1);
+  _update_layout(self);
+  _init_treeview(self, 1);
 }
 
-static gint sort_tree_count_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
+static gint _sort_tree_count_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
 {
   guint count_a = 0;
   guint count_b = 0;
@@ -2361,7 +2325,7 @@ static gint sort_tree_count_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIte
   return (count_b - count_a);
 }
 
-static gint sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
+static gint _sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
 {
   char *tag_a = NULL;
   char *tag_b = NULL;
@@ -2375,7 +2339,7 @@ static gint sort_tree_tag_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter 
   return sort;
 }
 
-static gint sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
+static gint _sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, dt_lib_module_t *self)
 {
   char *tag_a = NULL;
   char *tag_b = NULL;
@@ -2403,7 +2367,7 @@ static gint sort_tree_path_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter
   return sort;
 }
 
-static void toggle_sort_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
+static void _toggle_sort_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
 {
   if (dt_conf_get_bool("plugins/lighttable/tagging/listsortedbycount"))
   {
@@ -2413,12 +2377,12 @@ static void toggle_sort_button_callback(GtkToggleButton *source, dt_lib_module_t
   {
     dt_conf_set_bool("plugins/lighttable/tagging/listsortedbycount", TRUE);
   }
-  update_layout(self);
-  sort_attached_list(self, FALSE);
-  sort_dictionary_list(self, FALSE);
+  _update_layout(self);
+  _sort_attached_list(self, FALSE);
+  _sort_dictionary_list(self, FALSE);
 }
 
-static void toggle_hide_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
+static void _toggle_hide_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
 {
   if (dt_conf_get_bool("plugins/lighttable/tagging/hidehierarchy"))
   {
@@ -2428,16 +2392,16 @@ static void toggle_hide_button_callback(GtkToggleButton *source, dt_lib_module_t
   {
     dt_conf_set_bool("plugins/lighttable/tagging/hidehierarchy", TRUE);
   }
-  update_layout(self);
-  sort_attached_list(self, TRUE);
-  sort_dictionary_list(self, TRUE);
+  _update_layout(self);
+  _sort_attached_list(self, TRUE);
+  _sort_dictionary_list(self, TRUE);
 }
 
-static void toggle_dttags_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
+static void _toggle_dttags_button_callback(GtkToggleButton *source, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   d->dttags_flag = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->toggle_dttags_button));
-  init_treeview(self, 0);
+  _init_treeview(self, 0);
 }
 
 void gui_reset(dt_lib_module_t *self)
@@ -2445,8 +2409,8 @@ void gui_reset(dt_lib_module_t *self)
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   // clear entry box and query
   gtk_entry_set_text(d->entry, "");
-  set_keyword(self);
-  init_treeview(self, 1);
+  _set_keyword(self);
+  _init_treeview(self, 1);
 }
 
 int position()
@@ -2590,14 +2554,14 @@ void gui_init(dt_lib_module_t *self)
   liststore = gtk_list_store_new(DT_LIB_TAGGING_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_STRING,
                                 G_TYPE_STRING, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_BOOLEAN);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(liststore), DT_TAG_SORT_PATH_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_path_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_path_func, self, NULL);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(liststore), DT_TAG_SORT_NAME_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_tag_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_tag_func, self, NULL);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(liststore), DT_TAG_SORT_COUNT_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_count_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_count_func, self, NULL);
   d->attached_liststore = liststore;
   g_object_set(G_OBJECT(view), "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(view), "query-tooltip", G_CALLBACK(row_tooltip_setup), (gpointer)self);
+  g_signal_connect(G_OBJECT(view), "query-tooltip", G_CALLBACK(_row_tooltip_setup), (gpointer)self);
 
   col = gtk_tree_view_column_new();
   gtk_tree_view_append_column(view, col);
@@ -2619,8 +2583,8 @@ void gui_init(dt_lib_module_t *self)
                                                   "\nright-click for other actions on attached tag,"
                                                   "\nctrl-wheel scroll to resize the window"));
   dt_gui_add_help_link(GTK_WIDGET(view), "tagging.html#tagging_usage");
-  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(click_on_view_attached), (gpointer)self);
-  g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(mouse_scroll_attached), (gpointer)self);
+  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(_click_on_view_attached), (gpointer)self);
+  g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(_mouse_scroll_attached), (gpointer)self);
   gtk_container_add(GTK_CONTAINER(w), GTK_WIDGET(view));
 
   // attach/detach buttons
@@ -2632,14 +2596,14 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(button, _("attach tag to all selected images"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(attach_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_attach_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(_("detach"));
   d->detach_button = button;
   gtk_widget_set_hexpand(button, TRUE);
   gtk_widget_set_tooltip_text(button, _("detach tag from all selected images"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(detach_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_detach_button_clicked), (gpointer)self);
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_minus_simple, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
@@ -2648,7 +2612,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
   d->hide_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
-                                            G_CALLBACK(toggle_hide_button_callback), (gpointer)self);
+                                            G_CALLBACK(_toggle_hide_button_callback), (gpointer)self);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_sorting, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   d->toggle_sort_button = button;
@@ -2656,7 +2620,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
   d->sort_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
-                                            G_CALLBACK(toggle_sort_button_callback), (gpointer)self);
+                                            G_CALLBACK(_toggle_sort_button_callback), (gpointer)self);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_check_mark, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   d->toggle_dttags_button = button;
@@ -2665,7 +2629,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(button, _("toggle show or not darktable tags"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(toggle_dttags_button_callback), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_toggle_dttags_button_callback), (gpointer)self);
 
   gtk_box_pack_start(box, GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
@@ -2682,15 +2646,15 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(w, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
-  g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(tag_name_changed), (gpointer)self);
-  g_signal_connect(G_OBJECT(w), "activate", G_CALLBACK(entry_activated), (gpointer)self);
+  g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_tag_name_changed), (gpointer)self);
+  g_signal_connect(G_OBJECT(w), "activate", G_CALLBACK(_entry_activated), (gpointer)self);
   d->entry = GTK_ENTRY(w);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->entry));
 
   button = dtgtk_button_new(dtgtk_cairo_paint_multiply_small, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_widget_set_tooltip_text(button, _("clear entry"));
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(clear_entry_button_callback), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_clear_entry_button_callback), (gpointer)self);
   gtk_box_pack_start(box, GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
   // dictionary_view tree view
@@ -2706,11 +2670,11 @@ void gui_init(dt_lib_module_t *self)
   liststore = gtk_list_store_new(DT_LIB_TAGGING_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_STRING,
                                 G_TYPE_STRING, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_BOOLEAN);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(liststore), DT_TAG_SORT_PATH_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_path_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_path_func, self, NULL);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(liststore), DT_TAG_SORT_NAME_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_tag_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_tag_func, self, NULL);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(liststore), DT_TAG_SORT_COUNT_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_count_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_count_func, self, NULL);
   d->dictionary_liststore = liststore;
   model = gtk_tree_model_filter_new(GTK_TREE_MODEL(liststore), NULL);
   gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(model), DT_LIB_TAGGING_COL_VISIBLE);
@@ -2718,7 +2682,7 @@ void gui_init(dt_lib_module_t *self)
   treestore = gtk_tree_store_new(DT_LIB_TAGGING_NUM_COLS, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_STRING,
                                 G_TYPE_STRING, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_BOOLEAN);
   gtk_tree_sortable_set_sort_func(GTK_TREE_SORTABLE(treestore), DT_TAG_SORT_PATH_ID,
-                  (GtkTreeIterCompareFunc)sort_tree_path_func, self, NULL);
+                  (GtkTreeIterCompareFunc)_sort_tree_path_func, self, NULL);
   d->dictionary_treestore = treestore;
   model = gtk_tree_model_filter_new(GTK_TREE_MODEL(treestore), NULL);
   gtk_tree_model_filter_set_visible_column(GTK_TREE_MODEL_FILTER(model), DT_LIB_TAGGING_COL_VISIBLE);
@@ -2744,13 +2708,13 @@ void gui_init(dt_lib_module_t *self)
                                                       "\nright-click for other actions on selected tag,"
                                                       "\nctrl-wheel scroll to resize the window"));
   dt_gui_add_help_link(GTK_WIDGET(view), "tagging.html#tagging_usage");
-  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(click_on_view_dictionary), (gpointer)self);
-  g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(mouse_scroll_dictionary), (gpointer)self);
+  g_signal_connect(G_OBJECT(view), "button-press-event", G_CALLBACK(_click_on_view_dictionary), (gpointer)self);
+  g_signal_connect(G_OBJECT(view), "scroll-event", G_CALLBACK(_mouse_scroll_dictionary), (gpointer)self);
   gtk_container_add(GTK_CONTAINER(w), GTK_WIDGET(view));
   gtk_tree_view_set_model(view, GTK_TREE_MODEL(d->dictionary_listfilter));
   g_object_unref(d->dictionary_listfilter);
   g_object_set(G_OBJECT(view), "has-tooltip", TRUE, NULL);
-  g_signal_connect(G_OBJECT(view), "query-tooltip", G_CALLBACK(row_tooltip_setup), (gpointer)self);
+  g_signal_connect(G_OBJECT(view), "query-tooltip", G_CALLBACK(_row_tooltip_setup), (gpointer)self);
 
   // buttons
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
@@ -2761,7 +2725,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(button, _("create a new tag with the\nname you entered"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(new_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_new_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(C_("verb", "import..."));
   d->import_button = button;
@@ -2769,7 +2733,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(button, _("import tags from a Lightroom keyword file"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(import_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_import_button_clicked), (gpointer)self);
 
   button = gtk_button_new_with_label(C_("verb", "export..."));
   d->export_button = button;
@@ -2777,7 +2741,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(button, _("export all tags to a Lightroom keyword file"));
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(export_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_export_button_clicked), (gpointer)self);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_treelist, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   d->toggle_tree_button = button;
@@ -2785,7 +2749,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
   d->tree_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
-                                            G_CALLBACK(toggle_tree_button_callback), (gpointer)self);
+                                            G_CALLBACK(_toggle_tree_button_callback), (gpointer)self);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   d->toggle_suggestion_button = button;
@@ -2793,7 +2757,7 @@ void gui_init(dt_lib_module_t *self)
   dt_gui_add_help_link(button, "tagging.html#tagging_usage");
   gtk_box_pack_end(hbox, button, FALSE, TRUE, 0);
   d->suggestion_button_handler = g_signal_connect(G_OBJECT(button), "clicked",
-                                            G_CALLBACK(toggle_suggestion_button_callback), (gpointer)self);
+                                            G_CALLBACK(_toggle_suggestion_button_callback), (gpointer)self);
 
   gtk_box_pack_start(box, GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
@@ -2818,13 +2782,13 @@ void gui_init(dt_lib_module_t *self)
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
                             G_CALLBACK(_lib_selection_changed_callback), self);
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
-                            G_CALLBACK(collection_updated_callback), self);
+                            G_CALLBACK(_collection_updated_callback), self);
 
   d->collection = g_malloc(4096);
-  update_layout(self);
-  init_treeview(self, 0);
-  set_keyword(self);
-  init_treeview(self, 1);
+  _update_layout(self);
+  _init_treeview(self, 0);
+  _set_keyword(self);
+  _init_treeview(self, 1);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -2834,7 +2798,7 @@ void gui_cleanup(dt_lib_module_t *self)
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_tagging_redraw_callback), self);
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_tagging_tags_changed_callback), self);
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_lib_selection_changed_callback), self);
-  dt_control_signal_disconnect(darktable.signals, G_CALLBACK(collection_updated_callback), self);
+  dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
   g_free(d->collection);
   free(self->data);
   self->data = NULL;
@@ -2847,6 +2811,7 @@ static gboolean _lib_tagging_tag_key_press(GtkWidget *entry, GdkEventKey *event,
   switch(event->keyval)
   {
     case GDK_KEY_Escape:
+      g_list_free(d->floating_tag_imgs);
       gtk_widget_destroy(d->floating_tag_window);
       return TRUE;
     case GDK_KEY_Tab:
@@ -2855,16 +2820,16 @@ static gboolean _lib_tagging_tag_key_press(GtkWidget *entry, GdkEventKey *event,
     case GDK_KEY_KP_Enter:
     {
       const gchar *tag = gtk_entry_get_text(GTK_ENTRY(entry));
-      // both these functions can deal with -1 for all selected images. no need for extra code in here!
-      dt_tag_attach_string_list(tag, d->floating_tag_imgid, TRUE, TRUE);
-      dt_image_synch_xmp(d->floating_tag_imgid);
+      dt_tag_attach_string_list(tag, d->floating_tag_imgs, TRUE, TRUE);
+      dt_image_synch_xmps(d->floating_tag_imgs);
+      g_list_free(d->floating_tag_imgs);
 
       /** record last tag used */
       g_free(d->last_tag);
       d->last_tag = g_strdup(tag);
 
-      init_treeview(self, 0);
-      init_treeview(self, 1);
+      _init_treeview(self, 0);
+      _init_treeview(self, 1);
       gtk_widget_destroy(d->floating_tag_window);
       dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
@@ -2887,12 +2852,13 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
 
   if(d->last_tag)
   {
-    const int imgsel = dt_control_get_mouse_over_id();
+    GList *imgs = dt_view_get_images_to_act_on();
+    dt_tag_attach_string_list(d->last_tag, imgs, TRUE, TRUE);
+    dt_image_synch_xmps(imgs);
+    g_list_free(imgs);
 
-    dt_tag_attach_string_list(d->last_tag, imgsel, TRUE, TRUE);
-    dt_image_synch_xmp(imgsel);
-    init_treeview(self, 0);
-    init_treeview(self, 1);
+    _init_treeview(self, 0);
+    _init_treeview(self, 1);
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   }
   return TRUE;
@@ -2901,28 +2867,14 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
 static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                       GdkModifierType modifier, dt_lib_module_t *self)
 {
-  const int zoom = dt_conf_get_int("plugins/lighttable/images_in_row");
-  int mouse_over_id = -1;
-
-  // the order is:
-  // if(zoom == 1) => currently shown image
-  // else if(selection not empty) => selected images
-  // else if(cursor over image) => hovered image
-  // else => return
-  if(zoom == 1 || dt_collection_get_selected_count(darktable.collection) == 0)
-  {
-    mouse_over_id = dt_control_get_mouse_over_id();
-    if(mouse_over_id < 0) return TRUE;
-  }
-
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   if (d->tree_flag)
   {
     dt_control_log(_("tag shortcut is not active with tag tree view. please switch to list view"));
     return TRUE;  // doesn't work properly with tree treeview
   }
-  d->floating_tag_imgid = mouse_over_id;
 
+  d->floating_tag_imgs = dt_view_get_images_to_act_on();
   gint x, y;
   gint px, py, w, h;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);


### PR DESCRIPTION
- wire tagging on dt_view_get_images_to_act_on()
- rename static routines in tagging.c

solve #4576

notes
- hovered image, if any, is still the first target even in darkroom
- dt_image_synch_xmp() is also wired on dt_view_get_images_to_act_on() now
- tagging is still managing grouped images. When integrated in dt_view_get_images_to_act_on() some more cleaning can be done.



