### PR TITLE
culling : another batch of small fix

### DIFF
--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -187,6 +187,22 @@ static void _culling_reinit(dt_view_t *self)
   dt_culling_init(lib->culling, lib->culling->offset);
 }
 
+static void _culling_preview_refresh(dt_view_t *self)
+{
+  dt_library_t *lib = (dt_library_t *)self->data;
+  // full_preview change
+  if(lib->preview_state)
+  {
+    dt_culling_full_redraw(lib->preview, TRUE);
+  }
+
+  // culling change (note that full_preview can be combined with culling)
+  if(lib->current_layout == DT_LIGHTTABLE_LAYOUT_CULLING)
+  {
+    dt_culling_full_redraw(lib->culling, TRUE);
+  }
+}
+
 static gboolean _preview_get_state(dt_view_t *self)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
@@ -201,6 +217,7 @@ void init(dt_view_t *self)
   darktable.view_manager->proxy.lighttable.view = self;
   darktable.view_manager->proxy.lighttable.change_offset = _lighttable_change_offset;
   darktable.view_manager->proxy.lighttable.culling_init_mode = _culling_reinit;
+  darktable.view_manager->proxy.lighttable.culling_preview_refresh = _culling_preview_refresh;
 
   // ensure the memory table is up to date
   dt_collection_memory_update();

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1203,6 +1203,11 @@ void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm)
   if(vm->proxy.lighttable.module) vm->proxy.lighttable.culling_init_mode(vm->proxy.lighttable.view);
 }
 
+void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm)
+{
+  if(vm->proxy.lighttable.module) vm->proxy.lighttable.culling_preview_refresh(vm->proxy.lighttable.view);
+}
+
 dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm)
 {
   if(vm->proxy.lighttable.module)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -311,6 +311,7 @@ typedef struct dt_view_manager_t
       dt_lighttable_layout_t (*get_layout)(struct dt_lib_module_t *module);
       void (*set_layout)(struct dt_lib_module_t *module, dt_lighttable_layout_t layout);
       void (*culling_init_mode)(struct dt_view_t *view);
+      void (*culling_preview_refresh)(struct dt_view_t *view);
       dt_lighttable_culling_zoom_mode_t (*get_zoom_mode)(struct dt_lib_module_t *module);
       gboolean (*get_preview_state)(struct dt_view_t *view);
       void (*change_offset)(struct dt_view_t *view, gboolean reset, gint imgid);
@@ -442,6 +443,8 @@ gint dt_view_lighttable_get_zoom(dt_view_manager_t *vm);
 dt_lighttable_culling_zoom_mode_t dt_view_lighttable_get_culling_zoom_mode(dt_view_manager_t *vm);
 /** reinit culling for new mode */
 void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm);
+/** force refresh of culling and/or preview */
+void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm);
 /** sets the offset image (for culling and full preview) */
 void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, gint imgid);
 


### PR DESCRIPTION
- this fix the update of images list when collection change (broken in one of my last commits) fix #5035
- this add a warning when one enter in culling dynamic without selection
- this fix culling offset when starting dt in culling mode and the filmstrip as been scrolled