### PR TITLE
Locallaplacian speedup 2

### DIFF
--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -212,7 +212,7 @@ static inline void gauss_reduce_sse2(
     // prime the vertical axis
     const __m128 kernel = _mm_setr_ps(1.f, 4.f, 6.f, 4.f);
     __m128 left = convolve14641_vert(base,wd);
-    for(int col=0; col<cw-1; col+=2)
+    for(int col=0; col<cw-3; col+=2)
     {
       // convolve the next four pixel wide vertical slice
       base += 4;
@@ -231,7 +231,7 @@ static inline void gauss_reduce_sse2(
       base += 4;
       float right = base[0] + 4*(base[wd]+base[3*wd]) + 6*base[2*wd] + base[4*wd];
       __m128 conv = _mm_mul_ps(left,kernel);
-      out[cw-2] = (conv[0] + conv[1] + conv[2] + conv[3] + right) / 256.f;
+      out[cw-3] = (conv[0] + conv[1] + conv[2] + conv[3] + right) / 256.f;
     }
   }
   ll_fill_boundary1(coarse, cw, ch);

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -177,7 +177,7 @@ static inline void gauss_reduce_sse2(
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-      dt_omp_firstprivate(cw, ch, input)   \
+      dt_omp_firstprivate(cw, ch, input, wd, coarse) \
       schedule(static)
 #endif
   for(int j=1;j<ch-1;j++)

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -199,7 +199,9 @@ static inline void gauss_reduce_sse2(
   const int cw = (wd-1)/2+1, ch = (ht-1)/2+1;
 
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
+  // DON'T parallelize the very smallest levels of the pyramid, as the threading overhead
+  // is greater than the time needed to do it sequentially
+#pragma omp parallel for default(none) if (ch*cw>1000)  \
       dt_omp_firstprivate(cw, ch, input, wd, coarse) \
       schedule(static)
 #endif
@@ -250,7 +252,9 @@ static inline void gauss_reduce(
   memset(coarse, 0, sizeof(float)*cw*ch);
   // direct 5x5 stencil only on required pixels:
 #ifdef _OPENMP
-#pragma omp parallel for default(none) \
+  // DON'T parallelize the very smallest levels of the pyramid, as the threading overhead
+  // is greater than the time needed to do it sequentially
+#pragma omp parallel for default(none) if (ch*cw>500)  \
   dt_omp_firstprivate(coarse, cw, ch, input, w, wd) \
   schedule(static) \
   collapse(2)

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -591,7 +591,7 @@ void local_laplacian_internal(
     output[l] = dt_alloc_align(64, sizeof(float)*dl(w,l)*dl(h,l));
 
   // create gauss pyramid of padded input, write coarse directly to output
-#if defined(__SSE2__) && !defined(_OPENMP)
+#if defined(__SSE2__)
   if(use_sse2)
   {
     for(int l=1;l<last_level;l++)
@@ -630,7 +630,7 @@ void local_laplacian_internal(
 
     // create gaussian pyramids
     for(int l=1;l<=last_level;l++)
-#if defined(__SSE2__) && !defined(_OPENMP)
+#if defined(__SSE2__)
       if(use_sse2)
         gauss_reduce_sse2(buf[k][l-1], buf[k][l], dl(w,l-1), dl(h,l-1));
       else

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -138,7 +138,7 @@ static void pad_by_replication(
 {
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(buf, padding, w) \
+  dt_omp_firstprivate(buf, padding, h, w) \
   schedule(static)
 #endif
   for(int j=0;j<padding;j++)

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -118,14 +118,11 @@ static void pad_by_replication(
   dt_omp_firstprivate(buf, padding, w) \
   schedule(static)
 #endif
-  for(int j=0;j<padding;j++) memcpy(buf + w*j, buf+padding*w, sizeof(float)*w);
-#ifdef _OPENMP
-#pragma omp parallel for default(none) \
-  dt_omp_firstprivate(h, buf, padding, w) \
-  schedule(static)
-#endif
-  for(int j=h-padding;j<h;j++) memcpy(buf + w*j, buf+w*(h-padding-1), sizeof(float)*w);
-  return;
+  for(int j=0;j<padding;j++)
+  {
+    memcpy(buf + w*j, buf+padding*w, sizeof(float)*w);
+    memcpy(buf + w*(h-padding+j), buf+w*(h-padding-1), sizeof(float)*w);
+  }
 }
 
 static inline void gauss_expand(

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -210,7 +210,7 @@ static inline void gauss_reduce_sse2(
     // prime the vertical axis
     const __m128 kernel = _mm_setr_ps(1.f, 4.f, 6.f, 4.f);
     __m128 left = convolve14641_vert(base,wd);
-    for(int col=0; col<cw; col+=2)
+    for(int col=0; col<cw-1; col+=2)
     {
       // convolve the next four pixel wide vertical slice
       base += 4;
@@ -229,7 +229,7 @@ static inline void gauss_reduce_sse2(
       base += 4;
       float right = base[0] + 4*(base[wd]+base[3*wd]) + 6*base[2*wd] + base[4*wd];
       __m128 conv = _mm_mul_ps(left,kernel);
-      out[cw-1] = (conv[0] + conv[1] + conv[2] + conv[3] + right) / 256.f;
+      out[cw-2] = (conv[0] + conv[1] + conv[2] + conv[3] + right) / 256.f;
     }
   }
   ll_fill_boundary1(coarse, cw, ch);

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -29,6 +29,8 @@
 #include <xmmintrin.h>
 #endif
 
+//#define DEBUG_DUMP
+
 // downsample width/height to given level
 static inline int dl(int size, const int level)
 {
@@ -36,6 +38,22 @@ static inline int dl(int size, const int level)
     size = (size-1)/2+1;
   return size;
 }
+
+#ifdef DEBUG_DUMP
+static void dump_PFM(const char *filename, const float* out, const uint32_t w, const uint32_t h)
+{
+  FILE *f = g_fopen(filename, "wb");
+  fprintf(f, "PF\n%d %d\n-1.0\n", w, h);
+  for(int j=0;j<h;j++)
+    for(int i=0;i<w;i++)
+      for(int c=0;c<3;c++)
+        fwrite(out + w*j+i, 1, sizeof(float), f);
+  fclose(f);
+}
+#define debug_dump_PFM dump_PFM
+#else
+#define debug_dump_PFM(f,b,w,h)
+#endif
 
 // needs a boundary of 1 or 2px around i,j or else it will crash.
 // (translates to a 1px boundary around the corresponding pixel in the coarse buffer)
@@ -348,20 +366,15 @@ static inline float *ll_pad_input(
     }
     pad_by_replication(out, *wd2, *ht2, max_supp);
   }
-#if 0
+#ifdef DEBUG_DUMP
   if(b && b->mode == 2)
   {
-    FILE *f = fopen("/tmp/padded.pfm", "wb");
-    fprintf(f, "PF\n%d %d\n-1.0\n", *wd2, *ht2);
-    for(int j=0;j<*ht2;j++)
-      for(int i=0;i<*wd2;i++)
-        for(int c=0;c<3;c++)
-          fwrite(out + *wd2*j+i, 1, sizeof(float), f);
-    fclose(f);
+    dump_PFM("/tmp/padded.pfm",out,*wd2,*ht2);
   }
 #endif
   return out;
 }
+
 
 static inline float ll_laplacian(
     const float *const coarse,   // coarse res gaussian
@@ -640,28 +653,8 @@ void local_laplacian_internal(
     const int pw = dl(w,last_level), ph = dl(h,last_level);
     const int pw0 = dl(b->pwd, pl0), ph0 = dl(b->pht, pl0);
     const int pw1 = dl(b->pwd, pl1), ph1 = dl(b->pht, pl1);
-#if 0
-    {
-    FILE *f = fopen("/tmp/coarse.pfm", "wb");
-    fprintf(f, "PF\n%d %d\n-1.0\n", pw0, ph0);
-    for(int j=0;j<ph0;j++)
-      for(int i=0;i<pw0;i++)
-        for(int c=0;c<3;c++)
-          fwrite(b->output[pl0] + pw0*j+i, 1, sizeof(float), f);
-    fclose(f);
-    }
-#endif
-#if 0
-    {
-    FILE *f = fopen("/tmp/oldcoarse.pfm", "wb");
-    fprintf(f, "PF\n%d %d\n-1.0\n", pw, ph);
-    for(int j=0;j<ph;j++)
-      for(int i=0;i<pw;i++)
-        for(int c=0;c<3;c++)
-          fwrite(output[last_level] + pw*j+i, 1, sizeof(float), f);
-    fclose(f);
-    }
-#endif
+    debug_dump_PFM("/tmp/coarse.pfm", b->output[pl0], pw0, ph0);
+    debug_dump_PFM("/tmp/oldcoarse.pfm", output[last_level], pw, ph);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static) collapse(2) default(shared)
 #endif
@@ -699,17 +692,7 @@ void local_laplacian_internal(
 #endif
       output[last_level][j*pw+i] = weight * c1 + (1.0f-weight) * c0;
     }
-#if 0
-    {
-    FILE *f = fopen("/tmp/newcoarse.pfm", "wb");
-    fprintf(f, "PF\n%d %d\n-1.0\n", pw, ph);
-    for(int j=0;j<ph;j++)
-      for(int i=0;i<pw;i++)
-        for(int c=0;c<3;c++)
-          fwrite(output[last_level] + pw*j+i, 1, sizeof(float), f);
-    fclose(f);
-    }
-#endif
+    debug_dump_PFM("/tmp/newcoarse.pfm", output[last_level], pw, ph);
   }
 
   // assemble output pyramid coarse to fine

--- a/src/common/locallaplacian.c
+++ b/src/common/locallaplacian.c
@@ -205,8 +205,8 @@ static inline void gauss_reduce(
   const int cw = (wd-1)/2+1, ch = (ht-1)/2+1;
 
   // this is the scalar (non-simd) code:
-  const float a = 0.4f;
-  const float w[5] = {1./4.-a/2., 1./4., a, 1./4., 1./4.-a/2.};
+  const float w[5] = { 1.f, 4.f, 6.f, 4.f, 1.f };
+  const float scale = 1.f/256.f;
   memset(coarse, 0, sizeof(float)*cw*ch);
   // direct 5x5 stencil only on required pixels:
 #ifdef _OPENMP
@@ -215,9 +215,14 @@ static inline void gauss_reduce(
   schedule(static) \
   collapse(2)
 #endif
-  for(int j=1;j<ch-1;j++) for(int i=1;i<cw-1;i++)
-    for(int jj=-2;jj<=2;jj++) for(int ii=-2;ii<=2;ii++)
-      coarse[j*cw+i] += input[(2*j+jj)*wd+2*i+ii] * w[ii+2] * w[jj+2];
+  for(int j=1;j<ch-1;j++)
+    for(int i=1;i<cw-1;i++)
+    {
+      for(int jj=-2;jj<=2;jj++)
+        for(int ii=-2;ii<=2;ii++)
+          coarse[j*cw+i] += input[(2*j+jj)*wd+2*i+ii] * w[ii+2] * w[jj+2];
+      coarse[j*cw+i] *= scale;
+    }
   ll_fill_boundary1(coarse, cw, ch);
 }
 


### PR DESCRIPTION
By rearranging the order of computation, I was able to make the gauss_reduce_sse2 function in src/common/locallaplacian.c parallelizable.  Each thread can now be given 1/t of the entire 2d array instead of 1/t of a single row.  Being able to use vector instructions yields a 20+% speedup compared to the scalar version used in the current Git master.

|		| Git master		| New code		|
| ---		| ---			| ---			|
| No OpenMP	|3.695 secs (3.829 CPU)	|2.447 secs (2.674 CPU)	|
|2 threads	|1.940 secs (3.421 CPU)	|1.477 secs (2.476 CPU)	|
|8 threads	|0.627 secs (4.034 CPU)	|0.451 secs (2.691 CPU)	|
|32 threads	|0.302 secs (6.694 CPU)	|0.262 secs (4.072 CPU)	|
|64 threads	|0.373 secs (7.803 CPU)	|0.280 secs (5.905 CPU)	|

In the process, I found that the scalar and SSE versions were using different kernels.  The third commit in this PR adapts the scalar version to use the SSE version's kernel, since I figure the vast majority of users will have been running that code.

Scalar and SSE2 versions now produce the same output modulo floating-point roundoff causing some of the pixel values to differ by 1 (of a range of 65536) in 16-bit output.

Fixes #4808.

