### PR TITLE
Make module in focus slightly outstanding

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1998,12 +1998,12 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   /* add enabled button */
   if(module->enabled && module->default_enabled && module->hide_enable_button)
   {
-    hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
+    hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, module);
     gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_SWITCH]), "module-always-enabled-button");
   }
   else
   {
-    hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
+    hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, module);
     gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_SWITCH]), "module-enable-button");
   }
   gchar *module_label = dt_history_item_get_name(module);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -273,12 +273,17 @@ void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
 
   cairo_set_line_width(cr, 0.1);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  if(flags & CPF_FOCUS)
+  {
+    cairo_arc(cr, 0.5, 0.5, 0.66, 0, 2 * M_PI);
+    cairo_stroke(cr);
+  }
   cairo_arc(cr, 0.5, 0.5, 0.46, (-50 * 3.145 / 180), (230 * 3.145 / 180));
   cairo_move_to(cr, 0.5, 0.0);
   cairo_line_to(cr, 0.5, 0.5);
   cairo_stroke(cr);
 
-  if((flags & CPF_ACTIVE)) // If active add some green diffuse light
+  if(flags & CPF_ACTIVE) // If active add some diffuse light
   {
     cairo_arc(cr, 0.5, 0.5, 0.45, 0.0, 2*M_PI);
     cairo_clip(cr);
@@ -295,6 +300,11 @@ void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_scale(cr, s, s);
 
   cairo_set_line_width(cr, 0.1);
+  if(flags & CPF_FOCUS)
+  {
+    cairo_arc(cr, 0.5, 0.5, 0.7, 0, 2 * M_PI);
+    cairo_stroke(cr);
+  }
   cairo_arc(cr, 0.5, 0.5, 0.35, 0, 2 * M_PI);
   cairo_fill(cr);
 

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -39,7 +39,8 @@ typedef enum dtgtk_cairo_paint_flags_t
   CPF_DO_NOT_USE_BORDER = 1 << 10, // do not paint inner border
   CPF_CUSTOM_BG = 1 << 11,
   CPF_CUSTOM_FG = 1 << 12,
-  CPF_SPECIAL_FLAG = 1 << 13       // this needs to be the last one. also update shift in dtgtk_cairo_paint_alignment
+  CPF_FOCUS = 1 << 13, 
+  CPF_SPECIAL_FLAG = 1 << 14       // this needs to be the last one. also update shift in dtgtk_cairo_paint_alignment
 } dtgtk_cairo_paint_flags_t;
 
 

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -67,15 +67,19 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
   int flags = DTGTK_TOGGLEBUTTON(widget)->icon_flags;
 
   /* update active state paint flag */
-  gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  const gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
   if(active)
-  {
     flags |= CPF_ACTIVE;
-  }
   else
-  {
-    flags &= ~(CPF_ACTIVE);
-  }
+    flags &= ~CPF_ACTIVE;
+
+  /* update focus state paint flag */
+  const gboolean hasfocus = ((DTGTK_TOGGLEBUTTON(widget)->icon_data == darktable.develop->gui_module)
+                         && darktable.develop->gui_module);
+  if(hasfocus)
+    flags |= CPF_FOCUS;
+  else
+    flags &= ~CPF_FOCUS;
 
   /* prelight */
   if(state & GTK_STATE_FLAG_PRELIGHT)


### PR DESCRIPTION
Especially when working with more than one module in expanded state we might want
to know by vision what module currently 'has the focus'.

This pr adds this feature as a UI improvement. It does not use any non-css coloring, only makes
the on/off button slightly outstanding.
![Bildschirmfoto von 2020-05-06 18-28-33](https://user-images.githubusercontent.com/50982232/81203024-b23fa200-8fc7-11ea-8061-1c51d622d337.png)

Modules in focus will be shown like this 
![Bildschirmfoto von 2020-05-06 18-34-15](https://user-images.githubusercontent.com/50982232/81203548-60e3e280-8fc8-11ea-811c-2630a9657095.png)
 
![Bildschirmfoto von 2020-05-06 18-28-37](https://user-images.githubusercontent.com/50982232/81203068-c4b9db80-8fc7-11ea-9733-62930bc92d40.png)

![Bildschirmfoto von 2020-05-06 18-28-41](https://user-images.githubusercontent.com/50982232/81203075-c6839f00-8fc7-11ea-8d8e-77d17fb247e5.png)

module not in focus will not change.