### PR TITLE
German translation updates

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: darktable\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-26 13:29+0100\n"
-"PO-Revision-Date: 2020-03-26 13:34+0100\n"
+"POT-Creation-Date: 2020-05-03 21:23+0200\n"
+"PO-Revision-Date: 2020-05-03 22:32+0200\n"
 "Last-Translator: Tobias Ellinghaus <me@houz.org>\n"
 "Language-Team: German <>\n"
 "Language: de_DE\n"
@@ -13,7 +13,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 
 #: ../build/data/darktable.desktop.in.h:1 ../data/darktable.desktop.in.h:1
 msgid "Virtual Lighttable and Darkroom"
@@ -29,710 +29,71 @@ msgstr "Organisiere und entwickle Bilder von Digitalkameras"
 msgid "graphics;photography;raw;"
 msgstr "Graphik;Grafik;Photographie;Fotografie;Raw;"
 
-#: ../build/src/preferences_gen.h:2047
-msgid "GUI options"
-msgstr "GUI-Optionen"
+#: ../build/src/preferences_gen.h:1564 ../src/libs/tools/lighttable.c:90
+#: ../src/views/lighttable.c:182
+msgid "lighttable"
+msgstr "Leuchttisch"
 
-#: ../build/src/preferences_gen.h:2050 ../src/libs/import.c:97
-msgid "import"
-msgstr "Importieren"
+#: ../build/src/preferences_gen.h:1567
+msgid "color manage cached thumbnails"
+msgstr "Farben gespeicherter Vorschaubilder korrigieren"
 
-#: ../build/src/preferences_gen.h:2059
-msgid "ignore JPEG images when importing film rolls"
-msgstr "JPEG-Bilder beim Import von Filmrollen ignorieren"
-
-#: ../build/src/preferences_gen.h:2068 ../build/src/preferences_gen.h:2088
-#: ../build/src/preferences_gen.h:2111 ../build/src/preferences_gen.h:2134
-#: ../build/src/preferences_gen.h:2157 ../build/src/preferences_gen.h:2180
-#: ../build/src/preferences_gen.h:2237 ../build/src/preferences_gen.h:2314
-#: ../build/src/preferences_gen.h:2334 ../build/src/preferences_gen.h:2358
-#: ../build/src/preferences_gen.h:2378 ../build/src/preferences_gen.h:2398
-#: ../build/src/preferences_gen.h:2418 ../build/src/preferences_gen.h:2438
-#: ../build/src/preferences_gen.h:2509 ../build/src/preferences_gen.h:2556
-#: ../build/src/preferences_gen.h:2598 ../build/src/preferences_gen.h:2622
-#: ../build/src/preferences_gen.h:2679 ../build/src/preferences_gen.h:2725
-#: ../build/src/preferences_gen.h:2744 ../build/src/preferences_gen.h:2764
-#: ../build/src/preferences_gen.h:2784 ../build/src/preferences_gen.h:2840
-#: ../build/src/preferences_gen.h:2887 ../build/src/preferences_gen.h:2916
-#: ../build/src/preferences_gen.h:2936 ../build/src/preferences_gen.h:2956
-#: ../build/src/preferences_gen.h:2976 ../build/src/preferences_gen.h:2996
-#: ../build/src/preferences_gen.h:3016 ../build/src/preferences_gen.h:3036
-#: ../build/src/preferences_gen.h:3055 ../build/src/preferences_gen.h:3109
-#: ../build/src/preferences_gen.h:3157 ../build/src/preferences_gen.h:3177
-#: ../build/src/preferences_gen.h:3224 ../build/src/preferences_gen.h:3244
-#: ../build/src/preferences_gen.h:3291 ../build/src/preferences_gen.h:3345
-#: ../build/src/preferences_gen.h:3365 ../build/src/preferences_gen.h:3385
-#: ../build/src/preferences_gen.h:3432 ../build/src/preferences_gen.h:3484
-#: ../build/src/preferences_gen.h:3504 ../build/src/preferences_gen.h:3524
-#: ../build/src/preferences_gen.h:3544 ../build/src/preferences_gen.h:3573
-#: ../build/src/preferences_gen.h:3620 ../build/src/preferences_gen.h:3640
-#: ../build/src/preferences_gen.h:3677 ../build/src/preferences_gen.h:3697
-#: ../build/src/preferences_gen.h:3717 ../build/src/preferences_gen.h:3820
-#: ../build/src/preferences_gen.h:3875 ../build/src/preferences_gen.h:3959
-#: ../build/src/preferences_gen.h:4006 ../build/src/preferences_gen.h:4026
-#: ../build/src/preferences_gen.h:4080 ../build/src/preferences_gen.h:4104
-#: ../build/src/preferences_gen.h:4129 ../build/src/preferences_gen.h:4178
-#: ../build/src/preferences_gen.h:4202 ../build/src/preferences_gen.h:4226
-#: ../src/lua/preferences.c:619 ../src/lua/preferences.c:634
-#: ../src/lua/preferences.c:646 ../src/lua/preferences.c:658
-#: ../src/lua/preferences.c:674 ../src/lua/preferences.c:738
+#: ../build/src/preferences_gen.h:1577 ../build/src/preferences_gen.h:1598
+#: ../build/src/preferences_gen.h:1650 ../build/src/preferences_gen.h:1730
+#: ../build/src/preferences_gen.h:1755 ../build/src/preferences_gen.h:1784
+#: ../build/src/preferences_gen.h:1813 ../build/src/preferences_gen.h:1834
+#: ../build/src/preferences_gen.h:1855 ../build/src/preferences_gen.h:1876
+#: ../build/src/preferences_gen.h:1897 ../build/src/preferences_gen.h:1918
+#: ../build/src/preferences_gen.h:1939 ../build/src/preferences_gen.h:2026
+#: ../build/src/preferences_gen.h:2076 ../build/src/preferences_gen.h:2121
+#: ../build/src/preferences_gen.h:2150 ../build/src/preferences_gen.h:2210
+#: ../build/src/preferences_gen.h:2259 ../build/src/preferences_gen.h:2279
+#: ../build/src/preferences_gen.h:2300 ../build/src/preferences_gen.h:2321
+#: ../build/src/preferences_gen.h:2371 ../build/src/preferences_gen.h:2421
+#: ../build/src/preferences_gen.h:2472 ../build/src/preferences_gen.h:2522
+#: ../build/src/preferences_gen.h:2579 ../build/src/preferences_gen.h:2622
+#: ../build/src/preferences_gen.h:2677 ../build/src/preferences_gen.h:2703
+#: ../build/src/preferences_gen.h:2724 ../build/src/preferences_gen.h:2745
+#: ../build/src/preferences_gen.h:2766 ../build/src/preferences_gen.h:2809
+#: ../build/src/preferences_gen.h:2830 ../build/src/preferences_gen.h:2851
+#: ../build/src/preferences_gen.h:2872 ../build/src/preferences_gen.h:2893
+#: ../build/src/preferences_gen.h:2914 ../build/src/preferences_gen.h:2935
+#: ../build/src/preferences_gen.h:2955 ../build/src/preferences_gen.h:3006
+#: ../build/src/preferences_gen.h:3027 ../build/src/preferences_gen.h:3048
+#: ../build/src/preferences_gen.h:3158 ../build/src/preferences_gen.h:3216
+#: ../build/src/preferences_gen.h:3324 ../build/src/preferences_gen.h:3382
+#: ../build/src/preferences_gen.h:3432 ../build/src/preferences_gen.h:3453
+#: ../build/src/preferences_gen.h:3504 ../build/src/preferences_gen.h:3525
+#: ../build/src/preferences_gen.h:3575 ../build/src/preferences_gen.h:3604
+#: ../build/src/preferences_gen.h:3625 ../build/src/preferences_gen.h:3654
+#: ../build/src/preferences_gen.h:3710 ../build/src/preferences_gen.h:3735
+#: ../build/src/preferences_gen.h:3786 ../build/src/preferences_gen.h:3807
+#: ../build/src/preferences_gen.h:3831 ../build/src/preferences_gen.h:3855
+#: ../build/src/preferences_gen.h:3879 ../build/src/preferences_gen.h:3903
+#: ../build/src/preferences_gen.h:3966 ../build/src/preferences_gen.h:3991
+#: ../build/src/preferences_gen.h:4016 ../src/lua/preferences.c:619
+#: ../src/lua/preferences.c:634 ../src/lua/preferences.c:646
+#: ../src/lua/preferences.c:658 ../src/lua/preferences.c:674
+#: ../src/lua/preferences.c:738
 #, c-format
 msgid "double click to reset to `%s'"
 msgstr "Doppelklick, um auf „%s” zurückzusetzen"
 
-#: ../build/src/preferences_gen.h:2068 ../build/src/preferences_gen.h:2088
-#: ../build/src/preferences_gen.h:2237 ../build/src/preferences_gen.h:2334
-#: ../build/src/preferences_gen.h:2378 ../build/src/preferences_gen.h:2398
-#: ../build/src/preferences_gen.h:2418 ../build/src/preferences_gen.h:2438
-#: ../build/src/preferences_gen.h:2764 ../build/src/preferences_gen.h:2840
-#: ../build/src/preferences_gen.h:3016 ../build/src/preferences_gen.h:3157
-#: ../build/src/preferences_gen.h:3177 ../build/src/preferences_gen.h:3365
-#: ../build/src/preferences_gen.h:3524 ../build/src/preferences_gen.h:3544
-#: ../build/src/preferences_gen.h:3640 ../build/src/preferences_gen.h:3717
-#: ../build/src/preferences_gen.h:4006 ../build/src/preferences_gen.h:4026
-msgctxt "preferences"
-msgid "FALSE"
-msgstr "NEIN"
-
-#: ../build/src/preferences_gen.h:2071
-msgid ""
-"when having raw+JPEG images together in one directory it makes no sense to "
-"import both. with this flag one can ignore all JPEGs found."
-msgstr ""
-"Wenn Raw+JPEG-Bilder zusammen in einem Verzeichnis liegen, ist es nicht "
-"sinnvoll, beides zu importieren. Mit dieser Option können alle gefundenen "
-"JPEGs ignoriert werden."
-
-#: ../build/src/preferences_gen.h:2079
-msgid "recursive directory traversal when importing filmrolls"
-msgstr "Rekursiver Import von Verzeichnissen"
-
-#: ../build/src/preferences_gen.h:2098
-msgid "creator to be applied when importing"
-msgstr "Urheber, der beim Import hinzugefügt werden soll"
-
-#: ../build/src/preferences_gen.h:2121
-msgid "publisher to be applied when importing"
-msgstr "Herausgeber, der beim Import hinzugefügt werden soll"
-
-#: ../build/src/preferences_gen.h:2144
-msgid "rights to be applied when importing"
-msgstr "Rechte, die beim Import hinzugefügt werden sollen"
-
-#: ../build/src/preferences_gen.h:2167
-msgid "comma separated tags to be applied when importing"
-msgstr ""
-"Komma-separierte Stichwörter, die beim Import hinzugefügt werden sollen"
-
-#: ../build/src/preferences_gen.h:2190
-msgid "initial import rating"
-msgstr "Erstbewertung beim Importieren"
-
-#: ../build/src/preferences_gen.h:2208 ../build/src/preferences_gen.h:2811
-#: ../build/src/preferences_gen.h:2867 ../build/src/preferences_gen.h:3090
-#: ../build/src/preferences_gen.h:3137 ../build/src/preferences_gen.h:3744
-#: ../build/src/preferences_gen.h:3771 ../build/src/preferences_gen.h:3800
-#: ../build/src/preferences_gen.h:3986 ../src/lua/preferences.c:697
-#, c-format
-msgid "double click to reset to `%d'"
-msgstr "Doppelklick, um auf „%d” zurückzusetzen"
-
-#: ../build/src/preferences_gen.h:2211
-msgid "initial star rating for all images when importing a filmroll"
-msgstr ""
-"Anfängliche Anzahl Sterne für alle Bilder einer neu importierten Filmrolle"
-
-#: ../build/src/preferences_gen.h:2219 ../src/libs/tools/lighttable.c:90
-#: ../src/views/lighttable.c:186
-msgid "lighttable"
-msgstr "Leuchttisch"
-
-#: ../build/src/preferences_gen.h:2228
-msgid "don't use embedded preview JPEG but half-size raw"
-msgstr "Eingebettete Vorschau-JPEGs nicht nutzen, sondern Raw halber Größe"
-
-#: ../build/src/preferences_gen.h:2240
-msgid ""
-"check this option to not use the embedded JPEG from the raw file but process "
-"the raw data. this is slower but gives you color managed thumbnails."
-msgstr ""
-"Diese Option auswählen, damit die in Raw-Dateien eingebetteten JPEG-"
-"Vorschauen nicht benutzt werden, sondern die Raw-Daten verarbeitet werden. "
-"Das ist langsamer, bringt dafür aber Farbmanagement für Vorschaubilder."
-
-#: ../build/src/preferences_gen.h:2248
-msgid "high quality thumb processing from size"
-msgstr "Hochqualitatives Entwickeln für Vorschaubilder"
-
-#: ../build/src/preferences_gen.h:2259 ../build/src/preferences_gen.h:3600
-msgctxt "preferences"
-msgid "always"
-msgstr "immer"
-
-#: ../build/src/preferences_gen.h:2264
-msgctxt "preferences"
-msgid "small"
-msgstr "klein"
-
-#: ../build/src/preferences_gen.h:2269
-msgctxt "preferences"
-msgid "VGA"
-msgstr "VGA"
-
-#: ../build/src/preferences_gen.h:2274 ../build/src/preferences_gen.h:2314
-msgctxt "preferences"
-msgid "720p"
-msgstr "720p"
-
-#: ../build/src/preferences_gen.h:2279
-msgctxt "preferences"
-msgid "1080p"
-msgstr "1080p"
-
-#: ../build/src/preferences_gen.h:2284
-msgctxt "preferences"
-msgid "WQXGA"
-msgstr "WQXGA"
-
-#: ../build/src/preferences_gen.h:2289
-msgctxt "preferences"
-msgid "4K"
-msgstr "4K"
-
-#: ../build/src/preferences_gen.h:2294
-msgctxt "preferences"
-msgid "5K"
-msgstr "5K"
-
-#: ../build/src/preferences_gen.h:2299 ../build/src/preferences_gen.h:3595
-#: ../build/src/preferences_gen.h:3914
-msgctxt "preferences"
-msgid "never"
-msgstr "nie"
-
-#: ../build/src/preferences_gen.h:2317
-msgid ""
-"if the thumbnail size is greater than this value, it will be processed using "
-"the full quality rendering path (better but slower)."
-msgstr ""
-"wenn die Größe eines Vorschaubildes größer als dieser Wert ist, dann wird es "
-"mit voller Qualität berechnet (besser aber langsamer)."
-
-#: ../build/src/preferences_gen.h:2325
-msgid "enable extended thumb overlay"
-msgstr "erweitertes Vorschaubild aktivieren"
-
-#: ../build/src/preferences_gen.h:2337
-msgid "if set to true, thumb overlay shows filename and some exif data."
-msgstr ""
-"wenn auf true gesetzt, zeigt das Vorschaubild-Overlay den Dateinamen und "
-"einige Exif-Daten an."
-
-#: ../build/src/preferences_gen.h:2345
-msgid "pattern for the thumbnail tooltip (empty to disable)"
-msgstr ""
-
-#: ../build/src/preferences_gen.h:2361 ../build/src/preferences_gen.h:2625
-msgid "see manual to know all the tags you can use."
-msgstr "Siehe Handbuch, um mehr über Stichwörter zu erfahren."
-
-#: ../build/src/preferences_gen.h:2369
-msgid "use single-click in the collect panel"
-msgstr "verwende einfach Klick im Sammel-Eingabefeld"
-
-#: ../build/src/preferences_gen.h:2381
-msgid ""
-"check this option to use single-click to select items in the collect panel. "
-"this will allow you to do range selections for date-time and numeric values."
-msgstr ""
-"Aktiviere die Option, um Elemente im Sammel-Eingabefeld mit einem einzigen "
-"Mausklick auszuwählen. Dadurch können Bereiche für Datum/Uhrzeit und "
-"numerische Werte ausgewählt werden."
-
-#: ../build/src/preferences_gen.h:2389
-msgid "expand a single lighttable module at a time"
-msgstr "Nur ein einzelnes Leuchttisch-Modul ausklappen"
-
-#: ../build/src/preferences_gen.h:2401
-msgid "this option toggles the behavior of shift clicking in lighttable mode"
-msgstr ""
-"Diese Option schaltet das Verhalten von Umschalt-Klicks im Leuchttisch-Modus "
-"um"
-
-#: ../build/src/preferences_gen.h:2409
-msgid "scroll to lighttable modules when expanded/collapsed"
-msgstr "Zu Leuchttisch-Modul scrollen, wenn es ein-/ausgeklappt wird"
-
-#: ../build/src/preferences_gen.h:2421 ../build/src/preferences_gen.h:2787
-msgid ""
-"when this option is enabled then darktable will try to scroll the module to "
-"the top of the visible list"
-msgstr ""
-"Wenn diese Option aktiviert ist, dann wird darktable versuchen, das "
-"entsprechende Modul nach oben in den sichtbaren Bereich der Liste zu scrollen"
-
-#: ../build/src/preferences_gen.h:2429
-msgid "rating an image one star twice will not zero out the rating"
-msgstr "Doppelte Bewertung mit einem Stern setzt nicht null Sterne"
-
-#: ../build/src/preferences_gen.h:2441
-msgid ""
-"do not have the rating of one star behave as documented in the manual--an "
-"image rated one star twice will result in a zero star rating."
-msgstr ""
-"Sorgt dafür, dass im Gegensatz zur Beschreibung im Handbuch ein Bild bei "
-"doppelter Bewertung mit einem Stern nicht auf null Sterne gesetzt wird."
-
-#: ../build/src/preferences_gen.h:2449 ../src/views/darkroom.c:109
-msgid "darkroom"
-msgstr "Dunkelkammer"
-
-#: ../build/src/preferences_gen.h:2458
-msgid "pen pressure control for brush masks"
-msgstr "Drucksensitivität eines Stiftes für Pinsel-Masken"
-
-#: ../build/src/preferences_gen.h:2469 ../build/src/preferences_gen.h:2509
-msgctxt "preferences"
-msgid "off"
-msgstr "aus"
-
-#: ../build/src/preferences_gen.h:2474
-msgctxt "preferences"
-msgid "hardness (relative)"
-msgstr "Härte (relativ)"
-
-#: ../build/src/preferences_gen.h:2479
-msgctxt "preferences"
-msgid "hardness (absolute)"
-msgstr "Härte (absolut)"
-
-#: ../build/src/preferences_gen.h:2484
-msgctxt "preferences"
-msgid "opacity (relative)"
-msgstr "Deckkraft (relativ)"
-
-#: ../build/src/preferences_gen.h:2489
-msgctxt "preferences"
-msgid "opacity (absolute)"
-msgstr "Deckkraft (absolut)"
-
-#: ../build/src/preferences_gen.h:2494
-msgctxt "preferences"
-msgid "brush size (relative)"
-msgstr "Pinselgröße (relativ)"
-
-#: ../build/src/preferences_gen.h:2512
-msgid ""
-"off - pressure reading ignored, hardness/opacity/brush size - pressure "
-"reading controls specified attribute, absolute/relative - pressure reading "
-"is taken directly as attribute value or multiplied with pre-defined setting."
-msgstr ""
-"aus – Druck-Wert ignorieren, Härte/Deckkraft/Pinselgröße – Druck-Wert "
-"kontrolliert bestimmte Eigenschaften, absolut/relativ – Druck-Wert wird "
-"direkt als Wert benutzt oder mit vordefinierten Einstellungen multipliziert."
-
-#: ../build/src/preferences_gen.h:2520
-msgid "smoothing of brush strokes"
-msgstr "Begradigen von Pinselstrichen"
-
-#: ../build/src/preferences_gen.h:2531
-msgctxt "preferences"
-msgid "low"
-msgstr "gering"
-
-#: ../build/src/preferences_gen.h:2536 ../build/src/preferences_gen.h:2556
-msgctxt "preferences"
-msgid "medium"
-msgstr "mittel"
-
-#: ../build/src/preferences_gen.h:2541
-msgctxt "preferences"
-msgid "high"
-msgstr "hoch"
-
-#: ../build/src/preferences_gen.h:2559
-msgid ""
-"sets level for smoothing of brush strokes. stronger smoothing leads to less "
-"nodes and easier editing but with lower control of accuracy."
-msgstr ""
-"Setzt das Maß der Begradigung von Pinselstrichen. Stärkere Begradigung führt "
-"zu weniger Knoten und vereinfachtem Editieren, bedeutet aber zugleich eine "
-"geringere Kontrolle über die Genauigkeit."
-
-#: ../build/src/preferences_gen.h:2567
-msgid "display of individual color channels"
-msgstr "Anzeige einzelner Farbkanäle"
-
-#: ../build/src/preferences_gen.h:2578 ../build/src/preferences_gen.h:2598
-msgctxt "preferences"
-msgid "false color"
-msgstr "Falschfarben"
-
-#: ../build/src/preferences_gen.h:2583
-msgctxt "preferences"
-msgid "grey scale"
-msgstr "Graustufen"
-
-#: ../build/src/preferences_gen.h:2601
-msgid ""
-"defines how color channels are displayed when activated in the parametric "
-"masks feature."
-msgstr ""
-"legt fest, wie Farbkanäle angezeigt werden, wenn sie in der parametrischen "
-"Maske eingeschaltet wurden."
-
-#: ../build/src/preferences_gen.h:2609
-msgid "pattern for the image infos line"
-msgstr "Format der Bildinformationszeile"
-
-#: ../build/src/preferences_gen.h:2633
-msgid "position of the image infos line"
-msgstr "Position der Bildinformationszeile"
-
-#: ../build/src/preferences_gen.h:2644
-msgctxt "preferences"
-msgid "top left"
-msgstr "oben links"
-
-#: ../build/src/preferences_gen.h:2649
-msgctxt "preferences"
-msgid "top right"
-msgstr "oben rechts"
-
-#: ../build/src/preferences_gen.h:2654
-msgctxt "preferences"
-msgid "top center"
-msgstr "oben mittig"
-
-#: ../build/src/preferences_gen.h:2659 ../build/src/preferences_gen.h:2679
-msgctxt "preferences"
-msgid "bottom"
-msgstr "unten"
-
-#: ../build/src/preferences_gen.h:2664
-msgctxt "preferences"
-msgid "hidden"
-msgstr "verborgen"
-
-#: ../build/src/preferences_gen.h:2689
-msgid "show search module text entry"
-msgstr "zeige Suchmodul-Texteintrag"
-
-#: ../build/src/preferences_gen.h:2700
-msgctxt "preferences"
-msgid "show search text"
-msgstr "zeige Suchtext"
-
-#: ../build/src/preferences_gen.h:2705
-msgctxt "preferences"
-msgid "show groups"
-msgstr "zeige Gruppen"
-
-#: ../build/src/preferences_gen.h:2710 ../build/src/preferences_gen.h:2725
-msgctxt "preferences"
-msgid "show both"
-msgstr "zeige beide"
-
-#: ../build/src/preferences_gen.h:2735
-msgid "expand a single darkroom module at a time"
-msgstr "Nur ein einzelnes Dunkelkammer-Modul ausklappen"
-
-#: ../build/src/preferences_gen.h:2744 ../build/src/preferences_gen.h:2784
-#: ../build/src/preferences_gen.h:2887 ../build/src/preferences_gen.h:2916
-#: ../build/src/preferences_gen.h:2936 ../build/src/preferences_gen.h:2956
-#: ../build/src/preferences_gen.h:2976 ../build/src/preferences_gen.h:2996
-#: ../build/src/preferences_gen.h:3036 ../build/src/preferences_gen.h:3055
-#: ../build/src/preferences_gen.h:3109 ../build/src/preferences_gen.h:3244
-#: ../build/src/preferences_gen.h:3345 ../build/src/preferences_gen.h:3385
-#: ../build/src/preferences_gen.h:3504 ../build/src/preferences_gen.h:3573
-#: ../build/src/preferences_gen.h:3697 ../build/src/preferences_gen.h:3820
+#: ../build/src/preferences_gen.h:1577 ../build/src/preferences_gen.h:1650
+#: ../build/src/preferences_gen.h:2279 ../build/src/preferences_gen.h:2321
+#: ../build/src/preferences_gen.h:2522 ../build/src/preferences_gen.h:2579
+#: ../build/src/preferences_gen.h:2724 ../build/src/preferences_gen.h:2766
+#: ../build/src/preferences_gen.h:2809 ../build/src/preferences_gen.h:2830
+#: ../build/src/preferences_gen.h:2851 ../build/src/preferences_gen.h:2872
+#: ../build/src/preferences_gen.h:2893 ../build/src/preferences_gen.h:2935
+#: ../build/src/preferences_gen.h:2955 ../build/src/preferences_gen.h:3027
+#: ../build/src/preferences_gen.h:3158 ../build/src/preferences_gen.h:3382
+#: ../build/src/preferences_gen.h:3525 ../build/src/preferences_gen.h:3654
 msgctxt "preferences"
 msgid "TRUE"
 msgstr "JA"
 
-#: ../build/src/preferences_gen.h:2747
-msgid "this option toggles the behavior of shift clicking in darkroom mode"
-msgstr ""
-"Diese Option schaltet das Verhalten von Umschalt-Klicks im Dunkelkammer-"
-"Modus um"
-
-#: ../build/src/preferences_gen.h:2755
-msgid "expand the module when it is activated, and collapse it when disabled"
-msgstr "Modul ausklappen wenn aktiv, einklappen wenn inaktiv"
-
-#: ../build/src/preferences_gen.h:2767
-msgid ""
-"this option allows to expand or collapse automatically the module when it is "
-"enabled or disabled."
-msgstr ""
-"Diese Option erlaubt, Module automatisch ein- bzw. auszuklappen wenn "
-"aktiviert bzw. deaktiviert."
-
-#: ../build/src/preferences_gen.h:2775
-msgid "scroll to darkroom modules when expanded/collapsed"
-msgstr "Zu Dunkelkammer-Modul scrollen, wenn es ein-/ausgeklappt wird"
-
-#: ../build/src/preferences_gen.h:2795
-msgid "border around image in darkroom mode"
-msgstr "Rand um Bild im Dunkelkammer-Modus"
-
-#: ../build/src/preferences_gen.h:2814
-msgid ""
-"process the image in darkroom mode with a small border. set to 0 if you "
-"don't want any border."
-msgstr ""
-"zeige das Bild im Dunkelkammer-Modus mit einem kleinen Rand. Auf 0 setzen, "
-"wenn kein Rand erwünscht ist."
-
-#: ../build/src/preferences_gen.h:2822
-msgid "map / geolocalisation"
-msgstr "Karte / Geolokalisierung"
-
-# gefällt mir nicht, weder im Original, noch die Übersetzung.
-#: ../build/src/preferences_gen.h:2831
-msgid "only draw images on map that are currently collected and filtered"
-msgstr ""
-"Nur Bilder auf der Karte anzeigen, die aktuell gesammelt und gefiltert sind"
-
-#: ../build/src/preferences_gen.h:2843
-msgid ""
-"use the current filter settings to select the geotagged images drawn on the "
-"map, i.e. limit the images drawn to the current filmstrip. this limits the "
-"number of images drawn and thus reduces the time needed to draw the images."
-msgstr ""
-"Nutze die aktuellen Filter-Einstellungen, um die Bilder auszuwählen, die auf "
-"der Karte angezeigt werden, d.h., es werden nur die Bilder auf der Karte "
-"angezeigt, die momentan im Filmstreifen zu sehen sind. Dies beschränkt die "
-"Anzahl der anzuzeigenden Bilder und verringert daher die Zeit, die zum "
-"Zeichnen der Karte benötigt wird."
-
-#: ../build/src/preferences_gen.h:2851
-msgid "maximum number of images drawn on map"
-msgstr "Maximale Anzahl Bilder, die auf der Karte gezeigt werden"
-
-#: ../build/src/preferences_gen.h:2870
-msgid ""
-"the maximum number of geotagged images drawn on the map. increasing this "
-"number can slow drawing of the map down."
-msgstr ""
-"Die maximale Anzahl an Bilder, die auf der Karte angezeigt werden. Ein "
-"Erhöhen dieser Zahl kann das Zeichnen der Karte verlangsamen."
-
-#: ../build/src/preferences_gen.h:2878
-msgid "pretty print the image location"
-msgstr "Bildposition schön formatieren"
-
-#: ../build/src/preferences_gen.h:2890
-msgid ""
-"show a more readable representation of the location in the image information "
-"module"
-msgstr ""
-"Zeige eine besser lesbare Darstellung der Position im Bildinformations-Modul"
-
-#: ../build/src/preferences_gen.h:2898
-msgid "security"
-msgstr "Sicherheit"
-
-#: ../build/src/preferences_gen.h:2907
-msgid "ask before removing images from database"
-msgstr "Fragen, bevor Bilder aus der Datenbank entfernt werden"
-
-#: ../build/src/preferences_gen.h:2919
-msgid "always ask the user before any image is removed from DB."
-msgstr "Nachfragen, bevor ein Bild aus der Datenbank gelöscht wird."
-
-#: ../build/src/preferences_gen.h:2927
-msgid "ask before erasing images from disk / discarding history stack"
-msgstr "Fragen, bevor Bilder von der Festplatte / der Verlauf gelöscht werden"
-
-#: ../build/src/preferences_gen.h:2939
-msgid ""
-"always ask the user before any image file is deleted / history stack is "
-"discarded."
-msgstr ""
-"Nachfragen, bevor eine Bilddatei von der Festplatte gelöscht oder der "
-"Verlauf verworfen wird."
-
-#: ../build/src/preferences_gen.h:2947
-msgid "send files to trash when erasing images"
-msgstr "Benutze den Papierkorb beim Löschen"
-
-#: ../build/src/preferences_gen.h:2959
-msgid ""
-"send files to trash instead of permanently deleting files on system that "
-"supports it"
-msgstr ""
-"Sende Bilder in den Papierkorb statt sie permanent zu löschen. Dies muss vom "
-"System unterstützt werden"
-
-#: ../build/src/preferences_gen.h:2967
-msgid "ask before moving images from film roll folder"
-msgstr "Fragen, bevor Bilder aus dem Filmrollen-Ordner verschoben werden"
-
-#: ../build/src/preferences_gen.h:2979
-msgid "always ask the user before any image file is moved."
-msgstr "Nachfragen, bevor eine Bilddatei verschoben wird."
-
-#: ../build/src/preferences_gen.h:2987
-msgid "ask before copying images to new film roll folder"
-msgstr "Fragen, bevor Bilder in einen neuen Filmrollen-Ordner kopiert werden"
-
-#: ../build/src/preferences_gen.h:2999
-msgid "always ask the user before any image file is copied."
-msgstr "Nachfragen, bevor eine Bilddatei kopiert wird."
-
-#: ../build/src/preferences_gen.h:3007
-msgid "ask before removing empty folders"
-msgstr "Fragen, bevor leere Verzeichnisse entfernt werden"
-
-#: ../build/src/preferences_gen.h:3019
-msgid ""
-"always ask the user before removing any empty folder. this can happen after "
-"moving or deleting images."
-msgstr ""
-"Nachfragen, bevor leere Verzeichnisse gelöscht werden. Dies kann vorkommen "
-"wenn Bilder verschoben oder gelöscht werden."
-
-#: ../build/src/preferences_gen.h:3027
-msgid "ask before deleting a tag"
-msgstr "Vor dem Löschen eines Tag nachfragen"
-
-#: ../build/src/preferences_gen.h:3046
-msgid "ask before deleting a style"
-msgstr "Vor dem Löschen eines Stils nachfragen"
-
-#: ../build/src/preferences_gen.h:3065 ../build/src/preferences_gen.h:3894
-msgid "miscellaneous"
-msgstr "Verschieden"
-
-#: ../build/src/preferences_gen.h:3074
-msgid "waiting time between each picture in slideshow"
-msgstr "Wartezeit zwischen zwei Bildern in der Diaschau"
-
-#: ../build/src/preferences_gen.h:3100
-msgid "do not show april 1st game"
-msgstr "1.-April-Spiel nicht starten"
-
-#: ../build/src/preferences_gen.h:3119
-msgid "number of folder levels to show in lists"
-msgstr "Anzahl Verzeichnis-Ebenen, die in der Liste angezeigt werden sollen"
-
-#: ../build/src/preferences_gen.h:3140
-msgid ""
-"the number of folder levels to show in film roll names, starting from the "
-"right"
-msgstr ""
-"Die Anzahl an Verzeichnis-Ebenen, die im\n"
-"Filmrollennamen angezeigt werden sollen,\n"
-"beginnend von rechts"
-
-#: ../build/src/preferences_gen.h:3148
-msgid "overlay txt sidecar over zoomed images"
-msgstr "txt-Begleitdatei über gezoomtes Bild legen"
-
-#: ../build/src/preferences_gen.h:3160
-msgid ""
-"when there is a txt file next to an image it can be shown as an overlay over "
-"zoomed images on the lighttable. the txt file either has to be there at "
-"import time or the crawler has to be enabled"
-msgstr ""
-"Wenn es zu einem Bild eine txt-Datei gibt, dann kann diese über das "
-"eingezoomte Bild im Leuchttisch überlagert werden. Die txt-Datei muss "
-"entweder bereits beim Import des Bildes vorhanden oder der Crawler "
-"eingeschaltet sein"
-
-#: ../build/src/preferences_gen.h:3168
-msgid "mouse wheel scrolls modules side panel by default"
-msgstr ""
-"Mausrad blättert standardmäßig die Module der seitlichen Eingabefelder durch"
-
-#: ../build/src/preferences_gen.h:3180
-msgid ""
-"when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to "
-"use mouse wheel for data entry.  when disabled, this behavior is reversed"
-msgstr ""
-"wenn aktiviert, Mausrad zum Blättern der Module der seitlichen "
-"Eingabefelder. Strg+Alt zur Dateneingabe verwenden. Wenn deaktiviert, ist "
-"das Verhalten umgekehrt"
-
-#: ../build/src/preferences_gen.h:3188
-msgid "show scrollbars for center view"
-msgstr "zeige Scrollbalken für den Hauptbereich"
-
-#: ../build/src/preferences_gen.h:3199
-msgctxt "preferences"
-msgid "no scrollbars"
-msgstr "keine Scrollbalken"
-
-#: ../build/src/preferences_gen.h:3204 ../build/src/preferences_gen.h:3224
-msgctxt "preferences"
-msgid "lighttable"
-msgstr "Leuchttisch"
-
-#: ../build/src/preferences_gen.h:3209
-msgctxt "preferences"
-msgid "lighttable + darkroom"
-msgstr "Leuchttisch und Dunkelkammer"
-
-#: ../build/src/preferences_gen.h:3227
-msgid "defines where scrollbars should be displayed"
-msgstr "Definiert an welcher Stelle Scrollbalken angezeigt werden"
-
-#: ../build/src/preferences_gen.h:3235
-msgid "always show panels' scrollbars"
-msgstr "zeigt immer die Scrollbalken der Eingabefelder an"
-
-#: ../build/src/preferences_gen.h:3247
-msgid ""
-"defines whether the panel scrollbars should be always visible or activated "
-"only depending on the content.  (need a restart)"
-msgstr ""
-"definiert, ob die Scrollbalken der Eingabefelder immer sichtbar sind oder "
-"abhängig vom Inhalt. (benötigt einen Neustart)"
-
-#: ../build/src/preferences_gen.h:3255
-msgid "method to use for getting the display profile"
-msgstr "Methode, um das Monitorprofil zu ermitteln"
-
-#: ../build/src/preferences_gen.h:3266 ../build/src/preferences_gen.h:3291
-msgctxt "preferences"
-msgid "all"
-msgstr "alle"
-
-#: ../build/src/preferences_gen.h:3271
-msgctxt "preferences"
-msgid "xatom"
-msgstr "XAtom"
-
-#: ../build/src/preferences_gen.h:3276
-msgctxt "preferences"
-msgid "colord"
-msgstr "Colord"
-
-#: ../build/src/preferences_gen.h:3294
-msgid ""
-"this option allows to force a specific means of getting the current display "
-"profile. this is useful when one alternative gives wrong results"
-msgstr ""
-"Diese Option erlaubt es, eine bestimmte Methode zum Ermitteln des "
-"Anzeigenprofils festzulegen. Dies ist hilfreich, wenn eine der Alternativen "
-"falsche Ergebnisse liefert"
-
-#: ../build/src/preferences_gen.h:3324
-msgid "core options"
-msgstr "zentrale Optionen"
-
-#: ../build/src/preferences_gen.h:3327 ../src/imageio/format/j2k.c:652
-#: ../src/imageio/format/jpeg.c:591 ../src/imageio/format/webp.c:331
-#: ../src/libs/camera.c:592
-msgid "quality"
-msgstr "Qualität"
-
-#: ../build/src/preferences_gen.h:3336
-msgid "color manage cached thumbnails"
-msgstr "Farben gespeicherter Vorschaubilder korrigieren"
-
-#: ../build/src/preferences_gen.h:3348
+#: ../build/src/preferences_gen.h:1580
 msgid ""
 "if enabled, cached thumbnails will be color managed so that lighttable and "
 "filmstrip can show correct colors. otherwise the results may look wrong once "
@@ -743,42 +104,426 @@ msgstr ""
 "Andernfalls können die Bilder, sobald das Bildschirmfarbprofil geändert "
 "wurde, falsch aussehen."
 
-#: ../build/src/preferences_gen.h:3356
-msgid "always use LittleCMS 2 to apply output color profile"
-msgstr "Benutze immer LittleCMS 2, um das Ausgabefarbprofil anzuwenden"
+#: ../build/src/preferences_gen.h:1588
+msgid "don't use embedded preview JPEG but half-size raw"
+msgstr "Eingebettete Vorschau-JPEGs nicht nutzen, sondern Raw halber Größe"
 
-#: ../build/src/preferences_gen.h:3368
-msgid "this is slower than the default."
-msgstr "Dies ist langsamer als die Standardeinstellung."
+#: ../build/src/preferences_gen.h:1598 ../build/src/preferences_gen.h:1834
+#: ../build/src/preferences_gen.h:1855 ../build/src/preferences_gen.h:1876
+#: ../build/src/preferences_gen.h:1897 ../build/src/preferences_gen.h:1918
+#: ../build/src/preferences_gen.h:1939 ../build/src/preferences_gen.h:2300
+#: ../build/src/preferences_gen.h:2371 ../build/src/preferences_gen.h:2472
+#: ../build/src/preferences_gen.h:2622 ../build/src/preferences_gen.h:2745
+#: ../build/src/preferences_gen.h:2914 ../build/src/preferences_gen.h:3048
+#: ../build/src/preferences_gen.h:3453 ../build/src/preferences_gen.h:3504
+#: ../build/src/preferences_gen.h:3604 ../build/src/preferences_gen.h:3625
+#: ../build/src/preferences_gen.h:3786 ../build/src/preferences_gen.h:3807
+msgctxt "preferences"
+msgid "FALSE"
+msgstr "NEIN"
 
-#: ../build/src/preferences_gen.h:3376
-msgid "do high quality processing for slideshow"
-msgstr "Hochqualitatives Entwickeln für die Diashow"
+#: ../build/src/preferences_gen.h:1601
+msgid ""
+"check this option to not use the embedded JPEG from the raw file but process "
+"the raw data. this is slower but gives you color managed thumbnails."
+msgstr ""
+"Diese Option auswählen, damit die in Raw-Dateien eingebetteten JPEG-"
+"Vorschauen nicht benutzt werden, sondern die Raw-Daten verarbeitet werden. "
+"Das ist langsamer, bringt dafür aber Farbmanagement für Vorschaubilder."
 
-#: ../build/src/preferences_gen.h:3388
-msgid "same option as for export, but applies to slideshow."
-msgstr "Die selbe Option wie beim Export, hier jedoch für die Diashow."
+#: ../build/src/preferences_gen.h:1609
+msgid "number of folder levels to show in lists"
+msgstr "Anzahl Verzeichnis-Ebenen, die in der Liste angezeigt werden sollen"
 
-#: ../build/src/preferences_gen.h:3396
+#: ../build/src/preferences_gen.h:1629 ../build/src/preferences_gen.h:2350
+#: ../build/src/preferences_gen.h:2501 ../build/src/preferences_gen.h:2559
+#: ../build/src/preferences_gen.h:3077 ../build/src/preferences_gen.h:3106
+#: ../build/src/preferences_gen.h:3137 ../build/src/preferences_gen.h:3353
+#: ../build/src/preferences_gen.h:3933 ../src/lua/preferences.c:697
+#, c-format
+msgid "double click to reset to `%d'"
+msgstr "Doppelklick, um auf „%d” zurückzusetzen"
+
+#: ../build/src/preferences_gen.h:1632
+msgid ""
+"the number of folder levels to show in film roll names, starting from the "
+"right"
+msgstr ""
+"Die Anzahl an Verzeichnis-Ebenen, die im\n"
+"Filmrollennamen angezeigt werden sollen,\n"
+"beginnend von rechts"
+
+#: ../build/src/preferences_gen.h:1640
+msgid "sort collection recent to older"
+msgstr ""
+
+#: ../build/src/preferences_gen.h:1653
+msgid ""
+"changes the default collections-list order for folders, times and dates to "
+"run from recent to older"
+msgstr ""
+
+#: ../build/src/preferences_gen.h:1661
+msgid "high quality thumb processing from size"
+msgstr "Hochqualitatives Entwickeln für Vorschaubilder"
+
+#: ../build/src/preferences_gen.h:1672 ../build/src/preferences_gen.h:3409
+msgctxt "preferences"
+msgid "always"
+msgstr "immer"
+
+#: ../build/src/preferences_gen.h:1677
+msgctxt "preferences"
+msgid "small"
+msgstr "klein"
+
+#: ../build/src/preferences_gen.h:1682
+msgctxt "preferences"
+msgid "VGA"
+msgstr "VGA"
+
+#: ../build/src/preferences_gen.h:1687 ../build/src/preferences_gen.h:1730
+msgctxt "preferences"
+msgid "720p"
+msgstr "720p"
+
+#: ../build/src/preferences_gen.h:1692
+msgctxt "preferences"
+msgid "1080p"
+msgstr "1080p"
+
+#: ../build/src/preferences_gen.h:1697
+msgctxt "preferences"
+msgid "WQXGA"
+msgstr "WQXGA"
+
+#: ../build/src/preferences_gen.h:1702
+msgctxt "preferences"
+msgid "4K"
+msgstr "4K"
+
+#: ../build/src/preferences_gen.h:1707
+msgctxt "preferences"
+msgid "5K"
+msgstr "5K"
+
+#: ../build/src/preferences_gen.h:1712 ../build/src/preferences_gen.h:3276
+#: ../build/src/preferences_gen.h:3404
+msgctxt "preferences"
+msgid "never"
+msgstr "nie"
+
+#: ../build/src/preferences_gen.h:1733
+msgid ""
+"if the thumbnail size is greater than this value, it will be processed using "
+"the full quality rendering path (better but slower)."
+msgstr ""
+"wenn die Größe eines Vorschaubildes größer als dieser Wert ist, dann wird es "
+"mit voller Qualität berechnet (besser aber langsamer)."
+
+#: ../build/src/preferences_gen.h:1741
+msgid "delimiters for sizes categories"
+msgstr ""
+
+#: ../build/src/preferences_gen.h:1758
+msgid ""
+"sizes categories are used to be able to set different overlays and css "
+"values depending of the size of the thumbnail."
+msgstr ""
+
+#: ../build/src/preferences_gen.h:1766
+msgid "pattern for the thumbnail extended overlay text"
+msgstr ""
+
+#: ../build/src/preferences_gen.h:1787 ../build/src/preferences_gen.h:1816
+#: ../build/src/preferences_gen.h:2153
+msgid "see manual to know all the tags you can use."
+msgstr "Siehe Handbuch, um mehr über Stichwörter zu erfahren."
+
+#: ../build/src/preferences_gen.h:1795
+msgid "pattern for the thumbnail tooltip (empty to disable)"
+msgstr ""
+
+#: ../build/src/preferences_gen.h:1824
+msgid "use single-click in the collect panel"
+msgstr "verwende einfach Klick im Sammel-Eingabefeld"
+
+#: ../build/src/preferences_gen.h:1837
+msgid ""
+"check this option to use single-click to select items in the collect panel. "
+"this will allow you to do range selections for date-time and numeric values."
+msgstr ""
+"Aktiviere die Option, um Elemente im Sammel-Eingabefeld mit einem einzigen "
+"Mausklick auszuwählen. Dadurch können Bereiche für Datum/Uhrzeit und "
+"numerische Werte ausgewählt werden."
+
+#: ../build/src/preferences_gen.h:1845
+msgid "overlay txt sidecar over zoomed images"
+msgstr "txt-Begleitdatei über gezoomtes Bild legen"
+
+#: ../build/src/preferences_gen.h:1858
+msgid ""
+"when there is a txt file next to an image it can be shown as an overlay over "
+"zoomed images on the lighttable. the txt file either has to be there at "
+"import time or the crawler has to be enabled"
+msgstr ""
+"Wenn es zu einem Bild eine txt-Datei gibt, dann kann diese über das "
+"eingezoomte Bild im Leuchttisch überlagert werden. Die txt-Datei muss "
+"entweder bereits beim Import des Bildes vorhanden oder der Crawler "
+"eingeschaltet sein"
+
+#: ../build/src/preferences_gen.h:1866
+msgid "expand a single lighttable module at a time"
+msgstr "Nur ein einzelnes Leuchttisch-Modul ausklappen"
+
+#: ../build/src/preferences_gen.h:1879
+msgid "this option toggles the behavior of shift clicking in lighttable mode"
+msgstr ""
+"Diese Option schaltet das Verhalten von Umschalt-Klicks im Leuchttisch-Modus "
+"um"
+
+#: ../build/src/preferences_gen.h:1887
+msgid "scroll to lighttable modules when expanded/collapsed"
+msgstr "Zu Leuchttisch-Modul scrollen, wenn es ein-/ausgeklappt wird"
+
+#: ../build/src/preferences_gen.h:1900 ../build/src/preferences_gen.h:2324
+msgid ""
+"when this option is enabled then darktable will try to scroll the module to "
+"the top of the visible list"
+msgstr ""
+"Wenn diese Option aktiviert ist, dann wird darktable versuchen, das "
+"entsprechende Modul nach oben in den sichtbaren Bereich der Liste zu scrollen"
+
+#: ../build/src/preferences_gen.h:1908
+msgid "rating an image one star twice will not zero out the rating"
+msgstr "Doppelte Bewertung mit einem Stern setzt nicht null Sterne"
+
+#: ../build/src/preferences_gen.h:1921
+msgid ""
+"do not have the rating of one star behave as documented in the manual--an "
+"image rated one star twice will result in a zero star rating."
+msgstr ""
+"Sorgt dafür, dass im Gegensatz zur Beschreibung im Handbuch ein Bild bei "
+"doppelter Bewertung mit einem Stern nicht auf null Sterne gesetzt wird."
+
+#: ../build/src/preferences_gen.h:1929 ../build/src/preferences_gen.h:2361
+#, fuzzy
+msgid "show scrollbars for central view"
+msgstr "zeige Scrollbalken für den Hauptbereich"
+
+#: ../build/src/preferences_gen.h:1942 ../build/src/preferences_gen.h:2374
+#, fuzzy
+msgid "defines whether scrollbars should be displayed"
+msgstr "Definiert an welcher Stelle Scrollbalken angezeigt werden"
+
+#: ../build/src/preferences_gen.h:1969 ../src/views/darkroom.c:109
+msgid "darkroom"
+msgstr "Dunkelkammer"
+
+#: ../build/src/preferences_gen.h:1972
+msgid "pen pressure control for brush masks"
+msgstr "Drucksensitivität eines Stiftes für Pinsel-Masken"
+
+#: ../build/src/preferences_gen.h:1983 ../build/src/preferences_gen.h:2026
+msgctxt "preferences"
+msgid "off"
+msgstr "aus"
+
+#: ../build/src/preferences_gen.h:1988
+msgctxt "preferences"
+msgid "hardness (relative)"
+msgstr "Härte (relativ)"
+
+#: ../build/src/preferences_gen.h:1993
+msgctxt "preferences"
+msgid "hardness (absolute)"
+msgstr "Härte (absolut)"
+
+#: ../build/src/preferences_gen.h:1998
+msgctxt "preferences"
+msgid "opacity (relative)"
+msgstr "Deckkraft (relativ)"
+
+#: ../build/src/preferences_gen.h:2003
+msgctxt "preferences"
+msgid "opacity (absolute)"
+msgstr "Deckkraft (absolut)"
+
+#: ../build/src/preferences_gen.h:2008
+msgctxt "preferences"
+msgid "brush size (relative)"
+msgstr "Pinselgröße (relativ)"
+
+#: ../build/src/preferences_gen.h:2029
+msgid ""
+"off - pressure reading ignored, hardness/opacity/brush size - pressure "
+"reading controls specified attribute, absolute/relative - pressure reading "
+"is taken directly as attribute value or multiplied with pre-defined setting."
+msgstr ""
+"aus – Druck-Wert ignorieren, Härte/Deckkraft/Pinselgröße – Druck-Wert "
+"kontrolliert bestimmte Eigenschaften, absolut/relativ – Druck-Wert wird "
+"direkt als Wert benutzt oder mit vordefinierten Einstellungen multipliziert."
+
+#: ../build/src/preferences_gen.h:2037
+msgid "smoothing of brush strokes"
+msgstr "Begradigen von Pinselstrichen"
+
+#: ../build/src/preferences_gen.h:2048
+msgctxt "preferences"
+msgid "low"
+msgstr "gering"
+
+#: ../build/src/preferences_gen.h:2053 ../build/src/preferences_gen.h:2076
+msgctxt "preferences"
+msgid "medium"
+msgstr "mittel"
+
+#: ../build/src/preferences_gen.h:2058
+msgctxt "preferences"
+msgid "high"
+msgstr "hoch"
+
+#: ../build/src/preferences_gen.h:2079
+msgid ""
+"sets level for smoothing of brush strokes. stronger smoothing leads to less "
+"nodes and easier editing but with lower control of accuracy."
+msgstr ""
+"Setzt das Maß der Begradigung von Pinselstrichen. Stärkere Begradigung führt "
+"zu weniger Knoten und vereinfachtem Editieren, bedeutet aber zugleich eine "
+"geringere Kontrolle über die Genauigkeit."
+
+#: ../build/src/preferences_gen.h:2087
+msgid "display of individual color channels"
+msgstr "Anzeige einzelner Farbkanäle"
+
+#: ../build/src/preferences_gen.h:2098 ../build/src/preferences_gen.h:2121
+msgctxt "preferences"
+msgid "false color"
+msgstr "Falschfarben"
+
+#: ../build/src/preferences_gen.h:2103
+msgctxt "preferences"
+msgid "grey scale"
+msgstr "Graustufen"
+
+#: ../build/src/preferences_gen.h:2124
+msgid ""
+"defines how color channels are displayed when activated in the parametric "
+"masks feature."
+msgstr ""
+"legt fest, wie Farbkanäle angezeigt werden, wenn sie in der parametrischen "
+"Maske eingeschaltet wurden."
+
+#: ../build/src/preferences_gen.h:2132
+msgid "pattern for the image infos line"
+msgstr "Format der Bildinformationszeile"
+
+#: ../build/src/preferences_gen.h:2161
+msgid "position of the image infos line"
+msgstr "Position der Bildinformationszeile"
+
+#: ../build/src/preferences_gen.h:2172
+msgctxt "preferences"
+msgid "top left"
+msgstr "oben links"
+
+#: ../build/src/preferences_gen.h:2177
+msgctxt "preferences"
+msgid "top right"
+msgstr "oben rechts"
+
+#: ../build/src/preferences_gen.h:2182
+msgctxt "preferences"
+msgid "top center"
+msgstr "oben mittig"
+
+#: ../build/src/preferences_gen.h:2187 ../build/src/preferences_gen.h:2210
+msgctxt "preferences"
+msgid "bottom"
+msgstr "unten"
+
+#: ../build/src/preferences_gen.h:2192
+msgctxt "preferences"
+msgid "hidden"
+msgstr "verborgen"
+
+#: ../build/src/preferences_gen.h:2220
+msgid "show search module text entry"
+msgstr "zeige Suchmodul-Texteintrag"
+
+#: ../build/src/preferences_gen.h:2231
+msgctxt "preferences"
+msgid "show search text"
+msgstr "zeige Suchtext"
+
+#: ../build/src/preferences_gen.h:2236
+msgctxt "preferences"
+msgid "show groups"
+msgstr "zeige Gruppen"
+
+#: ../build/src/preferences_gen.h:2241 ../build/src/preferences_gen.h:2259
+msgctxt "preferences"
+msgid "show both"
+msgstr "zeige beide"
+
+#: ../build/src/preferences_gen.h:2269
+msgid "expand a single darkroom module at a time"
+msgstr "Nur ein einzelnes Dunkelkammer-Modul ausklappen"
+
+#: ../build/src/preferences_gen.h:2282
+msgid "this option toggles the behavior of shift clicking in darkroom mode"
+msgstr ""
+"Diese Option schaltet das Verhalten von Umschalt-Klicks im Dunkelkammer-"
+"Modus um"
+
+#: ../build/src/preferences_gen.h:2290
+msgid "expand the module when it is activated, and collapse it when disabled"
+msgstr "Modul ausklappen wenn aktiv, einklappen wenn inaktiv"
+
+#: ../build/src/preferences_gen.h:2303
+msgid ""
+"this option allows to expand or collapse automatically the module when it is "
+"enabled or disabled."
+msgstr ""
+"Diese Option erlaubt, Module automatisch ein- bzw. auszuklappen wenn "
+"aktiviert bzw. deaktiviert."
+
+#: ../build/src/preferences_gen.h:2311
+msgid "scroll to darkroom modules when expanded/collapsed"
+msgstr "Zu Dunkelkammer-Modul scrollen, wenn es ein-/ausgeklappt wird"
+
+#: ../build/src/preferences_gen.h:2332
+msgid "border around image in darkroom mode"
+msgstr "Rand um Bild im Dunkelkammer-Modus"
+
+#: ../build/src/preferences_gen.h:2353
+msgid ""
+"process the image in darkroom mode with a small border. set to 0 if you "
+"don't want any border."
+msgstr ""
+"zeige das Bild im Dunkelkammer-Modus mit einem kleinen Rand. Auf 0 setzen, "
+"wenn kein Rand erwünscht ist."
+
+#: ../build/src/preferences_gen.h:2382
 msgid "demosaicing for zoomed out darkroom mode"
 msgstr "Methode zum Entrastern in der herausgezoomten Dunkelkammer"
 
-#: ../build/src/preferences_gen.h:3407
+#: ../build/src/preferences_gen.h:2393
 msgctxt "preferences"
 msgid "always bilinear (fast)"
 msgstr "immer bilinear (schnell)"
 
-#: ../build/src/preferences_gen.h:3412 ../build/src/preferences_gen.h:3432
+#: ../build/src/preferences_gen.h:2398 ../build/src/preferences_gen.h:2421
 msgctxt "preferences"
 msgid "at most PPG (reasonable)"
 msgstr "höchstens PPG (sinnvoll)"
 
-#: ../build/src/preferences_gen.h:3417
+#: ../build/src/preferences_gen.h:2403
 msgctxt "preferences"
 msgid "full (possibly slow)"
 msgstr "vollständig (eventuell langsam)"
 
-#: ../build/src/preferences_gen.h:3435
+#: ../build/src/preferences_gen.h:2424
 msgid ""
 "interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, "
 "but not as sharp. middle ground is using PPG + interpolation modes specified "
@@ -791,31 +536,110 @@ msgstr ""
 "Einstellungen wie der volle Export. X-Trans-Sensoren nutzen VNG statt PPG "
 "als Mittelweg."
 
-#: ../build/src/preferences_gen.h:3443
+#: ../build/src/preferences_gen.h:2451
+#, fuzzy
+msgid "other views"
+msgstr "Tethering-Ansicht"
+
+#: ../build/src/preferences_gen.h:2454
+msgid "map / geolocalisation"
+msgstr "Karte / Geolokalisierung"
+
+# gefällt mir nicht, weder im Original, noch die Übersetzung.
+#: ../build/src/preferences_gen.h:2462
+msgid "only draw images on map that are currently collected and filtered"
+msgstr ""
+"Nur Bilder auf der Karte anzeigen, die aktuell gesammelt und gefiltert sind"
+
+#: ../build/src/preferences_gen.h:2475
+msgid ""
+"use the current filter settings to select the geotagged images drawn on the "
+"map, i.e. limit the images drawn to the current filmstrip. this limits the "
+"number of images drawn and thus reduces the time needed to draw the images."
+msgstr ""
+"Nutze die aktuellen Filter-Einstellungen, um die Bilder auszuwählen, die auf "
+"der Karte angezeigt werden, d.h., es werden nur die Bilder auf der Karte "
+"angezeigt, die momentan im Filmstreifen zu sehen sind. Dies beschränkt die "
+"Anzahl der anzuzeigenden Bilder und verringert daher die Zeit, die zum "
+"Zeichnen der Karte benötigt wird."
+
+#: ../build/src/preferences_gen.h:2483
+msgid "maximum number of images drawn on map"
+msgstr "Maximale Anzahl Bilder, die auf der Karte gezeigt werden"
+
+#: ../build/src/preferences_gen.h:2504
+msgid ""
+"the maximum number of geotagged images drawn on the map. increasing this "
+"number can slow drawing of the map down."
+msgstr ""
+"Die maximale Anzahl an Bilder, die auf der Karte angezeigt werden. Ein "
+"Erhöhen dieser Zahl kann das Zeichnen der Karte verlangsamen."
+
+#: ../build/src/preferences_gen.h:2512
+msgid "pretty print the image location"
+msgstr "Bildposition schön formatieren"
+
+#: ../build/src/preferences_gen.h:2525
+msgid ""
+"show a more readable representation of the location in the image information "
+"module"
+msgstr ""
+"Zeige eine besser lesbare Darstellung der Position im Bildinformations-Modul"
+
+#: ../build/src/preferences_gen.h:2533 ../src/views/slideshow.c:344
+msgid "slideshow"
+msgstr "Diashow"
+
+#: ../build/src/preferences_gen.h:2541
+msgid "waiting time between each picture in slideshow"
+msgstr "Wartezeit zwischen zwei Bildern in der Diaschau"
+
+#: ../build/src/preferences_gen.h:2569
+msgid "do high quality processing for slideshow"
+msgstr "Hochqualitatives Entwickeln für die Diashow"
+
+#: ../build/src/preferences_gen.h:2582
+msgid "same option as for export, but applies to slideshow."
+msgstr "Die selbe Option wie beim Export, hier jedoch für die Diashow."
+
+#: ../build/src/preferences_gen.h:2609
+#, fuzzy
+msgid "processing"
+msgstr "Maskennachbearbeitung"
+
+#: ../build/src/preferences_gen.h:2612
+msgid "always use LittleCMS 2 to apply output color profile"
+msgstr "Benutze immer LittleCMS 2, um das Ausgabefarbprofil anzuwenden"
+
+#: ../build/src/preferences_gen.h:2625
+msgid "this is slower than the default."
+msgstr "Dies ist langsamer als die Standardeinstellung."
+
+#: ../build/src/preferences_gen.h:2633
 msgid "pixel interpolator"
 msgstr "Pixel-Interpolation"
 
-#: ../build/src/preferences_gen.h:3454
+#: ../build/src/preferences_gen.h:2644
 msgctxt "preferences"
 msgid "bilinear"
 msgstr "bilinear"
 
-#: ../build/src/preferences_gen.h:3459
+#: ../build/src/preferences_gen.h:2649
 msgctxt "preferences"
 msgid "bicubic"
 msgstr "bikubisch"
 
-#: ../build/src/preferences_gen.h:3464
+#: ../build/src/preferences_gen.h:2654
 msgctxt "preferences"
 msgid "lanczos2"
 msgstr "Lanczos2"
 
-#: ../build/src/preferences_gen.h:3469 ../build/src/preferences_gen.h:3484
+#: ../build/src/preferences_gen.h:2659 ../build/src/preferences_gen.h:2677
 msgctxt "preferences"
 msgid "lanczos3"
 msgstr "Lanczos3"
 
-#: ../build/src/preferences_gen.h:3487
+#: ../build/src/preferences_gen.h:2680
 msgid ""
 "pixel interpolator used in rotation and lens correction (bilinear, bicubic, "
 "lanczos2, lanczos3)."
@@ -823,19 +647,41 @@ msgstr ""
 "Pixel-Interpolation, die bei Rotation und Objektivkorrektur benutzt wird "
 "(bilinear, bikubisch, Lanczos2, Lanczos3)."
 
-#: ../build/src/preferences_gen.h:3495
+#: ../build/src/preferences_gen.h:2688
+msgid "3D lut root folder"
+msgstr "3D-LUT-Verzeichnis"
+
+#: ../build/src/preferences_gen.h:2693 ../src/control/jobs/control_jobs.c:1553
+#: ../src/control/jobs/control_jobs.c:1613 ../src/gui/preferences.c:1821
+#: ../src/imageio/storage/disk.c:121 ../src/imageio/storage/disk.c:194
+#: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/gallery.c:179
+#: ../src/imageio/storage/latex.c:107 ../src/imageio/storage/latex.c:178
+#: ../src/libs/styles.c:301 ../src/lua/preferences.c:631
+msgid "select directory"
+msgstr "Verzeichnis wählen"
+
+#: ../build/src/preferences_gen.h:2706
+msgid ""
+"this folder (and sub-folders) contains Lut files used by lut3d modules. need "
+"to restart darktable."
+msgstr ""
+"Dieses Verzeichnis (einschließlich der Unterverzeichnisse) enthalten LUT-"
+"Dateien die vom lut3d-Modul verwendet werden. Neustart von darktable "
+"erforderlich."
+
+#: ../build/src/preferences_gen.h:2714
 msgid "auto-apply basecurve"
 msgstr "Basiskurve automatisch anwenden"
 
-#: ../build/src/preferences_gen.h:3507
+#: ../build/src/preferences_gen.h:2727
 msgid "use a basecurve by default (needs a restart)"
 msgstr "Benutze immer eine Basiskurve (Benötigt Neustart)"
 
-#: ../build/src/preferences_gen.h:3515
+#: ../build/src/preferences_gen.h:2735
 msgid "auto-apply per camera basecurve presets"
 msgstr "Kameraspezifische Basiskurven automatisch anwenden"
 
-#: ../build/src/preferences_gen.h:3527
+#: ../build/src/preferences_gen.h:2748
 msgid ""
 "use the per-camera basecurve by default instead of the generic manufacturer "
 "one if there is one available (needs a restart)"
@@ -843,78 +689,103 @@ msgstr ""
 "Benutze standardmäßig die kameraspezifischen Basiskurven anstatt die "
 "generischen Herstellerkurven (erfordert Neustart)"
 
-#: ../build/src/preferences_gen.h:3535
+#: ../build/src/preferences_gen.h:2756
 msgid "auto-apply sharpen"
 msgstr "Schärfung automatisch anwenden"
 
-#: ../build/src/preferences_gen.h:3547
+#: ../build/src/preferences_gen.h:2769
+#, fuzzy
 msgid ""
 "this added sharpen is not recommended on cameras without a low-pass filter. "
-"the default is to not add any sharpening automatically as most recent "
-"cameras have no low-pass filter. (need a restart)"
+"you should disable this option if you use one of those more recent cameras "
+"or sharpen your images with other means. (need a restart)"
 msgstr ""
 "Diese zusätzliche Schärfung wird bei Kameras ohne Tiefpassfilter nicht "
 "empfohlen. Die Standardeinstellung ist, keine automatische Schärfung "
 "hinzuzufügen, da die meisten aktuellen Kameras keinen Tiefpassfilter haben. "
 "(benötigt einen Neustart)"
 
-#: ../build/src/preferences_gen.h:3555
-msgid "xmp"
-msgstr "xmp"
+#: ../build/src/preferences_gen.h:2796
+msgid "security"
+msgstr "Sicherheit"
 
-#: ../build/src/preferences_gen.h:3564
-msgid "write sidecar file for each image"
-msgstr "Für jedes Bild Begleitdatei schreiben"
+#: ../build/src/preferences_gen.h:2799
+msgid "ask before removing images from database"
+msgstr "Fragen, bevor Bilder aus der Datenbank entfernt werden"
 
-#: ../build/src/preferences_gen.h:3576
+#: ../build/src/preferences_gen.h:2812
+msgid "always ask the user before any image is removed from DB."
+msgstr "Nachfragen, bevor ein Bild aus der Datenbank gelöscht wird."
+
+#: ../build/src/preferences_gen.h:2820
+msgid "ask before erasing images from disk / discarding history stack"
+msgstr "Fragen, bevor Bilder von der Festplatte / der Verlauf gelöscht werden"
+
+#: ../build/src/preferences_gen.h:2833
 msgid ""
-"these redundant files can later be re-imported into a different database, "
-"preserving your changes to the image."
+"always ask the user before any image file is deleted / history stack is "
+"discarded."
 msgstr ""
-"Begleitdateien können später wieder in eine andere Datenbank importiert "
-"werden, so dass Änderungen am Bild erhalten bleiben."
+"Nachfragen, bevor eine Bilddatei von der Festplatte gelöscht oder der "
+"Verlauf verworfen wird."
 
-#: ../build/src/preferences_gen.h:3584
-msgid "store xmp tags in compressed format"
-msgstr "XMP-Stichwörter komprimiert speichern"
+#: ../build/src/preferences_gen.h:2841
+msgid "send files to trash when erasing images"
+msgstr "Benutze den Papierkorb beim Löschen"
 
-#: ../build/src/preferences_gen.h:3605 ../build/src/preferences_gen.h:3620
-msgctxt "preferences"
-msgid "only large entries"
-msgstr "nur große Daten"
-
-#: ../build/src/preferences_gen.h:3623
+#: ../build/src/preferences_gen.h:2854
 msgid ""
-"entries in xmp tags can get rather large and may exceed the available space "
-"to store the history stack in output files. this option allows xmp tags to "
-"be compressed and save space."
+"send files to trash instead of permanently deleting files on system that "
+"supports it"
 msgstr ""
-"Daten in XMP-Stichwörter können recht groß werden und so den verfügbaren "
-"Speicherplatz in exportierten Dateien für Verlaufsstapel überschreiten. "
-"Diese Option erlaubt es, XMP-Stichwörter zu komprimieren und so "
-"Speicherplatz zu sparen."
+"Sende Bilder in den Papierkorb statt sie permanent zu löschen. Dies muss vom "
+"System unterstützt werden"
 
-#: ../build/src/preferences_gen.h:3631
-msgid "look for updated xmp files on startup"
-msgstr "Beim Start nach aktualisierten XMP-Dateien suchen"
+#: ../build/src/preferences_gen.h:2862
+msgid "ask before moving images from film roll folder"
+msgstr "Fragen, bevor Bilder aus dem Filmrollen-Ordner verschoben werden"
 
-#: ../build/src/preferences_gen.h:3643
+#: ../build/src/preferences_gen.h:2875
+msgid "always ask the user before any image file is moved."
+msgstr "Nachfragen, bevor eine Bilddatei verschoben wird."
+
+#: ../build/src/preferences_gen.h:2883
+msgid "ask before copying images to new film roll folder"
+msgstr "Fragen, bevor Bilder in einen neuen Filmrollen-Ordner kopiert werden"
+
+#: ../build/src/preferences_gen.h:2896
+msgid "always ask the user before any image file is copied."
+msgstr "Nachfragen, bevor eine Bilddatei kopiert wird."
+
+#: ../build/src/preferences_gen.h:2904
+msgid "ask before removing empty folders"
+msgstr "Fragen, bevor leere Verzeichnisse entfernt werden"
+
+#: ../build/src/preferences_gen.h:2917
 msgid ""
-"check file modification times of all xmp files on startup to check if any "
-"got updated in the meantime"
+"always ask the user before removing any empty folder. this can happen after "
+"moving or deleting images."
 msgstr ""
-"Prüfe die Zeitstempel aller XMP-Dateien beim Start, um diejenigen zu finden, "
-"die zwischenzeitlich bearbeitet wurden"
+"Nachfragen, bevor leere Verzeichnisse gelöscht werden. Dies kann vorkommen "
+"wenn Bilder verschoben oder gelöscht werden."
 
-#: ../build/src/preferences_gen.h:3651
+#: ../build/src/preferences_gen.h:2925
+msgid "ask before deleting a tag"
+msgstr "Vor dem Löschen eines Tag nachfragen"
+
+#: ../build/src/preferences_gen.h:2945
+msgid "ask before deleting a style"
+msgstr "Vor dem Löschen eines Stils nachfragen"
+
+#: ../build/src/preferences_gen.h:2984
 msgid "cpu / gpu / memory"
 msgstr "CPU/GPU/Speicher"
 
-#: ../build/src/preferences_gen.h:3660
+#: ../build/src/preferences_gen.h:2987
 msgid "memory in megabytes to use for thumbnail cache"
 msgstr "Speicher in Megabytes, der für den Vorschaubild-Cache benutzt wird"
 
-#: ../build/src/preferences_gen.h:3680
+#: ../build/src/preferences_gen.h:3009
 msgid ""
 "this controls how much memory is going to be used for thumbnails and other "
 "buffers (needs a restart)."
@@ -922,11 +793,11 @@ msgstr ""
 "Dies legt fest, wie viel Speicher für Vorschaubilder und andere Puffer "
 "genutzt wird (erfordert Neustart)."
 
-#: ../build/src/preferences_gen.h:3688
+#: ../build/src/preferences_gen.h:3017
 msgid "enable disk backend for thumbnail cache"
 msgstr "Festplattencache für Thumbnails benutzen"
 
-#: ../build/src/preferences_gen.h:3700
+#: ../build/src/preferences_gen.h:3030
 msgid ""
 "if enabled, write thumbnails to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -943,11 +814,11 @@ msgstr ""
 "Bilder betrachtet. Um alle Vorschaubilder der ganzen Sammlung außerhalb "
 "darktables zu erstellen kann ‚darktable-generate-cache‘ benutzt werden."
 
-#: ../build/src/preferences_gen.h:3708
+#: ../build/src/preferences_gen.h:3038
 msgid "enable disk backend for full preview cache"
 msgstr "Festplattencache für Vorschaubilder benutzen"
 
-#: ../build/src/preferences_gen.h:3720
+#: ../build/src/preferences_gen.h:3051
 msgid ""
 "if enabled, write full preview to disk (.cache/darktable/) when evicted from "
 "the memory cache. note that this can take a lot of memory (several gigabytes "
@@ -964,11 +835,11 @@ msgstr ""
 "generate-cache” können Vorschaubilder der ganzen Sammlung auch außerhalb "
 "darktables erstellt werden."
 
-#: ../build/src/preferences_gen.h:3728
+#: ../build/src/preferences_gen.h:3059
 msgid "number of background threads"
 msgstr "Anzahl Hintergrund-Threads"
 
-#: ../build/src/preferences_gen.h:3747
+#: ../build/src/preferences_gen.h:3080
 msgid ""
 "this controls for example how many threads are used to create thumbnails "
 "during import. the cache will grow to a maximum of twice this number of full "
@@ -978,11 +849,11 @@ msgstr ""
 "Vorschaubilder erzeugt werden. Der Cache wächst höchstens bis zu zweimal "
 "diesen Wert  an Bild-Puffern mit voller Auflösung (erfordert Neustart)."
 
-#: ../build/src/preferences_gen.h:3755
+#: ../build/src/preferences_gen.h:3088
 msgid "host memory limit (in MB) for tiling"
 msgstr "Speicherlimit (in MB) für Kachelung"
 
-#: ../build/src/preferences_gen.h:3774
+#: ../build/src/preferences_gen.h:3109
 msgid ""
 "this variable controls the maximum amount of memory (in MB) a module may use "
 "during image processing. lower values will force memory hungry modules to "
@@ -995,11 +866,11 @@ msgstr ""
 "Limit auf, ein Wert kleiner 500 wird als 500 interpretiert (erfordert "
 "Neustart)."
 
-#: ../build/src/preferences_gen.h:3782
+#: ../build/src/preferences_gen.h:3117
 msgid "minimum amount of memory (in MB) for a single buffer in tiling"
 msgstr "Minimale Speichermenge (in MB) für einen einzelnen Puffer beim Kacheln"
 
-#: ../build/src/preferences_gen.h:3803
+#: ../build/src/preferences_gen.h:3140
 msgid ""
 "if set to a positive, non-zero value this variable defines the minimum "
 "amount of memory (in MB) that tiling should take for a single image buffer. "
@@ -1010,11 +881,11 @@ msgstr ""
 "reserviert wird. Dieser Wert hat Vorrang vor den Heuristiken basierend auf "
 "host_memory_limit (erfordert Neustart)."
 
-#: ../build/src/preferences_gen.h:3811
+#: ../build/src/preferences_gen.h:3148
 msgid "activate OpenCL support"
 msgstr "OpenCL-Unterstützung aktivieren"
 
-#: ../build/src/preferences_gen.h:3823
+#: ../build/src/preferences_gen.h:3161
 msgid ""
 "if found, use OpenCL runtime on your system for improved processing speed. "
 "can be switched on and off at any time."
@@ -1022,37 +893,37 @@ msgstr ""
 "Benutze OpenCL-Laufzeitumgebung für schnellere Verarbeitung, wenn sie "
 "gefunden werden kann. Kann jederzeit an- und ausgeschaltet werden."
 
-#: ../build/src/preferences_gen.h:3824 ../build/src/preferences_gen.h:3879
+#: ../build/src/preferences_gen.h:3162 ../build/src/preferences_gen.h:3220
 msgid "not available"
 msgstr "nicht verfügbar"
 
-#: ../build/src/preferences_gen.h:3827 ../build/src/preferences_gen.h:3831
-#: ../build/src/preferences_gen.h:3882 ../build/src/preferences_gen.h:3886
+#: ../build/src/preferences_gen.h:3165 ../build/src/preferences_gen.h:3169
+#: ../build/src/preferences_gen.h:3223 ../build/src/preferences_gen.h:3227
 msgid "not available on this system"
 msgstr "auf diesem System nicht verfügbar"
 
-#: ../build/src/preferences_gen.h:3839
+#: ../build/src/preferences_gen.h:3177
 msgid "OpenCL scheduling profile"
 msgstr "OpenCL-Scheduler-Profil"
 
 #. Adding the restore defaults button
-#: ../build/src/preferences_gen.h:3850 ../build/src/preferences_gen.h:3875
-#: ../src/gui/preferences.c:631
+#: ../build/src/preferences_gen.h:3188 ../build/src/preferences_gen.h:3216
+#: ../src/gui/preferences.c:787
 msgctxt "preferences"
 msgid "default"
 msgstr "Standard"
 
-#: ../build/src/preferences_gen.h:3855
+#: ../build/src/preferences_gen.h:3193
 msgctxt "preferences"
 msgid "multiple GPUs"
 msgstr "mehrere GPUs"
 
-#: ../build/src/preferences_gen.h:3860
+#: ../build/src/preferences_gen.h:3198
 msgctxt "preferences"
 msgid "very fast GPU"
 msgstr "Sehr schnelle GPU"
 
-#: ../build/src/preferences_gen.h:3878
+#: ../build/src/preferences_gen.h:3219
 msgid ""
 "defines how preview and full pixelpipe tasks are scheduled on OpenCL enabled "
 "systems. default - GPU processes full and CPU processes preview pipe "
@@ -1067,64 +938,193 @@ msgstr ""
 "berechnen; sehr schnelle GPU – beide Pixelpipes werden nacheinander auf der "
 "selben GPU berechnen."
 
-#: ../build/src/preferences_gen.h:3903
+#: ../build/src/preferences_gen.h:3254
+#, fuzzy
+msgid "storage"
+msgstr "Dateiname"
+
+#: ../build/src/preferences_gen.h:3257
+#, fuzzy
+msgid "database"
+msgstr "Datenbank löschen"
+
+#: ../build/src/preferences_gen.h:3265
 msgid "check for database maintenance"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3919
+#: ../build/src/preferences_gen.h:3281
 #, fuzzy
 msgctxt "preferences"
 msgid "on startup"
 msgstr "1 Stern"
 
-#: ../build/src/preferences_gen.h:3924 ../build/src/preferences_gen.h:3959
+#: ../build/src/preferences_gen.h:3286 ../build/src/preferences_gen.h:3324
 #, fuzzy
 msgctxt "preferences"
 msgid "on close"
 msgstr "schließen"
 
-#: ../build/src/preferences_gen.h:3929
+#: ../build/src/preferences_gen.h:3291
 #, fuzzy
 msgctxt "preferences"
 msgid "on both"
 msgstr "zeige beide"
 
-#: ../build/src/preferences_gen.h:3934
+#: ../build/src/preferences_gen.h:3296
 msgctxt "preferences"
 msgid "on startup (don't ask)"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3939
+#: ../build/src/preferences_gen.h:3301
 msgctxt "preferences"
 msgid "on close (don't ask)"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3944
+#: ../build/src/preferences_gen.h:3306
 msgctxt "preferences"
 msgid "on both (don't ask)"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3962
+#: ../build/src/preferences_gen.h:3327
 msgid ""
 "this option indicates when to check database fragmentation and perform "
 "maintenance"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3970
+#: ../build/src/preferences_gen.h:3335
 msgid "database fragmentation ratio threshold"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3989
+#: ../build/src/preferences_gen.h:3356
 msgid ""
 "fragmentation ratio above which to ask or carry out automatically database "
 "maintenance"
 msgstr ""
 
-#: ../build/src/preferences_gen.h:3997
+#: ../build/src/preferences_gen.h:3364
+msgid "xmp"
+msgstr "xmp"
+
+#: ../build/src/preferences_gen.h:3372
+msgid "write sidecar file for each image"
+msgstr "Für jedes Bild Begleitdatei schreiben"
+
+#: ../build/src/preferences_gen.h:3385
+msgid ""
+"these redundant files can later be re-imported into a different database, "
+"preserving your changes to the image."
+msgstr ""
+"Begleitdateien können später wieder in eine andere Datenbank importiert "
+"werden, so dass Änderungen am Bild erhalten bleiben."
+
+#: ../build/src/preferences_gen.h:3393
+msgid "store xmp tags in compressed format"
+msgstr "XMP-Stichwörter komprimiert speichern"
+
+#: ../build/src/preferences_gen.h:3414 ../build/src/preferences_gen.h:3432
+msgctxt "preferences"
+msgid "only large entries"
+msgstr "nur große Daten"
+
+#: ../build/src/preferences_gen.h:3435
+msgid ""
+"entries in xmp tags can get rather large and may exceed the available space "
+"to store the history stack in output files. this option allows xmp tags to "
+"be compressed and save space."
+msgstr ""
+"Daten in XMP-Stichwörter können recht groß werden und so den verfügbaren "
+"Speicherplatz in exportierten Dateien für Verlaufsstapel überschreiten. "
+"Diese Option erlaubt es, XMP-Stichwörter zu komprimieren und so "
+"Speicherplatz zu sparen."
+
+#: ../build/src/preferences_gen.h:3443
+msgid "look for updated xmp files on startup"
+msgstr "Beim Start nach aktualisierten XMP-Dateien suchen"
+
+#: ../build/src/preferences_gen.h:3456
+msgid ""
+"check file modification times of all xmp files on startup to check if any "
+"got updated in the meantime"
+msgstr ""
+"Prüfe die Zeitstempel aller XMP-Dateien beim Start, um diejenigen zu finden, "
+"die zwischenzeitlich bearbeitet wurden"
+
+#: ../build/src/preferences_gen.h:3483
+msgid "miscellaneous"
+msgstr "Verschieden"
+
+#: ../build/src/preferences_gen.h:3486
+#, fuzzy
+msgid "interface"
+msgstr "Sprache der Oberfläche"
+
+#: ../build/src/preferences_gen.h:3494
+msgid "mouse wheel scrolls modules side panel by default"
+msgstr ""
+"Mausrad blättert standardmäßig die Module der seitlichen Eingabefelder durch"
+
+#: ../build/src/preferences_gen.h:3507
+msgid ""
+"when enabled, use mouse wheel to scroll modules side panel.  use ctrl+alt to "
+"use mouse wheel for data entry.  when disabled, this behavior is reversed"
+msgstr ""
+"wenn aktiviert, Mausrad zum Blättern der Module der seitlichen "
+"Eingabefelder. Strg+Alt zur Dateneingabe verwenden. Wenn deaktiviert, ist "
+"das Verhalten umgekehrt"
+
+#: ../build/src/preferences_gen.h:3515
+msgid "always show panels' scrollbars"
+msgstr "zeigt immer die Scrollbalken der Eingabefelder an"
+
+#: ../build/src/preferences_gen.h:3528
+msgid ""
+"defines whether the panel scrollbars should be always visible or activated "
+"only depending on the content.  (need a restart)"
+msgstr ""
+"definiert, ob die Scrollbalken der Eingabefelder immer sichtbar sind oder "
+"abhängig vom Inhalt. (benötigt einen Neustart)"
+
+#: ../build/src/preferences_gen.h:3536
+msgid "method to use for getting the display profile"
+msgstr "Methode, um das Monitorprofil zu ermitteln"
+
+#: ../build/src/preferences_gen.h:3547 ../build/src/preferences_gen.h:3575
+msgctxt "preferences"
+msgid "all"
+msgstr "alle"
+
+#: ../build/src/preferences_gen.h:3552
+msgctxt "preferences"
+msgid "xatom"
+msgstr "XAtom"
+
+#: ../build/src/preferences_gen.h:3557
+msgctxt "preferences"
+msgid "colord"
+msgstr "Colord"
+
+#: ../build/src/preferences_gen.h:3578
+msgid ""
+"this option allows to force a specific means of getting the current display "
+"profile. this is useful when one alternative gives wrong results"
+msgstr ""
+"Diese Option erlaubt es, eine bestimmte Methode zum Ermitteln des "
+"Anzeigenprofils festzulegen. Dies ist hilfreich, wenn eine der Alternativen "
+"falsche Ergebnisse liefert"
+
+#. tags
+#: ../build/src/preferences_gen.h:3586 ../src/develop/lightroom.c:1508
+#: ../src/gui/camera_import_dialog.c:465 ../src/libs/export_metadata.c:310
+#: ../src/libs/image.c:465 ../src/libs/import.c:591
+#: ../src/libs/metadata_view.c:148
+msgid "tags"
+msgstr "Stichwörter"
+
+#: ../build/src/preferences_gen.h:3594
 msgid "omit hierarchy in simple tag lists"
 msgstr "Hierarchie in einfacher Tag-Liste auslassen"
 
-#: ../build/src/preferences_gen.h:4009
+#: ../build/src/preferences_gen.h:3607
 msgid ""
 "when creating XMP file the hierarchical tags are also added as a simple list "
 "of non-hierarchical ones to make them visible to some other programs. when "
@@ -1137,11 +1137,11 @@ msgstr ""
 "der letzte Teil genommen und der Rest ignoriert. Von 'foo|bar|baz' wird also "
 "nur 'baz' eingefügt."
 
-#: ../build/src/preferences_gen.h:4017
+#: ../build/src/preferences_gen.h:3615
 msgid "disable the entry completion"
 msgstr "deaktiviert die Eingabevervollständigung"
 
-#: ../build/src/preferences_gen.h:4029
+#: ../build/src/preferences_gen.h:3628
 msgid ""
 "the entry completion is useful for those who enter tags from keyboard only. "
 "for others the entry completion can be embarrassing. need to restart "
@@ -1152,41 +1152,51 @@ msgstr ""
 "Eingabevervollständigung umständlich sein. Neustart von darktable "
 "erforderlich."
 
-#: ../build/src/preferences_gen.h:4037
+#. char *italic = g_strdup_printf("<i>%s</i>", _("other"));
+#. italic
+#: ../build/src/preferences_gen.h:3636 ../src/libs/tools/viewswitcher.c:145
+msgid "other"
+msgstr "andere"
+
+#: ../build/src/preferences_gen.h:3644
+msgid "do not show april 1st game"
+msgstr "1.-April-Spiel nicht starten"
+
+#: ../build/src/preferences_gen.h:3664
 msgid "password storage backend to use"
 msgstr "Passwort-Speicher-Backend, das benutzt werden soll"
 
-#: ../build/src/preferences_gen.h:4048 ../build/src/preferences_gen.h:4080
+#: ../build/src/preferences_gen.h:3675 ../build/src/preferences_gen.h:3710
 msgctxt "preferences"
 msgid "auto"
 msgstr "automatisch"
 
-#: ../build/src/preferences_gen.h:4053
+#: ../build/src/preferences_gen.h:3680
 msgctxt "preferences"
 msgid "none"
 msgstr "keins"
 
-#: ../build/src/preferences_gen.h:4058
+#: ../build/src/preferences_gen.h:3685
 msgctxt "preferences"
 msgid "libsecret"
 msgstr "libsecret"
 
-#: ../build/src/preferences_gen.h:4064
+#: ../build/src/preferences_gen.h:3691
 msgctxt "preferences"
 msgid "kwallet"
 msgstr "KWallet"
 
-#: ../build/src/preferences_gen.h:4083
+#: ../build/src/preferences_gen.h:3713
 msgid ""
 "the storage backend for password storage: auto, none, libsecret, kwallet"
 msgstr ""
 "Speicher-Backend für Passwörter: automatisch, keins, libsecret, KWallet"
 
-#: ../build/src/preferences_gen.h:4091
+#: ../build/src/preferences_gen.h:3721
 msgid "executable for playing audio files"
 msgstr "Programm zum Abspielen von Audiodateien"
 
-#: ../build/src/preferences_gen.h:4107
+#: ../build/src/preferences_gen.h:3738
 msgid ""
 "this external program is used to play audio files some cameras record to "
 "keep notes for images"
@@ -1194,50 +1204,76 @@ msgstr ""
 "Dieses externe Programm wird benutzt, um die Audiodateien abzuspielen, die "
 "einige Kameras für Notizen zu Bildern aufzeichnen"
 
-#: ../build/src/preferences_gen.h:4115
-msgid "3D lut root folder"
-msgstr "3D-LUT-Verzeichnis"
+#: ../build/src/preferences_gen.h:3765 ../build/src/preferences_gen.h:3768
+#: ../src/libs/import.c:98
+msgid "import"
+msgstr "Importieren"
 
-#: ../build/src/preferences_gen.h:4120 ../src/control/jobs/control_jobs.c:1551
-#: ../src/control/jobs/control_jobs.c:1611 ../src/gui/preferences.c:1611
-#: ../src/imageio/storage/disk.c:121 ../src/imageio/storage/disk.c:194
-#: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/gallery.c:179
-#: ../src/imageio/storage/latex.c:107 ../src/imageio/storage/latex.c:178
-#: ../src/libs/styles.c:300 ../src/lua/preferences.c:631
-msgid "select directory"
-msgstr "Verzeichnis wählen"
+#: ../build/src/preferences_gen.h:3776
+msgid "ignore JPEG images when importing film rolls"
+msgstr "JPEG-Bilder beim Import von Filmrollen ignorieren"
 
-#: ../build/src/preferences_gen.h:4132
+#: ../build/src/preferences_gen.h:3789
 msgid ""
-"this folder (and sub-folders) contains Lut files used by lut3d modules. need "
-"to restart darktable."
+"when having raw+JPEG images together in one directory it makes no sense to "
+"import both. with this flag one can ignore all JPEGs found."
 msgstr ""
-"Dieses Verzeichnis (einschließlich der Unterverzeichnisse) enthalten LUT-"
-"Dateien die vom lut3d-Modul verwendet werden. Neustart von darktable "
-"erforderlich."
+"Wenn Raw- und JPEG-Bilder zusammen in einem Verzeichnis liegen, ist es nicht "
+"sinnvoll, beide zu importieren. Mit dieser Option können alle gefundenen "
+"JPEG-Bilder ignoriert werden."
+
+#: ../build/src/preferences_gen.h:3797
+msgid "recursive directory traversal when importing filmrolls"
+msgstr "Rekursiver Import von Verzeichnissen"
+
+#: ../build/src/preferences_gen.h:3817
+msgid "creator to be applied when importing"
+msgstr "Urheber, der beim Import hinzugefügt werden soll"
+
+#: ../build/src/preferences_gen.h:3841
+msgid "publisher to be applied when importing"
+msgstr "Herausgeber, der beim Import hinzugefügt werden soll"
+
+#: ../build/src/preferences_gen.h:3865
+msgid "rights to be applied when importing"
+msgstr "Rechte, die beim Import hinzugefügt werden sollen"
+
+#: ../build/src/preferences_gen.h:3889
+msgid "comma separated tags to be applied when importing"
+msgstr ""
+"Komma-separierte Stichwörter, die beim Import hinzugefügt werden sollen"
+
+#: ../build/src/preferences_gen.h:3913
+msgid "initial import rating"
+msgstr "Erstbewertung beim Importieren"
+
+#: ../build/src/preferences_gen.h:3936
+msgid "initial star rating for all images when importing a filmroll"
+msgstr ""
+"Anfängliche Anzahl Sterne für alle Bilder einer neu importierten Filmrolle"
 
 # zu frei?
-#: ../build/src/preferences_gen.h:4162
+#: ../build/src/preferences_gen.h:3944
 msgid "session options"
 msgstr "Sitzungs-Optionen"
 
-#: ../build/src/preferences_gen.h:4165
+#: ../build/src/preferences_gen.h:3952
 msgid "base directory naming pattern"
 msgstr "Namensformat des Wurzelverzeichnisses"
 
-#: ../build/src/preferences_gen.h:4181 ../build/src/preferences_gen.h:4205
+#: ../build/src/preferences_gen.h:3969 ../build/src/preferences_gen.h:3994
 msgid "part of full import path for an import session"
 msgstr "Teil eines vollständigen Import-Pfades beim Importieren"
 
-#: ../build/src/preferences_gen.h:4189
+#: ../build/src/preferences_gen.h:3977
 msgid "sub directory naming pattern"
 msgstr "Namensformat der Unterordner"
 
-#: ../build/src/preferences_gen.h:4213
+#: ../build/src/preferences_gen.h:4002
 msgid "file naming pattern"
 msgstr "Namensformat der Dateien"
 
-#: ../build/src/preferences_gen.h:4229
+#: ../build/src/preferences_gen.h:4019
 msgid "file naming pattern used for a import session"
 msgstr "Das Namensformat für Dateien, welches beim Importieren benutzt wird"
 
@@ -1287,49 +1323,24 @@ msgstr "Zeige Bilder auf der Karte an"
 msgid "Print your images"
 msgstr "Drucke deine Bilder"
 
-#: ../src/bauhaus/bauhaus.c:1207
-#, fuzzy, c-format
-msgid "%s %s / %s: %s"
-msgstr "%s/%s: %s"
-
-#: ../src/bauhaus/bauhaus.c:1209
-#, fuzzy, c-format
-msgid "%s / %s: %s"
-msgstr "%s/%s: %s"
-
-#: ../src/bauhaus/bauhaus.c:1211 ../src/libs/tagging.c:2156
-#, c-format
-msgid "%s"
-msgstr "%s"
-
-#: ../src/bauhaus/bauhaus.c:2292
-#, c-format
-msgid "%s/%s: %s"
-msgstr "%s/%s: %s"
-
-#: ../src/bauhaus/bauhaus.c:2294
-#, c-format
-msgid "%s: %s"
-msgstr "%s: %s"
-
-#: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1551
-#: ../src/control/jobs/control_jobs.c:1611 ../src/gui/hist_dialog.c:187
-#: ../src/gui/preferences.c:1153 ../src/gui/preferences.c:1179
-#: ../src/gui/preferences.c:1261 ../src/gui/preferences.c:1382
-#: ../src/gui/preferences.c:1611 ../src/gui/presets.c:387
+#: ../src/chart/main.c:504 ../src/control/jobs/control_jobs.c:1553
+#: ../src/control/jobs/control_jobs.c:1613 ../src/gui/hist_dialog.c:187
+#: ../src/gui/preferences.c:1378 ../src/gui/preferences.c:1404
+#: ../src/gui/preferences.c:1486 ../src/gui/preferences.c:1592
+#: ../src/gui/preferences.c:1821 ../src/gui/presets.c:387
 #: ../src/gui/styles_dialog.c:340 ../src/imageio/storage/disk.c:121
 #: ../src/imageio/storage/gallery.c:108 ../src/imageio/storage/latex.c:107
-#: ../src/iop/lut3d.c:1588 ../src/libs/collect.c:243
-#: ../src/libs/copy_history.c:77 ../src/libs/geotagging.c:473
-#: ../src/libs/import.c:753 ../src/libs/import.c:860 ../src/libs/lib.c:227
-#: ../src/libs/styles.c:300 ../src/libs/styles.c:323 ../src/libs/tagging.c:2185
-#: ../src/libs/tagging.c:2226
+#: ../src/iop/lut3d.c:1606 ../src/libs/collect.c:241
+#: ../src/libs/copy_history.c:77 ../src/libs/geotagging.c:475
+#: ../src/libs/import.c:790 ../src/libs/import.c:897 ../src/libs/lib.c:227
+#: ../src/libs/styles.c:301 ../src/libs/styles.c:324 ../src/libs/tagging.c:2164
+#: ../src/libs/tagging.c:2205
 msgid "_cancel"
 msgstr "_Abbrechen"
 
-#: ../src/chart/main.c:504 ../src/gui/preferences.c:1153
-#: ../src/gui/preferences.c:1383 ../src/gui/styles_dialog.c:343
-#: ../src/libs/styles.c:301
+#: ../src/chart/main.c:504 ../src/gui/preferences.c:1378
+#: ../src/gui/preferences.c:1593 ../src/gui/styles_dialog.c:343
+#: ../src/libs/styles.c:302
 msgid "_save"
 msgstr "_Speichern"
 
@@ -1343,60 +1354,65 @@ msgstr ""
 "mittleres dE: %.02f\n"
 "maximales dE: %.02f"
 
-#: ../src/cli/main.c:127
+#: ../src/cli/main.c:129
 msgid "TODO: sorry, due to API restrictions we currently cannot set the BPP to"
 msgstr ""
 "TODO: Entschuldigung, aber aufgrund von API-Beschränkungen können wir die "
 "BPP momentan nicht setzen"
 
-#: ../src/cli/main.c:139
+#: ../src/cli/main.c:141
 msgid "unknown option for --hq"
 msgstr "Unbekannte Option für --hq"
 
-#: ../src/cli/main.c:155
+#: ../src/cli/main.c:157
+#, fuzzy
+msgid "unknown option for --export_masks"
+msgstr "Unbekannte Option für --upscale"
+
+#: ../src/cli/main.c:173
 msgid "unknown option for --upscale"
 msgstr "Unbekannte Option für --upscale"
 
-#: ../src/cli/main.c:180
+#: ../src/cli/main.c:198
 #, fuzzy
 msgid "unknown option for --apply-custom-presets"
 msgstr "Unbekannte Option für --upscale"
 
-#: ../src/cli/main.c:235
+#: ../src/cli/main.c:253
 #, c-format
 msgid "error: output file is a directory. please specify file name"
 msgstr ""
 "Fehler: Ausgabedatei ist ein Verzeichnis. Bitte einen Dateinamen angeben"
 
-#: ../src/cli/main.c:244
+#: ../src/cli/main.c:262
 msgid "output file already exists, it will get renamed"
 msgstr "Ausgabedatei existiert bereits, sie wird umbenannt"
 
-#: ../src/cli/main.c:261
+#: ../src/cli/main.c:279
 #, c-format
 msgid "error: can't open folder %s"
 msgstr "Fehler: kann Ordner „%s” nicht öffnen"
 
-#: ../src/cli/main.c:279
+#: ../src/cli/main.c:297
 #, c-format
 msgid "error: can't open file %s"
 msgstr "Fehler: kann Datei „%s” nicht öffnen"
 
-#: ../src/cli/main.c:293
+#: ../src/cli/main.c:311
 #, c-format
 msgid "no images to export, aborting\n"
 msgstr "keine Bilder zum exportieren gefunden, breche ab\n"
 
-#: ../src/cli/main.c:307
+#: ../src/cli/main.c:325
 #, c-format
 msgid "error: can't open xmp file %s"
 msgstr "Fehler: kann XMP-Datei „%s” nicht öffnen"
 
-#: ../src/cli/main.c:325
+#: ../src/cli/main.c:343
 msgid "empty history stack"
 msgstr "leerer Verlaufsstapel"
 
-#: ../src/cli/main.c:348
+#: ../src/cli/main.c:366
 msgid ""
 "cannot find disk storage module. please check your installation, something "
 "seems to be broken."
@@ -1404,201 +1420,202 @@ msgstr ""
 "Kann Modul zum Speichern auf der Festplatten nicht finden. Bitte die "
 "Installation prüfen, irgendwas scheint kaputt zu sein."
 
-#: ../src/cli/main.c:356
+#: ../src/cli/main.c:374
 msgid "failed to get parameters from storage module, aborting export ..."
 msgstr ""
 "Konnte keine Einstellungen vom Speicher-Modul bekommen, breche Export ab …"
 
-#: ../src/cli/main.c:369
+#: ../src/cli/main.c:387
 #, c-format
 msgid "unknown extension '.%s'"
 msgstr "unbekannte Datei-Erweiterung '.%s'"
 
-#: ../src/cli/main.c:378
+#: ../src/cli/main.c:396
 msgid "failed to get parameters from format module, aborting export ..."
 msgstr ""
 "Konnte keine Einstellungen vom Format-Modul bekommen, breche Export ab …"
 
-#: ../src/common/collection.c:555
+#: ../src/common/collection.c:580
 msgid "too much time to update aspect ratio for the collection"
 msgstr "zu viel Zeit um Seitenverhältnis der Sammlung zu aktualisieren"
 
-#: ../src/common/collection.c:593
+#: ../src/common/collection.c:618
 msgid "film roll"
 msgstr "Filmrolle"
 
-#: ../src/common/collection.c:594
+#: ../src/common/collection.c:619
 msgid "folders"
 msgstr "Verzeichnisse"
 
-#: ../src/common/collection.c:595
+#: ../src/common/collection.c:620
 msgid "camera"
 msgstr "Kamera"
 
-#: ../src/common/collection.c:596 ../src/libs/export_metadata.c:184
+#: ../src/common/collection.c:621 ../src/libs/export_metadata.c:184
 msgid "tag"
 msgstr "Tag"
 
-#: ../src/common/collection.c:597
+#: ../src/common/collection.c:622
 msgid "date"
 msgstr "Datum"
 
 #. DT_COLLECTION_SORT_FILENAME
-#: ../src/common/collection.c:598 ../src/libs/tools/filter.c:148
+#: ../src/common/collection.c:623 ../src/libs/tools/filter.c:148
 msgid "time"
 msgstr "Datum/Uhrzeit"
 
-#: ../src/common/collection.c:599 ../src/libs/history.c:74
+#: ../src/common/collection.c:624 ../src/libs/history.c:74
 msgid "history"
 msgstr "Verlauf"
 
 #. DT_COLLECTION_SORT_ID
-#: ../src/common/collection.c:600 ../src/develop/lightroom.c:1539
+#: ../src/common/collection.c:625 ../src/develop/lightroom.c:1539
 #: ../src/libs/tools/filter.c:151
 msgid "color label"
 msgstr "Farbmarkierung"
 
-#: ../src/common/collection.c:601 ../src/gui/preferences.c:515
-#: ../src/gui/preferences.c:1441 ../src/gui/presets.c:445
-#: ../src/libs/metadata_view.c:111
+#: ../src/common/collection.c:626 ../src/gui/preferences.c:658
+#: ../src/gui/preferences.c:1651 ../src/gui/presets.c:445
+#: ../src/libs/metadata_view.c:120
 msgid "lens"
 msgstr "Objektiv"
 
 #. focal length
-#: ../src/common/collection.c:602 ../src/gui/preferences.c:531
-#: ../src/gui/preferences.c:1490 ../src/gui/presets.c:494
+#: ../src/common/collection.c:627 ../src/gui/preferences.c:674
+#: ../src/gui/preferences.c:1700 ../src/gui/presets.c:494
 #: ../src/iop/ashift.c:4887 ../src/libs/camera.c:578
-#: ../src/libs/metadata_view.c:114
+#: ../src/libs/metadata_view.c:124
 msgid "focal length"
 msgstr "Brennweite"
 
 #. iso
-#: ../src/common/collection.c:603 ../src/gui/preferences.c:519
-#: ../src/gui/preferences.c:1447 ../src/gui/presets.c:451
-#: ../src/libs/camera.c:586 ../src/libs/metadata_view.c:116
+#: ../src/common/collection.c:628 ../src/gui/preferences.c:662
+#: ../src/gui/preferences.c:1657 ../src/gui/presets.c:451
+#: ../src/libs/camera.c:586 ../src/libs/metadata_view.c:126
 msgid "ISO"
 msgstr "ISO"
 
 #. aperture
-#: ../src/common/collection.c:604 ../src/gui/preferences.c:527
-#: ../src/gui/preferences.c:1475 ../src/gui/presets.c:479
+#: ../src/common/collection.c:629 ../src/gui/preferences.c:670
+#: ../src/gui/preferences.c:1685 ../src/gui/presets.c:479
 #: ../src/libs/camera.c:573 ../src/libs/camera.c:575
-#: ../src/libs/metadata_view.c:112
+#: ../src/libs/metadata_view.c:121
 msgid "aperture"
 msgstr "Blende"
 
 #. exposure
-#: ../src/common/collection.c:605 ../src/gui/preferences.c:523
-#: ../src/gui/preferences.c:1460 ../src/gui/presets.c:464
+#: ../src/common/collection.c:630 ../src/gui/preferences.c:666
+#: ../src/gui/preferences.c:1670 ../src/gui/presets.c:464
 #: ../src/iop/basicadj.c:771 ../src/iop/exposure.c:106
 #: ../src/iop/exposure.c:887 ../src/iop/relight.c:360
-#: ../src/libs/metadata_view.c:113
+#: ../src/libs/metadata_view.c:122
 msgid "exposure"
 msgstr "Belichtung"
 
 #. DT_COLLECTION_SORT_DESCRIPTION
-#: ../src/common/collection.c:606 ../src/iop/borders.c:1030
+#: ../src/common/collection.c:631 ../src/iop/borders.c:1030
 #: ../src/libs/tools/filter.c:157
 msgid "aspect ratio"
 msgstr "Seitenverhältnis"
 
-#: ../src/common/collection.c:607 ../src/libs/metadata_view.c:100
+#: ../src/common/collection.c:632 ../src/libs/metadata_view.c:105
 #: ../src/libs/tools/filter.c:147
 msgid "filename"
 msgstr "Dateiname"
 
-#: ../src/common/collection.c:608 ../src/develop/lightroom.c:1530
+#: ../src/common/collection.c:633 ../src/develop/lightroom.c:1530
 #: ../src/libs/geotagging.c:63
 msgid "geotagging"
 msgstr "Geotagging"
 
-#: ../src/common/collection.c:609
+#: ../src/common/collection.c:634
 msgid "grouping"
 msgstr "Gruppieren"
 
-#: ../src/common/collection.c:610 ../src/libs/metadata_view.c:103
-#: ../src/libs/metadata_view.c:302
+#: ../src/common/collection.c:635 ../src/libs/metadata_view.c:108
+#: ../src/libs/metadata_view.c:349
 msgid "local copy"
 msgstr "lokale Kopie"
 
-#: ../src/common/collection.c:611 ../src/gui/preferences.c:495
+#: ../src/common/collection.c:636 ../src/gui/preferences.c:638
 msgid "module"
 msgstr "Modul"
 
-#: ../src/common/collection.c:612
-#, fuzzy
+#: ../src/common/collection.c:637
 msgid "module order"
-msgstr "kürzere Seite"
+msgstr "Modulsortierung"
 
-#: ../src/common/collection.c:1330 ../src/develop/lightroom.c:828
-#: ../src/iop/bilateral.cc:373 ../src/iop/channelmixer.c:458
+#: ../src/common/collection.c:1355 ../src/develop/lightroom.c:828
+#: ../src/iop/bilateral.cc:369 ../src/iop/channelmixer.c:458
 #: ../src/iop/channelmixer.c:469 ../src/iop/colorbalance.c:2534
-#: ../src/iop/temperature.c:1380 ../src/libs/collect.c:1417
+#: ../src/iop/temperature.c:1387 ../src/libs/collect.c:1419
+#: ../src/views/darkroom.c:2344
 msgid "red"
 msgstr "Rot"
 
-#: ../src/common/collection.c:1332 ../src/develop/lightroom.c:830
-#: ../src/iop/temperature.c:1371 ../src/libs/collect.c:1417
+#: ../src/common/collection.c:1357 ../src/develop/lightroom.c:830
+#: ../src/iop/temperature.c:1378 ../src/libs/collect.c:1419
+#: ../src/views/darkroom.c:2346
 msgid "yellow"
 msgstr "Gelb"
 
-#: ../src/common/collection.c:1334 ../src/develop/lightroom.c:832
-#: ../src/iop/bilateral.cc:374 ../src/iop/channelmixer.c:459
+#: ../src/common/collection.c:1359 ../src/develop/lightroom.c:832
+#: ../src/iop/bilateral.cc:370 ../src/iop/channelmixer.c:459
 #: ../src/iop/channelmixer.c:475 ../src/iop/colorbalance.c:2541
-#: ../src/iop/temperature.c:1368 ../src/iop/temperature.c:1381
-#: ../src/libs/collect.c:1417
+#: ../src/iop/temperature.c:1375 ../src/iop/temperature.c:1388
+#: ../src/libs/collect.c:1419 ../src/views/darkroom.c:2345
 msgid "green"
 msgstr "Grün"
 
-#: ../src/common/collection.c:1336 ../src/develop/lightroom.c:834
-#: ../src/iop/bilateral.cc:375 ../src/iop/channelmixer.c:460
+#: ../src/common/collection.c:1361 ../src/develop/lightroom.c:834
+#: ../src/iop/bilateral.cc:371 ../src/iop/channelmixer.c:460
 #: ../src/iop/channelmixer.c:481 ../src/iop/colorbalance.c:2548
-#: ../src/iop/temperature.c:1382 ../src/libs/collect.c:1417
+#: ../src/iop/temperature.c:1389 ../src/libs/collect.c:1419
 msgid "blue"
 msgstr "Blau"
 
-#: ../src/common/collection.c:1338 ../src/libs/collect.c:1417
+#: ../src/common/collection.c:1363 ../src/libs/collect.c:1419
 msgid "purple"
 msgstr "Violett"
 
-#: ../src/common/collection.c:1352 ../src/common/collection.c:1360
-#: ../src/libs/collect.c:1364
+#: ../src/common/collection.c:1377 ../src/common/collection.c:1385
+#: ../src/libs/collect.c:1366
 msgid "basic"
 msgstr "Basis"
 
-#: ../src/common/collection.c:1354 ../src/libs/collect.c:1364
+#: ../src/common/collection.c:1379 ../src/libs/collect.c:1366
 #, fuzzy
 msgid "auto applied"
 msgstr "automatisch skalieren"
 
-#: ../src/common/collection.c:1356 ../src/libs/collect.c:1364
+#: ../src/common/collection.c:1381 ../src/libs/collect.c:1366
 msgid "altered"
 msgstr "geändert"
 
-#: ../src/common/collection.c:1369 ../src/libs/collect.c:1377
+#: ../src/common/collection.c:1394 ../src/libs/collect.c:1379
 msgid "tagged"
 msgstr "getaggt"
 
-#: ../src/common/collection.c:1375 ../src/libs/collect.c:1389
+#: ../src/common/collection.c:1400 ../src/libs/collect.c:1391
 msgid "not copied locally"
 msgstr "nicht lokal kopiert"
 
 #. grouping
-#: ../src/common/collection.c:1576 ../src/libs/collect.c:1491
+#: ../src/common/collection.c:1601 ../src/libs/collect.c:1493
 msgid "group leaders"
 msgstr "Gruppenführer"
 
-#: ../src/common/collection.c:1608 ../src/libs/collect.c:1552
+#: ../src/common/collection.c:1633 ../src/libs/collect.c:1554
 #, fuzzy
 msgid "not defined"
 msgstr "ungeändert"
 
-#: ../src/common/collection.c:1855
+#: ../src/common/collection.c:1880
 #, c-format
 msgid "%d image of %d (#%d) in current collection is selected"
 msgstr "%d Bild von %d (#%d) ist in der aktuellen Sammlung ausgewählt"
 
-#: ../src/common/collection.c:1861
+#: ../src/common/collection.c:1886
 #, c-format
 msgid "%d image of %d in current collection is selected"
 msgid_plural "%d images of %d in current collection are selected"
@@ -1606,147 +1623,147 @@ msgstr[0] "%d Bild von %d ist in der aktuellen Sammlung ausgewählt"
 msgstr[1] "%d Bilder von %d sind in der aktuellen Sammlung ausgewählt"
 
 #. init the category profile with NULL profile, the actual profile must be retrieved dynamically by the caller
-#: ../src/common/colorspaces.c:1379 ../src/common/colorspaces.c:1635
+#: ../src/common/colorspaces.c:1380 ../src/common/colorspaces.c:1636
 msgid "work profile"
 msgstr "Arbeitsprofil"
 
-#: ../src/common/colorspaces.c:1382 ../src/common/colorspaces.c:1631
+#: ../src/common/colorspaces.c:1383 ../src/common/colorspaces.c:1632
 #: ../src/iop/colorout.c:894
 msgid "export profile"
 msgstr "Exportprofil"
 
-#: ../src/common/colorspaces.c:1386 ../src/common/colorspaces.c:1633
-#: ../src/views/darkroom.c:2148
+#: ../src/common/colorspaces.c:1387 ../src/common/colorspaces.c:1634
+#: ../src/views/darkroom.c:2222
 msgid "softproof profile"
 msgstr "Softproof-Profil"
 
-#: ../src/common/colorspaces.c:1392 ../src/common/colorspaces.c:1395
-#: ../src/common/colorspaces.c:1615 ../src/common/colorspaces.c:1637
+#: ../src/common/colorspaces.c:1393 ../src/common/colorspaces.c:1396
+#: ../src/common/colorspaces.c:1616 ../src/common/colorspaces.c:1638
 msgid "system display profile"
 msgstr "System-Bildschirmprofil"
 
-#: ../src/common/colorspaces.c:1401
+#: ../src/common/colorspaces.c:1402
 msgid "sRGB (e.g. JPG)"
 msgstr "sRGB (z.B. JPEG)"
 
-#: ../src/common/colorspaces.c:1405 ../src/libs/print_settings.c:1029
+#: ../src/common/colorspaces.c:1406 ../src/libs/print_settings.c:1034
 msgid "sRGB (web-safe)"
 msgstr "sRGB (web-sicher)"
 
-#: ../src/common/colorspaces.c:1410 ../src/common/colorspaces.c:1603
-#: ../src/iop/colorin.c:2154 ../src/libs/print_settings.c:1036
+#: ../src/common/colorspaces.c:1411 ../src/common/colorspaces.c:1604
+#: ../src/iop/colorin.c:2155 ../src/libs/print_settings.c:1041
 msgid "Adobe RGB (compatible)"
 msgstr "Adobe RGB (kompatibel)"
 
-#: ../src/common/colorspaces.c:1415 ../src/common/colorspaces.c:1605
-#: ../src/iop/colorin.c:2155
+#: ../src/common/colorspaces.c:1416 ../src/common/colorspaces.c:1606
+#: ../src/iop/colorin.c:2156
 msgid "linear Rec709 RGB"
 msgstr "lineares Rec709-RGB"
 
-#: ../src/common/colorspaces.c:1419
+#: ../src/common/colorspaces.c:1420
 msgid "gamma Rec709 RGB"
 msgstr "Gamma Rec709 RGB"
 
-#: ../src/common/colorspaces.c:1424 ../src/common/colorspaces.c:1607
-#: ../src/iop/colorin.c:2156
+#: ../src/common/colorspaces.c:1425 ../src/common/colorspaces.c:1608
+#: ../src/iop/colorin.c:2157
 msgid "linear Rec2020 RGB"
 msgstr "lineares Rec2020-RGB"
 
-#: ../src/common/colorspaces.c:1429
+#: ../src/common/colorspaces.c:1430
 #, fuzzy
 msgid "PQ Rec2020 RGB"
 msgstr "lineares Rec2020-RGB"
 
-#: ../src/common/colorspaces.c:1434
+#: ../src/common/colorspaces.c:1435
 #, fuzzy
 msgid "HLG Rec2020 RGB"
 msgstr "lineares Rec2020-RGB"
 
-#: ../src/common/colorspaces.c:1439
+#: ../src/common/colorspaces.c:1440
 msgid "PQ P3 RGB"
 msgstr ""
 
-#: ../src/common/colorspaces.c:1444
+#: ../src/common/colorspaces.c:1445
 msgid "HLG P3 RGB"
 msgstr ""
 
-#: ../src/common/colorspaces.c:1449
+#: ../src/common/colorspaces.c:1450
 msgid "linear prophoto RGB"
 msgstr "lineares prophoto RGB"
 
-#: ../src/common/colorspaces.c:1454 ../src/common/colorspaces.c:1609
+#: ../src/common/colorspaces.c:1455 ../src/common/colorspaces.c:1610
 msgid "linear XYZ"
 msgstr "lineares XYZ"
 
-#: ../src/common/colorspaces.c:1458 ../src/common/colorspaces.c:1611
-#: ../src/libs/colorpicker.c:600 ../src/libs/colorpicker.c:638
+#: ../src/common/colorspaces.c:1459 ../src/common/colorspaces.c:1612
+#: ../src/libs/colorpicker.c:606 ../src/libs/colorpicker.c:644
 msgid "Lab"
 msgstr "Lab"
 
-#: ../src/common/colorspaces.c:1463 ../src/common/colorspaces.c:1613
+#: ../src/common/colorspaces.c:1464 ../src/common/colorspaces.c:1614
 msgid "linear infrared BGR"
 msgstr "linears Infrarot-BGR"
 
-#: ../src/common/colorspaces.c:1467
+#: ../src/common/colorspaces.c:1468
 msgid "BRG (for testing)"
 msgstr "BRG (zum Testen)"
 
-#: ../src/common/colorspaces.c:1601 ../src/iop/colorin.c:2153
-#: ../src/iop/lut3d.c:1778
+#: ../src/common/colorspaces.c:1602 ../src/iop/colorin.c:2154
+#: ../src/iop/lut3d.c:1796
 msgid "sRGB"
 msgstr "sRGB"
 
-#: ../src/common/colorspaces.c:1617
+#: ../src/common/colorspaces.c:1618
 msgid "embedded ICC profile"
 msgstr "eingebettetes ICC-Profil"
 
-#: ../src/common/colorspaces.c:1619
+#: ../src/common/colorspaces.c:1620
 msgid "embedded matrix"
 msgstr "eingebettete Matrix"
 
-#: ../src/common/colorspaces.c:1621
+#: ../src/common/colorspaces.c:1622
 msgid "standard color matrix"
 msgstr "Standard-Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1623
+#: ../src/common/colorspaces.c:1624
 msgid "enhanced color matrix"
 msgstr "Erweiterte Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1625
+#: ../src/common/colorspaces.c:1626
 msgid "vendor color matrix"
 msgstr "Hersteller-Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1627
+#: ../src/common/colorspaces.c:1628
 msgid "alternate color matrix"
 msgstr "Alternative Farb-Matrix"
 
-#: ../src/common/colorspaces.c:1629
+#: ../src/common/colorspaces.c:1630
 msgid "BRG (experimental)"
 msgstr "BRG (experimentell)"
 
-#: ../src/common/colorspaces.c:1639
+#: ../src/common/colorspaces.c:1640
 #, fuzzy
 msgid "gamma22 Rec709"
 msgstr "Gamma Rec709 RGB"
 
-#: ../src/common/colorspaces.c:1641
+#: ../src/common/colorspaces.c:1642
 #, fuzzy
 msgid "ProPhoto RGB"
 msgstr "lineares prophoto-RGB"
 
-#: ../src/common/colorspaces.c:1643
+#: ../src/common/colorspaces.c:1644
 msgid "PQ Rec2020"
 msgstr ""
 
-#: ../src/common/colorspaces.c:1645
+#: ../src/common/colorspaces.c:1646
 msgid "HLG Rec2020"
 msgstr ""
 
-#: ../src/common/colorspaces.c:1647
+#: ../src/common/colorspaces.c:1648
 msgid "PQ P3"
 msgstr ""
 
-#: ../src/common/colorspaces.c:1649
+#: ../src/common/colorspaces.c:1650
 msgid "HLG P3"
 msgstr ""
 
@@ -1780,26 +1797,26 @@ msgstr "drucke Bild „%s” auf „%s”"
 msgid "found strange path `%s'"
 msgstr "Ungewöhnlicher Pfad „%s” gefunden"
 
-#: ../src/common/darktable.c:252
+#: ../src/common/darktable.c:250
 #, c-format
 msgid "error loading directory `%s'"
 msgstr "Fehler beim Laden von Verzeichnis „%s”"
 
-#: ../src/common/darktable.c:275
+#: ../src/common/darktable.c:273
 #, c-format
 msgid "file `%s' has unknown format!"
 msgstr "Datei „%s” hat ein unbekanntes Format!"
 
-#: ../src/common/darktable.c:288 ../src/libs/import.c:819
+#: ../src/common/darktable.c:286 ../src/libs/import.c:856
 #, c-format
 msgid "error loading file `%s'"
 msgstr "Fehler beim Laden von Datei „%s”"
 
-#: ../src/common/darktable.c:809
+#: ../src/common/darktable.c:807
 msgid "darktable - run performance configuration?"
 msgstr "darktable - Geschwindigkeitseinstellungen anpassen?"
 
-#: ../src/common/darktable.c:810
+#: ../src/common/darktable.c:808
 msgid ""
 "we have an updated performance configuration logic - executing that might "
 "improve the performance of darktable.\n"
@@ -1815,49 +1832,80 @@ msgstr ""
 "insbesondere, wenn diese manuell geändert wurden.\n"
 "Sollen die Einstellungen angepasst werden?\n"
 
-#: ../src/common/darktable.c:814 ../src/common/variables.c:379
-#: ../src/imageio/format/pdf.c:669 ../src/imageio/format/pdf.c:694
-#: ../src/iop/clipping.c:2096 ../src/iop/filmicrgb.c:1577
-#: ../src/iop/toneequal.c:3329 ../src/libs/export.c:628
-#: ../src/libs/export.c:634 ../src/libs/metadata_view.c:281
+#: ../src/common/darktable.c:812 ../src/common/variables.c:453
+#: ../src/imageio/format/pdf.c:670 ../src/imageio/format/pdf.c:695
+#: ../src/iop/clipping.c:2196 ../src/iop/filmicrgb.c:1577
+#: ../src/iop/toneequal.c:3329 ../src/libs/export.c:636
+#: ../src/libs/export.c:642 ../src/libs/export.c:649
+#: ../src/libs/metadata_view.c:291
 msgid "no"
 msgstr "nein"
 
-#: ../src/common/darktable.c:814 ../src/common/database.c:2728
-#: ../src/common/variables.c:377 ../src/imageio/format/pdf.c:670
-#: ../src/imageio/format/pdf.c:695 ../src/iop/clipping.c:2097
-#: ../src/libs/export.c:629 ../src/libs/export.c:635
-#: ../src/libs/metadata_view.c:281
+#: ../src/common/darktable.c:812 ../src/common/database.c:2850
+#: ../src/common/variables.c:451 ../src/imageio/format/pdf.c:671
+#: ../src/imageio/format/pdf.c:696 ../src/iop/clipping.c:2197
+#: ../src/libs/export.c:637 ../src/libs/export.c:643 ../src/libs/export.c:650
+#: ../src/libs/metadata_view.c:291
 msgid "yes"
 msgstr "ja"
 
-#: ../src/common/database.c:2014
+#: ../src/common/database.c:2111
 #, c-format
 msgid ""
-"an error has occurred while trying to open the database from\n"
 "\n"
-"<span style=\"italic\">%s</span>\n"
+" At startup, the database failed to open because at least one of the two "
+"files in the database is locked.\n"
 "\n"
-"%s\n"
+" The persistence of the lock is mainly caused by one of the two following "
+"causes:\n"
+"\n"
+" - Another occurrence of darktable has already opened this database file and "
+"locked it for its benefit.\n"
+"\n"
+" - A previous occurrence of darktable ended abnormally and therefore \n"
+"   could not close one or both files in the database properly.\n"
+"\n"
+" How to solve this problem?\n"
+"\n"
+" 1 - Search in your environment if another darktable occurrence is active. "
+"If so, use it or close it. \n"
+"     The lock indicates that the process number of this occurrence is : "
+"<i><b>%d</b></i>\n"
+"\n"
+" 2 - If you can't find this other occurrence, try closing your session and "
+"reopening it or shutting down your computer. \n"
+"     This will delete all running programs and thus close the database "
+"correctly.\n"
+"\n"
+" 3 - If these two actions are not enough, it is because at least one of the "
+"two files that materialize the locks remains \n"
+"     and that these are no longer attached to any occurrence of darktable. "
+"It is then necessary to delete it (or them). \n"
+"     The two files are named <i>data.db.lock</i> and <i>library.db.lock</i> "
+"respectively. The opening mechanism signals \n"
+"     the presence of the <i><b>%s</b></i> file in the <i><b>%s</b></i> "
+"folder. \n"
+"     (full pathname: <i><b>%s</b></i>).\n"
+"\n"
+"     <u>Caution!</u> Do not delete these files without first checking that "
+"there are no more occurrences of darktable, \n"
+"     otherwise you risk generating serious inconsistencies in your "
+"database.\n"
+"\n"
+" As soon as you have identified and removed the cause of the lock, darktable "
+"will start without any problem.\n"
 msgstr ""
-"Es ist ein Fehler beim Öffnen der Datenbank von\n"
-"\n"
-"<span style=\"italic\">%s</span>\n"
-"\n"
-"aufgetreten.\n"
-"\n"
-"%s\n"
 
-#: ../src/common/database.c:2021
-msgid "darktable - error locking database"
-msgstr "darktable – Fehler beim Sperren der Datenbank"
+#: ../src/common/database.c:2141
+msgid "darktable cannot be started because the database is locked"
+msgstr ""
 
-#: ../src/common/database.c:2021 ../src/common/database.c:2192
-#: ../src/common/database.c:2437 ../src/common/database.c:2519
+#: ../src/common/database.c:2142 ../src/common/database.c:2314
+#: ../src/common/database.c:2559 ../src/common/database.c:2641
 msgid "close darktable"
 msgstr "darktable schließen"
 
-#: ../src/common/database.c:2132
+#: ../src/common/database.c:2254
 #, c-format
 msgid ""
 "the database lock file contains a pid that seems to be alive in your system: "
@@ -1866,18 +1914,18 @@ msgstr ""
 "Die Datenbank-Lock-Datei enthält eine PID, die zu einem laufenden Programm "
 "passt: %d"
 
-#: ../src/common/database.c:2138
+#: ../src/common/database.c:2260
 #, c-format
 msgid "the database lock file seems to be empty"
 msgstr "Die Datenbank-Lock-Datei scheint leer zu sein"
 
-#: ../src/common/database.c:2146
+#: ../src/common/database.c:2268
 #, c-format
 msgid "error opening the database lock file for reading: %s"
 msgstr "Fehler beim Öffnen der Datenbank-Lock-Datei zum Lesen: %s"
 
 #. the database has to be upgraded, let's ask user
-#: ../src/common/database.c:2183
+#: ../src/common/database.c:2305
 #, c-format
 msgid ""
 "the database schema has to be upgraded for\n"
@@ -1892,17 +1940,17 @@ msgstr ""
 "\n"
 "Möchten Sie fortfahren oder jetzt beenden, um ein Backup zu erstellen\n"
 
-#: ../src/common/database.c:2191
+#: ../src/common/database.c:2313
 msgid "darktable - schema migration"
 msgstr "darktable - Datenbank Umstellung"
 
-#: ../src/common/database.c:2192
+#: ../src/common/database.c:2314
 msgid "upgrade database"
 msgstr "Datenbank aktualisieren"
 
 #. oh, bad situation. the database is corrupt and can't be read!
 #. we inform the user here and let him decide what to do: exit or delete and try again.
-#: ../src/common/database.c:2426 ../src/common/database.c:2508
+#: ../src/common/database.c:2548 ../src/common/database.c:2630
 #, c-format
 msgid ""
 "an error has occurred while trying to open the database from\n"
@@ -1922,28 +1970,28 @@ msgstr ""
 "von einem Backup zurückgespielt werden kann, oder soll\n"
 "mit einer neuen Datei gestartet werden?"
 
-#: ../src/common/database.c:2436 ../src/common/database.c:2518
+#: ../src/common/database.c:2558 ../src/common/database.c:2640
 msgid "darktable - error opening database"
 msgstr "darktable - Fehler beim Öffnen der Datenbank"
 
-#: ../src/common/database.c:2437 ../src/common/database.c:2519
+#: ../src/common/database.c:2559 ../src/common/database.c:2641
 msgid "delete database"
 msgstr "Datenbank löschen"
 
-#: ../src/common/database.c:2705
+#: ../src/common/database.c:2827
 #, fuzzy
 msgid "click later to be asked on next startup"
 msgstr "zum Starten den Login-Knopf drücken"
 
-#: ../src/common/database.c:2709
+#: ../src/common/database.c:2831
 msgid "click later to be asked when closing darktable"
 msgstr ""
 
-#: ../src/common/database.c:2713
+#: ../src/common/database.c:2835
 msgid "click later to be asked next time when closing darktable"
 msgstr ""
 
-#: ../src/common/database.c:2717
+#: ../src/common/database.c:2839
 #, c-format
 msgid ""
 "the database could use some maintenance\n"
@@ -1956,12 +2004,12 @@ msgid ""
 "you can always change maintenance preferences in core options"
 msgstr ""
 
-#: ../src/common/database.c:2727
+#: ../src/common/database.c:2849
 #, fuzzy
 msgid "darktable - schema maintenance"
 msgstr "darktable - Datenbank Umstellung"
 
-#: ../src/common/database.c:2728
+#: ../src/common/database.c:2850
 #, fuzzy
 msgid "later"
 msgstr "bilateral"
@@ -1972,50 +2020,50 @@ msgstr ""
 "Dem schnell geführter Filter konnte kein Speicher zuweisen werden, "
 "überprüfen Sie Ihre RAM-Einstellungen."
 
-#: ../src/common/film.c:308
+#: ../src/common/film.c:269
 msgid "do you want to remove this empty directory?"
 msgid_plural "do you want to remove these empty directories?"
 msgstr[0] "Soll dieses leere Verzeichnis entfernt werden?"
 msgstr[1] "Sollen diese leeren Verzeichnisse entfernt werden?"
 
-#: ../src/common/film.c:315
+#: ../src/common/film.c:276
 msgid "remove empty directory?"
 msgid_plural "remove empty directories?"
 msgstr[0] "leeres Verzeichnis entfernen?"
 msgstr[1] "leere Verzeichnisse entfernen?"
 
-#: ../src/common/film.c:334 ../src/gui/preferences.c:503
+#: ../src/common/film.c:295 ../src/gui/preferences.c:646
 #: ../src/gui/styles_dialog.c:368
 msgid "name"
 msgstr "Name"
 
-#: ../src/common/film.c:432
+#: ../src/common/film.c:393
 msgid ""
 "cannot remove film roll having local copies with non accessible originals"
 msgstr ""
 "Filmrolle kann nicht entfernt werden, so lange lokale Kopien existieren, für "
 "die kein Zugriff auf die Originale besteht"
 
-#: ../src/common/history.c:684
+#: ../src/common/history.c:725
 msgid "you need to copy history from an image before you paste it onto another"
 msgstr ""
 "Es muss erst der Verlauf eines Bildes kopiert werden, bevor er auf ein "
 "anderes Bild angewandt werden kann"
 
-#: ../src/common/history.c:789 ../src/common/history.c:792
-#: ../src/common/history.c:808 ../src/common/styles.c:991
-#: ../src/common/styles.c:995 ../src/develop/blend_gui.c:2789
-#: ../src/develop/develop.c:1976 ../src/iop/ashift.c:4870
+#: ../src/common/history.c:836 ../src/common/history.c:839
+#: ../src/common/history.c:855 ../src/common/styles.c:999
+#: ../src/common/styles.c:1003 ../src/develop/blend_gui.c:2789
+#: ../src/develop/develop.c:2012 ../src/iop/ashift.c:4870
 #: ../src/libs/live_view.c:435
 msgid "on"
 msgstr "ein"
 
-#: ../src/common/history.c:789 ../src/common/history.c:792
-#: ../src/common/history.c:808 ../src/common/styles.c:991
-#: ../src/common/styles.c:995 ../src/develop/blend_gui.c:2521
-#: ../src/develop/blend_gui.c:2786 ../src/develop/develop.c:1976
-#: ../src/imageio/format/exr.cc:375 ../src/imageio/format/j2k.c:660
-#: ../src/iop/ashift.c:4869 ../src/iop/ashift.c:4875 ../src/iop/colorin.c:2152
+#: ../src/common/history.c:836 ../src/common/history.c:839
+#: ../src/common/history.c:855 ../src/common/styles.c:999
+#: ../src/common/styles.c:1003 ../src/develop/blend_gui.c:2521
+#: ../src/develop/blend_gui.c:2786 ../src/develop/develop.c:2012
+#: ../src/imageio/format/exr.cc:376 ../src/imageio/format/j2k.c:661
+#: ../src/iop/ashift.c:4869 ../src/iop/ashift.c:4875 ../src/iop/colorin.c:2153
 #: ../src/iop/demosaic.c:5159 ../src/iop/vignette.c:1152
 #: ../src/libs/live_view.c:434
 msgid "off"
@@ -2040,69 +2088,69 @@ msgstr ""
 "<h1>Danke,</h1><p>es sollte alles funktioniert haben, du kannst den Browser "
 "jetzt <b>schließen</b> und in darktable <b>weiter machen</b>.</p>"
 
-#: ../src/common/image.c:187
+#: ../src/common/image.c:188
 msgid "orphaned image"
 msgstr "verwaistes Bild"
 
-#: ../src/common/image.c:1604
+#: ../src/common/image.c:1584
 #, c-format
 msgid "cannot access local copy `%s'"
 msgstr "auf lokale Kopie „%s” kann nicht zugegriffen werden."
 
-#: ../src/common/image.c:1611
+#: ../src/common/image.c:1591
 #, c-format
 msgid "cannot write local copy `%s'"
 msgstr "lokale Kopie „%s” kann nicht erzeugt werden."
 
-#: ../src/common/image.c:1618
+#: ../src/common/image.c:1598
 #, c-format
 msgid "error moving local copy `%s' -> `%s'"
 msgstr "Fehler beim Verschieben lokaler Kopie „%s” auf „%s”"
 
-#: ../src/common/image.c:1634
+#: ../src/common/image.c:1614
 #, c-format
 msgid "error moving `%s': file not found"
 msgstr "Fehler beim Verschieben „%s”: Datei nicht gefunden"
 
-#: ../src/common/image.c:1644
+#: ../src/common/image.c:1624
 #, c-format
 msgid "error moving `%s' -> `%s': file exists"
 msgstr "Fehler beim Verschieben „%s” auf „%s”: Datei existiert bereits"
 
-#: ../src/common/image.c:1648
+#: ../src/common/image.c:1628
 #, c-format
 msgid "error moving `%s' -> `%s'"
 msgstr "Fehler beim Verschieben „%s” auf „%s”"
 
-#: ../src/common/image.c:1924
+#: ../src/common/image.c:1904
 msgid "cannot create local copy when the original file is not accessible."
 msgstr ""
 "lokale Kopie kann nicht erzeugt werden, wenn die Originaldatei nicht "
 "zugänglich ist."
 
-#: ../src/common/image.c:1938
+#: ../src/common/image.c:1918
 msgid "cannot create local copy."
 msgstr "lokale Kopie kann nicht erzeugt werden."
 
-#: ../src/common/image.c:2010 ../src/control/jobs/control_jobs.c:666
+#: ../src/common/image.c:1990 ../src/control/jobs/control_jobs.c:664
 msgid "cannot remove local copy when the original file is not accessible."
 msgstr ""
 "lokale Kopie kann nicht entfernt werden, wenn die Originaldatei nicht "
 "zugänglich ist."
 
-#: ../src/common/image.c:2184
+#: ../src/common/image.c:2171
 #, c-format
 msgid "%d local copy has been synchronized"
 msgid_plural "%d local copies have been synchronized"
 msgstr[0] "%d lokale Kopie wurde synchronisiert"
 msgstr[1] "%d lokale Kopien wurden synchronisiert"
 
-#: ../src/common/imageio.c:653 ../src/common/mipmap_cache.c:1063
+#: ../src/common/imageio.c:598 ../src/common/mipmap_cache.c:1063
 #, c-format
 msgid "image `%s' is not available!"
 msgstr "Bild „%s” ist nicht verfügbar!"
 
-#: ../src/common/imageio.c:671
+#: ../src/common/imageio.c:616
 #, c-format
 msgid ""
 "failed to allocate memory for %s, please lower the threads used for export "
@@ -2111,17 +2159,17 @@ msgstr ""
 "Fehler beim Reservieren von Speicher zum %s, bitte die Anzahl Threads für "
 "den Export herabsetzen oder mehr Speicher kaufen."
 
-#: ../src/common/imageio.c:672
+#: ../src/common/imageio.c:617
 msgctxt "noun"
 msgid "thumbnail export"
 msgstr "Exportieren der Vorschau"
 
-#: ../src/common/imageio.c:672
+#: ../src/common/imageio.c:617
 msgctxt "noun"
 msgid "export"
 msgstr "Exportieren"
 
-#: ../src/common/imageio.c:682
+#: ../src/common/imageio.c:627
 #, c-format
 msgid "cannot find the style '%s' to apply during export."
 msgstr "Stil „%s” kann zum Exportieren nicht gefunden werden."
@@ -2140,9 +2188,8 @@ msgid "custom"
 msgstr "benutzerdefinierte Sortierung"
 
 #: ../src/common/iop_order.c:59
-#, fuzzy
 msgid "legacy"
-msgstr "Legal"
+msgstr "veraltet"
 
 #: ../src/common/iop_order.c:60
 msgid "v3.0"
@@ -2188,15 +2235,15 @@ msgid "opencl scheduling profile set to default."
 msgstr "OpenCL-Scheduler-Profil wurde auf den Standardwert gesetzt."
 
 #: ../src/common/pdf.h:88 ../src/iop/lens.cc:1934
-#: ../src/libs/print_settings.c:1286
+#: ../src/libs/print_settings.c:1291
 msgid "mm"
 msgstr "mm"
 
-#: ../src/common/pdf.h:89 ../src/libs/print_settings.c:1287
+#: ../src/common/pdf.h:89 ../src/libs/print_settings.c:1292
 msgid "cm"
 msgstr "cm"
 
-#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:1288
+#: ../src/common/pdf.h:90 ../src/libs/print_settings.c:1293
 msgid "inch"
 msgstr "inch"
 
@@ -2226,21 +2273,21 @@ msgstr ""
 "Das GNOME Keyring-Backend wird nicht mehr unterstützt. Wählen Sie bitte ein "
 "anderes"
 
-#: ../src/common/ratings.c:153
+#: ../src/common/ratings.c:171
 #, c-format
 msgid "rejecting %d image"
 msgid_plural "rejecting %d images"
 msgstr[0] "%d Bild abgelehnt"
 msgstr[1] "%d Bilder abgelehnt"
 
-#: ../src/common/ratings.c:155
+#: ../src/common/ratings.c:173
 #, c-format
 msgid "applying rating %d to %d image"
 msgid_plural "applying rating %d to %d images"
 msgstr[0] "wende Bewertung %d auf %d Bild an"
 msgstr[1] "wende Bewertung %d auf %d Bilder an"
 
-#: ../src/common/ratings.c:163
+#: ../src/common/ratings.c:187
 msgid "no images selected to apply rating"
 msgstr "kein Bild ausgewählt, um Bewertung anzuwenden"
 
@@ -2252,8 +2299,8 @@ msgstr "Stil mit dem Namen „%s” existiert bereits"
 #. freed by _destroy_style_shortcut_callback
 #: ../src/common/styles.c:371 ../src/common/styles.c:375
 #: ../src/common/styles.c:469 ../src/common/styles.c:553
-#: ../src/common/styles.c:875 ../src/common/styles.c:1447
-#: ../src/common/styles.c:1466
+#: ../src/common/styles.c:883 ../src/common/styles.c:1455
+#: ../src/common/styles.c:1474
 #, c-format
 msgctxt "accel"
 msgid "styles/apply %s"
@@ -2265,27 +2312,27 @@ msgid "style named '%s' successfully created"
 msgstr "Stil mit dem Namen „%s” erfolgreich angelegt"
 
 #. fail :(
-#: ../src/common/styles.c:589 ../src/common/styles.c:607
-#: ../src/views/darkroom.c:689 ../src/views/print.c:268
+#: ../src/common/styles.c:593 ../src/common/styles.c:611
+#: ../src/views/darkroom.c:675 ../src/views/print.c:268
 msgid "no image selected!"
 msgstr "Kein Bild ausgewählt!"
 
-#: ../src/common/styles.c:662
+#: ../src/common/styles.c:666
 #, c-format
 msgid "module `%s' version mismatch: %d != %d"
 msgstr "Modul „%s” hat Versionskonflikt: %d ≠ %d"
 
-#: ../src/common/styles.c:1084
+#: ../src/common/styles.c:1092
 #, c-format
 msgid "failed to overwrite style file for %s"
 msgstr "Fehler beim Überschreiben der Stil-Datei für „%s”"
 
-#: ../src/common/styles.c:1090
+#: ../src/common/styles.c:1098
 #, c-format
 msgid "style file for %s exists"
 msgstr "Stil-Datei für „%s” existiert bereits"
 
-#: ../src/common/styles.c:1338
+#: ../src/common/styles.c:1346
 #, c-format
 msgid "style %s was successfully imported"
 msgstr "Stil „%s” erfolgreich importiert"
@@ -2299,9 +2346,45 @@ msgid "below sea level"
 msgstr "unter Null"
 
 #: ../src/common/utility.c:506 ../src/iop/watermark.c:827
-#: ../src/libs/metadata_view.c:581
+#: ../src/libs/metadata_view.c:639
 msgid "m"
 msgstr "m"
+
+#. clang-format off
+#: ../src/common/metadata.c:45 ../src/gui/camera_import_dialog.c:450
+msgid "creator"
+msgstr "Urheber"
+
+# Herausgeber? Verlag? oder noch was anderes?
+#: ../src/common/metadata.c:46 ../src/gui/camera_import_dialog.c:455
+msgid "publisher"
+msgstr "Herausgeber"
+
+#. title
+#. DT_COLLECTION_SORT_CUSTOM_ORDER
+#: ../src/common/metadata.c:47 ../src/imageio/format/pdf.c:584
+#: ../src/imageio/storage/gallery.c:185 ../src/imageio/storage/latex.c:185
+#: ../src/imageio/storage/piwigo.c:857 ../src/libs/tools/filter.c:155
+msgid "title"
+msgstr "Titel"
+
+#. DT_COLLECTION_SORT_TITLE
+#: ../src/common/metadata.c:48 ../src/gui/styles_dialog.c:372
+#: ../src/libs/tools/filter.c:156
+msgid "description"
+msgstr "Beschreibung"
+
+#: ../src/common/metadata.c:49 ../src/gui/camera_import_dialog.c:460
+msgid "rights"
+msgstr "Rechte"
+
+#: ../src/common/metadata.c:50
+msgid "notes"
+msgstr "Notizen"
+
+#: ../src/common/metadata.c:51
+msgid "version name"
+msgstr "Versionsname"
 
 #: ../src/control/control.c:262
 #, fuzzy
@@ -2420,160 +2503,160 @@ msgid_plural "duplicating %d images"
 msgstr[0] "Dupliziere %d Bild"
 msgstr[1] "Dupliziere %d Bilder"
 
-#: ../src/control/jobs/control_jobs.c:569
+#: ../src/control/jobs/control_jobs.c:568
 #, c-format
 msgid "flipping %d image"
 msgid_plural "flipping %d images"
 msgstr[0] "%d Bild spiegeln"
 msgstr[1] "%d Bilder spiegeln"
 
-#: ../src/control/jobs/control_jobs.c:642
+#: ../src/control/jobs/control_jobs.c:640
 #, c-format
 msgid "removing %d image"
 msgid_plural "removing %d images"
 msgstr[0] "%d Bild entfernen"
 msgstr[1] "%d Bilder entfernen"
 
-#: ../src/control/jobs/control_jobs.c:744
+#: ../src/control/jobs/control_jobs.c:742
 #, c-format
 msgid "could not send %s to trash%s%s"
 msgstr "Konnte %s nicht in den Papierkorb verschieben%s%s"
 
-#: ../src/control/jobs/control_jobs.c:745
+#: ../src/control/jobs/control_jobs.c:743
 #, c-format
 msgid "could not physically delete %s%s%s"
 msgstr "Konnte %s nicht physisch von der Festplatte löschen%s%s"
 
-#: ../src/control/jobs/control_jobs.c:755
+#: ../src/control/jobs/control_jobs.c:753
 msgid "physically delete"
 msgstr "physisch von der Festplatte löschen"
 
-#: ../src/control/jobs/control_jobs.c:756
+#: ../src/control/jobs/control_jobs.c:754
 msgid "physically delete all files"
 msgstr "alle Dateien physisch von der Festplatte löschen"
 
-#: ../src/control/jobs/control_jobs.c:758
+#: ../src/control/jobs/control_jobs.c:756
 msgid "only remove from the collection"
 msgstr "nur aus der Sammlung entfernen"
 
-#: ../src/control/jobs/control_jobs.c:759
+#: ../src/control/jobs/control_jobs.c:757
 msgid "skip to next file"
 msgstr "zur nächsten Datei gehen"
 
-#: ../src/control/jobs/control_jobs.c:760
+#: ../src/control/jobs/control_jobs.c:758
 msgid "stop process"
 msgstr "Prozess abbrechen"
 
-#: ../src/control/jobs/control_jobs.c:765
+#: ../src/control/jobs/control_jobs.c:763
 msgid "trashing error"
 msgstr "Fehler beim Verschieben in den Papierkorb"
 
-#: ../src/control/jobs/control_jobs.c:766
+#: ../src/control/jobs/control_jobs.c:764
 msgid "deletion error"
 msgstr "Fehler beim Löschen"
 
-#: ../src/control/jobs/control_jobs.c:907
+#: ../src/control/jobs/control_jobs.c:905
 #, c-format
 msgid "trashing %d image"
 msgid_plural "trashing %d images"
 msgstr[0] "%d Bild in den Papierkorb verschieben"
 msgstr[1] "%d Bilder in den Papierkorb verschieben"
 
-#: ../src/control/jobs/control_jobs.c:909
+#: ../src/control/jobs/control_jobs.c:907
 #, c-format
 msgid "deleting %d image"
 msgid_plural "deleting %d images"
 msgstr[0] "%d Bild löschen"
 msgstr[1] "%d Bilder löschen"
 
-#: ../src/control/jobs/control_jobs.c:1036
+#: ../src/control/jobs/control_jobs.c:1034
 msgid "failed to parse GPX file"
 msgstr "Fehler beim lesen der GPX-Datei"
 
-#: ../src/control/jobs/control_jobs.c:1101
+#: ../src/control/jobs/control_jobs.c:1099
 #, c-format
 msgid "applied matched GPX location onto %d image"
 msgid_plural "applied matched GPX location onto %d images"
 msgstr[0] "passende GPX-Position auf %d Bild angewandt"
 msgstr[1] "passende GPX-Position auf %d Bilder angewandt"
 
-#: ../src/control/jobs/control_jobs.c:1116
+#: ../src/control/jobs/control_jobs.c:1114
 #, c-format
 msgid "moving %d image"
 msgstr "%d Bild verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1117
+#: ../src/control/jobs/control_jobs.c:1115
 #, c-format
 msgid "moving %d images"
 msgstr "%d Bilder verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1122
+#: ../src/control/jobs/control_jobs.c:1120
 #, c-format
 msgid "copying %d image"
 msgstr "%d Bild kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1123
+#: ../src/control/jobs/control_jobs.c:1121
 #, c-format
 msgid "copying %d images"
 msgstr "%d Bilder kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1138
+#: ../src/control/jobs/control_jobs.c:1136
 #, c-format
 msgid "creating local copy of %d image"
 msgid_plural "creating local copies of %d images"
 msgstr[0] "lokale Kopie von %d Bild anlegen"
 msgstr[1] "lokale Kopien von %d Bildern anlegen"
 
-#: ../src/control/jobs/control_jobs.c:1141
+#: ../src/control/jobs/control_jobs.c:1139
 #, c-format
 msgid "removing local copy of %d image"
 msgid_plural "removing local copies of %d images"
 msgstr[0] "lokale Kopie von %d Bild entfernen"
 msgstr[1] "lokale Kopien von %d Bildern entfernen"
 
-#: ../src/control/jobs/control_jobs.c:1179
+#: ../src/control/jobs/control_jobs.c:1177
 #, c-format
 msgid "refreshing info for %d image"
 msgid_plural "refreshing info for %d images"
 msgstr[0] "Information des Bildes %d aktualisieren"
 msgstr[1] "Informationen der Bilder %d aktualisieren"
 
-#: ../src/control/jobs/control_jobs.c:1244
+#: ../src/control/jobs/control_jobs.c:1242
 #, c-format
 msgid "exporting %d image.."
 msgid_plural "exporting %d images.."
 msgstr[0] "Exportiere %d Bild.."
 msgstr[1] "Exportiere %d Bilder.."
 
-#: ../src/control/jobs/control_jobs.c:1276
+#: ../src/control/jobs/control_jobs.c:1274
 #, fuzzy, c-format
 msgid "exporting %d / %d to %s"
 msgstr "%d Bild nach %s exportieren"
 
-#: ../src/control/jobs/control_jobs.c:1293 ../src/views/darkroom.c:702
+#: ../src/control/jobs/control_jobs.c:1295 ../src/views/darkroom.c:688
 #: ../src/views/print.c:281
 #, c-format
 msgid "image `%s' is currently unavailable"
 msgstr "Bild „%s” ist momentan nicht verfügbar"
 
-#: ../src/control/jobs/control_jobs.c:1382
+#: ../src/control/jobs/control_jobs.c:1384
 msgid "merge hdr image"
 msgstr "HDR-Bild zusammenfassen"
 
-#: ../src/control/jobs/control_jobs.c:1396
+#: ../src/control/jobs/control_jobs.c:1398
 msgid "duplicate images"
 msgstr "Bilder duplizieren"
 
-#: ../src/control/jobs/control_jobs.c:1403
+#: ../src/control/jobs/control_jobs.c:1405
 msgid "flip images"
 msgstr "Bilder spiegeln"
 
 #. get all selected images now, to avoid the set changing during ui interaction
-#: ../src/control/jobs/control_jobs.c:1410
+#: ../src/control/jobs/control_jobs.c:1412
 msgid "remove images"
 msgstr "Bilder entfernen"
 
-#: ../src/control/jobs/control_jobs.c:1432
+#: ../src/control/jobs/control_jobs.c:1434
 #, c-format
 msgid "do you really want to remove %d selected image from the collection?"
 msgid_plural ""
@@ -2583,17 +2666,17 @@ msgstr[0] ""
 msgstr[1] ""
 "Sollen wirklich %d ausgewählte Bilder aus der Sammlung entfernt werden?"
 
-#: ../src/control/jobs/control_jobs.c:1439
+#: ../src/control/jobs/control_jobs.c:1441
 msgid "remove images?"
 msgstr "Bilder entfernen?"
 
 #. first get all selected images, to avoid the set changing during ui interaction
-#: ../src/control/jobs/control_jobs.c:1455
-#: ../src/control/jobs/control_jobs.c:1503
+#: ../src/control/jobs/control_jobs.c:1457
+#: ../src/control/jobs/control_jobs.c:1505
 msgid "delete images"
 msgstr "Bilder löschen"
 
-#: ../src/control/jobs/control_jobs.c:1479
+#: ../src/control/jobs/control_jobs.c:1481
 #, c-format
 msgid "do you really want to send %d selected image to trash?"
 msgid_plural "do you really want to send %d selected images to trash?"
@@ -2602,7 +2685,7 @@ msgstr[0] ""
 msgstr[1] ""
 "Sollen wirklich %d ausgewählte Bilder in den Papierkorb verschoben werden?"
 
-#: ../src/control/jobs/control_jobs.c:1481
+#: ../src/control/jobs/control_jobs.c:1483
 #, c-format
 msgid "do you really want to physically delete %d selected image from disk?"
 msgid_plural ""
@@ -2614,39 +2697,39 @@ msgstr[1] ""
 "Sollen wirklich %d ausgewählte Bilder physisch von der Festplatte gelöscht "
 "werden?"
 
-#: ../src/control/jobs/control_jobs.c:1488
-#: ../src/control/jobs/control_jobs.c:1526
+#: ../src/control/jobs/control_jobs.c:1490
+#: ../src/control/jobs/control_jobs.c:1528
 msgid "trash images?"
 msgstr "Bilder in den Papierkorb verschieben?"
 
-#: ../src/control/jobs/control_jobs.c:1488
-#: ../src/control/jobs/control_jobs.c:1526
+#: ../src/control/jobs/control_jobs.c:1490
+#: ../src/control/jobs/control_jobs.c:1528
 msgid "delete images?"
 msgstr "Bilder löschen?"
 
-#: ../src/control/jobs/control_jobs.c:1520
+#: ../src/control/jobs/control_jobs.c:1522
 #, fuzzy
 msgid "do you really want to send selected image to trash?"
 msgstr ""
 "Soll wirklich %d ausgewähltes Bild in den Papierkorb verschoben werden?"
 
-#: ../src/control/jobs/control_jobs.c:1521
+#: ../src/control/jobs/control_jobs.c:1523
 #, fuzzy
 msgid "do you really want to physically delete selected image from disk?"
 msgstr ""
 "Soll wirklich %d ausgewähltes Bild physisch von der Festplatte gelöscht "
 "werden?"
 
-#: ../src/control/jobs/control_jobs.c:1547
+#: ../src/control/jobs/control_jobs.c:1549
 msgid "move images"
 msgstr "Bilder verschieben"
 
-#: ../src/control/jobs/control_jobs.c:1552
-#: ../src/control/jobs/control_jobs.c:1612
+#: ../src/control/jobs/control_jobs.c:1554
+#: ../src/control/jobs/control_jobs.c:1614
 msgid "_select as destination"
 msgstr "als Ziel _wählen"
 
-#: ../src/control/jobs/control_jobs.c:1573
+#: ../src/control/jobs/control_jobs.c:1575
 #, c-format
 msgid ""
 "do you really want to physically move the %d selected image to %s?\n"
@@ -2662,17 +2745,17 @@ msgstr[1] ""
 "werden?\n"
 "(alle nicht ausgewählten Duplikate werden auch verschoben)"
 
-#: ../src/control/jobs/control_jobs.c:1582
+#: ../src/control/jobs/control_jobs.c:1584
 msgid "move image?"
 msgid_plural "move images?"
 msgstr[0] "Bild verschieben?"
 msgstr[1] "Bilder verschieben?"
 
-#: ../src/control/jobs/control_jobs.c:1607
+#: ../src/control/jobs/control_jobs.c:1609
 msgid "copy images"
 msgstr "Bilder kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1633
+#: ../src/control/jobs/control_jobs.c:1635
 #, c-format
 msgid "do you really want to physically copy the %d selected image to %s?"
 msgid_plural "do you really want to physically copy %d selected images to %s?"
@@ -2681,51 +2764,51 @@ msgstr[0] ""
 msgstr[1] ""
 "Sollen die %d ausgewählten Bilder wirklich physisch nach %s kopiert werden?"
 
-#: ../src/control/jobs/control_jobs.c:1639
+#: ../src/control/jobs/control_jobs.c:1641
 msgid "copy image?"
 msgid_plural "copy images?"
 msgstr[0] "Bild kopieren?"
 msgstr[1] "Bilder kopieren?"
 
-#: ../src/control/jobs/control_jobs.c:1659
-#: ../src/control/jobs/control_jobs.c:1666
+#: ../src/control/jobs/control_jobs.c:1661
+#: ../src/control/jobs/control_jobs.c:1668
 msgid "local copy images"
 msgstr "Bilder lokal kopieren"
 
-#: ../src/control/jobs/control_jobs.c:1673 ../src/libs/image.c:532
+#: ../src/control/jobs/control_jobs.c:1675 ../src/libs/image.c:518
 msgid "refresh exif"
-msgstr "Exif aktualisieren"
+msgstr "Exif-Daten aktualisieren"
 
-#: ../src/control/jobs/control_jobs.c:1736
+#: ../src/control/jobs/control_jobs.c:1738
 #, c-format
 msgid "failed to get parameters from storage module `%s', aborting export.."
 msgstr ""
 "Konnte keine Einstellungen vom Speicher-Modul „%s” bekommen, breche Export "
 "ab.."
 
-#: ../src/control/jobs/control_jobs.c:1751
+#: ../src/control/jobs/control_jobs.c:1754
 msgid "export images"
 msgstr "Bilder exportieren"
 
-#: ../src/control/jobs/control_jobs.c:1776
+#: ../src/control/jobs/control_jobs.c:1779
 #, c-format
 msgid "adding time offset to %d image"
 msgid_plural "adding time offset to %d images"
 msgstr[0] "füge Zeitversatz zu %d Bild hinzu"
 msgstr[1] "füge Zeitversatz zu %d Bildern hinzu"
 
-#: ../src/control/jobs/control_jobs.c:1791
+#: ../src/control/jobs/control_jobs.c:1794
 #, c-format
 msgid "added time offset to %d image"
 msgid_plural "added time offset to %d images"
 msgstr[0] "Zeitversatz zu %d Bild hinzugefügt"
 msgstr[1] "Zeitversatz zu %d Bildern hinzugefügt"
 
-#: ../src/control/jobs/control_jobs.c:1830 ../src/libs/geotagging.c:781
+#: ../src/control/jobs/control_jobs.c:1833 ../src/libs/geotagging.c:783
 msgid "time offset"
 msgstr "Zeitversatz"
 
-#: ../src/control/jobs/control_jobs.c:1854 ../src/libs/copy_history.c:332
+#: ../src/control/jobs/control_jobs.c:1857 ../src/libs/copy_history.c:332
 msgid "write sidecar files"
 msgstr "XMP schreiben"
 
@@ -2749,7 +2832,7 @@ msgstr[1] "Importiere %d Bilder"
 msgid "importing image %s"
 msgstr "Bild %s importieren"
 
-#: ../src/control/jobs/image_jobs.c:110 ../src/libs/import.c:753
+#: ../src/control/jobs/image_jobs.c:110 ../src/libs/import.c:790
 msgid "import image"
 msgstr "Bild importieren"
 
@@ -2956,30 +3039,30 @@ msgid "toggle polarity of drawn mask"
 msgstr "Polarität der gezeichneten Maske umkehren"
 
 #: ../src/develop/blend_gui.c:1948 ../src/libs/masks.c:1009
-#: ../src/libs/masks.c:1049 ../src/libs/masks.c:1660
+#: ../src/libs/masks.c:1049 ../src/libs/masks.c:1657
 msgid "add gradient"
 msgstr "Verlauf hinzufügen"
 
-#: ../src/develop/blend_gui.c:1957 ../src/iop/retouch.c:2660
-#: ../src/iop/spots.c:680 ../src/libs/masks.c:1005 ../src/libs/masks.c:1045
-#: ../src/libs/masks.c:1666
+#: ../src/develop/blend_gui.c:1957 ../src/iop/retouch.c:2674
+#: ../src/iop/spots.c:808 ../src/libs/masks.c:1005 ../src/libs/masks.c:1045
+#: ../src/libs/masks.c:1663
 msgid "add path"
 msgstr "Pfad hinzufügen"
 
-#: ../src/develop/blend_gui.c:1966 ../src/iop/retouch.c:2667
-#: ../src/iop/spots.c:687 ../src/libs/masks.c:1001 ../src/libs/masks.c:1041
-#: ../src/libs/masks.c:1673
+#: ../src/develop/blend_gui.c:1966 ../src/iop/retouch.c:2681
+#: ../src/iop/spots.c:815 ../src/libs/masks.c:1001 ../src/libs/masks.c:1041
+#: ../src/libs/masks.c:1670
 msgid "add ellipse"
 msgstr "Ellipse hinzufügen"
 
-#: ../src/develop/blend_gui.c:1975 ../src/iop/retouch.c:2674
-#: ../src/iop/spots.c:694 ../src/libs/masks.c:997 ../src/libs/masks.c:1037
-#: ../src/libs/masks.c:1680
+#: ../src/develop/blend_gui.c:1975 ../src/iop/retouch.c:2688
+#: ../src/iop/spots.c:822 ../src/libs/masks.c:997 ../src/libs/masks.c:1037
+#: ../src/libs/masks.c:1677
 msgid "add circle"
 msgstr "Kreis hinzufügen"
 
-#: ../src/develop/blend_gui.c:1984 ../src/iop/retouch.c:2654
-#: ../src/libs/masks.c:1033 ../src/libs/masks.c:1686
+#: ../src/develop/blend_gui.c:1984 ../src/iop/retouch.c:2668
+#: ../src/libs/masks.c:1033 ../src/libs/masks.c:1683
 msgid "add brush"
 msgstr "Pinsel hinzufügen"
 
@@ -3187,32 +3270,27 @@ msgstr "Modus des Überblendens wählen"
 
 #: ../src/develop/blend_gui.c:2584 ../src/develop/blend_gui.c:2642
 #: ../src/develop/blend_gui.c:2702
-#, fuzzy
 msgid "normal & difference modes"
-msgstr "Normal (überholt)"
+msgstr "Normale- & Differenz-Modi"
 
 #: ../src/develop/blend_gui.c:2593 ../src/develop/blend_gui.c:2651
 #: ../src/develop/blend_gui.c:2711
-#, fuzzy
 msgid "lighten modes"
-msgstr "Helligkeit"
+msgstr "aufhellende Modi"
 
 #: ../src/develop/blend_gui.c:2600 ../src/develop/blend_gui.c:2658
 #: ../src/develop/blend_gui.c:2718
-#, fuzzy
 msgid "darken modes"
-msgstr "weitere Module"
+msgstr "abdunkelnde Modi"
 
 #: ../src/develop/blend_gui.c:2607 ../src/develop/blend_gui.c:2665
 #: ../src/develop/blend_gui.c:2725
-#, fuzzy
 msgid "contrast enhancing modes"
-msgstr "Modus des Überblendens wählen"
+msgstr "kontrastverstärkende Modi"
 
 #: ../src/develop/blend_gui.c:2620 ../src/develop/blend_gui.c:2678
-#, fuzzy
 msgid "color channel modes"
-msgstr "Farbzusammenstellung"
+msgstr "Farbkanal-Modi"
 
 #: ../src/develop/blend_gui.c:2754 ../src/iop/watermark.c:1540
 msgid "opacity"
@@ -3292,7 +3370,7 @@ msgstr "Maske weichzeichnen"
 msgid "radius for gaussian blur of blend mask"
 msgstr "Radius des Gaußschen Weichzeichners der Maske"
 
-#: ../src/develop/blend_gui.c:2833 ../src/iop/retouch.c:2936
+#: ../src/develop/blend_gui.c:2833 ../src/iop/retouch.c:2950
 msgid "mask opacity"
 msgstr "Deckkraft der Maske"
 
@@ -3335,82 +3413,82 @@ msgstr "Maske des aktiven Moduls vorübergehend ausschalten"
 msgid "mask refinement"
 msgstr "Maskenverfeinerung"
 
-#: ../src/develop/develop.c:1748
+#: ../src/develop/develop.c:1780
 #, c-format
 msgid "%s: module `%s' version mismatch: %d != %d"
 msgstr "%s: Modul „%s” hat unpassende Version: %d != %d"
 
-#: ../src/develop/imageop.c:1011
+#: ../src/develop/imageop.c:1012
 msgid "new instance"
 msgstr "neue Instanz"
 
-#: ../src/develop/imageop.c:1017
+#: ../src/develop/imageop.c:1018
 msgid "duplicate instance"
 msgstr "Instanz duplizieren"
 
-#: ../src/develop/imageop.c:1023 ../src/libs/masks.c:1170
+#: ../src/develop/imageop.c:1024 ../src/libs/masks.c:1170
 msgid "move up"
 msgstr "aufwärtsschieben"
 
-#: ../src/develop/imageop.c:1029 ../src/libs/masks.c:1173
+#: ../src/develop/imageop.c:1030 ../src/libs/masks.c:1173
 msgid "move down"
 msgstr "abwärtsschieben"
 
-#: ../src/develop/imageop.c:1035 ../src/libs/image.c:168
-#: ../src/libs/tagging.c:1203 ../src/libs/tagging.c:1300
+#: ../src/develop/imageop.c:1036 ../src/libs/image.c:168
+#: ../src/libs/tagging.c:1258 ../src/libs/tagging.c:1348
 msgid "delete"
 msgstr "löschen"
 
-#: ../src/develop/imageop.c:1042 ../src/libs/tagging.c:1785
+#: ../src/develop/imageop.c:1043 ../src/libs/tagging.c:1771
 msgid "rename"
 msgstr "umbenennen"
 
-#: ../src/develop/imageop.c:1085 ../src/develop/imageop.c:2004
+#: ../src/develop/imageop.c:1086 ../src/develop/imageop.c:2010
 #, c-format
 msgid "%s is switched on"
 msgstr "%s ist eingeschaltet"
 
-#: ../src/develop/imageop.c:1085 ../src/develop/imageop.c:2004
+#: ../src/develop/imageop.c:1086 ../src/develop/imageop.c:2010
 #, c-format
 msgid "%s is switched off"
 msgstr "%s ist ausgeschaltet"
 
-#: ../src/develop/imageop.c:1413 ../src/gui/accelerators.c:828
-#: ../src/gui/accelerators.c:912 ../src/gui/accelerators.c:1127
-#: ../src/gui/accelerators.c:1152 ../src/gui/camera_import_dialog.c:445
+#: ../src/develop/imageop.c:1414 ../src/gui/accelerators.c:938
+#: ../src/gui/accelerators.c:1022 ../src/gui/accelerators.c:1237
+#: ../src/gui/accelerators.c:1262 ../src/gui/camera_import_dialog.c:445
 #: ../src/gui/presets.c:190 ../src/gui/presets.c:303 ../src/gui/presets.c:644
-#: ../src/iop/temperature.c:1461 ../src/libs/import.c:541 ../src/libs/lib.c:319
-#: ../src/libs/lib.c:347 ../src/libs/lib.c:1142
+#: ../src/iop/temperature.c:1468 ../src/libs/import.c:536 ../src/libs/lib.c:319
+#: ../src/libs/lib.c:347 ../src/libs/lib.c:1201
 msgid "preset"
 msgstr "Voreinstellung"
 
-#: ../src/develop/imageop.c:1433
+#: ../src/develop/imageop.c:1434
 msgctxt "accel"
 msgid "fusion"
 msgstr "Überblenden-Deckkraft"
 
 #. Adding the optional show accelerator to the table (blank)
-#: ../src/develop/imageop.c:1438
+#: ../src/develop/imageop.c:1439 ../src/libs/lib.c:621
 msgctxt "accel"
 msgid "show module"
 msgstr "Modul zeigen"
 
-#: ../src/develop/imageop.c:1439
+#: ../src/develop/imageop.c:1440
 msgctxt "accel"
 msgid "enable module"
 msgstr "Modul aktivieren"
 
-#: ../src/develop/imageop.c:1441 ../src/libs/lib.c:613
+#: ../src/develop/imageop.c:1442 ../src/libs/lib.c:613
 msgctxt "accel"
 msgid "reset module parameters"
 msgstr "Modul-Einstellungen zurücksetzen"
 
-#: ../src/develop/imageop.c:1442 ../src/libs/lib.c:617
+#: ../src/develop/imageop.c:1443 ../src/libs/lib.c:617
 msgctxt "accel"
 msgid "show preset menu"
 msgstr "Voreinstellungs-Menü zeigen"
 
-#: ../src/develop/imageop.c:1967
+#: ../src/develop/imageop.c:1973
 msgid ""
 "multiple instances actions\n"
 "middle-click creates new instance"
@@ -3418,17 +3496,17 @@ msgstr ""
 "Multi-Instanz-Optionen\n"
 "Mittelklick erzeugt neue Instanz"
 
-#: ../src/develop/imageop.c:1978 ../src/libs/lib.c:983
+#: ../src/develop/imageop.c:1984 ../src/libs/lib.c:1036
 msgid "reset parameters"
 msgstr "Einstellungen zurücksetzen"
 
 #. Adding the outer container
-#: ../src/develop/imageop.c:1986 ../src/gui/preferences.c:484
-#: ../src/libs/lib.c:992
+#: ../src/develop/imageop.c:1992 ../src/gui/preferences.c:628
+#: ../src/libs/lib.c:1045
 msgid "presets"
 msgstr "Voreinstellungen"
 
-#: ../src/develop/imageop.c:1988
+#: ../src/develop/imageop.c:1994
 msgid ""
 "presets\n"
 "middle-click to apply on new instance"
@@ -3445,13 +3523,6 @@ msgstr "Lightroom-XMP kann nicht gefunden werden!"
 #, c-format
 msgid "`%s' not a lightroom XMP!"
 msgstr "„%s” ist kein Lightroom-XMP!"
-
-#. tags
-#: ../src/develop/lightroom.c:1508 ../src/gui/camera_import_dialog.c:465
-#: ../src/libs/export_metadata.c:310 ../src/libs/image.c:479
-#: ../src/libs/import.c:555 ../src/libs/metadata_view.c:138
-msgid "tags"
-msgstr "Stichwörter"
 
 #. DT_COLLECTION_SORT_DATETIME
 #: ../src/develop/lightroom.c:1517 ../src/libs/tools/filter.c:149
@@ -3715,7 +3786,7 @@ msgstr "gleiche Form verwenden wie"
 msgid "masks can not contain themselves"
 msgstr "Masken können sich nicht selbst enthalten"
 
-#: ../src/develop/pixelpipe_hb.c:2768
+#: ../src/develop/pixelpipe_hb.c:2764
 msgid ""
 "darktable discovered problems with your OpenCL setup; disabling OpenCL for "
 "this session!"
@@ -3734,139 +3805,139 @@ msgid "double-click to reset"
 msgstr "Doppelklick zum Zurücksetzen"
 
 #. setup rating key accelerators
-#: ../src/dtgtk/thumbtable.c:1805
+#: ../src/dtgtk/thumbtable.c:1935
 msgctxt "accel"
 msgid "views/thumbtable/rate 0"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1806
+#: ../src/dtgtk/thumbtable.c:1936
 msgctxt "accel"
 msgid "views/thumbtable/rate 1"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1807
+#: ../src/dtgtk/thumbtable.c:1937
 msgctxt "accel"
 msgid "views/thumbtable/rate 2"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1808
+#: ../src/dtgtk/thumbtable.c:1938
 msgctxt "accel"
 msgid "views/thumbtable/rate 3"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1809
+#: ../src/dtgtk/thumbtable.c:1939
 msgctxt "accel"
 msgid "views/thumbtable/rate 4"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1810
+#: ../src/dtgtk/thumbtable.c:1940
 msgctxt "accel"
 msgid "views/thumbtable/rate 5"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1811
+#: ../src/dtgtk/thumbtable.c:1941
 msgctxt "accel"
 msgid "views/thumbtable/rate reject"
 msgstr ""
 
 #. setup history key accelerators
-#: ../src/dtgtk/thumbtable.c:1814
+#: ../src/dtgtk/thumbtable.c:1944
 msgctxt "accel"
 msgid "views/thumbtable/copy history"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1815
+#: ../src/dtgtk/thumbtable.c:1945
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/copy history parts"
 msgstr "Verlauf teilweise kopieren"
 
-#: ../src/dtgtk/thumbtable.c:1817
+#: ../src/dtgtk/thumbtable.c:1947
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/paste history"
 msgstr "Verlauf einfügen"
 
-#: ../src/dtgtk/thumbtable.c:1818
+#: ../src/dtgtk/thumbtable.c:1948
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/paste history parts"
 msgstr "Verlauf teilweise einfügen"
 
-#: ../src/dtgtk/thumbtable.c:1820
+#: ../src/dtgtk/thumbtable.c:1950
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/discard history"
 msgstr "Verlauf verwerfen"
 
-#: ../src/dtgtk/thumbtable.c:1822
+#: ../src/dtgtk/thumbtable.c:1952
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/duplicate image"
 msgstr "Bild duplizieren"
 
-#: ../src/dtgtk/thumbtable.c:1823
+#: ../src/dtgtk/thumbtable.c:1953
 msgctxt "accel"
 msgid "views/thumbtable/duplicate image virgin"
 msgstr ""
 
 #. setup color label accelerators
-#: ../src/dtgtk/thumbtable.c:1827
+#: ../src/dtgtk/thumbtable.c:1957
 msgctxt "accel"
 msgid "views/thumbtable/color red"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1828
+#: ../src/dtgtk/thumbtable.c:1958
 msgctxt "accel"
 msgid "views/thumbtable/color yellow"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1829
+#: ../src/dtgtk/thumbtable.c:1959
 msgctxt "accel"
 msgid "views/thumbtable/color green"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1830
+#: ../src/dtgtk/thumbtable.c:1960
 msgctxt "accel"
 msgid "views/thumbtable/color blue"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1831
+#: ../src/dtgtk/thumbtable.c:1961
 msgctxt "accel"
 msgid "views/thumbtable/color purple"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1832
+#: ../src/dtgtk/thumbtable.c:1962
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/clear color labels"
 msgstr "Farbmarkierungen entfernen"
 
 #. setup selection accelerators
-#: ../src/dtgtk/thumbtable.c:1835
+#: ../src/dtgtk/thumbtable.c:1965
 msgctxt "accel"
 msgid "views/thumbtable/select all"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1836
+#: ../src/dtgtk/thumbtable.c:1966
 msgctxt "accel"
 msgid "views/thumbtable/select none"
 msgstr ""
 
-#: ../src/dtgtk/thumbtable.c:1838
+#: ../src/dtgtk/thumbtable.c:1968
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/invert selection"
 msgstr "Auswahl invertieren"
 
-#: ../src/dtgtk/thumbtable.c:1839
+#: ../src/dtgtk/thumbtable.c:1969
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/select film roll"
 msgstr "Filmrolle auswählen"
 
 # eigentlich: "unbearbeitete auswählen", was aber zu lang für den Knopf ist.
-#: ../src/dtgtk/thumbtable.c:1840
+#: ../src/dtgtk/thumbtable.c:1970
 #, fuzzy
 msgctxt "accel"
 msgid "views/thumbtable/select untouched"
@@ -3959,7 +4030,7 @@ msgid "high temp. mercury-vapor fluorescent"
 msgstr "Hochtemperatur-Quecksilberdampflampe fluoreszierend"
 
 # too long?
-#. Found in Nikon P1000
+#. Found in Nikon Coolpix P1000
 #: ../src/external/wb_presets.c:68
 #, fuzzy
 msgid "high temp. mercury-vapor"
@@ -3970,44 +4041,40 @@ msgstr "Hochtemperatur-Quecksilberdampflampe fluoreszierend"
 msgid "D55"
 msgstr ""
 
-#: ../src/external/wb_presets.c:71
-msgid "ISO Studio Tungsten"
-msgstr ""
-
-#: ../src/external/wb_presets.c:73
+#: ../src/external/wb_presets.c:72
 msgid "flash"
 msgstr "Blitz"
 
 #. For Olympus with no real "Flash" preset:
-#: ../src/external/wb_presets.c:75
+#: ../src/external/wb_presets.c:74
 msgid "flash (auto mode)"
 msgstr "Blitz (automatischer Modus)"
 
-#: ../src/external/wb_presets.c:76
+#: ../src/external/wb_presets.c:75
 msgid "evening sun"
 msgstr "Abendsonne"
 
-#: ../src/external/wb_presets.c:77
+#: ../src/external/wb_presets.c:76
 msgid "underwater"
 msgstr "unter Wasser"
 
-#: ../src/external/wb_presets.c:78 ../src/views/darkroom.c:2045
+#: ../src/external/wb_presets.c:77 ../src/views/darkroom.c:2119
 msgid "black & white"
 msgstr "schwarz & weiß"
 
-#: ../src/external/wb_presets.c:80
+#: ../src/external/wb_presets.c:79
 msgid "spot WB"
 msgstr "manuell setzen"
 
-#: ../src/external/wb_presets.c:81
+#: ../src/external/wb_presets.c:80
 msgid "manual WB"
 msgstr "manueller Weißabgleich"
 
-#: ../src/external/wb_presets.c:82
+#: ../src/external/wb_presets.c:81
 msgid "camera WB"
 msgstr "Kamera Weißabgleich"
 
-#: ../src/external/wb_presets.c:83
+#: ../src/external/wb_presets.c:82
 msgid "auto WB"
 msgstr "automatischer Weißabgleich"
 
@@ -4072,17 +4139,21 @@ msgstr "Ansichten"
 
 #. accel to select next value
 #. accel to select previous value
+#. dynamic accel
 #. accel to select next value
 #. accel to select previous value
+#. dynamic
 #: ../src/gui/accelerators.c:43 ../src/gui/accelerators.c:53
 #: ../src/gui/accelerators.c:55 ../src/gui/accelerators.c:57
 #: ../src/gui/accelerators.c:59 ../src/gui/accelerators.c:61
 #: ../src/gui/accelerators.c:89 ../src/gui/accelerators.c:104
 #: ../src/gui/accelerators.c:106 ../src/gui/accelerators.c:108
 #: ../src/gui/accelerators.c:110 ../src/gui/accelerators.c:112
-#: ../src/gui/accelerators.c:243 ../src/gui/accelerators.c:245
-#: ../src/gui/accelerators.c:257 ../src/gui/accelerators.c:259
-#: ../src/gui/accelerators.c:590 ../src/gui/accelerators.c:599
+#: ../src/gui/accelerators.c:246 ../src/gui/accelerators.c:248
+#: ../src/gui/accelerators.c:259 ../src/gui/accelerators.c:261
+#: ../src/gui/accelerators.c:272 ../src/gui/accelerators.c:274
+#: ../src/gui/accelerators.c:681 ../src/gui/accelerators.c:690
+#: ../src/gui/accelerators.c:699
 msgctxt "accel"
 msgid "image operations"
 msgstr "Bildoperationen"
@@ -4108,12 +4179,14 @@ msgid "reset"
 msgstr "Zurücksetzen"
 
 #: ../src/gui/accelerators.c:60 ../src/gui/accelerators.c:111
-#: ../src/libs/styles.c:73
+#: ../src/libs/styles.c:74
 msgctxt "accel"
 msgid "edit"
 msgstr "Bearbeiten"
 
 #: ../src/gui/accelerators.c:62 ../src/gui/accelerators.c:113
+#: ../src/gui/accelerators.c:273 ../src/gui/accelerators.c:275
+#: ../src/gui/accelerators.c:700
 msgctxt "accel"
 msgid "dynamic"
 msgstr "Dynamik"
@@ -4123,20 +4196,50 @@ msgctxt "accel"
 msgid "lua"
 msgstr "Lua"
 
-#: ../src/gui/accelerators.c:244 ../src/gui/accelerators.c:246
-#: ../src/gui/accelerators.c:591
+#: ../src/gui/accelerators.c:247 ../src/gui/accelerators.c:249
+#: ../src/gui/accelerators.c:682
 msgctxt "accel"
 msgid "next"
 msgstr ""
 
-#: ../src/gui/accelerators.c:258 ../src/gui/accelerators.c:260
-#: ../src/gui/accelerators.c:600
+#: ../src/gui/accelerators.c:260 ../src/gui/accelerators.c:262
+#: ../src/gui/accelerators.c:691
 #, fuzzy
 msgctxt "accel"
 msgid "previous"
 msgstr "Kurzvorschau"
 
-#: ../src/gui/accelerators.c:895 ../src/libs/lib.c:402
+#: ../src/gui/accelerators.c:575
+#, fuzzy, c-format
+msgid "%s %s / %s: %s"
+msgstr "%s/%s: %s"
+
+#: ../src/gui/accelerators.c:577
+#, fuzzy, c-format
+msgid "%s / %s: %s"
+msgstr "%s/%s: %s"
+
+#: ../src/gui/accelerators.c:579
+#, c-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#: ../src/gui/accelerators.c:584
+#, fuzzy, c-format
+msgid "%s %s / %s"
+msgstr "%s/%s: %s"
+
+#: ../src/gui/accelerators.c:586
+#, fuzzy, c-format
+msgid "%s / %s"
+msgstr "%s/%s: %s"
+
+#: ../src/gui/accelerators.c:588 ../src/libs/tagging.c:2135
+#, c-format
+msgid "%s"
+msgstr "%s"
+
+#: ../src/gui/accelerators.c:1005 ../src/libs/lib.c:402
 msgid "deleting preset for obsolete module"
 msgstr "lösche Voreinstellung für obsoletes Modul"
 
@@ -4149,10 +4252,10 @@ msgid "reset value to default"
 msgstr "Auf Standard zurücksetzen"
 
 #: ../src/gui/camera_import_dialog.c:288 ../src/libs/export_metadata.c:269
-#: ../src/libs/geotagging.c:419 ../src/libs/metadata.c:423
-#: ../src/libs/tagging.c:1203 ../src/libs/tagging.c:1300
-#: ../src/libs/tagging.c:1388 ../src/libs/tagging.c:1561
-#: ../src/libs/tagging.c:1785
+#: ../src/libs/geotagging.c:421 ../src/libs/metadata.c:429
+#: ../src/libs/tagging.c:1258 ../src/libs/tagging.c:1348
+#: ../src/libs/tagging.c:1429 ../src/libs/tagging.c:1554
+#: ../src/libs/tagging.c:1771
 msgid "cancel"
 msgstr "Abbrechen"
 
@@ -4179,16 +4282,16 @@ msgid "storage file"
 msgstr "Dateiname"
 
 #. general settings
-#: ../src/gui/camera_import_dialog.c:347 ../src/gui/preferences.c:217
+#: ../src/gui/camera_import_dialog.c:347 ../src/gui/preferences.c:266
 msgid "general"
 msgstr "allgemein"
 
 #. ignoring of jpegs. hack while we don't handle raw+jpeg in the same directories.
-#: ../src/gui/camera_import_dialog.c:350 ../src/libs/import.c:431
+#: ../src/gui/camera_import_dialog.c:350 ../src/libs/import.c:455
 msgid "ignore JPEG files"
 msgstr "JPEG-Dateien ignorieren"
 
-#: ../src/gui/camera_import_dialog.c:352 ../src/libs/import.c:432
+#: ../src/gui/camera_import_dialog.c:352 ../src/libs/import.c:456
 msgid ""
 "do not load files with an extension of .jpg or .jpeg. this can be useful "
 "when there are raw+JPEG in a directory."
@@ -4197,30 +4300,17 @@ msgstr ""
 "wenn es Raw+JPEG im gleichen Ordner gibt."
 
 #. default metadata
-#: ../src/gui/camera_import_dialog.c:361 ../src/libs/import.c:444
+#: ../src/gui/camera_import_dialog.c:361 ../src/libs/import.c:466
 msgid "apply metadata on import"
 msgstr "Metadaten beim Import hinzufügen"
 
-#: ../src/gui/camera_import_dialog.c:362 ../src/libs/import.c:445
+#: ../src/gui/camera_import_dialog.c:362 ../src/libs/import.c:467
 msgid "apply some metadata to all newly imported images."
 msgstr "Metadaten zu allen neu importierten Bildern hinzufügen."
 
-#: ../src/gui/camera_import_dialog.c:396 ../src/libs/import.c:484
+#: ../src/gui/camera_import_dialog.c:396 ../src/libs/import.c:598
 msgid "comma separated list of tags"
 msgstr "Liste komma-separierter Tags"
-
-#: ../src/gui/camera_import_dialog.c:450
-msgid "creator"
-msgstr "Urheber"
-
-# Herausgeber? Verlag? oder noch was anderes?
-#: ../src/gui/camera_import_dialog.c:455
-msgid "publisher"
-msgstr "Herausgeber"
-
-#: ../src/gui/camera_import_dialog.c:460
-msgid "rights"
-msgstr "Rechte"
 
 #: ../src/gui/camera_import_dialog.c:489
 msgid "override today's date"
@@ -4238,7 +4328,7 @@ msgstr ""
 "$(YEAR), $(MONTH), $(DAY),\n"
 "$(HOUR), $(MINUTE), $(SECONDS)"
 
-#: ../src/gui/camera_import_dialog.c:508 ../src/libs/image.c:356
+#: ../src/gui/camera_import_dialog.c:508 ../src/libs/image.c:342
 msgid "images"
 msgstr "Bilder"
 
@@ -4389,12 +4479,12 @@ msgid "switch view"
 msgstr "Ansicht wechseln"
 
 #. Global zoom in & zoom out
-#: ../src/gui/gtk.c:1383 ../src/libs/tools/lighttable.c:213
+#: ../src/gui/gtk.c:1383 ../src/libs/tools/lighttable.c:214
 msgctxt "accel"
 msgid "zoom in"
 msgstr "Heranzoomen"
 
-#: ../src/gui/gtk.c:1384 ../src/libs/tools/lighttable.c:214
+#: ../src/gui/gtk.c:1384 ../src/libs/tools/lighttable.c:215
 msgctxt "accel"
 msgid "zoom out"
 msgstr "Herauszoomen"
@@ -4426,126 +4516,138 @@ msgid "$(VERSION) - duplicate version"
 msgstr "$(VERSION) – Version des Duplikats"
 
 #: ../src/gui/gtkentry.c:189
+msgid ""
+"$(VERSION_IF_MULTI) - same as $(VERSION) but null string if only one version "
+"exists"
+msgstr ""
+"$(VERSION_IF_MULTI) - itentisch mit $(VERSION) falls mehre Vesionen "
+"existieren, sonst leer"
+
+#: ../src/gui/gtkentry.c:190
+msgid "$(VERSION_NAME) - version name from metadata"
+msgstr "$(VERSION_NAME) - Versionsname aus den Metadaten"
+
+#: ../src/gui/gtkentry.c:191
 msgid "$(SEQUENCE) - sequence number"
 msgstr "$(SEQUENCE) – Sequenznummer"
 
-#: ../src/gui/gtkentry.c:190
+#: ../src/gui/gtkentry.c:192
 msgid "$(MAX_WIDTH) - maximum image export width"
 msgstr "$(MAX_WIDTH) – maximale Breite beim Bildexport"
 
-#: ../src/gui/gtkentry.c:191
+#: ../src/gui/gtkentry.c:193
 msgid "$(MAX_HEIGHT) - maximum image export height"
 msgstr "$(MAX_HEIGHT) – maximale Höhe beim Bildexport"
 
-#: ../src/gui/gtkentry.c:192
+#: ../src/gui/gtkentry.c:194
 msgid "$(YEAR) - year"
 msgstr "$(YEAR) – Jahr"
 
-#: ../src/gui/gtkentry.c:193
+#: ../src/gui/gtkentry.c:195
 msgid "$(MONTH) - month"
 msgstr "$(MONTH) – Monat"
 
-#: ../src/gui/gtkentry.c:194
+#: ../src/gui/gtkentry.c:196
 msgid "$(DAY) - day"
 msgstr "$(DAY) – Tag"
 
-#: ../src/gui/gtkentry.c:195
+#: ../src/gui/gtkentry.c:197
 msgid "$(HOUR) - hour"
 msgstr "$(HOUR) – Stunde"
 
-#: ../src/gui/gtkentry.c:196
+#: ../src/gui/gtkentry.c:198
 msgid "$(MINUTE) - minute"
 msgstr "$(MINUTE) – Minute"
 
-#: ../src/gui/gtkentry.c:197
+#: ../src/gui/gtkentry.c:199
 msgid "$(SECOND) - second"
 msgstr "$(SECOND) – Sekunde"
 
-#: ../src/gui/gtkentry.c:198
-msgid "$(EXIF_YEAR) - EXIF year"
-msgstr "$(EXIF_YEAR) – EXIF-Jahr"
-
-#: ../src/gui/gtkentry.c:199
-msgid "$(EXIF_MONTH) - EXIF month"
-msgstr "$(EXIF_MONTH) – EXIF-Monat"
-
 #: ../src/gui/gtkentry.c:200
-msgid "$(EXIF_DAY) - EXIF day"
-msgstr "$(EXIF_DAY) – EXIF-Tag"
+msgid "$(EXIF_YEAR) - EXIF year"
+msgstr "$(EXIF_YEAR) – Exif-Jahr"
 
 #: ../src/gui/gtkentry.c:201
-msgid "$(EXIF_HOUR) - EXIF hour"
-msgstr "$(EXIF_HOUR) – EXIF-Stunde"
+msgid "$(EXIF_MONTH) - EXIF month"
+msgstr "$(EXIF_MONTH) – Exif-Monat"
 
 #: ../src/gui/gtkentry.c:202
-msgid "$(EXIF_MINUTE) - EXIF minute"
-msgstr "$(EXIF_MINUTE) – EXIF-Minute"
+msgid "$(EXIF_DAY) - EXIF day"
+msgstr "$(EXIF_DAY) – Exif-Tag"
 
 #: ../src/gui/gtkentry.c:203
-msgid "$(EXIF_SECOND) - EXIF second"
-msgstr "$(EXIF_SECOND) – EXIF-Sekunde"
+msgid "$(EXIF_HOUR) - EXIF hour"
+msgstr "$(EXIF_HOUR) – Exif-Stunde"
 
 #: ../src/gui/gtkentry.c:204
+msgid "$(EXIF_MINUTE) - EXIF minute"
+msgstr "$(EXIF_MINUTE) – Exif-Minute"
+
+#: ../src/gui/gtkentry.c:205
+msgid "$(EXIF_SECOND) - EXIF second"
+msgstr "$(EXIF_SECOND) – Exif-Sekunde"
+
+#: ../src/gui/gtkentry.c:206
 msgid "$(EXIF_ISO) - ISO value"
 msgstr "$(EXIF_ISO) – ISO-Wert"
 
-#: ../src/gui/gtkentry.c:205
+#: ../src/gui/gtkentry.c:207
 msgid "$(MAKER) - camera maker"
 msgstr "$(MAKER) – Kamerahersteller"
 
-#: ../src/gui/gtkentry.c:206
+#: ../src/gui/gtkentry.c:208
 msgid "$(MODEL) - camera model"
 msgstr "$(MODEL) – Kameramodell"
 
-#: ../src/gui/gtkentry.c:207
+#: ../src/gui/gtkentry.c:209
 msgid "$(STARS) - star rating"
 msgstr "$(STARS) – Bewertung"
 
-#: ../src/gui/gtkentry.c:208
+#: ../src/gui/gtkentry.c:210
 msgid "$(LABELS) - colorlabels"
 msgstr "$(LABELS) – Farbmarkierungen"
 
-#: ../src/gui/gtkentry.c:209
+#: ../src/gui/gtkentry.c:211
 msgid "$(PICTURES_FOLDER) - pictures folder"
 msgstr "$(PICTURES_FOLDER) – Bilder-Verzeichnis"
 
-#: ../src/gui/gtkentry.c:210
+#: ../src/gui/gtkentry.c:212
 msgid "$(HOME) - home folder"
-msgstr "$(HOME) – home-Verzeichnis"
+msgstr "$(HOME) – Nutzer-Verzeichnis"
 
-#: ../src/gui/gtkentry.c:211
+#: ../src/gui/gtkentry.c:213
 msgid "$(DESKTOP) - desktop folder"
 msgstr "$(DESKTOP) – Desktop-Verzeichnis"
 
-#: ../src/gui/gtkentry.c:212
+#: ../src/gui/gtkentry.c:214
 msgid "$(TITLE) - title from metadata"
 msgstr "$(TITLE) – Titel aus den Metadaten"
 
-#: ../src/gui/gtkentry.c:213
+#: ../src/gui/gtkentry.c:215
 msgid "$(DESCRIPTION) - description from metadata"
 msgstr "$(DESCRIPTION) - Beschreibung aus den Metadaten"
 
-#: ../src/gui/gtkentry.c:214
+#: ../src/gui/gtkentry.c:216
 msgid "$(CREATOR) - creator from metadata"
 msgstr "$(CREATOR) – Urheber aus den Metadaten"
 
-#: ../src/gui/gtkentry.c:215
+#: ../src/gui/gtkentry.c:217
 msgid "$(PUBLISHER) - publisher from metadata"
 msgstr "$(PUBLISHER) – Herausgeber aus den Metadaten"
 
-#: ../src/gui/gtkentry.c:216
+#: ../src/gui/gtkentry.c:218
 msgid "$(RIGHTS) - rights from metadata"
 msgstr "$(RIGHTS) – Rechte aus den Metadaten"
 
-#: ../src/gui/gtkentry.c:217
+#: ../src/gui/gtkentry.c:219
 msgid "$(OPENCL_ACTIVATED) - whether OpenCL is activated"
 msgstr "$(OPENCL_ACTIVATED) – falls OpenCL aktiviert ist"
 
-#: ../src/gui/gtkentry.c:218
+#: ../src/gui/gtkentry.c:220
 msgid "$(CATEGORY0(category)) - subtag of level 0 in hierarchical tags"
 msgstr "$(CATEGORY0(category)) – Tag der Ebene 0 in hierarchischen Tags"
 
-#: ../src/gui/gtkentry.c:219
+#: ../src/gui/gtkentry.c:221
 msgid "$(TAGS) - tags as set in metadata settings"
 msgstr "$(TAGS) – Tags gemäß den Metadateneinstellungen"
 
@@ -4589,7 +4691,7 @@ msgstr "Abschnitte der goldenen Spirale"
 msgid "golden spiral"
 msgstr "Goldene Spirale"
 
-#: ../src/gui/guides.c:444 ../src/imageio/format/pdf.c:681
+#: ../src/gui/guides.c:444 ../src/imageio/format/pdf.c:682
 #: ../src/iop/denoiseprofile.c:4369 ../src/iop/lens.cc:2313
 #: ../src/iop/rawdenoise.c:1006 ../src/libs/tools/filter.c:125
 msgid "all"
@@ -4646,7 +4748,7 @@ msgstr "a_lles auswählen"
 msgid "select _none"
 msgstr "_nichts auswählen"
 
-#: ../src/gui/hist_dialog.c:190 ../src/gui/preferences.c:1384
+#: ../src/gui/hist_dialog.c:190 ../src/gui/preferences.c:1594
 #: ../src/gui/presets.c:387 ../src/libs/lib.c:227
 msgid "_ok"
 msgstr "_OK"
@@ -4664,38 +4766,37 @@ msgstr "Einstellung"
 
 #: ../src/gui/hist_dialog.c:240 ../src/gui/styles_dialog.c:458
 #: ../src/gui/styles_dialog.c:500
-#, fuzzy
 msgid "modules order"
-msgstr "Module"
+msgstr "Modulsortierung"
 
 #: ../src/gui/hist_dialog.c:268
 msgid "can't copy history out of unaltered image"
 msgstr "Kann keinen Verlauf aus unbearbeitetem Bild kopieren"
 
 #. format string and corresponding flag stored into the database
-#: ../src/gui/preferences.c:81 ../src/gui/presets.c:56
+#: ../src/gui/preferences.c:88 ../src/gui/presets.c:56
 msgid "normal images"
 msgstr "normale Bilder"
 
-#: ../src/gui/preferences.c:82 ../src/gui/presets.c:57
-#: ../src/libs/metadata_view.c:297
+#: ../src/gui/preferences.c:89 ../src/gui/presets.c:57
+#: ../src/libs/metadata_view.c:344
 msgid "raw"
 msgstr "Raw"
 
-#: ../src/gui/preferences.c:83 ../src/gui/presets.c:58
+#: ../src/gui/preferences.c:90 ../src/gui/presets.c:58
 msgid "HDR"
 msgstr "HDR"
 
 #. language
-#: ../src/gui/preferences.c:227
+#: ../src/gui/preferences.c:270
 msgid "interface language"
 msgstr "Sprache der Oberfläche"
 
-#: ../src/gui/preferences.c:242
+#: ../src/gui/preferences.c:285
 msgid "double click to reset to the system language"
 msgstr "Doppelklick, um auf die Standardsprache des Systems zurückzusetzen"
 
-#: ../src/gui/preferences.c:244
+#: ../src/gui/preferences.c:287
 msgid ""
 "set the language of the user interface. the system default is marked with an "
 "* (needs a restart)"
@@ -4703,69 +4804,92 @@ msgstr ""
 "Setzt die Sprache der Benutzeroberfläche. Der Systemstandard ist mit einem * "
 "markiert (erfordert Neustart)."
 
-#: ../src/gui/preferences.c:253
+#: ../src/gui/preferences.c:296
 msgid "theme"
 msgstr "Design"
 
-#: ../src/gui/preferences.c:277
+#: ../src/gui/preferences.c:324
 msgid "set the theme for the user interface"
 msgstr "Setzt das Design der Benutzeroberfläche"
 
-#: ../src/gui/preferences.c:288
+#. checkbox to allow user to modify theme with user.css
+#: ../src/gui/preferences.c:327
+msgid "modify selected theme with CSS tweaks below"
+msgstr ""
+
+#: ../src/gui/preferences.c:335
+msgid "modify theme with CSS keyed below (saved to user.css)"
+msgstr ""
+
+#: ../src/gui/preferences.c:355
+msgctxt "usercss"
+msgid "save theme tweaks"
+msgstr ""
+
+#: ../src/gui/preferences.c:395
 msgid "darktable preferences"
 msgstr "darktable-Voreinstellungen"
 
-#: ../src/gui/preferences.c:290
-msgid "close"
-msgstr "schließen"
-
 #. exif
-#: ../src/gui/preferences.c:507 ../src/gui/preferences.c:1425
-#: ../src/gui/presets.c:431 ../src/libs/metadata_view.c:109
+#: ../src/gui/preferences.c:650 ../src/gui/preferences.c:1635
+#: ../src/gui/presets.c:431 ../src/libs/metadata_view.c:118
 msgid "model"
 msgstr "Modell"
 
-#: ../src/gui/preferences.c:511 ../src/gui/preferences.c:1433
-#: ../src/gui/presets.c:438 ../src/libs/metadata_view.c:110
+#: ../src/gui/preferences.c:654 ../src/gui/preferences.c:1643
+#: ../src/gui/presets.c:438 ../src/libs/metadata_view.c:119
 msgid "maker"
 msgstr "Hersteller"
 
-#: ../src/gui/preferences.c:536 ../src/iop/basicadj.c:838
+#: ../src/gui/preferences.c:679 ../src/iop/basicadj.c:838
 #: ../src/iop/borders.c:1038 ../src/iop/levels.c:725
 #: ../src/iop/rgblevels.c:1107
 msgid "auto"
 msgstr "auto"
 
 #. Adding the import/export buttons
-#: ../src/gui/preferences.c:545 ../src/gui/preferences.c:638
+#: ../src/gui/preferences.c:688 ../src/gui/preferences.c:794
 msgctxt "preferences"
 msgid "import..."
 msgstr "importieren..."
 
 #. Adding the outer container
-#: ../src/gui/preferences.c:585
+#: ../src/gui/preferences.c:729
 msgid "shortcuts"
 msgstr "Tastenkombinationen"
 
-#: ../src/gui/preferences.c:596
+#: ../src/gui/preferences.c:740
 msgid "shortcut"
 msgstr "Tastenkombination"
 
-#: ../src/gui/preferences.c:600
+#: ../src/gui/preferences.c:744
 msgid "binding"
 msgstr "Belegung"
 
+#. Adding the search button
+#: ../src/gui/preferences.c:778
+#, fuzzy
+msgctxt "preferences"
+msgid "search"
+msgstr "Suchradius"
+
+#: ../src/gui/preferences.c:779
+msgid ""
+"click or press enter to search\n"
+"click or press enter again to cycle through results"
+msgstr ""
+
 #. export button
-#: ../src/gui/preferences.c:643 ../src/libs/styles.c:472
+#: ../src/gui/preferences.c:799 ../src/libs/styles.c:487
 msgid "export..."
-msgstr "exportieren..."
+msgstr "exportieren"
 
 #. Setting the notification text
-#: ../src/gui/preferences.c:917
+#: ../src/gui/preferences.c:1142
 msgid "press key combination to remap..."
 msgstr "Neue Tastenkombination drücken..."
 
-#: ../src/gui/preferences.c:1017
+#: ../src/gui/preferences.c:1242
 #, c-format
 msgid ""
 "%s accel is already mapped to\n"
@@ -4775,37 +4899,37 @@ msgstr ""
 "Tastenkombination „%s” bereits „%s”\n"
 "zugewiesen. Soll sie überschrieben werden?"
 
-#: ../src/gui/preferences.c:1023
+#: ../src/gui/preferences.c:1248
 msgid "accel conflict"
 msgstr "Konflikt bei der Beschleunigung"
 
-#: ../src/gui/preferences.c:1112 ../src/gui/presets.c:182 ../src/libs/lib.c:339
+#: ../src/gui/preferences.c:1337 ../src/gui/presets.c:182 ../src/libs/lib.c:339
 #, c-format
 msgid "do you really want to delete the preset `%s'?"
 msgstr "Soll die Voreinstellung „%s” wirklich gelöscht werden?"
 
-#: ../src/gui/preferences.c:1116 ../src/gui/presets.c:186 ../src/libs/lib.c:343
+#: ../src/gui/preferences.c:1341 ../src/gui/presets.c:186 ../src/libs/lib.c:343
 msgid "delete preset?"
 msgstr "Voreinstellung löschen?"
 
 #. Non-zero value indicates export
-#: ../src/gui/preferences.c:1152
+#: ../src/gui/preferences.c:1377
 msgid "select file to export"
 msgstr "Datei zum exportieren wählen"
 
 #. Zero value indicates import
-#: ../src/gui/preferences.c:1178
+#: ../src/gui/preferences.c:1403
 msgid "select file to import"
 msgstr "Datei zum importieren wählen"
 
-#: ../src/gui/preferences.c:1179 ../src/gui/preferences.c:1261
-#: ../src/libs/collect.c:244 ../src/libs/copy_history.c:78
-#: ../src/libs/geotagging.c:474 ../src/libs/import.c:754
-#: ../src/libs/import.c:861 ../src/libs/styles.c:324
+#: ../src/gui/preferences.c:1404 ../src/gui/preferences.c:1486
+#: ../src/libs/collect.c:242 ../src/libs/copy_history.c:78
+#: ../src/libs/geotagging.c:476 ../src/libs/import.c:791
+#: ../src/libs/import.c:898 ../src/libs/styles.c:325
 msgid "_open"
 msgstr "Ö_ffnen"
 
-#: ../src/gui/preferences.c:1220
+#: ../src/gui/preferences.c:1445
 msgid ""
 "are you sure you want to restore the default keybindings?  this will erase "
 "any modifications you have made."
@@ -4814,32 +4938,32 @@ msgstr ""
 "wollen? Alle persönlichen Änderungen gehen hierdurch verloren."
 
 #. Zero value indicates import
-#: ../src/gui/preferences.c:1260
+#: ../src/gui/preferences.c:1485
 msgid "select preset to import"
 msgstr "Voreinstellung zum importieren wählen"
 
-#: ../src/gui/preferences.c:1279
+#: ../src/gui/preferences.c:1504
 msgid "failed to import preset"
 msgstr "Voreinstellung konnte nicht importiert werden"
 
-#: ../src/gui/preferences.c:1379 ../src/gui/presets.c:385
+#: ../src/gui/preferences.c:1589 ../src/gui/presets.c:385
 #, c-format
 msgid "edit `%s' for module `%s'"
 msgstr "Bearbeite „%s“ des Moduls „%s“"
 
-#: ../src/gui/preferences.c:1402 ../src/gui/presets.c:408 ../src/libs/lib.c:251
+#: ../src/gui/preferences.c:1612 ../src/gui/presets.c:408 ../src/libs/lib.c:251
 msgid "description or further information"
 msgstr "Beschreibung für weitere Information"
 
-#: ../src/gui/preferences.c:1405 ../src/gui/presets.c:411
+#: ../src/gui/preferences.c:1615 ../src/gui/presets.c:411
 msgid "auto apply this preset to matching images"
 msgstr "Diese Voreinstellung automatisch auf passende Bilder anwenden"
 
-#: ../src/gui/preferences.c:1408 ../src/gui/presets.c:414
+#: ../src/gui/preferences.c:1618 ../src/gui/presets.c:414
 msgid "only show this preset for matching images"
 msgstr "Diese Voreinstellung nur für passende Bilder anzeigen"
 
-#: ../src/gui/preferences.c:1410 ../src/gui/presets.c:415
+#: ../src/gui/preferences.c:1620 ../src/gui/presets.c:415
 msgid ""
 "be very careful with this option. this might be the last time you see your "
 "preset."
@@ -4847,69 +4971,69 @@ msgstr ""
 "Mit dieser Option sehr vorsichtig sein. Es könnte das letzte Mal sein, dass "
 "diese Voreinstellung angezeigt wird."
 
-#: ../src/gui/preferences.c:1424 ../src/gui/presets.c:430
+#: ../src/gui/preferences.c:1634 ../src/gui/presets.c:430
 #, no-c-format
 msgid "string to match model (use % as wildcard)"
 msgstr ""
 "Zeichenkette, auf die das Modell passen muss (‚%‘ als Platzhalter benutzen)"
 
-#: ../src/gui/preferences.c:1432 ../src/gui/presets.c:437
+#: ../src/gui/preferences.c:1642 ../src/gui/presets.c:437
 #, no-c-format
 msgid "string to match maker (use % as wildcard)"
 msgstr ""
 "Zeichenkette, auf die der Hersteller passen muss (‚%‘ als Platzhalter "
 "benutzen)"
 
-#: ../src/gui/preferences.c:1440 ../src/gui/presets.c:444
+#: ../src/gui/preferences.c:1650 ../src/gui/presets.c:444
 #, no-c-format
 msgid "string to match lens (use % as wildcard)"
 msgstr ""
 "Zeichenkette, auf die das Objektiv passen muss (‚%‘ als Platzhalter benutzen)"
 
-#: ../src/gui/preferences.c:1450 ../src/gui/presets.c:454
+#: ../src/gui/preferences.c:1660 ../src/gui/presets.c:454
 msgid "minimum ISO value"
 msgstr "Mindest-ISO-Wert"
 
-#: ../src/gui/preferences.c:1453 ../src/gui/presets.c:457
+#: ../src/gui/preferences.c:1663 ../src/gui/presets.c:457
 msgid "maximum ISO value"
 msgstr "Maximum-ISO-Wert"
 
-#: ../src/gui/preferences.c:1464 ../src/gui/presets.c:468
+#: ../src/gui/preferences.c:1674 ../src/gui/presets.c:468
 msgid "minimum exposure time"
 msgstr "Mindest-Belichtungszeit"
 
-#: ../src/gui/preferences.c:1465 ../src/gui/presets.c:469
+#: ../src/gui/preferences.c:1675 ../src/gui/presets.c:469
 msgid "maximum exposure time"
 msgstr "Maximum-Belichtungszeit"
 
-#: ../src/gui/preferences.c:1479 ../src/gui/presets.c:483
+#: ../src/gui/preferences.c:1689 ../src/gui/presets.c:483
 msgid "minimum aperture value"
 msgstr "Mindest-Blendenwert"
 
-#: ../src/gui/preferences.c:1480 ../src/gui/presets.c:484
+#: ../src/gui/preferences.c:1690 ../src/gui/presets.c:484
 msgid "maximum aperture value"
 msgstr "Maximum-Blendenwert"
 
-#: ../src/gui/preferences.c:1495 ../src/gui/presets.c:500
+#: ../src/gui/preferences.c:1705 ../src/gui/presets.c:500
 msgid "minimum focal length"
 msgstr "Mindest-Brennweite"
 
-#: ../src/gui/preferences.c:1496 ../src/gui/presets.c:501
+#: ../src/gui/preferences.c:1706 ../src/gui/presets.c:501
 msgid "maximum focal length"
 msgstr "Maximum-Brennweite"
 
 #. raw/hdr/ldr
-#: ../src/gui/preferences.c:1505 ../src/gui/presets.c:507
-#: ../src/imageio/format/j2k.c:644
+#: ../src/gui/preferences.c:1715 ../src/gui/presets.c:507
+#: ../src/imageio/format/j2k.c:645
 msgid "format"
 msgstr "Format"
 
-#: ../src/gui/preferences.c:1612 ../src/imageio/storage/disk.c:122
+#: ../src/gui/preferences.c:1822 ../src/imageio/storage/disk.c:122
 #: ../src/imageio/storage/gallery.c:109 ../src/imageio/storage/latex.c:108
 msgid "_select as output destination"
 msgstr "als Ausgabeziel _wählen"
 
-#: ../src/gui/preferences.c:1623
+#: ../src/gui/preferences.c:1833
 #, c-format
 msgid "preset %s was successfully saved"
 msgstr "Voreinstellung „%s” wurde erfolgreich gespeichert"
@@ -4975,7 +5099,7 @@ msgstr "aktualisiere Voreinstellung"
 msgid "favourite"
 msgstr "Favorit"
 
-#: ../src/gui/styles_dialog.c:228 ../src/libs/styles.c:311
+#: ../src/gui/styles_dialog.c:228 ../src/libs/styles.c:312
 #, c-format
 msgid "style %s was successfully saved"
 msgstr "Stil „%s” erfolgreich gespeichert"
@@ -5000,11 +5124,6 @@ msgstr "Neuen Stil erstellen"
 msgid "enter a name for the new style"
 msgstr "Name für den neuen Stil eingeben"
 
-#. DT_COLLECTION_SORT_TITLE
-#: ../src/gui/styles_dialog.c:372 ../src/libs/tools/filter.c:156
-msgid "description"
-msgstr "Beschreibung"
-
 #: ../src/gui/styles_dialog.c:374
 msgid "enter a description for the new style, this description is searchable"
 msgstr ""
@@ -5018,11 +5137,11 @@ msgstr "aktualisieren"
 msgid "can't create style out of unaltered image"
 msgstr "Kann keinen Stil aus unbearbeitetem Bild erzeugen"
 
-#: ../src/imageio/format/copy.c:123 ../src/libs/image.c:500
+#: ../src/imageio/format/copy.c:124 ../src/libs/image.c:486
 msgid "copy"
 msgstr "kopieren"
 
-#: ../src/imageio/format/copy.c:139
+#: ../src/imageio/format/copy.c:140
 msgid ""
 "do a 1:1 copy of the selected files.\n"
 "the global options below do not apply!"
@@ -5031,89 +5150,94 @@ msgstr ""
 "Dateien. Die folgenden globalen Optionen\n"
 "werden nicht benutzt!"
 
-#: ../src/imageio/format/exr.cc:188
+#: ../src/imageio/format/exr.cc:189
 msgid "the selected output profile doesn't work well with exr"
 msgstr "das gewählte Ausgabe-Profil kann mit EXR Probleme geben"
 
-#: ../src/imageio/format/exr.cc:354
+#: ../src/imageio/format/exr.cc:355
 msgid "OpenEXR (float)"
 msgstr "OpenEXR (Fließkomma)"
 
-#: ../src/imageio/format/exr.cc:373
+#: ../src/imageio/format/exr.cc:374
 msgid "compression mode"
 msgstr "Kompression"
 
-#: ../src/imageio/format/exr.cc:376
+#: ../src/imageio/format/exr.cc:377
 msgid "RLE"
 msgstr "RLE"
 
-#: ../src/imageio/format/exr.cc:377
+#: ../src/imageio/format/exr.cc:378
 msgid "ZIPS"
 msgstr "ZIPS"
 
-#: ../src/imageio/format/exr.cc:378
+#: ../src/imageio/format/exr.cc:379
 msgid "ZIP"
 msgstr "ZIP"
 
-#: ../src/imageio/format/exr.cc:379
+#: ../src/imageio/format/exr.cc:380
 msgid "PIZ (default)"
 msgstr "PIZ (Standard)"
 
-#: ../src/imageio/format/exr.cc:380
+#: ../src/imageio/format/exr.cc:381
 msgid "PXR24 (lossy)"
 msgstr "PXR24 (verlustbehaftet)"
 
-#: ../src/imageio/format/exr.cc:381
+#: ../src/imageio/format/exr.cc:382
 msgid "B44 (lossy)"
 msgstr "B44 (verlustbehaftet)"
 
-#: ../src/imageio/format/exr.cc:382
+#: ../src/imageio/format/exr.cc:383
 msgid "B44A (lossy)"
 msgstr "B44A (verlustbehaftet)"
 
-#: ../src/imageio/format/j2k.c:611
+#: ../src/imageio/format/j2k.c:612
 msgid "JPEG 2000 (12-bit)"
 msgstr "JPEG 2000 (12 Bit)"
 
-#: ../src/imageio/format/j2k.c:645
+#: ../src/imageio/format/j2k.c:646
 msgid "J2K"
 msgstr "J2K"
 
-#: ../src/imageio/format/j2k.c:646
+#: ../src/imageio/format/j2k.c:647
 msgid "jp2"
 msgstr "jp2"
 
-#: ../src/imageio/format/j2k.c:659
+#: ../src/imageio/format/j2k.c:653 ../src/imageio/format/jpeg.c:592
+#: ../src/imageio/format/webp.c:332 ../src/libs/camera.c:592
+msgid "quality"
+msgstr "Qualität"
+
+#: ../src/imageio/format/j2k.c:660
 msgid "DCP mode"
 msgstr "DCP-Modus"
 
-#: ../src/imageio/format/j2k.c:661
+#: ../src/imageio/format/j2k.c:662
 msgid "Cinema2K, 24FPS"
 msgstr "Cinema2K, 24FPS"
 
-#: ../src/imageio/format/j2k.c:662
+#: ../src/imageio/format/j2k.c:663
 msgid "Cinema2K, 48FPS"
 msgstr "Cinema2K, 48FPS"
 
-#: ../src/imageio/format/j2k.c:663
+#: ../src/imageio/format/j2k.c:664
 msgid "Cinema4K, 24FPS"
 msgstr "Cinema4K, 24FPS"
 
-#: ../src/imageio/format/jpeg.c:573
+#: ../src/imageio/format/jpeg.c:574
 msgid "JPEG (8-bit)"
 msgstr "JPEG (8 Bit)"
 
-#: ../src/imageio/format/pdf.c:79 ../src/imageio/format/png.c:525
-#: ../src/imageio/format/tiff.c:696
+#: ../src/imageio/format/pdf.c:79 ../src/imageio/format/png.c:526
+#: ../src/imageio/format/tiff.c:707
 msgid "8 bit"
 msgstr "8 Bit"
 
-#: ../src/imageio/format/pdf.c:80 ../src/imageio/format/png.c:526
-#: ../src/imageio/format/tiff.c:697
+#: ../src/imageio/format/pdf.c:80 ../src/imageio/format/png.c:527
+#: ../src/imageio/format/tiff.c:708
 msgid "16 bit"
 msgstr "16 Bit"
 
-#: ../src/imageio/format/pdf.c:202 ../src/imageio/format/pdf.c:488
+#: ../src/imageio/format/pdf.c:202 ../src/imageio/format/pdf.c:489
 msgid "invalid paper size"
 msgstr "ungültiges Papierformat"
 
@@ -5121,35 +5245,27 @@ msgstr "ungültiges Papierformat"
 msgid "invalid border size, using 0"
 msgstr "ungültige Randgröße wurde durch 0 ersetzt"
 
-#: ../src/imageio/format/pdf.c:258 ../src/imageio/storage/disk.c:332
-#: ../src/imageio/storage/email.c:136 ../src/imageio/storage/gallery.c:349
-#: ../src/imageio/storage/gallery.c:390 ../src/imageio/storage/piwigo.c:969
+#: ../src/imageio/format/pdf.c:259 ../src/imageio/storage/disk.c:333
+#: ../src/imageio/storage/email.c:137 ../src/imageio/storage/gallery.c:350
+#: ../src/imageio/storage/gallery.c:391 ../src/imageio/storage/piwigo.c:970
 #, c-format
 msgid "could not export to file `%s'!"
 msgstr "Konnte nicht in Datei „%s” exportieren!"
 
-#: ../src/imageio/format/pdf.c:412
+#: ../src/imageio/format/pdf.c:413
 msgid "PDF"
 msgstr "PDF"
 
-#. title
-#. DT_COLLECTION_SORT_CUSTOM_ORDER
-#: ../src/imageio/format/pdf.c:583 ../src/imageio/storage/gallery.c:185
-#: ../src/imageio/storage/latex.c:185 ../src/imageio/storage/piwigo.c:857
-#: ../src/libs/tools/filter.c:155
-msgid "title"
-msgstr "Titel"
-
-#: ../src/imageio/format/pdf.c:593
+#: ../src/imageio/format/pdf.c:594
 msgid "enter the title of the pdf"
 msgstr "Titel des PDFs eingeben"
 
 #. // papers
-#: ../src/imageio/format/pdf.c:606 ../src/libs/print_settings.c:1271
+#: ../src/imageio/format/pdf.c:607 ../src/libs/print_settings.c:1276
 msgid "paper size"
 msgstr "Papierformat"
 
-#: ../src/imageio/format/pdf.c:611
+#: ../src/imageio/format/pdf.c:612
 msgid ""
 "paper size of the pdf\n"
 "either one from the list or \"<width> [unit] x <height> <unit>\n"
@@ -5159,30 +5275,30 @@ msgstr ""
 "entweder eins aus der Liste oder \"<Breite> [Einheit] x <Höhe> <Einheit>\n"
 "Beispiel: 210 mm x 2,97 cm"
 
-#: ../src/imageio/format/pdf.c:621
+#: ../src/imageio/format/pdf.c:622
 msgid "page orientation"
 msgstr "Seitenausrichtung"
 
-#: ../src/imageio/format/pdf.c:622 ../src/iop/borders.c:1039
-#: ../src/libs/print_settings.c:1280
+#: ../src/imageio/format/pdf.c:623 ../src/iop/borders.c:1039
+#: ../src/libs/print_settings.c:1285
 msgid "portrait"
 msgstr "Hochformat"
 
-#: ../src/imageio/format/pdf.c:623 ../src/iop/borders.c:1040
-#: ../src/libs/print_settings.c:1281
+#: ../src/imageio/format/pdf.c:624 ../src/iop/borders.c:1040
+#: ../src/libs/print_settings.c:1286
 msgid "landscape"
 msgstr "Querformat"
 
-#: ../src/imageio/format/pdf.c:626
+#: ../src/imageio/format/pdf.c:627
 msgid "paper orientation of the pdf"
 msgstr "Papier-Ausrichtung des PDFs"
 
 #. border
-#: ../src/imageio/format/pdf.c:631
+#: ../src/imageio/format/pdf.c:632
 msgid "border"
 msgstr "Rand"
 
-#: ../src/imageio/format/pdf.c:641
+#: ../src/imageio/format/pdf.c:642
 msgid ""
 "empty space around the pdf\n"
 "format: size + unit\n"
@@ -5193,19 +5309,19 @@ msgstr ""
 "Beispiele: 10 mm, 1 inch"
 
 #. dpi
-#: ../src/imageio/format/pdf.c:653
+#: ../src/imageio/format/pdf.c:654
 msgid "dpi"
 msgstr "DPI"
 
-#: ../src/imageio/format/pdf.c:661
+#: ../src/imageio/format/pdf.c:662
 msgid "dpi of the images inside the pdf"
 msgstr "DPI der Bilder im PDF"
 
-#: ../src/imageio/format/pdf.c:668
+#: ../src/imageio/format/pdf.c:669
 msgid "rotate images"
 msgstr "Bilder drehen"
 
-#: ../src/imageio/format/pdf.c:673
+#: ../src/imageio/format/pdf.c:674
 msgid ""
 "images can be rotated to match the pdf orientation to waste less space when "
 "printing"
@@ -5213,55 +5329,55 @@ msgstr ""
 "Bilder können so gedreht werden, dass sie der Ausrichtung des PDFs angepasst "
 "werden, um weniger Platz beim Drucken zu verschwenden"
 
-#: ../src/imageio/format/pdf.c:680
+#: ../src/imageio/format/pdf.c:681
 msgid "TODO: pages"
 msgstr "TODO: Seiten"
 
-#: ../src/imageio/format/pdf.c:682
+#: ../src/imageio/format/pdf.c:683
 msgid "single images"
 msgstr "einzelne Bilder"
 
-#: ../src/imageio/format/pdf.c:683
+#: ../src/imageio/format/pdf.c:684
 msgid "contact sheet"
 msgstr "Kontaktabzug"
 
 #. gtk_grid_attach(grid, GTK_WIDGET(d->pages), 0, ++line, 2, 1);
 #. g_signal_connect(G_OBJECT(d->pages), "value-changed", G_CALLBACK(pages_toggle_callback), self);
-#: ../src/imageio/format/pdf.c:686
+#: ../src/imageio/format/pdf.c:687
 msgid "what pages should be added to the pdf"
 msgstr "welche Seiten sollen dem PDF hinzugefügt werden"
 
-#: ../src/imageio/format/pdf.c:693
+#: ../src/imageio/format/pdf.c:694
 msgid "embed icc profiles"
 msgstr "ICC-Profil einbinden"
 
-#: ../src/imageio/format/pdf.c:698
+#: ../src/imageio/format/pdf.c:699
 msgid "images can be tagged with their icc profile"
 msgstr "Bilder können mit ihrem ICC-Profil versehen werden"
 
-#: ../src/imageio/format/pdf.c:704 ../src/imageio/format/png.c:524
-#: ../src/imageio/format/tiff.c:695
+#: ../src/imageio/format/pdf.c:705 ../src/imageio/format/png.c:525
+#: ../src/imageio/format/tiff.c:706
 msgid "bit depth"
 msgstr "Farbtiefe"
 
-#: ../src/imageio/format/pdf.c:714
+#: ../src/imageio/format/pdf.c:715
 msgid "bits per channel of the embedded images"
 msgstr "Bit pro Farbkanal der eingebetteten Bilder"
 
-#: ../src/imageio/format/pdf.c:720 ../src/imageio/format/png.c:538
-#: ../src/imageio/format/tiff.c:710
+#: ../src/imageio/format/pdf.c:721 ../src/imageio/format/png.c:539
+#: ../src/imageio/format/tiff.c:721
 msgid "compression"
 msgstr "Kompression"
 
-#: ../src/imageio/format/pdf.c:721 ../src/imageio/format/tiff.c:711
+#: ../src/imageio/format/pdf.c:722 ../src/imageio/format/tiff.c:722
 msgid "uncompressed"
 msgstr "unkomprimiert"
 
-#: ../src/imageio/format/pdf.c:722 ../src/imageio/format/tiff.c:712
+#: ../src/imageio/format/pdf.c:723 ../src/imageio/format/tiff.c:723
 msgid "deflate"
 msgstr "Deflate"
 
-#: ../src/imageio/format/pdf.c:725
+#: ../src/imageio/format/pdf.c:726
 msgid ""
 "method used for image compression\n"
 "uncompressed -- fast but big files\n"
@@ -5271,23 +5387,23 @@ msgstr ""
 "unkomprimiert – schnell, aber große Dateien\n"
 "Deflate – kleinere Dateien, aber langsamer"
 
-#: ../src/imageio/format/pdf.c:733
+#: ../src/imageio/format/pdf.c:734
 msgid "image mode"
 msgstr "Bildmodus"
 
-#: ../src/imageio/format/pdf.c:734
+#: ../src/imageio/format/pdf.c:735
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/imageio/format/pdf.c:735
+#: ../src/imageio/format/pdf.c:736
 msgid "draft"
 msgstr "Entwurf"
 
-#: ../src/imageio/format/pdf.c:736
+#: ../src/imageio/format/pdf.c:737
 msgid "debug"
 msgstr "Debug"
 
-#: ../src/imageio/format/pdf.c:739
+#: ../src/imageio/format/pdf.c:740
 msgid ""
 "normal -- just put the images into the pdf\n"
 "draft -- images are replaced with boxes\n"
@@ -5297,15 +5413,15 @@ msgstr ""
 "Entwurf – Bilder durch Rechtecke ersetzen\n"
 "Debug – nur Umrisse und Bounding Boxen zeigen"
 
-#: ../src/imageio/format/pfm.c:117
+#: ../src/imageio/format/pfm.c:118
 msgid "PFM (float)"
 msgstr "PFM (Fließkomma)"
 
-#: ../src/imageio/format/png.c:483
+#: ../src/imageio/format/png.c:484
 msgid "PNG (8/16-bit)"
 msgstr "PNG (8/16 Bit)"
 
-#: ../src/imageio/format/ppm.c:108
+#: ../src/imageio/format/ppm.c:109
 msgid "PPM (16-bit)"
 msgstr "PPM (16 Bit)"
 
@@ -5314,52 +5430,52 @@ msgstr "PPM (16 Bit)"
 msgid "image"
 msgstr "Bild"
 
-#: ../src/imageio/format/tiff.c:634
+#: ../src/imageio/format/tiff.c:645
 msgid "TIFF (8/16/32-bit)"
 msgstr "TIFF (8/16/32 Bit)"
 
-#: ../src/imageio/format/tiff.c:698
+#: ../src/imageio/format/tiff.c:709
 msgid "32 bit (float)"
 msgstr "32 Bit (Fließkomma)"
 
-#: ../src/imageio/format/tiff.c:713
+#: ../src/imageio/format/tiff.c:724
 msgid "deflate with predictor"
 msgstr "Deflate mit Predictor"
 
 # Adobe übersetzt das als "Predictor", habe dazu sonst nichts gefunden
-#: ../src/imageio/format/tiff.c:714
+#: ../src/imageio/format/tiff.c:725
 msgid "deflate with predictor (float)"
 msgstr "Deflate mit Predictor (Fließkomma)"
 
-#: ../src/imageio/format/tiff.c:720
+#: ../src/imageio/format/tiff.c:731
 msgid "compression level"
 msgstr "Kompressionsstärke"
 
-#: ../src/imageio/format/webp.c:287
+#: ../src/imageio/format/webp.c:288
 msgid "WebP (8-bit)"
 msgstr "WebP (8 Bit)"
 
-#: ../src/imageio/format/webp.c:324
+#: ../src/imageio/format/webp.c:325
 msgid "compression type"
 msgstr "Kompression"
 
-#: ../src/imageio/format/webp.c:325
+#: ../src/imageio/format/webp.c:326
 msgid "lossy"
 msgstr "verlustbehaftet"
 
-#: ../src/imageio/format/webp.c:326
+#: ../src/imageio/format/webp.c:327
 msgid "lossless"
 msgstr "verlustlos"
 
-#: ../src/imageio/format/webp.c:334
+#: ../src/imageio/format/webp.c:335
 msgid "applies only to lossy setting"
 msgstr "nur bei verlustbehafteter Kompression relevant"
 
-#: ../src/imageio/format/webp.c:345
+#: ../src/imageio/format/webp.c:346
 msgid "image hint"
 msgstr "Bild-Hinweis"
 
-#: ../src/imageio/format/webp.c:347
+#: ../src/imageio/format/webp.c:348
 msgid ""
 "image characteristics hint for the underlying encoder.\n"
 "picture : digital picture, like portrait, inner shot\n"
@@ -5371,23 +5487,23 @@ msgstr ""
 "Foto: Außenaufnahme mit natürlichem Licht\n"
 "Grafik: Bild mit begrenztem Farbumfang (Grafik, Kartenkachel usw.)"
 
-#: ../src/imageio/format/webp.c:351
+#: ../src/imageio/format/webp.c:352
 msgid "default"
 msgstr "Standard"
 
-#: ../src/imageio/format/webp.c:352
+#: ../src/imageio/format/webp.c:353
 msgid "picture"
 msgstr "Bild"
 
-#: ../src/imageio/format/webp.c:353
+#: ../src/imageio/format/webp.c:354
 msgid "photo"
 msgstr "Foto"
 
-#: ../src/imageio/format/webp.c:354
+#: ../src/imageio/format/webp.c:355
 msgid "graphic"
 msgstr "Grafik"
 
-#: ../src/imageio/storage/disk.c:70 ../src/libs/export.c:536
+#: ../src/imageio/storage/disk.c:70 ../src/libs/export.c:544
 msgid "file on disk"
 msgstr "Datei auf Festplatte"
 
@@ -5411,7 +5527,7 @@ msgid "create unique filename"
 msgstr "umbenennen"
 
 #: ../src/imageio/storage/disk.c:201 ../src/libs/copy_history.c:318
-#: ../src/libs/image.c:526
+#: ../src/libs/image.c:512 ../src/libs/styles.c:450
 msgid "overwrite"
 msgstr "überschreiben"
 
@@ -5419,33 +5535,33 @@ msgstr "überschreiben"
 msgid "skip"
 msgstr "überspringen"
 
-#: ../src/imageio/storage/disk.c:281 ../src/imageio/storage/gallery.c:274
-#: ../src/imageio/storage/latex.c:273
+#: ../src/imageio/storage/disk.c:282 ../src/imageio/storage/gallery.c:275
+#: ../src/imageio/storage/latex.c:274
 #, c-format
 msgid "could not create directory `%s'!"
 msgstr "Konnte Verzeichnis „%s” nicht erstellen!"
 
-#: ../src/imageio/storage/disk.c:288
+#: ../src/imageio/storage/disk.c:289
 #, c-format
 msgid "could not write to directory `%s'!"
 msgstr "Konnte nicht in Verzeichnis „%s” schreiben!"
 
-#: ../src/imageio/storage/disk.c:318
+#: ../src/imageio/storage/disk.c:319
 #, c-format
 msgid "%d/%d skipping `%s'"
 msgid_plural "%d/%d skipping `%s'"
 msgstr[0] "%d/%d überspringen `%s'"
 msgstr[1] "%d/%d überspringen `%s'"
 
-#: ../src/imageio/storage/disk.c:337 ../src/imageio/storage/email.c:143
-#: ../src/imageio/storage/gallery.c:398 ../src/imageio/storage/latex.c:362
+#: ../src/imageio/storage/disk.c:338 ../src/imageio/storage/email.c:144
+#: ../src/imageio/storage/gallery.c:399 ../src/imageio/storage/latex.c:363
 #, c-format
 msgid "%d/%d exported to `%s'"
 msgid_plural "%d/%d exported to `%s'"
 msgstr[0] "%d/%d exportiert nach `%s'"
 msgstr[1] "%d/%d exportiert nach `%s'"
 
-#: ../src/imageio/storage/disk.c:396
+#: ../src/imageio/storage/disk.c:397
 msgid ""
 "you are going to export on overwrite mode, this will overwrite any existing "
 "images\n"
@@ -5461,11 +5577,11 @@ msgstr ""
 msgid "send as email"
 msgstr "als E-Mail senden"
 
-#: ../src/imageio/storage/email.c:197
+#: ../src/imageio/storage/email.c:198
 msgid "images exported from darktable"
 msgstr "Aus darktable exportierte Bilder"
 
-#: ../src/imageio/storage/email.c:250
+#: ../src/imageio/storage/email.c:251
 msgid "could not launch email client!"
 msgstr "Konnte E-Mail-Programm nicht starten!"
 
@@ -5598,16 +5714,16 @@ msgstr "Übergeordnetes Album"
 msgid "click login button to start"
 msgstr "zum Starten den Login-Knopf drücken"
 
-#: ../src/imageio/storage/piwigo.c:988
+#: ../src/imageio/storage/piwigo.c:989
 msgid "cannot create a new piwigo album!"
 msgstr "Konnte kein neues Piwigo-Album erstellen!"
 
-#: ../src/imageio/storage/piwigo.c:997
+#: ../src/imageio/storage/piwigo.c:998
 msgid "could not upload to piwigo!"
 msgstr "Konnte nicht zu Piwigo hochladen!"
 
 #. this makes sense only if the export was successful
-#: ../src/imageio/storage/piwigo.c:1026
+#: ../src/imageio/storage/piwigo.c:1027
 #, c-format
 msgid "%d/%d exported to piwigo webalbum"
 msgid_plural "%d/%d exported to piwigo webalbum"
@@ -5663,7 +5779,7 @@ msgctxt "accel"
 msgid "guides"
 msgstr "Hilfslinien"
 
-#: ../src/iop/ashift.c:527 ../src/iop/clipping.c:3358
+#: ../src/iop/ashift.c:527 ../src/iop/clipping.c:3464
 #, fuzzy
 msgctxt "accel"
 msgid "automatic cropping"
@@ -5705,14 +5821,14 @@ msgid "lens shift (%s)"
 msgstr "Objektivverschiebung (%s)"
 
 #: ../src/iop/ashift.c:4635 ../src/iop/ashift.c:4636 ../src/iop/ashift.c:4741
-#: ../src/iop/ashift.c:4742 ../src/iop/clipping.c:1742
-#: ../src/iop/clipping.c:2042 ../src/iop/clipping.c:2088
+#: ../src/iop/ashift.c:4742 ../src/iop/clipping.c:1870
+#: ../src/iop/clipping.c:2142 ../src/iop/clipping.c:2188
 msgid "horizontal"
 msgstr "horizontal"
 
 #: ../src/iop/ashift.c:4635 ../src/iop/ashift.c:4636 ../src/iop/ashift.c:4741
-#: ../src/iop/ashift.c:4742 ../src/iop/clipping.c:1741
-#: ../src/iop/clipping.c:2043 ../src/iop/clipping.c:2087
+#: ../src/iop/ashift.c:4742 ../src/iop/clipping.c:1869
+#: ../src/iop/clipping.c:2143 ../src/iop/clipping.c:2187
 msgid "vertical"
 msgstr "vertikal"
 
@@ -5733,12 +5849,12 @@ msgstr "Objektivverschiebung (horizontal)"
 msgid "shear"
 msgstr "Scherung"
 
-#: ../src/iop/ashift.c:4868 ../src/iop/clipping.c:2219
+#: ../src/iop/ashift.c:4868 ../src/iop/clipping.c:2319
 #: ../src/libs/live_view.c:341
 msgid "guides"
 msgstr "Hilfslinien"
 
-#: ../src/iop/ashift.c:4874 ../src/iop/clipping.c:2095
+#: ../src/iop/ashift.c:4874 ../src/iop/clipping.c:2195
 msgid "automatic cropping"
 msgstr "automatisch Zuschneiden"
 
@@ -5799,7 +5915,7 @@ msgstr "Bild entlang einer Diagonalen scheren"
 msgid "display guide lines overlay"
 msgstr "Hilfslinien anzeigen"
 
-#: ../src/iop/ashift.c:4987 ../src/iop/clipping.c:2098
+#: ../src/iop/ashift.c:4987 ../src/iop/clipping.c:2198
 msgid "automatically crop to avoid black edges"
 msgstr "Automatisch zuschneiden, um schwarze Ränder zu vermeiden"
 
@@ -6205,15 +6321,15 @@ msgid "preserve colors"
 msgstr "erhalte Farben"
 
 #: ../src/iop/basecurve.c:2183 ../src/iop/basecurve.c:2196
-#: ../src/iop/basicadj.c:793 ../src/iop/clipping.c:1740
-#: ../src/iop/clipping.c:2041 ../src/iop/clipping.c:2086
-#: ../src/iop/clipping.c:2226 ../src/iop/clipping.c:2253
+#: ../src/iop/basicadj.c:793 ../src/iop/clipping.c:1868
+#: ../src/iop/clipping.c:2141 ../src/iop/clipping.c:2186
+#: ../src/iop/clipping.c:2326 ../src/iop/clipping.c:2353
 #: ../src/iop/colorreconstruction.c:1381 ../src/iop/lens.cc:2307
 #: ../src/iop/retouch.c:581 ../src/iop/rgbcurve.c:1613
 #: ../src/iop/rgblevels.c:1135 ../src/iop/tonecurve.c:1438
-#: ../src/libs/collect.c:1516 ../src/libs/export.c:519
+#: ../src/libs/collect.c:1518 ../src/libs/export.c:527
 #: ../src/libs/live_view.c:348 ../src/libs/live_view.c:373
-#: ../src/libs/live_view.c:382 ../src/libs/print_settings.c:1469
+#: ../src/libs/live_view.c:382 ../src/libs/print_settings.c:1474
 msgid "none"
 msgstr "keine"
 
@@ -6297,7 +6413,7 @@ msgstr ""
 "Soll die Belichtung angehoben oder abgesenkt werden (-1: Spitzlichter "
 "abschwächen, +1: Schatten abschwächen)"
 
-#: ../src/iop/basecurve.c:2218
+#: ../src/iop/basecurve.c:2218 ../src/libs/metadata_view.c:123
 msgid "exposure bias"
 msgstr "Belichtungstendenz"
 
@@ -6415,7 +6531,7 @@ msgstr "mittelgrau"
 msgid "middle grey adjustment"
 msgstr "mittlere Graueinstellung"
 
-#: ../src/iop/basicadj.c:819 ../src/iop/colisa.c:382 ../src/iop/retouch.c:2903
+#: ../src/iop/basicadj.c:819 ../src/iop/colisa.c:382 ../src/iop/retouch.c:2917
 #: ../src/iop/soften.c:750 ../src/iop/vignette.c:1160
 msgid "brightness"
 msgstr "Helligkeit"
@@ -6518,8 +6634,9 @@ msgstr "Modus"
 #: ../src/iop/lens.cc:2456 ../src/iop/levels.c:692
 #: ../src/iop/profile_gamma.c:859 ../src/iop/rgbcurve.c:1506
 #: ../src/iop/rgblevels.c:1033 ../src/libs/copy_history.c:316
-#: ../src/libs/export.c:688 ../src/libs/image.c:524
-#: ../src/libs/print_settings.c:1510 ../src/views/darkroom.c:1980
+#: ../src/libs/export.c:703 ../src/libs/image.c:510
+#: ../src/libs/print_settings.c:1515 ../src/libs/styles.c:448
+#: ../src/views/darkroom.c:2054
 msgid "mode"
 msgstr "Modus"
 
@@ -6604,40 +6721,40 @@ msgid "radius"
 msgstr "Radius"
 
 #: ../src/iop/bilateral.cc:90 ../src/iop/channelmixer.c:132
-#: ../src/iop/temperature.c:210
+#: ../src/iop/temperature.c:211
 msgctxt "accel"
 msgid "red"
 msgstr "Rot"
 
 #: ../src/iop/bilateral.cc:91 ../src/iop/channelmixer.c:133
-#: ../src/iop/temperature.c:211
+#: ../src/iop/temperature.c:212
 msgctxt "accel"
 msgid "green"
 msgstr "Grün"
 
 #: ../src/iop/bilateral.cc:92 ../src/iop/channelmixer.c:134
-#: ../src/iop/temperature.c:212
+#: ../src/iop/temperature.c:213
 msgctxt "accel"
 msgid "blue"
 msgstr "Blau"
 
-#: ../src/iop/bilateral.cc:367
+#: ../src/iop/bilateral.cc:363
 msgid "spatial extent of the gaussian"
 msgstr "Ausdehnung des Gaußschen Weichzeichners"
 
-#: ../src/iop/bilateral.cc:368
+#: ../src/iop/bilateral.cc:364
 msgid "how much to blur red"
 msgstr "wie stark soll Rot weichgezeichnet werden"
 
-#: ../src/iop/bilateral.cc:369
+#: ../src/iop/bilateral.cc:365
 msgid "how much to blur green"
 msgstr "wie stark soll Grün weichgezeichnet werden"
 
-#: ../src/iop/bilateral.cc:370
+#: ../src/iop/bilateral.cc:366
 msgid "how much to blur blue"
 msgstr "wie stark soll Blau weichgezeichnet werden"
 
-#: ../src/iop/bilateral.cc:372 ../src/iop/clahe.c:337 ../src/iop/dither.c:819
+#: ../src/iop/bilateral.cc:368 ../src/iop/clahe.c:337 ../src/iop/dither.c:819
 #: ../src/iop/lowpass.c:686 ../src/iop/shadhi.c:847 ../src/iop/sharpen.c:789
 msgid "radius"
 msgstr "Radius"
@@ -6767,7 +6884,7 @@ msgstr "2:1"
 msgid "16:9"
 msgstr "16:9"
 
-#: ../src/iop/borders.c:950 ../src/iop/clipping.c:2114
+#: ../src/iop/borders.c:950 ../src/iop/clipping.c:2214
 msgid "golden cut"
 msgstr "Goldener Schnitt"
 
@@ -6787,7 +6904,7 @@ msgstr "DIN"
 msgid "4:3"
 msgstr "4:3"
 
-#: ../src/iop/borders.c:955 ../src/iop/clipping.c:2104
+#: ../src/iop/borders.c:955 ../src/iop/clipping.c:2204
 msgid "square"
 msgstr "quadratisch"
 
@@ -6828,7 +6945,7 @@ msgstr "Randgröße"
 msgid "size of the border in percent of the full image"
 msgstr "Größe des Randes in Prozent des ganzen Bildes"
 
-#: ../src/iop/borders.c:1023 ../src/iop/clipping.c:2201
+#: ../src/iop/borders.c:1023 ../src/iop/clipping.c:2301
 msgid "aspect"
 msgstr "Format"
 
@@ -6842,7 +6959,7 @@ msgid "set the custom aspect ratio"
 msgstr "Seitenverhältnis setzen (b:h)"
 
 #: ../src/iop/borders.c:1037 ../src/iop/flip.c:75
-#: ../src/libs/print_settings.c:1279
+#: ../src/libs/print_settings.c:1284
 msgid "orientation"
 msgstr "Drehung"
 
@@ -7089,180 +7206,185 @@ msgstr "Größe der Strukturen, die erhalten bleiben sollen"
 msgid "strength of the effect"
 msgstr "Stärke des Effekts"
 
-#: ../src/iop/clipping.c:299
+#: ../src/iop/clipping.c:301
 msgid "crop and rotate"
 msgstr "Zuschneiden und drehen"
 
-#: ../src/iop/clipping.c:1612
+#: ../src/iop/clipping.c:1615
 msgid "invalid ratio format. it should be \"number:number\""
 msgstr "Ungültiges Seitenverhältnis. Es sollte „Zahl:Zahl“ sein"
 
-#: ../src/iop/clipping.c:1743 ../src/iop/clipping.c:2089
+#: ../src/iop/clipping.c:1632
+#, fuzzy
+msgid "invalid ratio format. it should be non zero"
+msgstr "Ungültiges Seitenverhältnis. Es sollte „Zahl:Zahl“ sein"
+
+#: ../src/iop/clipping.c:1871 ../src/iop/clipping.c:2189
 msgid "full"
 msgstr "vollständig"
 
-#: ../src/iop/clipping.c:1744
+#: ../src/iop/clipping.c:1872
 msgid "old system"
 msgstr "altes System"
 
-#: ../src/iop/clipping.c:1745
+#: ../src/iop/clipping.c:1873
 msgid "correction applied"
 msgstr "Korrektur angewandt"
 
-#: ../src/iop/clipping.c:2030
+#: ../src/iop/clipping.c:2130
 msgid "main"
 msgstr ""
 
-#: ../src/iop/clipping.c:2031
+#: ../src/iop/clipping.c:2131
 #, fuzzy
 msgid "margins"
 msgstr "oberer Rand"
 
-#: ../src/iop/clipping.c:2040 ../src/libs/live_view.c:372
+#: ../src/iop/clipping.c:2140 ../src/libs/live_view.c:372
 msgid "flip"
 msgstr "spiegeln"
 
-#: ../src/iop/clipping.c:2044 ../src/iop/clipping.c:2256
+#: ../src/iop/clipping.c:2144 ../src/iop/clipping.c:2356
 #: ../src/iop/colorbalance.c:2387 ../src/libs/live_view.c:376
 msgid "both"
 msgstr "beides"
 
-#: ../src/iop/clipping.c:2046
+#: ../src/iop/clipping.c:2146
 msgid "mirror image horizontally and/or vertically"
 msgstr "Bild horizontal und/oder vertikal spiegeln"
 
-#: ../src/iop/clipping.c:2050
+#: ../src/iop/clipping.c:2150
 msgid "angle"
 msgstr "Winkel"
 
 # sehr unschön :-(
-#: ../src/iop/clipping.c:2053
+#: ../src/iop/clipping.c:2153
 msgid "right-click and drag a line on the image to drag a straight line"
 msgstr ""
 "Mit rechter Maustaste ins Bild klicken und eine Linie ziehen, um eine gerade "
 "Kante zu markieren"
 
-#: ../src/iop/clipping.c:2057
+#: ../src/iop/clipping.c:2157
 #, fuzzy
 msgid "left"
 msgstr "oben links"
 
-#: ../src/iop/clipping.c:2060
+#: ../src/iop/clipping.c:2160
 msgid "the left margin cannot overlap with the right margin"
 msgstr ""
 
-#: ../src/iop/clipping.c:2064
+#: ../src/iop/clipping.c:2164
 #, fuzzy
 msgid "right"
 msgstr "Rechte"
 
-#: ../src/iop/clipping.c:2067
+#: ../src/iop/clipping.c:2167
 msgid "the right margin cannot overlap with the left margin"
 msgstr ""
 
-#: ../src/iop/clipping.c:2071
+#: ../src/iop/clipping.c:2171
 msgid "top"
 msgstr ""
 
-#: ../src/iop/clipping.c:2074
+#: ../src/iop/clipping.c:2174
 msgid "the top margin cannot overlap with the bottom margin"
 msgstr ""
 
-#: ../src/iop/clipping.c:2078
+#: ../src/iop/clipping.c:2178
 #, fuzzy
 msgid "bottom"
 msgstr "unten"
 
-#: ../src/iop/clipping.c:2081
+#: ../src/iop/clipping.c:2181
 msgid "the bottom margin cannot overlap with the top margin"
 msgstr ""
 
-#: ../src/iop/clipping.c:2085
+#: ../src/iop/clipping.c:2185
 msgid "keystone"
 msgstr "Trapezkorrektur"
 
-#: ../src/iop/clipping.c:2090
+#: ../src/iop/clipping.c:2190
 msgid "set perspective correction for your image"
 msgstr "Perspektivische Korrektur des Bildes festlegen"
 
-#: ../src/iop/clipping.c:2102
+#: ../src/iop/clipping.c:2202
 msgid "freehand"
 msgstr "frei"
 
-#: ../src/iop/clipping.c:2103
+#: ../src/iop/clipping.c:2203
 msgid "original image"
 msgstr "Original"
 
-#: ../src/iop/clipping.c:2105
+#: ../src/iop/clipping.c:2205
 msgid "10:8 in print"
 msgstr "10:8 für Druck"
 
-#: ../src/iop/clipping.c:2106
+#: ../src/iop/clipping.c:2206
 msgid "5:4, 4x5, 8x10"
 msgstr "5:4, 4×5, 8×10"
 
-#: ../src/iop/clipping.c:2107
+#: ../src/iop/clipping.c:2207
 msgid "11x14"
 msgstr "11×14"
 
-#: ../src/iop/clipping.c:2108
+#: ../src/iop/clipping.c:2208
 msgid "8.5x11, letter"
 msgstr "8,5×11, Letter"
 
-#: ../src/iop/clipping.c:2109
+#: ../src/iop/clipping.c:2209
 msgid "4:3, VGA, TV"
 msgstr "4:3, VGA, TV"
 
-#: ../src/iop/clipping.c:2110
+#: ../src/iop/clipping.c:2210
 msgid "5x7"
 msgstr "5×7"
 
-#: ../src/iop/clipping.c:2111
+#: ../src/iop/clipping.c:2211
 msgid "ISO 216, DIN 476, A4"
 msgstr "ISO 216, DIN 476, A4"
 
-#: ../src/iop/clipping.c:2112
+#: ../src/iop/clipping.c:2212
 msgid "3:2, 4x6, 35mm"
 msgstr "3:2, 4×6, 35mm"
 
-#: ../src/iop/clipping.c:2113
+#: ../src/iop/clipping.c:2213
 msgid "16:10, 8x5"
 msgstr "16:10, 8×5"
 
-#: ../src/iop/clipping.c:2115
+#: ../src/iop/clipping.c:2215
 msgid "16:9, HDTV"
 msgstr "16:9, HDTV"
 
-#: ../src/iop/clipping.c:2116
+#: ../src/iop/clipping.c:2216
 msgid "widescreen"
 msgstr "Breitbild"
 
-#: ../src/iop/clipping.c:2117
+#: ../src/iop/clipping.c:2217
 msgid "2:1, univisium"
 msgstr "2:1, Univisium"
 
-#: ../src/iop/clipping.c:2118
+#: ../src/iop/clipping.c:2218
 msgid "cinemascope"
 msgstr "CinemaScope"
 
-#: ../src/iop/clipping.c:2119
+#: ../src/iop/clipping.c:2219
 msgid "21:9"
 msgstr "21:9"
 
-#: ../src/iop/clipping.c:2120
+#: ../src/iop/clipping.c:2220
 msgid "anamorphic"
 msgstr "anamorph"
 
-#: ../src/iop/clipping.c:2121
+#: ../src/iop/clipping.c:2221
 msgid "3:1, panorama"
 msgstr "3:1, Panorama"
 
-#: ../src/iop/clipping.c:2153 ../src/iop/clipping.c:2165
+#: ../src/iop/clipping.c:2253 ../src/iop/clipping.c:2265
 #, c-format
 msgid "invalid ratio format for `%s'. it should be \"number:number\""
 msgstr "Ungültiges Seitenverhältnis für „%s”. Es sollte „Zahl:Zahl“ sein"
 
-#: ../src/iop/clipping.c:2212
+#: ../src/iop/clipping.c:2312
 msgid ""
 "set the aspect ratio\n"
 "the list is sorted: from most square to least square"
@@ -7270,91 +7392,91 @@ msgstr ""
 "Seitenverhältnis\n"
 "die Liste ist nach absteigendem Seitenverhätnis sortiert"
 
-#: ../src/iop/clipping.c:2248 ../src/libs/live_view.c:368
+#: ../src/iop/clipping.c:2348 ../src/libs/live_view.c:368
 msgid "display guide lines to help compose your photograph"
 msgstr "Hilfslinien anzeigen, die beim Komponieren der Fotografie helfen."
 
-#: ../src/iop/clipping.c:2252 ../src/iop/clipping.c:2257
+#: ../src/iop/clipping.c:2352 ../src/iop/clipping.c:2357
 #: ../src/libs/live_view.c:377
 msgid "flip guides"
 msgstr "Hilfslinien spiegeln"
 
-#: ../src/iop/clipping.c:2254 ../src/libs/live_view.c:374
+#: ../src/iop/clipping.c:2354 ../src/libs/live_view.c:374
 msgid "horizontally"
 msgstr "horizontal"
 
-#: ../src/iop/clipping.c:2255 ../src/libs/live_view.c:375
+#: ../src/iop/clipping.c:2355 ../src/libs/live_view.c:375
 msgid "vertically"
 msgstr "vertikal"
 
-#: ../src/iop/clipping.c:3348
+#: ../src/iop/clipping.c:3454
 msgctxt "accel"
 msgid "commit"
 msgstr "Änderungen übernehmen"
 
-#: ../src/iop/clipping.c:3349
+#: ../src/iop/clipping.c:3455
 msgctxt "accel"
 msgid "angle"
 msgstr "Winkel"
 
-#: ../src/iop/clipping.c:3350
+#: ../src/iop/clipping.c:3456
 #, fuzzy
 msgctxt "accel"
 msgid "left"
 msgstr "oben links"
 
-#: ../src/iop/clipping.c:3351
+#: ../src/iop/clipping.c:3457
 msgctxt "accel"
 msgid "top"
 msgstr ""
 
-#: ../src/iop/clipping.c:3352
+#: ../src/iop/clipping.c:3458
 #, fuzzy
 msgctxt "accel"
 msgid "right"
 msgstr "Rechte"
 
-#: ../src/iop/clipping.c:3353
+#: ../src/iop/clipping.c:3459
 #, fuzzy
 msgctxt "accel"
 msgid "bottom"
 msgstr "unten"
 
-#: ../src/iop/clipping.c:3354
+#: ../src/iop/clipping.c:3460
 #, fuzzy
 msgctxt "accel"
 msgid "aspect ratio"
 msgstr "Seitenverhältnis"
 
-#: ../src/iop/clipping.c:3355
+#: ../src/iop/clipping.c:3461
 #, fuzzy
 msgctxt "accel"
 msgid "guide lines"
 msgstr "Hilfslinien"
 
-#: ../src/iop/clipping.c:3356
+#: ../src/iop/clipping.c:3462
 #, fuzzy
 msgctxt "accel"
 msgid "flip"
 msgstr "spiegeln"
 
-#: ../src/iop/clipping.c:3357
+#: ../src/iop/clipping.c:3463
 #, fuzzy
 msgctxt "accel"
 msgid "keystone"
 msgstr "Trapezkorrektur"
 
-#: ../src/iop/clipping.c:3388
+#: ../src/iop/clipping.c:3494
 #, c-format
 msgid "[%s on borders] crop"
 msgstr "[%s on borders] Zuschnitt"
 
-#: ../src/iop/clipping.c:3394
+#: ../src/iop/clipping.c:3500
 #, c-format
 msgid "[%s on borders] crop keeping ratio"
 msgstr "[%s on borders] Verhältnis des Zuschnitt"
 
-#: ../src/iop/clipping.c:3399
+#: ../src/iop/clipping.c:3505
 #, c-format
 msgid "[%s] define/rotate horizon"
 msgstr "[%s] Horizont definieren/drehen"
@@ -7838,25 +7960,25 @@ msgid "unsupported input profile has been replaced by linear Rec709 RGB!"
 msgstr ""
 "Nicht unterstütztes Eingabeprofil wurde durch lineares Rec709-RGB ersetzt!"
 
-#: ../src/iop/colorin.c:2114
+#: ../src/iop/colorin.c:2115
 msgid "input profile"
 msgstr "Eingabeprofil"
 
-#: ../src/iop/colorin.c:2118
+#: ../src/iop/colorin.c:2119
 msgid "working profile"
 msgstr "Arbeitsprofil"
 
-#: ../src/iop/colorin.c:2128 ../src/iop/colorin.c:2139
+#: ../src/iop/colorin.c:2129 ../src/iop/colorin.c:2140
 #: ../src/iop/colorout.c:905
 #, c-format
 msgid "ICC profiles in %s or %s"
 msgstr "ICC-Profile in %s oder %s"
 
-#: ../src/iop/colorin.c:2150
+#: ../src/iop/colorin.c:2151
 msgid "gamut clipping"
 msgstr "Gamut beschneiden"
 
-#: ../src/iop/colorin.c:2158
+#: ../src/iop/colorin.c:2159
 msgid "confine Lab values to gamut of RGB color space"
 msgstr "Lab-Werte auf den Gamut von RGB-Farbräumen begrenzen"
 
@@ -8010,32 +8132,32 @@ msgstr "nicht unterstütztes Ausgabeprofil wurde durch sRGB ersetzt!"
 msgid "output intent"
 msgstr "Ausgabevorsatz"
 
-#: ../src/iop/colorout.c:882 ../src/libs/export.c:671
-#: ../src/libs/print_settings.c:1239 ../src/libs/print_settings.c:1454
-#: ../src/views/darkroom.c:2123 ../src/views/darkroom.c:2131
-#: ../src/views/lighttable.c:3455 ../src/views/lighttable.c:3463
+#: ../src/iop/colorout.c:882 ../src/libs/export.c:686
+#: ../src/libs/print_settings.c:1244 ../src/libs/print_settings.c:1459
+#: ../src/views/darkroom.c:2197 ../src/views/darkroom.c:2205
+#: ../src/views/lighttable.c:3451 ../src/views/lighttable.c:3459
 msgid "perceptual"
 msgstr "Wahrnehmung"
 
-#: ../src/iop/colorout.c:883 ../src/libs/export.c:672
-#: ../src/libs/print_settings.c:1240 ../src/libs/print_settings.c:1455
-#: ../src/views/darkroom.c:2124 ../src/views/darkroom.c:2132
-#: ../src/views/lighttable.c:3456 ../src/views/lighttable.c:3464
+#: ../src/iop/colorout.c:883 ../src/libs/export.c:687
+#: ../src/libs/print_settings.c:1245 ../src/libs/print_settings.c:1460
+#: ../src/views/darkroom.c:2198 ../src/views/darkroom.c:2206
+#: ../src/views/lighttable.c:3452 ../src/views/lighttable.c:3460
 msgid "relative colorimetric"
 msgstr "Kolorimetrisch (relativ)"
 
-#: ../src/iop/colorout.c:884 ../src/libs/export.c:673
-#: ../src/libs/print_settings.c:1241 ../src/libs/print_settings.c:1456
-#: ../src/views/darkroom.c:2125 ../src/views/darkroom.c:2133
-#: ../src/views/lighttable.c:3457 ../src/views/lighttable.c:3465
+#: ../src/iop/colorout.c:884 ../src/libs/export.c:688
+#: ../src/libs/print_settings.c:1246 ../src/libs/print_settings.c:1461
+#: ../src/views/darkroom.c:2199 ../src/views/darkroom.c:2207
+#: ../src/views/lighttable.c:3453 ../src/views/lighttable.c:3461
 msgctxt "rendering intent"
 msgid "saturation"
 msgstr "Sättigung"
 
-#: ../src/iop/colorout.c:885 ../src/libs/export.c:674
-#: ../src/libs/print_settings.c:1242 ../src/libs/print_settings.c:1457
-#: ../src/views/darkroom.c:2126 ../src/views/darkroom.c:2134
-#: ../src/views/lighttable.c:3458 ../src/views/lighttable.c:3466
+#: ../src/iop/colorout.c:885 ../src/libs/export.c:689
+#: ../src/libs/print_settings.c:1247 ../src/libs/print_settings.c:1462
+#: ../src/views/darkroom.c:2200 ../src/views/darkroom.c:2208
+#: ../src/views/lighttable.c:3454 ../src/views/lighttable.c:3462
 msgid "absolute colorimetric"
 msgstr "Kolorimetrisch (absolut)"
 
@@ -8120,7 +8242,7 @@ msgctxt "accel"
 msgid "acquire"
 msgstr "Berechnen"
 
-#: ../src/iop/colortransfer.c:124 ../src/libs/metadata.c:512
+#: ../src/iop/colortransfer.c:124 ../src/libs/metadata.c:520
 msgctxt "accel"
 msgid "apply"
 msgstr "Anwenden"
@@ -8149,7 +8271,7 @@ msgstr "berechnen"
 msgid "analyze this image"
 msgstr "dieses Bild analysieren"
 
-#: ../src/iop/colortransfer.c:696 ../src/libs/metadata.c:731
+#: ../src/iop/colortransfer.c:696 ../src/libs/metadata.c:739
 msgid "apply"
 msgstr "anwenden"
 
@@ -8201,7 +8323,7 @@ msgstr "natürliche Hautfarben"
 msgid "black & white film"
 msgstr "Schwarz-Weiß-Film"
 
-#: ../src/iop/colorzones.c:2234 ../src/iop/retouch.c:2240
+#: ../src/iop/colorzones.c:2234 ../src/iop/retouch.c:2249
 #: ../src/iop/toneequal.c:2016
 msgid "cannot display masks when the blending mask is displayed"
 msgstr ""
@@ -8685,8 +8807,8 @@ msgstr ""
 "Es ist flexibler, kann aber kleine Unterschiede\n"
 "in den bereits verarbeiteten Bildern aufweisen."
 
-#: ../src/iop/denoiseprofile.c:4469 ../src/libs/export.c:647
-#: ../src/libs/print_settings.c:1183 ../src/libs/print_settings.c:1403
+#: ../src/iop/denoiseprofile.c:4469 ../src/libs/export.c:662
+#: ../src/libs/print_settings.c:1188 ../src/libs/print_settings.c:1408
 msgid "profile"
 msgstr "Profil"
 
@@ -8739,8 +8861,8 @@ msgstr "Wavelets"
 msgid "wavelets auto"
 msgstr "Wavelets (auto)"
 
-#: ../src/iop/denoiseprofile.c:4486 ../src/libs/colorpicker.c:599
-#: ../src/libs/colorpicker.c:637
+#: ../src/iop/denoiseprofile.c:4486 ../src/libs/colorpicker.c:605
+#: ../src/libs/colorpicker.c:643
 msgid "RGB"
 msgstr "RGB"
 
@@ -9000,7 +9122,7 @@ msgstr ""
 "Pipette auswählen"
 
 #: ../src/iop/exposure.c:904 ../src/iop/highlights.c:1099
-#: ../src/views/darkroom.c:2008
+#: ../src/views/darkroom.c:2082
 msgid "clipping threshold"
 msgstr "Abschneide-Schwellwert"
 
@@ -9171,7 +9293,7 @@ msgstr ""
 
 #. geotagging
 #: ../src/iop/filmic.c:1762 ../src/iop/filmicrgb.c:1541
-#: ../src/libs/metadata_view.c:133
+#: ../src/libs/metadata_view.c:143
 msgid "latitude"
 msgstr "Breite"
 
@@ -9229,8 +9351,8 @@ msgstr ""
 "in Bereichen mit extremer Leuchtkraft.\n"
 "Verringern wenn Schatten/Spitzlichter übersättigt sind."
 
-#: ../src/iop/filmic.c:1805 ../src/libs/export.c:669
-#: ../src/libs/print_settings.c:1238 ../src/libs/print_settings.c:1451
+#: ../src/iop/filmic.c:1805 ../src/libs/export.c:684
+#: ../src/libs/print_settings.c:1243 ../src/libs/print_settings.c:1456
 msgid "intent"
 msgstr "Vorsatz"
 
@@ -9454,7 +9576,7 @@ msgstr ""
 #: ../src/iop/toneequal.c:3240 ../src/iop/toneequal.c:3246
 #: ../src/iop/toneequal.c:3252 ../src/iop/toneequal.c:3258
 #: ../src/iop/toneequal.c:3264 ../src/iop/toneequal.c:3270
-#: ../src/iop/toneequal.c:3276
+#: ../src/iop/toneequal.c:3276 ../src/libs/metadata_view.c:504
 #, c-format
 msgid "%+.2f EV"
 msgstr "%+.2f EV"
@@ -9966,7 +10088,7 @@ msgstr "Helligkeit des Filmmaterials"
 msgid "select color of film material"
 msgstr "Farbe des Filmmaterials auswählen"
 
-#: ../src/iop/invert.c:639
+#: ../src/iop/invert.c:639 ../src/iop/negadoctor.c:1157
 msgid "pick color of film material from image"
 msgstr "Farbe des Filmmaterials aus dem Bild übernehmen"
 
@@ -10108,7 +10230,7 @@ msgstr "Kamera finden"
 msgid "find lens"
 msgstr "Objektiv finden"
 
-#: ../src/iop/lens.cc:2414
+#: ../src/iop/lens.cc:2414 ../src/iop/negadoctor.c:1134
 msgid "corrections"
 msgstr "Korrekturen"
 
@@ -10249,7 +10371,7 @@ msgstr "Schwarz"
 msgid "gray percentile"
 msgstr "Grau-Perzentil"
 
-#: ../src/iop/levels.c:759
+#: ../src/iop/levels.c:759 ../src/views/darkroom.c:2343
 msgid "gray"
 msgstr "Grau"
 
@@ -10501,7 +10623,7 @@ msgstr "Helligkeit"
 msgid "soften with"
 msgstr "Weichzeichnen mit"
 
-#: ../src/iop/lowpass.c:693 ../src/iop/retouch.c:2920 ../src/iop/shadhi.c:838
+#: ../src/iop/lowpass.c:693 ../src/iop/retouch.c:2934 ../src/iop/shadhi.c:838
 msgid "gaussian"
 msgstr "Gauß"
 
@@ -10569,7 +10691,7 @@ msgstr "ungültiger Grad PNG-Datei %d %d"
 msgid "this darktable build is not compatible with compressed clut"
 msgstr ""
 
-#: ../src/iop/lut3d.c:539 ../src/iop/lut3d.c:783 ../src/iop/lut3d.c:870
+#: ../src/iop/lut3d.c:539 ../src/iop/lut3d.c:784 ../src/iop/lut3d.c:888
 #, c-format
 msgid "error - lut 3D size %d exceeds the maximum supported"
 msgstr ""
@@ -10588,81 +10710,96 @@ msgstr "Fehler: konnte Datei „%s” nicht laden"
 msgid "error - allocating buffer for png lut"
 msgstr "Fehler: konnte keinen Puffer für PNG-LUT-Datei reservieren"
 
-#: ../src/iop/lut3d.c:738
+#: ../src/iop/lut3d.c:739
 #, c-format
 msgid "error - invalid cube file: %s"
 msgstr "Fehler: ungültige Cube-Datei: %s"
 
-#: ../src/iop/lut3d.c:752
+#: ../src/iop/lut3d.c:753
 msgid "DOMAIN MIN <> 0.0 is not supported"
 msgstr "DOMAIN MIN ≠ 0.0 nicht unterstützt"
 
-#: ../src/iop/lut3d.c:763
+#: ../src/iop/lut3d.c:764
 msgid "DOMAIN MAX <> 1.0 is not supported"
 msgstr "DOMAIN MAX ≠ 1.0 nicht unterstützt"
 
-#: ../src/iop/lut3d.c:772
+#: ../src/iop/lut3d.c:773
 #, fuzzy
 msgid "[1D cube lut is not supported"
 msgstr "1D-Cube-LUTs nicht unterstützt"
 
-#: ../src/iop/lut3d.c:794 ../src/iop/lut3d.c:889
+#: ../src/iop/lut3d.c:795 ../src/iop/lut3d.c:907
 msgid "error - allocating buffer for cube lut"
 msgstr "Fehler: konnte keinen Puffer für Cube-LUT reservieren"
 
-#: ../src/iop/lut3d.c:805 ../src/iop/lut3d.c:902
+#: ../src/iop/lut3d.c:806 ../src/iop/lut3d.c:920
 msgid "error - cube lut size is not defined"
 msgstr "Fehler: Cube-LUT-Größe nicht definiert"
 
-#: ../src/iop/lut3d.c:821 ../src/iop/lut3d.c:928
-msgid "error - cube lut lines number is not correct"
+#: ../src/iop/lut3d.c:817
+#, fuzzy, c-format
+msgid "error - cube lut invalid number line %d"
 msgstr "Fehler: Cube-LUT-Zeilenzahl nicht korrekt"
 
-#: ../src/iop/lut3d.c:849
+#: ../src/iop/lut3d.c:833
+#, fuzzy, c-format
+msgid "error - cube lut lines number %d is not correct, should be %d"
+msgstr "Fehler: Cube-LUT-Zeilenzahl nicht korrekt"
+
+#: ../src/iop/lut3d.c:843
+#, c-format
+msgid "warning - cube lut %d out of range values [0,1]"
+msgstr ""
+
+#: ../src/iop/lut3d.c:867
 #, fuzzy, c-format
 msgid "error - invalid 3dl file: %s"
 msgstr "Fehler: ungültige Cube-Datei: %s"
 
-#: ../src/iop/lut3d.c:878
+#: ../src/iop/lut3d.c:896
 #, c-format
 msgid "error - the maximum shaper lut value %d is too low"
 msgstr ""
 
-#: ../src/iop/lut3d.c:944
+#: ../src/iop/lut3d.c:946
+msgid "error - cube lut lines number is not correct"
+msgstr "Fehler: Cube-LUT-Zeilenzahl nicht korrekt"
+
+#: ../src/iop/lut3d.c:962
 msgid "error - the maximum lut value does not match any valid bit depth"
 msgstr ""
 
-#: ../src/iop/lut3d.c:1582
+#: ../src/iop/lut3d.c:1600
 msgid "Lut root folder not defined"
 msgstr "LUT-Verzeichnis nicht definiert"
 
-#: ../src/iop/lut3d.c:1588
+#: ../src/iop/lut3d.c:1606
 msgid "select lut file"
 msgstr "LUT-Datei auswählen"
 
-#: ../src/iop/lut3d.c:1589
+#: ../src/iop/lut3d.c:1607
 msgid "_select"
 msgstr "Auswählen"
 
-#: ../src/iop/lut3d.c:1609
+#: ../src/iop/lut3d.c:1627
 msgid "hald cluts (png), 3D lut (cube or 3dl) or gmic compressed lut (gmz)"
 msgstr ""
 
-#: ../src/iop/lut3d.c:1611
+#: ../src/iop/lut3d.c:1629
 msgid "hald cluts (png) or 3D lut (cube or 3dl)"
 msgstr ""
 
-#: ../src/iop/lut3d.c:1620 ../src/libs/copy_history.c:92
-#: ../src/libs/geotagging.c:495 ../src/libs/import.c:784
-#: ../src/libs/styles.c:341
+#: ../src/iop/lut3d.c:1638 ../src/libs/copy_history.c:92
+#: ../src/libs/geotagging.c:497 ../src/libs/import.c:821
+#: ../src/libs/styles.c:342
 msgid "all files"
 msgstr "alle Dateien"
 
-#: ../src/iop/lut3d.c:1635
+#: ../src/iop/lut3d.c:1653
 msgid "Select file outside Lut root folder is not allowed"
 msgstr "Dateiauswahl außerhalb des LUT-Verzeichnisses nicht erlaubt"
 
-#: ../src/iop/lut3d.c:1715
+#: ../src/iop/lut3d.c:1733
 #, fuzzy
 msgid ""
 "select a png (haldclut), a cube, a 3dl or a gmz (compressed lut) file "
@@ -10674,7 +10811,7 @@ msgstr ""
 "Achtung: Das LUT-Verzeichnis muss in „Voreinstellungen/zentrale Optionen/"
 "Verschieden” festgelegt werden, bevor eine LUT-Datei gewählt werden kann."
 
-#: ../src/iop/lut3d.c:1719
+#: ../src/iop/lut3d.c:1737
 #, fuzzy
 msgid ""
 "select a png (haldclut), a cube or a 3dl file CAUTION: 3D lut folder must be "
@@ -10685,7 +10822,7 @@ msgstr ""
 "Achtung: Das LUT-Verzeichnis muss in „Voreinstellungen/zentrale Optionen/"
 "Verschieden” festgelegt werden, bevor eine LUT-Datei gewählt werden kann."
 
-#: ../src/iop/lut3d.c:1730
+#: ../src/iop/lut3d.c:1748
 #, fuzzy
 msgid ""
 "the file path (relative to lut folder) is saved with image along with the "
@@ -10696,7 +10833,7 @@ msgstr ""
 "Achtung: Das LUT-Verzeichnis muss in „Voreinstellungen/zentrale Optionen/"
 "Verschieden” festgelegt werden, bevor eine LUT-Datei gewählt werden kann."
 
-#: ../src/iop/lut3d.c:1733
+#: ../src/iop/lut3d.c:1751
 #, fuzzy
 msgid ""
 "the file path (relative to lut folder) is saved with image (and not the lut "
@@ -10707,60 +10844,60 @@ msgstr ""
 "Achtung: Das LUT-Verzeichnis muss in „Voreinstellungen/zentrale Optionen/"
 "Verschieden” festgelegt werden, bevor eine LUT-Datei gewählt werden kann."
 
-#: ../src/iop/lut3d.c:1742
+#: ../src/iop/lut3d.c:1760
 #, fuzzy
 msgid "enter lut name"
 msgstr "Tag eingeben"
 
-#: ../src/iop/lut3d.c:1764
+#: ../src/iop/lut3d.c:1782
 #, fuzzy
 msgid "select the LUT"
 msgstr "Farbton auswählen"
 
-#: ../src/iop/lut3d.c:1777
+#: ../src/iop/lut3d.c:1795
 msgid "application color space"
 msgstr "Anwendungsfarbraum"
 
-#: ../src/iop/lut3d.c:1779
+#: ../src/iop/lut3d.c:1797
 msgid "Adobe RGB"
 msgstr "Adobe RGB"
 
-#: ../src/iop/lut3d.c:1780
+#: ../src/iop/lut3d.c:1798
 #, fuzzy
 msgid "gamma rec709 RGB"
 msgstr "Gamma Rec709 RGB"
 
-#: ../src/iop/lut3d.c:1781
+#: ../src/iop/lut3d.c:1799
 #, fuzzy
 msgid "linear rec709 RGB"
 msgstr "lineares Rec709-RGB"
 
-#: ../src/iop/lut3d.c:1782
+#: ../src/iop/lut3d.c:1800
 #, fuzzy
 msgid "linear rec2020 RGB"
 msgstr "lineares Rec2020-RGB"
 
-#: ../src/iop/lut3d.c:1784
+#: ../src/iop/lut3d.c:1802
 msgid "select the color space in which the LUT has to be applied"
 msgstr "den Farbraum wählen, in dem die LUT angewendet wird"
 
-#: ../src/iop/lut3d.c:1788
+#: ../src/iop/lut3d.c:1806
 msgid "interpolation"
 msgstr "Interpolationsverfahren"
 
-#: ../src/iop/lut3d.c:1789
+#: ../src/iop/lut3d.c:1807
 msgid "tetrahedral"
 msgstr "tetraedrisch"
 
-#: ../src/iop/lut3d.c:1790
+#: ../src/iop/lut3d.c:1808
 msgid "trilinear"
 msgstr "trilinear"
 
-#: ../src/iop/lut3d.c:1791
+#: ../src/iop/lut3d.c:1809
 msgid "pyramid"
 msgstr "py­ra­mi­dal"
 
-#: ../src/iop/lut3d.c:1793
+#: ../src/iop/lut3d.c:1811
 msgid "select the interpolation method"
 msgstr "Interpolationsverfahren wählen"
 
@@ -10784,6 +10921,244 @@ msgstr ""
 #: ../src/iop/monochrome.c:626
 msgid "how much to keep highlights"
 msgstr "wie sehr sollen Spitzlichter ausgenommen werden"
+
+#: ../src/iop/negadoctor.c:206
+#, fuzzy
+msgid "negadoctor"
+msgstr "Faktor"
+
+#: ../src/iop/negadoctor.c:435
+msgid "color film"
+msgstr "Farbfilm"
+
+#: ../src/iop/negadoctor.c:449
+msgid "black and white film"
+msgstr "Schwarz-Weiß-Film"
+
+#: ../src/iop/negadoctor.c:509
+#, fuzzy
+msgid "D min"
+msgstr "Minimaler Zoom"
+
+#: ../src/iop/negadoctor.c:515 ../src/iop/negadoctor.c:1165
+msgid "D min red component"
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1121
+msgid "film stock"
+msgstr "Filmmaterial"
+
+#: ../src/iop/negadoctor.c:1122
+#, fuzzy
+msgid "black and white"
+msgstr "schwarz & weiß"
+
+#: ../src/iop/negadoctor.c:1123 ../src/iop/retouch.c:2890
+#: ../src/iop/watermark.c:1491
+msgid "color"
+msgstr "Farbe"
+
+#: ../src/iop/negadoctor.c:1126
+#, fuzzy
+msgid "toogle on or off the color controls"
+msgstr "Bedienelemente zum Ein- und Ausklappen der Bedienfelder umschalten"
+
+#: ../src/iop/negadoctor.c:1133
+msgid "film properties"
+msgstr "Filmeigenschaften"
+
+#: ../src/iop/negadoctor.c:1135
+msgid "print properties"
+msgstr "Druckeigenschaften"
+
+#. Dmin
+#: ../src/iop/negadoctor.c:1144
+msgid "color of the film base"
+msgstr "Farbe des Filmmaterials"
+
+#: ../src/iop/negadoctor.c:1152
+msgid "select color of film material from a swatch"
+msgstr "Farbe des Films aus einer Probe des Filmmaterials bestimmen"
+
+#: ../src/iop/negadoctor.c:1166 ../src/iop/negadoctor.c:1176
+#: ../src/iop/negadoctor.c:1186
+msgid ""
+"adjust the color and shade of the film transparent base.\n"
+"this value depends on the film material, \n"
+"the chemical fog produced while developing the film,\n"
+"and the scanner white balance."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1175
+msgid "D min green component"
+msgstr "D min grüne Komponente"
+
+#: ../src/iop/negadoctor.c:1185
+msgid "D min blue component"
+msgstr "D min blaue Komponente"
+
+#. D max and scanner bias
+#: ../src/iop/negadoctor.c:1195
+msgid "dynamic range of the film"
+msgstr "Dynamikbereich des Films"
+
+#: ../src/iop/negadoctor.c:1199
+msgid "D max"
+msgstr "D max"
+
+#: ../src/iop/negadoctor.c:1203
+msgid ""
+"maximum density of the film, corresponding to white after inversion.\n"
+"this value depends on the film specifications, the developing process,\n"
+"the dynamic range of the scene and the scanner exposure settings."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1209
+msgid "scanner exposure settings"
+msgstr "Scanner Belichtungseinstellungen"
+
+#: ../src/iop/negadoctor.c:1213
+msgid "scan exposure bias"
+msgstr "Belichtungstendenz"
+
+#: ../src/iop/negadoctor.c:1217
+msgid ""
+"correct the exposure of the scanner, for all RGB channels,\n"
+"before the inversion, so blacks are neither clipped or too pale."
+msgstr ""
+
+#. WB shadows
+#: ../src/iop/negadoctor.c:1223
+msgid "shadows color cast"
+msgstr "Farbverschiebung in den Schatten"
+
+#: ../src/iop/negadoctor.c:1232
+msgid "select color of shadows from a swatch"
+msgstr "Farbe der Schatten aus einer Probe entnehmen"
+
+#: ../src/iop/negadoctor.c:1237
+#, fuzzy
+msgid "pick shadows color from image"
+msgstr "Farbe aus dem Bild übernehmen"
+
+#: ../src/iop/negadoctor.c:1244
+#, fuzzy
+msgid "shadows red offset"
+msgstr "Schatten: Lift / Offset"
+
+#: ../src/iop/negadoctor.c:1245 ../src/iop/negadoctor.c:1254
+#: ../src/iop/negadoctor.c:1263
+msgid ""
+"correct the color cast in shadows so blacks are\n"
+"truly achromatic. Setting this value before\n"
+"the highlights illuminant white balance will help\n"
+"recovering the global white balance in difficult cases."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1253
+#, fuzzy
+msgid "shadows green offset"
+msgstr "Schatten: Lift / Offset"
+
+#: ../src/iop/negadoctor.c:1262
+#, fuzzy
+msgid "shadows blue offset"
+msgstr "Schatten: Lift / Offset"
+
+#. WB highlights
+#: ../src/iop/negadoctor.c:1271
+#, fuzzy
+msgid "highlights white balance"
+msgstr "Schatten/Spitzlichter-Balance"
+
+#: ../src/iop/negadoctor.c:1280
+#, fuzzy
+msgid "select color of illuminant from a swatch"
+msgstr "Farbe des Filmmaterials auswählen"
+
+#: ../src/iop/negadoctor.c:1285
+#, fuzzy
+msgid "pick illuminant color from image"
+msgstr "Füllfarbe aus Bild wählen"
+
+# wtf?
+#: ../src/iop/negadoctor.c:1292
+#, fuzzy
+msgid "illuminant red gain"
+msgstr "Luminanz Y"
+
+#: ../src/iop/negadoctor.c:1293 ../src/iop/negadoctor.c:1302
+#: ../src/iop/negadoctor.c:1311
+msgid ""
+"correct the color of the illuminant so whites are\n"
+"truly achromatic. Setting this value after\n"
+"the shadows color cast will help\n"
+"recovering the global white balance in difficult cases."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1301
+msgid "illuminant green gain"
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1310
+msgid "illuminant blue gain"
+msgstr ""
+
+#. print corrections
+#: ../src/iop/negadoctor.c:1319
+#, fuzzy
+msgid "virtual paper properties"
+msgstr "zusätzliche Eigenschaften"
+
+#: ../src/iop/negadoctor.c:1323
+#, fuzzy
+msgid "paper black (density correction)"
+msgstr "Schwarzwert-Anpassung"
+
+#: ../src/iop/negadoctor.c:1327
+msgid ""
+"correct the density of black after the inversion,\n"
+"to adjust the global contrast while avoiding clipping shadows."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1333
+#, fuzzy
+msgid "paper grade (gamma)"
+msgstr "Ziel-Gamma"
+
+#: ../src/iop/negadoctor.c:1335
+msgid ""
+"select the grade of the virtual paper, which is actually\n"
+"equivalent to applying a gamma. it compensates the film D max\n"
+"and recovers the contrast. use a high grade for high D max."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1342
+msgid "paper gloss (specular highlights)"
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1344
+msgid ""
+"gradually compress specular highlights past this value\n"
+"to avoid clipping while pushing the exposure for midtones.\n"
+"this somewhat reproduces the behaviour of matte paper."
+msgstr ""
+
+#: ../src/iop/negadoctor.c:1349
+#, fuzzy
+msgid "virtual print emulation"
+msgstr "Fuji Provia Emulation"
+
+#: ../src/iop/negadoctor.c:1353
+#, fuzzy
+msgid "print exposure adjustment"
+msgstr "Helligkeitsanpassung"
+
+#: ../src/iop/negadoctor.c:1357
+msgid ""
+"correct the printing exposure after inversion to adjust\n"
+"the global contrast and avoid clipping highlights."
+msgstr ""
 
 #: ../src/iop/nlmeans.c:81
 msgid "denoise (non-local means)"
@@ -11042,8 +11417,8 @@ msgstr "Breite"
 msgid "the fill-light in EV"
 msgstr "Füllicht in EV"
 
-#: ../src/iop/relight.c:366 ../src/libs/metadata_view.c:118
-#: ../src/libs/print_settings.c:1304
+#: ../src/iop/relight.c:366 ../src/libs/metadata_view.c:128
+#: ../src/libs/print_settings.c:1309
 msgid "width"
 msgstr "Breite"
 
@@ -11069,16 +11444,16 @@ msgstr "mittlere Helligkeit im Bild wählen"
 msgid "retouch"
 msgstr "Retusche"
 
-#: ../src/iop/retouch.c:1929
+#: ../src/iop/retouch.c:1936
 msgid "cannot display scales when the blending mask is displayed"
 msgstr ""
 "Kann keine Skalen anzeigen wenn die Maske zum Überblenden aktiviert ist"
 
-#: ../src/iop/retouch.c:2634
+#: ../src/iop/retouch.c:2648
 msgid "# shapes:"
 msgstr "# Formen:"
 
-#: ../src/iop/retouch.c:2639
+#: ../src/iop/retouch.c:2653
 msgid ""
 "to add a shape select an algorithm and a shape type and click on the image.\n"
 "shapes are added to the current scale"
@@ -11087,43 +11462,43 @@ msgstr ""
 "aus und klicken Sie auf das Bild.\n"
 "Formen werden zur aktuellen Skalierung hinzugefügt"
 
-#: ../src/iop/retouch.c:2646
+#: ../src/iop/retouch.c:2660
 msgid "show and edit shapes on the current scale"
 msgstr "Anzeigen und Bearbeiten von Formen in der aktuellen Größe"
 
-#: ../src/iop/retouch.c:2681
+#: ../src/iop/retouch.c:2695
 msgid "algorithms:"
 msgstr "Algorithmen:"
 
-#: ../src/iop/retouch.c:2686
+#: ../src/iop/retouch.c:2700
 msgid "activates fill tool"
 msgstr "aktiviert das Füllwerkzeug"
 
-#: ../src/iop/retouch.c:2693
+#: ../src/iop/retouch.c:2707
 msgid "activates blur tool"
 msgstr "aktiviert das Weichzeichnungswerkzeug"
 
-#: ../src/iop/retouch.c:2700
+#: ../src/iop/retouch.c:2714
 msgid "activates healing tool"
 msgstr "aktiviert das Heilwerkzeug"
 
-#: ../src/iop/retouch.c:2707
+#: ../src/iop/retouch.c:2721
 msgid "activates cloning tool"
 msgstr "aktiviert das Klonenwerkzeug"
 
-#: ../src/iop/retouch.c:2721
+#: ../src/iop/retouch.c:2735
 msgid "# scales:"
 msgstr "# Skalierungen:"
 
-#: ../src/iop/retouch.c:2730
+#: ../src/iop/retouch.c:2744
 msgid "current:"
 msgstr "aktuell:"
 
-#: ../src/iop/retouch.c:2739
+#: ../src/iop/retouch.c:2753
 msgid "merge from:"
 msgstr "Zusammenführen von:"
 
-#: ../src/iop/retouch.c:2752
+#: ../src/iop/retouch.c:2766
 msgid ""
 "top slider adjusts where the merge scales start\n"
 "bottom slider adjusts the number of scales\n"
@@ -11136,43 +11511,43 @@ msgstr ""
 "die rote Box zeigt die aktelle Skala an\n"
 "die grüne Linie zeigt an, dass die Skala Formen enthält."
 
-#: ../src/iop/retouch.c:2774
+#: ../src/iop/retouch.c:2788
 msgid "display masks"
 msgstr "Masken anzeigen"
 
-#: ../src/iop/retouch.c:2780
+#: ../src/iop/retouch.c:2794
 msgid "temporarily switch off shapes"
 msgstr "Formen vorübergehend ausschalten"
 
-#: ../src/iop/retouch.c:2787
+#: ../src/iop/retouch.c:2801
 msgid "display wavelet scale"
 msgstr "Wavelet-Skala anzeigen"
 
-#: ../src/iop/retouch.c:2795
+#: ../src/iop/retouch.c:2809
 msgid "cut shapes from current scale"
 msgstr "Zuschneiden der Formen vom aktuellen Maßstab"
 
-#: ../src/iop/retouch.c:2801
+#: ../src/iop/retouch.c:2815
 msgid "paste cut shapes to current scale"
 msgstr "Zugeschnittene Formen des aktuellen Maßstab einfügen"
 
-#: ../src/iop/retouch.c:2825
+#: ../src/iop/retouch.c:2839
 msgid "preview single scale"
 msgstr "Vorschau einer einzelnen Skala"
 
-#: ../src/iop/retouch.c:2832
+#: ../src/iop/retouch.c:2846
 msgid "adjust preview levels"
 msgstr "Vorschau-Ebenen anpassen"
 
-#: ../src/iop/retouch.c:2851
+#: ../src/iop/retouch.c:2865
 msgid "auto levels"
 msgstr "automatisches Level"
 
-#: ../src/iop/retouch.c:2863
+#: ../src/iop/retouch.c:2877
 msgid "shape selected:"
 msgstr "Form ausgewählt:"
 
-#: ../src/iop/retouch.c:2867
+#: ../src/iop/retouch.c:2881
 msgid ""
 "click on a shape to select it,\n"
 "to unselect click on an empty space"
@@ -11180,121 +11555,123 @@ msgstr ""
 "klicke auf eine Form, um diese auszuwählen, \n"
 "um die Auswahl aufzuheben, klick auf eine leere Stelle"
 
-#: ../src/iop/retouch.c:2874
+#: ../src/iop/retouch.c:2888
 msgid "fill mode"
 msgstr "Füllmodus"
 
-#: ../src/iop/retouch.c:2875
+#: ../src/iop/retouch.c:2889
 msgid "erase"
 msgstr "löschen"
 
-#: ../src/iop/retouch.c:2876 ../src/iop/watermark.c:1491
-msgid "color"
-msgstr "Farbe"
-
-#: ../src/iop/retouch.c:2877
+#: ../src/iop/retouch.c:2891
 msgid "erase the detail or fills with chosen color"
 msgstr "löscht das Detail oder füllt mit der gewählten Farbe"
 
-#: ../src/iop/retouch.c:2889 ../src/iop/retouch.c:2890
+#: ../src/iop/retouch.c:2903 ../src/iop/retouch.c:2904
 msgid "select fill color"
 msgstr "Füllfarbe auswählen"
 
-#: ../src/iop/retouch.c:2896
+#: ../src/iop/retouch.c:2910
 msgid "pick fill color from image"
 msgstr "Füllfarbe aus Bild wählen"
 
-#: ../src/iop/retouch.c:2900
+#: ../src/iop/retouch.c:2914
 msgid "fill color: "
 msgstr "Füllfarbe: "
 
-#: ../src/iop/retouch.c:2905
+#: ../src/iop/retouch.c:2919
 msgid "adjusts color brightness to fine-tune it. works with erase as well"
 msgstr ""
 "passt die Farbintensität an, um diese zu verfeinern. Funktioniert auch mit "
 "Radieren"
 
-#: ../src/iop/retouch.c:2919
+#: ../src/iop/retouch.c:2933
 msgid "blur type"
 msgstr "Weichzeichnungstyp"
 
-#: ../src/iop/retouch.c:2921
+#: ../src/iop/retouch.c:2935
 msgid "bilateral"
 msgstr "bilateral"
 
-#: ../src/iop/retouch.c:2922
+#: ../src/iop/retouch.c:2936
 msgid "type for the blur algorithm"
 msgstr "Typ des Weichzeichnungsalgorithmus"
 
-#: ../src/iop/retouch.c:2928
+#: ../src/iop/retouch.c:2942
 msgid "blur radius"
 msgstr "Weichzeichnungsradius"
 
 # Ugh ...
-#: ../src/iop/retouch.c:2929
+#: ../src/iop/retouch.c:2943
 msgid "radius of the selected blur type"
 msgstr "Radius des selektierten Weichzeichnungstyp"
 
-#: ../src/iop/retouch.c:2937
+#: ../src/iop/retouch.c:2951
 msgid "set the opacity on the selected shape"
 msgstr "setzt die Deckkraft der selektierten Form"
 
 #. add all the controls to the iop
-#: ../src/iop/retouch.c:2941
+#: ../src/iop/retouch.c:2955
 msgid "retouch tools"
 msgstr "Retusche-Werkzeuge"
 
 #. wavelet decompose
-#: ../src/iop/retouch.c:2950
+#: ../src/iop/retouch.c:2964
 msgid "wavelet decompose"
 msgstr "Waveletzerlegung"
 
 #. shapes
-#: ../src/iop/retouch.c:2964
+#: ../src/iop/retouch.c:2978
 msgid "shapes"
 msgstr "Formen"
 
-#: ../src/iop/retouch.c:3318
+#: ../src/iop/retouch.c:3332
 msgctxt "accel"
 msgid "retouch tool circle"
 msgstr "Retuschierwerkzeug Kreis"
 
-#: ../src/iop/retouch.c:3319
+#: ../src/iop/retouch.c:3333
 msgctxt "accel"
 msgid "retouch tool ellipse"
 msgstr "Retuschierwerkzeug Ellipse"
 
-#: ../src/iop/retouch.c:3320
+#: ../src/iop/retouch.c:3334
 msgctxt "accel"
 msgid "retouch tool path"
 msgstr "Retuschierwerkzeug Pfad"
 
-#: ../src/iop/retouch.c:3321
+#: ../src/iop/retouch.c:3335
 msgctxt "accel"
 msgid "retouch tool brush"
 msgstr "Retuschierwerkzeug Pinsel"
 
-#: ../src/iop/retouch.c:3323
+#: ../src/iop/retouch.c:3337 ../src/iop/spots.c:850
 msgctxt "accel"
 msgid "continuous add circle"
 msgstr "endlos Kreise hinzufügen"
 
-#: ../src/iop/retouch.c:3324
+#: ../src/iop/retouch.c:3338 ../src/iop/spots.c:851
 msgctxt "accel"
 msgid "continuous add ellipse"
 msgstr "endlos Ellipsen hinzufügen"
 
-#: ../src/iop/retouch.c:3325
+#: ../src/iop/retouch.c:3339 ../src/iop/spots.c:852
 msgctxt "accel"
 msgid "continuous add path"
 msgstr "endlos Pfad hinzufügen"
 
-#: ../src/iop/retouch.c:3326
+#: ../src/iop/retouch.c:3340
 msgctxt "accel"
 msgid "continuous add brush"
 msgstr "endlos Pinsel hinzufügen"
 
-#: ../src/iop/retouch.c:4417 ../src/iop/retouch.c:5273
+#: ../src/iop/retouch.c:3342 ../src/iop/spots.c:853
+#, fuzzy
+msgctxt "accel"
+msgid "show or hide shapes"
+msgstr "Flecken anzeigen/verstecken"
+
+#: ../src/iop/retouch.c:4493 ../src/iop/retouch.c:5349
 #, c-format
 msgid "max scale is %i for this image size"
 msgstr "Die maximale Skalierung ist %i für diese Bildgröße"
@@ -11562,9 +11939,8 @@ msgid "the mix of effect"
 msgstr "Stärke des Effekts"
 
 #: ../src/iop/splittoning.c:90
-#, fuzzy
 msgid "split-toning"
-msgstr "Split-Toning"
+msgstr "Teiltonung"
 
 #: ../src/iop/splittoning.c:110
 msgctxt "accel"
@@ -11661,11 +12037,11 @@ msgstr "Fleckenentfernung"
 msgid "spot module is limited to 64 shapes. please add a new instance !"
 msgstr ""
 
-#: ../src/iop/spots.c:672
+#: ../src/iop/spots.c:792
 msgid "number of strokes:"
 msgstr "Anzahl Korrekturen:"
 
-#: ../src/iop/spots.c:675
+#: ../src/iop/spots.c:795
 msgid ""
 "click on a shape and drag on canvas.\n"
 "use the mouse wheel to adjust size.\n"
@@ -11675,126 +12051,132 @@ msgstr ""
 "Größe kann mit Mausrad angepasst werden.\n"
 "Rechtsklick entfernt eine Form."
 
-#: ../src/iop/spots.c:719
+#: ../src/iop/spots.c:801
+#, fuzzy
+msgid "show and edit shapes"
+msgstr "Masken-Elemente anzeigen und bearbeiten"
+
+#: ../src/iop/spots.c:847
 msgctxt "accel"
 msgid "spot circle tool"
 msgstr "Kreiswerkzeug"
 
-#: ../src/iop/spots.c:720
+#: ../src/iop/spots.c:848
 msgctxt "accel"
 msgid "spot ellipse tool"
 msgstr "Ellipsenwerkzeug"
 
-#: ../src/iop/spots.c:721
+#: ../src/iop/spots.c:849
 msgctxt "accel"
 msgid "spot path tool"
 msgstr "Pfadwerkzeug"
 
-#: ../src/iop/spots.c:722
-msgctxt "accel"
-msgid "spot show or hide"
-msgstr "Flecken anzeigen/verstecken"
-
-#: ../src/iop/temperature.c:161
+#: ../src/iop/temperature.c:162
 msgctxt "modulename"
 msgid "white balance"
 msgstr "Weißabgleich"
 
-#: ../src/iop/temperature.c:208
+#: ../src/iop/temperature.c:209
 msgctxt "accel"
 msgid "tint"
 msgstr "Farbton"
 
-#: ../src/iop/temperature.c:209
+#: ../src/iop/temperature.c:210
 msgctxt "accel"
 msgid "temperature"
 msgstr "Farbtemperatur"
 
-#: ../src/iop/temperature.c:213
+#: ../src/iop/temperature.c:214
 #, fuzzy
 msgctxt "accel"
 msgid "presets"
 msgstr "Voreinstellungen"
 
-#: ../src/iop/temperature.c:215
+#: ../src/iop/temperature.c:216
 msgctxt "accel"
 msgid "preset/camera"
 msgstr "Voreinstellung/Kamera"
 
-#: ../src/iop/temperature.c:216
+#: ../src/iop/temperature.c:217
 msgctxt "accel"
 msgid "preset/camera neutral"
 msgstr "Voreinstellung/Neutral"
 
-#: ../src/iop/temperature.c:217
+#: ../src/iop/temperature.c:218
 msgctxt "accel"
 msgid "preset/spot"
 msgstr "Voreinstellung/Manuell setzen"
 
-#: ../src/iop/temperature.c:785
+#: ../src/iop/temperature.c:787
 msgctxt "white balance"
 msgid "camera"
 msgstr "Kamera"
 
-#: ../src/iop/temperature.c:786
+#: ../src/iop/temperature.c:788
 msgctxt "white balance"
 msgid "camera neutral"
 msgstr "neutral"
 
-#: ../src/iop/temperature.c:787
+#: ../src/iop/temperature.c:789
 msgctxt "white balance"
 msgid "spot"
 msgstr "manuell setzen"
 
-#: ../src/iop/temperature.c:962
+#: ../src/iop/temperature.c:790
+#, fuzzy
+msgctxt "white balance"
+msgid "user modified"
+msgstr "Modul suchen"
+
+#: ../src/iop/temperature.c:967
 #, c-format
 msgid "`%s' color matrix not found for image"
 msgstr "„%s” Farbmatrix für Bild nicht gefunden"
 
-#: ../src/iop/temperature.c:986
+#: ../src/iop/temperature.c:991
 #, c-format
 msgid "failed to read camera white balance information from `%s'!"
 msgstr "Konnte Weißabgleichsdaten der Kamera nicht aus „%s“ lesen!"
 
-#: ../src/iop/temperature.c:1369
+#: ../src/iop/temperature.c:1376 ../src/views/darkroom.c:2348
 msgid "magenta"
 msgstr "Magenta"
 
-#: ../src/iop/temperature.c:1370
+#: ../src/iop/temperature.c:1377 ../src/views/darkroom.c:2347
 msgid "cyan"
 msgstr "Cyan"
 
 # https://de.wikipedia.org/wiki/Demosaicing übersetzt "emerald" mit "Cyan"
-#: ../src/iop/temperature.c:1383
+#: ../src/iop/temperature.c:1390
 msgid "emerald"
 msgstr "Cyan"
 
-#: ../src/iop/temperature.c:1446
+#: ../src/iop/temperature.c:1453
 msgid "tint"
 msgstr "Farbton"
 
-#: ../src/iop/temperature.c:1447
+#: ../src/iop/temperature.c:1454
 msgid "temperature"
 msgstr "Farbtemperatur"
 
-#: ../src/iop/temperature.c:1463
+#: ../src/iop/temperature.c:1470
 msgid "choose white balance preset from camera"
 msgstr "aus den Weißabgleichsvorgaben der Kamera wählen"
 
-#: ../src/iop/temperature.c:1466
+#: ../src/iop/temperature.c:1473
 msgid "finetune"
 msgstr "anpassen"
 
-#: ../src/iop/temperature.c:1467
+#: ../src/iop/temperature.c:1474
 #, c-format
 msgid "%.0f mired"
 msgstr "%.0f Mired"
 
-#: ../src/iop/temperature.c:1471
+#: ../src/iop/temperature.c:1478
 msgid "fine tune white balance preset"
 msgstr "Weißabgleichsvorgabe feinabstimmen"
 
-#: ../src/iop/temperature.c:1476
+#: ../src/iop/temperature.c:1483
 msgid "white balance disabled for camera"
 msgstr "Weißabgleich für Kamera deaktiviert"
 
@@ -12562,7 +12944,7 @@ msgid "position"
 msgstr "Position"
 
 #. Create the 3x3 gtk table toggle button table...
-#: ../src/iop/watermark.c:1564 ../src/libs/print_settings.c:1389
+#: ../src/iop/watermark.c:1564 ../src/libs/print_settings.c:1394
 msgid "alignment"
 msgstr "Position"
 
@@ -12746,45 +13128,45 @@ msgstr "Verschlusszeit"
 msgid "WB"
 msgstr "Weißabgleich"
 
-#: ../src/libs/collect.c:118
+#: ../src/libs/collect.c:116
 msgid "collect images"
 msgstr "Bilder sammeln"
 
-#: ../src/libs/collect.c:243
+#: ../src/libs/collect.c:241
 msgid "search filmroll"
 msgstr "Filmrolle suchen"
 
-#: ../src/libs/collect.c:324
+#: ../src/libs/collect.c:322
 #, c-format
 msgid "problem selecting new path for the filmroll in %s"
 msgstr "Problem beim Auswählen des neuen Pfads für die Filmrolle in %s"
 
-#: ../src/libs/collect.c:376
+#: ../src/libs/collect.c:374
 msgid "search filmroll..."
 msgstr "Filmrolle suchen ..."
 
-#: ../src/libs/collect.c:380
+#: ../src/libs/collect.c:378
 msgid "remove..."
 msgstr "entfernen ..."
 
-#: ../src/libs/collect.c:1004
+#: ../src/libs/collect.c:1010
 msgid "uncategorized"
 msgstr "Sonstige"
 
-#: ../src/libs/collect.c:1377
+#: ../src/libs/collect.c:1379
 msgid "not tagged"
 msgstr "nicht getaggt"
 
-#: ../src/libs/collect.c:1389
+#: ../src/libs/collect.c:1391
 msgid "copied locally"
 msgstr "lokal kopiert"
 
-#: ../src/libs/collect.c:1491
+#: ../src/libs/collect.c:1493
 msgid "group followers"
 msgstr "Gruppenmitglieder"
 
 #: ../src/libs/collect.c:1744 ../src/libs/collect.c:1759
-#: ../src/libs/collect.c:2196
+#: ../src/libs/collect.c:2182
 msgid "clear this rule"
 msgstr "diese Regel löschen"
 
@@ -12792,11 +13174,11 @@ msgstr "diese Regel löschen"
 msgid "clear this rule or add new rules"
 msgstr "diese Regel löschen oder weitere Regeln hinzufügen"
 
-#: ../src/libs/collect.c:1803
+#: ../src/libs/collect.c:1801
 msgid "type your query, use <, <=, >, >=, <>, =, [;] as operators"
 msgstr "Abfrage eingeben, verfügbare Operatoren sind <, <=, >, >=, <>, =, [;]"
 
-#: ../src/libs/collect.c:1808
+#: ../src/libs/collect.c:1806
 msgid ""
 "type your query, use <, <=, >, >=, <>, =, [;] as operators, type dates in "
 "the form : YYYY:MM:DD HH:MM:SS (only the year is mandatory)"
@@ -12805,37 +13187,37 @@ msgstr ""
 "Datumsangaben in der Form YYYY:MM:DD HH:MM:SS (nur das Jahr ist zwingend "
 "erforderlich)"
 
-#: ../src/libs/collect.c:1814
+#: ../src/libs/collect.c:1812
 #, fuzzy, no-c-format
 msgid "type your query, use `%' as wildcard and `,' to separate values"
 msgstr "Anfrage eingeben, ‚%‘ als Paltzhalter benutzen"
 
-#: ../src/libs/collect.c:1819 ../src/libs/collect.c:2303
+#: ../src/libs/collect.c:1817 ../src/libs/collect.c:2289
 #, no-c-format
 msgid "type your query, use `%' as wildcard"
 msgstr "Anfrage eingeben, ‚%‘ als Paltzhalter benutzen"
 
-#: ../src/libs/collect.c:2202
+#: ../src/libs/collect.c:2188
 msgid "narrow down search"
 msgstr "Suche verfeinern"
 
-#: ../src/libs/collect.c:2207
+#: ../src/libs/collect.c:2193
 msgid "add more images"
 msgstr "mehr Bilder hinzufügen"
 
-#: ../src/libs/collect.c:2212
+#: ../src/libs/collect.c:2198
 msgid "exclude images"
 msgstr "Bilder ausschließen"
 
-#: ../src/libs/collect.c:2219
+#: ../src/libs/collect.c:2205
 msgid "change to: and"
 msgstr "ändere zu: UND"
 
-#: ../src/libs/collect.c:2224
+#: ../src/libs/collect.c:2210
 msgid "change to: or"
 msgstr "ändere zu: ODER"
 
-#: ../src/libs/collect.c:2229
+#: ../src/libs/collect.c:2215
 msgid "change to: except"
 msgstr "ändere zu: AUSSER"
 
@@ -12853,49 +13235,49 @@ msgctxt "accel"
 msgid "add sample"
 msgstr "Sample hinzufügen"
 
-#: ../src/libs/colorpicker.c:396
+#: ../src/libs/colorpicker.c:402
 msgid "hover to highlight sample on canvas, click to lock sample"
 msgstr ""
 "Maus über das Farbfeld bewegen, um den Messpunkt im Bild hervorzuheben, zum "
 "Sperren klicken"
 
-#: ../src/libs/colorpicker.c:412
+#: ../src/libs/colorpicker.c:418
 msgid "X"
 msgstr ""
 
-#: ../src/libs/colorpicker.c:518
+#: ../src/libs/colorpicker.c:524
 msgid "live samples"
 msgstr "Live-Messwerte"
 
-#: ../src/libs/colorpicker.c:572
+#: ../src/libs/colorpicker.c:578
 msgid "point"
 msgstr "Punkt"
 
-#: ../src/libs/colorpicker.c:573
+#: ../src/libs/colorpicker.c:579
 msgid "area"
 msgstr "Fläche"
 
-#: ../src/libs/colorpicker.c:588 ../src/libs/colorpicker.c:626
+#: ../src/libs/colorpicker.c:594 ../src/libs/colorpicker.c:632
 msgid "mean"
 msgstr "Mittel"
 
-#: ../src/libs/colorpicker.c:589 ../src/libs/colorpicker.c:627
+#: ../src/libs/colorpicker.c:595 ../src/libs/colorpicker.c:633
 msgid "min"
 msgstr "Minimum"
 
-#: ../src/libs/colorpicker.c:590 ../src/libs/colorpicker.c:628
+#: ../src/libs/colorpicker.c:596 ../src/libs/colorpicker.c:634
 msgid "max"
 msgstr "Maximum"
 
-#: ../src/libs/colorpicker.c:612
+#: ../src/libs/colorpicker.c:618
 msgid "restrict histogram to selection"
 msgstr "Histogramm auf Auswahl beschränken"
 
-#: ../src/libs/colorpicker.c:645 ../src/libs/export_metadata.c:160
+#: ../src/libs/colorpicker.c:651 ../src/libs/export_metadata.c:160
 msgid "add"
 msgstr "hinzufügen"
 
-#: ../src/libs/colorpicker.c:654
+#: ../src/libs/colorpicker.c:660
 msgid "display sample areas on image"
 msgstr "Messpunkte im Bild anzeigen"
 
@@ -12947,9 +13329,9 @@ msgstr[1] ""
 msgid "delete images' history?"
 msgstr "Bearbeitungsverlauf der Bilder löschen?"
 
-#: ../src/libs/copy_history.c:274 ../src/libs/image.c:389
+#: ../src/libs/copy_history.c:274 ../src/libs/image.c:375
 msgid "copy..."
-msgstr "kopieren..."
+msgstr "kopieren"
 
 #: ../src/libs/copy_history.c:277
 msgid ""
@@ -12973,7 +13355,7 @@ msgstr ""
 
 #: ../src/libs/copy_history.c:289
 msgid "paste..."
-msgstr "einfügen..."
+msgstr "einfügen"
 
 #: ../src/libs/copy_history.c:291
 msgid ""
@@ -13019,11 +13401,11 @@ msgstr ""
 "Verlauf aller ausgewählten\n"
 "Bilder verwerfen"
 
-#: ../src/libs/copy_history.c:317
+#: ../src/libs/copy_history.c:317 ../src/libs/styles.c:449
 msgid "append"
 msgstr "hinzufügen"
 
-#: ../src/libs/copy_history.c:319
+#: ../src/libs/copy_history.c:319 ../src/libs/styles.c:451
 msgid "how to handle existing history"
 msgstr ""
 "wie soll mit einem vorhandenen\n"
@@ -13031,7 +13413,7 @@ msgstr ""
 
 #: ../src/libs/copy_history.c:325
 msgid "load sidecar file..."
-msgstr "XMP Begleitdatei laden..."
+msgstr "XMP-Begleitdatei laden"
 
 #: ../src/libs/copy_history.c:328
 msgid ""
@@ -13097,36 +13479,36 @@ msgstr ""
 msgid "create a duplicate of the image with same history stack"
 msgstr "Erstellt ein Duplikat des Bildes mit dem gleichen Verlaufsstapel"
 
-#: ../src/libs/export.c:70
+#: ../src/libs/export.c:72
 msgid "export selected"
 msgstr "ausgewählte exportieren"
 
-#: ../src/libs/export.c:128
+#: ../src/libs/export.c:130
 msgid "export to disk"
 msgstr "Exportieren"
 
-#: ../src/libs/export.c:549
+#: ../src/libs/export.c:557
 msgid "storage options"
 msgstr "Speicher-Optionen"
 
-#: ../src/libs/export.c:554
+#: ../src/libs/export.c:562
 msgid "target storage"
 msgstr "Speicherziel"
 
-#: ../src/libs/export.c:577
+#: ../src/libs/export.c:585
 msgid "format options"
 msgstr "Format-Optionen"
 
-#: ../src/libs/export.c:582
+#: ../src/libs/export.c:590
 msgid "file format"
 msgstr "Dateiformat"
 
-#: ../src/libs/export.c:600
+#: ../src/libs/export.c:608
 msgid "global options"
 msgstr "globale Optionen"
 
 # unschön
-#: ../src/libs/export.c:605
+#: ../src/libs/export.c:613
 msgid ""
 "maximum output width\n"
 "set to 0 for no scaling"
@@ -13135,7 +13517,7 @@ msgstr ""
 "auf 0 setzen für keine Skalierung"
 
 # unschön
-#: ../src/libs/export.c:607
+#: ../src/libs/export.c:615
 msgid ""
 "maximum output height\n"
 "set to 0 for no scaling"
@@ -13144,74 +13526,83 @@ msgstr ""
 "auf 0 setzen für keine Skalierung"
 
 # "maximale Größe" sprengt leider das Layout. :-(
-#: ../src/libs/export.c:615
+#: ../src/libs/export.c:623
 msgid "max size"
 msgstr "max. Größe"
 
-#: ../src/libs/export.c:621
+#: ../src/libs/export.c:629
 msgid "x"
 msgstr "×"
 
-#: ../src/libs/export.c:627
+#: ../src/libs/export.c:635
 msgid "allow upscaling"
 msgstr "Vergrößern erlauben"
 
-#: ../src/libs/export.c:633
+#: ../src/libs/export.c:641
 msgid "high quality resampling"
 msgstr "Hochqualitatives Resampling"
 
-#: ../src/libs/export.c:636
+#: ../src/libs/export.c:644
 msgid "do high quality resampling during export"
 msgstr "Hochqualitatives Resampling beim Export"
 
-#: ../src/libs/export.c:649 ../src/libs/export.c:670
-#: ../src/libs/print_settings.c:1406 ../src/libs/print_settings.c:1453
+#: ../src/libs/export.c:648
+#, fuzzy
+msgid "store masks"
+msgstr "Raster-Maske"
+
+#: ../src/libs/export.c:651
+msgid "store masks as layers in exported images. only works for some formats."
+msgstr ""
+
+#: ../src/libs/export.c:664 ../src/libs/export.c:685
+#: ../src/libs/print_settings.c:1411 ../src/libs/print_settings.c:1458
 msgid "image settings"
 msgstr "Bildeinstellungen"
 
-#: ../src/libs/export.c:660 ../src/libs/print_settings.c:1442
+#: ../src/libs/export.c:675 ../src/libs/print_settings.c:1447
 #, c-format
 msgid "output ICC profiles in %s or %s"
 msgstr "Ausgabe-ICC-Profile in %s oder %s"
 
-#: ../src/libs/export.c:680 ../src/libs/print_settings.c:1467
+#: ../src/libs/export.c:695 ../src/libs/print_settings.c:1472
 msgid "style"
 msgstr "Stil"
 
-#: ../src/libs/export.c:683
+#: ../src/libs/export.c:698
 msgid "temporary style to use while exporting"
 msgstr "Stil, der beim Export vorübergehend angewandt werden soll"
 
-#: ../src/libs/export.c:692 ../src/libs/print_settings.c:1512
+#: ../src/libs/export.c:707 ../src/libs/print_settings.c:1517
 msgid "replace history"
 msgstr "Verlauf ersetzen"
 
-#: ../src/libs/export.c:693 ../src/libs/print_settings.c:1513
+#: ../src/libs/export.c:708 ../src/libs/print_settings.c:1518
 msgid "append history"
 msgstr "Verlauf hinzufügen"
 
-#: ../src/libs/export.c:698 ../src/libs/print_settings.c:1520
+#: ../src/libs/export.c:713 ../src/libs/print_settings.c:1525
 msgid ""
 "whether the style items are appended to the history or replacing the history"
 msgstr ""
 "sollen Stil-Module an den Verlauf angehängt werden, oder diesen ersetzen"
 
 #. Export button
-#: ../src/libs/export.c:716
+#: ../src/libs/export.c:736
 msgid "export"
 msgstr "exportieren"
 
-#: ../src/libs/export.c:718
+#: ../src/libs/export.c:738
 msgid "export with current settings"
 msgstr "mit aktuellen Einstellungen exportieren"
 
-#: ../src/libs/export.c:724
+#: ../src/libs/export.c:744
 msgid "edit metadata exportation details"
-msgstr "Metadaten-Exportdetails bearbeiten"
+msgstr "Metadaten-Exporteinstellungen bearbeiten"
 
 #. enable shortcut to export with current export settings:
-#: ../src/libs/export.c:1318 ../src/libs/styles.c:71
-#: ../src/views/darkroom.c:3382
+#: ../src/libs/export.c:1368 ../src/libs/styles.c:72
+#: ../src/views/darkroom.c:3510
 msgctxt "accel"
 msgid "export"
 msgstr "Exportieren"
@@ -13246,8 +13637,8 @@ msgstr "Weichzeichnungstyp"
 msgid "edit metadata exportation"
 msgstr "Metadaten-Export bearbeiten"
 
-#: ../src/libs/export_metadata.c:269 ../src/libs/metadata.c:423
-#: ../src/libs/tagging.c:1388 ../src/libs/tagging.c:1561
+#: ../src/libs/export_metadata.c:269 ../src/libs/metadata.c:429
+#: ../src/libs/tagging.c:1429 ../src/libs/tagging.c:1554
 msgid "save"
 msgstr "Speichern"
 
@@ -13261,11 +13652,11 @@ msgstr "Exif Daten"
 
 #: ../src/libs/export_metadata.c:287
 msgid "export exif metadata"
-msgstr "Exif Metadaten exportieren"
+msgstr "Exif-Metadaten exportieren"
 
-#: ../src/libs/export_metadata.c:289 ../src/libs/image.c:357
-#: ../src/libs/image.c:493 ../src/libs/metadata.c:428
-#: ../src/libs/metadata.c:613
+#: ../src/libs/export_metadata.c:289 ../src/libs/image.c:343
+#: ../src/libs/image.c:479 ../src/libs/metadata.c:434
+#: ../src/libs/metadata.c:621
 msgid "metadata"
 msgstr "Metadaten"
 
@@ -13292,7 +13683,7 @@ msgstr ""
 "Wenn der Remote-Speicher darktable xmp-Metadaten nicht versteht, können Sie "
 "stattdessen berechnete Metadaten verwenden."
 
-#: ../src/libs/export_metadata.c:307 ../src/libs/image.c:486
+#: ../src/libs/export_metadata.c:307 ../src/libs/image.c:472
 msgid "geo tags"
 msgstr "Geo-Tags"
 
@@ -13334,7 +13725,7 @@ msgstr ""
 
 #: ../src/libs/export_metadata.c:328
 msgid "hierarchical tags"
-msgstr "Hierarchische Stichwörter"
+msgstr "hierarchische Stichwörter"
 
 #: ../src/libs/export_metadata.c:329
 msgid "export hierarchical tags (to Xmp.lr.Hierarchical Subject)"
@@ -13355,7 +13746,7 @@ msgstr ""
 
 #: ../src/libs/export_metadata.c:339
 msgid "per metadata settings"
-msgstr "mit Bezug auf die Metadaten-Einstellungen"
+msgstr "Konfiguration der einzelnen Metadaten"
 
 #: ../src/libs/export_metadata.c:350
 msgid "list of available tags"
@@ -13370,7 +13761,6 @@ msgid "formula"
 msgstr "Formel"
 
 #: ../src/libs/export_metadata.c:361
-#, fuzzy
 msgid ""
 "list of calculated metadata\n"
 "if formula is empty, the corresponding metadata is removed from exported "
@@ -13382,11 +13772,12 @@ msgid ""
 "click on formula cell to edit. recognized variables:\n"
 msgstr ""
 "Liste der berechneten Metadaten\n"
-"wenn das Formular leer ist, wurden die entsprechenden Metadaten aus der "
-"exportierten Datei entfernt\n"
-"andernfalls werden die entsprechenden Metadaten berechnet und der "
-"exportierten Datei hinzugefügt\n"
-"Klicken Sie auf die Formularzelle, um die erkannten Variablen zu bearbeiten:"
+"Wenn eine Formel leer ist, werden die entsprechenden Metadaten aus der "
+"exportierten Datei entfernt.  Besteht die Formel lediglich aus einem „=”, so "
+"werden die Exif-Metadaten exportiert, auch dann, wenn Exif-Metadaten-Export "
+"abgeschaltet ist. Andernfalls werden die entsprechenden Metadaten gemäß der "
+"Formel neu berechnet und der exportierten Datei hinzugefügt. Formeln können "
+"die folgenden Variablen enthalten:\n"
 
 #: ../src/libs/export_metadata.c:418
 msgid "add an output metadata tag"
@@ -13396,7 +13787,7 @@ msgstr "Hinzufügen eines Ausgabe-Metadaten-Tag"
 msgid "delete metadata tag"
 msgstr "Metadaten-Tag löschen"
 
-#: ../src/libs/geotagging.c:411
+#: ../src/libs/geotagging.c:413
 msgid ""
 "enter the time shown on the selected picture\n"
 "format: hh:mm:ss"
@@ -13404,23 +13795,23 @@ msgstr ""
 "Zeit eingeben, die auf dem ausgewählten Bild angezeigt wird\n"
 "Format: hh:mm:ss"
 
-#: ../src/libs/geotagging.c:420
+#: ../src/libs/geotagging.c:422
 msgid "ok"
 msgstr "OK"
 
-#: ../src/libs/geotagging.c:473
+#: ../src/libs/geotagging.c:475
 msgid "open GPX file"
 msgstr "GPX-Datei öffnen"
 
-#: ../src/libs/geotagging.c:490
+#: ../src/libs/geotagging.c:492
 msgid "GPS data exchange format"
 msgstr "GPS-Daten-Austauschformat (GPX)"
 
-#: ../src/libs/geotagging.c:500
+#: ../src/libs/geotagging.c:502
 msgid "camera time zone"
 msgstr "Zeitzone der Kamera"
 
-#: ../src/libs/geotagging.c:501
+#: ../src/libs/geotagging.c:503
 msgid ""
 "most cameras don't store the time zone in EXIF. give the correct time zone "
 "so the GPX data can be correctly matched"
@@ -13429,7 +13820,7 @@ msgstr ""
 "die korrekte Zeitzone angegeben werden, damit die GPX-Daten richtig "
 "zugeordnet werden können"
 
-#: ../src/libs/geotagging.c:792
+#: ../src/libs/geotagging.c:794
 msgid ""
 "time offset\n"
 "format: [+-]?[[hh:]mm:]ss"
@@ -13437,81 +13828,89 @@ msgstr ""
 "Zeitversatz\n"
 "Format: [+-]?[[hh:]mm:]ss"
 
-#: ../src/libs/geotagging.c:802
+#: ../src/libs/geotagging.c:804
 msgid "calculate the time offset from an image"
 msgstr "Zeitversatz anhand eines Bildes berechnen"
 
-#: ../src/libs/geotagging.c:807
+#: ../src/libs/geotagging.c:809
 msgid "apply time offset to selected images"
 msgstr "Zeitversatz auf ausgewählte Bilder anwenden"
 
 #. gpx
-#: ../src/libs/geotagging.c:815
+#: ../src/libs/geotagging.c:817
 msgid "apply GPX track file..."
-msgstr "GPX-Track-Datei anwenden..."
+msgstr "GPX-Track-Datei anwenden"
 
-#: ../src/libs/geotagging.c:816
+#: ../src/libs/geotagging.c:818
 msgid "parses a GPX file and updates location of selected images"
 msgstr "liest eine GPX-Datei und setzt die Position der ausgewählten Bilder"
 
-#: ../src/libs/histogram.c:48
+#: ../src/libs/histogram.c:71
 msgid "histogram"
 msgstr "Histogramm"
 
-#: ../src/libs/histogram.c:374
-msgid "set histogram mode to linear"
-msgstr "zum linearen Histogramm wechseln"
+#: ../src/libs/histogram.c:512 ../src/libs/histogram.c:546
+msgid "set mode to waveform"
+msgstr "zu Wellenform-Histogramm wechseln"
 
-#: ../src/libs/histogram.c:377
-msgid "set histogram mode to waveform"
-msgstr "zum Waveform-Histogramm wechseln"
+#: ../src/libs/histogram.c:515
+msgid "set mode to histogram"
+msgstr "zu Histogramm wechseln"
 
-#: ../src/libs/histogram.c:380
-msgid "set histogram mode to logarithmic"
-msgstr "zum logarithmischen Histogramm wechseln"
+#: ../src/libs/histogram.c:530
+msgid "set mode to linear"
+msgstr "Histogramm linear skalieren"
 
-#: ../src/libs/histogram.c:389
+#: ../src/libs/histogram.c:533
+msgid "set mode to logarithmic"
+msgstr "Histogramm logarithmischen skalieren"
+
+#: ../src/libs/histogram.c:543
+msgid "set mode to RGB parade"
+msgstr "zu getrennten RGB-Kanälen wechseln"
+
+#: ../src/libs/histogram.c:559
 msgid "click to hide red channel"
 msgstr "klicken, um den Rot-Kanal auszublenden"
 
-#: ../src/libs/histogram.c:389
+#: ../src/libs/histogram.c:559
 msgid "click to show red channel"
 msgstr "klicken, um den Rot-Kanal anzuzeigen"
 
-#: ../src/libs/histogram.c:394
+#: ../src/libs/histogram.c:564
 msgid "click to hide green channel"
 msgstr "klicken, um den Grün-Kanal auszublenden"
 
-#: ../src/libs/histogram.c:395
+#: ../src/libs/histogram.c:565
 msgid "click to show green channel"
 msgstr "klicken, um den Grün-Kanal anzuzeigen"
 
-#: ../src/libs/histogram.c:400
+#: ../src/libs/histogram.c:570
 msgid "click to hide blue channel"
 msgstr "klicken, um den Blau-Kanal auszublenden"
 
-#: ../src/libs/histogram.c:400
+#: ../src/libs/histogram.c:570
 msgid "click to show blue channel"
 msgstr "klicken, um den Blau-Kanal anzuzeigen"
 
-#: ../src/libs/histogram.c:406
+#: ../src/libs/histogram.c:576
 msgid ""
 "drag to change black point,\n"
 "doubleclick resets"
 msgstr ""
-"Ziehen, um den Schwarzpunkt zu ändern,\n"
+"ziehen, um den Schwarzpunkt zu ändern,\n"
 "Doppelklick zum Zurücksetzen"
 
 #. connect callbacks
-#: ../src/libs/histogram.c:411 ../src/libs/histogram.c:579
+#: ../src/libs/histogram.c:581 ../src/libs/histogram.c:783
 msgid ""
 "drag to change exposure,\n"
 "doubleclick resets"
 msgstr ""
-"Ziehen, um die Belichtung zu ändern,\n"
+"ziehen, um die Belichtung zu ändern,\n"
 "Doppelklick zum Zurücksetzen"
 
-#: ../src/libs/histogram.c:614
+#: ../src/libs/histogram.c:818
 msgctxt "accel"
 msgid "hide histogram"
 msgstr "Histogramm verbergen"
@@ -13554,7 +13953,7 @@ msgstr "Modul aktivieren"
 msgid "deprecated module"
 msgstr "Modul suchen"
 
-#: ../src/libs/history.c:677 ../src/libs/snapshots.c:346
+#: ../src/libs/history.c:677 ../src/libs/snapshots.c:458
 msgid "original"
 msgstr "Original"
 
@@ -13575,363 +13974,375 @@ msgid "physically delete from disk"
 msgstr "physisch von der Festplatte löschen"
 
 #. delete
-#: ../src/libs/image.c:368 ../src/libs/styles.c:458
+#: ../src/libs/image.c:354 ../src/libs/styles.c:473
 msgid "remove"
 msgstr "entfernen"
 
-#: ../src/libs/image.c:371
+#: ../src/libs/image.c:357
 msgid "remove from the collection"
 msgstr "aus der Sammlung entfernen"
 
-#: ../src/libs/image.c:382
+#: ../src/libs/image.c:368
 msgid "move..."
-msgstr "verschieben..."
+msgstr "verschieben"
 
-#: ../src/libs/image.c:385
+#: ../src/libs/image.c:371
 msgid "move to other folder"
 msgstr "in anderen Ordner verschieben"
 
-#: ../src/libs/image.c:392
+#: ../src/libs/image.c:378
 msgid "copy to other folder"
 msgstr "in anderen Ordner kopieren"
 
-#: ../src/libs/image.c:396
+#: ../src/libs/image.c:382
 msgid "create HDR"
 msgstr "HDR erzeugen"
 
-#: ../src/libs/image.c:401
+#: ../src/libs/image.c:387
 msgid "create a high dynamic range image from selected shots"
 msgstr "Hochkontrastbild (HDRI) aus ausgewählten Bildern erzeugen"
 
-#: ../src/libs/image.c:403
+#: ../src/libs/image.c:389
 msgid "duplicate"
 msgstr "duplizieren"
 
-#: ../src/libs/image.c:406
+#: ../src/libs/image.c:392
 msgid "add a duplicate to the collection, including its history stack"
 msgstr "füge ein Duplikat zur Sammlung hinzu, inklusive des Verlaufsstapels"
 
-#: ../src/libs/image.c:413
+#: ../src/libs/image.c:399
 msgid "rotate selected images 90 degrees CCW"
 msgstr "Ausgewählte Bilder um 90° gegen den Uhrzeigersinn drehen"
 
-#: ../src/libs/image.c:419
+#: ../src/libs/image.c:405
 msgid "rotate selected images 90 degrees CW"
 msgstr "Ausgewählte Bilder um 90° im Uhrzeigersinn drehen"
 
-#: ../src/libs/image.c:423
+#: ../src/libs/image.c:409
 msgid "reset rotation"
 msgstr "Drehung entfernen"
 
-#: ../src/libs/image.c:426
+#: ../src/libs/image.c:412
 msgid "reset rotation to EXIF data"
 msgstr "Drehung auf EXIF-Angabe zurücksetzen"
 
-#: ../src/libs/image.c:431
+#: ../src/libs/image.c:417
 msgid "copy locally"
 msgstr "lokal kopieren"
 
-#: ../src/libs/image.c:434
+#: ../src/libs/image.c:420
 msgid "copy the image locally"
 msgstr "Bild in lokalen Cache kopieren"
 
-#: ../src/libs/image.c:438
+#: ../src/libs/image.c:424
 msgid "resync local copy"
 msgstr "Kopie zurückspielen"
 
-#: ../src/libs/image.c:441
+#: ../src/libs/image.c:427
 msgid "synchronize the image's XMP and remove the local copy"
 msgstr "XMP des Bildes synchronisieren und lokale Kopie entfernen"
 
 #. DT_COLLECTION_SORT_COLOR
-#: ../src/libs/image.c:446 ../src/libs/tools/filter.c:152
+#: ../src/libs/image.c:432 ../src/libs/tools/filter.c:152
 msgid "group"
 msgstr "gruppieren"
 
-#: ../src/libs/image.c:449
+#: ../src/libs/image.c:435
 msgid "add selected images to expanded group or create a new one"
 msgstr ""
 "ausgewählte Bilder zur aufgeklappten Gruppe hinzufügen oder neue Gruppe "
 "erstellen"
 
-#: ../src/libs/image.c:453
+#: ../src/libs/image.c:439
 msgid "ungroup"
 msgstr "Gruppe auflösen"
 
-#: ../src/libs/image.c:456
+#: ../src/libs/image.c:442
 msgid "remove selected images from the group"
 msgstr "Ausgewählte Bilder aus der Gruppe entfernen"
 
-#: ../src/libs/image.c:465 ../src/libs/tools/ratings.c:55
+#: ../src/libs/image.c:451 ../src/libs/tools/ratings.c:55
 msgid "ratings"
 msgstr "Bewertungen"
 
-#: ../src/libs/image.c:467
+#: ../src/libs/image.c:453
 #, fuzzy
 msgid "select ratings metadata"
 msgstr "Interpolationsverfahren wählen"
 
-#: ../src/libs/image.c:472
-#, fuzzy
+#: ../src/libs/image.c:458
 msgid "colors"
-msgstr "Farbe"
+msgstr "Farben"
 
-#: ../src/libs/image.c:474
+#: ../src/libs/image.c:460
 #, fuzzy
 msgid "select colors metadata"
 msgstr "Farbe des Filmmaterials auswählen"
 
-#: ../src/libs/image.c:481
+#: ../src/libs/image.c:467
 #, fuzzy
 msgid "select tags metadata"
 msgstr "Tag auswählen"
 
-#: ../src/libs/image.c:488
+#: ../src/libs/image.c:474
 #, fuzzy
 msgid "select geo tags metadata"
 msgstr "Metadaten-Tag löschen"
 
-#: ../src/libs/image.c:495
+#: ../src/libs/image.c:481
 #, fuzzy
 msgid "select dt metadata (from metadata editor module)"
 msgstr "Exportiere darktable xmp-Metadaten (aus dem Metadaten-Editor-Modul)"
 
-#: ../src/libs/image.c:504
+#: ../src/libs/image.c:490
 msgid "set the (first) selected image as source of metadata"
 msgstr ""
 
-#: ../src/libs/image.c:508
-#, fuzzy
+#: ../src/libs/image.c:494
 msgid "paste"
-msgstr "Einfügen"
+msgstr "einfügen"
 
-#: ../src/libs/image.c:512
+#: ../src/libs/image.c:498
 #, fuzzy
 msgid "paste selected metadata on selected images"
 msgstr "Metadaten für ausgewählte Bilder schreiben"
 
-#: ../src/libs/image.c:516 ../src/libs/metadata.c:724
+#: ../src/libs/image.c:502 ../src/libs/metadata.c:732
 msgid "clear"
 msgstr "löschen"
 
-#: ../src/libs/image.c:519
+#: ../src/libs/image.c:505
 #, fuzzy
 msgid "clear selected metadata on selected images"
 msgstr "Metadaten für ausgewählte Bilder schreiben"
 
-#: ../src/libs/image.c:525
-#, fuzzy
+#: ../src/libs/image.c:511
 msgid "merge"
-msgstr "Zusammenführen von:"
+msgstr "zusammenfügen"
 
-#: ../src/libs/image.c:527
+#: ../src/libs/image.c:513
 #, fuzzy
 msgid "how to handle existing metadata"
 msgstr ""
 "wie soll mit einem vorhandenen\n"
 "Verlauf umgegangen werden"
 
-#: ../src/libs/image.c:535
+#: ../src/libs/image.c:521
 msgid "update image information to match changes to file"
 msgstr ""
 "Bildinformationen aktualisieren, um Änderungen an der Datei abzugleichen."
 
-#: ../src/libs/image.c:565
+#: ../src/libs/image.c:551
 msgctxt "accel"
 msgid "remove from collection"
 msgstr "Aus der Sammlung entfernen"
 
-#: ../src/libs/image.c:566
+#: ../src/libs/image.c:552
 msgctxt "accel"
 msgid "delete from disk or send to trash"
 msgstr "Von der Festplatte löschen oder in den Papierkorb verschieben"
 
-#: ../src/libs/image.c:567
+#: ../src/libs/image.c:553
 msgctxt "accel"
 msgid "move to other folder"
 msgstr "In anderen Ordner verschieben"
 
-#: ../src/libs/image.c:568
+#: ../src/libs/image.c:554
 msgctxt "accel"
 msgid "copy to other folder"
 msgstr "In anderen Ordner kopieren"
 
-#: ../src/libs/image.c:569
+#: ../src/libs/image.c:555
 msgctxt "accel"
 msgid "rotate selected images 90 degrees CW"
 msgstr "Ausgewählte Bilder um 90° im Uhrzeigersinn drehen"
 
-#: ../src/libs/image.c:570
+#: ../src/libs/image.c:556
 msgctxt "accel"
 msgid "rotate selected images 90 degrees CCW"
 msgstr "Ausgewählte Bilder um 90° gegen den Uhrzeigersinn drehen"
 
-#: ../src/libs/image.c:571
+#: ../src/libs/image.c:557
 msgctxt "accel"
 msgid "create HDR"
 msgstr "HDR erzeugen"
 
-#: ../src/libs/image.c:572
+#: ../src/libs/image.c:558
 msgctxt "accel"
 msgid "duplicate"
 msgstr "Duplizieren"
 
-#: ../src/libs/image.c:573
+#: ../src/libs/image.c:559
 msgctxt "accel"
 msgid "reset rotation"
 msgstr "Drehung zurücksetzen"
 
-#: ../src/libs/image.c:574
+#: ../src/libs/image.c:560
 msgctxt "accel"
 msgid "copy the image locally"
 msgstr "Bild lokal kopieren"
 
-#: ../src/libs/image.c:575
+#: ../src/libs/image.c:561
 msgctxt "accel"
 msgid "resync the local copy"
 msgstr "Lokale Kopie synchronisieren"
 
-#: ../src/libs/image.c:576
+#: ../src/libs/image.c:562
 msgctxt "accel"
 msgid "refresh exif"
-msgstr "Exif aktualisieren"
+msgstr "Exif-Daten aktualisieren"
 
-#: ../src/libs/image.c:577
+#: ../src/libs/image.c:563
 #, fuzzy
 msgctxt "accel"
 msgid "copy metadata"
 msgstr "Metadaten"
 
-#: ../src/libs/image.c:578
+#: ../src/libs/image.c:564
 #, fuzzy
 msgctxt "accel"
 msgid "replace metadata"
 msgstr "Metadaten-Tag löschen"
 
-#: ../src/libs/image.c:579
+#: ../src/libs/image.c:565
 #, fuzzy
 msgctxt "accel"
 msgid "paste metadata"
 msgstr "Metadaten"
 
-#: ../src/libs/image.c:580
+#: ../src/libs/image.c:566
 #, fuzzy
 msgctxt "accel"
 msgid "clear metadata"
 msgstr "Metadaten"
 
 #. Grouping keys
-#: ../src/libs/image.c:582
+#: ../src/libs/image.c:568
 msgctxt "accel"
 msgid "group"
 msgstr "Gruppieren"
 
-#: ../src/libs/image.c:583
+#: ../src/libs/image.c:569
 msgctxt "accel"
 msgid "ungroup"
 msgstr "Gruppierung aufheben"
 
-#: ../src/libs/import.c:119
+#: ../src/libs/import.c:120
 msgctxt "accel"
 msgid "scan for devices"
 msgstr "Nach Geräten suchen"
 
-#: ../src/libs/import.c:120
+#: ../src/libs/import.c:121
 msgctxt "accel"
 msgid "import from camera"
 msgstr "Von Kamera importieren"
 
 # "Tethering" scheint auch im deutschsprachigen Raum verbreitet zu sein.
-#: ../src/libs/import.c:121
+#: ../src/libs/import.c:122
 msgctxt "accel"
 msgid "tethered shoot"
 msgstr "Tethering-Aufnahme"
 
-#: ../src/libs/import.c:122
+#: ../src/libs/import.c:123
 msgctxt "accel"
 msgid "import image"
 msgstr "Bild importieren"
 
-#: ../src/libs/import.c:123
+#: ../src/libs/import.c:124
 msgctxt "accel"
 msgid "import folder"
 msgstr "Verzeichnis importieren"
 
-#: ../src/libs/import.c:216
+#: ../src/libs/import.c:217
 #, c-format
 msgid "device \"%s\" connected on port \"%s\"."
 msgstr "Gerät „%s“ an Port „%s“ angeschlossen."
 
-#: ../src/libs/import.c:226
+#: ../src/libs/import.c:227
 msgid "import from camera"
 msgstr "Von Kamera importieren"
 
 # "Tethering" scheint auch im deutschsprachigen Raum verbreitet zu sein.
-#: ../src/libs/import.c:232
+#: ../src/libs/import.c:233
 msgid "tethered shoot"
 msgstr "Tethering-Aufnahme"
 
 #. No supported devices is detected lets notice user..
-#: ../src/libs/import.c:256
+#: ../src/libs/import.c:257
 msgid "no supported devices found"
 msgstr "Keine unterstützten Geräte gefunden"
 
 # zu frei?
 #. add extra lines to 'extra'. don't forget to destroy the widgets later.
-#: ../src/libs/import.c:406
+#: ../src/libs/import.c:433
 msgid "import options"
 msgstr "Import-Optionen"
 
 #. recursive opening.
-#: ../src/libs/import.c:424
+#: ../src/libs/import.c:448
 #, fuzzy
 msgid "import folders recursively"
 msgstr "Verzeichnisse rekursiv importieren"
 
-#: ../src/libs/import.c:426
+#: ../src/libs/import.c:450
 #, fuzzy
 msgid "recursively import subfolders. Each folder goes into a new film roll."
 msgstr ""
 "Verzeichnisse rekursiv importieren. Jedes Verzeichnis kommt in eine eigene "
 "Filmrolle."
 
-#: ../src/libs/import.c:779
+#: ../src/libs/import.c:539
+#, fuzzy
+msgid "metadata to be applied per default"
+msgstr "Urheber, der beim Import hinzugefügt werden soll"
+
+#: ../src/libs/import.c:548
+#, fuzzy
+msgid "to be imported"
+msgstr "%s wurde importiert"
+
+#: ../src/libs/import.c:550
+msgid ""
+"selected metadata are imported from image and override the default value"
+msgstr ""
+
+#: ../src/libs/import.c:816
 msgid "supported images"
 msgstr "unterstütze Bilder"
 
-#: ../src/libs/import.c:835
+#: ../src/libs/import.c:872
 msgid "file has unknown format!"
 msgstr "Datei hat ein unbekanntes Format!"
 
-#: ../src/libs/import.c:860
+#: ../src/libs/import.c:897
 #, fuzzy
 msgid "import folder"
 msgstr "Verzeichnis importieren"
 
 #. add import single image buttons
-#: ../src/libs/import.c:976
+#: ../src/libs/import.c:1013
 msgid "image..."
-msgstr "Bild..."
+msgstr "Bild"
 
-#: ../src/libs/import.c:980
+#: ../src/libs/import.c:1017
 msgid "select one or more images to import"
 msgstr "Ein oder mehrere Bilder zum Import wählen"
 
 #. adding the import folder button
-#: ../src/libs/import.c:987
+#: ../src/libs/import.c:1024
 msgid "folder..."
-msgstr "Verzeichnis..."
+msgstr "Verzeichnis"
 
-#: ../src/libs/import.c:991
+#: ../src/libs/import.c:1028
 msgid "select a folder to import as film roll"
 msgstr "Verzeichnis zum Import wählen"
 
 #. add the rescan button
-#: ../src/libs/import.c:1000
+#: ../src/libs/import.c:1037
 msgid "scan for devices"
-msgstr "Nach Geräten suchen"
+msgstr "nach Geräten suchen"
 
-#: ../src/libs/import.c:1004
+#: ../src/libs/import.c:1041
 msgid "scan for newly attached devices"
 msgstr "Suche nach neu angeschlossenen Geräten"
 
@@ -14037,7 +14448,7 @@ msgstr "ID"
 msgid "overlay another image over the live view"
 msgstr "Live-View mit anderem Bild überlagern"
 
-#: ../src/libs/live_view.c:390 ../src/libs/metadata_view.c:98
+#: ../src/libs/live_view.c:390 ../src/libs/metadata_view.c:103
 msgid "image id"
 msgstr "Bild-ID"
 
@@ -14111,7 +14522,7 @@ msgstr "HSL-Helligkeit"
 
 #: ../src/libs/live_view.c:427
 msgid "mode of the overlay"
-msgstr "Modus der Überlagerung"
+msgstr "Modus der Bildinfos"
 
 #: ../src/libs/live_view.c:433
 msgid "split line"
@@ -14192,7 +14603,7 @@ msgstr "Modus: Ausschluss"
 msgid "cleanup unused shapes"
 msgstr "unbenutzte Formen entfernen"
 
-#: ../src/libs/masks.c:1654
+#: ../src/libs/masks.c:1651
 msgid "created shapes"
 msgstr "Verfügbare Formen"
 
@@ -14200,21 +14611,21 @@ msgstr "Verfügbare Formen"
 msgid "metadata editor"
 msgstr "Metadaten-Editor"
 
-#: ../src/libs/metadata.c:90 ../src/libs/metadata.c:126
+#: ../src/libs/metadata.c:93 ../src/libs/metadata.c:129
 msgid "<leave unchanged>"
 msgstr "<nicht ändern>"
 
-#: ../src/libs/metadata.c:422
+#: ../src/libs/metadata.c:428
 #, fuzzy
 msgid "metadata settings"
 msgstr "mit Bezug auf die Metadaten-Einstellungen"
 
-#: ../src/libs/metadata.c:430
+#: ../src/libs/metadata.c:436
 #, fuzzy
 msgid "hidden"
 msgstr "verborgen"
 
-#: ../src/libs/metadata.c:433
+#: ../src/libs/metadata.c:439
 msgid ""
 "tick if the corresponding metadata is of no interest for you\n"
 "it will be hidden from metadata editor, collection, image information and "
@@ -14222,27 +14633,27 @@ msgid ""
 "neither will it be exported"
 msgstr ""
 
-#: ../src/libs/metadata.c:436 ../src/libs/tagging.c:1418
-#: ../src/libs/tagging.c:1605
+#: ../src/libs/metadata.c:442 ../src/libs/tagging.c:1459
+#: ../src/libs/tagging.c:1598
 msgid "private"
 msgstr "privat"
 
-#: ../src/libs/metadata.c:439
+#: ../src/libs/metadata.c:445
 msgid ""
 "tick if you want to keep this information private (not exported with images)"
 msgstr ""
 
-#: ../src/libs/metadata.c:511
+#: ../src/libs/metadata.c:519
 msgctxt "accel"
 msgid "clear"
 msgstr "löschen"
 
-#: ../src/libs/metadata.c:575
+#: ../src/libs/metadata.c:583
 #, fuzzy
 msgid "metadata list"
 msgstr "Metadaten-Editor"
 
-#: ../src/libs/metadata.c:677
+#: ../src/libs/metadata.c:685
 msgid ""
 "metadata text. ctrl-wheel scroll to resize the text box\n"
 " ctrl-enter inserts a new line (caution, may not be compatible with standard "
@@ -14252,141 +14663,157 @@ msgid ""
 "press escape to exit the popup window"
 msgstr ""
 
-#: ../src/libs/metadata.c:726
+#: ../src/libs/metadata.c:734
 msgid "remove metadata from selected images"
 msgstr "Metadaten von ausgewählten Bildern entfernen"
 
-#: ../src/libs/metadata.c:733
+#: ../src/libs/metadata.c:741
 msgid "write metadata for selected images"
 msgstr "Metadaten für ausgewählte Bilder schreiben"
 
-#: ../src/libs/metadata.c:741
-#, fuzzy
+#: ../src/libs/metadata.c:749
 msgid "configure metadata"
-msgstr "Exif Metadaten exportieren"
+msgstr "Exif-Metadaten exportieren"
 
 #. <title>\0<description>\0<rights>\0<creator>\0<publisher>
-#: ../src/libs/metadata.c:783
+#: ../src/libs/metadata.c:791
 msgid "CC BY"
 msgstr "CC BY"
 
-#: ../src/libs/metadata.c:783
+#: ../src/libs/metadata.c:791
 msgid "Creative Commons Attribution (CC BY)"
 msgstr "Creative Commons Namensnennung (CC-BY)"
 
-#: ../src/libs/metadata.c:784
+#: ../src/libs/metadata.c:792
 msgid "CC BY-SA"
 msgstr "CC BY-SA"
 
-#: ../src/libs/metadata.c:784
+#: ../src/libs/metadata.c:792
 msgid "Creative Commons Attribution-ShareAlike (CC BY-SA)"
 msgstr ""
 "Creative Commons Namensnennung, Weitergabe unter gleichen Bedingungen (CC-BY-"
 "SA)"
 
-#: ../src/libs/metadata.c:785
+#: ../src/libs/metadata.c:793
 msgid "CC BY-ND"
 msgstr "CC BY-ND"
 
-#: ../src/libs/metadata.c:785
+#: ../src/libs/metadata.c:793
 msgid "Creative Commons Attribution-NoDerivs (CC BY-ND)"
 msgstr "Creative Commons Namensnennung, keine Bearbeitung (CC-BY-ND)"
 
-#: ../src/libs/metadata.c:786
+#: ../src/libs/metadata.c:794
 msgid "CC BY-NC"
 msgstr "CC BY-NC"
 
-#: ../src/libs/metadata.c:786
+#: ../src/libs/metadata.c:794
 msgid "Creative Commons Attribution-NonCommercial (CC BY-NC)"
 msgstr "Creative Commons Namensnennung, nicht kommerziell (CC-BY-NC)"
 
-#: ../src/libs/metadata.c:787
+#: ../src/libs/metadata.c:795
 msgid "CC BY-NC-SA"
 msgstr "CC BY-NC-SA"
 
-#: ../src/libs/metadata.c:788
+#: ../src/libs/metadata.c:796
 msgid "Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)"
 msgstr ""
 "Creative Commons Namensnennung, nicht kommerziell, Weitergabe unter gleichen "
 "Bedingungen (CC-BY-NC-SA)"
 
-#: ../src/libs/metadata.c:789
+#: ../src/libs/metadata.c:797
 msgid "CC BY-NC-ND"
 msgstr "CC BY-NC-ND"
 
-#: ../src/libs/metadata.c:790
+#: ../src/libs/metadata.c:798
 msgid "Creative Commons Attribution-NonCommercial-NoDerivs (CC BY-NC-ND)"
 msgstr ""
 "Creative Commons Namensnennung, nicht kommerziell, keine Bearbeitung (CC-BY-"
 "NC-ND)"
 
-#: ../src/libs/metadata.c:791
+#: ../src/libs/metadata.c:799
 msgid "all rights reserved"
 msgstr "alle Rechte vorbehalten"
 
-#: ../src/libs/metadata.c:791
+#: ../src/libs/metadata.c:799
 msgid "all rights reserved."
 msgstr "alle Rechte vorbehalten."
 
 #. internal
-#: ../src/libs/metadata_view.c:97
+#: ../src/libs/metadata_view.c:102
 msgid "filmroll"
 msgstr "Filmrolle"
 
-#: ../src/libs/metadata_view.c:99
+#: ../src/libs/metadata_view.c:104
 msgid "group id"
 msgstr "Gruppen-ID"
 
-#: ../src/libs/metadata_view.c:101
+#: ../src/libs/metadata_view.c:106
 msgid "version"
 msgstr "Version"
 
 #. DT_COLLECTION_SORT_GROUP
-#: ../src/libs/metadata_view.c:102 ../src/libs/tools/filter.c:153
+#: ../src/libs/metadata_view.c:107 ../src/libs/tools/filter.c:153
 msgid "full path"
 msgstr "voller Pfad"
 
-#: ../src/libs/metadata_view.c:105
+#: ../src/libs/metadata_view.c:109
+msgid "import timestamp"
+msgstr "Importzeitstempel"
+
+#: ../src/libs/metadata_view.c:110
+msgid "change timestamp"
+msgstr "Änderungszeitstempel"
+
+#: ../src/libs/metadata_view.c:111
+msgid "export timestamp"
+msgstr "Exportzeitstempel"
+
+#: ../src/libs/metadata_view.c:112
+#, fuzzy
+msgid "print timestamp"
+msgstr "XMP-Zeitstempel"
+
+#: ../src/libs/metadata_view.c:114
 msgid "flags"
 msgstr "Flags"
 
-#: ../src/libs/metadata_view.c:115
+#: ../src/libs/metadata_view.c:125
 msgid "focus distance"
 msgstr "Fokus-Entfernung"
 
-#: ../src/libs/metadata_view.c:117
+#: ../src/libs/metadata_view.c:127
 msgid "datetime"
 msgstr "Datum/Uhrzeit"
 
-#: ../src/libs/metadata_view.c:119 ../src/libs/print_settings.c:1308
+#: ../src/libs/metadata_view.c:129 ../src/libs/print_settings.c:1313
 msgid "height"
 msgstr "Höhe"
 
-#: ../src/libs/metadata_view.c:121
+#: ../src/libs/metadata_view.c:131
 msgid "export width"
 msgstr "Exportbreite"
 
-#: ../src/libs/metadata_view.c:122
+#: ../src/libs/metadata_view.c:132
 msgid "export height"
 msgstr "Exporthöhe"
 
-#: ../src/libs/metadata_view.c:134
+#: ../src/libs/metadata_view.c:144
 msgid "longitude"
 msgstr "Länge"
 
-#: ../src/libs/metadata_view.c:135
+#: ../src/libs/metadata_view.c:145
 msgid "elevation"
 msgstr "Höhe"
 
-#: ../src/libs/metadata_view.c:139
+#: ../src/libs/metadata_view.c:149
 msgid "categories"
 msgstr "Kategorien"
 
-#: ../src/libs/metadata_view.c:151
+#: ../src/libs/metadata_view.c:161
 msgid "image information"
 msgstr "Bildinformation"
 
-#: ../src/libs/metadata_view.c:263
+#: ../src/libs/metadata_view.c:273
 #, c-format
 msgid ""
 "double click to jump to film roll\n"
@@ -14396,107 +14823,107 @@ msgstr ""
 "%s\n"
 "zu springen"
 
-#: ../src/libs/metadata_view.c:294
+#: ../src/libs/metadata_view.c:341
 msgid "unused"
 msgstr "nicht benutzt"
 
-#: ../src/libs/metadata_view.c:295
+#: ../src/libs/metadata_view.c:342
 msgid "unused/deprecated"
 msgstr "unbenutzt/veraltet"
 
-#: ../src/libs/metadata_view.c:296
+#: ../src/libs/metadata_view.c:343
 msgid "ldr"
 msgstr "LDR"
 
-#: ../src/libs/metadata_view.c:298
+#: ../src/libs/metadata_view.c:345
 msgid "hdr"
 msgstr "HDR"
 
-#: ../src/libs/metadata_view.c:299
+#: ../src/libs/metadata_view.c:346
 msgid "marked for deletion"
 msgstr "wird gelöscht"
 
-#: ../src/libs/metadata_view.c:300
+#: ../src/libs/metadata_view.c:347
 msgid "auto-applying presets applied"
 msgstr "automatische Voreinstellungen angewandt"
 
-#: ../src/libs/metadata_view.c:301
+#: ../src/libs/metadata_view.c:348
 msgid "legacy flag. set for all new images"
 msgstr "altes Flag, für alle neuen Bilder gesetzt"
 
-#: ../src/libs/metadata_view.c:303
+#: ../src/libs/metadata_view.c:350
 msgid "has .txt"
 msgstr "hat .txt"
 
-#: ../src/libs/metadata_view.c:304
+#: ../src/libs/metadata_view.c:351
 msgid "has .wav"
 msgstr "hat .wav"
 
-#: ../src/libs/metadata_view.c:316
+#: ../src/libs/metadata_view.c:363
 msgid "image rejected"
 msgstr "Bild abgelehnt"
 
-#: ../src/libs/metadata_view.c:321
+#: ../src/libs/metadata_view.c:368
 #, c-format
 msgid "image has %d star"
 msgid_plural "image has %d stars"
 msgstr[0] "Bild hat %d Stern"
 msgstr[1] "Bild hat %d Sterne"
 
-#: ../src/libs/metadata_view.c:401 ../src/libs/snapshots.c:354
+#: ../src/libs/metadata_view.c:448 ../src/libs/snapshots.c:466
 msgid "unknown"
 msgstr "unbekannt"
 
-#: ../src/libs/metadata_view.c:402
+#: ../src/libs/metadata_view.c:449
 msgid "tiff"
 msgstr "TIFF"
 
-#: ../src/libs/metadata_view.c:403
+#: ../src/libs/metadata_view.c:450
 msgid "png"
 msgstr "PNG"
 
-#: ../src/libs/metadata_view.c:404
+#: ../src/libs/metadata_view.c:451
 msgid "j2k"
 msgstr "j2k"
 
-#: ../src/libs/metadata_view.c:405
+#: ../src/libs/metadata_view.c:452
 msgid "jpeg"
 msgstr "JPEG"
 
-#: ../src/libs/metadata_view.c:406
+#: ../src/libs/metadata_view.c:453
 msgid "exr"
 msgstr "EXR"
 
-#: ../src/libs/metadata_view.c:407
+#: ../src/libs/metadata_view.c:454
 msgid "rgbe"
 msgstr "RGBE"
 
-#: ../src/libs/metadata_view.c:408
+#: ../src/libs/metadata_view.c:455
 msgid "pfm"
 msgstr "PFM"
 
-#: ../src/libs/metadata_view.c:409
+#: ../src/libs/metadata_view.c:456
 msgid "GraphicsMagick"
 msgstr "GraphicsMagick"
 
-#: ../src/libs/metadata_view.c:410
+#: ../src/libs/metadata_view.c:457
 msgid "rawspeed"
 msgstr "rawspeed"
 
-#: ../src/libs/metadata_view.c:411
+#: ../src/libs/metadata_view.c:458
 msgid "netpnm"
 msgstr "NetPNM"
 
-#: ../src/libs/metadata_view.c:412
+#: ../src/libs/metadata_view.c:459
 msgid "avif"
 msgstr ""
 
-#: ../src/libs/metadata_view.c:417
+#: ../src/libs/metadata_view.c:464
 #, c-format
 msgid "loader: %s"
 msgstr "geladen mit: %s"
 
-#: ../src/libs/metadata_view.c:708
+#: ../src/libs/metadata_view.c:766
 msgctxt "accel"
 msgid "jump to film roll"
 msgstr "Zu Filmrolle springen"
@@ -14511,7 +14938,7 @@ msgstr "eingeschaltete Module"
 
 #: ../src/libs/modulegroups.c:206
 msgid "show only your favourite modules (selected in `more modules' below)"
-msgstr "Favoriten (unten unter ‚weitere Module‘ ausgewählt)"
+msgstr "Favoriten (unten unter „weitere Module” ausgewählt)"
 
 #: ../src/libs/modulegroups.c:212
 msgid "basic group"
@@ -14708,101 +15135,101 @@ msgid "hide navigation thumbnail"
 msgstr "Navigationsvorschaubild ausblenden"
 
 #. //////////////////////// PRINT SETTINGS
-#: ../src/libs/print_settings.c:44 ../src/libs/print_settings.c:1396
+#: ../src/libs/print_settings.c:44 ../src/libs/print_settings.c:1401
 msgid "print settings"
 msgstr "Druckeinstellungen"
 
 #. FIXME: ellipsize title/printer as the export completed message is ellipsized
-#: ../src/libs/print_settings.c:237 ../src/libs/print_settings.c:437
+#: ../src/libs/print_settings.c:238 ../src/libs/print_settings.c:442
 #, c-format
 msgid "processing `%s' for `%s'"
 msgstr "Verarbeiten von „%s” für „%s”"
 
-#: ../src/libs/print_settings.c:279
+#: ../src/libs/print_settings.c:281
 #, c-format
 msgid "cannot open printer profile `%s'"
 msgstr "Konnte Druckerprofile „%s” nicht öffnen"
 
-#: ../src/libs/print_settings.c:288
+#: ../src/libs/print_settings.c:290
 #, c-format
 msgid "error getting output profile for image %d"
 msgstr "Fehler für das Ausgabeprofils des Bildes %d"
 
-#: ../src/libs/print_settings.c:296
+#: ../src/libs/print_settings.c:298
 #, c-format
 msgid "cannot apply printer profile `%s'"
 msgstr "Konnte Druckerprofile „%s” nicht anwenden"
 
-#: ../src/libs/print_settings.c:316
+#: ../src/libs/print_settings.c:318
 msgid "failed to create temporary pdf for printing"
 msgstr "Fehler beim Erstellen der temporären PDF-Datei für den Druck"
 
-#: ../src/libs/print_settings.c:392
+#: ../src/libs/print_settings.c:397
 msgid "cannot print until a picture is selected"
 msgstr "vor dem Drucken ein Bild auswählen"
 
-#: ../src/libs/print_settings.c:397
+#: ../src/libs/print_settings.c:402
 msgid "cannot print until a printer is selected"
 msgstr "vor dem Drucken einen Drucker auswählen"
 
-#: ../src/libs/print_settings.c:402
+#: ../src/libs/print_settings.c:407
 msgid "cannot print until a paper is selected"
 msgstr "vor dem Drucken ein Papierformat auswählen"
 
 #. in this case no need to release from cache what we couldn't get
-#: ../src/libs/print_settings.c:429
+#: ../src/libs/print_settings.c:434
 #, c-format
 msgid "cannot get image %d for printing"
 msgstr "erhalte Bild %d nicht zum Drucken"
 
-#: ../src/libs/print_settings.c:696
+#: ../src/libs/print_settings.c:701
 #, c-format
 msgid "%3.2f (dpi:%d)"
 msgstr "%3.2f (DPI:%d)"
 
-#: ../src/libs/print_settings.c:1163
+#: ../src/libs/print_settings.c:1168
 msgid "printer"
 msgstr "Drucker"
 
-#: ../src/libs/print_settings.c:1175
+#: ../src/libs/print_settings.c:1180
 msgid "media"
 msgstr "Medium"
 
-#: ../src/libs/print_settings.c:1194
+#: ../src/libs/print_settings.c:1199
 msgid "color management in printer driver"
 msgstr "Farbverwaltung im Druckertreiber"
 
-#: ../src/libs/print_settings.c:1229
+#: ../src/libs/print_settings.c:1234
 #, c-format
 msgid "printer ICC profiles in %s or %s"
 msgstr "Drucker-ICC-Profile in %s oder %s"
 
-#: ../src/libs/print_settings.c:1251
+#: ../src/libs/print_settings.c:1256
 msgid "black point compensation"
 msgstr "Tiefenkompensation"
 
-#: ../src/libs/print_settings.c:1259
+#: ../src/libs/print_settings.c:1264
 msgid "activate black point compensation when applying the printer profile"
 msgstr "aktiviere Tiefenkompensation wenn das Druckerprofile angewandt wird"
 
 #. //////////////////////// PAGE SETTINGS
-#: ../src/libs/print_settings.c:1265
+#: ../src/libs/print_settings.c:1270
 msgid "page"
 msgstr "Seite"
 
-#: ../src/libs/print_settings.c:1302
+#: ../src/libs/print_settings.c:1307
 msgid "image width/height"
 msgstr "Bildbreite/-höhe"
 
-#: ../src/libs/print_settings.c:1306
+#: ../src/libs/print_settings.c:1311
 msgid " x "
 msgstr " x "
 
-#: ../src/libs/print_settings.c:1314
+#: ../src/libs/print_settings.c:1319
 msgid "scale factor"
 msgstr "Skalierungsfaktor"
 
-#: ../src/libs/print_settings.c:1319
+#: ../src/libs/print_settings.c:1324
 msgid ""
 "image scale factor from native printer DPI:\n"
 " < 1 means that it is downscaled (best quality)\n"
@@ -14815,47 +15242,47 @@ msgstr ""
 "ein zu großer Wert kann zu schlechter Druckqualität führen"
 
 #. d->b_top  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1333
+#: ../src/libs/print_settings.c:1338
 msgid "top margin"
 msgstr "oberer Rand"
 
 #. d->b_left  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1337
+#: ../src/libs/print_settings.c:1342
 msgid "left margin"
 msgstr "linker Rand"
 
-#: ../src/libs/print_settings.c:1340
+#: ../src/libs/print_settings.c:1345
 msgid "lock"
 msgstr "sperren"
 
-#: ../src/libs/print_settings.c:1341
+#: ../src/libs/print_settings.c:1346
 msgid "change all margins uniformly"
 msgstr "alle Ränder einheitlich ändern"
 
 #. d->b_right  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1345
+#: ../src/libs/print_settings.c:1350
 msgid "right margin"
 msgstr "rechter Rand"
 
 #. d->b_bottom  = gtk_spin_button_new_with_range(0, 10000, 1);
-#: ../src/libs/print_settings.c:1349
+#: ../src/libs/print_settings.c:1354
 msgid "bottom margin"
 msgstr "unterer Rand"
 
-#: ../src/libs/print_settings.c:1491
+#: ../src/libs/print_settings.c:1496
 msgid "temporary style to use while printing"
 msgstr "Stil, der beim Drucken vorübergehend angewandt werden soll"
 
 #. Print button
-#: ../src/libs/print_settings.c:1528
+#: ../src/libs/print_settings.c:1533
 msgid "print"
 msgstr "drucken"
 
-#: ../src/libs/print_settings.c:1530
+#: ../src/libs/print_settings.c:1535
 msgid "print with current settings"
 msgstr "mit aktuellen Einstellungen drucken"
 
-#: ../src/libs/print_settings.c:1997
+#: ../src/libs/print_settings.c:2002
 msgctxt "accel"
 msgid "print"
 msgstr "Drucken"
@@ -14929,7 +15356,7 @@ msgid ""
 "current collection"
 msgstr ""
 "wähle alle Bilder der aktuellen Sammlung\n"
-"aus, die nicht bearbeitet sind"
+"aus, die noch nicht bearbeitet wurden"
 
 #: ../src/libs/select.c:250
 msgctxt "accel"
@@ -14964,21 +15391,32 @@ msgstr "Sitzung"
 msgid "create"
 msgstr "erzeugen"
 
-#: ../src/libs/snapshots.c:80
+#: ../src/libs/snapshots.c:84
 msgid "snapshots"
 msgstr "Snapshots"
 
-#: ../src/libs/snapshots.c:101
+#: ../src/libs/snapshots.c:105
 msgctxt "accel"
 msgid "take snapshot"
 msgstr "Snapshot erstellen"
 
+#: ../src/libs/snapshots.c:106
+#, fuzzy
+msgctxt "accel"
+msgid "toggle last snapshot"
+msgstr "Snapshot erstellen"
+
+#: ../src/libs/snapshots.c:131
+msgctxt "snapshot sign"
+msgid "S"
+msgstr ""
+
 #. create take snapshot button
-#: ../src/libs/snapshots.c:271
+#: ../src/libs/snapshots.c:382
 msgid "take snapshot"
 msgstr "Snapshot erstellen"
 
-#: ../src/libs/snapshots.c:274
+#: ../src/libs/snapshots.c:386
 msgid ""
 "take snapshot to compare with another image or the same image at another "
 "stage of development"
@@ -14986,38 +15424,39 @@ msgstr ""
 "Snapshot erstellen, um mit einem anderen Bild oder dem aktuellen Bild in "
 "einem anderen Bearbeitungszustand zu vergleichen"
 
-#: ../src/libs/styles.c:49
+#: ../src/libs/styles.c:50
 msgid "styles"
 msgstr "Stile"
 
-#: ../src/libs/styles.c:70
+#: ../src/libs/styles.c:71
 msgctxt "accel"
-msgid "delete"
-msgstr "Löschen"
+msgid "remove"
+msgstr "entfernen"
 
-#: ../src/libs/styles.c:72
+#: ../src/libs/styles.c:73
 msgctxt "accel"
 msgid "import"
 msgstr "Importieren"
 
-#: ../src/libs/styles.c:274
-#, c-format
-msgid "do you really want to delete style '%s'?"
+#: ../src/libs/styles.c:275
+#, fuzzy, c-format
+msgid "do you really want to remove style '%s'?"
 msgstr "Stil '%s' wirklich löschen?"
 
-#: ../src/libs/styles.c:279
-msgid "delete style?"
+#: ../src/libs/styles.c:280
+#, fuzzy
+msgid "remove style?"
 msgstr "Stil löschen?"
 
-#: ../src/libs/styles.c:323
+#: ../src/libs/styles.c:324
 msgid "select style"
 msgstr "Stil auswählen"
 
-#: ../src/libs/styles.c:336
+#: ../src/libs/styles.c:337
 msgid "darktable style files"
 msgstr "darktable-Stil-Datei"
 
-#: ../src/libs/styles.c:411
+#: ../src/libs/styles.c:418
 msgid ""
 "available styles,\n"
 "doubleclick to apply"
@@ -15025,107 +15464,108 @@ msgstr ""
 "verfügbare Stile,\n"
 "Doppelklick zum Anwenden"
 
-#: ../src/libs/styles.c:417
+#: ../src/libs/styles.c:424
 msgid "filter style names"
 msgstr "Stil-Namen filtern"
 
-#: ../src/libs/styles.c:432
+#: ../src/libs/styles.c:439
 msgid "create duplicate"
 msgstr "Duplikat erzeugen"
 
-#: ../src/libs/styles.c:437
+#: ../src/libs/styles.c:444
 msgid "creates a duplicate of the image before applying style"
 msgstr "Erzeuge ein Duplikat des Bildes, bevor der Stil angewendet wird."
 
 #. create
-#: ../src/libs/styles.c:445
+#: ../src/libs/styles.c:460
 msgid "create..."
-msgstr "erzeugen..."
+msgstr "erzeugen"
 
-#: ../src/libs/styles.c:447
+#: ../src/libs/styles.c:462
 msgid "create styles from history stack of selected images"
 msgstr "Stile aus den Verlaufsstapeln der ausgewählten Bilder erzeugen"
 
 #. edit
-#: ../src/libs/styles.c:451
+#: ../src/libs/styles.c:466
 msgid "edit..."
-msgstr "bearbeiten..."
+msgstr "bearbeiten"
 
 # hmm, ...
-#: ../src/libs/styles.c:454
+#: ../src/libs/styles.c:469
 msgid "edit the selected style in list above"
 msgstr "ausgewählten Stil in der Liste bearbeiten"
 
 # hmm, ...
-#: ../src/libs/styles.c:461
-msgid "deletes the selected style in list above"
+#: ../src/libs/styles.c:476
+#, fuzzy
+msgid "removes the selected style in list above"
 msgstr "ausgewählten Stil in der Liste löschen"
 
 #. import button
-#: ../src/libs/styles.c:465 ../src/libs/tagging.c:2766
+#: ../src/libs/styles.c:480 ../src/libs/tagging.c:2744
 msgctxt "verb"
 msgid "import..."
-msgstr "Importieren..."
+msgstr "importieren"
 
-#: ../src/libs/styles.c:467
+#: ../src/libs/styles.c:482
 msgid "import style from a style file"
 msgstr "Stil aus einer Stil-Datei importieren"
 
 # hmm, ...
-#: ../src/libs/styles.c:474
+#: ../src/libs/styles.c:489
 msgid "export the selected style into a style file"
 msgstr "ausgewählten Stil in eine Stil-Datei exportieren"
 
-#: ../src/libs/tagging.c:95
+#: ../src/libs/tagging.c:94
 msgid "tagging"
 msgstr "Verschlagwortung"
 
-#: ../src/libs/tagging.c:120
+#: ../src/libs/tagging.c:119
 msgctxt "accel"
 msgid "attach"
 msgstr "Anhängen"
 
-#: ../src/libs/tagging.c:121
+#: ../src/libs/tagging.c:120
 msgctxt "accel"
 msgid "detach"
 msgstr "Entfernen"
 
-#: ../src/libs/tagging.c:122
+#: ../src/libs/tagging.c:121
 msgctxt "accel"
 msgid "new"
 msgstr "Neu"
 
-#: ../src/libs/tagging.c:123
+#: ../src/libs/tagging.c:122
 msgctxt "accel"
 msgid "tag"
 msgstr "Tag"
 
-#: ../src/libs/tagging.c:124
+#: ../src/libs/tagging.c:123
 #, fuzzy
 msgctxt "accel"
 msgid "redo last tag"
 msgstr "Tag erstellen"
 
-#: ../src/libs/tagging.c:1074
+#: ../src/libs/tagging.c:1126
 msgid "attach tag to all"
 msgstr "Tag an alle anhängen"
 
-#: ../src/libs/tagging.c:1082 ../src/libs/tagging.c:1976
+#: ../src/libs/tagging.c:1134 ../src/libs/tagging.c:1955
 msgid "detach tag"
 msgstr "Tag abwählen"
 
-#: ../src/libs/tagging.c:1202
+#: ../src/libs/tagging.c:1257
 msgid "delete tag?"
 msgstr "Tag löschen?"
 
-#: ../src/libs/tagging.c:1209 ../src/libs/tagging.c:1306
-#: ../src/libs/tagging.c:1567
+#: ../src/libs/tagging.c:1264 ../src/libs/tagging.c:1354
+#: ../src/libs/tagging.c:1560
 #, c-format
 msgid "tag: %s "
 msgstr "Tag: %s"
 
 # Korrekte Schreibweise nach Duden = das Tag
-#: ../src/libs/tagging.c:1216
+#: ../src/libs/tagging.c:1271
 #, c-format
 msgid ""
 "do you really want to delete the tag `%s'?\n"
@@ -15140,81 +15580,78 @@ msgstr[1] ""
 "soll der Tag „%s“ wirklich gelöscht werden?\n"
 "%d Bilder haben diesen Tag angehängt!"
 
-#: ../src/libs/tagging.c:1252
+#: ../src/libs/tagging.c:1307
 #, c-format
 msgid "tag %s removed"
 msgstr "Tag %s entfernt"
 
-#: ../src/libs/tagging.c:1299 ../src/libs/tagging.c:1992
-msgid "delete branch"
-msgstr "Zweig löschen"
+#: ../src/libs/tagging.c:1347 ../src/libs/tagging.c:1971
+#, fuzzy
+msgid "delete path"
+msgstr "Tag löschen"
 
-#: ../src/libs/tagging.c:1313
+#: ../src/libs/tagging.c:1361
 #, c-format
 msgid "<u>%d</u> tag will be deleted."
 msgid_plural "<u>%d</u> tags will be deleted."
 msgstr[0] "<u>%d</u>Tag wird gelöscht."
 msgstr[1] "<u>%d</u> Tags werden gelöscht."
 
-#: ../src/libs/tagging.c:1318 ../src/libs/tagging.c:1579
-#: ../src/libs/tagging.c:1803
+#: ../src/libs/tagging.c:1366 ../src/libs/tagging.c:1572
+#: ../src/libs/tagging.c:1789
 #, c-format
 msgid "<u>%d</u> image will be updated"
 msgid_plural "<u>%d</u> images will be updated "
 msgstr[0] "<u>%d</u> Bild wird aktualisiert"
 msgstr[1] "<u>%d</u> Bilder werden aktualisiert"
 
-#: ../src/libs/tagging.c:1344
+#: ../src/libs/tagging.c:1392
 #, c-format
 msgid "%d tags removed"
 msgstr "%d Stichwörter entfernt"
 
-#: ../src/libs/tagging.c:1387
+#: ../src/libs/tagging.c:1428
 msgid "create tag"
 msgstr "Tag erstellen"
 
-#: ../src/libs/tagging.c:1397 ../src/libs/tagging.c:1587
+#: ../src/libs/tagging.c:1438 ../src/libs/tagging.c:1580
 msgid "name: "
 msgstr "Name: "
 
-#: ../src/libs/tagging.c:1409
+#: ../src/libs/tagging.c:1450
 #, c-format
 msgid "add to: \"%s\" "
-msgstr "hinzufügen zu: \"%s\" "
+msgstr "hinzufügen zu: „%s” "
 
-#: ../src/libs/tagging.c:1415 ../src/libs/tagging.c:1602
+#: ../src/libs/tagging.c:1456 ../src/libs/tagging.c:1595
 msgid "category"
 msgstr "Kategorie"
 
-#: ../src/libs/tagging.c:1424 ../src/libs/tagging.c:1611
+#: ../src/libs/tagging.c:1465 ../src/libs/tagging.c:1604
 msgid "synonyms: "
 msgstr "Synonyme: "
 
-#: ../src/libs/tagging.c:1441 ../src/libs/tagging.c:1633
-#: ../src/libs/tagging.c:1825
+#: ../src/libs/tagging.c:1482 ../src/libs/tagging.c:1626
+#: ../src/libs/tagging.c:1811
 msgid "empty tag is not allowed, aborting"
 msgstr "Leerer Tag ist nicht erlaubt. Abbruch."
 
-#: ../src/libs/tagging.c:1443
-msgid "'|' character is not allowed to create a tag. aborting."
-msgstr "'|' Zeichen ist für die Erstellung eines Tag nicht erlaubt. Abbruch."
-
-#: ../src/libs/tagging.c:1454
+#: ../src/libs/tagging.c:1493
 msgid "tag name already exists. aborting."
 msgstr "Tag existiert bereits. Abbruch."
 
-#: ../src/libs/tagging.c:1560
+#: ../src/libs/tagging.c:1553
 msgid "edit tag"
 msgstr "Tag bearbeiten"
 
-#: ../src/libs/tagging.c:1574 ../src/libs/tagging.c:1798
+#: ../src/libs/tagging.c:1567 ../src/libs/tagging.c:1784
 #, c-format
 msgid "<u>%d</u> tag will be updated."
 msgid_plural "<u>%d</u> tags will be updated."
 msgstr[0] "<u>%d</u> Tag wird aktualisiert."
 msgstr[1] "<u>%d</u> Tags werden aktualisiert."
 
-#: ../src/libs/tagging.c:1635
+#: ../src/libs/tagging.c:1628
 msgid ""
 "'|' character is not allowed for renaming tag.\n"
 "to modify the hierachy use rename path instead. Aborting."
@@ -15222,100 +15659,100 @@ msgstr ""
 "'|' Zeichen ist für die Umbenennung von Stichwörtern nicht erlaubt.\n"
 "Um die Hierarchie zu ändern, verwenden stattdessen Pfad Umbenennen. Abbruch."
 
-#: ../src/libs/tagging.c:1674
+#: ../src/libs/tagging.c:1667
 #, c-format
 msgid "at least one new tag name (%s) already exists, aborting"
 msgstr "Mindestens ein neuer Tag (%s) existiert bereits, Abbruch des Vorgangs"
 
-#: ../src/libs/tagging.c:1784
+#: ../src/libs/tagging.c:1770
 msgid "rename path?"
 msgstr "Pfad umbenennen?"
 
-#: ../src/libs/tagging.c:1791
+#: ../src/libs/tagging.c:1777
 #, c-format
 msgid "selected path: %s "
 msgstr "Pfad auswähler: %s "
 
-#: ../src/libs/tagging.c:1827
+#: ../src/libs/tagging.c:1813
 msgid "'|' misplaced, empty tag is not allowed, aborting"
 msgstr "'|' falsch platziert, leerer Tag ist nicht erlaubt, Abbruch"
 
-#: ../src/libs/tagging.c:1853
+#: ../src/libs/tagging.c:1839
 #, c-format
 msgid "at least one new tagname (%s) already exists, aborting."
 msgstr "Mindestens ein neuer Tag (%s) existiert bereits. Abbruch."
 
-#: ../src/libs/tagging.c:1972
+#: ../src/libs/tagging.c:1951
 msgid "attach tag"
 msgstr "Tag anhängen"
 
-#: ../src/libs/tagging.c:1987
+#: ../src/libs/tagging.c:1966
 msgid "delete tag"
 msgstr "Tag löschen"
 
-#: ../src/libs/tagging.c:1998
+#: ../src/libs/tagging.c:1977
 msgid "create tag..."
 msgstr "Tag erstellen..."
 
-#: ../src/libs/tagging.c:2002
+#: ../src/libs/tagging.c:1981
 msgid "edit tag..."
 msgstr "Tag bearbeiten..."
 
-#: ../src/libs/tagging.c:2011
+#: ../src/libs/tagging.c:1990
 msgid "rename path..."
 msgstr "Pfad umbenennen..."
 
-#: ../src/libs/tagging.c:2018
+#: ../src/libs/tagging.c:1997
 msgid "copy to entry"
 msgstr "Kopieren in den Eintrag"
 
-#: ../src/libs/tagging.c:2035
+#: ../src/libs/tagging.c:2014
 msgid "go to tag collection"
 msgstr "gehe zur Tag-Sammlung"
 
-#: ../src/libs/tagging.c:2041
+#: ../src/libs/tagging.c:2020
 msgid "go back to work"
 msgstr "Wieder an die Arbeit gehen"
 
-#: ../src/libs/tagging.c:2157
+#: ../src/libs/tagging.c:2136
 msgid "(private)"
 msgstr "(privat)"
 
-#: ../src/libs/tagging.c:2183
+#: ../src/libs/tagging.c:2162
 msgid "Select a keyword file"
 msgstr "Tag auswählen"
 
-#: ../src/libs/tagging.c:2186
+#: ../src/libs/tagging.c:2165
 msgid "_import"
 msgstr "_importieren"
 
-#: ../src/libs/tagging.c:2200
+#: ../src/libs/tagging.c:2179
 msgid "error importing tags"
 msgstr "Fehler beim Importieren der Stichwörter"
 
-#: ../src/libs/tagging.c:2202
+#: ../src/libs/tagging.c:2181
 #, c-format
 msgid "%zd tags imported"
 msgstr "%zd Stichwörter importiert"
 
-#: ../src/libs/tagging.c:2224
+#: ../src/libs/tagging.c:2203
 msgid "Select file to export to"
 msgstr "Datei zum exportieren wählen"
 
-#: ../src/libs/tagging.c:2227
+#: ../src/libs/tagging.c:2206
 msgid "_export"
 msgstr "_exportieren"
 
-#: ../src/libs/tagging.c:2242
+#: ../src/libs/tagging.c:2221
 msgid "error exporting tags"
 msgstr "Fehler beim Exportieren der Stichwörter"
 
-#: ../src/libs/tagging.c:2244
+#: ../src/libs/tagging.c:2223
 #, c-format
 msgid "%zd tags exported"
 msgstr "%zd Stichwörter exportiert"
 
-#: ../src/libs/tagging.c:2618
+#: ../src/libs/tagging.c:2596
 msgid ""
 "attached tags,\n"
 "double-click to detach\n"
@@ -15327,43 +15764,43 @@ msgstr ""
 "Rechtsklick für andere Aktionen des ausgewählten Tag,\n"
 "Strg-Mausrad, um die Größe des Fensters zu ändern."
 
-#: ../src/libs/tagging.c:2629
+#: ../src/libs/tagging.c:2607
 msgid "attach"
 msgstr "anhängen"
 
-#: ../src/libs/tagging.c:2632
+#: ../src/libs/tagging.c:2610
 msgid "attach tag to all selected images"
 msgstr "Tag an alle ausgewählten Bilder anhängen"
 
-#: ../src/libs/tagging.c:2637
+#: ../src/libs/tagging.c:2615
 msgid "detach"
 msgstr "entfernen"
 
-#: ../src/libs/tagging.c:2640
+#: ../src/libs/tagging.c:2618
 msgid "detach tag from all selected images"
 msgstr "Tag von allen ausgewählten Bildern entfernen"
 
-#: ../src/libs/tagging.c:2647
+#: ../src/libs/tagging.c:2625
 msgid "toggle list with / without hierarchy"
 msgstr "Wechseln zwischen Liste mit / ohne Hirarchie"
 
-#: ../src/libs/tagging.c:2655
+#: ../src/libs/tagging.c:2633
 msgid "toggle sort by name or by count"
 msgstr "Zwischen Sortierung nach Name oder Anzahl umschalten"
 
-#: ../src/libs/tagging.c:2665
+#: ../src/libs/tagging.c:2643
 msgid "toggle show or not darktable tags"
 msgstr "Anzeige von Stichwörtern aktivieren oder deaktivieren"
 
-#: ../src/libs/tagging.c:2681
+#: ../src/libs/tagging.c:2659
 msgid "enter tag name"
 msgstr "Tag eingeben"
 
-#: ../src/libs/tagging.c:2691
+#: ../src/libs/tagging.c:2669
 msgid "clear entry"
 msgstr "Eintrag löschen"
 
-#: ../src/libs/tagging.c:2743
+#: ../src/libs/tagging.c:2721
 msgid ""
 "tag dictionary,\n"
 "double-click to attach,\n"
@@ -15375,11 +15812,11 @@ msgstr ""
 "Rechtsklick für andere Aktionen des ausgewählten Tag,\n"
 "Strg-Mausrad, um die Größe des Fensters zu ändern."
 
-#: ../src/libs/tagging.c:2758
+#: ../src/libs/tagging.c:2736
 msgid "new"
 msgstr "neu"
 
-#: ../src/libs/tagging.c:2761
+#: ../src/libs/tagging.c:2739
 msgid ""
 "create a new tag with the\n"
 "name you entered"
@@ -15387,36 +15824,36 @@ msgstr ""
 "neuer Tag mit dem eingegebenen\n"
 "Namen erstellen"
 
-#: ../src/libs/tagging.c:2769
+#: ../src/libs/tagging.c:2747
 msgid "import tags from a Lightroom keyword file"
 msgstr "Tags aus einer Lightroom-Stichwortdatei importieren"
 
-#: ../src/libs/tagging.c:2774
+#: ../src/libs/tagging.c:2752
 msgctxt "verb"
 msgid "export..."
-msgstr "exportieren..."
+msgstr "exportieren"
 
-#: ../src/libs/tagging.c:2777
+#: ../src/libs/tagging.c:2755
 msgid "export all tags to a Lightroom keyword file"
 msgstr "alle Tags in eine Lightroom-Stichwortdatei exportieren"
 
-#: ../src/libs/tagging.c:2784
+#: ../src/libs/tagging.c:2762
 msgid "toggle list / tree view"
 msgstr "Wechseln zwischen Listen- / Baumansicht"
 
-#: ../src/libs/tagging.c:2792
+#: ../src/libs/tagging.c:2770
 msgid "toggle list with / without suggestion"
 msgstr "Wechseln zwischen Liste mit / ohne Vorschlag"
 
-#: ../src/libs/tagging.c:2921
+#: ../src/libs/tagging.c:2889
 msgid ""
 "tag shortcut is not active with tag tree view. please switch to list view"
 msgstr ""
 "Tag-Kurzbefehle in der Baumansicht nicht aktiv. Bitte zur Listenansicht "
 "wechseln."
 
-#: ../src/libs/tools/battery_indicator.c:37
-#: ../src/libs/tools/battery_indicator.c:70
+#: ../src/libs/tools/battery_indicator.c:38
+#: ../src/libs/tools/battery_indicator.c:71
 msgid "battery indicator"
 msgstr "Batterieanzeige"
 
@@ -15471,20 +15908,20 @@ msgstr ""
 "Alle Markierungen der\n"
 "ausgewählten Bilder entfernen"
 
-#: ../src/libs/tools/darktable.c:60
+#: ../src/libs/tools/darktable.c:61
 msgid "darktable"
 msgstr "darktable"
 
-#: ../src/libs/tools/darktable.c:251
+#: ../src/libs/tools/darktable.c:252
 #, c-format
 msgid "copyright (c) the authors 2009-%s"
 msgstr "Copyright © die Urheber 2009–%s"
 
-#: ../src/libs/tools/darktable.c:255
+#: ../src/libs/tools/darktable.c:256
 msgid "organize and develop images from digital cameras"
 msgstr "Organisiere und entwickle Bilder von Digitalkameras"
 
-#: ../src/libs/tools/darktable.c:270
+#: ../src/libs/tools/darktable.c:271
 msgid "translator-credits"
 msgstr "Tobias Ellinghaus"
 
@@ -15528,74 +15965,125 @@ msgstr "benutzerdefinierte Sortierung"
 msgid "shuffle"
 msgstr "mischen"
 
-#: ../src/libs/tools/global_toolbox.c:53
+#: ../src/libs/tools/global_toolbox.c:52
 msgid "preferences"
 msgstr "Voreinstellungen"
 
+#. we write the label with the size categorie
+#: ../src/libs/tools/global_toolbox.c:118
+#: ../src/libs/tools/global_toolbox.c:177
+msgid "overlay mode for size"
+msgstr "Überlagerungsmodus für Größe"
+
 # schreckliche übersetzung für "expand" ...
-#: ../src/libs/tools/global_toolbox.c:89 ../src/libs/tools/global_toolbox.c:141
+#: ../src/libs/tools/global_toolbox.c:154
+#: ../src/libs/tools/global_toolbox.c:237
 msgid "expand grouped images"
 msgstr "gruppierte Bilder ausklappen"
 
-#: ../src/libs/tools/global_toolbox.c:91 ../src/libs/tools/global_toolbox.c:143
+#: ../src/libs/tools/global_toolbox.c:156
+#: ../src/libs/tools/global_toolbox.c:239
 msgid "collapse grouped images"
 msgstr "gruppierte Bilder zusammenfassen"
 
-#: ../src/libs/tools/global_toolbox.c:100
-#: ../src/libs/tools/global_toolbox.c:161
-msgid "hide image overlays"
-msgstr "Bildinfos verbergen"
-
-#: ../src/libs/tools/global_toolbox.c:102
 #: ../src/libs/tools/global_toolbox.c:163
-msgid "show image overlays"
-msgstr "Bildinfos anzeigen"
+msgid "click to change the type of overlays shown on thumbnails"
+msgstr "klicken, um Art der Bildinfos in Vorschaubildern zu wählen"
 
-#: ../src/libs/tools/global_toolbox.c:109
+#: ../src/libs/tools/global_toolbox.c:179
+msgid "no overlays"
+msgstr "keine Bildinfos"
+
+#: ../src/libs/tools/global_toolbox.c:183
+msgid "overlays on mouse hover"
+msgstr "Bildinfos bei Überfahren mit Maus"
+
+#: ../src/libs/tools/global_toolbox.c:187
+msgid "extended overlays on mouse hover"
+msgstr "erweiterte Bildinfos bei Überfahren mit Maus"
+
+#: ../src/libs/tools/global_toolbox.c:190
+msgid "permanent overlays"
+msgstr "permanente Bildinfos"
+
+#: ../src/libs/tools/global_toolbox.c:194
+msgid "permanent extended overlays"
+msgstr "permanente erweiterte Bildinfos"
+
+#: ../src/libs/tools/global_toolbox.c:198
+msgid "permanent overlays extended on mouse hover"
+msgstr "permanente Bildinfos erweitert bei Überfahren mit Maus"
+
+#: ../src/libs/tools/global_toolbox.c:205
 msgid "enable this, then click on a control element to see its online help"
 msgstr ""
-"aktiviere dies und klicke dann auf ein Bedienelement, um die Online-Hilfe "
-"anzuzeigen"
+"dies aktivieren und dann dann auf ein Bedienelement\n"
+"klicken, um die Online-Hilfe anzuzeigen"
 
-#: ../src/libs/tools/global_toolbox.c:119
+#: ../src/libs/tools/global_toolbox.c:215
 msgid "show global preferences"
-msgstr "Zeige globale Voreinstellungen"
+msgstr "zeige globale Voreinstellungen"
 
-#: ../src/libs/tools/global_toolbox.c:230
+#: ../src/libs/tools/global_toolbox.c:310
 msgid "do you want to access https://darktable.gitlab.io/doc/?"
 msgstr "Möchten Sie auf https://darktable.gitlab.io/doc/ zugreifen?"
 
-#: ../src/libs/tools/global_toolbox.c:235
+#: ../src/libs/tools/global_toolbox.c:315
 msgid "access the online usermanual?"
 msgstr "Auf das Online-Benutzerhandbuch zugreifen?"
 
-#: ../src/libs/tools/global_toolbox.c:278
+#: ../src/libs/tools/global_toolbox.c:358
 msgid "help url opened in web browser"
 msgstr "Hilfe-URL wird in Webbrowser geöffnet"
 
-#: ../src/libs/tools/global_toolbox.c:282
+#: ../src/libs/tools/global_toolbox.c:362
 #, fuzzy
 msgid "error while opening help url in web browser"
 msgstr "Hilfe-URL wird in Webbrowser geöffnet"
 
-#: ../src/libs/tools/global_toolbox.c:293
+#: ../src/libs/tools/global_toolbox.c:373
 msgid "there is no help available for this element"
 msgstr "Für dieses Element ist keine Hilfe verfügbar"
 
-#: ../src/libs/tools/global_toolbox.c:335
+#: ../src/libs/tools/global_toolbox.c:415
 msgctxt "accel"
 msgid "grouping"
 msgstr "Gruppieren"
 
-#: ../src/libs/tools/global_toolbox.c:336
+#: ../src/libs/tools/global_toolbox.c:416
 msgctxt "accel"
 msgid "preferences"
 msgstr "Voreinstellungen"
 
-#: ../src/libs/tools/global_toolbox.c:337
+#: ../src/libs/tools/global_toolbox.c:418
 msgctxt "accel"
-msgid "show overlays"
-msgstr "Bildinfos anzeigen"
+msgid "no overlays"
+msgstr "keine Bildinfos"
+
+#: ../src/libs/tools/global_toolbox.c:419
+msgctxt "accel"
+msgid "overlays on mouse hover"
+msgstr "Bildinfos bei Überfahren mit Maus"
+
+#: ../src/libs/tools/global_toolbox.c:420
+msgctxt "accel"
+msgid "extended overlays on mouse hover"
+msgstr ""
+
+#: ../src/libs/tools/global_toolbox.c:421
+msgctxt "accel"
+msgid "permanent overlays"
+msgstr "permanente Bildinfos"
+
+#: ../src/libs/tools/global_toolbox.c:422
+msgctxt "accel"
+msgid "permanent extended overlays"
+msgstr "permanente erweiterte Bildinfos"
+
+#: ../src/libs/tools/global_toolbox.c:423
+msgctxt "accel"
+msgid "permanent overlays extended on mouse hover"
+msgstr "permanente Bildinfos erweitert bei Überfahren mit Maus"
 
 #: ../src/libs/tools/hinter.c:42
 msgid "hinter"
@@ -15605,48 +16093,48 @@ msgstr "Hinweise"
 msgid "image infos"
 msgstr "Bildinformation"
 
-#: ../src/libs/tools/lighttable.c:141
+#: ../src/libs/tools/lighttable.c:142
 msgid "zoomable light table"
 msgstr "zoombarer Leuchttisch"
 
-#: ../src/libs/tools/lighttable.c:142
+#: ../src/libs/tools/lighttable.c:143
 msgid "file manager"
 msgstr "Dateiverwaltung"
 
-#: ../src/libs/tools/lighttable.c:143
+#: ../src/libs/tools/lighttable.c:144
 msgid "culling"
 msgstr "Sichten"
 
-#: ../src/libs/tools/lighttable.c:174
+#: ../src/libs/tools/lighttable.c:175
 msgid "fixed zoom"
 msgstr "manuelle Sortierung"
 
-#: ../src/libs/tools/lighttable.c:175
+#: ../src/libs/tools/lighttable.c:176
 msgid "dynamic zoom"
 msgstr "Dynamischer Zoom"
 
 #. view accels
-#: ../src/libs/tools/lighttable.c:212
+#: ../src/libs/tools/lighttable.c:213
 msgctxt "accel"
 msgid "zoom max"
 msgstr "Maximaler Zoom"
 
-#: ../src/libs/tools/lighttable.c:215
+#: ../src/libs/tools/lighttable.c:216
 msgctxt "accel"
 msgid "zoom min"
 msgstr "Minimaler Zoom"
 
-#: ../src/libs/tools/lighttable.c:217
+#: ../src/libs/tools/lighttable.c:218
 msgctxt "accel"
 msgid "toggle culling mode"
 msgstr "Sichten-Modus umschalten"
 
-#: ../src/libs/tools/lighttable.c:218
+#: ../src/libs/tools/lighttable.c:219
 msgctxt "accel"
 msgid "toggle culling dynamic mode"
 msgstr "dynamischen Sichten-Modus umschalten"
 
-#: ../src/libs/tools/lighttable.c:219
+#: ../src/libs/tools/lighttable.c:220
 msgctxt "accel"
 msgid "toggle culling zoom mode"
 msgstr "Sichten-Zoommodus umschalten"
@@ -15678,12 +16166,6 @@ msgstr "Ansichts-Toolbox"
 msgid "viewswitcher"
 msgstr "Ansichtwechsler"
 
-#. char *italic = g_strdup_printf("<i>%s</i>", _("other"));
-#. italic
-#: ../src/libs/tools/viewswitcher.c:145
-msgid "other"
-msgstr "andere"
-
 #: ../src/lua/lualib.c:295
 msgctxt "accel"
 msgid "reset lib parameters"
@@ -15707,94 +16189,94 @@ msgstr "Lua-Optionen"
 msgid "loading image"
 msgstr "%d Bild verschieben"
 
-#: ../src/views/darkroom.c:633
+#: ../src/views/darkroom.c:619
 msgid "gamut check"
 msgstr "Gamut überprüfen"
 
-#: ../src/views/darkroom.c:633
+#: ../src/views/darkroom.c:619
 msgid "soft proof"
 msgstr "Softproof"
 
-#: ../src/views/darkroom.c:1146
+#: ../src/views/darkroom.c:1133
 msgid "no userdefined presets for favorite modules were found"
 msgstr ""
 "keine benutzerdefinierten Voreinstellungen für Favoriten-Module gefunden"
 
-#: ../src/views/darkroom.c:1151
+#: ../src/views/darkroom.c:1138
 #, c-format
 msgid "applied style `%s' on current image"
 msgstr "Stil „%s” auf aktuelles Bild angewandt"
 
-#: ../src/views/darkroom.c:1263
+#: ../src/views/darkroom.c:1250
 msgid "no styles have been created yet"
 msgstr "es wurde noch kein Stil angelegt"
 
-#: ../src/views/darkroom.c:1916
+#: ../src/views/darkroom.c:1990
 msgid "quick access to presets of your favorites"
 msgstr "Schnellzugriff auf Voreinstellungen der Favoriten"
 
-#: ../src/views/darkroom.c:1925
+#: ../src/views/darkroom.c:1999
 msgid "quick access for applying any of your styles"
-msgstr "Schnellzugriff um einen Stil anzuwenden"
+msgstr "Schnellzugriff, um einen Stil anzuwenden"
 
-#: ../src/views/darkroom.c:1938
+#: ../src/views/darkroom.c:2012
 msgid "display a second darkroom image window"
 msgstr "ein zweites Dunkelkammer-Vorschaufenster anzeigen"
 
-#: ../src/views/darkroom.c:1947
+#: ../src/views/darkroom.c:2021
 msgid "toggle ISO 12646 color assessment conditions"
 msgstr ""
 
-#: ../src/views/darkroom.c:1957
+#: ../src/views/darkroom.c:2031
 msgid ""
 "toggle raw over exposed indication\n"
 "right click for options"
 msgstr ""
-"Anzeige von Über-/Unterbelichtung der\n"
-"Raw-Werte umschalten\n"
+"Anzeige von Über-/Unterbelichtung\n"
+"der Raw-Werte umschalten\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:1981
+#: ../src/views/darkroom.c:2055
 msgid "mark with CFA color"
 msgstr "mit CFA-Farben markieren"
 
-#: ../src/views/darkroom.c:1982
+#: ../src/views/darkroom.c:2056
 msgid "mark with solid color"
 msgstr "mit fester Farbe markieren"
 
-#: ../src/views/darkroom.c:1983
+#: ../src/views/darkroom.c:2057
 msgid "false color"
 msgstr "Falschfarben"
 
-#: ../src/views/darkroom.c:1985
+#: ../src/views/darkroom.c:2059
 msgid "select how to mark the clipped pixels"
 msgstr "auswählen, wie überbelichtete Pixel markiert werden sollen"
 
-#: ../src/views/darkroom.c:1992 ../src/views/darkroom.c:2044
+#: ../src/views/darkroom.c:2066 ../src/views/darkroom.c:2118
 msgid "color scheme"
 msgstr "Farbzusammenstellung"
 
-#: ../src/views/darkroom.c:1993
+#: ../src/views/darkroom.c:2067
 msgctxt "solidcolor"
 msgid "red"
 msgstr "Rot"
 
-#: ../src/views/darkroom.c:1994
+#: ../src/views/darkroom.c:2068
 msgctxt "solidcolor"
 msgid "green"
 msgstr "Grün"
 
-#: ../src/views/darkroom.c:1995
+#: ../src/views/darkroom.c:2069
 msgctxt "solidcolor"
 msgid "blue"
 msgstr "Blau"
 
-#: ../src/views/darkroom.c:1996
+#: ../src/views/darkroom.c:2070
 msgctxt "solidcolor"
 msgid "black"
 msgstr "Schwarz"
 
-#: ../src/views/darkroom.c:2000
+#: ../src/views/darkroom.c:2074
 msgid ""
 "select the solid color to indicate over exposure.\n"
 "will only be used if mode = mark with solid color"
@@ -15802,7 +16284,7 @@ msgstr ""
 "feste Farbe zum Markieren der Überbelichtung auswählen.\n"
 "wird nur im entsprechenden Modus benutzt"
 
-#: ../src/views/darkroom.c:2010
+#: ../src/views/darkroom.c:2084
 msgid ""
 "threshold of what shall be considered overexposed\n"
 "1.0 - white level\n"
@@ -15812,7 +16294,7 @@ msgstr ""
 "1,0 – Weißwert\n"
 "0,0 – Schwarzwert"
 
-#: ../src/views/darkroom.c:2021
+#: ../src/views/darkroom.c:2095
 msgid ""
 "toggle over/under exposed indication\n"
 "right click for options"
@@ -15820,36 +16302,36 @@ msgstr ""
 "Anzeige von Über-/Unterbelichtung umschalten\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2046
+#: ../src/views/darkroom.c:2120
 msgid "red & blue"
 msgstr "Rot & Blau"
 
-#: ../src/views/darkroom.c:2047
+#: ../src/views/darkroom.c:2121
 msgid "purple & green"
 msgstr "Violett & Grün"
 
-#: ../src/views/darkroom.c:2049
+#: ../src/views/darkroom.c:2123
 msgid "select colors to indicate over/under exposure"
 msgstr ""
 "Farben wählen, mit denen über-/unterbelichtete Bereiche markiert werden"
 
-#: ../src/views/darkroom.c:2058
+#: ../src/views/darkroom.c:2132
 msgid "lower threshold"
 msgstr "unterer Schwellwert"
 
-#: ../src/views/darkroom.c:2059
+#: ../src/views/darkroom.c:2133
 msgid "threshold of what shall be considered underexposed"
 msgstr "Schwellwert dafür, was als unterbelichtet markiert wird"
 
-#: ../src/views/darkroom.c:2067
+#: ../src/views/darkroom.c:2141
 msgid "upper threshold"
 msgstr "oberer Schwellwert"
 
-#: ../src/views/darkroom.c:2068
+#: ../src/views/darkroom.c:2142
 msgid "threshold of what shall be considered overexposed"
 msgstr "Schwellwert dafür, was als überbelichtet markiert wird"
 
-#: ../src/views/darkroom.c:2079
+#: ../src/views/darkroom.c:2153
 msgid ""
 "toggle softproofing\n"
 "right click for profile options"
@@ -15857,7 +16339,7 @@ msgstr ""
 "Softproof umschalten\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2093
+#: ../src/views/darkroom.c:2167
 msgid ""
 "toggle gamut checking\n"
 "right click for profile options"
@@ -15865,194 +16347,223 @@ msgstr ""
 "Gamutüberprüfung umschalten\n"
 "Rechtsklick für Einstellungen"
 
-#: ../src/views/darkroom.c:2121 ../src/views/lighttable.c:3453
+#: ../src/views/darkroom.c:2195 ../src/views/lighttable.c:3449
 msgid "display intent"
 msgstr "Anzeigevorsatz"
 
-#: ../src/views/darkroom.c:2129 ../src/views/lighttable.c:3461
+#: ../src/views/darkroom.c:2203 ../src/views/lighttable.c:3457
 msgid "preview display intent"
 msgstr "Vorschau des Anzeigevorsatz"
 
-#: ../src/views/darkroom.c:2149 ../src/views/lighttable.c:3469
+#: ../src/views/darkroom.c:2223 ../src/views/lighttable.c:3465
 msgid "display profile"
 msgstr "Anzeigeprofil"
 
-#: ../src/views/darkroom.c:2150 ../src/views/lighttable.c:3473
+#: ../src/views/darkroom.c:2224 ../src/views/lighttable.c:3469
 msgid "preview display profile"
 msgstr "Vorschau des Bildschirmprofil"
 
-#: ../src/views/darkroom.c:2151
+#: ../src/views/darkroom.c:2225
 msgid "histogram profile"
 msgstr "Histogrammprofil"
 
-#: ../src/views/darkroom.c:2205 ../src/views/lighttable.c:3503
+#: ../src/views/darkroom.c:2279 ../src/views/lighttable.c:3499
 #, c-format
 msgid "display ICC profiles in %s or %s"
 msgstr "Anzeige-ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2208 ../src/views/lighttable.c:3506
+#: ../src/views/darkroom.c:2282 ../src/views/lighttable.c:3502
 #, c-format
 msgid "preview display ICC profiles in %s or %s"
 msgstr "Vorschau der Anzeige-ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2211
+#: ../src/views/darkroom.c:2285
 #, c-format
 msgid "softproof ICC profiles in %s or %s"
 msgstr "Softproof-ICC-Profile in %s oder %s"
 
-#: ../src/views/darkroom.c:2214
+#: ../src/views/darkroom.c:2288
 #, c-format
 msgid "histogram and color picker ICC profiles in %s or %s"
 msgstr "Histogramm und Farbwähler ICC-Profile in %s oder %s"
 
+#: ../src/views/darkroom.c:2321
+msgid ""
+"set the color of lines that overlay the image (drawn masks, crop and rotate "
+"guides etc.)"
+msgstr ""
+
+#: ../src/views/darkroom.c:2342
+msgid "overlay color"
+msgstr "Überlagerungsfarbe"
+
+#: ../src/views/darkroom.c:2350
+#, fuzzy
+msgid "set overlay color"
+msgstr "Rahmenfarbe wählen"
+
 #. Zoom shortcuts
-#: ../src/views/darkroom.c:3377
+#: ../src/views/darkroom.c:3505
 msgctxt "accel"
 msgid "zoom close-up"
 msgstr "Nahansicht"
 
-#: ../src/views/darkroom.c:3378
+#: ../src/views/darkroom.c:3506
 msgctxt "accel"
 msgid "zoom fill"
 msgstr "Ansicht füllen"
 
-#: ../src/views/darkroom.c:3379
+#: ../src/views/darkroom.c:3507
 msgctxt "accel"
 msgid "zoom fit"
 msgstr "Ansicht einpassen"
 
 #. Shortcut to skip images
-#: ../src/views/darkroom.c:3385
+#: ../src/views/darkroom.c:3513
 msgctxt "accel"
 msgid "image forward"
 msgstr "Nächstes Bild"
 
-#: ../src/views/darkroom.c:3386
+#: ../src/views/darkroom.c:3514
 msgctxt "accel"
 msgid "image back"
 msgstr "Vorheriges Bild"
 
 #. toggle ISO 12646 color assessment condition
-#: ../src/views/darkroom.c:3389
+#: ../src/views/darkroom.c:3517
 #, fuzzy
 msgctxt "accel"
 msgid "color assessment"
 msgstr "Farbzusammenstellung"
 
 #. toggle raw overexposure indication
-#: ../src/views/darkroom.c:3392
+#: ../src/views/darkroom.c:3520
 msgctxt "accel"
 msgid "raw overexposed"
 msgstr "Raw-Überbelichtet"
 
 #. toggle overexposure indication
-#: ../src/views/darkroom.c:3395
+#: ../src/views/darkroom.c:3523
 msgctxt "accel"
 msgid "overexposed"
 msgstr "Überbelichtet"
 
+#. cycle overlay colors
+#: ../src/views/darkroom.c:3526
+#, fuzzy
+msgctxt "accel"
+msgid "cycle overlay colors"
+msgstr "Rahmenfarbe wählen"
+
 #. toggle softproofing
-#: ../src/views/darkroom.c:3398
+#: ../src/views/darkroom.c:3529
 msgctxt "accel"
 msgid "softproof"
 msgstr "Softproof"
 
 #. toggle gamut check
-#: ../src/views/darkroom.c:3401
+#: ../src/views/darkroom.c:3532
 msgctxt "accel"
 msgid "gamut check"
 msgstr "Gamut überprüfen"
 
+#. toggle visability of drawn masks for current gui module
+#: ../src/views/darkroom.c:3535
+#, fuzzy
+msgctxt "accel"
+msgid "show drawn masks"
+msgstr "gezeichnete Maske"
+
 #. brush size +/-
-#: ../src/views/darkroom.c:3404
+#: ../src/views/darkroom.c:3538
 msgctxt "accel"
 msgid "increase brush size"
 msgstr "Größe des Pinsels erhöhen"
 
-#: ../src/views/darkroom.c:3405
+#: ../src/views/darkroom.c:3539
 msgctxt "accel"
 msgid "decrease brush size"
 msgstr "Größe des Pinsels verringern"
 
 #. brush hardness +/-
-#: ../src/views/darkroom.c:3408
+#: ../src/views/darkroom.c:3542
 msgctxt "accel"
 msgid "increase brush hardness"
 msgstr "Härte des Pinsels erhöhen"
 
-#: ../src/views/darkroom.c:3409
+#: ../src/views/darkroom.c:3543
 msgctxt "accel"
 msgid "decrease brush hardness"
 msgstr "Härte des Pinsels verringern"
 
 #. brush opacity +/-
-#: ../src/views/darkroom.c:3412
+#: ../src/views/darkroom.c:3546
 msgctxt "accel"
 msgid "increase brush opacity"
 msgstr "Deckkraft des Pinsels erhöhen"
 
-#: ../src/views/darkroom.c:3413
+#: ../src/views/darkroom.c:3547
 msgctxt "accel"
 msgid "decrease brush opacity"
 msgstr "Deckkraft des Pinsels verringern"
 
 #. fullscreen view
-#: ../src/views/darkroom.c:3416
+#: ../src/views/darkroom.c:3550
 msgctxt "accel"
 msgid "full preview"
 msgstr "Kurzvorschau"
 
 #. undo/redo
-#: ../src/views/darkroom.c:3419 ../src/views/lighttable.c:3001
-#: ../src/views/map.c:900
+#: ../src/views/darkroom.c:3553 ../src/views/lighttable.c:2997
+#: ../src/views/map.c:920
 msgctxt "accel"
 msgid "undo"
 msgstr "Rückgängig"
 
-#: ../src/views/darkroom.c:3420 ../src/views/lighttable.c:3002
-#: ../src/views/map.c:901
+#: ../src/views/darkroom.c:3554 ../src/views/lighttable.c:2998
+#: ../src/views/map.c:921
 msgctxt "accel"
 msgid "redo"
 msgstr "Wiederherstellen"
 
 #. add an option to allow skip mouse events while editing masks
-#: ../src/views/darkroom.c:3423
+#: ../src/views/darkroom.c:3557
 msgctxt "accel"
 msgid "allow to pan & zoom while editing masks"
 msgstr "erlauben das Schwenken und Zoomen während der Bearbeitung von Masken"
 
 #. set focus to the search modules text box
-#: ../src/views/darkroom.c:3426
+#: ../src/views/darkroom.c:3560
 msgctxt "accel"
 msgid "search modules"
 msgstr "suche Modul"
 
-#: ../src/views/darkroom.c:3525
+#: ../src/views/darkroom.c:3667
 msgid "switch to lighttable"
 msgstr "Zum Leuchttisch wechseln"
 
-#: ../src/views/darkroom.c:3530 ../src/views/lighttable.c:3145
+#: ../src/views/darkroom.c:3672 ../src/views/lighttable.c:3141
 msgid "zoom in the image"
 msgstr "Zoomen im Bild"
 
-#: ../src/views/darkroom.c:3536
+#: ../src/views/darkroom.c:3678
 msgid "unbounded zoom in the image"
 msgstr "unbegrenztes Zoomen im Bild"
 
-#: ../src/views/darkroom.c:3541
+#: ../src/views/darkroom.c:3683
 msgid "zoom to 100% 200% and back"
 msgstr "Zoom auf 100%, 200% und zurück"
 
-#: ../src/views/darkroom.c:3547
+#: ../src/views/darkroom.c:3689
 msgid "[modules] expand module without closing others"
 msgstr "[modules] Module ausklappen, ohne andere zu schließen"
 
-#: ../src/views/darkroom.c:3553
+#: ../src/views/darkroom.c:3695
 msgid "[modules] change module position in pipe"
 msgstr "Modulposition ändern"
 
 #. workaround for GTK Quartz backend bug
-#: ../src/views/darkroom.c:4267 ../src/views/darkroom.c:4285
+#: ../src/views/darkroom.c:4409 ../src/views/darkroom.c:4427
 msgid "darktable - darkroom preview"
 msgstr "darktable - Dunkelkammer Vorschau"
 
@@ -16060,263 +16571,263 @@ msgstr "darktable - Dunkelkammer Vorschau"
 msgid "good knight"
 msgstr "Good Knight"
 
-#: ../src/views/lighttable.c:854 ../src/views/slideshow.c:372
+#: ../src/views/lighttable.c:850 ../src/views/slideshow.c:376
 msgid "there are no images in this collection"
 msgstr "Diese Sammlung enthält keine Bilder"
 
-#: ../src/views/lighttable.c:858
+#: ../src/views/lighttable.c:854
 msgid "if you have not imported any images yet"
 msgstr "Falls noch keine Bilder importiert wurden"
 
-#: ../src/views/lighttable.c:862
+#: ../src/views/lighttable.c:858
 msgid "you can do so in the import module"
 msgstr "Kann im Import-Modul erfolgen"
 
-#: ../src/views/lighttable.c:870
+#: ../src/views/lighttable.c:866
 msgid "try to relax the filter settings in the top panel"
 msgstr "Filterregeln in der oberen Leiste anpassen"
 
-#: ../src/views/lighttable.c:879
+#: ../src/views/lighttable.c:875
 msgid "or add images in the collection module in the left panel"
 msgstr "oder Bilder links im Sammlungs-Plugin hinzufügen"
 
-#: ../src/views/lighttable.c:1935
+#: ../src/views/lighttable.c:1931
 #, c-format
 msgid "you have reached the start of your selection (%d image)"
 msgid_plural "you have reached the start of your selection (%d images)"
 msgstr[0] "Anfang der Auswahl erreicht (%d Bild)"
 msgstr[1] "Anfang der Auswahl erreicht (%d Bilder)"
 
-#: ../src/views/lighttable.c:1940
+#: ../src/views/lighttable.c:1936
 msgid "you have reached the start of your collection"
 msgstr "Anfang der Sammlung erreicht"
 
-#: ../src/views/lighttable.c:1964
+#: ../src/views/lighttable.c:1960
 #, c-format
 msgid "you have reached the end of your selection (%d image)"
 msgid_plural "you have reached the end of your selection (%d images)"
 msgstr[0] "Ende der Auswahl erreicht (%d Bild)"
 msgstr[1] "Ende der Auswahl erreicht (%d Bilder)"
 
-#: ../src/views/lighttable.c:1969
+#: ../src/views/lighttable.c:1965
 msgid "you have reached the end of your collection"
 msgstr "Ende der Sammlung erreicht"
 
-#: ../src/views/lighttable.c:2332
+#: ../src/views/lighttable.c:2328
 #, c-format
 msgid "zooming is limited to %d images"
 msgstr "Zoom ist auf %d Bilder beschränkt"
 
 #. movement keys
-#: ../src/views/lighttable.c:2969
+#: ../src/views/lighttable.c:2965
 #, fuzzy
 msgctxt "accel"
 msgid "move page up"
 msgstr "aufwärtsschieben"
 
-#: ../src/views/lighttable.c:2970
+#: ../src/views/lighttable.c:2966
 #, fuzzy
 msgctxt "accel"
 msgid "move page down"
 msgstr "abwärtsschieben"
 
-#: ../src/views/lighttable.c:2971
+#: ../src/views/lighttable.c:2967
 #, fuzzy
 msgctxt "accel"
 msgid "move up"
 msgstr "aufwärtsschieben"
 
-#: ../src/views/lighttable.c:2972
+#: ../src/views/lighttable.c:2968
 #, fuzzy
 msgctxt "accel"
 msgid "move down"
 msgstr "abwärtsschieben"
 
-#: ../src/views/lighttable.c:2973
+#: ../src/views/lighttable.c:2969
 #, fuzzy
 msgctxt "accel"
 msgid "move left"
 msgstr "oben links"
 
-#: ../src/views/lighttable.c:2974
+#: ../src/views/lighttable.c:2970
 #, fuzzy
 msgctxt "accel"
 msgid "move right"
 msgstr "oben rechts"
 
-#: ../src/views/lighttable.c:2975
+#: ../src/views/lighttable.c:2971
 #, fuzzy
 msgctxt "accel"
 msgid "move start"
 msgstr "1 Stern"
 
-#: ../src/views/lighttable.c:2976
+#: ../src/views/lighttable.c:2972
 #, fuzzy
 msgctxt "accel"
 msgid "move end"
 msgstr "abwärtsschieben"
 
 #. movement keys with selection
-#: ../src/views/lighttable.c:2979
+#: ../src/views/lighttable.c:2975
 msgctxt "accel"
 msgid "move page up and select"
 msgstr ""
 
-#: ../src/views/lighttable.c:2980
+#: ../src/views/lighttable.c:2976
 msgctxt "accel"
 msgid "move page down and select"
 msgstr ""
 
-#: ../src/views/lighttable.c:2981
+#: ../src/views/lighttable.c:2977
 msgctxt "accel"
 msgid "move up and select"
 msgstr ""
 
-#: ../src/views/lighttable.c:2982
+#: ../src/views/lighttable.c:2978
 #, fuzzy
 msgctxt "accel"
 msgid "move down and select"
 msgstr "abwärtsschieben"
 
 # besser "Bedienfeld"?
-#: ../src/views/lighttable.c:2983
+#: ../src/views/lighttable.c:2979
 #, fuzzy
 msgctxt "accel"
 msgid "move left and select"
 msgstr "linkes Feld umschalten"
 
-#: ../src/views/lighttable.c:2984
+#: ../src/views/lighttable.c:2980
 #, fuzzy
 msgctxt "accel"
 msgid "move right and select"
 msgstr "rechtes Feld umschalten"
 
-#: ../src/views/lighttable.c:2985
+#: ../src/views/lighttable.c:2981
 #, fuzzy
 msgctxt "accel"
 msgid "move start and select"
 msgstr "Start und Stop"
 
-#: ../src/views/lighttable.c:2986
+#: ../src/views/lighttable.c:2982
 msgctxt "accel"
 msgid "move end and select"
 msgstr ""
 
-#: ../src/views/lighttable.c:2988
+#: ../src/views/lighttable.c:2984
 #, fuzzy
 msgctxt "accel"
 msgid "align images to grid"
 msgstr "Bilder wieder am Raster ausrichten"
 
-#: ../src/views/lighttable.c:2989
+#: ../src/views/lighttable.c:2985
 #, fuzzy
 msgctxt "accel"
 msgid "reset first image offset"
 msgstr "Zeitversatz"
 
-#: ../src/views/lighttable.c:2990
+#: ../src/views/lighttable.c:2986
 msgctxt "accel"
 msgid "select toggle image"
 msgstr "Bildauswahl umschalten"
 
-#: ../src/views/lighttable.c:2991
+#: ../src/views/lighttable.c:2987
 msgctxt "accel"
 msgid "select single image"
 msgstr "Einzelnes Bild auswählen"
 
 #. Preview key
-#: ../src/views/lighttable.c:2994
+#: ../src/views/lighttable.c:2990
 msgctxt "accel"
 msgid "preview"
 msgstr "Kurzvorschau"
 
-#: ../src/views/lighttable.c:2995
+#: ../src/views/lighttable.c:2991
 msgctxt "accel"
 msgid "preview with focus detection"
 msgstr "Kurzvorschau mit Fokuserkennung"
 
-#: ../src/views/lighttable.c:2996
+#: ../src/views/lighttable.c:2992
 msgctxt "accel"
 msgid "sticky preview"
 msgstr "Vorschau"
 
-#: ../src/views/lighttable.c:2997
+#: ../src/views/lighttable.c:2993
 msgctxt "accel"
 msgid "sticky preview with focus detection"
 msgstr "Vorschau mit Fokuserkennung"
 
 #. zoom for full preview
-#: ../src/views/lighttable.c:3005
+#: ../src/views/lighttable.c:3001
 msgctxt "accel"
 msgid "preview zoom 100%"
 msgstr "Vorschau-Zoom 100%"
 
-#: ../src/views/lighttable.c:3006
+#: ../src/views/lighttable.c:3002
 msgctxt "accel"
 msgid "preview zoom fit"
 msgstr "Vorschau einpassen"
 
-#: ../src/views/lighttable.c:3132
+#: ../src/views/lighttable.c:3128
 msgid "open image in darkroom"
 msgstr "Bild in der Dunkelkammer öffnen"
 
-#: ../src/views/lighttable.c:3139
+#: ../src/views/lighttable.c:3135
 msgid "switch to next/previous image"
 msgstr "Zum nächsten/vorherigen Bild wechseln"
 
-#: ../src/views/lighttable.c:3152 ../src/views/lighttable.c:3174
+#: ../src/views/lighttable.c:3148 ../src/views/lighttable.c:3170
 msgid "scroll the collection"
 msgstr "Sammlung durchblättern"
 
-#: ../src/views/lighttable.c:3158
+#: ../src/views/lighttable.c:3154
 msgid "change number of images per row"
 msgstr "Anzahl der Bilder pro Zeile ändern"
 
-#: ../src/views/lighttable.c:3166
+#: ../src/views/lighttable.c:3162
 msgid "change image order"
 msgstr "Bildreihenfolge ändern"
 
-#: ../src/views/lighttable.c:3180
+#: ../src/views/lighttable.c:3176
 msgid "zoom all the images"
 msgstr "Alle Bilder skalieren"
 
-#: ../src/views/lighttable.c:3185
+#: ../src/views/lighttable.c:3181
 msgid "pan inside all the images"
 msgstr "Innerhalb aller Bilder verschieben"
 
-#: ../src/views/lighttable.c:3191
+#: ../src/views/lighttable.c:3187
 msgid "zoom current image"
 msgstr "Aktuelles bild skalieren"
 
-#: ../src/views/lighttable.c:3197
+#: ../src/views/lighttable.c:3193
 msgid "pan inside current image"
 msgstr "Innerhalb des aktuellen Bild verschieben"
 
-#: ../src/views/lighttable.c:3204
+#: ../src/views/lighttable.c:3200
 msgid "zoom the main view"
 msgstr "Hauptansicht skalieren"
 
-#: ../src/views/lighttable.c:3209
+#: ../src/views/lighttable.c:3205
 msgid "pan inside the main view"
 msgstr "Innerhalb der Hauptansicht verschieben"
 
-#: ../src/views/lighttable.c:3430
+#: ../src/views/lighttable.c:3426
 msgid "set display profile"
 msgstr "Anzeigeprofil setzen"
 
-#: ../src/views/map.c:134
+#: ../src/views/map.c:132
 msgid "map"
 msgstr "Karte"
 
-#: ../src/views/map.c:1399
+#: ../src/views/map.c:1378
 msgid "[on image] open in darkroom"
 msgstr "[on image] In der Dunkelkammer öffnen"
 
-#: ../src/views/map.c:1404
+#: ../src/views/map.c:1383
 msgid "[on map] zoom map"
 msgstr "[on map] Karte skalieren"
 
-#: ../src/views/map.c:1409
+#: ../src/views/map.c:1388
 msgid "move image location"
 msgstr "Bild verschieben"
 
@@ -16325,42 +16836,38 @@ msgctxt "view"
 msgid "print"
 msgstr "Drucken"
 
-#: ../src/views/slideshow.c:310 ../src/views/slideshow.c:326
+#: ../src/views/slideshow.c:314 ../src/views/slideshow.c:330
 msgid "end of images. press any key to return to lighttable mode"
 msgstr ""
 "Letztes Bild. Eine beliebige Taste drücken, um zurück zum Leuchttisch zu "
 "gelangen"
 
-#: ../src/views/slideshow.c:340
-msgid "slideshow"
-msgstr "Diashow"
-
-#: ../src/views/slideshow.c:462
+#: ../src/views/slideshow.c:466
 msgid "waiting to start slideshow"
 msgstr "Warte auf den Start der Diaschau"
 
-#: ../src/views/slideshow.c:586 ../src/views/slideshow.c:602
-#: ../src/views/slideshow.c:608
+#: ../src/views/slideshow.c:590 ../src/views/slideshow.c:606
+#: ../src/views/slideshow.c:612
 msgid "slideshow paused"
 msgstr "Diashow pausiert"
 
-#: ../src/views/slideshow.c:593 ../src/views/slideshow.c:598
+#: ../src/views/slideshow.c:597 ../src/views/slideshow.c:602
 #, c-format
 msgid "slideshow delay set to %d second"
 msgid_plural "slideshow delay set to %d seconds"
 msgstr[0] "Diaschau-Wartezeit auf %d Sekunde gesetzt"
 msgstr[1] "Diaschau-Wartezeit auf %d Sekunden gesetzt"
 
-#: ../src/views/slideshow.c:624
+#: ../src/views/slideshow.c:628
 msgctxt "accel"
 msgid "start and stop"
 msgstr "Start und Stop"
 
-#: ../src/views/slideshow.c:638
+#: ../src/views/slideshow.c:642
 msgid "go to next image"
 msgstr "Zum nächsten Bild gehen"
 
-#: ../src/views/slideshow.c:643
+#: ../src/views/slideshow.c:647
 msgid "go to previous image"
 msgstr "Zum vorherigen Bild gehen"
 
@@ -16377,67 +16884,128 @@ msgstr "neue Sitzung „%s” gestartet"
 msgid "no camera with tethering support available for use..."
 msgstr "keine Kamera mit Tethering-Unterstützung verfügbar ..."
 
-#: ../src/views/view.c:2351
+#: ../src/views/view.c:2371
 msgid "Left click"
 msgstr "Linksklick"
 
-#: ../src/views/view.c:2354
+#: ../src/views/view.c:2374
 msgid "Right click"
 msgstr "Rechtsklick"
 
-#: ../src/views/view.c:2357
+#: ../src/views/view.c:2377
 msgid "Middle click"
 msgstr "Mittelklick"
 
-#: ../src/views/view.c:2360
+#: ../src/views/view.c:2380
 msgid "Scroll"
 msgstr "Scrollen"
 
-#: ../src/views/view.c:2363
+#: ../src/views/view.c:2383
 msgid "Left double-click"
 msgstr "Doppelklick links"
 
-#: ../src/views/view.c:2366
+#: ../src/views/view.c:2386
 msgid "Right double-click"
 msgstr "Doppelklick rechts"
 
-#: ../src/views/view.c:2369
+#: ../src/views/view.c:2389
 msgid "Drag and drop"
 msgstr "Drag and Drop"
 
-#: ../src/views/view.c:2372
+#: ../src/views/view.c:2392
 msgid "Left click+Drag"
 msgstr "Linksklick+ziehen"
 
-#: ../src/views/view.c:2375
+#: ../src/views/view.c:2395
 msgid "Right click+Drag"
 msgstr "Rechtsklick+ziehen"
 
-#: ../src/views/view.c:2396
+#: ../src/views/view.c:2416
 msgid "darktable - accels window"
 msgstr "darktable - Beschlunigungsfenster"
 
-#: ../src/views/view.c:2452
+#: ../src/views/view.c:2472
 msgid "switch to a classic window which will stay open after key release."
 msgstr ""
 "Umschalten zum klassischen Fenster, das nach der Tastenbetätigung geöffnet "
 "bleibt."
 
-#: ../src/views/view.c:2568
+#: ../src/views/view.c:2588
 msgid "+Scroll"
 msgstr "+Mausrad"
 
-#: ../src/views/view.c:2583
+#: ../src/views/view.c:2603
 msgid "mouse actions"
 msgstr "Mausaktionen"
 
-#: ../src/views/view.c:2621
+#: ../src/views/view.c:2641
 msgid "Accel"
 msgstr "Beschleunigung"
 
-#: ../src/views/view.c:2623
+#: ../src/views/view.c:2643
 msgid "Action"
 msgstr "Aktion"
+
+#~ msgid "GUI options"
+#~ msgstr "GUI-Optionen"
+
+#~ msgid "if set to true, thumb overlay shows filename and some exif data."
+#~ msgstr ""
+#~ "wenn auf true gesetzt, zeigt das Vorschaubild-Overlay den Dateinamen und "
+#~ "einige Exif-Daten an."
+
+#~ msgctxt "preferences"
+#~ msgid "no scrollbars"
+#~ msgstr "keine Scrollbalken"
+
+#~ msgctxt "preferences"
+#~ msgid "lighttable"
+#~ msgstr "Leuchttisch"
+
+#~ msgctxt "preferences"
+#~ msgid "lighttable + darkroom"
+#~ msgstr "Leuchttisch und Dunkelkammer"
+
+#~ msgid "core options"
+#~ msgstr "zentrale Optionen"
+
+#~ msgid "%s/%s: %s"
+#~ msgstr "%s/%s: %s"
+
+#~ msgid ""
+#~ "an error has occurred while trying to open the database from\n"
+#~ "\n"
+#~ "<span style=\"italic\">%s</span>\n"
+#~ "\n"
+#~ "%s\n"
+#~ msgstr ""
+#~ "Es ist ein Fehler beim Öffnen der Datenbank von\n"
+#~ "\n"
+#~ "<span style=\"italic\">%s</span>\n"
+#~ "\n"
+#~ "aufgetreten.\n"
+#~ "\n"
+#~ "%s\n"
+
+#~ msgid "darktable - error locking database"
+#~ msgstr "darktable – Fehler beim Sperren der Datenbank"
+
+#~ msgid "close"
+#~ msgstr "schließen"
+
+#~ msgctxt "accel"
+#~ msgid "delete"
+#~ msgstr "Löschen"
+
+#~ msgid "delete branch"
+#~ msgstr "Zweig löschen"
+
+#~ msgid "'|' character is not allowed to create a tag. aborting."
+#~ msgstr ""
+#~ "'|' Zeichen ist für die Erstellung eines Tag nicht erlaubt. Abbruch."
+
+#~ msgid "show image overlays"
+#~ msgstr "Bildinfos anzeigen"
 
 #~ msgid "width of the side panels in pixels"
 #~ msgstr "Breite der Seitenleisten in Pixeln"
@@ -18294,9 +18862,6 @@ msgstr "Aktion"
 #~ msgid "gamma"
 #~ msgstr "Gamma"
 
-#~ msgid "film strip"
-#~ msgstr "Filmstreifen"
-
 #~ msgctxt "accel"
 #~ msgid "history copy"
 #~ msgstr "Verlaufsstapel kopieren"
@@ -18367,10 +18932,6 @@ msgstr "Aktion"
 #~ msgctxt "accel"
 #~ msgid "rating"
 #~ msgstr "Bewertung"
-
-#~ msgctxt "accel"
-#~ msgid "remove"
-#~ msgstr "entfernen"
 
 #~ msgctxt "accel"
 #~ msgid "reset camera from exif data"


### PR DESCRIPTION
I added a few missing translations, and cleaned-up some others. 

Due to `intltool-update` the diff is unreasonably large and actual changes are difficult do grasp. Following https://stackoverflow.com/a/11291001, I added to `.git/info/attributes`

    *.po    diff=po

and to `.git/config`

    [diff "po"]
    textconv=msgcat --no-location --no-wrap --sort-output

which allows me to inspect the actual changes via `git diff master my_translation_de`.
