### PR TITLE
Allow masks to be displayed in the border area (fixing #4610)

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -607,21 +607,7 @@ void expose(
   {
     // masks
     if(dev->form_visible && dev->gui_module->enabled)
-    {
-      // The masks paths should only be displayed inside the visible image
-      const int pwidth = (dev->pipe->output_backbuf_width<<closeup) / darktable.gui->ppd;
-      const int pheight = (dev->pipe->output_backbuf_height<<closeup) / darktable.gui->ppd;
-
-      const float hbar = (self->width - pwidth) * .5f;
-      const float tbar = (self->height - pheight) * .5f;
-      cairo_save(cri);
-      cairo_rectangle(cri, hbar, tbar, (double)pwidth, (double)pheight);
-      cairo_clip(cri);
-
       dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
-
-      cairo_restore(cri);
-    }
     // module
     if(dev->gui_module && dev->gui_module->gui_post_expose)
       dev->gui_module->gui_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);


### PR DESCRIPTION
A while ago the masks display was restricted to the true image area, this leads to
restrictions while modifying the masks so we should keep showing them :-(

