### PR TITLE
Fix indexing out of bounds in Chromatic Aberration module.

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -471,7 +471,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
           if(rrmax < rr1)
           {
-            for(int rr = 0; rr < border; rr++)
+            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
               for(int cc = ccmin; cc < ccmax; cc++)
               {
                 int c = FC(rr, cc, filters);
@@ -492,7 +492,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
           if(ccmax < cc1)
           {
             for(int rr = rrmin; rr < rrmax; rr++)
-              for(int cc = 0; cc < border; cc++)
+              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
               {
                 int c = FC(rr, cc, filters);
                 rgb[c][rr * ts + ccmax + cc] = (in[(top + rr) * width + (width - cc - 2)]);
@@ -512,8 +512,8 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
           if(rrmax < rr1 && ccmax < cc1)
           {
-            for(int rr = 0; rr < border; rr++)
-              for(int cc = 0; cc < border; cc++)
+            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
+              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
               {
                 int c = FC(rr, cc, filters);
                 rgb[c][(rrmax + rr) * ts + ccmax + cc] = (in[(height - rr - 2) * width + (width - cc - 2)]);
@@ -523,7 +523,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
           if(rrmin > 0 && ccmax < cc1)
           {
             for(int rr = 0; rr < border; rr++)
-              for(int cc = 0; cc < border; cc++)
+              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
               {
                 int c = FC(rr, cc, filters);
                 rgb[c][(rr)*ts + ccmax + cc] = (in[(border2 - rr) * width + (width - cc - 2)]);
@@ -532,7 +532,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
           if(rrmax < rr1 && ccmin > 0)
           {
-            for(int rr = 0; rr < border; rr++)
+            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
               for(int cc = 0; cc < border; cc++)
               {
                 int c = FC(rr, cc, filters);
@@ -1128,7 +1128,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
           if(rrmax < rr1)
           {
-            for(int rr = 0; rr < border; rr++)
+            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
               for(int cc = ccmin; cc < ccmax; cc++)
               {
                 int c = FC(rr, cc, filters);
@@ -1151,7 +1151,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
           if(ccmax < cc1)
           {
             for(int rr = rrmin; rr < rrmax; rr++)
-              for(int cc = 0; cc < border; cc++)
+              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
               {
                 int c = FC(rr, cc, filters);
                 rgb[c][rr * ts + ccmax + cc] = (in[(top + rr) * width + (width - cc - 2)]);
@@ -1173,8 +1173,8 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
           if(rrmax < rr1 && ccmax < cc1)
           {
-            for(int rr = 0; rr < border; rr++)
-              for(int cc = 0; cc < border; cc++)
+            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
+              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
               {
                 int c = FC(rr, cc, filters);
                 rgb[c][(rrmax + rr) * ts + ccmax + cc] = (in[(height - rr - 2) * width + (width - cc - 2)]);
@@ -1185,7 +1185,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
           if(rrmin > 0 && ccmax < cc1)
           {
             for(int rr = 0; rr < border; rr++)
-              for(int cc = 0; cc < border; cc++)
+              for(int cc = 0; cc < MIN(border, cc1 - ccmax); cc++)
               {
                 int c = FC(rr, cc, filters);
                 rgb[c][(rr)*ts + ccmax + cc] = (in[(border2 - rr) * width + (width - cc - 2)]);
@@ -1195,7 +1195,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 
           if(rrmax < rr1 && ccmin > 0)
           {
-            for(int rr = 0; rr < border; rr++)
+            for(int rr = 0; rr < MIN(border, rr1 - rrmax); rr++)
               for(int cc = 0; cc < border; cc++)
               {
                 int c = FC(rr, cc, filters);


### PR DESCRIPTION
This is a port of the upstream patch
https://github.com/Beep6581/RawTherapee/commit/2f32afa8, fixing issue
https://github.com/Beep6581/RawTherapee/issues/4116

At certain resolutions, border filling of the last tile will overwrite
the previous, creating a garbled line across the image.

Note that RawTherapee commit only fixes one set of copy/pasted loops,
while this commit fixes both. In fact the other fixed set seems
necessary to get rid of the artifacts I saw, and looking at the code,
it indeed seems to fix indexing out-of-bounds.