### PR TITLE
Lua API change and API manual update

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -278,6 +278,17 @@ making a backup is strongly advised.
 
 ## Lua
 
+- API changed to 6.0.0 
+
+- facebook, flickr, and picasa removed from types.dt_imageio_storage_module_t.
+
+- piwigo added to type.dt_imageio_storage_module_t.
+
+- notes and version_name metadata fields added to types.dt_lua_image_t data type.
+
+- Added 4 new properties to dt_collection_properties_t, 
+  DT_COLLECTION_PROP_IMPORT_TIMESTAMP, DT_COLLECTION_PROP_CHANGE_TIMESTAMP,
+  DT_COLLECTION_PROP_EXPORT_TIMESTAMP, DT_COLLECTION_PROP_PRINT_TIMESTAMP
 
 ## Changed Dependencies
 

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -573,11 +573,9 @@
 <para>The type of storage object to create, one of : <itemizedlist>
 <listitem><para>disk</para></listitem>
 <listitem><para>email</para></listitem>
-<listitem><para>facebook</para></listitem>
-<listitem><para>flickr</para></listitem>
 <listitem><para>gallery</para></listitem>
 <listitem><para>latex</para></listitem>
-<listitem><para>picasa</para></listitem>
+<listitem><para>piwigo</para></listitem>
 </itemizedlist>
 (Other, lua-defined, storage types may appear.)</para>
 
@@ -4286,6 +4284,48 @@ This function is recursion-safe and can be used to dump _G if needed.</para>
     </tgroup></informaltable>
 </section>
 
+<section status="final" id="types_dt_lua_image_t_notes">
+<title>types.dt_lua_image_t.notes</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>notes</secondary>
+</indexterm>
+<synopsis>string</synopsis>
+<para>The notes field for the image.</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis><link linkend="attributes_write">write</link></emphasis></para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
+<section status="final" id="types_dt_lua_image_t_version_name">
+<title>types.dt_lua_image_t.version_name</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>version_name</secondary>
+</indexterm>
+<synopsis>string</synopsis>
+<para>The version_name field for the image.</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis><link linkend="attributes_write">write</link></emphasis></para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
 <section status="final" id="types_dt_lua_image_t_exif_maker">
 <title>types.dt_lua_image_t.exif_maker</title>
 <indexterm>
@@ -5964,48 +6004,6 @@ darktable.database.import(), then dt_lua_image_t.is_raw is not guaranteed to be 
     </tgroup></informaltable>
 </section>
 
-<section status="final" id="types_dt_imageio_module_storage_data_flickr">
-<title>types.dt_imageio_module_storage_data_flickr</title>
-<indexterm>
-<primary>Lua API</primary>
-<secondary>dt_imageio_module_storage_data_flickr</secondary>
-</indexterm>
-<synopsis>dt_type</synopsis>
-<para>An object containing parameters to export to flickr.</para>
-<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
-    <colspec colwidth="2*"/>
-    <colspec colwidth="8*"/>
-    <tbody><row>
-    <entry>Attributes:</entry>
-    <entry><itemizedlist>
-<listitem><para><emphasis><link linkend="attributes_parent">parent</link> : </emphasis><link linkend="types_dt_imageio_module_storage_t">types.dt_imageio_module_storage_t</link></para></listitem>
-</itemizedlist>
-</entry>
-    </row></tbody>
-    </tgroup></informaltable>
-</section>
-
-<section status="final" id="types_dt_imageio_module_storage_data_facebook">
-<title>types.dt_imageio_module_storage_data_facebook</title>
-<indexterm>
-<primary>Lua API</primary>
-<secondary>dt_imageio_module_storage_data_facebook</secondary>
-</indexterm>
-<synopsis>dt_type</synopsis>
-<para>An object containing parameters to export to facebook.</para>
-<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
-    <colspec colwidth="2*"/>
-    <colspec colwidth="8*"/>
-    <tbody><row>
-    <entry>Attributes:</entry>
-    <entry><itemizedlist>
-<listitem><para><emphasis><link linkend="attributes_parent">parent</link> : </emphasis><link linkend="types_dt_imageio_module_storage_t">types.dt_imageio_module_storage_t</link></para></listitem>
-</itemizedlist>
-</entry>
-    </row></tbody>
-    </tgroup></informaltable>
-</section>
-
 <section status="final" id="types_dt_imageio_module_storage_data_latex">
 <title>types.dt_imageio_module_storage_data_latex</title>
 <indexterm>
@@ -6069,14 +6067,14 @@ darktable.database.import(), then dt_lua_image_t.is_raw is not guaranteed to be 
 
 </section>
 
-<section status="final" id="types_dt_imageio_module_storage_data_picasa">
-<title>types.dt_imageio_module_storage_data_picasa</title>
+<section status="final" id="types_dt_imageio_module_storage_data_piwigo">
+<title>types.dt_imageio_module_storage_data_piwigo</title>
 <indexterm>
 <primary>Lua API</primary>
-<secondary>dt_imageio_module_storage_data_picasa</secondary>
+<secondary>dt_imageio_module_storage_data_piwigo</secondary>
 </indexterm>
 <synopsis>dt_type</synopsis>
-<para>An object containing parameters to export to picasa.</para>
+<para>An object containing parameters to export to piwigo.</para>
 <informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
     <colspec colwidth="2*"/>
     <colspec colwidth="8*"/>
@@ -7194,6 +7192,10 @@ darktable.database.import(), then dt_lua_image_t.is_raw is not guaranteed to be 
 <listitem><para>DT_COLLECTION_PROP_TAG</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_DAY</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_TIME</para></listitem>
+<listitem><para>DT_COLLECTION_PROP_IMPORT_TIMESTAMP</para></listitem>
+<listitem><para>DT_COLLECTION_PROP_CHANGE_TIMESTAMP</para></listitem>
+<listitem><para>DT_COLLECTION_PROP_EXPORT_TIMESTAMP</para></listitem>
+<listitem><para>DT_COLLECTION_PROP_PRINT_TIMESTAMP</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_HISTORY</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_COLORLABEL</para></listitem>
 <listitem><para>DT_COLLECTION_PROP_TITLE</para></listitem>

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -33,12 +33,13 @@
 // 2.0.0 was 3.0.0
 // 2.2.0 was 4.0.0 ( removed the ugly yield functions make scripts incompatible)
 // 2.4.0 was 5.0.0 (going to lua 5.3 is a major API bump)
+// 3.2.0 was 6.0.0 (removed facebook, flickr, and picasa from types.dt_imageio_storage_module_t)
 /* incompatible API change */
-#define LUA_API_VERSION_MAJOR 5
+#define LUA_API_VERSION_MAJOR 6
 /* backward compatible API change */
 #define LUA_API_VERSION_MINOR 0
 /* bugfixes that should not change anything to the API */
-#define LUA_API_VERSION_PATCH 2
+#define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */
 #define LUA_API_VERSION_SUFFIX ""
 


### PR DESCRIPTION
Changed Lua API version to 6.0.0.  Removal of the facebook, flickr, and picasa module storages broke backward compatibility which caused the major version change.  Updated Lua API manual to reflect the removed module storages, addition of piwigo module storage, addition of TIMESTAMP collection properties, and dt_lua_image_t metadata additions.  Updated README.md with Lua changes.