### PR TITLE
Static and ordered album or "images order" aware tags

### DIFF
--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -87,7 +87,6 @@ typedef enum dt_collection_properties_t
   DT_COLLECTION_PROP_FILMROLL = 0,
   DT_COLLECTION_PROP_FOLDERS,
   DT_COLLECTION_PROP_FILENAME,
-  DT_COLLECTION_PROP_ALBUM,
 
   DT_COLLECTION_PROP_CAMERA,
   DT_COLLECTION_PROP_LENS,
@@ -114,7 +113,7 @@ typedef enum dt_collection_properties_t
   DT_COLLECTION_PROP_HISTORY,
   DT_COLLECTION_PROP_MODULE,
   DT_COLLECTION_PROP_ORDER,
- 
+
   DT_COLLECTION_PROP_LAST
 } dt_collection_properties_t;
 
@@ -165,7 +164,7 @@ typedef struct dt_collection_t
   gchar *query, *query_no_group;
   gchar **where_ext;
   unsigned int count, count_no_group;
-  unsigned int album_id;
+  unsigned int tagid;
   dt_collection_params_t params;
   dt_collection_params_t store;
 } dt_collection_t;
@@ -208,8 +207,8 @@ void dt_collection_set_query_flags(const dt_collection_t *collection, uint32_t f
 
 /** set the film_id of collection */
 void dt_collection_set_film_id(const dt_collection_t *collection, const uint32_t film_id);
-/** set the album_id of collection */
-void dt_collection_set_album_id(dt_collection_t *collection, const uint32_t album_id);
+/** set the tagid of collection */
+void dt_collection_set_tag_id(dt_collection_t *collection, const uint32_t tagid);
 /** set the star level for filter */
 void dt_collection_set_rating(const dt_collection_t *collection, uint32_t rating);
 /** get the star level for filter. The value returned starts on 0 **/
@@ -263,9 +262,9 @@ void dt_collection_split_operator_number(const gchar *input, char **number1, cha
 void dt_collection_split_operator_datetime(const gchar *input, char **number1, char **number2, char **op);
 void dt_collection_split_operator_exposure(const gchar *input, char **number1, char **number2, char **op);
 
-int64_t dt_collection_get_image_position(const int32_t image_id, const int32_t album_id);
+int64_t dt_collection_get_image_position(const int32_t image_id, const int32_t tagid);
 void dt_collection_shift_image_positions(const unsigned int length, const int64_t image_position,
-                                         const int32_t album_id);
+                                         const int32_t tagid);
 
 /* move images with drag and drop */
 void dt_collection_move_before(const int32_t image_id, GList * selected_images);

--- a/src/common/collection.h
+++ b/src/common/collection.h
@@ -79,12 +79,15 @@ typedef enum dt_collection_sort_t
   DT_COLLECTION_SORT_SHUFFLE
 } dt_collection_sort_t;
 
+#define DT_COLLECTION_ORDER_FLAG 0x8000
+
 /* NOTE: any reordeing in this module require a legacy_preset entry in src/libs/collect.c */
 typedef enum dt_collection_properties_t
 {
   DT_COLLECTION_PROP_FILMROLL = 0,
   DT_COLLECTION_PROP_FOLDERS,
   DT_COLLECTION_PROP_FILENAME,
+  DT_COLLECTION_PROP_ALBUM,
 
   DT_COLLECTION_PROP_CAMERA,
   DT_COLLECTION_PROP_LENS,
@@ -162,6 +165,7 @@ typedef struct dt_collection_t
   gchar *query, *query_no_group;
   gchar **where_ext;
   unsigned int count, count_no_group;
+  unsigned int album_id;
   dt_collection_params_t params;
   dt_collection_params_t store;
 } dt_collection_t;
@@ -203,7 +207,9 @@ uint32_t dt_collection_get_query_flags(const dt_collection_t *collection);
 void dt_collection_set_query_flags(const dt_collection_t *collection, uint32_t flags);
 
 /** set the film_id of collection */
-void dt_collection_set_film_id(const dt_collection_t *collection, uint32_t film_id);
+void dt_collection_set_film_id(const dt_collection_t *collection, const uint32_t film_id);
+/** set the album_id of collection */
+void dt_collection_set_album_id(dt_collection_t *collection, const uint32_t album_id);
 /** set the star level for filter */
 void dt_collection_set_rating(const dt_collection_t *collection, uint32_t rating);
 /** get the star level for filter. The value returned starts on 0 **/
@@ -257,8 +263,9 @@ void dt_collection_split_operator_number(const gchar *input, char **number1, cha
 void dt_collection_split_operator_datetime(const gchar *input, char **number1, char **number2, char **op);
 void dt_collection_split_operator_exposure(const gchar *input, char **number1, char **number2, char **op);
 
-int64_t dt_collection_get_image_position(const int32_t image_id);
-void dt_collection_shift_image_positions(const unsigned int length, const int64_t image_position);
+int64_t dt_collection_get_image_position(const int32_t image_id, const int32_t album_id);
+void dt_collection_shift_image_positions(const unsigned int length, const int64_t image_position,
+                                         const int32_t album_id);
 
 /* move images with drag and drop */
 void dt_collection_move_before(const int32_t image_id, GList * selected_images);

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -44,7 +44,7 @@
 
 // whenever _create_*_schema() gets changed you HAVE to bump this version and add an update path to
 // _upgrade_*_schema_step()!
-#define CURRENT_DATABASE_VERSION_LIBRARY 29
+#define CURRENT_DATABASE_VERSION_LIBRARY 30
 #define CURRENT_DATABASE_VERSION_DATA     6
 
 typedef struct dt_database_t
@@ -1611,6 +1611,65 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     sqlite3_exec(db->handle, "COMMIT", NULL, NULL, NULL);
     new_version = 29;
   }
+  else if(version == 29)
+  {
+    sqlite3_exec(db->handle, "BEGIN TRANSACTION", NULL, NULL, NULL);
+
+    // add position in tagged_images table
+    TRY_EXEC("ALTER TABLE main.tagged_images ADD COLUMN position INTEGER",
+             "[init] can't add `position' column to tagged_images table in database\n");
+
+    TRY_EXEC("CREATE INDEX IF NOT EXISTS main.tagged_images_imgid_index ON tagged_images (imgid)",
+             "[init] can't create image index on tagged_images\n");
+    TRY_EXEC("CREATE INDEX IF NOT EXISTS main.tagged_images_position_index ON tagged_images (position)",
+             "[init] can't create position index on tagged_images\n");
+    TRY_EXEC("UPDATE main.tagged_images SET position = (tagid + imgid) << 32",
+             "[init] can't populate position on tagged_images\n");
+
+    // remove caption and description field from images table
+
+    TRY_EXEC("CREATE TABLE main.i (id INTEGER PRIMARY KEY AUTOINCREMENT, group_id INTEGER, film_id INTEGER, "
+             "width INTEGER, height INTEGER, filename VARCHAR, maker VARCHAR, model VARCHAR, "
+             "lens VARCHAR, exposure REAL, aperture REAL, iso REAL, focal_length REAL, "
+             "focus_distance REAL, datetime_taken CHAR(20), flags INTEGER, "
+             "output_width INTEGER, output_height INTEGER, crop REAL, "
+             "raw_parameters INTEGER, raw_denoise_threshold REAL, "
+             "raw_auto_bright_threshold REAL, raw_black INTEGER, raw_maximum INTEGER, "
+             "license VARCHAR, sha1sum CHAR(40), "
+             "orientation INTEGER, histogram BLOB, lightmap BLOB, longitude REAL, "
+             "latitude REAL, altitude REAL, color_matrix BLOB, colorspace INTEGER, version INTEGER, "
+             "max_version INTEGER, write_timestamp INTEGER, history_end INTEGER, position INTEGER, "
+             "aspect_ratio REAL, exposure_bias REAL, "
+             "import_timestamp INTEGER DEFAULT -1, change_timestamp INTEGER DEFAULT -1, "
+             "export_timestamp INTEGER DEFAULT -1, print_timestamp INTEGER DEFAULT -1)",
+             "[init] can't create table i\n");
+
+    TRY_EXEC("INSERT INTO main.i SELECT id, group_id, film_id, width, height, filename, maker, model,"
+             " lens, exposure, aperture, iso, focal_length, focus_distance, datetime_taken, flags,"
+             " output_width, output_height, crop, raw_parameters, raw_denoise_threshold,"
+             " raw_auto_bright_threshold, raw_black, raw_maximum, license, sha1sum,"
+             " orientation, histogram, lightmap, longitude, latitude, altitude, color_matrix, colorspace, version,"
+             " max_version, write_timestamp, history_end, position, aspect_ratio, exposure_bias,"
+             " import_timestamp, change_timestamp, export_timestamp, print_timestamp "
+             "FROM main.images",
+             "[init] can't populate table i\n");
+    TRY_EXEC("DROP TABLE main.images",
+             "[init] can't drop table images\n");
+    TRY_EXEC("ALTER TABLE main.i RENAME TO images",
+             "[init] can't rename i to images\n");
+
+    TRY_EXEC("CREATE INDEX main.images_group_id_index ON images (group_id)",
+          "[init] can't create group_id index on images table\n");
+    TRY_EXEC("CREATE INDEX main.images_film_id_index ON images (film_id)",
+          "[init] can't create film_id index on images table\n");
+    TRY_EXEC("CREATE INDEX main.images_filename_index ON images (filename)",
+          "[init] can't create filename index on images table\n");
+    TRY_EXEC("CREATE INDEX main.image_position_index ON images (position)",
+          "[init] can't create position index on images table\n");
+
+    sqlite3_exec(db->handle, "COMMIT", NULL, NULL, NULL);
+    new_version = 30;
+  }
   else
     new_version = version; // should be the fallback so that calling code sees that we are in an infinite loop
 
@@ -1874,11 +1933,11 @@ static void _create_library_schema(dt_database_t *db)
       "output_width INTEGER, output_height INTEGER, crop REAL, "
       "raw_parameters INTEGER, raw_denoise_threshold REAL, "
       "raw_auto_bright_threshold REAL, raw_black INTEGER, raw_maximum INTEGER, "
-      "caption VARCHAR, description VARCHAR, license VARCHAR, sha1sum CHAR(40), "
+      "license VARCHAR, sha1sum CHAR(40), "
       "orientation INTEGER, histogram BLOB, lightmap BLOB, longitude REAL, "
       "latitude REAL, altitude REAL, color_matrix BLOB, colorspace INTEGER, version INTEGER, "
-      "max_version INTEGER, write_timestamp INTEGER, history_end INTEGER, position INTEGER, aspect_ratio REAL, "
-      "exposure_bias REAL, "
+      "max_version INTEGER, write_timestamp INTEGER, history_end INTEGER, position INTEGER, "
+      "aspect_ratio REAL, exposure_bias REAL, "
       "import_timestamp INTEGER DEFAULT -1, change_timestamp INTEGER DEFAULT -1, "
       "export_timestamp INTEGER DEFAULT -1, print_timestamp INTEGER DEFAULT -1)",
       NULL, NULL, NULL);
@@ -1908,9 +1967,11 @@ static void _create_library_schema(dt_database_t *db)
       NULL, NULL, NULL);
 
   ////////////////////////////// tagged_images
-  sqlite3_exec(db->handle, "CREATE TABLE main.tagged_images (imgid INTEGER, tagid INTEGER, "
+  sqlite3_exec(db->handle, "CREATE TABLE main.tagged_images (imgid INTEGER, tagid INTEGER, position INTEGER, "
                            "PRIMARY KEY (imgid, tagid))", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE INDEX main.tagged_images_tagid_index ON tagged_images (tagid)", NULL, NULL, NULL);
+  sqlite3_exec(db->handle, "CREATE INDEX main.tagged_images_imgid_index ON selected_images (imgid)", NULL, NULL, NULL);
+  sqlite3_exec(db->handle, "CREATE INDEX main.tagged_images_position_index ON selected_images (position)", NULL, NULL, NULL);
   ////////////////////////////// color_labels
   sqlite3_exec(db->handle, "CREATE TABLE main.color_labels (imgid INTEGER, color INTEGER)", NULL, NULL, NULL);
   sqlite3_exec(db->handle, "CREATE UNIQUE INDEX main.color_labels_idx ON color_labels (imgid, color)", NULL, NULL,

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -1626,7 +1626,7 @@ static int _upgrade_library_schema_step(dt_database_t *db, int version)
     TRY_EXEC("UPDATE main.tagged_images SET position = (tagid + imgid) << 32",
              "[init] can't populate position on tagged_images\n");
 
-    // remove caption and description field from images table
+    // remove caption and description fields from images table
 
     TRY_EXEC("CREATE TABLE main.i (id INTEGER PRIMARY KEY AUTOINCREMENT, group_id INTEGER, film_id INTEGER, "
              "width INTEGER, height INTEGER, filename VARCHAR, maker VARCHAR, model VARCHAR, "

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2017,8 +2017,12 @@ static void _exif_import_tags(dt_image_t *img, Exiv2::XmpData::iterator &pos)
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "INSERT INTO data.tags (id, name) VALUES (NULL, ?1)",
                               -1, &stmt_ins_tags, NULL);
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                              "INSERT INTO main.tagged_images (tagid, imgid) VALUES (?1, ?2)", -1,
-                              &stmt_ins_tagged, NULL);
+                              "INSERT INTO main.tagged_images (tagid, imgid, position)"
+                              "  VALUES (?1, ?2,"
+                              // 4294967295 << 32 = 0xFFFFFFFF00000000
+                              "    (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32)) + (1 << 32)"
+                              "      FROM main.tagged_images))",
+                               -1, &stmt_ins_tagged, NULL);
   for(int i = 0; i < cnt; i++)
   {
     char tagbuf[1024];

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2019,8 +2019,7 @@ static void _exif_import_tags(dt_image_t *img, Exiv2::XmpData::iterator &pos)
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "INSERT INTO main.tagged_images (tagid, imgid, position)"
                               "  VALUES (?1, ?2,"
-                              // 4294967295 << 32 = 0xFFFFFFFF00000000
-                              "    (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32)) + (1 << 32)"
+                              "    (SELECT (IFNULL(MAX(position),0) & 0xFFFFFFFF00000000) + (1 << 32)"
                               "      FROM main.tagged_images))",
                                -1, &stmt_ins_tagged, NULL);
   for(int i = 0; i < cnt; i++)

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -867,8 +867,7 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                 "INSERT INTO main.tagged_images (imgid, tagid, position)"
                                 "  SELECT ?1, tagid, "
-                                // 4294967295 << 32 = 0xFFFFFFFF00000000
-                                "        (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32))"
+                                "        (SELECT (IFNULL(MAX(position),0) & 0xFFFFFFFF00000000)"
                                 "         FROM main.tagged_images)"
                                 "         + (ROW_NUMBER() OVER (ORDER BY imgid) << 32)"
                                 " FROM main.tagged_images AS ti"
@@ -1218,8 +1217,7 @@ static uint32_t dt_image_import_internal(const int32_t film_id, const char *file
     (dt_database_get(darktable.db),
      "INSERT INTO main.images (id, film_id, filename, license, sha1sum, flags, version, "
      "                         max_version, history_end, position, import_timestamp)"
-     // 4294967295 << 32 = 0xFFFFFFFF00000000
-     " SELECT NULL, ?1, ?2, '', '', ?3, 0, 0, 0, (IFNULL(MAX(position),0) & (4294967295 << 32))  + (1 << 32), ?4 "
+     " SELECT NULL, ?1, ?2, '', '', ?3, 0, 0, 0, (IFNULL(MAX(position),0) & 0xFFFFFFFF00000000)  + (1 << 32), ?4 "
      " FROM images",
      -1, &stmt, NULL);
 
@@ -1820,8 +1818,7 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                                     "INSERT INTO main.tagged_images (imgid, tagid, position)"
                                     " SELECT ?1, tagid, "
-                                    // 4294967295 << 32 = 0xFFFFFFFF00000000
-                                    "        (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32))"
+                                    "        (SELECT (IFNULL(MAX(position),0) & 0xFFFFFFFF00000000)"
                                     "         FROM main.tagged_images)"
                                     "         + (ROW_NUMBER() OVER (ORDER BY imgid) << 32)"
                                     " FROM main.tagged_images AS ti"

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -778,10 +778,10 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
 {
   sqlite3_stmt *stmt;
   int32_t newid = -1;
-  const int64_t image_position = dt_collection_get_image_position(imgid);
+  const int64_t image_position = dt_collection_get_image_position(imgid, 0);
   const int64_t new_image_position = (image_position < 0) ? max_image_position() : image_position + 1;
 
-  dt_collection_shift_image_positions(1, new_image_position);
+  dt_collection_shift_image_positions(1, new_image_position, 0);
 
   DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
                               "SELECT a.id"
@@ -808,14 +808,14 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
      "   aperture, iso, focal_length, focus_distance, datetime_taken, flags,"
      "   output_width, output_height, crop, raw_parameters, raw_denoise_threshold,"
      "   raw_auto_bright_threshold, raw_black, raw_maximum,"
-     "   caption, description, license, sha1sum, orientation, histogram, lightmap,"
+     "   license, sha1sum, orientation, histogram, lightmap,"
      "   longitude, latitude, altitude, color_matrix, colorspace, version, max_version, history_end,"
      "   position, aspect_ratio, exposure_bias, import_timestamp)"
      " SELECT NULL, group_id, film_id, width, height, filename, maker, model, lens,"
      "       exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
      "       flags, width, height, crop, raw_parameters, raw_denoise_threshold,"
      "       raw_auto_bright_threshold, raw_black, raw_maximum,"
-     "       caption, description, license, sha1sum, orientation, histogram, lightmap,"
+     "       license, sha1sum, orientation, histogram, lightmap,"
      "       longitude, latitude, altitude, color_matrix, colorspace, NULL, NULL, 0, ?1,"
      "       aspect_ratio, exposure_bias, import_timestamp"
      " FROM main.images WHERE id = ?2",
@@ -865,8 +865,14 @@ int32_t dt_image_duplicate_with_version(const int32_t imgid, const int32_t newve
     sqlite3_finalize(stmt);
 
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "INSERT INTO main.tagged_images (imgid, tagid)"
-                                "  SELECT ?1, tagid FROM main.tagged_images WHERE imgid = ?2",
+                                "INSERT INTO main.tagged_images (imgid, tagid, position)"
+                                "  SELECT ?1, tagid, "
+                                // 4294967295 << 32 = 0xFFFFFFFF00000000
+                                "        (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32))"
+                                "         FROM main.tagged_images)"
+                                "         + (ROW_NUMBER() OVER (ORDER BY imgid) << 32)"
+                                " FROM main.tagged_images AS ti"
+                                " WHERE imgid = ?2",
                                 -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, newid);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
@@ -1210,9 +1216,10 @@ static uint32_t dt_image_import_internal(const int32_t film_id, const char *file
   //insert a v0 record (which may be updated later if no v0 xmp exists)
   DT_DEBUG_SQLITE3_PREPARE_V2
     (dt_database_get(darktable.db),
-     "INSERT INTO main.images (id, film_id, filename, caption, description, license, sha1sum, flags, version, "
+     "INSERT INTO main.images (id, film_id, filename, license, sha1sum, flags, version, "
      "                         max_version, history_end, position, import_timestamp)"
-     " SELECT NULL, ?1, ?2, '', '', '', '', ?3, 0, 0, 0, (IFNULL(MAX(position),0) & (4294967295 << 32))  + (1 << 32), ?4 "
+     // 4294967295 << 32 = 0xFFFFFFFF00000000
+     " SELECT NULL, ?1, ?2, '', '', ?3, 0, 0, 0, (IFNULL(MAX(position),0) & (4294967295 << 32))  + (1 << 32), ?4 "
      " FROM images",
      -1, &stmt, NULL);
 
@@ -1747,14 +1754,14 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
          "   aperture, iso, focal_length, focus_distance, datetime_taken, flags,"
          "   output_width, output_height, crop, raw_parameters, raw_denoise_threshold,"
          "   raw_auto_bright_threshold, raw_black, raw_maximum,"
-         "   caption, description, license, sha1sum, orientation, histogram, lightmap,"
+         "   license, sha1sum, orientation, histogram, lightmap,"
          "   longitude, latitude, altitude, color_matrix, colorspace, version, max_version,"
          "   position, aspect_ratio, exposure_bias)"
          " SELECT NULL, group_id, ?1 as film_id, width, height, ?2 as filename, maker, model, lens,"
          "        exposure, aperture, iso, focal_length, focus_distance, datetime_taken,"
          "        flags, width, height, crop, raw_parameters, raw_denoise_threshold,"
          "        raw_auto_bright_threshold, raw_black, raw_maximum,"
-         "        caption, description, license, sha1sum, orientation, histogram, lightmap,"
+         "        license, sha1sum, orientation, histogram, lightmap,"
          "        longitude, latitude, altitude, color_matrix, colorspace, -1, -1,"
          "        ?3, aspect_ratio, exposure_bias"
          " FROM main.images"
@@ -1811,9 +1818,13 @@ int32_t dt_image_copy_rename(const int32_t imgid, const int32_t filmid, const gc
         sqlite3_step(stmt);
         sqlite3_finalize(stmt);
         DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                    "INSERT INTO main.tagged_images (imgid, tagid)"
-                                    " SELECT ?1, tagid"
-                                    " FROM main.tagged_images"
+                                    "INSERT INTO main.tagged_images (imgid, tagid, position)"
+                                    " SELECT ?1, tagid, "
+                                    // 4294967295 << 32 = 0xFFFFFFFF00000000
+                                    "        (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32))"
+                                    "         FROM main.tagged_images)"
+                                    "         + (ROW_NUMBER() OVER (ORDER BY imgid) << 32)"
+                                    " FROM main.tagged_images AS ti"
                                     " WHERE imgid = ?2",
                                     -1, &stmt, NULL);
         DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, newid);

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -63,7 +63,14 @@ static gchar *_get_tb_added_tag_string_values(const int img, GList *before, GLis
   {
     if(!g_list_find(b, a->data))
     {
-      tag_list = dt_util_dstrcat(tag_list, "(%d,%d),", GPOINTER_TO_INT(img), GPOINTER_TO_INT(a->data));
+      tag_list = dt_util_dstrcat(tag_list,
+                                 "(%d,%d,"
+                                 // 4294967295 << 32 = 0xFFFFFFFF00000000
+                                 "  (SELECT (IFNULL(MAX(position),0) & (4294967295 << 32)) + (1 << 32)"
+                                 "    FROM main.tagged_images)"
+                                 "),",
+                                 GPOINTER_TO_INT(img),
+                                 GPOINTER_TO_INT(a->data));
     }
     a = g_list_next(a);
   }
@@ -91,7 +98,7 @@ static void _bulk_add_tags(const gchar *tag_list)
   {
     char *query = NULL;
     sqlite3_stmt *stmt;
-    query = dt_util_dstrcat(query, "INSERT INTO main.tagged_images (imgid, tagid) VALUES %s", tag_list);
+    query = dt_util_dstrcat(query, "INSERT INTO main.tagged_images (imgid, tagid, position) VALUES %s", tag_list);
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), query, -1, &stmt, NULL);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -452,13 +459,12 @@ gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on(TRUE);
+    imgs = dt_view_get_images_to_act_on(!group_on);
   else
   {
     if(dt_is_tag_attached(tagid, imgid)) return FALSE;
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   }
-  if(group_on) dt_grouping_add_grouped_images(&imgs);
   const gboolean res = dt_tag_attach_images(tagid, imgs, undo_on);
   g_list_free(imgs);
   return res;
@@ -1669,6 +1675,77 @@ char *dt_tag_get_subtags(const gint imgid, const char *category, const int level
   if(tags) tags[strlen(tags) - 1] = '\0'; // remove the last comma
   sqlite3_finalize(stmt);
   return tags;
+}
+
+const gboolean dt_tag_get_album_order_by_id(const uint32_t album_id, uint32_t *sort,
+                                            gboolean *descending)
+{
+  gboolean res = FALSE;
+  if(!sort  || !descending) return res;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+          "SELECT T.flags FROM data.tags AS T "
+          "WHERE T.id = ?1",
+          -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, album_id);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const uint32_t flags = sqlite3_column_int(stmt, 0);
+    if((flags & (DT_TF_ALBUM | DT_TF_ORDER_SET)) == (DT_TF_ALBUM | DT_TF_ORDER_SET))
+    {
+      // the 16 upper bits of flags hold the order
+      *sort = (flags & ~DT_TF_DESCENDING) >> 16;
+      *descending = flags & DT_TF_DESCENDING;
+      res = TRUE;
+    }
+  }
+  sqlite3_finalize(stmt);
+  return res;
+}
+
+const uint32_t dt_tag_get_album_id_by_name(const char * const name)
+{
+  uint32_t albumid = 0;
+  if(!name) return albumid;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+          "SELECT T.id, T.flags FROM data.tags AS T "
+          "WHERE T.name = ?1",
+          -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, name, -1, SQLITE_TRANSIENT);
+  if(sqlite3_step(stmt) == SQLITE_ROW)
+  {
+    const uint32_t tagid = sqlite3_column_int(stmt, 0);
+    const uint32_t flags = sqlite3_column_int(stmt, 1);
+    if((flags & (DT_TF_ALBUM)) == (DT_TF_ALBUM))
+    {
+      albumid = tagid;
+    }
+  }
+  sqlite3_finalize(stmt);
+  return albumid;
+}
+
+
+void dt_tag_set_album_order_by_id(const uint32_t album_id, const uint32_t sort,
+                                  const gboolean descending)
+{
+  // use the upper 16 bits of flags to store the order
+  const uint32_t flags = sort << 16 | (descending ? DT_TF_DESCENDING : 0)
+                                    | DT_TF_ORDER_SET;
+  sqlite3_stmt *stmt;
+  DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
+                              "UPDATE data.tags"
+                              " SET flags = (flags & ?3) | ?2 "
+                              // only is the tag is an album
+                              "WHERE id = ?1 AND (flags & ?4) = ?4",
+                              -1, &stmt, NULL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, album_id);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, flags);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 3, DT_TF_ALL);
+  DT_DEBUG_SQLITE3_BIND_INT(stmt, 4, DT_TF_ALBUM);
+  sqlite3_step(stmt);
+  sqlite3_finalize(stmt);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -38,13 +38,11 @@ typedef enum dt_tag_flags_t
   DT_TF_NONE        = 0,
   DT_TF_CATEGORY    = 1 << 0, // this tag (or path) is not a keyword to be exported
   DT_TF_PRIVATE     = 1 << 1, // this tag is private. Will be exported only on demand
-  DT_TF_ALBUM       = 1 << 2, // this tag is an album. It holds its own sort by type
-                              // CAUTION hardcoded in collect and collection queries
-  DT_TF_ORDER_SET   = 1 << 3, // set if the album has got an order
+  DT_TF_ORDER_SET   = 1 << 2, // set if the tag has got an images order
   DT_TF_DESCENDING  = 1 << 31,
 } dt_tag_flags_t;
 
-#define DT_TF_ALL (DT_TF_CATEGORY | DT_TF_PRIVATE | DT_TF_ALBUM | DT_TF_ORDER_SET)
+#define DT_TF_ALL (DT_TF_CATEGORY | DT_TF_PRIVATE | DT_TF_ORDER_SET)
 
 typedef enum dt_tag_selection_t
 {
@@ -198,19 +196,16 @@ uint32_t dt_tag_images_count(gint tagid);
 /** retrieves the subtags of requested level for the requested category */
 char *dt_tag_get_subtags(const gint imgid, const char *category, const int level);
 
-/** return the images order associated to that album */
-const gboolean dt_tag_get_album_order_by_id(const uint32_t album_id, uint32_t *sort,
-                                              gboolean *descending);
+/** return the images order associated to that tag */
+const gboolean dt_tag_get_tag_order_by_id(const uint32_t tagid, uint32_t *sort,
+                                          gboolean *descending);
 
-/** save the images order on the album */
-void dt_tag_set_album_order_by_id(const uint32_t album_id, const uint32_t sort,
-                                  const gboolean descending);
+/** save the images order on the tag */
+void dt_tag_set_tag_order_by_id(const uint32_t tagid, const uint32_t sort,
+                                const gboolean descending);
 
-/** return the albumid of that album - return 0 if not found*/
-const uint32_t dt_tag_get_album_id_by_name(const char * const name);
-
-/** set images positions for tag set as album */
-void dt_tag_set_album_positions(const uint32_t tagid, const GList * const tagged_images);
+/** return the tagid of that tag - return 0 if not found*/
+const uint32_t dt_tag_get_tag_id_by_name(const char * const name);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/tags.h
+++ b/src/common/tags.h
@@ -35,10 +35,16 @@ typedef struct dt_tag_t
 
 typedef enum dt_tag_flags_t
 {
-  DT_TF_NONE     = 0,
-  DT_TF_CATEGORY = 1 << 0,  // this tag (or path) is not a keyword to be exported
-  DT_TF_PRIVATE  = 1 << 1, // this tag is private. Will be exported only on demand
+  DT_TF_NONE        = 0,
+  DT_TF_CATEGORY    = 1 << 0, // this tag (or path) is not a keyword to be exported
+  DT_TF_PRIVATE     = 1 << 1, // this tag is private. Will be exported only on demand
+  DT_TF_ALBUM       = 1 << 2, // this tag is an album. It holds its own sort by type
+                              // CAUTION hardcoded in collect and collection queries
+  DT_TF_ORDER_SET   = 1 << 3, // set if the album has got an order
+  DT_TF_DESCENDING  = 1 << 31,
 } dt_tag_flags_t;
+
+#define DT_TF_ALL (DT_TF_CATEGORY | DT_TF_PRIVATE | DT_TF_ALBUM | DT_TF_ORDER_SET)
 
 typedef enum dt_tag_selection_t
 {
@@ -191,6 +197,20 @@ uint32_t dt_tag_images_count(gint tagid);
 
 /** retrieves the subtags of requested level for the requested category */
 char *dt_tag_get_subtags(const gint imgid, const char *category, const int level);
+
+/** return the images order associated to that album */
+const gboolean dt_tag_get_album_order_by_id(const uint32_t album_id, uint32_t *sort,
+                                              gboolean *descending);
+
+/** save the images order on the album */
+void dt_tag_set_album_order_by_id(const uint32_t album_id, const uint32_t sort,
+                                  const gboolean descending);
+
+/** return the albumid of that album - return 0 if not found*/
+const uint32_t dt_tag_get_album_id_by_name(const char * const name);
+
+/** set images positions for tag set as album */
+void dt_tag_set_album_positions(const uint32_t tagid, const GList * const tagged_images);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -103,6 +103,8 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
     G_CALLBACK(_image_info_changed_destroy_callback), FALSE }, // DT_SIGNAL_IMAGE_INFO_CHANGED
   { "dt-style-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_STYLE_CHANGED
+  { "dt-images-order-change", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,
+    FALSE }, // DT_SIGNAL_IMAGES_ORDER_CHANGE
   { "dt-filmrolls-changed", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
     FALSE }, // DT_SIGNAL_FILMROLLS_CHANGED
   { "dt-filmrolls-imported", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__UINT, 1, uint_arg, NULL,

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -91,6 +91,9 @@ typedef enum dt_signal_t
   /** \brief This signal is raised when a style is added/deleted/changed  */
   DT_SIGNAL_STYLE_CHANGED,
 
+  /** \brief This signal is raised to request image order change */
+  DT_SIGNAL_IMAGES_ORDER_CHANGE,
+
   /** \brief This signal is raised when a filmroll is deleted/changed but not imported
       \note when a filmroll is imported, use DT_SIGNALS_FILMOLLS_IMPORTED, as the gui
        has to behave differently

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -453,28 +453,14 @@ static void _tree_tagname_show(GtkTreeViewColumn *col, GtkCellRenderer *renderer
                      DT_LIB_TAGGING_COL_FLAGS, &flags,
                      DT_LIB_TAGGING_COL_PATH, &path, -1);
   const gboolean hide = dictionary_view ? (d->tree_flag ? TRUE : d->hide_path_flag) : d->hide_path_flag;
-
-  const char *markups[] = {
-      "%s",                     // normal tag
-      "<i>%s</i>",              // category
-      "<b>%s</b>",              // album
-      "<i><b>%s</b></i>",       // category & album
-      "%s (%d)",                // normal tag with count
-      "<i>%s</i> (%d)",         // category with count
-      "<b>%s</b> (%d)",         // album with count
-      "<i><b>%s</b></i> (%d)"}; // category & album with count
-
-  const gboolean iscategory = (flags & DT_TF_CATEGORY) || !tagid;
-  const gboolean isalbum = flags & DT_TF_ALBUM;
-  const int i = iscategory ? isalbum ? 3 : 1 : isalbum ? 2 : 0;
-
+  const gboolean istag = !(flags & DT_TF_CATEGORY) && tagid;
   if ((dictionary_view && !count) || (!dictionary_view && count <= 1))
   {
-    coltext = g_markup_printf_escaped(markups[i], hide ? name : path);
+    coltext = g_markup_printf_escaped(istag ? "%s" : "<i>%s</i>", hide ? name : path);
   }
   else
   {
-    coltext = g_markup_printf_escaped(markups[i+4], hide ? name : path, count);
+    coltext = g_markup_printf_escaped(istag ? "%s (%d)" : "<i>%s</i> (%d)", hide ? name : path, count);
   }
   g_object_set(renderer, "markup", coltext, NULL);
   g_free(coltext);
@@ -1457,7 +1443,6 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
   GtkWidget *category;
   GtkWidget *private;
   GtkWidget *parent;
-  GtkWidget *album;
   GtkTextBuffer *buffer = NULL;
   GtkWidget *vbox2 = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(vbox), vbox2, FALSE, TRUE, 0);
@@ -1471,9 +1456,6 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
   category = gtk_check_button_new_with_label(_("category"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(category), FALSE);
   gtk_box_pack_end(GTK_BOX(vbox2), category, FALSE, TRUE, 0);
-  album = gtk_check_button_new_with_label(_("album"));
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(album), FALSE);
-  gtk_box_pack_end(GTK_BOX(vbox2), album, FALSE, TRUE, 0);
   private = gtk_check_button_new_with_label(_("private"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(private), FALSE);
   gtk_box_pack_end(GTK_BOX(vbox2), private, FALSE, TRUE, 0);
@@ -1523,7 +1505,6 @@ static void _pop_menu_dictionary_create_tag(GtkWidget *menuitem, dt_lib_module_t
     if (dt_tag_new(new_tagname, &new_tagid))
     {
       const gint new_flags = ((gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(category)) ? DT_TF_CATEGORY : 0) |
-                      (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(album)) ? DT_TF_ALBUM : 0) |
                       (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(private)) ? DT_TF_PRIVATE : 0));
       if (new_tagid) dt_tag_set_flags(new_tagid, new_flags);
       GtkTextIter start, end;
@@ -1604,7 +1585,6 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
 
   gint flags = 0;
   GtkWidget *category;
-  GtkWidget *album;
   GtkWidget *private;
   GtkTextBuffer *buffer = NULL;
   if (tagid)
@@ -1615,9 +1595,6 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
     category = gtk_check_button_new_with_label(_("category"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(category), flags & DT_TF_CATEGORY);
     gtk_box_pack_end(GTK_BOX(vbox2), category, FALSE, TRUE, 0);
-    album = gtk_check_button_new_with_label(_("album"));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(album), flags & DT_TF_ALBUM);
-    gtk_box_pack_end(GTK_BOX(vbox2), album, FALSE, TRUE, 0);
     private = gtk_check_button_new_with_label(_("private"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(private), flags & DT_TF_PRIVATE);
     gtk_box_pack_end(GTK_BOX(vbox2), private, FALSE, TRUE, 0);
@@ -1731,11 +1708,10 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
     if (tagid)
     {
       gint new_flags = ((gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(category)) ? DT_TF_CATEGORY : 0) |
-                       (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(album)) ? DT_TF_ALBUM : 0) |
-                       (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(private)) ? DT_TF_PRIVATE : 0));
+                      (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(private)) ? DT_TF_PRIVATE : 0));
       GtkTextIter start, end;
       gtk_text_buffer_get_start_iter(buffer, &start);
-      gtk_text_buffer_get_end_iter(buffer,  &end);
+      gtk_text_buffer_get_end_iter(buffer, &end);
       gchar *new_synonyms_list = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
       // refresh iter
       gtk_tree_selection_get_selected(selection, &model, &iter);
@@ -1743,9 +1719,9 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
       GtkTreeModel *store = gtk_tree_model_filter_get_model(GTK_TREE_MODEL_FILTER(model));
       gtk_tree_model_filter_convert_iter_to_child_iter(GTK_TREE_MODEL_FILTER(model),
                                                        &store_iter, &iter);
-      if (new_flags != (flags & (DT_TF_CATEGORY | DT_TF_PRIVATE | DT_TF_ALBUM)))
+      if (new_flags != (flags & (DT_TF_CATEGORY | DT_TF_PRIVATE)))
       {
-        new_flags = (flags & ~(DT_TF_CATEGORY | DT_TF_PRIVATE | DT_TF_ALBUM)) | new_flags;
+        new_flags = (flags & ~(DT_TF_CATEGORY | DT_TF_PRIVATE)) | new_flags;
         dt_tag_set_flags(tagid, new_flags);
         if (!d->tree_flag)
           gtk_list_store_set(GTK_LIST_STORE(store), &store_iter, DT_LIB_TAGGING_COL_FLAGS, new_flags, -1);
@@ -1762,7 +1738,6 @@ static void _pop_menu_dictionary_edit_tag(GtkWidget *menuitem, dt_lib_module_t *
       }
       g_free(new_synonyms_list);
     }
-    _raise_signal_tag_changed(self);
   }
   _init_treeview(self, 0);
   gtk_widget_destroy(dialog);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -58,9 +58,9 @@ static void _lib_filter_comparator_changed(GtkComboBox *widget, gpointer user_da
 static void _lib_filter_update_query(dt_lib_module_t *self);
 /* make sure that the comparator button matches what is shown in the filter dropdown */
 static gboolean _lib_filter_sync_combobox_and_comparator(dt_lib_module_t *self);
-/* save the images order if the first collect filter is on album*/
-static void _lib_filter_set_album_order(dt_lib_module_t *self);
-/* image order change from outside */
+/* save the images order if the first collect filter is on tag*/
+static void _lib_filter_set_tag_order(dt_lib_module_t *self);
+/* images order change from outside */
 static void _lib_filter_images_order_change(gpointer instance, int order, dt_lib_module_t *self);
 
 typedef struct dt_sort_items
@@ -289,19 +289,19 @@ static void _lib_filter_combobox_changed(GtkComboBox *widget, gpointer user_data
   _lib_filter_update_query(user_data);
 }
 
-/* save the images order if the first collect filter is on album*/
-static void _lib_filter_set_album_order(dt_lib_module_t *self)
+/* save the images order if the first collect filter is on tag*/
+static void _lib_filter_set_tag_order(dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
-  if(darktable.collection->album_id)
+  if(darktable.collection->tagid)
   {
     const uint32_t sort = items[gtk_combo_box_get_active(GTK_COMBO_BOX(d->sort))].id;
     const gboolean descending = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->reverse));
-    dt_tag_set_album_order_by_id(darktable.collection->album_id, sort, descending);
+    dt_tag_set_tag_order_by_id(darktable.collection->tagid, sort, descending);
   }
 }
 
-static void _lib_filter_images_order_change(gpointer instance, int order, dt_lib_module_t *self)
+static void _lib_filter_images_order_change(gpointer instance, const int order, dt_lib_module_t *self)
 {
   dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
   gtk_combo_box_set_active(GTK_COMBO_BOX(d->sort), _filter_get_items(order & ~DT_COLLECTION_ORDER_FLAG));
@@ -322,7 +322,7 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
   dt_collection_set_sort(darktable.collection, DT_COLLECTION_SORT_NONE, reverse);
 
   /* save the images order */
-  _lib_filter_set_album_order(user_data);
+  _lib_filter_set_tag_order(user_data);
 
   /* update query and view */
   _lib_filter_update_query(user_data);
@@ -341,7 +341,7 @@ static void _lib_filter_sort_combobox_changed(GtkComboBox *widget, gpointer user
   dt_collection_set_sort(darktable.collection, items[gtk_combo_box_get_active(widget)].id, -1);
 
   /* save the images order */
-  _lib_filter_set_album_order(user_data);
+  _lib_filter_set_tag_order(user_data);
 
   /* update the query and view */
   _lib_filter_update_query(user_data);

--- a/src/libs/tools/filter.c
+++ b/src/libs/tools/filter.c
@@ -58,6 +58,10 @@ static void _lib_filter_comparator_changed(GtkComboBox *widget, gpointer user_da
 static void _lib_filter_update_query(dt_lib_module_t *self);
 /* make sure that the comparator button matches what is shown in the filter dropdown */
 static gboolean _lib_filter_sync_combobox_and_comparator(dt_lib_module_t *self);
+/* save the images order if the first collect filter is on album*/
+static void _lib_filter_set_album_order(dt_lib_module_t *self);
+/* image order change from outside */
+static void _lib_filter_images_order_change(gpointer instance, int order, dt_lib_module_t *self);
 
 typedef struct dt_sort_items
 {
@@ -211,6 +215,9 @@ void gui_init(dt_lib_module_t *self)
 
   g_signal_connect_swapped(G_OBJECT(d->comparator), "map",
                            G_CALLBACK(_lib_filter_sync_combobox_and_comparator), self);
+
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_IMAGES_ORDER_CHANGE,
+                            G_CALLBACK(_lib_filter_images_order_change), self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -282,6 +289,25 @@ static void _lib_filter_combobox_changed(GtkComboBox *widget, gpointer user_data
   _lib_filter_update_query(user_data);
 }
 
+/* save the images order if the first collect filter is on album*/
+static void _lib_filter_set_album_order(dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  if(darktable.collection->album_id)
+  {
+    const uint32_t sort = items[gtk_combo_box_get_active(GTK_COMBO_BOX(d->sort))].id;
+    const gboolean descending = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->reverse));
+    dt_tag_set_album_order_by_id(darktable.collection->album_id, sort, descending);
+  }
+}
+
+static void _lib_filter_images_order_change(gpointer instance, int order, dt_lib_module_t *self)
+{
+  dt_lib_tool_filter_t *d = (dt_lib_tool_filter_t *)self->data;
+  gtk_combo_box_set_active(GTK_COMBO_BOX(d->sort), _filter_get_items(order & ~DT_COLLECTION_ORDER_FLAG));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->reverse), order & DT_COLLECTION_ORDER_FLAG);
+}
+
 static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget, gpointer user_data)
 {
   const gboolean reverse = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
@@ -293,7 +319,10 @@ static void _lib_filter_reverse_button_changed(GtkDarktableToggleButton *widget,
   gtk_widget_queue_draw(GTK_WIDGET(widget));
 
   /* update last settings */
-  dt_collection_set_sort(darktable.collection, -1, reverse);
+  dt_collection_set_sort(darktable.collection, DT_COLLECTION_SORT_NONE, reverse);
+
+  /* save the images order */
+  _lib_filter_set_album_order(user_data);
 
   /* update query and view */
   _lib_filter_update_query(user_data);
@@ -310,6 +339,9 @@ static void _lib_filter_sort_combobox_changed(GtkComboBox *widget, gpointer user
 {
   /* update the ui last settings */
   dt_collection_set_sort(darktable.collection, items[gtk_combo_box_get_active(widget)].id, -1);
+
+  /* save the images order */
+  _lib_filter_set_album_order(user_data);
 
   /* update the query and view */
   _lib_filter_update_query(user_data);


### PR DESCRIPTION
Attempt to solve #5018 
Main changes
- add album attribute to tag
- add album filter entry in collect module
- add image order selection to album/tag info (highest 16 bits of flags)
- add position to tagged_images
- remove caption & description fields from images table
- position update on tag attachment
- position change on drag & drop for albums
- legacy params

For the user:
An album is a tag which has the "album" attribute (as private or category).

![image](https://user-images.githubusercontent.com/23012047/82379931-16b62480-99fe-11ea-9968-2b7077b7f5a0.png)

A new entry in collect module allows to filter the albums of the db. Unlike tag filter, the user can only see the images of that album, whatever its place in the hierarchy.

![image](https://user-images.githubusercontent.com/23012047/82380012-32212f80-99fe-11ea-902f-652916026d25.png)

When the first collect filter is "album", any order change is saved with that specific album, including the custom sort image order.

If the first collect filter is not an album, the order changes are applied on the current collection, just as before.





