### PR TITLE
Handle corrupted images gracefully

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -70,7 +70,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 
   dt_image_init(&dev->image_storage);
   dev->image_status = dev->preview_status = dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-  dev->image_loading = dev->preview_loading = dev->preview2_loading = dev->history_updating = 0;
+  dev->image_loading = dev->preview_loading = dev->preview2_loading = dev->history_updating = dev->image_invalid = 0;
   dev->image_force_reload = 0;
   dev->preview_input_changed = dev->preview2_input_changed = 0;
 
@@ -541,7 +541,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
   dt_control_toast_busy_enter();
   // let gui know to draw preview instead of us, if it's there:
   dev->image_status = DT_DEV_PIXELPIPE_RUNNING;
-
+  
   dt_mipmap_buffer_t buf;
   dt_times_t start;
   dt_get_times(&start);
@@ -556,6 +556,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
     dt_control_toast_busy_leave();
     dev->image_status = DT_DEV_PIXELPIPE_DIRTY;
     dt_pthread_mutex_unlock(&dev->pipe_mutex);
+    dev->image_invalid++;
     return;
   }
 
@@ -661,7 +662,7 @@ restart:
 
   dev->image_status = DT_DEV_PIXELPIPE_VALID;
   dev->image_loading = 0;
-
+  dev->image_invalid = 0;
   dt_mipmap_cache_release(darktable.mipmap_cache, &buf);
   // if a widget needs to be redraw there's the DT_SIGNAL_*_PIPE_FINISHED signals
   dt_control_log_busy_leave();

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -148,10 +148,11 @@ typedef struct dt_develop_t
   int32_t gui_leaving;  // set if everything is scheduled to shut down.
   int32_t gui_synch;    // set by the render threads if gui_update should be called in the modules.
   int32_t focus_hash;   // determines whether to start a new history item or to merge down.
-  int32_t image_loading, first_load, image_force_reload, history_updating, image_invalid;
-  int32_t preview_loading, preview_input_changed;
-  int32_t preview2_loading, preview2_input_changed;
+  gboolean preview_loading, preview2_loading, image_loading, history_updating, image_force_reload, first_load;
+  gboolean preview_input_changed, preview2_input_changed;
+
   dt_dev_pixelpipe_status_t image_status, preview_status, preview2_status;
+  int32_t image_invalid_cnt;
   uint32_t timestamp;
   uint32_t average_delay;
   uint32_t preview_average_delay;

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -148,7 +148,7 @@ typedef struct dt_develop_t
   int32_t gui_leaving;  // set if everything is scheduled to shut down.
   int32_t gui_synch;    // set by the render threads if gui_update should be called in the modules.
   int32_t focus_hash;   // determines whether to start a new history item or to merge down.
-  int32_t image_loading, first_load, image_force_reload, history_updating;
+  int32_t image_loading, first_load, image_force_reload, history_updating, image_invalid;
   int32_t preview_loading, preview_input_changed;
   int32_t preview2_loading, preview2_input_changed;
   dt_dev_pixelpipe_status_t image_status, preview_status, preview2_status;

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -422,7 +422,7 @@ void expose(
     float fontsize;
     gchar *load_txt;
 
-    if(dev->image_invalid)
+    if(dev->image_invalid_cnt)
     {
       fontsize = DT_PIXEL_APPLY_DPI(20);
       load_txt = dt_util_dstrcat(NULL, "%s `%s' %s\n\n%s\n%s",
@@ -431,9 +431,9 @@ void expose(
           ", switch to lighttable now.",
           "Please check image (use exiv2 or exiftool) for corrupted data. If the image",
           "seems to be intact concider to open an issue at https://github.com/darktable-org/darktable." );
-      if(dev->image_invalid > 400)
+      if(dev->image_invalid_cnt > 400)
       {
-        dev->image_invalid = 0;
+        dev->image_invalid_cnt = 0;
         dt_view_manager_switch(darktable.view_manager, "lighttable");
       }
     }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -419,12 +419,34 @@ void expose(
     PangoRectangle ink;
     PangoLayout *layout;
     PangoFontDescription *desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
-    const float fontsize = DT_PIXEL_APPLY_DPI(14);
+    float fontsize;
+    gchar *load_txt;
+
+    if(dev->image_invalid)
+    {
+      fontsize = DT_PIXEL_APPLY_DPI(20);
+      load_txt = dt_util_dstrcat(NULL, "%s `%s' %s\n\n%s\n%s",
+          "darktable could not load image",
+          dev->image_storage.filename,
+          ", switch to lighttable now.",
+          "Please check image (use exiv2 or exiftool) for corrupted data. If the image",
+          "seems to be intact concider to open an issue at https://github.com/darktable-org/darktable." );
+      if(dev->image_invalid > 400)
+      {
+        dev->image_invalid = 0;
+        dt_view_manager_switch(darktable.view_manager, "lighttable");
+      }
+    }
+    else
+    {
+      fontsize = DT_PIXEL_APPLY_DPI(14);
+      load_txt = dt_util_dstrcat(NULL, "%s %s ...", _("loading image"), dev->image_storage.filename);
+    }
+
     pango_font_description_set_absolute_size(desc, fontsize * PANGO_SCALE);
     pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
     layout = pango_cairo_create_layout(cr);
     pango_layout_set_font_description(layout, desc);
-    gchar *load_txt = dt_util_dstrcat(NULL, "%s %s ...", _("loading image"), dev->image_storage.filename);
     pango_layout_set_text(layout, load_txt, -1);
     pango_layout_get_pixel_extents(layout, &ink, NULL);
     const float xc = width / 2.0, yc = height * 0.85 - DT_PIXEL_APPLY_DPI(10), wd = ink.width * .5f;


### PR DESCRIPTION
If an image could not be opened we have the 'image loading' message
forever until the user decides to switch back to lighttable mode.

This pr introduces `image_invalid` in `dt_develop_t`. If we find an error
while loading the mipmap cache this is switched on.

In darkroom expose we show a more meaningful message in this case and after
a while switch back to lighttable automatically.

fixes #5039