### PR TITLE
add new function dt_toast_log for accels and opacity

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1965,7 +1965,7 @@ radiobutton radio
 }
 
 /* Messages shown on bottom middle of the UI. For example "loading image..." or "working on..." ones */
-#log-msg
+#log-msg, #toast-msg
 {
   color: @log_fg_color;
   font-size: 1em;
@@ -1973,4 +1973,9 @@ radiobutton radio
   background-color: @log_bg_color;
   padding: 8px 20px 4px 20px;
   border-radius: 14px;
+}
+
+#toast-msg
+{
+   background-color: rgba(25,25,25,0.6);
 }

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -57,6 +57,11 @@ void dt_control_init(dt_control_t *s)
   s->log_message_timeout_id = 0;
   dt_pthread_mutex_init(&(s->log_mutex), NULL);
 
+  s->toast_pos = s->toast_ack = 0;
+  s->toast_busy = 0;
+  s->toast_message_timeout_id = 0;
+  dt_pthread_mutex_init(&(s->toast_mutex), NULL);
+
   pthread_cond_init(&s->cond, NULL);
   dt_pthread_mutex_init(&s->cond_mutex, NULL);
   dt_pthread_mutex_init(&s->queue_mutex, NULL);
@@ -173,6 +178,7 @@ void dt_control_cleanup(dt_control_t *s)
   dt_pthread_mutex_destroy(&s->queue_mutex);
   dt_pthread_mutex_destroy(&s->cond_mutex);
   dt_pthread_mutex_destroy(&s->log_mutex);
+  dt_pthread_mutex_destroy(&s->toast_mutex);
   dt_pthread_mutex_destroy(&s->res_mutex);
   dt_pthread_mutex_destroy(&s->run_mutex);
   dt_pthread_mutex_destroy(&s->progress_system.mutex);
@@ -381,6 +387,16 @@ static gboolean _dt_ctl_log_message_timeout_callback(gpointer data)
   return FALSE;
 }
 
+static gboolean _dt_ctl_toast_message_timeout_callback(gpointer data)
+{
+  dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  if(darktable.control->toast_ack != darktable.control->toast_pos)
+    darktable.control->toast_ack = (darktable.control->toast_ack + 1) % DT_CTL_TOAST_SIZE;
+  darktable.control->toast_message_timeout_id = 0;
+  dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
+  dt_control_toast_redraw();
+  return FALSE;
+}
 
 void dt_control_button_pressed(double x, double y, double pressure, int which, int type, uint32_t state)
 {
@@ -411,6 +427,22 @@ void dt_control_button_pressed(double x, double y, double pressure, int which, i
     }
   dt_pthread_mutex_unlock(&darktable.control->log_mutex);
 
+  // ack toast message:
+  dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  if(darktable.control->toast_ack != darktable.control->toast_pos)
+    if(which == 1 /*&& x > xc - 10 && x < xc + 10*/ && y > yc - 10 && y < yc + 10)
+    {
+      if(darktable.control->toast_message_timeout_id)
+      {
+        g_source_remove(darktable.control->toast_message_timeout_id);
+        darktable.control->toast_message_timeout_id = 0;
+      }
+      darktable.control->toast_ack = (darktable.control->toast_ack + 1) % DT_CTL_TOAST_SIZE;
+      dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
+      return;
+    }
+  dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
+
   if(!dt_view_manager_button_pressed(darktable.view_manager, x, y, pressure, which, type, state))
     if(type == GDK_2BUTTON_PRESS && which == 1) dt_ctl_switch_mode();
 }
@@ -418,6 +450,7 @@ void dt_control_button_pressed(double x, double y, double pressure, int which, i
 static gboolean _redraw_center(gpointer user_data)
 {
   dt_control_log_redraw();
+  dt_control_toast_redraw();
   return FALSE; // don't call this again
 }
 
@@ -438,6 +471,23 @@ void dt_control_log(const char *msg, ...)
   g_idle_add(_redraw_center, 0);
 }
 
+void dt_toast_log(const char *msg, ...)
+{
+  dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  va_list ap;
+  va_start(ap, msg);
+  vsnprintf(darktable.control->toast_message[darktable.control->toast_pos], DT_CTL_TOAST_MSG_SIZE, msg, ap);
+  va_end(ap);
+  if(darktable.control->toast_message_timeout_id) g_source_remove(darktable.control->toast_message_timeout_id);
+  darktable.control->toast_ack = darktable.control->toast_pos;
+  darktable.control->toast_pos = (darktable.control->toast_pos + 1) % DT_CTL_TOAST_SIZE;
+  darktable.control->toast_message_timeout_id
+      = g_timeout_add(DT_CTL_TOAST_TIMEOUT, _dt_ctl_toast_message_timeout_callback, NULL);
+  dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
+  // redraw center later in gui thread:
+  g_idle_add(_redraw_center, 0);
+}
+
 static void dt_control_log_ack_all()
 {
   dt_pthread_mutex_lock(&darktable.control->log_mutex);
@@ -453,11 +503,27 @@ void dt_control_log_busy_enter()
   dt_pthread_mutex_unlock(&darktable.control->log_mutex);
 }
 
+void dt_control_toast_busy_enter()
+{
+  dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  darktable.control->toast_busy++;
+  dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
+}
+
 void dt_control_log_busy_leave()
 {
   dt_pthread_mutex_lock(&darktable.control->log_mutex);
   darktable.control->log_busy--;
   dt_pthread_mutex_unlock(&darktable.control->log_mutex);
+  /* lets redraw */
+  dt_control_queue_redraw_center();
+}
+
+void dt_control_toast_busy_leave()
+{
+  dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  darktable.control->toast_busy--;
+  dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
   /* lets redraw */
   dt_control_queue_redraw_center();
 }
@@ -480,6 +546,11 @@ void dt_control_navigation_redraw()
 void dt_control_log_redraw()
 {
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_CONTROL_LOG_REDRAW);
+}
+
+void dt_control_toast_redraw()
+{
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
 }
 
 static gboolean _gtk_widget_queue_draw(gpointer user_data)

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -57,8 +57,11 @@ int dt_control_key_released(guint key, guint state);
 int dt_control_key_pressed_override(guint key, guint state);
 gboolean dt_control_configure(GtkWidget *da, GdkEventConfigure *event, gpointer user_data);
 void dt_control_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
+void dt_toast_log(const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void dt_control_log_busy_enter();
+void dt_control_toast_busy_enter();
 void dt_control_log_busy_leave();
+void dt_control_toast_busy_leave();
 // disable the possibility to change the cursor shape with dt_control_change_cursor
 void dt_control_forbid_change_cursor();
 // enable the possibility to change the cursor shape with dt_control_change_cursor
@@ -96,6 +99,11 @@ void dt_control_navigation_redraw();
  */
 void dt_control_log_redraw();
 
+/** \brief request redraw of the toast widget.
+    This redraws the message label.
+ */
+void dt_control_toast_redraw();
+
 void dt_ctl_switch_mode();
 void dt_ctl_switch_mode_to(const char *mode);
 void dt_ctl_switch_mode_to_by_view(const dt_view_t *view);
@@ -127,6 +135,9 @@ typedef struct dt_control_accels_t
 #define DT_CTL_LOG_SIZE 10
 #define DT_CTL_LOG_MSG_SIZE 200
 #define DT_CTL_LOG_TIMEOUT 5000
+#define DT_CTL_TOAST_SIZE 10
+#define DT_CTL_TOAST_MSG_SIZE 200
+#define DT_CTL_TOAST_TIMEOUT 1500
 /**
  * this manages everything time-consuming.
  * distributes the jobs on all processors,
@@ -174,6 +185,13 @@ typedef struct dt_control_t
   guint log_message_timeout_id;
   int log_busy;
   dt_pthread_mutex_t log_mutex;
+
+  // toast log
+  int toast_pos, toast_ack;
+  char toast_message[DT_CTL_TOAST_SIZE][DT_CTL_TOAST_MSG_SIZE];
+  guint toast_message_timeout_id;
+  int toast_busy;
+  dt_pthread_mutex_t toast_mutex;
 
   // gui settings
   dt_pthread_mutex_t global_mutex, image_mutex;

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -157,6 +157,9 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   { "dt-control-log-redraw", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_CONTROL_LOG_REDRAW
 
+  { "dt-control-toast-redraw", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
+    FALSE }, // DT_SIGNAL_CONTROL_TOAST_REDRAW
+
   { "dt-control-pickerdata-ready", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL,
     FALSE }, // DT_SIGNAL_CONTROL_PICKERDATA_REAEDY
 

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -217,6 +217,11 @@ typedef enum dt_signal_t
   */
   DT_SIGNAL_CONTROL_LOG_REDRAW,
 
+  /** \brief This signal is raised when dt_control_toast_redraw() is called.
+    no param, no returned value
+  */
+  DT_SIGNAL_CONTROL_TOAST_REDRAW,
+
   /** \brief This signal is raised when new color picker data are available in the pixelpipe.
     1 module
     2 piece

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -304,6 +304,7 @@ void dt_dev_process_preview_job(dt_develop_t *dev)
   }
 
   dt_control_log_busy_enter();
+  dt_control_toast_busy_enter();
   dev->preview_pipe->input_timestamp = dev->timestamp;
   dev->preview_status = DT_DEV_PIXELPIPE_RUNNING;
 
@@ -314,6 +315,7 @@ void dt_dev_process_preview_job(dt_develop_t *dev)
   if(!buf.buf)
   {
     dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
     dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
     dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
     return; // not loaded yet. load will issue a gtk redraw on completion, which in turn will trigger us again
@@ -342,6 +344,7 @@ restart:
   if(dev->gui_leaving)
   {
     dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
     dev->preview_status = DT_DEV_PIXELPIPE_INVALID;
     dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
     dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -359,6 +362,7 @@ restart:
     if(dev->preview_loading || dev->preview_input_changed)
     {
       dt_control_log_busy_leave();
+      dt_control_toast_busy_leave();
       dev->preview_status = DT_DEV_PIXELPIPE_INVALID;
       dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
       dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -375,6 +379,7 @@ restart:
 
   // if a widget needs to be redraw there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_log_busy_leave();
+  dt_control_toast_busy_leave();
   dt_pthread_mutex_unlock(&dev->preview_pipe_mutex);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 
@@ -403,6 +408,7 @@ void dt_dev_process_preview2_job(dt_develop_t *dev)
   }
 
   dt_control_log_busy_enter();
+  dt_control_toast_busy_enter();
   dev->preview2_pipe->input_timestamp = dev->timestamp;
   dev->preview2_status = DT_DEV_PIXELPIPE_RUNNING;
 
@@ -413,6 +419,7 @@ void dt_dev_process_preview2_job(dt_develop_t *dev)
   if(!buf.buf)
   {
     dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
     dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
     dt_pthread_mutex_unlock(&dev->preview2_pipe_mutex);
     return; // not loaded yet. load will issue a gtk redraw on completion, which in turn will trigger us again
@@ -441,6 +448,7 @@ restart:
   if(dev->gui_leaving)
   {
     dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
     dev->preview2_status = DT_DEV_PIXELPIPE_INVALID;
     dt_pthread_mutex_unlock(&dev->preview2_pipe_mutex);
     dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -487,6 +495,7 @@ restart:
     if(dev->preview2_loading || dev->preview2_input_changed)
     {
       dt_control_log_busy_leave();
+      dt_control_toast_busy_leave();
       dev->preview2_status = DT_DEV_PIXELPIPE_INVALID;
       dt_pthread_mutex_unlock(&dev->preview2_pipe_mutex);
       dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
@@ -506,6 +515,7 @@ restart:
   dt_dev_average_delay_update(&start, &dev->preview2_average_delay);
 
   dt_control_log_busy_leave();
+  dt_control_toast_busy_leave();
   dt_pthread_mutex_unlock(&dev->preview2_pipe_mutex);
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
 
@@ -523,6 +533,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
   }
 
   dt_control_log_busy_enter();
+  dt_control_toast_busy_enter();
   // let gui know to draw preview instead of us, if it's there:
   dev->image_status = DT_DEV_PIXELPIPE_RUNNING;
 
@@ -537,6 +548,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
   if(!buf.buf)
   {
     dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
     dev->image_status = DT_DEV_PIXELPIPE_DIRTY;
     dt_pthread_mutex_unlock(&dev->pipe_mutex);
     return;
@@ -576,6 +588,7 @@ restart:
   {
     dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
     dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
     dev->image_status = DT_DEV_PIXELPIPE_INVALID;
     dt_pthread_mutex_unlock(&dev->pipe_mutex);
     return;
@@ -621,6 +634,7 @@ restart:
     {
       dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
       dt_control_log_busy_leave();
+      dt_control_toast_busy_leave();
       dev->image_status = DT_DEV_PIXELPIPE_INVALID;
       dt_pthread_mutex_unlock(&dev->pipe_mutex);
       return;
@@ -646,6 +660,7 @@ restart:
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
   // if a widget needs to be redraw there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_log_busy_leave();
+  dt_control_toast_busy_leave();
   dt_pthread_mutex_unlock(&dev->pipe_mutex);
 
   if(dev->gui_attached && !dev->gui_leaving)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1727,6 +1727,8 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
 
       opacity = CLAMP(opacity + amount, 0.05f, 1.0f);
       dt_conf_set_float("plugins/darkroom/masks/opacity", opacity);
+      const int opacitypercent = opacity * 100;
+      dt_toast_log(_("opacity: %d%%"), opacitypercent);
     }
 
     _set_hinter_message(gui, form);
@@ -2409,6 +2411,8 @@ void dt_masks_form_change_opacity(dt_masks_form_t *form, int parentid, int up)
     {
       const float opacity = CLAMP(fpt->opacity + amount, 0.05f, 1.0f);
       fpt->opacity = opacity;
+      const int opacitypercent = opacity * 100;
+      dt_toast_log(_("opacity: %d%%"), opacitypercent);
       dt_dev_add_masks_history_item(darktable.develop, NULL, TRUE);
       dt_masks_update_image(darktable.develop);
       break;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1793,6 +1793,8 @@ void dt_thumbtable_set_parent(dt_thumbtable_t *table, GtkWidget *new_parent, dt_
       {
         gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
                                     gtk_widget_get_parent(dt_ui_log_msg(darktable.gui->ui)), -1);
+        gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
+                                    gtk_widget_get_parent(dt_ui_toast_msg(darktable.gui->ui)), -1);
       }
     }
     else

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -572,20 +572,20 @@ void dt_accel_widget_toast(GtkWidget *widget)
       if(w->label[0] != '\0')
       { // label is not empty
         if(w->module && w->module->multi_name[0] != '\0')
-          dt_control_log(_("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, text);
+          dt_toast_log(_("%s %s / %s: %s"), w->module->name(), w->module->multi_name, w->label, text);
         else if(w->module && !strstr(w->module->name(), w->label))
-          dt_control_log(_("%s / %s: %s"), w->module->name(), w->label, text);
+          dt_toast_log(_("%s / %s: %s"), w->module->name(), w->label, text);
         else
-          dt_control_log(_("%s: %s"), w->label, text);
+          dt_toast_log(_("%s: %s"), w->label, text);
       }
       else
       { //label is empty
         if(w->module && w->module->multi_name[0] != '\0')
-          dt_control_log(_("%s %s / %s"), w->module->name(), w->module->multi_name, text);
+          dt_toast_log(_("%s %s / %s"), w->module->name(), w->module->multi_name, text);
         else if(w->module)
-          dt_control_log(_("%s / %s"), w->module->name(), text);
+          dt_toast_log(_("%s / %s"), w->module->name(), text);
         else
-          dt_control_log(_("%s"), text);
+          dt_toast_log(_("%s"), text);
       }
     }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -95,8 +95,8 @@ typedef struct dt_ui_t
   /* thumb table */
   dt_thumbtable_t *thumbtable;
 
-  /* log msg label */
-  GtkWidget *log_msg;
+  /* log msg and toast labels */
+  GtkWidget *log_msg, *toast_msg;
 } dt_ui_t;
 
 /* initialize the whole left panel */
@@ -121,6 +121,7 @@ static void _ui_init_panel_bottom(dt_ui_t *ui, GtkWidget *container);
 static void _ui_widget_redraw_callback(gpointer instance, GtkWidget *widget);
 /* callback for redraw log signals */
 static void _ui_log_redraw_callback(gpointer instance, GtkWidget *widget);
+static void _ui_toast_redraw_callback(gpointer instance, GtkWidget *widget);
 
 /* Set the HiDPI stuff */
 static void configure_ppd_dpi(dt_gui_gtk_t *gui);
@@ -1517,6 +1518,12 @@ static gboolean _ui_log_button_press_event(GtkWidget *widget, GdkEvent *event, g
   return TRUE;
 }
 
+static gboolean _ui_toast_button_press_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)
+{
+  gtk_widget_hide(GTK_WIDGET(user_data));
+  return TRUE;
+}
+
 static void init_widgets(dt_gui_gtk_t *gui)
 {
 
@@ -1585,6 +1592,7 @@ static void init_widgets(dt_gui_gtk_t *gui)
   gtk_widget_show_all(dt_ui_main_window(gui->ui));
 
   gtk_widget_set_visible(dt_ui_log_msg(gui->ui), FALSE);
+  gtk_widget_set_visible(dt_ui_toast_msg(gui->ui), FALSE);
   gtk_widget_set_visible(gui->scrollbars.hscrollbar, FALSE);
   gtk_widget_set_visible(gui->scrollbars.vscrollbar, FALSE);
 
@@ -1689,6 +1697,20 @@ static void init_main_table(GtkWidget *container)
   gtk_widget_set_halign(eb, GTK_ALIGN_CENTER);
   gtk_overlay_add_overlay(GTK_OVERLAY(ocda), eb);
 
+  /* the toast message */
+  eb = gtk_event_box_new();
+  darktable.gui->ui->toast_msg = gtk_label_new("");
+  g_signal_connect(G_OBJECT(eb), "button-press-event", G_CALLBACK(_ui_toast_button_press_event),
+                   darktable.gui->ui->toast_msg);
+  gtk_widget_set_events(eb, GDK_BUTTON_PRESS_MASK | darktable.gui->scroll_mask);
+  g_signal_connect(G_OBJECT(eb), "scroll-event", G_CALLBACK(scrolled), NULL);
+  gtk_label_set_ellipsize(GTK_LABEL(darktable.gui->ui->toast_msg), PANGO_ELLIPSIZE_MIDDLE);
+  gtk_widget_set_name(darktable.gui->ui->toast_msg, "toast-msg");
+  gtk_container_add(GTK_CONTAINER(eb), darktable.gui->ui->toast_msg);
+  gtk_widget_set_valign(eb, GTK_ALIGN_START);
+  gtk_widget_set_halign(eb, GTK_ALIGN_CENTER);
+  gtk_overlay_add_overlay(GTK_OVERLAY(ocda), eb);
+
   /* center should redraw when signal redraw center is raised*/
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_REDRAW_CENTER,
                             G_CALLBACK(_ui_widget_redraw_callback), darktable.gui->ui->center);
@@ -1696,6 +1718,10 @@ static void init_main_table(GtkWidget *container)
   /* update log message label */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_LOG_REDRAW, G_CALLBACK(_ui_log_redraw_callback),
                             darktable.gui->ui->log_msg);
+
+  /* update toast message label */
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW, G_CALLBACK(_ui_toast_redraw_callback),
+                            darktable.gui->ui->toast_msg);
 
   // Adding the scrollbars
   GtkWidget *vscrollBar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, NULL);
@@ -2029,6 +2055,10 @@ dt_thumbtable_t *dt_ui_thumbtable(struct dt_ui_t *ui)
 GtkWidget *dt_ui_log_msg(struct dt_ui_t *ui)
 {
   return ui->log_msg;
+}
+GtkWidget *dt_ui_toast_msg(struct dt_ui_t *ui)
+{
+  return ui->toast_msg;
 }
 
 GtkWidget *dt_ui_main_window(dt_ui_t *ui)
@@ -2465,6 +2495,28 @@ static void _ui_log_redraw_callback(gpointer instance, GtkWidget *widget)
     if(gtk_widget_get_visible(widget)) gtk_widget_hide(widget);
   }
   dt_pthread_mutex_unlock(&darktable.control->log_mutex);
+}
+
+static void _ui_toast_redraw_callback(gpointer instance, GtkWidget *widget)
+{
+  // draw toast message, if any
+  dt_pthread_mutex_lock(&darktable.control->toast_mutex);
+  if(darktable.control->toast_ack != darktable.control->toast_pos)
+  {
+    if(strcmp(darktable.control->toast_message[darktable.control->toast_ack], gtk_label_get_text(GTK_LABEL(widget))))
+      gtk_label_set_text(GTK_LABEL(widget), darktable.control->toast_message[darktable.control->toast_ack]);
+    if(!gtk_widget_get_visible(widget))
+    {
+      const int h = gtk_widget_get_allocated_height(dt_ui_center_base(darktable.gui->ui));
+      gtk_widget_set_margin_bottom(gtk_widget_get_parent(widget), 0.15 * h - DT_PIXEL_APPLY_DPI(10));
+      gtk_widget_show(widget);
+    }
+  }
+  else
+  {
+    if(gtk_widget_get_visible(widget)) gtk_widget_hide(widget);
+  }
+  dt_pthread_mutex_unlock(&darktable.control->toast_mutex);
 }
 
 void dt_ellipsize_combo(GtkComboBox *cbox)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -323,6 +323,8 @@ GtkWidget *dt_ui_main_window(struct dt_ui_t *ui);
 struct dt_thumbtable_t *dt_ui_thumbtable(struct dt_ui_t *ui);
 /** \brief get the log message widget */
 GtkWidget *dt_ui_log_msg(struct dt_ui_t *ui);
+/** \brief get the toast message widget */
+GtkWidget *dt_ui_toast_msg(struct dt_ui_t *ui);
 
 GtkBox *dt_ui_get_container(struct dt_ui_t *ui, const dt_ui_container_t c);
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -185,7 +185,11 @@ static void _lib_duplicate_thumb_release_callback(GtkWidget *widget, GdkEventBut
   dt_lib_duplicate_t *d = (dt_lib_duplicate_t *)self->data;
 
   d->imgid = 0;
-  if(d->busy) dt_control_log_busy_leave();
+  if(d->busy) 
+  {
+    dt_control_log_busy_leave();
+    dt_control_toast_busy_leave();
+  }
   d->busy = FALSE;
   dt_control_queue_redraw_center();
 }
@@ -261,12 +265,20 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
 
   if(res)
   {
-    if(!d->busy) dt_control_log_busy_enter();
+    if(!d->busy)
+    {
+      dt_control_log_busy_enter();
+      dt_control_toast_busy_enter();
+    }
     d->busy = TRUE;
   }
   else
   {
-    if(d->busy) dt_control_log_busy_leave();
+    if(d->busy) 
+    {
+      dt_control_log_busy_leave();
+      dt_control_toast_busy_leave();
+    }
     d->busy = FALSE;
   }
 }

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -1184,6 +1184,8 @@ void gui_init(dt_view_t *self)
   gtk_overlay_add_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)), lib->preview->widget);
   gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
                               gtk_widget_get_parent(dt_ui_log_msg(darktable.gui->ui)), -1);
+  gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
+                              gtk_widget_get_parent(dt_ui_toast_msg(darktable.gui->ui)), -1);
   // create display profile button
   GtkWidget *const profile_button = dtgtk_button_new(dtgtk_cairo_paint_display, CPF_STYLE_FLAT,
                                                      NULL);

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -852,6 +852,8 @@ void enter(dt_view_t *self)
   // ensure the log msg widget stay on top
   gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
                               gtk_widget_get_parent(dt_ui_log_msg(darktable.gui->ui)), -1);
+  gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
+                              gtk_widget_get_parent(dt_ui_toast_msg(darktable.gui->ui)), -1);
 
   gtk_widget_show_all(GTK_WIDGET(lib->map));
 

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -466,6 +466,8 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
   // update log visibility
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_CONTROL_LOG_REDRAW);
 
+  // update toast visibility
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_CONTROL_TOAST_REDRAW);
   return 0;
 }
 


### PR DESCRIPTION
adds a new function dt_toast_log that replaces dt_control_log for
messages that need to display briefly (e.g. dynamic accelerators)

show mask opacity using new function when amended with CTRL+Scroll as
well as when changing sliders and comboboxes with keyboard shortcuts