### PR TITLE
thumbs : ensure mouse_over_id on double-click

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -366,6 +366,7 @@ static gboolean _event_main_press(GtkWidget *widget, GdkEventButton *event, gpoi
          || (event->type == GDK_BUTTON_PRESS
              && (event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK | GDK_MOD1_MASK)) == 0 && thumb->single_click)))
   {
+    dt_control_set_mouse_over_id(thumb->imgid); // to ensure we haven't lost imgid during double-click
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, thumb->imgid);
   }
   return FALSE;


### PR DESCRIPTION
Seems that the id is reset for some people... I don't know why, but ensuring we have the right id doesn't harm ;)
This fix #4502