### PR TITLE
change icon display for 'always-on' and 'always-off' iop module header buttons

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1172,16 +1172,11 @@ void dt_iop_gui_set_enable_button(dt_iop_module_t *module)
 {
   if(module->off)
   {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), module->enabled);
     if(module->hide_enable_button)
-    {
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), FALSE);
       gtk_widget_set_sensitive(GTK_WIDGET(module->off), FALSE);
-    }
     else
-    {
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), module->enabled);
       gtk_widget_set_sensitive(GTK_WIDGET(module->off), TRUE);
-    }
   }
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2012,10 +2012,15 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_PRESETS]), "module-preset-button");
 
   /* add enabled button */
-  if(module->enabled && module->default_enabled && module->hide_enable_button)
+  if(module->default_enabled && module->hide_enable_button)
   {
     hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, module);
     gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_SWITCH]), "module-always-enabled-button");
+  }
+  else if(!module->default_enabled && module->hide_enable_button)
+  {
+    hw[IOP_MODULE_SWITCH] = dtgtk_togglebutton_new(dtgtk_cairo_paint_switch_off, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_DO_NOT_USE_BORDER, module);
+    gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_SWITCH]), "module-always-disabled-button");
   }
   else
   {

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -313,6 +313,19 @@ void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_identity_matrix(cr);
 }
 
+void dtgtk_cairo_paint_switch_off(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  const gint s = w < h ? w : h;
+  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_scale(cr, s, s);
+  cairo_set_line_width(cr, 0.1);
+
+  cairo_arc(cr, 0.5, 0.5, 0.50, 0, 2 * M_PI);
+  cairo_stroke(cr);
+
+  cairo_identity_matrix(cr);
+}
+
 void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   const gint s = w < h ? w : h;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -67,6 +67,8 @@ void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint an always-on switch icon */
 void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint an always-off switch icon */
+void dtgtk_cairo_paint_switch_off(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a deprecated switch icon */
 void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a plusminus icon */


### PR DESCRIPTION
Makes the displayed shade of the 'always-on' module closer to that of the 'on' module (to match the display in the history module), though it is still made slightly darker by gtk because the button is insensitive.

Also adds an 'always-off' icon. Examples of all possible states below (ignoring the potential 'focus highlighting' in #5091), in order:

- Off (can be switched on)
- Forced Off (cannot be switched on for this image)
- Forced On (cannot be switched off for this image)
- On (can be switched off)

![Screenshot_2020-05-17_12-38-38](https://user-images.githubusercontent.com/9555491/82143389-803a0580-983b-11ea-87b6-d7a00896c67b.png)
