### PR TITLE
Grayscale images should write grayscale tiff files.

### DIFF
--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -154,12 +154,86 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
   {
     TIFFSetField(tif, TIFFTAG_ICCPROFILE, (uint32_t)profile_len, profile);
   }
-  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)3);
+
+/* Howto check for a grayscale image?
+   We test every pixel for differences between the rgb channels using specific thresholds
+   for every precision. If there is such a pixel we keep it as an rgb image, otherwise
+   it's safe to assume a grayscale.
+   As there might be pipeline errors at the border we leave them alone.
+   After these checks layers can be used later on.
+   Exporting using masks currently does not support grayscale images.
+*/
+  int layers = 3;  // default are rgb images
+  if((d->global.height > 4) && (d->global.width > 4) && (n_pages == 1))
+  {
+    layers = 1;    // let's now assume a grayscale  
+    if(d->bpp == 32)
+    {
+      for(int y = 1; y < d->global.height-1; y++)
+      {
+        float *in = (float *)in_void + (size_t)4 * y * d->global.width;
+        for(int x = 1; x < d->global.width-1; x++, in += 4)
+        {
+          if((fabs(fmax(in[0], 0.001f) / fmax(in[1], 0.001f)) > 1.01f) ||
+             (fabs(fmax(in[0], 0.001f) / fmax(in[2], 0.001f)) > 1.01f) ||
+             (fabs(fmax(in[1], 0.001f) / fmax(in[2], 0.001f)) > 1.01f)) 
+          {
+            layers = 3;
+            goto checkdone;      
+          }
+        }
+      }
+    }
+    else if(d->bpp == 16)
+    {
+      for(int y = 1; y < d->global.height-1; y++)
+      {
+        uint16_t *in = (uint16_t *)in_void + (size_t)4 * y * d->global.width;
+        for(int x = 1; x < d->global.width-1; x++, in += 4)
+        {
+          if((abs(in[0] - in[1]) > 100) ||
+             (abs(in[0] - in[2]) > 100) ||
+             (abs(in[1] - in[2]) > 100))
+          {
+            layers = 3;
+            goto checkdone;      
+          }
+        }
+      }
+    }
+    else
+    {
+      for(int y = 1; y < d->global.height-1; y++)
+      {
+        uint8_t *in = (uint8_t *)in_void + (size_t)4 * y * d->global.width;
+        for(int x = 1; x < d->global.width-1; x++, in += 4)
+        {
+          if((abs(in[0] - in[1]) > 5) ||
+             (abs(in[0] - in[2]) > 5) ||
+             (abs(in[1] - in[2]) > 5))
+          {
+            layers = 3;
+            goto checkdone;
+          }
+        }
+      }
+    }
+
+  }
+  checkdone:  
+  if(layers == 1)
+    dt_control_log(_("will export as a grayscale image"));
+
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (uint16_t)layers);
   TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
   TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
   TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)d->global.width);
   TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)d->global.height);
-  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+  if(layers == 3)
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+  else
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
+
   TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
   TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, (uint32_t)1);
   TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
@@ -172,7 +246,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, (uint16_t)RESUNIT_INCH);
   }
 
-  const size_t rowsize = (d->global.width * 3) * d->bpp / 8;
+  const size_t rowsize = (d->global.width * layers) * d->bpp / 8;
   if((rowdata = malloc(rowsize)) == NULL)
   {
     rc = 1;
@@ -186,9 +260,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
       float *in = (float *)in_void + (size_t)4 * y * d->global.width;
       float *out = (float *)rowdata;
 
-      for(int x = 0; x < d->global.width; x++, in += 4, out += 3)
+      for(int x = 0; x < d->global.width; x++, in += 4, out += layers)
       {
-        memcpy(out, in, 3 * sizeof(float));
+        memcpy(out, in, layers * sizeof(float));
       }
 
       if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -205,9 +279,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
       uint16_t *in = (uint16_t *)in_void + (size_t)4 * y * d->global.width;
       uint16_t *out = (uint16_t *)rowdata;
 
-      for(int x = 0; x < d->global.width; x++, in += 4, out += 3)
+      for(int x = 0; x < d->global.width; x++, in += 4, out += layers)
       {
-        memcpy(out, in, 3 * sizeof(uint16_t));
+        memcpy(out, in, layers * sizeof(uint16_t));
       }
 
       if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)
@@ -224,9 +298,9 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
       uint8_t *in = (uint8_t *)in_void + (size_t)4 * y * d->global.width;
       uint8_t *out = (uint8_t *)rowdata;
 
-      for(int x = 0; x < d->global.width; x++, in += 4, out += 3)
+      for(int x = 0; x < d->global.width; x++, in += 4, out += layers)
       {
-        memcpy(out, in, 3 * sizeof(uint8_t));
+        memcpy(out, in, layers * sizeof(uint8_t));
       }
 
       if(TIFFWriteScanline(tif, rowdata, y, 0) == -1)


### PR DESCRIPTION
If we dt develop an image as a grayscale - whatever method we choose to do so -
we can decrease file size for exporting as a tiff.

As dt workflow does not have a special grayscale mode we check all pixels for a
minimum difference between the rgb values and if there is none found we assume
this to be a grayscale.

These images have only one color channel and set `TIFFTAG_PHOTOMETRIC` as
`PHOTOMETRIC_MINISBLACK` instead of `PHOTOMETRIC_RGB`.