### PR TITLE
Disable CMake packaging for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,9 +512,10 @@ add_subdirectory(tools)
 # This contains fixup_bundle
 # And adding a separate subderectory as a last one will make sure
 # that fixup_bundle will run _after_ all files has been installed
-add_subdirectory(packaging)
-
-include(cmake/darktable-packaging.cmake)
+if("${CMAKE_BUILD_TYPE}" MATCHES "Release")
+    add_subdirectory(packaging)
+    include(cmake/darktable-packaging.cmake)
+endif("${CMAKE_BUILD_TYPE}" MATCHES "Release")
 
 # uninstall target
 configure_file(


### PR DESCRIPTION
This will disable fixup_bundle() for Debug type of build.
fixup_bundle() is only needed for redistributable builds, normally of Release type, and causes a very long building time on Windows, which makes the debug painful.