### PR TITLE
Fix: Appveyor: implement known lensfun version workaround per build.txt

### DIFF
--- a/.ci/ci-script-windows.sh
+++ b/.ci/ci-script-windows.sh
@@ -82,6 +82,14 @@ cat > "$FONTCONFIG_FILE" <<EOF
 EOF
 
 execute 'Installing base-devel and toolchain'  pacman -S --needed --noconfirm mingw-w64-x86_64-{toolchain,clang,cmake}
-execute 'Installing dependencies' pacman -S --needed --noconfirm  mingw-w64-x86_64-{exiv2,lcms2,lensfun,dbus-glib,openexr,sqlite3,libxslt,libsoup,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes}
+execute 'Installing dependencies (except lensfun)' pacman -S --needed --noconfirm  mingw-w64-x86_64-{exiv2,lcms2,dbus-glib,openexr,sqlite3,libxslt,libsoup,libwebp,libsecret,lua,graphicsmagick,openjpeg2,gtk3,pugixml,libexif,osm-gps-map,libgphoto2,flickcurl,drmingw,gettext,python3,iso-codes}
+
+# Lensfun must be dealt with separately in an MSYS64 environment per note in Windows build instructions added in commit ca5a4fb
+execute 'Downloading known good lensfun 0.3.2-4' curl -fSs -o mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz
+execute 'Installing known good lensfun' pacman -U --needed --noconfirm mingw-w64-x86_64-lensfun-0.3.2-4-any.pkg.tar.xz
+# Downgraded lensfun package is explicitly packaged to python 3.6 directories
+# but fortunately compatible with 3.8
+execute 'Copying python 3.6 lensfun libraries to 3.8' cp -R /mingw64/lib/python3.6/site-packages/lensfun* /mingw64/lib/python3.8/site-packages
 execute 'Updating lensfun databse' lensfun-update-data
+
 execute 'Building darktable' build_darktable


### PR DESCRIPTION
I have added scripting to implement the workaround described in the Windows [build instructions](https://github.com/darktable-org/darktable/blob/master/packaging/windows/BUILD.txt). 

- Changes are together in one section of the script to help clarity
- These can be removed again when dt is integrated with lensfun-next, but the timescales for this are unknown, and dependent on upstream
- There is a manual download of the MSYS64 package for lensfun 0.3.2-4 with an explicit URL. I think this risk is acceptable because if MSYS64 change the repo and remove that version, it's very likely the repo changes will break the build in other places anyway.
- The MSYS64 package 0.3.2-4 was packaged with the python version at the time, 3.6; MSYS64 python is now at 3.8 so there is a step included to copy the files across. 
