### PR TITLE
thumb overlays enhancements

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -719,6 +719,13 @@
     <longdescription>sizes categories are used to be able to set different overlays and css values depending of the size of the thumbnail.</longdescription>
   </dtconfig>
   <dtconfig prefs="gui" section="lighttable">
+    <name>plugins/lighttable/extended_pattern</name>
+    <type>string</type>
+    <default>$(FILE_NAME).$(FILE_EXTENSION)$(NL)$(EXIF_EXPOSURE) f/$(EXIF_APERTURE) $(EXIF_FOCAL_LENGTH)mm ISO $(EXIF_ISO)</default>
+    <shortdescription>pattern for the thumbnail extended overlay text</shortdescription>
+    <longdescription>see manual to know all the tags you can use.</longdescription>
+  </dtconfig>
+  <dtconfig prefs="gui" section="lighttable">
     <name>plugins/lighttable/thumbnail_tooltip_pattern</name>
     <type>string</type>
     <default>&lt;b&gt;$(FILE_NAME).$(FILE_EXTENSION)&lt;/b&gt;$(NL)$(EXIF_DAY)/$(EXIF_MONTH)/$(EXIF_YEAR) $(EXIF_HOUR):$(EXIF_MINUTE):$(EXIF_SECOND)$(NL)$(EXIF_EXPOSURE) s • f/$(EXIF_APERTURE) • $(EXIF_FOCAL_LENGTH) mm • ISO $(EXIF_ISO)</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -453,7 +453,7 @@
     <default>true</default>
     <shortdescription>sort collection recent to older</shortdescription>
     <longdescription>changes the default collections-list order for folders, times and dates to run from recent to older</longdescription>
-  </dtconfig> 
+  </dtconfig>
   <dtconfig>
     <name>ui_last/colorpicker_mean</name>
     <type>int</type>
@@ -616,6 +616,69 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/overlays/0/0</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>overlays for filemanager at size 0 = none</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/overlays/0/1</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>overlays for filemanager at size 1 = on hover</shortdescription>
+    <longdescription/>
+  </dtconfig>
+    <dtconfig>
+    <name>plugins/lighttable/overlays/0/2</name>
+    <type>int</type>
+    <default>4</default>
+    <shortdescription>overlays for filemanager at size 2 = always extended</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/overlays/1/0</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>overlays for filmstrip at size 0 = none</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/overlays/1/1</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>overlays for filmstrip at size 1 = on hover</shortdescription>
+    <longdescription/>
+  </dtconfig>
+    <dtconfig>
+    <name>plugins/lighttable/overlays/1/2</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>overlays for filmstrip at size 2 = on hover</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/overlays/2/0</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>overlays for zomable lighttable at size 0 = none</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/overlays/2/1</name>
+    <type>int</type>
+    <default>1</default>
+    <shortdescription>overlays for zomable lighttable at size 1 = on hover</shortdescription>
+    <longdescription/>
+  </dtconfig>
+    <dtconfig>
+    <name>plugins/lighttable/overlays/2/2</name>
+    <type>int</type>
+    <default>4</default>
+    <shortdescription>overlays for zomable lighttable at size 2 = always extended</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/timeline/last_zoom</name>
     <type>int</type>
     <default>0</default>
@@ -649,11 +712,11 @@
     <longdescription>if the thumbnail size is greater than this value, it will be processed using the full quality rendering path (better but slower).</longdescription>
   </dtconfig>
   <dtconfig prefs="gui" section="lighttable">
-    <name>plugins/lighttable/extended_thumb_overlay</name>
-    <type>bool</type>
-    <default>false</default>
-    <shortdescription>enable extended thumb overlay</shortdescription>
-    <longdescription>if set to true, thumb overlay shows filename and some exif data.</longdescription>
+    <name>plugins/lighttable/thumbnail_sizes</name>
+    <type>string</type>
+    <default>120|400</default>
+    <shortdescription>delimiters for sizes categories</shortdescription>
+    <longdescription>sizes categories are used to be able to set different overlays and css values depending of the size of the thumbnail.</longdescription>
   </dtconfig>
   <dtconfig prefs="gui" section="lighttable">
     <name>plugins/lighttable/thumbnail_tooltip_pattern</name>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1548,20 +1548,6 @@ Details :
   color: transparent;
   font-weight: bold;
 }
-#thumb_main:hover #thumb_bottom,
-.dt_show_overlays #thumb_bottom
-{
-  background-image: linear-gradient(0deg, rgb(101, 101, 101) 0%, rgba(107, 107, 107, 0.25) 75%,rgba(127,127,127,0) 100%);
-}
-#thumb_main:hover #thumb_bottom:hover
-{
-  background-image: linear-gradient(0deg, rgb(101, 101, 101) 0%, rgba(107, 107, 107, 0.5) 75%,rgba(127,127,127,0) 100%);
-}
-.dt_extended_overlay#thumb_main:hover #thumb_bottom,
-.dt_extended_overlay.dt_show_overlays #thumb_bottom
-{
-  background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
-}
 .dt_extended_overlay#thumb_main:hover #thumb_bottom_label,
 .dt_extended_overlay.dt_show_overlays #thumb_bottom_label
 {
@@ -1581,27 +1567,32 @@ Details :
 }
 
 /* thumbnails buttons */
-.dt_thumb_btn
+.dt_overlays_none .dt_thumb_btn,
+.dt_overlays_hover .dt_thumb_btn,
+.dt_overlays_hover_extended .dt_thumb_btn
 {
   color: transparent;
   background-color: transparent;
 }
 #thumb_main:hover .dt_thumb_btn,
-.dt_show_overlays .dt_thumb_btn
+.dt_overlays_always .dt_thumb_btn,
+.dt_overlays_always_extended .dt_thumb_btn
 {
   color: @thumbnail_hover_outline_color;
 }
 
 /* reject */
 #thumb_main:hover #thumb_reject:active,
-.dt_show_overlays #thumb_reject:active
+.dt_overlays_always #thumb_reject:active,
+.dt_overlays_always_extended #thumb_reject:active
 {
   color: red;
 }
 
 /* stars */
 #thumb_main:hover #thumb_star:active,
-.dt_show_overlays #thumb_star:active
+.dt_overlays_always #thumb_star:active,
+.dt_overlays_always_extended #thumb_star:active
 {
   color: @bauhaus_fg_hover;
   background-color: @thumbnail_hover_outline_color;
@@ -1627,7 +1618,8 @@ Details :
   border-top: 2px solid rgb(255, 187, 0); /* to not overlay thumb borders */
 }
 #thumb_main:hover #thumb_localcopy,
-.dt_show_overlays #thumb_localcopy
+.dt_overlays_always #thumb_localcopy,
+.dt_overlays_always_extended #thumb_localcopy
 {
   color: white;
   background-color: white;
@@ -1637,18 +1629,24 @@ Details :
 #thumb_main:hover #thumb_altered,
 #thumb_main:hover #thumb_group,
 #thumb_main:hover #thumb_audio,
-.dt_show_overlays #thumb_altered,
-.dt_show_overlays #thumb_group,
-.dt_show_overlays #thumb_audio
+.dt_overlays_always #thumb_altered,
+.dt_overlays_always #thumb_group,
+.dt_overlays_always #thumb_audio,
+.dt_overlays_always_extended #thumb_altered,
+.dt_overlays_always_extended #thumb_group,
+.dt_overlays_always_extended #thumb_audio
 {
   color: @thumbnail_outline_color;
 }
 #thumb_main:hover #thumb_group:hover,
 #thumb_main:hover #thumb_group:active,
 #thumb_main:hover #thumb_audio:hover,
-.dt_show_overlays #thumb_group:hover,
-.dt_show_overlays #thumb_group:active,
-.dt_show_overlays #thumb_audio:hover
+.dt_overlays_always #thumb_group:hover,
+.dt_overlays_always #thumb_group:active,
+.dt_overlays_always #thumb_audio:hover,
+.dt_overlays_always_extended #thumb_group:hover,
+.dt_overlays_always_extended #thumb_group:active,
+.dt_overlays_always_extended #thumb_audio:hover
 {
   color: @thumbnail_hover_fg_color;
 }
@@ -1661,4 +1659,50 @@ Details :
   background-color: @log_bg_color;
   padding: 8px 20px 4px 20px;
   border-radius: 14px;
+}
+
+
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
+}
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
+.dt_overlays_always_extended #thumb_bottom_label
+{
+  color: @thumbnail_hover_font_color;
+}
+
+.dt_overlays_none #thumb_reject,
+.dt_overlays_none #thumb_star,
+.dt_overlays_none #thumb_colorlabels,
+.dt_overlays_none #thumb_localcopy,
+.dt_overlays_none #thumb_altered,
+.dt_overlays_none #thumb_group,
+.dt_overlays_none #thumb_audio,
+.dt_overlays_none #thumb_main:hover #thumb_reject,
+.dt_overlays_none #thumb_main:hover #thumb_star,
+.dt_overlays_none #thumb_main:hover #thumb_colorlabels,
+.dt_overlays_none #thumb_main:hover #thumb_localcopy,
+.dt_overlays_none #thumb_main:hover #thumb_altered,
+.dt_overlays_none #thumb_main:hover #thumb_group,
+.dt_overlays_none #thumb_main:hover #thumb_audio,
+.dt_overlays_none #thumb_reject:active,
+.dt_overlays_none #thumb_star:active,
+.dt_overlays_none #thumb_colorlabels:active,
+.dt_overlays_none #thumb_localcopy:active,
+.dt_overlays_none #thumb_altered:active,
+.dt_overlays_none #thumb_group:active,
+.dt_overlays_none #thumb_audio:active
+{
+  background-color: transparent;
+  color: transparent;
+}
+
+.dt_overlays_always #thumb_image
+{
+  margin : 1px 4px 1px 4px;
+}
+.dt_overlays_always_extended #thumb_image
+{
+  margin : 1px 4px 1px 4px;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1428,10 +1428,12 @@ Hierachy :
 Details :
 
   #thumbtable_filemanager / #thumbtable_filmstrip / #thumbtable_zoom
-    class = .dt_thumbtable           present for all thumbtable types
-    class = .dt_show_overlays       if user has choosed to always show overlay
+    class = .dt_thumbtable          present for all thumbtable types
     class = .dt_thumbtable_reorder  if we are dragging images in custom reordering mode
-    class = .dt_extended_overlay    for extended overlay mode (filename + exif)
+    Classes to determine how are shown overlays on/under the image :
+    class = .dt_overlays_none / .dt_overlays_hover / .dt_overlays_hover_extended / .dt_overlays_always / .dt_overlays_always_extended
+    Classes to determine the category of size of the thumbnails (cat sizes limits are defined in dartablerc key=plugins/lighttable/thumbnail_sizes
+    class = .dt_thumbnails_?? where ?? is the cat number
   #thumb_main
     state = :selected  if the thumb is in current selection
     state = :active    if the thumb correspond to one of the images worked on (filmstrip)
@@ -1536,6 +1538,16 @@ Details :
 {
   border: 2px solid @plugin_bg_color;
 }
+.dt_thumbnails_2 #thumb_image
+{
+  margin : 2px;
+}
+.dt_overlays_always #thumb_image,
+.dt_overlays_always_extended #thumb_image
+{
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
 
 /* bottom area */
 #thumb_bottom
@@ -1548,8 +1560,8 @@ Details :
   color: transparent;
   font-weight: bold;
 }
-.dt_extended_overlay#thumb_main:hover #thumb_bottom_label,
-.dt_extended_overlay.dt_show_overlays #thumb_bottom_label
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
+.dt_overlays_always_extended #thumb_bottom_label
 {
   color: @thumbnail_hover_font_color;
 }
@@ -1564,6 +1576,15 @@ Details :
 .dt_group_right #thumb_bottom
 {
   border-right-width: 2px;
+}
+/* uncomment to see gradient under the stars. This may enhance visibility in certain cases, esp. bright images
+.dt_overlays_hover #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(0deg, rgb(101, 101, 101) 0%, rgba(107, 107, 107, 0.25) 75%,rgba(127,127,127,0) 100%);
+}*/
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
 }
 
 /* thumbnails buttons */
@@ -1650,28 +1671,6 @@ Details :
 {
   color: @thumbnail_hover_fg_color;
 }
-
-#log-msg
-{
-  color: @log_fg_color;
-  font-size: 14px;
-  font-weight: bold;
-  background-color: @log_bg_color;
-  padding: 8px 20px 4px 20px;
-  border-radius: 14px;
-}
-
-
-.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom
-{
-  background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
-}
-.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
-.dt_overlays_always_extended #thumb_bottom_label
-{
-  color: @thumbnail_hover_font_color;
-}
-
 .dt_overlays_none #thumb_reject,
 .dt_overlays_none #thumb_star,
 .dt_overlays_none #thumb_colorlabels,
@@ -1698,11 +1697,12 @@ Details :
   color: transparent;
 }
 
-.dt_overlays_always #thumb_image
+#log-msg
 {
-  margin : 1px 4px 1px 4px;
-}
-.dt_overlays_always_extended #thumb_image
-{
-  margin : 1px 4px 1px 4px;
+  color: @log_fg_color;
+  font-size: 14px;
+  font-weight: bold;
+  background-color: @log_bg_color;
+  padding: 8px 20px 4px 20px;
+  border-radius: 14px;
 }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -901,44 +901,43 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   // bottom background
   if(thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
   {
-    const int fsize2 = MIN(DT_PIXEL_APPLY_DPI(16.0), 0.67 * 0.91 * width / 10.0);
     attrlist = pango_attr_list_new();
-    attr = pango_attr_size_new_absolute(fsize2 * PANGO_SCALE);
+    attr = pango_attr_size_new_absolute(1.5 * r1 * PANGO_SCALE);
     pango_attr_list_insert(attrlist, attr);
     gtk_label_set_attributes(GTK_LABEL(thumb->w_bottom), attrlist);
     pango_attr_list_unref(attrlist);
-    gtk_widget_set_size_request(thumb->w_bottom, width, 0.09 * width + 4.0 * r1 + 1.5 * fsize2);
+    gtk_widget_set_size_request(thumb->w_bottom, width, 8.0 * r1);
   }
   else
-    gtk_widget_set_size_request(thumb->w_bottom, width, 0.09 * width + 3.0 * r1);
+    gtk_widget_set_size_request(thumb->w_bottom, width, 4.0 * r1);
   // reject icon
   gtk_widget_set_size_request(thumb->w_reject, 3.0 * r1, 3.0 * r1);
   gtk_widget_set_margin_start(thumb->w_reject, 0.045 * width - r1 * 0.75);
-  gtk_widget_set_margin_bottom(thumb->w_reject, 0.045 * width - r1 * 0.75);
+  gtk_widget_set_margin_bottom(thumb->w_reject, 0.5 * r1);
   // stars
   for(int i = 0; i < MAX_STARS; i++)
   {
     gtk_widget_set_size_request(thumb->w_stars[i], 3.0 * r1, 3.0 * r1);
-    gtk_widget_set_margin_bottom(thumb->w_stars[i], 0.045 * width - r1 * 0.75);
+    gtk_widget_set_margin_bottom(thumb->w_stars[i], 0.5 * r1);
     gtk_widget_set_margin_start(thumb->w_stars[i], (width - 15.0 * r1) * 0.5 + i * 3.0 * r1);
   }
   // the color labels
   gtk_widget_set_size_request(thumb->w_color, 3.0 * r1, 3.0 * r1);
-  gtk_widget_set_margin_bottom(thumb->w_color, 0.045 * width);
+  gtk_widget_set_margin_bottom(thumb->w_color, 0.5 * r1);
   gtk_widget_set_margin_end(thumb->w_color, 0.045 * width);
   // the local copy indicator
   gtk_widget_set_size_request(thumb->w_local_copy, 2.0 * r1, 2.0 * r1);
   // the altered icon
   gtk_widget_set_size_request(thumb->w_altered, 2.0 * r1, 2.0 * r1);
-  gtk_widget_set_margin_top(thumb->w_altered, 0.045 * width);
+  gtk_widget_set_margin_top(thumb->w_altered, 0.5 * r1);
   gtk_widget_set_margin_end(thumb->w_altered, 0.045 * width);
   // the group bouton
   gtk_widget_set_size_request(thumb->w_group, 2.0 * r1, 2.0 * r1);
-  gtk_widget_set_margin_top(thumb->w_group, 0.045 * width);
+  gtk_widget_set_margin_top(thumb->w_group, 0.5 * r1);
   gtk_widget_set_margin_end(thumb->w_group, 0.045 * width + 3.0 * r1);
   // the sound icon
   gtk_widget_set_size_request(thumb->w_audio, 2.0 * r1, 2.0 * r1);
-  gtk_widget_set_margin_top(thumb->w_audio, 0.045 * width);
+  gtk_widget_set_margin_top(thumb->w_audio, 0.5 * r1);
   gtk_widget_set_margin_end(thumb->w_audio, 0.045 * width + 6.0 * r1);
 
   // update values

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -30,6 +30,15 @@ typedef enum dt_thumbnail_border_t
   DT_THUMBNAIL_BORDER_BOTTOM = 1 << 3,
 } dt_thumbnail_border_t;
 
+typedef enum dt_thumbnail_overlay_t
+{
+  DT_THUMBNAIL_OVERLAYS_NONE,
+  DT_THUMBNAIL_OVERLAYS_HOVER_NORMAL,
+  DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED,
+  DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL,
+  DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED
+} dt_thumbnail_overlay_t;
+
 typedef enum dt_thumbnail_selection_mode_t
 {
   DT_THUMBNAIL_SEL_MODE_NORMAL = 0, // user can change selection with normal mouse click (+CTRL or +SHIFT)
@@ -89,12 +98,14 @@ typedef struct
   dt_thumbnail_selection_mode_t sel_mode; // do we allow to change selection with mouse ?
   gboolean single_click;                  // do we activate on single or double click ?
   gboolean disable_mouseover;             // do we allow to change mouseoverid by mouse move
+
+  dt_thumbnail_overlay_t over; // type of overlays
 } dt_thumbnail_t;
 
-dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid);
+dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over);
 void dt_thumbnail_destroy(dt_thumbnail_t *thumb);
 GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb);
-void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height);
+void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force);
 void dt_thumbnail_set_group_border(dt_thumbnail_t *thumb, dt_thumbnail_border_t border);
 void dt_thumbnail_set_mouseover(dt_thumbnail_t *thumb, gboolean over);
 
@@ -108,6 +119,8 @@ void dt_thumbnail_update_infos(dt_thumbnail_t *thumb);
 // force image recomputing
 void dt_thumbnail_image_refresh(dt_thumbnail_t *thumb);
 
+// do we need to display simple overlays or extended ?
+void dt_thumbnail_set_extended_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -60,7 +60,7 @@ typedef struct
   int rating;
   int colorlabels;
   gchar *filename;
-  gchar info_line[50];
+  gchar info_line[256];
   gboolean is_altered;
   gboolean has_audio;
   gboolean is_grouped;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -43,6 +43,98 @@ static void _list_remove_thumb(gpointer user_data)
   dt_thumbnail_destroy(thumb);
 }
 
+// get the class name associated with the overlays mode
+gchar *_thumbs_get_overlays_class(dt_thumbnail_overlay_t over)
+{
+  switch(over)
+  {
+    case DT_THUMBNAIL_OVERLAYS_NONE:
+      return dt_util_dstrcat(NULL, "dt_overlays_none");
+    case DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED:
+      return dt_util_dstrcat(NULL, "dt_overlays_hover_extended");
+    case DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL:
+      return dt_util_dstrcat(NULL, "dt_overlays_always");
+    case DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED:
+      return dt_util_dstrcat(NULL, "dt_overlays_always_extended");
+    default:
+      return dt_util_dstrcat(NULL, "dt_overlays_hover");
+  }
+}
+
+// get the size categorie, depending on the thumb size
+static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
+{
+  // we get the size delimitations to differentiate sizes categories
+  // one we set as many categories as we want (this can be usefull if we want to finetune very precisely css)
+  gchar *txt = dt_conf_get_string("plugins/lighttable/thumbnail_sizes");
+  gchar **ts = g_strsplit(txt, "|", -1);
+  int i = 0;
+  while(ts[i])
+  {
+    const int s = g_ascii_strtoll(ts[i], NULL, 10);
+    if(table->thumb_size < s) break;
+    i++;
+  }
+  table->prefs_size = i;
+  g_strfreev(ts);
+  g_free(txt);
+  return table->prefs_size;
+}
+
+// update thumbtable class and overlays mode, depending on size categorie
+static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
+{
+  int ns = _thumbs_get_prefs_size(table);
+
+  // we change the class that indicate the thumb size
+  gchar *c0 = dt_util_dstrcat(NULL, "dt_thumbnails_%d", table->prefs_size);
+  gchar *c1 = dt_util_dstrcat(NULL, "dt_thumbnails_%d", ns);
+  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
+  gtk_style_context_remove_class(context, c0);
+  gtk_style_context_add_class(context, c1);
+  g_free(c0);
+  g_free(c1);
+  table->prefs_size = ns;
+
+  // we change the overlay mode
+  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/%d/%d", table->mode, ns);
+  dt_thumbnail_overlay_t over = dt_conf_get_int(txt);
+  dt_thumbtable_set_overlays_mode(table, over);
+
+  g_free(txt);
+}
+
+// change the type of overlays that should be shown
+void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over)
+{
+  if(over == table->overlays) return;
+  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/%d/%d", table->mode, table->prefs_size);
+  dt_conf_set_int(txt, over);
+  g_free(txt);
+  gchar *cl0 = _thumbs_get_overlays_class(table->overlays);
+  gchar *cl1 = _thumbs_get_overlays_class(over);
+
+  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
+  gtk_style_context_remove_class(context, cl0);
+  gtk_style_context_add_class(context, cl1);
+
+  // we need to change the overlay content if we pass from normal to extended overlays
+  // this is not done on the fly with css to avoid computing extended msg for nothing and to reserve space if needed
+  GList *l = table->list;
+  while(l)
+  {
+    dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+    dt_thumbnail_set_extended_overlay(th, over);
+    // and we resize the bottom area
+    dt_thumbnail_resize(th, th->width, th->height, TRUE);
+    l = g_list_next(l);
+  }
+
+  table->overlays = over;
+  g_free(cl0);
+  g_free(cl1);
+}
+
 // get the thumb at specific position
 static dt_thumbnail_t *_thumb_get_at_pos(dt_thumbtable_t *table, int x, int y)
 {
@@ -193,6 +285,7 @@ static gboolean _compute_sizes(dt_thumbtable_t *table, gboolean force)
     return FALSE;
   }
 
+  int old_size = table->thumb_size;
   if(table->mode == DT_THUMBTABLE_MODE_FILEMANAGER)
   {
     const int npr = dt_view_lighttable_get_zoom(darktable.view_manager);
@@ -240,6 +333,12 @@ static gboolean _compute_sizes(dt_thumbtable_t *table, gboolean force)
       table->center_offset = 0;
       ret = TRUE;
     }
+  }
+
+  // if the thumb size has changed, we nee to set overlays, etc... correctly
+  if(table->thumb_size != old_size)
+  {
+    _thumbs_update_overlays_mode(table);
   }
   return ret;
 }
@@ -356,7 +455,7 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
       if(posy < table->view_height) // we don't load invisible thumbs
       {
         dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
-                                                 sqlite3_column_int(stmt, 0));
+                                                 sqlite3_column_int(stmt, 0), table->overlays);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -398,7 +497,7 @@ static int _thumbs_load_needed(dt_thumbtable_t *table)
       if(posy + table->thumb_size >= 0) // we don't load invisible thumbs
       {
         dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, sqlite3_column_int(stmt, 1),
-                                                 sqlite3_column_int(stmt, 0));
+                                                 sqlite3_column_int(stmt, 0), table->overlays);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -605,7 +704,7 @@ static void _zoomable_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
     th->x = anchor_posx - (anchor_x - posx) * new_size;
     th->y = anchor_posy - (anchor_y - posy) * new_size;
     gtk_layout_move(GTK_LAYOUT(table->widget), th->w_main, th->x, th->y);
-    dt_thumbnail_resize(th, new_size, new_size);
+    dt_thumbnail_resize(th, new_size, new_size, FALSE);
     l = g_list_next(l);
   }
 
@@ -1334,6 +1433,13 @@ dt_thumbtable_t *dt_thumbtable_new()
   gtk_style_context_add_class(context, "dt_thumbtable");
   if(dt_conf_get_bool("lighttable/ui/expose_statuses")) gtk_style_context_add_class(context, "dt_show_overlays");
 
+  // overlays mode
+  table->overlays
+      = DT_THUMBNAIL_OVERLAYS_NONE; //(dt_thumbnail_overlay_t)dt_conf_get_int("lighttable/ui/overlays_mode");
+  gchar *cl = _thumbs_get_overlays_class(table->overlays);
+  gtk_style_context_add_class(context, cl);
+  g_free(cl);
+
   table->offset = MAX(1, dt_conf_get_int("plugins/lighttable/recentcollect/pos0"));
 
   // set widget signals
@@ -1509,7 +1615,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
           thumb->y = posy;
           gtk_layout_move(GTK_LAYOUT(table->widget), thumb->w_main, posx, posy);
         }
-        dt_thumbnail_resize(thumb, table->thumb_size, table->thumb_size);
+        dt_thumbnail_resize(thumb, table->thumb_size, table->thumb_size, FALSE);
         newlist = g_list_append(newlist, thumb);
         // and we remove the thumb from the old list
         table->list = g_list_remove(table->list, thumb);
@@ -1517,7 +1623,7 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       else
       {
         // we create a completly new thumb
-        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, nid, nrow);
+        dt_thumbnail_t *thumb = dt_thumbnail_new(table->thumb_size, table->thumb_size, nid, nrow, table->overlays);
         if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
         {
           thumb->single_click = TRUE;
@@ -1643,6 +1749,9 @@ void dt_thumbtable_set_parent(dt_thumbtable_t *table, GtkWidget *new_parent, dt_
     }
 
     table->mode = mode;
+
+    // we force overlays update as the size may not change in certain cases
+    _thumbs_update_overlays_mode(table);
   }
 
   // do we show scrollbars ?
@@ -2162,6 +2271,7 @@ gboolean dt_thumbtable_reset_first_offset(dt_thumbtable_t *table)
   dt_thumbtable_set_offset(table, table->offset + offset, TRUE);
   return TRUE;
 }
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1777,16 +1777,6 @@ void dt_thumbtable_set_parent(dt_thumbtable_t *table, GtkWidget *new_parent, dt_
   table->code_scrolling = FALSE;
 }
 
-// define if overlays should always be shown or just on mouse-over
-void dt_thumbtable_set_overlays(dt_thumbtable_t *table, gboolean show)
-{
-  GtkStyleContext *context = gtk_widget_get_style_context(table->widget);
-  if(show)
-    gtk_style_context_add_class(context, "dt_show_overlays");
-  else
-    gtk_style_context_remove_class(context, "dt_show_overlays");
-}
-
 // get current offset
 int dt_thumbtable_get_offset(dt_thumbtable_t *table)
 {

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -100,8 +100,6 @@ dt_thumbtable_t *dt_thumbtable_new();
 void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force);
 // change thumbtable parent widget
 void dt_thumbtable_set_parent(dt_thumbtable_t *table, GtkWidget *new_parent, dt_thumbtable_mode_t mode);
-// define if overlays should always be shown or just on mouse-over
-void dt_thumbtable_set_overlays(dt_thumbtable_t *table, gboolean show);
 // get/set offset (and redraw if needed)
 int dt_thumbtable_get_offset(dt_thumbtable_t *table);
 gboolean dt_thumbtable_set_offset(dt_thumbtable_t *table, int offset, gboolean redraw);

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -44,6 +44,7 @@ typedef enum dt_thumbtable_move_t
 typedef struct dt_thumbtable_t
 {
   dt_thumbtable_mode_t mode;
+  dt_thumbnail_overlay_t overlays;
 
   GtkWidget *widget; // GtkLayout -- main widget
 
@@ -61,6 +62,7 @@ typedef struct dt_thumbtable_t
   int thumbs_per_row; // number of image in a row (1 for filmstrip ; MAX_ZOOM for zoomable)
   int rows; // number of rows (the last one is not fully visible) for filmstrip it's the number of columns
   int thumb_size;              // demanded thumb size (real size can differ of 1 due to rounding)
+  int prefs_size;              // size value to dertermine overlays mode and css class
   int view_width, view_height; // last main widget size
   GdkRectangle thumbs_area;    // coordinate of all the currently loaded thumbs area
 
@@ -127,6 +129,9 @@ void dt_thumbtable_init_accels(dt_thumbtable_t *table);
 // connect all accels if thumbtable is active in the view and they are not loaded
 // disconnect them if not
 void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, int view);
+
+// change the type of overlays that should be shown (over or under the image)
+void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -316,7 +316,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     const int imgid = sqlite3_column_int(stmt, 1);
 
-    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, imgid, -1);
+    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, imgid, -1, DT_THUMBNAIL_OVERLAYS_NONE);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
     thumb->disable_mouseover = TRUE;
     dt_thumbnail_set_mouseover(thumb, imgid == dev->image_storage.id);

--- a/src/libs/tools/darktable.c
+++ b/src/libs/tools/darktable.c
@@ -23,6 +23,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "develop/develop.h"
+#include "dtgtk/thumbtable.h"
 #include "gui/gtk.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -75,6 +75,13 @@ int position()
   return 1001;
 }
 
+static void _overlays_accels_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
+                                      GdkModifierType modifier, gpointer data)
+{
+  dt_thumbnail_overlay_t over = (dt_thumbnail_overlay_t)GPOINTER_TO_INT(data);
+  dt_thumbtable_set_overlays_mode(dt_ui_thumbtable(darktable.gui->ui), over);
+}
+
 static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
 {
   if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w))) return;
@@ -393,7 +400,12 @@ void init_key_accels(dt_lib_module_t *self)
 {
   dt_accel_register_lib(self, NC_("accel", "grouping"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "preferences"), 0, 0);
-  dt_accel_register_lib(self, NC_("accel", "show overlays"), 0, 0);
+
+  dt_accel_register_lib(self, NC_("accel", "no overlays"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "overlays on mouse hover"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "extended overlays on mouse hover"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "permanent overlays"), 0, 0);
+  dt_accel_register_lib(self, NC_("accel", "permanent extended overlays"), 0, 0);
 }
 
 void connect_key_accels(dt_lib_module_t *self)
@@ -402,7 +414,22 @@ void connect_key_accels(dt_lib_module_t *self)
 
   dt_accel_connect_button_lib(self, "grouping", d->grouping_button);
   dt_accel_connect_button_lib(self, "preferences", d->preferences_button);
-  dt_accel_connect_button_lib(self, "show overlays", d->overlays_button);
+
+  dt_accel_connect_lib(
+      self, "no overlays",
+      g_cclosure_new(G_CALLBACK(_overlays_accels_callback), GINT_TO_POINTER(DT_THUMBNAIL_OVERLAYS_NONE), NULL));
+  dt_accel_connect_lib(self, "overlays on mouse hover",
+                       g_cclosure_new(G_CALLBACK(_overlays_accels_callback),
+                                      GINT_TO_POINTER(DT_THUMBNAIL_OVERLAYS_HOVER_NORMAL), NULL));
+  dt_accel_connect_lib(self, "extended overlays on mouse hover",
+                       g_cclosure_new(G_CALLBACK(_overlays_accels_callback),
+                                      GINT_TO_POINTER(DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED), NULL));
+  dt_accel_connect_lib(self, "permanent overlays",
+                       g_cclosure_new(G_CALLBACK(_overlays_accels_callback),
+                                      GINT_TO_POINTER(DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL), NULL));
+  dt_accel_connect_lib(self, "permanent extended overlays",
+                       g_cclosure_new(G_CALLBACK(_overlays_accels_callback),
+                                      GINT_TO_POINTER(DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED), NULL));
 }
 
 #ifdef USE_LUA

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -37,6 +37,7 @@ DT_MODULE(1)
 typedef struct dt_lib_tool_preferences_t
 {
   GtkWidget *preferences_button, *grouping_button, *overlays_button, *help_button;
+  GtkWidget *over_popup, *over_label, *over_r0, *over_r1, *over_r2, *over_r3, *over_r4;
 } dt_lib_tool_preferences_t;
 
 /* callback for grouping button */
@@ -44,7 +45,7 @@ static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user
 /* callback for preference button */
 static void _lib_preferences_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for overlays button */
-static void _lib_overlays_button_clicked(GtkWidget *widget, gpointer user_data);
+// static void _lib_overlays_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for help button */
 static void _lib_help_button_clicked(GtkWidget *widget, gpointer user_data);
 
@@ -74,6 +75,54 @@ int position()
   return 1001;
 }
 
+static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
+{
+  if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w))) return;
+
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
+
+  dt_thumbnail_overlay_t over = DT_THUMBNAIL_OVERLAYS_HOVER_NORMAL;
+  if(w == d->over_r0)
+    over = DT_THUMBNAIL_OVERLAYS_NONE;
+  else if(w == d->over_r2)
+    over = DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED;
+  else if(w == d->over_r3)
+    over = DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL;
+  else if(w == d->over_r4)
+    over = DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED;
+
+  dt_thumbtable_set_overlays_mode(dt_ui_thumbtable(darktable.gui->ui), over);
+
+  gtk_widget_hide(d->over_popup);
+}
+
+static void _overlays_show_popup(dt_lib_module_t *self)
+{
+  dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
+
+  // we write the label with the size categorie
+  gchar *txt = dt_util_dstrcat(NULL, "%s %d", _("overlay mode for size"),
+                               dt_ui_thumbtable(darktable.gui->ui)->prefs_size);
+  gtk_label_set_text(GTK_LABEL(d->over_label), txt);
+
+  // we get and set the current value
+  dt_thumbnail_overlay_t mode = dt_ui_thumbtable(darktable.gui->ui)->overlays;
+
+  if(mode == DT_THUMBNAIL_OVERLAYS_NONE)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r0), TRUE);
+  else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r2), TRUE);
+  else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r3), TRUE);
+  else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r4), TRUE);
+  else
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r1), TRUE);
+
+  gtk_widget_show_all(d->over_popup);
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -94,14 +143,40 @@ void gui_init(dt_lib_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->grouping_button), darktable.gui->grouping);
 
   /* create the "show/hide overlays" button */
-  d->overlays_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT, NULL);
+  d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT, NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), d->overlays_button, FALSE, FALSE, 0);
-  if(darktable.gui->show_overlays)
-    gtk_widget_set_tooltip_text(d->overlays_button, _("hide image overlays"));
-  else
-    gtk_widget_set_tooltip_text(d->overlays_button, _("show image overlays"));
-  g_signal_connect(G_OBJECT(d->overlays_button), "clicked", G_CALLBACK(_lib_overlays_button_clicked), NULL);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->overlays_button), darktable.gui->show_overlays);
+  d->over_popup = gtk_popover_new(d->overlays_button);
+  gtk_widget_set_size_request(d->over_popup, 350, -1);
+#if GTK_CHECK_VERSION(3, 16, 0)
+  g_object_set(G_OBJECT(d->over_popup), "transitions-enabled", FALSE, NULL);
+#endif
+  g_signal_connect_swapped(G_OBJECT(d->overlays_button), "button-press-event", G_CALLBACK(_overlays_show_popup),
+                           self);
+
+  GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+
+  gtk_container_add(GTK_CONTAINER(d->over_popup), vbox);
+
+  d->over_label = gtk_label_new(_("overlay mode for size"));
+  gtk_box_pack_start(GTK_BOX(vbox), d->over_label, TRUE, TRUE, 0);
+  d->over_r0 = gtk_radio_button_new_with_label(NULL, _("no overlays"));
+  g_signal_connect(G_OBJECT(d->over_r0), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  gtk_box_pack_start(GTK_BOX(vbox), d->over_r0, TRUE, TRUE, 0);
+  d->over_r1
+      = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0), _("overlays on mouse hover"));
+  g_signal_connect(G_OBJECT(d->over_r1), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  gtk_box_pack_start(GTK_BOX(vbox), d->over_r1, TRUE, TRUE, 0);
+  d->over_r2 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
+                                                           _("extended overlays on mouse hover"));
+  g_signal_connect(G_OBJECT(d->over_r2), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  gtk_box_pack_start(GTK_BOX(vbox), d->over_r2, TRUE, TRUE, 0);
+  d->over_r3 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0), _("permanent overlays"));
+  g_signal_connect(G_OBJECT(d->over_r3), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  gtk_box_pack_start(GTK_BOX(vbox), d->over_r3, TRUE, TRUE, 0);
+  d->over_r4 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
+                                                           _("permanent extended overlays"));
+  g_signal_connect(G_OBJECT(d->over_r4), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  gtk_box_pack_start(GTK_BOX(vbox), d->over_r4, TRUE, TRUE, 0);
 
   /* create the widget help button */
   d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, CPF_STYLE_FLAT, NULL);
@@ -151,22 +226,6 @@ static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user
       LUA_ASYNC_TYPENAME,"const char*","global_toolbox-grouping_toggle",
       LUA_ASYNC_TYPENAME,"bool",darktable.gui->grouping,
       LUA_ASYNC_DONE);
-#endif // USE_LUA
-}
-
-static void _lib_overlays_button_clicked(GtkWidget *widget, gpointer user_data)
-{
-  gboolean show = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-  if(show)
-    gtk_widget_set_tooltip_text(widget, _("hide image overlays"));
-  else
-    gtk_widget_set_tooltip_text(widget, _("show image overlays"));
-  dt_conf_set_bool("lighttable/ui/expose_statuses", show);
-  dt_thumbtable_set_overlays(dt_ui_thumbtable(darktable.gui->ui), show);
-
-#ifdef USE_LUA
-  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper, 0, NULL, NULL, LUA_ASYNC_TYPENAME, "const char*",
-                          "global_toolbox-overlay_toggle", LUA_ASYNC_TYPENAME, "bool", show, LUA_ASYNC_DONE);
 #endif // USE_LUA
 }
 

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -44,8 +44,6 @@ typedef struct dt_lib_tool_preferences_t
 static void _lib_filter_grouping_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for preference button */
 static void _lib_preferences_button_clicked(GtkWidget *widget, gpointer user_data);
-/* callback for overlays button */
-// static void _lib_overlays_button_clicked(GtkWidget *widget, gpointer user_data);
 /* callback for help button */
 static void _lib_help_button_clicked(GtkWidget *widget, gpointer user_data);
 
@@ -102,6 +100,12 @@ static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
   dt_thumbtable_set_overlays_mode(dt_ui_thumbtable(darktable.gui->ui), over);
 
   gtk_widget_hide(d->over_popup);
+
+#ifdef USE_LUA
+  gboolean show = (over == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL || over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED);
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper, 0, NULL, NULL, LUA_ASYNC_TYPENAME, "const char*",
+                          "global_toolbox-overlay_toggle", LUA_ASYNC_TYPENAME, "bool", show, LUA_ASYNC_DONE);
+#endif // USE_LUA
 }
 
 static void _overlays_show_popup(dt_lib_module_t *self)
@@ -112,6 +116,7 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   gchar *txt = dt_util_dstrcat(NULL, "%s %d", _("overlay mode for size"),
                                dt_ui_thumbtable(darktable.gui->ui)->prefs_size);
   gtk_label_set_text(GTK_LABEL(d->over_label), txt);
+  g_free(txt);
 
   // we get and set the current value
   dt_thumbnail_overlay_t mode = dt_ui_thumbtable(darktable.gui->ui)->overlays;


### PR DESCRIPTION
this fix #4545 
this fix #4689 
this close #4549 

Rework the thumbnails overlays. What change : 
- user can choose between 5 type of overlays via a popup associated to the star icon of the global toolbox
- overlays can be : none ; on mouse hover ; extended on mouse hover ; permanent ; permanent extended
- with the 2 "permanent" overlays, the space for overlays is "reserved" so the overlays doesn't overlap the image
- overlays settings are saved per thumbtable mode (filemananger, zoomable, filmstrip) and per thumbnail size (divided in categories)
- categories of sizes can be finetune in pref dialog by writing size values separated by | ex : "120|300" => category 0: sizes [0-120] ; category 1 : sizes [120-300] ; category 2 : sizes [300-...]
 - accels with no default key are available for switch overlays modes
- overlays modes and size categories can be used in css via specific class
- default overlays : none for size 0 ; mouse hover for size 1 (without background) ; permanent extended for size 2
- last (but not least) the extended overlay is now defined by a pattern in prefs like for the tooltip. Default value produce the same lines of text as currently.

I'm not sure how to add more flexibility...
Please test, especially to see if default overlays are ok for you.