### PR TITLE
thumbs fix

### DIFF
--- a/src/control/jobs/camera_jobs.c
+++ b/src/control/jobs/camera_jobs.c
@@ -286,6 +286,15 @@ void _camera_import_image_downloaded(const dt_camera_t *camera, const char *file
 
   dt_control_job_set_progress(t->job, t->fraction);
 
+  if(t->import_count + 1 == g_list_length(t->images))
+  {
+    // only redraw at the end, to not spam the cpu with exposure events
+    dt_control_queue_redraw_center();
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
+
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_FILMROLLS_IMPORTED,
+                            dt_import_session_film_id(t->shared.session));
+  }
   t->import_count++;
 }
 

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -151,6 +151,44 @@ static gboolean _compute_sizes(dt_culling_t *table, gboolean force)
   return ret;
 }
 
+// set mouse_over_id to thumb under mouse or to first thumb
+static void _thumbs_refocus(dt_culling_t *table)
+{
+  int overid = -1;
+
+  if(table->mouse_inside)
+  {
+    // the exact position of the mouse
+    int x = -1;
+    int y = -1;
+    gdk_window_get_origin(gtk_widget_get_window(table->widget), &x, &y);
+    x = table->pan_x - x;
+    y = table->pan_y - y;
+
+    // which thumb is under the mouse ?
+    GList *l = table->list;
+    while(l)
+    {
+      dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+      if(th->x <= x && th->x + th->width > x && th->y <= y && th->y + th->height > y)
+      {
+        overid = th->imgid;
+        break;
+      }
+      l = g_list_next(l);
+    }
+  }
+
+  // if overid not valid, we use the offest image
+  if(overid <= 0)
+  {
+    overid = table->offset_imgid;
+  }
+
+  // and we set the overid
+  dt_control_set_mouse_over_id(overid);
+}
+
 static void _thumbs_move(dt_culling_t *table, int move)
 {
   if(move == 0) return;
@@ -276,6 +314,7 @@ static void _thumbs_move(dt_culling_t *table, int move)
   {
     table->offset = new_offset;
     dt_culling_full_redraw(table, TRUE);
+    _thumbs_refocus(table);
   }
 }
 
@@ -443,12 +482,18 @@ static gboolean _event_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 
 static gboolean _event_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)
 {
+  dt_culling_t *table = (dt_culling_t *)user_data;
   // if the leaving cause is the hide of the widget, no mouseover change
-  if(!gtk_widget_is_visible(widget)) return FALSE;
+  if(!gtk_widget_is_visible(widget))
+  {
+    table->mouse_inside = FALSE;
+    return FALSE;
+  }
 
   // if we leave thumbtable in favour of an inferior (a thumbnail) it's not a real leave !
   if(event->detail == GDK_NOTIFY_INFERIOR) return FALSE;
 
+  table->mouse_inside = FALSE;
   dt_control_set_mouse_over_id(-1);
   return TRUE;
 }
@@ -509,7 +554,13 @@ static gboolean _event_button_press(GtkWidget *widget, GdkEventButton *event, gp
 static gboolean _event_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_culling_t *table = (dt_culling_t *)user_data;
-  if(!table->panning) return FALSE;
+  table->mouse_inside = TRUE;
+  if(!table->panning)
+  {
+    table->pan_x = event->x_root;
+    table->pan_y = event->y_root;
+    return FALSE;
+  }
 
   GList *l;
 
@@ -642,7 +693,11 @@ static void _dt_selection_changed_callback(gpointer instance, gpointer user_data
     dt_view_lighttable_set_zoom(darktable.view_manager, nz);
   }
   // if we navigate only in the selection we just redraw to ensure no unselected image is present
-  if(table->navigate_inside_selection) dt_culling_full_redraw(table, TRUE);
+  if(table->navigate_inside_selection)
+  {
+    dt_culling_full_redraw(table, TRUE);
+    _thumbs_refocus(table);
+  }
 }
 
 static void _dt_profile_change_callback(gpointer instance, int type, gpointer user_data)
@@ -695,6 +750,7 @@ static void _dt_filmstrip_change(gpointer instance, int imgid, gpointer user_dat
 
   table->offset = _thumb_get_rowid(imgid);
   dt_culling_full_redraw(table, TRUE);
+  _thumbs_refocus(table);
 }
 
 dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
@@ -1424,6 +1480,7 @@ void dt_culling_change_offset_image(dt_culling_t *table, int imgid)
 {
   table->offset = _thumb_get_rowid(imgid);
   dt_culling_full_redraw(table, TRUE);
+  _thumbs_refocus(table);
 }
 
 void dt_culling_zoom_max(dt_culling_t *table, gboolean only_current)

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -60,9 +60,10 @@ typedef struct dt_culling_t
 
   gboolean select_desactivate;
 
-  gboolean panning; // are we moving zoomed images ?
-  int pan_x;        // last position during panning
-  int pan_y;        //
+  gboolean panning;      // are we moving zoomed images ?
+  int pan_x;             // last position during panning
+  int pan_y;             //
+  gboolean mouse_inside; // is the mouse inside culling center view ?
 
   gboolean focus; // do we show focus rectangles on images ?
 } dt_culling_t;

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -126,19 +126,18 @@ static int generate_thumbnail_cache(const dt_mipmap_size_t min_mip, const dt_mip
 
 static void usage(const char *progname)
 {
-  fprintf(
-      stderr,
-      "usage: %s [-h, --help; --version]\n"
-      "  [--min-mip <0-7> (default = 0)] [-m, --max-mip <0-7> (default = 2)]\n"
-      "  [--min-imgid <N>] [--max-imgid <N>]\n"
-      "  [--core <darktable options>]\n"
-      "\n"
-      "When multiple mipmap sizes are requested, the biggest one is computed\n"
-      "while the rest are quickly downsampled.\n"
-      "\n"
-      "The --min-imgid and --max-imgid specify the range of internal image ID\n"
-      "numbers to work on.\n",
-      progname);
+  fprintf(stderr,
+          "usage: %s [-h, --help; --version]\n"
+          "  [--min-mip <0-8> (default = 0)] [-m, --max-mip <0-8> (default = 2)]\n"
+          "  [--min-imgid <N>] [--max-imgid <N>]\n"
+          "  [--core <darktable options>]\n"
+          "\n"
+          "When multiple mipmap sizes are requested, the biggest one is computed\n"
+          "while the rest are quickly downsampled.\n"
+          "\n"
+          "The --min-imgid and --max-imgid specify the range of internal image ID\n"
+          "numbers to work on.\n",
+          progname);
 }
 
 int main(int argc, char *arg[])
@@ -174,12 +173,12 @@ int main(int argc, char *arg[])
     else if((!strcmp(arg[k], "-m") || !strcmp(arg[k], "--max-mip")) && argc > k + 1)
     {
       k++;
-      max_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), 0), 7);
+      max_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), 0), 8);
     }
     else if(!strcmp(arg[k], "--min-mip") && argc > k + 1)
     {
       k++;
-      min_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), 0), 7);
+      min_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), 0), 8);
     }
     else if(!strcmp(arg[k], "--min-imgid") && argc > k + 1)
     {
@@ -216,10 +215,20 @@ int main(int argc, char *arg[])
 
   if(!dt_conf_get_bool("cache_disk_backend"))
   {
+    fprintf(stderr, _("warning: disk backend for thumbnail cache is disabled (cache_disk_backend)\nif you want "
+                      "to pre-generate thumbnails and for darktable to use them, you need to enable disk backend "
+                      "for thumbnail cache\nno thumbnails to be generated, done.\n"));
+    dt_cleanup();
+    free(m_arg);
+    exit(EXIT_FAILURE);
+  }
+
+  if(max_mip == 8 && !dt_conf_get_bool("cache_disk_backend_full"))
+  {
     fprintf(stderr,
-            _("warning: disk backend for thumbnail cache is disabled (cache_disk_backend)\nif you want "
-              "to pre-generate thumbnails and for darktable to use them, you need to enable disk backend "
-              "for thumbnail cache\nno thumbnails to be generated, done."));
+            _("warning: disk backend for full preview cache is disabled (cache_disk_backend_full)\nif you want "
+              "to pre-generate full preview and for darktable to use them, you need to enable disk backend "
+              "for full preview cache\nno thumbnails to be generated, done.\n"));
     dt_cleanup();
     free(m_arg);
     exit(EXIT_FAILURE);

--- a/src/generate-cache/main.c
+++ b/src/generate-cache/main.c
@@ -173,12 +173,12 @@ int main(int argc, char *arg[])
     else if((!strcmp(arg[k], "-m") || !strcmp(arg[k], "--max-mip")) && argc > k + 1)
     {
       k++;
-      max_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), 0), 8);
+      max_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), DT_MIPMAP_0), DT_MIPMAP_8);
     }
     else if(!strcmp(arg[k], "--min-mip") && argc > k + 1)
     {
       k++;
-      min_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), 0), 8);
+      min_mip = (dt_mipmap_size_t)MIN(MAX(atoi(arg[k]), DT_MIPMAP_0), DT_MIPMAP_8);
     }
     else if(!strcmp(arg[k], "--min-imgid") && argc > k + 1)
     {

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1031,6 +1031,7 @@ static void dt_dev_jump_image(dt_develop_t *dev, int diff, gboolean by_key)
     // if we are here, that means that the current is not anymore in the list
     // in this case, let's use the current offset image
     new_id = dt_ui_thumbtable(darktable.gui->ui)->offset_imgid;
+    new_offset = dt_ui_thumbtable(darktable.gui->ui)->offset;
   }
   g_free(query);
   sqlite3_finalize(stmt);


### PR DESCRIPTION
- fix filmstrip rewind in some situation, as mentioned by @esq4 in #5042 
- fix the focus when no mouse movement (key navigation) in culling/preview
- allow generate-cache to work with mipmap 8 (mentioned by @Nilvus )
- refresh view after camera import (fix #5166 )