### PR TITLE
channel mixer: Fix incorrect clipping of only red channel in HSL mix

### DIFF
--- a/data/kernels/extended.cl
+++ b/data/kernels/extended.cl
@@ -156,9 +156,9 @@ channelmixer (read_only image2d_t in, write_only image2d_t out, const int width,
 
   float4 pixel = read_imagef(in, sampleri, (int2)(x, y));
 
-  float hmix = clamp(pixel.x * red[CHANNEL_HUE], 0.0f, 1.0f) + pixel.y * green[CHANNEL_HUE] + pixel.z * blue[CHANNEL_HUE];
-  float smix = clamp(pixel.x * red[CHANNEL_SATURATION], 0.0f, 1.0f) + pixel.y * green[CHANNEL_SATURATION] + pixel.z * blue[CHANNEL_SATURATION];
-  float lmix = clamp(pixel.x * red[CHANNEL_LIGHTNESS], 0.0f, 1.0f) + pixel.y * green[CHANNEL_LIGHTNESS] + pixel.z * blue[CHANNEL_LIGHTNESS];
+  float hmix = clamp(pixel.x * red[CHANNEL_HUE] + pixel.y * green[CHANNEL_HUE] + pixel.z * blue[CHANNEL_HUE], 0.0f, 1.0f);
+  float smix = clamp(pixel.x * red[CHANNEL_SATURATION] + pixel.y * green[CHANNEL_SATURATION] + pixel.z * blue[CHANNEL_SATURATION], 0.0f, 1.0f);
+  float lmix = clamp(pixel.x * red[CHANNEL_LIGHTNESS] + pixel.y * green[CHANNEL_LIGHTNESS] + pixel.z * blue[CHANNEL_LIGHTNESS], 0.0f, 1.0f);
 
   if( hmix != 0.0f || smix != 0.0f || lmix != 0.0f )
   {

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -170,12 +170,12 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     {
       float h, s, l, hmix, smix, lmix, rmix, gmix, bmix, graymix;
       // Calculate the HSL mix
-      hmix = CLIP(in[0] * data->red[CHANNEL_HUE]) + (in[1] * data->green[CHANNEL_HUE])
-             + (in[2] * data->blue[CHANNEL_HUE]);
-      smix = CLIP(in[0] * data->red[CHANNEL_SATURATION]) + (in[1] * data->green[CHANNEL_SATURATION])
-             + (in[2] * data->blue[CHANNEL_SATURATION]);
-      lmix = CLIP(in[0] * data->red[CHANNEL_LIGHTNESS]) + (in[1] * data->green[CHANNEL_LIGHTNESS])
-             + (in[2] * data->blue[CHANNEL_LIGHTNESS]);
+      hmix = CLIP((in[0] * data->red[CHANNEL_HUE]) + (in[1] * data->green[CHANNEL_HUE])
+             + (in[2] * data->blue[CHANNEL_HUE]));
+      smix = CLIP((in[0] * data->red[CHANNEL_SATURATION]) + (in[1] * data->green[CHANNEL_SATURATION])
+             + (in[2] * data->blue[CHANNEL_SATURATION]));
+      lmix = CLIP((in[0] * data->red[CHANNEL_LIGHTNESS]) + (in[1] * data->green[CHANNEL_LIGHTNESS])
+             + (in[2] * data->blue[CHANNEL_LIGHTNESS]));
 
       // If HSL mix is used apply to out[]
       if(hmix != 0.0 || smix != 0.0 || lmix != 0.0)
@@ -187,7 +187,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
         l = (lmix != 0.0) ? lmix : l;
         hsl2rgb(out, h, s, l);
       }
-      else // no HSL copt in[] to out[]
+      else // no HSL copy in[] to out[]
         for(int c = 0; c < 3; c++) out[c] = in[c];
 
       // Calculate graymix and RGB mix


### PR DESCRIPTION
In the HSL mix calculations, missing enclosing parentheses were leading to clipping being applied only on the red channel component, instead of the sum of all the RGB components. Fixes #2986