### PR TITLE
small fixes and enhancements to new overlays

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -721,7 +721,7 @@
   <dtconfig prefs="gui" section="lighttable">
     <name>plugins/lighttable/extended_pattern</name>
     <type>string</type>
-    <default>$(FILE_NAME).$(FILE_EXTENSION)$(NL)$(EXIF_EXPOSURE) f/$(EXIF_APERTURE) $(EXIF_FOCAL_LENGTH)mm ISO $(EXIF_ISO)</default>
+    <default>$(FILE_NAME).$(FILE_EXTENSION)$(NL)$(EXIF_EXPOSURE) f/$(EXIF_APERTURE) $(EXIF_FOCAL_LENGTH)mm ISO $(EXIF_ISO)$(SIDECAR_TXT)</default>
     <shortdescription>pattern for the thumbnail extended overlay text</shortdescription>
     <longdescription>see manual to know all the tags you can use.</longdescription>
   </dtconfig>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1552,20 +1552,6 @@ Details :
   margin-bottom: 1px;
 }
 
-/* custom metadata */
-#thumb_main:hover #thumb_custom_metadata_eb
-{
-  background-color: @thumbnail_custom_metadata_bg_color;
-}
-#thumb_custom_metadata
-{
-  color: transparent;
-}
-#thumb_main:hover #thumb_custom_metadata
-{
-  color: @thumbnail_custom_metadata_fg_color;
-}
-
 /* bottom area */
 #thumb_bottom
 {
@@ -1716,17 +1702,13 @@ Details :
 .dt_overlays_none #thumb_main:hover #thumb_altered,
 .dt_overlays_none #thumb_main:hover #thumb_group,
 .dt_overlays_none #thumb_main:hover #thumb_audio,
-.dt_overlays_none #thumb_main:hover #thumb_custom_metadata,
-.dt_overlays_none #thumb_main:hover #thumb_custom_metadata_eb,
 .dt_overlays_none #thumb_reject:active,
 .dt_overlays_none #thumb_star:active,
 .dt_overlays_none #thumb_colorlabels:active,
 .dt_overlays_none #thumb_localcopy:active,
 .dt_overlays_none #thumb_altered:active,
 .dt_overlays_none #thumb_group:active,
-.dt_overlays_none #thumb_audio:active,
-.dt_overlays_none #thumb_custom_metadata:active,
-.dt_overlays_none #thumb_custom_metadata_eb:active
+.dt_overlays_none #thumb_audio:active
 {
   background-color: transparent;
   color: transparent;

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -65,6 +65,8 @@ typedef struct dt_variables_data_t
 
   uint32_t tags_flags;
 
+  int flags;
+
 } dt_variables_data_t;
 
 static char *expand(dt_variables_params_t *params, char **source, char extra_stop);
@@ -130,6 +132,8 @@ static void init_expansion(dt_variables_params_t *params, gboolean iterate)
     if(!isnan(img->geoloc.longitude)) params->data->longitude = img->geoloc.longitude;
     if(!isnan(img->geoloc.latitude)) params->data->latitude = img->geoloc.latitude;
     if(!isnan(img->geoloc.elevation)) params->data->elevation = img->geoloc.elevation;
+
+    params->data->flags = img->flags;
 
     dt_image_cache_read_release(darktable.image_cache, img);
   }
@@ -311,6 +315,33 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     result = g_strdup(g_get_user_special_dir(G_USER_DIRECTORY_DESKTOP));
   else if(has_prefix(variable, "STARS"))
     result = g_strdup_printf("%d", params->data->stars);
+  else if(has_prefix(variable, "RATING_ICONS"))
+  {
+    switch(params->data->stars)
+    {
+      case -1:
+        result = g_strdup("X");
+        break;
+      case 1:
+        result = g_strdup("★");
+        break;
+      case 2:
+        result = g_strdup("★★");
+        break;
+      case 3:
+        result = g_strdup("★★★");
+        break;
+      case 4:
+        result = g_strdup("★★★★");
+        break;
+      case 5:
+        result = g_strdup("★★★★★");
+        break;
+      default:
+        result = g_strdup("");
+        break;
+    }
+  }
   else if(has_prefix(variable, "LABELS"))
   {
     // TODO: currently we concatenate all the color labels with a ',' as a separator. Maybe it's better to
@@ -424,6 +455,21 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     g_list_free_full(tags_list, g_free);
     result = g_strdup(tags);
     g_free(tags);
+  }
+  else if(has_prefix(variable, "SIDECAR_TXT") && g_strcmp0(params->jobcode, "infos") == 0
+          && (params->data->flags & DT_IMAGE_HAS_TXT))
+  {
+    char *path = dt_image_get_text_path(params->imgid);
+    if(path)
+    {
+      gchar *txt = NULL;
+      if(g_file_get_contents(path, &txt, NULL, NULL))
+      {
+        result = g_strdup_printf("\n%s", txt);
+      }
+      g_free(txt);
+      g_free(path);
+    }
   }
   else
   {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -725,7 +725,8 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     gtk_widget_set_valign(thumb->w_bottom_eb, GTK_ALIGN_END);
     gtk_widget_set_halign(thumb->w_bottom_eb, GTK_ALIGN_CENTER);
     gtk_widget_show(thumb->w_bottom_eb);
-    if(thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
+    if(thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED
+       || thumb->over == DT_THUMBNAIL_OVERLAYS_MIXED)
     {
       gchar *lb = dt_util_dstrcat(NULL, "%s", thumb->info_line);
       thumb->w_bottom = gtk_label_new(lb);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -715,50 +715,6 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
     gtk_widget_show(thumb->w_image);
     gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_main), thumb->w_image);
 
-    // custom metadata overlay from a .txt file
-    thumb->w_custom_metadata_eb = gtk_event_box_new();
-    gtk_widget_set_name(thumb->w_custom_metadata_eb, "thumb_custom_metadata_eb");
-    gtk_widget_set_valign(thumb->w_custom_metadata_eb, GTK_ALIGN_START);
-    gtk_widget_set_halign(thumb->w_custom_metadata_eb, GTK_ALIGN_START);
-    gtk_overlay_add_overlay(GTK_OVERLAY(thumb->w_main), thumb->w_custom_metadata_eb);
-    gtk_overlay_set_overlay_pass_through(GTK_OVERLAY(thumb->w_main), thumb->w_custom_metadata_eb, TRUE);
-    g_signal_connect(G_OBJECT(thumb->w_custom_metadata_eb), "enter-notify-event", G_CALLBACK(_event_box_enter_leave),
-                     thumb);
-    g_signal_connect(G_OBJECT(thumb->w_custom_metadata_eb), "leave-notify-event", G_CALLBACK(_event_box_enter_leave),
-                     thumb);
-
-    thumb->w_custom_metadata = gtk_label_new("");
-    gtk_widget_set_name(thumb->w_custom_metadata, "thumb_custom_metadata");
-    gtk_widget_set_valign(thumb->w_custom_metadata, GTK_ALIGN_START);
-    gtk_widget_set_halign(thumb->w_custom_metadata, GTK_ALIGN_START);
-    gtk_label_set_xalign(GTK_LABEL(thumb->w_custom_metadata), 0.0);
-    gtk_container_add(GTK_CONTAINER(thumb->w_custom_metadata_eb), thumb->w_custom_metadata);
-
-    if(thumb->has_txt)
-    {
-      char *path = dt_image_get_text_path(thumb->imgid);
-      if(path)
-      {
-        FILE *fd = g_fopen(path, "rb");
-        if(fd)
-        {
-          fseek(fd, 0, SEEK_END);
-          const size_t filesize = ftell(fd);
-          fseek(fd, 0, SEEK_SET);
-          char *txt = malloc(filesize);
-          if(fread(txt, 1, filesize, fd) == filesize)
-          {
-            gtk_label_set_text(GTK_LABEL(thumb->w_custom_metadata), txt);
-            gtk_widget_show(thumb->w_custom_metadata_eb);
-            gtk_widget_show(thumb->w_custom_metadata);
-          }
-          free(txt);
-          fclose(fd);
-        }
-        g_free(path);
-      }
-    }
-
     // the infos background
     thumb->w_bottom_eb = gtk_event_box_new();
     gtk_widget_set_name(thumb->w_bottom_eb, "thumb_bottom");
@@ -877,7 +833,6 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
     {
       thumb->has_audio = (img->flags & DT_IMAGE_HAS_WAV);
       thumb->has_localcopy = (img->flags & DT_IMAGE_LOCAL_COPY);
-      thumb->has_txt = (img->flags & DT_IMAGE_HAS_TXT) && dt_conf_get_bool("plugins/lighttable/draw_custom_metadata");
     }
     dt_image_cache_read_release(darktable.image_cache, img);
   }
@@ -969,16 +924,6 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   gtk_label_set_attributes(GTK_LABEL(thumb->w_ext), attrlist);
   pango_attr_list_unref(attrlist);
 
-  // custom metadata
-  gtk_widget_set_size_request(thumb->w_custom_metadata_eb, width, -1);
-  gtk_widget_set_margin_start(thumb->w_custom_metadata_eb, 0);
-  gtk_widget_set_margin_top(thumb->w_custom_metadata_eb, 0.045 * width + 3 * fsize);
-
-  gtk_widget_set_margin_start(thumb->w_custom_metadata, 0.045 * width);
-  gtk_widget_set_margin_top(thumb->w_custom_metadata, fsize);
-  gtk_widget_set_margin_bottom(thumb->w_custom_metadata, fsize);
-  gtk_widget_set_size_request(thumb->w_custom_metadata, (1.0 - 2.0 * 0.045) * width, -1);
-
   // bottom background
   if(thumb->over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED || thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED
      || thumb->over == DT_THUMBNAIL_OVERLAYS_MIXED)
@@ -988,7 +933,10 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
     pango_attr_list_insert(attrlist, attr);
     gtk_label_set_attributes(GTK_LABEL(thumb->w_bottom), attrlist);
     pango_attr_list_unref(attrlist);
-    gtk_widget_set_size_request(thumb->w_bottom, width, 8.0 * r1);
+    int w = 0;
+    int h = 0;
+    pango_layout_get_pixel_size(gtk_label_get_layout(GTK_LABEL(thumb->w_bottom)), &w, &h);
+    gtk_widget_set_size_request(thumb->w_bottom, width, 4.0 * r1 + h);
   }
   else
     gtk_widget_set_size_request(thumb->w_bottom, width, 4.0 * r1);
@@ -1065,7 +1013,6 @@ void dt_thumbnail_set_mouseover(dt_thumbnail_t *thumb, gboolean over)
   if(!thumb->mouse_over)
   {
     _set_flag(thumb->w_bottom_eb, GTK_STATE_FLAG_PRELIGHT, FALSE);
-    _set_flag(thumb->w_custom_metadata_eb, GTK_STATE_FLAG_PRELIGHT, FALSE);
   }
   gtk_widget_queue_draw(thumb->w_main);
 }

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -64,7 +64,6 @@ typedef struct
   gchar info_line[256];
   gboolean is_altered;
   gboolean has_audio;
-  gboolean has_txt;
   gboolean is_grouped;
   gboolean is_bw;
   gboolean is_hdr;
@@ -75,8 +74,6 @@ typedef struct
   GtkWidget *w_main;               // GtkOverlay -- contains all others widgets
   GtkWidget *w_back;               // GtkEventBox -- thumbnail background
   GtkWidget *w_ext;                // GtkLabel -- thumbnail extension
-  GtkWidget *w_custom_metadata_eb; // GtkEventBox -- container for label to make it draw properly
-  GtkWidget *w_custom_metadata;    // GtkLabel -- overlay of .txt file
 
   GtkWidget *w_image;        // GtkDrawingArea -- thumbnail image
   GtkBorder *img_margin;     // in percentage of the main widget size

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -77,10 +77,9 @@ static int _thumbs_get_prefs_size(dt_thumbtable_t *table)
     if(table->thumb_size < s) break;
     i++;
   }
-  table->prefs_size = i;
   g_strfreev(ts);
   g_free(txt);
-  return table->prefs_size;
+  return i;
 }
 
 // update thumbtable class and overlays mode, depending on size categorie

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -160,6 +160,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* create the "show/hide overlays" button */
   d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT, NULL);
+  gtk_widget_set_tooltip_text(d->overlays_button, _("click to change the type of overlays shown on thumbnails"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->overlays_button, FALSE, FALSE, 0);
   d->over_popup = gtk_popover_new(d->overlays_button);
   gtk_widget_set_size_request(d->over_popup, 350, -1);


### PR DESCRIPTION
fix #4757, fix #4758

This content : 
- fix `dt_thumbnail_???` css class that wasn't set correctly
- add a tooltip to the overlays icon
- fix the extended content with overlays mixed and new thumbs
- fix extended text height if content is different from 2 lines
- add 2 new variables for patterns : `$(RATING_ICONS)` to show reject/stars icons with utf8 chars like in the filter dropdown and `$(SIDECAR_TXT)` to display the content of a sidecar txt file if any. This last one as been added by default to the "extended" pattern, knowing that nothing will be written if no sidecar is present. This replace the specific overlay used actually.