### PR TITLE
Prefer original filename while importing to allow correct grouping

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -847,6 +847,14 @@
   </dtconfig>
 
   <dtconfig prefs="import" section="session">
+    <name>session/use_filename</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>keep original filename</shortdescription>
+    <longdescription>keep original filename instead of a pattern while importing from camera or card</longdescription>
+  </dtconfig>
+
+  <dtconfig prefs="import" section="session">
     <name>session/filename_pattern</name>
     <type>string</type>
     <default>$(YEAR)$(MONTH)$(DAY)_$(SEQUENCE).$(FILE_EXTENSION)</default>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -849,7 +849,7 @@
   <dtconfig prefs="import" section="session">
     <name>session/use_filename</name>
     <type>bool</type>
-    <default>true</default>
+    <default>false</default>
     <shortdescription>keep original filename</shortdescription>
     <longdescription>keep original filename instead of a pattern while importing from camera or card</longdescription>
   </dtconfig>

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -230,18 +230,20 @@ const char *dt_import_session_name(struct dt_import_session_t *self)
   return self->vp->jobcode;
 }
 
-
+/* This returns a unique filename using session path **and** the filename.
+   If current is true we will use the original filename otherwise use the pattern.
+*/
 const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean current)
 {
   const char *path;
   char *fname, *previous_fname;
   char *pattern;
-
-  if(current && self->current_filename != NULL) return self->current_filename;
+  gchar *result_fname;
 
   /* expand next filename */
   g_free((void *)self->current_filename);
   self->current_filename = NULL;
+
   pattern = _import_session_filename_pattern();
   if(pattern == NULL)
   {
@@ -251,7 +253,12 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
 
   /* verify that expanded path and filename yields a unique file */
   path = dt_import_session_path(self, TRUE);
-  gchar *result_fname = dt_variables_expand(self->vp, pattern, TRUE);
+
+  if(current)
+    result_fname = g_strdup(self->vp->filename);
+  else
+    result_fname = dt_variables_expand(self->vp, pattern, TRUE);
+
   previous_fname = fname = g_build_path(G_DIR_SEPARATOR_S, path, result_fname, (char *)NULL);
   if(g_file_test(fname, G_FILE_TEST_EXISTS) == TRUE)
   {

--- a/src/common/import_session.c
+++ b/src/common/import_session.c
@@ -233,7 +233,7 @@ const char *dt_import_session_name(struct dt_import_session_t *self)
 /* This returns a unique filename using session path **and** the filename.
    If current is true we will use the original filename otherwise use the pattern.
 */
-const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean current)
+const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean use_filename)
 {
   const char *path;
   char *fname, *previous_fname;
@@ -254,7 +254,7 @@ const char *dt_import_session_filename(struct dt_import_session_t *self, gboolea
   /* verify that expanded path and filename yields a unique file */
   path = dt_import_session_path(self, TRUE);
 
-  if(current)
+  if(use_filename)
     result_fname = g_strdup(self->vp->filename);
   else
     result_fname = dt_variables_expand(self->vp, pattern, TRUE);

--- a/src/common/import_session.h
+++ b/src/common/import_session.h
@@ -59,7 +59,8 @@ const char *dt_import_session_name(struct dt_import_session_t *self);
  */
 const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean current);
 /** \brief get import session path
-    \param[in] current If TRUE the current filename will be returned without evaluating a new filename.
+    \param[in] current If TRUE the filename passed by dt_import_session_set_filename will be returned
+    without evaluating a new filename.
 */
 const char *dt_import_session_path(struct dt_import_session_t *self, gboolean current);
 

--- a/src/common/import_session.h
+++ b/src/common/import_session.h
@@ -57,9 +57,9 @@ const char *dt_import_session_name(struct dt_import_session_t *self);
 /** \brief get import session filename.
     \param[in] current If TRUE the current filename will be returned without evaluating a new filename.
  */
-const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean current);
+const char *dt_import_session_filename(struct dt_import_session_t *self, gboolean use_filename);
 /** \brief get import session path
-    \param[in] current If TRUE the filename passed by dt_import_session_set_filename will be returned
+    \param[in] use_filename If TRUE the filename passed by dt_import_session_set_filename will be returned
     without evaluating a new filename.
 */
 const char *dt_import_session_path(struct dt_import_session_t *self, gboolean current);

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -295,12 +295,12 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   const gchar *file;
   struct dt_camera_shared_t *shared;
   shared = (dt_camera_shared_t *)data;
-  const gboolean current = dt_conf_get_bool("session/use_filename");
+  const gboolean use_filename = dt_conf_get_bool("session/use_filename");
 
   dt_import_session_set_filename(shared->session, filename);
   if(exif_time)
     dt_import_session_set_exif_time(shared->session, *exif_time);
-  file = dt_import_session_filename(shared->session, current);
+  file = dt_import_session_filename(shared->session, use_filename);
 
   if(file == NULL) return NULL;
 

--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -295,13 +295,12 @@ static const char *_camera_request_image_filename(const dt_camera_t *camera, con
   const gchar *file;
   struct dt_camera_shared_t *shared;
   shared = (dt_camera_shared_t *)data;
+  const gboolean current = dt_conf_get_bool("session/use_filename");
 
-  /* update import session with original filename so that $(FILE_EXTENSION)
-   *     and alikes can be expanded. */
   dt_import_session_set_filename(shared->session, filename);
   if(exif_time)
     dt_import_session_set_exif_time(shared->session, *exif_time);
-  file = dt_import_session_filename(shared->session, FALSE);
+  file = dt_import_session_filename(shared->session, current);
 
   if(file == NULL) return NULL;
 


### PR DESCRIPTION
This is an attempt for a better import, see related issues #3998 and #4988 for discussing and arguments.

While importing from camera or cards (not while tethering) it seems to be better & safer to keep the original base filename instead of using the pattern.

We could also advise to use another pattern or make such as default, instead this pr gives another bool option to keep the filename as default.
