### PR TITLE
Only show masks in darkrooms expose for valid modules. Fix #4668

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -606,7 +606,7 @@ void expose(
   else
   {
     // masks
-    if(dev->form_visible && dev->gui_module->enabled)
+    if(dev->gui_module && dev->form_visible && dev->gui_module->enabled)
       dt_masks_events_post_expose(dev->gui_module, cri, width, height, pointerx, pointery);
     // module
     if(dev->gui_module && dev->gui_module->gui_post_expose)


### PR DESCRIPTION
There were dr crashes as reported & discussed in #4668 and #4614

We were somewhat on the wrong track. The crash could be reproduced but the important
detail was that the modules had to be closed on the right panel to get the crash.

There was simply a test missing, we only can display the mask if `dev->gui_module` is valid too :-)