### PR TITLE
last two small color picker changes.

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1652,7 +1652,8 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
     bd->colorpicker_set_values = dt_color_picker_new(module, DT_COLOR_PICKER_AREA, header);
     dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(bd->colorpicker_set_values),
-                               dtgtk_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+                                 dtgtk_cairo_paint_colorpicker_set_values, 
+                                 CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
     gtk_widget_set_tooltip_text(bd->colorpicker_set_values, _("set the range based on an area from the image\n"
                                                               "drag to use the input image\n"
                                                               "ctrl+drag to use the output image"));

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -255,7 +255,7 @@ GtkWidget *dt_color_picker_new(dt_iop_module_t *module, dt_iop_color_picker_kind
 
   if(w == NULL || GTK_IS_BOX(w))
   {
-    GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+    GtkWidget *button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
     _iop_init_picker(color_picker, module, kind, button);
     g_signal_connect_data(G_OBJECT(button), "button-press-event", 
                           G_CALLBACK(_iop_color_picker_callback_button_press), color_picker, (GClosureNotify)g_free, 0);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -43,7 +43,7 @@ static gboolean _iop_record_point_area(dt_iop_color_picker_t *self)
 {
   gboolean selection_changed = FALSE;
 
-  if(self)
+  if(self && self->module)
   {
     for(int k = 0; k < 2; k++)
     {
@@ -118,20 +118,19 @@ static void _iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean upda
     else
       dt_bauhaus_widget_set_quad_active(picker->colorpick, FALSE);
 
-    picker->module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
-
     darktable.gui->reset = reset;
   }
 }
 
 void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update)
 {
-  if(module->picker)
+  if(module && module->picker)
   {
     if(strcmp(gtk_widget_get_name(module->picker->colorpick), "keep-active") != 0)
     {
       _iop_color_picker_reset(module->picker, update);
       module->picker = NULL;
+      module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
     }
   }
 }
@@ -152,10 +151,12 @@ static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *mod
 
 static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
 {
-  if(self->module->dt->gui->reset) return FALSE;
+  dt_iop_module_t *module = self->module ? self->module : dt_iop_get_colorout_module();
+
+  if(!module || module->dt->gui->reset) return FALSE;
 
   // set module active if not yet the case
-  if(self->module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->module->off), TRUE);
+  if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
   const uint32_t state = e != NULL
                         ? e->state
@@ -163,10 +164,10 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   gboolean ctrl_key_pressed = (state & gtk_accelerator_get_default_mod_mask()) == GDK_CONTROL_MASK;
   dt_iop_color_picker_kind_t kind = self->kind;
 
-  if (self->module->picker != self || (ctrl_key_pressed && kind == DT_COLOR_PICKER_POINT_AREA))
+  if (module->picker != self || (ctrl_key_pressed && kind == DT_COLOR_PICKER_POINT_AREA))
   {
-    _iop_color_picker_reset(self->module->picker, TRUE);
-    self->module->picker = self;
+    _iop_color_picker_reset(module->picker, TRUE);
+    module->picker = self;
 
     const int reset = darktable.gui->reset;
     darktable.gui->reset = 1;
@@ -178,7 +179,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
 
     darktable.gui->reset = reset;
 
-    self->module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
+    module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 
     if(kind == DT_COLOR_PICKER_POINT_AREA)
     {
@@ -197,16 +198,17 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
       dt_lib_colorpicker_set_point(darktable.lib, pos[0], pos[1]);
     }
 
-    self->module->dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
+    module->dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;
+    dt_iop_request_focus(module);
   }
   else
   {
-    _iop_color_picker_reset(self->module->picker, TRUE);
-    self->module->picker = NULL;
+    _iop_color_picker_reset(module->picker, TRUE);
+    module->picker = NULL;
+    module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   }
 
   dt_control_queue_redraw();
-  dt_iop_request_focus(self->module);
 
   return TRUE;
 }

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2376,7 +2376,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_name(c->colorpicker, "keep-active");
   c->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(c->colorpicker_set_values),
-                               dtgtk_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+                               dtgtk_cairo_paint_colorpicker_set_values, 
+                               CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_widget_set_size_request(c->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(c->colorpicker_set_values, _("create a curve based on an area from the image\n"
                                                            "drag to create a flat curve\n"

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1479,7 +1479,8 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_name(g->colorpicker, "keep-active");
   g->colorpicker_set_values = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, hbox);
   dtgtk_togglebutton_set_paint(DTGTK_TOGGLEBUTTON(g->colorpicker_set_values),
-                               dtgtk_cairo_paint_colorpicker_set_values, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+                               dtgtk_cairo_paint_colorpicker_set_values, 
+                               CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, NULL);
   gtk_widget_set_size_request(g->colorpicker_set_values, DT_PIXEL_APPLY_DPI(14), DT_PIXEL_APPLY_DPI(14));
   gtk_widget_set_tooltip_text(g->colorpicker_set_values, _("create a curve based on an area from the image\n"
                                                            "drag to create a flat curve\n"

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -25,6 +25,7 @@
 #include "dtgtk/button.h"
 #include "dtgtk/togglebutton.h"
 #include "gui/accelerators.h"
+#include "gui/color_picker_proxy.h"
 #include "gui/gtk.h"
 #include "libs/lib.h"
 #include "libs/lib_api.h"
@@ -204,19 +205,6 @@ static void _picker_button_toggled(GtkToggleButton *button, gpointer p)
   dt_lib_colorpicker_t *data = ((dt_lib_module_t *)p)->data;
   gtk_widget_set_sensitive(GTK_WIDGET(data->add_sample_button), gtk_toggle_button_get_active(button));
   if(darktable.gui->reset) return;
-  dt_iop_module_t *module = dt_iop_get_colorout_module();
-  if(module)
-  {
-    dt_iop_request_focus(module);
-    module->request_color_pick = gtk_toggle_button_get_active(button) ? DT_REQUEST_COLORPICK_MODULE
-                                                                      : DT_REQUEST_COLORPICK_OFF;
-    dt_dev_invalidate_from_gui(darktable.develop);
-  }
-  else
-  {
-    dt_iop_request_focus(NULL);
-  }
-  dt_control_queue_redraw();
 }
 
 static void _statistic_changed(GtkComboBox *widget, gpointer p)
@@ -582,10 +570,8 @@ void gui_init(dt_lib_module_t *self)
 
   g_signal_connect(G_OBJECT(data->size_selector), "changed", G_CALLBACK(_size_changed), (gpointer)self);
 
-  data->picker_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_colorpicker, CPF_STYLE_BOX, NULL);
+  data->picker_button = dt_color_picker_new(NULL, DT_COLOR_PICKER_AREA, picker_subrow);
   gtk_widget_set_name(GTK_WIDGET(data->picker_button), "control-button");
-  gtk_box_pack_start(GTK_BOX(picker_subrow), data->picker_button, FALSE, FALSE, 0);
-
   g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), self);
 
   gtk_box_pack_start(GTK_BOX(output_options), picker_subrow, TRUE, TRUE, 0);


### PR DESCRIPTION
Really.

The colorpicker module is not an iop module so it was patched in via the colorout module. Also it's lifetime is different so it owning both the colorpicker and a link to the iop module would blow up.

My solution is to have a link to a null module be interpreted as colorout by color_picker_proxy. Not the prettiest solution, but better than what was previously going on since now at least the color picker button correctly gets switched off.

Also removing background color from button pickers so they look same as quad pickers. Still behave slightly differently when mouse is hovering.