### PR TITLE
prevent dynamic shortcuts giving keyboard focus to sliders

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3270,7 +3270,6 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
     if(w->type == DT_BAUHAUS_SLIDER)
     {
-      gtk_widget_grab_focus(self->dynamic_accel_current->widget);
       float value = dt_bauhaus_slider_get(self->dynamic_accel_current->widget);
       float step = dt_bauhaus_slider_get_step(self->dynamic_accel_current->widget);
 


### PR DESCRIPTION
prevents dynamic slider shortcuts from giving keyboard focus to the
slider being changed. This is not consistent with any other shortcuts
and also gives keyboard focus to the slider when the module itself is collapsed.