### PR TITLE
optionnal escape for markup in variable replacement

### DIFF
--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -518,6 +518,12 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
   }
   if(!result) result = g_strdup("");
 
+  if(params->escape_markup)
+  {
+    gchar *e_res = g_markup_escape_text(result, -1);
+    g_free(result);
+    return e_res;
+  }
   return result;
 }
 

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -38,6 +38,9 @@ typedef struct dt_variables_params_t
   /** internal variables data */
   struct dt_variables_data_t *data;
 
+  /** do we need to escape variables text for markup ? */
+  gboolean escape_markup;
+
 } dt_variables_params_t;
 
 /** allocate and initializes a dt_variables_params_t. */

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -64,6 +64,7 @@ static void _thumb_update_extended_infos_line(dt_thumbnail_t *thumb)
   vp->jobcode = "infos";
   vp->imgid = thumb->imgid;
   vp->sequence = 0;
+  vp->escape_markup = TRUE;
 
   if(thumb->info_line) g_free(thumb->info_line);
   thumb->info_line = dt_variables_expand(vp, pattern, TRUE);
@@ -465,7 +466,7 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
   }
   else
   {
-    // we compute the info line (we reuse the function used in export to disk)
+    // we compute the tooltip (we reuse the function used in export to disk)
     char input_dir[1024] = { 0 };
     gboolean from_cache = TRUE;
     dt_image_full_path(thumb->imgid, input_dir, sizeof(input_dir), &from_cache);
@@ -477,6 +478,7 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
     vp->jobcode = "infos";
     vp->imgid = thumb->imgid;
     vp->sequence = 0;
+    vp->escape_markup = TRUE;
 
     gchar *msg = dt_variables_expand(vp, pattern, TRUE);
 

--- a/src/libs/tools/image_infos.c
+++ b/src/libs/tools/image_infos.c
@@ -102,6 +102,7 @@ void _lib_imageinfo_update_message(gpointer instance, dt_lib_module_t *self)
   vp->jobcode = "infos";
   vp->imgid = imgid;
   vp->sequence = 0;
+  vp->escape_markup = TRUE;
 
   gchar *pattern = dt_conf_get_string("plugins/darkroom/image_infos_pattern");
   gchar *msg = dt_variables_expand(vp, pattern, TRUE);


### PR DESCRIPTION
used with pattern for thumbnails, info line, etc...
Fix #4981