### PR TITLE
action on grouped image aligned to new dt_view_get_images_to_act_on()

### DIFF
--- a/src/common/colorlabels.c
+++ b/src/common/colorlabels.c
@@ -173,13 +173,12 @@ static void _colorlabels_execute(GList *imgs, const int labels, GList **undo, co
 }
 
 void dt_colorlabels_set_labels(const GList *img, const int labels, const gboolean clear_on,
-                               const gboolean undo_on, const gboolean group_on)
+                               const gboolean undo_on)
 {
   GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_COLORLABELS);
 
     _colorlabels_execute(imgs, labels, &undo, undo_on, clear_on ? DT_CA_SET : DT_CA_ADD);

--- a/src/common/colorlabels.h
+++ b/src/common/colorlabels.h
@@ -23,7 +23,7 @@ void dt_colorlabels_remove_labels(const int imgid);
 void dt_colorlabels_set_label(const int imgid, const int color);
 /** assign a color label to image imgid or all selected for imgid == -1*/
 void dt_colorlabels_set_labels(const GList *img, const int color, const gboolean clear_on,
-                               const gboolean undo_on, const gboolean group_on);
+                               const gboolean undo_on);
 /** assign a color label to the list of image*/
 void dt_colorlabels_toggle_label_on_list(GList *list, const int color, const gboolean undo_on);
 /** remove a color label from imgid */

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1299,7 +1299,7 @@ void dt_exif_apply_default_metadata(dt_image_t *img)
         {
           setting = dt_util_dstrcat(NULL, "ui_last/import_last_%s", name);
           str = dt_conf_get_string(setting);
-          if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, dt_metadata_get_key(i), str, FALSE, FALSE);
+          if(str != NULL && str[0] != '\0') dt_metadata_set(img->id, dt_metadata_get_key(i), str, FALSE);
           g_free(str);
           g_free(setting);
         }
@@ -1311,7 +1311,7 @@ void dt_exif_apply_default_metadata(dt_image_t *img)
     {
       GList *imgs = NULL;
       imgs = g_list_append(imgs, GINT_TO_POINTER(img->id));
-      dt_tag_attach_string_list(str, imgs, FALSE, FALSE);
+      dt_tag_attach_string_list(str, imgs, FALSE);
       g_list_free(imgs);
     }
     g_free(str);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -447,13 +447,12 @@ void _image_set_location(GList *imgs, const dt_image_geoloc_t *geoloc, GList **u
   }
 }
 
-void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc, const gboolean undo_on, const gboolean group_on)
+void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc, const gboolean undo_on)
 {
   GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_GEOTAG);
 
     _image_set_location(imgs, geoloc, &undo, undo_on);
@@ -476,7 +475,8 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
     imgs = dt_view_get_images_to_act_on(TRUE);
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
-  dt_image_set_locations(imgs, geoloc, undo_on, group_on);
+  if(group_on) dt_grouping_add_grouped_images(&imgs);
+  dt_image_set_locations(imgs, geoloc, undo_on);
   g_list_free(imgs);
 }
 

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -284,7 +284,7 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
                            const gboolean undo_on, const gboolean group_on);
 /** set images location lon/lat/ele */
 void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc,
-                           const gboolean undo_on, const gboolean group_on);
+                           const gboolean undo_on);
 /** get image location lon/lat/ele */
 void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
 /** returns 1 if there is history data found for this image, 0 else. */

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -539,7 +539,7 @@ static void _metadata_execute(const GList *imgs, const GList *metadata, GList **
   }
 }
 
-void dt_metadata_set(const int imgid, const char *key, const char *value, const gboolean undo_on, const gboolean group_on)
+void dt_metadata_set(const int imgid, const char *key, const char *value, const gboolean undo_on)
 {
   if(!key || !imgid) return;
 
@@ -554,7 +554,6 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
     if(imgs)
     {
       GList *undo = NULL;
-      if(group_on) dt_grouping_add_grouped_images(&imgs);
       if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
 
       const gchar *ckey = dt_util_dstrcat(NULL, "%d", keyid);
@@ -698,13 +697,12 @@ void dt_metadata_clear(GList *imgs, const gboolean undo_on)
 }
 
 void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboolean clear_on,
-                             const gboolean undo_on, const gboolean group_on)
+                             const gboolean undo_on)
 {
   GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_METADATA);
 
     _metadata_execute(imgs, metadata, &undo, undo_on, clear_on ? DT_MA_SET : DT_MA_ADD);

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -89,7 +89,7 @@ const char *dt_metadata_get_key_by_subkey(const char *subkey);
 const int dt_metadata_get_type(const uint32_t keyid);
 
 /** Set metadata for a specific image, or all selected for id == -1. */
-void dt_metadata_set(int id, const char *key, const char *value, const gboolean undo_on, const gboolean group_on); // duplicate.c, lua/image.c
+void dt_metadata_set(int id, const char *key, const char *value, const gboolean undo_on); // duplicate.c, lua/image.c
 
 /** Set imported metadata for a specific image */
 void dt_metadata_set_import(int id, const char *key, const char *value); // exif.cc, ligthroom.c
@@ -102,7 +102,7 @@ void dt_metadata_set_list(GList *imgs, GList *key_value, const gboolean undo_on)
     list is a set of keyid, value
     if clear_on TRUE the image metadata are cleared before attaching the new ones*/
 void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboolean clear_on,
-                             const gboolean undo_on, const gboolean group_on);
+                             const gboolean undo_on);
 /** Get metadata (named keys) for a specific image, or all selected for id == -1.
     For keys which return a string, the caller has to make sure that it
     is freed after usage. */

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -420,7 +420,7 @@ static void _tag_execute(const GList *tags, const GList *imgs,
   }
 }
 
-gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolean undo_on, const gboolean group_on)
+gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolean undo_on)
 {
   if(!img) return FALSE;
   GList *undo = NULL;
@@ -430,7 +430,6 @@ gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolea
   if(imgs)
   {
     tags = g_list_prepend(tags, GINT_TO_POINTER(tagid));
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
     _tag_execute(tags, imgs, &undo, undo_on, DT_TA_ATTACH);
@@ -459,8 +458,8 @@ gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_
     if(dt_is_tag_attached(tagid, imgid)) return FALSE;
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   }
-
-  const gboolean res = dt_tag_attach_images(tagid, imgs, undo_on, group_on);
+  if(group_on) dt_grouping_add_grouped_images(&imgs);
+  const gboolean res = dt_tag_attach_images(tagid, imgs, undo_on);
   g_list_free(imgs);
   return res;
 }
@@ -472,13 +471,12 @@ void dt_tag_attach_from_gui(const guint tagid, const gint imgid, const gboolean 
 }
 
 void dt_tag_set_tags(const GList *tags, const GList *img, const gboolean ignore_dt_tags,
-                     const gboolean clear_on, const gboolean undo_on, const gboolean group_on)
+                     const gboolean clear_on, const gboolean undo_on)
 {
   GList *imgs = g_list_copy((GList *)img);
   if(imgs)
   {
     GList *undo = NULL;
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
     _tag_execute(tags, imgs, &undo, undo_on,
@@ -494,7 +492,7 @@ void dt_tag_set_tags(const GList *tags, const GList *img, const gboolean ignore_
   }
 }
 
-void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboolean undo_on, const gboolean group_on)
+void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboolean undo_on)
 {
   // tags may not exist yet
   // undo only undoes the tags attachments. it doesn't remove created tags.
@@ -521,7 +519,6 @@ void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboole
     if(imgs)
     {
       GList *undo = NULL;
-      if(group_on) dt_grouping_add_grouped_images(&imgs);
       if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
       _tag_execute(tagl, imgs, &undo, undo_on, DT_TA_ATTACH);
@@ -540,7 +537,7 @@ void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboole
   g_strfreev(tokens);
 }
 
-void dt_tag_detach_images(const guint tagid, const GList *img, const gboolean undo_on, const gboolean group_on)
+void dt_tag_detach_images(const guint tagid, const GList *img, const gboolean undo_on)
 {
   GList *imgs = g_list_copy((GList *)img);
   if(imgs)
@@ -548,7 +545,6 @@ void dt_tag_detach_images(const guint tagid, const GList *img, const gboolean un
     GList *tags = NULL;
     tags = g_list_prepend(tags, GINT_TO_POINTER(tagid));
     GList *undo = NULL;
-    if(group_on) dt_grouping_add_grouped_images(&imgs);
     if(undo_on) dt_undo_start_group(darktable.undo, DT_UNDO_TAGS);
 
     _tag_execute(tags, imgs, &undo, undo_on, DT_TA_DETACH);
@@ -570,8 +566,9 @@ void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, 
     imgs = dt_view_get_images_to_act_on(TRUE);
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+  if(group_on) dt_grouping_add_grouped_images(&imgs);
 
-  dt_tag_detach_images(tagid, imgs, undo_on, group_on);
+  dt_tag_detach_images(tagid, imgs, undo_on);
   g_list_free(imgs);
 }
 

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -84,7 +84,7 @@ gboolean dt_tag_exists(const char *name, guint *tagid);
 
 /** attach a tag on images list. tagid id of tag to attach. img the list of image
  * id to attach tag to */
-gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolean undo_on, const gboolean group_on);
+gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolean undo_on);
 /** attach a tag on images. tagid id of tag to attach. imgid the image
  * id to attach tag to, if < 0 images to act on are used. */
 gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);
@@ -99,15 +99,15 @@ gboolean dt_is_tag_attached(const guint tagid, const gint imgid);
  * if clear_on TRUE the image tags are cleared before attaching the new ones*/
 void dt_tag_set_tags(const GList *tags, const GList *img,
                      const gboolean ignore_dt_tags, const gboolean clear_on,
-                     const gboolean undo_on, const gboolean group_on);
+                     const gboolean undo_on);
 
 /** attach a list of tags on list of images. \param[in] tags a comma separated string of tags. \param[in]
  * img the list of images to attach tag to. \note If tag not exists it's created.*/
-void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboolean undo_on, const gboolean group_on);
+void dt_tag_attach_string_list(const gchar *tags, const GList *img, const gboolean undo_on);
 
 /** detach tag from images. \param[in] tagid if of tag to deattach. \param[in] img the list of image id to detach
  * tag from */
-void dt_tag_detach_images(const guint tagid, const GList *img, const gboolean undo_on, const gboolean group_on);
+void dt_tag_detach_images(const guint tagid, const GList *img, const gboolean undo_on);
 /** detach tag from images. \param[in] tagid if of tag to dettach. \param[in] imgid the image id to detach
  * tag from, if < 0 images to act on are used. */
 void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on);

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -81,7 +81,7 @@ static gboolean _lib_duplicate_caption_out_callback(GtkWidget *widget, GdkEvent 
   const int imgid = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget),"imgid"));
 
   // we write the content of the textbox to the caption field
-  dt_metadata_set(imgid, "Xmp.darktable.version_name", gtk_entry_get_text(GTK_ENTRY(widget)), FALSE, FALSE);
+  dt_metadata_set(imgid, "Xmp.darktable.version_name", gtk_entry_get_text(GTK_ENTRY(widget)), FALSE);
   dt_image_synch_xmp(imgid);
 
   return FALSE;
@@ -182,7 +182,7 @@ static void _lib_duplicate_thumb_release_callback(GtkWidget *widget, GdkEventBut
   dt_lib_duplicate_t *d = (dt_lib_duplicate_t *)self->data;
 
   d->imgid = 0;
-  if(d->busy) 
+  if(d->busy)
   {
     dt_control_log_busy_leave();
     dt_control_toast_busy_leave();
@@ -285,7 +285,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
   }
   else
   {
-    if(d->busy) 
+    if(d->busy)
     {
       dt_control_log_busy_leave();
       dt_control_toast_busy_leave();

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -227,12 +227,12 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     if(colors_flag)
     {
       const int colors = (action == DT_MA_CLEAR) ? 0 : dt_colorlabels_get_labels(imageid);
-      dt_colorlabels_set_labels(imgs, colors, action != DT_MA_MERGE, TRUE, FALSE);
+      dt_colorlabels_set_labels(imgs, colors, action != DT_MA_MERGE, TRUE);
     }
     if(dtmetadata_flag)
     {
       GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
-      dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE, FALSE);
+      dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE);
       g_list_free_full(metadata, g_free);
     }
     if(geotag_flag)
@@ -242,14 +242,14 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
         geoloc->longitude = geoloc->latitude = geoloc->elevation = NAN;
       else
         dt_image_get_location(imageid, geoloc);
-      dt_image_set_locations(imgs, geoloc, TRUE, FALSE);
+      dt_image_set_locations(imgs, geoloc, TRUE);
       g_free(geoloc);
     }
     if(dttag_flag)
     {
       // affect only user tags (not dt tags)
       GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
-      dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE, FALSE);
+      dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE);
       g_list_free(tags);
     }
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -998,14 +998,14 @@ static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_li
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
   if(!imgs) return;
 
   GList *affected_images = dt_tag_get_images_from_list(imgs, tagid);
   g_list_free(imgs);
   if(affected_images)
   {
-    dt_tag_detach_images(tagid, affected_images, TRUE, TRUE);
+    dt_tag_detach_images(tagid, affected_images, TRUE);
 
     _init_treeview(self, 0);
     if (d->tree_flag || !d->suggestion_flag)
@@ -1184,8 +1184,8 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   const gchar *tag = gtk_entry_get_text(d->entry);
   if(!tag || tag[0] == '\0') return;
 
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
-  dt_tag_attach_string_list(tag, imgs, TRUE, TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  dt_tag_attach_string_list(tag, imgs, TRUE);
   dt_image_synch_xmps(imgs);
   g_list_free(imgs);
 
@@ -2835,7 +2835,7 @@ static gboolean _lib_tagging_tag_key_press(GtkWidget *entry, GdkEventKey *event,
     case GDK_KEY_KP_Enter:
     {
       const gchar *tag = gtk_entry_get_text(GTK_ENTRY(entry));
-      dt_tag_attach_string_list(tag, d->floating_tag_imgs, TRUE, TRUE);
+      dt_tag_attach_string_list(tag, d->floating_tag_imgs, TRUE);
       dt_image_synch_xmps(d->floating_tag_imgs);
       g_list_free(d->floating_tag_imgs);
 
@@ -2869,7 +2869,7 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
   if(d->last_tag)
   {
     GList *imgs = dt_view_get_images_to_act_on(TRUE);
-    dt_tag_attach_string_list(d->last_tag, imgs, TRUE, TRUE);
+    dt_tag_attach_string_list(d->last_tag, imgs, TRUE);
     dt_image_synch_xmps(imgs);
     g_list_free(imgs);
 
@@ -2890,7 +2890,7 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
     return TRUE;  // doesn't work properly with tree treeview
   }
 
-  d->floating_tag_imgs = dt_view_get_images_to_act_on(TRUE);
+  d->floating_tag_imgs = dt_view_get_images_to_act_on(FALSE);
   gint x, y;
   gint px, py, w, h;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);

--- a/src/lua/image.c
+++ b/src/lua/image.c
@@ -252,7 +252,7 @@ static int metadata_member(lua_State *L)
   else
   {
     dt_image_t *my_image = checkwriteimage(L, 1);
-    dt_metadata_set(my_image->id, key, luaL_checkstring(L, 3), FALSE, FALSE);
+    dt_metadata_set(my_image->id, key, luaL_checkstring(L, 3), FALSE);
     dt_image_synch_xmp(my_image->id);
     releasewriteimage(L, my_image);
     return 0;

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -1234,7 +1234,7 @@ static void drag_and_drop_received(GtkWidget *widget, GdkDragContext *context, g
       osm_gps_map_point_get_degrees(pt, &latitude, &longitude);
       osm_gps_map_point_free(pt);
       const dt_image_geoloc_t geoloc = { longitude, latitude, NAN };
-      dt_image_set_locations(imgs, &geoloc, TRUE, TRUE);
+      dt_image_set_locations(imgs, &geoloc, TRUE);
       g_list_free(imgs);
       success = TRUE;
     }
@@ -1312,7 +1312,7 @@ static void _view_map_dnd_remove_callback(GtkWidget *widget, GdkDragContext *con
       }
       //  image(s) dropped into the filmstrip, let's remove it (them) in this case
       const dt_image_geoloc_t geoloc = { NAN, NAN, NAN };
-      dt_image_set_locations(imgs, &geoloc, TRUE, TRUE);
+      dt_image_set_locations(imgs, &geoloc, TRUE);
       g_list_free(imgs);
       success = TRUE;
     }


### PR DESCRIPTION
As dt_view_get_images_to_act_on() has now the ability to add grouped images, this last action ( EDIT add grouped images) is removed from action on image list.
However it remains on action on single image.
