### PR TITLE
Preview downsampling

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1538,6 +1538,7 @@
       <enum>
         <option>1.0 (none)</option>
         <option>0.5</option>
+        <option>0.333</option>
         <option>0.25</option>
       </enum>
     </type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1532,6 +1532,19 @@
     <shortdescription>demosaicing for zoomed out darkroom mode</shortdescription>
     <longdescription>interpolation when not viewing 1:1 in darkroom mode: bilinear is fastest, but not as sharp. middle ground is using PPG + interpolation modes specified below, full will use exactly the settings for full-size export. X-Trans sensors use VNG rather than PPG as middle ground.</longdescription>
   </dtconfig>
+  <dtconfig prefs="darkroom" >
+    <name>preview_downsampling</name>
+    <type>
+      <enum>
+        <option>1.0 (none)</option>
+        <option>0.5</option>
+        <option>0.25</option>
+      </enum>
+    </type>
+    <default>1.0 (none)</default>
+    <shortdescription>reduce resolution of preview image</shortdescription>
+    <longdescription>decrease to speed up preview rendering, may hinder accurate masking</longdescription>
+  </dtconfig>
   <dtconfig prefs="processing">
     <name>plugins/lighttable/export/pixel_interpolator</name>
     <type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1536,13 +1536,13 @@
     <name>preview_downsampling</name>
     <type>
       <enum>
-        <option>1.0 (none)</option>
-        <option>0.5</option>
-        <option>0.333</option>
-        <option>0.25</option>
+        <option>original</option>
+        <option>to 1/2</option>
+        <option>to 1/3</option>
+        <option>to 1/4</option>
       </enum>
     </type>
-    <default>1.0 (none)</default>
+    <default>original</default>
     <shortdescription>reduce resolution of preview image</shortdescription>
     <longdescription>decrease to speed up preview rendering, may hinder accurate masking</longdescription>
   </dtconfig>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -107,7 +107,8 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   g_free(histogram_type);
   gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
   dev->preview_downsampling = (g_strcmp0(preview_downsample, "1.0 (none)") == 0) ? 1.0f : 
-      (g_strcmp0(preview_downsample, "0.5")==0) ? 0.5f : 0.25f;
+      (g_strcmp0(preview_downsample, "0.5")==0) ? 0.5f : 
+      (g_strcmp0(preview_downsample, "0.333")==0) ? 1/3.0f : 0.25f;
   g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -106,9 +106,9 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
   gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-  dev->preview_downsampling = (g_strcmp0(preview_downsample, "1.0 (none)") == 0) ? 1.0f : 
-      (g_strcmp0(preview_downsample, "0.5")==0) ? 0.5f : 
-      (g_strcmp0(preview_downsample, "0.333")==0) ? 1/3.0f : 0.25f;
+  dev->preview_downsampling = (g_strcmp0(preview_downsample, "none") == 0) ? 1.0f : 
+      (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f : 
+      (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f : 0.25f;
   g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;
@@ -2441,9 +2441,9 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, c
     modules = g_list_next(modules);
     pieces = g_list_next(pieces);
   }
-  if (transf_direction == DT_DEV_TRANSFORM_DIR_ALL 
+  if ((dev->preview_downsampling != 1.0f) && (transf_direction == DT_DEV_TRANSFORM_DIR_ALL 
                         || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
-                        || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL)
+                        || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL))
     for(size_t idx=0; idx < 2 * points_count; idx++) points[idx] *= dev->preview_downsampling;
     
   dt_pthread_mutex_unlock(&dev->history_mutex);
@@ -2453,9 +2453,9 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
                                       float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
-  if (transf_direction == DT_DEV_TRANSFORM_DIR_ALL
+  if ((dev->preview_downsampling != 1.0f) && (transf_direction == DT_DEV_TRANSFORM_DIR_ALL
     || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
-    || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL) 
+    || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL)) 
       for(size_t idx=0; idx < 2 * points_count; idx++) points[idx] /= dev->preview_downsampling;
   
   GList *modules = g_list_last(pipe->iop);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -106,7 +106,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
   gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-  dev->preview_downsampling = (g_strcmp0(preview_downsample, "none") == 0) ? 1.0f : 
+  dev->preview_downsampling = (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f : 
       (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f : 
       (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f : 0.25f;
   g_free(preview_downsample);

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -53,7 +53,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 {
   memset(dev, 0, sizeof(dt_develop_t));
   dev->full_preview = FALSE;
-  dev->preview_downsampling = 1.0f;
   dev->gui_module = NULL;
   dev->timestamp = 0;
   dev->average_delay = DT_DEV_AVERAGE_DELAY_START;
@@ -106,6 +105,10 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(histogram_type, "logarithmic") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
+  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+  dev->preview_downsampling = (g_strcmp0(preview_downsample, "1.0 (none)") == 0) ? 1.0f : 
+      (g_strcmp0(preview_downsample, "0.5")==0) ? 0.5f : 0.25f;
+  g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -684,7 +687,7 @@ float dt_dev_get_zoom_scale(dt_develop_t *dev, dt_dev_zoom_t zoom, int closeup_f
   const float h = preview ? dev->preview_pipe->processed_height : dev->pipe->processed_height;
   const float ps = dev->pipe->backbuf_width
                        ? dev->pipe->processed_width / (float)dev->preview_pipe->processed_width
-                       : dev->preview_pipe->iscale / dev->preview_downsampling;
+                       : dev->preview_pipe->iscale;
 
   switch(zoom)
   {
@@ -703,6 +706,7 @@ float dt_dev_get_zoom_scale(dt_develop_t *dev, dt_dev_zoom_t zoom, int closeup_f
       if(preview) zoom_scale *= ps;
       break;
   }
+  if (preview) zoom_scale /= dev->preview_downsampling;
   
   return zoom_scale;
 }
@@ -2436,7 +2440,11 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, c
     modules = g_list_next(modules);
     pieces = g_list_next(pieces);
   }
-
+  if (transf_direction == DT_DEV_TRANSFORM_DIR_ALL 
+                        || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
+                        || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL)
+    for(size_t idx=0; idx < 2 * points_count; idx++) points[idx] *= dev->preview_downsampling;
+    
   dt_pthread_mutex_unlock(&dev->history_mutex);
   return 1;
 }
@@ -2444,6 +2452,10 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
                                       float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
+  if (transf_direction == DT_DEV_TRANSFORM_DIR_ALL
+    || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_EXCL
+    || transf_direction == DT_DEV_TRANSFORM_DIR_FORW_INCL) 
+      for(size_t idx=0; idx < 2 * points_count; idx++) points[idx] /= dev->preview_downsampling;
   
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
@@ -2761,7 +2773,7 @@ float dt_second_window_get_zoom_scale(dt_develop_t *dev, const dt_dev_zoom_t zoo
   const float h = preview ? dev->preview_pipe->processed_height : dev->preview2_pipe->processed_height;
   const float ps = dev->preview2_pipe->backbuf_width
                        ? dev->preview2_pipe->processed_width / (float)dev->preview_pipe->processed_width
-                       : dev->preview_pipe->iscale / dev->preview_downsampling;
+                       : dev->preview_pipe->iscale;
 
   switch(zoom)
   {
@@ -2780,6 +2792,7 @@ float dt_second_window_get_zoom_scale(dt_develop_t *dev, const dt_dev_zoom_t zoo
       if(preview) zoom_scale *= ps;
       break;
   }
+  if (preview) zoom_scale /= dev->preview_downsampling;
   return zoom_scale;
 }
 

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -106,7 +106,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(histogram_type, "logarithmic") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
-
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -176,7 +175,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dev->second_window.zoom = DT_ZOOM_FIT;
   dev->second_window.closeup = 0;
   dev->second_window.zoom_x = dev->second_window.zoom_y = 0;
-  dev->second_window.zoom_scale = 1.f;
+  dev->second_window.zoom_scale = 1.0f;
 }
 
 void dt_dev_cleanup(dt_develop_t *dev)
@@ -566,7 +565,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
   }
 
   dt_dev_zoom_t zoom;
-  float zoom_x, zoom_y, scale;
+  float zoom_x = 0.0f, zoom_y = 0.0f, scale = 0.0f;
   int window_width, window_height, x, y, closeup;
   dt_dev_pixelpipe_change_t pipe_changed;
 
@@ -704,6 +703,7 @@ float dt_dev_get_zoom_scale(dt_develop_t *dev, dt_dev_zoom_t zoom, int closeup_f
       if(preview) zoom_scale *= ps;
       break;
   }
+  
   return zoom_scale;
 }
 
@@ -1923,7 +1923,7 @@ void dt_dev_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float *zoom_y, d
 {
   int procw = 0, proch = 0;
   dt_dev_get_processed_size(dev, &procw, &proch);
-  float boxw = 1, boxh = 1; // viewport in normalised space
+  float boxw = 1.0f, boxh = 1.0f; // viewport in normalised space
                             //   if(zoom == DT_ZOOM_1)
                             //   {
                             //     const float imgw = (closeup ? 2 : 1)*procw;
@@ -1953,8 +1953,8 @@ void dt_dev_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float *zoom_y, d
   if(*zoom_x > .5 - boxw / 2) *zoom_x = .5 - boxw / 2;
   if(*zoom_y < boxh / 2 - .5) *zoom_y = boxh / 2 - .5;
   if(*zoom_y > .5 - boxh / 2) *zoom_y = .5 - boxh / 2;
-  if(boxw > 1.0) *zoom_x = 0.f;
-  if(boxh > 1.0) *zoom_y = 0.f;
+  if(boxw > 1.0) *zoom_x = 0.0f;
+  if(boxh > 1.0) *zoom_y = 0.0f;
 
   if(boxww) *boxww = boxw;
   if(boxhh) *boxhh = boxh;
@@ -1990,8 +1990,8 @@ void dt_dev_get_pointer_zoom_pos(dt_develop_t *dev, const float px, const float 
                                  float *zoom_y)
 {
   dt_dev_zoom_t zoom;
-  int closeup, procw = 0, proch = 0;
-  float zoom2_x, zoom2_y;
+  int closeup = 0, procw = 0, proch = 0;
+  float zoom2_x = 0.0f, zoom2_y = 0.0f;
   zoom = dt_control_get_dev_zoom();
   closeup = dt_control_get_dev_closeup();
   zoom2_x = dt_control_get_dev_zoom_x();
@@ -2402,11 +2402,11 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
 
 int dt_dev_distort_transform(dt_develop_t *dev, float *points, size_t points_count)
 {
-  return dt_dev_distort_transform_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  return dt_dev_distort_transform_plus(dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 int dt_dev_distort_backtransform(dt_develop_t *dev, float *points, size_t points_count)
 {
-  return dt_dev_distort_backtransform_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
+  return dt_dev_distort_backtransform_plus(dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, points, points_count);
 }
 
 int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, const double iop_order, const int transf_direction,
@@ -2436,6 +2436,7 @@ int dt_dev_distort_transform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pipe, c
     modules = g_list_next(modules);
     pieces = g_list_next(pieces);
   }
+
   dt_pthread_mutex_unlock(&dev->history_mutex);
   return 1;
 }
@@ -2443,6 +2444,7 @@ int dt_dev_distort_backtransform_plus(dt_develop_t *dev, dt_dev_pixelpipe_t *pip
                                       float *points, size_t points_count)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
+  
   GList *modules = g_list_last(pipe->iop);
   GList *pieces = g_list_last(pipe->nodes);
   while(modules)
@@ -2488,7 +2490,7 @@ dt_dev_pixelpipe_iop_t *dt_dev_distort_get_iop_pipe(dt_develop_t *dev, struct dt
 
 uint64_t dt_dev_hash(dt_develop_t *dev)
 {
-  return dt_dev_hash_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL);
+  return dt_dev_hash_plus(dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL);
 }
 
 uint64_t dt_dev_hash_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, const double iop_order, const int transf_direction)
@@ -2585,7 +2587,7 @@ int dt_dev_sync_pixelpipe_hash(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pip
 
 uint64_t dt_dev_hash_distort(dt_develop_t *dev)
 {
-  return dt_dev_hash_distort_plus(dev, dev->preview_pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL);
+  return dt_dev_hash_distort_plus(dev, dev->preview_pipe, 0.0f, DT_DEV_TRANSFORM_DIR_ALL);
 }
 
 uint64_t dt_dev_hash_distort_plus(dt_develop_t *dev, struct dt_dev_pixelpipe_t *pipe, const double iop_order, const int transf_direction)
@@ -2753,7 +2755,7 @@ float dt_second_window_get_free_zoom_scale(dt_develop_t *dev)
 float dt_second_window_get_zoom_scale(dt_develop_t *dev, const dt_dev_zoom_t zoom, const int closeup_factor,
                                       const int preview)
 {
-  float zoom_scale;
+  float zoom_scale = 0.0f;
 
   const float w = preview ? dev->preview_pipe->processed_width : dev->preview2_pipe->processed_width;
   const float h = preview ? dev->preview_pipe->processed_height : dev->preview2_pipe->processed_height;
@@ -2817,7 +2819,7 @@ void dt_second_window_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float 
 {
   int procw = 0, proch = 0;
   dt_second_window_get_processed_size(dev, &procw, &proch);
-  float boxw = 1, boxh = 1; // viewport in normalised space
+  float boxw = 1.0f, boxh = 1.0f; // viewport in normalised space
                             //   if(zoom == DT_ZOOM_1)
                             //   {
                             //     const float imgw = (closeup ? 2 : 1)*procw;
@@ -2847,8 +2849,8 @@ void dt_second_window_check_zoom_bounds(dt_develop_t *dev, float *zoom_x, float 
   if(*zoom_x > .5 - boxw / 2) *zoom_x = .5 - boxw / 2;
   if(*zoom_y < boxh / 2 - .5) *zoom_y = boxh / 2 - .5;
   if(*zoom_y > .5 - boxh / 2) *zoom_y = .5 - boxh / 2;
-  if(boxw > 1.0) *zoom_x = 0.f;
-  if(boxh > 1.0) *zoom_y = 0.f;
+  if(boxw > 1.0) *zoom_x = 0.0f;
+  if(boxh > 1.0) *zoom_y = 0.0f;
 
   if(boxww) *boxww = boxw;
   if(boxhh) *boxhh = boxh;

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -2097,8 +2097,10 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   // in creation mode
   if(gui->creation)
   {
-    const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;
+    const float pr_d = darktable.develop->preview_downsampling;
+    const float iwd = darktable.develop->preview_pipe->iwidth;
+    const float iht = darktable.develop->preview_pipe->iheight;
+    const float min_iwd_iht= pr_d * MIN(iwd,iht);
 
     if(gui->guipoints_count == 0)
     {
@@ -2119,8 +2121,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
       const float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
 
-      const float radius1 = masks_border * masks_hardness * MIN(wd,ht);
-      const float radius2 = masks_border * MIN(wd,ht);
+      const float radius1 = masks_border * masks_hardness * min_iwd_iht;
+      const float radius2 = masks_border * min_iwd_iht;
 
       float xpos = 0.0f, ypos = 0.0f;
       if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)
@@ -2194,7 +2196,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
           break;
       }
 
-      radius = oldradius = masks_border * masks_hardness * MIN(wd,ht);
+      radius = oldradius = masks_border * masks_hardness * min_iwd_iht;
       opacity = oldopacity = masks_density;
 
       cairo_set_line_width(cr, 2 * radius);
@@ -2233,7 +2235,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
             break;
         }
 
-        radius = masks_border * masks_hardness * MIN(wd,ht);
+        radius = masks_border * masks_hardness * min_iwd_iht;
         opacity = masks_density;
 
         if(radius != oldradius || opacity != oldopacity)
@@ -2258,7 +2260,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_stroke(cr);
       cairo_set_dash(cr, dashed, len, 0);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
-                guipoints[2 * (gui->guipoints_count - 1) + 1], masks_border * MIN(wd,ht), 0,
+                guipoints[2 * (gui->guipoints_count - 1) + 1], masks_border * min_iwd_iht, 0,
                 2.0 * M_PI);
       cairo_stroke(cr);
 

--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -62,7 +62,7 @@ static float _brush_point_line_distance2(int index, int pointscount, const float
   const float l = r3 * r3 + r4 * r4;
   const float p = r / l;
 
-  float dx, dy, db, dh, dd;
+  float dx = 0.0f, dy = 0.0f, db = 0.0f, dh = 0.0f, dd = 0.0f;
 
   if(l == 0.0f)
   {
@@ -304,7 +304,7 @@ static void _brush_init_ctrl_points(dt_masks_form_t *form)
       }
 
 
-      float bx1, by1, bx2, by2;
+      float bx1 = 0.0f, by1 = 0.0f, bx2 = 0.0f, by2 = 0.0f;
       _brush_catmull_to_bezier(point1->corner[0], point1->corner[1], point2->corner[0], point2->corner[1],
                                point3->corner[0], point3->corner[1], point4->corner[0], point4->corner[1],
                                &bx1, &by1, &bx2, &by2);
@@ -968,7 +968,7 @@ static void dt_brush_get_distance(float x, int y, float as, dt_masks_form_gui_t 
 static int dt_brush_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float **points,
                                       int *points_count, float **border, int *border_count, int source)
 {
-  return _brush_get_points_border(dev, form, 0.f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
+  return _brush_get_points_border(dev, form, 0.0f, DT_DEV_TRANSFORM_DIR_ALL, dev->preview_pipe, points, points_count, border,
                                   border_count, NULL, NULL, source);
 }
 
@@ -1164,13 +1164,13 @@ static int dt_brush_events_button_pressed(struct dt_iop_module_t *module, float 
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border;
+  float masks_border = 0.0f;
   if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
   else
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
 
-  float masks_hardness;
+  float masks_hardness = 0.0f;
   if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
     masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_hardness"), HARDNESS_MAX);
   else
@@ -1492,7 +1492,7 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
   dt_masks_form_gui_points_t *gpt = (dt_masks_form_gui_points_t *)g_list_nth_data(gui->points, index);
   if(!gpt) return 0;
 
-  float masks_border;
+  float masks_border = 0.0f;
   if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
     masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
   else
@@ -2082,7 +2082,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   dashed[1] /= zoom_scale;
   const int len = sizeof(dashed) / sizeof(dashed[0]);
 
-  float dx = 0, dy = 0, dxs = 0, dys = 0;
+  float dx = 0.0f, dy = 0.0f, dxs = 0.0f, dys = 0.0f;
   if((gui->group_selected == index) && gui->form_dragging)
   {
     dx = gui->posx + gui->dx - gpt->points[2];
@@ -2105,13 +2105,13 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       dt_masks_form_t *form = darktable.develop->form_visible;
       if(!form) return;
 
-      float masks_border;
+      float masks_border = 0.0f;
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         masks_border = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_border"), BORDER_MAX);
       else
         masks_border = MIN(dt_conf_get_float("plugins/darkroom/masks/brush/border"), BORDER_MAX);
 
-      float masks_hardness;
+      float masks_hardness = 0.0f;
       if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
         masks_hardness = MIN(dt_conf_get_float("plugins/darkroom/spots/brush_hardness"), HARDNESS_MAX);
       else
@@ -2119,11 +2119,11 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
       const float opacity = dt_conf_get_float("plugins/darkroom/masks/opacity");
 
-      const float radius1 = masks_border * masks_hardness * MIN(wd, ht);
-      const float radius2 = masks_border * MIN(wd, ht);
+      const float radius1 = masks_border * masks_hardness * MIN(wd,ht);
+      const float radius2 = masks_border * MIN(wd,ht);
 
-      float xpos, ypos;
-      if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
+      float xpos = 0.0f, ypos = 0.0f;
+      if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)
       {
         xpos = (.5f + dt_control_get_dev_zoom_x()) * darktable.develop->preview_pipe->backbuf_width;
         ypos = (.5f + dt_control_get_dev_zoom_y()) * darktable.develop->preview_pipe->backbuf_height;
@@ -2147,7 +2147,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
 
       if(form->type & DT_MASKS_CLONE)
       {
-        float x = 0.f, y = 0.f;
+        float x = 0.0f, y = 0.0f;
         dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, xpos, ypos, xpos, ypos, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
@@ -2156,8 +2156,8 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
     }
     else
     {
-      float masks_border, masks_hardness, masks_density;
-      float radius, oldradius, opacity, oldopacity, pressure;
+      float masks_border = 0.0f, masks_hardness = 0.0f, masks_density = 0.0f;
+      float radius = 0.0f, oldradius = 0.0f, opacity = 0.0f, oldopacity = 0.0f, pressure = 0.0f;
       int stroked = 1;
 
       const float *guipoints = dt_masks_dynbuf_buffer(gui->guipoints);
@@ -2194,7 +2194,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
           break;
       }
 
-      radius = oldradius = masks_border * masks_hardness * MIN(wd, ht);
+      radius = oldradius = masks_border * masks_hardness * MIN(wd,ht);
       opacity = oldopacity = masks_density;
 
       cairo_set_line_width(cr, 2 * radius);
@@ -2233,7 +2233,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
             break;
         }
 
-        radius = masks_border * masks_hardness * MIN(wd, ht);
+        radius = masks_border * masks_hardness * MIN(wd,ht);
         opacity = masks_density;
 
         if(radius != oldradius || opacity != oldopacity)
@@ -2258,14 +2258,14 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
       cairo_stroke(cr);
       cairo_set_dash(cr, dashed, len, 0);
       cairo_arc(cr, guipoints[2 * (gui->guipoints_count - 1)],
-                guipoints[2 * (gui->guipoints_count - 1) + 1], masks_border * MIN(wd, ht), 0,
+                guipoints[2 * (gui->guipoints_count - 1) + 1], masks_border * MIN(wd,ht), 0,
                 2.0 * M_PI);
       cairo_stroke(cr);
 
       if(darktable.develop->form_visible && (darktable.develop->form_visible->type & DT_MASKS_CLONE))
       {
         const int i = gui->guipoints_count - 1;
-        float x = 0.f, y = 0.f;
+        float x = 0.0f, y = 0.0f;
         dt_masks_calculate_source_pos_value(gui, DT_MASKS_BRUSH, guipoints[0], guipoints[1], guipoints[i * 2],
                                             guipoints[i * 2 + 1], &x, &y, TRUE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
@@ -2317,7 +2317,7 @@ static void dt_brush_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks_
   {
     for(int k = 0; k < nb; k++)
     {
-      float anchor_size;
+      float anchor_size = 0.0f;
       if(k == gui->point_dragging || k == gui->point_selected)
       {
         anchor_size = 7.0f / zoom_scale;
@@ -2491,7 +2491,7 @@ static int dt_brush_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_io
   }
 
   // now we want to find the area, so we search min/max points
-  float xmin, xmax, ymin, ymax;
+  float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
   guint nb_corner = g_list_length(form->points);
@@ -2541,7 +2541,7 @@ static int dt_brush_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *pi
   }
 
   // now we want to find the area, so we search min/max points
-  float xmin, xmax, ymin, ymax;
+  float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
   guint nb_corner = g_list_length(form->points);
@@ -2796,7 +2796,7 @@ static int dt_brush_get_mask_roi(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t
   }
 
   // now we want to find the area, so we search min/max points
-  float xmin, xmax, ymin, ymax;
+  float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
 

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -495,9 +495,10 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   // in creation mode
   if(gui->creation)
   {
-    float wd = darktable.develop->preview_pipe->iwidth;
-    float ht = darktable.develop->preview_pipe->iheight;
-    const float min_wd_ht = MIN(wd,ht);                                                           
+    const float pr_d = darktable.develop->preview_downsampling;
+    float iwd = darktable.develop->preview_pipe->iwidth;
+    float iht = darktable.develop->preview_pipe->iheight;                                           
+    const float min_iwd_iht = pr_d * MIN(iwd,iht);                                                           
     if(gui->guipoints_count == 0)
     {
       dt_masks_form_t *form = darktable.develop->form_visible;
@@ -515,8 +516,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
         radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 0.5f);
       }
       radius2 += radius1;
-      radius1 *= MIN(wd,ht);
-      radius2 *= MIN(wd,ht);
+      radius1 *= min_iwd_iht;
+      radius2 *= min_iwd_iht;
 
       float xpos = 0.0f, ypos = 0.0f;
       if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -64,7 +64,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
   {
     if((state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK)
     {
-      float masks_border;
+      float masks_border = 0.0f;
 
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         masks_border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
@@ -83,7 +83,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     }
     else if(state == 0)
     {
-      float masks_size;
+      float masks_size = 0.0f;
 
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
         masks_size = dt_conf_get_float("plugins/darkroom/spots/circle_size");
@@ -497,13 +497,13 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   {
     float wd = darktable.develop->preview_pipe->iwidth;
     float ht = darktable.develop->preview_pipe->iheight;
-
+    const float min_wd_ht = MIN(wd,ht);                                                           
     if(gui->guipoints_count == 0)
     {
       dt_masks_form_t *form = darktable.develop->form_visible;
       if(!form) return;
 
-      float radius1, radius2;
+      float radius1 = 0.0f, radius2 = 0.0f;
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
         radius1 = dt_conf_get_sanitize_set("plugins/darkroom/spots/circle_size", 0.001f, 0.5f);
@@ -515,11 +515,11 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
         radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 0.5f);
       }
       radius2 += radius1;
-      radius1 *= MIN(wd, ht);
-      radius2 *= MIN(wd, ht);
+      radius1 *= MIN(wd,ht);
+      radius2 *= MIN(wd,ht);
 
-      float xpos, ypos;
-      if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
+      float xpos = 0.0f, ypos = 0.0f;
+      if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)
       {
         const float zoom_x = dt_control_get_dev_zoom_x();
         const float zoom_y = dt_control_get_dev_zoom_y();
@@ -562,7 +562,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       // draw a cross where the source will be created
       if(form->type & DT_MASKS_CLONE)
       {
-        float x = 0.f, y = 0.f;
+        float x = 0.0f, y = 0.0f;
         dt_masks_calculate_source_pos_value(gui, DT_MASKS_CIRCLE, xpos, ypos, xpos, ypos, &x, &y, FALSE);
         dt_masks_draw_clone_source_pos(cr, zoom_scale, x, y);
       }
@@ -574,7 +574,7 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
   }
 
   if(!gpt) return;
-  float dx = 0, dy = 0, dxs = 0, dys = 0;
+  float dx = 0.0f, dy = 0.0f, dxs = 0.0f, dys = 0.0f;
   if((gui->group_selected == index) && gui->form_dragging)
   {
     dx = gui->posx + gui->dx - gpt->points[0];
@@ -780,7 +780,7 @@ static int dt_circle_get_source_area(dt_iop_module_t *module, dt_dev_pixelpipe_i
   }
 
   // now we search min and max
-  float xmin, xmax, ymin, ymax;
+  float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
   for(int i = 1; i < l + 1; i++)
@@ -831,7 +831,7 @@ static int dt_circle_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *p
   }
 
   // now we search min and max
-  float xmin, xmax, ymin, ymax;
+  float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
   for(int i = 1; i < l + 1; i++)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -330,8 +330,8 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
     const int closeup = dt_control_get_dev_closeup();
     const float zoom_scale = dt_dev_get_zoom_scale(darktable.develop, zoom, 1 << closeup, 1);
     const float diff = 5.0f * zoom_scale;
-    float x0, y0;
-    float rotation;
+    float x0 = 0.0f, y0 = 0.0f;
+    float rotation = 0.0f;
     if(!gui->form_dragging
        || (gui->posx_source - gui->posx > -diff && gui->posx_source - gui->posx < diff
            && gui->posy_source - gui->posy > -diff && gui->posy_source - gui->posy < diff))
@@ -483,15 +483,15 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
   if(gui->creation)
   {
     const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;
+    const float ht = darktable.develop->preview_pipe->iheight;                                                            
     const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
-    const float distance = 0.1f * fminf(wd, ht);
+    const float distance = 0.1f * MIN(wd, ht);
     const float scale = sqrtf(wd * wd + ht * ht);
 
-    float xpos, ypos, xpos0, ypos0;
+    float xpos = 0.0f, ypos = 0.0f, xpos0 = 0.0f, ypos0 = 0.0f;
     const float zoom_x = dt_control_get_dev_zoom_x();
     const float zoom_y = dt_control_get_dev_zoom_y();
-    if((gui->posx == -1.f && gui->posy == -1.f) || gui->mouse_leaved_center)
+    if((gui->posx == -1.0f && gui->posy == -1.0f) || gui->mouse_leaved_center)
     {
       xpos = (.5f + zoom_x) * darktable.develop->preview_pipe->backbuf_width;
       ypos = (.5f + zoom_y) * darktable.develop->preview_pipe->backbuf_height;
@@ -504,7 +504,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
 
     // get the rotation angle only if we are not too close from starting point
     const float diff = 5.0f * zoom_scale;
-    float rotation;
+    float rotation = 0.0f;
     if(!gui->form_dragging
        || (gui->posx_source - gui->posx > -diff && gui->posx_source - gui->posx < diff
            && gui->posy_source - gui->posy > -diff && gui->posy_source - gui->posy < diff))
@@ -536,9 +536,9 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     cairo_stroke(cr);
 
     // draw the arrow
-    float anchor_x, anchor_y;
-    float pivot_start_x, pivot_start_y;
-    float pivot_end_x, pivot_end_y;
+    float anchor_x = 0.0f, anchor_y = 0.0f;
+    float pivot_start_x = 0.0f, pivot_start_y = 0.0f;
+    float pivot_end_x = 0.0f, pivot_end_y = 0.0f;
     anchor_x = xpos0;
     anchor_y = ypos0;
     pivot_start_x = xpos0 + sinf(rotation) * distance;
@@ -645,7 +645,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     const float ht = darktable.develop->preview_pipe->iheight;
 
     int count = 0;
-    float x, y;
+    float x = 0.0f, y = 0.0f;
 
     while(count < points_count)
     {
@@ -702,7 +702,7 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     const float ht = darktable.develop->preview_pipe->iheight;
 
     int count = 0;
-    float x, y;
+    float x = 0.0f, y = 0.0f;
 
     while(count < border_count)
     {
@@ -751,9 +751,9 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
     }
   }
 
-  float anchor_x, anchor_y;
-  float pivot_start_x, pivot_start_y;
-  float pivot_end_x, pivot_end_y;
+  float anchor_x = 0.0f, anchor_y = 0.0f;
+  float pivot_start_x = 0.0f, pivot_start_y = 0.0f;
+  float pivot_end_x = 0.0f, pivot_end_y = 0.0f;
 
   _gradient_point_transform(xref, yref, gpt->points[0] + dx, gpt->points[1] + dy, sinv, cosv, &anchor_x, &anchor_y);
   _gradient_point_transform(xref, yref, gpt->points[2] + dx, gpt->points[3] + dy, sinv, cosv, &pivot_end_x, &pivot_end_y);
@@ -1006,23 +1006,13 @@ static int dt_gradient_get_area(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t 
 {
   const float wd = piece->pipe->iwidth, ht = piece->pipe->iheight;
 
-  float points[8];
-
-  // now we set the points
-  points[0] = 0;
-  points[1] = 0;
-  points[2] = wd;
-  points[3] = 0;
-  points[4] = wd;
-  points[5] = ht;
-  points[6] = 0;
-  points[7] = ht;
+  float points[8] = { 0.0f, 0.0f, wd, 0.0f, wd, ht, 0.0f, ht };
 
   // and we transform them with all distorted modules
   if(!dt_dev_distort_transform_plus(module->dev, piece->pipe, module->iop_order, DT_DEV_TRANSFORM_DIR_BACK_INCL, points, 4)) return 0;
 
   // now we search min and max
-  float xmin, xmax, ymin, ymax;
+  float xmin = 0.0f, xmax = 0.0f, ymin = 0.0f, ymax = 0.0f;
   xmin = ymin = FLT_MAX;
   xmax = ymax = FLT_MIN;
   for(int i = 0; i < 4; i++)

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -482,11 +482,12 @@ static void dt_gradient_events_post_expose(cairo_t *cr, float zoom_scale, dt_mas
   // preview gradient creation
   if(gui->creation)
   {
-    const float wd = darktable.develop->preview_pipe->iwidth;
-    const float ht = darktable.develop->preview_pipe->iheight;                                                            
+    const float pr_dn = darktable.develop->preview_downsampling;
+    const float iwd = pr_dn * darktable.develop->preview_pipe->iwidth;
+    const float iht = pr_dn * darktable.develop->preview_pipe->iheight;                                                   
     const float compression = MIN(1.0f, dt_conf_get_float("plugins/darkroom/masks/gradient/compression"));
-    const float distance = 0.1f * MIN(wd, ht);
-    const float scale = sqrtf(wd * wd + ht * ht);
+    const float distance = 0.1f * MIN(iwd, iht);
+    const float scale = sqrtf(iwd * iwd + iht * iht);
 
     float xpos = 0.0f, ypos = 0.0f, xpos0 = 0.0f, ypos0 = 0.0f;
     const float zoom_x = dt_control_get_dev_zoom_x();

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -716,7 +716,7 @@ int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float *
   if(form->type & DT_MASKS_CIRCLE)
   {
     dt_masks_point_circle_t *circle = (dt_masks_point_circle_t *)(g_list_first(form->points)->data);
-    float x, y;
+    float x = 0.0f, y = 0.0f;
     if(source)
       x = form->source[0], y = form->source[1];
     else
@@ -754,7 +754,7 @@ int dt_masks_get_points_border(dt_develop_t *dev, dt_masks_form_t *form, float *
   else if(form->type & DT_MASKS_ELLIPSE)
   {
     dt_masks_point_ellipse_t *ellipse = (dt_masks_point_ellipse_t *)(g_list_first(form->points)->data);
-    float x, y, a, b;
+    float x = 0.0f, y = 0.0f, a = 0.0f, b = 0.0f;
     if(source)
       x = form->source[0], y = form->source[1];
     else
@@ -1572,7 +1572,7 @@ int dt_masks_events_mouse_moved(struct dt_iop_module_t *module, double x, double
   // record mouse position even if there are no masks visible
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
   dt_masks_form_t *form = darktable.develop->form_visible;
-  float pzx, pzy;
+  float pzx = 0.0f, pzy = 0.0f;
 
   dt_dev_get_pointer_zoom_pos(darktable.develop, x, y, &pzx, &pzy);
   pzx += 0.5f;
@@ -1619,7 +1619,7 @@ int dt_masks_events_button_released(struct dt_iop_module_t *module, double x, do
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
-  float pzx, pzy;
+  float pzx = 0.0f, pzy = 0.0f;
   dt_dev_get_pointer_zoom_pos(darktable.develop, x, y, &pzx, &pzy);
   pzx += 0.5f;
   pzy += 0.5f;
@@ -1648,7 +1648,7 @@ int dt_masks_events_button_pressed(struct dt_iop_module_t *module, double x, dou
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
-  float pzx, pzy;
+  float pzx = 0.0f, pzy = 0.0f;
   dt_dev_get_pointer_zoom_pos(darktable.develop, x, y, &pzx, &pzy);
   pzx += 0.5f;
   pzy += 0.5f;
@@ -1696,7 +1696,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
 
   dt_masks_form_t *form = darktable.develop->form_visible;
   dt_masks_form_gui_t *gui = darktable.develop->form_gui;
-  float pzx, pzy;
+  float pzx = 0.0f, pzy = 0.0f;
   dt_dev_get_pointer_zoom_pos(darktable.develop, x, y, &pzx, &pzy);
   pzx += 0.5f;
   pzy += 0.5f;
@@ -1746,7 +1746,7 @@ void dt_masks_events_post_expose(struct dt_iop_module_t *module, cairo_t *cr, in
   float wd = dev->preview_pipe->backbuf_width;
   float ht = dev->preview_pipe->backbuf_height;
   if(wd < 1.0 || ht < 1.0) return;
-  float pzx, pzy;
+  float pzx = 0.0f, pzy = 0.0f;
   dt_dev_get_pointer_zoom_pos(dev, pointerx, pointery, &pzx, &pzy);
   pzx += 0.5f;
   pzy += 0.5f;
@@ -2960,7 +2960,7 @@ void dt_masks_set_source_pos_initial_value(dt_masks_form_gui_t *gui, const int m
   if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE_TEMP)
   {
     // if is has not been defined by the user, set some default
-    if(gui->posx_source == -1.f && gui->posy_source == -1.f)
+    if(gui->posx_source == -1.0f && gui->posy_source == -1.0f)
     {
       if(mask_type & DT_MASKS_CIRCLE)
       {
@@ -3038,8 +3038,8 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          const float initial_ypos, const float xpos, const float ypos, float *px,
                                          float *py, const int adding)
 {
-  float x = 0.f, y = 0.f;
-
+  float x = 0.0f, y = 0.0f;
+                                                            
   const float iwd = darktable.develop->preview_pipe->iwidth;
   const float iht = darktable.develop->preview_pipe->iheight;
 
@@ -3050,7 +3050,7 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
   }
   else if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE_TEMP)
   {
-    if(gui->posx_source == -1.f && gui->posy_source == -1.f)
+    if(gui->posx_source == -1.0f && gui->posy_source == -1.0f)
     {
       if(mask_type & DT_MASKS_CIRCLE)
       {

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -3039,10 +3039,10 @@ void dt_masks_calculate_source_pos_value(dt_masks_form_gui_t *gui, const int mas
                                          float *py, const int adding)
 {
   float x = 0.0f, y = 0.0f;
-                                                            
-  const float iwd = darktable.develop->preview_pipe->iwidth;
-  const float iht = darktable.develop->preview_pipe->iheight;
-
+  const float pr_d = darktable.develop->preview_downsampling;                                                            
+  const float iwd = pr_d * darktable.develop->preview_pipe->iwidth;
+  const float iht = pr_d * darktable.develop->preview_pipe->iheight;
+  
   if(gui->source_pos_type == DT_MASKS_SOURCE_POS_RELATIVE)
   {
     x = xpos + gui->posx_source;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -500,7 +500,9 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   const float ht = darktable.develop->preview_pipe->backbuf_height;
   const int width = roi->width;
   const int height = roi->height;
-  const dt_image_t *const image = &(darktable.develop->image_storage);
+  const dt_image_t image = darktable.develop->image_storage;
+  const int op_after_demosaic = dt_ioppr_is_iop_before(darktable.develop->preview_pipe->iop_order_list, 
+                                                       module->op, "demosaic", 0);
 
   // do not continue if one of the point coordinates is set to a negative value indicating a not yet defined
   // position
@@ -521,13 +523,12 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   }
 
   // transform back to current module coordinates
-  dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
-                                    module->iop_order, ((picker_source == PIXELPIPE_PICKER_INPUT) ? DT_DEV_TRANSFORM_DIR_FORW_INCL
-                                     : DT_DEV_TRANSFORM_DIR_FORW_EXCL),fbox, 2);
+  dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe, module->iop_order, 
+                               ((picker_source == PIXELPIPE_PICKER_INPUT) ? DT_DEV_TRANSFORM_DIR_FORW_INCL
+                               : DT_DEV_TRANSFORM_DIR_FORW_EXCL),fbox, 2);
 
-  if (!dt_image_is_rawprepare_supported(image))
-      for(int idx = 0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
-  
+  if (op_after_demosaic || !dt_image_is_rawprepare_supported(&image))
+    for(int idx = 0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
   fbox[0] -= roi->x;
   fbox[1] -= roi->y;
   fbox[2] -= roi->x;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -525,6 +525,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
                                      : DT_DEV_TRANSFORM_DIR_FORW_EXCL),
                                     fbox, 2);
 
+  for(int idx = 0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
   fbox[0] -= roi->x;
   fbox[1] -= roi->y;
   fbox[2] -= roi->x;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -500,6 +500,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   const float ht = darktable.develop->preview_pipe->backbuf_height;
   const int width = roi->width;
   const int height = roi->height;
+  const dt_image_t *const image = &(darktable.develop->image_storage);
 
   // do not continue if one of the point coordinates is set to a negative value indicating a not yet defined
   // position
@@ -522,10 +523,11 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   // transform back to current module coordinates
   dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
                                     module->iop_order, ((picker_source == PIXELPIPE_PICKER_INPUT) ? DT_DEV_TRANSFORM_DIR_FORW_INCL
-                                     : DT_DEV_TRANSFORM_DIR_FORW_EXCL),
-                                    fbox, 2);
+                                     : DT_DEV_TRANSFORM_DIR_FORW_EXCL),fbox, 2);
 
-  for(int idx = 0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
+  if (!dt_image_is_rawprepare_supported(image))
+      for(int idx = 0; idx < 4; idx++) fbox[idx] *= darktable.develop->preview_downsampling;
+  
   fbox[0] -= roi->x;
   fbox[1] -= roi->y;
   fbox[2] -= roi->x;

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -154,9 +154,9 @@ int dt_dev_pixelpipe_init_cached(dt_dev_pixelpipe_t *pipe, size_t size, int32_t 
   if(!dt_dev_pixelpipe_cache_init(&(pipe->cache), entries, pipe->backbuf_size)) return 0;
   pipe->cache_obsolete = 0;
   pipe->backbuf = NULL;
-  pipe->backbuf_scale = 0.f;
-  pipe->backbuf_zoom_x = 0.f;
-  pipe->backbuf_zoom_y = 0.f;
+  pipe->backbuf_scale = 0.0f;
+  pipe->backbuf_zoom_x = 0.0f;
+  pipe->backbuf_zoom_y = 0.0f;
 
   pipe->output_backbuf = NULL;
   pipe->output_backbuf_width = 0;
@@ -450,7 +450,7 @@ static void histogram_collect_cl(int devid, dt_dev_pixelpipe_iop_t *piece, cl_me
                                  float *buffer, size_t bufsize)
 {
   float *tmpbuf = NULL;
-  float *pixel;
+  float *pixel = NULL;
 
   // if buffer is supplied and if size fits let's use it
   if(buffer && bufsize >= (size_t)roi->width * roi->height * 4 * sizeof(float))
@@ -505,7 +505,7 @@ static int pixelpipe_picker_helper(dt_iop_module_t *module, const dt_iop_roi_t *
   // position
   if(module->color_picker_point[0] < 0 || module->color_picker_point[1] < 0) return 1;
 
-  float fbox[4];
+  float fbox[4] = { 0.0f };
 
   // get absolute pixel coordinates in final preview image
   if(darktable.lib->proxy.colorpicker.size)
@@ -573,13 +573,7 @@ static void pixelpipe_picker(dt_iop_module_t *module, dt_iop_buffer_dsc_t *dsc, 
     return;
   }
 
-  float min[4], max[4], avg[4];
-  for(int k = 0; k < 4; k++)
-  {
-    min[k] = INFINITY;
-    max[k] = -INFINITY;
-    avg[k] = 0.0f;
-  }
+  float min[4] = { INFINITY }, max[4] = { -INFINITY }, avg[4] = { 0.0f };
 
   dt_color_picker_helper(dsc, pixel, roi, box, avg, min, max, image_cst,
                          dt_iop_color_picker_get_active_cst(module));
@@ -629,7 +623,7 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
   region[1] = box[3] - box[1];
   region[2] = 1;
 
-  float *pixel;
+  float *pixel = NULL;
   float *tmpbuf = NULL;
 
   const size_t size = region[0] * region[1];
@@ -656,13 +650,7 @@ static void pixelpipe_picker_cl(int devid, dt_iop_module_t *module, dt_iop_buffe
   box[2] = region[0];
   box[3] = region[1];
 
-  float min[4], max[4], avg[4];
-  for(int k = 0; k < 4; k++)
-  {
-    min[k] = INFINITY;
-    max[k] = -INFINITY;
-    avg[k] = 0.0f;
-  }
+  float min[4] = { INFINITY }, max[4] = { -INFINITY }, avg[4] = { 0.0f };
 
   dt_color_picker_helper(dsc, pixel, &roi_copy, box, avg, min, max, image_cst,
                          dt_iop_color_picker_get_active_cst(module));
@@ -686,15 +674,15 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
                                        float *pick_color_rgb_mean, float *pick_color_lab_min,
                                        float *pick_color_lab_max, float *pick_color_lab_mean)
 {
-  float picked_color_rgb_min[3];
-  float picked_color_rgb_max[3];
-  float picked_color_rgb_mean[3];
+  float picked_color_rgb_min[3] = { 0.0f };
+  float picked_color_rgb_max[3] = { 0.0f };
+  float picked_color_rgb_mean[3] = { 0.0f };
 
   for(int k = 0; k < 3; k++) picked_color_rgb_min[k] = FLT_MAX;
   for(int k = 0; k < 3; k++) picked_color_rgb_max[k] = FLT_MIN;
 
-  int box[4];
-  int point[2];
+  int box[4] = { 0 };
+  int point[2] = { 0 };
 
   for(int k = 0; k < 4; k += 2)
     box[k] = MIN(roi_in->width - 1, MAX(0, pick_box[k] * roi_in->width));
@@ -703,8 +691,7 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
   point[0] = MIN(roi_in->width - 1, MAX(0, pick_point[0] * roi_in->width));
   point[1] = MIN(roi_in->height - 1, MAX(0, pick_point[1] * roi_in->height));
 
-  float rgb[3];
-  for(int k = 0; k < 3; k++) rgb[k] = 0.0f;
+  float rgb[3] = { 0.0f };
 
   const float w = 1.0 / ((box[3] - box[1] + 1) * (box[2] - box[0] + 1));
 
@@ -735,7 +722,7 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
   if(xform_rgb2rgb)
   {
     // Preparing the data for transformation
-    float rgb_ddata[9];
+    float rgb_ddata[9] = { 0.0f };
     for(int i = 0; i < 3; i++)
     {
       rgb_ddata[i] = picked_color_rgb_mean[i];
@@ -743,7 +730,7 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
       rgb_ddata[i + 6] = picked_color_rgb_max[i];
     }
 
-    float rgb_odata[9];
+    float rgb_odata[9] = { 0.0f };
     cmsDoTransform(xform_rgb2rgb, rgb_ddata, rgb_odata, 3);
 
     for(int i = 0; i < 3; i++)
@@ -767,7 +754,7 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
   if(xform_rgb2lab)
   {
     // Preparing the data for transformation
-    float rgb_data[9];
+    float rgb_data[9] = { 0.0f };
     for(int i = 0; i < 3; i++)
     {
       rgb_data[i] = picked_color_rgb_mean[i];
@@ -775,7 +762,7 @@ static void _pixelpipe_pick_from_image(const float *const pixel, const dt_iop_ro
       rgb_data[i + 6] = picked_color_rgb_max[i];
     }
 
-    float Lab_data[9];
+    float Lab_data[9] = { 0.0f };
     cmsDoTransform(xform_rgb2lab, rgb_data, Lab_data, 3);
 
     for(int i = 0; i < 3; i++)
@@ -2556,8 +2543,8 @@ post_process_collect_info:
         const int imgsize = roi_out->height * roi_out->width * 4;
         for(int i = 0; i < imgsize; i += 4)
         {
-          for(int c = 0; c < 3; c++) input_tmp[i + c] = ((float)pixel[i + (2 - c)]) * (1.f / 255.f);
-          input_tmp[i + 3] = 0.f;
+          for(int c = 0; c < 3; c++) input_tmp[i + c] = ((float)pixel[i + (2 - c)]) * (1.0f / 255.0f);
+          input_tmp[i + 3] = 0.0f;
         }
 
         _pixelpipe_final_histogram(dev, (const float *const)input_tmp, roi_out);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -2313,7 +2313,7 @@ static float find_nearest_on_curve_t (const float complex p0,
                                       const float complex x,
                                       const int n)
 {
-  float min_t = 0, min_dist = cabs (x - p0);
+  float min_t = 0.0f, min_dist = cabs (x - p0);
 
   for (int i = 0; i < n; i++)
   {
@@ -2695,7 +2695,8 @@ void gui_post_expose (struct dt_iop_module_t *module,
   const float bb_width = develop->preview_pipe->backbuf_width;
   const float bb_height = develop->preview_pipe->backbuf_height;
   const float iscale = develop->preview_pipe->iscale;
-  const float scale = MAX (bb_width, bb_height);
+  const float pr_d = develop->preview_downsampling;
+  const float scale = pr_d * MAX (bb_width, bb_height);
   if (bb_width < 1.0 || bb_height < 1.0)
     return;
 
@@ -2778,6 +2779,7 @@ static void get_point_scale(struct dt_iop_module_t *module, float x, float y, fl
   pzy += 0.5f;
   const float wd = darktable.develop->preview_pipe->backbuf_width;
   const float ht = darktable.develop->preview_pipe->backbuf_height;
+  const float pr_d = darktable.develop->preview_downsampling;
   float pts[2] = { pzx * wd, pzy * ht };
   dt_dev_distort_backtransform_plus(darktable.develop, darktable.develop->preview_pipe,
                                     module->iop_order,DT_DEV_TRANSFORM_DIR_FORW_EXCL, pts, 1);
@@ -2786,7 +2788,7 @@ static void get_point_scale(struct dt_iop_module_t *module, float x, float y, fl
   const float nx = pts[0] / darktable.develop->preview_pipe->iwidth;
   const float ny = pts[1] / darktable.develop->preview_pipe->iheight;
 
-  *scale = darktable.develop->preview_pipe->iscale / get_zoom_scale(module->dev);
+  *scale = pr_d * darktable.develop->preview_pipe->iscale / pr_d * get_zoom_scale(module->dev);
   *pt = (nx * darktable.develop->pipe->iwidth) +  (ny * darktable.develop->pipe->iheight) * I;
 }
 


### PR DESCRIPTION
These changes allow speeding up the darkroom, since the number of pixels being updated in the preview image (the small image at the top left of the screen) is reduced to 1/4 or 1/16.

For the moment, this requires a re-start to work reliably.

There may be circumstances where you do not want to use this, where you are using more advanced, edge-aware statistics.

The story has been written out in PR #4702 ... I had given up, and then after a week and a clear head I found what worked (due in part to a discussion with @TurboGit about crop & rotate transforms. Initial creds to @bastibe 

Two commits: the first is janitorial work, cleaning up uninitialised variables, and formatting that Travis doesn't like, vis `1.f` The second contains the functional changes.

Please test: this time it seems to work, but I said that last time :-D