### PR TITLE
show dialog windows in predictable places - at mouse cursor or center

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1115,6 +1115,8 @@ void dt_cleanup()
 {
   const int init_gui = (darktable.gui != NULL);
 
+  // last chance to ask user for any input...
+
   dt_database_maybe_maintenance(darktable.db, init_gui, TRUE);
 
 #ifdef HAVE_PRINT
@@ -1124,8 +1126,14 @@ void dt_cleanup()
 #ifdef USE_LUA
   dt_lua_finalize_early();
 #endif
+
+  // anything that asks user for input should be placed before this line
+
   if(init_gui)
   {
+    // hide main window and do rest of the cleanup in the background
+    gtk_widget_hide(dt_ui_main_window(darktable.gui->ui));
+
     dt_ctl_switch_mode_to("");
     dt_dbus_destroy(darktable.dbus);
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -887,11 +887,8 @@ void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t color, float opacity
 
 void dt_gui_gtk_quit()
 {
-  //GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
-
-  // Write out windows dimension before miminizing
+  // Write out windows dimension
   dt_gui_gtk_write_config();
-  //gtk_window_iconify(win);
 
   GtkWidget *widget;
   widget = darktable.gui->widgets.left_border;
@@ -2633,11 +2630,14 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
-  if(darktable.gui) {
+  if(darktable.gui)
+  {
     GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
     gtk_window_set_transient_for(GTK_WINDOW(window), win);
     gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
-  } else {
+  }
+  else
+  {
     gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
   }
 
@@ -2689,11 +2689,14 @@ char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
-  if(darktable.gui) {
+  if(darktable.gui) 
+  {
     GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
     gtk_window_set_transient_for(GTK_WINDOW(window), win);
     gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
-  } else {
+  }
+  else 
+  {
     gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
   }
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -890,10 +890,12 @@ void dt_gui_gtk_quit()
   GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
   GtkStyleContext *context = gtk_widget_get_style_context(win);
   gtk_style_context_add_class(context, "dt_gui_quit");
+  gtk_window_set_title(GTK_WINDOW(win), _("closing darktable..."));
+
+  // don't minimize or hide main window, it'll be hiden by gtk
 
   // Write out windows dimension
   dt_gui_gtk_write_config();
-  gtk_widget_hide(GTK_WIDGET(win));
 
   GtkWidget *widget;
   widget = darktable.gui->widgets.left_border;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -887,6 +887,10 @@ void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t color, float opacity
 
 void dt_gui_gtk_quit()
 {
+  GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
+  GtkStyleContext *context = gtk_widget_get_style_context(win);
+  gtk_style_context_add_class(context, "dt_gui_quit");
+
   // Write out windows dimension
   dt_gui_gtk_write_config();
 

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -893,6 +893,7 @@ void dt_gui_gtk_quit()
 
   // Write out windows dimension
   dt_gui_gtk_write_config();
+  gtk_widget_hide(GTK_WIDGET(win));
 
   GtkWidget *widget;
   widget = darktable.gui->widgets.left_border;
@@ -2638,7 +2639,14 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
   {
     GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
     gtk_window_set_transient_for(GTK_WINDOW(window), win);
-    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+    if(gtk_widget_get_visible(GTK_WIDGET(win)))
+    {
+      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+    }
+    else
+    {
+      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+    }
   }
   else
   {
@@ -2693,13 +2701,20 @@ char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
-  if(darktable.gui) 
+  if(darktable.gui)
   {
     GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
     gtk_window_set_transient_for(GTK_WINDOW(window), win);
-    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+    if(gtk_widget_get_visible(GTK_WIDGET(win)))
+    {
+      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+    }
+    else
+    {
+      gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+    }
   }
-  else 
+  else
   {
     gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
   }

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -887,11 +887,11 @@ void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t color, float opacity
 
 void dt_gui_gtk_quit()
 {
-  GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
+  //GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
 
   // Write out windows dimension before miminizing
   dt_gui_gtk_write_config();
-  gtk_window_iconify(win);
+  //gtk_window_iconify(win);
 
   GtkWidget *widget;
   widget = darktable.gui->widgets.left_border;
@@ -2633,7 +2633,13 @@ gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *mar
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
-  gtk_window_set_position (GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+  if(darktable.gui) {
+    GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
+    gtk_window_set_transient_for(GTK_WINDOW(window), win);
+    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+  } else {
+    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+  }
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_add(GTK_CONTAINER(window), vbox);
@@ -2683,7 +2689,13 @@ char *dt_gui_show_standalone_string_dialog(const char *title, const char *markup
   gtk_window_set_title(GTK_WINDOW(window), title);
   g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 
-  gtk_window_set_position (GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+  if(darktable.gui) {
+    GtkWindow *win = GTK_WINDOW(dt_ui_main_window(darktable.gui->ui));
+    gtk_window_set_transient_for(GTK_WINDOW(window), win);
+    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER_ON_PARENT);
+  } else {
+    gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_MOUSE);
+  }
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
   gtk_widget_set_margin_start(vbox, 10);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -892,8 +892,6 @@ void dt_gui_gtk_quit()
   gtk_style_context_add_class(context, "dt_gui_quit");
   gtk_window_set_title(GTK_WINDOW(win), _("closing darktable..."));
 
-  // don't minimize or hide main window, it'll be hiden by gtk
-
   // Write out windows dimension
   dt_gui_gtk_write_config();
 
@@ -906,6 +904,9 @@ void dt_gui_gtk_quit()
   g_signal_handlers_block_by_func(widget, draw_borders, GINT_TO_POINTER(2));
   widget = darktable.gui->widgets.bottom_border;
   g_signal_handlers_block_by_func(widget, draw_borders, GINT_TO_POINTER(3));
+
+  // hide main window
+  gtk_widget_hide(dt_ui_main_window(darktable.gui->ui));
 }
 
 gboolean dt_gui_quit_callback(GtkWidget *widget, GdkEvent *event, gpointer user_data)


### PR DESCRIPTION
we want to show dialog windows in very predictable manner, so in case of multi-screen action or multi-window action, dialogs blocking input won't cause harm to users.

with this change dialogs are shown at mouse cursor if dt gui isn't yet initialised (or is already closed) or at dt window center on top

additionally based on @parafin suggestion - the main window isn't minimalised on closing. I invite anybody to come up with nice closing message though...

This improves solution from #5116 and should be generally better fir for #5110 