### PR TITLE
Add hex encoded rgb to colorpickers tooltips

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -175,13 +175,13 @@ static void _update_picker_output(dt_lib_module_t *self)
     switch(input_color)
     {
       case 0: // rgb
-        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   %02X%02X%02X",
+        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   (0x%02X%02X%02X)",
                  (int)round(rgb[0] * 255.f),
                  (int)round(rgb[1] * 255.f),
                  (int)round(rgb[2] * 255.f),
-                 (int)round(rgb[0] * 255.f),
-                 (int)round(rgb[1] * 255.f),
-                 (int)round(rgb[2] * 255.f));
+                 (int)round(data->rgb.red   * 255.f),
+                 (int)round(data->rgb.green * 255.f),
+                 (int)round(data->rgb.blue  * 255.f));
         snprintf(text, sizeof(text), "%3d %3d %3d",
                  (int)round(data->rgb.red   * 255.f),
                  (int)round(data->rgb.green * 255.f),
@@ -293,13 +293,13 @@ static void _update_samples_output(dt_lib_module_t *self)
     {
       case 0:
         // RGB
-        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   %02X%02X%02X",
+        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   (0x%02X%02X%02X)",
                  (int)round(rgb[0] * 255.f),
                  (int)round(rgb[1] * 255.f),
                  (int)round(rgb[2] * 255.f),
-                 (int)round(rgb[0] * 255.f),
-                 (int)round(rgb[1] * 255.f),
-                 (int)round(rgb[2] * 255.f));
+                 (int)round(sample->rgb.red   * 255.f),
+                 (int)round(sample->rgb.green * 255.f),
+                 (int)round(sample->rgb.blue  * 255.f));
         snprintf(text, sizeof(text), "%3d %3d %3d",
                  (int)round(sample->rgb.red   * 255.f),
                  (int)round(sample->rgb.green * 255.f),

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -175,7 +175,10 @@ static void _update_picker_output(dt_lib_module_t *self)
     switch(input_color)
     {
       case 0: // rgb
-        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d",
+        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   %02X%02X%02X",
+                 (int)round(rgb[0] * 255.f),
+                 (int)round(rgb[1] * 255.f),
+                 (int)round(rgb[2] * 255.f),
                  (int)round(rgb[0] * 255.f),
                  (int)round(rgb[1] * 255.f),
                  (int)round(rgb[2] * 255.f));
@@ -290,7 +293,10 @@ static void _update_samples_output(dt_lib_module_t *self)
     {
       case 0:
         // RGB
-        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d",
+        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   %02X%02X%02X",
+                 (int)round(rgb[0] * 255.f),
+                 (int)round(rgb[1] * 255.f),
+                 (int)round(rgb[2] * 255.f),
                  (int)round(rgb[0] * 255.f),
                  (int)round(rgb[1] * 255.f),
                  (int)round(rgb[2] * 255.f));


### PR DESCRIPTION
Inspired by #4611 this does not implement the whole "wish list" but it adds
the rgb hex value to the tooltip.