### PR TITLE
Fix reading non-existing new timestamps from old sidecar

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -3290,8 +3290,12 @@ gboolean read_xmp_timestamps(Exiv2::XmpData &xmpData, const int imgid)
     if((pos = xmpData.findKey(Exiv2::XmpKey(xmpkey))) != xmpData.end())
     {
       snprintf(tmp, sizeof(tmp), " %s = %ld,", timestamps[i], pos->toLong());
-      g_strlcat(values, tmp, sizeof(values));
     }
+    else
+    {
+      snprintf(tmp, sizeof(tmp), " %s = 0,", timestamps[i]);
+    }
+      g_strlcat(values, tmp, sizeof(values));
   }
 
   values[strlen(values) - 1] = '\0'; /* remove last comma */


### PR DESCRIPTION
In `read_xmp_timestamps` we look for the new timestamps and write values into the database.

While importing an old sidecar without those keys available we dont't find them, the comma
removing is bad as there might be none and the syntax for sqlite updating is wrong.

This ends in all_ok being FALSE and import fails to read the sidecar in a correct way, in fact it
loses the whoöe history.

How to reproduce? Import an image with an old sidecar (before introducing the new timestamps)
on the console.