### PR TITLE
set dialog windows position to location near mouse

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2606,6 +2606,8 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
+  gtk_window_set_position (GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_add(GTK_CONTAINER(window), vbox);
 
@@ -2653,6 +2655,8 @@ char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup
   gtk_window_set_icon_name(GTK_WINDOW(window), "darktable");
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+
+  gtk_window_set_position (GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
   gtk_widget_set_margin_start(vbox, 10);


### PR DESCRIPTION
Fixes #5110

Previously dialog creation didn't use any hinting which might've placed dialog in unexpected place (even I had to look for dialog **somwewhere** on my 2 screens).

This change gives gtk hint to create window possibly near mouse cursor (while keeping whole window visible).