### PR TITLE
Tone equalizer color pickers fixes

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1888,7 +1888,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 
   if(p->exposure_boost != 0.0f)
   {
-    // Reset the contrast boost and do nothing
+    // Reset the exposure boost and do nothing
     p->exposure_boost = 0.0f;
     const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1853,6 +1853,7 @@ static void contrast_boost_callback(GtkWidget *slider, gpointer user_data)
 
   // Unlock the colour picker so we can display our own custom cursor
   dt_iop_color_picker_reset(self, TRUE);
+  dt_bauhaus_widget_set_quad_active(slider, FALSE);
 }
 
 static void exposure_boost_callback(GtkWidget *slider, gpointer user_data)
@@ -1867,6 +1868,7 @@ static void exposure_boost_callback(GtkWidget *slider, gpointer user_data)
 
   // Unlock the colour picker so we can display our own custom cursor
   dt_iop_color_picker_reset(self, TRUE);
+  dt_bauhaus_widget_set_quad_active(slider, FALSE);
 }
 
 static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
@@ -1897,6 +1899,7 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
+    dt_bauhaus_widget_set_quad_active(quad, FALSE);
     return;
   }
 
@@ -1960,6 +1963,7 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
+    dt_bauhaus_widget_set_quad_active(quad, FALSE);
     return;
   }
 


### PR DESCRIPTION
The tone equalizer uses color pickers in a particular way compared to
others: the user never actually selects an area to pick, the whole
image is always used. As a consequence, the fact that the picker
widget is active doesn't mean "the picker is active and an area can be
selected on screen", but rather "the value of the slider was set
automatically".

The previous behavior was close to this, but broken in some
corner-cases:

* If one selected a value manually, and then clicked the button, then
  the button was toggled to active, but the behavior was to reset the
  value to 0. The visual feedback was the opposite of the behavior.

* When the slider was set manually, the picker widget was kept active,
  while the value wasn't the one set automatically anymore.

Fix this by marking the widget inactive whenever the value is set by
something other than the color picker.

While we're there, fix a trivial typo in a comment.