### PR TITLE
filmic RGB v4 update : new color science

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -2334,6 +2334,24 @@ char *dt_image_get_text_path(const int32_t imgid)
   return dt_image_get_text_path_from_path(image_path);
 }
 
+float dt_image_get_exposure_bias(const struct dt_image_t *image_storage)
+{
+  // just check that pointers exist and are initialized
+  if((image_storage) && (image_storage->exif_exposure_bias))
+  {
+    // sanity checks because I don't trust exif tags too much
+    if(image_storage->exif_exposure_bias == NAN ||
+       image_storage->exif_exposure_bias != image_storage->exif_exposure_bias ||
+       isnan(image_storage->exif_exposure_bias) ||
+       CLAMP(image_storage->exif_exposure_bias, -5.0f, 5.0f) != image_storage->exif_exposure_bias)
+      return 0.0f; // isnan
+    else
+      return CLAMP(image_storage->exif_exposure_bias, -5.0f, 5.0f);
+  }
+  else
+    return 0.0f;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -366,6 +366,8 @@ char *dt_image_get_audio_path_from_path(const char *image_path);
 char *dt_image_get_text_path(const int32_t imgid);
 char *dt_image_get_text_path_from_path(const char *image_path);
 
+float dt_image_get_exposure_bias(const struct dt_image_t *image_storage);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2327,10 +2327,7 @@ void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_filmicrgb_params_t));
   module->default_params = calloc(1, sizeof(dt_iop_filmicrgb_params_t));
-
-  // Auto-apply filmic if basecurve is not
-  module->default_enabled = !dt_conf_get_bool("plugins/darkroom/basecurve/auto_apply");
-
+  module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_filmicrgb_params_t);
   module->gui_data = NULL;
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -637,7 +637,7 @@ inline static void blur_2D_Bspline_horizontal(const float *const restrict in, fl
   // Convolve B-spline filter over columns
   #ifdef _OPENMP
   #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(stdout, out, in, width, height, ch, bound_bot, bound_top, mult) \
+    dt_omp_firstprivate(out, in, width, height, ch, bound_bot, bound_top, mult) \
     schedule(simd:static) collapse(2)
   #endif
   for(size_t i = 0; i < height; i++)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -45,12 +45,14 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+
 
 
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
 
 
-DT_MODULE_INTROSPECTION(1, dt_iop_filmicrgb_params_t)
+DT_MODULE_INTROSPECTION(2, dt_iop_filmicrgb_params_t)
 
 /**
  * DOCUMENTATION
@@ -107,6 +109,20 @@ typedef enum dt_iop_filmicrgb_methods_type_t
 } dt_iop_filmicrgb_methods_type_t;
 
 
+typedef enum dt_iop_filmicrgb_curve_type_t
+{
+  DT_FILMIC_CURVE_POLY_4 = 0,
+  DT_FILMIC_CURVE_POLY_3 = 1
+} dt_iop_filmicrgb_curve_type_t;
+
+
+typedef enum dt_iop_filmicrgb_colorscience_type_t
+{
+  DT_FILMIC_COLORSCIENCE_V1 = 0,
+  DT_FILMIC_COLORSCIENCE_V2 = 1,
+} dt_iop_filmicrgb_colorscience_type_t;
+
+
 typedef struct dt_iop_filmic_rgb_spline_t
 {
   float DT_ALIGNED_PIXEL M1[4], M2[4], M3[4], M4[4], M5[4]; // factors for the interpolation polynom
@@ -121,6 +137,11 @@ typedef struct dt_iop_filmicrgb_params_t
   float grey_point_source;
   float black_point_source;
   float white_point_source;
+  float reconstruct_threshold;
+  float reconstruct_feather;
+  float reconstruct_bloom_vs_details;
+  float reconstruct_grey_vs_color;
+  float reconstruct_structure_vs_texture;
   float security_factor;
   float grey_point_target;
   float black_point_target;
@@ -131,6 +152,12 @@ typedef struct dt_iop_filmicrgb_params_t
   float saturation;
   float balance;
   int preserve_color;
+  int version;
+  int auto_hardness;
+  int custom_grey;
+  int high_quality_reconstruction;
+  dt_iop_filmicrgb_curve_type_t shadows;
+  dt_iop_filmicrgb_curve_type_t highlights;
 } dt_iop_filmicrgb_params_t;
 
 typedef struct dt_iop_filmicrgb_gui_data_t
@@ -138,6 +165,7 @@ typedef struct dt_iop_filmicrgb_gui_data_t
   GtkWidget *white_point_source;
   GtkWidget *grey_point_source;
   GtkWidget *black_point_source;
+  GtkWidget *reconstruct_threshold, *reconstruct_bloom_vs_details, *reconstruct_grey_vs_color, *reconstruct_structure_vs_texture, *reconstruct_feather;
   GtkWidget *security_factor;
   GtkWidget *auto_button;
   GtkWidget *grey_point_target;
@@ -149,22 +177,37 @@ typedef struct dt_iop_filmicrgb_gui_data_t
   GtkWidget *saturation;
   GtkWidget *balance;
   GtkWidget *preserve_color;
+  GtkWidget *autoset_display_gamma;
+  GtkWidget *shadows, *highlights;
+  GtkWidget *version;
+  GtkWidget *auto_hardness;
+  GtkWidget *custom_grey;
+  GtkWidget *high_quality_reconstruction;
   GtkNotebook *notebook;
   GtkDrawingArea *area;
   struct dt_iop_filmic_rgb_spline_t spline DT_ALIGNED_ARRAY;
+  gint show_mask;
 } dt_iop_filmicrgb_gui_data_t;
 
 typedef struct dt_iop_filmicrgb_data_t
 {
   float max_grad;
+  float white_source;
   float grey_source;
   float black_source;
+  float reconstruct_threshold;
+  float reconstruct_feather;
+  float reconstruct_bloom_vs_details;
+  float reconstruct_grey_vs_color;
+  float reconstruct_structure_vs_texture;
   float dynamic_range;
   float saturation;
   float output_power;
   float contrast;
   float sigma_toe, sigma_shoulder;
   int preserve_color;
+  int version;
+  int high_quality_reconstruction;
   struct dt_iop_filmic_rgb_spline_t spline DT_ALIGNED_ARRAY;
 } dt_iop_filmicrgb_data_t;
 
@@ -196,61 +239,63 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-void init_presets(dt_iop_module_so_t *self)
+int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
+                  const int new_version)
 {
-  dt_iop_filmicrgb_params_t p;
-  memset(&p, 0, sizeof(p));
+  if(old_version == 1 && new_version == 2)
+  {
+    typedef struct dt_iop_filmicrgb_params_v1_t
+    {
+      float grey_point_source;
+      float black_point_source;
+      float white_point_source;
+      float security_factor;
+      float grey_point_target;
+      float black_point_target;
+      float white_point_target;
+      float output_power;
+      float latitude;
+      float contrast;
+      float saturation;
+      float balance;
+      int preserve_color;
+    } dt_iop_filmicrgb_params_v1_t;
 
-  // Output
-  p.output_power = 2.44f;
-  p.white_point_target = 100.0f;
-  p.black_point_target = 0.0f;
-  p.grey_point_target = 18.45f;
+    dt_iop_filmicrgb_params_v1_t *o = (dt_iop_filmicrgb_params_v1_t *)old_params;
+    dt_iop_filmicrgb_params_t *n = (dt_iop_filmicrgb_params_t *)new_params;
+    dt_iop_filmicrgb_params_t *d = (dt_iop_filmicrgb_params_t *)self->default_params;
 
-  // Input - standard raw picture
-  p.contrast = 1.4f;
-  p.preserve_color = DT_FILMIC_METHOD_MAX_RGB;
-  p.balance = 0.0f;
-  p.saturation = 0.0f;
-  p.latitude = 15.0f;
-  p.security_factor = 22.4f;
+    *n = *d; // start with a fresh copy of default parameters
 
-  // Presets low-key
-  p.grey_point_source = 18.45f;
-  p.white_point_source = 3.5f;
-  p.black_point_source = -3.5f;
-  dt_gui_presets_add_generic(_("07 EV dynamic range"), self->op, self->version(), &p, sizeof(p), 1);
-
-  // Presets indoors
-  p.grey_point_source = 9.225f;
-  p.white_point_source = 4.5f;
-  p.black_point_source = -4.5f;
-  dt_gui_presets_add_generic(_("09 EV dynamic range"), self->op, self->version(), &p, sizeof(p), 1);
-
-  // Presets dim-outdoors
-  p.grey_point_source = 4.6125f;
-  p.white_point_source = 5.5f;
-  p.black_point_source = -5.5f;
-  dt_gui_presets_add_generic(_("11 EV dynamic range"), self->op, self->version(), &p, sizeof(p), 1);
-
-  // Presets outdoors
-  p.grey_point_source = 2.30625f;
-  p.white_point_source = 6.5f;
-  p.black_point_source = -6.5f;
-  dt_gui_presets_add_generic(_("13 EV dynamic range"), self->op, self->version(), &p, sizeof(p), 1);
-
-  // Presets backlighting
-  p.grey_point_source = 1.153125f;
-  p.white_point_source = 7.5f;
-  p.black_point_source = -7.5f;
-  dt_gui_presets_add_generic(_("15 EV (backlighting)"), self->op, self->version(), &p, sizeof(p), 1);
-
-  // Presets HDR
-  p.grey_point_source = 0.5765625f;
-  p.white_point_source = 8.5f;
-  p.black_point_source = -8.5f;
-  dt_gui_presets_add_generic(_("17 EV (HDR)"), self->op, self->version(), &p, sizeof(p), 1);
+    n->grey_point_source = o->grey_point_source;
+    n->white_point_source = o->white_point_source;
+    n->black_point_source = o->black_point_source;
+    n->security_factor = o->security_factor;
+    n->grey_point_target = o->grey_point_target;
+    n->black_point_target = o->black_point_target;
+    n->white_point_target = o->white_point_target;
+    n->output_power = o->output_power;
+    n->latitude = o->latitude;
+    n->contrast = o->contrast;
+    n->saturation = o->saturation;
+    n->balance = o->balance;
+    n->preserve_color = o->preserve_color;
+    n->shadows = DT_FILMIC_CURVE_POLY_4;
+    n->highlights = DT_FILMIC_CURVE_POLY_3;
+    n->reconstruct_threshold = 3.0f; // for old edits, this ensures clipping threshold >> white level, so it's a no-op
+    n->reconstruct_bloom_vs_details = d->reconstruct_bloom_vs_details;
+    n->reconstruct_grey_vs_color = d->reconstruct_grey_vs_color;
+    n->reconstruct_structure_vs_texture = d->reconstruct_structure_vs_texture;
+    n->reconstruct_feather = 3.0f;
+    n->version = DT_FILMIC_COLORSCIENCE_V1;
+    n->auto_hardness = TRUE;
+    n->custom_grey = TRUE;
+    n->high_quality_reconstruction = FALSE;
+    return 0;
+  }
+  return 1;
 }
+
 
 void init_key_accels(dt_iop_module_so_t *self)
 {
@@ -363,7 +408,7 @@ static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline float log_tonemapping(const float x, const float grey, const float black, const float dynamic_range)
+static inline float log_tonemapping_v1(const float x, const float grey, const float black, const float dynamic_range)
 {
   const float temp = (log2f(x / grey) - black) / dynamic_range;
   return fmaxf(fminf(temp, 1.0f), 1.52587890625e-05f);
@@ -373,36 +418,29 @@ static inline float log_tonemapping(const float x, const float grey, const float
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
+static inline float log_tonemapping_v2(const float x, const float grey, const float black, const float dynamic_range)
+{
+  return clamp_simd((log2f(x / grey) - black) / dynamic_range);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd aligned(M1, M2, M3, M4:16)
+#endif
 static inline float filmic_spline(const float x,
                                   const float M1[4], const float M2[4], const float M3[4], const float M4[4], const float M5[4],
                                   const float latitude_min, const float latitude_max)
 {
-#ifdef _OPENMP
-  // use OpenMP vector reduction with mask
-  const int toe = (x < latitude_min);
-  const int shoulder = (x > latitude_max);
-  const int latitude = (toe == shoulder); // == FALSE
-  const int mask[4] DT_ALIGNED_PIXEL = { toe, shoulder, latitude, 0 };
-
-  float sum = 0.0f;
-
-#pragma omp simd reduction(+:sum) aligned(M1, M2, M3, M4, M5, mask:16)
-  for(int i = 0; i < 3; ++i) sum += mask[i] * (M1[i] + x * (M2[i] + x * (M3[i] + x * (M4[i] + x * M5[i]))));
-  return sum;
-
-#else
-  // use inline checks and hope for some clever stuff from the compiler
   return (x < latitude_min) ? M1[0] + x * (M2[0] + x * (M3[0] + x * (M4[0] + x * M5[0]))) : // toe
          (x > latitude_max) ? M1[1] + x * (M2[1] + x * (M3[1] + x * (M4[1] + x * M5[1]))) : // shoulder
                               M1[2] + x * (M2[2] + x * (M3[2] + x * (M4[2] + x * M5[2])));  // latitude
-#endif
 }
 
 
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
-static inline float filmic_desaturate(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
+static inline float filmic_desaturate_v1(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
 {
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
@@ -417,9 +455,762 @@ static inline float filmic_desaturate(const float x, const float sigma_toe, cons
 #ifdef _OPENMP
 #pragma omp declare simd
 #endif
+static inline float filmic_desaturate_v2(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
+{
+  const float radius_toe = x;
+  const float radius_shoulder = 1.0f - x;
+  const float sat2 = 0.5f / sqrtf(saturation);
+  const float key_toe = expf(-radius_toe * radius_toe / sigma_toe * sat2);
+  const float key_shoulder = expf(-radius_shoulder * radius_shoulder / sigma_shoulder * sat2);
+
+  return (saturation - (key_toe + key_shoulder) * (saturation));
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
 static inline float linear_saturation(const float x, const float luminance, const float saturation)
 {
   return luminance + saturation * (x - luminance);
+}
+
+
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
+static inline float fmaxabsf(const float a, const float b)
+{
+  const float abs_a = fabsf(a);
+  const float abs_b = fabsf(b);
+  return (abs_a > abs_b) ? a : b;
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
+static inline float fminabsf(const float a, const float b)
+{
+  const float abs_a = fabsf(a);
+  const float abs_b = fabsf(b);
+  return (abs_a < abs_b) ? a : b;
+}
+
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
+static inline float sqf(const float x)
+{
+  return x*x;
+}
+
+
+#define MAX_NUM_SCALES 12
+
+
+static inline gint mask_clipped_pixels(const float *const restrict in,
+                                       float *const restrict mask,
+                                       const float normalize, const float feathering,
+                                       const size_t width, const size_t height, const size_t ch)
+{
+  /* 1. Detect if pixels are clipped and count them,
+   * 2. assign them a weight in [0. ; 1.] depending on how close from clipping they are. The weights are defined
+   *    by a sigmoid centered in `reconstruct_threshold` so the transition is soft and symmetrical
+   */
+
+  int clipped = 0;
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(in, mask, normalize, feathering, width, height, ch) \
+  schedule(simd:static) aligned(mask, in:64) reduction(+:clipped)
+#endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float pix_max = sqrtf(sqf(in[k]) + sqf(in[k+ 1]) + sqf(in[k + 2]));
+    const float argument = -pix_max * normalize + feathering;
+    const float weight = 1.0f / ( 1.0f + exp2f(argument));
+    mask[k / ch] = weight;
+
+    // at x = 4, the sigmoid produces opacity = 5.882 %.
+    // any x > 4 will produce neglictible changes over the image,
+    // especially since we have reduced visual sensitivity in highlights.
+    // so we discard pixels for argument > 4. for they are not worth computing.
+    clipped += (4.f > argument);
+  }
+
+  // If clipped area is < 9 pixels, recovery is not worth the computational cost, so skip it.
+  return (clipped > 9);
+}
+
+
+// B spline filter
+#define fsize 5
+static const float DT_ALIGNED_ARRAY filter[fsize] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+
+
+inline static void blur_2D_Bspline_vertical(const float *const restrict in, float *const restrict out,
+                                            const size_t width, const size_t height, const size_t ch, const size_t mult,
+                                            const int bound_left, const int bound_right)
+{
+  // À-trous B-spline interpolation/blur shifted by mult
+  // Convolve B-spline filter over lines
+  #ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+    dt_omp_firstprivate(in, out, filter, width, height, ch, bound_left, bound_right, mult) \
+    schedule(simd:static) collapse(2)
+  #endif
+  for(size_t i = 0; i < height; i++)
+    for(size_t j = 0; j < width; j++)
+    {
+      const size_t index_out = (i * width + j) * ch;
+      float DT_ALIGNED_PIXEL accumulator[4] = { 0.0f };
+
+      // Are we in the boundary zone that needs bound checking ?
+      const int check = !((j > 2 * mult) && (j < width - 2 * mult));
+
+      // -funswitch-loops should compile 2 loops, for each check outcome
+      if(check)
+      {
+        #ifdef _OPENMP
+        #pragma omp simd aligned(in, filter:64) aligned(accumulator:16) reduction(+:accumulator)
+        #endif
+        for(size_t jj = 0; jj < fsize; ++jj)
+          for(size_t c = 0; c < 3; ++c)
+          {
+            int index_x = mult * (jj - (fsize - 1) / 2) + j;
+            index_x = (index_x < bound_left)  ? bound_left  :
+                      (index_x > bound_right) ? bound_right :
+                                                index_x     ;
+
+
+            accumulator[c] += filter[jj] * in[(i * width + index_x) * ch + c];
+          }
+      }
+      else // fast-track
+      {
+        #ifdef _OPENMP
+        #pragma omp simd aligned(in, filter:64) aligned(accumulator:16) reduction(+:accumulator)
+        #endif
+        for(size_t jj = 0; jj < fsize; ++jj)
+          for(size_t c = 0; c < 3; ++c)
+          {
+            const size_t index_x = mult * (jj - (fsize - 1) / 2) + j;
+            accumulator[c] += filter[jj] * in[(i * width + index_x) * ch + c];
+          }
+      }
+
+      #ifdef _OPENMP
+      #pragma omp simd aligned(out:64) aligned(accumulator:16)
+      #endif
+      for(size_t c = 0; c < 3; ++c)
+        out[index_out + c] = accumulator[c];
+
+    }
+}
+
+
+inline static void blur_2D_Bspline_horizontal(const float *const restrict in, float *const restrict out,
+                                              const size_t width, const size_t height, const size_t ch, const size_t mult,
+                                              const int bound_top, const int bound_bot)
+{
+  // À-trous B-spline interpolation/blur shifted by mult
+  // Convolve B-spline filter over columns
+  #ifdef _OPENMP
+  #pragma omp parallel for default(none) \
+    dt_omp_firstprivate(stdout, out, in, width, height, ch, filter, bound_bot, bound_top, mult) \
+    schedule(simd:static) collapse(2)
+  #endif
+  for(size_t i = 0; i < height; i++)
+    for(size_t j = 0; j < width; j++)
+    {
+      const size_t index_out = (i * width + j) * ch;
+      float DT_ALIGNED_PIXEL accumulator[4] = { 0.0f };
+
+      // Are we in the boundary zone that needs bound checking ?
+      const int check = !((i > 2 * mult) && (i < height - 2 * mult));
+
+      // -funswitch-loops should compile 2 loops, for each check outcome
+      if(check)
+      {
+        #ifdef _OPENMP
+        #pragma omp simd aligned(in, filter:64) aligned(accumulator:16) reduction(+:accumulator)
+        #endif
+        for(size_t ii = 0; ii < fsize; ++ii)
+          for(size_t c = 0; c < 3; ++c)
+          {
+            int index_y = mult * (ii - (fsize - 1) / 2) + i;
+            index_y = (index_y < bound_top) ? bound_top :
+                      (index_y > bound_bot) ? bound_bot :
+                                              index_y   ;
+            accumulator[c] += filter[ii] * in[(index_y * width + j) * ch + c];
+          }
+      }
+      else // fast-track
+      {
+        for(size_t ii = 0; ii < fsize; ++ii)
+        {
+          const size_t index_y = mult * (ii - (fsize - 1) / 2) + i;
+
+          #ifdef _OPENMP
+          #pragma omp simd aligned(in, filter:64) aligned(accumulator:16) reduction(+:accumulator)
+          #endif
+          for(size_t c = 0; c < 3; ++c)
+            accumulator[c] += filter[ii] * in[(index_y * width + j) * ch + c];
+        }
+      }
+
+      #ifdef _OPENMP
+      #pragma omp simd aligned(out:64) aligned(accumulator:16)
+      #endif
+      for(size_t c = 0; c < ch; ++c) out[index_out + c] = accumulator[c];
+    }
+}
+
+
+inline static void wavelets_reconstruct_RGB(const float *const restrict HF, const float *const restrict LF,
+                                            const float *const restrict texture, const float *const restrict mask,
+                                            float *const restrict reconstructed,
+                                            const size_t width, const size_t height, const size_t ch,
+                                            const float gamma, const float gamma_comp, const float beta, const float beta_comp, const float delta,
+                                            const size_t s, const size_t scales)
+{
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(width, height, ch, HF, LF, texture, mask, reconstructed, gamma, gamma_comp, beta, beta_comp, delta, s, scales) \
+  schedule(simd:static) aligned(HF, LF, texture, mask, reconstructed:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float alpha = mask[k / ch];
+
+    // cache RGB wavelets scales just to be sure the compiler doesn't reload them
+    const float DT_ALIGNED_ARRAY HF_c[4] = { HF[k], HF[k + 1], HF[k + 2], HF[k + 3] };
+    const float DT_ALIGNED_ARRAY LF_c[4] = { LF[k], LF[k + 1], LF[k + 2], LF[k + 3] };
+
+    // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
+    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other channels
+    float grey_texture = gamma * texture[k / ch];
+
+    // synthesize the max of all interpolated/inpainted RGB channels as a flat details term for the whole pixel
+    // this is smoother than grey_texture and will fill holes smoothly in details layers if grey_texture ~= 0.f
+    float grey_details = gamma_comp * fmaxabsf(fmaxabsf(HF_c[0], HF_c[1]), HF_c[2]);
+
+    // synthesize both terms with weighting
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    const float grey_HF = beta_comp * (grey_details + grey_texture);
+
+    // synthesize the min of all low-frequency RGB channels as a flat structure term for the whole pixel
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    float grey_residual = beta_comp * fminf(fminf(LF_c[0], LF_c[1]), LF_c[2]);
+
+    for(size_t c = 0; c < 3; c++)
+    {
+      // synthesize interpolated/inpainted RGB channels color details residuals and weigh them
+      // this brings back some color on top of the grey_residual
+      const float color_residual = LF_c[c] * beta;
+
+      // synthesize interpolated/inpainted RGB channels color details and weigh them
+      // this brings back some color on top of the grey_details
+      const float color_details = HF_c[c] * beta * gamma_comp;
+
+      // reconstruction
+      reconstructed[k + c] += alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
+    }
+  }
+}
+
+
+inline static void wavelets_reconstruct_ratios(const float *const restrict HF, const float *const restrict LF,
+                                               const float *const restrict texture, const float *const restrict mask,
+                                               float *const restrict reconstructed,
+                                               const size_t width, const size_t height, const size_t ch,
+                                               const float gamma, const float gamma_comp, const float beta, const float beta_comp, const float delta,
+                                               const size_t s, const size_t scales)
+{
+  /*
+  * This is the adapted version of the RGB reconstruction
+  * RGB contain high frequencies that we try to recover, so we favor them in the reconstruction.
+  * The ratios represent the chromaticity in image and contain low frequencies in the absence of noise or aberrations,
+  * so, here, we favor them instead.
+  *
+  * Consequences : 
+  *  1. use min of interpolated channels details instead of max, to get smoother details
+  *  4. use the max of low frequency channels instead of min, to favor achromatic solution.
+  *
+  * Note : ratios close to 1 mean higher spectral purity (more white). Ratios close to 0 mean lower spectral purity (more colorful)
+  */
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(width, height, ch, HF, LF, texture, mask, reconstructed, gamma, gamma_comp, beta, beta_comp, delta, s, scales) \
+  schedule(simd:static) aligned(HF, LF, texture, mask, reconstructed:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float alpha = mask[k / ch];
+
+    // cache RGB wavelets scales just to be sure the compiler doesn't reload them
+    const float DT_ALIGNED_ARRAY HF_c[4] = { HF[k], HF[k + 1], HF[k + 2], HF[k + 3] };
+    const float DT_ALIGNED_ARRAY LF_c[4] = { LF[k], LF[k + 1], LF[k + 2], LF[k + 3] };
+
+    // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
+    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other channels
+    float grey_texture = gamma * texture[k / ch];
+
+    // synthesize the max of all interpolated/inpainted RGB channels as a flat details term for the whole pixel
+    // this is smoother than grey_texture and will fill holes smoothly in details layers if grey_texture ~= 0.f
+    float grey_details = gamma_comp * fmaxabsf(fmaxabsf(HF_c[0], HF_c[1]), HF_c[2]);
+
+    // synthesize both terms with weighting
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    const float grey_HF = beta_comp * (grey_details + grey_texture);
+
+    // synthesize the min of all low-frequency RGB channels as a flat structure term for the whole pixel
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    float grey_residual = beta_comp * fmaxf(fmaxf(LF_c[0], LF_c[1]), LF_c[2]);
+
+    for(size_t c = 0; c < 3; c++)
+    {
+      // synthesize interpolated/inpainted RGB channels color details residuals and weigh them
+      // this brings back some color on top of the grey_residual
+      const float color_residual = LF_c[c] * beta;
+
+      // synthesize interpolated/inpainted RGB channels color details and weigh them
+      // this brings back some color on top of the grey_details
+      const float color_details = HF_c[c] * beta * gamma_comp;
+
+      // reconstruction
+      reconstructed[k + c] += alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
+    }
+  }
+}
+
+
+static inline void init_reconstruct(const float *const restrict in, const float *const restrict mask, float *const restrict reconstructed,
+                                    const size_t width, const size_t height, const size_t ch)
+{
+  // init the reconstructed buffer with non-clipped and partially clipped pixels
+  // Note : it's a simple multiplied alpha blending where mask = alpha weight
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(in, mask, reconstructed, width, height, ch) \
+    schedule(simd:static) aligned(in, mask, reconstructed:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k++)
+  {
+    reconstructed[k] = in[k] * (1.f - mask[k/ch]);
+  }
+}
+
+static inline void wavelets_detail_level_RGB(const float *const restrict detail, const float *const restrict LF,
+                                             float *const restrict HF, float *const restrict texture,
+                                             const size_t width, const size_t height, const size_t ch)
+{
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture) \
+    schedule(simd:static) aligned(HF, LF, detail, texture:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    for(size_t c = 0; c < 3; ++c) HF[k + c] = detail[k + c] - LF[k + c];
+    texture[k / ch] = fmaxabsf(fmaxabsf(HF[k], HF[k + 1]), HF[k + 2]);
+  }
+}
+
+
+static inline void wavelets_detail_level_ratios(const float *const restrict detail, const float *const restrict LF,
+                                                float *const restrict HF, float *const restrict texture,
+                                                const size_t width, const size_t height, const size_t ch)
+{
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture) \
+    schedule(simd:static) aligned(HF, LF, detail, texture:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    for(size_t c = 0; c < 3; ++c) HF[k + c] = detail[k + c] - LF[k + c];
+    texture[k / ch] = fminabsf(fminabsf(HF[k], HF[k + 1]), HF[k + 2]);
+  }
+}
+
+
+static int get_scales(const dt_iop_roi_t *roi_in, const dt_dev_pixelpipe_iop_t *const piece)
+{
+  /* How many wavelets scales do we need to compute at current zoom level ?
+   * 0. To get the same preview no matter the zoom scale, the relative image coverage ratio of the filter at
+   * the coarsest wavelet level should always stay constant.
+   * 1. The image coverage of each B spline filter of size `fsize` is `2^(level) * (fsize - 1) / 2 + 1` pixels
+   * 2. The coarsest level filter at full resolution should cover `1/fsize` of the largest image dimension.
+   * 3. The coarsest level filter at current zoom level should cover `scale/fsize` of the largest image dimension.
+   *
+   * So we compute the level that solves 1. subject to 3. Of course, integer rounding doesn't make that 1:1 accurate.
+   */
+  const float scale = roi_in->scale / piece->iscale;
+  const size_t size = MAX(piece->buf_in.height * piece->iscale, piece->buf_in.width * piece->iscale);
+  const int scales = floorf(log2f((2.0f * size * scale / ((fsize - 1) * fsize)) - 1.0f));
+  return CLAMP(scales, 1, MAX_NUM_SCALES);
+}
+
+static inline gint reconstruct_highlights(const float *const restrict in, const float *const restrict mask,
+                                          float *const restrict reconstructed, const int variant,
+                                          const dt_iop_filmicrgb_data_t *const data, dt_dev_pixelpipe_iop_t *piece,
+                                          const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  gint success = TRUE;
+
+  // wavelets scales
+  const int scales = get_scales(roi_in, piece);
+
+  // wavelets scales buffers
+  float *const restrict LF_even = dt_alloc_sse_ps(roi_out->width * roi_out->height * 4); // low-frequencies RGB
+  float *const restrict LF_odd = dt_alloc_sse_ps(roi_out->width * roi_out->height * 4); // low-frequencies RGB
+  float *const restrict HF_RGB = dt_alloc_sse_ps(roi_out->width * roi_out->height * 4); // high-frequencies RGB
+  float *const restrict HF_grey = dt_alloc_sse_ps(roi_out->width * roi_out->height); // max(high-frequencies RGB) grey
+
+  // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
+  float *const restrict temp = dt_alloc_sse_ps(roi_out->width * roi_out->height * 4);
+
+  if(!LF_even || !LF_odd || !HF_RGB || !HF_grey || !temp)
+  {
+    dt_control_log(_("filmic highlights reconstruction failed to allocate memory, check your RAM settings"));
+    success = FALSE;
+    goto error;
+  }
+
+  // Init reconstructed with valid parts of image
+  init_reconstruct(in, mask, reconstructed, roi_out->width, roi_out->height, 4);
+
+  // structure inpainting vs. texture duplicating weight
+  const float gamma = (data->reconstruct_structure_vs_texture);
+  const float gamma_comp = 1.0f - data->reconstruct_structure_vs_texture;
+
+  // colorful vs. grey weight
+  const float beta = data->reconstruct_grey_vs_color;
+  const float beta_comp = 1.f - data->reconstruct_grey_vs_color;
+
+  // bloom vs reconstruct weight
+  const float delta = data->reconstruct_bloom_vs_details;
+
+  // boundary conditions
+  const int bound_left = 0;
+  const int bound_right = roi_out->width - 1;
+  const int bound_top = 0;
+  const int bound_bot = roi_out->height - 1;
+
+  // À trous wavelet decompose
+  // there is a paper from a guy we know that explains it : https://jo.dreggn.org/home/2010_atrous.pdf
+  // the wavelets decomposition here is the same as the equalizer/atrous module,
+  // but simplified because we don't need the edge-aware term, so we can seperate the convolution kernel
+  // with a vertical and horizontal blur, wich is 10 multiply-add instead of 25 by pixel.
+  for(int s = 0; s < scales; ++s)
+  {
+    const float *restrict detail;
+    float *restrict LF;
+
+    // swap buffers so we only need 2 LF buffers : the LF at scale (s-1) and the one at current scale (s)
+    if(s == 0)
+    {
+      detail = in;
+      LF = LF_odd;
+    }
+    else if(s % 2 != 0)
+    {
+      detail = LF_odd;
+      LF = LF_even;
+    }
+    else
+    {
+      detail = LF_even;
+      LF = LF_odd;
+    }
+
+    const int mult = 1 << s; // fancy-pants C notation for 2^s with integer type, don't be afraid
+
+    // Compute wavelets low-frequency scales
+    blur_2D_Bspline_vertical(detail, temp, roi_out->width, roi_out->height, 4, mult,
+                             bound_left, bound_right);
+    blur_2D_Bspline_horizontal(temp, LF, roi_out->width, roi_out->height, 4, mult,
+                               bound_top, bound_bot);
+
+    // Compute wavelets high-frequency scales and save the maximum of texture over the RGB channels
+    // Note : HF_RGB = detail - LF, HF_grey = max(HF_RGB)
+    if(variant == 0)
+      wavelets_detail_level_RGB(detail, LF, HF_RGB, HF_grey, roi_out->width, roi_out->height, 4);
+    else if(variant == 1)
+      wavelets_detail_level_ratios(detail, LF, HF_RGB, HF_grey, roi_out->width, roi_out->height, 4);
+
+    // interpolate/blur/inpaint (same thing) the RGB high-frequency to fill holes
+    blur_2D_Bspline_vertical(HF_RGB, temp, roi_out->width, roi_out->height, 4, mult,
+                             bound_left, bound_right);
+    blur_2D_Bspline_horizontal(temp, HF_RGB, roi_out->width, roi_out->height, 4, mult,
+                               bound_top, bound_bot);
+
+    // Reconstruct clipped parts
+    if(variant == 0)
+      wavelets_reconstruct_RGB(HF_RGB, LF, HF_grey, mask, reconstructed, roi_out->width, roi_out->height, 4,
+                               gamma, gamma_comp, beta, beta_comp, delta, s, scales);
+    else if(variant == 1)
+      wavelets_reconstruct_ratios(HF_RGB, LF, HF_grey, mask, reconstructed, roi_out->width, roi_out->height, 4,
+                               gamma, gamma_comp, beta, beta_comp, delta, s, scales);
+  }
+
+error:
+  if(temp) dt_free_align(temp);
+  if(LF_even) dt_free_align(LF_even);
+  if(LF_odd) dt_free_align(LF_odd);
+  if(HF_RGB) dt_free_align(HF_RGB);
+  if(HF_grey) dt_free_align(HF_grey);
+  return success;
+}
+
+static inline void filmic_split_v1(const float *const restrict in, float *const restrict out,
+                                   const dt_iop_order_iccprofile_info_t *const work_profile,
+                                   const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
+                                   const size_t width, const size_t height, const size_t ch)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, spline) \
+  schedule(simd:static) aligned(in, out:64)
+#endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+    float DT_ALIGNED_PIXEL temp[4];
+
+    // Log tone-mapping
+    for(int c = 0; c < 3; c++)
+      temp[c] = log_tonemapping_v1((pix_in[c] < 1.52587890625e-05f) ? 1.52587890625e-05f : pix_in[c],
+                                   data->grey_source, data->black_source, data->dynamic_range);
+
+    // Get the desaturation coeff based on the log value
+    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(temp,
+                                                                         work_profile->matrix_in,
+                                                                         work_profile->lut_in,
+                                                                         work_profile->unbounded_coeffs_in,
+                                                                         work_profile->lutsize,
+                                                                         work_profile->nonlinearlut)
+                                      : dt_camera_rgb_luminance(temp);
+    const float desaturation = filmic_desaturate_v1(lum, data->sigma_toe, data->sigma_shoulder, data->saturation);
+
+    // Desaturate on the non-linear parts of the curve
+    // Filmic S curve on the max RGB
+    // Apply the transfer function of the display
+    for(int c = 0; c < 3; c++)
+      pix_out[c] = powf(clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+  }
+}
+
+
+static inline void filmic_split_v2(const float *const restrict in, float *const restrict out,
+                                   const dt_iop_order_iccprofile_info_t *const work_profile,
+                                   const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
+                                   const size_t width, const size_t height, const size_t ch)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, spline) \
+  schedule(simd:static) aligned(in, out:64)
+#endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+    float DT_ALIGNED_PIXEL temp[4];
+
+    // Log tone-mapping
+    for(int c = 0; c < 3; c++)
+      temp[c] = log_tonemapping_v2((pix_in[c] < 1.52587890625e-05f) ? 1.52587890625e-05f : pix_in[c],
+                                    data->grey_source, data->black_source, data->dynamic_range);
+
+    // Get the desaturation coeff based on the log value
+    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(temp,
+                                                                         work_profile->matrix_in,
+                                                                         work_profile->lut_in,
+                                                                         work_profile->unbounded_coeffs_in,
+                                                                         work_profile->lutsize,
+                                                                         work_profile->nonlinearlut)
+                                      : dt_camera_rgb_luminance(temp);
+    const float desaturation = filmic_desaturate_v2(lum, data->sigma_toe, data->sigma_shoulder, data->saturation);
+
+    // Desaturate on the non-linear parts of the curve
+    // Filmic S curve on the max RGB
+    // Apply the transfer function of the display
+    for(int c = 0; c < 3; c++)
+      pix_out[c] = powf(clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+  }
+}
+
+
+static inline void filmic_chroma_v1(const float *const restrict in, float *const restrict out,
+                                    const dt_iop_order_iccprofile_info_t *const work_profile,
+                                    const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
+                                    const int variant,
+                                    const size_t width, const size_t height, const size_t ch)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, variant, spline) \
+  schedule(simd:static) aligned(in, out:64)
+#endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+
+    float DT_ALIGNED_PIXEL ratios[4];
+    float norm = get_pixel_norm(pix_in, variant, work_profile);
+
+    norm = (norm < 1.52587890625e-05f) ? 1.52587890625e-05f : norm; // norm can't be < to 2^(-16)
+
+    // Save the ratios
+    for(int c = 0; c < 3; c++) ratios[c] = pix_in[c] / norm;
+
+    // Sanitize the ratios
+    const float min_ratios = fminf(fminf(ratios[0], ratios[1]), ratios[2]);
+    if(min_ratios < 0.0f) for(int c = 0; c < 3; c++) ratios[c] -= min_ratios;
+
+    // Log tone-mapping
+    norm = log_tonemapping_v1(norm, data->grey_source, data->black_source, data->dynamic_range);
+
+    // Get the desaturation value based on the log value
+    const float desaturation = filmic_desaturate_v1(norm, data->sigma_toe, data->sigma_shoulder, data->saturation);
+
+    for(int c = 0; c < 3; c++) ratios[c] *= norm;
+
+    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(ratios,
+                                                                         work_profile->matrix_in,
+                                                                         work_profile->lut_in,
+                                                                         work_profile->unbounded_coeffs_in,
+                                                                         work_profile->lutsize,
+                                                                         work_profile->nonlinearlut)
+                                      : dt_camera_rgb_luminance(ratios);
+
+    // Desaturate on the non-linear parts of the curve and save ratios
+    for(int c = 0; c < 3; c++) ratios[c] = linear_saturation(ratios[c], lum, desaturation) / norm;
+
+    // Filmic S curve on the max RGB
+    // Apply the transfer function of the display
+    norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+
+    // Re-apply ratios
+    for(int c = 0; c < 3; c++) pix_out[c] = ratios[c] * norm;
+  }
+}
+
+
+static inline void filmic_chroma_v2(const float *const restrict in, float *const restrict out,
+                                    const dt_iop_order_iccprofile_info_t *const work_profile,
+                                    const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
+                                    const int variant,
+                                    const size_t width, const size_t height, const size_t ch)
+{
+
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, variant, spline) \
+    schedule(simd:static) aligned(in, out:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    const float *const restrict pix_in = in + k;
+    float *const restrict pix_out = out + k;
+
+    float norm = get_pixel_norm(pix_in, variant, work_profile);
+    norm = (norm < 1.52587890625e-05f) ? 1.52587890625e-05f : norm; // norm can't be < to 2^(-16)
+
+    // Save the ratios
+    float DT_ALIGNED_PIXEL ratios[4];
+    for(int c = 0; c < 3; c++) ratios[c] = pix_in[c] / norm;
+
+    // Sanitize the ratios
+    const float min_ratios = fminf(fminf(ratios[0], ratios[1]), ratios[2]);
+    const int sanitize = (min_ratios < 0.0f);
+
+    if(sanitize)
+      for(int c = 0; c < 3; c++)
+        ratios[c] -= min_ratios;
+
+    // Log tone-mapping
+    norm = log_tonemapping_v2(norm, data->grey_source, data->black_source, data->dynamic_range);
+
+    // Get the desaturation value based on the log value
+    const float desaturation = filmic_desaturate_v2(norm, data->sigma_toe, data->sigma_shoulder, data->saturation);
+
+    // Filmic S curve on the max RGB
+    // Apply the transfer function of the display
+    norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+
+    // Re-apply ratios with saturation change
+    for(int c = 0; c < 3; c++)
+    {
+      ratios[c] = fmaxf(ratios[c] + (1.0f - ratios[c]) * (1.0f - desaturation), 0.0f);
+      pix_out[c] = ratios[c] * norm;
+    }
+
+    // Gamut mapping
+    const float max_pix = fmaxf(fmaxf(pix_out[0], pix_out[1]), pix_out[2]);
+    const int penalize = (max_pix > 1.0f);
+
+    // Penalize the ratios by the amount of clipping
+    if(penalize)
+    {
+      for(int c = 0; c < 3; c++)
+      {
+        ratios[c] = fmaxf(ratios[c] + (1.0f - max_pix), 0.0f);
+        pix_out[c] = clamp_simd(ratios[c] * norm);
+      }
+    }
+  }
+}
+
+static inline void display_mask(const float *const restrict mask, float *const restrict out,
+                                const size_t width, const size_t height, const size_t ch)
+{
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(width, height, ch, out, mask) \
+    schedule(simd:static) aligned(mask, out:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k++)
+    out[k] = mask[k / ch];
+}
+
+
+static inline void compute_ratios(const float *const restrict in, float *const restrict norms, float *const restrict ratios,
+                                  const dt_iop_order_iccprofile_info_t *const work_profile, const int variant,
+                                  const size_t width, const size_t height, const size_t ch)
+{
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(ch, width, height, norms, ratios, in, work_profile, variant) \
+    schedule(simd:static) aligned(norms, ratios, in:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    float norm = get_pixel_norm(in + k, variant, work_profile);
+    norm = (norm < 1.52587890625e-05f) ? 1.52587890625e-05f : norm; // norm can't be < to 2^(-16)
+    norms[k / ch] = norm;
+
+    for(size_t c = 0; c < 3; c++) ratios[k + c] = in[k + c] / norm;
+  }
+}
+
+static inline void restore_ratios(float *const restrict ratios, const float *const restrict norms,
+                                  const size_t width, const size_t height, const size_t ch)
+{
+  #ifdef _OPENMP
+  #pragma omp parallel for simd default(none) \
+    dt_omp_firstprivate(width, height, ch, norms, ratios) \
+    schedule(simd:static) aligned(norms, ratios:64)
+  #endif
+  for(size_t k = 0; k < height * width * ch; k += ch)
+  {
+    for(size_t c = 0; c < 3; c++) ratios[k + c] *= norms[k/ch];
+  }
 }
 
 
@@ -429,7 +1220,13 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const dt_iop_filmicrgb_data_t *const data = (dt_iop_filmicrgb_data_t *)piece->data;
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
 
-  const int ch = piece->colors;
+  if(piece->colors != 4)
+  {
+    dt_control_log(_("filmic works only on RGB input"));
+    return;
+  }
+
+  const size_t ch = 4;
 
   /** The log2(x) -> -INF when x -> 0
   * thus very low values (noise) will get even lower, resulting in noise negative amplification,
@@ -438,101 +1235,79 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   * However, at this point of the pixelpipe, the RAW levels have already been corrected and everything can happen with black levels
   * in the exposure module. So we define the threshold as the first non-null 16 bit integer
   */
- ;
 
-  const float *const restrict in = (float *)ivoid;
+  float *restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;
 
   const int variant = data->preserve_color;
   const dt_iop_filmic_rgb_spline_t spline = (dt_iop_filmic_rgb_spline_t)data->spline;
 
-  if(variant == DT_FILMIC_METHOD_NONE) // no chroma preservation
+  float *const restrict mask =  dt_alloc_sse_ps(roi_out->width * roi_out->height);
+
+  // build a mask of clipped pixels
+  const float normalize = data->reconstruct_feather / data->reconstruct_threshold;
+  const int recover_highlights = mask_clipped_pixels(in, mask, normalize, data->reconstruct_feather, roi_out->width, roi_out->height, 4);
+
+  // display mask and exit
+  if(self->dev->gui_attached && piece->pipe->type == DT_DEV_PIXELPIPE_FULL && mask)
   {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(ch, data, in, out, roi_out, work_profile, spline) \
-  schedule(simd:static) aligned(in, out:64)
-#endif
-    for(size_t k = 0; k < roi_out->height * roi_out->width * ch; k += ch)
+    dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+
+    if(g->show_mask)
     {
-      const float *const pix_in = in + k;
-      float *const pix_out = out + k;
-      float DT_ALIGNED_PIXEL temp[4];
-
-      // Log tone-mapping
-      for(int c = 0; c < 3; c++)
-        temp[c] = log_tonemapping((pix_in[c] < 1.52587890625e-05f) ? 1.52587890625e-05f : pix_in[c],
-                                   data->grey_source, data->black_source, data->dynamic_range);
-
-      // Get the desaturation coeff based on the log value
-      const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(temp,
-                                                                           work_profile->matrix_in,
-                                                                           work_profile->lut_in,
-                                                                           work_profile->unbounded_coeffs_in,
-                                                                           work_profile->lutsize,
-                                                                           work_profile->nonlinearlut)
-                                        : dt_camera_rgb_luminance(temp);
-      const float desaturation = filmic_desaturate(lum, data->sigma_toe, data->sigma_shoulder, data->saturation);
-
-      // Desaturate on the non-linear parts of the curve
-      // Filmic S curve on the max RGB
-      // Apply the transfer function of the display
-      for(int c = 0; c < 3; c++)
-        pix_out[c] = powf(clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
-
+      display_mask(mask, out, roi_out->width, roi_out->height, 4);
+      dt_free_align(mask);
+      return;
     }
   }
-  else // chroma preservation
+
+  float *const restrict reconstructed = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+
+  if(recover_highlights && mask && reconstructed)
   {
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(ch, data, in, out, roi_out, work_profile, variant, spline) \
-  schedule(simd:static) aligned(in, out:64)
-#endif
-    for(size_t k = 0; k < roi_out->height * roi_out->width * ch; k += ch)
+    const gint success_1 = reconstruct_highlights(in, mask, reconstructed, 0, data, piece, roi_in, roi_out);
+
+    if(data->high_quality_reconstruction && success_1)
     {
-      const float *const pix_in = in + k;
-      float *const pix_out = out + k;
+      float *const restrict norms = dt_alloc_sse_ps(roi_out->width * roi_out->height);
+      float *const restrict ratios = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
 
-      float DT_ALIGNED_PIXEL ratios[4];
-      float norm = get_pixel_norm(pix_in, variant, work_profile);
+      // reconstruct highlights PASS 2 on ratios
+      if(norms && ratios)
+      {
+        compute_ratios(reconstructed, norms, ratios, work_profile, variant, roi_out->width, roi_out->height, 4);
+        const gint success_2 = reconstruct_highlights(ratios, mask, reconstructed, 1, data, piece, roi_in, roi_out);
+        if(success_2) restore_ratios(reconstructed, norms, roi_out->width, roi_out->height, 4);
+      }
 
-      norm = (norm < 1.52587890625e-05f) ? 1.52587890625e-05f : norm; // norm can't be < to 2^(-16)
+      if(norms) dt_free_align(norms);
+      if(ratios) dt_free_align(ratios);
 
-      // Save the ratios
-      for(int c = 0; c < 3; c++) ratios[c] = pix_in[c] / norm;
-
-      // Sanitize the ratios
-      const float min_ratios = fminf(fminf(ratios[0], ratios[1]), ratios[2]);
-      if(min_ratios < 0.0f) for(int c = 0; c < 3; c++) ratios[c] -= min_ratios;
-
-      // Log tone-mapping
-      norm = log_tonemapping(norm, data->grey_source, data->black_source, data->dynamic_range);
-
-      // Get the desaturation value based on the log value
-      const float desaturation = filmic_desaturate(norm, data->sigma_toe, data->sigma_shoulder, data->saturation);
-
-      for(int c = 0; c < 3; c++) ratios[c] *= norm;
-
-      const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(ratios,
-                                                                           work_profile->matrix_in,
-                                                                           work_profile->lut_in,
-                                                                           work_profile->unbounded_coeffs_in,
-                                                                           work_profile->lutsize,
-                                                                           work_profile->nonlinearlut)
-                                        : dt_camera_rgb_luminance(ratios);
-
-      // Desaturate on the non-linear parts of the curve and save ratios
-      for(int c = 0; c < 3; c++) ratios[c] = linear_saturation(ratios[c], lum, desaturation) / norm;
-
-      // Filmic S curve on the max RGB
-      // Apply the transfer function of the display
-      norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
-
-      // Re-apply ratios
-      for(int c = 0; c < 3; c++) pix_out[c] = ratios[c] * norm;
     }
+
+    if(success_1) in = reconstructed; // use reconstructed buffer as tonemapping input
   }
+
+  if(mask) dt_free_align(mask);
+
+  if(variant == DT_FILMIC_METHOD_NONE)
+  {
+    // no chroma preservation
+    if(data->version == DT_FILMIC_COLORSCIENCE_V1)
+      filmic_split_v1(in, out, work_profile, data, spline, roi_out->width, roi_in->height, ch);
+    else if(data->version == DT_FILMIC_COLORSCIENCE_V2)
+      filmic_split_v2(in, out, work_profile, data, spline, roi_out->width, roi_in->height, ch);
+  }
+  else
+  {
+    // chroma preservation
+    if(data->version == DT_FILMIC_COLORSCIENCE_V1)
+      filmic_chroma_v1(in, out, work_profile, data, spline, variant, roi_out->width, roi_out->height, ch);
+    else if(data->version == DT_FILMIC_COLORSCIENCE_V2)
+      filmic_chroma_v2(in, out, work_profile, data, spline, variant, roi_out->width, roi_out->height, ch);
+  }
+
+  if(reconstructed) dt_free_align(reconstructed);
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK)
     dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
@@ -762,6 +1537,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
        apply_autotune(self);
 }
 
+
 static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -774,7 +1550,9 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   float grey_var = log2f(prev_grey / p->grey_point_source);
   p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+
+  if(p->auto_hardness)
+    p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
@@ -796,11 +1574,15 @@ static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 
   p->white_point_source = dt_bauhaus_slider_get(slider);
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  --darktable.gui->reset;
+  if(p->auto_hardness)
+  {
+    p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+
+    ++darktable.gui->reset;
+    dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+    --darktable.gui->reset;
+  }
 
   dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -815,11 +1597,15 @@ static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 
   p->black_point_source = dt_bauhaus_slider_get(slider);
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  --darktable.gui->reset;
+  if(p->auto_hardness)
+  {
+    p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+
+    ++darktable.gui->reset;
+    dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+    --darktable.gui->reset;
+  }
 
   dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -845,7 +1631,9 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
 
   p->white_point_source = EVmax;
   p->black_point_source = EVmin;
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+
+  if(p->auto_hardness)
+    p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
@@ -855,6 +1643,80 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
 
   dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_queue_draw(self->widget);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void reconstruct_threshold_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->reconstruct_threshold = dt_bauhaus_slider_get(slider);
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void reconstruct_feather_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->reconstruct_feather = dt_bauhaus_slider_get(slider);
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void show_mask_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  g->show_mask = !(g->show_mask);
+  dt_bauhaus_widget_set_quad_active(g->reconstruct_feather, g->show_mask);
+  dt_dev_reprocess_center(self->dev);
+}
+
+static void reconstruct_bloom_vs_details_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  p->reconstruct_bloom_vs_details = dt_bauhaus_slider_get(slider);
+
+  if(p->reconstruct_bloom_vs_details == -100.f)
+  {
+    // user disabled the reconstruction in favor of full blooming
+    // so the structure vs. texture setting doesn't make any difference
+    // make it insensitive to not confuse users
+    gtk_widget_set_sensitive(g->reconstruct_structure_vs_texture, FALSE);
+  }
+  else
+  {
+    gtk_widget_set_sensitive(g->reconstruct_structure_vs_texture, TRUE);
+  }
+
+  gtk_widget_queue_draw(self->widget);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void reconstruct_grey_vs_color_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->reconstruct_grey_vs_color = dt_bauhaus_slider_get(slider);
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void reconstruct_structure_vs_texture_callback(GtkWidget *slider, gpointer user_data)
+{
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(self->dt->gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->reconstruct_structure_vs_texture = dt_bauhaus_slider_get(slider);
+
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -946,6 +1808,23 @@ static void balance_callback(GtkWidget *slider, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
+static void version_callback(GtkWidget *combo, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->version = dt_bauhaus_combobox_get(combo);
+
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+
+  if(p->version == DT_FILMIC_COLORSCIENCE_V1)
+    dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
+  else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
+    dt_bauhaus_widget_set_label(g->saturation, NULL, _("middle tones saturation"));
+
+  gtk_widget_queue_draw(self->widget);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
 static void preserve_color_callback(GtkWidget *combo, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -954,8 +1833,101 @@ static void preserve_color_callback(GtkWidget *combo, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
+static void shadows_callback(GtkWidget *combo, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->shadows = dt_bauhaus_combobox_get(combo);
+  gtk_widget_queue_draw(self->widget);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void highlights_callback(GtkWidget *combo, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->highlights = dt_bauhaus_combobox_get(combo);
+  gtk_widget_queue_draw(self->widget);
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+
+static void custom_grey_callback(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+
+  p->custom_grey = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+  const int reset = darktable.gui->reset;
+  darktable.gui->reset = 1;
+  gtk_widget_set_visible(g->grey_point_source, p->custom_grey);
+  gtk_widget_set_visible(g->grey_point_target, p->custom_grey);
+  darktable.gui->reset = reset;
+
+  gtk_widget_queue_draw(self->widget);
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void auto_hardness_callback(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->auto_hardness = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+  if(p->auto_hardness)
+  {
+    dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+
+    p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+
+    const int reset = darktable.gui->reset;
+    darktable.gui->reset = 1;
+    dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
+    darktable.gui->reset = reset;
+
+    gtk_widget_queue_draw(self->widget);
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+static void high_quality_reconstruction_callback(GtkWidget *widget, dt_iop_module_t *self)
+{
+  if(darktable.gui->reset) return;
+  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
+  p->high_quality_reconstruction = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+
+void gui_focus(struct dt_iop_module_t *self, gboolean in)
+{
+  if(!in) dt_iop_color_picker_reset(self, TRUE);
+}
+
+
+#define ORDER_4 5
+#define ORDER_3 4
+
+
 inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_params_t *const p, struct dt_iop_filmic_rgb_spline_t *const spline)
 {
+  float grey_display;
+
+  if(p->custom_grey)
+  {
+    // user set a custom value
+    grey_display = powf(CLAMP(p->grey_point_target, p->black_point_target, p->white_point_target) / 100.0f, 1.0f / (p->output_power));
+  }
+  else
+  {
+    // use 18.45% grey and don't bother
+    grey_display = powf(0.1845f, 1.0f / (p->output_power));
+  }
+
   const float white_source = p->white_point_source;
   const float black_source = p->black_point_source;
   const float dynamic_range = white_source - black_source;
@@ -967,7 +1939,6 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
 
   // target luminance desired after filmic curve
   const float black_display = CLAMP(p->black_point_target, 0.0f, p->grey_point_target) / 100.0f; // in %
-  const float grey_display = powf(CLAMP(p->grey_point_target, p->black_point_target, p->white_point_target) / 100.0f, 1.0f / (p->output_power));
   const float white_display = CLAMP(p->white_point_target, p->grey_point_target, 100.0f)  / 100.0f; // in %
 
   const float latitude = CLAMP(p->latitude, 0.0f, 100.0f) / 100.0f * dynamic_range; // in % of dynamic range
@@ -1028,75 +1999,100 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
    * https://eng.aurelienpierre.com/2018/11/30/filmic-darktable-and-the-quest-of-the-hdr-tone-mapping/#filmic_s_curve
    *
    **/
-
-  // solve the linear central part - linear function
-  const float f = contrast;
-  const float g = spline->y[1] - f * spline->x[1];
-
-  // solve the toe part - fourth order polynom
   const double Tl = spline->x[1];
   const double Tl2 = Tl * Tl;
   const double Tl3 = Tl2 * Tl;
   const double Tl4 = Tl3 * Tl;
 
-  double A0[25] = {0.,         0.,       0.,      0., 1., // position in 0
-                   0.,         0.,       0.,      1., 0., // first derivative in 0
-                   Tl4,        Tl3,      Tl2,     Tl, 1., // position at toe node
-                   4. * Tl3,   3. * Tl2, 2. * Tl, 1., 0., // first derivative at toe node
-                   12. * Tl2,  6. * Tl,  2.,      0., 0. }; // second derivative at toe node
-
-  double b0[5] = { black_display, 0., spline->y[1], f, 0. };
-
-  gauss_solve(A0, b0, 5);
-  const float a = b0[0];
-  const float b = b0[1];
-  const float c = b0[2];
-  const float d = b0[3];
-  const float e = b0[4];
-
-  // solve the shoulder part - 3rd order polynom
   const double Sl = spline->x[3];
   const double Sl2 = Sl * Sl;
   const double Sl3 = Sl2 * Sl;
+  const double Sl4 = Sl3 * Sl;
 
-  double A1[16] = { 1.,        1.,        1.,      1., // position in 1
-                    Sl3,       Sl2,       Sl,      1., // position at shoulder node
-                    3. * Sl2,  2. * Sl,   1.,      0., // first derivative at shoulder node
-                    6. * Sl,   2.,        0.,      0. }; // second derivative at shoulder node
+  // solve the linear central part - affine function
+  spline->M2[2] = contrast;                                    // * x¹ (slope)
+  spline->M1[2] = spline->y[1] - spline->M2[2] * spline->x[1]; // * x⁰ (offset)
+  spline->M3[2] = 0.f;                                         // * x²
+  spline->M4[2] = 0.f;                                         // * x³
+  spline->M5[2] = 0.f;                                         // * x⁴
 
-  double b1[4] = { white_display, spline->y[3], f, 0. };
+  // solve the toe part
+  if(p->shadows == DT_FILMIC_CURVE_POLY_4)
+  {
+    // fourth order polynom - only mode in darktable 3.0.0
+    double A0[ORDER_4 * ORDER_4] = {0.,         0.,       0.,      0., 1.,   // position in 0
+                                    0.,         0.,       0.,      1., 0.,   // first derivative in 0
+                                    Tl4,        Tl3,      Tl2,     Tl, 1.,   // position at toe node
+                                    4. * Tl3,   3. * Tl2, 2. * Tl, 1., 0.,   // first derivative at toe node
+                                    12. * Tl2,  6. * Tl,  2.,      0., 0. }; // second derivative at toe node
 
-  gauss_solve(A1, b1, 4);
-  const float h = 0.0f;
-  const float i = b1[0];
-  const float j = b1[1];
-  const float k = b1[2];
-  const float l = b1[3];
+    double b0[ORDER_4] = { spline->y[0], 0., spline->y[1], spline->M2[2], 0. };
 
-  // offsets
-  spline->M1[0] = e;
-  spline->M1[1] = l;
-  spline->M1[2] = g;
+    gauss_solve(A0, b0, ORDER_4);
 
-  // factors of x
-  spline->M2[0] = d;
-  spline->M2[1] = k;
-  spline->M2[2] = f;
+    spline->M5[0] = b0[0]; // * x⁴
+    spline->M4[0] = b0[1]; // * x³
+    spline->M3[0] = b0[2]; // * x²
+    spline->M2[0] = b0[3]; // * x¹
+    spline->M1[0] = b0[4]; // * x⁰
+  }
+  else
+  {
+    // third order polynom
+    double A0[ORDER_3 * ORDER_3] = {0.,        0.,       0.,     1.,   // position in 0
+                                    Tl3,       Tl2,      Tl,     1.,   // position at toe node
+                                    3. * Tl2,  2. * Tl,  1.,     0.,   // first derivative at toe node
+                                    6. * Tl,   2.,       0.,     0. }; // second derivative at toe node
 
-  // factors of x²
-  spline->M3[0] = c;
-  spline->M3[1] = j;
-  spline->M3[2] = 0.f;
+    double b0[ORDER_3] = { spline->y[0], spline->y[1], spline->M2[2], 0. };
 
-  // factors of x³
-  spline->M4[0] = b;
-  spline->M4[1] = i;
-  spline->M4[2] = 0.f;
+    gauss_solve(A0, b0, ORDER_3);
 
-  // factors of x⁴
-  spline->M5[0] = a;
-  spline->M5[1] = h;
-  spline->M5[2] = 0.f;
+    spline->M5[0] = 0.0f;  // * x⁴
+    spline->M4[0] = b0[0]; // * x³
+    spline->M3[0] = b0[1]; // * x²
+    spline->M2[0] = b0[2]; // * x¹
+    spline->M1[0] = b0[3]; // * x⁰
+  }
+
+  // solve the shoulder part
+  if(p->highlights == DT_FILMIC_CURVE_POLY_3)
+  {
+    // 3rd order polynom - only mode in darktable 3.0.0
+    double A1[ORDER_3 * ORDER_3] = { 1.,        1.,        1.,      1.,   // position in 1
+                                     Sl3,       Sl2,       Sl,      1.,   // position at shoulder node
+                                     3. * Sl2,  2. * Sl,   1.,      0.,   // first derivative at shoulder node
+                                     6. * Sl,   2.,        0.,      0. }; // second derivative at shoulder node
+
+    double b1[ORDER_3] = { spline->y[4], spline->y[3], spline->M2[2], 0. };
+
+    gauss_solve(A1, b1, ORDER_3);
+
+    spline->M5[1] = 0.0f;  // * x⁴
+    spline->M4[1] = b1[0]; // * x³
+    spline->M3[1] = b1[1]; // * x²
+    spline->M2[1] = b1[2]; // * x¹
+    spline->M1[1] = b1[3]; // * x⁰
+  }
+  else
+  {
+    // 4th order polynom
+    double A1[ORDER_4 * ORDER_4] = { 1.,        1.,        1.,      1.,      1.,   // position in 1
+                                     4.,        3.,        2.,      1.,      0.,   // first derivative in 1
+                                     Sl4,       Sl3,       Sl2,     Sl,      1.,   // position at shoulder node
+                                     4. * Sl3,  3. * Sl2,  2. * Sl, 1.,      0.,   // first derivative at shoulder node
+                                     12. * Sl2, 6. * Sl,   2.     , 0.,      0. }; // second derivative at shoulder node
+
+    double b1[ORDER_4] = { spline->y[4], 0., spline->y[3], spline->M2[2], 0. };
+
+    gauss_solve(A1, b1, ORDER_4);
+
+    spline->M5[1] = b1[0]; // * x⁴
+    spline->M4[1] = b1[1]; // * x³
+    spline->M3[1] = b1[2]; // * x²
+    spline->M2[1] = b1[3]; // * x¹
+    spline->M1[1] = b1[4]; // * x⁰
+  }
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
@@ -1105,19 +2101,29 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)p1;
   dt_iop_filmicrgb_data_t *d = (dt_iop_filmicrgb_data_t *)piece->data;
 
-  d->preserve_color = p->preserve_color;
+  // source and display greys
+  float grey_source, grey_display;
+  if(p->custom_grey)
+  {
+    // user set a custom value
+    grey_source = p->grey_point_source / 100.0f; // in %
+    grey_display = powf(p->grey_point_target / 100.0f, 1.0f / (p->output_power));
+  }
+  else
+  {
+    // use 18.45% grey and don't bother
+    grey_source = 0.1845f; // in %
+    grey_display = powf(0.1845f, 1.0f / (p->output_power));
+  }
 
   // source luminance - Used only in the log encoding
   const float white_source = p->white_point_source;
-  const float grey_source = p->grey_point_source / 100.0f; // in %
   const float black_source = p->black_point_source;
   const float dynamic_range = white_source - black_source;
 
   // luminance after log encoding
   const float grey_log = fabsf(p->black_point_source) / dynamic_range;
 
-  // target luminance desired after filmic curve
-  const float grey_display = powf(p->grey_point_target / 100.0f, 1.0f / (p->output_power));
 
   float contrast = p->contrast;
   if (contrast < grey_display / grey_log)
@@ -1132,6 +2138,14 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->grey_source = grey_source;
   d->output_power = p->output_power;
   d->contrast = contrast;
+  d->version = p->version;
+  d->preserve_color = p->preserve_color;
+  d->high_quality_reconstruction = p->high_quality_reconstruction;
+
+  // TODO: write OpenCL for v2
+  if(p->version == DT_FILMIC_COLORSCIENCE_V2)
+    piece->process_cl_ready = FALSE;
+
 
   // compute the curves and their LUT
   dt_iop_filmic_rgb_compute_spline(p, &d->spline);
@@ -1139,6 +2153,15 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->saturation = (2.0f * p->saturation / 100.0f + 1.0f);
   d->sigma_toe = powf(d->spline.latitude_min / 3.0f, 2.0f);
   d->sigma_shoulder = powf((1.0f - d->spline.latitude_max) / 3.0f, 2.0f);
+
+  d->reconstruct_threshold = powf(2.0f, white_source + p->reconstruct_threshold) * grey_source;
+  d->reconstruct_feather = exp2f(12.f / p->reconstruct_feather);
+
+  // offset and rescale user param to alpha blending so 0 -> 50% and 1 -> 100%
+  d->reconstruct_structure_vs_texture = (p->reconstruct_structure_vs_texture / 100.0f + 1.f) / 2.f;
+  d->reconstruct_bloom_vs_details = (p->reconstruct_bloom_vs_details / 100.0f + 1.f) / 2.f;
+  d->reconstruct_grey_vs_color = (p->reconstruct_grey_vs_color / 100.0f + 1.f) / 2.f;
+
 }
 
 void init_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
@@ -1161,6 +2184,8 @@ void gui_update(dt_iop_module_t *self)
 
   dt_iop_color_picker_reset(self, TRUE);
 
+  g->show_mask = FALSE;
+
   self->color_picker_box[0] = self->color_picker_box[1] = .25f;
   self->color_picker_box[2] = self->color_picker_box[3] = .50f;
   self->color_picker_point[0] = self->color_picker_point[1] = 0.5f;
@@ -1169,16 +2194,47 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->security_factor, p->security_factor);
+  dt_bauhaus_slider_set_soft(g->reconstruct_threshold, p->reconstruct_threshold);
+  dt_bauhaus_slider_set_soft(g->reconstruct_feather, p->reconstruct_feather);
+  dt_bauhaus_slider_set_soft(g->reconstruct_bloom_vs_details, p->reconstruct_bloom_vs_details);
+  dt_bauhaus_slider_set_soft(g->reconstruct_grey_vs_color, p->reconstruct_grey_vs_color);
+  dt_bauhaus_slider_set_soft(g->reconstruct_structure_vs_texture, p->reconstruct_structure_vs_texture);
   dt_bauhaus_slider_set_soft(g->white_point_target, p->white_point_target);
   dt_bauhaus_slider_set_soft(g->grey_point_target, p->grey_point_target);
   dt_bauhaus_slider_set_soft(g->black_point_target, p->black_point_target);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
   dt_bauhaus_slider_set_soft(g->latitude, p->latitude);
-  dt_bauhaus_slider_set(g->contrast, p->contrast);
-  dt_bauhaus_slider_set(g->saturation, p->saturation);
-  dt_bauhaus_slider_set(g->balance, p->balance);
+  dt_bauhaus_slider_set_soft(g->contrast, p->contrast);
+  dt_bauhaus_slider_set_soft(g->saturation, p->saturation);
+  dt_bauhaus_slider_set_soft(g->balance, p->balance);
 
+  dt_bauhaus_combobox_set(g->version, p->version);
   dt_bauhaus_combobox_set(g->preserve_color, p->preserve_color);
+  dt_bauhaus_combobox_set(g->shadows, p->shadows);
+  dt_bauhaus_combobox_set(g->highlights, p->highlights);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->auto_hardness), p->auto_hardness);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->custom_grey), p->custom_grey);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->high_quality_reconstruction), p->high_quality_reconstruction);
+
+  gtk_widget_set_visible(g->grey_point_source, p->custom_grey);
+  gtk_widget_set_visible(g->grey_point_target, p->custom_grey);
+
+  if(p->reconstruct_bloom_vs_details == -100.f)
+  {
+    // user disabled the reconstruction in favor of full blooming
+    // so the structure vs. texture setting doesn't make any difference
+    // make it insensitive to not confuse users
+    gtk_widget_set_sensitive(g->reconstruct_structure_vs_texture, FALSE);
+  }
+  else
+  {
+    gtk_widget_set_sensitive(g->reconstruct_structure_vs_texture, TRUE);
+  }
+
+  if(p->version == DT_FILMIC_COLORSCIENCE_V1)
+    dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
+  else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
+    dt_bauhaus_widget_set_label(g->saturation, NULL, _("middle tones saturation"));
 
   gtk_widget_queue_draw(self->widget);
 
@@ -1194,19 +2250,30 @@ void init(dt_iop_module_t *module)
 
   dt_iop_filmicrgb_params_t tmp
     = (dt_iop_filmicrgb_params_t){
-                                 .grey_point_source   = 9.225, // source grey
-                                 .black_point_source  = -10.55f,  // source black
+                                 .grey_point_source   = 18.45,  // source grey
+                                 .black_point_source  = -10.55f,// source black
                                  .white_point_source  = 3.45f,  // source white
+                                 .reconstruct_threshold = 0.0f,
+                                 .reconstruct_feather   = 3.0f,
+                                 .reconstruct_bloom_vs_details = 100.0f,
+                                 .reconstruct_grey_vs_color    = 0.0f,
+                                 .reconstruct_structure_vs_texture = 50.0f,
                                  .security_factor     = 0.0f,
                                  .grey_point_target   = 18.45f, // target grey
-                                 .black_point_target  = 0.0,  // target black
+                                 .black_point_target  = 0.0,    // target black
                                  .white_point_target  = 100.0,  // target white
                                  .output_power        = 5.98f,  // target power (~ gamma)
-                                 .latitude            = 45.0f,  // intent latitude
+                                 .latitude            = 40.0f,  // intent latitude
                                  .contrast            = 1.30f,  // intent contrast
-                                 .saturation          = 5.0f,   // intent saturation
-                                 .balance             = 12.0f, // balance shadows/highlights
-                                 .preserve_color      = DT_FILMIC_METHOD_POWER_NORM // run the saturated variant
+                                 .saturation          = 0.0f,   // intent saturation
+                                 .balance             = 12.0f,  // balance shadows/highlights
+                                 .preserve_color      = DT_FILMIC_METHOD_POWER_NORM, // run the saturated variant
+                                 .shadows             = DT_FILMIC_CURVE_POLY_4,
+                                 .highlights          = DT_FILMIC_CURVE_POLY_4,
+                                 .version             = DT_FILMIC_COLORSCIENCE_V2,
+                                 .auto_hardness     = TRUE,
+                                 .custom_grey         = FALSE,
+                                 .high_quality_reconstruction = FALSE
                               };
   memcpy(module->params, &tmp, sizeof(dt_iop_filmicrgb_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_filmicrgb_params_t));
@@ -1293,12 +2360,26 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   const float sigma_shoulder = powf((1.0f - g->spline.latitude_max) / 3.0f, 2.0f);
 
   cairo_set_source_rgb(cr, .5, .5, .5);
-  cairo_move_to(cr, 0, height * (1.0 - filmic_desaturate(0.0f, sigma_toe, sigma_shoulder, saturation)));
-  for(int k = 1; k < 256; k++)
+
+  if(p->version == DT_FILMIC_COLORSCIENCE_V1)
   {
-    const float x = k / 255.0;
-    float y = filmic_desaturate(x, sigma_toe, sigma_shoulder, saturation);
-    cairo_line_to(cr, x * width, height * (1.0 - y));
+    cairo_move_to(cr, 0, height * (1.0 - filmic_desaturate_v1(0.0f, sigma_toe, sigma_shoulder, saturation)));
+    for(int k = 1; k < 256; k++)
+    {
+      const float x = k / 255.0;
+      float y = filmic_desaturate_v1(x, sigma_toe, sigma_shoulder, saturation);
+      cairo_line_to(cr, x * width, height * (1.0 - y));
+    }
+  }
+  else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
+  {
+    cairo_move_to(cr, 0, height * (1.0 - filmic_desaturate_v2(0.0f, sigma_toe, sigma_shoulder, saturation)));
+    for(int k = 1; k < 256; k++)
+    {
+      const float x = k / 255.0;
+      float y = filmic_desaturate_v2(x, sigma_toe, sigma_shoulder, saturation);
+      cairo_line_to(cr, x * width, height * (1.0 - y));
+    }
   }
   cairo_stroke(cr);
 
@@ -1367,6 +2448,8 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
 
+  g->show_mask = FALSE;
+
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 
@@ -1383,10 +2466,15 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *page1 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
   GtkWidget *page2 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
   GtkWidget *page3 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  GtkWidget *page4 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  GtkWidget *page5 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+
 
   gtk_notebook_append_page(GTK_NOTEBOOK(g->notebook), page1, gtk_label_new(_("scene")));
+  gtk_notebook_append_page(GTK_NOTEBOOK(g->notebook), page5, gtk_label_new(_("reconstruct")));
   gtk_notebook_append_page(GTK_NOTEBOOK(g->notebook), page2, gtk_label_new(_("look")));
   gtk_notebook_append_page(GTK_NOTEBOOK(g->notebook), page3, gtk_label_new(_("display")));
+  gtk_notebook_append_page(GTK_NOTEBOOK(g->notebook), page4, gtk_label_new(_("options")));
   gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->notebook, 0)));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
 
@@ -1450,6 +2538,72 @@ void gui_init(dt_iop_module_t *self)
                                                 "ensure you understand its assumptions before using it."));
   gtk_box_pack_start(GTK_BOX(page1), g->auto_button, FALSE, FALSE, 0);
 
+  // Reconstruction threshold
+  g->reconstruct_threshold = dt_bauhaus_slider_new_with_range(self, -6., 6., 0.1, p->reconstruct_threshold, 2);
+  dt_bauhaus_slider_set_format(g->reconstruct_threshold, _("%+.2f EV"));
+  dt_bauhaus_widget_set_label(g->reconstruct_threshold, NULL, _("highlights clipping threshold"));
+  gtk_box_pack_start(GTK_BOX(page5), g->reconstruct_threshold, FALSE, FALSE, 0);
+  gtk_widget_set_tooltip_text(g->reconstruct_threshold, _("set the exposure threshold upon which\n"
+                                                          "clipped highlights get reconstructed.\n"
+                                                          "values are relative to the scene white point.\n"
+                                                          "0 EV means the threshold is the same as the scene white point.\n"
+                                                          "decrease to include more areas,\n"
+                                                          "increase to exclude more areas."));
+  g_signal_connect(G_OBJECT(g->reconstruct_threshold), "value-changed", G_CALLBACK(reconstruct_threshold_callback), self);
+
+  // Reconstruction feather
+  g->reconstruct_feather = dt_bauhaus_slider_new_with_range(self, 0.25, 6., 0.1, p->reconstruct_feather, 2);
+  dt_bauhaus_slider_set_format(g->reconstruct_feather, _("%+.2f EV"));
+  dt_bauhaus_widget_set_label(g->reconstruct_feather, NULL, _("highlights clipping transition"));
+  gtk_box_pack_start(GTK_BOX(page5), g->reconstruct_feather, FALSE, FALSE, 0);
+  gtk_widget_set_tooltip_text(g->reconstruct_feather, _("soften the transition between clipped highlights and valid pixels.\n"
+                                                        "decrease to make the transition harder and sharper,\n"
+                                                        "increase to make the transition softer and blurrier."));
+  g_signal_connect(G_OBJECT(g->reconstruct_feather), "value-changed", G_CALLBACK(reconstruct_feather_callback), self);
+  dt_bauhaus_widget_set_quad_paint(g->reconstruct_feather, dtgtk_cairo_paint_showmask, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  dt_bauhaus_widget_set_quad_toggle(g->reconstruct_feather, TRUE);
+  g_signal_connect(G_OBJECT(g->reconstruct_feather), "quad-pressed", G_CALLBACK(show_mask_callback), self);
+
+
+  // Reconstruction structure/texture
+  g->reconstruct_structure_vs_texture = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->reconstruct_structure_vs_texture, 2);
+  dt_bauhaus_widget_set_label(g->reconstruct_structure_vs_texture, NULL, _("balance structure/texture"));
+  dt_bauhaus_slider_set_format(g->reconstruct_structure_vs_texture, "%.2f %%");
+  gtk_box_pack_start(GTK_BOX(page5), g->reconstruct_structure_vs_texture, FALSE, FALSE, 0);
+  gtk_widget_set_tooltip_text(g->reconstruct_structure_vs_texture, _("decide which reconstruction strategy to favor,\n"
+                                                                     "between inpainting a smooth color gradient,\n"
+                                                                     "or trying to recover the textured details.\n"
+                                                                     "0% is an equal mix of both.\n"
+                                                                     "increase if at least one RGB channel is not clipped.\n"
+                                                                     "decrease if all RGB channels are clipped over large areas."));
+  g_signal_connect(G_OBJECT(g->reconstruct_structure_vs_texture), "value-changed", G_CALLBACK(reconstruct_structure_vs_texture_callback), self);
+
+  // Bloom vs. reconstruct
+  g->reconstruct_bloom_vs_details = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->reconstruct_grey_vs_color, 2);
+  dt_bauhaus_widget_set_label(g->reconstruct_bloom_vs_details, NULL, _("balance bloom/reconstruct"));
+  dt_bauhaus_slider_set_format(g->reconstruct_bloom_vs_details, "%.2f %%");
+  gtk_box_pack_start(GTK_BOX(page5), g->reconstruct_bloom_vs_details, FALSE, FALSE, 0);
+  gtk_widget_set_tooltip_text(g->reconstruct_bloom_vs_details, _("decide which reconstruction strategy to favor,\n"
+                                                                 "between blooming highlights like film does,\n"
+                                                                 "or trying to recover sharp details.\n"
+                                                                 "0% is an equal mix of both.\n"
+                                                                 "increase if you want more details.\n"
+                                                                 "decrease if you want more blur."));
+  g_signal_connect(G_OBJECT(g->reconstruct_bloom_vs_details), "value-changed", G_CALLBACK(reconstruct_bloom_vs_details_callback), self);
+
+  // Bloom threshold
+  g->reconstruct_grey_vs_color = dt_bauhaus_slider_new_with_range(self, -100., 100., 0.1, p->reconstruct_grey_vs_color, 2);
+  dt_bauhaus_widget_set_label(g->reconstruct_grey_vs_color, NULL, _("balance grey/colorful details"));
+  dt_bauhaus_slider_set_format(g->reconstruct_grey_vs_color, "%.2f %%");
+  gtk_box_pack_start(GTK_BOX(page5), g->reconstruct_grey_vs_color, FALSE, FALSE, 0);
+  gtk_widget_set_tooltip_text(g->reconstruct_grey_vs_color, _("decide which reconstruction strategy to favor,\n"
+                                                              "between recovering monochromatic highlights,\n"
+                                                              "or trying to recover colorful highlights.\n"
+                                                              "0% is an equal mix of both.\n"
+                                                              "increase if you want more color.\n"
+                                                              "decrease if you see magenta or out-of-gamut highlights."));
+  g_signal_connect(G_OBJECT(g->reconstruct_grey_vs_color), "value-changed", G_CALLBACK(reconstruct_grey_vs_color_callback), self);
+
   // contrast slider
   g->contrast = dt_bauhaus_slider_new_with_range(self, 0.0, 5.0, 0.01, p->contrast, 3);
   dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
@@ -1459,9 +2613,20 @@ void gui_init(dt_iop_module_t *self)
                                              "affects mostly the mid-tones"));
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
 
+
+  // brightness slider
+  g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 10.0, 0.1, p->output_power, 2);
+  dt_bauhaus_widget_set_label(g->output_power, NULL, _("hardness"));
+  gtk_box_pack_start(GTK_BOX(page2), g->output_power, FALSE, FALSE, 0);
+  gtk_widget_set_tooltip_text(g->output_power, _("equivalent to paper grade in analog.\n"
+                                                 "increase to make highlights brighter and less compressed.\n"
+                                                 "decrease to mute highlights."));
+  g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
+
+
   // latitude slider
   g->latitude = dt_bauhaus_slider_new_with_range(self, 0.01, 100.0, 1.0, p->latitude, 2);
-  dt_bauhaus_slider_set_soft_range(g->latitude, 5.0, 45.0);
+  dt_bauhaus_slider_set_soft_range(g->latitude, 5.0, 50.0);
   dt_bauhaus_widget_set_label(g->latitude, NULL, _("latitude"));
   dt_bauhaus_slider_set_format(g->latitude, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(page2), g->latitude, FALSE, FALSE, 0);
@@ -1484,8 +2649,13 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
 
   // saturation slider
-  g->saturation = dt_bauhaus_slider_new_with_range(self, -50., 200., 0.5, p->saturation, 2);
-  dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
+  g->saturation = dt_bauhaus_slider_new_with_range(self, -50., 50., 0.5, p->saturation, 2);
+
+  if(p->version == DT_FILMIC_COLORSCIENCE_V1)
+    dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
+  else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
+    dt_bauhaus_widget_set_label(g->saturation, NULL, _("middle tones saturation"));
+
   dt_bauhaus_slider_set_soft_max(g->saturation, 50.0);
   dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(page2), g->saturation, FALSE, FALSE, 0);
@@ -1494,19 +2664,6 @@ void gui_init(dt_iop_module_t *self)
                                                "increase if shadows and/or highlights are under-saturated."));
   g_signal_connect(G_OBJECT(g->saturation), "value-changed", G_CALLBACK(saturation_callback), self);
 
-
-  // Preserve color
-  g->preserve_color = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->preserve_color, NULL, _("preserve chrominance"));
-  dt_bauhaus_combobox_add(g->preserve_color, _("no"));
-  dt_bauhaus_combobox_add(g->preserve_color, _("max RGB"));
-  dt_bauhaus_combobox_add(g->preserve_color, _("luminance Y"));
-  dt_bauhaus_combobox_add(g->preserve_color, _("RGB power norm"));
-  gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original color are preserved.\n"
-                                                   "may reinforce chromatic aberrations and chroma noise,\n"
-                                                   "so ensure they are properly corrected elsewhere.\n"));
-  gtk_box_pack_start(GTK_BOX(page2), g->preserve_color , FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->preserve_color), "value-changed", G_CALLBACK(preserve_color_callback), self);
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1, p->black_point_target, 2);
@@ -1535,13 +2692,81 @@ void gui_init(dt_iop_module_t *self)
                                                         "this should be 100%\nexcept if you want a faded look"));
   g_signal_connect(G_OBJECT(g->white_point_target), "value-changed", G_CALLBACK(white_point_target_callback), self);
 
-  // power/gamma slider
-  g->output_power = dt_bauhaus_slider_new_with_range(self, 1.0, 10.0, 0.1, p->output_power, 2);
-  dt_bauhaus_widget_set_label(g->output_power, NULL, _("target power transfer function"));
-  gtk_box_pack_start(GTK_BOX(page3), g->output_power, FALSE, FALSE, 0);
-  gtk_widget_set_tooltip_text(g->output_power, _("power or gamma of the transfer function\nof the display or color space.\n"
-                                                 "you should never touch that unless you know what you are doing."));
-  g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
+
+  // Color science
+  g->version = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->version, NULL, _("color science"));
+  dt_bauhaus_combobox_add(g->version, _("v3 (2019)"));
+  dt_bauhaus_combobox_add(g->version, _("v4 (2020)"));
+  gtk_widget_set_tooltip_text(g->version, _("v3 is darktable 3.0 desaturation method, same as color balance.\n"
+                                            "v4 is a newer desaturation method, based on spectral purity of light."));
+  gtk_box_pack_start(GTK_BOX(page4), g->version, FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->version), "value-changed", G_CALLBACK(version_callback), self);
+
+  // Preserve color
+  g->preserve_color = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->preserve_color, NULL, _("preserve chrominance"));
+  dt_bauhaus_combobox_add(g->preserve_color, _("no"));
+  dt_bauhaus_combobox_add(g->preserve_color, _("max RGB"));
+  dt_bauhaus_combobox_add(g->preserve_color, _("luminance Y"));
+  dt_bauhaus_combobox_add(g->preserve_color, _("RGB power norm"));
+  gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original color are preserved.\n"
+                                                   "may reinforce chromatic aberrations and chroma noise,\n"
+                                                   "so ensure they are properly corrected elsewhere.\n"));
+  gtk_box_pack_start(GTK_BOX(page4), g->preserve_color , FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->preserve_color), "value-changed", G_CALLBACK(preserve_color_callback), self);
+
+
+  // Curve type
+  g->highlights = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->highlights, NULL, _("contrast in highlights"));
+  dt_bauhaus_combobox_add(g->highlights, _("hard"));
+  dt_bauhaus_combobox_add(g->highlights, _("soft"));
+  gtk_widget_set_tooltip_text(g->highlights, _("choose the desired curvature of the filmic spline in highlights.\n"
+                                               "hard uses a high curvature resulting in more tonal compression.\n"
+                                               "soft uses a low curvature resulting in less tonal compression."));
+  gtk_box_pack_start(GTK_BOX(page4), g->highlights, FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->highlights), "value-changed", G_CALLBACK(highlights_callback), self);
+
+  g->shadows = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_widget_set_label(g->shadows, NULL, _("contrast in shadows"));
+  dt_bauhaus_combobox_add(g->shadows, _("hard"));
+  dt_bauhaus_combobox_add(g->shadows, _("soft"));
+  gtk_widget_set_tooltip_text(g->shadows, _("choose the desired curvature of the filmic spline in shadows.\n"
+                                            "hard uses a high curvature resulting in more tonal compression.\n"
+                                            "soft uses a low curvature resulting in less tonal compression."));
+  gtk_box_pack_start(GTK_BOX(page4), g->shadows , FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->shadows), "value-changed", G_CALLBACK(shadows_callback), self);
+
+
+  // Custom grey
+  g->custom_grey = gtk_check_button_new_with_label(_("use custom middle-grey values"));
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(g->custom_grey), p->custom_grey);
+  gtk_widget_set_tooltip_text(g->custom_grey, _("enable to input custom middle-grey values\n."
+                                                "this is not recommended in general.\n"
+                                                "fix the global exposure in the exposure module instead.\n"
+                                                "disable to use standard 18.45 %% middle grey."));
+  gtk_box_pack_start(GTK_BOX(page4), g->custom_grey, FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->custom_grey), "toggled", G_CALLBACK(custom_grey_callback), self);
+
+  // Auto-hardness
+  g->auto_hardness = gtk_check_button_new_with_label(_("auto adjust hardness"));
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(g->auto_hardness), p->auto_hardness);
+  gtk_widget_set_tooltip_text(g->auto_hardness, _("enable to auto-set the look hardness depending on the scene white and black points.\n"
+                                                    "this keeps the middle grey on the identity line and improves fast tuning.\n"
+                                                    "disable if you want a manual control."));
+  gtk_box_pack_start(GTK_BOX(page4), g->auto_hardness , FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->auto_hardness), "toggled", G_CALLBACK(auto_hardness_callback), self);
+
+
+  // High quality reconstruction
+  g->high_quality_reconstruction = gtk_check_button_new_with_label(_("use high-quality reconstruction"));
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(g->high_quality_reconstruction), p->high_quality_reconstruction);
+  gtk_widget_set_tooltip_text(g->high_quality_reconstruction, _("enable to run an extra pass of chromaticity reconstructione\n."
+                                                                "this will be slower but will yield more neutral highlights.\n"
+                                                                "it also helps with difficult cases of magenta highlights."));
+  gtk_box_pack_start(GTK_BOX(page4), g->high_quality_reconstruction , FALSE, FALSE, 0);
+  g_signal_connect(G_OBJECT(g->high_quality_reconstruction), "toggled", G_CALLBACK(high_quality_reconstruction_callback), self);
 
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->op));
 }


### PR DESCRIPTION
* add a new desaturation method based on spectral purity of the light emission, independent of XYZ space, and a basic gamut mapping in pipeline RGB space following the same strategy,
* change the default saturation strategy : 0% and 100% luminance bounds are forced to 0% saturation, but the midtones are resaturated instead.
* add an highlights reconstruction method in wavelet space, bounded to the scene white value, to bloom highlights or recover details with 3 different strategies.
* hide the middle-grey settings by default, and set them to 18.45% instead. A box needs to be checked in "options" tab to get them back. These have confused too many users and overlap with exposure setting anyway.
* make the display gamma auto-adjustment optional (checkbox in "options" tab).
* allow 2 different curvatures for the filmic curve toe and shoulder : hard (4th order polynomial), with more tonal compression, and soft (3rd order polynomial), with less tonal compression.

NOTES:
* v3 algos (dt 3.0-3.0.2) are still available as an option.

WARNINGS: 
* older presets are **NOT** imported at this time,
* OpenCL kernels are **NOT** available at this time for the v4 color science and highlights recovery.

DEMO (no additional highlight reconstruction or color adjustments):
filmic v3 (2019):
![Shoot Minh-Ly Toronto-0034-_DSC0242_12](https://user-images.githubusercontent.com/2779157/80124842-23776200-8591-11ea-9028-46a9d4b1dcb7.jpg)

filmic v4 (2020):
![Shoot Minh-Ly Toronto-0034-_DSC0242_13](https://user-images.githubusercontent.com/2779157/80124889-37bb5f00-8591-11ea-9575-5255740deaaa.jpg)

filmic v4 without highlights reconstruction:
![6Q1B0045_02](https://user-images.githubusercontent.com/2779157/80124955-4d308900-8591-11ea-82af-c7196c6253fe.jpg)

filmic v4 with highlights reconstruction:
![6Q1B0045_01](https://user-images.githubusercontent.com/2779157/80125000-591c4b00-8591-11ea-8cd7-5e2752e9946f.jpg)

filmic v4 without highlights reconstruction:
![DSC_0552_06](https://user-images.githubusercontent.com/2779157/80125264-b6180100-8591-11ea-890d-9c42ca1ef6f8.jpg)

filmic v4 with highlights reconstruction:
![DSC_0552_07](https://user-images.githubusercontent.com/2779157/80125300-c6c87700-8591-11ea-9c1d-69156e627ddc.jpg)

