### PR TITLE
Code cleanup _tree_query_tooltip in libs/masks.c

### DIFF
--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1250,13 +1250,12 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
   gtk_tree_model_get(model, &iter, TREE_IC_USED_VISIBLE, &show, TREE_USED_TEXT, &tmp, -1);
   if(show)
   { 
-    // dt_print(DT_DEBUG_MASKS, "[_tree_query_tooltip] '%s'\n", tmp);
     gtk_tooltip_set_markup(tooltip, tmp);
     gtk_tree_view_set_tooltip_row(tree_view, tooltip, path);
   }
 
-  if(path) gtk_tree_path_free(path);
-  if(tmp) g_free(tmp);
+  gtk_tree_path_free(path);
+  g_free(tmp);
 
   return show;
 }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1250,7 +1250,7 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
   gtk_tree_model_get(model, &iter, TREE_IC_USED_VISIBLE, &show, TREE_USED_TEXT, &tmp, -1);
   if(show)
   { 
-    dt_print(DT_DEBUG_MASKS, "[_tree_query_tooltip] '%s'\n", tmp);
+    // dt_print(DT_DEBUG_MASKS, "[_tree_query_tooltip] '%s'\n", tmp);
     gtk_tooltip_set_markup(tooltip, tmp);
     gtk_tree_view_set_tooltip_row(tree_view, tooltip, path);
   }

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -1242,25 +1242,23 @@ static gboolean _tree_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean 
   GtkTreeView *tree_view = GTK_TREE_VIEW(widget);
   GtkTreeModel *model = gtk_tree_view_get_model(tree_view);
   GtkTreePath *path = NULL;
-  gchar *tmp;
-  gboolean show;
-
-  char buffer[512];
+  gchar *tmp = NULL;
+  gboolean show = FALSE;
 
   if(!gtk_tree_view_get_tooltip_context(tree_view, &x, &y, keyboard_tip, &model, &path, &iter)) return FALSE;
 
   gtk_tree_model_get(model, &iter, TREE_IC_USED_VISIBLE, &show, TREE_USED_TEXT, &tmp, -1);
-  if(!show) return FALSE;
+  if(show)
+  { 
+    dt_print(DT_DEBUG_MASKS, "[_tree_query_tooltip] '%s'\n", tmp);
+    gtk_tooltip_set_markup(tooltip, tmp);
+    gtk_tree_view_set_tooltip_row(tree_view, tooltip, path);
+  }
 
-  g_strlcpy(buffer, tmp, sizeof(buffer));
-  gtk_tooltip_set_markup(tooltip, buffer);
+  if(path) gtk_tree_path_free(path);
+  if(tmp) g_free(tmp);
 
-  gtk_tree_view_set_tooltip_row(tree_view, tooltip, path);
-
-  gtk_tree_path_free(path);
-  g_free(tmp);
-
-  return TRUE;
+  return show;
 }
 
 static int _is_form_used(int formid, dt_masks_form_t *grp, char *text, size_t text_length)


### PR DESCRIPTION
There has been a discussion in @GrahamByrnes PR #4614 about `_tree_query_tooltip` and
it became obvious that there has probably been some copy&paste from other code.

See https://fossies.org/linux/gtk+/tests/testtooltips.c, the buffer is just
required to combine strings. Here in our code it's simply not necessary.

Gtk3 docs for `gtk_tree_model_get` tell us what we have to g_free later.

So this pr is a cleanup to smaller, simpler and less obfuscicating code.
