### PR TITLE
grouping fix

### DIFF
--- a/src/common/grouping.c
+++ b/src/common/grouping.c
@@ -82,6 +82,8 @@ int dt_grouping_remove_from_group(const int image_id)
     wimg->group_id = image_id;
     dt_image_cache_write_release(darktable.image_cache, wimg, DT_IMAGE_CACHE_SAFE);
     imgs = g_list_prepend(imgs, GINT_TO_POINTER(image_id));
+    // refresh also the group leader which may be alone now
+    imgs = g_list_prepend(imgs, GINT_TO_POINTER(img_group_id));
   }
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_IMAGE_INFO_CHANGED, imgs);
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -886,12 +886,14 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
 
     g_free(filename);
 
+    const dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
+    const int grpid = img->group_id;
+    dt_image_cache_read_release(darktable.image_cache, img);
     if(darktable.gui && darktable.gui->grouping)
     {
-      const dt_image_t *img = dt_image_cache_get(darktable.image_cache, newid, 'r');
-      darktable.gui->expanded_group_id = img->group_id;
-      dt_image_cache_read_release(darktable.image_cache, img);
+      darktable.gui->expanded_group_id = grpid;
     }
+    dt_grouping_add_to_group(grpid, newid);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, NULL);
   }
   return newid;

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -563,7 +563,6 @@ static int32_t dt_control_flip_images_job_run(dt_job_t *job)
   dt_control_image_enumerator_t *params = dt_control_job_get_params(job);
   const int cw = params->flag;
   GList *t = params->index;
-  GList *imgs = NULL;
   const guint total = g_list_length(t);
   char message[512] = { 0 };
   snprintf(message, sizeof(message), ngettext("flipping %d image", "flipping %d images", total), total);
@@ -576,7 +575,6 @@ static int32_t dt_control_flip_images_job_run(dt_job_t *job)
     const double fraction = 1.0 / total;
     dt_image_set_aspect_ratio(imgid, FALSE);
     dt_control_job_set_progress(job, fraction);
-    imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   }
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(params->index));
   dt_control_queue_redraw_center();


### PR DESCRIPTION
grouping fix
- duplicate selected
- remove/delete selected (duplicate or real image)

cleanup unused code in control_jobs.c

fixes #4840