### PR TITLE
RGB parade as histogram alternative

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1843,12 +1843,35 @@
     <name>plugins/darkroom/histogram/mode</name>
     <type>
       <enum>
-        <option>linear</option>
-        <option>logarithmic</option>
+	<option>histogram</option>
         <option>waveform</option>
       </enum>
     </type>
+    <default>histogram</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/histogram/histogram</name>
+    <type>
+      <enum>
+	<option>logarithmic</option>
+        <option>linear</option>
+      </enum>
+    </type>
     <default>logarithmic</default>
+    <shortdescription/>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/histogram/waveform</name>
+    <type>
+      <enum>
+	<option>overlaid</option>
+        <option>parade</option>
+      </enum>
+    </type>
+    <default>overlaid</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -47,7 +47,9 @@
 #define DT_DEV_AVERAGE_DELAY_COUNT 5
 #define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
 
-const gchar *dt_dev_histogram_type_names[DT_DEV_HISTOGRAM_N] = { "logarithmic", "linear", "waveform" };
+const gchar *dt_dev_scope_type_names[DT_DEV_SCOPE_N] = { "histogram", "waveform" };
+const gchar *dt_dev_histogram_type_names[DT_DEV_HISTOGRAM_N] = { "logarithmic", "linear" };
+const gchar *dt_dev_waveform_type_names[DT_DEV_WAVEFORM_N] = { "overlaid", "parade" };
 
 void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
@@ -83,13 +85,35 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dev->histogram_pre_tonecurve = NULL;
   dev->histogram_pre_levels = NULL;
   gchar *mode = dt_conf_get_string("plugins/darkroom/histogram/mode");
-  if(g_strcmp0(mode, "linear") == 0)
-    dev->histogram_type = DT_DEV_HISTOGRAM_LINEAR;
-  else if(g_strcmp0(mode, "logarithmic") == 0)
-    dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
+  if(g_strcmp0(mode, "histogram") == 0)
+    dev->scope_type = DT_DEV_SCOPE_HISTOGRAM;
   else if(g_strcmp0(mode, "waveform") == 0)
-    dev->histogram_type = DT_DEV_HISTOGRAM_WAVEFORM;
+    dev->scope_type = DT_DEV_SCOPE_WAVEFORM;
+  else if(g_strcmp0(mode, "linear") == 0)
+  { // update legacy conf
+    dev->scope_type = DT_DEV_SCOPE_HISTOGRAM;
+    dt_conf_set_string("plugins/darkroom/histogram/mode","histogram");
+    dt_conf_set_string("plugins/darkroom/histogram/histogram","linear");
+  }
+  else if(g_strcmp0(mode, "logarithmic") == 0)
+  { // update legacy conf
+    dev->scope_type = DT_DEV_SCOPE_HISTOGRAM;
+    dt_conf_set_string("plugins/darkroom/histogram/mode","histogram");
+    dt_conf_set_string("plugins/darkroom/histogram/histogram","logarithmic");
+  }
   g_free(mode);
+  gchar *histogram_type = dt_conf_get_string("plugins/darkroom/histogram/histogram");
+  if(g_strcmp0(histogram_type, "linear") == 0)
+    dev->histogram_type = DT_DEV_HISTOGRAM_LINEAR;
+  else if(g_strcmp0(histogram_type, "logarithmic") == 0)
+    dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
+  g_free(histogram_type);
+  gchar *waveform_type = dt_conf_get_string("plugins/darkroom/histogram/waveform");
+  if(g_strcmp0(waveform_type, "overlaid") == 0)
+    dev->waveform_type = DT_DEV_WAVEFORM_OVERLAID;
+  else if(g_strcmp0(waveform_type, "parade") == 0)
+    dev->waveform_type = DT_DEV_WAVEFORM_PARADE;
+  g_free(waveform_type);
 
   dev->forms = NULL;
   dev->form_visible = NULL;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -140,10 +140,11 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     // Hardcoded hack: histogram widget will probably be either 175 or
     // 350 pixels high depending on hidpi
     dev->histogram_waveform_height = 175;
-    // NOTE: this should be cairo_format_stride_for_width(CAIRO_FORMAT_A8, dev->histogram_waveform_width),
-    // but as mipmap widths are already reasonable, don't enforce UI things here
-    dev->histogram_waveform_stride = dev->histogram_waveform_width;
-    dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride * 3, sizeof(uint8_t));
+    // making the stride work for cairo muddles UI and underlying
+    // data, and mipmap widths should already reasonable, but better
+    // to be safe, and the histogram is for the sake of UI, after all
+    dev->histogram_waveform_stride = cairo_format_stride_for_width(CAIRO_FORMAT_A8, dev->histogram_waveform_width);
+    dev->histogram_waveform = calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride * 3, sizeof(uint8_t));
   }
 
   dev->iop_instance = 0;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -48,8 +48,6 @@
 #define DT_IOP_ORDER_INFO (darktable.unmuted & DT_DEBUG_IOPORDER)
 
 const gchar *dt_dev_scope_type_names[DT_DEV_SCOPE_N] = { "histogram", "waveform" };
-const gchar *dt_dev_histogram_type_names[DT_DEV_HISTOGRAM_N] = { "logarithmic", "linear" };
-const gchar *dt_dev_waveform_type_names[DT_DEV_WAVEFORM_N] = { "overlaid", "parade" };
 
 void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
@@ -108,12 +106,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(histogram_type, "logarithmic") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
-  gchar *waveform_type = dt_conf_get_string("plugins/darkroom/histogram/waveform");
-  if(g_strcmp0(waveform_type, "overlaid") == 0)
-    dev->waveform_type = DT_DEV_WAVEFORM_OVERLAID;
-  else if(g_strcmp0(waveform_type, "parade") == 0)
-    dev->waveform_type = DT_DEV_WAVEFORM_PARADE;
-  g_free(waveform_type);
 
   dev->forms = NULL;
   dev->form_visible = NULL;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -140,8 +140,10 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     // Hardcoded hack: histogram widget will probably be either 175 or
     // 350 pixels high depending on hidpi
     dev->histogram_waveform_height = 175;
-    dev->histogram_waveform_stride = 4 * dev->histogram_waveform_width;
-    dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride, sizeof(uint8_t));
+    // NOTE: this should be cairo_format_stride_for_width(CAIRO_FORMAT_A8, dev->histogram_waveform_width),
+    // but as mipmap widths are already reasonable, don't enforce UI things here
+    dev->histogram_waveform_stride = dev->histogram_waveform_width;
+    dev->histogram_waveform = (uint8_t *)calloc(dev->histogram_waveform_height * dev->histogram_waveform_stride * 3, sizeof(uint8_t));
   }
 
   dev->iop_instance = 0;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -90,13 +90,6 @@ typedef enum dt_dev_histogram_type_t
   DT_DEV_HISTOGRAM_N // needs to be the last one
 } dt_dev_histogram_type_t;
 
-typedef enum dt_dev_waveform_type_t
-{
-  DT_DEV_WAVEFORM_OVERLAID = 0,
-  DT_DEV_WAVEFORM_PARADE,
-  DT_DEV_WAVEFORM_N // needs to be the last one
-} dt_dev_waveform_type_t;
-
 typedef enum dt_dev_transform_direction_t
 {
   DT_DEV_TRANSFORM_DIR_ALL = 0,
@@ -137,8 +130,6 @@ typedef enum dt_dev_pixelpipe_display_mask_t
 } dt_dev_pixelpipe_display_mask_t;
 
 extern const gchar *dt_dev_scope_type_names[];
-extern const gchar *dt_dev_histogram_type_names[];
-extern const gchar *dt_dev_waveform_type_names[];
 
 typedef struct dt_dev_proxy_exposure_t
 {
@@ -209,7 +200,6 @@ typedef struct dt_develop_t
   uint32_t histogram_waveform_width, histogram_waveform_height, histogram_waveform_stride;
   dt_dev_scope_type_t scope_type;
   dt_dev_histogram_type_t histogram_type;
-  dt_dev_waveform_type_t waveform_type;
 
   // list of forms iop can use for masks or whatever
   GList *forms;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -76,13 +76,26 @@ typedef enum dt_dev_rawoverexposed_colorscheme_t {
   DT_DEV_RAWOVEREXPOSED_BLACK = 3
 } dt_dev_rawoverexposed_colorscheme_t;
 
+typedef enum dt_dev_scope_type_t
+{
+  DT_DEV_SCOPE_HISTOGRAM = 0,
+  DT_DEV_SCOPE_WAVEFORM,
+  DT_DEV_SCOPE_N // needs to be the last one
+} dt_dev_scope_type_t;
+
 typedef enum dt_dev_histogram_type_t
 {
   DT_DEV_HISTOGRAM_LOGARITHMIC = 0,
   DT_DEV_HISTOGRAM_LINEAR,
-  DT_DEV_HISTOGRAM_WAVEFORM,
   DT_DEV_HISTOGRAM_N // needs to be the last one
 } dt_dev_histogram_type_t;
+
+typedef enum dt_dev_waveform_type_t
+{
+  DT_DEV_WAVEFORM_OVERLAID = 0,
+  DT_DEV_WAVEFORM_PARADE,
+  DT_DEV_WAVEFORM_N // needs to be the last one
+} dt_dev_waveform_type_t;
 
 typedef enum dt_dev_transform_direction_t
 {
@@ -123,7 +136,9 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
+extern const gchar *dt_dev_scope_type_names[];
 extern const gchar *dt_dev_histogram_type_names[];
+extern const gchar *dt_dev_waveform_type_names[];
 
 typedef struct dt_dev_proxy_exposure_t
 {
@@ -192,7 +207,9 @@ typedef struct dt_develop_t
   uint32_t histogram_max, histogram_pre_tonecurve_max, histogram_pre_levels_max;
   uint8_t *histogram_waveform;
   uint32_t histogram_waveform_width, histogram_waveform_height, histogram_waveform_stride;
+  dt_dev_scope_type_t scope_type;
   dt_dev_histogram_type_t histogram_type;
+  dt_dev_waveform_type_t waveform_type;
 
   // list of forms iop can use for masks or whatever
   GList *forms;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -1012,34 +1012,30 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
   // that makes a maximum possible count of 900 in buf, while even if
   // waveform buffer is 128 (about smallest possible), bin_width is
   // 12, making max count of 10,800, still much smaller than uint16_t
-  uint16_t *buf = (uint16_t *)calloc(waveform_width * waveform_height * 3, sizeof(uint16_t));
-  memset(dev->histogram_waveform, 0, sizeof(uint8_t) * waveform_height * waveform_stride * 3);
+  uint16_t *buf = calloc(waveform_width * waveform_height * 3, sizeof(uint16_t));
+  memset(waveform, 0, sizeof(uint8_t) * waveform_height * waveform_stride * 3);
 
   // 1.0 is at 8/9 of the height!
-  const double _height = (double)(waveform_height - 1);
+  const float _height = (float)(waveform_height - 1);
 
   // count the colors into buf ...
-  // work bin-wise so omp threads won't conflict
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
   dt_omp_firstprivate(roi_in, bin_width, _height, waveform_width, input, buf) \
-  schedule(static,bin_width*64)
+  schedule(static)
 #endif
-  for(int in_x = 0; in_x < roi_in->width; in_x++)
+  for(int in_y = 0; in_y < roi_in->height; in_y++)
   {
-    const int out_x = in_x / bin_width;
-    for(int in_y = 0; in_y < roi_in->height; in_y++)
+    for(int in_x = 0; in_x < roi_in->width; in_x++)
     {
       const float *const in = input + 4 * (in_y*roi_in->width + in_x);
+      const int out_x = in_x / bin_width;
       for(int k = 0; k < 3; k++)
       {
-        const float c = in[2 - k];
-        // catch NaNs as they don't convert well to integers
-        // FIXME: skip NaN's rather than treating as 0?
-        const float v = isnan(c) ? 0.0f : c;
-        const int out_y = CLAMP(1.0 - (8.0 / 9.0) * v, 0.0, 1.0) * _height;
-        uint16_t *const out = buf + (out_x + waveform_width * out_y) * 3 + k;
-        (*out)++;
+        const float v = 1.0f - (8.0f / 9.0f) * in[2 - k];
+        // flipped from dt's CLAMPS so as to treat NaN's as 0 (NaN compares false)
+        const int out_y = (v < 1.0f ? (v > 0.0f ? v : 0.0f) : 1.0f) * _height;
+        __sync_add_and_fetch(buf + (out_x + waveform_width * out_y) * 3 + k, 1);
       }
     }
   }
@@ -1065,19 +1061,19 @@ static void _pixelpipe_final_histogram_waveform(dt_develop_t *dev, const float *
 #ifdef _OPENMP
 #pragma omp parallel for SIMD() default(none) \
   dt_omp_firstprivate(waveform_width, waveform_height, waveform_stride, buf, waveform, cache, scale, gamma) \
-  schedule(static)
+  schedule(static) collapse(2)
 #endif
   for(int k = 0; k < 3; k++)
   {
     for(int out_y = 0; out_y < waveform_height; out_y++)
     {
+      const uint16_t *const in = buf + (waveform_width * out_y) * 3 + k;
       uint8_t *const out = waveform + (waveform_stride * (waveform_height * k + out_y));
       for(int out_x = 0; out_x < waveform_width; out_x++)
       {
-        const uint16_t *const in = buf + (waveform_width * out_y + out_x) * 3;
         //mincol[k] = MIN(mincol[k], in[k]);
         //maxcol[k] = MAX(maxcol[k], in[k]);
-        const uint16_t v = in[k];
+        const uint16_t v = in[out_x * 3];
         // cache XORd result so common casees cached and cache misses are quick to find
         if(!cache[v])
         {

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -2574,7 +2574,7 @@ post_process_collect_info:
       // this HAS to be done on the float input data, otherwise we get really ugly artifacts due to rounding
       // issues when putting colors into the bins.
       // FIXME: is above comment true now that waveform is scaled via Cairo?
-      if(input && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+      if(input && dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
       {
         _pixelpipe_final_histogram_waveform(dev, (const float *const )input, &roi_in);
       }

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -32,14 +32,26 @@
 
 DT_MODULE(1)
 
+typedef enum dt_lib_histogram_highlight_t
+{
+  DT_LIB_HISTOGRAM_HIGHLIGHT_NONE = 0,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_TYPE,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_MODE,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_RED,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_GREEN,
+  DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE,
+} dt_lib_histogram_highlight_t;
+
 typedef struct dt_lib_histogram_t
 {
   float exposure, black;
   int32_t dragging;
   int32_t button_down_x, button_down_y;
-  int32_t highlight;
+  dt_lib_histogram_highlight_t highlight;
   gboolean red, green, blue;
-  float mode_x, red_x, green_x, blue_x;
+  float type_x, mode_x, red_x, green_x, blue_x;
   float button_w, button_h, button_y, button_spacing;
 } dt_lib_histogram_t;
 
@@ -89,7 +101,7 @@ static void _draw_color_toggle(cairo_t *cr, float x, float y, float width, float
   cairo_stroke(cr);
 }
 
-static void _draw_mode_toggle(cairo_t *cr, float x, float y, float width, float height, int type)
+static void _draw_type_toggle(cairo_t *cr, float x, float y, float width, float height, int type)
 {
   cairo_save(cr);
   cairo_translate(cr, x, y);
@@ -108,6 +120,66 @@ static void _draw_mode_toggle(cairo_t *cr, float x, float y, float width, float 
   cairo_move_to(cr, 2.0 * border, height - 2.0 * border);
   switch(type)
   {
+    case DT_DEV_SCOPE_HISTOGRAM:
+      // FIXME: draw a wavey histogram arc
+      cairo_line_to(cr, width - 2.0 * border, 2.0 * border);
+      cairo_stroke(cr);
+      break;
+    case DT_DEV_SCOPE_WAVEFORM:
+    {
+      cairo_pattern_t *pattern;
+      pattern = cairo_pattern_create_linear(0.0, 1.5 * border, 0.0, height - 3.0 * border);
+
+      cairo_pattern_add_color_stop_rgba(pattern, 0.0, 0.0, 0.0, 0.0, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 0.2, 0.2, 0.2, 0.2, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 0.5, 1.0, 1.0, 1.0, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 0.6, 1.0, 1.0, 1.0, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 1.0, 0.2, 0.2, 0.2, 0.5);
+
+      cairo_rectangle(cr, 1.5 * border, 1.5 * border, (width - 3.0 * border) * 0.3, height - 3.0 * border);
+      cairo_set_source(cr, pattern);
+      cairo_fill(cr);
+
+      cairo_save(cr);
+      cairo_scale(cr, 1, -1);
+      cairo_translate(cr, 0, -height);
+      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.2, 1.5 * border,
+                      (width - 3.0 * border) * 0.6, height - 3.0 * border);
+      cairo_set_source(cr, pattern);
+      cairo_fill(cr);
+      cairo_restore(cr);
+
+      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.7, 1.5 * border,
+                      (width - 3.0 * border) * 0.3, height - 3.0 * border);
+      cairo_set_source(cr, pattern);
+      cairo_fill(cr);
+
+      cairo_pattern_destroy(pattern);
+      break;
+    }
+  }
+  cairo_restore(cr);
+}
+
+static void _draw_histogram_mode_toggle(cairo_t *cr, float x, float y, float width, float height, int mode)
+{
+  cairo_save(cr);
+  cairo_translate(cr, x, y);
+
+  // border
+  const float border = MIN(width * .05, height * .05);
+  set_color(cr, darktable.bauhaus->graph_border);
+  cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
+  cairo_fill_preserve(cr);
+  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
+  cairo_set_line_width(cr, border);
+  cairo_stroke(cr);
+
+  // icon
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
+  cairo_move_to(cr, 2.0 * border, height - 2.0 * border);
+  switch(mode)
+  {
     case DT_DEV_HISTOGRAM_LINEAR:
       cairo_line_to(cr, width - 2.0 * border, 2.0 * border);
       cairo_stroke(cr);
@@ -117,8 +189,64 @@ static void _draw_mode_toggle(cairo_t *cr, float x, float y, float width, float 
                      2.0 * border);
       cairo_stroke(cr);
       break;
-    case DT_DEV_HISTOGRAM_WAVEFORM:
+  }
+  cairo_restore(cr);
+}
+
+static void _draw_waveform_mode_toggle(cairo_t *cr, float x, float y, float width, float height, int mode)
+{
+  cairo_save(cr);
+  cairo_translate(cr, x, y);
+
+  // border
+  const float border = MIN(width * .05, height * .05);
+  set_color(cr, darktable.bauhaus->graph_border);
+  cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
+  cairo_fill_preserve(cr);
+  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
+  cairo_set_line_width(cr, border);
+  cairo_stroke(cr);
+
+  // icon
+  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
+  cairo_move_to(cr, 2.0 * border, height - 2.0 * border);
+  switch(mode)
+  {
+    case DT_DEV_WAVEFORM_OVERLAID:
     {
+      cairo_pattern_t *pattern;
+      pattern = cairo_pattern_create_linear(0.0, 1.5 * border, 0.0, height - 3.0 * border);
+
+      cairo_pattern_add_color_stop_rgba(pattern, 0.0, 0.0, 0.0, 0.0, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 0.2, 0.2, 0.2, 0.2, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 0.5, 1.0, 1.0, 1.0, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 0.6, 1.0, 1.0, 1.0, 0.5);
+      cairo_pattern_add_color_stop_rgba(pattern, 1.0, 0.2, 0.2, 0.2, 0.5);
+
+      cairo_rectangle(cr, 1.5 * border, 1.5 * border, (width - 3.0 * border) * 0.3, height - 3.0 * border);
+      cairo_set_source(cr, pattern);
+      cairo_fill(cr);
+
+      cairo_save(cr);
+      cairo_scale(cr, 1, -1);
+      cairo_translate(cr, 0, -height);
+      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.2, 1.5 * border,
+                      (width - 3.0 * border) * 0.6, height - 3.0 * border);
+      cairo_set_source(cr, pattern);
+      cairo_fill(cr);
+      cairo_restore(cr);
+
+      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.7, 1.5 * border,
+                      (width - 3.0 * border) * 0.3, height - 3.0 * border);
+      cairo_set_source(cr, pattern);
+      cairo_fill(cr);
+
+      cairo_pattern_destroy(pattern);
+      break;
+    }
+    case DT_DEV_WAVEFORM_PARADE:
+    {
+      // FIXME: make parade pattern
       cairo_pattern_t *pattern;
       pattern = cairo_pattern_create_linear(0.0, 1.5 * border, 0.0, height - 3.0 * border);
 
@@ -170,6 +298,7 @@ static gboolean _lib_histogram_configure_callback(GtkWidget *widget, GdkEventCon
   d->green_x = d->blue_x - offset;
   d->red_x = d->green_x - offset;
   d->mode_x = d->red_x - offset;
+  d->type_x = d->mode_x - offset;
 
   return TRUE;
 }
@@ -189,14 +318,14 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   const int waveform_width = dev->histogram_waveform_width;
   const int waveform_height = dev->histogram_waveform_height;
   const gint waveform_stride = dev->histogram_waveform_stride;
-  const size_t histsize = dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM
+  const size_t histsize = dev->scope_type == DT_DEV_SCOPE_WAVEFORM
                             ? sizeof(uint8_t) * waveform_height * waveform_stride
                             : 256 * 4 * sizeof(uint32_t); // histogram size is hardcoded :(
   void *buf = malloc(histsize);
 
   if(buf)
   {
-    if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+    if(dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
       memcpy(buf, dev->histogram_waveform, histsize);
     else
       memcpy(buf, dev->histogram, histsize);
@@ -221,19 +350,19 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   cairo_restore(cr);
 
   // exposure change regions
-  if(d->highlight == 1)
+  if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT)
   {
     cairo_set_source_rgb(cr, .5, .5, .5);
-    if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+    if(dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
       cairo_rectangle(cr, 0, 7.0/9.0 * height, width, height);
     else
       cairo_rectangle(cr, 0, 0, 0.2 * width, height);
     cairo_fill(cr);
   }
-  else if(d->highlight == 2)
+  else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
   {
     cairo_set_source_rgb(cr, .5, .5, .5);
-    if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+    if(dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
       cairo_rectangle(cr, 0, 0, width, 7.0/9.0 * height);
     else
       cairo_rectangle(cr, 0.2 * width, 0, width, height);
@@ -243,7 +372,7 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   // draw grid
   set_color(cr, darktable.bauhaus->graph_grid);
 
-  if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+  if(dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
     dt_draw_waveform_lines(cr, 0, 0, width, height);
   else
     dt_draw_grid(cr, 4, 0, 0, width, height);
@@ -252,7 +381,7 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   if(dev->image_storage.id == dev->preview_pipe->output_imgid)
   {
     cairo_save(cr);
-    if(dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+    if(dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
     {
       uint8_t *hist_wav = buf;
       // make the color channel selector work:
@@ -304,9 +433,20 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   }
 
   // buttons to control the display of the histogram: linear/log, r, g, b
-  if(d->highlight != 0)
+  if(d->highlight != DT_LIB_HISTOGRAM_HIGHLIGHT_NONE)
   {
-    _draw_mode_toggle(cr, d->mode_x, d->button_y, d->button_w, d->button_h, dev->histogram_type);
+    _draw_type_toggle(cr, d->type_x, d->button_y, d->button_w, d->button_h, dev->scope_type);
+    switch(dev->scope_type)
+    {
+      case DT_DEV_SCOPE_HISTOGRAM:
+        _draw_histogram_mode_toggle(cr, d->mode_x, d->button_y, d->button_w, d->button_h, dev->histogram_type);
+        break;
+      case DT_DEV_SCOPE_WAVEFORM:
+        _draw_waveform_mode_toggle(cr, d->mode_x, d->button_y, d->button_w, d->button_h, dev->waveform_type);
+        break;
+      case DT_DEV_SCOPE_N:
+        g_assert_not_reached();
+    }
     cairo_set_source_rgba(cr, 1.0, 0.0, 0.0, 0.33);
     _draw_color_toggle(cr, d->red_x, d->button_y, d->button_w, d->button_h, d->red);
     cairo_set_source_rgba(cr, 0.0, 1.0, 0.0, 0.33);
@@ -333,7 +473,7 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
   dt_develop_t *dev = darktable.develop;
 
   /* check if exposure hooks are available */
-  const gboolean hooks_available = dt_dev_exposure_hooks_available(darktable.develop);
+  const gboolean hooks_available = dt_dev_exposure_hooks_available(dev);
 
   if(!hooks_available) return TRUE;
 
@@ -341,19 +481,19 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
   gtk_widget_get_allocation(widget, &allocation);
   if(d->dragging)
   {
-    const float diff = dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM ? d->button_down_y - event->y
-                                                                        : event->x - d->button_down_x;
-    const int range = dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM ? allocation.height
-                                                                       : allocation.width;
-    if (d->highlight == 2)
+    const float diff = dev->scope_type == DT_DEV_SCOPE_WAVEFORM ? d->button_down_y - event->y
+                                                                : event->x - d->button_down_x;
+    const int range = dev->scope_type == DT_DEV_SCOPE_WAVEFORM ? allocation.height
+                                                               : allocation.width;
+    if (d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
     {
       const float exposure = d->exposure + diff * 4.0f / (float)range;
-      dt_dev_exposure_set_exposure(darktable.develop, exposure);
+      dt_dev_exposure_set_exposure(dev, exposure);
     }
-    else if(d->highlight == 1)
+    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT)
     {
       const float black = d->black - diff * .1f / (float)range;
-      dt_dev_exposure_set_black(darktable.develop, black);
+      dt_dev_exposure_set_black(dev, black);
     }
   }
   else
@@ -365,49 +505,82 @@ static gboolean _lib_histogram_motion_notify_callback(GtkWidget *widget, GdkEven
 
     if(posx < 0.0f || posx > 1.0f || posy < 0.0f || posy > 1.0f)
       ;
+    // FIXME: simplify this, check for y position, and if it's in range, check for x, and set highlight, and depending on that draw tooltip
+    else if(x > d->type_x && x < d->type_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
+    {
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_TYPE;
+      switch(dev->scope_type)
+      {
+        case DT_DEV_SCOPE_HISTOGRAM:
+          gtk_widget_set_tooltip_text(widget, _("set mode to waveform"));
+          break;
+        case DT_DEV_SCOPE_WAVEFORM:
+          gtk_widget_set_tooltip_text(widget, _("set mode to histogram"));
+          break;
+        case DT_DEV_SCOPE_N:
+          g_assert_not_reached();
+      }
+    }
     else if(x > d->mode_x && x < d->mode_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
     {
-      d->highlight = 3;
-      switch(dev->histogram_type)
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_MODE;
+      switch(dev->scope_type)
       {
-        case DT_DEV_HISTOGRAM_LOGARITHMIC:
-          gtk_widget_set_tooltip_text(widget, _("set histogram mode to linear"));
+        case DT_DEV_SCOPE_HISTOGRAM:
+          switch(dev->histogram_type)
+          {
+            case DT_DEV_HISTOGRAM_LOGARITHMIC:
+              gtk_widget_set_tooltip_text(widget, _("set mode to linear"));
+              break;
+            case DT_DEV_HISTOGRAM_LINEAR:
+              gtk_widget_set_tooltip_text(widget, _("set mode to waveform"));
+              break;
+            default:
+              g_assert_not_reached();
+          }
           break;
-        case DT_DEV_HISTOGRAM_LINEAR:
-          gtk_widget_set_tooltip_text(widget, _("set histogram mode to waveform"));
+        case DT_DEV_SCOPE_WAVEFORM:
+          switch(dev->waveform_type)
+          {
+            case DT_DEV_WAVEFORM_OVERLAID:
+              gtk_widget_set_tooltip_text(widget, _("set mode to RGB parade"));
+              break;
+            case DT_DEV_WAVEFORM_PARADE:
+              gtk_widget_set_tooltip_text(widget, _("set mode to waveform"));
+              break;
+            default:
+              g_assert_not_reached();
+          }
           break;
-        case DT_DEV_HISTOGRAM_WAVEFORM:
-          gtk_widget_set_tooltip_text(widget, _("set histogram mode to logarithmic"));
-          break;
-        case DT_DEV_HISTOGRAM_N:
+        case DT_DEV_SCOPE_N:
           g_assert_not_reached();
       }
     }
     else if(x > d->red_x && x < d->red_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
     {
-      d->highlight = 4;
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_RED;
       gtk_widget_set_tooltip_text(widget, d->red ? _("click to hide red channel") : _("click to show red channel"));
     }
     else if(x > d->green_x && x < d->green_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
     {
-      d->highlight = 5;
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_GREEN;
       gtk_widget_set_tooltip_text(widget, d->red ? _("click to hide green channel")
                                                  : _("click to show green channel"));
     }
     else if(x > d->blue_x && x < d->blue_x + d->button_w && y > d->button_y && y < d->button_y + d->button_h)
     {
-      d->highlight = 6;
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE;
       gtk_widget_set_tooltip_text(widget, d->red ? _("click to hide blue channel") : _("click to show blue channel"));
     }
-    else if((posx < 0.2f && dev->histogram_type != DT_DEV_HISTOGRAM_WAVEFORM) ||
-            (posy > 7.0f/9.0f && dev->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM))
+    else if((posx < 0.2f && dev->scope_type == DT_DEV_SCOPE_HISTOGRAM) ||
+            (posy > 7.0f/9.0f && dev->scope_type == DT_DEV_SCOPE_WAVEFORM))
     {
-      d->highlight = 1;
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT;
       gtk_widget_set_tooltip_text(widget, _("drag to change black point,\ndoubleclick resets"));
     }
     else
     {
-      d->highlight = 2;
+      d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE;
       gtk_widget_set_tooltip_text(widget, _("drag to change exposure,\ndoubleclick resets"));
     }
     gtk_widget_queue_draw(widget);
@@ -433,41 +606,61 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
+  dt_develop_t *dev = darktable.develop;
 
   /* check if exposure hooks are available */
-  const gboolean hooks_available = dt_dev_exposure_hooks_available(darktable.develop);
+  const gboolean hooks_available = dt_dev_exposure_hooks_available(dev);
 
   if(!hooks_available) return TRUE;
 
-  if(event->type == GDK_2BUTTON_PRESS && (d->highlight == 1 || d->highlight ==2))
+  if(event->type == GDK_2BUTTON_PRESS &&
+     (d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT || d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE))
   {
-    dt_dev_exposure_reset_defaults(darktable.develop);
+    dt_dev_exposure_reset_defaults(dev);
   }
   else
   {
-    if(d->highlight == 3) // mode button
+    if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_TYPE)
     {
-      darktable.develop->histogram_type = (darktable.develop->histogram_type + 1) % DT_DEV_HISTOGRAM_N;
+      dev->scope_type = (dev->scope_type + 1) % DT_DEV_SCOPE_N;
       dt_conf_set_string("plugins/darkroom/histogram/mode",
-                         dt_dev_histogram_type_names[darktable.develop->histogram_type]);
+                         dt_dev_scope_type_names[dev->scope_type]);
       // we need to reprocess the preview pipe
       // FIXME: can we only make the regular histogram if we're drawing it? if so then reprocess the preview pipe when switch to that as well
-      if(darktable.develop->histogram_type == DT_DEV_HISTOGRAM_WAVEFORM)
+      if(dev->scope_type == DT_DEV_SCOPE_WAVEFORM)
       {
-        dt_dev_process_preview(darktable.develop);
+        dt_dev_process_preview(dev);
       }
     }
-    else if(d->highlight == 4) // red button
+    if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_MODE)
+    {
+      switch(dev->scope_type)
+      {
+        case DT_DEV_SCOPE_HISTOGRAM:
+          dev->histogram_type = (dev->histogram_type + 1) % DT_DEV_HISTOGRAM_N;
+          dt_conf_set_string("plugins/darkroom/histogram/histogram",
+                             dt_dev_histogram_type_names[dev->histogram_type]);
+          break;
+        case DT_DEV_SCOPE_WAVEFORM:
+          dev->waveform_type = (dev->waveform_type + 1) % DT_DEV_WAVEFORM_N;
+          dt_conf_set_string("plugins/darkroom/histogram/waveform",
+                             dt_dev_waveform_type_names[dev->waveform_type]);
+          break;
+        case DT_DEV_SCOPE_N:
+          g_assert_not_reached();
+      }
+    }
+    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_RED)
     {
       d->red = !d->red;
       dt_conf_set_bool("plugins/darkroom/histogram/show_red", d->red);
     }
-    else if(d->highlight == 5) // green button
+    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_GREEN)
     {
       d->green = !d->green;
       dt_conf_set_bool("plugins/darkroom/histogram/show_green", d->green);
     }
-    else if(d->highlight == 6) // blue button
+    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE)
     {
       d->blue = !d->blue;
       dt_conf_set_bool("plugins/darkroom/histogram/show_blue", d->blue);
@@ -476,9 +669,15 @@ static gboolean _lib_histogram_button_press_callback(GtkWidget *widget, GdkEvent
     {
       d->dragging = 1;
 
-      if(d->highlight == 2) d->exposure = dt_dev_exposure_get_exposure(darktable.develop);
+      if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
+      {
+        d->exposure = dt_dev_exposure_get_exposure(dev);
+      }
 
-      if(d->highlight == 1) d->black = dt_dev_exposure_get_black(darktable.develop);
+      if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLUE)
+      {
+        d->black = dt_dev_exposure_get_black(dev);
+      }
 
       d->button_down_x = event->x;
       d->button_down_y = event->y;
@@ -504,9 +703,9 @@ static gboolean _lib_histogram_scroll_callback(GtkWidget *widget, GdkEventScroll
   // scroll events
   if(dt_gui_get_scroll_unit_deltas(event, NULL, &delta_y))
   {
-    if(d->highlight == 2)
+    if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_EXPOSURE)
       dt_dev_exposure_set_exposure(darktable.develop, ce - 0.15f * delta_y);
-    else if(d->highlight == 1)
+    else if(d->highlight == DT_LIB_HISTOGRAM_HIGHLIGHT_BLACK_POINT)
       dt_dev_exposure_set_black(darktable.develop, cb + 0.001f * delta_y);
   }
 
@@ -535,7 +734,7 @@ static gboolean _lib_histogram_leave_notify_callback(GtkWidget *widget, GdkEvent
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
   d->dragging = 0;
-  d->highlight = 0;
+  d->highlight = DT_LIB_HISTOGRAM_HIGHLIGHT_NONE;
   dt_control_change_cursor(GDK_LEFT_PTR);
   gtk_widget_queue_draw(widget);
   return TRUE;

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -132,9 +132,11 @@ static void _draw_type_toggle(cairo_t *cr, float x, float y, float width, float 
   switch(type)
   {
     case DT_DEV_SCOPE_HISTOGRAM:
-      // FIXME: draw a wavey histogram arc
-      cairo_line_to(cr, width - 2.0 * border, 2.0 * border);
-      cairo_stroke(cr);
+      cairo_curve_to(cr, 0.3 * width, height - 2.0 * border, 0.3 * width, 2.0 * border,
+                     0.5 * width, 2.0 * border);
+      cairo_curve_to(cr, 0.7 * width, 2.0 * border, 0.7 * width, height - 2.0 * border, 
+                     width - 2.0 * border, height - 2.0 * border);
+      cairo_fill(cr);
       break;
     case DT_DEV_SCOPE_WAVEFORM:
     {
@@ -211,84 +213,35 @@ static void _draw_waveform_mode_toggle(cairo_t *cr, float x, float y, float widt
 
   // border
   const float border = MIN(width * .05, height * .05);
-  set_color(cr, darktable.bauhaus->graph_border);
-  cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
-  cairo_fill_preserve(cr);
-  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
-  cairo_set_line_width(cr, border);
-  cairo_stroke(cr);
-
-  // icon
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
-  cairo_move_to(cr, 2.0 * border, height - 2.0 * border);
   switch(mode)
   {
     case DT_LIB_HISTOGRAM_WAVEFORM_OVERLAID:
     {
-      cairo_pattern_t *pattern;
-      pattern = cairo_pattern_create_linear(0.0, 1.5 * border, 0.0, height - 3.0 * border);
-
-      cairo_pattern_add_color_stop_rgba(pattern, 0.0, 0.0, 0.0, 0.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.2, 0.2, 0.2, 0.2, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.5, 1.0, 1.0, 1.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.6, 1.0, 1.0, 1.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 1.0, 0.2, 0.2, 0.2, 0.5);
-
-      cairo_rectangle(cr, 1.5 * border, 1.5 * border, (width - 3.0 * border) * 0.3, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
-      cairo_fill(cr);
-
-      cairo_save(cr);
-      cairo_scale(cr, 1, -1);
-      cairo_translate(cr, 0, -height);
-      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.2, 1.5 * border,
-                      (width - 3.0 * border) * 0.6, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
-      cairo_fill(cr);
-      cairo_restore(cr);
-
-      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.7, 1.5 * border,
-                      (width - 3.0 * border) * 0.3, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
-      cairo_fill(cr);
-
-      cairo_pattern_destroy(pattern);
+      cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.33);
+      cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
+      cairo_fill_preserve(cr);
       break;
     }
     case DT_LIB_HISTOGRAM_WAVEFORM_PARADE:
     {
-      // FIXME: make parade pattern
-      cairo_pattern_t *pattern;
-      pattern = cairo_pattern_create_linear(0.0, 1.5 * border, 0.0, height - 3.0 * border);
-
-      cairo_pattern_add_color_stop_rgba(pattern, 0.0, 0.0, 0.0, 0.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.2, 0.2, 0.2, 0.2, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.5, 1.0, 1.0, 1.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 0.6, 1.0, 1.0, 1.0, 0.5);
-      cairo_pattern_add_color_stop_rgba(pattern, 1.0, 0.2, 0.2, 0.2, 0.5);
-
-      cairo_rectangle(cr, 1.5 * border, 1.5 * border, (width - 3.0 * border) * 0.3, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
+      cairo_set_source_rgba(cr, 1.0, 0.0, 0.0, 0.33);
+      cairo_rectangle(cr, border, border, width / 3.0, height - 2.0 * border);
       cairo_fill(cr);
-
-      cairo_save(cr);
-      cairo_scale(cr, 1, -1);
-      cairo_translate(cr, 0, -height);
-      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.2, 1.5 * border,
-                      (width - 3.0 * border) * 0.6, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
+      cairo_set_source_rgba(cr, 0.0, 1.0, 0.0, 0.33);
+      cairo_rectangle(cr, width / 3.0, border, width / 3.0, height - 2.0 * border);
       cairo_fill(cr);
-      cairo_restore(cr);
-
-      cairo_rectangle(cr, 1.5 * border + (width - 3.0 * border) * 0.7, 1.5 * border,
-                      (width - 3.0 * border) * 0.3, height - 3.0 * border);
-      cairo_set_source(cr, pattern);
+      cairo_set_source_rgba(cr, 0.0, 0.0, 1.0, 0.33);
+      cairo_rectangle(cr, width * 2.0 / 3.0, border, width / 3.0, height - 2.0 * border);
       cairo_fill(cr);
-
-      cairo_pattern_destroy(pattern);
+      cairo_rectangle(cr, border, border, width - 2.0 * border, height - 2.0 * border);
       break;
     }
   }
+
+  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.5);
+  cairo_set_line_width(cr, border);
+  cairo_stroke(cr);
+
   cairo_restore(cr);
 }
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -285,7 +285,7 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
   const size_t histsize = dev->scope_type == DT_DEV_SCOPE_WAVEFORM
                             ? sizeof(uint8_t) * waveform_height * waveform_stride * 3
                             : 256 * 4 * sizeof(uint32_t); // histogram size is hardcoded :(
-  void *buf = malloc(histsize);
+  void *buf = dt_alloc_align(64, histsize);
 
   if(buf)
   {
@@ -352,31 +352,27 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
 
       if(d->waveform_type == DT_LIB_HISTOGRAM_WAVEFORM_OVERLAID)
       {
-        uint8_t *w = calloc(waveform_stride * waveform_height * 4, sizeof(uint8_t));
-        for(int k = 0; k < 3; k++)
-          if(mask[k])
-          {
-            uint8_t *in = hist_wav + waveform_stride * waveform_height * k;
-            for(int y = 0; y < waveform_height; ++y)
-              for(int x = 0; x < waveform_width; ++x)
-              {
-                w[(y * waveform_stride + x) * 4 + k] = in[y * waveform_stride + x];
-                // setting the alpha helps especially to make the blue channel visible
-                w[(y * waveform_stride + x) * 4 + 3] = MAX(w[(y * waveform_stride + x) * 4 + 3],in[y * waveform_stride + x]);
-              }
-          }
+        // NOTE: The nice way to do this would be to draw each color
+        // channel separately, overlaid, via cairo. Unfortunately,
+        // that is about twice as slow as compositing the channels by
+        // hand, so we do the latter, at the cost of allocating some
+        // memory here and of some extra code (and comments) and of
+        // making the color channel selector work by hand.
+        uint8_t *wf = dt_alloc_align(64, sizeof(uint8_t) * waveform_height * waveform_stride * 4);
+        for(int y = 0; y < waveform_height; y++)
+          for(int x = 0; x < waveform_width; x++)
+            for(int k = 0; k < 3; k++)
+              wf[4 * (y * waveform_stride + x) + k] = hist_wav[waveform_stride * (y + k * waveform_height) + x] * mask[k];
 
         cairo_surface_t *source
-                = cairo_image_surface_create_for_data(w, CAIRO_FORMAT_ARGB32,
-                                                      waveform_width, waveform_height, waveform_stride*4);
-        // FIXME: why don't need to think about ppd?
-        //cairo_scale(cr, darktable.gui->ppd*width/waveform_width, darktable.gui->ppd*height/waveform_height);
-        cairo_scale(cr, (double)width/waveform_width, (double)height/waveform_height);
+            = dt_cairo_image_surface_create_for_data(wf, CAIRO_FORMAT_RGB24,
+                                                     waveform_width, waveform_height, waveform_stride * 4);
+        cairo_scale(cr, darktable.gui->ppd*width/waveform_width, darktable.gui->ppd*height/waveform_height);
         cairo_set_source_surface(cr, source, 0.0, 0.0);
-        cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+        cairo_set_operator(cr, CAIRO_OPERATOR_ADD);
         cairo_paint(cr);
         cairo_surface_destroy(source);
-        free(w);
+        free(wf);
       }
       else
       { // RGB parade
@@ -391,9 +387,6 @@ static gboolean _lib_histogram_draw_callback(GtkWidget *widget, cairo_t *crf, gp
           {
             cairo_save(cr);
             cairo_set_source_rgb(cr, k==0, k==1, k==2);
-            // FIXME: useful to clip?
-            cairo_rectangle(cr, 0, 0, waveform_width, waveform_height);
-            cairo_clip(cr);
             cairo_surface_t *alpha
                 = cairo_image_surface_create_for_data(hist_wav + waveform_stride * waveform_height * (2-k),
                                                       CAIRO_FORMAT_A8, waveform_width, waveform_height, waveform_stride);


### PR DESCRIPTION
This adds RGB parade as a histogram alternative (see #4149).

To not require cycling through too many histogram types, the single button which cycled between linear/logarithmic/waveform is replaced by two buttons. One toggles between "regular" histogram and waveform-style. The other, when in histogram mode, toggles between linear and logarithmic histogram. When in waveform mode, it toggles between waveform and RGB parade.

Much of the code changes (including a new conf entry) are to allow this mode/submode switching. This will also clear the way for other modes (e.g. vectorscope) without bothering users who already don't want to see a waveform when simply want to switch between linear and logarithmic histograms. 

There are also some optimizations, particularly to histogram calculation. This PR should be equivalent speed to the code in master, for both calculating and drawing histograms. It requires 3/4 the memory to store the calculated waveform histogram, though it uses more temporary memory when drawing the waveform histogram.

