### PR TITLE
keyboard shortcuts: global zoom and module search

### DIFF
--- a/src/control/control.c
+++ b/src/control/control.c
@@ -669,13 +669,6 @@ int dt_control_key_pressed_override(guint key, guint state)
     darktable.develop->darkroom_skip_mouse_events = TRUE;
     return 1;
   }
-  // set focus to the search module text box
-  else if(key == accels->darkroom_search_modules_focus.accel_key
-          && state == accels->darkroom_search_modules_focus.accel_mods)
-  {
-    dt_dev_modulegroups_search_text_focus(darktable.develop);
-    return 1;
-  }
   // show/hide the accels window
   else if(key == accels->global_accels_window.accel_key && state == accels->global_accels_window.accel_mods)
   {

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -121,8 +121,7 @@ typedef struct dt_control_accels_t
       lighttable_sel_pagedown, lighttable_sel_start, lighttable_sel_end, lighttable_center, lighttable_preview,
       lighttable_preview_display_focus, lighttable_timeline, lighttable_preview_zoom_100,
       lighttable_preview_zoom_fit, global_focus_peaking, global_sideborders, global_accels_window,
-      darkroom_preview, slideshow_start, global_zoom_in, global_zoom_out, darkroom_skip_mouse_events,
-      darkroom_search_modules_focus;
+      darkroom_preview, slideshow_start, darkroom_skip_mouse_events;
 } dt_control_accels_t;
 
 #define DT_CTL_LOG_SIZE 10

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -224,19 +224,9 @@ static void key_accel_changed(GtkAccelMap *object, gchar *accel_path, guint acce
   dt_accel_path_view(path, sizeof(path), "darkroom", "allow to pan & zoom while editing masks");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_skip_mouse_events);
 
-  // set focus to the search module text box
-  dt_accel_path_view(path, sizeof(path), "darkroom", "search modules");
-  gtk_accel_map_lookup_entry(path, &darktable.control->accels.darkroom_search_modules_focus);
-
   // Global
   dt_accel_path_global(path, sizeof(path), "toggle side borders");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_sideborders);
-
-  dt_accel_path_global(path, sizeof(path), "zoom in");
-  gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_zoom_in);
-
-  dt_accel_path_global(path, sizeof(path), "zoom out");
-  gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_zoom_out);
 
   dt_accel_path_global(path, sizeof(path), "show accels window");
   gtk_accel_map_lookup_entry(path, &darktable.control->accels.global_accels_window);
@@ -1378,10 +1368,6 @@ int dt_gui_gtk_init(dt_gui_gtk_t *gui)
 
   dt_accel_connect_global("switch view",
                           g_cclosure_new(G_CALLBACK(view_switch_key_accel_callback), NULL, NULL));
-
-  // Global zoom in & zoom out
-  dt_accel_register_global(NC_("accel", "zoom in"), GDK_KEY_plus, GDK_CONTROL_MASK);
-  dt_accel_register_global(NC_("accel", "zoom out"), GDK_KEY_minus, GDK_CONTROL_MASK);
 
   // accels window
   dt_accel_register_global(NC_("accel", "show accels window"), GDK_KEY_h, 0);


### PR DESCRIPTION
Global zoom (in/out) previously wasn't working when a slider or combobox had keyboard
focus (as they always do when they are changed).

These have been changed to be normal per-view shorcuts with the same
defaults and so are no longer dependent on keyboard focus. For darkroom
this also has the effect of placing all zoom shortcuts in the same
section in preferences.

Module search has been changed to also be consistent with other per-view
shortcuts (though it wasn't exhibiting the same issues).