### PR TITLE
Fix for #4884 : libavif 0.7.2 API change (and darktable compilation error)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,7 +321,7 @@ if(USE_WEBP)
 endif(USE_WEBP)
 
 if (USE_AVIF)
-    find_package(libavif 0.6.0 CONFIG)
+    find_package(libavif 0.7.2 CONFIG)
     if (TARGET avif)
         list(APPEND LIBS avif)
         add_definitions(-DHAVE_LIBAVIF=1)

--- a/src/common/imageio_avif.c
+++ b/src/common/imageio_avif.c
@@ -345,7 +345,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB:
 
         switch (nclx.matrixCoefficients) {
-        case AVIF_NCLX_MATRIX_COEFFICIENTS_SRGB:
+        case AVIF_NCLX_MATRIX_COEFFICIENTS_BT709:
         case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
           cp->type = DT_COLORSPACE_SRGB;
           break;
@@ -358,7 +358,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       /*
        * GAMMA22 BT709
        */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_GAMMA22:
+      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT470M:
 
         switch (nclx.matrixCoefficients) {
         case AVIF_NCLX_MATRIX_COEFFICIENTS_BT709:
@@ -418,7 +418,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       /*
        * PQ BT2020
        */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_PQ:
+      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084:
 
         switch (nclx.matrixCoefficients) {
         case AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL:
@@ -434,7 +434,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       /*
        * HLG BT2020
        */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_HLG:
+      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG:
 
         switch (nclx.matrixCoefficients) {
         case AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL:
@@ -456,13 +456,13 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
     /*
      * P3
      */
-    case AVIF_NCLX_COLOUR_PRIMARIES_P3:
+    case AVIF_NCLX_COLOUR_PRIMARIES_SMPTE432:
 
       switch (nclx.transferCharacteristics) {
       /*
        * PQ P3
        */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_PQ:
+      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084:
 
         switch (nclx.matrixCoefficients) {
         case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:
@@ -477,7 +477,7 @@ dt_imageio_retval_t dt_imageio_avif_read_color_profile(const char *filename, str
       /*
        * HLG P3
        */
-      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_HLG:
+      case AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG:
 
         switch (nclx.matrixCoefficients) {
         case AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL:

--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -304,9 +304,9 @@ int write_image(struct dt_imageio_module_data_t *data,
     switch (over_type) {
       case DT_COLORSPACE_SRGB:
         nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_SRGB,
+          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT709,
           .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB,
-          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_SRGB,
+          .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT709,
 #if AVIF_VERSION > 700
           .range = AVIF_RANGE_FULL,
 #else
@@ -317,7 +317,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       case DT_COLORSPACE_REC709:
         nclx = (avifNclxColorProfile) {
           .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT709,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_GAMMA22,
+          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT470M,
           .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT709,
 #if AVIF_VERSION > 700
           .range = AVIF_RANGE_FULL,
@@ -353,7 +353,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       case DT_COLORSPACE_PQ_REC2020:
         nclx = (avifNclxColorProfile) {
           .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT2020,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_PQ,
+          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084,
           .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL,
 #if AVIF_VERSION > 700
           .range = AVIF_RANGE_FULL,
@@ -365,7 +365,7 @@ int write_image(struct dt_imageio_module_data_t *data,
       case DT_COLORSPACE_HLG_REC2020:
         nclx = (avifNclxColorProfile) {
           .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_BT2020,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_HLG,
+          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG,
           .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_BT2020_NCL,
 #if AVIF_VERSION > 700
           .range = AVIF_RANGE_FULL,
@@ -376,8 +376,8 @@ int write_image(struct dt_imageio_module_data_t *data,
         break;
       case DT_COLORSPACE_PQ_P3:
         nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_P3,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_PQ,
+          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_SMPTE432,
+          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_SMPTE2084,
           .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
 #if AVIF_VERSION > 700
           .range = AVIF_RANGE_FULL,
@@ -388,8 +388,8 @@ int write_image(struct dt_imageio_module_data_t *data,
         break;
       case DT_COLORSPACE_HLG_P3:
         nclx = (avifNclxColorProfile) {
-          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_P3,
-          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_HLG,
+          .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_SMPTE432,
+          .transferCharacteristics = AVIF_NCLX_TRANSFER_CHARACTERISTICS_HLG,
           .matrixCoefficients = AVIF_NCLX_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL,
 #if AVIF_VERSION > 700
           .range = AVIF_RANGE_FULL,


### PR DESCRIPTION
libavif API changed with commit 7ecf41815810d1d89a80fd7b25d8d78b6f4fd277 (0.7.2)
This fixes #4884 
Tested: I was able to save an image (slowly) in avif and repoen it in darktable.