### PR TITLE
configurable overlay line colors

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1309,22 +1309,6 @@
     <shortdescription>border around image in darkroom mode</shortdescription>
     <longdescription>process the image in darkroom mode with a small border. set to 0 if you don't want any border.</longdescription>
   </dtconfig>
-  <dtconfig prefs="gui" section="darkroom">
-    <name>darkroom/ui/overlay_color</name>
-    <type>
-       <enum>
-          <option>gray</option>
-          <option>red</option>
-          <option>green</option>
-          <option>yellow</option>
-          <option>cyan</option>
-          <option>magenta</option>
-       </enum>
-    </type>
-    <default>gray</default>
-    <shortdescription>color of lines overlaying the darkroom image</shortdescription>
-    <longdescription>set the color of lines that overlay the image in the darkroom. Affects crop and rotate guides, drawn masks, vignetting and graduated density modules</longdescription>
-  </dtconfig>
   <dtconfig prefs="gui">
     <name>scrollbars</name>
     <type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1309,6 +1309,22 @@
     <shortdescription>border around image in darkroom mode</shortdescription>
     <longdescription>process the image in darkroom mode with a small border. set to 0 if you don't want any border.</longdescription>
   </dtconfig>
+  <dtconfig prefs="gui" section="darkroom">
+    <name>darkroom/ui/overlay_color</name>
+    <type>
+       <enum>
+          <option>gray</option>
+          <option>red</option>
+          <option>green</option>
+          <option>yellow</option>
+          <option>cyan</option>
+          <option>magenta</option>
+       </enum>
+    </type>
+    <default>gray</default>
+    <shortdescription>color of lines overlaying the darkroom image</shortdescription>
+    <longdescription>set the color of lines that overlay the image in the darkroom. Affects crop and rotate guides, drawn masks, vignetting and graduated density modules</longdescription>
+  </dtconfig>
   <dtconfig prefs="gui">
     <name>scrollbars</name>
     <type>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -149,6 +149,9 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dev->overexposed.lower = dt_conf_get_float("darkroom/ui/overexposed/lower");
   dev->overexposed.upper = dt_conf_get_float("darkroom/ui/overexposed/upper");
 
+  dev->overlay_color.enabled = FALSE;
+  dev->overlay_color.color = dt_conf_get_int("darkroom/ui/overlay_color");
+
   dev->iso_12646.enabled = FALSE;
 
   dev->second_window.zoom = DT_ZOOM_FIT;
@@ -222,6 +225,8 @@ void dt_dev_cleanup(dt_develop_t *dev)
   dt_conf_set_int("darkroom/ui/overexposed/colorscheme", dev->overexposed.colorscheme);
   dt_conf_set_float("darkroom/ui/overexposed/lower", dev->overexposed.lower);
   dt_conf_set_float("darkroom/ui/overexposed/upper", dev->overexposed.upper);
+
+  dt_conf_set_int("darkroom/ui/overlay_color", dev->overlay_color.color);
 }
 
 void dt_dev_process_image(dt_develop_t *dev)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -53,6 +53,16 @@ typedef enum dt_dev_overexposed_colorscheme_t
   DT_DEV_OVEREXPOSED_PURPLEGREEN = 2
 } dt_dev_overexposed_colorscheme_t;
 
+typedef enum dt_dev_overlay_colors_t
+{
+  DT_DEV_OVERLAY_GRAY = 0,
+  DT_DEV_OVERLAY_RED = 1,
+  DT_DEV_OVERLAY_GREEN = 2,
+  DT_DEV_OVERLAY_YELLOW = 3,
+  DT_DEV_OVERLAY_CYAN = 4,
+  DT_DEV_OVERLAY_MAGENTA = 5
+} dt_dev_overlay_colors_t;
+
 typedef enum dt_dev_rawoverexposed_mode_t {
   DT_DEV_RAWOVEREXPOSED_MODE_MARK_CFA = 0,
   DT_DEV_RAWOVEREXPOSED_MODE_MARK_SOLID = 1,
@@ -271,6 +281,16 @@ typedef struct dt_develop_t
     dt_dev_rawoverexposed_colorscheme_t colorscheme;
     float threshold;
   } rawoverexposed;
+
+  // for the overlay color indicator
+  struct
+  {
+    guint timeout;
+    GtkWidget *floating_window, *button, *colors; // yes, having gtk stuff in here is ugly. live with it.
+
+    gboolean enabled;
+    dt_dev_overlay_colors_t color;
+  } overlay_color;
 
   // ISO 12646-compliant colour assessment conditions
   struct

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2295,14 +2295,14 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
           cairo_set_line_width(cr, 5.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 3.0 / zoom_scale);
-        cairo_set_source_rgba(cr, .3, .3, .3, .8);
+        dt_draw_set_color_overlay(cr, 0.3, 0.8);
         cairo_stroke_preserve(cr);
         if((gui->group_selected == index)
            && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2))
           cairo_set_line_width(cr, 2.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 1.0 / zoom_scale);
-        cairo_set_source_rgba(cr, .8, .8, .8, .8);
+        dt_draw_set_color_overlay(cr, 0.8, 0.8);
         cairo_stroke(cr);
         // and we update the segment number
         seg = (seg + 1) % nb;
@@ -2326,7 +2326,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       {
         anchor_size = 5.0f / zoom_scale;
       }
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5) + dx,
                       gpt->points[k * 6 + 3] - (anchor_size * 0.5) + dy, anchor_size, anchor_size);
       cairo_fill_preserve(cr);
@@ -2338,7 +2338,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -2360,21 +2360,21 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     cairo_move_to(cr, gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke_preserve(cr);
     cairo_set_line_width(cr, 0.75 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
 
     if((gui->group_selected == index) && (k == gui->feather_dragging || k == gui->feather_selected))
       cairo_arc(cr, ffx, ffy, 3.0f / zoom_scale, 0, 2.0 * M_PI);
     else
       cairo_arc(cr, ffx, ffy, 1.5f / zoom_scale, 0, 2.0 * M_PI);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_fill_preserve(cr);
 
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke(cr);
   }
 
@@ -2394,14 +2394,14 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_set_dash(cr, dashed, len, 0);
     cairo_stroke_preserve(cr);
     if(gui->border_selected)
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
 
@@ -2445,13 +2445,13 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
 
     // we draw the source
@@ -2460,7 +2460,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6] + dxs, gpt->source[nb * 6 + 1] + dys);
     for(int i = nb * 3; i < gpt->source_count; i++)
       cairo_line_to(cr, gpt->source[i * 2] + dxs, gpt->source[i * 2 + 1] + dys);
@@ -2470,7 +2470,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -537,25 +537,25 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       // draw circle
       cairo_set_dash(cr, dashed, 0, 0);
       cairo_set_line_width(cr, 3.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
       cairo_arc(cr, xpos, ypos, radius1, 0, 2.0 * M_PI);
 
       cairo_stroke_preserve(cr);
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_stroke(cr);
 
       // draw border
       cairo_set_dash(cr, dashed, len, 0);
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
       cairo_arc(cr, xpos, ypos, radius2, 0, 2.0 * M_PI);
 
       cairo_stroke_preserve(cr);
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_set_dash(cr, dashed, len, 4);
       cairo_stroke(cr);
 
@@ -593,7 +593,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_line_width(cr, 5.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 3.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_move_to(cr, gpt->points[2] + dx, gpt->points[3] + dy);
     for(int i = 2; i < gpt->points_count; i++)
     {
@@ -605,7 +605,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
   }
 
@@ -617,7 +617,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
     cairo_move_to(cr, gpt->border[2] + dx, gpt->border[3] + dy);
     for(int i = 2; i < gpt->border_count; i++)
@@ -631,7 +631,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
   }
@@ -676,13 +676,13 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
         cairo_set_line_width(cr, 2.5 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.5 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
       cairo_stroke_preserve(cr);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
         cairo_set_line_width(cr, 1.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 0.5 / zoom_scale);
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_stroke(cr);
     }
 
@@ -692,7 +692,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_move_to(cr, gpt->source[2] + dxs, gpt->source[3] + dys);
     for(int i = 2; i < gpt->source_count; i++)
     {
@@ -704,7 +704,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -195,7 +195,7 @@ static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selecte
     cairo_set_line_width(cr, 5.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 3.0 / zoom_scale);
-  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+  dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
   _ellipse_point_transform(xref, yref, points[10] + dx, points[11] + dy, sinr, cosr, scalea, scaleb, sinv, cosv,
                            &x, &y);
@@ -214,7 +214,7 @@ static void dt_ellipse_draw_shape(cairo_t *cr, double *dashed, const int selecte
     cairo_set_line_width(cr, 2.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  dt_draw_set_color_overlay(cr, 0.8, 0.8);
   cairo_stroke(cr);
 }
 
@@ -237,7 +237,7 @@ static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len,
     cairo_set_line_width(cr, 2.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+  dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
   _ellipse_point_transform(xref, yref, border[10] + dx, border[11] + dy, sinr, cosr, scaleab, scalebb, sinv, cosv,
                            &x, &y);
@@ -257,7 +257,7 @@ static void dt_ellipse_draw_border(cairo_t *cr, double *dashed, const float len,
     cairo_set_line_width(cr, 2.0 / zoom_scale);
   else
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  dt_draw_set_color_overlay(cr, 0.8, 0.8);
   cairo_set_dash(cr, dashed, len, 4);
   cairo_stroke(cr);
 }
@@ -1238,7 +1238,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
 
     for(int i = 1; i < 5; i++)
     {
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
 
       if(i == gui->point_dragging || i == gui->point_selected)
         anchor_size = 7.0f / zoom_scale;
@@ -1255,7 +1255,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -1303,13 +1303,13 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
         cairo_set_line_width(cr, 2.5 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.5 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
       cairo_stroke_preserve(cr);
       if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
         cairo_set_line_width(cr, 1.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 0.5 / zoom_scale);
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_stroke(cr);
     }
 
@@ -1319,7 +1319,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     _ellipse_point_transform(xrefs, yrefs, gpt->source[10] + dxs, gpt->source[11] + dys, sinr, cosr, scalea,
                              scaleb, sinv, cosv, &x, &y);
     cairo_move_to(cr, x, y);
@@ -1337,7 +1337,7 @@ static void dt_ellipse_events_post_expose(cairo_t *cr, float zoom_scale, dt_mask
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -525,14 +525,14 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
 
     // draw main line
     cairo_set_line_width(cr, 5.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
     cairo_move_to(cr, 0.0f, ypos - xpos * trotation);
     cairo_line_to(cr, darktable.develop->preview_pipe->backbuf_width,
                   ypos + (darktable.develop->preview_pipe->backbuf_width - xpos) * trotation);
     cairo_stroke_preserve(cr);
     cairo_set_line_width(cr, 2.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
 
     // draw the arrow
@@ -547,16 +547,16 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     pivot_end_y = ypos0 + cosf(rotation) * distance;
     cairo_set_dash(cr, dashed, 0, 0);
     cairo_set_line_width(cr, 2.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
     // from start to end
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_line_to(cr, pivot_start_x, pivot_start_y);
     cairo_line_to(cr, pivot_end_x, pivot_end_y);
     cairo_stroke(cr);
 
     // start side of the gradient
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
     cairo_fill_preserve(cr);
     cairo_stroke(cr);
@@ -564,7 +564,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     // end side of the gradient
     cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
     cairo_fill_preserve(cr);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke(cr);
 
     // draw arrow on the end of the gradient to clearly display the direction
@@ -582,7 +582,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     const float arrow_y1 = pivot_end_y + (arrow_length * sin(angle + arrow_angle));
     const float arrow_y2 = pivot_end_y + (arrow_length * sin(angle - arrow_angle));
 
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_move_to(cr, pivot_end_x, pivot_end_y);
     cairo_line_to(cr, arrow_x1, arrow_y1);
     cairo_line_to(cr, arrow_x2, arrow_y2);
@@ -598,20 +598,20 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     pivot_end_y = ypos0 + cosf(rotation) * compression * scale;
     cairo_set_dash(cr, dashed, len, 0);
     cairo_set_line_width(cr, 2.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_move_to(cr, 0.0f, pivot_start_y - pivot_start_x * trotation);
     cairo_line_to(cr, darktable.develop->preview_pipe->backbuf_width,
                   pivot_start_y + (darktable.develop->preview_pipe->backbuf_width - pivot_start_x) * trotation);
     cairo_stroke_preserve(cr);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_move_to(cr, 0.0f, pivot_end_y - pivot_end_x * trotation);
     cairo_line_to(cr, darktable.develop->preview_pipe->backbuf_width,
                   pivot_end_y + (darktable.develop->preview_pipe->backbuf_width - pivot_end_x) * trotation);
     cairo_stroke_preserve(cr);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
 
@@ -668,7 +668,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
         cairo_set_line_width(cr, 5.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 3.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
       cairo_move_to(cr, x, y);
 
@@ -688,7 +688,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -725,7 +725,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
       cairo_move_to(cr, x, y);
 
@@ -745,7 +745,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_set_dash(cr, dashed, len, 4);
       cairo_stroke(cr);
     }
@@ -763,7 +763,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
   {
     cairo_set_dash(cr, dashed, 0, 0);
     const float anchor_size = (gui->form_dragging || gui->form_selected) ? 7.0f / zoom_scale : 5.0f / zoom_scale;
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_rectangle(cr, anchor_x - (anchor_size * 0.5), anchor_y - (anchor_size * 0.5), anchor_size, anchor_size);
     cairo_fill_preserve(cr);
 
@@ -771,7 +771,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke(cr);
   }
 
@@ -783,16 +783,16 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
     // from start to end
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_move_to(cr, pivot_start_x, pivot_start_y);
     cairo_line_to(cr, pivot_end_x, pivot_end_y);
     cairo_stroke(cr);
 
     // start side of the gradient
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_arc(cr, pivot_start_x, pivot_start_y, 3.0f / zoom_scale, 0, 2.0f * M_PI);
     cairo_fill_preserve(cr);
     cairo_stroke(cr);
@@ -800,7 +800,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     // end side of the gradient
     cairo_arc(cr, pivot_end_x, pivot_end_y, 1.0f / zoom_scale, 0, 2.0f * M_PI);
     cairo_fill_preserve(cr);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke(cr);
 
     // draw arrow on the end of the gradient to clearly display the direction
@@ -818,7 +818,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     const float arrow_y1 = pivot_end_y + (arrow_length * sin(angle + arrow_angle));
     const float arrow_y2 = pivot_end_y + (arrow_length * sin(angle - arrow_angle));
 
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_move_to(cr, pivot_end_x, pivot_end_y);
     cairo_line_to(cr, arrow_x1, arrow_y1);
     cairo_line_to(cr, arrow_x2, arrow_y2);

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1793,14 +1793,14 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
           cairo_set_line_width(cr, 5.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 3.0 / zoom_scale);
-        cairo_set_source_rgba(cr, .3, .3, .3, .8);
+        dt_draw_set_color_overlay(cr, 0.3, 0.8);
         cairo_stroke_preserve(cr);
         if((gui->group_selected == index)
            && (gui->form_selected || gui->form_dragging || gui->seg_selected == seg2))
           cairo_set_line_width(cr, 2.0 / zoom_scale);
         else
           cairo_set_line_width(cr, 1.0 / zoom_scale);
-        cairo_set_source_rgba(cr, .8, .8, .8, .8);
+        dt_draw_set_color_overlay(cr, 0.8, 0.8);
         cairo_stroke(cr);
         // and we update the segment number
         seg = (seg + 1) % nb;
@@ -1824,7 +1824,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       {
         anchor_size = 5.0f / zoom_scale;
       }
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_rectangle(cr, gpt->points[k * 6 + 2] - (anchor_size * 0.5) + dx,
                       gpt->points[k * 6 + 3] - (anchor_size * 0.5) + dy, anchor_size, anchor_size);
       cairo_fill_preserve(cr);
@@ -1836,7 +1836,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
       cairo_stroke(cr);
     }
   }
@@ -1859,21 +1859,21 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
     cairo_move_to(cr, gpt->points[k * 6 + 2] + dx, gpt->points[k * 6 + 3] + dy);
     cairo_line_to(cr, ffx, ffy);
     cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke_preserve(cr);
     cairo_set_line_width(cr, 0.75 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
 
     if((gui->group_selected == index) && (k == gui->feather_dragging || k == gui->feather_selected))
       cairo_arc(cr, ffx, ffy, 3.0f / zoom_scale, 0, 2.0 * M_PI);
     else
       cairo_arc(cr, ffx, ffy, 1.5f / zoom_scale, 0, 2.0 * M_PI);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_fill_preserve(cr);
 
     cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke(cr);
   }
 
@@ -1902,14 +1902,14 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_set_dash(cr, dashed, len, 0);
     cairo_stroke_preserve(cr);
     if(gui->border_selected)
       cairo_set_line_width(cr, 2.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.0 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_set_dash(cr, dashed, len, 4);
     cairo_stroke(cr);
 
@@ -1925,7 +1925,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       {
         anchor_size = 5.0f / zoom_scale;
       }
-      cairo_set_source_rgba(cr, .8, .8, .8, .8);
+      dt_draw_set_color_overlay(cr, 0.8, 0.8);
       cairo_rectangle(cr, gpt->border[k * 6] - (anchor_size * 0.5) + dx,
                       gpt->border[k * 6 + 1] - (anchor_size * 0.5) + dy, anchor_size, anchor_size);
       cairo_fill_preserve(cr);
@@ -1934,7 +1934,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
         cairo_set_line_width(cr, 2.0 / zoom_scale);
       else
         cairo_set_line_width(cr, 1.0 / zoom_scale);
-      cairo_set_source_rgba(cr, .3, .3, .3, .8);
+      dt_draw_set_color_overlay(cr, 0.3, 0.8);
       cairo_set_dash(cr, dashed, 0, 0);
       cairo_stroke(cr);
     }
@@ -1982,13 +1982,13 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke_preserve(cr);
     if((gui->group_selected == index) && (gui->form_selected || gui->form_dragging))
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
 
     // we draw the source
@@ -1997,7 +1997,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       cairo_set_line_width(cr, 2.5 / zoom_scale);
     else
       cairo_set_line_width(cr, 1.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_move_to(cr, gpt->source[nb * 6] + dxs, gpt->source[nb * 6 + 1] + dys);
     for(int i = nb * 3; i < gpt->source_count; i++)
       cairo_line_to(cr, gpt->source[i * 2] + dxs, gpt->source[i * 2 + 1] + dys);
@@ -2007,7 +2007,7 @@ static void dt_path_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_f
       cairo_set_line_width(cr, 1.0 / zoom_scale);
     else
       cairo_set_line_width(cr, 0.5 / zoom_scale);
-    cairo_set_source_rgba(cr, .8, .8, .8, .8);
+    dt_draw_set_color_overlay(cr, 0.8, 0.8);
     cairo_stroke(cr);
   }
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1012,6 +1012,29 @@ void dtgtk_cairo_paint_timer(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   cairo_identity_matrix(cr);
 }
 
+void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  const gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+  cairo_set_line_width(cr, 0.1);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  
+  cairo_move_to(cr, 0.0, 0.3);
+  cairo_line_to(cr, 1.0, 0.3);
+  cairo_move_to(cr, 0.0, 0.6);
+  cairo_line_to(cr, 1.0, 0.6);
+
+  cairo_move_to(cr, 0.3, 0.0);
+  cairo_line_to(cr, 0.3, 1.0);
+  cairo_move_to(cr, 0.6, 0.0);
+  cairo_line_to(cr, 0.6, 1.0);
+
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+}
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -175,6 +175,8 @@ void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h
 void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a duplicate/multi instance indicator */
 void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint a simple grid icon */
+void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -28,6 +28,7 @@
 #include "common/darktable.h"
 #include "common/splines.h"
 #include "control/conf.h"
+#include "develop/develop.h"
 #include <cairo.h>
 #include <glib.h>
 #include <math.h>
@@ -48,34 +49,32 @@ typedef struct dt_draw_curve_t
 /** set color based on gui overlay preference */
 static inline void dt_draw_set_color_overlay(cairo_t *cr, double amt, double alpha)
 {
-  char *overlay_color = dt_conf_get_string("darkroom/ui/overlay_color");
+  const int overlay_color = dt_conf_get_int("darkroom/ui/overlay_color");
 
-  if(!strcmp(overlay_color, "gray"))
+  if(overlay_color == DT_DEV_OVERLAY_GRAY)
   {
     cairo_set_source_rgba(cr, 1.0 * amt, 1.0 * amt, 1.0 * amt, alpha);
   }
-  else if(!strcmp(overlay_color, "red"))
+  else if(overlay_color == DT_DEV_OVERLAY_RED)
   {
     cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 0.0, alpha);
   }
-  else if(!strcmp(overlay_color, "green"))
+  else if(overlay_color == DT_DEV_OVERLAY_GREEN)
   {
     cairo_set_source_rgba(cr, 0.0, 1.0 * amt, 0.0, alpha);
   }
-  else if(!strcmp(overlay_color, "yellow"))
+  else if(overlay_color == DT_DEV_OVERLAY_YELLOW)
   {
     cairo_set_source_rgba(cr, 1.0 * amt, 1.0 * amt, 0.0, alpha);
   }
-  else if(!strcmp(overlay_color, "cyan"))
+  else if(overlay_color == DT_DEV_OVERLAY_CYAN)
   {
     cairo_set_source_rgba(cr, 0.0, 1.0 * amt, 1.0 * amt, alpha);
   }
-  else if(!strcmp(overlay_color, "magenta"))
+  else if(overlay_color == DT_DEV_OVERLAY_MAGENTA)
   {
     cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 1.0 * amt, alpha);
   }
-
-  g_free(overlay_color);
 
 }
 

--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -27,6 +27,7 @@
 #include "common/curve_tools.h"
 #include "common/darktable.h"
 #include "common/splines.h"
+#include "control/conf.h"
 #include <cairo.h>
 #include <glib.h>
 #include <math.h>
@@ -43,6 +44,40 @@ typedef struct dt_draw_curve_t
   CurveData c;
   CurveSample csample;
 } dt_draw_curve_t;
+
+/** set color based on gui overlay preference */
+static inline void dt_draw_set_color_overlay(cairo_t *cr, double amt, double alpha)
+{
+  char *overlay_color = dt_conf_get_string("darkroom/ui/overlay_color");
+
+  if(!strcmp(overlay_color, "gray"))
+  {
+    cairo_set_source_rgba(cr, 1.0 * amt, 1.0 * amt, 1.0 * amt, alpha);
+  }
+  else if(!strcmp(overlay_color, "red"))
+  {
+    cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 0.0, alpha);
+  }
+  else if(!strcmp(overlay_color, "green"))
+  {
+    cairo_set_source_rgba(cr, 0.0, 1.0 * amt, 0.0, alpha);
+  }
+  else if(!strcmp(overlay_color, "yellow"))
+  {
+    cairo_set_source_rgba(cr, 1.0 * amt, 1.0 * amt, 0.0, alpha);
+  }
+  else if(!strcmp(overlay_color, "cyan"))
+  {
+    cairo_set_source_rgba(cr, 0.0, 1.0 * amt, 1.0 * amt, alpha);
+  }
+  else if(!strcmp(overlay_color, "magenta"))
+  {
+    cairo_set_source_rgba(cr, 1.0 * amt, 0.0, 1.0 * amt, alpha);
+  }
+
+  g_free(overlay_color);
+
+}
 
 /** draws a rating star
  */

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2322,7 +2322,7 @@ static void gui_draw_sym(cairo_t *cr, float x, float y, gboolean active)
   pango_layout_set_font_description(layout, desc);
   pango_layout_set_text(layout, "ꝏ", -1);
   pango_layout_get_pixel_extents(layout, &ink, NULL);
-  cairo_set_source_rgba(cr, .5, .5, .5, .7);
+  dt_draw_set_color_overlay(cr, 0.5, 0.7);
   gui_draw_rounded_rectangle(
       cr, ink.width + DT_PIXEL_APPLY_DPI(4), ink.height + DT_PIXEL_APPLY_DPI(8),
       x - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(2), y - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(4));
@@ -2386,7 +2386,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   {
     cairo_set_line_width(cr, dashes / 2.0);
     cairo_rectangle(cr, g->clip_x * wd, g->clip_y * ht, g->clip_w * wd, g->clip_h * ht);
-    cairo_set_source_rgb(cr, .7, .7, .7);
+    dt_draw_set_color_overlay(cr, 0.7, 1.0);
     cairo_stroke(cr);
   }
 
@@ -2443,7 +2443,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_rectangle(cr, left, top, cwidth, cheight);
   cairo_clip(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
-  cairo_set_source_rgb(cr, .8, .8, .8);
+  dt_draw_set_color_overlay(cr, 0.8, 1.0);
   cairo_set_dash(cr, &dashes, 1, 0);
 
   // Move coordinates to local center selection.
@@ -2461,13 +2461,13 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     guide->draw(cr, -cwidth / 2, -cheight / 2, cwidth, cheight, zoom_scale, guide->user_data);
     cairo_stroke_preserve(cr);
     cairo_set_dash(cr, &dashes, 0, 0);
-    cairo_set_source_rgba(cr, 0.3, .3, .3, .8);
+    dt_draw_set_color_overlay(cr, 0.3, 0.8);
     cairo_stroke(cr);
   }
   cairo_restore(cr);
 
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
-  cairo_set_source_rgb(cr, .3, .3, .3);
+  dt_draw_set_color_overlay(cr, 0.3, 1.0);
   const int border = DT_PIXEL_APPLY_DPI(30.0) / zoom_scale;
   if(g->straightening)
   {
@@ -2511,7 +2511,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     const float xp = pzx * wd + DT_PIXEL_APPLY_DPI(20) / zoom_scale;
     const float yp = pzy * ht - ink.height;
     gui_draw_rounded_rectangle(cr, text_w + 2 * margin, text_h + 2 * margin, xp - margin, yp - margin);
-    cairo_set_source_rgb(cr, .7, .7, .7);
+    cairo_set_source_rgba(cr, .7, .7, .7, .7);
     cairo_move_to(cr, xp, yp);
     pango_cairo_show_layout(cr, layout);
     pango_font_description_free(desc);
@@ -2731,7 +2731,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                                  c[0] - ink.width / 2.0f - DT_PIXEL_APPLY_DPI(4),
                                  c[1] - ink.height / 2.0f - DT_PIXEL_APPLY_DPI(6));
       cairo_move_to(cr, c[0] - ink.width / 2.0f, c[1] - 3.0 * ink.height / 4.0f);
-      cairo_set_source_rgba(cr, .2, .2, .2, .9);
+      dt_draw_set_color_overlay(cr, 0.2, 0.9);
       pango_cairo_show_layout(cr, layout);
       pango_font_description_free(desc);
       g_object_unref(layout);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -496,7 +496,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(5.0) / zoom_scale);
   else
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) / zoom_scale);
-  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+  dt_draw_set_color_overlay(cr, 0.3, 0.8);
 
   cairo_move_to(cr, xa, ya);
   cairo_line_to(cr, xb, yb);
@@ -506,7 +506,7 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.0) / zoom_scale);
   else
     cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
-  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  dt_draw_set_color_overlay(cr, 0.8, 0.8);
   cairo_move_to(cr, xa, ya);
   cairo_line_to(cr, xb, yb);
   cairo_stroke(cr);
@@ -527,14 +527,14 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_close_path(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
   if(g->selected == 1 || g->dragging == 1)
-    cairo_set_source_rgba(cr, .8, .8, .8, 1.0);
+    dt_draw_set_color_overlay(cr, 0.8, 1.0);
   else
-    cairo_set_source_rgba(cr, .8, .8, .8, .5);
+    dt_draw_set_color_overlay(cr, 0.8, 0.5);
   cairo_fill_preserve(cr);
   if(g->selected == 1 || g->dragging == 1)
-    cairo_set_source_rgba(cr, .3, .3, .3, 1.0);
+    dt_draw_set_color_overlay(cr, 0.3, 1.0);
   else
-    cairo_set_source_rgba(cr, .3, .3, .3, .5);
+    dt_draw_set_color_overlay(cr, 0.3, 0.5);
   cairo_stroke(cr);
 
   x1 = xb - (xb - xa) * ext / l;
@@ -549,14 +549,14 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
   cairo_close_path(cr);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
   if(g->selected == 2 || g->dragging == 2)
-    cairo_set_source_rgba(cr, .8, .8, .8, 1.0);
+    dt_draw_set_color_overlay(cr, 0.8, 1.0);
   else
-    cairo_set_source_rgba(cr, .8, .8, .8, .5);
+    dt_draw_set_color_overlay(cr, 0.8, 0.5);
   cairo_fill_preserve(cr);
   if(g->selected == 2 || g->dragging == 2)
-    cairo_set_source_rgba(cr, .3, .3, .3, 1.0);
+    dt_draw_set_color_overlay(cr, 0.3, 1.0);
   else
-    cairo_set_source_rgba(cr, .3, .3, .3, .5);
+    dt_draw_set_color_overlay(cr, 0.3, 0.5);
   cairo_stroke(cr);
 }
 

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -457,10 +457,10 @@ void gui_post_expose(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, i
                       -vignette_fy, zoom_scale);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(3.0) / zoom_scale);
-  cairo_set_source_rgba(cr, .3, .3, .3, .8);
+  dt_draw_set_color_overlay(cr, 0.3, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.0) / zoom_scale);
-  cairo_set_source_rgba(cr, .8, .8, .8, .8);
+  dt_draw_set_color_overlay(cr, 0.8, 0.8);
   draw_overlay(cr, vignette_w, vignette_h, vignette_fx, vignette_fy, grab, zoom_scale);
 }
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1314,6 +1314,37 @@ static void _iso_12646_quickbutton_clicked(GtkWidget *w, gpointer user_data)
   dt_dev_reprocess_center(d);
 }
 
+/* overlay color */
+static void _overlay_color_quickbutton_clicked(GtkWidget *w, gpointer user_data)
+{
+  dt_develop_t *d = (dt_develop_t *)user_data;
+  d->overlay_color.enabled = !d->overlay_color.enabled;
+  dt_dev_reprocess_center(d);
+}
+
+static gboolean _overlay_color_quickbutton_pressed(GtkWidget *widget, GdkEvent *event, gpointer user_data)
+{
+  dt_develop_t *d = (dt_develop_t *)user_data;
+  _toolbar_show_popup(d->overlay_color.floating_window);
+  return TRUE;
+}
+
+static gboolean _overlay_color_quickbutton_released(GtkWidget *widget, GdkEvent *event, gpointer user_data)
+{
+  dt_develop_t *d = (dt_develop_t *)user_data;
+  if(d->overlay_color.timeout > 0) g_source_remove(d->overlay_color.timeout);
+  d->overlay_color.timeout = 0;
+  return FALSE;
+}
+
+static void overlay_colors_callback(GtkWidget *combo, gpointer user_data)
+{
+  dt_develop_t *d = (dt_develop_t *)user_data;
+  d->overlay_color.color = dt_bauhaus_combobox_get(combo);
+  dt_conf_set_int("darkroom/ui/overlay_color", d->overlay_color.color);
+  dt_dev_reprocess_center(d);
+}
+
 /* overexposed */
 static void _overexposed_quickbutton_clicked(GtkWidget *w, gpointer user_data)
 {
@@ -1904,6 +1935,18 @@ static gboolean _brush_opacity_down_callback(GtkAccelGroup *accel_group, GObject
   return TRUE;
 }
 
+static gboolean _overlay_cycle_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                             GdkModifierType modifier, gpointer data)
+{
+  dt_develop_t *dev = (dt_develop_t *)data;
+  GtkWidget * combobox = dev->overlay_color.colors;
+
+  const int currentval = dt_bauhaus_combobox_get(combobox);
+  const int nextval = currentval + 1 >= dt_bauhaus_combobox_length(combobox) ? 0 : currentval + 1;
+  dt_bauhaus_combobox_set(combobox, nextval);
+  return TRUE;
+}
+
 void gui_init(dt_view_t *self)
 {
   dt_develop_t *dev = (dt_develop_t *)self->data;
@@ -2237,6 +2280,47 @@ void gui_init(dt_view_t *self)
                               G_CALLBACK(_display_profile_changed), (gpointer)display_profile);
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               G_CALLBACK(_display2_profile_changed), (gpointer)display2_profile);
+  }
+
+  /* create overlay color changer popup tool */
+  {
+    // the button
+    dev->overlay_color.button
+        = dtgtk_togglebutton_new(dtgtk_cairo_paint_overexposed, CPF_STYLE_FLAT, NULL);
+    gtk_widget_set_tooltip_text(dev->overlay_color.button,
+                                _("set the color of lines that overlay the image (drawn masks, crop and rotate guides etc.)"));
+    g_signal_connect(G_OBJECT(dev->overlay_color.button), "clicked",
+                     G_CALLBACK(_overlay_color_quickbutton_clicked), dev);
+    g_signal_connect(G_OBJECT(dev->overlay_color.button), "button-press-event",
+                     G_CALLBACK(_overlay_color_quickbutton_pressed), dev);
+    g_signal_connect(G_OBJECT(dev->overlay_color.button), "button-release-event",
+                     G_CALLBACK(_overlay_color_quickbutton_released), dev);
+    dt_view_manager_module_toolbox_add(darktable.view_manager, dev->overlay_color.button, DT_VIEW_DARKROOM);
+
+    // and the popup window
+    dev->overlay_color.floating_window = gtk_popover_new(dev->overlay_color.button);
+    gtk_widget_set_size_request(GTK_WIDGET(dev->overlay_color.floating_window), dialog_width, -1);
+#if GTK_CHECK_VERSION(3, 16, 0)
+    g_object_set(G_OBJECT(dev->overlay_color.floating_window), "transitions-enabled", FALSE, NULL);
+#endif
+
+    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_container_add(GTK_CONTAINER(dev->overlay_color.floating_window), vbox);
+
+    /** let's fill the encapsulating widget */
+    GtkWidget *overlay_colors = dev->overlay_color.colors = dt_bauhaus_combobox_new(NULL);
+    dt_bauhaus_widget_set_label(overlay_colors, NULL, _("overlay color"));
+    dt_bauhaus_combobox_add(overlay_colors, _("gray"));
+    dt_bauhaus_combobox_add(overlay_colors, _("red"));
+    dt_bauhaus_combobox_add(overlay_colors, _("green"));
+    dt_bauhaus_combobox_add(overlay_colors, _("yellow"));
+    dt_bauhaus_combobox_add(overlay_colors, _("cyan"));
+    dt_bauhaus_combobox_add(overlay_colors, _("magenta"));
+    dt_bauhaus_combobox_set(overlay_colors, dev->overlay_color.color);
+    gtk_widget_set_tooltip_text(overlay_colors, _("set overlay color"));
+    g_signal_connect(G_OBJECT(overlay_colors), "value-changed", G_CALLBACK(overlay_colors_callback), dev);
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(overlay_colors), TRUE, TRUE, 0);
+    gtk_widget_set_state_flags(overlay_colors, GTK_STATE_FLAG_SELECTED, TRUE);
   }
 
   darktable.view_manager->proxy.darkroom.view = self;
@@ -3427,6 +3511,9 @@ void init_key_accels(dt_view_t *self)
   // toggle overexposure indication
   dt_accel_register_view(self, NC_("accel", "overexposed"), GDK_KEY_o, 0);
 
+  // cycle overlay colors
+  dt_accel_register_view(self, NC_("accel", "cycle overlay colors"), GDK_KEY_o, GDK_CONTROL_MASK);
+
   // toggle softproofing
   dt_accel_register_view(self, NC_("accel", "softproof"), GDK_KEY_s, GDK_CONTROL_MASK);
 
@@ -3510,6 +3597,10 @@ void connect_key_accels(dt_view_t *self)
   // toggle overexposure indication
   closure = g_cclosure_new(G_CALLBACK(_toolbox_toggle_callback), data->overexposed.button, NULL);
   dt_accel_connect_view(self, "overexposed", closure);
+
+  // cycle through overlay colors
+  closure = g_cclosure_new(G_CALLBACK(_overlay_cycle_callback), (gpointer)self->data, NULL);
+  dt_accel_connect_view(self, "cycle overlay colors", closure);
 
   // toggle softproof indication
   closure = g_cclosure_new(G_CALLBACK(_toolbox_toggle_callback), data->profile.softproof_button, NULL);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2286,7 +2286,7 @@ void gui_init(dt_view_t *self)
   {
     // the button
     dev->overlay_color.button
-        = dtgtk_togglebutton_new(dtgtk_cairo_paint_overexposed, CPF_STYLE_FLAT, NULL);
+        = dtgtk_togglebutton_new(dtgtk_cairo_paint_grid, CPF_STYLE_FLAT, NULL);
     gtk_widget_set_tooltip_text(dev->overlay_color.button,
                                 _("set the color of lines that overlay the image (drawn masks, crop and rotate guides etc.)"));
     g_signal_connect(G_OBJECT(dev->overlay_color.button), "clicked",


### PR DESCRIPTION
Adds a new bottom-panel darkroom icon to allow user to choose the color of the lines
that display in the following scenarios:

 - when creating or editing masks (including in spot removal and retouch
   module)
 - in the vignetting module
 - in the graduated density module
 - in the crop and rotate module (guide lines and keystone correction)

color options available are gray (default), red, green, yellow, cyan, magenta.

A keyboard shortcut is available to cycle through the available options (default ctrl-o).

Resolves #3657