### PR TITLE
Write correct sidecar including history after applying presets

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1428,8 +1428,9 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 
   image->flags |= DT_IMAGE_AUTO_PRESETS_APPLIED | DT_IMAGE_NO_LEGACY_PRESETS;
 
-  // make sure these end up in the image_cache + xmp (sync through here if we set the flag)
-  dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
+  // make sure these end up in the image_cache; as the history is not correct right now
+  // we don't write the sidecar here but later in dt_dev_read_history_ext
+  dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_RELAXED);
 
   return TRUE;
 }
@@ -1824,6 +1825,10 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
   if(first_run)
   {
     flags = flags | (auto_apply_modules ? DT_HISTORY_HASH_AUTO : DT_HISTORY_HASH_BASIC);
+
+    // As we have a proper history right now and this s is first_run we write the xmp now
+    dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
+    dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
   }
   else if(legacy_params)
   {

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1826,7 +1826,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
   {
     flags = flags | (auto_apply_modules ? DT_HISTORY_HASH_AUTO : DT_HISTORY_HASH_BASIC);
 
-    // As we have a proper history right now and this s is first_run we write the xmp now
+    // As we have a proper history right now and this is first_run we write the xmp now
     dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
     dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
   }


### PR DESCRIPTION
Whenever we apply any presets on a 'fresh' image we want a **correct** sidecar file to be written.

As there is no history in  `_dev_auto_apply_presets` we must write the sidecar  later in
`dt_dev_read_history_ext`

This is related to #4586 (fixing it) #4595 (first attempt but not fully understanding the problem) and maybe #4089 

In the discussion #4595 i still got wrong the underlying problem. How to reproduce is pretty simple:
Use a fresh image and open it in darkroom, you will see presets applied in history stack. But look at the sidecar right now, it has
1. darktable:auto_presets_applied="1"
2. but is has **no** history data

This is simply wrong. We normally don't observe problems because reimporting such an image is unusual but in that case the sidecar is wrong and will prohibit applying the presets.

Anyway -- this might be a significant problem if we use img plus xmp as backup and reimport any time later.

