### PR TITLE
Overlay max size 2

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1130,7 +1130,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // stars + reject having a width of 2 * r1 and spaced by r1 => 18 * r1
     // colorlabels => 3 * r1 + space r1
     // inner margins are 0.045 * width
-    const float r1 = fminf((DT_PIXEL_APPLY_DPI(16.0f) + 4.0f) / 2.0f, 0.91 * width / 22.0f);
+    const float r1 = fminf((DT_PIXEL_APPLY_DPI(16.0f) + 4.0f) / 2.0f, 0.91f * width / 22.0f);
 
     // file extension
     gtk_widget_set_margin_top(thumb->w_ext, 0.5 * r1);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1130,7 +1130,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // stars + reject having a width of 2 * r1 and spaced by r1 => 18 * r1
     // colorlabels => 3 * r1 + space r1
     // inner margins are 0.045 * width
-    const float r1 = fminf(DT_PIXEL_APPLY_DPI(20.0f) / 2.0f, 0.91 * width / 22.0f);
+    const float r1 = fminf((DT_PIXEL_APPLY_DPI(16.0f) + 4.0f) / 2.0f, 0.91 * width / 22.0f);
 
     // file extension
     gtk_widget_set_margin_top(thumb->w_ext, 0.5 * r1);
@@ -1201,7 +1201,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // we need to squeeze 5 stars + 1 reject + 1 colorlabels symbols on a thumbnail width
     // all icons having a width of 3.0 * r1 => 21 * r1
     // we want r1 spaces at extremities, after reject, before colorlables => 4 * r1
-    const float r1 = fminf(DT_PIXEL_APPLY_DPI(20.0f) / 2.0f, width / 25.0f);
+    const float r1 = fminf((DT_PIXEL_APPLY_DPI(16.0f) + 4.0f)/ 2.0f, width / 25.0f);
 
     // file extension
     gtk_widget_set_margin_top(thumb->w_ext, 0.5 * r1);
@@ -1295,7 +1295,7 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   gtk_widget_set_size_request(thumb->w_main, width, height);
   // file extension
   gtk_widget_set_margin_start(thumb->w_ext, 0.045 * width);
-  const int fsize = fminf(DT_PIXEL_APPLY_DPI(20.0), .09 * width);
+  const int fsize = fminf(DT_PIXEL_APPLY_DPI(16.0f) + 4.0f, 0.09f * width);
   PangoAttrList *attrlist = pango_attr_list_new();
   PangoAttribute *attr = pango_attr_size_new_absolute(fsize * PANGO_SCALE);
   pango_attr_list_insert(attrlist, attr);


### PR DESCRIPTION
I repropose this PR, rebased for the new culling rewrite.
It does not affect LoDPI screens but makes the maximum size of icons and text of thumbtable overlays slightly smaller and harmonized with the rest of the GUI.
Please see #4886 for screenshots