### PR TITLE
Enable windows build with latest MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ include(compiler-versions)
 
 if(WIN32)
   message("-- Win32 build detected, setting default features")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .dll ${CMAKE_FIND_LIBRARY_SUFFIXES})
   set(USE_COLORD OFF)
   set(USE_KWALLET OFF)
   set(BUILD_CMSTEST OFF)


### PR DESCRIPTION
This PR replaces previous attempt  #4741  to solve how to build on windows with cmake 3.17, which is latest version with MSYS/mingw. This is discussed in issue #4692.  This PR just explicitly adds .dll to the library suffixes which are searched for, i.e. this is identical to the behaviour with previous versions of cmake.