### PR TITLE
Add Lua control of lighttable image visibility

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -293,6 +293,12 @@ making a backup is strongly advised.
 - added darktable.gui.panel_get_size and darktable.gui.panel_set_size functions 
   to set the width of the  left or right panels and the height of the bottom panel.
 
+- Added function darktable.gui.views.lighttable.is_image_visible to check if an image 
+  is visible in lighttable view.
+
+- Added function darktable.gui.views.lighttable.set_image_visible to force an 
+  image to be visible in lighttable view.
+  
 ## Changed Dependencies
 
 

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -1095,6 +1095,61 @@
 </entry>
     </row></tbody>
     </tgroup></informaltable>
+
+<section status="final" id="darktable_gui_views_lighttable_is_image_visible">
+<title>darktable.gui.views.lighttable.is_image_visible</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>is_image_visible</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_views_lighttable_is_image_visible_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>
+) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>Check if the image is visible in lighttable view.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_views_lighttable_is_image_visible_image"><term>image</term><listitem>
+<synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>The image to be checked.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis>boolean</synopsis>
+<para>True if the image is displayed. False if the image is partially displayed or not displayed.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_views_lighttable_set_image_visible">
+<title>darktable.gui.views.lighttable.set_image_visible</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>set_image_visible</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_views_lighttable_set_image_visible_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>
+) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>Set the image visible in lighttable view.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_views_lighttable_set_image_visible_image"><term>image</term><listitem>
+<synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>The image to set visible.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis>int</synopsis>
+<para>An error is returned if no image is specified.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
 </section>
 
 <section status="final" id="darktable_gui_views_tethering">

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -111,6 +111,8 @@ void dt_thumbtable_zoom_changed(dt_thumbtable_t *table, int oldzoom, int newzoom
 
 // ensure that the mentionned image is visible by moving the view if needed
 gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, int imgid);
+// check if the mentioned image is visible
+gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, int imgid);
 
 // move by key actions.
 // this key accels are not managed here but inside view

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -42,6 +42,10 @@
 #include "views/view.h"
 #include "views/view_api.h"
 
+#ifdef USE_LUA
+#include "lua/image.h"
+#endif
+
 #include <assert.h>
 #include <dirent.h>
 #include <errno.h>
@@ -223,6 +227,40 @@ static gboolean _preview_get_state(dt_view_t *self)
   return lib->preview_state;
 }
 
+#ifdef USE_LUA
+
+static int set_image_visible_cb(lua_State *L)
+{
+  dt_lua_image_t imgid = -1;
+  if(luaL_testudata(L, 1, "dt_lua_image_t"))
+  {
+    luaA_to(L, dt_lua_image_t, &imgid, 1);
+     dt_thumbtable_set_offset_image(dt_ui_thumbtable(darktable.gui->ui), imgid, TRUE);
+    return 0;
+  }
+  else
+  {
+    return luaL_error(L, "no image specified");
+  }
+}
+
+static gboolean is_image_visible_cb(lua_State *L)
+{
+  dt_lua_image_t imgid = -1;
+  if(luaL_testudata(L, 1, "dt_lua_image_t"))
+  {
+    luaA_to(L, dt_lua_image_t, &imgid, 1);
+    lua_pushboolean(L, dt_thumbtable_check_imgid_visibility(dt_ui_thumbtable(darktable.gui->ui), imgid));
+    return 1;
+  }
+  else
+  {
+    return luaL_error(L, "no image specified");
+  }
+}
+
+#endif
+
 void init(dt_view_t *self)
 {
   self->data = calloc(1, sizeof(dt_library_t));
@@ -235,6 +273,20 @@ void init(dt_view_t *self)
 
   // ensure the memory table is up to date
   dt_collection_memory_update();
+  
+#ifdef USE_LUA
+  lua_State *L = darktable.lua_state.state;
+  const int my_type = dt_lua_module_entry_get_type(L, "view", self->module_name);
+  lua_pushlightuserdata(L, self);
+  lua_pushcclosure(L, set_image_visible_cb, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "set_image_visible");
+  lua_pushcclosure(L, is_image_visible_cb, 1);
+  dt_lua_gtk_wrap(L);
+  lua_pushcclosure(L, dt_lua_type_member_common, 1);
+  dt_lua_type_register_const_type(L, my_type, "is_image_visible");
+#endif
 }
 
 


### PR DESCRIPTION
Added lua function darktable.gui.views.lighttable.is_image_visible to check if an image is visible in lighttable view.  Added lua function darktable.gui.views.lighttable.set_image_visible to make an image
visible in the lighttable view.  Updated Release Notes and Lua API manual.

Fixes #3831.