### PR TITLE
change gui->reset bracketing to ++/-- for brevity

### DIFF
--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -171,9 +171,9 @@ static int dt_imageio_load_modules_format(dt_imageio_t *iio)
       continue;
     }
     module->gui_data = NULL;
-    if(darktable.gui) darktable.gui->reset = 1;
+    if(darktable.gui) ++darktable.gui->reset;
     module->gui_init(module);
-    if(darktable.gui) darktable.gui->reset = 0;
+    if(darktable.gui) --darktable.gui->reset;
     if(module->widget) g_object_ref(module->widget);
     g_free(libname);
     res = g_list_insert_sorted(res, module, dt_imageio_sort_modules_format);

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -660,8 +660,7 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
   GtkDarktableGradientSlider *widget;
   GtkLabel *label;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   for (int s = 0; s < 2; s++)
   {
@@ -713,7 +712,7 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
     }
   }
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 
@@ -723,8 +722,7 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
   dt_develop_blend_params_t *bp = module->blend_params;
   dt_develop_blend_params_t *dp = module->default_blendop_params;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   const int in_ch = data->channels[tab][0];
   const int out_ch = data->channels[tab][1];
@@ -813,7 +811,7 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
     _blendof_blendif_disp_alternative_reset(GTK_WIDGET(data->upper_slider), module);
   }
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 
@@ -1052,8 +1050,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
 
   if(event->button == 1)
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     dt_iop_request_focus(self);
     dt_iop_color_picker_reset(self, TRUE);
@@ -1092,7 +1089,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), FALSE);
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     return TRUE;
   }
@@ -1123,8 +1120,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
   {
     if(darktable.gui->reset) return TRUE;
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     dt_develop_blend_params_t *bp = module->blend_params;
     const int tab = data->tab;
@@ -1205,7 +1201,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
         gtk_label_set_text(data->upper_label[k], text);
     }
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     // save values to parameters
     dt_pthread_mutex_lock(&data->lock);
@@ -1437,8 +1433,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 
   if(!data || !data->blendif_support || !data->blendif_inited) return;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_pthread_mutex_lock(&data->lock);
   if(data->timeout_handle)
@@ -1456,7 +1451,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
   const int tab = data->tab;
   _blendop_blendif_update_tab(module, tab);
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 
@@ -1764,8 +1759,7 @@ void dt_iop_gui_update_masks(dt_iop_module_t *module)
 
   if(!bd || !bd->masks_support || !bd->masks_inited) return;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   /* update masks state */
   dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, module->blend_params->mask_id);
@@ -1805,7 +1799,7 @@ void dt_iop_gui_update_masks(dt_iop_module_t *module)
     }
   }
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
@@ -2088,8 +2082,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
 
   if(!(module->flags() & IOP_FLAGS_SUPPORTS_BLENDING) || !bd || !bd->blend_inited) return;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   const unsigned int mode = g_list_index(bd->masks_modes, GUINT_TO_POINTER(module->blend_params->mask_mode));
 
@@ -2276,7 +2269,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   else
     gtk_widget_show(GTK_WIDGET(bd->masks_modes_box));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -877,10 +877,9 @@ static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module
       {
         if(module->off)
         {
-          const int reset = darktable.gui->reset;
-          darktable.gui->reset = 1;
+          ++darktable.gui->reset;
           dt_iop_gui_set_enable_button(module);
-          darktable.gui->reset = reset;
+          --darktable.gui->reset;
         }
       }
     }
@@ -927,10 +926,9 @@ static void _dev_add_history_item_ext(dt_develop_t *dev, dt_iop_module_t *module
       {
         if(module->off)
         {
-          const int reset = darktable.gui->reset;
-          darktable.gui->reset = 1;
+          ++darktable.gui->reset;
           dt_iop_gui_set_enable_button(module);
-          darktable.gui->reset = reset;
+          --darktable.gui->reset;
         }
       }
     }
@@ -1230,8 +1228,7 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt)
 void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
 {
   dt_pthread_mutex_lock(&dev->history_mutex);
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   GList *dev_iop = g_list_copy(dev->iop);
 
   dt_dev_pop_history_items_ext(dev, cnt);
@@ -1288,7 +1285,7 @@ void dt_dev_pop_history_items(dt_develop_t *dev, int32_t cnt)
     dev->preview2_pipe->cache_obsolete = 1;
   }
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_invalidate_all(dev);
   dt_pthread_mutex_unlock(&dev->history_mutex);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -561,8 +561,7 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   dt_iop_gui_set_expanded(next, TRUE, FALSE);
   gtk_widget_grab_focus(next->expander);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   // we remove the plugin effectively
   if(!dt_iop_is_hidden(module))
@@ -646,7 +645,7 @@ static void dt_iop_gui_delete_callback(GtkButton *button, dt_iop_module_t *modul
   /* redraw */
   dt_control_queue_redraw_center();
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 dt_iop_module_t *dt_iop_gui_get_previous_visible_module(dt_iop_module_t *module)
@@ -815,8 +814,7 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
   /* initialize gui if iop have one defined */
   if(!dt_iop_is_hidden(module))
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     module->gui_init(module);
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
     if(copy_params)
@@ -848,7 +846,7 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
                           expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
     dt_iop_gui_set_expanded(module, TRUE, FALSE);
     dt_iop_gui_update_blending(module);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
 
   if(dt_conf_get_bool("darkroom/ui/single_module"))
@@ -1650,8 +1648,7 @@ void dt_iop_gui_update(dt_iop_module_t *module)
 {
   if(module->gui_data)
   {
-    int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     if(!dt_iop_is_hidden(module))
     {
       if(module->params) module->gui_update(module);
@@ -1660,16 +1657,15 @@ void dt_iop_gui_update(dt_iop_module_t *module)
       _iop_gui_update_label(module);
       dt_iop_gui_set_enable_button(module);
     }
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
 }
 
 void dt_iop_gui_reset(dt_iop_module_t *module)
 {
-  int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   if(module->gui_reset && !dt_iop_is_hidden(module)) module->gui_reset(module);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 static void dt_iop_gui_reset_callback(GtkButton *button, dt_iop_module_t *module)

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -2206,10 +2206,9 @@ void dt_masks_iop_value_changed_callback(GtkWidget *widget, struct dt_iop_module
   if(sel == 0) return;
   if(sel == 1)
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_combobox_set(bd->masks_combo, 0);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     return;
   }
   if(sel > 0)

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -110,15 +110,14 @@ static void _iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean upda
 {
   if(picker)
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     if(DTGTK_IS_TOGGLEBUTTON(picker->colorpick))
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(picker->colorpick), FALSE);
     else
       dt_bauhaus_widget_set_quad_active(picker->colorpick, FALSE);
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
 }
 
@@ -169,15 +168,14 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
     _iop_color_picker_reset(module->picker, TRUE);
     module->picker = self;
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     if(DTGTK_IS_TOGGLEBUTTON(self->colorpick))
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->colorpick), TRUE);
     else
       dt_bauhaus_widget_set_quad_active(self->colorpick, TRUE);
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     module->request_color_pick = DT_REQUEST_COLORPICK_MODULE;
 

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4243,13 +4243,12 @@ static int fit_v_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
       // module is enable -> we process directly
       if(do_fit(self, p, fitaxis))
       {
-        const int reset = darktable.gui->reset;
-        darktable.gui->reset = 1;
+        ++darktable.gui->reset;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = reset;
+        --darktable.gui->reset;
       }
     }
     else
@@ -4297,13 +4296,12 @@ static int fit_h_button_clicked(GtkWidget *widget, GdkEventButton *event, gpoint
       // module is enable -> we process directly
       if(do_fit(self, p, fitaxis))
       {
-        const int reset = darktable.gui->reset;
-        darktable.gui->reset = 1;
+        ++darktable.gui->reset;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = reset;
+        --darktable.gui->reset;
       }
     }
     else
@@ -4353,13 +4351,12 @@ static int fit_both_button_clicked(GtkWidget *widget, GdkEventButton *event, gpo
       // module is enable -> we process directly
       if(do_fit(self, p, fitaxis))
       {
-        const int reset = darktable.gui->reset;
-        darktable.gui->reset = 1;
+        ++darktable.gui->reset;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = reset;
+        --darktable.gui->reset;
       }
     }
     else
@@ -4479,13 +4476,12 @@ static void process_after_preview_callback(gpointer instance, gpointer user_data
     case ASHIFT_JOBCODE_FIT:
       if(do_fit(self, p, (dt_iop_ashift_fitaxis_t)jobparams))
       {
-        const int reset = darktable.gui->reset;
-        darktable.gui->reset = 1;
+        ++darktable.gui->reset;
         dt_bauhaus_slider_set_soft(g->rotation, p->rotation);
         dt_bauhaus_slider_set_soft(g->lensshift_v, p->lensshift_v);
         dt_bauhaus_slider_set_soft(g->lensshift_h, p->lensshift_h);
         dt_bauhaus_slider_set_soft(g->shear, p->shear);
-        darktable.gui->reset = reset;
+        --darktable.gui->reset;
       }
       dt_dev_add_history_item(darktable.develop, self, TRUE);
       break;
@@ -4741,12 +4737,11 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   snprintf(string_v, sizeof(string_v), _("lens shift (%s)"), isflipped ? _("horizontal") : _("vertical"));
   snprintf(string_h, sizeof(string_h), _("lens shift (%s)"), isflipped ? _("vertical") : _("horizontal"));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_widget_set_label(g->lensshift_v, NULL, string_v);
   dt_bauhaus_widget_set_label(g->lensshift_h, NULL, string_h);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->eye), g->lines_suppressed);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return FALSE;
 }

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1318,10 +1318,9 @@ static void reset_mix(dt_iop_module_t *self)
 {
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
   c->drag_params = *(dt_iop_atrous_params_t *)self->params;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(c->mix, 1.0f);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 void gui_update(struct dt_iop_module_t *self)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -399,12 +399,11 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, gpointer user_
 
     dt_pthread_mutex_unlock(&g->lock);
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     gui_update(self);
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   else
   {
@@ -433,12 +432,11 @@ static void _signal_profile_user_changed(gpointer instance, uint8_t profile_type
 
       if(g)
       {
-        const int reset = darktable.gui->reset;
-        darktable.gui->reset = 1;
+        ++darktable.gui->reset;
 
         dt_bauhaus_slider_set_default(g->sl_middle_grey, def_middle_grey);
 
-        darktable.gui->reset = reset;
+        --darktable.gui->reset;
       }
     }
   }
@@ -606,10 +604,9 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
                                                                        work_profile->nonlinearlut) * 100.f)
                                   : dt_camera_rgb_luminance(self->picked_color);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->sl_middle_grey, p->middle_grey);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1760,8 +1760,7 @@ static void aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
   }
 
   // Update combobox label
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   if(act == -1)
   {
@@ -1774,7 +1773,7 @@ static void aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
     // we got a default ratio
     dt_bauhaus_combobox_set(g->aspect_presets, act);
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 static void angle_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -1791,8 +1790,7 @@ static void cxywh_callback(GtkWidget *slider, dt_iop_module_t *self)
   dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
   dt_iop_clipping_params_t *p = (dt_iop_clipping_params_t *)self->params;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   p->cx = dt_bauhaus_slider_get(g->cx) / 100;
   dt_bauhaus_slider_set_soft_max(g->cw, 100 - p->cx * 100);
@@ -1803,7 +1801,7 @@ static void cxywh_callback(GtkWidget *slider, dt_iop_module_t *self)
   p->ch = (100 - dt_bauhaus_slider_get(g->ch)) / 100;
   dt_bauhaus_slider_set_soft_max(g->cy, p->ch * 100);
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   g->clip_x = p->cx;
   g->clip_w = fabsf(p->cw) - p->cx;
@@ -3108,15 +3106,14 @@ int mouse_moved(struct dt_iop_module_t *self, double x, double y, double pressur
           p->cw = copysignf(points[2] / (float)piece->buf_out.width, p->cw);
           p->ch = copysignf(points[3] / (float)piece->buf_out.height, p->ch);
 
-          const int reset = darktable.gui->reset;
-          darktable.gui->reset = 1;
+          ++darktable.gui->reset;
 
           dt_bauhaus_slider_set(g->cx, p->cx*100);
           dt_bauhaus_slider_set(g->cy, p->cy*100);
           dt_bauhaus_slider_set(g->cw, 100-p->cw*100);
           dt_bauhaus_slider_set(g->ch, 100-p->ch*100);
 
-          darktable.gui->reset = reset;
+          --darktable.gui->reset;
         }
       }
     }

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -908,12 +908,11 @@ static inline void set_RGB_sliders(GtkWidget *R, GtkWidget *G, GtkWidget *B, flo
     p[CHANNEL_GREEN] = rgb[1] * 2.0f;
     p[CHANNEL_BLUE] = rgb[2] * 2.0f;
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set_soft(R, p[CHANNEL_RED] - 1.0f);
     dt_bauhaus_slider_set_soft(G, p[CHANNEL_GREEN] - 1.0f);
     dt_bauhaus_slider_set_soft(B, p[CHANNEL_BLUE] - 1.0f);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
 }
 
@@ -993,10 +992,9 @@ static void apply_autogrey(dt_iop_module_t *self)
 
   p->grey = XYZ[1] * 100.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey, p->grey);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1030,13 +1028,12 @@ static void apply_lift_neutralize(dt_iop_module_t *self)
   p->lift[CHANNEL_GREEN] = RGB[1] + 1.0f;
   p->lift[CHANNEL_BLUE] = RGB[2] + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->lift_r, RGB[0]);
   dt_bauhaus_slider_set_soft(g->lift_g, RGB[1]);
   dt_bauhaus_slider_set_soft(g->lift_b, RGB[2]);
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1070,13 +1067,12 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
   p->gamma[CHANNEL_GREEN] = CLAMP(2.0 - RGB[1], 0.0001f, 2.0f);
   p->gamma[CHANNEL_BLUE] = CLAMP(2.0 - RGB[2], 0.0001f, 2.0f);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->gamma_r, -RGB[0] + 1.0f);
   dt_bauhaus_slider_set_soft(g->gamma_g, -RGB[1] + 1.0f);
   dt_bauhaus_slider_set_soft(g->gamma_b, -RGB[2] + 1.0f);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1110,13 +1106,12 @@ static void apply_gain_neutralize(dt_iop_module_t *self)
   p->gain[CHANNEL_GREEN] = RGB[1];
   p->gain[CHANNEL_BLUE] = RGB[2];
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->gain_r, RGB[0] - 1.0f);
   dt_bauhaus_slider_set_soft(g->gain_g, RGB[1] - 1.0f);
   dt_bauhaus_slider_set_soft(g->gain_b, RGB[2] - 1.0f);
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1138,10 +1133,9 @@ static void apply_lift_auto(dt_iop_module_t *self)
 
   p->lift[CHANNEL_FACTOR] = -p->gain[CHANNEL_FACTOR] * XYZ[1] + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1164,10 +1158,9 @@ static void apply_gamma_auto(dt_iop_module_t *self)
   p->gamma[CHANNEL_FACTOR]
       = 2.0f - logf(0.1842f) / logf(MAX(p->gain[CHANNEL_FACTOR] * XYZ[1] + p->lift[CHANNEL_FACTOR] - 1.0f, 0.000001f));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1189,10 +1182,9 @@ static void apply_gain_auto(dt_iop_module_t *self)
 
   p->gain[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR] / (XYZ[1]);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1294,8 +1286,7 @@ static void apply_autocolor(dt_iop_module_t *self)
   p->gain[CHANNEL_GREEN] = RGB_gain[1];
   p->gain[CHANNEL_BLUE] = RGB_gain[2];
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->lift_r, RGB_lift[0]);
   dt_bauhaus_slider_set_soft(g->lift_g, RGB_lift[1]);
   dt_bauhaus_slider_set_soft(g->lift_b, RGB_lift[2]);
@@ -1311,7 +1302,7 @@ static void apply_autocolor(dt_iop_module_t *self)
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1359,12 +1350,11 @@ static void apply_autoluma(dt_iop_module_t *self)
     p->gamma[CHANNEL_FACTOR] = CLAMP(2.0f - logf(0.1842f) / logf(MAX(p->gain[CHANNEL_FACTOR] * g->luma_patches[GAMMA] + p->lift[CHANNEL_FACTOR] - 1.0f, 0.000001f)), 0.0f, 2.0f);
   }
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
   dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
   dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1981,10 +1971,9 @@ static void lift_red_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->lift[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1998,10 +1987,9 @@ static void lift_green_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->lift[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2015,10 +2003,9 @@ static void lift_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->lift[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2043,10 +2030,9 @@ static void gamma_red_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gamma[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 static void gamma_green_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -2059,10 +2045,9 @@ static void gamma_green_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gamma[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2076,10 +2061,9 @@ static void gamma_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gamma[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2103,10 +2087,9 @@ static void gain_red_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gain[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -2120,10 +2103,9 @@ static void gain_green_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gain[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 static void gain_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -2136,10 +2118,9 @@ static void gain_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
 
   p->gain[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -992,10 +992,9 @@ static void target_a_callback(GtkWidget *slider, gpointer user_data)
     const float Cout = sqrtf(
         p->target_a[g->patch]*p->target_a[g->patch]+
         p->target_b[g->patch]*p->target_b[g->patch]);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1; // avoid history item
+    ++darktable.gui->reset; // avoid history item
     dt_bauhaus_slider_set(g->scale_C, Cout);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   else
   {
@@ -1006,10 +1005,9 @@ static void target_a_callback(GtkWidget *slider, gpointer user_data)
     const float Cout = sqrtf(
         p->target_a[g->patch]*p->target_a[g->patch]+
         p->target_b[g->patch]*p->target_b[g->patch]);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1; // avoid history item
+    ++darktable.gui->reset; // avoid history item
     dt_bauhaus_slider_set(g->scale_C, Cout-Cin);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1026,10 +1024,9 @@ static void target_b_callback(GtkWidget *slider, gpointer user_data)
     const float Cout = sqrtf(
         p->target_a[g->patch]*p->target_a[g->patch]+
         p->target_b[g->patch]*p->target_b[g->patch]);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1; // avoid history item
+    ++darktable.gui->reset; // avoid history item
     dt_bauhaus_slider_set(g->scale_C, Cout);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   else
   {
@@ -1040,10 +1037,9 @@ static void target_b_callback(GtkWidget *slider, gpointer user_data)
     const float Cout = sqrtf(
         p->target_a[g->patch]*p->target_a[g->patch]+
         p->target_b[g->patch]*p->target_b[g->patch]);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1; // avoid history item
+    ++darktable.gui->reset; // avoid history item
     dt_bauhaus_slider_set(g->scale_C, Cout-Cin);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1066,22 +1062,20 @@ static void target_C_callback(GtkWidget *slider, gpointer user_data)
     const float Cnew = CLAMP(dt_bauhaus_slider_get(slider), 0.01, 128.0);
     p->target_a[g->patch] = CLAMP(p->target_a[g->patch]*Cnew/Cout, -128.0, 128.0);
     p->target_b[g->patch] = CLAMP(p->target_b[g->patch]*Cnew/Cout, -128.0, 128.0);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1; // avoid history item
+    ++darktable.gui->reset; // avoid history item
     dt_bauhaus_slider_set(g->scale_a, p->target_a[g->patch]);
     dt_bauhaus_slider_set(g->scale_b, p->target_b[g->patch]);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   else
   {
     const float Cnew = CLAMP(Cin + dt_bauhaus_slider_get(slider), 0.01, 128.0);
     p->target_a[g->patch] = CLAMP(p->target_a[g->patch]*Cnew/Cout, -128.0, 128.0);
     p->target_b[g->patch] = CLAMP(p->target_b[g->patch]*Cnew/Cout, -128.0, 128.0);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1; // avoid history item
+    ++darktable.gui->reset; // avoid history item
     dt_bauhaus_slider_set(g->scale_a, p->target_a[g->patch] - p->source_a[g->patch]);
     dt_bauhaus_slider_set(g->scale_b, p->target_b[g->patch] - p->source_b[g->patch]);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1203,12 +1197,11 @@ static gboolean checker_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data
     // freshly picked, also select it in gui:
     int pick = self->request_color_pick;
     g->drawn_patch = cells_x * bestj + besti;
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_combobox_set(g->combobox_patch, g->drawn_patch);
     g->patch = g->drawn_patch;
     self->gui_update(self);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     self->request_color_pick = pick; // restore, the combobox will kill it
   }
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(2.));

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -307,12 +307,11 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   p->hue        = H;
   p->saturation = S;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->gslider1, p->hue);
   dt_bauhaus_slider_set(g->gslider2, p->saturation);
   update_saturation_slider_end_color(g->gslider2, p->hue);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1022,8 +1022,7 @@ static void process_clusters(gpointer instance, gpointer user_data)
   if(!g || !g->buffer) return;
   if(!(p->flag & ACQUIRE)) return;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_pthread_mutex_lock(&g->lock);
   const int width = g->width;
@@ -1089,7 +1088,7 @@ static void process_clusters(gpointer instance, gpointer user_data)
   }
 
   p->flag &= ~(GET_TARGET | GET_SOURCE | ACQUIRE);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   if(p->flag & HAS_SOURCE) dt_dev_add_history_item(darktable.develop, self, TRUE);
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -717,10 +717,9 @@ static void _reset_display_selection(dt_iop_module_t *self)
     }
     if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->bt_showmask)))
     {
-      const int reset = darktable.gui->reset;
-      darktable.gui->reset = 1;
+      ++darktable.gui->reset;
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->bt_showmask), FALSE);
-      darktable.gui->reset = reset;
+      --darktable.gui->reset;
     }
   }
 }
@@ -2103,12 +2102,11 @@ static void _channel_tabs_switch_callback(GtkNotebook *notebook, GtkWidget *page
 
   c->channel = (dt_iop_colorzones_channel_t)page_num;
 
-  const int reset = self->dt->gui->reset;
-  self->dt->gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_bauhaus_combobox_set(c->interpolator, p->curve_type[c->channel]);
 
-  self->dt->gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
   if(c->display_mask) dt_dev_reprocess_center(self->dev);
@@ -2201,10 +2199,9 @@ static void _display_mask_callback(GtkToggleButton *togglebutton, dt_iop_module_
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_toggle_button_set_active(togglebutton, FALSE);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     return;
   }
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3898,28 +3898,25 @@ static gboolean denoiseprofile_draw_variance(GtkWidget *widget, cairo_t *crf, gp
   if(!isnan(c->variance_R))
   {
     gchar *str = g_strdup_printf("%.2f", c->variance_R);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_label_set_text(c->label_var_R, str);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     g_free(str);
   }
   if(!isnan(c->variance_G))
   {
     gchar *str = g_strdup_printf("%.2f", c->variance_G);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_label_set_text(c->label_var_G, str);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     g_free(str);
   }
   if(!isnan(c->variance_B))
   {
     gchar *str = g_strdup_printf("%.2f", c->variance_B);
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_label_set_text(c->label_var_B, str);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     g_free(str);
   }
   return FALSE;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -540,10 +540,9 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   // switch off auto exposure when we lose focus (switching images etc)
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->autoexpp, 0.01);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 void init(dt_iop_module_t *module)
@@ -649,10 +648,9 @@ static void exposure_set_white(struct dt_iop_module_t *self, const float white)
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -666,10 +664,9 @@ static void dt_iop_exposure_set_exposure(struct dt_iop_module_t *self, const flo
 
     p->deflicker_target_level = exposure;
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->deflicker_target_level, p->deflicker_target_level);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     dt_dev_add_history_item(darktable.develop, self, TRUE);
   }
@@ -708,10 +705,9 @@ static void exposure_set_black(struct dt_iop_module_t *self, const float black)
   }
 
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->black, p->black);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -805,10 +801,9 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   {
     gchar *str = g_strdup_printf(_("%.2f EV"), g->deflicker_computed_exposure);
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_label_set_text(g->deflicker_used_EC, str);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     g_free(str);
   }

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -712,10 +712,9 @@ static void sanitize_latitude(dt_iop_filmic_params_t *p, dt_iop_filmic_gui_data_
     // The film latitude is its linear part
     // it can never be higher than the dynamic range
     p->latitude_stops =  (p->white_point_source - p->black_point_source) * 0.99f;
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set_soft(g->latitude_stops, p->latitude_stops);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
 }
 
@@ -735,12 +734,11 @@ static void apply_auto_grey(dt_iop_module_t *self)
   p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -763,10 +761,9 @@ static void apply_auto_black(dt_iop_module_t *self)
 
   p->black_point_source = EVmin;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   sanitize_latitude(p, g);
 
@@ -792,10 +789,9 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
 
   p->white_point_source = EVmax;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   sanitize_latitude(p, g);
 
@@ -823,11 +819,10 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->white_point_source = EVmax;
   p->black_point_source = EVmin;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   sanitize_latitude(p, g);
 
@@ -865,12 +860,11 @@ static void apply_autotune(dt_iop_module_t *self)
   p->black_point_source = EVmin;
   p->white_point_source = EVmax;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   sanitize_latitude(p, g);
 
@@ -906,11 +900,10 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -648,13 +648,12 @@ static void apply_auto_grey(dt_iop_module_t *self)
   p->white_point_source = p->white_point_source + grey_var;
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   gtk_widget_queue_draw(self->widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -677,11 +676,10 @@ static void apply_auto_black(dt_iop_module_t *self)
   p->black_point_source = fmaxf(EVmin, -16.0f);
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -705,11 +703,10 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
   p->white_point_source = EVmax;
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -740,13 +737,12 @@ static void apply_autotune(dt_iop_module_t *self)
   p->white_point_source = EVmax;
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   gtk_widget_queue_draw(self->widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -780,12 +776,11 @@ static void grey_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->white_point_source = p->white_point_source + grey_var;
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -803,10 +798,9 @@ static void white_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->white_point_source = dt_bauhaus_slider_get(slider);
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -823,10 +817,9 @@ static void black_point_source_callback(GtkWidget *slider, gpointer user_data)
   p->black_point_source = dt_bauhaus_slider_get(slider);
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_queue_draw(self->widget);
@@ -854,12 +847,11 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->black_point_source = EVmin;
   p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
   dt_bauhaus_slider_set_soft(g->output_power, p->output_power);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
   gtk_widget_queue_draw(self->widget);

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -447,12 +447,11 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   p->hue        = H;
   p->saturation = S;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->gslider1, p->hue);
   dt_bauhaus_slider_set(g->gslider2, p->saturation);
   update_saturation_slider_end_color(g->gslider2, p->hue);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -674,10 +673,9 @@ int button_released(struct dt_iop_module_t *self, double x, double y, int which,
       r = p->rotation;
       set_points_from_grad(self, &g->xa, &g->ya, &g->xb, &g->yb, r, o);
     }
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->scale3, r);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     p->rotation = r;
     p->offset = o;
     g->dragging = 0;

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -437,10 +437,9 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
   char *str = g_strdup_printf(ngettext("fixed %d pixel", "fixed %d pixels", g->pixels_fixed), g->pixels_fixed);
   g->pixels_fixed = -1;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   gtk_label_set_text(g->message, str);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   g_free(str);
 

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -173,10 +173,9 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   dt_iop_invert_params_t *p = self->params;
   for(int k = 0; k < 4; k++) p->color[k] = grayrgb[k];
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   gui_update_from_coeffs(self);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   dt_control_queue_redraw_widget(self->widget);

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2274,11 +2274,10 @@ static void corrections_done(gpointer instance, gpointer user_data)
     modifiers = g_list_next(modifiers);
   }
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   gtk_label_set_text(g->message, message);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->message), message);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -544,12 +544,11 @@ static void Dmin_picker_callback(GtkColorButton *widget, dt_iop_module_t *self)
   p->Dmin[1] = c.green;
   p->Dmin[2] = c.blue;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0] * 100.0f); // warning: GUI is in %
   dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1] * 100.0f); // warning: GUI is in %
   dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2] * 100.0f); // warning: GUI is in %
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   Dmin_picker_update(self);
   dt_iop_color_picker_reset(self, TRUE);
@@ -595,12 +594,11 @@ static void WB_low_picker_callback(GtkColorButton *widget, dt_iop_module_t *self
   float RGB_min = v_minf(RGB);
   for(size_t k = 0; k < 3; k++) p->wb_low[k] = RGB[k] / RGB_min;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->wb_low_R, p->wb_low[0]);
   dt_bauhaus_slider_set(g->wb_low_G, p->wb_low[1]);
   dt_bauhaus_slider_set(g->wb_low_B, p->wb_low[2]);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   WB_low_picker_update(self);
   dt_iop_color_picker_reset(self, TRUE);
@@ -647,12 +645,11 @@ static void WB_high_picker_callback(GtkColorButton *widget, dt_iop_module_t *sel
   float RGB_min = v_minf(RGB);
   for(size_t k = 0; k < 3; k++) p->wb_high[k] = RGB[k] / RGB_min;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->wb_high_R, p->wb_high[0]);
   dt_bauhaus_slider_set(g->wb_high_G, p->wb_high[1]);
   dt_bauhaus_slider_set(g->wb_high_B, p->wb_high[2]);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   WB_high_picker_update(self);
   dt_iop_color_picker_reset(self, TRUE);
@@ -671,12 +668,11 @@ static void apply_auto_Dmin(dt_iop_module_t *self)
 
   for(int k = 0; k < 4; k++) p->Dmin[k] = self->picked_color[k];
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0] * 100.0f); // warning: GUI is in %
   dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1] * 100.0f); // warning: GUI is in %
   dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2] * 100.0f); // warning: GUI is in %
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   Dmin_picker_update(self);
   dt_control_queue_redraw_widget(self->widget);
@@ -699,10 +695,9 @@ static void apply_auto_Dmax(dt_iop_module_t *self)
   // Take the max(RGB) for safety. Big values unclip whites
   p->D_max = v_maxf(RGB);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->D_max, p->D_max);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_control_queue_redraw_widget(self->widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -722,10 +717,9 @@ static void apply_auto_offset(dt_iop_module_t *self)
   // Take the min(RGB) for safety. Negative values unclip blacks
   p->offset = v_minf(RGB);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->offset, p->offset); // warning: GUI is in %
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_control_queue_redraw_widget(self->widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -746,12 +740,11 @@ static void apply_auto_WB_low(dt_iop_module_t *self)
   const float RGB_v_min = v_minf(RGB_min); // warning: can be negative
   for(int c = 0; c < 3; c++) p->wb_low[c] =  RGB_v_min / RGB_min[c];
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->wb_low_R, p->wb_low[0]);
   dt_bauhaus_slider_set(g->wb_low_G, p->wb_low[1]);
   dt_bauhaus_slider_set(g->wb_low_B, p->wb_low[2]);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   WB_low_picker_update(self);
   dt_control_queue_redraw_widget(self->widget);
@@ -773,12 +766,11 @@ static void apply_auto_WB_high(dt_iop_module_t *self)
   const float RGB_v_min = v_minf(RGB_min); // warning : must be positive
   for(int c = 0; c < 3; c++) p->wb_high[c] = RGB_min[c] / RGB_v_min;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->wb_high_R, p->wb_high[0]);
   dt_bauhaus_slider_set(g->wb_high_G, p->wb_high[1]);
   dt_bauhaus_slider_set(g->wb_high_B, p->wb_high[2]);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   WB_high_picker_update(self);
   dt_control_queue_redraw_widget(self->widget);
@@ -803,10 +795,9 @@ static void apply_auto_black(dt_iop_module_t *self)
   }
   p->black = v_maxf(RGB);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->black, p->black * 100.0f);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_control_queue_redraw_widget(self->widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -830,10 +821,9 @@ static void apply_auto_exposure(dt_iop_module_t *self)
   }
   p->exposure = v_minf(RGB);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_control_queue_redraw_widget(self->widget);
   dt_dev_add_history_item(darktable.develop, self, TRUE);

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -391,10 +391,9 @@ static void apply_auto_grey(dt_iop_module_t *self)
   float grey = fmax(fmax(self->picked_color[0], self->picked_color[1]), self->picked_color[2]);
   p->grey_point = 100.f * grey;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->grey_point, p->grey_point);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -414,10 +413,9 @@ static void apply_auto_black(dt_iop_module_t *self)
 
   p->shadows_range = EVmin;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->shadows_range, p->shadows_range);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -440,10 +438,9 @@ static void apply_auto_dynamic_range(dt_iop_module_t *self)
 
   p->dynamic_range = EVmax - EVmin;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->dynamic_range, p->dynamic_range);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -488,11 +485,10 @@ static void security_threshold_callback(GtkWidget *slider, gpointer user_data)
   p->dynamic_range = EVmax - EVmin;
   p->shadows_range = EVmin;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->dynamic_range, p->dynamic_range);
   dt_bauhaus_slider_set_soft(g->shadows_range, p->shadows_range);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -521,12 +517,11 @@ static void apply_autotune(dt_iop_module_t *self)
   p->shadows_range = EVmin;
   p->dynamic_range = EVmax - EVmin;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->grey_point, p->grey_point);
   dt_bauhaus_slider_set(g->shadows_range, p->shadows_range);
   dt_bauhaus_slider_set(g->dynamic_range, p->dynamic_range);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -589,8 +589,7 @@ static void rt_shape_selection_changed(dt_iop_module_t *self)
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   int selection_changed = 0;
 
@@ -649,7 +648,7 @@ static void rt_shape_selection_changed(dt_iop_module_t *self)
   else
     gtk_widget_hide(GTK_WIDGET(g->sl_mask_opacity));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   if(selection_changed) dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1892,8 +1891,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 static void rt_copypaste_scale_callback(GtkToggleButton *togglebutton, dt_iop_module_t *self)
 {
   if(darktable.gui->reset) return;
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   int scale_copied = 0;
   const int active = gtk_toggle_button_get_active(togglebutton);
@@ -1916,7 +1914,7 @@ static void rt_copypaste_scale_callback(GtkToggleButton *togglebutton, dt_iop_mo
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_copy_scale), g->copied_scale >= 0);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), g->copied_scale < 0);
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   if(scale_copied) dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -1933,10 +1931,9 @@ static void rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, dt_
   {
     dt_control_log(_("cannot display scales when the blending mask is displayed"));
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_toggle_button_set_active(togglebutton, FALSE);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     return;
   }
 
@@ -2048,10 +2045,9 @@ void gui_post_expose (struct dt_iop_module_t *self,
 
   if(shape_id > 0)
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set(g->sl_mask_opacity, rt_masks_form_get_opacity(self, shape_id));
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
 }
 
@@ -2086,8 +2082,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
 
   if(event->button == 1)
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     dt_iop_color_picker_reset(self, TRUE);
 
@@ -2120,7 +2115,7 @@ static gboolean rt_edit_masks_callback(GtkWidget *widget, GdkEventButton *event,
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     return TRUE;
   }
@@ -2143,8 +2138,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
 {
   if(darktable.gui->reset) return FALSE;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
@@ -2191,7 +2185,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
 
   if(!accept)
   {
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     return FALSE;
   }
 
@@ -2229,7 +2223,7 @@ static gboolean rt_select_algorithm_callback(GtkToggleButton *togglebutton, GdkE
     dt_control_queue_redraw_center();
   }
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
   return TRUE;
@@ -2246,10 +2240,9 @@ static void rt_showmask_callback(GtkToggleButton *togglebutton, dt_iop_module_t 
   {
     dt_control_log(_("cannot display masks when the blending mask is displayed"));
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_toggle_button_set_active(togglebutton, FALSE);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     return;
   }
 
@@ -2316,8 +2309,7 @@ static void rt_fill_mode_callback(GtkComboBox *combo, dt_iop_module_t *self)
 {
   if(self->dt->gui->reset) return;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
@@ -2335,7 +2327,7 @@ static void rt_fill_mode_callback(GtkComboBox *combo, dt_iop_module_t *self)
 
   rt_show_hide_controls(self, g, p, g);
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
@@ -3330,8 +3322,7 @@ void init_key_accels(dt_iop_module_so_t *module)
 static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                       GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3340,7 +3331,7 @@ static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *accel
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_beign_added(module, DT_MASKS_CIRCLE));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3348,8 +3339,7 @@ static gboolean _add_circle_key_accel(GtkAccelGroup *accel_group, GObject *accel
 static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                        GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3358,7 +3348,7 @@ static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acce
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_beign_added(module, DT_MASKS_ELLIPSE));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3366,8 +3356,7 @@ static gboolean _add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acce
 static gboolean _add_brush_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                      GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3376,7 +3365,7 @@ static gboolean _add_brush_key_accel(GtkAccelGroup *accel_group, GObject *accele
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_beign_added(module, DT_MASKS_BRUSH));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3384,8 +3373,7 @@ static gboolean _add_brush_key_accel(GtkAccelGroup *accel_group, GObject *accele
 static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                     GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3394,7 +3382,7 @@ static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceler
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_beign_added(module, DT_MASKS_PATH));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3402,8 +3390,7 @@ static gboolean _add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceler
 static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                                  GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3412,7 +3399,7 @@ static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GOb
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), rt_shape_is_beign_added(module, DT_MASKS_CIRCLE));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3420,8 +3407,7 @@ static gboolean _continuous_add_circle_key_accel(GtkAccelGroup *accel_group, GOb
 static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                                   GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3430,7 +3416,7 @@ static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GO
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), rt_shape_is_beign_added(module, DT_MASKS_ELLIPSE));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3438,8 +3424,7 @@ static gboolean _continuous_add_ellipse_key_accel(GtkAccelGroup *accel_group, GO
 static gboolean _continuous_add_brush_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                                 GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3448,7 +3433,7 @@ static gboolean _continuous_add_brush_key_accel(GtkAccelGroup *accel_group, GObj
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), rt_shape_is_beign_added(module, DT_MASKS_BRUSH));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3456,8 +3441,7 @@ static gboolean _continuous_add_brush_key_accel(GtkAccelGroup *accel_group, GObj
 static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                                GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3466,7 +3450,7 @@ static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObje
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), rt_shape_is_beign_added(module, DT_MASKS_PATH));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }
@@ -3474,8 +3458,7 @@ static gboolean _continuous_add_path_key_accel(GtkAccelGroup *accel_group, GObje
 static gboolean _show_or_hide_accel(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
                                                GdkModifierType modifier, gpointer data)
 {
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_module_t *module = (dt_iop_module_t *)data;
   const dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)module->gui_data;
@@ -3522,7 +3505,7 @@ static gboolean _show_or_hide_accel(GtkAccelGroup *accel_group, GObject *acceler
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == module));
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   return TRUE;
 }

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -169,12 +169,11 @@ static void _develop_ui_pipe_finished_callback(gpointer instance, dt_iop_module_
 
     dt_pthread_mutex_unlock(&g->lock);
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     gui_update(self);
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
   }
   else
   {

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -479,13 +479,12 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   *p_hue        = H;
   *p_saturation = S;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(hue, H);
   dt_bauhaus_slider_set(sat, S);
   update_colorpicker_color(colorpicker, H, S);
   update_saturation_slider_end_color(sat, H);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   gtk_widget_queue_draw(GTK_WIDGET(g->balance_scale));
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -305,8 +305,7 @@ static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   dt_iop_color_picker_reset(self, TRUE);
 
@@ -326,7 +325,7 @@ static gboolean _edit_masks(GtkWidget *widget, GdkEventButton *e, dt_iop_module_
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
   }
 
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   dt_control_queue_redraw_center();
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1158,15 +1158,14 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   double TempK, tint;
   mul2temp(self, p->coeffs, &TempK, &tint);
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->scale_k, TempK);
   dt_bauhaus_slider_set(g->scale_tint, tint);
   dt_bauhaus_slider_set(g->scale_r, p->coeffs[0]);
   dt_bauhaus_slider_set(g->scale_g, p->coeffs[1]);
   dt_bauhaus_slider_set(g->scale_b, p->coeffs[2]);
   dt_bauhaus_slider_set(g->scale_g2, p->coeffs[3]);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 static void temp_changed(dt_iop_module_t *self)
@@ -1189,13 +1188,12 @@ static void temp_changed(dt_iop_module_t *self)
   coeffs[1] = 1.0;
   for(int c = 0; c < 4; c++) p->coeffs[c] = g->mod_coeff[c] = coeffs[c];
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set(g->scale_r, p->coeffs[0]);
   dt_bauhaus_slider_set(g->scale_g, p->coeffs[1]);
   dt_bauhaus_slider_set(g->scale_b, p->coeffs[2]);
   dt_bauhaus_slider_set(g->scale_g2, p->coeffs[3]);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -562,10 +562,9 @@ static int sanity_check(dt_iop_module_t *self)
       // Repaint the on/off icon
       if(self->off)
       {
-        const int reset = darktable.gui->reset;
-        darktable.gui->reset = 1;
+        ++darktable.gui->reset;
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), self->enabled);
-        darktable.gui->reset = reset;
+        --darktable.gui->reset;
       }
     }
     return 0;
@@ -1889,10 +1888,9 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
   {
     // Reset the exposure boost and do nothing
     p->exposure_boost = 0.0f;
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1920,10 +1918,9 @@ static void auto_adjust_exposure_boost(GtkWidget *quad, gpointer user_data)
   p->exposure_boost += target - g->histogram_average;
 
   // Update the GUI stuff
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->exposure_boost, p->exposure_boost);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 
@@ -1953,10 +1950,9 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
   {
     // Reset the contrast boost and do nothing
     p->contrast_boost = 0.0f;
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     dt_bauhaus_slider_set_soft(g->contrast_boost, p->contrast_boost);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     invalidate_luminance_cache(self);
     dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1985,10 +1981,9 @@ static void auto_adjust_contrast_boost(GtkWidget *quad, gpointer user_data)
   p->contrast_boost = (3.0f - origin);
 
   // Update the GUI stuff
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->contrast_boost, p->contrast_boost);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
   invalidate_luminance_cache(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 
@@ -2303,10 +2298,9 @@ int scrolled(struct dt_iop_module_t *self, double x, double y, int up, uint32_t 
   if(commit)
   {
     // Update GUI with new params
-    const int reset = self->dt->gui->reset;
-    self->dt->gui->reset = 1;
+    ++darktable.gui->reset;
     update_exposure_sliders(g, p);
-    self->dt->gui->reset = reset;
+    --darktable.gui->reset;
 
     dt_dev_add_history_item(darktable.develop, self, FALSE);
   }
@@ -2986,10 +2980,9 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
     p->speculars = d->speculars;
 
     // update UI sliders
-    const int reset = self->dt->gui->reset;
-    self->dt->gui->reset = 1;
+    ++darktable.gui->reset;
     update_exposure_sliders(g, p);
-    self->dt->gui->reset = reset;
+    --darktable.gui->reset;
 
     // Redraw graph
     gtk_widget_queue_draw(self->widget);
@@ -3045,10 +3038,9 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
   else if(g->area_dragging && !height_valid)
   {
     // cursor left area : force commit to avoid glitches
-    const int reset = self->dt->gui->reset;
-    self->dt->gui->reset = 1;
+    ++darktable.gui->reset;
     update_exposure_sliders(g, p);
-    self->dt->gui->reset = reset;
+    --darktable.gui->reset;
 
     dt_dev_add_history_item(darktable.develop, self, FALSE);
 
@@ -3102,10 +3094,9 @@ static gboolean area_button_release(GtkWidget *widget, GdkEventButton *event, gp
     if(g->area_dragging)
     {
       // Update GUI with new params
-      const int reset = self->dt->gui->reset;
-      self->dt->gui->reset = 1;
+      ++darktable.gui->reset;
       update_exposure_sliders(g, p);
-      self->dt->gui->reset = reset;
+      --darktable.gui->reset;
 
       dt_dev_add_history_item(darktable.develop, self, FALSE);
 
@@ -3154,12 +3145,11 @@ static void _develop_ui_pipe_started_callback(gpointer instance, gpointer user_d
     dt_pthread_mutex_unlock(&g->lock);
   }
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   dt_pthread_mutex_lock(&g->lock);
   dt_bauhaus_widget_set_quad_active(GTK_WIDGET(g->show_luminance_mask), g->mask_display);
   dt_pthread_mutex_unlock(&g->lock);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1879,8 +1879,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
   // we check if something as change since last call
   if(d->view_rule != -1) return;
 
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   const int _a = dt_conf_get_int("plugins/lighttable/collect/num_rules") - 1;
   const int active = CLAMP(_a, 0, (MAX_RULES - 1));
   d->nb_rules = active + 1;
@@ -1939,7 +1938,7 @@ static void _lib_collect_gui_update(dt_lib_module_t *self)
 
   // update list of proposals
   update_view(d->rule + d->active_rule);
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 }
 
 void gui_reset(dt_lib_module_t *self)

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -140,11 +140,10 @@ static void _update_picker_output(dt_lib_module_t *self)
   dt_iop_module_t *module = dt_iop_get_colorout_module();
   if(module)
   {
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->picker_button),
                                  module->request_color_pick != DT_REQUEST_COLORPICK_OFF);
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     int input_color = dt_conf_get_int("ui_last/colorpicker_model");
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -380,8 +380,7 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
 
       if(darktable.develop->gui_module == mod) dt_iop_request_focus(NULL);
 
-      const int reset = darktable.gui->reset;
-      darktable.gui->reset = 1;
+      ++darktable.gui->reset;
 
       // we remove the plugin effectively
       if(!dt_iop_is_hidden(mod))
@@ -406,7 +405,7 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
       // don't delete the module, a pipe may still need it
       dev->alliop = g_list_append(dev->alliop, mod);
 
-      darktable.gui->reset = reset;
+      --darktable.gui->reset;
 
       // and reset the list
       modules = g_list_first(iop_list);

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -219,8 +219,7 @@ void expose(
   if(dev->gui_synch && !dev->image_loading)
   {
     // synch module guis from gtk thread:
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
     GList *modules = dev->iop;
     while(modules)
     {
@@ -228,7 +227,7 @@ void expose(
       dt_iop_gui_update(module);
       modules = g_list_next(modules);
     }
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
     dev->gui_synch = 0;
   }
 
@@ -824,8 +823,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   dt_dev_reload_image(dev, imgid);
 
   // make sure no signals propagate here:
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
 
   const guint nb_iop = g_list_length(dev->iop);
   dt_dev_pixelpipe_cleanup_nodes(dev->pipe);
@@ -946,7 +944,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
      are blocked due to implementation of dt_iop_request_focus so we do it now
      A double history entry is not generated.
   */
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   /* Now we can request focus again and write a safe plugins/darkroom/active */
   if(active_plugin)
@@ -1982,8 +1980,7 @@ static gboolean _toggle_mask_visibility_callback(GtkAccelGroup *accel_group, GOb
   {
     dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)mod->blend_data;
 
-    const int reset = darktable.gui->reset;
-    darktable.gui->reset = 1;
+    ++darktable.gui->reset;
 
     dt_iop_color_picker_reset(mod, TRUE);
 
@@ -2003,7 +2000,7 @@ static gboolean _toggle_mask_visibility_callback(GtkAccelGroup *accel_group, GOb
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), FALSE);
     }
 
-    darktable.gui->reset = reset;
+    --darktable.gui->reset;
 
     return TRUE;
   }
@@ -2705,8 +2702,7 @@ void enter(dt_view_t *self)
    * add IOP modules to plugin list
    */
   // avoid triggering of events before plugin is ready:
-  const int reset = darktable.gui->reset;
-  darktable.gui->reset = 1;
+  ++darktable.gui->reset;
   char option[1024];
   GList *modules = g_list_last(dev->iop);
   while(modules)
@@ -2741,7 +2737,7 @@ void enter(dt_view_t *self)
     modules = g_list_previous(modules);
   }
   // make signals work again:
-  darktable.gui->reset = reset;
+  --darktable.gui->reset;
 
   /* signal that darktable.develop is initialized and ready to be used */
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE);


### PR DESCRIPTION
just another small attempt to improve code readability/maintainability and brevity (saving one line and variable each time). using prefix notation to make it easier to spot and check matching on/off switches (search for "gui->reset;" including the semi-colon)

but it is an invasive change (touches 35 files, mostly search+replace) that doesn't provide any advantage _now_ so definitely not high priority