### PR TITLE
Allow user to choose to keep delete button on last object in duplicate module

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -355,11 +355,12 @@
     <default>false</default>
     <shortdescription>ask before removing empty folders</shortdescription>
     <longdescription>always ask the user before removing any empty folder. this can happen after moving or deleting images.</longdescription>
+  </dtconfig>
   <dtconfig prefs="security">
     <name>allow_delete_last_duplicate</name>
     <type>bool</type>
     <default>false</default>
-    <shortdescription>allow all files to be deleted from duplicate module</shortdescription>
+    <shortdescription>allow all files to be deleted via duplicate module</shortdescription>
     <longdescription>leaves delete button on last file in duplicate module, removes if false</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable">

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -355,6 +355,12 @@
     <default>false</default>
     <shortdescription>ask before removing empty folders</shortdescription>
     <longdescription>always ask the user before removing any empty folder. this can happen after moving or deleting images.</longdescription>
+  <dtconfig prefs="security">
+    <name>allow_delete_last_duplicate</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>allow all files to be deleted from duplicate module</shortdescription>
+    <longdescription>leaves delete button on last file in duplicate module, removes if false</longdescription>
   </dtconfig>
   <dtconfig prefs="lighttable">
     <name>show_folder_levels</name>

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -161,8 +161,7 @@ static void _lib_duplicate_thumb_press_callback(GtkWidget *widget, GdkEventButto
       dt_dev_invalidate(darktable.develop);
 
       d->imgid = imgid;
-      int fw, fh;
-      fw = fh = 0;
+      int fw = 0, fh = 0;
       dt_image_get_final_size(imgid, &fw, &fh);
       if(d->cur_final_width <= 0)
         dt_image_get_final_size(dev->image_storage.id, &d->cur_final_width, &d->cur_final_height);
@@ -362,8 +361,8 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 
   gtk_widget_show(d->duplicate_box);
 
-  // we have a single image, do not allow it to be removed so hide last bt
-  if(count==1)
+  // we have a single image, do not allow it to be removed so hide last bt unless authorised
+  if(count==1 && !dt_conf_get_bool("allow_delete_last_duplicate"))
   {
     gtk_widget_set_sensitive(bt, FALSE);
     gtk_widget_set_visible(bt, FALSE);


### PR DESCRIPTION
A very small PR: I'd like to be able to delete directly from dr, but the delete button disappears from the duplicate module once only a single image remains.
Since some might be nervous about this causing unintended deletions, it's enabled by a choice in the "security" section of prefs. The default is FALSE, ie current behaviour.

Would close #4950.