### PR TITLE
set opacity without zooming during path mask creation

### DIFF
--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1729,6 +1729,7 @@ int dt_masks_events_mouse_scrolled(struct dt_iop_module_t *module, double x, dou
       dt_conf_set_float("plugins/darkroom/masks/opacity", opacity);
       const int opacitypercent = opacity * 100;
       dt_toast_log(_("opacity: %d%%"), opacitypercent);
+      ret = 1;
     }
 
     _set_hinter_message(gui, form);


### PR DESCRIPTION
resolves issue when pressing ctrl+scroll before placing a path mask,
whereby the opacity was being changed *and* the image was also being
zoomed.