### PR TITLE
Adding a bayer->monochrome demosaic algorithm

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -2500,9 +2500,10 @@ static void blk4_monochrome(float *out, const float *const in, dt_iop_roi_t *con
 
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
-  dt_omp_firstprivate(in, roi_out, roi_in) \
-  shared(out, rgb_pars, filters,rgb_filter) \
-  schedule(static)
+  dt_omp_firstprivate(in, roi_out, roi_in, rgb_pars, filters,rgb_filter) \
+  shared(out) \
+  schedule(static) \
+  collapse(2)
 #endif
 
   for(int j = 0; j < (roi_out->height); j++)


### PR DESCRIPTION
Most of us can't afford or don't have a monochrome camera but want a b&w output
for some situations/motives. In these cases we have to use a standard demosaic algorithm and
later do a conversion.

DT's available demosaic algorithms calculate a pixel's colour in clever ways, this takes time and adds some artefacts.

This pr is a suggestion, personally i have been using this code for a while, results are really good
compared to amaze+channel_mixer (i could find no example being worse) and it's fast.

For bayer sensors we have a regular pattern in 2x2 blocks (2g, 1r, 1b). For a given pixel (x,y) this
algo takes data from p(x,y), p(x+1,y), p(x,y+1) and p(x+1,y+1) and calculates grayscale data using a
weighing filter (currently luminance, yellow, red or none).

To allow easy testing for all without changing the module version i took the
`yet_unused_data_specific_to_demosaicing_method` as the filter index. (A version ready to merge
should have this either name-changed or should have an extra parameter plus a module version update)