### PR TITLE
Use dt_collection_get_query_no_group() to get selected images

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -900,7 +900,7 @@ uint32_t dt_collection_get_selected_count(const dt_collection_t *collection)
 GList *dt_collection_get(const dt_collection_t *collection, int limit, gboolean selected)
 {
   GList *list = NULL;
-  const gchar *query = dt_collection_get_query(collection);
+  const gchar *query = dt_collection_get_query_no_group(collection);
   if(query)
   {
     sqlite3_stmt *stmt = NULL;


### PR DESCRIPTION
File operations from the "selected images" module worked only on the first
image of a group when grouping was enabled.

Fixes #3154