### PR TITLE
More reliable export size in dt_imageio_export_with_flags

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -746,8 +746,8 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
             ? FALSE
             : high_quality;
 
-  const int width = format_params->max_width;
-  const int height = format_params->max_height;
+  const int width = format_params->max_width > 0 ? format_params->max_width + 1 : 0;
+  const int height = format_params->max_height > 0 ? format_params->max_height + 1 : 0;
 
   const float max_scale = ( upscale && ( width > 0 || height > 0 )) ? 100.0 : 1.0;
 
@@ -762,11 +762,15 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
 
   if(dt_dev_distort_backtransform_plus(&dev, &pipe, 0.f, DT_DEV_TRANSFORM_DIR_ALL, origin, 1))
   {
-    processed_width = scale * pipe.processed_width + 0.5f;
-    processed_height = scale * pipe.processed_height + 0.5f;
+    processed_width = scale * pipe.processed_width + 0.8f;
+    processed_height = scale * pipe.processed_height + 0.8f;
 
-    if(ceilf(processed_width / scale) + origin[0] > pipe.iwidth) processed_width--;
-    if(ceilf(processed_height / scale) + origin[1] > pipe.iheight) processed_height--;
+    if((ceilf(processed_width / scale) + origin[0] > pipe.iwidth) ||
+       (ceilf(processed_height / scale) + origin[1] > pipe.iheight)) 
+    {
+      processed_width--;
+      processed_height--;
+    }
   }
   else
   {


### PR DESCRIPTION
Fixes #4979, for discussions about problems related to this see #3808 #3666 #3646 #3757

This pr tries to make the export output size more predictable.

1. After doing the overflow checks via `dt_dev_distort_backtransform_plus` we should
correct both sizes if any overflow was detected. This will potentially crop more but
the size does not depend on rotation any more.

2. If we use format_params max_width/height we are more pessimistic about the output
size (likely we will decrease dx and dy after the backtransform test) and thus increase
a given value here.

@upegelow @TurboGit you both worked on this lately