### PR TITLE
blendop masks: allow continuous creation with ctrl+click

### DIFF
--- a/src/develop/masks/brush.c
+++ b/src/develop/masks/brush.c
@@ -1608,9 +1608,10 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
       {
         dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
         // and we switch in edit mode to show all the forms
-        if(gui->creation_continuous)
+        // spots and retouch have their own handling of creation_continuous
+        if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
-        else
+        else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
         dt_masks_iop_update(crea_module);
         gui->creation_module = NULL;
@@ -1622,11 +1623,30 @@ static int dt_brush_events_button_released(struct dt_iop_module_t *module, float
 
       if(gui->creation_continuous)
       {
-        dt_masks_form_t *form_new = dt_masks_create(form->type);
-        dt_masks_change_form_gui(form_new);
+        //spot and retouch manage creation_continuous in their own way
+        if(strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+        {
+          dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+          for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+            if(bd->masks_type[n] == form->type)
+              gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
 
-        darktable.develop->form_gui->creation = TRUE;
-        darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+          dt_masks_form_t *newform = dt_masks_create(form->type);
+          dt_masks_change_form_gui(newform);
+          darktable.develop->form_gui->creation = TRUE;
+          darktable.develop->form_gui->creation_module = crea_module;
+          darktable.develop->form_gui->creation_continuous = TRUE;
+          darktable.develop->form_gui->creation_continuous_module = crea_module;
+        }
+        else
+        {
+          dt_masks_form_t *form_new = dt_masks_create(form->type);
+          dt_masks_change_form_gui(form_new);
+
+          darktable.develop->form_gui->creation = TRUE;
+          darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+        }
       }
       else if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -261,9 +261,10 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       // we save the move
       dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
       // and we switch in edit mode to show all the forms
-      if(gui->creation_continuous)
+      // spots and retouch have their own handling of creation_continuous
+      if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
-      else
+      else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
       gui->creation_module = NULL;
@@ -309,6 +310,22 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
       gui2->form_selected = TRUE; // we also want to be selected after button released
 
       dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, form->formid));
+    }
+    //spot and retouch manage creation_continuous in their own way
+    if(crea_module && gui->creation_continuous && strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+    {
+      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+      for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+        if(bd->masks_type[n] == form->type)
+          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
+
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+      dt_masks_form_t *newform = dt_masks_create(form->type);
+      dt_masks_change_form_gui(newform);
+      darktable.develop->form_gui->creation = TRUE;
+      darktable.develop->form_gui->creation_module = crea_module;
+      darktable.develop->form_gui->creation_continuous = TRUE;
+      darktable.develop->form_gui->creation_continuous_module = crea_module;
     }
     return 1;
   }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -667,9 +667,10 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       // we save the move
       dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
       // and we switch in edit mode to show all the forms
-      if(gui->creation_continuous)
+      // spots and retouch have their own handling of creation_continuous
+      if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
         dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
-      else
+      else if(!gui->creation_continuous)
         dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
       dt_masks_iop_update(crea_module);
       gui->creation_module = NULL;
@@ -715,6 +716,22 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       gui2->form_selected = TRUE; // we also want to be selected after button released
 
       dt_masks_select_form(module, dt_masks_get_from_id(darktable.develop, form->formid));
+    }
+    //spot and retouch manage creation_continuous in their own way
+    if(crea_module && gui->creation_continuous && strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+    {
+      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+      for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+        if(bd->masks_type[n] == form->type)
+          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
+
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+      dt_masks_form_t *newform = dt_masks_create(form->type);
+      dt_masks_change_form_gui(newform);
+      darktable.develop->form_gui->creation = TRUE;
+      darktable.develop->form_gui->creation_module = crea_module;
+      darktable.develop->form_gui->creation_continuous = TRUE;
+      darktable.develop->form_gui->creation_continuous_module = crea_module;
     }
     return 1;
   }

--- a/src/develop/masks/gradient.c
+++ b/src/develop/masks/gradient.c
@@ -388,6 +388,21 @@ static int dt_gradient_events_button_released(struct dt_iop_module_t *module, fl
       dt_dev_masks_selection_change(darktable.develop, form->formid, TRUE);
     }
 
+    if(crea_module && gui->creation_continuous)
+    {
+      dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+      for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+        if(bd->masks_type[n] == form->type)
+          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
+
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+      dt_masks_form_t *newform = dt_masks_create(form->type);
+      dt_masks_change_form_gui(newform);
+      darktable.develop->form_gui->creation = TRUE;
+      darktable.develop->form_gui->creation_module = crea_module;
+      darktable.develop->form_gui->creation_continuous = TRUE;
+      darktable.develop->form_gui->creation_continuous_module = crea_module;
+    }
     return 1;
   }
 

--- a/src/develop/masks/path.c
+++ b/src/develop/masks/path.c
@@ -1011,9 +1011,10 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
       {
         dt_dev_add_history_item(darktable.develop, crea_module, TRUE);
         // and we switch in edit mode to show all the forms
-        if(gui->creation_continuous)
+        // spots and retouch have their own handling of creation_continuous
+        if(gui->creation_continuous && ( strcmp(crea_module->so->op, "spots") == 0 || strcmp(crea_module->so->op, "retouch") == 0))
           dt_masks_set_edit_mode_single_form(crea_module, form->formid, DT_MASKS_EDIT_FULL);
-        else
+        else if(!gui->creation_continuous)
           dt_masks_set_edit_mode(crea_module, DT_MASKS_EDIT_FULL);
         dt_masks_iop_update(crea_module);
         gui->creation_module = NULL;
@@ -1025,11 +1026,30 @@ static int dt_path_events_button_pressed(struct dt_iop_module_t *module, float p
 
       if(gui->creation_continuous)
       {
-        dt_masks_form_t *form_new = dt_masks_create(form->type);
-        dt_masks_change_form_gui(form_new);
+        //spot and retouch manage creation_continuous in their own way
+        if(strcmp(crea_module->so->op, "spots") != 0 && strcmp(crea_module->so->op, "retouch") != 0)
+        {
+          dt_iop_gui_blend_data_t *bd = (dt_iop_gui_blend_data_t *)crea_module->blend_data;
+          for(int n = 0; n < DEVELOP_MASKS_NB_SHAPES; n++)
+            if(bd->masks_type[n] == form->type)
+              gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[n]), TRUE);
 
-        darktable.develop->form_gui->creation = TRUE;
-        darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+          gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
+          dt_masks_form_t *newform = dt_masks_create(form->type);
+          dt_masks_change_form_gui(newform);
+          darktable.develop->form_gui->creation = TRUE;
+          darktable.develop->form_gui->creation_module = crea_module;
+          darktable.develop->form_gui->creation_continuous = TRUE;
+          darktable.develop->form_gui->creation_continuous_module = crea_module;
+        }
+        else
+        {
+          dt_masks_form_t *form_new = dt_masks_create(form->type);
+          dt_masks_change_form_gui(form_new);
+
+          darktable.develop->form_gui->creation = TRUE;
+          darktable.develop->form_gui->creation_module = gui->creation_continuous_module;
+        }
       }
       else if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {


### PR DESCRIPTION
adds ability to draw continuous masks (similar to how retouch and spot
removal modules work) by control-clicking on the drawn mask creation
buttons.

Resolves #5078