### PR TITLE
keyboard shortcuts: correct handling of shift modifier

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1027,19 +1027,33 @@ static gboolean window_configure(GtkWidget *da, GdkEvent *event, gpointer user_d
   return FALSE;
 }
 
+guint dt_gui_translated_key_state(GdkEventKey *event)
+{
+  if (gdk_keyval_to_lower(event->keyval) == gdk_keyval_to_upper(event->keyval) )
+  {
+    //not an alphabetic character
+    //find any modifiers consumed to produce keyval
+    guint consumed;
+    gdk_keymap_translate_keyboard_state(gdk_keymap_get_for_display(gdk_display_get_default()), event->hardware_keycode, event->state, event->group, NULL, NULL, NULL, &consumed);
+    return event->state & ~consumed & KEY_STATE_MASK;
+  }
+  else
+    return event->state & KEY_STATE_MASK;
+}
+
 static gboolean key_pressed_override(GtkWidget *w, GdkEventKey *event, gpointer user_data)
 {
-  return dt_control_key_pressed_override(event->keyval, event->state & KEY_STATE_MASK);
+  return dt_control_key_pressed_override(event->keyval, dt_gui_translated_key_state(event));
 }
 
 static gboolean key_pressed(GtkWidget *w, GdkEventKey *event, gpointer user_data)
 {
-  return dt_control_key_pressed(gdk_keyval_to_lower(event->keyval), event->state & KEY_STATE_MASK);
+  return dt_control_key_pressed(gdk_keyval_to_lower(event->keyval), dt_gui_translated_key_state(event));
 }
 
 static gboolean key_released(GtkWidget *w, GdkEventKey *event, gpointer user_data)
 {
-  return dt_control_key_released(gdk_keyval_to_lower(event->keyval), event->state & KEY_STATE_MASK);
+  return dt_control_key_released(gdk_keyval_to_lower(event->keyval), dt_gui_translated_key_state(event));
 }
 
 static gboolean button_pressed(GtkWidget *w, GdkEventButton *event, gpointer user_data)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -368,6 +368,10 @@ void dt_gui_add_help_link(GtkWidget *widget, const char *link);
 // load a CSS theme
 void dt_gui_load_theme(const char *theme);
 
+//translate key press events to remove any modifiers used to produce the keyval
+// for example when the shift key is used to create the asterisk character
+guint dt_gui_translated_key_state(GdkEventKey *event);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1194,6 +1194,8 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
   // Otherwise, determine whether we're in remap mode or not
   if(darktable.control->accel_remap_str)
   {
+    const guint event_mods = dt_gui_translated_key_state(event);
+
     // First locate the accel list entry
     g_strlcpy(query.path, darktable.control->accel_remap_str, sizeof(query.path));
     GSList *remapped = g_slist_find_custom(darktable.control->accelerator_list, (gpointer)&query, _accelcmp);
@@ -1209,7 +1211,7 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
       if (a != accel_current && gtk_accel_map_lookup_entry(a->path, &key))
       {
         if (key.accel_key == gdk_keyval_to_lower(event->keyval) &&
-            key.accel_mods == (event->state & KEY_STATE_MASK) &&
+            key.accel_mods == event_mods &&
             !(a->local && accel_current->local && strcmp(a->module, accel_current->module)) &&
             (a->views & accel_current->views) != 0)
         {
@@ -1224,14 +1226,14 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
     {
       // no conflict
       gtk_accel_map_change_entry(darktable.control->accel_remap_str, gdk_keyval_to_lower(event->keyval),
-                                 event->state & KEY_STATE_MASK, TRUE);
+                                 event_mods, TRUE);
     }
     else
     {
       // we ask for confirmation
       GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
       gchar *accel_txt
-          = gtk_accelerator_get_label(gdk_keyval_to_lower(event->keyval), event->state & KEY_STATE_MASK);
+          = gtk_accelerator_get_label(gdk_keyval_to_lower(event->keyval), event_mods);
       gchar txt[512] = { 0 };
       if(g_str_has_prefix(accel_conflict->translated_path, "<Darktable>/"))
         g_strlcpy(txt, accel_conflict->translated_path + 12, sizeof(txt));
@@ -1252,7 +1254,7 @@ static gboolean tree_key_press(GtkWidget *widget, GdkEventKey *event, gpointer d
       {
         // Change the accel map entry
         if(gtk_accel_map_change_entry(darktable.control->accel_remap_str, gdk_keyval_to_lower(event->keyval),
-                                      event->state & KEY_STATE_MASK, TRUE))
+                                      event_mods, TRUE))
         {
           // Then remove conflicts
           g_slist_foreach(darktable.control->accelerator_list, delete_matching_accels, (gpointer)(accel_current));


### PR DESCRIPTION
Where the shift modifier is required in order to access a
non-alphanumeric character, shift should not be treated as a modifier
key. For example, when using <plus> for global zoom on a UK keyboard
this incorrectly appears in the preferences window as ``<shift>+<plus>`` and
the default value of ``<primary>+<plus>`` does not function correctly.

Replace all references to ``event->state`` with call to ``dt_gui_translated_key_state``
to ignore this already-consumed modifier for keyboard shortcuts.

Resolves #4894