### PR TITLE
Introduce dt_color_picker_new minimalist color picker setup

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -256,6 +256,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
   if(!g_module_symbol(module->module, "gui_init", (gpointer) & (module->gui_init))) module->gui_init = NULL;
   if(!g_module_symbol(module->module, "gui_update", (gpointer) & (module->gui_update)))
     module->gui_update = NULL;
+  if(!g_module_symbol(module->module, "color_picker_apply", (gpointer) & (module->color_picker_apply)))
+    module->color_picker_apply = NULL;
   if(!g_module_symbol(module->module, "gui_cleanup", (gpointer) & (module->gui_cleanup)))
     module->gui_cleanup = default_gui_cleanup;
 
@@ -426,6 +428,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->gui_update = so->gui_update;
   module->gui_reset = so->gui_reset;
   module->gui_init = so->gui_init;
+  module->color_picker_apply = so->color_picker_apply;
   module->gui_cleanup = so->gui_cleanup;
 
   module->gui_post_expose = so->gui_post_expose;

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -204,6 +204,7 @@ typedef struct dt_iop_module_so_t
   void (*gui_reset)(struct dt_iop_module_t *self);
   void (*gui_update)(struct dt_iop_module_t *self);
   void (*gui_init)(struct dt_iop_module_t *self);
+  void (*color_picker_apply)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece);
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   void (*gui_post_expose)(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
                           int32_t pointerx, int32_t pointery);
@@ -437,6 +438,8 @@ typedef struct dt_iop_module_t
   void (*gui_reset)(struct dt_iop_module_t *self);
   /** construct widget. */
   void (*gui_init)(struct dt_iop_module_t *self);
+  /** apply color picker results */
+  void (*color_picker_apply)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece);
   /** destroy widget. */
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   /** optional method called after darkroom expose. */

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -128,6 +128,9 @@ void dt_iop_color_picker_init();
 /* global cleanup */
 void dt_iop_color_picker_cleanup();
 
+/* link color picker to widget */
+GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -50,7 +50,6 @@ typedef struct dt_iop_invert_gui_data_t
   GtkWidget *picker;
   double RGB_to_CAM[4][3];
   double CAM_to_RGB[3][4];
-  dt_iop_color_picker_t color_picker;
 } dt_iop_invert_gui_data_t;
 
 typedef struct dt_iop_invert_global_data_t
@@ -161,7 +160,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   static float old[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
@@ -635,16 +634,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->colorpicker), "color-set", G_CALLBACK(colorpicker_callback), self);
   gtk_box_pack_start(GTK_BOX(g->pickerbuttons), GTK_WIDGET(g->colorpicker), TRUE, TRUE, 0);
 
-  g->picker = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
-  gtk_widget_set_tooltip_text(g->picker, _("pick color of film material from image"));
-  g_signal_connect(G_OBJECT(g->picker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-  gtk_box_pack_start(GTK_BOX(g->pickerbuttons), g->picker, TRUE, TRUE, 0);
-
-  dt_iop_init_single_picker(&g->color_picker,
-                     self,
-                     GTK_WIDGET(g->picker),
-                     DT_COLOR_PICKER_AREA,
-                     _iop_color_picker_apply);
+  g->picker = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, GTK_WIDGET(g->pickerbuttons));
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -109,6 +109,8 @@ void gui_update(struct dt_iop_module_t *self);
 void gui_reset(struct dt_iop_module_t *self);
 /** construct widget. */
 void gui_init(struct dt_iop_module_t *self);
+/** apply color picker results */
+void color_picker_apply(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece);
 /** destroy widget. */
 void gui_cleanup(struct dt_iop_module_t *self);
 /** optional method called after darkroom expose. */


### PR DESCRIPTION
This introduces a new call dt_color_picker_new which wraps setting up the color_picker structure and linking it to a slider or creating a button and boxing it. Since it passes the color_picker as a parameter in the callback, it can support an unlimited number of pickers per module without needing to maintain a color_picker object in the gui data or having to define an enum to refer to each of the pickers; the picker widget is directly checked in the new overloaded color_picker_apply method. The get-set and update calls are no longer necessary, even for multi-picker.

This is backward compatible with the existing approach, so I have only transitioned a few modules to demonstrate how it works and will do the others at the same time as rolling out #4804 across all modules.

I am also looking at refactoring out the commonalities of colorzones, rgbcurve and blending double-color-pick buttons.

After everything has transitioned and unless there is a desire to maintain compatibility with out-of-tree modules, I'd like to go over color_picker_proxy once again and simplify a lot of complexity that doesn't seem like it would be necessary anymore. I will likely be asking questions on IRC to understand what the original purpose of some of it was. For example, why are the picker point and area stored in dt_iop_module_t, rather than directly in the color picker or even globally? It might require too many changes throughout the modules to change that now to be worth the hassle, but at least I want to make sure we don't have the intention to support more than one color picker at the same time?

BTW negadoctor::_iop_color_picker_update shows how hard it is to keep all that duplicate boiler plate code in sync :-)

@TurboGit @edgardoh 