### PR TITLE
Fix overlays icons size for HiDPI Windows 10

### DIFF
--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -101,7 +101,7 @@ static gboolean _button_draw(GtkWidget *widget, cairo_t *cr)
   if(DTGTK_BUTTON(widget)->icon)
   {
     /* set inner border and icon size */
-    float f_border = (1 + 0.66 * (darktable.gui->dpi_factor-1)) * ((flags & CPF_DO_NOT_USE_BORDER) ? 4.0 : 6.0);
+    float f_border = ((flags & CPF_DO_NOT_USE_BORDER) ? 4.0 : 6.0);
     int border = round(f_border);
     int icon_width = round(text ? height - (f_border * 2) : width - (f_border * 2));
     int icon_height = round(height - (f_border * 2));

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1574,12 +1574,7 @@ void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, 
 {
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
 
-  //cairo_set_line_width(cr, .25);
-  //cairo_rectangle(cr, -w/2.0, -h/2.0, w, h);
-  //cairo_stroke(cr);
-
   float s = (w < h ? w / 2.0 : h / 2.0);
-  //s = 11.0;
   cairo_scale(cr, s, s);
 
   cairo_set_line_width(cr, .25);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1383,22 +1383,23 @@ void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_altered(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  const float r = 0.5;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_translate(cr, x + w / 2.0, y + h / 2.0);
+
+  const float s = (w < h ? w / 2.0 : h / 2.0);
   cairo_scale(cr, s, s);
 
-  cairo_set_line_width(cr, 1.0 / (float)s);
-  cairo_arc(cr, 0.5, 0.5, r, 0, 2.0f * M_PI);
+  const float r = 0.95;
+  cairo_set_line_width(cr, .1);
+  cairo_arc(cr, 0, 0, r, 0, 2.0f * M_PI);
   const float dx = r * cosf(M_PI / 8.0f), dy = r * sinf(M_PI / 8.0f);
-  cairo_move_to(cr, 0.5 - dx, 0.5 - dy);
-  cairo_curve_to(cr, 0.5, 0.5 - 2 * dy, 0.5, 0.5 + 2 * dy, 0.5 + dx, 0.5 + dy);
-  cairo_move_to(cr, 0.5 - .20 * dx, 0.5 + .8 * dy);
-  cairo_line_to(cr, 0.5 - .80 * dx, 0.5 + .8 * dy);
-  cairo_move_to(cr, 0.5 + .20 * dx, 0.5 - .8 * dy);
-  cairo_line_to(cr, 0.5 + .80 * dx, 0.5 - .8 * dy);
-  cairo_move_to(cr, 0.5 + .50 * dx, 0.5 - .8 * dy - 0.3 * dx);
-  cairo_line_to(cr, 0.5 + .50 * dx, 0.5 - .8 * dy + 0.3 * dx);
+  cairo_move_to(cr,  - dx,  - dy);
+  cairo_curve_to(cr, 0, -2.0 * dy, 0, 2.0 * dy, dx, dy);
+  cairo_move_to(cr, -.2 * dx,  .8 * dy);
+  cairo_line_to(cr, -.8 * dx,  .8 * dy);
+  cairo_move_to(cr,  .2 * dx, -.8 * dy);
+  cairo_line_to(cr,  .8 * dx, -.8 * dy);
+  cairo_move_to(cr,  .5 * dx, -.8 * dy - .3 * dx);
+  cairo_line_to(cr,  .5 * dx, -.8 * dy + .3 * dx);
   cairo_stroke(cr);
 }
 
@@ -1569,81 +1570,80 @@ void dtgtk_cairo_paint_showmask(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_fill(cr);
 }
 
-
-
 void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w / 1.75 : h / 1.75);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
+
+  //cairo_set_line_width(cr, .25);
+  //cairo_rectangle(cr, -w/2.0, -h/2.0, w, h);
+  //cairo_stroke(cr);
+
+  float s = (w < h ? w / 2.0 : h / 2.0);
+  //s = 11.0;
   cairo_scale(cr, s, s);
 
   cairo_set_line_width(cr, .25);
-  cairo_arc(cr, 0.5, 0.5, 0.6, 0., 2.0f * M_PI);
+  cairo_arc(cr, 0.0, 0.0, 0.625, 0., 2.0f * M_PI);
   cairo_stroke(cr);
 
-  double dashes = .35;
+  double dashes = .3436;
   cairo_set_dash(cr, &dashes, 1, 0);
-  cairo_arc(cr, 0.5, 0.5, 0.8, 0., 2.0f * M_PI);
+  cairo_arc(cr, 0.0, 0.0, 0.875, 0., 2.0f * M_PI);
   cairo_stroke(cr);
 }
 
 void dtgtk_cairo_paint_overlays(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w / 1.75 : h / 1.75);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, .1);
+  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
 
-  dt_draw_star(cr, 0.5, 0.5, 1.0, 1.0/2.5);
+  const float s = (w < h ? w / 2.0 : h / 2.0);
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, .1);
+  dt_draw_star(cr, 0.0, 0.12, 1.0, 1.0/2.5);
 
   cairo_stroke(cr);
 }
 
 void dtgtk_cairo_paint_help(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PangoLayout *layout;
-  PangoRectangle ink;
-  // grow is needed because ink.* are int and everything gets rounded to 1 or so otherwise,
-  // leading to imprecise positioning
-  static const float grow = 12.0;
-  PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
-  pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
-  layout = pango_cairo_create_layout(cr);
-  pango_layout_set_font_description(layout, desc);
-  const gint s = (w < h ? w : h);
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
-  cairo_scale(cr, s / grow, s / grow);
 
-  pango_layout_set_text(layout, "?", -1);
-  pango_layout_get_pixel_extents(layout, &ink, NULL);
-  cairo_move_to(cr, 0 - ink.x - ink.width / 2.0, 0 - ink.y - ink.height / 2.0);
-  pango_cairo_show_layout(cr, layout);
-  pango_font_description_free(desc);
-  g_object_unref(layout);
+  const float s = (w < h ? w / 2.0 : h / 2.0);
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, 0.2);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+
+  cairo_arc(cr, 0.0, -0.5, 0.4, - M_PI, 0.25 * M_PI);
+  cairo_arc_negative(cr, 0.7, 0.4, 0.7, -0.75 * M_PI, - M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.0, 0.85, 0.05, 0.0, 2.0 * M_PI);
+  cairo_stroke(cr);
 }
 
-// TODO: Find better icon
 void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PangoLayout *layout;
-  PangoRectangle ink;
-  // grow is needed because ink.* are int and everything gets rounded to 1 or so otherwise,
-  // leading to imprecise positioning
-  static const float grow = 12.0;
-  PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
-  pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
-  layout = pango_cairo_create_layout(cr);
-  pango_layout_set_font_description(layout, desc);
-  const gint s = (w < h ? w : h);
-  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
-  cairo_scale(cr, s / grow, s / grow);
+  cairo_translate(cr, x + w / 2.0, y + h / 2.0);
 
-  pango_layout_set_text(layout, "G", -1);
-  pango_layout_get_pixel_extents(layout, &ink, NULL);
-  cairo_move_to(cr, 0 - ink.x - ink.width / 2.0, 0 - ink.y - ink.height / 2.0);
-  pango_cairo_show_layout(cr, layout);
-  pango_font_description_free(desc);
-  g_object_unref(layout);
+  const float s = (w < h ? w / 2.0 : h / 2.0);
+  cairo_scale(cr, s, s);
+
+  cairo_set_line_width(cr, .1);
+  cairo_arc(cr, 0.0, 0.0, 0.95, 0., 2.0f * M_PI);
+  cairo_stroke(cr);
+  cairo_arc(cr, -0.35, -0.33, 0.25, 0., 2.0f * M_PI);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+  cairo_arc(cr, -0.35, 0.35, 0.25, 0., 2.0f * M_PI);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.35, -0.35, 0.25, 0., 2.0f * M_PI);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+  cairo_arc(cr, 0.35, 0.35, 0.25, 0., 2.0f * M_PI);
+  cairo_fill(cr);
+  cairo_stroke(cr);
 }
 
 void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -80,7 +80,12 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
 
     if(flags & CPF_DO_NOT_USE_BORDER)
     {
-      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0, 0, allocation.width, allocation.height, flags, bg_color);
+      float f_border = (darktable.gui->dpi_factor - 1.0) * 6.0;
+      int border = round(f_border);
+      int icon_width = round(allocation.width - (f_border * 2.0));
+      int icon_height = round(allocation.height - (f_border * 2.0));
+
+      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, border, border, icon_width, icon_height, flags, bg_color);
     }
     else
     {

--- a/src/dtgtk/thumbnail_btn.c
+++ b/src/dtgtk/thumbnail_btn.c
@@ -80,12 +80,7 @@ static gboolean _thumbnail_btn_draw(GtkWidget *widget, cairo_t *cr)
 
     if(flags & CPF_DO_NOT_USE_BORDER)
     {
-      float f_border = (darktable.gui->dpi_factor - 1.0) * 6.0;
-      int border = round(f_border);
-      int icon_width = round(allocation.width - (f_border * 2.0));
-      int icon_height = round(allocation.height - (f_border * 2.0));
-
-      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, border, border, icon_width, icon_height, flags, bg_color);
+      DTGTK_THUMBNAIL_BTN(widget)->icon(cr, 0, 0, allocation.width, allocation.height, flags, bg_color);
     }
     else
     {

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -135,7 +135,7 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   if(DTGTK_TOGGLEBUTTON(widget)->icon)
   {
     /* set inner border and icon size */
-    float f_border = (1 + 0.66 * (darktable.gui->dpi_factor-1)) * ((flags & CPF_DO_NOT_USE_BORDER) ? 4.0 : 6.0);
+    float f_border = ((flags & CPF_DO_NOT_USE_BORDER) ? 4.0 : 6.0);
     int border = round(f_border);
     int icon_width = round(text ? height - (f_border * 2) : width - (f_border * 2));
     int icon_height = round(height - (f_border * 2));

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -744,7 +744,7 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_apply_button_clicked), self);
 
   button = dtgtk_button_new(dtgtk_cairo_paint_preferences,
-      CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX | CPF_BG_TRANSPARENT, NULL);
+      CPF_DO_NOT_USE_BORDER | CPF_STYLE_BOX, NULL);
   d->config_button = button;
   gtk_widget_set_tooltip_text(button, _("configure metadata"));
   gtk_grid_attach(grid, button, 2, 0, 1, 1);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -148,7 +148,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   /* create the grouping button */
-  d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, CPF_STYLE_FLAT, NULL);
+  d->grouping_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_grouping, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), d->grouping_button, FALSE, FALSE, 0);
   if(darktable.gui->grouping)
     gtk_widget_set_tooltip_text(d->grouping_button, _("expand grouped images"));
@@ -159,7 +159,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->grouping_button), darktable.gui->grouping);
 
   /* create the "show/hide overlays" button */
-  d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT, NULL);
+  d->overlays_button = dtgtk_button_new(dtgtk_cairo_paint_overlays, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_widget_set_tooltip_text(d->overlays_button, _("click to change the type of overlays shown on thumbnails"));
   gtk_box_pack_start(GTK_BOX(self->widget), d->overlays_button, FALSE, FALSE, 0);
   d->over_popup = gtk_popover_new(d->overlays_button);
@@ -200,7 +200,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(vbox), d->over_r5, TRUE, TRUE, 0);
 
   /* create the widget help button */
-  d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, CPF_STYLE_FLAT, NULL);
+  d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), d->help_button, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(d->help_button, _("enable this, then click on a control element to see its online help"));
   g_signal_connect(G_OBJECT(d->help_button), "clicked", G_CALLBACK(_lib_help_button_clicked), d);


### PR DESCRIPTION
Hi, this tries to fix the wrong size of some thumbnail overlay icons in the new Lightable for HiDPI displays in Windows 10.

![Cattura24](https://user-images.githubusercontent.com/43290988/79795020-9398a480-8353-11ea-8389-897533515127.JPG)

It does not affect non-HiDPI displays.
However it's a workaround. The problem of icons scaling incorrectly cannot be solved if we keep a mix of Cairo drawing icons and simple text icons like "G" or "?". They will always scale differently with DPI and proportions cannot be kept accurately.
For a proper solution we should replace completely text icons.
