### PR TITLE
Color picker changes to remaining modules and blend

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -403,8 +403,6 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *lower_polarity;
   GtkWidget *colorpicker;
   GtkWidget *colorpicker_set_values;
-  dt_iop_color_picker_t color_picker;
-  int picker_set_upper_lower;
   GtkWidget *showmask;
   GtkWidget *suppress;
   void (*scale_print[8])(float value, char *string, int n);
@@ -479,6 +477,8 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module);
 void dt_iop_gui_update_masks(dt_iop_module_t *module);
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
 void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
+
+gboolean blend_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece);
 
 /** routine to translate from mode id to sequence in option list */
 int dt_iop_gui_blending_mode_seq(dt_iop_gui_blend_data_t *bd, int mode);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -21,6 +21,7 @@
 #include "libs/lib.h"
 #include "control/control.h"
 #include "gui/gtk.h"
+#include "develop/blend.h"
 
 typedef enum _internal__status
 {
@@ -342,6 +343,14 @@ void dt_iop_color_picker_cleanup(void)
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_iop_color_picker_signal_callback), NULL);
 }
 
+void dt_iop_color_picker_both_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+{
+  if(!self->blend_data || !blend_color_picker_apply(self, piece))
+  {
+    if(self->color_picker_apply) self->color_picker_apply(self, piece);
+  }
+}
+
 GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w)
 {
   dt_iop_color_picker_t *color_picker = (dt_iop_color_picker_t *)g_malloc(sizeof(dt_iop_color_picker_t));
@@ -349,7 +358,7 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
   if(w == NULL || GTK_IS_BOX(w))
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-    dt_iop_init_single_picker(color_picker, module, button, kind, module->color_picker_apply);
+    dt_iop_init_single_picker(color_picker, module, button, kind, dt_iop_color_picker_both_apply);
     g_signal_connect_data(G_OBJECT(button), "button-press-event", 
                           G_CALLBACK(dt_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
     if (w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
@@ -360,7 +369,7 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
   {
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
-    dt_iop_init_single_picker(color_picker, module, w, kind, module->color_picker_apply);
+    dt_iop_init_single_picker(color_picker, module, w, kind, dt_iop_color_picker_both_apply);
     g_signal_connect_data(G_OBJECT(w), "quad-pressed", 
                           G_CALLBACK(dt_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
 

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -348,9 +348,10 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
 
   if(w == NULL || GTK_IS_BOX(w))
   {
-    GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+    GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     dt_iop_init_single_picker(color_picker, module, button, kind, module->color_picker_apply);
-    g_signal_connect_data(G_OBJECT(button), "toggled", G_CALLBACK(dt_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
+    g_signal_connect_data(G_OBJECT(button), "button-press-event", 
+                          G_CALLBACK(dt_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
     if (w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
 
     return button;
@@ -360,7 +361,8 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
     dt_iop_init_single_picker(color_picker, module, w, kind, module->color_picker_apply);
-    g_signal_connect_data(G_OBJECT(w), "quad-pressed", G_CALLBACK(dt_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
+    g_signal_connect_data(G_OBJECT(w), "quad-pressed", 
+                          G_CALLBACK(dt_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
 
     return w;
   }

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -263,13 +263,12 @@ static void _middle_grey_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
-/*
-static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
+
+static void _color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
 {
-  _turn_select_region_off(self->module);
-  dt_iop_color_picker_callback(button, self);
+  _turn_select_region_off(self);
 }
-*/
+
 static void _brightness_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -807,6 +806,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->sl_middle_grey, TRUE, TRUE, 0);
 
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->sl_middle_grey);
+  g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback), self);
 
   g->sl_brightness = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->brightness, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_brightness, -4.0, 4.0);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -74,8 +74,6 @@ typedef struct dt_iop_basicadj_gui_data_t
   GtkWidget *sl_saturation;
   GtkWidget *sl_vibrance;
   GtkWidget *sl_clip;
-
-  dt_iop_color_picker_t color_picker;
 } dt_iop_basicadj_gui_data_t;
 
 typedef struct dt_iop_basicadj_data_t
@@ -265,13 +263,13 @@ static void _middle_grey_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
-
+/*
 static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
 {
   _turn_select_region_off(self->module);
   dt_iop_color_picker_callback(button, self);
 }
-
+*/
 static void _brightness_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
@@ -594,7 +592,7 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;
@@ -808,11 +806,7 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(g->sl_middle_grey), "value-changed", G_CALLBACK(_middle_grey_callback), self);
   gtk_box_pack_start(GTK_BOX(self->widget), g->sl_middle_grey, TRUE, TRUE, 0);
 
-  dt_bauhaus_widget_set_quad_paint(g->sl_middle_grey, dtgtk_cairo_paint_colorpicker,
-                                   CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  dt_bauhaus_widget_set_quad_toggle(g->sl_middle_grey, TRUE);
-  g_signal_connect(G_OBJECT(g->sl_middle_grey), "quad-pressed", G_CALLBACK(_color_picker_callback),
-                   &g->color_picker);
+  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->sl_middle_grey);
 
   g->sl_brightness = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, .01, p->brightness, 2);
   dt_bauhaus_slider_enable_soft_boundaries(g->sl_brightness, -4.0, 4.0);
@@ -865,9 +859,6 @@ void gui_init(struct dt_iop_module_t *self)
   // and profile change
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                             G_CALLBACK(_signal_profile_user_changed), self);
-
-  dt_iop_init_single_picker(&g->color_picker, self, GTK_WIDGET(g->sl_middle_grey), DT_COLOR_PICKER_AREA,
-                            _iop_color_picker_apply);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -65,13 +65,6 @@ typedef enum dt_iop_colorzones_channel_t
   DT_IOP_COLORZONES_MAX_CHANNELS = 3
 } dt_iop_colorzones_channel_t;
 
-typedef enum dt_iop_colorzones_pickcolor_type_t
-{
-  DT_IOP_COLORZONES_PICK_NONE = 0,
-  DT_IOP_COLORZONES_PICK_COLORPICK = 1,
-  DT_IOP_COLORZONES_PICK_SET_VALUES = 2
-} dt_iop_colorzones_pickcolor_type_t;
-
 typedef struct dt_iop_colorzones_node_t
 {
   float x;
@@ -113,12 +106,10 @@ typedef struct dt_iop_colorzones_gui_data_t
   GtkWidget *colorpicker;
   GtkWidget *colorpicker_set_values;
   GtkWidget *chk_edit_by_area;
-  int picker_set_upper_lower; // creates the curve flat, positive or negative
   dt_iop_colorzones_channel_t channel;
   float draw_ys[DT_IOP_COLORZONES_MAX_CHANNELS][DT_IOP_COLORZONES_RES];
   float draw_min_ys[DT_IOP_COLORZONES_RES];
   float draw_max_ys[DT_IOP_COLORZONES_RES];
-  dt_iop_color_picker_t color_picker;
   float zoom_factor;
   float offset_x, offset_y;
   int edit_by_area;
@@ -1695,7 +1686,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 
   if(dt_gui_get_scroll_delta(event, &delta_y))
   {
-    if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+    if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
 
     if(c->edit_by_area)
     {
@@ -1785,7 +1776,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
       const float dy = _mouse_to_curve(c->mouse_y - translate_mouse_y, c->zoom_factor, c->offset_y)
                        - _mouse_to_curve(old_m_y - translate_mouse_y, c->zoom_factor, c->offset_y);
 
-      if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+      if(self->picker->colorpick == c->colorpicker_set_values)
         dt_iop_color_picker_reset(self, TRUE);
       return _move_point_internal(self, widget, dx, dy, event->state);
     }
@@ -1798,7 +1789,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
       if(c->x_move < 0)
       {
         dt_iop_colorzones_get_params(p, c, c->channel, c->mouse_x, c->mouse_y, c->mouse_radius);
-        if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+        if(self->picker->colorpick == c->colorpicker_set_values)
           dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
       }
@@ -1836,7 +1827,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
         // no vertex was close, create a new one!
         c->selected = _add_node(curve, &p->curve_num_nodes[ch], linx, liny);
 
-        if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+        if(self->picker->colorpick == c->colorpicker_set_values)
           dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
       }
@@ -1939,7 +1930,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
           if(dist < min) c->selected = selected;
         }
 
-        if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+        if(self->picker->colorpick == c->colorpicker_set_values)
           dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
         gtk_widget_queue_draw(self->widget);
@@ -1958,7 +1949,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       c->selected = -2; // avoid motion notify re-inserting immediately.
       dt_bauhaus_combobox_set(c->interpolator, p->curve_type[ch]);
 
-      if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+      if(self->picker->colorpick == c->colorpicker_set_values)
         dt_iop_color_picker_reset(self, TRUE);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       gtk_widget_queue_draw(self->widget);
@@ -1984,7 +1975,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
         curve[c->selected].x = reset_value;
       }
 
-      if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+      if(self->picker->colorpick == c->colorpicker_set_values)
         dt_iop_color_picker_reset(self, TRUE);
       gtk_widget_queue_draw(self->widget);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -2017,7 +2008,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
     }
     c->selected = -2; // avoid re-insertion of that point immediately after this
 
-    if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+    if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
     gtk_widget_queue_draw(self->widget);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     return TRUE;
@@ -2105,7 +2096,7 @@ static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, 
 
   if(!handled) return TRUE;
 
-  if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   return _move_point_internal(self, widget, dx, dy, event->state);
 }
 
@@ -2125,33 +2116,17 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
 
   self->dt->gui->reset = reset;
 
-  if(c->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   if(c->display_mask) dt_dev_reprocess_center(self->dev);
   gtk_widget_queue_draw(self->widget);
 }
 
-static gboolean _color_picker_callback_button_press(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *module)
+static void _color_picker_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
 {
-  if(darktable.gui->reset) return FALSE;
-
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)module->gui_data;
-  dt_iop_color_picker_t *color_picker = &c->color_picker;
-
-  if(widget == c->colorpicker)
-    color_picker->kind = DT_COLOR_PICKER_POINT_AREA;
-  else
-    color_picker->kind = DT_COLOR_PICKER_AREA;
-
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((e->state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
-    c->picker_set_upper_lower = 1;
-  else if((e->state & modifiers) == GDK_SHIFT_MASK)
-    c->picker_set_upper_lower = -1;
-  else
-    c->picker_set_upper_lower = 0;
-
-  return dt_iop_color_picker_callback_button_press(widget, e, color_picker);
+  if(gtk_toggle_button_get_active(togglebutton))
+    dt_iop_color_picker_set_cst(module->picker, iop_cs_LCh);
 }
+
 
 static void _select_by_callback(GtkWidget *widget, dt_iop_module_t *self)
 {
@@ -2161,7 +2136,7 @@ static void _select_by_callback(GtkWidget *widget, dt_iop_module_t *self)
 
   _reset_parameters(p, 2 - (dt_iop_colorzones_channel_t)dt_bauhaus_combobox_get(widget), p->splines_version);
 
-  if(g->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   if(g->display_mask) _reset_display_selection(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -2175,7 +2150,7 @@ static void _strength_changed_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->strength = dt_bauhaus_slider_get(slider);
 
-  if(g->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2194,7 +2169,7 @@ static void _interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
   else if(combo == 2)
     p->curve_type[g->channel] = MONOTONE_HERMITE;
 
-  if(g->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
@@ -2217,7 +2192,7 @@ static void _mode_callback(GtkWidget *widget, dt_iop_module_t *self)
 
   p->mode = dt_bauhaus_combobox_get(widget);
 
-  if(g->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
@@ -2248,10 +2223,10 @@ static void _display_mask_callback(GtkToggleButton *togglebutton, dt_iop_module_
   dt_dev_reprocess_center(module->dev);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
-  if(g->color_picker.current_picker == DT_IOP_COLORZONES_PICK_SET_VALUES)
+  if(self->picker->colorpick == g->colorpicker_set_values)
   {
     dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
     dt_iop_colorzones_params_t *d = (dt_iop_colorzones_params_t *)self->default_params;
@@ -2269,9 +2244,19 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
       curve[k].y = d->curve[ch_curve][k].y;
     }
 
+    guint state = gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+    int picker_set_upper_lower;
+    if((state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
+      picker_set_upper_lower = 1;
+    else if((state & modifiers) == GDK_SHIFT_MASK)
+      picker_set_upper_lower = -1;
+    else
+      picker_set_upper_lower = 0;
+
     // now add 5 nodes: feather, min, center, max, feather
     const float feather = 0.02f;
-    const float increment = 0.1f * g->picker_set_upper_lower;
+    const float increment = 0.1f * picker_set_upper_lower;
     float x = 0.f;
 
     if(ch_val == DT_IOP_COLORZONES_L)
@@ -2325,40 +2310,6 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   dt_control_queue_redraw_widget(self->widget);
 }
 
-static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
-{
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
-  const int current_picker = g->color_picker.current_picker;
-
-  g->color_picker.current_picker = DT_IOP_COLORZONES_PICK_NONE;
-
-  if(button == g->colorpicker)
-    g->color_picker.current_picker = DT_IOP_COLORZONES_PICK_COLORPICK;
-  else if(button == g->colorpicker_set_values)
-    g->color_picker.current_picker = DT_IOP_COLORZONES_PICK_SET_VALUES;
-
-  if(current_picker == g->color_picker.current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
-  else
-    return g->color_picker.current_picker;
-}
-
-static void _iop_color_picker_update(dt_iop_module_t *self)
-{
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
-  const int which_colorpicker = g->color_picker.current_picker;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker),
-                               which_colorpicker == DT_IOP_COLORZONES_PICK_COLORPICK);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker_set_values),
-                               which_colorpicker == DT_IOP_COLORZONES_PICK_SET_VALUES);
-
-  darktable.gui->reset = reset;
-  dt_control_queue_redraw_widget(self->widget);
-}
-
 void gui_reset(struct dt_iop_module_t *self)
 {
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
@@ -2401,7 +2352,6 @@ void gui_init(struct dt_iop_module_t *self)
   c->selected = -1;
   c->offset_x = c->offset_y = 0.f;
   c->zoom_factor = 1.f;
-  c->picker_set_upper_lower = 0;
   c->x_move = -1;
   c->mouse_radius = 1.f / DT_IOP_COLORZONES_BANDS;
   c->dragging = 0;
@@ -2429,27 +2379,22 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
   gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(_channel_tabs_switch_callback), self);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);
 
   // color pickers
-  c->colorpicker_set_values = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker_set_values,
-                                                     CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_tooltip_text(c->colorpicker_set_values, _("create a curve based on an area from the image\n"
-                                                           "click to create a flat curve\n"
-                                                           "ctrl+click to create a positive curve\n"
-                                                           "shift+click to create a negative curve"));
-  gtk_widget_set_size_request(GTK_WIDGET(c->colorpicker_set_values), DT_PIXEL_APPLY_DPI(14),
-                              DT_PIXEL_APPLY_DPI(14));
-  g_signal_connect(G_OBJECT(c->colorpicker_set_values), "button-press-event",
-                   G_CALLBACK(_color_picker_callback_button_press), self);
-  gtk_box_pack_end(GTK_BOX(hbox), GTK_WIDGET(c->colorpicker_set_values), FALSE, FALSE, 0);
-
-  c->colorpicker
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click to select an area"));
-  g_signal_connect(G_OBJECT(c->colorpicker), "button-press-event", G_CALLBACK(_color_picker_callback_button_press),
-                   self);
-  gtk_box_pack_end(GTK_BOX(hbox), c->colorpicker, FALSE, FALSE, 0);
+  c->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
+                               dtgtk_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_widget_set_size_request(c->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
+  gtk_widget_set_tooltip_text(c->colorpicker_set_values, _("create a curve based on an area from the image\n"
+                                                           "drag to create a flat curve\n"
+                                                           "ctrl+drag to create a positive curve\n"
+                                                           "shift+drag to create a negative curve"));
+
+  g_signal_connect(G_OBJECT(c->colorpicker), "toggled", G_CALLBACK(_color_picker_callback), self);
+  g_signal_connect(G_OBJECT(c->colorpicker_set_values), "toggled", G_CALLBACK(_color_picker_callback), self);
 
   // the nice graph
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
@@ -2544,10 +2489,6 @@ void gui_init(struct dt_iop_module_t *self)
         "- centripetal is better to avoids cusps and oscillations with close nodes but is less smooth\n"
         "- monotonic is better for accuracy of pure analytical functions (log, gamma, exp)\n"));
   g_signal_connect(G_OBJECT(c->interpolator), "value-changed", G_CALLBACK(_interpolator_callback), self);
-
-  dt_iop_init_picker(&c->color_picker, self, DT_COLOR_PICKER_POINT_AREA, _iop_color_picker_get_set,
-                     _iop_color_picker_apply, _iop_color_picker_update);
-  dt_iop_color_picker_set_cst(&c->color_picker, iop_cs_LCh);
 }
 
 void gui_update(struct dt_iop_module_t *self)

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -41,13 +41,6 @@
 
 DT_MODULE_INTROSPECTION(1, dt_iop_rgbcurve_params_t)
 
-typedef enum dt_iop_rgbcurve_pickcolor_type_t
-{
-  DT_IOP_RGBCURVE_PICK_NONE = 0,
-  DT_IOP_RGBCURVE_PICK_COLORPICK = 1,
-  DT_IOP_RGBCURVE_PICK_SET_VALUES = 2
-} dt_iop_rgbcurve_pickcolor_type_t;
-
 typedef enum rgbcurve_channel_t
 {
   DT_IOP_RGBCURVE_R = 0,
@@ -91,7 +84,6 @@ typedef struct dt_iop_rgbcurve_gui_data_t
   GtkNotebook *channel_tabs;
   GtkWidget *colorpicker;
   GtkWidget *colorpicker_set_values;
-  dt_iop_color_picker_t color_picker;
   GtkWidget *interpolator;
   rgbcurve_channel_t channel;
   double mouse_x, mouse_y;
@@ -104,7 +96,6 @@ typedef struct dt_iop_rgbcurve_gui_data_t
   GtkWidget *cmb_preserve_colors;
   float zoom_factor;
   float offset_x, offset_y;
-  int picker_set_upper_lower; // creates the curve flat, positive or negative
 } dt_iop_rgbcurve_gui_data_t;
 
 typedef struct dt_iop_rgbcurve_data_t
@@ -339,29 +330,6 @@ static void _rgbcurve_show_hide_controls(dt_iop_rgbcurve_params_t *p, dt_iop_rgb
     gtk_widget_set_visible(g->cmb_preserve_colors, FALSE);
 }
 
-static gboolean _color_picker_callback_button_press(GtkWidget *widget, GdkEventButton *e, dt_iop_module_t *module)
-{
-  if(darktable.gui->reset) return FALSE;
-
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)module->gui_data;
-  dt_iop_color_picker_t *color_picker = &g->color_picker;
-
-  if(widget == g->colorpicker)
-    color_picker->kind = DT_COLOR_PICKER_POINT_AREA;
-  else
-    color_picker->kind = DT_COLOR_PICKER_AREA;
-
-  GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  if((e->state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
-    g->picker_set_upper_lower = 1;
-  else if((e->state & modifiers) == GDK_SHIFT_MASK)
-    g->picker_set_upper_lower = -1;
-  else
-    g->picker_set_upper_lower = 0;
-
-  return dt_iop_color_picker_callback_button_press(widget, e, color_picker);
-}
-
 static gboolean _is_identity(dt_iop_rgbcurve_params_t *p, rgbcurve_channel_t channel)
 {
   for(int k=0; k<p->curve_num_nodes[channel]; k++)
@@ -561,10 +529,10 @@ static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float
   return _add_node(p->curve_nodes[ch], &p->curve_num_nodes[ch], x, y);
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
-  if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES)
+  if(self->picker->colorpick == g->colorpicker_set_values)
   {
     dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
     dt_iop_rgbcurve_params_t *d = (dt_iop_rgbcurve_params_t *)self->default_params;
@@ -581,8 +549,18 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
       p->curve_nodes[ch][k].y = d->curve_nodes[ch][k].y;
     }
 
+    guint state = gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
+    int picker_set_upper_lower;
+    if((state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
+      picker_set_upper_lower = 1;
+    else if((state & modifiers) == GDK_SHIFT_MASK)
+      picker_set_upper_lower = -1;
+    else
+      picker_set_upper_lower = 0;
+
     // now add 4 nodes: min, avg, center, max
-    const float increment = 0.05f * g->picker_set_upper_lower;
+    const float increment = 0.05f * picker_set_upper_lower;
 
     _add_node_from_picker(p, self->picked_color_min, 0.f, ch, work_profile);
     _add_node_from_picker(p, self->picked_color, increment, ch, work_profile);
@@ -599,40 +577,6 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
 
-  dt_control_queue_redraw_widget(self->widget);
-}
-
-static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
-{
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
-  const int current_picker = g->color_picker.current_picker;
-
-  g->color_picker.current_picker = DT_IOP_RGBCURVE_PICK_NONE;
-
-  if(button == g->colorpicker)
-    g->color_picker.current_picker = DT_IOP_RGBCURVE_PICK_COLORPICK;
-  else if(button == g->colorpicker_set_values)
-    g->color_picker.current_picker = DT_IOP_RGBCURVE_PICK_SET_VALUES;
-
-  if(current_picker == g->color_picker.current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
-  else
-    return g->color_picker.current_picker;
-}
-
-static void _iop_color_picker_update(dt_iop_module_t *self)
-{
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
-  const int which_colorpicker = g->color_picker.current_picker;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker),
-                               which_colorpicker == DT_IOP_RGBCURVE_PICK_COLORPICK);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker_set_values),
-                               which_colorpicker == DT_IOP_RGBCURVE_PICK_SET_VALUES);
-
-  darktable.gui->reset = reset;
   dt_control_queue_redraw_widget(self->widget);
 }
 
@@ -756,7 +700,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 
   if(g->selected < 0) return TRUE;
 
-  if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
 
   if(dt_gui_get_scroll_delta(event, &delta_y))
   {
@@ -804,7 +748,7 @@ static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, 
 
   if(!handled) return TRUE;
 
-  if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
   return _move_point_internal(self, widget, dx, dy, event->state);
 }
 
@@ -1278,12 +1222,12 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
       const float dy = _mouse_to_curve(g->mouse_y - translate_mouse_y, g->zoom_factor, g->offset_y)
                        - _mouse_to_curve(old_m_y - translate_mouse_y, g->zoom_factor, g->offset_y);
 
-      if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+      if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
       return _move_point_internal(self, widget, dx, dy, event->state);
     }
     else if(nodes < DT_IOP_RGBCURVE_MAXNODES && g->selected >= -1)
     {
-      if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+      if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
       // no vertex was close, create a new one!
       g->selected = _add_node(curve_nodes, &p->curve_num_nodes[ch], linx, liny);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1379,7 +1323,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
             if(dist < min) g->selected = selected;
           }
 
-          if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES)
+          if(self->picker->colorpick == g->colorpicker_set_values)
             dt_iop_color_picker_reset(self, TRUE);
           dt_dev_add_history_item(darktable.develop, self, TRUE);
           gtk_widget_queue_draw(self->widget);
@@ -1402,7 +1346,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
         }
         g->selected = -2; // avoid motion notify re-inserting immediately.
         dt_bauhaus_combobox_set(g->interpolator, p->curve_type[DT_IOP_RGBCURVE_R]);
-        if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES)
+        if(self->picker->colorpick == g->colorpicker_set_values)
           dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
         gtk_widget_queue_draw(self->widget);
@@ -1414,7 +1358,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
           p->curve_autoscale = DT_S_SCALE_MANUAL_RGB;
           g->selected = -2; // avoid motion notify re-inserting immediately.
           dt_bauhaus_combobox_set(g->autoscale, 1);
-          if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES)
+          if(self->picker->colorpick == g->colorpicker_set_values)
             dt_iop_color_picker_reset(self, TRUE);
           dt_dev_add_history_item(darktable.develop, self, TRUE);
           gtk_widget_queue_draw(self->widget);
@@ -1429,7 +1373,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
     {
       const float reset_value = g->selected == 0 ? 0.f : 1.f;
       curve_nodes[g->selected].y = curve_nodes[g->selected].x = reset_value;
-      if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+      if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       gtk_widget_queue_draw(self->widget);
       return TRUE;
@@ -1442,7 +1386,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
     }
     g->selected = -2; // avoid re-insertion of that point immediately after this
     p->curve_num_nodes[ch]--;
-    if(g->color_picker.current_picker == DT_IOP_RGBCURVE_PICK_SET_VALUES) dt_iop_color_picker_reset(self, TRUE);
+    if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     gtk_widget_queue_draw(self->widget);
     return TRUE;
@@ -1476,7 +1420,6 @@ void change_image(struct dt_iop_module_t *self)
     g->selected = -1;
     g->offset_x = g->offset_y = 0.f;
     g->zoom_factor = 1.f;
-    g->picker_set_upper_lower = 0;
   }
 }
 
@@ -1532,33 +1475,25 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->channel_tabs, g->channel)));
   gtk_notebook_set_current_page(GTK_NOTEBOOK(g->channel_tabs), g->channel);
 
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->channel_tabs), TRUE, TRUE, 0);
+  
+
   // color pickers
-  g->colorpicker_set_values = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker_set_values,
-                                                     CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
+  gtk_widget_set_tooltip_text(g->colorpicker, _("pick GUI color from image\nctrl+click to select an area"));
+  g->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
+  dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker_set_values),
+                               dtgtk_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  gtk_widget_set_size_request(g->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(g->colorpicker_set_values, _("create a curve based on an area from the image\n"
-                                                           "click to create a flat curve\n"
-                                                           "ctrl+click to create a positive curve\n"
-                                                           "shift+click to create a negative curve"));
-  gtk_widget_set_size_request(GTK_WIDGET(g->colorpicker_set_values), DT_PIXEL_APPLY_DPI(14),
-                              DT_PIXEL_APPLY_DPI(14));
-  g_signal_connect(G_OBJECT(g->colorpicker_set_values), "button-press-event",
-                   G_CALLBACK(_color_picker_callback_button_press), self);
-
-  g->colorpicker
-      = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_size_request(GTK_WIDGET(g->colorpicker), DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
-  gtk_widget_set_tooltip_text(g->colorpicker, _("pick GUI color from image"));
-  g_signal_connect(G_OBJECT(g->colorpicker), "button-press-event", G_CALLBACK(_color_picker_callback_button_press),
-                   self);
-
-  GtkWidget *notebook = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(notebook), GTK_WIDGET(g->channel_tabs), FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(notebook), GTK_WIDGET(g->colorpicker_set_values), FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(notebook), GTK_WIDGET(g->colorpicker), FALSE, FALSE, 0);
+                                                           "drag to create a flat curve\n"
+                                                           "ctrl+drag to create a positive curve\n"
+                                                           "shift+drag to create a negative curve"));
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(notebook), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(tab_switch_callback), self);
 
@@ -1624,9 +1559,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->sizegroup = GTK_SIZE_GROUP(gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL));
   gtk_size_group_add_widget(g->sizegroup, GTK_WIDGET(g->area));
   gtk_size_group_add_widget(g->sizegroup, GTK_WIDGET(g->channel_tabs));
-
-  dt_iop_init_picker(&g->color_picker, self, DT_COLOR_PICKER_POINT_AREA, _iop_color_picker_get_set,
-                     _iop_color_picker_apply, _iop_color_picker_update);
 }
 
 void gui_update(struct dt_iop_module_t *self)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -767,13 +767,11 @@ static void _tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint p
   gtk_widget_queue_draw(self->widget);
 }
 
-/*
-static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
+static void _color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
 {
-  _turn_select_region_off(self->module);
-  dt_iop_color_picker_callback(button, self);
+  _turn_select_region_off(self);
 }
-*/
+
 void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
@@ -820,7 +818,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
         p->levels[channel][1] = mean_picked_color;
       }
     }
-    else if(self->picker->colorpick == c->greypick)
+    else if(self->picker->colorpick == c->whitepick)
     {
       if(mean_picked_color < p->levels[channel][1])
       {
@@ -1047,14 +1045,17 @@ void gui_init(dt_iop_module_t *self)
   c->blackpick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->blackpick, _("pick black point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->blackpick), "picker-black");
+  g_signal_connect(G_OBJECT(c->blackpick), "toggled", G_CALLBACK(_color_picker_callback), self);
 
   c->greypick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->greypick, _("pick medium gray point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->greypick), "picker-grey");
+  g_signal_connect(G_OBJECT(c->greypick), "toggled", G_CALLBACK(_color_picker_callback), self);
 
   c->whitepick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->whitepick, _("pick white point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->whitepick), "picker-white");
+  g_signal_connect(G_OBJECT(c->whitepick), "toggled", G_CALLBACK(_color_picker_callback), self);
 
   GtkWidget *pick_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_box_pack_start(GTK_BOX(pick_hbox), GTK_WIDGET(c->blackpick), TRUE, TRUE, 0);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -57,14 +57,6 @@ typedef struct dt_iop_rgblevels_params_t
   float levels[DT_IOP_RGBLEVELS_MAX_CHANNELS][3];
 } dt_iop_rgblevels_params_t;
 
-typedef enum dt_iop_rgblevels_pick_t
-{
-  DT_IOP_RGBLEVELS_PICK_NONE,
-  DT_IOP_RGBLEVELS_PICK_BLACK,
-  DT_IOP_RGBLEVELS_PICK_GREY,
-  DT_IOP_RGBLEVELS_PICK_WHITE
-} dt_iop_rgblevels_pick_t;
-
 typedef struct dt_iop_rgblevels_gui_data_t
 {
   dt_pthread_mutex_t lock;
@@ -87,7 +79,6 @@ typedef struct dt_iop_rgblevels_gui_data_t
   int dragging, handle_move;
   float drag_start_percentage;
   dt_iop_rgblevels_channel_t channel;
-  dt_iop_color_picker_t color_picker;
   float last_picked_color;
   GtkWidget *blackpick, *greypick, *whitepick;
 } dt_iop_rgblevels_gui_data_t;
@@ -776,34 +767,14 @@ static void _tab_switch_callback(GtkNotebook *notebook, GtkWidget *page, guint p
   gtk_widget_queue_draw(self->widget);
 }
 
+/*
 static void _color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
 {
   _turn_select_region_off(self->module);
   dt_iop_color_picker_callback(button, self);
 }
-
-static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
-{
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
-
-  const dt_iop_rgblevels_pick_t current_picker = g->color_picker.current_picker;
-
-  g->color_picker.current_picker = DT_IOP_RGBLEVELS_PICK_NONE;
-
-  if(button == GTK_WIDGET(g->blackpick))
-    g->color_picker.current_picker = DT_IOP_RGBLEVELS_PICK_BLACK;
-  else if(button == GTK_WIDGET(g->greypick))
-    g->color_picker.current_picker = DT_IOP_RGBLEVELS_PICK_GREY;
-  else if(button == GTK_WIDGET(g->whitepick))
-    g->color_picker.current_picker = DT_IOP_RGBLEVELS_PICK_WHITE;
-
-  if (current_picker == g->color_picker.current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
-  else
-    return g->color_picker.current_picker;
-}
-
-static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+*/
+void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
@@ -827,7 +798,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
 
     c->last_picked_color = mean_picked_color;
 
-    if(DT_IOP_RGBLEVELS_PICK_BLACK == c->color_picker.current_picker)
+    if(self->picker->colorpick == c->blackpick)
     {
       if(mean_picked_color > p->levels[channel][1])
       {
@@ -838,7 +809,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
         p->levels[channel][0] = mean_picked_color;
       }
     }
-    else if(DT_IOP_RGBLEVELS_PICK_GREY == c->color_picker.current_picker)
+    else if(self->picker->colorpick == c->greypick)
     {
       if(mean_picked_color < p->levels[channel][0] || mean_picked_color > p->levels[channel][2])
       {
@@ -849,7 +820,7 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
         p->levels[channel][1] = mean_picked_color;
       }
     }
-    else if(DT_IOP_RGBLEVELS_PICK_WHITE == c->color_picker.current_picker)
+    else if(self->picker->colorpick == c->greypick)
     {
       if(mean_picked_color < p->levels[channel][1])
       {
@@ -869,18 +840,6 @@ static void _iop_color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpi
     }
   }
 
-}
-
-static void _iop_color_picker_update(dt_iop_module_t *self)
-{
-  dt_iop_rgblevels_gui_data_t *g = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
-  const dt_iop_rgblevels_pick_t which_colorpicker = g->color_picker.current_picker;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->blackpick), which_colorpicker == DT_IOP_RGBLEVELS_PICK_BLACK);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->greypick), which_colorpicker == DT_IOP_RGBLEVELS_PICK_GREY);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->whitepick), which_colorpicker == DT_IOP_RGBLEVELS_PICK_WHITE);
-  darktable.gui->reset = reset;
 }
 
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
@@ -1085,15 +1044,15 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(_area_leave_notify_callback), self);
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_area_scroll_callback), self);
 
-  c->blackpick = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  c->blackpick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->blackpick, _("pick black point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->blackpick), "picker-black");
 
-  c->greypick = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  c->greypick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->greypick, _("pick medium gray point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->greypick), "picker-grey");
 
-  c->whitepick = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  c->whitepick = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, NULL);
   gtk_widget_set_tooltip_text(c->whitepick, _("pick white point from image"));
   gtk_widget_set_name(GTK_WIDGET(c->whitepick), "picker-white");
 
@@ -1107,7 +1066,7 @@ void gui_init(dt_iop_module_t *self)
   c->bt_auto_levels = gtk_button_new_with_label(_("auto"));
   gtk_widget_set_tooltip_text(c->bt_auto_levels, _("apply auto levels"));
 
-  c->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT, NULL);
+  c->bt_select_region = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_object_set(G_OBJECT(c->bt_select_region), "tooltip-text",
                _("apply auto levels based on a region defined by the user\n"
                  "click and drag to draw the area\n"
@@ -1126,9 +1085,6 @@ void gui_init(dt_iop_module_t *self)
 
   g_signal_connect(G_OBJECT(c->bt_auto_levels), "clicked", G_CALLBACK(_auto_levels_callback), self);
   g_signal_connect(G_OBJECT(c->bt_select_region), "toggled", G_CALLBACK(_select_region_toggled_callback), self);
-  g_signal_connect(G_OBJECT(c->blackpick), "toggled", G_CALLBACK(_color_picker_callback), &c->color_picker);
-  g_signal_connect(G_OBJECT(c->greypick), "toggled", G_CALLBACK(_color_picker_callback), &c->color_picker);
-  g_signal_connect(G_OBJECT(c->whitepick), "toggled", G_CALLBACK(_color_picker_callback), &c->color_picker);
 
   c->cmb_preserve_colors = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(c->cmb_preserve_colors, NULL, _("preserve colors"));
@@ -1142,13 +1098,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), c->cmb_preserve_colors, TRUE, TRUE, 0);
   gtk_widget_set_tooltip_text(c->cmb_preserve_colors, _("method to preserve colors when applying contrast"));
   g_signal_connect(G_OBJECT(c->cmb_preserve_colors), "value-changed", G_CALLBACK(_preserve_colors_callback), self);
-
-  dt_iop_init_picker(&c->color_picker,
-              self,
-              DT_COLOR_PICKER_POINT,
-              _iop_color_picker_get_set,
-              _iop_color_picker_apply,
-              _iop_color_picker_update);
 
   // add signal handler for preview pipe finish
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_PREVIEW_PIPE_FINISHED,

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -146,7 +146,6 @@ typedef struct dt_iop_tonecurve_gui_data_t
   GtkWidget *autoscale_ab;
   GtkNotebook *channel_tabs;
   GtkWidget *colorpicker;
-  dt_iop_color_picker_t color_picker;
   GtkWidget *interpolator;
   GtkWidget *scale;
   tonecurve_channel_t channel;
@@ -1128,7 +1127,7 @@ static float to_lin(const float x, const float base, const int ch, const int sem
   }
 }
 
-static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_tonecurve_global_data_t *gd = (dt_iop_tonecurve_global_data_t *)self->global_data;
 
@@ -1139,31 +1138,6 @@ static void _iop_color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_
     gd->picked_color_max[k] = self->picked_color_max[k];
     gd->picked_output_color[k] = self->picked_output_color[k];
   }
-  dt_control_queue_redraw_widget(self->widget);
-}
-
-static int _iop_color_picker_get_set(dt_iop_module_t *self, GtkWidget *button)
-{
-  dt_iop_color_picker_t *picker = self->picker;
-  const int current_picker = picker->current_picker;
-
-  picker->current_picker = 1;
-
-  if(current_picker == picker->current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
-  else
-    return picker->current_picker;
-}
-
-static void _iop_color_picker_update(dt_iop_module_t *self)
-{
-  dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->colorpicker), g->color_picker.current_picker == 1);
-
-  darktable.gui->reset = reset;
   dt_control_queue_redraw_widget(self->widget);
 }
 
@@ -1380,18 +1354,16 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
   gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
+  
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);
 
-  GtkWidget *tb = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-  gtk_widget_set_tooltip_text(tb, _("pick GUI color from image\nctrl+click to select an area"));
-  c->colorpicker = tb;
-
-  GtkWidget *notebook = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(notebook), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
-  gtk_box_pack_end(GTK_BOX(notebook), GTK_WIDGET(tb), FALSE, FALSE, 0);
+  c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
+  gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click to select an area"));
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(notebook), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
 
@@ -1412,7 +1384,6 @@ void gui_init(struct dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(c->area), "leave-notify-event", G_CALLBACK(dt_iop_tonecurve_leave_notify), self);
   g_signal_connect(G_OBJECT(c->area), "enter-notify-event", G_CALLBACK(dt_iop_tonecurve_enter_notify), self);
   g_signal_connect(G_OBJECT(c->area), "configure-event", G_CALLBACK(area_resized), self);
-  g_signal_connect(G_OBJECT(tb), "button-press-event", G_CALLBACK(dt_iop_color_picker_callback_button_press), &c->color_picker);
   g_signal_connect(G_OBJECT(c->area), "scroll-event", G_CALLBACK(_scrolled), self);
   g_signal_connect(G_OBJECT(c->area), "key-press-event", G_CALLBACK(dt_iop_tonecurve_key_press), self);
 
@@ -1461,17 +1432,9 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), c->logbase , TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(c->logbase), "value-changed", G_CALLBACK(logbase_callback), self);
 
-
   c->sizegroup = GTK_SIZE_GROUP(gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL));
   gtk_size_group_add_widget(c->sizegroup, GTK_WIDGET(c->area));
   gtk_size_group_add_widget(c->sizegroup, GTK_WIDGET(c->channel_tabs));
-
-  dt_iop_init_picker(&c->color_picker,
-              self,
-              DT_COLOR_PICKER_POINT_AREA,
-              _iop_color_picker_get_set,
-              _iop_color_picker_apply,
-              _iop_color_picker_update);
 
   dt_bauhaus_combobox_set(c->scale, 0); // linear
 }


### PR DESCRIPTION
Converted the color pickers in the remaining modules and the blending parametric mask to the more compact dt_color_picker_new approach.

There is also a change in behaviour for some "set values" pickers; previously ctrl or shift modifiers had to be pressed while selecting the picker button to enable creation of positive or negative curves. Now, the modifier needs to be held while selecting the area (or at least while releasing the mouse button). Together with the area extendable corners commit from a few days back, this allows changing the curve type without clicking the button (off and back on) again. This also turned out easier to implement (no need to remember modifiers) but please let me know if this is an unwelcome change.

There are some iop modules, basicadj, rgblevels and colorchecker, that do not (fully) use the color_picker proxy framework. I do not completely understand the reason for this yet or whether they could be easily converted. But the result is that their buttons do not (yet) get switched off when one of the standard color checkers gets enabled. Similarly the colorpicker (left hand side) module.

Now that all users of colorpickerproxy have been converted to a minimalist use of the framework the next step is to strip out any of the complexity (differentiation between module and blend for example) that is no longer required. At the same time I'll try to address the few corner cases where pickers do not get disabled by enabling another one or switching modules. I would have preferred there to be one global place, rather than one for each module, where color picker results were stored, but changing that now would mean too many changes and opportunity for breakage.