### PR TITLE
Keep white balance as spot when set via the picker (Fix #3521)

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -901,6 +901,10 @@ void gui_update(struct dt_iop_module_t *self)
         }
       }
     }
+
+    // Still not found after testing all sorts of presets? Then it must be a spot.
+    if(!found)
+      dt_bauhaus_combobox_set(g->presets, 2);
   }
 }
 


### PR DESCRIPTION
This has been outstanding for a while. What is the problem?

in `temperature.c` we use `gui_update`. We check the **current** coeffs against
all found presets but forgot about a 'not found' situation? That must be a spot :-)