### PR TITLE
Allow int and int64 to be <0 when given an explicit min

### DIFF
--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -466,7 +466,7 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int']" mode="tab">
-    <xsl:text>    gint min = 0;&#xA;    gint max = G_MAXINT;&#xA;</xsl:text>
+    <xsl:text>    gint min = G_MININT;&#xA;    gint max = G_MAXINT;&#xA;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
     <xsl:text>    double tmp;
@@ -485,7 +485,7 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
   </xsl:template>
 
   <xsl:template match="dtconfig[type='int64']" mode="tab">
-    <xsl:text>    gint64 min = 0;&#xA;    gint64 max = G_MAXINT64;&#xA;</xsl:text>
+    <xsl:text>    gint64 min = G_MININT64;&#xA;    gint64 max = G_MAXINT64;&#xA;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
     <xsl:text>    min *= factor; max *= factor;
@@ -586,7 +586,9 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
   </xsl:template>
 
-  <xsl:template match="type" mode="range"  priority="1"/>
+  <xsl:template match="type" mode="range"  priority="1">
+    <xsl:text>    min = 0;&#xA;</xsl:text>
+  </xsl:template>
 
 <!-- Also look for the factor used in the GUI. -->
   <xsl:template match="type[@factor]" mode="factor" priority="3">


### PR DESCRIPTION
This allows `int` and `int64` values to be set <0 in preferences. Currently they are limited to >=0 by definition of the range of the spin_buttons.
To preserve current behaviour, the minimum is still set to zero unless an explicit `min="-X"` is supplied with your choice of negative bound -X.

I bumped into this while debugging, it may prove useful to someone in future. Currently there are only a couple of negative int values set in darktablerc and neither of them is visible in prefs, but it seems a very minimal change to create more flexibility.

Discussed in #5070 and thanks to @elstoc for persuading me that xml style sheets are not so hard and suggesting the opt-in strategy :-)