### PR TITLE
Laplacian cleanup

### DIFF
--- a/src/common/locallaplacian.h
+++ b/src/common/locallaplacian.h
@@ -79,19 +79,3 @@ size_t local_laplacian_memory_use(const int width,      // width of input image
 size_t local_laplacian_singlebuffer_size(const int width,       // width of input image
                                          const int height);     // height of input image
 
-
-#if defined(__SSE2__)
-void local_laplacian_sse2(
-    const float *const input,   // input buffer in some Labx or yuvx format
-    float *const out,           // output buffer with colour
-    const int wd,               // width and
-    const int ht,               // height of the input buffer
-    const float sigma,          // user param: separate shadows/midtones/highlights
-    const float shadows,        // user param: lift shadows
-    const float highlights,     // user param: compress highlights
-    const float clarity,        // user param: increase clarity/local contrast
-    local_laplacian_boundary_t *b) // can be 0
-{
-  local_laplacian_internal(input, out, wd, ht, sigma, shadows, highlights, clarity, 1, b);
-}
-#endif

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -286,36 +286,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 }
 
 
-#if defined(__SSE2__)
-void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
-{
-  // this is called for preview and full pipe separately, each with its own pixelpipe piece.
-  // get our data struct:
-  dt_iop_bilat_data_t *d = (dt_iop_bilat_data_t *)piece->data;
-  // the total scale is composed of scale before input to the pipeline (iscale),
-  // and the scale of the roi.
-  const float scale = piece->iscale / roi_in->scale;
-  const float sigma_r = d->sigma_r; // does not depend on scale
-  const float sigma_s = d->sigma_s / scale;
-
-  if(d->mode == s_mode_bilateral)
-  {
-    dt_bilateral_t *b = dt_bilateral_init(roi_in->width, roi_in->height, sigma_s, sigma_r);
-    dt_bilateral_splat(b, (float *)i);
-    dt_bilateral_blur(b);
-    dt_bilateral_slice(b, (float *)i, (float *)o, d->detail);
-    dt_bilateral_free(b);
-  }
-  else // s_mode_local_laplacian
-  {
-    local_laplacian_sse2(i, o, roi_in->width, roi_in->height, d->midtone, d->sigma_s, d->sigma_r, d->detail, 0);
-  }
-
-  if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(i, o, roi_in->width, roi_in->height);
-}
-#endif
-
 void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
              const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -343,6 +313,15 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(i, o, roi_in->width, roi_in->height);
 }
+
+#if defined(__SSE2__)
+//until such time as the alternate entry point for SSE code is eliminated, just forward to process()
+void process_sse2(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const i, void *const o,
+             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+{
+  process(self, piece, i, o, roi_in, roi_out);
+}
+#endif
 
 /** init, cleanup, commit to pipeline */
 void init(dt_iop_module_t *module)


### PR DESCRIPTION
Combine SSE and scalar alternative functions such that common code only occurs once.  Why would we ever *not* want to run the faster vectorized code if the target supports it?
