### PR TITLE
export metadata fix - allow to export multiple values for the same category

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -981,6 +981,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // set up memory.darktable_iop_names table
   dt_iop_set_darktable_iop_table();
 
+  // set up the list of exiv2 metadata
+  dt_exif_set_exiv2_taglist();
+
   if(init_gui)
   {
 #ifdef HAVE_GPHOTO2

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -76,6 +76,9 @@ extern "C" {
 
 #define DT_XMP_EXIF_VERSION 4
 
+// persistent list of exiv2 tags. set up in dt_init()
+static GList *exiv2_taglist = NULL;
+
 static const char *_get_exiv2_type(const int type)
 {
   switch(type)
@@ -154,11 +157,12 @@ static void _get_xmp_tags(const char *prefix, GList **taglist)
   }
 }
 
-GList *dt_exif_get_exiv2_taglist()
+void dt_exif_set_exiv2_taglist()
 {
+  if(exiv2_taglist) return;
+
   Exiv2::XmpParser::initialize();
   ::atexit(Exiv2::XmpParser::terminate);
-  GList *taglist = NULL;
 
   try
   {
@@ -178,7 +182,7 @@ GList *dt_exif_get_exiv2_taglist()
           while(tagInfo->tag_ != 0xFFFF)
           {
             char *tag = dt_util_dstrcat(NULL, "Exif.%s.%s,%s", groupList->groupName_, tagInfo->name_, _get_exiv2_type(tagInfo->typeId_));
-            taglist = g_list_prepend(taglist, tag);
+            exiv2_taglist = g_list_prepend(exiv2_taglist, tag);
             tagInfo++;
           }
         }
@@ -190,7 +194,7 @@ GList *dt_exif_get_exiv2_taglist()
     while(iptcEnvelopeList->number_ != 0xFFFF)
     {
       char *tag = dt_util_dstrcat(NULL, "Iptc.Envelope.%s,%s", iptcEnvelopeList->name_, _get_exiv2_type(iptcEnvelopeList->type_));
-      taglist = g_list_prepend(taglist, tag);
+      exiv2_taglist = g_list_prepend(exiv2_taglist, tag);
       iptcEnvelopeList++;
     }
 
@@ -198,49 +202,73 @@ GList *dt_exif_get_exiv2_taglist()
     while(iptcApplication2List->number_ != 0xFFFF)
     {
       char *tag = dt_util_dstrcat(NULL, "Iptc.Application2.%s,%s", iptcApplication2List->name_, _get_exiv2_type(iptcApplication2List->type_));
-      taglist = g_list_prepend(taglist, tag);
+      exiv2_taglist = g_list_prepend(exiv2_taglist, tag);
       iptcApplication2List++;
     }
 
-    _get_xmp_tags("dc", &taglist);
-    _get_xmp_tags("xmp", &taglist);
-    _get_xmp_tags("xmpRights", &taglist);
-    _get_xmp_tags("xmpMM", &taglist);
-    _get_xmp_tags("xmpBJ", &taglist);
-    _get_xmp_tags("xmpTPg", &taglist);
-    _get_xmp_tags("xmpDM", &taglist);
-    _get_xmp_tags("pdf", &taglist);
-    _get_xmp_tags("photoshop", &taglist);
-    _get_xmp_tags("crs", &taglist);
-    _get_xmp_tags("tiff", &taglist);
-    _get_xmp_tags("exif", &taglist);
-    _get_xmp_tags("exifEX", &taglist);
-    _get_xmp_tags("aux", &taglist);
-    _get_xmp_tags("iptc", &taglist);
-    _get_xmp_tags("iptcExt", &taglist);
-    _get_xmp_tags("plus", &taglist);
-    _get_xmp_tags("mwg-rs", &taglist);
-    _get_xmp_tags("mwg-kw", &taglist);
-    _get_xmp_tags("dwc", &taglist);
-    _get_xmp_tags("dcterms", &taglist);
-    _get_xmp_tags("digiKam", &taglist);
-    _get_xmp_tags("kipi", &taglist);
-    _get_xmp_tags("GPano", &taglist);
-    _get_xmp_tags("lr", &taglist);
-    _get_xmp_tags("MP", &taglist);
-    _get_xmp_tags("MPRI", &taglist);
-    _get_xmp_tags("MPReg", &taglist);
-    _get_xmp_tags("acdsee", &taglist);
-    _get_xmp_tags("mediapro", &taglist);
-    _get_xmp_tags("expressionmedia", &taglist);
-    _get_xmp_tags("MicrosoftPhoto", &taglist);
+    _get_xmp_tags("dc", &exiv2_taglist);
+    _get_xmp_tags("xmp", &exiv2_taglist);
+    _get_xmp_tags("xmpRights", &exiv2_taglist);
+    _get_xmp_tags("xmpMM", &exiv2_taglist);
+    _get_xmp_tags("xmpBJ", &exiv2_taglist);
+    _get_xmp_tags("xmpTPg", &exiv2_taglist);
+    _get_xmp_tags("xmpDM", &exiv2_taglist);
+    _get_xmp_tags("pdf", &exiv2_taglist);
+    _get_xmp_tags("photoshop", &exiv2_taglist);
+    _get_xmp_tags("crs", &exiv2_taglist);
+    _get_xmp_tags("tiff", &exiv2_taglist);
+    _get_xmp_tags("exif", &exiv2_taglist);
+    _get_xmp_tags("exifEX", &exiv2_taglist);
+    _get_xmp_tags("aux", &exiv2_taglist);
+    _get_xmp_tags("iptc", &exiv2_taglist);
+    _get_xmp_tags("iptcExt", &exiv2_taglist);
+    _get_xmp_tags("plus", &exiv2_taglist);
+    _get_xmp_tags("mwg-rs", &exiv2_taglist);
+    _get_xmp_tags("mwg-kw", &exiv2_taglist);
+    _get_xmp_tags("dwc", &exiv2_taglist);
+    _get_xmp_tags("dcterms", &exiv2_taglist);
+    _get_xmp_tags("digiKam", &exiv2_taglist);
+    _get_xmp_tags("kipi", &exiv2_taglist);
+    _get_xmp_tags("GPano", &exiv2_taglist);
+    _get_xmp_tags("lr", &exiv2_taglist);
+    _get_xmp_tags("MP", &exiv2_taglist);
+    _get_xmp_tags("MPRI", &exiv2_taglist);
+    _get_xmp_tags("MPReg", &exiv2_taglist);
+    _get_xmp_tags("acdsee", &exiv2_taglist);
+    _get_xmp_tags("mediapro", &exiv2_taglist);
+    _get_xmp_tags("expressionmedia", &exiv2_taglist);
+    _get_xmp_tags("MicrosoftPhoto", &exiv2_taglist);
   }
   catch (Exiv2::AnyError& e)
   {
     std::string s(e.what());
     std::cerr << "[exiv2 taglist] " << s << std::endl;
   }
-  return taglist;
+}
+
+const GList * const dt_exif_get_exiv2_taglist()
+{
+  if(!exiv2_taglist)
+    dt_exif_set_exiv2_taglist();
+  return exiv2_taglist;
+}
+
+static const char *_exif_get_exiv2_tag_type(const char *tagname)
+{
+  if(!tagname) return NULL;
+  GList *tag = exiv2_taglist;
+  while(tag)
+  {
+    char *t = (char *)tag->data;
+    if(g_str_has_prefix(t, tagname) && t[strlen(tagname)] == ',')
+    if(t)
+    {
+      t += strlen(tagname) + 1;
+      return t;
+    }
+    tag = g_list_next(tag);
+  }
+  return NULL;
 }
 
 // exiv2's readMetadata is not thread safe in 0.26. so we lock it. since readMetadata might throw an exception we
@@ -3844,6 +3872,7 @@ int dt_exif_xmp_attach_export(const int imgid, const char *filename, void *metad
         {
           if(!(m->flags & DT_META_EXIF) && (formula[0] == '=') && g_str_has_prefix(tagname, "Exif."))
           {
+            // remove this specific exif
             Exiv2::ExifData::const_iterator pos;
             if(dt_exif_read_exif_tag(exifOldData, &pos, tagname))
             {
@@ -3856,7 +3885,23 @@ int dt_exif_xmp_attach_export(const int imgid, const char *filename, void *metad
             if(result && result[0])
             {
               if(g_str_has_prefix(tagname, "Xmp."))
+              {
+                const char *type = _exif_get_exiv2_tag_type(tagname);
+                // if xmpBag or xmpSeq, split the list when necessary
+                // else provide the string as is (can be a list of strings)
+                if(!g_strcmp0(type, "XmpBag") || !g_strcmp0(type, "XmpSeq"))
+                {
+                  char *tuple = g_strrstr(result, ",");
+                  while(tuple)
+                  {
+                    tuple[0] = '\0';
+                    tuple++;
+                    xmpData[tagname] = tuple;
+                    tuple = g_strrstr(result, ",");
+                  }
+                }
                 xmpData[tagname] = result;
+              }
               else if(g_str_has_prefix(tagname, "Iptc."))
                 iptcData[tagname] = result;
               else if(g_str_has_prefix(tagname, "Exif."))

--- a/src/common/exif.h
+++ b/src/common/exif.h
@@ -26,8 +26,12 @@
 extern "C" {
 #endif
 
+/** set the list of available tags from Exvi2 */
+void dt_exif_set_exiv2_taglist();
+
 /** get the list of available tags from Exvi2 */
-GList *dt_exif_get_exiv2_taglist();
+/** must not be freed */
+const GList * const dt_exif_get_exiv2_taglist();
 
 /** read metadata from file with full path name, XMP data trumps IPTC data trumps EXIF data, store to image
  * struct. returns 0 on success. */

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -1643,11 +1643,11 @@ ssize_t dt_tag_export(const char *filename)
   return count;
 }
 
-char *dt_tag_get_subtag(const gint imgid, const char *category, const int level)
+char *dt_tag_get_subtags(const gint imgid, const char *category, const int level)
 {
   if (!category) return NULL;
   const guint rootnb = dt_util_string_count_char(category, '|');
-  char *result = NULL;
+  char *tags = NULL;
   sqlite3_stmt *stmt;
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
           "SELECT DISTINCT T.name FROM main.tagged_images AS I "
@@ -1664,13 +1664,14 @@ char *dt_tag_get_subtag(const gint imgid, const char *category, const int level)
     if (tagnb >= rootnb + level)
     {
       gchar **pch = g_strsplit(tag, "|", -1);
-      result = g_strdup(pch[rootnb + level]);
+      char *subtag = pch[rootnb + level];
+      tags = dt_util_dstrcat(tags, "%s,", subtag);
       g_strfreev(pch);
-      break;
     }
   }
+  if(tags) tags[strlen(tags) - 1] = '\0'; // remove the last comma
   sqlite3_finalize(stmt);
-  return result;
+  return tags;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -189,8 +189,8 @@ uint32_t dt_selected_images_count();
 /** get number of images affected with that tag */
 uint32_t dt_tag_images_count(gint tagid);
 
-/** retrieves the subtag of requested level for the requested category */
-char *dt_tag_get_subtag(const gint imgid, const char *category, const int level);
+/** retrieves the subtags of requested level for the requested category */
+char *dt_tag_get_subtags(const gint imgid, const char *category, const int level);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -477,7 +477,7 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
           end[0] = '|';
           end[1] = '\0';
           (*variable) += strlen(category) + 1;
-          char *tag = dt_tag_get_subtag(params->imgid, category, (int)level);
+          char *tag = dt_tag_get_subtags(params->imgid, category, (int)level);
           if (tag)
           {
             result = g_strdup(tag);

--- a/src/libs/export_metadata.c
+++ b/src/libs/export_metadata.c
@@ -373,7 +373,7 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
   gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(liststore), DT_LIB_EXPORT_METADATA_COL_XMP, GTK_SORT_ASCENDING);
   gtk_tree_view_set_model(view, GTK_TREE_MODEL(liststore));
   g_object_unref(liststore);
-  d->taglist = dt_exif_get_exiv2_taglist();
+  d->taglist = (GList *)dt_exif_get_exiv2_taglist();
   GList *list = dt_util_str_to_glist("\1", metadata_presets);
   int32_t flags = 0;
   if (list)
@@ -462,7 +462,6 @@ char *dt_lib_export_metadata_configuration_dialog(char *metadata_presets, const 
     g_free(metadata_presets);
     dt_lib_export_metadata_set_conf(newlist);
   }
-  g_list_free_full(d->taglist, g_free);
   gtk_widget_destroy(dialog);
   free(d);
   return newlist;


### PR DESCRIPTION
fixes #4964 

When an image is tagged with several people the list of people can be exported into a single tag.
If the tag is an xmpBag or an xmpSeq the values are added separately.
If not, an xmpText or a string for example, the values are added as a single string with different values comma separated.

@TurboGit, the exiv2 tags list is now a permanent list. Please tell me if there is better way to implement this.


