### PR TITLE
expand single darkroom module: make parameter work across groups

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1537,6 +1537,13 @@
     <longdescription>this option toggles the behavior of shift clicking in darkroom mode</longdescription>
   </dtconfig>
   <dtconfig prefs="darkroom">
+    <name>darkroom/ui/single_module_group_only</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>only collapse modules in current group</shortdescription>
+    <longdescription>if only expanding a single module at a time, only collapse other modules in the current group - ignore modules in other groups</longdescription>
+  </dtconfig>
+  <dtconfig prefs="darkroom">
     <name>darkroom/ui/activate_expand</name>
     <type>bool</type>
     <default>false</default>

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2070,16 +2070,18 @@ static void dt_iop_gui_set_single_expanded(dt_iop_module_t *module, gboolean exp
 void dt_iop_gui_set_expanded(dt_iop_module_t *module, gboolean expanded, gboolean collapse_others)
 {
   if(!module->expander) return;
-
   /* handle shiftclick on expander, hide all except this */
   if(collapse_others)
   {
+    const int current_group = dt_dev_modulegroups_get(module->dev);
+    const gboolean group_only = dt_conf_get_bool("darkroom/ui/single_module_group_only");
+
     GList *iop = g_list_first(module->dev->iop);
     gboolean all_other_closed = TRUE;
     while(iop)
     {
       dt_iop_module_t *m = (dt_iop_module_t *)iop->data;
-      if(m != module)
+      if(m != module && (dt_iop_shown_in_group(m, current_group) || !group_only))
       {
         all_other_closed = all_other_closed && !m->expanded;
         dt_iop_gui_set_single_expanded(m, FALSE);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2074,13 +2074,12 @@ void dt_iop_gui_set_expanded(dt_iop_module_t *module, gboolean expanded, gboolea
   /* handle shiftclick on expander, hide all except this */
   if(collapse_others)
   {
-    const int current_group = dt_dev_modulegroups_get(module->dev);
     GList *iop = g_list_first(module->dev->iop);
     gboolean all_other_closed = TRUE;
     while(iop)
     {
       dt_iop_module_t *m = (dt_iop_module_t *)iop->data;
-      if(m != module && dt_iop_shown_in_group(m, current_group))
+      if(m != module)
       {
         all_other_closed = all_other_closed && !m->expanded;
         dt_iop_gui_set_single_expanded(m, FALSE);


### PR DESCRIPTION
ensures that, if the "expand single darkroom module" preference is set, this setting is observed across all module groups.

I've also raised #5129 for discussion about whether a different (better?) solution might be wanted longer term. For now, this fix makes sure the 'expand single module' parameter always works consistently even when changing group.