### PR TITLE
Tag fix

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -172,13 +172,10 @@ static void _colorlabels_execute(GList *imgs, const int labels, GList **undo, co
   }
 }
 
-void dt_colorlabels_set_labels(const int imgid, const int labels, const gboolean clear_on, const gboolean undo_on, const gboolean group_on)
+void dt_colorlabels_set_labels(const GList *img, const int labels, const gboolean clear_on,
+                               const gboolean undo_on, const gboolean group_on)
 {
-  GList *imgs = NULL;
-  if(imgid == -1)
-    imgs = dt_collection_get_selected(darktable.collection, -1);
-  else
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;

--- a/src/common/colorlabels.h
+++ b/src/common/colorlabels.h
@@ -22,7 +22,8 @@ void dt_colorlabels_remove_labels(const int imgid);
 /** assign a color label to imgid - no undo no image group*/
 void dt_colorlabels_set_label(const int imgid, const int color);
 /** assign a color label to image imgid or all selected for imgid == -1*/
-void dt_colorlabels_set_labels(const int imgid, const int color, const gboolean clear_on, const gboolean undo_on, const gboolean group_on);
+void dt_colorlabels_set_labels(const GList *img, const int color, const gboolean clear_on,
+                               const gboolean undo_on, const gboolean group_on);
 /** assign a color label to the list of image*/
 void dt_colorlabels_toggle_label_on_list(GList *list, const int color, const gboolean undo_on);
 /** remove a color label from imgid */

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -415,13 +415,9 @@ void _image_set_location(GList *imgs, const dt_image_geoloc_t *geoloc, GList **u
   }
 }
 
-void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on)
+void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on)
 {
-  GList *imgs = NULL;
-  if(imgid == -1)
-    imgs = dt_collection_get_selected(darktable.collection, -1);
-  else
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;
@@ -439,6 +435,17 @@ void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc, const
     g_list_free(imgs);
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
+}
+
+void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on)
+{
+  GList *imgs = NULL;
+  if(imgid == -1)
+    imgs = dt_view_get_images_to_act_on();
+  else
+    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  dt_image_set_locations(imgs, geoloc, undo_on, group_on);
+  g_list_free(imgs);
 }
 
 void dt_image_reset_final_size(const int32_t imgid)

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -264,9 +264,13 @@ dt_image_orientation_t dt_image_get_orientation(const int imgid);
 /** get max width and height of the final processed image with its current hisotry stack */
 gboolean dt_image_get_final_size(const int32_t imgid, int *width, int *height);
 void dt_image_reset_final_size(const int32_t imgid);
-/** set image location lon/lat */
-void dt_image_set_location(const int32_t imgid, dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on);
-/** get image location lon/lat */
+/** set image location lon/lat/ele */
+void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
+                           const gboolean undo_on, const gboolean group_on);
+/** set images location lon/lat/ele */
+void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc,
+                           const gboolean undo_on, const gboolean group_on);
+/** get image location lon/lat/ele */
 void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
 /** returns 1 if there is history data found for this image, 0 else. */
 gboolean dt_image_altered(const uint32_t imgid);

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -418,9 +418,9 @@ GList *dt_metadata_get(const int id, const char *key, uint32_t *count)
   return result;
 }
 
-static void _metadata_add_metadata_to_list(GList **list, GList *metadata)
+static void _metadata_add_metadata_to_list(GList **list, const GList *metadata)
 {
-  GList *m = metadata;
+  const GList *m = metadata;
   while(m)
   {
     GList *m2 = g_list_next(m);
@@ -445,10 +445,10 @@ static void _metadata_add_metadata_to_list(GList **list, GList *metadata)
   }
 }
 
-static void _metadata_remove_metadata_from_list(GList **list, GList *metadata)
+static void _metadata_remove_metadata_from_list(GList **list, const GList *metadata)
 {
   // caution: metadata is a simple list here
-  GList *m = metadata;
+  const GList *m = metadata;
   while(m)
   {
     GList *same_key = g_list_find_custom(*list, m->data, _compare_metadata);
@@ -474,9 +474,10 @@ typedef enum dt_tag_actions_t
   DT_MA_REMOVE
 } dt_tag_actions_t;
 
-static void _metadata_execute(GList *imgs, GList *metadata, GList **undo, const gboolean undo_on, const gint action)
+static void _metadata_execute(const GList *imgs, const GList *metadata, GList **undo,
+                              const gboolean undo_on, const gint action)
 {
-  GList *images = imgs;
+  const GList *images = imgs;
   while(images)
   {
     const int image_id = GPOINTER_TO_INT(images->data);
@@ -487,7 +488,7 @@ static void _metadata_execute(GList *imgs, GList *metadata, GList **undo, const 
     switch(action)
     {
       case DT_MA_SET:
-        undometadata->after = metadata ? g_list_copy_deep(metadata, (GCopyFunc)g_strdup, NULL) : NULL;
+        undometadata->after = metadata ? g_list_copy_deep((GList *)metadata, (GCopyFunc)g_strdup, NULL) : NULL;
         break;
       case DT_MA_ADD:
         undometadata->after = g_list_copy_deep(undometadata->before, (GCopyFunc)g_strdup, NULL);
@@ -694,13 +695,10 @@ void dt_metadata_clear(const int imgid, const gboolean undo_on, const gboolean g
   }
 }
 
-void dt_metadata_set_list_id(const int imgid, GList *metadata, const gboolean clear_on, const gboolean undo_on, const gboolean group_on)
+void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboolean clear_on,
+                             const gboolean undo_on, const gboolean group_on)
 {
-  GList *imgs = NULL;
-  if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on();
-  else
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -90,11 +90,11 @@ void dt_metadata_set_import(int id, const char *key, const char *value); // exif
 /** list is a set of key, value */
 void dt_metadata_set_list(int id, GList *key_value, const gboolean undo_on, const gboolean group_on); // libs/metadata.c
 
-/** Set metadata (id keys) for a specific image, or all selected for id == -1.
+/** Set metadata (id keys) for a list of images.
     list is a set of keyid, value
     if clear_on TRUE the image metadata are cleared before attaching the new ones*/
-void dt_metadata_set_list_id(const int id, GList *key_value, const gboolean clear_on, const gboolean undo_on, const gboolean group_on); // libs/image.c
-
+void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboolean clear_on,
+                             const gboolean undo_on, const gboolean group_on);
 /** Get metadata (named keys) for a specific image, or all selected for id == -1.
     For keys which return a string, the caller has to make sure that it
     is freed after usage. */

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -25,11 +25,12 @@
 int dt_ratings_get(const int imgid);
 
 /** apply rating to the specified image */
-void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean toggle_on, const gboolean undo_on,
-                               const gboolean group_on);
+void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean toggle_on,
+                               const gboolean undo_on, const gboolean group_on);
 
 /** apply rating to all images in the list */
-void dt_ratings_apply_on_list(GList *list, const int rating, const gboolean undo_on);
+void dt_ratings_apply_on_list(const GList *list, const int rating,
+                              const gboolean undo_on, const gboolean group_on);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -485,14 +485,10 @@ void dt_tag_attach_from_gui(const guint tagid, const gint imgid, const gboolean 
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 }
 
-void dt_tag_set_tags(GList *tags, const gint imgid, const gboolean ignore_dt_tags,
+void dt_tag_set_tags(const GList *tags, const GList *img, const gboolean ignore_dt_tags,
                      const gboolean clear_on, const gboolean undo_on, const gboolean group_on)
 {
-  GList *imgs = NULL;
-  if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on();
-  else
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -92,7 +92,7 @@ gboolean dt_is_tag_attached(const guint tagid, const gint imgid);
 /** attach a list of tags on selected images. \param[in] tags a list of ids of tags. \param[in] imgid the
  * image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's created
  * if clear_on TRUE the image tags are cleared before attaching the new ones*/
-void dt_tag_set_tags(GList *tags, const gint imgid,
+void dt_tag_set_tags(const GList *tags, const GList *img,
                      const gboolean ignore_dt_tags, const gboolean clear_on,
                      const gboolean undo_on, const gboolean group_on);
 

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -92,7 +92,9 @@ gboolean dt_is_tag_attached(const guint tagid, const gint imgid);
 /** attach a list of tags on selected images. \param[in] tags a list of ids of tags. \param[in] imgid the
  * image id to attach tag to, if < 0 selected images are used. \note If tag not exists it's created
  * if clear_on TRUE the image tags are cleared before attaching the new ones*/
-void dt_tag_set_tags(GList *tags, const gint imgid, const gboolean clear_on, const gboolean undo_on, const gboolean group_on);
+void dt_tag_set_tags(GList *tags, const gint imgid,
+                     const gboolean ignore_dt_tags, const gboolean clear_on,
+                     const gboolean undo_on, const gboolean group_on);
 
 /** attach a list of tags on list of images. \param[in] tags a comma separated string of tags. \param[in]
  * img the list of images to attach tag to. \note If tag not exists it's created.*/
@@ -133,8 +135,8 @@ GList *dt_tag_get_hierarchical(gint imgid);
  *  the difference to dt_tag_get_hierarchical() is that this one checks option for exportation */
 GList *dt_tag_get_hierarchical_export(gint imgid, int32_t flags);
 
-/** get a flat list of tag id, without darktable tags*/
-GList *dt_tag_get_tags(gint imgid);
+/** get a flat list of tags id attached to image id*/
+GList *dt_tag_get_tags(const gint imgid, const gboolean ignore_dt_tags);
 
 /** get the subset of images from the given list that have a given tag attached */
 GList *dt_tag_get_images_from_list(const GList *img, gint tagid);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1703,7 +1703,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
                             GdkModifierType modifier, gpointer data)
 {
   GList *imgs = dt_view_get_images_to_act_on();
-  dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
+  dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE, TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
 }

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -244,12 +244,11 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   }
   if(dttag_flag)
   {
-    GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid);
-    dt_tag_set_tags(tags, img, action != DT_MA_MERGE, TRUE, TRUE);
+    // affect only user tags (not dt tags)
+    GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
+    dt_tag_set_tags(tags, img, TRUE, action != DT_MA_MERGE, TRUE, TRUE);
     g_list_free(tags);
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   }
-
   if(undo_type)
   {
     dt_undo_end_group(darktable.undo);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -207,54 +207,58 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   const gboolean geotag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags");
   const gboolean dttag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/tags");
   const int imageid = d->imageid;
-  const int img = dt_view_get_image_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on();
+  if(imgs)
+  {
+    const dt_undo_type_t undo_type = (rating_flag ? DT_UNDO_RATINGS : 0) |
+                                    (colors_flag ? DT_UNDO_COLORLABELS : 0) |
+                                    (dtmetadata_flag ? DT_UNDO_METADATA : 0) |
+                                    (geotag_flag ? DT_UNDO_LT_GEOTAG : 0) |
+                                    (dttag_flag ? DT_UNDO_TAGS : 0);
+    if(undo_type) dt_undo_start_group(darktable.undo, undo_type);
 
-  const dt_undo_type_t undo_type = (rating_flag ? DT_UNDO_RATINGS : 0) |
-                                  (colors_flag ? DT_UNDO_COLORLABELS : 0) |
-                                  (dtmetadata_flag ? DT_UNDO_METADATA : 0) |
-                                  (geotag_flag ? DT_UNDO_LT_GEOTAG : 0) |
-                                  (dttag_flag ? DT_UNDO_TAGS : 0);
-  if(undo_type) dt_undo_start_group(darktable.undo, undo_type);
+    if(rating_flag)
+    {
+      const int stars = (action == DT_MA_CLEAR) ? 0 : dt_ratings_get(imageid);
+      dt_ratings_apply_on_list(imgs, stars, TRUE, TRUE);
+    }
+    if(colors_flag)
+    {
+      const int colors = (action == DT_MA_CLEAR) ? 0 : dt_colorlabels_get_labels(imageid);
+      dt_colorlabels_set_labels(imgs, colors, action != DT_MA_MERGE, TRUE, TRUE);
+    }
+    if(dtmetadata_flag)
+    {
+      GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
+      dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE, TRUE);
+      g_list_free_full(metadata, g_free);
+    }
+    if(geotag_flag)
+    {
+      dt_image_geoloc_t *geoloc = (dt_image_geoloc_t *)malloc(sizeof(dt_image_geoloc_t));
+      if(action == DT_MA_CLEAR)
+        geoloc->longitude = geoloc->latitude = geoloc->elevation = NAN;
+      else
+        dt_image_get_location(imageid, geoloc);
+      dt_image_set_locations(imgs, geoloc, TRUE, TRUE);
+      g_free(geoloc);
+    }
+    if(dttag_flag)
+    {
+      // affect only user tags (not dt tags)
+      GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
+      dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE, TRUE);
+      g_list_free(tags);
+    }
 
-  if(rating_flag)
-  {
-    const int stars = (action == DT_MA_CLEAR) ? 0 : dt_ratings_get(imageid);
-    dt_ratings_apply_on_image(img, stars, FALSE, TRUE, TRUE);
-  }
-  if(colors_flag)
-  {
-    const int colors = (action == DT_MA_CLEAR) ? 0 : dt_colorlabels_get_labels(imageid);
-    dt_colorlabels_set_labels(img, colors, action != DT_MA_MERGE, TRUE, TRUE);
-  }
-  if(dtmetadata_flag)
-  {
-    GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
-    dt_metadata_set_list_id(img, metadata, action != DT_MA_MERGE, TRUE, TRUE);
-    g_list_free_full(metadata, g_free);
-  }
-  if(geotag_flag)
-  {
-    dt_image_geoloc_t *geoloc = (dt_image_geoloc_t *)malloc(sizeof(dt_image_geoloc_t));
-    if(action == DT_MA_CLEAR)
-      geoloc->longitude = geoloc->latitude = geoloc->elevation = NAN;
-    else
-      dt_image_get_location(imageid, geoloc);
-    dt_image_set_location(img, geoloc, TRUE, TRUE);
-    g_free(geoloc);
-  }
-  if(dttag_flag)
-  {
-    // affect only user tags (not dt tags)
-    GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
-    dt_tag_set_tags(tags, img, TRUE, action != DT_MA_MERGE, TRUE, TRUE);
-    g_list_free(tags);
-  }
-  if(undo_type)
-  {
-    dt_undo_end_group(darktable.undo);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
-    dt_control_queue_redraw_center();
-    dt_image_synch_xmp(img);
+    if(undo_type)
+    {
+      dt_undo_end_group(darktable.undo);
+      dt_image_synch_xmps(imgs);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+      dt_control_queue_redraw_center();
+    }
+    else g_list_free(imgs);
   }
 }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -165,6 +165,7 @@ static void _update(dt_lib_module_t *self, gboolean early_bark_out)
     imgs_count++;
     imgs = g_list_next(imgs);
   }
+  g_list_free(imgs);
   if(images)
   {
     images[strlen(images) - 1] = '\0';

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -197,7 +197,7 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   if(d->current > 0)
   {
     GList *imgs = dt_view_get_images_to_act_on();
-    dt_ratings_apply_on_list(imgs, d->current, TRUE);
+    dt_ratings_apply_on_list(imgs, d->current, TRUE, TRUE);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
 
     dt_control_queue_redraw_center();


### PR DESCRIPTION
tag fix - repair darktable tags not detachable (fix #4677 for 3.2 as done for 3.0.1)

metadata copy fix & update - align on dt_view_get_images_to_act_on()

rating fix - apply rating on grouped images

EDIT: for copy metadata (tags) I've taken the option to copy/clear only user tags (and not the dt ones). Of course the background routines are able to do both if necessary.

