### PR TITLE
Speed & clean up purging script

### DIFF
--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -100,7 +100,7 @@ done
 
 if [ "$dryrun" -eq 0 ]
 then
-    # delete now-empty filmrolls
+    # delete now-empty film rolls
     sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
     sqlite3 "$DBFILE" "VACUUM; ANALYZE"
 else

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -73,18 +73,15 @@ then
     exit 1
 fi
 
-QUERY="SELECT A.id,B.folder,A.filename FROM images AS A JOIN film_rolls AS B ON A.film_id = B.id"
+QUERY="SELECT images.id, film_rolls.folder || '/' || images.filename FROM images JOIN film_rolls ON images.film_id = film_rolls.id"
 
 echo "Removing the following non existent file(s):"
 
-sqlite3 "$DBFILE" "$QUERY" | while read -r result
+sqlite3 -separator $'\t' "$DBFILE" "$QUERY" | while read -r id path
 do
-    ID=$(echo "$result" | cut -f1 -d"|")
-    FD=$(echo "$result" | cut -f2 -d"|")
-    FL=$(echo "$result" | cut -f3 -d"|")
-    if ! [ -f "$FD/$FL" ]
+    if ! [ -f "$path" ]
     then
-        echo "  $FD/$FL with ID = $ID"
+        echo "  ${path} with ID = ${id}"
 
         if [ "$dryrun" -eq 0 ]
         then

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -99,12 +99,12 @@ then
     done
 
     # delete now-empty film rolls
-    sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
+    sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE NOT EXISTS (SELECT 1 FROM images WHERE images.film_id = film_rolls.id)"
     sqlite3 "$DBFILE" "VACUUM; ANALYZE"
 else
     echo
     echo Remove following now-empty filmrolls:
-    sqlite3 "$DBFILE" "SELECT folder FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
+    sqlite3 "$DBFILE" "SELECT folder FROM film_rolls WHERE NOT EXISTS (SELECT 1 FROM images WHERE images.film_id = film_rolls.id)"
 
     echo
     echo to really remove non existing images from the database call:

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -29,7 +29,7 @@ commandline="$0 $*"
 while [ "$#" -ge 1 ]
 do
     option="$1"
-    case ${option} in
+    case "$option" in
     -h | --help)
         echo "Delete non existing images from darktable's database"
         echo "Usage:   $0 [options]"
@@ -86,7 +86,7 @@ do
     then
         echo "  $FD/$FL with ID = $ID"
 
-        if [ $dryrun -eq 0 ]
+        if [ "$dryrun" -eq 0 ]
         then
             for table in images meta_data
             do
@@ -101,7 +101,7 @@ do
     fi
 done
 
-if [ $dryrun -eq 0 ]
+if [ "$dryrun" -eq 0 ]
 then
     # delete now-empty filmrolls
     sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -17,8 +17,8 @@ then
     exit 1
 fi
 
-configdir="$HOME/.config/darktable"
-DBFILE="$configdir/library.db"
+configdir="${HOME}/.config/darktable"
+DBFILE="${configdir}/library.db"
 dryrun=1
 library=""
 
@@ -32,7 +32,7 @@ do
     case "$option" in
     -h | --help)
         echo "Delete non existing images from darktable's database"
-        echo "Usage:   $0 [options]"
+        echo "Usage:   ${0} [options]"
         echo ""
         echo "Options:"
         echo "  -c|--configdir <path>    path to the darktable config directory"
@@ -54,7 +54,7 @@ do
         dryrun=0
         ;;
     *)
-        echo "warning: ignoring unknown option $option"
+        echo "warning: ignoring unknown option ${option}"
         ;;
     esac
     shift
@@ -90,12 +90,12 @@ do
         then
             for table in images meta_data
             do
-                sqlite3 "$DBFILE" "DELETE FROM $table WHERE id=$ID"
+                sqlite3 "$DBFILE" "DELETE FROM ${table} WHERE id=${id}"
             done
 
             for table in color_labels history masks_history selected_images tagged_images history_hash module_order
             do
-                sqlite3 "$DBFILE" "DELETE FROM $table WHERE imgid=$ID"
+                sqlite3 "$DBFILE" "DELETE FROM ${table} WHERE imgid=${id}"
             done
         fi
     fi

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -68,14 +68,11 @@ if [ ! -f "$DBFILE" ]; then
     exit 1
 fi
 
-TMPFILE=$(mktemp -t tmp.XXXXXXXXXX)
 QUERY="SELECT A.id,B.folder,A.filename FROM images AS A JOIN film_rolls AS B ON A.film_id = B.id"
-
-sqlite3 "$DBFILE" "$QUERY" > "$TMPFILE"
 
 echo "Removing the following non existent file(s):"
 
-cat "$TMPFILE" | while read -r result
+sqlite3 "$DBFILE" "$QUERY" | while read -r result
 do
   ID=$(echo "$result" | cut -f1 -d"|")
   FD=$(echo "$result" | cut -f2 -d"|")
@@ -95,7 +92,6 @@ do
     fi
   fi
 done
-rm "$TMPFILE"
 
 
 if [ $dryrun -eq 0 ]; then

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -5,12 +5,14 @@
 #        -p  do the purge, otherwise only display non existing images
 #
 
-if ! command -v sqlite3 > /dev/null; then
+if ! command -v sqlite3 >/dev/null
+then
     echo "error: please install sqlite3 binary".
     exit 1
 fi
 
-if pgrep -x "darktable" > /dev/null ; then
+if pgrep -x "darktable" >/dev/null
+then
     echo "error: darktable is running, please exit first"
     exit 1
 fi
@@ -24,46 +26,49 @@ library=""
 commandline="$0 $*"
 
 # handle command line arguments
-while [ "$#" -ge 1 ] ; do
-  option="$1"
-  case ${option} in
-  -h|--help)
-    echo "Delete non existing images from darktable's database"
-    echo "Usage:   $0 [options]"
-    echo ""
-    echo "Options:"
-    echo "  -c|--configdir <path>    path to the darktable config directory"
-    echo "                           (default: '${configdir}')"
-    echo "  -l|--library <path>      path to the library.db"
-    echo "                           (default: '${DBFILE}')"
-    echo "  -p|--purge               actually delete the tags instead of just finding them"
-    exit 0
-    ;;
-  -l|--library)
-    library="$2"
-    shift
-    ;;
-  -c|--configdir)
-    configdir="$2"
-    shift
-    ;;
-  -p|--purge)
-    dryrun=0
-    ;;
-  *)
-    echo "warning: ignoring unknown option $option"
-    ;;
-  esac
+while [ "$#" -ge 1 ]
+do
+    option="$1"
+    case ${option} in
+    -h | --help)
+        echo "Delete non existing images from darktable's database"
+        echo "Usage:   $0 [options]"
+        echo ""
+        echo "Options:"
+        echo "  -c|--configdir <path>    path to the darktable config directory"
+        echo "                           (default: '${configdir}')"
+        echo "  -l|--library <path>      path to the library.db"
+        echo "                           (default: '${DBFILE}')"
+        echo "  -p|--purge               actually delete the tags instead of just finding them"
+        exit 0
+        ;;
+    -l | --library)
+        library="$2"
+        shift
+        ;;
+    -c | --configdir)
+        configdir="$2"
+        shift
+        ;;
+    -p | --purge)
+        dryrun=0
+        ;;
+    *)
+        echo "warning: ignoring unknown option $option"
+        ;;
+    esac
     shift
 done
 
 DBFILE="$configdir/library.db"
 
-if [ "$library" != "" ]; then
+if [ "$library" != "" ]
+then
     DBFILE="$library"
 fi
 
-if [ ! -f "$DBFILE" ]; then
+if [ ! -f "$DBFILE" ]
+then
     echo "error: library db '${DBFILE}' doesn't exist"
     exit 1
 fi
@@ -74,27 +79,30 @@ echo "Removing the following non existent file(s):"
 
 sqlite3 "$DBFILE" "$QUERY" | while read -r result
 do
-  ID=$(echo "$result" | cut -f1 -d"|")
-  FD=$(echo "$result" | cut -f2 -d"|")
-  FL=$(echo "$result" | cut -f3 -d"|")
-  if ! [ -f "$FD/$FL" ];
-  then
-    echo "  $FD/$FL with ID = $ID"
+    ID=$(echo "$result" | cut -f1 -d"|")
+    FD=$(echo "$result" | cut -f2 -d"|")
+    FL=$(echo "$result" | cut -f3 -d"|")
+    if ! [ -f "$FD/$FL" ]
+    then
+        echo "  $FD/$FL with ID = $ID"
 
-    if [ $dryrun -eq 0 ]; then
-        for table in images meta_data; do
-            sqlite3 "$DBFILE" "DELETE FROM $table WHERE id=$ID"
-        done
+        if [ $dryrun -eq 0 ]
+        then
+            for table in images meta_data
+            do
+                sqlite3 "$DBFILE" "DELETE FROM $table WHERE id=$ID"
+            done
 
-        for table in color_labels history masks_history selected_images tagged_images history_hash module_order; do
-            sqlite3 "$DBFILE" "DELETE FROM $table WHERE imgid=$ID"
-        done
+            for table in color_labels history masks_history selected_images tagged_images history_hash module_order
+            do
+                sqlite3 "$DBFILE" "DELETE FROM $table WHERE imgid=$ID"
+            done
+        fi
     fi
-  fi
 done
 
-
-if [ $dryrun -eq 0 ]; then
+if [ $dryrun -eq 0 ]
+then
     # delete now-empty filmrolls
     sqlite3 "$DBFILE" "DELETE FROM film_rolls WHERE (SELECT COUNT(A.id) FROM images AS A WHERE A.film_id=film_rolls.id)=0"
     sqlite3 "$DBFILE" "VACUUM; ANALYZE"

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -71,7 +71,7 @@ fi
 TMPFILE=$(mktemp -t tmp.XXXXXXXXXX)
 QUERY="SELECT A.id,B.folder,A.filename FROM images AS A JOIN film_rolls AS B ON A.film_id = B.id"
 
-sqlite3 $DBFILE "$QUERY" > "$TMPFILE"
+sqlite3 "$DBFILE" "$QUERY" > "$TMPFILE"
 
 echo "Removing the following non existent file(s):"
 

--- a/tools/purge_non_existing_images.sh
+++ b/tools/purge_non_existing_images.sh
@@ -5,7 +5,7 @@
 #        -p  do the purge, otherwise only display non existing images
 #
 
-if ! which sqlite3 > /dev/null; then
+if ! command -v sqlite3 > /dev/null; then
     echo "error: please install sqlite3 binary".
     exit 1
 fi


### PR DESCRIPTION
Done:

1. Run fewer & faster queries (cuts down the runtime by about 60x on my machine with about 50k images).
1. Run fewer slow `read` commands.
1. Fix some shellcheck lints, inconsistencies etc..