### PR TITLE
preferences: add global font size setting

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2631,9 +2631,11 @@ void dt_gui_load_theme(const char *theme)
   {
     //font name can only use period as decimal separator
     //but printf format strings use comma for some locales, so replace comma with period
-    const gchar *font_size = dt_util_dstrcat(NULL, _("%.1f"), dt_conf_get_float("font_size"));
-    const gchar *font_name = dt_util_dstrcat(NULL, _("Sans %s"), dt_util_str_replace(font_size, ",", ".")); 
+    gchar *font_size = dt_util_dstrcat(NULL, _("%.1f"), dt_conf_get_float("font_size"));
+    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %s"), dt_util_str_replace(font_size, ",", ".")); 
     g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
+    g_free(font_size);
+    g_free(font_name);
   }
 
   char path[PATH_MAX] = { 0 }, datadir[PATH_MAX] = { 0 }, configdir[PATH_MAX] = { 0 }, usercsspath[PATH_MAX] = { 0 };

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2627,10 +2627,13 @@ void dt_gui_load_theme(const char *theme)
   //set font size
   if(dt_conf_get_bool("use_system_font"))
     gtk_settings_reset_property(gtk_settings_get_default(), "gtk-font-name");
-  else {
-    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %.1f"), dt_conf_get_float("font_size"));
+  else 
+  {
+    //font name can only use period as decimal separator
+    //but printf format strings use comma for some locales, so replace comma with period
+    const gchar *font_size = dt_util_dstrcat(NULL, _("%.1f"), dt_conf_get_float("font_size"));
+    const gchar *font_name = dt_util_dstrcat(NULL, _("Sans %s"), dt_util_str_replace(font_size, ",", ".")); 
     g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
-    g_free(font_name);
   }
 
   char path[PATH_MAX] = { 0 }, datadir[PATH_MAX] = { 0 }, configdir[PATH_MAX] = { 0 }, usercsspath[PATH_MAX] = { 0 };

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2621,9 +2621,13 @@ void dt_gui_add_help_link(GtkWidget *widget, const char *link)
 // load a CSS theme
 void dt_gui_load_theme(const char *theme)
 {
+  if(!dt_conf_key_exists("use_system_font"))
+    dt_conf_set_bool("use_system_font", TRUE);
+
   //set font size
-  if(dt_conf_get_float("font_size") != 0.0f)
-  {
+  if(dt_conf_get_bool("use_system_font"))
+    gtk_settings_reset_property(gtk_settings_get_default(), "gtk-font-name");
+  else {
     gchar *font_name = dt_util_dstrcat(NULL, _("Sans %f"), dt_conf_get_float("font_size"));
     g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
     g_free(font_name);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2621,6 +2621,14 @@ void dt_gui_add_help_link(GtkWidget *widget, const char *link)
 // load a CSS theme
 void dt_gui_load_theme(const char *theme)
 {
+  //set font size
+  if(dt_conf_get_float("font_size") != 0.0f)
+  {
+    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %f"), dt_conf_get_float("font_size"));
+    g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
+    g_free(font_name);
+  }
+
   char path[PATH_MAX] = { 0 }, datadir[PATH_MAX] = { 0 }, configdir[PATH_MAX] = { 0 }, usercsspath[PATH_MAX] = { 0 };
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2628,7 +2628,7 @@ void dt_gui_load_theme(const char *theme)
   if(dt_conf_get_bool("use_system_font"))
     gtk_settings_reset_property(gtk_settings_get_default(), "gtk-font-name");
   else {
-    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %f"), dt_conf_get_float("font_size"));
+    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %.1f"), dt_conf_get_float("font_size"));
     g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
     g_free(font_name);
   }

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -203,6 +203,18 @@ static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
+static void use_sys_font_callback(GtkWidget *widget, gpointer user_data)
+{
+  dt_conf_set_bool("use_system_font", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
+  if(dt_conf_get_bool("use_system_font"))
+    gtk_widget_set_state_flags(GTK_WIDGET(user_data), GTK_STATE_FLAG_INSENSITIVE, TRUE);
+  else
+    gtk_widget_set_state_flags(GTK_WIDGET(user_data), GTK_STATE_FLAG_NORMAL, TRUE);
+    
+  dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
+  dt_bauhaus_load_theme();
+}
+
 static void save_usercss_callback(GtkWidget *widget, gpointer user_data)
 {
   //get file locations
@@ -330,16 +342,40 @@ static void init_tab_general(GtkWidget *stack)
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
+  //Font size check and spin buttons
+  GtkWidget *usesysfont = gtk_check_button_new();
+  GtkWidget *fontsize = gtk_spin_button_new_with_range(5.0f, 30.0f, 0.2f);
+
+  //checkbox to use system font size
+  if(dt_conf_get_bool("use_system_font"))
+    gtk_widget_set_state_flags(fontsize, GTK_STATE_FLAG_INSENSITIVE, TRUE);
+  else
+    gtk_widget_set_state_flags(fontsize, GTK_STATE_FLAG_NORMAL, TRUE);
+
+  label = gtk_label_new(_("use system font size"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), usesysfont, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(usesysfont, _("use system font size"));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(usesysfont), dt_conf_get_bool("use_system_font"));
+  g_signal_connect(G_OBJECT(usesysfont), "toggled", G_CALLBACK(use_sys_font_callback), (gpointer)fontsize);
+
+
   //font size selector
+  if(dt_conf_get_float("font_size") < 5.0f || dt_conf_get_float("font_size") > 20.0f)
+    dt_conf_set_float("font_size", 12.0f);
+
   label = gtk_label_new(_("font size in points"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);
-  GtkWidget *fontsize = gtk_spin_button_new_with_range(0.0f, 30.0f, 0.2f);
   labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), fontsize, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(fontsize, _("font size in points (0 to use system default)"));
+  gtk_widget_set_tooltip_text(fontsize, _("font size in points"));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
   g_signal_connect(G_OBJECT(fontsize), "value_changed", G_CALLBACK(font_size_changed_callback), 0);
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -196,6 +196,13 @@ static void usercss_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
+static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
+{
+  dt_conf_set_float("font_size", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+  dt_gui_load_theme(dt_conf_get_string("ui_last/theme"));
+  dt_bauhaus_load_theme();
+}
+
 static void save_usercss_callback(GtkWidget *widget, gpointer user_data)
 {
   //get file locations
@@ -322,6 +329,20 @@ static void init_tab_general(GtkWidget *stack)
 
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
+
+  //font size selector
+  label = gtk_label_new(_("font size in points"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  GtkWidget *fontsize = gtk_spin_button_new_with_range(0.0f, 30.0f, 0.2f);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), fontsize, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(fontsize, _("font size in points (0 to use system default)"));
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
+  g_signal_connect(G_OBJECT(fontsize), "value_changed", G_CALLBACK(font_size_changed_callback), 0);
+
 
   //checkbox to allow user to modify theme with user.css
   label = gtk_label_new(_("modify selected theme with CSS tweaks below"));


### PR DESCRIPTION
add a new option to the general tab of the settings dialog to set the
font size for darktable

Resolves #3207.