### PR TITLE
Fix errors using ninja under windows with mingw64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,11 @@ else(${intltool_merge_BIN} STREQUAL "intltool_merge_BIN-NOTFOUND")
   message(STATUS "Found intltool-merge")
 endif(${intltool_merge_BIN} STREQUAL "intltool_merge_BIN-NOTFOUND")
 
+if(WIN32)
+  set(intltool_merge_BIN ${perl_BIN} ${intltool_merge_BIN})
+endif(WIN32)
+
+
 # we need desktop-file-validate to check darktable.desktop
 find_program(desktop_file_validate_BIN desktop-file-validate)
 if(${desktop_file_validate_BIN} STREQUAL "desktop_file_validate_BIN-NOTFOUND")

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -32,7 +32,9 @@ IF(WIN32 AND NOT BUILD_MSYS2_INSTALL)
       set(EXTRA_DEPS)
 
       function(process_file filename)
+        set(ENV{PATH} \"${MINGW_PATH}\")
         execute_process(COMMAND \"${cygcheck_BIN}\" \"\${filename}\" OUTPUT_VARIABLE FILES ERROR_QUIET)
+        string(REPLACE \"/\" \"\\\\\" FILES \"\${FILES}\") # make sure every path contains only backslashes
         string(REGEX MATCHALL \"${DIRS}[^\\n\\r]*[dD][lL][lL]\" FILES_LIST \"\${FILES}\")
         set(EXTRA_DEPS \${EXTRA_DEPS} \${FILES_LIST} PARENT_SCOPE)
       endfunction()
@@ -52,7 +54,7 @@ IF(WIN32 AND NOT BUILD_MSYS2_INSTALL)
       # install(...) doesn't work in here, and file(INSTALL ...) doesn't put anything into installers,
       # so we have to go over the list of files and do it manually
       foreach(filename IN LISTS EXTRA_DEPS)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy \"\${filename}\" \"\${CMAKE_INSTALL_PREFIX}/bin/\")
+        execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"\${filename}\" \"\${CMAKE_INSTALL_PREFIX}/bin/\")
       endforeach()
 
       " COMPONENT DTApplication)


### PR DESCRIPTION
To fix an error with intltool_merge not getting found. This was taken from @mbaumgae 's support-visual-studio branche. I hope he doesn't mind. None of the documentation fixes were included (since I don't build it anyway).

I'm still having a problem with the osmgpsmap library, so I have to disable the map view at the moment.