### PR TITLE
Allowing larger vignette scales

### DIFF
--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -560,7 +560,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     else if(grab == 2) // change the width
     {
       float max = 0.5 * ((p->whratio <= 1.0) ? bigger_side * p->whratio : bigger_side);
-      float new_vignette_w = MIN(bigger_side * 0.5, MAX(0.1, pzx * wd - vignette_x));
+      float new_vignette_w = MIN(bigger_side, MAX(0.1, pzx * wd - vignette_x));
       float ratio = new_vignette_w / vignette_h;
       float new_scale = 100.0 * new_vignette_w / max;
       // FIXME: When going over the 1.0 boundary from wide to narrow (>1.0 -> <=1.0) the height slightly
@@ -590,7 +590,7 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
     }
     else if(grab == 4) // change the height
     {
-      float new_vignette_h = MIN(bigger_side * 0.5, MAX(0.1, vignette_y - pzy * ht));
+      float new_vignette_h = MIN(bigger_side, MAX(0.1, vignette_y - pzy * ht));
       float ratio = new_vignette_h / vignette_w;
       float max = 0.5 * ((ratio <= 1.0) ? bigger_side * (2.0 - p->whratio) : bigger_side);
       // FIXME: When going over the 1.0 boundary from narrow to wide (>1.0 -> <=1.0) the width slightly
@@ -1138,7 +1138,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   label1 = dtgtk_reset_label_new(_("automatic ratio"), self, &p->autoratio, sizeof p->autoratio);
 
-  g->scale = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0.5, p->scale, 2);
+  g->scale = dt_bauhaus_slider_new_with_range(self, 0.0, 200.0, 0.5, p->scale, 2);
   g->falloff_scale = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1.0, p->falloff_scale, 2);
   g->brightness = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->brightness, 3);
   g->saturation = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->saturation, 3);


### PR DESCRIPTION
The vignette module is mostly used for artistic reasons, the area to be used is
restricted to the image.

Some people have images shot without proper vignette correction via the lens module,
one example #4578. The vignetting module is not perfect for manual correction, but it's
not so bad at all. The main UI restriction seems to be a too small area that can be selected.

This pr simply allows the scale to be selected in the 0-200% range instead of 0-100. I tested
on many images and it's not perfect but much more suitable than before.