### PR TITLE
Lua - change size of side and bottom panels.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -290,6 +290,9 @@ making a backup is strongly advised.
   DT_COLLECTION_PROP_IMPORT_TIMESTAMP, DT_COLLECTION_PROP_CHANGE_TIMESTAMP,
   DT_COLLECTION_PROP_EXPORT_TIMESTAMP, DT_COLLECTION_PROP_PRINT_TIMESTAMP
 
+- added darktable.gui.panel_get_size and darktable.gui.panel_set_size functions 
+  to set the width of the  left or right panels and the height of the bottom panel.
+
 ## Changed Dependencies
 
 

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -834,6 +834,54 @@
 
 </section>
 
+<section status="final" id="darktable_gui_panel_get_size">
+<title>darktable.gui.panel_get_size</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_get_size</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_panel_get_size_panel">panel</link></emphasis> : <link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link>
+)int</synopsis>
+<para>Gets the size in pixels of the specified panel.  This only works for the left, right, and bottom panels.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_panel_get_size_panel"><term>panel</term><listitem>
+<synopsis><link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link></synopsis>
+<para>The panel to get the size of.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_panel_set_size">
+<title>darktable.gui.panel_set_size</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>panel_set_size</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_panel_set_size_panel">panel</link></emphasis> : <link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link>
+	<emphasis><link linkend="darktable_gui_panel_set_size_size">size</link></emphasis> : int
+)</synopsis>
+<para>Sets the size in pixels of the specified panel.  This only works for the left, right, and bottom panels.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_panel_set_size_panel"><term>panel</term><listitem>
+<synopsis><link linkend="types_dt_ui_panel_t">types.dt_ui_panel_t</link></synopsis>
+<para>The panel to set the size of.</para>
+
+</listitem></varlistentry>
+<varlistentry id="darktable_gui_panel_set_size_size"><term>size</term><listitem>
+<synopsis>int></synopsis>
+<para>The size to set the panel to.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
 <section status="final" id="darktable_gui_create_job">
 <title>darktable.gui.create_job</title>
 <indexterm>

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -63,6 +63,8 @@
  */
 
 #define DT_UI_PANEL_MODULE_SPACING 0
+#define DT_UI_PANEL_SIDE_DEFAULT_SIZE 350
+#define DT_UI_PANEL_BOTTOM_DEFAULT_SIZE 120
 
 typedef enum dt_gui_view_switch_t
 {
@@ -1842,7 +1844,7 @@ static void _ui_init_panel_size(GtkWidget *widget)
   if(strcmp(gtk_widget_get_name(widget), "right") == 0)
   {
     key = _panels_get_panel_path(DT_UI_PANEL_RIGHT, "_size");
-    s = 350; // default panel size
+    s = DT_UI_PANEL_SIDE_DEFAULT_SIZE; // default panel size
     if(key && dt_conf_key_exists(key))
       s = CLAMP(dt_conf_get_int(key), dt_conf_get_int("min_panel_width"), dt_conf_get_int("max_panel_width"));
     if(key) gtk_widget_set_size_request(widget, s, -1);
@@ -1850,7 +1852,7 @@ static void _ui_init_panel_size(GtkWidget *widget)
   else if(strcmp(gtk_widget_get_name(widget), "left") == 0)
   {
     key = _panels_get_panel_path(DT_UI_PANEL_LEFT, "_size");
-    s = 350; // default panel size
+    s = DT_UI_PANEL_SIDE_DEFAULT_SIZE; // default panel size
     if(key && dt_conf_key_exists(key))
       s = CLAMP(dt_conf_get_int(key), dt_conf_get_int("min_panel_width"), dt_conf_get_int("max_panel_width"));
     if(key) gtk_widget_set_size_request(widget, s, -1);
@@ -1858,7 +1860,7 @@ static void _ui_init_panel_size(GtkWidget *widget)
   else if(strcmp(gtk_widget_get_name(widget), "bottom") == 0)
   {
     key = _panels_get_panel_path(DT_UI_PANEL_BOTTOM, "_size");
-    s = 120; // default panel size
+    s = DT_UI_PANEL_BOTTOM_DEFAULT_SIZE; // default panel size
     if(key && dt_conf_key_exists(key))
       s = CLAMP(dt_conf_get_int(key), dt_conf_get_int("min_panel_height"), dt_conf_get_int("max_panel_height"));
     if(key) gtk_widget_set_size_request(widget, -1, s);
@@ -2056,9 +2058,9 @@ int dt_ui_panel_get_size(dt_ui_t *ui, const dt_ui_panel_t p)
     else // size hasn't been adjusted, so return default sizes
     {
       if(p == DT_UI_PANEL_BOTTOM)
-        size = 120;
+        size = DT_UI_PANEL_BOTTOM_DEFAULT_SIZE;
       else
-        size = 350;
+        size = DT_UI_PANEL_SIDE_DEFAULT_SIZE;
     }
     return size;
   }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2040,6 +2040,46 @@ gboolean dt_ui_panel_visible(dt_ui_t *ui, const dt_ui_panel_t p)
   return gtk_widget_get_visible(ui->panels[p]);
 }
 
+int dt_ui_panel_get_size(dt_ui_t *ui, const dt_ui_panel_t p)
+{
+  gchar *key = NULL;
+  int size;
+
+  if(p == DT_UI_PANEL_LEFT || p == DT_UI_PANEL_RIGHT || p == DT_UI_PANEL_BOTTOM)
+  {
+    key = _panels_get_panel_path(p, "_size");
+    if(key && dt_conf_key_exists(key))
+    {
+      size = dt_conf_get_int(key);
+      g_free(key);
+    }
+    else // size hasn't been adjusted, so return default sizes
+    {
+      if(p == DT_UI_PANEL_BOTTOM)
+        size = 120;
+      else
+        size = 350;
+    }
+    return size;
+  }
+  return -1;
+}
+
+void dt_ui_panel_set_size(dt_ui_t *ui, const dt_ui_panel_t p, int s)
+{
+  gchar *key = NULL;
+  int width;
+
+  if(p == DT_UI_PANEL_LEFT || p == DT_UI_PANEL_RIGHT || p == DT_UI_PANEL_BOTTOM)
+  {
+    width = CLAMP(s, dt_conf_get_int("min_panel_width"), dt_conf_get_int("max_panel_width"));
+    gtk_widget_set_size_request(ui->panels[p], width, -1);
+    key = _panels_get_panel_path(p, "_size");
+    dt_conf_set_int(key, width);
+    g_free(key);
+  }
+}
+
 GtkWidget *dt_ui_center(dt_ui_t *ui)
 {
   return ui->center;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -314,6 +314,10 @@ void dt_ui_toggle_panels_visibility(struct dt_ui_t *ui);
 void dt_ui_notify_user();
 /** \brief get visible state of panel */
 gboolean dt_ui_panel_visible(struct dt_ui_t *ui, const dt_ui_panel_t);
+/**  \brief get width of right, left, or bottom panel */
+int dt_ui_panel_get_size(struct dt_ui_t *ui, const dt_ui_panel_t p);
+/**  \brief set width of right, left, or bottom panel */
+void dt_ui_panel_set_size(struct dt_ui_t *ui, const dt_ui_panel_t p, int s);
 /** \brief get the center drawable widget */
 GtkWidget *dt_ui_center(struct dt_ui_t *ui);
 GtkWidget *dt_ui_center_base(struct dt_ui_t *ui);

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -164,6 +164,56 @@ static int panel_show_all_cb(lua_State *L)
   return 0;
 }
 
+static int panel_get_size_cb(lua_State *L)
+{
+  dt_ui_panel_t p;
+  int size;
+
+  if(lua_gettop(L) > 0)
+  {
+    luaA_to(L, dt_ui_panel_t, &p, 1);
+    if(p == DT_UI_PANEL_LEFT || p == DT_UI_PANEL_RIGHT || p == DT_UI_PANEL_BOTTOM)
+    {
+      size = dt_ui_panel_get_size(darktable.gui->ui, p);
+      lua_pushnumber(L, size);
+      return 1;
+    }
+    else
+    {
+      return luaL_error(L, "size not supported for specified panel");
+    }
+  }
+  else
+  {
+    return luaL_error(L, "no panel specified");
+  }
+}
+
+static int panel_set_size_cb(lua_State *L)
+{
+  dt_ui_panel_t p;
+  int size;
+
+  if(lua_gettop(L) > 1)
+  {
+    luaA_to(L, dt_ui_panel_t, &p, 1);
+    luaA_to(L, int, &size, 2);
+    if(p == DT_UI_PANEL_LEFT || p == DT_UI_PANEL_RIGHT || p == DT_UI_PANEL_BOTTOM)
+    {
+      dt_ui_panel_set_size(darktable.gui->ui, p, size);
+      return 0;
+    }
+    else
+    {
+      return luaL_error(L, "changing size not supported for specified panel");
+    }
+  }
+  else
+  {
+    return luaL_error(L, "no panel specified");
+  }
+}
+
 typedef dt_progress_t *dt_lua_backgroundjob_t;
 
 static int job_canceled(lua_State *L)
@@ -317,6 +367,12 @@ int dt_lua_init_gui(lua_State *L)
     lua_pushcfunction(L, panel_show_all_cb);
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "panel_show_all");
+    lua_pushcfunction(L, panel_get_size_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_get_size");
+    lua_pushcfunction(L, panel_set_size_cb);
+    lua_pushcclosure(L, dt_lua_type_member_common, 1);
+    dt_lua_type_register_const_type(L, type_id, "panel_set_size");
     lua_pushcfunction(L, lua_create_job);
     lua_pushcclosure(L, dt_lua_type_member_common, 1);
     dt_lua_type_register_const_type(L, type_id, "create_job");


### PR DESCRIPTION
Added darktable.gui.panel_get_size and darktable.gui.panel_set_size functions to change the size of the side and bottom panels.

Updated Lua API documentation with new functions.

Updated README.md Lua section.

Fixes #4174.