### PR TITLE
generalize the use of dt_view_image(s)_to_act_on

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -441,7 +441,7 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on();
+    imgs = dt_view_get_images_to_act_on(TRUE);
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   dt_image_set_locations(imgs, geoloc, undo_on, group_on);
@@ -2104,7 +2104,7 @@ void dt_image_synch_xmp(const int selected)
   }
   else
   {
-    GList *imgs = dt_view_get_images_to_act_on();
+    GList *imgs = dt_view_get_images_to_act_on(FALSE);
     dt_image_synch_xmps(imgs);
     g_list_free(imgs);
   }

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -523,7 +523,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
   {
     GList *imgs = NULL;
     if(imgid == -1)
-      imgs = dt_view_get_images_to_act_on();
+      imgs = dt_view_get_images_to_act_on(TRUE);
     else
       imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if(imgs)
@@ -620,7 +620,7 @@ void dt_metadata_set_list(const int imgid, GList *key_value, const gboolean undo
   {
     GList *imgs = NULL;
     if(imgid == -1)
-      imgs = dt_view_get_images_to_act_on();
+      imgs = dt_view_get_images_to_act_on(TRUE);
     else
       imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if(imgs)
@@ -667,7 +667,7 @@ void dt_metadata_clear(const int imgid, const gboolean undo_on, const gboolean g
   {
     GList *imgs = NULL;
     if(imgid == -1)
-      imgs = dt_view_get_images_to_act_on();
+      imgs = dt_view_get_images_to_act_on(TRUE);
     else
       imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if(imgs)

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -589,7 +589,7 @@ void dt_metadata_set_import(const int imgid, const char *key, const char *value)
   }
 }
 
-void dt_metadata_set_list(const int imgid, GList *key_value, const gboolean undo_on, const gboolean group_on)
+void dt_metadata_set_list(GList *imgs, GList *key_value, const gboolean undo_on)
 {
   GList *metadata = NULL;
   GList *kv = key_value;
@@ -616,34 +616,25 @@ void dt_metadata_set_list(const int imgid, GList *key_value, const gboolean undo
     }
   }
 
-  if(metadata)
+  if(metadata && imgs)
   {
-    GList *imgs = NULL;
-    if(imgid == -1)
-      imgs = dt_view_get_images_to_act_on(TRUE);
-    else
-      imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
-    if(imgs)
+    GList *undo = NULL;
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
+
+    _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_ADD);
+
+    if(undo_on)
     {
-      GList *undo = NULL;
-      if(group_on) dt_grouping_add_grouped_images(&imgs);
-      if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
-
-      _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_ADD);
-
-      g_list_free(imgs);
-      if(undo_on)
-      {
-        dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
-        dt_undo_end_group(darktable.undo);
-      }
-      dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
+      dt_undo_end_group(darktable.undo);
     }
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+
     g_list_free_full(metadata, g_free);
   }
 }
 
-void dt_metadata_clear(const int imgid, const gboolean undo_on, const gboolean group_on)
+void dt_metadata_clear(GList *imgs, const gboolean undo_on)
 {
   // do not clear internal or hidden metadata
   GList *metadata = NULL;
@@ -665,27 +656,18 @@ void dt_metadata_clear(const int imgid, const gboolean undo_on, const gboolean g
 
   if(metadata)
   {
-    GList *imgs = NULL;
-    if(imgid == -1)
-      imgs = dt_view_get_images_to_act_on(TRUE);
-    else
-      imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
-    if(imgs)
+    GList *undo = NULL;
+    if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
+
+    _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_REMOVE);
+
+    if(undo_on)
     {
-      GList *undo = NULL;
-      if(group_on) dt_grouping_add_grouped_images(&imgs);
-      if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
-
-      _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_REMOVE);
-
-      g_list_free(imgs);
-      if(undo_on)
-      {
-        dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
-        dt_undo_end_group(darktable.undo);
-      }
-      dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+      dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
+      dt_undo_end_group(darktable.undo);
     }
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
+
     g_list_free_full(metadata, g_free);
   }
 }

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -90,7 +90,7 @@ void dt_metadata_set_import(int id, const char *key, const char *value); // exif
 
 /** Set metadata (named keys) for a specific image, or all selected for id == -1. */
 /** list is a set of key, value */
-void dt_metadata_set_list(int id, GList *key_value, const gboolean undo_on, const gboolean group_on); // libs/metadata.c
+void dt_metadata_set_list(GList *imgs, GList *key_value, const gboolean undo_on); // libs/metadata.c
 
 /** Set metadata (id keys) for a list of images.
     list is a set of keyid, value
@@ -106,7 +106,7 @@ GList *dt_metadata_get(int id, const char *key, uint32_t *count); // exif.cc, va
 GList *dt_metadata_get_list_id(int id); // libs/image.c
 
 /** Remove metadata from specific images, or all selected for id == -1. */
-void dt_metadata_clear(int id, const gboolean undo_on, const gboolean group_on); // libs/metadata.c
+void dt_metadata_clear(GList *imgs, const gboolean undo_on); // libs/metadata.c
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/ratings.c
+++ b/src/common/ratings.c
@@ -119,15 +119,13 @@ static void _ratings_apply(GList *imgs, const int rating, GList **undo, const gb
   }
 }
 
-void dt_ratings_apply_on_list(const GList *img, const int rating,
-                              const gboolean undo_on, const gboolean group_on)
+void dt_ratings_apply_on_list(const GList *img, const int rating, const gboolean undo_on)
 {
   GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_RATINGS);
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
 
     _ratings_apply(imgs, rating, &undo, undo_on);
 

--- a/src/common/ratings.h
+++ b/src/common/ratings.h
@@ -32,8 +32,7 @@ void dt_ratings_apply_on_image(const int imgid, const int rating, const gboolean
                                const gboolean undo_on, const gboolean group_on);
 
 /** apply rating to all images in the list */
-void dt_ratings_apply_on_list(const GList *list, const int rating,
-                              const gboolean undo_on, const gboolean group_on);
+void dt_ratings_apply_on_list(const GList *list, const int rating, const gboolean undo_on);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -33,6 +33,11 @@ typedef struct dt_selection_t
   uint32_t last_single_id;
 } dt_selection_t;
 
+const dt_collection_t *dt_selection_get_collection(struct dt_selection_t *selection)
+{
+  return selection->collection;
+}
+
 /* updates the internal collection of an selection */
 static void _selection_update_collection(gpointer instance, dt_collection_change_t query_change, gpointer imgs,
                                          int next, gpointer user_data);

--- a/src/common/selection.h
+++ b/src/common/selection.h
@@ -48,6 +48,8 @@ void dt_selection_select_filmroll(struct dt_selection_t *selection);
 void dt_selection_select_unaltered(struct dt_selection_t *selection);
 /** selects a set of images from a list. the list is unaltered */
 void dt_selection_select_list(struct dt_selection_t *selection, GList *list);
+/** selects a set of images from a list. the list is unaltered */
+const struct dt_collection_t *dt_selection_get_collection(struct dt_selection_t *selection);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/styles.h
+++ b/src/common/styles.h
@@ -64,7 +64,7 @@ gboolean dt_styles_create_from_image(const char *name, const char *description,
                                      const int32_t imgid, GList *items, gboolean copy_iop_order);
 
 /** creates styles from selection */
-void dt_styles_create_from_selection(void);
+void dt_styles_create_from_list(GList *list);
 
 /** creates a new style from specified style, items are the style number of items to include in style */
 void dt_styles_create_from_style(const char *name, const char *newname, const char *description,
@@ -75,7 +75,7 @@ void dt_styles_update(const char *name, const char *newname, const char *descrip
                       const int32_t imgid, GList *update, gboolean copy_iop_order);
 
 /** applies the style to selection of images */
-void dt_styles_apply_to_selection(const char *name, gboolean duplicate);
+void dt_styles_apply_to_list(const char *name, GList *list, gboolean duplicate);
 
 /** applies the item style to dev->history */
 void dt_styles_apply_style_item(dt_develop_t *dev, dt_style_item_t *style_item, GList **modules_used, const gboolean append);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -453,7 +453,7 @@ gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on();
+    imgs = dt_view_get_images_to_act_on(TRUE);
   else
   {
     if(dt_is_tag_attached(tagid, imgid)) return FALSE;
@@ -567,7 +567,7 @@ void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, 
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on();
+    imgs = dt_view_get_images_to_act_on(TRUE);
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
 
@@ -633,7 +633,7 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
   }
   else
   {
-    GList *imgs = dt_view_get_images_to_act_on();
+    GList *imgs = dt_view_get_images_to_act_on(TRUE);
     while(imgs)
     {
       images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -98,18 +98,6 @@ static void dt_control_image_enumerator_job_film_init(dt_control_image_enumerato
   sqlite3_finalize(stmt);
 }
 
-/* enumerator of selected images */
-static void dt_control_image_enumerator_job_selected_init(dt_control_image_enumerator_t *t)
-{
-  const int imgid = dt_view_get_image_to_act_on();
-
-  if(imgid < 0) /* get sorted list of selected images */
-    t->index = dt_collection_get_selected(darktable.collection, -1);
-  else
-    /* Create a list with only one image */
-    t->index = g_list_append(NULL, GINT_TO_POINTER(imgid));
-}
-
 static int32_t _generic_dt_control_fileop_images_job_run(dt_job_t *job,
                                                          int32_t (*fileop_callback)(const int32_t,
                                                                                     const int32_t),
@@ -178,7 +166,8 @@ static void dt_control_image_enumerator_cleanup(void *p)
 typedef enum {PROGRESS_NONE, PROGRESS_SIMPLE, PROGRESS_CANCELLABLE} progress_type_t;
 
 static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback execute, const char *message,
-                                                      int flag, gpointer data, progress_type_t progress_type)
+                                                      int flag, gpointer data, progress_type_t progress_type,
+                                                      gboolean only_visible)
 {
   dt_job_t *job = dt_control_job_create(execute, "%s", message);
   if(!job) return NULL;
@@ -190,7 +179,8 @@ static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback ex
   }
   if(progress_type != PROGRESS_NONE)
     dt_control_job_add_progress(job, _(message), progress_type == PROGRESS_CANCELLABLE);
-  dt_control_image_enumerator_job_selected_init(params);
+  params->index = dt_view_get_images_to_act_on(only_visible);
+
   dt_control_job_set_params(job, params, dt_control_image_enumerator_cleanup);
 
   params->flag = flag;
@@ -1372,7 +1362,7 @@ static dt_job_t *dt_control_gpx_apply_job_create(const gchar *filename, int32_t 
   if(filmid != -1)
     dt_control_image_enumerator_job_film_init(params, filmid);
   else
-    dt_control_image_enumerator_job_selected_init(params);
+    params->index = dt_view_get_images_to_act_on(TRUE);
 
   dt_control_gpx_apply_t *data = params->data;
   data->filename = g_strdup(filename);
@@ -1383,10 +1373,9 @@ static dt_job_t *dt_control_gpx_apply_job_create(const gchar *filename, int32_t 
 
 void dt_control_merge_hdr()
 {
-  dt_control_add_job(
-      darktable.control, DT_JOB_QUEUE_USER_FG,
-      dt_control_generic_images_job_create(&dt_control_merge_hdr_job_run, N_("merge hdr image"), 0, NULL,
-                                           PROGRESS_CANCELLABLE));
+  dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
+                     dt_control_generic_images_job_create(&dt_control_merge_hdr_job_run, N_("merge hdr image"), 0,
+                                                          NULL, PROGRESS_CANCELLABLE, TRUE));
 }
 
 void dt_control_gpx_apply(const gchar *filename, int32_t filmid, const gchar *tz)
@@ -1399,34 +1388,28 @@ void dt_control_duplicate_images()
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
                      dt_control_generic_images_job_create(&dt_control_duplicate_images_job_run,
-                                                          N_("duplicate images"), 0, NULL, PROGRESS_SIMPLE));
+                                                          N_("duplicate images"), 0, NULL, PROGRESS_SIMPLE, TRUE));
 }
 
 void dt_control_flip_images(const int32_t cw)
 {
-  dt_control_add_job(
-      darktable.control, DT_JOB_QUEUE_USER_FG,
-      dt_control_generic_images_job_create(&dt_control_flip_images_job_run, N_("flip images"), cw, NULL,
-                                           PROGRESS_SIMPLE));
+  dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
+                     dt_control_generic_images_job_create(&dt_control_flip_images_job_run, N_("flip images"), cw,
+                                                          NULL, PROGRESS_SIMPLE, TRUE));
 }
 
 gboolean dt_control_remove_images()
 {
   // get all selected images now, to avoid the set changing during ui interaction
-  dt_job_t *job = dt_control_generic_images_job_create(&dt_control_remove_images_job_run, N_("remove images"), 0, NULL,
-                                                       PROGRESS_SIMPLE);
+  dt_job_t *job = dt_control_generic_images_job_create(&dt_control_remove_images_job_run, N_("remove images"), 0,
+                                                       NULL, PROGRESS_SIMPLE, FALSE);
   if(dt_conf_get_bool("ask_before_remove"))
   {
     GtkWidget *dialog;
     GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-    int number;
-    if (dt_view_get_image_to_act_on() != -1)
-      number = 1;
-    else
-      number = dt_collection_get_selected_count(darktable.collection);
-
-    // Do not show the dialog if no image is selected:
+    const dt_control_image_enumerator_t *e = (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
+    const int number = g_list_length(e->index);
     if(number == 0)
     {
       dt_control_job_dispose(job);
@@ -1435,8 +1418,8 @@ gboolean dt_control_remove_images()
 
     dialog = gtk_message_dialog_new(
         GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("do you really want to remove %d selected image from the collection?",
-                 "do you really want to remove %d selected images from the collection?", number),
+        ngettext("do you really want to remove %d image from the collection?",
+                 "do you really want to remove %d images from the collection?", number),
         number);
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
@@ -1458,19 +1441,16 @@ gboolean dt_control_remove_images()
 void dt_control_delete_images()
 {
   // first get all selected images, to avoid the set changing during ui interaction
-  dt_job_t *job = dt_control_generic_images_job_create(&dt_control_delete_images_job_run, N_("delete images"), 0, NULL,
-                                                       PROGRESS_SIMPLE);
+  dt_job_t *job = dt_control_generic_images_job_create(&dt_control_delete_images_job_run, N_("delete images"), 0,
+                                                       NULL, PROGRESS_SIMPLE, FALSE);
   int send_to_trash = dt_conf_get_bool("send_to_trash");
   if(dt_conf_get_bool("ask_before_delete"))
   {
     GtkWidget *dialog;
     GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-    int number;
-    if (dt_view_get_image_to_act_on() != -1)
-      number = 1;
-    else
-      number = dt_collection_get_selected_count(darktable.collection);
+    const dt_control_image_enumerator_t *e = (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
+    const int number = g_list_length(e->index);
 
     // Do not show the dialog if no image is selected:
     if(number == 0)
@@ -1481,11 +1461,10 @@ void dt_control_delete_images()
 
     dialog = gtk_message_dialog_new(
         GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        send_to_trash
-        ? ngettext("do you really want to send %d selected image to trash?",
-          "do you really want to send %d selected images to trash?", number)
-        : ngettext("do you really want to physically delete %d selected image from disk?",
-          "do you really want to physically delete %d selected images from disk?", number),
+        send_to_trash ? ngettext("do you really want to send %d image to trash?",
+                                 "do you really want to send %d images to trash?", number)
+                      : ngettext("do you really want to physically delete %d image from disk?",
+                                 "do you really want to physically delete %d images from disk?", number),
         number);
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
@@ -1546,12 +1525,16 @@ void dt_control_move_images()
   // Open file chooser dialog
   gchar *dir = NULL;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  const int number = dt_collection_get_selected_count(darktable.collection);
 
-  // Do not show the dialog if no image is selected:
-  if(number == 0) return;
   dt_job_t *job = dt_control_generic_images_job_create(&dt_control_move_images_job_run, N_("move images"), 0, dir,
-                                                       PROGRESS_CANCELLABLE);
+                                                       PROGRESS_CANCELLABLE, FALSE);
+  const dt_control_image_enumerator_t *e = (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
+  const int number = g_list_length(e->index);
+  if(number == 0)
+  {
+    dt_control_job_dispose(job);
+    return;
+  }
 
   GtkWidget *filechooser = gtk_file_chooser_dialog_new(
       _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
@@ -1574,14 +1557,14 @@ void dt_control_move_images()
 
   if(dt_conf_get_bool("ask_before_move"))
   {
-    GtkWidget *dialog = gtk_message_dialog_new(
-        GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("do you really want to physically move the %d selected image to %s?\n"
-                 "(all unselected duplicates will be moved along)",
-                 "do you really want to physically move %d selected images to %s?\n"
-                 "(all unselected duplicates will be moved along)",
-                 number),
-        number, dir);
+    GtkWidget *dialog = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT,
+                                               GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+                                               ngettext("do you really want to physically move %d image to %s?\n"
+                                                        "(all duplicates will be moved along)",
+                                                        "do you really want to physically move %d images to %s?\n"
+                                                        "(all duplicates will be moved along)",
+                                                        number),
+                                               number, dir);
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
 #endif
@@ -1606,12 +1589,15 @@ void dt_control_copy_images()
   // Open file chooser dialog
   gchar *dir = NULL;
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  int number = dt_collection_get_selected_count(darktable.collection);
-
-  // Do not show the dialog if no image is selected:
-  if(number == 0) return;
   dt_job_t *job = dt_control_generic_images_job_create(&dt_control_copy_images_job_run, N_("copy images"), 0, dir,
-                                                       PROGRESS_CANCELLABLE);
+                                                       PROGRESS_CANCELLABLE, FALSE);
+  const dt_control_image_enumerator_t *e = (dt_control_image_enumerator_t *)dt_control_job_get_params(job);
+  const int number = g_list_length(e->index);
+  if(number == 0)
+  {
+    dt_control_job_dispose(job);
+    return;
+  }
 
   GtkWidget *filechooser = gtk_file_chooser_dialog_new(
       _("select directory"), GTK_WINDOW(win), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, _("_cancel"),
@@ -1636,8 +1622,8 @@ void dt_control_copy_images()
   {
     GtkWidget *dialog = gtk_message_dialog_new(
         GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-        ngettext("do you really want to physically copy the %d selected image to %s?",
-                 "do you really want to physically copy %d selected images to %s?", number),
+        ngettext("do you really want to physically copy %d image to %s?",
+                 "do you really want to physically copy %d images to %s?", number),
         number, dir);
 #ifdef GDK_WINDOWING_QUARTZ
     dt_osx_disallow_fullscreen(dialog);
@@ -1662,21 +1648,23 @@ void dt_control_set_local_copy_images()
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
                      dt_control_generic_images_job_create(&dt_control_local_copy_images_job_run,
-                                                          N_("local copy images"), 1, NULL, PROGRESS_CANCELLABLE));
+                                                          N_("local copy images"), 1, NULL, PROGRESS_CANCELLABLE,
+                                                          FALSE));
 }
 
 void dt_control_reset_local_copy_images()
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
                      dt_control_generic_images_job_create(&dt_control_local_copy_images_job_run,
-                                                          N_("local copy images"), 0, NULL, PROGRESS_CANCELLABLE));
+                                                          N_("local copy images"), 0, NULL, PROGRESS_CANCELLABLE,
+                                                          FALSE));
 }
 
 void dt_control_refresh_exif()
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
-                     dt_control_generic_images_job_create(&dt_control_refresh_exif_run,
-                                                          N_("refresh exif"), 0, NULL, PROGRESS_CANCELLABLE));
+                     dt_control_generic_images_job_create(&dt_control_refresh_exif_run, N_("refresh exif"), 0,
+                                                          NULL, PROGRESS_CANCELLABLE, FALSE));
 }
 
 static dt_control_image_enumerator_t *dt_control_export_alloc()
@@ -1840,7 +1828,7 @@ static dt_job_t *dt_control_time_offset_job_create(const long int offset, int im
   if(imgid != -1)
     params->index = g_list_append(params->index, GINT_TO_POINTER(imgid));
   else
-    dt_control_image_enumerator_job_selected_init(params);
+    params->index = dt_view_get_images_to_act_on(TRUE);
 
   dt_control_time_offset_t *data = params->data;
   data->offset = offset;
@@ -1858,7 +1846,8 @@ void dt_control_write_sidecar_files()
 {
   dt_control_add_job(darktable.control, DT_JOB_QUEUE_USER_FG,
                      dt_control_generic_images_job_create(&dt_control_write_sidecar_files_job_run,
-                                                          N_("write sidecar files"), 0, NULL, PROGRESS_NONE));
+                                                          N_("write sidecar files"), 0, NULL, PROGRESS_NONE,
+                                                          FALSE));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -751,7 +751,7 @@ static void _filemanager_zoom(dt_thumbtable_t *table, int oldzoom, int newzoom)
   if(!thumb)
   {
     // otherwise we use the classic retrieving method
-    const int id = dt_view_get_image_to_act_on2();
+    const int id = dt_view_get_image_to_act_on();
     thumb = _thumbtable_get_thumb(table, id);
     if(thumb)
     {
@@ -1842,12 +1842,12 @@ static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable,
 static gboolean _accel_copy(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                             GdkModifierType modifier, gpointer data)
 {
-  return dt_history_copy(dt_view_get_image_to_act_on2());
+  return dt_history_copy(dt_view_get_image_to_act_on());
 }
 static gboolean _accel_copy_parts(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                   GdkModifierType modifier, gpointer data)
 {
-  return dt_history_copy_parts(dt_view_get_image_to_act_on2());
+  return dt_history_copy_parts(dt_view_get_image_to_act_on());
 }
 static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
@@ -1876,7 +1876,7 @@ static gboolean _accel_hist_discard(GtkAccelGroup *accel_group, GObject *acceler
 static gboolean _accel_duplicate(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                  GdkModifierType modifier, gpointer data)
 {
-  const int sourceid = dt_view_get_image_to_act_on2();
+  const int sourceid = dt_view_get_image_to_act_on();
   const int newimgid = dt_image_duplicate(sourceid);
   if(newimgid <= 0) return FALSE;
 

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1336,7 +1336,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
 
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
-  table->drag_list = dt_view_get_images_to_act_on();
+  table->drag_list = dt_view_get_images_to_act_on(FALSE);
 
   // if we are dragging a single image -> use the thumbnail of that image
   // otherwise use the generic d&d icon
@@ -1826,7 +1826,7 @@ gboolean dt_thumbtable_set_offset_image(dt_thumbtable_t *table, const int imgid,
 static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                             GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE, TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
@@ -1834,7 +1834,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
 static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
@@ -1852,7 +1852,7 @@ static gboolean _accel_copy_parts(GtkAccelGroup *accel_group, GObject *accelerat
 static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   const gboolean ret = dt_history_paste_on_list(imgs, TRUE);
   if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return ret;
@@ -1860,7 +1860,7 @@ static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable,
 static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                    GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   const gboolean ret = dt_history_paste_parts_on_list(imgs, TRUE);
   if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return ret;
@@ -1868,7 +1868,7 @@ static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *accelera
 static gboolean _accel_hist_discard(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                     GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   const gboolean ret = dt_history_delete_on_list(imgs, TRUE);
   if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return ret;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1826,16 +1826,16 @@ gboolean dt_thumbtable_set_offset_image(dt_thumbtable_t *table, const int imgid,
 static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                             GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
-  dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE, TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
 }
 static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
-  dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(data), FALSE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
 }

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -96,7 +96,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
   {
     char *dtfilename;
     dtfilename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    GList *imgs = dt_view_get_images_to_act_on();
+    GList *imgs = dt_view_get_images_to_act_on(TRUE);
     if(dt_history_load_and_apply_on_list(dtfilename, imgs) != 0)
     {
       g_list_free(imgs);
@@ -138,7 +138,7 @@ static void copy_button_clicked(GtkWidget *widget, gpointer user_data)
 static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   if(g_list_length(imgs) < 1) return;
 
   const int missing = dt_history_compress_on_list(imgs);
@@ -179,7 +179,7 @@ static void delete_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   gint res = GTK_RESPONSE_YES;
 
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
 
   if(dt_conf_get_bool("ask_before_delete"))
   {
@@ -222,7 +222,7 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
   dt_conf_set_int("plugins/lighttable/copy_history/pastemode", mode);
 
   /* copy history from previously copied image and past onto selection */
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
 
   if(dt_history_paste_on_list(imgs, TRUE))
   {
@@ -233,7 +233,7 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
 static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   /* copy history from previously copied image and past onto selection */
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
 
   if(dt_history_paste_parts_on_list(imgs, TRUE))
   {

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -126,7 +126,7 @@ static void copy_button_clicked(GtkWidget *widget, gpointer user_data)
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
 
-  const int id = dt_view_get_image_to_act_on2();
+  const int id = dt_view_get_image_to_act_on();
 
   if(id > 0 && dt_history_copy(id))
   {
@@ -166,7 +166,7 @@ static void copy_parts_button_clicked(GtkWidget *widget, gpointer user_data)
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
 
-  const int id = dt_view_get_image_to_act_on2();
+  const int id = dt_view_get_image_to_act_on();
 
   if(id > 0 && dt_history_copy_parts(id))
   {

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -153,14 +153,7 @@ static void export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   gchar *icc_filename = dt_conf_get_string(CONFIG_PREFIX "iccprofile");
   dt_iop_color_intent_t icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent");
 
-  const int imgid = dt_view_get_image_to_act_on();
-  GList *list = NULL;
-
-  if(imgid != -1)
-    list = g_list_append(list, GINT_TO_POINTER(imgid));
-  else
-    list = dt_collection_get_selected(darktable.collection, -1);
-
+  GList *list = dt_view_get_images_to_act_on(TRUE);
   dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, export_masks,
                     style, style_append, icc_type, icc_filename, icc_intent, d->metadata_export);
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -207,7 +207,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   const gboolean geotag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags");
   const gboolean dttag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/tags");
   const int imageid = d->imageid;
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   if(imgs)
   {
     const dt_undo_type_t undo_type = (rating_flag ? DT_UNDO_RATINGS : 0) |

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -207,9 +207,11 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   const gboolean geotag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags");
   const gboolean dttag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/tags");
   const int imageid = d->imageid;
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
   if(imgs)
   {
+    // for all the above actions, we don't use the grpu_on tag, as grouped images have already been added to image
+    // list
     const dt_undo_type_t undo_type = (rating_flag ? DT_UNDO_RATINGS : 0) |
                                     (colors_flag ? DT_UNDO_COLORLABELS : 0) |
                                     (dtmetadata_flag ? DT_UNDO_METADATA : 0) |
@@ -220,17 +222,17 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     if(rating_flag)
     {
       const int stars = (action == DT_MA_CLEAR) ? 0 : dt_ratings_get(imageid);
-      dt_ratings_apply_on_list(imgs, stars, TRUE, TRUE);
+      dt_ratings_apply_on_list(imgs, stars, TRUE, FALSE);
     }
     if(colors_flag)
     {
       const int colors = (action == DT_MA_CLEAR) ? 0 : dt_colorlabels_get_labels(imageid);
-      dt_colorlabels_set_labels(imgs, colors, action != DT_MA_MERGE, TRUE, TRUE);
+      dt_colorlabels_set_labels(imgs, colors, action != DT_MA_MERGE, TRUE, FALSE);
     }
     if(dtmetadata_flag)
     {
       GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
-      dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE, TRUE);
+      dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE, FALSE);
       g_list_free_full(metadata, g_free);
     }
     if(geotag_flag)
@@ -240,14 +242,14 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
         geoloc->longitude = geoloc->latitude = geoloc->elevation = NAN;
       else
         dt_image_get_location(imageid, geoloc);
-      dt_image_set_locations(imgs, geoloc, TRUE, TRUE);
+      dt_image_set_locations(imgs, geoloc, TRUE, FALSE);
       g_free(geoloc);
     }
     if(dttag_flag)
     {
       // affect only user tags (not dt tags)
       GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
-      dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE, TRUE);
+      dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE, FALSE);
       g_list_free(tags);
     }
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -266,7 +266,7 @@ static void copy_metadata_callback(GtkWidget *widget, dt_lib_module_t *self)
 {
   dt_lib_image_t *d = (dt_lib_image_t *)self->data;
 
-  d->imageid = dt_view_get_image_to_act_on2();
+  d->imageid = dt_view_get_image_to_act_on();
   if(d->imageid)
   {
     gtk_widget_set_sensitive(d->paste_metadata_button, TRUE);

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -222,7 +222,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     if(rating_flag)
     {
       const int stars = (action == DT_MA_CLEAR) ? 0 : dt_ratings_get(imageid);
-      dt_ratings_apply_on_list(imgs, stars, TRUE, FALSE);
+      dt_ratings_apply_on_list(imgs, stars, TRUE);
     }
     if(colors_flag)
     {

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -158,7 +158,7 @@ static void _update(dt_lib_module_t *self, gboolean early_bark_out)
   // using dt_metadata_get() is not possible here. we want to do all this in a single pass, everything else
   // takes ages.
   char *images = NULL;
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   while(imgs)
   {
     images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -212,8 +212,10 @@ static gboolean _draw(GtkWidget *widget, cairo_t *cr, dt_lib_module_t *self)
 
 static void _clear_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
-  dt_metadata_clear(-1, TRUE, TRUE);
-  dt_image_synch_xmp(-1);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  dt_metadata_clear(imgs, TRUE);
+  dt_image_synch_xmps(imgs);
+  g_list_free(imgs);
   _update(self, FALSE);
 }
 
@@ -227,7 +229,6 @@ static void _write_metadata(dt_lib_module_t *self)
 {
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
 
-  const int32_t mouse_over_id = d->imgsel;
   d->editing = FALSE;
 
   gchar *metadata[DT_METADATA_NUMBER];
@@ -240,7 +241,8 @@ static void _write_metadata(dt_lib_module_t *self)
       _append_kv(&key_value, dt_metadata_get_key(keyid), metadata[i]);
   }
 
-  dt_metadata_set_list(mouse_over_id, key_value, TRUE, TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  dt_metadata_set_list(imgs, key_value, TRUE);
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {
@@ -251,7 +253,8 @@ static void _write_metadata(dt_lib_module_t *self)
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
 
-  dt_image_synch_xmp(mouse_over_id);
+  dt_image_synch_xmps(imgs);
+  g_list_free(imgs);
   _update(self, FALSE);
 }
 
@@ -366,13 +369,7 @@ static void _update_layout(dt_lib_module_t *self)
 
 static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
 {
-  const dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
   /* lets trigger an expose for a redraw of widget */
-  if(d->editing)
-  {
-    _write_metadata(self);
-    gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
-  }
   _update(self, FALSE);
 }
 
@@ -919,11 +916,13 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
     if(metadata[i][0] != '\0') _append_kv(&key_value, dt_metadata_get_key(i), metadata[i]);
   }
 
-  dt_metadata_set_list(-1, key_value, TRUE, TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  dt_metadata_set_list(imgs, key_value, TRUE);
 
   g_list_free(key_value);
 
-  dt_image_synch_xmp(-1);
+  dt_image_synch_xmps(imgs);
+  g_list_free(imgs);
   _update(self, FALSE);
   return 0;
 }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -214,14 +214,18 @@ static void _styles_row_activated_callback(GtkTreeView *view, GtkTreePath *path,
   gchar *name;
   gtk_tree_model_get(model, &iter, DT_STYLES_COL_FULLNAME, &name, -1);
 
-  if(name) dt_styles_apply_to_selection(name, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
+  GList *list = dt_view_get_images_to_act_on(TRUE);
+  if(name) dt_styles_apply_to_list(name, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
+  g_list_free(list);
 }
 
 static void create_clicked(GtkWidget *w, gpointer user_data)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
 
-  dt_styles_create_from_selection();
+  GList *list = dt_view_get_images_to_act_on(TRUE);
+  dt_styles_create_from_list(list);
+  g_list_free(list);
   _gui_styles_update_view(d);
 }
 
@@ -365,7 +369,12 @@ static gboolean entry_activated(GtkEntry *entry, gpointer user_data)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
   const gchar *name = gtk_entry_get_text(d->entry);
-  if(name) dt_styles_apply_to_selection(name, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
+  if(name)
+  {
+    GList *imgs = dt_view_get_images_to_act_on(TRUE);
+    dt_styles_apply_to_list(name, imgs, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
+    g_list_free(imgs);
+  }
 
   return FALSE;
 }

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -998,7 +998,7 @@ static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_li
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   if(!imgs) return;
 
   GList *affected_images = dt_tag_get_images_from_list(imgs, tagid);
@@ -1184,7 +1184,7 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   const gchar *tag = gtk_entry_get_text(d->entry);
   if(!tag || tag[0] == '\0') return;
 
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   dt_tag_attach_string_list(tag, imgs, TRUE, TRUE);
   dt_image_synch_xmps(imgs);
   g_list_free(imgs);
@@ -2868,7 +2868,7 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
 
   if(d->last_tag)
   {
-    GList *imgs = dt_view_get_images_to_act_on();
+    GList *imgs = dt_view_get_images_to_act_on(TRUE);
     dt_tag_attach_string_list(d->last_tag, imgs, TRUE, TRUE);
     dt_image_synch_xmps(imgs);
     g_list_free(imgs);
@@ -2890,7 +2890,7 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
     return TRUE;  // doesn't work properly with tree treeview
   }
 
-  d->floating_tag_imgs = dt_view_get_images_to_act_on();
+  d->floating_tag_imgs = dt_view_get_images_to_act_on(TRUE);
   gint x, y;
   gint px, py, w, h;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -98,7 +98,7 @@ void gui_cleanup(dt_lib_module_t *self)
 
 static void _lib_colorlabels_button_clicked_callback(GtkWidget *w, gpointer user_data)
 {
-  GList *imgs = dt_view_get_images_to_act_on();
+  GList *imgs = dt_view_get_images_to_act_on(TRUE);
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(user_data), TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
 }

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -98,7 +98,7 @@ void gui_cleanup(dt_lib_module_t *self)
 
 static void _lib_colorlabels_button_clicked_callback(GtkWidget *w, gpointer user_data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(user_data), TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
 }

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -196,8 +196,8 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   dt_lib_ratings_t *d = (dt_lib_ratings_t *)self->data;
   if(d->current > 0)
   {
-    GList *imgs = dt_view_get_images_to_act_on(TRUE);
-    dt_ratings_apply_on_list(imgs, d->current, TRUE, TRUE);
+    GList *imgs = dt_view_get_images_to_act_on(FALSE);
+    dt_ratings_apply_on_list(imgs, d->current, TRUE);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
 
     dt_control_queue_redraw_center();

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -196,7 +196,7 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   dt_lib_ratings_t *d = (dt_lib_ratings_t *)self->data;
   if(d->current > 0)
   {
-    GList *imgs = dt_view_get_images_to_act_on();
+    GList *imgs = dt_view_get_images_to_act_on(TRUE);
     dt_ratings_apply_on_list(imgs, d->current, TRUE, TRUE);
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
 

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -77,26 +77,15 @@ static int hovered_cb(lua_State *L)
 
 static int act_on_cb(lua_State *L)
 {
-
-  int32_t imgid = dt_view_get_image_to_act_on();
   lua_newtable(L);
-  if(imgid != -1)
+  GList *image = dt_view_get_images_to_act_on(FALSE);
+  while(image)
   {
-    luaA_push(L, dt_lua_image_t, &imgid);
+    luaA_push(L, dt_lua_image_t, &image->data);
     luaL_ref(L, -2);
-    return 1;
+    image = g_list_delete_link(image, image);
   }
-  else
-  {
-    GList *image = dt_collection_get_selected(darktable.collection, -1);
-    while(image)
-    {
-      luaA_push(L, dt_lua_image_t, &image->data);
-      luaL_ref(L, -2);
-      image = g_list_delete_link(image, image);
-    }
-    return 1;
-  }
+  return 1;
 }
 
 

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -815,7 +815,7 @@ static gboolean _display_selected(gpointer user_data)
   dt_view_t *self = (dt_view_t *)user_data;
   gboolean done = FALSE;
 
-  GList *selected_images = dt_collection_get_selected(darktable.collection, -1);
+  GList *selected_images = dt_view_get_images_to_act_on(TRUE);
   if(selected_images)
   {
     done = _view_map_center_on_image_list(self, selected_images);
@@ -878,12 +878,10 @@ void enter(dt_view_t *self)
                             G_CALLBACK(_view_map_filmstrip_activate_callback), self);
 
   /* scroll filmstrip to the first selected image */
-  GList *selected_images = dt_collection_get_selected(darktable.collection, 1);
-  if(selected_images)
+  int imgid = dt_view_get_image_to_act_on();
+  if(imgid > 0)
   {
-    dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), GPOINTER_TO_INT(selected_images->data),
-                                   TRUE);
-    g_list_free(selected_images);
+    dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), imgid, TRUE);
   }
 
   g_timeout_add(250, _display_selected, self);

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -268,34 +268,17 @@ int try_enter(dt_view_t *self)
 
   prt->image_id = -1;
 
-  int selected = dt_control_get_mouse_over_id();
-  if(selected < 0)
-  {
-    // try last selected
-    sqlite3_stmt *stmt;
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1, &stmt,
-                                NULL);
-    if(sqlite3_step(stmt) == SQLITE_ROW) selected = sqlite3_column_int(stmt, 0);
-    sqlite3_finalize(stmt);
+  int imgid = dt_view_get_image_to_act_on();
 
-    // Leave as selected only the image being edited
-    DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.selected_images", NULL, NULL, NULL);
-    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "INSERT OR IGNORE INTO main.selected_images VALUES (?1)", -1, &stmt, NULL);
-    DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, selected);
-    sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-  }
-
-  if(selected < 0)
+  if(imgid < 0)
   {
     // fail :(
-    dt_control_log(_("no image selected!"));
+    dt_control_log(_("no image to open !"));
     return 1;
   }
 
   // this loads the image from db if needed:
-  const dt_image_t *img = dt_image_cache_get(darktable.image_cache, selected, 'r');
+  const dt_image_t *img = dt_image_cache_get(darktable.image_cache, imgid, 'r');
   // get image and check if it has been deleted from disk first!
 
   char imgfilename[PATH_MAX] = { 0 };
@@ -304,13 +287,12 @@ int try_enter(dt_view_t *self)
   if(!g_file_test(imgfilename, G_FILE_TEST_IS_REGULAR))
   {
     dt_control_log(_("image `%s' is currently unavailable"), img->filename);
-    // dt_image_remove(selected);
     dt_image_cache_read_release(darktable.image_cache, img);
     return 1;
   }
   // and drop the lock again.
   dt_image_cache_read_release(darktable.image_cache, img);
-  prt->image_id = selected;
+  prt->image_id = imgid;
   return 0;
 }
 

--- a/src/views/slideshow.c
+++ b/src/views/slideshow.c
@@ -425,12 +425,11 @@ void enter(dt_view_t *self)
   }
 
   // if one selected start with it, otherwise start at the current lighttable offset
-  GList *selected = dt_collection_get_selected(darktable.collection, 1);
+  const int imgid = dt_view_get_image_to_act_on();
   gint selrank = -1;
 
-  if(selected)
+  if(imgid > 0)
   {
-    const gint selid = GPOINTER_TO_INT(selected->data);
     GList *imgids = dt_collection_get_all(darktable.collection, -1);
 
     GList *l = imgids;
@@ -438,15 +437,13 @@ void enter(dt_view_t *self)
     while(l)
     {
       const gint id = GPOINTER_TO_INT(l->data);
-      if(id == selid) break;
+      if(id == imgid) break;
       selrank++;
       l = g_list_next(l);
     }
 
     g_list_free(imgids);
   }
-
-  g_list_free(selected);
 
   d->buf[S_CURRENT].rank = selrank == -1 ? dt_thumbtable_get_offset(dt_ui_thumbtable(darktable.gui->ui)) : selrank;
   d->buf[S_LEFT].rank = d->buf[S_CURRENT].rank - 1;

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -888,7 +888,7 @@ GList *dt_view_get_images_to_act_on(gboolean only_visible)
 }
 
 // get the main image to act on during global changes (libs, accels)
-int dt_view_get_image_to_act_on2()
+int dt_view_get_image_to_act_on()
 {
   /** Here's how it works -- same as for list, except we don't care about mouse inside selection or table
    *

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -836,8 +836,11 @@ GList *dt_view_get_images_to_act_on(gboolean only_visible)
       if(inside_sel)
       {
         // collumn 1
-        DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1,
-                                    &stmt, NULL);
+        DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                    "SELECT m.imgid FROM memory.collected_images as m, main.selected_images as s "
+                                    "WHERE m.imgid=s.imgid "
+                                    "ORDER BY m.rowid",
+                                    -1, &stmt, NULL);
         while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
         {
           _images_to_act_on_insert_in_list(&l, sqlite3_column_int(stmt, 0), only_visible);
@@ -874,8 +877,11 @@ GList *dt_view_get_images_to_act_on(gboolean only_visible)
     {
       // collumn 4
       sqlite3_stmt *stmt;
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT imgid FROM main.selected_images", -1,
-                                  &stmt, NULL);
+      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                                  "SELECT m.imgid FROM memory.collected_images as m, main.selected_images as s "
+                                  "WHERE m.imgid=s.imgid "
+                                  "ORDER BY m.rowid",
+                                  -1, &stmt, NULL);
       while(stmt != NULL && sqlite3_step(stmt) == SQLITE_ROW)
       {
         _images_to_act_on_insert_in_list(&l, sqlite3_column_int(stmt, 0), only_visible);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -750,42 +750,6 @@ static inline void dt_view_draw_audio(cairo_t *cr, const float x, const float y,
   cairo_stroke(cr);
 }
 
-int32_t dt_view_get_image_to_act_on()
-{
-  // this works as follows:
-  // - if mouse hovers over an image, that's the one, except:
-  // - if images are selected and the mouse hovers over the selection,
-  //   in which case it affects the whole selection.
-  // - if the mouse is outside the center view (or no image hovered over otherwise)
-  //   it only affects the selection.
-  const int32_t mouse_over_id = dt_control_get_mouse_over_id();
-
-  const gboolean full_preview_mode
-      = darktable.view_manager->proxy.lighttable.get_preview_state(darktable.view_manager->proxy.lighttable.view);
-
-  const int layout = darktable.view_manager->proxy.lighttable.get_layout(
-      darktable.view_manager->proxy.lighttable.module);
-
-  if(full_preview_mode || layout == DT_LIGHTTABLE_LAYOUT_CULLING)
-  {
-    return mouse_over_id;
-  }
-  else
-  {
-    /* clear and reset statement */
-    DT_DEBUG_SQLITE3_CLEAR_BINDINGS(darktable.view_manager->statements.is_selected);
-    DT_DEBUG_SQLITE3_RESET(darktable.view_manager->statements.is_selected);
-
-    /* setup statement and iterate over rows */
-    DT_DEBUG_SQLITE3_BIND_INT(darktable.view_manager->statements.is_selected, 1, mouse_over_id);
-
-    if(mouse_over_id <= 0 || sqlite3_step(darktable.view_manager->statements.is_selected) == SQLITE_ROW)
-      return -1;
-    else
-      return mouse_over_id;
-  }
-}
-
 static int _images_to_act_on_find_custom(gconstpointer a, gconstpointer b)
 {
   return (GPOINTER_TO_INT(a) != GPOINTER_TO_INT(b));

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -190,7 +190,7 @@ typedef enum dt_view_image_over_t
 // get images to act on for gloabals change (via libs or accels)
 GList *dt_view_get_images_to_act_on(gboolean only_visible);
 // get the main image to act on during global changes (libs, accels)
-int dt_view_get_image_to_act_on2();
+int dt_view_get_image_to_act_on();
 
 /** guess the image_over flag assuming that all possible controls are displayed */
 dt_view_image_over_t dt_view_guess_image_over(int32_t width, int32_t height, int32_t zoom, int32_t px, int32_t py);

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -187,11 +187,6 @@ typedef enum dt_view_image_over_t
   DT_VIEW_END     = 10, // placeholder for the end of the list
 } dt_view_image_over_t;
 
-/** returns -1 if the action has to be applied to the selection,
-    or the imgid otherwise
-    TODO : remove it in profit of next functions*/
-int32_t dt_view_get_image_to_act_on();
-
 // get images to act on for gloabals change (via libs or accels)
 GList *dt_view_get_images_to_act_on(gboolean only_visible);
 // get the main image to act on during global changes (libs, accels)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -193,7 +193,7 @@ typedef enum dt_view_image_over_t
 int32_t dt_view_get_image_to_act_on();
 
 // get images to act on for gloabals change (via libs or accels)
-GList *dt_view_get_images_to_act_on();
+GList *dt_view_get_images_to_act_on(gboolean only_visible);
 // get the main image to act on during global changes (libs, accels)
 int dt_view_get_image_to_act_on2();
 


### PR DESCRIPTION
As said in some post here, that's the last part of my big lighttable (and a little more) rewrite.
fix #4292, fix #4669

### Why
The idea is to have an unique function to determine on which image we should act on and to use it everywhere, so the user experience is consistent.
There's 2 functions to do that : 
- `dt_view_get_images_to_act_on` (with an argument to say if we want "hidden because grouped" images or not) => we get a list of images
- `dt_view_get_image_to_act_on` => we get the first image to act on

### How they work
I just make a copy/paste of the comment in the code.
Note that active image(s) are the one(s) shown on the center view, except for lighttable filemanager/zoomable where there's none.
- `dt_view_get_images_to_act_on`
```
/** Here's how it works
   *
   *             mouse over| x | x | x |   |   |
   *     mouse inside table| x | x |   |   |   |
   * mouse inside selection| x |   |   |   |   |
   *          active images| ? | ? | x |   | x |
   *                       |   |   |   |   |   |
   *                       | S | O | O | S | A |
   *  S = selection ; O = mouseover ; A = active images
   *  the mouse can be outside thumbtable in case of filmstrip + mouse in center widget
   *
   *  if only_visible is FALSE, then it will add also not visible images because of grouping
   **/
```
- `dt_view_get_image_to_act_on`
```
/** Here's how it works -- same as for list, except we don't care about mouse inside selection or table
   *
   *             mouse over| x |   |   |
   *          active images| ? |   | x |
   *                       |   |   |   |
   *                       | O | S | A |
   *  First image of ...
   *  S = selection ; O = mouseover ; A = active images
   **/
```

### All images or only the visible ones ?
Here's the current (with this PR) state of different actions (I've try to keep the same behavior as before)
```
dt_control_gpx_apply_job_create     => visible
dt_control_time_offset_job_create   => visible
dt_control_copy_images              => all
dt_control_delete_images            => all
dt_control_duplicate_images         => visible
dt_control_flip_images              => visible
dt_control_merge_hdr                => visible
dt_control_refresh_exif             => all
dt_control_remove_images            => all
dt_control_reset_local_copy_images  => all
dt_control_set_local_copy_images    => all
dt_control_write_sidecar_files      => all
export                              => visible
LUA act_on_cb                       => all
metadata paste/clear                => all
history compress/delete/paste       => visible
lt styles create/apply              => visible
lt metadata                         => all
lt ratings/colorlabels              => all
```
Please stand up if you see some error, omission, or whatever...

### Other changes
- This is used too for views entering (darkroom, maps, print, slideshow)
- In the metadata lib, I've removed the "save on exit" because it was completely buggy even without my changes : the text is applied to the image hovered when you quit the lib... not what is expected at all !

### Finally : 
It would be great if we have lot of testers for this, as this is a delicate area.