### PR TITLE
[RFC] IOP Introspection completion, (partial) refactoring and janitorial work.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ FILE(GLOB SOURCE_FILES
   "develop/develop.c"
   "develop/imageop.c"
   "develop/imageop_math.c"
+  "develop/imageop_gui.c"
   "develop/lightroom.c"
   "develop/pixelpipe.c"
   "develop/blend.c"

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -752,7 +752,8 @@ void dt_bauhaus_slider_set_hard_max(GtkWidget* widget, float val)
   d->max = MIN(d->max, d->hard_max);
   d->soft_max = MIN(d->soft_max, d->hard_max);
   if(rawval < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
-  if(pos > val) {
+  if(pos > val) 
+  {
     dt_bauhaus_slider_set_soft(widget,val);
   }
   else
@@ -772,21 +773,9 @@ void dt_bauhaus_slider_set_soft_min(GtkWidget* widget, float val)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float pos = dt_bauhaus_slider_get(widget);
   float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
-  d->soft_min = rawval;
-  d->hard_min = MIN(d->hard_min,d->soft_min);
-  d->min =  d->soft_min;
-  if(rawval > d->soft_max) dt_bauhaus_slider_set_soft_max(widget,val);
-  if(rawval > d->hard_max) dt_bauhaus_slider_set_hard_max(widget,val);
-  if(pos < val)
-  {
-    dt_bauhaus_slider_set_soft(widget,val);
-  }
-  else
-  {
-    dt_bauhaus_slider_set_soft(widget,pos);
-  }
+  d->min = d->soft_min = CLAMP(rawval,d->hard_min,d->hard_max);
+  dt_bauhaus_slider_set_soft(widget,dt_bauhaus_slider_get(widget));
 }
 
 float dt_bauhaus_slider_get_soft_min(GtkWidget* widget)
@@ -800,18 +789,9 @@ void dt_bauhaus_slider_set_soft_max(GtkWidget* widget, float val)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float pos = dt_bauhaus_slider_get(widget);
   float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
-  d->soft_max = rawval;
-  d->hard_max = MAX(d->soft_max, d->hard_max);
-  d->max =  d->soft_max;
-  if(rawval < d->soft_min) dt_bauhaus_slider_set_soft_min(widget,val);
-  if(rawval < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
-  if(pos > val) {
-    dt_bauhaus_slider_set_soft(widget,val);
-  } else {
-    dt_bauhaus_slider_set_soft(widget,pos);
-  }
+  d->max = d->soft_max = CLAMP(rawval,d->hard_min,d->hard_max);
+  dt_bauhaus_slider_set_soft(widget,dt_bauhaus_slider_get(widget));
 }
 
 float dt_bauhaus_slider_get_soft_max(GtkWidget* widget)
@@ -827,6 +807,12 @@ void dt_bauhaus_slider_set_default(GtkWidget *widget, float def)
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float val = d->callback(widget, def, DT_BAUHAUS_SET);
   d->defpos = (val - d->min) / (d->max - d->min);
+}
+
+void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max)
+{
+  dt_bauhaus_slider_set_soft_min(widget,soft_min);
+  dt_bauhaus_slider_set_soft_max(widget,soft_max);
 }
 
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max)
@@ -954,6 +940,7 @@ GtkWidget *dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, 
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(g_object_new(DT_BAUHAUS_WIDGET_TYPE, NULL));
   return dt_bauhaus_slider_from_widget(w,self, min, max, step, defval, digits, feedback);
 }
+
 GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *self, float min, float max,
                                                          float step, float defval, int digits, int feedback)
 {
@@ -2218,6 +2205,8 @@ void dt_bauhaus_slider_reset(GtkWidget *widget)
 
   d->min = d->soft_min;
   d->max = d->soft_max;
+  d->scale = 5.0f * d->step / (d->max - d->min);
+
   dt_bauhaus_slider_set_normalized(w, d->defpos);
 
   return;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -22,6 +22,8 @@
 #include "control/conf.h"
 #include "develop/develop.h"
 #include "gui/gtk.h"
+#include "gui/color_picker_proxy.h"
+
 #ifdef GDK_WINDOWING_QUARTZ
 #include "osx/osx.h"
 #endif
@@ -993,6 +995,111 @@ GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t 
                    (gpointer)NULL);
   g_signal_connect(G_OBJECT(w), "destroy", G_CALLBACK(dt_bauhaus_slider_destroy), (gpointer)NULL);
   return GTK_WIDGET(w);
+}
+
+typedef struct dt_module_param_t
+{
+  dt_iop_module_t *module;
+  const char *param;
+} dt_module_param_t;
+
+static void generic_slider_callback(GtkWidget *slider, dt_module_param_t *data)
+{
+  if(darktable.gui->reset) return;
+
+  dt_iop_module_t *self = data->module;
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+
+  /* todo: 
+     call generic callback to update module gui
+     save previous value
+     if configure_callback defined, call with param and prev value
+     same configure_callback can also be called from gui_update (with param=null)
+  */
+
+  *(float*)self->so->get_p(p, data->param) = dt_bauhaus_slider_get(slider);
+
+  dt_iop_color_picker_reset(self, TRUE);
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post)
+{
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  dt_introspection_field_t *f = self->so->get_f(param);
+
+  GtkWidget *slider = NULL;
+  gchar *str;
+
+  if (f && f->header.type == DT_INTROSPECTION_TYPE_FLOAT)
+  {
+    float min = f->Float.Min;
+    float max = f->Float.Max;
+    float defval = *(float*)self->so->get_p(p, param);
+    int digits = 2;
+    float step;
+
+    float top = fmaxf(fabsf(min),fabsf(max));
+    if (top>=100)
+    {
+      step = 1.f;
+    }
+    else
+    {
+      step = top / 100;
+      float log10step = log10f(step);
+      float fdigits = floorf(log10step+.1);
+      step = powf(10.f,fdigits);
+      if (log10step - fdigits > .5)
+        step *= 5;
+      if (fdigits < -2.f) 
+        digits = -fdigits;
+    }
+
+    slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, step, defval, digits, 1);
+
+    if (*f->Float.header.description)
+    {
+      dt_bauhaus_widget_set_label(slider, NULL, gettext(f->Float.header.description));
+    }
+    else
+    {
+      str = dt_util_str_replace(f->Float.header.field_name, "_", " ");
+    
+      dt_bauhaus_widget_set_label(slider, NULL, gettext(str));
+
+      g_free(str);
+    }
+
+    if (min < 0 || (post && *post))
+    {
+      str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), digits, post);
+
+      dt_bauhaus_slider_set_format(slider, str);
+    
+      g_free(str);
+    }
+
+    dt_module_param_t *module_param = (dt_module_param_t *)g_malloc(sizeof(dt_module_param_t));
+    module_param->module = self;
+    module_param->param = param;
+    g_signal_connect_data(G_OBJECT(slider), "value-changed", G_CALLBACK(generic_slider_callback), module_param, (GClosureNotify)g_free, 0);
+
+    // todo: add tooltip
+  }
+  else
+  {
+    str = g_strdup_printf(_("'%s' is not a parameter"), param);
+
+    slider = GTK_WIDGET(GTK_LABEL(gtk_label_new(str)));
+
+    g_free(str);
+  }
+
+  gtk_box_pack_start(GTK_BOX(self->widget), slider, TRUE, TRUE, 0);
+
+  return slider;
 }
 
 static void dt_bauhaus_combobox_destroy(dt_bauhaus_widget_t *widget, gpointer user_data)

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -285,6 +285,7 @@ void dt_bauhaus_slider_set_format(GtkWidget *w, const char *format);
 void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g, float b);
 void dt_bauhaus_slider_clear_stops(GtkWidget *widget);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
+void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max);
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max);
 void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(GtkWidget *self, float value, dt_bauhaus_callback_t dir));
 

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -260,6 +260,9 @@ GtkWidget *dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, 
 
 GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* widget, dt_iop_module_t *self, float min, float max,
                                                          float step, float defval, int digits, int feedback);
+
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post);
+
 // outside doesn't see the real type, we cast it internally.
 void dt_bauhaus_slider_set(GtkWidget *w, float pos);
 void dt_bauhaus_slider_set_soft(GtkWidget *w, float pos);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -260,9 +260,6 @@ GtkWidget *dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, 
 
 GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* widget, dt_iop_module_t *self, float min, float max,
                                                          float step, float defval, int digits, int feedback);
-
-GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post);
-
 // outside doesn't see the real type, we cast it internally.
 void dt_bauhaus_slider_set(GtkWidget *w, float pos);
 void dt_bauhaus_slider_set_soft(GtkWidget *w, float pos);

--- a/src/common/introspection.h
+++ b/src/common/introspection.h
@@ -185,6 +185,7 @@ typedef struct dt_introspection_type_enum_tuple_t
 {
   const char                         *name;
   int                                 value;
+  const char                         *description;
 } dt_introspection_type_enum_tuple_t;
 
 typedef struct dt_introspection_type_enum_t

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -155,12 +155,10 @@ static void default_gui_cleanup(dt_iop_module_t *self)
 
 static void default_cleanup(dt_iop_module_t *module)
 {
-  g_free(module->gui_data);
-  module->gui_data = NULL; // just to be sure
   g_free(module->params);
   module->params = NULL;
-  g_free(module->global_data); // just to be sure
-  module->global_data = NULL;
+  free(module->default_params);
+  module->default_params = NULL;
 }
 
 
@@ -334,7 +332,7 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
   if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) 
     module->init = default_init;
   if(!g_module_symbol(module->module, "cleanup", (gpointer) & (module->cleanup)))
-    module->cleanup = &default_cleanup;
+    module->cleanup = default_cleanup;
   if(!g_module_symbol(module->module, "init_global", (gpointer) & (module->init_global)))
     module->init_global = NULL;
   if(!g_module_symbol(module->module, "cleanup_global", (gpointer) & (module->cleanup_global)))

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -256,6 +256,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
   if(!g_module_symbol(module->module, "gui_init", (gpointer) & (module->gui_init))) module->gui_init = NULL;
   if(!g_module_symbol(module->module, "gui_update", (gpointer) & (module->gui_update)))
     module->gui_update = NULL;
+  if(!g_module_symbol(module->module, "gui_changed", (gpointer) & (module->gui_changed))) 
+    module->gui_changed = NULL;
   if(!g_module_symbol(module->module, "gui_cleanup", (gpointer) & (module->gui_cleanup)))
     module->gui_cleanup = default_gui_cleanup;
 
@@ -426,6 +428,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->gui_update = so->gui_update;
   module->gui_reset = so->gui_reset;
   module->gui_init = so->gui_init;
+  module->gui_changed = so->gui_changed;
   module->gui_cleanup = so->gui_cleanup;
 
   module->gui_post_expose = so->gui_post_expose;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -208,6 +208,50 @@ static dt_introspection_field_t *default_get_f(const char *name)
   return NULL;
 }
 
+void default_init(dt_iop_module_t *module)
+{
+  size_t param_size = module->so->get_introspection()->size;
+  module->params_size = param_size;
+  module->params = (dt_iop_params_t *)malloc(param_size);
+  module->default_params = (dt_iop_params_t *)malloc(param_size);
+
+  module->default_enabled = 0;
+  module->gui_data = NULL;
+
+  dt_introspection_field_t *i = module->so->get_introspection_linear();
+  for (int num = module->so->get_introspection()->field->Struct.entries; num; num--,i++)
+  {
+    if (i->header.type == DT_INTROSPECTION_TYPE_FLOAT)
+    {
+      *(float*)(module->default_params + i->header.offset) = i->Float.Default;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_INT)
+    {
+      *(int*)(module->default_params + i->header.offset) = i->Int.Default;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_UINT)
+    {
+      *(unsigned int*)(module->default_params + i->header.offset) = i->UInt.Default;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_ENUM)
+    {
+//      Introspection $DEFAULT: not available for enums
+//      *(enum*)(module->default_params + i->header.offset) = i->Enum.Default;
+      *(int*)(module->default_params + i->header.offset) = 0;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_BOOL)
+    {
+      *(gboolean*)(module->default_params + i->header.offset) = i->Bool.Default;
+    }
+    else
+    {
+      fprintf(stderr, "[default_init] can't support module `%s': needs custom init()\n", module->op);
+    }
+  }
+
+  memcpy(module->params, module->default_params, param_size);
+}
+
 int dt_iop_load_module_so(void *m, const char *libname, const char *op)
 {
   dt_iop_module_so_t *module = (dt_iop_module_so_t *)m;
@@ -287,7 +331,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
     module->configure = NULL;
   if(!g_module_symbol(module->module, "scrolled", (gpointer) & (module->scrolled))) module->scrolled = NULL;
 
-  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) goto error;
+  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) 
+    module->init = default_init;
   if(!g_module_symbol(module->module, "cleanup", (gpointer) & (module->cleanup)))
     module->cleanup = &default_cleanup;
   if(!g_module_symbol(module->module, "init_global", (gpointer) & (module->init_global)))

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -204,6 +204,7 @@ typedef struct dt_iop_module_so_t
   void (*gui_reset)(struct dt_iop_module_t *self);
   void (*gui_update)(struct dt_iop_module_t *self);
   void (*gui_init)(struct dt_iop_module_t *self);
+  void (*gui_changed)(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   void (*gui_post_expose)(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
                           int32_t pointerx, int32_t pointery);
@@ -437,6 +438,8 @@ typedef struct dt_iop_module_t
   void (*gui_reset)(struct dt_iop_module_t *self);
   /** construct widget. */
   void (*gui_init)(struct dt_iop_module_t *self);
+  /** called by standard widget callbacks after value changed */
+  void (*gui_changed)(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
   /** destroy widget. */
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   /** optional method called after darkroom expose. */

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -1,0 +1,146 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2009-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/imageop_gui.h"
+#include "develop/imageop.h"
+#include "bauhaus/bauhaus.h"
+#include "gui/color_picker_proxy.h"
+
+#ifdef GDK_WINDOWING_QUARTZ
+#include "osx/osx.h"
+#endif
+
+#include <assert.h>
+#include <gmodule.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#if defined(__SSE__)
+#include <xmmintrin.h>
+#endif
+#include <time.h>
+
+typedef struct dt_module_param_t
+{
+  dt_iop_module_t *module;
+  int param_offset;
+} dt_module_param_t;
+
+static void generic_slider_callback(GtkWidget *slider, dt_module_param_t *data)
+{
+  if(darktable.gui->reset) return;
+
+  dt_iop_module_t *self = data->module;
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+
+  /* todo: 
+     call generic callback to update module gui
+     save previous value
+     if configure_callback defined, call with param and prev value
+     same configure_callback can also be called from gui_update (with param=null)
+  */
+
+  *(float*)(p + data->param_offset) = dt_bauhaus_slider_get(slider);
+
+  dt_iop_color_picker_reset(self, TRUE);
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+}
+
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post)
+{
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  dt_introspection_field_t *f = self->so->get_f(param);
+
+  GtkWidget *slider = NULL;
+  gchar *str;
+
+  if (f && f->header.type == DT_INTROSPECTION_TYPE_FLOAT)
+  {
+    float min = f->Float.Min;
+    float max = f->Float.Max;
+    float defval = *(float*)self->so->get_p(p, param);
+    int digits = 2;
+    float step;
+
+    float top = fmaxf(fabsf(min),fabsf(max));
+    if (top>=100)
+    {
+      step = 1.f;
+    }
+    else
+    {
+      step = top / 100;
+      float log10step = log10f(step);
+      float fdigits = floorf(log10step+.1);
+      step = powf(10.f,fdigits);
+      if (log10step - fdigits > .5)
+        step *= 5;
+      if (fdigits < -2.f) 
+        digits = -fdigits;
+    }
+
+    slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, step, defval, digits, 1);
+
+    if (*f->Float.header.description)
+    {
+      dt_bauhaus_widget_set_label(slider, NULL, gettext(f->Float.header.description));
+    }
+    else
+    {
+      str = dt_util_str_replace(f->Float.header.field_name, "_", " ");
+    
+      dt_bauhaus_widget_set_label(slider, NULL, gettext(str));
+
+      g_free(str);
+    }
+
+    if (min < 0 || (post && *post))
+    {
+      str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), digits, post);
+
+      dt_bauhaus_slider_set_format(slider, str);
+    
+      g_free(str);
+    }
+
+    dt_module_param_t *module_param = (dt_module_param_t *)g_malloc(sizeof(dt_module_param_t));
+    module_param->module = self;
+    module_param->param_offset = self->so->get_p(p, param) - p;
+    g_signal_connect_data(G_OBJECT(slider), "value-changed", G_CALLBACK(generic_slider_callback), module_param, (GClosureNotify)g_free, 0);
+
+    // todo: add tooltip
+  }
+  else
+  {
+    str = g_strdup_printf(_("'%s' is not a parameter"), param);
+
+    slider = GTK_WIDGET(GTK_LABEL(gtk_label_new(str)));
+
+    g_free(str);
+  }
+
+  gtk_box_pack_start(GTK_BOX(self->widget), slider, TRUE, TRUE, 0);
+
+  return slider;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -84,7 +84,7 @@ static void generic_combobox_callback(GtkWidget *combobox, dt_module_param_t *da
   }
 }
 
-GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post)
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param)
 {
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
   dt_introspection_field_t *f = self->so->get_f(param);
@@ -132,6 +132,8 @@ GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const ch
       g_free(str);
     }
 
+    const char *post = ""; // set " %%", " EV" etc
+
     if (min < 0 || (post && *post))
     {
       str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), digits, post);
@@ -145,12 +147,10 @@ GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const ch
     module_param->module = self;
     module_param->param_offset = self->so->get_p(p, param) - p;
     g_signal_connect_data(G_OBJECT(slider), "value-changed", G_CALLBACK(generic_slider_callback), module_param, (GClosureNotify)g_free, 0);
-
-    // todo: add tooltip
   }
   else
   {
-    str = g_strdup_printf(_("'%s' is not a parameter"), param);
+    str = g_strdup_printf("'%s' is not a float/slider parameter", param);
 
     slider = GTK_WIDGET(GTK_LABEL(gtk_label_new(str)));
 
@@ -199,12 +199,10 @@ GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const 
         dt_bauhaus_combobox_add(combobox, gettext(iter->description));
       }
     }
-
-    // todo: add tooltip
   }
   else
   {
-    str = g_strdup_printf(_("'%s' is not an int/combox parameter"), param);
+    str = g_strdup_printf(_("'%s' is not an enum/int/combobox parameter"), param);
 
     combobox = GTK_WIDGET(GTK_LABEL(gtk_label_new(str)));
 

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -1,0 +1,27 @@
+    /*
+    This file is part of darktable,
+    Copyright (C) 2009-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "develop/imageop.h"
+
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -20,7 +20,7 @@
 
 #include "develop/imageop.h"
 
-GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post);
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param);
 
 GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const char *param);
 

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -22,6 +22,8 @@
 
 GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param, const char *post);
 
+GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const char *param);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -28,6 +28,7 @@
 #include "common/colorspaces_inline_conversions.h"
 #include "common/rgb_norms.h"
 #include "develop/imageop.h"
+#include "develop/imageop_gui.h"
 #include "gui/accelerators.h"
 #include "gui/color_picker_proxy.h"
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -196,7 +196,7 @@ static void _turn_selregion_picker_off(struct dt_iop_module_t *self)
   _turn_select_region_off(self);
   dt_iop_color_picker_reset(self, TRUE);
 }
-
+/*
 static void preserve_colors_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -208,7 +208,7 @@ static void preserve_colors_callback(GtkWidget *widget, dt_iop_module_t *self)
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
-
+*/
 static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
 {
   _turn_select_region_off(self->module);
@@ -668,8 +668,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_contrast, -1.0, 5.0);
   gtk_widget_set_tooltip_text(g->sl_contrast, _("contrast adjustment"));
 
-  g->cmb_preserve_colors = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->cmb_preserve_colors, NULL, _("preserve colors"));
+  g->cmb_preserve_colors = dt_bauhaus_combobox_new_from_params_box(self, "preserve_colors") ;
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("none"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("luminance"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("max RGB"));
@@ -677,9 +676,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("sum RGB"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("norm RGB"));
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("basic power"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->cmb_preserve_colors, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(g->cmb_preserve_colors, _("method to preserve colors when applying contrast"));
-  g_signal_connect(G_OBJECT(g->cmb_preserve_colors), "value-changed", G_CALLBACK(preserve_colors_callback), self);
 
   g->sl_middle_grey = dt_bauhaus_slider_new_from_params_box(self, "middle_grey", " %%");
   dt_bauhaus_slider_set_step(g->sl_middle_grey, .5);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -648,23 +648,24 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
 
-  g->sl_black_point = dt_bauhaus_slider_new_from_params_box(self, "black_point", "");
+  g->sl_black_point = dt_bauhaus_slider_new_from_params_box(self, "black_point");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_black_point, -1.0, 1.0);
   gtk_widget_set_tooltip_text(g->sl_black_point, _("adjust the black level to unclip negative RGB values.\n"
                                                     "you should never use it to add more density in blacks!\n"
                                                     "if poorly set, it will clip near-black colors out of gamut\n"
                                                     "by pushing RGB values into negatives"));
 
-  g->sl_exposure = dt_bauhaus_slider_new_from_params_box(self, "exposure", " EV");
+  g->sl_exposure = dt_bauhaus_slider_new_from_params_box(self, "exposure");
   dt_bauhaus_slider_set_step(g->sl_exposure, .02);
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_exposure, -18.0, 18.0);
+  dt_bauhaus_slider_set_format(g->sl_exposure, _("%.2f EV"));
   gtk_widget_set_tooltip_text(g->sl_exposure, _("adjust the exposure correction"));
 
-  g->sl_hlcompr = dt_bauhaus_slider_new_from_params_box(self, "hlcompr", "");
+  g->sl_hlcompr = dt_bauhaus_slider_new_from_params_box(self, "hlcompr");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_hlcompr, 0.0, 500.0);
   gtk_widget_set_tooltip_text(g->sl_hlcompr, _("highlight compression adjustment"));
 
-  g->sl_contrast = dt_bauhaus_slider_new_from_params_box(self, "contrast", "");
+  g->sl_contrast = dt_bauhaus_slider_new_from_params_box(self, "contrast");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_contrast, -1.0, 5.0);
   gtk_widget_set_tooltip_text(g->sl_contrast, _("contrast adjustment"));
 
@@ -678,8 +679,9 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->cmb_preserve_colors, _("basic power"));
   gtk_widget_set_tooltip_text(g->cmb_preserve_colors, _("method to preserve colors when applying contrast"));
 
-  g->sl_middle_grey = dt_bauhaus_slider_new_from_params_box(self, "middle_grey", " %%");
+  g->sl_middle_grey = dt_bauhaus_slider_new_from_params_box(self, "middle_grey");
   dt_bauhaus_slider_set_step(g->sl_middle_grey, .5);
+  dt_bauhaus_slider_set_format(g->sl_middle_grey, "%.2f %%");
   gtk_widget_set_tooltip_text(g->sl_middle_grey, _("middle grey adjustment"));
 
   dt_bauhaus_widget_set_quad_paint(g->sl_middle_grey, dtgtk_cairo_paint_colorpicker,
@@ -688,14 +690,14 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback),
                    &g->color_picker);
 
-  g->sl_brightness = dt_bauhaus_slider_new_from_params_box(self, "brightness", "");
+  g->sl_brightness = dt_bauhaus_slider_new_from_params_box(self, "brightness");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_brightness, -4.0, 4.0);
   gtk_widget_set_tooltip_text(g->sl_brightness,_("brightness adjustment"));
 
-  g->sl_saturation = dt_bauhaus_slider_new_from_params_box(self, "saturation", "");
+  g->sl_saturation = dt_bauhaus_slider_new_from_params_box(self, "saturation");
   gtk_widget_set_tooltip_text(g->sl_saturation,_("saturation adjustment"));
 
-  g->sl_vibrance = dt_bauhaus_slider_new_from_params_box(self, "vibrance", "");
+  g->sl_vibrance = dt_bauhaus_slider_new_from_params_box(self, "vibrance");
   gtk_widget_set_tooltip_text(g->sl_vibrance, _("vibrance adjustment"));
  
   GtkWidget *autolevels_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(10));
@@ -718,7 +720,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
 
-  g->sl_clip = dt_bauhaus_slider_new_from_params_box(self, "clip", "");
+  g->sl_clip = dt_bauhaus_slider_new_from_params_box(self, "clip");
   gtk_widget_set_tooltip_text(g->sl_clip, _("adjusts clipping value for auto exposure calculation"));
 
   // add signal handler for preview pipe finish

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -37,17 +37,19 @@ DT_MODULE_INTROSPECTION(2, dt_iop_basicadj_params_t)
 
 typedef struct dt_iop_basicadj_params_t
 {
-  float black_point;
-  float exposure;
-  float hlcompr;
-  float hlcomprthresh;
-  float contrast;
+  float black_point;    /* $MIN:-0.10 $MAX:0.10
+                           $DESCRIPTION:"black level correction" */
+  float exposure;       // $MIN:-4.0 $MAX:4.0
+  float hlcompr;        /* $MIN:0 $MAX:100
+                           $DESCRIPTION:"highlight compression" */
+  float hlcomprthresh;  
+  float contrast;       // $MIN:-1.0 $MAX:1.0
   int preserve_colors;
-  float middle_grey;
-  float brightness;
-  float saturation;
-  float vibrance;
-  float clip;
+  float middle_grey;    // $MIN:0.05 $MAX:100 $DEFAULT:18.42
+  float brightness;     // $MIN:-1.0 $MAX:1.0
+  float saturation;     // $MIN:-1.0 $MAX:1.0
+  float vibrance;       // $MIN:-1.0 $MAX:1.0
+  float clip;           // $MIN:-1.0 $MAX:1.0
 } dt_iop_basicadj_params_t;
 
 typedef struct dt_iop_basicadj_gui_data_t
@@ -194,54 +196,6 @@ static void _turn_selregion_picker_off(struct dt_iop_module_t *self)
   dt_iop_color_picker_reset(self, TRUE);
 }
 
-static void _black_point_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->black_point = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _exposure_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->exposure = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _hlcompr_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->hlcompr = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _contrast_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->contrast = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
 static void preserve_colors_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -254,70 +208,10 @@ static void preserve_colors_callback(GtkWidget *widget, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void _middle_grey_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->middle_grey = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
 static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
 {
   _turn_select_region_off(self->module);
   dt_iop_color_picker_callback(button, self);
-}
-
-static void _brightness_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->brightness = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _saturation_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->saturation = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _vibrance_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->vibrance = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _clip_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
-
-  p->clip = dt_bauhaus_slider_get(slider);
-
-  _turn_selregion_picker_off(self);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 static void _auto_levels_callback(GtkButton *button, dt_iop_module_t *self)
@@ -747,46 +641,31 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_basicadj_gui_data_t));
   dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
-  dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
 
   dt_pthread_mutex_init(&g->lock, NULL);
   change_image(self);
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
 
-  g->sl_black_point = dt_bauhaus_slider_new_with_range(self, -0.10, 0.10, .001, p->black_point, 4);
+  g->sl_black_point = dt_bauhaus_slider_new_from_params_box(self, "black_point", "");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_black_point, -1.0, 1.0);
-  dt_bauhaus_widget_set_label(g->sl_black_point, NULL, _("black level correction"));
-  dt_bauhaus_slider_set_format(g->sl_black_point, "%.4f");
-  g_object_set(g->sl_black_point, "tooltip-text", _("adjust the black level to unclip negative RGB values.\n"
+  gtk_widget_set_tooltip_text(g->sl_black_point, _("adjust the black level to unclip negative RGB values.\n"
                                                     "you should never use it to add more density in blacks!\n"
                                                     "if poorly set, it will clip near-black colors out of gamut\n"
-                                                    "by pushing RGB values into negatives"),
-               (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_black_point), "value-changed", G_CALLBACK(_black_point_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_black_point, TRUE, TRUE, 0);
+                                                    "by pushing RGB values into negatives"));
 
-  g->sl_exposure = dt_bauhaus_slider_new_with_range(self, -4.0, 4.0, .02, p->exposure, 2);
+  g->sl_exposure = dt_bauhaus_slider_new_from_params_box(self, "exposure", " EV");
+  dt_bauhaus_slider_set_step(g->sl_exposure, .02);
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_exposure, -18.0, 18.0);
-  dt_bauhaus_widget_set_label(g->sl_exposure, NULL, _("exposure"));
-  dt_bauhaus_slider_set_format(g->sl_exposure, _("%.2f EV"));
-  g_object_set(g->sl_exposure, "tooltip-text", _("adjust the exposure correction"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_exposure), "value-changed", G_CALLBACK(_exposure_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_exposure, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->sl_exposure, _("adjust the exposure correction"));
 
-  g->sl_hlcompr = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 1.0, p->hlcompr, 2);
+  g->sl_hlcompr = dt_bauhaus_slider_new_from_params_box(self, "hlcompr", "");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_hlcompr, 0.0, 500.0);
-  dt_bauhaus_widget_set_label(g->sl_hlcompr, NULL, _("highlight compression"));
-  g_object_set(g->sl_hlcompr, "tooltip-text", _("highlight compression adjustment"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_hlcompr), "value-changed", G_CALLBACK(_hlcompr_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_hlcompr, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->sl_hlcompr, _("highlight compression adjustment"));
 
-  g->sl_contrast = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->contrast, 2);
+  g->sl_contrast = dt_bauhaus_slider_new_from_params_box(self, "contrast", "");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_contrast, -1.0, 5.0);
-  dt_bauhaus_widget_set_label(g->sl_contrast, NULL, _("contrast"));
-  g_object_set(g->sl_contrast, "tooltip-text", _("contrast adjustment"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_contrast), "value-changed", G_CALLBACK(_contrast_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_contrast, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->sl_contrast, _("contrast adjustment"));
 
   g->cmb_preserve_colors = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->cmb_preserve_colors, NULL, _("preserve colors"));
@@ -801,12 +680,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->cmb_preserve_colors, _("method to preserve colors when applying contrast"));
   g_signal_connect(G_OBJECT(g->cmb_preserve_colors), "value-changed", G_CALLBACK(preserve_colors_callback), self);
 
-  g->sl_middle_grey = dt_bauhaus_slider_new_with_range(self, 0.05, 100.0, .5, p->middle_grey, 2);
-  dt_bauhaus_widget_set_label(g->sl_middle_grey, NULL, _("middle grey"));
-  dt_bauhaus_slider_set_format(g->sl_middle_grey, "%.2f %%");
-  g_object_set(g->sl_middle_grey, "tooltip-text", _("middle grey adjustment"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_middle_grey), "value-changed", G_CALLBACK(_middle_grey_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_middle_grey, TRUE, TRUE, 0);
+  g->sl_middle_grey = dt_bauhaus_slider_new_from_params_box(self, "middle_grey", " %%");
+  dt_bauhaus_slider_set_step(g->sl_middle_grey, .5);
+  gtk_widget_set_tooltip_text(g->sl_middle_grey, _("middle grey adjustment"));
 
   dt_bauhaus_widget_set_quad_paint(g->sl_middle_grey, dtgtk_cairo_paint_colorpicker,
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
@@ -814,25 +690,16 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback),
                    &g->color_picker);
 
-  g->sl_brightness = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->brightness, 2);
+  g->sl_brightness = dt_bauhaus_slider_new_from_params_box(self, "brightness", "");
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_brightness, -4.0, 4.0);
-  dt_bauhaus_widget_set_label(g->sl_brightness, NULL, _("brightness"));
-  g_object_set(g->sl_brightness, "tooltip-text", _("brightness adjustment"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_brightness), "value-changed", G_CALLBACK(_brightness_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_brightness, TRUE, TRUE, 0);
+  gtk_widget_set_tooltip_text(g->sl_brightness,_("brightness adjustment"));
 
-  g->sl_saturation = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->saturation, 2);
-  dt_bauhaus_widget_set_label(g->sl_saturation, NULL, _("saturation"));
-  g_object_set(g->sl_saturation, "tooltip-text", _("saturation adjustment"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_saturation), "value-changed", G_CALLBACK(_saturation_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_saturation, TRUE, TRUE, 0);
+  g->sl_saturation = dt_bauhaus_slider_new_from_params_box(self, "saturation", "");
+  gtk_widget_set_tooltip_text(g->sl_saturation,_("saturation adjustment"));
 
-  g->sl_vibrance = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->vibrance, 2);
-  dt_bauhaus_widget_set_label(g->sl_vibrance, NULL, _("vibrance"));
-  g_object_set(g->sl_vibrance, "tooltip-text", _("vibrance adjustment"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_vibrance), "value-changed", G_CALLBACK(_vibrance_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_vibrance, TRUE, TRUE, 0);
-
+  g->sl_vibrance = dt_bauhaus_slider_new_from_params_box(self, "vibrance", "");
+  gtk_widget_set_tooltip_text(g->sl_vibrance, _("vibrance adjustment"));
+ 
   GtkWidget *autolevels_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(10));
 
   g->bt_auto_levels = gtk_button_new_with_label(_("auto"));
@@ -853,11 +720,8 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
 
-  g->sl_clip = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->clip, 3);
-  dt_bauhaus_widget_set_label(g->sl_clip, NULL, _("clip"));
-  g_object_set(g->sl_clip, "tooltip-text", _("adjusts clipping value for auto exposure calculation"), (char *)NULL);
-  g_signal_connect(G_OBJECT(g->sl_clip), "value-changed", G_CALLBACK(_clip_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sl_clip, TRUE, TRUE, 0);
+  g->sl_clip = dt_bauhaus_slider_new_from_params_box(self, "clip", "");
+  gtk_widget_set_tooltip_text(g->sl_clip, _("adjusts clipping value for auto exposure calculation"));
 
   // add signal handler for preview pipe finish
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -26,6 +26,7 @@
 #include "control/control.h"
 #include "develop/develop.h"
 #include "develop/imageop_math.h"
+#include "develop/imageop_gui.h"
 #include "dtgtk/button.h"
 #include "dtgtk/drawingarea.h"
 #include "dtgtk/expander.h"

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "common/introspection.h"
 
 #include <cairo/cairo.h>
+#include <gtk/gtk.h>
 #include <glib.h>
 #include <stdint.h>
 
@@ -109,6 +110,8 @@ void gui_update(struct dt_iop_module_t *self);
 void gui_reset(struct dt_iop_module_t *self);
 /** construct widget. */
 void gui_init(struct dt_iop_module_t *self);
+/** called by standard widget callbacks after value changed */
+void gui_changed(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
 /** destroy widget. */
 void gui_cleanup(struct dt_iop_module_t *self);
 /** optional method called after darkroom expose. */

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -137,7 +137,7 @@ typedef struct dt_iop_shadhi_params_t
   float highlights_ccorrect;
   unsigned int flags;
   float low_approximation;
-  dt_iop_shadhi_algo_t shadhi_algo; // $DESCRIPTION: "soften with"
+  dt_iop_shadhi_algo_t shadhi_algo; // $DESCRIPTION: "soften with" $DEFAULT: 0
 } dt_iop_shadhi_params_t;
 
 typedef struct dt_iop_shadhi_gui_data_t
@@ -834,11 +834,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->shadows = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->shadows, 2);
   g->highlights = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->highlights, 2);
   g->whitepoint = dt_bauhaus_slider_new_with_range(self, -10.0, 10.0, .2, p->whitepoint, 2);
-  g->shadhi_algo = dt_bauhaus_combobox_new_from_params_box(self, "shadhi_algo");
-/*  dt_bauhaus_widget_set_label(g->shadhi_algo, NULL, _("soften with"));
-  dt_bauhaus_combobox_add(g->shadhi_algo, _("gaussian"));
-  dt_bauhaus_combobox_add(g->shadhi_algo, _("bilateral filter"));
-*/  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 500.0, 2., p->radius, 2);
+  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 500.0, 2., p->radius, 2);
   g->compress = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->compress, 2);
   g->shadows_ccorrect = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->shadows_ccorrect, 2);
   g->highlights_ccorrect = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->highlights_ccorrect, 2);
@@ -860,7 +856,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->shadows, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->highlights, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->whitepoint, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->shadhi_algo, TRUE, TRUE, 0);
+  g->shadhi_algo = dt_bauhaus_combobox_new_from_params_box(self, "shadhi_algo");
   gtk_box_pack_start(GTK_BOX(self->widget), g->radius, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->compress, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->shadows_ccorrect, TRUE, TRUE, 0);

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -28,6 +28,7 @@
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
+#include "develop/imageop_gui.h"
 #include "develop/tiling.h"
 #include "dtgtk/togglebutton.h"
 #include "gui/accelerators.h"
@@ -64,8 +65,8 @@ DT_MODULE_INTROSPECTION(5, dt_iop_shadhi_params_t)
 
 typedef enum dt_iop_shadhi_algo_t
 {
-  SHADHI_ALGO_GAUSSIAN,
-  SHADHI_ALGO_BILATERAL
+  SHADHI_ALGO_GAUSSIAN, // $DESC: "gaussian"
+  SHADHI_ALGO_BILATERAL // $DESC: "bilateral filter"
 } dt_iop_shadhi_algo_t;
 
 /* legacy version 1 params */
@@ -125,7 +126,6 @@ typedef struct dt_iop_shadhi_params4_t
 
 typedef struct dt_iop_shadhi_params_t
 {
-  // $VERSION: 1
   dt_gaussian_order_t order;
   float radius;
   float shadows;
@@ -133,15 +133,11 @@ typedef struct dt_iop_shadhi_params_t
   float highlights;
   float reserved2;
   float compress;
-  // $VERSION: 2
   float shadows_ccorrect;
   float highlights_ccorrect;
-  // $VERSION: 3
   unsigned int flags;
-  // $VERSION: 4
   float low_approximation;
-  // $VERSION: 5
-  dt_iop_shadhi_algo_t shadhi_algo;
+  dt_iop_shadhi_algo_t shadhi_algo; // $DESCRIPTION: "soften with"
 } dt_iop_shadhi_params_t;
 
 typedef struct dt_iop_shadhi_gui_data_t
@@ -838,11 +834,11 @@ void gui_init(struct dt_iop_module_t *self)
   g->shadows = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->shadows, 2);
   g->highlights = dt_bauhaus_slider_new_with_range(self, -100.0, 100.0, 2., p->highlights, 2);
   g->whitepoint = dt_bauhaus_slider_new_with_range(self, -10.0, 10.0, .2, p->whitepoint, 2);
-  g->shadhi_algo = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->shadhi_algo, NULL, _("soften with"));
+  g->shadhi_algo = dt_bauhaus_combobox_new_from_params_box(self, "shadhi_algo");
+/*  dt_bauhaus_widget_set_label(g->shadhi_algo, NULL, _("soften with"));
   dt_bauhaus_combobox_add(g->shadhi_algo, _("gaussian"));
   dt_bauhaus_combobox_add(g->shadhi_algo, _("bilateral filter"));
-  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 500.0, 2., p->radius, 2);
+*/  g->radius = dt_bauhaus_slider_new_with_range(self, 0.1, 500.0, 2., p->radius, 2);
   g->compress = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->compress, 2);
   g->shadows_ccorrect = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->shadows_ccorrect, 2);
   g->highlights_ccorrect = dt_bauhaus_slider_new_with_range(self, 0, 100.0, 2., p->highlights_ccorrect, 2);

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -125,6 +125,7 @@ typedef struct dt_iop_shadhi_params4_t
 
 typedef struct dt_iop_shadhi_params_t
 {
+  // $VERSION: 1
   dt_gaussian_order_t order;
   float radius;
   float shadows;
@@ -132,10 +133,14 @@ typedef struct dt_iop_shadhi_params_t
   float highlights;
   float reserved2;
   float compress;
+  // $VERSION: 2
   float shadows_ccorrect;
   float highlights_ccorrect;
+  // $VERSION: 3
   unsigned int flags;
+  // $VERSION: 4
   float low_approximation;
+  // $VERSION: 5
   dt_iop_shadhi_algo_t shadhi_algo;
 } dt_iop_shadhi_params_t;
 

--- a/tools/introspection/ast.pm
+++ b/tools/introspection/ast.pm
@@ -891,9 +891,11 @@ sub get_introspection_code
   my $arrays_line = "static dt_introspection_type_enum_tuple_t f".$linearisation_pos."[] = { ";
   foreach(@enumerator_list)
   {
-    $arrays_line .= "\n    { \"$_\", $_ },";
+    $d = $_;
+    $d =~ s/\_/ /g;
+    $arrays_line .= "\n    { \"$_\", $_, \"$d\" },";
   }
-  $arrays_line .= "\n    { NULL, 0 },\n  };";
+  $arrays_line .= "\n    { NULL, 0, NULL },\n  };";
   push(@arrays, $arrays_line);
   push(@assignments, "introspection_linear[$linearisation_pos].Enum.values = f$linearisation_pos;");
 


### PR DESCRIPTION
This is meant as a discussion document, very much a work in progress. I will try to update it here based on input I receive in the comments and on IRC. Hopefully there is interest to proceed with some form of it. If there is a better location to organise a discussion, please let me know that as well. Or if someone else wants to lead/organise it.

# 1. INTRODUCTION

A couple of weeks back there was a short discussion with @houz on IRC about using introspection to enable/enhance export _and import_ of human readable versions of module parameters. The current introspection framework already allows specifying minimum and maximum values (and type etc) for each parameter, but this feature is not widely used and couldn't be guaranteed to be in sync with the actual restrictions that are enforced in the module gui.

This started me thinking about making the definition of dt_iop_params_t leading in the creation of module interfaces (gui and otherwise) and possibly also reducing the complexity/opacity of and duplications in the gui aspect of each iop module. As the wiki points out:

> There is duplicated code in the software that could be factorized and put into libraries. 

After playing around with some ideas and checking their viability, I would now like to see if there is interest in going ahead with this and to agree on the design of the basic components. I am offering to take care of a substantial part of the clean up work across all modules, but if others are willing to take some, I would be happy with that.

In first instance, this pull request is a partial implementation to illustrate the infrastructure ideas and how these could be used in a few modules, as examples. It is just meant to facilitate discussion, the conclusions of which I would use to update this first comment. Actual commits of complete infrastructure work and module updates would all go into separate pull requests (see 5.PROJECT below)

# 2. GOALS

Create complete and consistent introspection information for all iop modules.
Reduce the amount of boiler plate required to define module gui; make remaining code more readable/maintainable.
Continue to fully support the current way of defining the user interface for highly taylored modules; conversion/adoption optional.
Achieve more consistency by providing defaults (that can be fully taylored using existing approaches).

# 3. INFRASTRUCTURE

I have spend a lot of time browsing through the ui code of a lot of the iop modules and collecting data on the features being used in defining their interfaces in gui_init ([slider_new_grep.xlsx](https://github.com/darktable-org/darktable/files/4530229/slider_new_grep.xlsx)). There is obviously a lot of similarity and boilerplate code, but there are significant differences as well, so it is impossible to come up with a one size fits all. What I am aiming for is provide componentised utility functions with sensible defaults to help with the largest common denominator, where all the existing customisation can still be added on top.

## 3.1 Widget Creation

Currently, each gui_init function builds the whole module ui from scratch, without referring to the introspection information that is collected from the dt_iop_params_t. The first step is to populate more introspection comments ($MIN, $MAX, $DEFAULT) and then refer to those values in the widget creation. The changes in basicadj.c in this pull request illustrate this.

### 3.1.1 Sliders

For now, only the creation of sliders is implemented. There's a new call in bauhaus.c that replaces much of the boiler plate and then after that any tailoring can still be done in the usual way. Besides creating the sliders using the defaults from introspection, a generic callback function is installed that reads any changes in the slider back into the param structure. 

### 3.1.2 Add more properties

Some of the settings required for the most common sliders cannot yet be specified in introspection comments. I would therefore suggest adding fields for $SOFT_MIN and $SOFT_MAX and possibly $STEP and $DIGITS. This would no longer fit on one line with the parameter type+name, so maybe a shorthand formatting could be introduced. Something like:
`float x, // -16 -4 0 4 16 .01 3`
Very much open for discussion. Maybe @houz would be willing to implement something in the perl code (mine is very rusty)?
Actually, the step size and number of digits are commonly 1/100th of the max and the equivalent number of digits, so just using the defaults often is sufficient. The format is then basic on number of digits. I've added a + if range is negative and positive and no + if only positive numbers. This is not done everywhere currently, but might be nice to have this consistently?
Most formats are variants of %, EV and degrees, so if we could flag the type (for example by adding $P, $E or $D) then we wouldn't need to pass the (partial) format to the dt_bauhaus_slider_new_from_params_box call.
I'm using the $DESCRIPTION comment as label, or if it isn't provided, just the variable name (changing _ to space). This should probably also be done in the perl code, so that it is constistent everywhere.

### 3.1.3 Comboboxes & Checkboxes

In a way similar to sliders, comboboxes and checkboxes could be set up in a utility function call, with a type specific callback function to read changed parameters back to dt_iop_params_t. For comboboxes introspection needs to be extended to allow descriptive text to be added to each enum definition.

## 3.2 Value-Changed Callbacks

For each type, float (slider), int (combobox) and bool (checkbox) a generic callback function is needed in bauhaus.c. I've already set up a possible implementation of the slider version. This gets connected to each slider in the module, with an extra paramater for the field name. It includes all the standard boilerplate to pick up new values and create a history entry. Many modules don't do anything more complicated than this but currently still need to define a complete set of callback functions for each field.

If any further effects are required (changing other widgets values or enabling/disabling them etc) then control can be passed from within the generic value-changed callback to a 1-per-module overloaded callback, to update fields/bounderies etc.
In filmicrgb, this could look like:
```C
static void value_changed_callback(GtkWidget *w, dt_iop_module_t *self, void *prev)
{
  dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;

  if (w = g->security_threshold || w = g->black_point_source || w = g->white_point_source)
  {
    if (w = g->security_threshold)
    {
      float previous = *(float*)prev;
      float ratio = (p->security_factor - previous) / (previous + 100.0f);

      float EVmin = p->black_point_source;
      EVmin = EVmin + ratio * EVmin;

      float EVmax = p->white_point_source;
      EVmax = EVmax + ratio * EVmax;

      p->white_point_source = EVmax;
      p->black_point_source = EVmin;

      dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
      dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
    }

    p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));

    dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
  }
}
```
The call from the generic value-changed callback would be wrapped in
```C
const int reset = darktable.gui->reset;
darktable.gui->reset = 1;
...
darktable.gui->reset = reset;
```
and also passes on the previous/old version of the field that was changed. This covers all the situations we see now but with much less duplication.

## 3.3 Field_name enums

The existing introspection framework only refers to fields by their name, which leads to many string lookups. It would be useful to generate an enum that provides a number for each field and that can be used within the module itself to refer to fields more efficiently. The value changed callback functions for example could use that enum. 

## 3.4 Localisation 

Any labels that are defined via introspection (based on field name or comment text) need to be localised, so the introspection_.c files need to be processed by xgettext.

## 3.5 Tooltips

In my example code tooltips are still set up in the old way and are not available via introspection. There might be a way to define them immediately after dt_iop_params_t as an array of tuple pairs "field enum", "string"), so that the generic widget creation functions could attach them.

## 3.6 Multiple Widgets

If most widgets don't require any setup beyond the defaults and introspection-provided values, it would be possible to have their creation entirely driven from the list of fields available via introspection. 

### 3.6.1 Range

For the simplest modules, gui_data could contain an array of widgets (rather than individually named widget fields as now), that can be indexed using the field_name enums, and gui_init could be a simple call to `create_widget_range(1, last_field_enum_value)`. Or if the module contains pages/headings or custom widgets, these could be set up something like this:
```C
GtkWidget *page1, *page2, *page3;
self->widget = page1 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
create_widget_range(self, f_grey_point_source, f_security_factor);
self->widget = page2 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
create_widget_range(self, f_latitude, f_preserve_color);
etc
```

### 3.6.2 Default gui_init()

If there is no tailoring required at all, gui_init does not need to be defined at all, causing a fall-back to the default initialisation with just generates widgets for all the fields in the introspection.

Similarly, the init method and gui_update could all have a default implementation that loops over all the fields in introspection and picks up their defaults or loads the values from a param struct into the corresponding widgets. 

# 4. FURTHER IDEAS

## 4.1 Sub-Sections

For modules with a more complicated structure a tailor made gui_init would still be required. But I have played around a bit, in filmicrgb.c with ways that this structure can be specified in the comments of the param_t definition, using the $PAGE keyword (or $SECTION keyword). These could either be translated into dummy "fields" in the introspection structure, or be indicated by flags for each field (new_page, new_section).

If the order of the widgets in the module should be different than in the param structure (which can't be changed without creating a new version) this can be indicated with the $AFTER keyword (which is not completely trivial to implement).

## 4.2 Versions:

instead of creating (copy/pasting) new struct for each type, put type version markers $VERSION in type definition and 
let introspection calc type sizes for each version. (or even generate additional partial typedefs, by adding _v1_t etc).
Introspection can then tell that version -1 is a same ordered subset.
Only works if only adding params, but can start at any point (now. version 3. whatever)
And legacy_params might still need to do some transforming.

# 5. PROJECT

I've tried to phrase this brain storming text a little like a menu of options. Maybe there is no apitite for drastic changes, but on the other hand the maximum space and complexity changes can be achieved by being a little ambitious and that would put the code in a state where future changes are less daunting.
To get the maximum benefit from this project, some changes need to be made to all modules (introspection comment tags) whereas others can be made over time or not at all ("refactoring", cleanup, simplification). So I would suggest the following steps:
- [ ] Infrastructure work
  - [ ] introspection
  - [ ] bauhaus
- [ ] Documentation
  - [ ] A few easier to harder modules as showcase
  - [ ] useless.c
- [ ] Bulk
  - [ ] Split modules across participants
  - [ ] Submit separate PR for each; involve main authors
        Decide whether non-default settings need to be kept case-by-case
  - [ ] Complex modules just introspection first
  - [ ] Complex modules deeper adjustments, possibly requiring further infrastrure work.
        Mark any code that is not brought up to new "standard", so it won't be copied.

# Appendix A. CHALLENGE AREAS

Slider = 100*param, (1-param)*100 etc.
Buttons in module.
Read only widgets.

# Appendix B. QUESTIONS:

- I find the definitions of "hard" and "soft" min/max confusing and I'm not sure if it is fully implemented as intended (especially what happens with a reset).
- why are get_p and get_f unrolled (if(!strcmp(name, "black_point")) return &(p->black_point); etc) rather than looping over introspection_linear?
- Should gui defaults be initialised from params or default_params (or by definition the same)
in gui_update, what's diff between dt_bauhaus_slider_set_soft and dt_bauhaus_slider_set? (can we automate gui_update?)
- For legacy version 1->2->3->..->n garanteed to be 1->n? (some legacy_params go through all legacy upgrades. Some just go directly from each old version to current)

# Appendix C. COMMON BUGS:

# Appendix D. PEOPLE I HOPE ARE INTERESTED
@houz @TurboGit @AlicVB @johnny-bit @elstoc 
Please include anybody who might have strong opinions, interest, knowledge. Thanks!