### PR TITLE
spot removal: various enhancements

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -71,7 +71,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 
   dt_image_init(&dev->image_storage);
   dev->image_status = dev->preview_status = dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-  dev->image_loading = dev->preview_loading = dev->preview2_loading = 0;
+  dev->image_loading = dev->preview_loading = dev->preview2_loading = dev->history_updating = 0;
   dev->image_force_reload = 0;
   dev->preview_input_changed = dev->preview2_input_changed = 0;
 
@@ -1199,6 +1199,8 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
 
   dt_dev_pop_history_items_ext(dev, cnt);
 
+  darktable.develop->history_updating = 1;
+
   // update all gui modules
   GList *modules = dev->iop;
   while(modules)
@@ -1207,6 +1209,8 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
     dt_iop_gui_update(module);
     modules = g_list_next(modules);
   }
+
+  darktable.develop->history_updating = 0;
 
   // check if the order of modules has changed
   int dev_iop_changed = (g_list_length(dev_iop) != g_list_length(dev->iop));

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -142,7 +142,7 @@ typedef struct dt_develop_t
   int32_t gui_leaving;  // set if everything is scheduled to shut down.
   int32_t gui_synch;    // set by the render threads if gui_update should be called in the modules.
   int32_t focus_hash;   // determines whether to start a new history item or to merge down.
-  int32_t image_loading, first_load, image_force_reload;
+  int32_t image_loading, first_load, image_force_reload, history_updating;
   int32_t preview_loading, preview_input_changed;
   int32_t preview2_loading, preview2_input_changed;
   dt_dev_pixelpipe_status_t image_status, preview_status, preview2_status;

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -43,7 +43,7 @@ typedef struct dt_iop_spots_params_t
 typedef struct dt_iop_spots_gui_data_t
 {
   GtkLabel *label;
-  GtkWidget *bt_path, *bt_circle, *bt_ellipse;
+  GtkWidget *bt_path, *bt_circle, *bt_ellipse, *bt_edit_masks;
 } dt_iop_spots_gui_data_t;
 
 typedef struct dt_iop_spots_params_t dt_iop_spots_data_t;
@@ -190,52 +190,148 @@ static gboolean _reset_form_creation(GtkWidget *widget, dt_iop_module_t *self)
   if(widget != g->bt_circle || nb >= 64) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
   if(widget != g->bt_ellipse || nb >= 64) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
 
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
+
   return (nb < 64);
 }
 
-static gboolean _add_path(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *self)
+static int _shape_is_being_added(dt_iop_module_t *self, const int shape_type)
 {
+  int being_added = 0;
+
+  if(self->dev->form_gui && self->dev->form_visible
+     && ((self->dev->form_gui->creation && self->dev->form_gui->creation_module == self)
+         || (self->dev->form_gui->creation_continuous && self->dev->form_gui->creation_continuous_module == self)))
+  {
+    if(self->dev->form_visible->type & DT_MASKS_GROUP)
+    {
+      GList *forms = g_list_first(self->dev->form_visible->points);
+      if(forms)
+      {
+        dt_masks_point_group_t *grpt = (dt_masks_point_group_t *)forms->data;
+        if(grpt)
+        {
+          const dt_masks_form_t *form = dt_masks_get_from_id(darktable.develop, grpt->formid);
+          if(form) being_added = (form->type & shape_type);
+        }
+      }
+    }
+    else
+      being_added = (self->dev->form_visible->type & shape_type);
+  }
+  return being_added;
+}
+
+static gboolean _add_shape(GtkWidget *widget, const int creation_continuous, dt_iop_module_t *self)
+{
+  //turn module on (else shape creation won't work)
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
+
+  //switch mask edit mode off
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  if(bd) bd->masks_shown = DT_MASKS_EDIT_OFF;
+
   if(!_reset_form_creation(widget, self)) return TRUE;
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return FALSE;
+
+  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
   // we want to be sure that the iop has focus
   dt_iop_request_focus(self);
   // we create the new form
-  dt_masks_form_t *form = dt_masks_create(DT_MASKS_PATH | DT_MASKS_CLONE);
+  dt_masks_type_t type = DT_MASKS_CIRCLE;
+  if(widget == g->bt_path)
+    type = DT_MASKS_PATH;
+  else if(widget == g->bt_circle)
+    type = DT_MASKS_CIRCLE;
+  else if(widget == g->bt_ellipse)
+    type = DT_MASKS_ELLIPSE;
+
+
+  dt_masks_form_t *form = dt_masks_create(type | DT_MASKS_CLONE);
   dt_masks_change_form_gui(form);
   darktable.develop->form_gui->creation = TRUE;
   darktable.develop->form_gui->creation_module = self;
-  dt_control_queue_redraw_center();
-  return FALSE;
-}
-static gboolean _add_circle(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *self)
-{
-  if(!_reset_form_creation(widget, self)) return TRUE;
-  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return FALSE;
-  // we want to be sure that the iop has focus
-  dt_iop_request_focus(self);
-  // we create the new form
-  dt_masks_form_t *spot = dt_masks_create(DT_MASKS_CIRCLE | DT_MASKS_CLONE);
-  dt_masks_change_form_gui(spot);
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = self;
-  dt_control_queue_redraw_center();
-  return FALSE;
-}
-static gboolean _add_ellipse(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *self)
-{
-  if(!_reset_form_creation(widget, self)) return TRUE;
-  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) return FALSE;
-  // we want to be sure that the iop has focus
-  dt_iop_request_focus(self);
-  // we create the new form
-  dt_masks_form_t *spot = dt_masks_create(DT_MASKS_ELLIPSE | DT_MASKS_CLONE);
-  dt_masks_change_form_gui(spot);
-  darktable.develop->form_gui->creation = TRUE;
-  darktable.develop->form_gui->creation_module = self;
+
+  if(creation_continuous)
+  {
+    darktable.develop->form_gui->creation_continuous = TRUE;
+    darktable.develop->form_gui->creation_continuous_module = self;
+  }
+  else
+  {
+    darktable.develop->form_gui->creation_continuous = FALSE;
+    darktable.develop->form_gui->creation_continuous_module = NULL;
+  }
+
   dt_control_queue_redraw_center();
   return FALSE;
 }
 
+static gboolean _add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return FALSE;
+
+  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+  const int creation_continuous = !((e->state & modifiers) == GDK_CONTROL_MASK);
+
+  return _add_shape(widget, creation_continuous, self);
+}
+
+static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return FALSE;
+
+  // if we don't have the focus, request for it and quit, gui_focus() do the rest
+  if(darktable.develop->gui_module != self)
+  {
+    dt_iop_request_focus(self);
+    return FALSE;
+  }
+
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+
+  //hide all shapes and free if some are in creation
+  if(darktable.develop->form_gui->creation && darktable.develop->form_gui->creation_module == self)
+    dt_masks_change_form_gui(NULL);
+
+  if(darktable.develop->form_gui->creation_continuous_module == self)
+  {
+    darktable.develop->form_gui->creation_continuous = FALSE;
+    darktable.develop->form_gui->creation_continuous_module = NULL;
+  }
+
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
+
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+
+  dt_iop_color_picker_reset(self, TRUE);
+
+  dt_masks_set_edit_mode(self, self->dev->form_gui->edit_mode == DT_MASKS_EDIT_FULL ? DT_MASKS_EDIT_OFF : DT_MASKS_EDIT_FULL);
+
+  // update edit shapes status
+  dt_develop_blend_params_t *bp = self->blend_params;
+  dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, bp->mask_id);
+  //only toggle shape show button if shapes exist
+  if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
+                                 (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));
+  }
+  else
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
+  }
+
+  darktable.gui->reset = reset;
+
+  dt_control_queue_redraw_center();
+
+  return TRUE;
+}
 
 static gboolean masks_form_is_in_roi(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,
                                      dt_masks_form_t *form, const dt_iop_roi_t *roi_in,
@@ -591,23 +687,40 @@ void cleanup(dt_iop_module_t *module)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  // dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
-  if(self->enabled)
+  if(self->enabled && !darktable.develop->image_loading)
   {
+    dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+
     if(in)
     {
-      // got focus, show all shapes
-      dt_masks_set_edit_mode(self, DT_MASKS_EDIT_FULL);
+      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+
+      // update edit shapes status
+      dt_develop_blend_params_t *bp = self->blend_params;
+      dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, bp->mask_id);
+      //only toggle shape show button if shapes exist
+      if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
+      {
+        if(bd->masks_shown == DT_MASKS_EDIT_OFF) dt_masks_set_edit_mode(self, DT_MASKS_EDIT_FULL);
+
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
+                                     (bd->masks_shown != DT_MASKS_EDIT_OFF) 
+                                     && (darktable.develop->gui_module == self));
+      }
+      else
+      {
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
+      }
     }
     else
     {
       // lost focus, hide all shapes
       if (darktable.develop->form_gui->creation && darktable.develop->form_gui->creation_module == self)
         dt_masks_change_form_gui(NULL);
-      dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
       dt_masks_set_edit_mode(self, DT_MASKS_EDIT_OFF);
     }
   }
@@ -644,21 +757,28 @@ void gui_update(dt_iop_module_t *self)
   gchar *str = g_strdup_printf("%d", nb);
   gtk_label_set_text(g->label, str);
   g_free(str);
-  // update buttons status
-  int b1 = 0, b2 = 0, b3 = 0;
-  if(self->dev->form_gui && self->dev->form_visible && self->dev->form_gui->creation
-     && self->dev->form_gui->creation_module == self)
+
+  // enable/disable shapes toolbar
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), _shape_is_being_added(self, DT_MASKS_CIRCLE));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), _shape_is_being_added(self, DT_MASKS_PATH));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), _shape_is_being_added(self, DT_MASKS_ELLIPSE));
+
+  // update edit shapes status
+  dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)self->blend_data;
+
+  if(darktable.develop->history_updating) bd->masks_shown = DT_MASKS_EDIT_OFF;
+
+  //only toggle shape show button if shapes exist
+  if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
   {
-    if(self->dev->form_visible->type & DT_MASKS_CIRCLE)
-      b1 = 1;
-    else if(self->dev->form_visible->type & DT_MASKS_PATH)
-      b2 = 1;
-    else if(self->dev->form_visible->type & DT_MASKS_ELLIPSE)
-      b3 = 1;
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
+                                 (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));
   }
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), b1);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), b2);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), b3);
+  else
+  {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
+  }
+  dt_control_queue_redraw_center();
 }
 
 void gui_init(dt_iop_module_t *self)
@@ -675,22 +795,30 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(hbox, _("click on a shape and drag on canvas.\nuse the mouse wheel "
                                       "to adjust size.\nright click to remove a shape."));
 
+  g->bt_edit_masks
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_eye, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  g_signal_connect(G_OBJECT(g->bt_edit_masks), "button-press-event", G_CALLBACK(_edit_masks), self);
+  g_object_set(G_OBJECT(g->bt_edit_masks), "tooltip-text", _("show and edit shapes"),
+               (char *)NULL);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
+  gtk_box_pack_end(GTK_BOX(hbox), g->bt_edit_masks, FALSE, FALSE, 0);
+
   g->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  g_signal_connect(G_OBJECT(g->bt_path), "button-press-event", G_CALLBACK(_add_path), self);
+  g_signal_connect(G_OBJECT(g->bt_path), "button-press-event", G_CALLBACK(_add_shape_callback), self);
   gtk_widget_set_tooltip_text(g->bt_path, _("add path"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), g->bt_path, FALSE, FALSE, 0);
 
   g->bt_ellipse
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  g_signal_connect(G_OBJECT(g->bt_ellipse), "button-press-event", G_CALLBACK(_add_ellipse), self);
+  g_signal_connect(G_OBJECT(g->bt_ellipse), "button-press-event", G_CALLBACK(_add_shape_callback), self);
   gtk_widget_set_tooltip_text(g->bt_ellipse, _("add ellipse"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), g->bt_ellipse, FALSE, FALSE, 0);
 
   g->bt_circle
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  g_signal_connect(G_OBJECT(g->bt_circle), "button-press-event", G_CALLBACK(_add_circle), self);
+  g_signal_connect(G_OBJECT(g->bt_circle), "button-press-event", G_CALLBACK(_add_shape_callback), self);
   gtk_widget_set_tooltip_text(g->bt_circle, _("add circle"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), g->bt_circle, FALSE, FALSE, 0);
@@ -719,6 +847,9 @@ void init_key_accels (dt_iop_module_so_t *module)
   dt_accel_register_iop (module, TRUE, NC_("accel", "spot circle tool"),   0, 0);
   dt_accel_register_iop (module, TRUE, NC_("accel", "spot ellipse tool"),   0, 0);
   dt_accel_register_iop (module, TRUE, NC_("accel", "spot path tool"),     0, 0);
+  dt_accel_register_iop (module, TRUE, NC_("accel", "continuous add circle"),   0, 0);
+  dt_accel_register_iop (module, TRUE, NC_("accel", "continuous add ellipse"),   0, 0);
+  dt_accel_register_iop (module, TRUE, NC_("accel", "continuous add path"),     0, 0);
   dt_accel_register_iop (module, TRUE, NC_("accel", "show or hide shapes"),  0, 0);
 }
 
@@ -727,7 +858,7 @@ static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *accel
 {
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_circle(GTK_WIDGET(g->bt_circle), NULL, module);
+  _add_shape(GTK_WIDGET(g->bt_circle), 0, module);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), TRUE);
   return TRUE;
 }
@@ -737,7 +868,7 @@ static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acce
 {
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_ellipse(GTK_WIDGET(g->bt_ellipse), NULL, module);
+  _add_shape(GTK_WIDGET(g->bt_ellipse), 0, module);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), TRUE);
   return TRUE;
 }
@@ -747,8 +878,38 @@ static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceler
 {
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
-  _add_path(GTK_WIDGET(g->bt_path), NULL, module);
+  _add_shape(GTK_WIDGET(g->bt_path), 0, module);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), TRUE);
+  return TRUE;
+}
+
+static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                      GdkModifierType modifier, gpointer data)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
+  _add_shape(GTK_WIDGET(g->bt_circle), 1, module);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), _shape_is_being_added(module, DT_MASKS_CIRCLE));
+  return TRUE;
+}
+
+static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                       GdkModifierType modifier, gpointer data)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
+  _add_shape(GTK_WIDGET(g->bt_ellipse), 1, module);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), _shape_is_being_added(module, DT_MASKS_ELLIPSE));
+  return TRUE;
+}
+
+static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                    GdkModifierType modifier, gpointer data)
+{
+  dt_iop_module_t *module = (dt_iop_module_t *)data;
+  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
+  _add_shape(GTK_WIDGET(g->bt_path), 1, module);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), _shape_is_being_added(module, DT_MASKS_PATH));
   return TRUE;
 }
 
@@ -756,8 +917,8 @@ static gboolean _show_hide_key_accel(GtkAccelGroup *accel_group, GObject *accele
                                      GdkModifierType modifier, gpointer data)
 {
   dt_iop_module_t *module = (dt_iop_module_t *)data;
-  dt_masks_set_edit_mode(module, module->dev->form_gui->edit_mode == DT_MASKS_EDIT_FULL ? DT_MASKS_EDIT_OFF : DT_MASKS_EDIT_FULL);
-  return TRUE;
+  const dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *) module->gui_data;
+  return _edit_masks(g->bt_edit_masks, NULL, module);
 }
 
 void connect_key_accels (dt_iop_module_t *module)
@@ -772,6 +933,15 @@ void connect_key_accels (dt_iop_module_t *module)
 
   closure = g_cclosure_new(G_CALLBACK(_add_path_key_accel), (gpointer)module, NULL);
   dt_accel_connect_iop (module, "spot path tool", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_circle_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop (module, "continuous add circle", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_ellipse_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop (module, "continuous add ellipse", closure);
+
+  closure = g_cclosure_new(G_CALLBACK(_continuous_add_path_key_accel), (gpointer)module, NULL);
+  dt_accel_connect_iop (module, "continuous add path", closure);
 
   closure = g_cclosure_new(G_CALLBACK(_show_hide_key_accel), (gpointer)module, NULL);
   dt_accel_connect_iop (module, "show or hide shapes", closure);


### PR DESCRIPTION
a number of enhancements to the spot removal module, adapted from
similar functionality in the retouch module:

- new button added to show/hide shapes

- continuous shape creation mode added, which is now the default when
  clicking on the shape buttons. Can be switched to single shape
  creation with ctrl-click.

- new keyboard shortcuts added for continuous shape creation

- clicking on the shape creation buttons while the module is disabled
  now enables the module allowing immediate shape placement

Resolves #2342