### PR TITLE
set thumbnails margins via css

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1530,6 +1530,7 @@ Details :
 #thumb_image
 {
   border: none;
+  margin : 5px; /* not real pixels, but percentage of the thumb size */
 }
 #thumb_main:active #thumb_image
 {

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1530,7 +1530,7 @@ Details :
 #thumb_image
 {
   border: none;
-  margin : 5px; /* not real pixels, but percentage of the thumb size */
+  margin : 4px; /* not real pixels, but percentage of the thumb size */
 }
 #thumb_main:active #thumb_image
 {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -141,6 +141,17 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
   // if we don't have it in memory, we want the image surface
   if(!thumb->img_surf || thumb->img_surf_dirty)
   {
+    if(!thumb->img_margin)
+    {
+      // we retrieve image margins from css
+      GtkStateFlags state = gtk_widget_get_state_flags(thumb->w_image);
+      thumb->img_margin = gtk_border_new();
+      GtkStyleContext *context = gtk_widget_get_style_context(thumb->w_image);
+      gtk_style_context_get_margin(context, state, thumb->img_margin);
+    }
+    const float ratio_h = (float)(100 - thumb->img_margin->top - thumb->img_margin->bottom) / 100.0;
+    const float ratio_w = (float)(100 - thumb->img_margin->left - thumb->img_margin->right) / 100.0;
+
     if(v->view(v) == DT_VIEW_DARKROOM && dev->preview_pipe->output_imgid == thumb->imgid
        && dev->preview_pipe->output_backbuf)
     {
@@ -168,7 +179,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       if(tmp_surface)
       {
         const float scale
-            = fminf(thumb->width * 0.91 / (float)buf_width, thumb->height * 0.91 / (float)buf_height);
+            = fminf(thumb->width * ratio_w / (float)buf_width, thumb->height * ratio_h / (float)buf_height);
         const int img_width = buf_width * scale;
         const int img_height = buf_height * scale;
         thumb->img_surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_width, img_height);
@@ -199,8 +210,8 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     }
     else
     {
-      const gboolean res
-          = dt_view_image_get_surface(thumb->imgid, thumb->width * 0.91, thumb->height * 0.91, &thumb->img_surf);
+      const gboolean res = dt_view_image_get_surface(thumb->imgid, thumb->width * ratio_w, thumb->height * ratio_h,
+                                                     &thumb->img_surf);
       if(res)
       {
         // if the image is missing, we reload it again
@@ -778,6 +789,7 @@ void dt_thumbnail_destroy(dt_thumbnail_t *thumb)
   thumb->img_surf = NULL;
   if(thumb->w_main) gtk_widget_destroy(thumb->w_main);
   if(thumb->filename) g_free(thumb->filename);
+  if(thumb->img_margin) gtk_border_free(thumb->img_margin);
   free(thumb);
 }
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -225,6 +225,11 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     thumb->img_width = cairo_image_surface_get_width(thumb->img_surf);
     thumb->img_height = cairo_image_surface_get_height(thumb->img_surf);
     gtk_widget_set_size_request(widget, thumb->img_width, thumb->img_height);
+    // and we set the position of the image
+    const int posx = MAX(thumb->width * thumb->img_margin->left / 100, (thumb->width - thumb->img_width) / 2);
+    const int posy = MAX(thumb->height * thumb->img_margin->top / 100, (thumb->height - thumb->img_height) / 2);
+    gtk_widget_set_margin_start(thumb->w_image, posx);
+    gtk_widget_set_margin_top(thumb->w_image, posy);
 
     // now that we know image ratio, we can fill the extension label
     const char *ext = thumb->filename + strlen(thumb->filename);
@@ -617,8 +622,8 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     thumb->w_image = gtk_drawing_area_new();
     gtk_widget_set_name(thumb->w_image, "thumb_image");
     gtk_widget_set_size_request(thumb->w_image, thumb->width, thumb->height);
-    gtk_widget_set_valign(thumb->w_image, GTK_ALIGN_CENTER);
-    gtk_widget_set_halign(thumb->w_image, GTK_ALIGN_CENTER);
+    gtk_widget_set_valign(thumb->w_image, GTK_ALIGN_START);
+    gtk_widget_set_halign(thumb->w_image, GTK_ALIGN_START);
     gtk_widget_set_events(thumb->w_image, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
                                               | GDK_ENTER_NOTIFY_MASK | GDK_POINTER_MOTION_HINT_MASK
                                               | GDK_POINTER_MOTION_MASK);

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -66,6 +66,7 @@ typedef struct
   GtkWidget *w_ext;  // GtkLabel -- thumbnail extension
 
   GtkWidget *w_image;        // GtkDrawingArea -- thumbnail image
+  GtkBorder *img_margin;     // in percentage of the main widget size
   cairo_surface_t *img_surf; // cached surface at exact dimensions to speed up redraw
   gboolean img_surf_preview; // if TRUE, the image is originated from preview pipe
   gboolean img_surf_dirty;   // if TRUE, we need to recreate the surface on next drawing code


### PR DESCRIPTION
fix #4643 

This allow images margins for filemanager, zoomable lighttable and filmstrip to be set via css.
As Gtkoverflow doesn't support natively margins and gtk doesn't support percentage values for css margins we do that by hand...