### PR TITLE
CSS rework from new overlays modes and some cleaning

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -85,10 +85,11 @@
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_30;
-@define-color thumbnail_bg_color @grey_55;
-@define-color thumbnail_infos_color @grey_75;
-@define-color thumbnail_selected_bg_color @grey_85;
+@define-color thumbnail_font_color @grey_45;
+@define-color thumbnail_bg_color @grey_50;
+@define-color thumbnail_infos_color @grey_80;
+@define-color thumbnail_selected_bg_color @grey_70;
+
 @define-color thumbnail_hover_bg_color @grey_95;
 @define-color thumbnail_hover_fg_color @grey_75;
 

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -85,17 +85,12 @@
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_65;
+@define-color thumbnail_font_color @grey_30;
 @define-color thumbnail_bg_color @grey_55;
-@define-color thumbnail_outline_color @grey_65;
-@define-color thumbnail_selected_font_color @grey_65;
-@define-color thumbnail_selected_bg_color @grey_75;
-@define-color thumbnail_selected_outline_color @grey_65;
-@define-color thumbnail_hover_font_color @grey_60;
-@define-color thumbnail_hover_bg_color @grey_90;
+@define-color thumbnail_infos_color @grey_75;
+@define-color thumbnail_selected_bg_color @grey_85;
+@define-color thumbnail_hover_bg_color @grey_95;
 @define-color thumbnail_hover_fg_color @grey_75;
-@define-color thumbnail_hover_outline_color @grey_65;
-@define-color filmstrip_bg_color @darkroom_bg_color;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
 @define-color graph_bg @grey_25;

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -87,11 +87,9 @@
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_35;
 @define-color thumbnail_bg_color @grey_70;
 @define-color thumbnail_infos_color @grey_45;
-@define-color thumbnail_selected_bg_color @grey_80;
-@define-color thumbnail_hover_bg_color @grey_85;
+@define-color thumbnail_selected_bg_color @grey_85;
 @define-color thumbnail_hover_fg_color @grey_70;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
@@ -124,3 +122,12 @@ menuitem arrow
 {
   color: shade(@plugin_fg_color, 0.8);
 }
+
+.dt_overlays_always #thumb_main:selected #thumb_star:active,
+.dt_overlays_always_extended #thumb_main:selected #thumb_star:active,
+.dt_overlays_mixed #thumb_main:selected #thumb_star:active
+{
+  color: @bauhaus_fg_hover;
+  background-color: @thumbnail_hover_fg_color;
+}
+

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -87,24 +87,19 @@
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_80;
+@define-color thumbnail_font_color @grey_35;
 @define-color thumbnail_bg_color @grey_70;
-@define-color thumbnail_outline_color @grey_80;
-@define-color thumbnail_selected_font_color @grey_80;
-@define-color thumbnail_selected_bg_color @grey_90;
-@define-color thumbnail_selected_outline_color @grey_60;
-@define-color thumbnail_hover_font_color @grey_55;
+@define-color thumbnail_infos_color @grey_45;
+@define-color thumbnail_selected_bg_color @grey_80;
 @define-color thumbnail_hover_bg_color @grey_85;
 @define-color thumbnail_hover_fg_color @grey_70;
-@define-color thumbnail_hover_outline_color @grey_60;
-@define-color filmstrip_bg_color @darkroom_bg_color;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
 @define-color graph_bg @grey_40;
 @define-color graph_border @grey_15;
 @define-color graph_fg @grey_100;
 @define-color graph_fg_active @grey_95;
-@define-color graph_grid @grey_35;
+@define-color graph_grid @grey_30;
 @define-color inset_histogram alpha(@grey_95, 0.50);
 
 menu,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -128,17 +128,13 @@
 @define-color lighttable_bg_font_color @grey_75;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_50;
+@define-color thumbnail_font_color @grey_50; /* overlay and extension name hover text color */
 @define-color thumbnail_bg_color @grey_40;
 @define-color thumbnail_bg50_color @grey_100;
-@define-color thumbnail_outline_color @grey_50;
-@define-color thumbnail_selected_font_color @grey_50;
-@define-color thumbnail_selected_bg_color @grey_60;
-@define-color thumbnail_selected_outline_color @grey_50;
-@define-color thumbnail_hover_font_color @grey_50;
-@define-color thumbnail_hover_bg_color @grey_80;
+@define-color thumbnail_infos_color @grey_60; /* buttons and metadata text color on thumbnails */
+@define-color thumbnail_selected_bg_color @grey_75;
+@define-color thumbnail_hover_bg_color @grey_85;
 @define-color thumbnail_hover_fg_color @grey_70;
-@define-color thumbnail_hover_outline_color @grey_50;
 @define-color thumbnail_custom_metadata_bg_color alpha(black, 0.4);
 @define-color thumbnail_custom_metadata_fg_color @grey_80;
 @define-color filmstrip_bg_color @darkroom_bg_color;
@@ -288,9 +284,8 @@ box *
   padding: 0.75em;
 }
 
-#module-header
+#module-header  /* module name */
 {
-  /* module name */
   padding: 0.5em 0.5em 0.25em 0.5em;
 }
 
@@ -491,11 +486,7 @@ textview
   margin: 12pt 0 6pt 0;
 }
 
-/* Special modules */
-
-#lib-modulelist
-{
-}
+/* Special modules: search and image infos ones */
 
 #search-box
 {
@@ -661,7 +652,7 @@ menuitem check
   margin-right: 5px;
 }
 
-/* header and footer combobox */
+/* Header and footer combobox */
 #header-toolbar combobox,
 #footer-toolbar combobox
 {
@@ -845,7 +836,7 @@ notebook header /* add space between notebook tabs and options below */
   color: @bauhaus_fg;
 }
 
-/* separator */
+/* Separator */
 
 separator
 {
@@ -861,7 +852,7 @@ separator:hover
   color: @button_border;
 }
 
-/* empty space at top/bottom of sidepanels when scrolled */
+/* Empty space at top/bottom of sidepanels when scrolled */
 undershoot,
 undershoot.top,
 undershoot.bottom,
@@ -877,16 +868,7 @@ overshoot.right
   border:none;
 }
 
-
-/* Rating stars in lighttable */
-#lib-rating-stars
-{
-  min-height: 1em;
-  min-width: 9em;
-  margin-right: 1em;
-}
-
-/* Special modules */
+/* Special modules: navigation one */
 #navigation-module
 {
   background-color: @graph_bg;
@@ -901,13 +883,13 @@ overshoot.right
   margin: 2px 0;
 }
 
-/* entries options */
+/* Entries options */
 entry
 {
   margin: 2px 0;
 }
 
-#left #lib-plugin-ui entry /* This will avoid have too much height on entry items in filter collections modules */
+#left #lib-plugin-ui entry /* This will avoid having too much height on entry items in filter collections modules */
 {
   padding: 0px;
   margin: 8px 0px;
@@ -925,7 +907,7 @@ entry
   padding: 1px;
 }
 
-/* checkbutton check state */
+/* Checkbutton check state */
 #lib-plugin-ui checkbutton check,
 #iop-plugin-ui checkbutton check,
 checkbutton:not(#import_metadata) check
@@ -933,19 +915,19 @@ checkbutton:not(#import_metadata) check
   margin: 5px 8px 5px 0;
 }
 
-/* arrow size of dropdown button arrow on filter collection */
+/* Arrow size of dropdown button arrow on filter collection */
 #left #lib-plugin-ui #dt-button
 {
   padding: 0px;
 }
 
-/* arrow size of some buttons on darkroom modules */
+/* Arrow size of some buttons on darkroom modules */
 #iop-plugin-ui #dt-button
 {
   padding: 2px;
 }
 
-/* choose below spacing between history items in darkroom */
+/* Choose below spacing between history items in darkroom */
 #left #history-button,
 #left #history-button-enabled,
 #left #history-switch,
@@ -961,7 +943,7 @@ checkbutton:not(#import_metadata) check
   margin: 0px 1px 1px 1px;
 }
 
-/* then font size */
+/* Then font size */
 #left #history-switch-always-enabled,
 #left #history-switch-default-enabled,
 #left #history-switch,
@@ -975,7 +957,7 @@ checkbutton:not(#import_metadata) check
   font-size: 0.5em;
 }
 
-/* other stuff */
+/* Other stuff */
 #iop-bottom-bar
 {
     min-height: 1.2em;
@@ -988,7 +970,7 @@ combobox label
 
 /* STUFF TO MERGE WITH ABOVE RULES */
 
-/* about darktable dialog popup */
+/* About darktable dialog popup */
 aboutdialog,
 aboutdialog box,
 aboutdialog box *
@@ -1001,7 +983,7 @@ aboutdialog headerbar
   padding: 2px;
 }
 
-/* progress bar on bottom left side when exporting, importing, etc... */
+/* Progress bar on bottom left side when exporting, importing, etc... */
 progressbar *
 {
   background-color: @text_color;
@@ -1017,7 +999,7 @@ progressbar progress
   background-color: @fg_color;
 }
 
-/* filechooser sidebar options */
+/* Filechooser sidebar options */
 filechooser sidebar-icon
 {
   padding: 0px 5px 0px 10px;
@@ -1028,7 +1010,7 @@ filechooser sidebar-row
   padding-top: 3px;
 }
 
-/* other stuff */
+/* Other stuff */
 cell:selected
 {
   background-color: shade(@selected_bg_color, 1.2);
@@ -1127,7 +1109,7 @@ cell:selected
 /* Pseudo-classes : need to be defined last to not be overwritten */
 /* All states options are designed below, active, hover, selected, disabled and check states */
 
-/* main states */
+/* Main states */
 * button:selected,
 * button:active,
 * button:checked,
@@ -1197,6 +1179,7 @@ combobox window *:hover,
 #lib-plugin-ui #control-button:hover,
 #right #iop-plugin-ui #control-button:hover,
 #control-button:hover,
+radiobutton:hover label,
 #view_label:hover,
 #view_dropdown menuitem:hover,
 #view_dropdown:hover
@@ -1314,7 +1297,7 @@ filechooser checkbutton:checked
   color: @disabled_fg_color;
 }
 
-/* sliders states */
+/* Sliders states */
 #bauhaus-popup:hover,
 #bauhaus-combobox:hover,
 #bauhaus-slider:hover
@@ -1334,7 +1317,7 @@ filechooser checkbutton:checked
   color: @plugin_bg;
 }
 
-/* notebooks states */
+/* Notebooks states */
 notebook tab:hover
 {
   border-bottom: 2px solid @button_hover_fg;
@@ -1358,7 +1341,7 @@ notebook tab:checked label
   color: @button_checked_fg;
 }
 
-/* entries states */
+/* Entries states */
 entry:hover
 {
   color: @field_hover_fg;
@@ -1380,7 +1363,7 @@ textview text selection
   background-color: @field_selected_bg;
 }
 
-/* scrollbars hover state */
+/* Scrollbars hover state */
 scrollbar.horizontal slider:hover,
 scrollbar.vertical slider:hover,
 #iop-plugin-ui scrollbar slider:hover,
@@ -1391,7 +1374,7 @@ scale contents trough slider:hover
   background-color: @scroll_bar_active;
 }
 
-/* color picker visibility for levels and rgb levels modules, be careful to not change that unless you really now what you do */
+/* Color picker visibility for levels and rgb levels modules, be careful to not change that unless you really now what you do */
 
 #picker-black
 {
@@ -1408,7 +1391,7 @@ scale contents trough slider:hover
   color: @grey_100;
 }
 
-/* thumbtable css
+/* Thumbtable css part
 
 Hierachy :
 
@@ -1458,7 +1441,7 @@ Details :
     state = :active : the image is the group leader
 */
 
-/* thumbtable */
+/* Thumbtable */
 .dt_thumbtable
 {
   background-color: @lighttable_bg_color;
@@ -1471,15 +1454,18 @@ Details :
   50% {border-color: @thumbnail_bg50_color; border-width : 6px;}
   100% {border-color: @lighttable_bg_color; border-width : 2px;}
 }
+
 #thumb_back
 {
   background-color: @thumbnail_bg_color;
   border: 1px solid @lighttable_bg_color;
 }
+
 #thumb_main:selected #thumb_back
 {
   background-color: @thumbnail_selected_bg_color;
 }
+
 #thumb_main:hover #thumb_back
 {
   background-color: @thumbnail_hover_bg_color;
@@ -1515,35 +1501,33 @@ Details :
   animation-iteration-count: 3;
 }
 
-/* extension */
+/* Image extension name */
 #thumb_ext
 {
   font-weight: bold;
-  color: @thumbnail_font_color;
+  color: @thumbnail_infos_color;
 }
 #thumb_main:selected #thumb_ext
 {
-  color: @thumbnail_selected_font_color;
+  color: @thumbnail_infos_color;
 }
 #thumb_main:hover #thumb_ext
 {
-  color: @thumbnail_hover_font_color;
+  color: @thumbnail_font_color;
 }
 
-/* image */
+/* Image */
 #thumb_image
 {
   border: none;
-  margin : 4px; /* not real pixels, but percentage of the thumb size */
+  margin : 3px; /* not real pixels, but percentage of the thumb size */
 }
+
 #thumb_main:active #thumb_image
 {
   border: 2px solid @plugin_bg_color;
 }
-.dt_thumbnails_2 #thumb_image
-{
-  margin : 2px;
-}
+
 .dt_overlays_always #thumb_image,
 .dt_overlays_always_extended #thumb_image,
 .dt_overlays_mixed #thumb_image
@@ -1552,7 +1536,7 @@ Details :
   margin-bottom: 1px;
 }
 
-/* custom metadata */
+/* Custom metadata */
 #thumb_main:hover #thumb_custom_metadata_eb
 {
   background-color: @thumbnail_custom_metadata_bg_color;
@@ -1566,23 +1550,37 @@ Details :
   color: @thumbnail_custom_metadata_fg_color;
 }
 
-/* bottom area */
+/* Popover overlays options from star icon */
+
+radiobutton
+{
+  padding: 2px;
+}
+
+/* Bottom area */
 #thumb_bottom
 {
   border : 1px solid transparent; /* to not overlay thumb borders */
 }
+
 #thumb_bottom_label
 {
   border : 5px solid transparent; /* act as text margins */
   color: transparent;
-  font-weight: bold;
 }
+
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
-.dt_overlays_always_extended #thumb_bottom_label,
+.dt_overlays_always_extended #thumb_bottom_label
+{
+  color: @thumbnail_infos_color;
+}
+
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom_label
 {
-  color: @thumbnail_hover_font_color;
+  color: @thumbnail_font_color;
 }
+
 .dt_group_left #thumb_bottom
 {
   border-left-width: 2px;
@@ -1595,18 +1593,16 @@ Details :
 {
   border-right-width: 2px;
 }
-/* uncomment to see gradient under the stars. This may enhance visibility in certain cases, esp. bright images
-.dt_overlays_hover #thumb_main:hover #thumb_bottom
-{
-  background-image: linear-gradient(0deg, rgb(101, 101, 101) 0%, rgba(107, 107, 107, 0.25) 75%,rgba(127,127,127,0) 100%);
-}*/
+
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom
 {
   background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
 }
 
-/* thumbnails buttons */
+/* Thumbnails buttons */
+
+/* rating stars in lighttable */
 .dt_overlays_none .dt_thumb_btn,
 .dt_overlays_hover .dt_thumb_btn,
 .dt_overlays_hover_extended .dt_thumb_btn
@@ -1614,12 +1610,13 @@ Details :
   color: transparent;
   background-color: transparent;
 }
+
 #thumb_main:hover .dt_thumb_btn,
 .dt_overlays_always .dt_thumb_btn,
 .dt_overlays_always_extended .dt_thumb_btn,
 .dt_overlays_mixed .dt_thumb_btn
 {
-  color: @thumbnail_hover_outline_color;
+  color: @thumbnail_infos_color;
 }
 
 /* reject */
@@ -1637,8 +1634,8 @@ Details :
 .dt_overlays_always_extended #thumb_star:active,
 .dt_overlays_mixed #thumb_star:active
 {
-  color: @bauhaus_fg_hover;
-  background-color: @thumbnail_hover_outline_color;
+  color: @thumbnail_hover_bg_color;
+  background-color: @thumbnail_infos_color;
 }
 #thumb_main:hover #thumb_star:hover
 {
@@ -1683,7 +1680,7 @@ Details :
 .dt_overlays_mixed #thumb_group,
 .dt_overlays_mixed #thumb_audio
 {
-  color: @thumbnail_outline_color;
+  color: @thumbnail_infos_color;
 }
 #thumb_main:hover #thumb_group:hover,
 #thumb_main:hover #thumb_group:active,
@@ -1732,6 +1729,7 @@ Details :
   color: transparent;
 }
 
+/* Messages shown on bottom middle of the UI. For example "loading image..." or "working on..." ones */
 #log-msg
 {
   color: @log_fg_color;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -135,8 +135,6 @@
 @define-color thumbnail_selected_bg_color @grey_75;
 @define-color thumbnail_hover_bg_color @grey_85;
 @define-color thumbnail_hover_fg_color @grey_70;
-@define-color thumbnail_custom_metadata_bg_color alpha(black, 0.4);
-@define-color thumbnail_custom_metadata_fg_color @grey_80;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 @define-color culling_selected_border_color @grey_10;
 @define-color culling_filmstrip_selected_border_color @grey_10;
@@ -1523,6 +1521,11 @@ Details :
   margin : 3px; /* not real pixels, but percentage of the thumb size */
 }
 
+.dt_thumbnails_2 #thumb_image /* update consistently margins if big thumbnails (less images per row) are shown) */
+{
+  margin : 2px;
+}
+
 #thumb_main:active #thumb_image
 {
   border: 2px solid @plugin_bg_color;
@@ -1534,20 +1537,6 @@ Details :
 {
   margin-top: 1px;
   margin-bottom: 1px;
-}
-
-/* Custom metadata */
-#thumb_main:hover #thumb_custom_metadata_eb
-{
-  background-color: @thumbnail_custom_metadata_bg_color;
-}
-#thumb_custom_metadata
-{
-  color: transparent;
-}
-#thumb_main:hover #thumb_custom_metadata
-{
-  color: @thumbnail_custom_metadata_fg_color;
 }
 
 /* Popover overlays options from star icon */
@@ -1704,8 +1693,6 @@ radiobutton
 .dt_overlays_none #thumb_altered,
 .dt_overlays_none #thumb_group,
 .dt_overlays_none #thumb_audio,
-.dt_overlays_none #thumb_custom_metadata,
-.dt_overlays_none #thumb_custom_metadata_eb,
 .dt_overlays_none #thumb_main:hover #thumb_reject,
 .dt_overlays_none #thumb_main:hover #thumb_star,
 .dt_overlays_none #thumb_main:hover #thumb_colorlabels,
@@ -1713,17 +1700,13 @@ radiobutton
 .dt_overlays_none #thumb_main:hover #thumb_altered,
 .dt_overlays_none #thumb_main:hover #thumb_group,
 .dt_overlays_none #thumb_main:hover #thumb_audio,
-.dt_overlays_none #thumb_main:hover #thumb_custom_metadata,
-.dt_overlays_none #thumb_main:hover #thumb_custom_metadata_eb,
 .dt_overlays_none #thumb_reject:active,
 .dt_overlays_none #thumb_star:active,
 .dt_overlays_none #thumb_colorlabels:active,
 .dt_overlays_none #thumb_localcopy:active,
 .dt_overlays_none #thumb_altered:active,
 .dt_overlays_none #thumb_group:active,
-.dt_overlays_none #thumb_audio:active,
-.dt_overlays_none #thumb_custom_metadata:active,
-.dt_overlays_none #thumb_custom_metadata_eb:active
+.dt_overlays_none #thumb_audio:active
 {
   background-color: transparent;
   color: transparent;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -128,13 +128,13 @@
 @define-color lighttable_bg_font_color @grey_75;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_50; /* overlay and extension name hover text color */
+@define-color thumbnail_font_color @grey_35; /* overlay and extension name hover text color */
 @define-color thumbnail_bg_color @grey_40;
 @define-color thumbnail_bg50_color @grey_100;
-@define-color thumbnail_infos_color @grey_60; /* buttons and metadata text color on thumbnails */
-@define-color thumbnail_selected_bg_color @grey_75;
-@define-color thumbnail_hover_bg_color @grey_85;
-@define-color thumbnail_hover_fg_color @grey_70;
+@define-color thumbnail_infos_color @grey_70; /* buttons and metadata text color on thumbnails */
+@define-color thumbnail_selected_bg_color @grey_65;
+@define-color thumbnail_hover_bg_color @grey_90;
+@define-color thumbnail_hover_fg_color @grey_75;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 @define-color culling_selected_border_color @grey_10;
 @define-color culling_filmstrip_selected_border_color @grey_10;
@@ -1502,7 +1502,6 @@ Details :
 /* Image extension name */
 #thumb_ext
 {
-  font-weight: bold;
   color: @thumbnail_infos_color;
 }
 #thumb_main:selected #thumb_ext
@@ -1565,6 +1564,8 @@ radiobutton
 }
 
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
+.dt_overlays_always_extended #thumb_main:hover #thumb_bottom_label,
+.dt_overlays_always_extended #thumb_main:selected #thumb_bottom_label,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom_label
 {
   color: @thumbnail_font_color;
@@ -1600,12 +1601,20 @@ radiobutton
   background-color: transparent;
 }
 
-#thumb_main:hover .dt_thumb_btn,
 .dt_overlays_always .dt_thumb_btn,
 .dt_overlays_always_extended .dt_thumb_btn,
 .dt_overlays_mixed .dt_thumb_btn
 {
   color: @thumbnail_infos_color;
+}
+
+#thumb_main:hover .dt_thumb_btn,
+.dt_overlays_always_extended #thumb_main:hover .dt_thumb_btn,
+.dt_overlays_always #thumb_main:selected .dt_thumb_btn,
+.dt_overlays_always_extended #thumb_main:selected .dt_thumb_btn,
+.dt_overlays_mixed #thumb_main:selected .dt_thumb_btn
+{
+  color: @thumbnail_font_color;
 }
 
 /* reject */
@@ -1621,11 +1630,15 @@ radiobutton
 #thumb_main:hover #thumb_star:active,
 .dt_overlays_always #thumb_star:active,
 .dt_overlays_always_extended #thumb_star:active,
-.dt_overlays_mixed #thumb_star:active
+.dt_overlays_mixed #thumb_star:active,
+.dt_overlays_always #thumb_main:selected #thumb_star:active,
+.dt_overlays_always_extended #thumb_main:selected #thumb_star:active,
+.dt_overlays_mixed #thumb_main:selected #thumb_star:active
 {
   color: @thumbnail_hover_bg_color;
   background-color: @thumbnail_infos_color;
 }
+
 #thumb_main:hover #thumb_star:hover
 {
   color: @bauhaus_fg_hover;


### PR DESCRIPTION
CSS lighttable rework since new overlays modes and some more:
- Improve star icon popover menu (hover effect, padding)
- Cleaning some unuseful lines and making CSS more readable by adding/improve some comments
- Bottom metadata text on thumbnails image is now normal size instead of bold (more consistent I think to the lighter darktable 3 UI)
- Remove gradient part (even if commented). Just tested with changes I made, stars are better without gradient, even on brighter images as gradient only appear under images. @AlicVB and @aurelienpierre: is it ok for you with this PR?
- Merging and renaming some things to simplify and help having a more consistent UI by tweaking just one things for similar ones (like all bottom infos and extension name or altered, group icons on thumbnails).

If someone use local copies, could he test if rendering is ok on all themes? And post here screenshot if it's not ok or suggest CSS tweak (lines 1646 to 1667)

@TurboGit: It's actually a WIP as I would like to have some feedback about that work and if all overlays modes are readable and consistent on all modes, and especially from @elstoc, @AlicVB and @aurelienpierre.. I've made some tests but that's just me and my environment.

And more on that, I'm waiting for @AlicVB feedback on that and  #4748 discussion as I removed the following lines but seems to be a bug:

```
.dt_thumbnails_2 #thumb_image
{
  margin : 2px;
}
```

Should fix #4748 