### PR TITLE
Make sure color picker gets applied after enabling

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -188,12 +188,14 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
       float box[4];
       _iop_get_area(self, box);
       dt_lib_colorpicker_set_box_area(darktable.lib, box);
+      self->pick_pos[0] = NAN; // trigger difference on first apply
     }
     else
     {
       float pos[2];
       _iop_get_point(self, pos);
       dt_lib_colorpicker_set_point(darktable.lib, pos[0], pos[1]);
+      self->pick_box[0] = NAN; // trigger difference on first apply
     }
 
     module->dev->preview_status = DT_DEV_PIXELPIPE_DIRTY;


### PR DESCRIPTION
Fixes #5125 

62670ed9ca4b24f6ad0f42adc49231a739e0b6e1 changed color picker behavior to only trigger a color_picker_apply callback if the selected region changed. However, an apply should always be triggered immediately after enabling the color picker, otherwise for example switching to white balance/spot doesn't have any effect because the previously selected region is re-enabled.

Many thanks to @AxelG-DE for the bug report.