### PR TITLE
Enable windows build with latest MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ include(compiler-versions)
 
 if(WIN32)
   message("-- Win32 build detected, setting default features")
+  LIST(APPEND CMAKE_PREFIX_PATH /mingw64/x86_64-w64-mingw32)
   set(USE_COLORD OFF)
   set(USE_KWALLET OFF)
   set(BUILD_CMSTEST OFF)


### PR DESCRIPTION
Latest MSYS2 uses cmake 3.17 which no longer searches for .dll files when locating libraries for linking.  This results in the windows build failing as various libraries required for mapping are not found (issue #4692) .  This PR explicitly points cmake to the location where relevant libraries are located.