### PR TITLE
another attempt at the 'module-in-focus' button

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -271,22 +271,16 @@ void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_FOCUS)
-  {
-    cairo_set_line_width(cr, 0.05);
-    cairo_arc(cr, 0.5, 0.5, 0.60, 0, M_PI);
-    cairo_stroke(cr);
-  }
   cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.46, (-50 * 3.145 / 180), (230 * 3.145 / 180));
   cairo_move_to(cr, 0.5, 0.0);
   cairo_line_to(cr, 0.5, 0.5);
   cairo_stroke(cr);
-  if(flags & CPF_ACTIVE) // If active add some diffuse light
+  if(flags & CPF_FOCUS) // If focused add some diffuse light
   {
     cairo_arc(cr, 0.5, 0.5, 0.45, 0.0, 2*M_PI);
     cairo_clip(cr);
-    cairo_paint_with_alpha(cr, 0.33);
+    cairo_paint_with_alpha(cr, 0.4);
   }
 
   cairo_identity_matrix(cr);


### PR DESCRIPTION
Following on from further discussions in #5062, this is my attempt at a 'module-in-focus' button, which indicates focus by slightly shading the on/off button when a module is in focus.

on (focused)
off (unfocused)
![Screenshot_2020-05-16_19-40-20](https://user-images.githubusercontent.com/9555491/82127659-3c002400-97ad-11ea-92d9-c85868e0f56b.png) 
on(unfocused)
off (focused)
![Screenshot_2020-05-16_19-40-59](https://user-images.githubusercontent.com/9555491/82127661-40c4d800-97ad-11ea-9531-bfb195ed8bdc.png)

I've not changed the icons for the modules that can't be toggled on/off. I think those are fine as they are.