### PR TITLE
removes unnecessarily adding the source to include_directories:

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -582,7 +582,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
 string(REPLACE ";" "\", \"" DT_SUPPORTED_EXTENSIONS_STRING "${DT_SUPPORTED_EXTENSIONS}")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.h" "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 
-include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
 
 #
 # Build external deps

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
 add_executable(darktable-cli main.c)
 

--- a/src/cltest/CMakeLists.txt
+++ b/src/cltest/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
 add_executable(darktable-cltest main.c)
 

--- a/src/generate-cache/CMakeLists.txt
+++ b/src/generate-cache/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
 add_executable(darktable-generate-cache main.c)
 

--- a/src/imageio/format/CMakeLists.txt
+++ b/src/imageio/format/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../" "${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../")
+
 include_directories(SYSTEM "${PNG_PNG_INCLUDE_DIR}")
 
 include(manage-symbol-visibility)

--- a/src/imageio/storage/CMakeLists.txt
+++ b/src/imageio/storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../" "${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../")
 
 include(manage-symbol-visibility)
 

--- a/src/iop/CMakeLists.txt
+++ b/src/iop/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/../")
 
 include(manage-symbol-visibility)
 

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/../")
 
 include(manage-symbol-visibility)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/../")
+
 add_executable(darktable-test-variables variables.c)
 target_link_libraries(darktable-test-variables lib_darktable)
 

--- a/src/views/CMakeLists.txt
+++ b/src/views/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/../" "${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/../")
 
 include(manage-symbol-visibility)
 


### PR DESCRIPTION
DefineCMakeDefaults contains set(CMAKE_INCLUDE_CURRENT_DIR ON) which
automatically lets CMake add its source and build directory to the include
directories.

https://cmake.org/cmake/help/v3.0/variable/CMAKE_INCLUDE_CURRENT_DIR.html
Automatically add the current source- and build directories to the include path.

If this variable is enabled, CMake automatically adds in each directory ${CMAKE_CURRENT_SOURCE_DIR} and ${CMAKE_CURRENT_BINARY_DIR} to the include path for this directory. These additional include directories do not propagate down to subdirectories. This is useful mainly for out-of-source builds, where files generated into the build tree are included by files located in the source tree.

By default CMAKE_INCLUDE_CURRENT_DIR is OFF.

-> Increased maintainability
-> Increased readability
-> Automatic consistent behavior by CMAKE_INCLUDE_CURRENT_DIR
-> one global place to tweak the compile behavior

~This is one change that I would like to have been be merged before I will
create a PR for darktable out of source builds~