### PR TITLE
Fix lua entry widget password field

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -293,6 +293,9 @@ making a backup is strongly advised.
 - added darktable.gui.panel_get_size and darktable.gui.panel_set_size functions 
   to set the width of the  left or right panels and the height of the bottom panel.
 
+- fixed is_password field of entry widget to work according to the API manual, so 
+  now when it is set to true the field is hidden.
+
 ## Changed Dependencies
 
 

--- a/src/lua/widget/entry.c
+++ b/src/lua/widget/entry.c
@@ -62,7 +62,7 @@ static int is_password_member(lua_State *L)
   luaA_to(L,lua_entry,&entry,1);
   if(lua_gettop(L) > 2) {
     const gboolean visibility = lua_toboolean(L,3);
-    gtk_entry_set_visibility(GTK_ENTRY(entry->widget),visibility);
+    gtk_entry_set_visibility(GTK_ENTRY(entry->widget),!visibility);
     return 0;
   }
   lua_pushboolean(L,gtk_entry_get_visibility(GTK_ENTRY(entry->widget)));


### PR DESCRIPTION
When `is_password` is set to true, the entry widget should act as a password field, obscuring the text.  The value supplied was being applied to `gtk_set_entry_visibility` unchanged, so the text was visible when `is_password` was true and obscured when `is_password` was false.  Negated the boolean value when it was applied to fix it.  Updated the RELEASE_NOTES.md with the fix.