### PR TITLE
group fix - mirror images group changes to thumbnails

### DIFF
--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -64,6 +64,16 @@ static void _collection_changed_destroy_callback(gpointer instance, int query_ch
   }
 }
 
+// callback for the destructor of DT_SIGNAL_IMAGE_INFO_CHANGED
+static void _image_info_changed_destroy_callback(gpointer instance, gpointer imgs, gpointer user_data)
+{
+  if(imgs && g_list_length(imgs) > 0)
+  {
+    g_list_free(imgs);
+    imgs = NULL;
+  }
+}
+
 static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   /* Global signals */
   { "dt-global-mouse-over-image-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
@@ -89,6 +99,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     FALSE }, // DT_SIGNAL_TAG_CHANGED
   { "dt-metadata-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
     FALSE }, // DT_SIGNAL_METADATA_CHANGED
+  { "dt-image-info-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 1, pointer_arg,
+    G_CALLBACK(_image_info_changed_destroy_callback), FALSE }, // DT_SIGNAL_IMAGE_INFO_CHANGED
   { "dt-style-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_STYLE_CHANGED
   { "dt-filmrolls-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -69,6 +69,7 @@ typedef enum dt_signal_t
     3 : next untouched imgid in the list (-1 if no list)
     no returned value
     */
+  /** image list not to be freed by the caller, automatically freed */
   DT_SIGNAL_COLLECTION_CHANGED,
 
   /** \brief This signal is raised when the selection is changed
@@ -81,6 +82,11 @@ typedef enum dt_signal_t
 
   /** \brief This signal is raised when metadata status (shown/hidden) or value has changed */
   DT_SIGNAL_METADATA_CHANGED,
+
+  /** \brief This signal is raised when any of image info has changed  */
+  /** image list not to be freed by the caller, automatically freed */
+  // TODO check if tag and metadata could be included there
+  DT_SIGNAL_IMAGE_INFO_CHANGED,
 
   /** \brief This signal is raised when a style is added/deleted/changed  */
   DT_SIGNAL_STYLE_CHANGED,

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -426,34 +426,6 @@ static int _thumbs_remove_unneeded(dt_thumbtable_t *table)
   return changed;
 }
 
-// change thumbnails group id
-void dt_thumbtable_group_change_representative(dt_thumbtable_t *table, const int group_id, const int new_group_id)
-{
-  GList *l = table->list;
-  while(l)
-  {
-    dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
-    if(th->groupid == group_id) th->groupid = new_group_id;
-    l = g_list_next(l);
-  }
-}
-
-// set thumbnail's group id
-void dt_thumbtable_set_image_group(dt_thumbtable_t *table, const int imgid, const int group_id)
-{
-  GList *l = table->list;
-  while(l)
-  {
-    dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
-    if(th->imgid == imgid)
-    {
-      th->groupid = group_id;
-      break;
-    }
-    l = g_list_next(l);
-  }
-}
-
 // load all needed thumbnails in the list and the widget
 // needed == that should appear in the current view (possibly not entirely)
 static int _thumbs_load_needed(dt_thumbtable_t *table)
@@ -1049,6 +1021,29 @@ static void _dt_active_images_callback(gpointer instance, gpointer user_data)
   dt_thumbtable_set_offset_image(table, activeid, TRUE);
 }
 
+// this is called each time the images info change
+static void _dt_image_info_changed_callback(gpointer instance, gpointer imgs, gpointer user_data)
+{
+  if(!user_data || !imgs) return;
+  dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
+  const GList * i = imgs;
+  while(i)
+  {
+    const GList *l = (const GList *)table->list;
+    while(l)
+    {
+      dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+      if(GPOINTER_TO_INT(i->data) == th->imgid)
+      {
+        dt_thumbnail_update_infos(th);
+        break;
+      }
+      l = g_list_next(l);
+    }
+    i = g_list_next(i);
+  }
+}
+
 // this is called each time mouse_over id change
 static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
 {
@@ -1513,8 +1508,10 @@ dt_thumbtable_t *dt_thumbtable_new()
                             G_CALLBACK(_dt_active_images_callback), table);
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                             G_CALLBACK(_dt_profile_change_callback), table);
-  dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(_dt_pref_change_callback),
-                            table);
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                            G_CALLBACK(_dt_pref_change_callback), table);
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED,
+                            G_CALLBACK(_dt_image_info_changed_callback), table);
   gtk_widget_show(table->widget);
 
   g_object_ref(table->widget);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -426,6 +426,34 @@ static int _thumbs_remove_unneeded(dt_thumbtable_t *table)
   return changed;
 }
 
+// change thumbnails group id
+void dt_thumbtable_group_change_representative(dt_thumbtable_t *table, const int group_id, const int new_group_id)
+{
+  GList *l = table->list;
+  while(l)
+  {
+    dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+    if(th->groupid == group_id) th->groupid = new_group_id;
+    l = g_list_next(l);
+  }
+}
+
+// set thumbnail's group id
+void dt_thumbtable_set_image_group(dt_thumbtable_t *table, const int imgid, const int group_id)
+{
+  GList *l = table->list;
+  while(l)
+  {
+    dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+    if(th->imgid == imgid)
+    {
+      th->groupid = group_id;
+      break;
+    }
+    l = g_list_next(l);
+  }
+}
+
 // load all needed thumbnails in the list and the widget
 // needed == that should appear in the current view (possibly not entirely)
 static int _thumbs_load_needed(dt_thumbtable_t *table)
@@ -1069,7 +1097,7 @@ static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
         gboolean b = TRUE;
         if(table->mode != DT_THUMBTABLE_MODE_FILMSTRIP)
         {
-          // left brorder
+          // left border
           if(pos != 0 && th->x != table->thumbs_area.x)
           {
             dt_thumbnail_t *th1 = (dt_thumbnail_t *)g_list_nth_data(table->list, pos - 1);
@@ -1079,7 +1107,7 @@ static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
           {
             dt_thumbnail_set_group_border(th, DT_THUMBNAIL_BORDER_LEFT);
           }
-          // right brorder
+          // right border
           b = TRUE;
           if(table->mode != DT_THUMBTABLE_MODE_FILMSTRIP && pos < g_list_length(table->list) - 1
              && (th->x + th->width * 1.5) < table->thumbs_area.width)
@@ -1099,7 +1127,7 @@ static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
           dt_thumbnail_set_group_border(th, DT_THUMBNAIL_BORDER_BOTTOM);
         }
 
-        // top brorder
+        // top border
         b = TRUE;
         if(pos - table->thumbs_per_row >= 0)
         {
@@ -1113,7 +1141,7 @@ static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
           else
             dt_thumbnail_set_group_border(th, DT_THUMBNAIL_BORDER_TOP);
         }
-        // bottom brorder
+        // bottom border
         b = TRUE;
         if(pos + table->thumbs_per_row < g_list_length(table->list))
         {

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -131,6 +131,12 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, int view);
 // change the type of overlays that should be shown (over or under the image)
 void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over);
 
+// change thumbnails group id
+void dt_thumbtable_group_change_representative(dt_thumbtable_t *table, const int group_id, const int new_group_id);
+
+// set thumbnail's group id
+void dt_thumbtable_set_image_group(dt_thumbtable_t *table, const int imgid, const int group_id);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -131,12 +131,6 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, int view);
 // change the type of overlays that should be shown (over or under the image)
 void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over);
 
-// change thumbnails group id
-void dt_thumbtable_group_change_representative(dt_thumbtable_t *table, const int group_id, const int new_group_id);
-
-// set thumbnail's group id
-void dt_thumbtable_set_image_group(dt_thumbtable_t *table, const int imgid, const int group_id);
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
Fixes #4791 fro me.

Some doubts.
- is the way to specify the thumbnails table (always) correct ?
- in views/lighttable it seems there is a lot unused code: button_press(), key_release()... I understand that this part is now treated by dtgtk/thumbnail.c. Is that not to be cleaned up ?

