### PR TITLE
last phase of the colorpicker refactor

### DIFF
--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -478,7 +478,7 @@ void dt_iop_gui_update_masks(dt_iop_module_t *module);
 void dt_iop_gui_cleanup_blending(dt_iop_module_t *module);
 void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module);
 
-gboolean blend_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece);
+gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece);
 
 /** routine to translate from mode id to sequence in option list */
 int dt_iop_gui_blending_mode_seq(dt_iop_gui_blend_data_t *bd, int mode);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1116,10 +1116,10 @@ static void _blendop_masks_polarity_callback(GtkToggleButton *togglebutton, dt_i
   dt_control_queue_redraw_widget(GTK_WIDGET(togglebutton));
 }
 
-gboolean blend_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece)
+gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_gui_blend_data_t *data = module->blend_data;
-  if(module->picker->colorpick == data->colorpicker_set_values)
+  if(picker == data->colorpicker_set_values)
   {
     if(darktable.gui->reset) return TRUE;
 
@@ -1223,7 +1223,7 @@ gboolean blend_color_picker_apply(struct dt_iop_module_t *module, dt_dev_pixelpi
 
     return TRUE;
   }
-  else if(module->picker->colorpick == data->colorpicker)
+  else if(picker == data->colorpicker)
   {
     if(darktable.gui->reset) return TRUE;
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -450,12 +450,6 @@ static void _blendop_blendif_contrast_callback(GtkWidget *slider, dt_iop_gui_ble
   dt_dev_add_history_item(darktable.develop, data->module, TRUE);
 }
 
-static void _blendop_blendif_reset_picker_set_values(dt_iop_gui_blend_data_t *data)
-{
-  if(data->module->picker->colorpick == data->colorpicker_set_values)
-    dt_iop_color_picker_reset(data->module, TRUE);
-}
-
 static void _blendop_blendif_sliders_callback(GtkDarktableGradientSlider *slider, dt_iop_gui_blend_data_t *data)
 {
   if(darktable.gui->reset) return;
@@ -478,7 +472,7 @@ static void _blendop_blendif_sliders_callback(GtkDarktableGradientSlider *slider
 
   float *parameters = &(bp->blendif_parameters[4 * ch]);
 
-  _blendop_blendif_reset_picker_set_values(data);
+  dt_iop_color_picker_reset(data->module, TRUE);
 
   dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++) parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
@@ -660,7 +654,7 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
 {
   dt_iop_gui_blend_data_t *data = module->blend_data;
 
-  dt_iop_color_picker_set_cst(module->picker, _blendop_blendif_get_picker_colorspace(data));
+  dt_iop_color_picker_set_cst(module, _blendop_blendif_get_picker_colorspace(data));
 
   float *raw_mean, *raw_min, *raw_max;
   GtkDarktableGradientSlider *widget;
@@ -688,8 +682,9 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
       label = data->upper_picker_label;
     }
 
-    if((module->picker->colorpick == data->colorpicker || module->picker->colorpick == data->colorpicker_set_values) 
-      && (module->request_color_pick != DT_REQUEST_COLORPICK_OFF) && (raw_min[0] != INFINITY))
+    if((gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker)) ||
+        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values))) && 
+       (raw_min[0] != INFINITY))
     {
       float picker_mean[8], picker_min[8], picker_max[8];
       float cooked[8];
@@ -829,10 +824,12 @@ static void _blendop_blendif_tab_switch(GtkNotebook *notebook, GtkWidget *page, 
 
   data->tab = page_num;
 
-  if((data->module->picker->colorpick == data->colorpicker || data->module->picker->colorpick == data->colorpicker_set_values) &&
-    (cst_old != _blendop_blendif_get_picker_colorspace(data) || data->module->picker->colorpick == data->colorpicker_set_values))
+  if(cst_old != _blendop_blendif_get_picker_colorspace(data) &&
+     (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker)) ||
+      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values))))
+      
   {
-    dt_iop_color_picker_set_cst(data->module->picker, _blendop_blendif_get_picker_colorspace(data));
+    dt_iop_color_picker_set_cst(data->module, _blendop_blendif_get_picker_colorspace(data));
     dt_dev_reprocess_all(data->module->dev);
     dt_control_queue_redraw();
   }
@@ -1651,6 +1648,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->colorpicker = dt_color_picker_new(module, DT_COLOR_PICKER_POINT_AREA, header);
     gtk_widget_set_tooltip_text(bd->colorpicker, _("pick GUI color from image\nctrl+click to select an area"));
+    gtk_widget_set_name(bd->colorpicker, "keep-active");
 
     bd->colorpicker_set_values = dt_color_picker_new(module, DT_COLOR_PICKER_AREA, header);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->colorpicker_set_values),

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -389,7 +389,6 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
     module->picked_color_max[k] = module->picked_output_color_max[k] = -666.0f;
   }
   module->picker = NULL;
-  module->blend_picker = NULL;
   module->histogram_cst = iop_cs_NONE;
   module->color_picker_box[0] = module->color_picker_box[1] = .25f;
   module->color_picker_box[2] = module->color_picker_box[3] = .75f;
@@ -1516,7 +1515,6 @@ void dt_iop_cleanup_module(dt_iop_module_t *module)
   free(module->default_blendop_params);
   module->default_blendop_params = NULL;
   module->picker = NULL;
-  module->blend_picker = NULL;
   free(module->histogram);
   module->histogram = NULL;
   g_hash_table_destroy(module->raster_mask.source.users);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1728,6 +1728,8 @@ void dt_iop_request_focus(dt_iop_module_t *module)
     if(darktable.develop->gui_module->gui_focus)
       darktable.develop->gui_module->gui_focus(darktable.develop->gui_module, FALSE);
 
+    dt_iop_color_picker_reset(darktable.develop->gui_module, TRUE);
+
     gtk_widget_set_state_flags(dt_iop_gui_get_pluginui(darktable.develop->gui_module), GTK_STATE_FLAG_NORMAL,
                                TRUE);
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -120,9 +120,8 @@ typedef void dt_iop_global_data_t;
 /** color picker request */
 typedef enum dt_dev_request_colorpick_flags_t
 {
-  DT_REQUEST_COLORPICK_OFF = 0,         // off
-  DT_REQUEST_COLORPICK_MODULE = 1 << 0, // requested by module (should take precedence)
-  DT_REQUEST_COLORPICK_BLEND = 1 << 1   // requested by parametric blending gui
+  DT_REQUEST_COLORPICK_OFF = 0,   // off
+  DT_REQUEST_COLORPICK_MODULE = 1 // requested by module (should take precedence)
 } dt_dev_request_colorpick_flags_t;
 
 /** colorspace enums, must be in synch with dt_iop_colorspace_type_t in color_conversion.cl */
@@ -302,9 +301,8 @@ typedef struct dt_iop_module_t
   int request_mask_display;
   /** set to 1 if you want the blendif mask to be suppressed in the module in focus. gui mode only. */
   int32_t suppress_mask;
-  /** color picker proxys */
+  /** color picker proxy */
   struct dt_iop_color_picker_t *picker;
-  struct dt_iop_color_picker_t *blend_picker;
   /** bounding box in which the mean color is requested. */
   float color_picker_box[4];
   /** single point to pick if in point mode */

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -203,7 +203,7 @@ typedef struct dt_iop_module_so_t
   void (*gui_reset)(struct dt_iop_module_t *self);
   void (*gui_update)(struct dt_iop_module_t *self);
   void (*gui_init)(struct dt_iop_module_t *self);
-  void (*color_picker_apply)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece);
+  void (*color_picker_apply)(struct dt_iop_module_t *self, GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   void (*gui_post_expose)(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
                           int32_t pointerx, int32_t pointery);
@@ -437,7 +437,7 @@ typedef struct dt_iop_module_t
   /** construct widget. */
   void (*gui_init)(struct dt_iop_module_t *self);
   /** apply color picker results */
-  void (*color_picker_apply)(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece);
+  void (*color_picker_apply)(struct dt_iop_module_t *self, GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
   /** destroy widget. */
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   /** optional method called after darkroom expose. */

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -23,46 +23,51 @@
 #include "gui/gtk.h"
 #include "develop/blend.h"
 
-typedef enum _internal__status
+static gboolean _iop_record_point_area(dt_iop_color_picker_t *self)
 {
-  PICKER_STATUS_NONE = 0,
-  PICKER_STATUS_SELECTED
-} dt_internal_status_t;
+  gboolean selection_changed = FALSE;
 
-typedef enum dt_iop_color_picker_requested_by_t
-{
-  DT_COLOR_PICKER_REQ_MODULE = 0,
-  DT_COLOR_PICKER_REQ_BLEND
-} dt_iop_color_picker_requested_by_t;
+  if(self)
+  {
+    for(int k = 0; k < 2; k++)
+    {
+      if(self->pick_pos[k] != self->module->color_picker_point[k])
+      {
+      
+        self->pick_pos[k] = self->module->color_picker_point[k];
+        selection_changed = TRUE;
+      }
 
-static void _iop_record_point(dt_iop_color_picker_t *self)
-{
-  const int pick_index = CLAMP(self->current_picker, 1, 9) - 1;
-  self->pick_pos[pick_index][0] = self->module->color_picker_point[0];
-  self->pick_pos[pick_index][1] = self->module->color_picker_point[1];
-  for(int k = 0; k < 4; k++) self->pick_box[pick_index][k] = self->module->color_picker_box[k];
+    }
+    for(int k = 0; k < 4; k++) 
+    {
+      if (self->pick_box[k] != self->module->color_picker_box[k])
+      {
+        self->pick_box[k] = self->module->color_picker_box[k];
+        selection_changed = TRUE;
+      }
+    }
+  }
+
+  return selection_changed;
 }
 
 static void _iop_get_point(dt_iop_color_picker_t *self, float *pos)
 {
-  const int pick_index = CLAMP(self->current_picker, 1, 9) - 1;
-
   pos[0] = pos[1] = 0.5f;
 
-  if(!isnan(self->pick_pos[pick_index][0]) && !isnan(self->pick_pos[pick_index][1]))
+  if(!isnan(self->pick_pos[0]) && !isnan(self->pick_pos[1]))
   {
-    pos[0] = self->pick_pos[pick_index][0];
-    pos[1] = self->pick_pos[pick_index][1];
+    pos[0] = self->pick_pos[0];
+    pos[1] = self->pick_pos[1];
   }
 }
 
 static void _iop_get_area(dt_iop_color_picker_t *self, float *box)
 {
-  const int pick_index = CLAMP(self->current_picker, 1, 9) - 1;
-
-  if(!isnan(self->pick_box[pick_index][0]) && !isnan(self->pick_box[pick_index][1]))
+  if(!isnan(self->pick_box[0]) && !isnan(self->pick_box[1]))
   {
-    for(int k = 0; k < 4; k++) box[k] = self->pick_box[pick_index][k];
+    for(int k = 0; k < 4; k++) box[k] = self->pick_box[k];
   }
   else
   {
@@ -73,203 +78,95 @@ static void _iop_get_area(dt_iop_color_picker_t *self, float *box)
   }
 }
 
-static int _internal_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button)
+static void _iop_color_picker_apply(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece)
 {
-  const int current_picker = picker->current_picker;
-
-  picker->current_picker = PICKER_STATUS_SELECTED;
-
-  if(current_picker == picker->current_picker)
-    return DT_COLOR_PICKER_ALREADY_SELECTED;
-  else
-    return picker->current_picker;
-}
-
-static void _internal_iop_color_picker_update(dt_iop_color_picker_t *picker)
-{
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
-
-  if(DTGTK_IS_TOGGLEBUTTON(picker->colorpick))
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(picker->colorpick), picker->current_picker == PICKER_STATUS_SELECTED);
-  else
-    dt_bauhaus_widget_set_quad_active(picker->colorpick, picker->current_picker == PICKER_STATUS_SELECTED);
-
-  darktable.gui->reset = reset;
-}
-
-void dt_iop_color_picker_apply_module(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && module->picker && module->picker->apply)
+  if(_iop_record_point_area(module->picker))
   {
-    if(module->picker->skip_apply)
-      module->picker->skip_apply = FALSE;
-    else
-      module->picker->apply(module, piece);
-    _iop_record_point(module->picker);
-  }
-  else if(module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && module->blend_picker && module->blend_picker->apply)
-  {
-    if(module->blend_picker->skip_apply)
-      module->blend_picker->skip_apply = FALSE;
-    else
-      module->blend_picker->apply(module, piece);
-    _iop_record_point(module->blend_picker);
+    if(!module->blend_data || !blend_color_picker_apply(module, piece))
+    {
+      if(module->color_picker_apply) 
+        module->color_picker_apply(module, piece);
+    }
   }
 }
 
 static void _iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean update)
 {
-  if((picker->requested_by == DT_COLOR_PICKER_REQ_MODULE && picker->module->request_color_pick == DT_REQUEST_COLORPICK_MODULE) ||
-      (picker->requested_by == DT_COLOR_PICKER_REQ_BLEND && picker->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND))
+  if(picker)
+  {
+    const int reset = darktable.gui->reset;
+    darktable.gui->reset = 1;
+
+    if(DTGTK_IS_TOGGLEBUTTON(picker->colorpick))
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(picker->colorpick), FALSE);
+    else
+      dt_bauhaus_widget_set_quad_active(picker->colorpick, FALSE);
+
     picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-  picker->current_picker = PICKER_STATUS_NONE;
-  if(update) dt_iop_color_picker_update(picker);
+
+    darktable.gui->reset = reset;
+  }
 }
 
 void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update)
 {
-  if(module->picker) _iop_color_picker_reset(module->picker, update);
-  if(module->blend_picker) _iop_color_picker_reset(module->blend_picker, update);
-}
-
-int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button)
-{
-  if(picker->get_set)
-    return picker->get_set(picker->module, button);
-  else
-    return _internal_iop_color_picker_get_set(picker, button);
-}
-
-void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(picker->skip_apply)
-    picker->skip_apply = FALSE;
-  else
-    picker->apply(picker->module, piece);
-}
-
-void dt_iop_color_picker_update(dt_iop_color_picker_t *picker)
-{
-  if(picker->update)
-    picker->update(picker->module);
-  else
-    _internal_iop_color_picker_update(picker);
+  if(module->picker)
+  {
+    if(strcmp(gtk_widget_get_name(module->picker->colorpick), "keep-active") != 0)
+    {
+      _iop_color_picker_reset(module->picker, update);
+      module->picker = NULL;
+    }
+  }
 }
 
 static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
-                             dt_iop_color_picker_kind_t kind, const int requested_by,
-                             int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                             void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
-                             void (*update)(dt_iop_module_t *self))
+                             dt_iop_color_picker_kind_t kind, GtkWidget *button)
 {
-  picker->module  = module;
-  picker->get_set = get_set;
-  picker->apply   = apply;
-  picker->update  = update;
-  picker->kind    = kind;
-  picker->requested_by = requested_by;
+  picker->module     = module;
+  picker->kind       = kind;
   picker->picker_cst = iop_cs_NONE;
-  picker->skip_apply = FALSE;
-  if(picker->requested_by == DT_COLOR_PICKER_REQ_MODULE)
-    module->picker  = picker;
-  else
-    module->blend_picker  = picker;
-
-  for(int i = 0; i<9; i++)
-  {
-    for(int j = 0; j<2; j++)
-      picker->pick_pos[i][j] = NAN;
-    for(int j = 0; j < 4; j++) picker->pick_box[i][j] = NAN;
-  }
+  picker->colorpick  = button;
+  
+  for(int j = 0; j<2; j++) picker->pick_pos[j] = NAN;
+  for(int j = 0; j < 4; j++) picker->pick_box[j] = NAN;
 
   _iop_color_picker_reset(picker, TRUE);
 }
 
-void dt_iop_init_single_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, GtkWidget *colorpick,
-                               dt_iop_color_picker_kind_t kind,
-                               void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece))
-{
-  picker->colorpick = colorpick;
-  dt_iop_init_picker(picker, module, kind, NULL, apply, NULL);
-}
-
-void dt_iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, dt_iop_color_picker_kind_t kind,
-                        int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                        void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
-                        void (*update)(dt_iop_module_t *self))
-{
-  _iop_init_picker(picker,
-                    module,
-                    kind,
-                    DT_COLOR_PICKER_REQ_MODULE,
-                    get_set,
-                    apply,
-                    update);
-}
-
-void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
-                              dt_iop_color_picker_kind_t kind,
-                              int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                              void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
-                              void (*update)(dt_iop_module_t *self))
-{
-  _iop_init_picker(picker,
-                    module,
-                    kind,
-                    DT_COLOR_PICKER_REQ_BLEND,
-                    get_set,
-                    apply,
-                    update);
-}
-
-static gboolean _iop_color_picker_callback(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
+static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
 {
   if(self->module->dt->gui->reset) return FALSE;
 
   // set module active if not yet the case
   if(self->module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->module->off), TRUE);
 
-  // When using multiple single pickers with one module; switch old one off and put new one in place
-  if (self->module->picker != self)
+  const uint32_t state = e != NULL
+                        ? e->state
+                        : gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
+  gboolean ctrl_key_pressed = (state & gtk_accelerator_get_default_mod_mask()) == GDK_CONTROL_MASK;
+  dt_iop_color_picker_kind_t kind = self->kind;
+
+  if (self->module->picker != self || (ctrl_key_pressed && kind == DT_COLOR_PICKER_POINT_AREA))
   {
-    dt_iop_color_picker_reset(self->module, TRUE);
+    _iop_color_picker_reset(self->module->picker, TRUE);
     self->module->picker = self;
-  }
 
-  // get the current color picker (a module can have multiple one)
-  // should returns -1 if the same picker was already selected.
-  const int clicked_colorpick = dt_iop_color_picker_get_set(self, button);
+    const int reset = darktable.gui->reset;
+    darktable.gui->reset = 1;
 
-  if(self->module->request_color_pick == DT_REQUEST_COLORPICK_OFF || clicked_colorpick != DT_COLOR_PICKER_ALREADY_SELECTED)
-  {
-    if(self->requested_by == DT_COLOR_PICKER_REQ_MODULE)
-    {
-      if(self->module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && self->module->blend_picker)
-        _iop_color_picker_reset(self->module->blend_picker, TRUE);
-
-      self->module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
-    }
+    if(DTGTK_IS_TOGGLEBUTTON(self->colorpick))
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->colorpick), TRUE);
     else
-    {
-      if(self->module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && self->module->picker)
-        _iop_color_picker_reset(self->module->picker, TRUE);
+      dt_bauhaus_widget_set_quad_active(self->colorpick, TRUE);
 
-      self->module->request_color_pick = DT_REQUEST_COLORPICK_BLEND;
-    }
+    darktable.gui->reset = reset;
 
-    if(clicked_colorpick != DT_COLOR_PICKER_ALREADY_SELECTED)
-      self->current_picker = clicked_colorpick;
+    self->module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
-    dt_iop_color_picker_kind_t kind = self->kind;
     if(kind == DT_COLOR_PICKER_POINT_AREA)
     {
-      const uint32_t state = (e != NULL) ? e->state: 0;
-      GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-      if((state & modifiers) == GDK_CONTROL_MASK)
-        kind = DT_COLOR_PICKER_AREA;
-      else
-        kind = DT_COLOR_PICKER_POINT;
+      kind = ctrl_key_pressed ? DT_COLOR_PICKER_AREA : DT_COLOR_PICKER_POINT;
     }
     if(kind == DT_COLOR_PICKER_AREA)
     {
@@ -288,49 +185,40 @@ static gboolean _iop_color_picker_callback(GtkWidget *button, GdkEventButton *e,
   }
   else
   {
-    /* focus on the center area, to force a redraw when focus on module is called below */
-    _iop_color_picker_reset(self, FALSE);
+    _iop_color_picker_reset(self->module->picker, TRUE);
+    self->module->picker = NULL;
   }
-  dt_iop_color_picker_update(self);
+
   dt_control_queue_redraw();
   dt_iop_request_focus(self->module);
 
   return TRUE;
 }
 
-void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
+static void _iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self)
 {
-  _iop_color_picker_callback(button, NULL, self);
+  _iop_color_picker_callback_button_press(button, NULL, self);
 }
 
-gboolean dt_iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
+void dt_iop_color_picker_set_cst(dt_iop_module_t *module, const dt_iop_colorspace_type_t picker_cst)
 {
-  return _iop_color_picker_callback(button, e, self);
-}
-
-void dt_iop_color_picker_set_cst(dt_iop_color_picker_t *picker, const dt_iop_colorspace_type_t picker_cst)
-{
-  picker->picker_cst = picker_cst;
+  if(module->picker) 
+    module->picker->picker_cst = picker_cst;
 }
 
 dt_iop_colorspace_type_t dt_iop_color_picker_get_active_cst(dt_iop_module_t *module)
 {
-  dt_iop_colorspace_type_t picker_cst = iop_cs_NONE;
-
-  if(module->request_color_pick == DT_REQUEST_COLORPICK_BLEND && module->blend_picker)
-    picker_cst = module->blend_picker->picker_cst;
-  else if(module->request_color_pick == DT_REQUEST_COLORPICK_MODULE && module->picker)
-    picker_cst = module->picker->picker_cst;
-
-  return picker_cst;
+  if(module->picker)
+    return module->picker->picker_cst;
+  else
+    return iop_cs_NONE;
 }
 
 static void _iop_color_picker_signal_callback(gpointer instance, dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece,
                                               gpointer user_data)
 {
-  dt_iop_color_picker_apply_module(module, piece);
+  _iop_color_picker_apply(module, piece);
 }
-
 
 void dt_iop_color_picker_init(void)
 {
@@ -343,14 +231,6 @@ void dt_iop_color_picker_cleanup(void)
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_iop_color_picker_signal_callback), NULL);
 }
 
-void dt_iop_color_picker_both_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
-{
-  if(!self->blend_data || !blend_color_picker_apply(self, piece))
-  {
-    if(self->color_picker_apply) self->color_picker_apply(self, piece);
-  }
-}
-
 GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind_t kind, GtkWidget *w)
 {
   dt_iop_color_picker_t *color_picker = (dt_iop_color_picker_t *)g_malloc(sizeof(dt_iop_color_picker_t));
@@ -358,9 +238,9 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
   if(w == NULL || GTK_IS_BOX(w))
   {
     GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
-    dt_iop_init_single_picker(color_picker, module, button, kind, dt_iop_color_picker_both_apply);
+    _iop_init_picker(color_picker, module, kind, button);
     g_signal_connect_data(G_OBJECT(button), "button-press-event", 
-                          G_CALLBACK(dt_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
+                          G_CALLBACK(_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);
     if (w) gtk_box_pack_start(GTK_BOX(w), button, FALSE, FALSE, 0);
 
     return button;
@@ -369,9 +249,9 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
   {
     dt_bauhaus_widget_set_quad_paint(w, dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     dt_bauhaus_widget_set_quad_toggle(w, TRUE);
-    dt_iop_init_single_picker(color_picker, module, w, kind, dt_iop_color_picker_both_apply);
+    _iop_init_picker(color_picker, module, kind, w);
     g_signal_connect_data(G_OBJECT(w), "quad-pressed", 
-                          G_CALLBACK(dt_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
+                          G_CALLBACK(_iop_color_picker_callback), color_picker, (GClosureNotify)g_free, 0);
 
     return w;
   }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -23,6 +23,22 @@
 #include "gui/gtk.h"
 #include "develop/blend.h"
 
+typedef struct dt_iop_color_picker_t
+{
+  dt_iop_module_t *module;
+  dt_iop_color_picker_kind_t kind;
+  /** requested colorspace for the color picker, valid options are:
+   * iop_cs_NONE: module colorspace
+   * iop_cs_LCh: for Lab modules
+   * iop_cs_HSL: for RGB modules
+   */
+  dt_iop_colorspace_type_t picker_cst;
+  /** used to avoid recursion when a parameter is modified in the apply() */
+  GtkWidget *colorpick;
+  float pick_pos[2]; // last picker positions (max 9 picker per module)
+  float pick_box[4]; // last picker areas (max 9 picker per module)
+} dt_iop_color_picker_t;
+
 static gboolean _iop_record_point_area(dt_iop_color_picker_t *self)
 {
   gboolean selection_changed = FALSE;
@@ -82,10 +98,10 @@ static void _iop_color_picker_apply(dt_iop_module_t *module, dt_dev_pixelpipe_io
 {
   if(_iop_record_point_area(module->picker))
   {
-    if(!module->blend_data || !blend_color_picker_apply(module, piece))
+    if(!module->blend_data || !blend_color_picker_apply(module, module->picker->colorpick, piece))
     {
       if(module->color_picker_apply) 
-        module->color_picker_apply(module, piece);
+        module->color_picker_apply(module, module->picker->colorpick, piece);
     }
   }
 }

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -27,8 +27,6 @@
   a single color picker is available in a module.
 */
 
-#define DT_COLOR_PICKER_ALREADY_SELECTED -1
-
 #include <gtk/gtk.h>
 #include "develop/imageop.h"
 
@@ -43,81 +41,23 @@ typedef struct dt_iop_color_picker_t
 {
   dt_iop_module_t *module;
   dt_iop_color_picker_kind_t kind;
-  int requested_by;
   /** requested colorspace for the color picker, valid options are:
    * iop_cs_NONE: module colorspace
    * iop_cs_LCh: for Lab modules
    * iop_cs_HSL: for RGB modules
    */
   dt_iop_colorspace_type_t picker_cst;
-  unsigned short current_picker;
   /** used to avoid recursion when a parameter is modified in the apply() */
-  gboolean skip_apply;
   GtkWidget *colorpick;
-  float pick_pos[9][2]; // last picker positions (max 9 picker per module)
-  float pick_box[9][4]; // last picker areas (max 9 picker per module)
-  /* get and set the selected picker corresponding to button, the module must record the previous
-     selected picker and return DT_COLOR_PICKER_ALREADY_SELECTED if the same picker has been selected. The return
-     value corresponds to the module internal picker id. */
-  int (*get_set)(dt_iop_module_t *self, GtkWidget *button);
-  /* apply the picked color to the selected picker (internal picker id, if multiple are available
-     on the module */
-  void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece);
-  /* update the picker icon to correspond to the current selected picker if any */
-  void (*update)(dt_iop_module_t *self);
+  float pick_pos[2]; // last picker positions (max 9 picker per module)
+  float pick_box[4]; // last picker areas (max 9 picker per module)
 } dt_iop_color_picker_t;
 
-/* init color picker, this must be called when all picker widgets are created */
-void dt_iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, dt_iop_color_picker_kind_t kind,
-                        int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                        void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
-                        void (*update)(dt_iop_module_t *self));
-
-/* init for a single color picker in iop, this must be called when all picker widget are created */
-void dt_iop_init_single_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module, GtkWidget *colorpick,
-                               dt_iop_color_picker_kind_t kind,
-                               void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece));
-
-/* same as previous but for the blend module */
-void dt_iop_init_blend_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *module,
-                              dt_iop_color_picker_kind_t kind,
-                              int (*get_set)(dt_iop_module_t *self, GtkWidget *button),
-                              void (*apply)(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece),
-                              void (*update)(dt_iop_module_t *self));
-
-/* the color picker callback which must be used for every picker, as an example:
-
-      g_signal_connect(G_OBJECT(g->button), "quad-pressed",
-                       G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-
-or for a simple togglebutton:
-
-      g_signal_connect(G_OBJECT(g->color_picker_button), "toggled",
-                       G_CALLBACK(dt_iop_color_picker_callback), &g->color_picker);
-*/
-void dt_iop_color_picker_callback(GtkWidget *button, dt_iop_color_picker_t *self);
-
-/* same as before but when DT_COLOR_PICKER_POINT_AREA is used, works only with togglebutton
-
-      g_signal_connect(G_OBJECT(g->color_picker_button), "button-press-event",
-                       G_CALLBACK(dt_iop_color_picker_callback_button_press), &g->color_picker);
-*/
-gboolean dt_iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self);
-
-/* called by pixelpipe when color has been updated */
-void dt_iop_color_picker_apply_module(dt_iop_module_t *module, dt_dev_pixelpipe_iop_t *piece);
-
-/* call proxy get_set */
-int dt_iop_color_picker_get_set(dt_iop_color_picker_t *picker, GtkWidget *button);
-/* call proxy apply */
-void dt_iop_color_picker_apply(dt_iop_color_picker_t *picker, dt_dev_pixelpipe_iop_t *piece);
-/* call proxy update */
-void dt_iop_color_picker_update(dt_iop_color_picker_t *picker);
-/* reset current color picker and/or blend color picker, and if update is TRUE also call update proxy */
+//* reset current color picker and/or blend color picker, and if update is TRUE also call update proxy */
 void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update);
 
 /* sets the picker colorspace */
-void dt_iop_color_picker_set_cst(dt_iop_color_picker_t *picker, const dt_iop_colorspace_type_t picker_cst);
+void dt_iop_color_picker_set_cst(dt_iop_module_t *module, const dt_iop_colorspace_type_t picker_cst);
 
 /* returns the active picker colorspace (if any) */
 dt_iop_colorspace_type_t dt_iop_color_picker_get_active_cst(dt_iop_module_t *module);

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -37,22 +37,6 @@ typedef enum _iop_color_picker_kind_t
   DT_COLOR_PICKER_POINT_AREA // allow the user to select between point and area
 } dt_iop_color_picker_kind_t;
 
-typedef struct dt_iop_color_picker_t
-{
-  dt_iop_module_t *module;
-  dt_iop_color_picker_kind_t kind;
-  /** requested colorspace for the color picker, valid options are:
-   * iop_cs_NONE: module colorspace
-   * iop_cs_LCh: for Lab modules
-   * iop_cs_HSL: for RGB modules
-   */
-  dt_iop_colorspace_type_t picker_cst;
-  /** used to avoid recursion when a parameter is modified in the apply() */
-  GtkWidget *colorpick;
-  float pick_pos[2]; // last picker positions (max 9 picker per module)
-  float pick_box[4]; // last picker areas (max 9 picker per module)
-} dt_iop_color_picker_t;
-
 //* reset current color picker and/or blend color picker, and if update is TRUE also call update proxy */
 void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update);
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -591,7 +591,7 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
   dt_iop_basicadj_params_t *p = (dt_iop_basicadj_params_t *)self->params;

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -611,9 +611,6 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   dt_bauhaus_slider_set(g->sl_middle_grey, p->middle_grey);
   darktable.gui->reset = reset;
 
-  // avoid recursion
-  self->picker->skip_apply = TRUE;
-
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -723,7 +723,7 @@ void cleanup(dt_iop_module_t *module)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  if(!in) _turn_selregion_picker_off(self);
+  if(!in) _turn_select_region_off(self);
 }
 
 void change_image(struct dt_iop_module_t *self)

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -601,7 +601,7 @@ void init_presets(dt_iop_module_so_t *self)
   dt_gui_presets_add_generic(_("15:10 postcard black"), self->op, self->version(), &p, sizeof(p), 1);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
@@ -627,14 +627,14 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
                         .blue = self->picked_color[2],
                         .alpha = 1.0 };
 
-  if(self->picker->colorpick == g->frame_picker)
+  if(picker == g->frame_picker)
   {
     p->frame_color[0] = self->picked_color[0];
     p->frame_color[1] = self->picked_color[1];
     p->frame_color[2] = self->picked_color[2];
     gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->frame_colorpick), &c);
   }
-  else if(self->picker->colorpick == g->border_picker)
+  else if(picker == g->border_picker)
   {
     p->color[0] = self->picked_color[0];
     p->color[1] = self->picked_color[1];

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1369,26 +1369,26 @@ static void apply_autoluma(dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if     (self->picker->colorpick == g->hue_lift)
+  if     (picker == g->hue_lift)
     apply_lift_neutralize(self);
-  else if(self->picker->colorpick == g->hue_gamma)
+  else if(picker == g->hue_gamma)
     apply_gamma_neutralize(self);
-  else if(self->picker->colorpick == g->hue_gain)
+  else if(picker == g->hue_gain)
     apply_gain_neutralize(self);
-  else if(self->picker->colorpick == g->lift_factor)
+  else if(picker == g->lift_factor)
     apply_lift_auto(self);
-  else if(self->picker->colorpick == g->gamma_factor)
+  else if(picker == g->gamma_factor)
     apply_gamma_auto(self);
-  else if(self->picker->colorpick == g->gain_factor)
+  else if(picker == g->gain_factor)
     apply_gain_auto(self);
-  else if(self->picker->colorpick == g->grey)
+  else if(picker == g->grey)
     apply_autogrey(self);
-  else if(self->picker->colorpick == g->auto_luma)
+  else if(picker == g->auto_luma)
     apply_autoluma(self);
-  else if(self->picker->colorpick == g->auto_color)
+  else if(picker == g->auto_color)
     apply_autocolor(self);
   else
     fprintf(stderr, "[colorbalance] unknown color picker\n");

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1396,11 +1396,6 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   _check_tuner_picker_labels(self);
 }
 
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  if(!in) dt_iop_color_picker_reset(self, TRUE);
-}
-
 void init(dt_iop_module_t *module)
 {
   module->params = calloc(1, sizeof(dt_iop_colorbalance_params_t));

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -285,7 +285,7 @@ static void saturation_callback(GtkWidget *slider, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
   dt_iop_colorize_params_t *p = (dt_iop_colorize_params_t *)self->params;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2314,7 +2314,6 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
   if(!in)
   {
-    dt_iop_color_picker_reset(self, TRUE);
     _reset_display_selection(self);
   }
 }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2216,10 +2216,10 @@ static void _display_mask_callback(GtkToggleButton *togglebutton, dt_iop_module_
   dt_dev_reprocess_center(module->dev);
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
-  if(self->picker->colorpick == g->colorpicker_set_values)
+  if(picker == g->colorpicker_set_values)
   {
     dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
     dt_iop_colorzones_params_t *d = (dt_iop_colorzones_params_t *)self->default_params;

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -1686,7 +1686,7 @@ static gboolean _area_scrolled_callback(GtkWidget *widget, GdkEventScroll *event
 
   if(dt_gui_get_scroll_delta(event, &delta_y))
   {
-    if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+    dt_iop_color_picker_reset(self, TRUE);
 
     if(c->edit_by_area)
     {
@@ -1776,8 +1776,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
       const float dy = _mouse_to_curve(c->mouse_y - translate_mouse_y, c->zoom_factor, c->offset_y)
                        - _mouse_to_curve(old_m_y - translate_mouse_y, c->zoom_factor, c->offset_y);
 
-      if(self->picker->colorpick == c->colorpicker_set_values)
-        dt_iop_color_picker_reset(self, TRUE);
+      dt_iop_color_picker_reset(self, TRUE);
       return _move_point_internal(self, widget, dx, dy, event->state);
     }
   }
@@ -1789,8 +1788,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
       if(c->x_move < 0)
       {
         dt_iop_colorzones_get_params(p, c, c->channel, c->mouse_x, c->mouse_y, c->mouse_radius);
-        if(self->picker->colorpick == c->colorpicker_set_values)
-          dt_iop_color_picker_reset(self, TRUE);
+        dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
       }
     }
@@ -1827,8 +1825,7 @@ static gboolean _area_motion_notify_callback(GtkWidget *widget, GdkEventMotion *
         // no vertex was close, create a new one!
         c->selected = _add_node(curve, &p->curve_num_nodes[ch], linx, liny);
 
-        if(self->picker->colorpick == c->colorpicker_set_values)
-          dt_iop_color_picker_reset(self, TRUE);
+        dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
       }
     }
@@ -1930,8 +1927,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
           if(dist < min) c->selected = selected;
         }
 
-        if(self->picker->colorpick == c->colorpicker_set_values)
-          dt_iop_color_picker_reset(self, TRUE);
+        dt_iop_color_picker_reset(self, TRUE);
         dt_dev_add_history_item(darktable.develop, self, TRUE);
         gtk_widget_queue_draw(self->widget);
       }
@@ -1949,8 +1945,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
       c->selected = -2; // avoid motion notify re-inserting immediately.
       dt_bauhaus_combobox_set(c->interpolator, p->curve_type[ch]);
 
-      if(self->picker->colorpick == c->colorpicker_set_values)
-        dt_iop_color_picker_reset(self, TRUE);
+      dt_iop_color_picker_reset(self, TRUE);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       gtk_widget_queue_draw(self->widget);
 
@@ -1975,8 +1970,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
         curve[c->selected].x = reset_value;
       }
 
-      if(self->picker->colorpick == c->colorpicker_set_values)
-        dt_iop_color_picker_reset(self, TRUE);
+      dt_iop_color_picker_reset(self, TRUE);
       gtk_widget_queue_draw(self->widget);
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       return TRUE;
@@ -2008,7 +2002,7 @@ static gboolean _area_button_press_callback(GtkWidget *widget, GdkEventButton *e
     }
     c->selected = -2; // avoid re-insertion of that point immediately after this
 
-    if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+    dt_iop_color_picker_reset(self, TRUE);
     gtk_widget_queue_draw(self->widget);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
     return TRUE;
@@ -2096,7 +2090,7 @@ static gboolean _area_key_press_callback(GtkWidget *widget, GdkEventKey *event, 
 
   if(!handled) return TRUE;
 
-  if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   return _move_point_internal(self, widget, dx, dy, event->state);
 }
 
@@ -2116,7 +2110,7 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
 
   self->dt->gui->reset = reset;
 
-  if(self->picker->colorpick == c->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   if(c->display_mask) dt_dev_reprocess_center(self->dev);
   gtk_widget_queue_draw(self->widget);
 }
@@ -2124,7 +2118,7 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
 static void _color_picker_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
 {
   if(gtk_toggle_button_get_active(togglebutton))
-    dt_iop_color_picker_set_cst(module->picker, iop_cs_LCh);
+    dt_iop_color_picker_set_cst(module, iop_cs_LCh);
 }
 
 
@@ -2136,7 +2130,7 @@ static void _select_by_callback(GtkWidget *widget, dt_iop_module_t *self)
 
   _reset_parameters(p, 2 - (dt_iop_colorzones_channel_t)dt_bauhaus_combobox_get(widget), p->splines_version);
 
-  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   if(g->display_mask) _reset_display_selection(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -2146,11 +2140,10 @@ static void _strength_changed_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
-  dt_iop_colorzones_gui_data_t *g = (dt_iop_colorzones_gui_data_t *)self->gui_data;
 
   p->strength = dt_bauhaus_slider_get(slider);
 
-  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2169,7 +2162,7 @@ static void _interpolator_callback(GtkWidget *widget, dt_iop_module_t *self)
   else if(combo == 2)
     p->curve_type[g->channel] = MONOTONE_HERMITE;
 
-  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
@@ -2192,7 +2185,7 @@ static void _mode_callback(GtkWidget *widget, dt_iop_module_t *self)
 
   p->mode = dt_bauhaus_combobox_get(widget);
 
-  if(self->picker->colorpick == g->colorpicker_set_values) dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, TRUE);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(GTK_WIDGET(g->area));
 }
@@ -2301,9 +2294,6 @@ void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
     x += feather;
     if(x > 0.f && x < 1.f) _add_node(curve, &p->curve_num_nodes[ch_curve], x, .5f);
 
-    // avoid recursion
-    self->picker->skip_apply = TRUE;
-
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
 
@@ -2384,6 +2374,7 @@ void gui_init(struct dt_iop_module_t *self)
   // color pickers
   c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click to select an area"));
+  gtk_widget_set_name(c->colorpicker, "keep-active");
   c->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
                                dtgtk_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -727,7 +727,7 @@ static float dt_iop_exposure_get_black(struct dt_iop_module_t *self)
   return p->black;
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1100,11 +1100,6 @@ static void preserve_color_callback(GtkWidget *widget, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  if(!in) dt_iop_color_picker_reset(self, TRUE);
-}
-
 void compute_curve_lut(dt_iop_filmic_params_t *p, float *table, float *table_temp, int res,
   dt_iop_filmic_data_t *d, dt_iop_filmic_nodes_t *nodes_data)
 {

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -878,16 +878,16 @@ static void apply_autotune(dt_iop_module_t *self)
   gtk_widget_queue_draw(self->widget);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  if     (self->picker->colorpick == g->grey_point_source)
+  if     (picker == g->grey_point_source)
     apply_auto_grey(self);
-  else if(self->picker->colorpick == g->black_point_source)
+  else if(picker == g->black_point_source)
     apply_auto_black(self);
-  else if(self->picker->colorpick == g->white_point_source)
+  else if(picker == g->white_point_source)
     apply_auto_white_point_source(self);
-  else if(self->picker->colorpick == g->auto_button)
+  else if(picker == g->auto_button)
     apply_autotune(self);
   else
     fprintf(stderr, "[filmic] unknown color picker\n");

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -752,17 +752,17 @@ static void apply_autotune(dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 
-  if (self->picker->colorpick == g->grey_point_source)
+  if      (picker == g->grey_point_source)
        apply_auto_grey(self);
-  else if (self->picker->colorpick == g->black_point_source)
+  else if (picker == g->black_point_source)
        apply_auto_black(self);
-  else if (self->picker->colorpick == g->white_point_source)
+  else if (picker == g->white_point_source)
        apply_auto_white_point_source(self);
-  else if (self->picker->colorpick == g->auto_button)
+  else if (picker == g->auto_button)
        apply_autotune(self);
 }
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -962,12 +962,6 @@ static void preserve_color_callback(GtkWidget *combo, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  if(!in) dt_iop_color_picker_reset(self, TRUE);
-}
-
-
 inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_params_t *const p, struct dt_iop_filmic_rgb_spline_t *const spline)
 {
   const float white_source = p->white_point_source;

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -428,7 +428,7 @@ static inline void update_saturation_slider_end_color(GtkWidget *slider, float h
   dt_bauhaus_slider_set_stop(slider, 1.0, rgb[0], rgb[1], rgb[2]);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
   dt_iop_graduatednd_params_t *p = (dt_iop_graduatednd_params_t *)self->params;

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -160,7 +160,7 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(g->colorpicker), &color);
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   static float old[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -43,6 +43,7 @@ struct dt_dev_pixelpipe_iop_t;
 struct dt_iop_roi_t;
 struct dt_develop_tiling_t;
 struct dt_iop_buffer_dsc_t;
+struct _GtkWidget;
 
 #ifndef DT_IOP_PARAMS_T
 #define DT_IOP_PARAMS_T
@@ -110,7 +111,7 @@ void gui_reset(struct dt_iop_module_t *self);
 /** construct widget. */
 void gui_init(struct dt_iop_module_t *self);
 /** apply color picker results */
-void color_picker_apply(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece);
+void color_picker_apply(struct dt_iop_module_t *self, struct _GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
 /** destroy widget. */
 void gui_cleanup(struct dt_iop_module_t *self);
 /** optional method called after darkroom expose. */

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -246,7 +246,7 @@ static void compute_lut(dt_dev_pixelpipe_iop_t *piece)
   }
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
   dt_iop_levels_params_t *p = (dt_iop_levels_params_t *)self->params;
@@ -269,7 +269,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
     c->last_picked_color = mean_picked_color;
 
-    if(self->picker->colorpick == c->blackpick)
+    if(picker == c->blackpick)
     {
       if(mean_picked_color > p->levels[1])
       {
@@ -280,7 +280,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
         p->levels[0] = mean_picked_color;
       }
     }
-    else if(self->picker->colorpick == c->greypick)
+    else if(picker == c->greypick)
     {
       if(mean_picked_color < p->levels[0] || mean_picked_color > p->levels[2])
       {
@@ -291,7 +291,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
         p->levels[1] = mean_picked_color;
       }
     }
-    else if(self->picker->colorpick == c->whitepick)
+    else if(picker == c->whitepick)
     {
       if(mean_picked_color < p->levels[1])
       {

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -450,7 +450,7 @@ static gboolean dt_iop_monochrome_draw(GtkWidget *widget, cairo_t *crf, gpointer
   return TRUE;
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_monochrome_params_t *p = (dt_iop_monochrome_params_t *)self->params;
 

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -840,24 +840,24 @@ static void apply_auto_exposure(dt_iop_module_t *self)
 }
 
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
 
-  if     (self->picker->colorpick == g->Dmin_sampler)
+  if     (picker == g->Dmin_sampler)
     apply_auto_Dmin(self);
-  else if(self->picker->colorpick == g->WB_high_sampler)
+  else if(picker == g->WB_high_sampler)
     apply_auto_WB_high(self);
-  else if(self->picker->colorpick == g->offset)
+  else if(picker == g->offset)
     apply_auto_offset(self);
-  else if(self->picker->colorpick == g->D_max)
+  else if(picker == g->D_max)
     apply_auto_Dmax(self);
-  else if(self->picker->colorpick == g->WB_low_sampler)
+  else if(picker == g->WB_low_sampler)
     apply_auto_WB_low(self);
-  else if(self->picker->colorpick == g->exposure)
+  else if(picker == g->exposure)
     apply_auto_exposure(self);
-  else if(self->picker->colorpick == g->black)
+  else if(picker == g->black)
     apply_auto_black(self);
   else
     fprintf(stderr, "[negadoctor] unknown color picker\n");

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -1344,12 +1344,6 @@ void gui_cleanup(dt_iop_module_t *self)
 }
 
 
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  if(!in) dt_iop_color_picker_reset(self, TRUE);
-}
-
-
 void gui_reset(dt_iop_module_t *self)
 {
   dt_iop_color_picker_reset(self, TRUE);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -611,11 +611,6 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
     fprintf(stderr, "[profile_gamma] unknown color picker\n");
 }
 
-void gui_focus(struct dt_iop_module_t *self, gboolean in)
-{
-  if(!in) dt_iop_color_picker_reset(self, TRUE);
-}
-
 void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
                    dt_dev_pixelpipe_iop_t *piece)
 {

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -596,16 +596,16 @@ static void mode_callback(GtkWidget *combo, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
-  if     (self->picker->colorpick == g->grey_point)
+  if     (picker == g->grey_point)
     apply_auto_grey(self);
-  else if(self->picker->colorpick == g->shadows_range)
+  else if(picker == g->shadows_range)
     apply_auto_black(self);
-  else if(self->picker->colorpick == g->dynamic_range)
+  else if(picker == g->dynamic_range)
     apply_auto_dynamic_range(self);
-  else if(self->picker->colorpick == g->auto_button)
+  else if(picker == g->auto_button)
     apply_autotune(self);
   else
     fprintf(stderr, "[profile_gamma] unknown color picker\n");

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -301,7 +301,7 @@ void cleanup(dt_iop_module_t *module)
 }
 
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
   float mean, min, max;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1856,7 +1856,7 @@ static gboolean rt_levelsbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module
   return TRUE;
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -529,10 +529,10 @@ static inline int _add_node_from_picker(dt_iop_rgbcurve_params_t *p, const float
   return _add_node(p->curve_nodes[ch], &p->curve_num_nodes[ch], x, y);
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
-  if(self->picker->colorpick == g->colorpicker_set_values)
+  if(picker == g->colorpicker_set_values)
   {
     dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
     dt_iop_rgbcurve_params_t *d = (dt_iop_rgbcurve_params_t *)self->default_params;

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -894,7 +894,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
-  if(!in) _turn_selregion_picker_off(self);
+  if(!in) _turn_select_region_off(self);
 }
 
 void gui_reset(struct dt_iop_module_t *self)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -772,7 +772,7 @@ static void _color_picker_callback(GtkWidget *button, dt_iop_module_t *self)
   _turn_select_region_off(self);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
   dt_iop_rgblevels_params_t *p = (dt_iop_rgblevels_params_t *)self->params;
@@ -796,7 +796,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 
     c->last_picked_color = mean_picked_color;
 
-    if(self->picker->colorpick == c->blackpick)
+    if(picker == c->blackpick)
     {
       if(mean_picked_color > p->levels[channel][1])
       {
@@ -807,7 +807,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
         p->levels[channel][0] = mean_picked_color;
       }
     }
-    else if(self->picker->colorpick == c->greypick)
+    else if(picker == c->greypick)
     {
       if(mean_picked_color < p->levels[channel][0] || mean_picked_color > p->levels[channel][2])
       {
@@ -818,7 +818,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
         p->levels[channel][1] = mean_picked_color;
       }
     }
-    else if(self->picker->colorpick == c->whitepick)
+    else if(picker == c->whitepick)
     {
       if(mean_picked_color < p->levels[channel][1])
       {

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -439,7 +439,7 @@ static void colorpick_callback(GtkColorButton *widget, dt_iop_module_t *self)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
   dt_iop_splittoning_params_t *p = (dt_iop_splittoning_params_t *)self->params;
@@ -451,7 +451,7 @@ void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
   float H = .0f, S = .0f, L = .0f;
   rgb2hsl(self->picked_color, &H, &S, &L);
 
-  if(self->picker->colorpick == g->highlight_hue_gslider)
+  if(picker == g->highlight_hue_gslider)
   {
     p_hue = &p->highlight_hue;
     p_saturation = &p->highlight_saturation;

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1340,7 +1340,7 @@ static void finetune_changed(GtkWidget *widget, gpointer user_data)
   apply_preset((dt_iop_module_t *)user_data);
 }
 
-void color_picker_apply(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   if(self->dt->gui->reset) return;
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1127,7 +1127,7 @@ static float to_lin(const float x, const float base, const int ch, const int sem
   }
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_tonecurve_global_data_t *gd = (dt_iop_tonecurve_global_data_t *)self->global_data;
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2042,7 +2042,7 @@ static void switch_cursors(struct dt_iop_module_t *self)
   GtkWidget *widget = dt_ui_main_window(darktable.gui->ui);
 
   // if we are editing masks or using colour-pickers, do not display controls
-  if(!sanity_check(self) || in_mask_editing(self) || (self->blend_picker && self->blend_picker->module->request_color_pick))
+  if(!sanity_check(self) || in_mask_editing(self) || (self->picker && self->request_color_pick != DT_REQUEST_COLORPICK_OFF))
   {
     // display default cursor
     GdkCursor *const cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1152,7 +1152,7 @@ static void watermark_callback(GtkWidget *tb, gpointer user_data)
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-void color_picker_apply(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece)
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;


### PR DESCRIPTION
Removed blender specific portions from color_picker_proxy.
Allow DT_COLOR_PICKER_POINT_AREA for quad pickers as well.
Call dt_iop_color_picker_reset from imageop.c to enforce switching off pickers at focus change.
Setting the name of a toggle button widget to "keep-active" means it will not get switched off when any of the other widgets change. Used in color zones, rgb curve and blend.Made color picker structure private to color_picker_proxy; passing the active color picker widget to apply function for easy switch statement. This made the patch big again, sorry.
Do not call apply when picked spot/area is unchanged; this avoids duplicate processing when the first call to apply triggers a recalc and second signal (alternative, hopefully more generic/robust, approach to skip_apply)