### PR TITLE
$(CATEGORYn(category)) - accepts 10 levels instead of 4 [0-9]

### DIFF
--- a/doc/usermanual/lighttable/panels/export.xml
+++ b/doc/usermanual/lighttable/panels/export.xml
@@ -413,10 +413,10 @@
             </row>
             <row>
               <entry>
-                <code>$(CATEGORYn$(category))</code>
+                <code>$(CATEGORYn(category))</code>
               </entry>
               <entry>
-                tag name of level n [0,3] of selected category (or tag)
+                tag name of level n [0,9] of selected category (or tag)
               </entry>
             </row>
           </tbody>

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -392,10 +392,10 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup_printf("%d", params->data->max_height);
   else if (has_prefix(variable, "CATEGORY"))
   {
-    // TAG should be followed by n [0,3] and "(category)". category can contain 0 or more '|'
-    if (*variable[0] == '0' || *variable[0] == '1' || *variable[0] == '2' || *variable[0] == '3')
+    // CATEGORY should be followed by n [0,9] and "(category)". category can contain 0 or more '|'
+    if (g_ascii_isdigit(*variable[0]))
     {
-      const uint8_t level = (uint8_t)*variable[0] & 0b11;
+      const uint8_t level = (uint8_t)*variable[0] & 0b1111;
       (*variable) ++;
       if (*variable[0] == '(')
       {


### PR DESCRIPTION
$(CATEGORYn(category)) with n being 0 to 9 instead of 0 to 3.
Fixes also doc error as related in #4597 
