### PR TITLE
Use new slider_set_soft_range instead of confusing enable_soft_boundaries

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -752,7 +752,8 @@ void dt_bauhaus_slider_set_hard_max(GtkWidget* widget, float val)
   d->max = MIN(d->max, d->hard_max);
   d->soft_max = MIN(d->soft_max, d->hard_max);
   if(rawval < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
-  if(pos > val) {
+  if(pos > val) 
+  {
     dt_bauhaus_slider_set_soft(widget,val);
   }
   else
@@ -772,21 +773,9 @@ void dt_bauhaus_slider_set_soft_min(GtkWidget* widget, float val)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float pos = dt_bauhaus_slider_get(widget);
   float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
-  d->soft_min = rawval;
-  d->hard_min = MIN(d->hard_min,d->soft_min);
-  d->min =  d->soft_min;
-  if(rawval > d->soft_max) dt_bauhaus_slider_set_soft_max(widget,val);
-  if(rawval > d->hard_max) dt_bauhaus_slider_set_hard_max(widget,val);
-  if(pos < val)
-  {
-    dt_bauhaus_slider_set_soft(widget,val);
-  }
-  else
-  {
-    dt_bauhaus_slider_set_soft(widget,pos);
-  }
+  d->min = d->soft_min = CLAMP(rawval,d->hard_min,d->hard_max);
+  dt_bauhaus_slider_set_soft(widget,dt_bauhaus_slider_get(widget));
 }
 
 float dt_bauhaus_slider_get_soft_min(GtkWidget* widget)
@@ -800,18 +789,9 @@ void dt_bauhaus_slider_set_soft_max(GtkWidget* widget, float val)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float pos = dt_bauhaus_slider_get(widget);
   float rawval = d->callback(widget, val, DT_BAUHAUS_SET);
-  d->soft_max = rawval;
-  d->hard_max = MAX(d->soft_max, d->hard_max);
-  d->max =  d->soft_max;
-  if(rawval < d->soft_min) dt_bauhaus_slider_set_soft_min(widget,val);
-  if(rawval < d->hard_min) dt_bauhaus_slider_set_hard_min(widget,val);
-  if(pos > val) {
-    dt_bauhaus_slider_set_soft(widget,val);
-  } else {
-    dt_bauhaus_slider_set_soft(widget,pos);
-  }
+  d->max = d->soft_max = CLAMP(rawval,d->hard_min,d->hard_max);
+  dt_bauhaus_slider_set_soft(widget,dt_bauhaus_slider_get(widget));
 }
 
 float dt_bauhaus_slider_get_soft_max(GtkWidget* widget)
@@ -827,6 +807,12 @@ void dt_bauhaus_slider_set_default(GtkWidget *widget, float def)
   dt_bauhaus_slider_data_t *d = &w->data.slider;
   float val = d->callback(widget, def, DT_BAUHAUS_SET);
   d->defpos = (val - d->min) / (d->max - d->min);
+}
+
+void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max)
+{
+  dt_bauhaus_slider_set_soft_min(widget,soft_min);
+  dt_bauhaus_slider_set_soft_max(widget,soft_max);
 }
 
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max)
@@ -954,6 +940,7 @@ GtkWidget *dt_bauhaus_slider_new_with_range_and_feedback(dt_iop_module_t *self, 
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(g_object_new(DT_BAUHAUS_WIDGET_TYPE, NULL));
   return dt_bauhaus_slider_from_widget(w,self, min, max, step, defval, digits, feedback);
 }
+
 GtkWidget *dt_bauhaus_slider_from_widget(dt_bauhaus_widget_t* w,dt_iop_module_t *self, float min, float max,
                                                          float step, float defval, int digits, int feedback)
 {
@@ -2218,6 +2205,8 @@ void dt_bauhaus_slider_reset(GtkWidget *widget)
 
   d->min = d->soft_min;
   d->max = d->soft_max;
+  d->scale = 5.0f * d->step / (d->max - d->min);
+
   dt_bauhaus_slider_set_normalized(w, d->defpos);
 
   return;

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -285,6 +285,7 @@ void dt_bauhaus_slider_set_format(GtkWidget *w, const char *format);
 void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g, float b);
 void dt_bauhaus_slider_clear_stops(GtkWidget *widget);
 void dt_bauhaus_slider_set_default(GtkWidget *widget, float def);
+void dt_bauhaus_slider_set_soft_range(GtkWidget *widget, float soft_min, float soft_max);
 void dt_bauhaus_slider_enable_soft_boundaries(GtkWidget *widget, float hard_min, float hard_max);
 void dt_bauhaus_slider_set_callback(GtkWidget *widget, float (*callback)(GtkWidget *self, float value, dt_bauhaus_callback_t dir));
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1459,8 +1459,8 @@ void gui_init(dt_iop_module_t *self)
   dtgtk_justify_notebook_tabs(g->notebook);
 
   // grey_point_source slider
-  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.1, 36., 0.1, p->grey_point_source, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->grey_point_source, 0.0, 100.0);
+  g->grey_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 100.0, 0.1, p->grey_point_source, 2);
+  dt_bauhaus_slider_set_soft_range(g->grey_point_source, 0.1, 36.0);
   dt_bauhaus_widget_set_label(g->grey_point_source, NULL, _("middle grey luminance"));
   gtk_box_pack_start(GTK_BOX(page1), g->grey_point_source, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
@@ -1473,8 +1473,8 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->grey_point_source), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
 
   // White slider
-  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 2.0, 8.0, 0.1, p->white_point_source, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->white_point_source, 0.0, 16.0);
+  g->white_point_source = dt_bauhaus_slider_new_with_range(self, 0.0, 16.0, 0.1, p->white_point_source, 2);
+  dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_widget_set_label(g->white_point_source, NULL, _("white relative exposure"));
   gtk_box_pack_start(GTK_BOX(page1), g->white_point_source, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->white_point_source, _("%+.2f EV"));
@@ -1487,8 +1487,8 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->white_point_source), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
 
   // Black slider
-  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -14.0, -3.0, 0.1, p->black_point_source, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->black_point_source, -16.0, -0.1);
+  g->black_point_source = dt_bauhaus_slider_new_with_range(self, -16.0, -0.1, 0.1, p->black_point_source, 2);
+  dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3.0);
   dt_bauhaus_widget_set_label(g->black_point_source, NULL, _("black relative exposure"));
   gtk_box_pack_start(GTK_BOX(page1), g->black_point_source, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->black_point_source, _("%+.2f EV"));
@@ -1501,8 +1501,8 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->black_point_source), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
 
   // Security factor
-  g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->security_factor, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->security_factor, -50, 200);
+  g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 200., 1.0, p->security_factor, 2);
+  dt_bauhaus_slider_set_soft_max(g->security_factor, 50.0);
   dt_bauhaus_widget_set_label(g->security_factor, NULL, _("dynamic range scaling"));
   gtk_box_pack_start(GTK_BOX(page1), g->security_factor, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_format(g->security_factor, "%+.2f %%");
@@ -1527,8 +1527,8 @@ void gui_init(dt_iop_module_t *self)
 
 
   // contrast slider
-  g->contrast = dt_bauhaus_slider_new_with_range(self, 1., 2., 0.01, p->contrast, 3);
-  dt_bauhaus_slider_enable_soft_boundaries(g->contrast, 0.0, 5.0);
+  g->contrast = dt_bauhaus_slider_new_with_range(self, 0.0, 5.0, 0.01, p->contrast, 3);
+  dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
   dt_bauhaus_widget_set_label(g->contrast, NULL, _("contrast"));
   gtk_box_pack_start(GTK_BOX(page2), g->contrast, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
@@ -1536,8 +1536,8 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->contrast), "value-changed", G_CALLBACK(contrast_callback), self);
 
   // latitude slider
-  g->latitude = dt_bauhaus_slider_new_with_range(self, 5.0, 45.0, 1.0, p->latitude, 2);
-  dt_bauhaus_slider_enable_soft_boundaries(g->latitude, 0.01, 100.0);
+  g->latitude = dt_bauhaus_slider_new_with_range(self, 0.01, 100.0, 1.0, p->latitude, 2);
+  dt_bauhaus_slider_set_soft_range(g->latitude, 5.0, 45.0);
   dt_bauhaus_widget_set_label(g->latitude, NULL, _("latitude"));
   dt_bauhaus_slider_set_format(g->latitude, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(page2), g->latitude, FALSE, FALSE, 0);
@@ -1560,9 +1560,9 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->balance), "value-changed", G_CALLBACK(balance_callback), self);
 
   // saturation slider
-  g->saturation = dt_bauhaus_slider_new_with_range(self, -50., 50., 0.5, p->saturation, 2);
+  g->saturation = dt_bauhaus_slider_new_with_range(self, -50., 200., 0.5, p->saturation, 2);
   dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
-  dt_bauhaus_slider_enable_soft_boundaries(g->saturation, -50, 200.0);
+  dt_bauhaus_slider_set_soft_max(g->saturation, 50.0);
   dt_bauhaus_slider_set_format(g->saturation, "%.2f %%");
   gtk_box_pack_start(GTK_BOX(page2), g->saturation, FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\n"


### PR DESCRIPTION
As discussed on IRC, added dt_bauhaus_slider_set_soft_range which should be less confusing than the currently used dt_bauhaus_slider_enable_soft_boundaries.

Also removed some behaviour that I thought might be unexpected/unwanted. Now setting soft limits doesn't move hard limits or the current value of the slider. The hard limits will be used to guard the values allowed by introspection, so it should be very clear (with set_hard_min/max) if they are manipulated.

I have cursorily checked that nothing depends on the previous behavior (there are not that many calls to set soft limits after the initial widget definitions) but am not giving guarantees because this code is confusing and the naming may have misled people.

Filmicrgb now uses the new function, but I intend to implement it accross all iops when I go over them to add introspection, because that will get rid of a lot of the dt_bauhaus_slider_new_with_range calls anyway.

I'm not completely happy with the name "dt_bauhaus_slider_set_soft", or it's use, either. Its purpose isn't to set soft limits, but to set the position value and move the active limits if the value to be set doesn't fit within that range. The _normal_ dt_bauhaus_slider_set assumes that the current value is within the active limits. The code usually calls dt_bauhaus_slider_set if there are no soft limits. Which means adding soft limits would require carefully vetting the code to see if _soft needs to be added anywhere.