### PR TITLE
CSS improvement for culling and preview rewrite

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -133,11 +133,9 @@
 @define-color thumbnail_bg50_color @grey_100;
 @define-color thumbnail_infos_color @grey_70; /* buttons and metadata text color on thumbnails */
 @define-color thumbnail_selected_bg_color @grey_65;
-@define-color thumbnail_hover_bg_color @grey_90;
-@define-color thumbnail_hover_fg_color @grey_75;
+@define-color thumbnail_hover_bg_color @grey_85;
+@define-color thumbnail_hover_fg_color @grey_70;
 @define-color filmstrip_bg_color @darkroom_bg_color;
-@define-color culling_selected_border_color @grey_10;
-@define-color culling_filmstrip_selected_border_color @grey_10;
 
 /* Brushes */
 @define-color brush_cursor alpha(white, .9);
@@ -559,95 +557,6 @@ dialog scrollbar
   margin: 1pt;
 }
 
-/* Context menu & tooltips & comboboxes */
-/* Basically everything that pops out/over on UI */
-
-combobox,
-combobox button
-{
-  border: 1px solid transparent;
-  padding: 1px;
-  background-color: transparent;
-  border-radius: 2pt;
-  color: @bauhaus_fg;
-  outline-style: none;
-  min-height: 1em;
-  min-width: 1em;
-}
-
-combobox entry
-{
-  margin: 0 0.5em;
-}
-
-combobox *
-{
-  min-height: 1em;
-  min-width: 1em;
-}
-
-context-menu,
-menu,
-menuitem > menu, /* sub-menu */
-menuitem arrow,
-tooltip,
-popover,
-#background_job_eventbox,
-combobox window,
-dialog combobox window
-{
-  background-color: @tooltip_bg_color;
-  color: @tooltip_fg_color;
-  outline-style:none;
-  border-radius: 2pt;
-  border: 0;
-  outline-style: none;
-  min-height: 0.4em;
-  min-width: 0.4em;
-  padding: 0.4em;
-}
-
-/* Views links in header */
-
-#view_dropdown,
-#view_label
-{
-  background-color: transparent;
-  outline-style:none;
-  border-radius: 2px;
-  padding: 0.4em;
-  color: @section_label;
-}
-
-#view_label {
-  margin: 0.1em 0;
-}
-
-/* Menus options */
-
-menuitem button,
-popover button,
-tooltip button
-{
-  background-color: transparent;
-}
-
-menuitem check
-{
-  border-radius: 2px;
-  border: 1px solid shade(@tooltip_bg_color, 4);
-  min-width: 10px;
-  min-height: 10px;
-  margin-right: 5px;
-}
-
-/* Header and footer combobox */
-#header-toolbar combobox,
-#footer-toolbar combobox
-{
-  margin: 0 0.5em;
-}
-
 /* Dialog windows */
 
 dialog,
@@ -715,6 +624,95 @@ frame#import_metadata checkbutton
   border-radius: 2px;
   border: 1px solid @border_color;
   background-color: shade(@bg_color, 0.7);
+}
+
+/* Context menu & tooltips & comboboxes */
+/* Basically everything that pops out/over on UI */
+
+combobox,
+combobox button
+{
+  border: 1px solid transparent;
+  padding: 1px;
+  background-color: transparent;
+  border-radius: 2pt;
+  color: @bauhaus_fg;
+  outline-style: none;
+  min-height: 1em;
+  min-width: 1em;
+}
+
+combobox entry
+{
+  margin: 0 0.5em;
+}
+
+combobox *
+{
+  min-height: 1em;
+  min-width: 1em;
+}
+
+context-menu,
+menu,
+menuitem > menu, /* sub-menu */
+menuitem arrow,
+tooltip,
+popover,
+#background_job_eventbox,
+combobox window,
+dialog combobox window
+{
+  background-color: @tooltip_bg_color;
+  color: @tooltip_fg_color;
+  outline-style:none;
+  border-radius: 2pt;
+  border: 0;
+  outline-style: none;
+  min-height: 0.4em;
+  min-width: 0.4em;
+  padding: 0.2em;
+}
+
+/* Views links in header */
+
+#view_dropdown,
+#view_label
+{
+  background-color: transparent;
+  outline-style:none;
+  border-radius: 2px;
+  padding: 0.4em;
+  color: @section_label;
+}
+
+#view_label {
+  margin: 0.1em 0;
+}
+
+/* Menus options */
+
+menuitem button,
+popover button,
+tooltip button
+{
+  background-color: transparent;
+}
+
+menuitem check
+{
+  border-radius: 2px;
+  border: 1px solid shade(@tooltip_bg_color, 4);
+  min-width: 10px;
+  min-height: 10px;
+  margin-right: 5px;
+}
+
+/* Header and footer combobox */
+#header-toolbar combobox,
+#footer-toolbar combobox
+{
+  margin: 0 0.5em;
 }
 
 /* Tree view (lists and tables) */
@@ -1576,7 +1574,7 @@ Details :
 @keyframes lastactive
 {
   0% {border-color: @lighttable_bg_color; border-width : 2px;}
-  50% {border-color: @thumbnail_bg50_color; border-width : 6px;}
+  50% {border-color: @thumbnail_bg50_color; border-width : 4px;}
   100% {border-color: @lighttable_bg_color; border-width : 2px;}
 }
 
@@ -1630,14 +1628,7 @@ Details :
 #thumb_ext
 {
   color: @thumbnail_infos_color;
-}
-#thumb_main:selected #thumb_ext
-{
-  color: @thumbnail_infos_color;
-}
-#thumb_main:hover #thumb_ext
-{
-  color: @thumbnail_font_color;
+  margin-top: -1px;
 }
 
 /* Image */
@@ -1667,9 +1658,23 @@ Details :
 
 /* Popover overlays options from star icon */
 
-radiobutton
+#overlays_label
 {
-  padding: 2px;
+  font-weight: bold;
+  padding: 4px 0;
+  margin: 0 5px 5px 5px;
+  border-bottom: 1px inset @button_border;
+}
+
+radiobutton radio,
+radiobutton label
+{
+  padding: 0.2em;
+}
+
+radiobutton radio
+{
+  padding: 0.25em;
 }
 
 /* Bottom area */
@@ -1684,15 +1689,15 @@ radiobutton
   color: transparent;
 }
 
-.dt_overlays_hover_extended #thumb_image:hover #thumb_bottom_label,
 .dt_overlays_always_extended #thumb_bottom_label
 {
   color: @thumbnail_infos_color;
 }
 
+.dt_overlays_hover_block #thumb_image:hover #thumb_bottom_label,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
 .dt_overlays_always_extended #thumb_main:hover #thumb_bottom_label,
 .dt_overlays_always_extended #thumb_main:selected #thumb_bottom_label,
-.dt_overlays_hover_block #thumb_image:hover #thumb_bottom_label,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom_label
 {
   color: @thumbnail_font_color;
@@ -1716,6 +1721,7 @@ radiobutton
 {
   background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
 }
+
 .dt_overlays_hover_block #thumb_image:hover #thumb_bottom
 {
   background-image: none;
@@ -1723,13 +1729,12 @@ radiobutton
 }
 
 /* Thumbnails buttons */
-
-/* rating stars in lighttable */
 .dt_overlays_none .dt_thumb_btn,
 .dt_overlays_hover .dt_thumb_btn,
 .dt_overlays_hover_extended .dt_thumb_btn,
 .dt_overlays_hover_block .dt_thumb_btn,
 .dt_overlays_hover_block #thumb_main:hover .dt_thumb_btn,
+.dt_overlays_hover_block #thumb_main:hover #thumb_star:active,
 .dt_overlays_hover_block #thumb_main:hover #thumb_reject:active,
 .dt_overlays_hover_block #thumb_main:hover #thumb_altered,
 .dt_overlays_hover_block #thumb_main:hover #thumb_group,
@@ -1751,6 +1756,7 @@ radiobutton
 }
 
 #thumb_main:hover .dt_thumb_btn,
+#thumb_main:selected #thumb_ext,
 .dt_overlays_hover_block #thumb_image:hover .dt_thumb_btn,
 .dt_overlays_always_extended #thumb_main:hover .dt_thumb_btn,
 .dt_overlays_always #thumb_main:selected .dt_thumb_btn,
@@ -1775,6 +1781,7 @@ radiobutton
 
 /* stars */
 #thumb_main:hover #thumb_star:active,
+.dt_overlays_hover_block #thumb_image:hover #thumb_star:active,
 .dt_overlays_always #thumb_star:active,
 .dt_overlays_always_extended #thumb_star:active,
 .dt_overlays_mixed #thumb_star:active,
@@ -1782,8 +1789,8 @@ radiobutton
 .dt_overlays_always_extended #thumb_main:selected #thumb_star:active,
 .dt_overlays_mixed #thumb_main:selected #thumb_star:active
 {
-  color: @thumbnail_hover_bg_color;
-  background-color: @thumbnail_infos_color;
+  color: @thumbnail_hover_fg_color;
+  background-color: @thumbnail_font_color;
 }
 
 #thumb_main:hover #thumb_star:hover
@@ -1806,7 +1813,7 @@ radiobutton
 {
   border-top: 2px solid rgb(255, 187, 0); /* to not overlay thumb borders */
 }
-#thumb_main:hover #thumb_localcopy,
+#thumb_image:hover #thumb_localcopy,
 .dt_overlays_hover_block #thumb_image:hover #thumb_localcopy,
 .dt_overlays_always #thumb_localcopy,
 .dt_overlays_always_extended #thumb_localcopy,
@@ -1820,9 +1827,6 @@ radiobutton
 #thumb_main:hover #thumb_altered,
 #thumb_main:hover #thumb_group,
 #thumb_main:hover #thumb_audio,
-.dt_overlays_hover_block #thumb_image:hover #thumb_altered,
-.dt_overlays_hover_block #thumb_image:hover #thumb_group,
-.dt_overlays_hover_block #thumb_image:hover #thumb_audio,
 .dt_overlays_always #thumb_altered,
 .dt_overlays_always #thumb_group,
 .dt_overlays_always #thumb_audio,
@@ -1835,12 +1839,11 @@ radiobutton
 {
   color: @thumbnail_infos_color;
 }
+
 #thumb_main:hover #thumb_group:hover,
 #thumb_main:hover #thumb_group:active,
 #thumb_main:hover #thumb_audio:hover,
-.dt_overlays_hover_block #thumb_image:hover #thumb_group:hover,
-.dt_overlays_hover_block #thumb_image:hover #thumb_group:active,
-.dt_overlays_hover_block #thumb_image:hover #thumb_audio:hover,
+#thumb_main:hover #thumb_ext,
 .dt_overlays_always #thumb_group:hover,
 .dt_overlays_always #thumb_group:active,
 .dt_overlays_always #thumb_audio:hover,
@@ -1879,17 +1882,16 @@ radiobutton
   color: transparent;
 }
 
-/* Messages shown on bottom middle of the UI. For example "loading image..." or "working on..." ones */
-#log-msg
+/* set color to be visible on overlays hover block in culling, preview and related thumbnail modes */
+.dt_overlays_hover_block #thumb_image:hover #thumb_altered,
+.dt_overlays_hover_block #thumb_image:hover #thumb_group,
+.dt_overlays_hover_block #thumb_image:hover #thumb_group:active,
+.dt_overlays_hover_block #thumb_image:hover #thumb_audio
 {
-  color: @log_fg_color;
-  font-size: 1em;
-  font-weight: bold;
-  background-color: @log_bg_color;
-  padding: 8px 20px 4px 20px;
-  border-radius: 14px;
+  color: @thumbnail_font_color;
 }
 
+/* Culling and preview modes */
 .dt_culling, .dt_preview
 {
   background-color: @lighttable_bg_color;
@@ -1922,12 +1924,12 @@ radiobutton
 .dt_culling #thumb_main:selected #thumb_image,
 .dt_preview #thumb_main:selected #thumb_image
 {
-  border: 4px solid @plugin_bg_color;
+  border: 2px solid @plugin_bg_color;
 }
 .dt_culling #thumb_main:hover #thumb_image,
 .dt_preview #thumb_main:hover #thumb_image
 {
-  border: 4px solid @thumbnail_hover_bg_colorte;
+  border: 2px solid @thumbnail_hover_bg_color;
 }
 
 #thumb_zoom_label
@@ -1938,14 +1940,37 @@ radiobutton
   padding: 1px 6px;
 }
 
-.dt_overlays_hover_block #thumb_image:hover #thumb_zoom_label
-{
-  color: @grey90;
-  background-color: rgba(0, 0, 0, 0.5);
-}
-
 .dt_overlays_hover_block #thumb_bottom
 {
-  margin-top: 5px;  /* not real pixels, but percentage of the image size */
+  margin-top: 3px;  /* not real pixels, but percentage of the image size */
   margin-left: 0px; /* not real pixels, but percentage of the image size */
+}
+
+.dt_overlays_hover_block #thumb_image:hover #thumb_zoom_label
+{
+  color: @bauhaus_fg_hover;
+  background-color: rgba(20, 20, 20, 0.5);
+}
+
+/* padding of overlays block hover on culling/preview and thumbnail overlay mode */
+.dt_overlays_hover_block #thumb_image:hover #thumb_bottom_label
+{
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+.dt_overlays_hover_block #thumb_image:hover #thumb_colorlabels
+{
+  padding-right: 6px;
+}
+
+/* Messages shown on bottom middle of the UI. For example "loading image..." or "working on..." ones */
+#log-msg
+{
+  color: @log_fg_color;
+  font-size: 1em;
+  font-weight: bold;
+  background-color: @log_bg_color;
+  padding: 8px 20px 4px 20px;
+  border-radius: 14px;
 }

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1216,7 +1216,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     int w = 0;
     int h = 0;
     pango_layout_get_pixel_size(gtk_label_get_layout(GTK_LABEL(thumb->w_bottom)), &w, &h);
-    gtk_widget_set_size_request(thumb->w_bottom, CLAMP(w, 25 * r1, width), 6.5 * r1 + h);
+    gtk_widget_set_size_request(thumb->w_bottom, CLAMP(w, 25 * r1, width), 6.75 * r1 + h);
 
     gtk_label_set_xalign(GTK_LABEL(thumb->w_bottom), 0);
     gtk_label_set_yalign(GTK_LABEL(thumb->w_bottom), 0);


### PR DESCRIPTION
Here it is, CSS improvements for the culling and preview rewrite from @AlicVB.

This fix star icons remains visible when moving mouse cursor outside the image on preview mode (and culling one).
Fix also paddings (thumbnail.c is to adjust bottom padding of overlay block infos).
Fix also images infos not seen on hover extended mode.

I also made a little cleanup for no more used lines and some minor other tweaks.

This also improve popover overlays mode when clicking on star icon.
![2020-05-07_22-52](https://user-images.githubusercontent.com/45535283/81415337-9b748900-9148-11ea-9c16-40475eca4c49.png)

This PR is over so could be merged if no issue is seen.

Just take in account that some things remains to improve and especially how icons are rendered on thumbnails (group, altered, ext name and even stars). Colors and hover effect are not good as they are but that will be for another PR as I will now work on optimize CSS code before. It's now quite messy with all new things added and some things become quite hard to tweak without having to change different places and sometimes separated ones. Will try to clean that and optimize all things I can. For example, in reality it's not possible to change all text size in one place. line 161 doesn't change all texts. Will take time.