### PR TITLE
Change most iop modules with color pickers to dt_color_picker_new

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -346,12 +346,12 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
 {
   dt_iop_color_picker_t *color_picker = (dt_iop_color_picker_t *)g_malloc(sizeof(dt_iop_color_picker_t));
 
-  if (GTK_IS_BOX(w))
+  if(w == NULL || GTK_IS_BOX(w))
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
     dt_iop_init_single_picker(color_picker, module, button, kind, module->color_picker_apply);
     g_signal_connect_data(G_OBJECT(button), "toggled", G_CALLBACK(dt_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
-    gtk_box_pack_start(GTK_BOX(w), button, TRUE, TRUE, 0);
+    if (w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
 
     return button;
   }

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -56,13 +56,6 @@ DT_MODULE_INTROSPECTION(3, dt_iop_borders_params_t)
 #define DT_IOP_BORDERS_POSITION_H_COUNT 5
 #define DT_IOP_BORDERS_POSITION_V_COUNT 5
 
-typedef enum dt_iop_borders_pickcolor_type_t
-{
-  DT_BORDERS_NONE = 0,
-  DT_BORDERS_FRAME,
-  DT_BORDERS_BORDER
-} dt_iop_borders_pickcolor_type_t;
-
 typedef struct dt_iop_borders_params_t
 {
   float color[3];           // border color
@@ -91,7 +84,7 @@ typedef struct dt_iop_borders_gui_data_t
   GtkWidget *pos_v;
   GtkWidget *pos_v_slider;
   GtkWidget *colorpick;
-  GtkToggleButton *border_picker; // the 1st button
+  GtkWidget *border_picker; // the 1st button
   float aspect_ratios[DT_IOP_BORDERS_ASPECT_COUNT];
   float pos_h_ratios[DT_IOP_BORDERS_POSITION_H_COUNT];
   float pos_v_ratios[DT_IOP_BORDERS_POSITION_V_COUNT];
@@ -99,8 +92,7 @@ typedef struct dt_iop_borders_gui_data_t
   GtkWidget *frame_size;
   GtkWidget *frame_offset;
   GtkWidget *frame_colorpick;
-  GtkToggleButton *frame_picker; // the 2nd button
-  dt_iop_color_picker_t color_picker;
+  GtkWidget *frame_picker; // the 2nd button
 } dt_iop_borders_gui_data_t;
 
 // ******* Check and update legacy params...(esp. ver 4)
@@ -609,26 +601,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("15:10 postcard black"), self->op, self->version(), &p, sizeof(p), 1);
 }
 
-static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
-{
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
-
-  const dt_iop_borders_pickcolor_type_t current_picker = g->color_picker.current_picker;
-
-  g->color_picker.current_picker = DT_BORDERS_NONE;
-
-  if(button == GTK_WIDGET(g->frame_picker))
-    g->color_picker.current_picker = DT_BORDERS_FRAME;
-  else if(button == GTK_WIDGET(g->border_picker))
-    g->color_picker.current_picker = DT_BORDERS_BORDER;
-
-  if (current_picker == g->color_picker.current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
-  else
-    return g->color_picker.current_picker;
-}
-
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
@@ -654,14 +627,14 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
                         .blue = self->picked_color[2],
                         .alpha = 1.0 };
 
-  if(g->color_picker.current_picker == DT_BORDERS_FRAME)
+  if(self->picker->colorpick == g->frame_picker)
   {
     p->frame_color[0] = self->picked_color[0];
     p->frame_color[1] = self->picked_color[1];
     p->frame_color[2] = self->picked_color[2];
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->frame_colorpick), &c);
   }
-  else if(g->color_picker.current_picker == DT_BORDERS_BORDER)
+  else if(self->picker->colorpick == g->border_picker)
   {
     p->color[0] = self->picked_color[0];
     p->color[1] = self->picked_color[1];
@@ -670,17 +643,6 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
   }
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void _iop_color_picker_update(dt_iop_module_t *self)
-{
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
-  const dt_iop_borders_pickcolor_type_t which_colorpicker = g->color_picker.current_picker;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
-  gtk_toggle_button_set_active(g->frame_picker, which_colorpicker == DT_BORDERS_FRAME);
-  gtk_toggle_button_set_active(g->border_picker, which_colorpicker == DT_BORDERS_BORDER);
-  darktable.gui->reset = reset;
 }
 
 static void aspect_changed(GtkWidget *combo, dt_iop_module_t *self)
@@ -1088,44 +1050,31 @@ void gui_init(struct dt_iop_module_t *self)
 
   GdkRGBA color = (GdkRGBA){.red = p->color[0], .green = p->color[1], .blue = p->color[2], .alpha = 1.0 };
 
-  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  GtkWidget *label, *box;
+
+  box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float));
+  gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   g->colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select border color"));
-  GtkWidget *label = dtgtk_reset_label_new(_("border color"), self, &p->color, 3 * sizeof(float));
   g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(colorpick_color_set), self);
-
-  g->border_picker = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL));
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->border_picker), _("pick border color from image"));
-  g_signal_connect(G_OBJECT(g->border_picker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-
-  gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->colorpick), FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->border_picker), FALSE, FALSE, 0);
+  g->border_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->border_picker), _("pick border color from image"));
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
 
   box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  label = dtgtk_reset_label_new(_("frame line color"), self, &p->color, 3 * sizeof(float));
+  gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   g->frame_colorpick = gtk_color_button_new_with_rgba(&color);
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->frame_colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->frame_colorpick), _("select frame line color"));
-  label = dtgtk_reset_label_new(_("frame line color"), self, &p->color, 3 * sizeof(float));
   g_signal_connect(G_OBJECT(g->frame_colorpick), "color-set", G_CALLBACK(frame_colorpick_color_set), self);
-
-  g->frame_picker = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL));
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker), _("pick frame line color from image"));
-  g_signal_connect(G_OBJECT(g->frame_picker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-
-  gtk_box_pack_start(GTK_BOX(box), label, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->frame_colorpick), FALSE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->frame_picker), FALSE, FALSE, 0);
+  g->frame_picker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->frame_picker), _("pick frame line color from image"));
   gtk_box_pack_start(GTK_BOX(self->widget), box, TRUE, TRUE, 0);
-
-  dt_iop_init_picker(&g->color_picker,
-              self,
-              DT_COLOR_PICKER_POINT,
-              _iop_color_picker_get_set,
-              _iop_color_picker_apply,
-              _iop_color_picker_update);
 }
 
 

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -65,7 +65,6 @@ typedef struct dt_iop_colorize_gui_data_t
 {
   GtkWidget *scale1, *scale2; //  lightness, source_lightnessmix
   GtkWidget *gslider1, *gslider2; // hue, saturation
-  dt_iop_color_picker_t color_picker;
 } dt_iop_colorize_gui_data_t;
 
 typedef struct dt_iop_colorize_data_t
@@ -286,7 +285,7 @@ static void saturation_callback(GtkWidget *slider, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;
@@ -427,9 +426,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(g->gslider1, 0.830f, 1.0f, 0.0f, 1.0f);
   dt_bauhaus_slider_set_stop(g->gslider1, 1.0f, 1.0f, 0.0f, 0.0f);
   gtk_widget_set_tooltip_text(g->gslider1, _("select the hue tone"));
-  dt_bauhaus_widget_set_quad_paint(g->gslider1, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->gslider1, TRUE);
-  g_signal_connect(G_OBJECT(g->gslider1), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_POINT, g->gslider1);
 
   /* saturation slider */
   g->gslider2 = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
@@ -461,12 +458,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->gslider2), "value-changed", G_CALLBACK(saturation_callback), self);
   g_signal_connect(G_OBJECT(g->scale1), "value-changed", G_CALLBACK(lightness_callback), self);
   g_signal_connect(G_OBJECT(g->scale2), "value-changed", G_CALLBACK(source_lightness_mix_callback), self);
-
-  dt_iop_init_single_picker(&g->color_picker,
-                     self,
-                     g->gslider1,
-                     DT_COLOR_PICKER_POINT,
-                     _iop_color_picker_apply);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -84,7 +84,6 @@ typedef struct dt_iop_exposure_gui_data_t
   GtkLabel *deflicker_used_EC;
   float deflicker_computed_exposure;
   dt_pthread_mutex_t lock;
-  dt_iop_color_picker_t color_picker;
 } dt_iop_exposure_gui_data_t;
 
 typedef struct dt_iop_exposure_data_t
@@ -728,7 +727,7 @@ static float dt_iop_exposure_get_black(struct dt_iop_module_t *self)
   return p->black;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
 
@@ -902,8 +901,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->autoexpp, _("percentage of bright values clipped out, toggle color picker to activate"));
   dt_bauhaus_slider_set_format(g->autoexpp, "%.3f%%");
   dt_bauhaus_widget_set_label(g->autoexpp, NULL, _("clipping threshold"));
-  dt_bauhaus_widget_set_quad_paint(g->autoexpp, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->autoexpp, TRUE);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->autoexpp);
   gtk_box_pack_start(GTK_BOX(vbox_manual), GTK_WIDGET(g->autoexpp), TRUE, TRUE, 0);
 
   gtk_widget_show_all(vbox_manual);
@@ -948,18 +946,11 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->black), "value-changed", G_CALLBACK(black_callback), self);
   g_signal_connect(G_OBJECT(g->exposure), "value-changed", G_CALLBACK(exposure_callback), self);
   g_signal_connect(G_OBJECT(g->autoexpp), "value-changed", G_CALLBACK(autoexpp_callback), self);
-  g_signal_connect(G_OBJECT(g->autoexpp), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
   g_signal_connect(G_OBJECT(g->deflicker_percentile), "value-changed", G_CALLBACK(deflicker_params_callback),
                    self);
   g_signal_connect(G_OBJECT(g->deflicker_target_level), "value-changed",
                    G_CALLBACK(deflicker_params_callback), self);
   g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(draw), self);
-
-  dt_iop_init_single_picker(&g->color_picker,
-                     self,
-                     GTK_WIDGET(g->autoexpp),
-                     DT_COLOR_PICKER_AREA,
-                     _iop_color_picker_apply);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -82,15 +82,6 @@ DT_MODULE_INTROSPECTION(3, dt_iop_filmic_params_t)
  *
  * */
 
-typedef enum dt_iop_filmic_pickcolor_type_t
-{
-  DT_PICKPROFLOG_NONE = 0,
-  DT_PICKPROFLOG_GREY_POINT = 1,
-  DT_PICKPROFLOG_BLACK_POINT = 2,
-  DT_PICKPROFLOG_WHITE_POINT = 3,
-  DT_PICKPROFLOG_AUTOTUNE = 4
-} dt_iop_filmic_pickcolor_type_t;
-
 typedef struct dt_iop_filmic_params_t
 {
   float grey_point_source;
@@ -130,7 +121,6 @@ typedef struct dt_iop_filmic_gui_data_t
   GtkWidget *preserve_color;
   GtkWidget *extra_expander;
   GtkWidget *extra_toggle;
-  dt_iop_color_picker_t color_picker;
   GtkDrawingArea *area;
   float table[256];      // precomputed look-up table
   float table_temp[256]; // precomputed look-up for the optimized interpolation
@@ -888,59 +878,19 @@ static void apply_autotune(dt_iop_module_t *self)
   gtk_widget_queue_draw(self->widget);
 }
 
-static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
-  dt_iop_filmic_gui_data_t *g =  (dt_iop_filmic_gui_data_t *)self->gui_data;
-
-  const int current_picker = g->color_picker.current_picker;
-
-  g->color_picker.current_picker = DT_PICKPROFLOG_NONE;
-
-  if(button == g->grey_point_source)
-    g->color_picker.current_picker = DT_PICKPROFLOG_GREY_POINT;
-  else if(button == g->black_point_source)
-    g->color_picker.current_picker = DT_PICKPROFLOG_BLACK_POINT;
-  else if(button == g->white_point_source)
-    g->color_picker.current_picker = DT_PICKPROFLOG_WHITE_POINT;
-  else if(button == g->auto_button)
-    g->color_picker.current_picker = DT_PICKPROFLOG_AUTOTUNE;
-
-  if (current_picker == g->color_picker.current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
+  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  if     (self->picker->colorpick == g->grey_point_source)
+    apply_auto_grey(self);
+  else if(self->picker->colorpick == g->black_point_source)
+    apply_auto_black(self);
+  else if(self->picker->colorpick == g->white_point_source)
+    apply_auto_white_point_source(self);
+  else if(self->picker->colorpick == g->auto_button)
+    apply_autotune(self);
   else
-    return g->color_picker.current_picker;
-}
-
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
-{
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  switch(g->color_picker.current_picker)
-  {
-     case DT_PICKPROFLOG_GREY_POINT:
-       apply_auto_grey(self);
-       break;
-     case DT_PICKPROFLOG_BLACK_POINT:
-       apply_auto_black(self);
-       break;
-     case DT_PICKPROFLOG_WHITE_POINT:
-       apply_auto_white_point_source(self);
-       break;
-     case DT_PICKPROFLOG_AUTOTUNE:
-       apply_autotune(self);
-       break;
-     default:
-       break;
-  }
-}
-
-static void _iop_color_picker_update(dt_iop_module_t *self)
-{
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  const int which_colorpicker = g->color_picker.current_picker;
-  dt_bauhaus_widget_set_quad_active(g->grey_point_source, which_colorpicker == DT_PICKPROFLOG_GREY_POINT);
-  dt_bauhaus_widget_set_quad_active(g->black_point_source, which_colorpicker == DT_PICKPROFLOG_BLACK_POINT);
-  dt_bauhaus_widget_set_quad_active(g->white_point_source, which_colorpicker == DT_PICKPROFLOG_WHITE_POINT);
-  dt_bauhaus_widget_set_quad_active(g->auto_button, which_colorpicker == DT_PICKPROFLOG_AUTOTUNE);
+    fprintf(stderr, "[filmic] unknown color picker\n");
 }
 
 static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
@@ -1692,9 +1642,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the subject.\n"
                                                       "except in back-lighting situations, this should be around 18%."));
   g_signal_connect(G_OBJECT(g->grey_point_source), "value-changed", G_CALLBACK(grey_point_source_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->grey_point_source, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->grey_point_source, TRUE);
-  g_signal_connect(G_OBJECT(g->grey_point_source), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->grey_point_source);
 
   // White slider
   g->white_point_source = dt_bauhaus_slider_new_with_range(self, 2.0, 8.0, 0.1, p->white_point_source, 2);
@@ -1706,9 +1654,7 @@ void gui_init(dt_iop_module_t *self)
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "adjust so highlights clipping is avoided"));
   g_signal_connect(G_OBJECT(g->white_point_source), "value-changed", G_CALLBACK(white_point_source_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->white_point_source, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->white_point_source, TRUE);
-  g_signal_connect(G_OBJECT(g->white_point_source), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->white_point_source);
 
   // Black slider
   g->black_point_source = dt_bauhaus_slider_new_with_range(self, -14.0, -3.0, 0.1, p->black_point_source, 2);
@@ -1720,9 +1666,7 @@ void gui_init(dt_iop_module_t *self)
                                                        "this is a reading a lightmeter would give you on the scene.\n"
                                                        "increase to get more contrast.\ndecrease to recover more details in low-lights."));
   g_signal_connect(G_OBJECT(g->black_point_source), "value-changed", G_CALLBACK(black_point_source_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->black_point_source, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->black_point_source, TRUE);
-  g_signal_connect(G_OBJECT(g->black_point_source), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->black_point_source);
 
   // Security factor
   g->security_factor = dt_bauhaus_slider_new_with_range(self, -50., 50., 1.0, p->security_factor, 2);
@@ -1736,10 +1680,7 @@ void gui_init(dt_iop_module_t *self)
   // Auto tune slider
   g->auto_button = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->auto_button, NULL, _("auto tune levels"));
-  dt_bauhaus_widget_set_quad_paint(g->auto_button, dtgtk_cairo_paint_colorpicker,
-                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->auto_button, TRUE);
-  g_signal_connect(G_OBJECT(g->auto_button), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->auto_button);
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some guessing.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\nbut fails for high-keys and low-keys." ));
@@ -1872,13 +1813,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->output_power, _("power or gamma of the transfer function\nof the display or color space.\n"
                                                  "you should never touch that unless you know what you are doing."));
   g_signal_connect(G_OBJECT(g->output_power), "value-changed", G_CALLBACK(output_power_callback), self);
-
-  dt_iop_init_picker(&g->color_picker,
-              self,
-              DT_COLOR_PICKER_AREA,
-              _iop_color_picker_get_set,
-              _iop_color_picker_apply,
-              _iop_color_picker_update);
 }
 
 

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -118,8 +118,6 @@ typedef struct dt_iop_graduatednd_gui_data_t
   GtkWidget *scale1, *scale2, *scale3;                   // density, hardness, rotation
   GtkWidget *gslider1, *gslider2;                        // hue, saturation
 
-  dt_iop_color_picker_t color_picker;
-
   int selected;
   int dragging;
 
@@ -430,7 +428,7 @@ static inline void update_saturation_slider_end_color(GtkWidget *slider, float h
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;
@@ -1259,9 +1257,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_stop(g->gslider1, 1.0f, 1.0f, 0.0f, 0.0f);
   gtk_widget_set_tooltip_text(g->gslider1, _("select the hue tone of filter"));
   g_signal_connect(G_OBJECT(g->gslider1), "value-changed", G_CALLBACK(hue_callback), self);
-  dt_bauhaus_widget_set_quad_paint(g->gslider1, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->gslider1, TRUE);
-  g_signal_connect(G_OBJECT(g->gslider1), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_POINT, g->gslider1);
 
   /* saturation slider */
   g->gslider2 = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, 0.01f, 0.0f, 2);
@@ -1277,12 +1273,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->selected = 0;
   g->dragging = 0;
   g->define = 0;
-
-  dt_iop_init_single_picker(&g->color_picker,
-                     self,
-                     g->gslider1,
-                     DT_COLOR_PICKER_POINT,
-                     _iop_color_picker_apply);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -685,18 +685,21 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(autobutton, _("apply auto levels"));
   gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(autobutton), TRUE, TRUE, 0);
 
-  c->blackpick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  c->blackpick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->blackpick, _("pick black point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->blackpick), "picker-black");
 
-  c->greypick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  c->greypick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->greypick, _("pick medium gray point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->greypick), "picker-grey");
 
-  c->whitepick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  c->whitepick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->whitepick, _("pick white point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->whitepick), "picker-white");
 
+  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(c->blackpick), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(c->greypick ), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(c->whitepick), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(vbox_manual), box, TRUE, TRUE, 0);
 
   gtk_widget_show_all(vbox_manual);

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -58,10 +58,8 @@ typedef struct dt_iop_monochrome_gui_data_t
 {
   GtkDrawingArea *area;
   GtkWidget *highlights;
-  GtkWidget *colorpicker;
   int dragging;
   cmsHTRANSFORM xform;
-  dt_iop_color_picker_t color_picker;
 } dt_iop_monochrome_gui_data_t;
 
 typedef struct dt_iop_monochrome_global_data_t
@@ -452,7 +450,7 @@ static gboolean dt_iop_monochrome_draw(GtkWidget *widget, cairo_t *crf, gpointer
   return TRUE;
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
 
@@ -620,29 +618,17 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(dt_iop_monochrome_leave_notify), self);
   g_signal_connect(G_OBJECT(g->area), "scroll-event", G_CALLBACK(dt_iop_monochrome_scrolled), self);
 
-  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
-
   g->highlights = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.01, 0.0, 2);
   gtk_widget_set_tooltip_text(g->highlights, _("how much to keep highlights"));
   dt_bauhaus_widget_set_label(g->highlights, NULL, _("highlights"));
-  gtk_box_pack_start(GTK_BOX(box), g->highlights, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->highlights, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->highlights), "value-changed", G_CALLBACK(highlights_callback), self);
-
-  g->colorpicker = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_box_pack_end(GTK_BOX(box), GTK_WIDGET(g->colorpicker), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->colorpicker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-
-  gtk_box_pack_end(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->highlights);
 
   cmsHPROFILE hsRGB = dt_colorspaces_get_profile(DT_COLORSPACE_SRGB, "", DT_PROFILE_DIRECTION_IN)->profile;
   cmsHPROFILE hLab = dt_colorspaces_get_profile(DT_COLORSPACE_LAB, "", DT_PROFILE_DIRECTION_ANY)->profile;
   g->xform = cmsCreateTransform(hLab, TYPE_Lab_DBL, hsRGB, TYPE_RGB_DBL, INTENT_PERCEPTUAL,
                                 0); // cmsFLAGS_NOTPRECALC);
-  dt_iop_init_single_picker(&g->color_picker,
-                     self,
-                     GTK_WIDGET(g->colorpicker),
-                     DT_COLOR_PICKER_AREA,
-                     _iop_color_picker_apply);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -77,7 +77,6 @@ typedef struct dt_iop_temperature_gui_data_t
   GtkWidget *box_enabled;
   GtkWidget *label_disabled;
   GtkWidget *stack;
-  GtkWidget *colorpicker;
   int preset_cnt;
   int preset_num[50];
   double daylight_wb[4];
@@ -768,7 +767,6 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), "enabled");
 
   dt_iop_color_picker_reset(self, TRUE);
-  gtk_widget_hide(g->colorpicker);
 
   double TempK, tint;
   mul2temp(self, p->coeffs, &TempK, &tint);
@@ -1264,7 +1262,7 @@ static void apply_preset(dt_iop_module_t *self)
 
       //reset previously stored color picker information
       for(int k = 0; k < 4; k++) old[k] = 0.0f;
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker), TRUE);
+      dt_iop_color_picker_callback(g->presets, &g->color_picker);
       break;
     case 3: // directly changing one of the coeff sliders also changes the mod_coeff so it can be read here
       for(int k = 0; k < 4; k++) p->coeffs[k] = g->mod_coeff[k];
@@ -1341,7 +1339,7 @@ static void finetune_changed(GtkWidget *widget, gpointer user_data)
   apply_preset((dt_iop_module_t *)user_data);
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
 
@@ -1488,17 +1486,11 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "disabled" : "enabled");
 
-  g->colorpicker = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_size_request(GTK_WIDGET(g->colorpicker), DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
-  gtk_box_pack_start(GTK_BOX(g->box_enabled), GTK_WIDGET(g->colorpicker), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->colorpicker), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-  gtk_widget_show_all(g->colorpicker);
-
   dt_iop_init_single_picker(&g->color_picker,
                      self,
-                     GTK_WIDGET(g->colorpicker),
+                     GTK_WIDGET(g->presets),
                      DT_COLOR_PICKER_AREA,
-                     _iop_color_picker_apply);
+                     color_picker_apply);
 
   self->gui_update(self);
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -109,8 +109,7 @@ typedef struct dt_iop_watermark_gui_data_t
   GtkWidget *text;
   GtkWidget *colorpick;
   GtkWidget *fontsel;
-  GtkToggleButton *color_picker_button;
-  dt_iop_color_picker_t color_picker;
+  GtkWidget *color_picker_button;
 } dt_iop_watermark_gui_data_t;
 
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
@@ -1153,7 +1152,7 @@ static void watermark_callback(GtkWidget *tb, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
@@ -1493,13 +1492,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->colorpick, _("watermark color, tag:\n$(WATERMARK_COLOR)"));
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->colorpick), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->colorpick), _("select watermark color"));
-
-  g->color_picker_button = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL));
-  gtk_widget_set_tooltip_text(GTK_WIDGET(g->color_picker_button), _("pick color from image"));
-  g_signal_connect(G_OBJECT(g->color_picker_button), "toggled", G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-
   gtk_box_pack_start(GTK_BOX(box), g->colorpick, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(box), GTK_WIDGET(g->color_picker_button), FALSE, TRUE, 0);
+  g->color_picker_button = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, box);
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->color_picker_button), _("pick color from image"));
 
   gtk_grid_attach(GTK_GRID(self->widget), label, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(self->widget), box, label, GTK_POS_RIGHT, 2, 1);
@@ -1608,12 +1603,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->text), "changed", G_CALLBACK(text_callback), self);
   g_signal_connect(G_OBJECT(g->colorpick), "color-set", G_CALLBACK(colorpick_color_set), self);
   g_signal_connect(G_OBJECT(g->fontsel), "font-set", G_CALLBACK(fontsel_callback), self);
-
-  dt_iop_init_single_picker(&g->color_picker,
-                     self,
-                     GTK_WIDGET(g->color_picker_button),
-                     DT_COLOR_PICKER_POINT,
-                     _iop_color_picker_apply);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)


### PR DESCRIPTION
This should have no user visible or behaviour changes. Testing would be much appreciated!

There are a few remaining modules that have some additional features so I'm putting those in separate commits so that they could be reverted separately if needed. Those are:
basicadj
colorchecker
colorzones
rgb curve
rgb levels
and
tone curve

As mentioned in #4956, tone equaliser uses color picker buttons but not the same underlying functionality. Thanks to @moy for resolving its confusing behavior.