### PR TITLE
fix $(EXIF_EXPOSURE) issue on watermark

### DIFF
--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -868,7 +868,7 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
   dt_variables_params_t *params;
   dt_variables_params_init(&params);
   params->filename = image->filename;
-  params->jobcode = "watermark";
+  params->jobcode = "infos";
   params->sequence = 0;
   params->imgid = image->id;
   dt_variables_set_tags_flags(params, flags);


### PR DESCRIPTION
Resolves #4646 $(EXIF_EXPOSURE) part.
I cannot reproduce the second related issue (random characters...).
