### PR TITLE
make toggle button background follow CSS

### DIFF
--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -45,17 +45,9 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
 
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
 
-  GdkRGBA bg_color, fg_color;
+  GdkRGBA fg_color;
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
-  if(button->icon_flags & CPF_CUSTOM_BG)
-    bg_color = button->bg;
-  else
-  {
-    GdkRGBA *bc;
-    gtk_style_context_get(context, state, "background-color", &bc, NULL);
-    bg_color = *bc;
-    gdk_rgba_free(bc);
-  }
+
   if(button->icon_flags & CPF_CUSTOM_FG)
     fg_color = button->fg;
   else if(button->icon_flags & CPF_IGNORE_FG_STATE)
@@ -102,9 +94,7 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
       // PRELIGHT, but not on ACTIVE
       if(!(flags & CPF_BG_TRANSPARENT) || (flags & CPF_PRELIGHT))
       {
-        cairo_rectangle(cr, 0, 0, width, height);
-        gdk_cairo_set_source_rgba(cr, &bg_color);
-        cairo_fill(cr);
+        gtk_render_background(context, cr, 0, 0, width, height);
       }
     }
     else if(!(flags & CPF_ACTIVE) || (flags & CPF_IGNORE_FG_STATE))


### PR DESCRIPTION
This will make the toggle button honor css for background settings for color and border radius.
the issue is mentioned in #5132 
Problem was that the background was manually drawn with a cairo rectangle

it's part of my reworking of buttons, but I propose here separately