### PR TITLE
Create widgets based on introspection data

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,7 @@ FILE(GLOB SOURCE_FILES
   "develop/develop.c"
   "develop/imageop.c"
   "develop/imageop_math.c"
+  "develop/imageop_gui.c"
   "develop/lightroom.c"
   "develop/pixelpipe.c"
   "develop/blend.c"

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -208,6 +208,50 @@ static dt_introspection_field_t *default_get_f(const char *name)
   return NULL;
 }
 
+void default_init(dt_iop_module_t *module)
+{
+  size_t param_size = module->so->get_introspection()->size;
+  module->params_size = param_size;
+  module->params = (dt_iop_params_t *)malloc(param_size);
+  module->default_params = (dt_iop_params_t *)malloc(param_size);
+
+  module->default_enabled = 0;
+  module->gui_data = NULL;
+
+  dt_introspection_field_t *i = module->so->get_introspection_linear();
+  for (int num = module->so->get_introspection()->field->Struct.entries; num; num--,i++)
+  {
+    if (i->header.type == DT_INTROSPECTION_TYPE_FLOAT)
+    {
+      *(float*)(module->default_params + i->header.offset) = i->Float.Default;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_INT)
+    {
+      *(int*)(module->default_params + i->header.offset) = i->Int.Default;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_UINT)
+    {
+      *(unsigned int*)(module->default_params + i->header.offset) = i->UInt.Default;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_ENUM)
+    {
+//      Introspection $DEFAULT: not available for enums
+//      *(enum*)(module->default_params + i->header.offset) = i->Enum.Default;
+      *(int*)(module->default_params + i->header.offset) = 0;
+    }
+    else if (i->header.type == DT_INTROSPECTION_TYPE_BOOL)
+    {
+      *(gboolean*)(module->default_params + i->header.offset) = i->Bool.Default;
+    }
+    else
+    {
+      fprintf(stderr, "[default_init] can't support module `%s': needs custom init()\n", module->op);
+    }
+  }
+
+  memcpy(module->params, module->default_params, param_size);
+}
+
 int dt_iop_load_module_so(void *m, const char *libname, const char *op)
 {
   dt_iop_module_so_t *module = (dt_iop_module_so_t *)m;
@@ -258,6 +302,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
     module->gui_update = NULL;
   if(!g_module_symbol(module->module, "color_picker_apply", (gpointer) & (module->color_picker_apply)))
     module->color_picker_apply = NULL;
+  if(!g_module_symbol(module->module, "gui_changed", (gpointer) & (module->gui_changed))) 
+    module->gui_changed = NULL;
   if(!g_module_symbol(module->module, "gui_cleanup", (gpointer) & (module->gui_cleanup)))
     module->gui_cleanup = default_gui_cleanup;
 
@@ -287,7 +333,8 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
     module->configure = NULL;
   if(!g_module_symbol(module->module, "scrolled", (gpointer) & (module->scrolled))) module->scrolled = NULL;
 
-  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) goto error;
+  if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) 
+    module->init = default_init;
   if(!g_module_symbol(module->module, "cleanup", (gpointer) & (module->cleanup)))
     module->cleanup = &default_cleanup;
   if(!g_module_symbol(module->module, "init_global", (gpointer) & (module->init_global)))
@@ -428,6 +475,7 @@ int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt
   module->gui_reset = so->gui_reset;
   module->gui_init = so->gui_init;
   module->color_picker_apply = so->color_picker_apply;
+  module->gui_changed = so->gui_changed;
   module->gui_cleanup = so->gui_cleanup;
 
   module->gui_post_expose = so->gui_post_expose;

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -155,12 +155,10 @@ static void default_gui_cleanup(dt_iop_module_t *self)
 
 static void default_cleanup(dt_iop_module_t *module)
 {
-  g_free(module->gui_data);
-  module->gui_data = NULL; // just to be sure
   g_free(module->params);
   module->params = NULL;
-  g_free(module->global_data); // just to be sure
-  module->global_data = NULL;
+  free(module->default_params);
+  module->default_params = NULL;
 }
 
 
@@ -336,7 +334,7 @@ int dt_iop_load_module_so(void *m, const char *libname, const char *op)
   if(!g_module_symbol(module->module, "init", (gpointer) & (module->init))) 
     module->init = default_init;
   if(!g_module_symbol(module->module, "cleanup", (gpointer) & (module->cleanup)))
-    module->cleanup = &default_cleanup;
+    module->cleanup = default_cleanup;
   if(!g_module_symbol(module->module, "init_global", (gpointer) & (module->init_global)))
     module->init_global = NULL;
   if(!g_module_symbol(module->module, "cleanup_global", (gpointer) & (module->cleanup_global)))

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -204,6 +204,7 @@ typedef struct dt_iop_module_so_t
   void (*gui_update)(struct dt_iop_module_t *self);
   void (*gui_init)(struct dt_iop_module_t *self);
   void (*color_picker_apply)(struct dt_iop_module_t *self, GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
+  void (*gui_changed)(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   void (*gui_post_expose)(struct dt_iop_module_t *self, cairo_t *cr, int32_t width, int32_t height,
                           int32_t pointerx, int32_t pointery);
@@ -438,6 +439,8 @@ typedef struct dt_iop_module_t
   void (*gui_init)(struct dt_iop_module_t *self);
   /** apply color picker results */
   void (*color_picker_apply)(struct dt_iop_module_t *self, GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
+  /** called by standard widget callbacks after value changed */
+  void (*gui_changed)(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
   /** destroy widget. */
   void (*gui_cleanup)(struct dt_iop_module_t *self);
   /** optional method called after darkroom expose. */

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -1,0 +1,219 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2009-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "develop/imageop_gui.h"
+#include "develop/imageop.h"
+#include "bauhaus/bauhaus.h"
+#include "gui/color_picker_proxy.h"
+
+#ifdef GDK_WINDOWING_QUARTZ
+#include "osx/osx.h"
+#endif
+
+#include <assert.h>
+#include <gmodule.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#if defined(__SSE__)
+#include <xmmintrin.h>
+#endif
+#include <time.h>
+
+typedef struct dt_module_param_t
+{
+  dt_iop_module_t *module;
+  int param_offset;
+} dt_module_param_t;
+
+static void generic_slider_callback(GtkWidget *slider, dt_module_param_t *data)
+{
+  if(darktable.gui->reset) return;
+
+  dt_iop_module_t *self = data->module;
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  float *field = (float*)(p + data->param_offset);
+
+  float previous = *field;
+  *field = dt_bauhaus_slider_get(slider);
+
+  if (*field != previous)  // ignore unchanged (second call for button release)
+  {
+    if (self->gui_changed) self->gui_changed(self, slider, &previous);
+
+    dt_iop_color_picker_reset(self, TRUE);
+
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+  }
+}
+
+static void generic_combobox_callback(GtkWidget *combobox, dt_module_param_t *data)
+{
+  if(darktable.gui->reset) return;
+
+  dt_iop_module_t *self = data->module;
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  int *field = (int*)(p + data->param_offset);
+
+  int previous = *field;
+  *field = dt_bauhaus_combobox_get(combobox);
+
+  if (*field != previous) // ignore unchanged (second call for button release)
+  {
+    if (self->gui_changed) self->gui_changed(self, combobox, &previous);
+
+    dt_iop_color_picker_reset(self, TRUE);
+
+    dt_dev_add_history_item(darktable.develop, self, TRUE);
+  }
+}
+
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param)
+{
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  dt_introspection_field_t *f = self->so->get_f(param);
+
+  GtkWidget *slider = NULL;
+  gchar *str;
+
+  if (f && f->header.type == DT_INTROSPECTION_TYPE_FLOAT)
+  {
+    float min = f->Float.Min;
+    float max = f->Float.Max;
+    float defval = *(float*)self->so->get_p(p, param);
+    int digits = 2;
+    float step;
+
+    float top = fmaxf(fabsf(min),fabsf(max));
+    if (top>=100)
+    {
+      step = 1.f;
+    }
+    else
+    {
+      step = top / 100;
+      float log10step = log10f(step);
+      float fdigits = floorf(log10step+.1);
+      step = powf(10.f,fdigits);
+      if (log10step - fdigits > .5)
+        step *= 5;
+      if (fdigits < -2.f) 
+        digits = -fdigits;
+    }
+
+    slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, step, defval, digits, 1);
+
+    if (*f->header.description)
+    {
+      dt_bauhaus_widget_set_label(slider, NULL, gettext(f->header.description));
+    }
+    else
+    {
+      str = dt_util_str_replace(f->header.field_name, "_", " ");
+    
+      dt_bauhaus_widget_set_label(slider, NULL, gettext(str));
+
+      g_free(str);
+    }
+
+    const char *post = ""; // set " %%", " EV" etc
+
+    if (min < 0 || (post && *post))
+    {
+      str = g_strdup_printf("%%%s.0%df%s", (min < 0 ? "+" : ""), digits, post);
+
+      dt_bauhaus_slider_set_format(slider, str);
+    
+      g_free(str);
+    }
+
+    dt_module_param_t *module_param = (dt_module_param_t *)g_malloc(sizeof(dt_module_param_t));
+    module_param->module = self;
+    module_param->param_offset = self->so->get_p(p, param) - p;
+    g_signal_connect_data(G_OBJECT(slider), "value-changed", G_CALLBACK(generic_slider_callback), module_param, (GClosureNotify)g_free, 0);
+  }
+  else
+  {
+    str = g_strdup_printf("'%s' is not a float/slider parameter", param);
+
+    slider = GTK_WIDGET(GTK_LABEL(gtk_label_new(str)));
+
+    g_free(str);
+  }
+
+  gtk_box_pack_start(GTK_BOX(self->widget), slider, FALSE, FALSE, 0);
+
+  return slider;
+}
+
+GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const char *param)
+{
+  dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  dt_introspection_field_t *f = self->so->get_f(param);
+
+  GtkWidget *combobox = NULL;
+  gchar *str;
+
+  if (f && (f->header.type == DT_INTROSPECTION_TYPE_ENUM || f->header.type == DT_INTROSPECTION_TYPE_INT))
+  {
+    combobox = dt_bauhaus_combobox_new(self);
+
+    if (*f->header.description)
+    {
+      dt_bauhaus_widget_set_label(combobox, NULL, gettext(f->header.description));
+    }
+    else
+    {
+      str = dt_util_str_replace(f->header.field_name, "_", " ");
+    
+      dt_bauhaus_widget_set_label(combobox, NULL, gettext(str));
+
+      g_free(str);
+    }
+
+    dt_module_param_t *module_param = (dt_module_param_t *)g_malloc(sizeof(dt_module_param_t));
+    module_param->module = self;
+    module_param->param_offset = self->so->get_p(p, param) - p;
+    g_signal_connect_data(G_OBJECT(combobox), "value-changed", G_CALLBACK(generic_combobox_callback), module_param, (GClosureNotify)g_free, 0);
+
+    if (f->header.type == DT_INTROSPECTION_TYPE_ENUM)
+    {
+     for(dt_introspection_type_enum_tuple_t *iter = f->Enum.values; iter->name; iter++)
+      {
+//        dt_bauhaus_combobox_add(combobox, gettext(iter->description));
+      }
+    }
+  }
+  else
+  {
+    str = g_strdup_printf(_("'%s' is not an enum/int/combobox parameter"), param);
+
+    combobox = GTK_WIDGET(GTK_LABEL(gtk_label_new(str)));
+
+    g_free(str);
+  }
+
+  gtk_box_pack_start(GTK_BOX(self->widget), combobox, FALSE, FALSE, 0);
+
+  return combobox;
+}
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -94,13 +94,13 @@ GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const ch
 
   if (f && f->header.type == DT_INTROSPECTION_TYPE_FLOAT)
   {
-    float min = f->Float.Min;
-    float max = f->Float.Max;
-    float defval = *(float*)self->so->get_p(p, param);
+    const float min = f->Float.Min;
+    const float max = f->Float.Max;
+    const float defval = *(float*)self->so->get_p(p, param);
     int digits = 2;
-    float step;
+    float step = 0;
 
-    float top = fmaxf(fabsf(min),fabsf(max));
+    const float top = fmaxf(fabsf(min),fabsf(max));
     if (top>=100)
     {
       step = 1.f;
@@ -108,8 +108,8 @@ GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const ch
     else
     {
       step = top / 100;
-      float log10step = log10f(step);
-      float fdigits = floorf(log10step+.1);
+      const float log10step = log10f(step);
+      const float fdigits = floorf(log10step+.1);
       step = powf(10.f,fdigits);
       if (log10step - fdigits > .5)
         step *= 5;
@@ -168,7 +168,7 @@ GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const 
   dt_introspection_field_t *f = self->so->get_f(param);
 
   GtkWidget *combobox = NULL;
-  gchar *str;
+  gchar *str = NULL;
 
   if (f && (f->header.type == DT_INTROSPECTION_TYPE_ENUM || f->header.type == DT_INTROSPECTION_TYPE_INT))
   {
@@ -180,6 +180,7 @@ GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const 
     }
     else
     {
+// this should preferably be done in the introspection generator      
       str = dt_util_str_replace(f->header.field_name, "_", " ");
     
       dt_bauhaus_widget_set_label(combobox, NULL, gettext(str));
@@ -196,6 +197,7 @@ GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const 
     {
      for(dt_introspection_type_enum_tuple_t *iter = f->Enum.values; iter->name; iter++)
       {
+//        This is dependent on perl code generating introspection definitions that @houz is finishing        
 //        dt_bauhaus_combobox_add(combobox, gettext(iter->description));
       }
     }

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -1,0 +1,29 @@
+    /*
+    This file is part of darktable,
+    Copyright (C) 2009-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "develop/imageop.h"
+
+GtkWidget *dt_bauhaus_slider_new_from_params_box(dt_iop_module_t *self, const char *param);
+
+GtkWidget *dt_bauhaus_combobox_new_from_params_box(dt_iop_module_t *self, const char *param);
+
+// modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
+// vim: shiftwidth=2 expandtab tabstop=2 cindent
+// kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/iop_api.h
+++ b/src/iop/iop_api.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "common/introspection.h"
 
 #include <cairo/cairo.h>
+#include <gtk/gtk.h>
 #include <glib.h>
 #include <stdint.h>
 
@@ -112,6 +113,8 @@ void gui_reset(struct dt_iop_module_t *self);
 void gui_init(struct dt_iop_module_t *self);
 /** apply color picker results */
 void color_picker_apply(struct dt_iop_module_t *self, struct _GtkWidget *picker, struct dt_dev_pixelpipe_iop_t *piece);
+/** called by standard widget callbacks after value changed */
+void gui_changed(struct dt_iop_module_t *self, GtkWidget *widget, void *previous);
 /** destroy widget. */
 void gui_cleanup(struct dt_iop_module_t *self);
 /** optional method called after darkroom expose. */


### PR DESCRIPTION
This is the first step from #4804: adding the new calls to create sliders and comboboxes from introspection data.

This still needs @houz to find time to finish the perl work to pick up combobox item names from introspection comments in the enum definitions, but if this is merged I can at least start working on all the iop modules and switch their gui_inits to using the new calls. Those should obviously only be merged after all that infrastructure work is completed.

None of the changes in this PR touches any active code apart from setting up the new callbacks and could be reversed out again later for any reason.