### PR TITLE
lua - generic metadata

### DIFF
--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -33,6 +33,7 @@
 //    Must match with dt_metadata_t in metadata.h.
 //    Exif.cc: add the new metadata into dt_xmp_keys[]
 //    libs/metadata.c increment version and change legacy_param() accordingly
+// CAUTION : key, subkey (last term of key) & name must be unique
 
 static const struct
 {
@@ -115,6 +116,30 @@ const char *dt_metadata_get_key(const uint32_t keyid)
     return dt_metadata_def[keyid].key;
   else
     return NULL;
+}
+
+const char *dt_metadata_get_subkey(const uint32_t keyid)
+{
+  if(keyid < DT_METADATA_NUMBER)
+  {
+    char *t = g_strrstr(dt_metadata_def[keyid].key, ".");
+    if(t) return t + 1;
+  }
+  return NULL;
+}
+
+const char *dt_metadata_get_key_by_subkey(const char *subkey)
+{
+  if(subkey)
+  {
+    for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+    {
+      char *t = g_strrstr(dt_metadata_def[i].key, ".");
+      if(t && !g_strcmp0(t + 1, subkey))
+        return dt_metadata_def[i].key;
+    }
+  }
+  return NULL;
 }
 
 const int dt_metadata_get_type(const uint32_t keyid)

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -79,6 +79,12 @@ const dt_metadata_t dt_metadata_get_keyid(const char* key);
 /** return the key of the metadata keyid */
 const char *dt_metadata_get_key(const uint32_t keyid);
 
+/** return the metadata subeky of the metadata keyid */
+const char *dt_metadata_get_subkey(const uint32_t keyid);
+
+/** return the key of the metadata subkey */
+const char *dt_metadata_get_key_by_subkey(const char *subkey);
+
 /** return the type of the metadata keyid */
 const int dt_metadata_get_type(const uint32_t keyid);
 


### PR DESCRIPTION
Following this [discussion](https://github.com/darktable-org/darktable/pull/4194#issuecomment-626341505) with @GLLM it appears that new metadata are missing from lua. 

This PR should solves this issue but I'm unable to test it ... Once again @wpferguson can I ask you to check this change works from lua standpoint.
The old metadata, `title`, `description`, `rights`, `creator`, `publisher` plus the new ones, `notes` and `version name` should be readable/writable from lua.

Thanks in advance


