### PR TITLE
Optimization of Denoise (bilateral filter) iop

### DIFF
--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -357,7 +357,7 @@ public:
     elevated[0] = elevated[1] + 2 * position[0] * scaleFactor[0];
 
     // prepare to find the closest lattice points
-    float scale = 1.0f / (D + 1);
+    constexpr float scale = 1.0f / (D + 1);
 
     // greedily search for the closest zero-colored lattice point
     int sum = 0;
@@ -483,7 +483,7 @@ public:
    */
   void slice(float *col, size_t replay_index)
   {
-    float *base = hashTables[0].getValues();
+    const float *base = hashTables[0].getValues();
     for(int j = 0; j < VD; j++) col[j] = 0;
     for(int i = 0; i <= D; i++)
     {
@@ -501,7 +501,7 @@ public:
     // Prepare arrays
     float *newValue = new float[VD * hashTables[0].size()];
     float *oldValue = hashTables[0].getValues();
-    float *hashTableBase = oldValue;
+    const float *hashTableBase = oldValue;
 
     float zero[VD];
     for(int k = 0; k < VD; k++) zero[k] = 0;

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -501,7 +501,7 @@ public:
     // Prepare arrays
     float *newValue = new float[VD * hashTables[0].size()];
     float *oldValue = hashTables[0].getValues();
-    const float *hashTableBase = oldValue;
+    float *hashTableBase = oldValue;
 
     float zero[VD];
     for(int k = 0; k < VD; k++) zero[k] = 0;

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -526,10 +526,10 @@ public:
         neighbor1[j] = key[j] - D;
         neighbor2[j] = key[j] + D; // keys to the neighbors along the given axis.
 
-        float *oldVal = oldValue + i * VD;
+        const float *oldVal = oldValue + i * VD;
         float *newVal = newValue + i * VD;
 
-        float *vm1, *vp1;
+        const float *vm1, *vp1;
 
         vm1 = hashTables[0].lookup(neighbor1, false); // look up first neighbor
         if(vm1)

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -215,7 +215,6 @@ private:
     // Migrate the value vectors.
     Value *newValues = new Value[capacity / 2];
     std::copy(values, values + filled, newValues);
-    std::fill(newValues + filled, newValues + capacity/2, 0);
     delete[] values;
     values = newValues;
 

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -490,6 +490,7 @@ public:
     Value *newValue = new Value[hashTables[0].size()];
     Value *oldValue = hashTables[0].getValues();
     const Value *hashTableBase = oldValue;
+    const Key *keyBase = hashTables[0].getKeys();
 
     const Value zero { 0 };
 
@@ -502,10 +503,10 @@ public:
       // For each vertex in the lattice,
       for(int i = 0; i < hashTables[0].size(); i++) // blur point i in dimension j
       {
-        const Key *key = hashTables[0].getKeys() + i; // keys to current vertex
+        const Key &key = keyBase[i]; // keys to current vertex
 	// construct keys to the neighbors along the given axis.
-	Key neighbor1(*key,j,+1);
-	Key neighbor2(*key,j,-1);
+	Key neighbor1(key,j,+1);
+	Key neighbor2(key,j,-1);
 
         const Value *oldVal = oldValue + i;
 

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -55,9 +55,7 @@ public:
   // Struct for a key
   struct Key
   {
-    Key()
-    {
-    }
+    Key() = default;
     Key(const Key& origin, int dim, int direction)  // construct neighbor in dimension 'dim'
     {
        for (int i = 0; i < KD; i++) key[i] = origin.key[i] + direction;
@@ -91,9 +89,7 @@ public:
   // Struct for an associated value
   struct Value
   {
-    Value()
-    {
-    }
+    Value() = default;
     Value(int init) { for (int i = 0; i < VD; i++) { value[i] = init; } }
     Value(const Value&) = default; // let the compiler write the copy constructor
     Value& operator= (const Value&) = default;
@@ -163,8 +159,7 @@ public:
   }
 
   /* Returns the index into the hash table for a given key.
-   *     key: a pointer to the position vector.
-   *       h: hash of the position vector.
+   *     key: a reference to the position vector.
    *  create: a flag specifying whether an entry should be created,
    *          should an entry with the given key not found.
    */
@@ -200,7 +195,7 @@ public:
   }
 
   /* Looks up the value vector associated with a given key vector.
-   *        k : pointer to the key vector to be looked up.
+   *        k : reference to the key vector to be looked up.
    *   create : true if a non-existing key should be created.
    */
   Value *lookup(const Key &k, bool create = true)

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -131,8 +131,8 @@ public:
     capacity_bits = 0x7fff;
     filled = 0;
     entries = new Entry[capacity];
-    keys = new Key[capacity / 2];
-    values = new Value[capacity / 2] { 0 };
+    keys = new Key[maxFill()];
+    values = new Value[maxFill()] { 0 };
   }
 
   ~HashTablePermutohedral()
@@ -143,19 +143,24 @@ public:
   }
 
   // Returns the number of vectors stored.
-  int size()
+  int size() const
   {
     return filled;
   }
 
+  size_t maxFill() const
+  {
+    return capacity/2 ;
+  }
+
   // Returns a pointer to the keys array.
-  const Key *getKeys()
+  const Key *getKeys() const
   {
     return keys;
   }
 
   // Returns a pointer to the values array.
-  Value *getValues()
+  Value *getValues() const
   {
     return values;
   }
@@ -177,7 +182,7 @@ public:
       {
         if(!create) return -1; // Return not found.
 	// Double hash table size if necessary
-	if(filled >= (capacity / 2) - 1)
+	if(filled >= maxFill())
 	   {
 	   grow();
 	   }
@@ -206,10 +211,7 @@ public:
     return (offset < 0) ? nullptr : values + offset;
   };
 
-private:
   /* Grows the size of the hash table */
-public:
-  int maxFill() const { return capacity/2 ; }
   void grow(int order = 1)
   {
     size_t oldCapacity = capacity;
@@ -220,13 +222,13 @@ public:
     }
 
     // Migrate the value vectors.
-    Value *newValues = new Value[capacity / 2];
+    Value *newValues = new Value[maxFill()];
     std::copy(values, values + filled, newValues);
     delete[] values;
     values = newValues;
 
     // Migrate the key vectors.
-    Key *newKeys = new Key[capacity / 2];
+    Key *newKeys = new Key[maxFill()];
     std::copy(keys, keys + filled, newKeys);
     delete[] keys;
     keys = newKeys;
@@ -268,7 +270,8 @@ private:
 /******************************************************************
  * The algorithm class that performs the filter                   *
  *                                                                *
- * PermutohedralLattice::filter(...) does all the work.           *
+ * PermutohedralLattice::splat(...) and                           *
+ * PermutohedralLattic::slice() do almost all the work.           *
  *                                                                *
  ******************************************************************/
 template <int D, int VD> class PermutohedralLattice
@@ -455,7 +458,7 @@ public:
      * won't waste much space if we simply grow the destination table enough to hold the sum of the
      * entries in the individual tables
      */
-    int total_entries = hashTables[0].size();
+    size_t total_entries = hashTables[0].size();
     for(int i = 1; i < nThreads; i++)
       total_entries += hashTables[i].size();
     int order = 0;

--- a/src/iop/Permutohedral.h
+++ b/src/iop/Permutohedral.h
@@ -209,18 +209,6 @@ public:
   };
 
   /* Hash function used in this implementation. A simple base conversion. */
-  size_t hash(const short *key)
-  {
-    size_t k = 0;
-    for(int i = 0; i < KD; i++)
-    {
-      k += key[i];
-      k *= 2531011;
-    }
-    return k;
-  }
-
-  /* Hash function used in this implementation. A simple base conversion. */
   size_t hash(const Key &key)
   {
     size_t k = 0;

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -128,9 +128,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
   else if(rad <= 6)
   {
-    float *in = (float *)ivoid;
-    float *out = (float *)ovoid;
-
     static const size_t weights_size = 2 * (6 + 1) * 2 * (6 + 1);
     float mat[weights_size];
     const int wd = 2 * rad + 1;
@@ -151,13 +148,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #pragma omp parallel for default(none) \
     dt_omp_firstprivate(ch, ivoid, ovoid, rad, roi_in, roi_out, wd, weights_buf) \
     shared(m, mat, isig2col) \
-    private(in, out) \
     schedule(static)
 #endif
     for(int j = rad; j < roi_out->height - rad; j++)
     {
-      in = ((float *)ivoid) + ch * ((size_t)j * roi_in->width + rad);
-      out = ((float *)ovoid) + ch * ((size_t)j * roi_out->width + rad);
+      const float *in = ((float *)ivoid) + ch * ((size_t)j * roi_in->width + rad);
+      float *out = ((float *)ovoid) + ch * ((size_t)j * roi_out->width + rad);
       float *weights = weights_buf + weights_size * dt_get_thread_num();
       float *w = weights + rad * wd + rad;
       float sumw;
@@ -167,7 +163,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         for(int l = -rad; l <= rad; l++)
           for(int k = -rad; k <= rad; k++)
           {
-            float *inp = in + ch * (l * roi_in->width + k);
+	    const float *inp = in + ch * (l * roi_in->width + k);
             sumw += w[l * wd + k] = m[l * wd + k]
                                     * expf(-((in[0] - inp[0]) * (in[0] - inp[0]) * isig2col[0]
                                              + (in[1] - inp[1]) * (in[1] - inp[1]) * isig2col[1]
@@ -179,7 +175,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         for(int l = -rad; l <= rad; l++)
           for(int k = -rad; k <= rad; k++)
           {
-            float *inp = in + ch * ((size_t)l * roi_in->width + k);
+            const float *inp = in + ch * ((size_t)l * roi_in->width + k);
             float pix_weight = w[(size_t)l * wd + k];
             for(int c = 0; c < 3; c++) out[c] += inp[c] * pix_weight;
           }
@@ -199,8 +195,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
              ((float *)ivoid) + (size_t)ch * j * roi_in->width, (size_t)ch * sizeof(float) * roi_out->width);
     for(int j = rad; j < roi_out->height - rad; j++)
     {
-      in = ((float *)ivoid) + (size_t)ch * roi_out->width * j;
-      out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
+      const float *in = ((float *)ivoid) + (size_t)ch * roi_out->width * j;
+      float *out = ((float *)ovoid) + (size_t)ch * roi_out->width * j;
       for(int i = 0; i < rad; i++)
         for(int c = 0; c < 3; c++) out[ch * i + c] = in[ch * i + c];
       for(int i = roi_out->width - rad; i < roi_out->width; i++)


### PR DESCRIPTION
After finding that Bilateral spends a long time running on only one core in my new 32-core setup when using low(ish) values for blur amount and radius, I dived into the code and optimized it.  The long single-threaded processing was merging multiple hash tables into one, which triggered repeated expensive resize operations.  Optimizations include caching hash values for keys, eliminating the multiple resizes by adaptively resizing to slightly more than the eventual size before starting the merge, and eliminating redundant data (saving 20 bytes per pixel).

When checking into the required final size of the merged hash table, I found that relatively few keys were common between the tables participating in the merge, so simply resizing the destination table to have capacity to store the sum of the sizes will usually result in a table of exactly the size it would have reached through multiple on-demand resizes (since size is always a power of two).

Fixes #4764