### PR TITLE
culling overlays

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -686,6 +686,20 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/overlays/culling/0</name>
+    <type>int</type>
+    <default>6</default>
+    <shortdescription>overlays for culling = block</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/overlays/culling/1</name>
+    <type>int</type>
+    <default>6</default>
+    <shortdescription>overlays for full preview = block</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/timeline/last_zoom</name>
     <type>int</type>
     <default>0</default>

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1563,7 +1563,7 @@ void dt_culling_zoom_fit(dt_culling_t *table, gboolean only_current)
 // change the type of overlays that should be shown
 void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over)
 {
-  if(over == table->overlays) return;
+  if(!table || over == table->overlays) return;
   gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", table->mode);
   dt_conf_set_int(txt, over);
   g_free(txt);

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -66,6 +66,8 @@ typedef struct dt_culling_t
   gboolean mouse_inside; // is the mouse inside culling center view ?
 
   gboolean focus; // do we show focus rectangles on images ?
+
+  dt_thumbnail_overlay_t overlays; // overlays type
 } dt_culling_t;
 
 dt_culling_t *dt_culling_new(dt_culling_mode_t mode);

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -68,6 +68,7 @@ typedef struct dt_culling_t
   gboolean focus; // do we show focus rectangles on images ?
 
   dt_thumbnail_overlay_t overlays; // overlays type
+  int overlays_block_timeout;      // overlay block visibility duration
 } dt_culling_t;
 
 dt_culling_t *dt_culling_new(dt_culling_mode_t mode);

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -87,6 +87,8 @@ void dt_culling_change_offset_image(dt_culling_t *table, int offset);
 void dt_culling_zoom_max(dt_culling_t *table, gboolean only_current);
 void dt_culling_zoom_fit(dt_culling_t *table, gboolean only_current);
 
+// set the overlays type
+void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1490,8 +1490,9 @@ static void _widget_change_parent_overlay(GtkWidget *w, GtkOverlay *new_parent)
   gtk_widget_show(w);
   g_object_unref(w);
 }
-void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over)
+void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over, int timeout)
 {
+  thumb->overlay_timeout_duration = timeout;
   // if no change, do nothing...
   if(thumb->over == over) return;
   dt_thumbnail_overlay_t old_over = thumb->over;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1261,7 +1261,8 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // reject icon
     gtk_widget_set_size_request(thumb->w_reject, 3.0 * r1, 3.0 * r1);
     gtk_widget_set_valign(thumb->w_reject, GTK_ALIGN_END);
-    gtk_widget_set_margin_start(thumb->w_reject, 0.03 * width);
+    int pos = MAX(0.03 * width, (width - 15.0 * r1) * 0.5 - 4 * 3.0 * r1);
+    gtk_widget_set_margin_start(thumb->w_reject, pos);
     gtk_widget_set_margin_bottom(thumb->w_reject, 0.03 * width);
 
     // stars
@@ -1276,9 +1277,10 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // the color labels
     gtk_widget_set_size_request(thumb->w_color, 3.0 * r1, 3.0 * r1);
     gtk_widget_set_valign(thumb->w_color, GTK_ALIGN_END);
-    gtk_widget_set_halign(thumb->w_color, GTK_ALIGN_END);
+    gtk_widget_set_halign(thumb->w_color, GTK_ALIGN_START);
     gtk_widget_set_margin_bottom(thumb->w_color, 0.03 * width);
-    gtk_widget_set_margin_end(thumb->w_color, 0.03 * width);
+    pos = MIN(width - (0.03 * width + r1 * 3.0), (width - 15.0 * r1) * 0.5 + 8.25 * 3.0 * r1);
+    gtk_widget_set_margin_start(thumb->w_color, pos);
 
     // the local copy indicator
     gtk_widget_set_size_request(thumb->w_local_copy, 1.618 * r1, 1.618 * r1);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -590,8 +590,11 @@ static gboolean _event_main_motion(GtkWidget *widget, GdkEventMotion *event, gpo
       thumb->overlay_timeout_id = 0;
     }
     _thumbs_show_overlays(thumb);
-    thumb->overlay_timeout_id
-        = g_timeout_add_seconds(thumb->overlay_timeout_duration, _thumbs_hide_overlays, thumb);
+    if(thumb->overlay_timeout_duration >= 0)
+    {
+      thumb->overlay_timeout_id
+          = g_timeout_add_seconds(thumb->overlay_timeout_duration, _thumbs_hide_overlays, thumb);
+    }
   }
 
   if(!thumb->mouse_over && !thumb->disable_mouseover) dt_control_set_mouse_over_id(thumb->imgid);

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -148,7 +148,7 @@ void dt_thumbnail_update_infos(dt_thumbnail_t *thumb);
 void dt_thumbnail_image_refresh(dt_thumbnail_t *thumb);
 
 // do we need to display simple overlays or extended ?
-void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over);
+void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over, int timeout);
 
 // force reloading image infos
 void dt_thumbnail_reload_infos(dt_thumbnail_t *thumb);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -44,7 +44,7 @@ static void _list_remove_thumb(gpointer user_data)
 }
 
 // get the class name associated with the overlays mode
-gchar *_thumbs_get_overlays_class(dt_thumbnail_overlay_t over)
+static gchar *_thumbs_get_overlays_class(dt_thumbnail_overlay_t over)
 {
   switch(over)
   {

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -121,21 +121,49 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
   gtk_style_context_remove_class(context, cl0);
   gtk_style_context_add_class(context, cl1);
 
+  txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
+  int timeout = 2;
+  if(!dt_conf_key_exists(txt))
+    timeout = dt_conf_get_int("plugins/lighttable/overlay_timeout");
+  else
+    timeout = dt_conf_get_int(txt);
+  g_free(txt);
+
   // we need to change the overlay content if we pass from normal to extended overlays
   // this is not done on the fly with css to avoid computing extended msg for nothing and to reserve space if needed
   GList *l = table->list;
   while(l)
   {
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
-    dt_thumbnail_set_overlay(th, over);
+    dt_thumbnail_set_overlay(th, over, timeout);
     // and we resize the bottom area
     dt_thumbnail_resize(th, th->width, th->height, TRUE);
     l = g_list_next(l);
   }
 
   table->overlays = over;
+  table->overlays_block_timeout = timeout;
   g_free(cl0);
   g_free(cl1);
+}
+
+// change the type of overlays that should be shown
+void dt_thumbtable_set_overlays_block_timeout(dt_thumbtable_t *table, const int timeout)
+{
+  if(!table) return;
+  gchar *txt
+      = dt_util_dstrcat(NULL, "plugins/lighttable/overlays_block_timeout/%d/%d", table->mode, table->prefs_size);
+  dt_conf_set_int(txt, timeout);
+  g_free(txt);
+
+  // we need to change the overlay timeout for each thumbnails
+  GList *l = table->list;
+  while(l)
+  {
+    dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
+    th->overlay_timeout_duration = timeout;
+    l = g_list_next(l);
+  }
 }
 
 // get the thumb at specific position
@@ -338,7 +366,7 @@ static gboolean _compute_sizes(dt_thumbtable_t *table, gboolean force)
     }
   }
 
-  // if the thumb size has changed, we nee to set overlays, etc... correctly
+  // if the thumb size has changed, we need to set overlays, etc... correctly
   if(table->thumb_size != old_size)
   {
     _thumbs_update_overlays_mode(table);
@@ -1014,7 +1042,6 @@ static void _dt_pref_change_callback(gpointer instance, gpointer user_data)
   while(l)
   {
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
-    th->overlay_timeout_duration = dt_conf_get_int("plugins/lighttable/overlay_timeout");
     dt_thumbnail_reload_infos(th);
     dt_thumbnail_resize(th, th->width, th->height, TRUE);
     l = g_list_next(l);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -110,7 +110,7 @@ static void _thumbs_update_overlays_mode(dt_thumbtable_t *table)
 // change the type of overlays that should be shown
 void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over)
 {
-  if(over == table->overlays) return;
+  if(!table || over == table->overlays) return;
   gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/%d/%d", table->mode, table->prefs_size);
   dt_conf_set_int(txt, over);
   g_free(txt);

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -156,6 +156,8 @@ void dt_thumbtable_set_overlays_block_timeout(dt_thumbtable_t *table, const int 
   dt_conf_set_int(txt, timeout);
   g_free(txt);
 
+  table->overlays_block_timeout = timeout;
+
   // we need to change the overlay timeout for each thumbnails
   GList *l = table->list;
   while(l)

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -45,6 +45,7 @@ typedef struct dt_thumbtable_t
 {
   dt_thumbtable_mode_t mode;
   dt_thumbnail_overlay_t overlays;
+  int overlays_block_timeout;
 
   GtkWidget *widget; // GtkLayout -- main widget
 
@@ -132,6 +133,8 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, int view);
 
 // change the type of overlays that should be shown (over or under the image)
 void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over);
+// change the timeout of the overlays block
+void dt_thumbtable_set_overlays_block_timeout(dt_thumbtable_t *table, const int timeout);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -160,7 +160,31 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   gboolean show = FALSE;
 
   // thumbnails part
-  if(gtk_widget_is_visible(dt_ui_thumbtable(darktable.gui->ui)->widget))
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  gboolean thumbs_state;
+  if(g_strcmp0(cv->module_name, "slideshow") == 0)
+  {
+    thumbs_state = FALSE;
+  }
+  else if(g_strcmp0(cv->module_name, "lighttable") == 0)
+  {
+    if(dt_view_lighttable_preview_state(darktable.view_manager)
+       || dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING)
+    {
+      thumbs_state = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+    }
+    else
+    {
+      thumbs_state = TRUE;
+    }
+  }
+  else
+  {
+    thumbs_state = dt_ui_panel_visible(darktable.gui->ui, DT_UI_PANEL_BOTTOM);
+  }
+
+
+  if(thumbs_state)
   {
     // we write the label with the size categorie
     gchar *txt = dt_util_dstrcat(NULL, "%s %d", _("thumbnails overlays for size"),
@@ -195,7 +219,6 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   }
 
   // and we do the same for culling/preview if needed
-  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
   if(g_strcmp0(cv->module_name, "lighttable") == 0
      && (dt_view_lighttable_preview_state(darktable.view_manager)
          || dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING))
@@ -239,6 +262,8 @@ static void _overlays_show_popup(dt_lib_module_t *self)
 
 
   if(show) gtk_widget_show(d->over_popup);
+  else
+    dt_control_log(_("overlays not available here..."));
 }
 
 static void _main_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -22,6 +22,7 @@
 #include "control/conf.h"
 #include "control/control.h"
 #include "dtgtk/button.h"
+#include "dtgtk/culling.h"
 #include "dtgtk/thumbtable.h"
 #include "dtgtk/togglebutton.h"
 #include "gui/accelerators.h"
@@ -37,7 +38,10 @@ DT_MODULE(1)
 typedef struct dt_lib_tool_preferences_t
 {
   GtkWidget *preferences_button, *grouping_button, *overlays_button, *help_button;
-  GtkWidget *over_popup, *over_label, *over_r0, *over_r1, *over_r2, *over_r3, *over_r4, *over_r5, *over_r6;
+  GtkWidget *over_popup, *thumbnails_box, *culling_box;
+  GtkWidget *over_label, *over_r0, *over_r1, *over_r2, *over_r3, *over_r4, *over_r5, *over_r6;
+  GtkWidget *over_culling_label, *over_culling_r0, *over_culling_r1, *over_culling_r2, *over_culling_r3,
+      *over_culling_r4, *over_culling_r5, *over_culling_r6;
 } dt_lib_tool_preferences_t;
 
 /* callback for grouping button */
@@ -112,35 +116,129 @@ static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
 #endif // USE_LUA
 }
 
+static void _overlays_toggle_culling_button(GtkWidget *w, gpointer user_data)
+{
+  if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w))) return;
+
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
+
+  dt_thumbnail_overlay_t over = DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK;
+  if(w == d->over_culling_r0)
+    over = DT_THUMBNAIL_OVERLAYS_NONE;
+  else if(w == d->over_culling_r1)
+    over = DT_THUMBNAIL_OVERLAYS_HOVER_NORMAL;
+  else if(w == d->over_culling_r2)
+    over = DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED;
+  else if(w == d->over_culling_r3)
+    over = DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL;
+  else if(w == d->over_culling_r4)
+    over = DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED;
+  else if(w == d->over_culling_r5)
+    over = DT_THUMBNAIL_OVERLAYS_MIXED;
+
+  dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
+  if(dt_view_lighttable_preview_state(darktable.view_manager)) cmode = DT_CULLING_MODE_PREVIEW;
+  gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", cmode);
+  dt_conf_set_int(txt, over);
+  g_free(txt);
+  dt_view_lighttable_culling_preview_refresh(darktable.view_manager);
+
+  gtk_widget_hide(d->over_popup);
+
+#ifdef USE_LUA
+  gboolean show = (over == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL || over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED);
+  dt_lua_async_call_alien(dt_lua_event_trigger_wrapper, 0, NULL, NULL, LUA_ASYNC_TYPENAME, "const char*",
+                          "global_toolbox-overlay_toggle", LUA_ASYNC_TYPENAME, "bool", show, LUA_ASYNC_DONE);
+#endif // USE_LUA
+}
+
 static void _overlays_show_popup(dt_lib_module_t *self)
 {
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
 
-  // we write the label with the size categorie
-  gchar *txt = dt_util_dstrcat(NULL, "%s %d", _("overlay mode for size"),
-                               dt_ui_thumbtable(darktable.gui->ui)->prefs_size);
-  gtk_label_set_text(GTK_LABEL(d->over_label), txt);
-  g_free(txt);
+  gboolean show = FALSE;
 
-  // we get and set the current value
-  dt_thumbnail_overlay_t mode = dt_ui_thumbtable(darktable.gui->ui)->overlays;
+  // thumbnails part
+  if(gtk_widget_is_visible(dt_ui_thumbtable(darktable.gui->ui)->widget))
+  {
+    // we write the label with the size categorie
+    gchar *txt = dt_util_dstrcat(NULL, "%s %d", _("thumbnails overlays for size"),
+                                 dt_ui_thumbtable(darktable.gui->ui)->prefs_size);
+    gtk_label_set_text(GTK_LABEL(d->over_label), txt);
+    g_free(txt);
 
-  if(mode == DT_THUMBNAIL_OVERLAYS_NONE)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r0), TRUE);
-  else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r2), TRUE);
-  else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r3), TRUE);
-  else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r4), TRUE);
-  else if(mode == DT_THUMBNAIL_OVERLAYS_MIXED)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r5), TRUE);
-  else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r6), TRUE);
+    // we get and set the current value
+    dt_thumbnail_overlay_t mode = dt_ui_thumbtable(darktable.gui->ui)->overlays;
+
+    if(mode == DT_THUMBNAIL_OVERLAYS_NONE)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r0), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r2), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r3), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r4), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_MIXED)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r5), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r6), TRUE);
+    else
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r1), TRUE);
+
+    gtk_widget_show_all(d->thumbnails_box);
+    show = TRUE;
+  }
   else
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r1), TRUE);
+  {
+    gtk_widget_hide(d->thumbnails_box);
+  }
 
-  gtk_widget_show_all(d->over_popup);
+  // and we do the same for culling/preview if needed
+  const dt_view_t *cv = dt_view_manager_get_current_view(darktable.view_manager);
+  if(g_strcmp0(cv->module_name, "lighttable") == 0
+     && (dt_view_lighttable_preview_state(darktable.view_manager)
+         || dt_view_lighttable_get_layout(darktable.view_manager) == DT_LIGHTTABLE_LAYOUT_CULLING))
+  {
+    dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
+    if(dt_view_lighttable_preview_state(darktable.view_manager)) cmode = DT_CULLING_MODE_PREVIEW;
+
+    // we write the label text
+    if(cmode == DT_CULLING_MODE_CULLING)
+      gtk_label_set_text(GTK_LABEL(d->over_culling_label), _("culling overlays"));
+    else
+      gtk_label_set_text(GTK_LABEL(d->over_culling_label), _("preview overlays"));
+
+    // we get and set the current value
+    gchar *otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", cmode);
+    dt_thumbnail_overlay_t mode = dt_conf_get_int(otxt);
+    g_free(otxt);
+
+    if(mode == DT_THUMBNAIL_OVERLAYS_NONE)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r0), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r2), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r3), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r4), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_MIXED)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r5), TRUE);
+    else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r6), TRUE);
+    else
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r1), TRUE);
+
+    gtk_widget_show_all(d->culling_box);
+    show = TRUE;
+  }
+  else
+  {
+    gtk_widget_hide(d->culling_box);
+  }
+
+
+  if(show) gtk_widget_show(d->over_popup);
 }
 
 static void _main_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
@@ -206,35 +304,77 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_container_add(GTK_CONTAINER(d->over_popup), vbox);
 
+  // thumbnails overlays
+  d->thumbnails_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+
   d->over_label = gtk_label_new(_("overlay mode for size"));
   gtk_widget_set_name(d->over_label, "overlays_label");
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_label, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_label, TRUE, TRUE, 0);
   d->over_r0 = gtk_radio_button_new_with_label(NULL, _("no overlays"));
   g_signal_connect(G_OBJECT(d->over_r0), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r0, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r0, TRUE, TRUE, 0);
   d->over_r1
       = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0), _("overlays on mouse hover"));
   g_signal_connect(G_OBJECT(d->over_r1), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r1, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r1, TRUE, TRUE, 0);
   d->over_r2 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
                                                            _("extended overlays on mouse hover"));
   g_signal_connect(G_OBJECT(d->over_r2), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r2, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r2, TRUE, TRUE, 0);
   d->over_r3 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0), _("permanent overlays"));
   g_signal_connect(G_OBJECT(d->over_r3), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r3, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r3, TRUE, TRUE, 0);
   d->over_r4 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
                                                            _("permanent extended overlays"));
   g_signal_connect(G_OBJECT(d->over_r4), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r4, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r4, TRUE, TRUE, 0);
   d->over_r5 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
                                                            _("permanent overlays extended on mouse hover"));
   g_signal_connect(G_OBJECT(d->over_r5), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r5, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r5, TRUE, TRUE, 0);
   d->over_r6 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
                                                            _("overlays block on mouse hover"));
   g_signal_connect(G_OBJECT(d->over_r6), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(vbox), d->over_r6, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r6, TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(vbox), d->thumbnails_box, TRUE, TRUE, 0);
+
+  // culling/preview overlays
+  d->culling_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+
+  d->over_culling_label = gtk_label_new(_("overlay mode for size"));
+  gtk_widget_set_name(d->over_culling_label, "overlays_label");
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_label, TRUE, TRUE, 0);
+  d->over_culling_r0 = gtk_radio_button_new_with_label(NULL, _("no overlays"));
+  g_signal_connect(G_OBJECT(d->over_culling_r0), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r0, TRUE, TRUE, 0);
+  d->over_culling_r1 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
+                                                                   _("overlays on mouse hover"));
+  g_signal_connect(G_OBJECT(d->over_culling_r1), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r1, TRUE, TRUE, 0);
+  d->over_culling_r2 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
+                                                                   _("extended overlays on mouse hover"));
+  g_signal_connect(G_OBJECT(d->over_culling_r2), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r2, TRUE, TRUE, 0);
+  d->over_culling_r3
+      = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0), _("permanent overlays"));
+  g_signal_connect(G_OBJECT(d->over_culling_r3), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r3, TRUE, TRUE, 0);
+  d->over_culling_r4 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
+                                                                   _("permanent extended overlays"));
+  g_signal_connect(G_OBJECT(d->over_culling_r4), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r4, TRUE, TRUE, 0);
+  d->over_culling_r5 = gtk_radio_button_new_with_label_from_widget(
+      GTK_RADIO_BUTTON(d->over_culling_r0), _("permanent overlays extended on mouse hover"));
+  g_signal_connect(G_OBJECT(d->over_culling_r5), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r5, TRUE, TRUE, 0);
+  d->over_culling_r6 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
+                                                                   _("overlays block on mouse hover"));
+  g_signal_connect(G_OBJECT(d->over_culling_r6), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r6, TRUE, TRUE, 0);
+
+  gtk_box_pack_start(GTK_BOX(vbox), d->culling_box, TRUE, TRUE, 0);
+  gtk_widget_show(vbox);
 
   /* create the widget help button */
   d->help_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_help, CPF_STYLE_FLAT, NULL);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -240,6 +240,17 @@ static void _overlays_show_popup(dt_lib_module_t *self)
     else
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r1), TRUE);
 
+    if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
+    {
+      gtk_widget_set_tooltip_text(d->over_timeout,
+                                  _("duration before the block overlay is hidden after each mouse movement on the "
+                                    "image\nset -1 to never hide the overlay"));
+    }
+    else
+    {
+      gtk_widget_set_tooltip_text(d->over_timeout, _("timeout only available for block overlay"));
+    }
+
     gtk_widget_show_all(d->thumbnails_box);
     show = TRUE;
   }
@@ -288,6 +299,17 @@ static void _overlays_show_popup(dt_lib_module_t *self)
     {
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r6), TRUE);
       gtk_widget_set_sensitive(d->over_culling_timeout, TRUE);
+    }
+
+    if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
+    {
+      gtk_widget_set_tooltip_text(d->over_culling_timeout,
+                                  _("duration before the block overlay is hidden after each mouse movement on the "
+                                    "image\nset -1 to never hide the overlay"));
+    }
+    else
+    {
+      gtk_widget_set_tooltip_text(d->over_culling_timeout, _("timeout only available for block overlay"));
     }
 
     gtk_widget_show_all(d->culling_box);
@@ -397,7 +419,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r5, TRUE, TRUE, 0);
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   d->over_r6 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
-                                                           _("overlays block on mouse hover. duration (s) "));
+                                                           _("overlays block on mouse hover during (s) "));
   g_signal_connect(G_OBJECT(d->over_r6), "toggled", G_CALLBACK(_overlays_toggle_button), self);
   gtk_box_pack_start(GTK_BOX(hbox), d->over_r6, TRUE, TRUE, 0);
   d->over_timeout = gtk_spin_button_new_with_range(-1, 99, 1);
@@ -425,8 +447,8 @@ void gui_init(dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(d->over_culling_r4), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
   gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r4, TRUE, TRUE, 0);
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  d->over_culling_r6 = gtk_radio_button_new_with_label_from_widget(
-      GTK_RADIO_BUTTON(d->over_culling_r0), _("overlays block on mouse hover. duration (s) "));
+  d->over_culling_r6 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
+                                                                   _("overlays block on mouse hover during (s) "));
   g_signal_connect(G_OBJECT(d->over_culling_r6), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
   gtk_box_pack_start(GTK_BOX(hbox), d->over_culling_r6, TRUE, TRUE, 0);
   d->over_culling_timeout = gtk_spin_button_new_with_range(-1, 99, 1);

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -39,9 +39,9 @@ typedef struct dt_lib_tool_preferences_t
 {
   GtkWidget *preferences_button, *grouping_button, *overlays_button, *help_button;
   GtkWidget *over_popup, *thumbnails_box, *culling_box;
-  GtkWidget *over_label, *over_r0, *over_r1, *over_r2, *over_r3, *over_r4, *over_r5, *over_r6;
-  GtkWidget *over_culling_label, *over_culling_r0, *over_culling_r1, *over_culling_r2, *over_culling_r3,
-      *over_culling_r4, *over_culling_r5, *over_culling_r6;
+  GtkWidget *over_label, *over_r0, *over_r1, *over_r2, *over_r3, *over_r4, *over_r5, *over_r6, *over_timeout;
+  GtkWidget *over_culling_label, *over_culling_r0, *over_culling_r3, *over_culling_r4, *over_culling_r6,
+      *over_culling_timeout;
 } dt_lib_tool_preferences_t;
 
 /* callback for grouping button */
@@ -107,7 +107,10 @@ static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
 
   dt_thumbtable_set_overlays_mode(dt_ui_thumbtable(darktable.gui->ui), over);
 
-  gtk_widget_hide(d->over_popup);
+  gtk_widget_set_sensitive(d->over_timeout, (over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK));
+
+  // we don't hide the popup in case of block overlay, as the user may want to tweak the duration
+  if(over != DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK) gtk_widget_hide(d->over_popup);
 
 #ifdef USE_LUA
   gboolean show = (over == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL || over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED);
@@ -126,31 +129,51 @@ static void _overlays_toggle_culling_button(GtkWidget *w, gpointer user_data)
   dt_thumbnail_overlay_t over = DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK;
   if(w == d->over_culling_r0)
     over = DT_THUMBNAIL_OVERLAYS_NONE;
-  else if(w == d->over_culling_r1)
-    over = DT_THUMBNAIL_OVERLAYS_HOVER_NORMAL;
-  else if(w == d->over_culling_r2)
-    over = DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED;
   else if(w == d->over_culling_r3)
     over = DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL;
   else if(w == d->over_culling_r4)
     over = DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED;
-  else if(w == d->over_culling_r5)
-    over = DT_THUMBNAIL_OVERLAYS_MIXED;
 
   dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
   if(dt_view_lighttable_preview_state(darktable.view_manager)) cmode = DT_CULLING_MODE_PREVIEW;
   gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", cmode);
   dt_conf_set_int(txt, over);
   g_free(txt);
-  dt_view_lighttable_culling_preview_refresh(darktable.view_manager);
+  dt_view_lighttable_culling_preview_reload_overlays(darktable.view_manager);
 
-  gtk_widget_hide(d->over_popup);
+  gtk_widget_set_sensitive(d->over_culling_timeout, (over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK));
+
+  // we don't hide the popup in case of block overlay, as the user may want to tweak the duration
+  if(over != DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK) gtk_widget_hide(d->over_popup);
 
 #ifdef USE_LUA
   gboolean show = (over == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL || over == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED);
   dt_lua_async_call_alien(dt_lua_event_trigger_wrapper, 0, NULL, NULL, LUA_ASYNC_TYPENAME, "const char*",
                           "global_toolbox-overlay_toggle", LUA_ASYNC_TYPENAME, "bool", show, LUA_ASYNC_DONE);
 #endif // USE_LUA
+}
+
+static void _overlays_timeout_changed(GtkWidget *w, gpointer user_data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)user_data;
+  dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
+
+  const int val = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(w));
+
+  if(w == d->over_timeout)
+  {
+    dt_thumbtable_set_overlays_block_timeout(dt_ui_thumbtable(darktable.gui->ui), val);
+  }
+  else if(w == d->over_culling_timeout)
+  {
+    dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
+    if(dt_view_lighttable_preview_state(darktable.view_manager)) cmode = DT_CULLING_MODE_PREVIEW;
+    gchar *txt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling_block_timeout/%d", cmode);
+    dt_conf_set_int(txt, val);
+    g_free(txt);
+
+    dt_view_lighttable_culling_preview_reload_overlays(darktable.view_manager);
+  }
 }
 
 static void _overlays_show_popup(dt_lib_module_t *self)
@@ -195,6 +218,10 @@ static void _overlays_show_popup(dt_lib_module_t *self)
     // we get and set the current value
     dt_thumbnail_overlay_t mode = dt_ui_thumbtable(darktable.gui->ui)->overlays;
 
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->over_timeout),
+                              dt_ui_thumbtable(darktable.gui->ui)->overlays_block_timeout);
+    gtk_widget_set_sensitive(d->over_timeout, FALSE);
+
     if(mode == DT_THUMBNAIL_OVERLAYS_NONE)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r0), TRUE);
     else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
@@ -206,7 +233,10 @@ static void _overlays_show_popup(dt_lib_module_t *self)
     else if(mode == DT_THUMBNAIL_OVERLAYS_MIXED)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r5), TRUE);
     else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
+    {
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r6), TRUE);
+      gtk_widget_set_sensitive(d->over_timeout, TRUE);
+    }
     else
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_r1), TRUE);
 
@@ -237,20 +267,28 @@ static void _overlays_show_popup(dt_lib_module_t *self)
     dt_thumbnail_overlay_t mode = dt_conf_get_int(otxt);
     g_free(otxt);
 
+    otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling_block_timeout/%d", cmode);
+    int timeout = 2;
+    if(!dt_conf_key_exists(otxt))
+      timeout = dt_conf_get_int("plugins/lighttable/overlay_timeout");
+    else
+      timeout = dt_conf_get_int(otxt);
+    g_free(otxt);
+
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(d->over_culling_timeout), timeout);
+    gtk_widget_set_sensitive(d->over_culling_timeout, FALSE);
+
     if(mode == DT_THUMBNAIL_OVERLAYS_NONE)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r0), TRUE);
-    else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r2), TRUE);
     else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r3), TRUE);
     else if(mode == DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r4), TRUE);
-    else if(mode == DT_THUMBNAIL_OVERLAYS_MIXED)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r5), TRUE);
-    else if(mode == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r6), TRUE);
     else
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r1), TRUE);
+    {
+      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->over_culling_r6), TRUE);
+      gtk_widget_set_sensitive(d->over_culling_timeout, TRUE);
+    }
 
     gtk_widget_show_all(d->culling_box);
     show = TRUE;
@@ -357,10 +395,15 @@ void gui_init(dt_lib_module_t *self)
                                                            _("permanent overlays extended on mouse hover"));
   g_signal_connect(G_OBJECT(d->over_r5), "toggled", G_CALLBACK(_overlays_toggle_button), self);
   gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r5, TRUE, TRUE, 0);
+  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   d->over_r6 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_r0),
-                                                           _("overlays block on mouse hover"));
+                                                           _("overlays block on mouse hover. duration (s) "));
   g_signal_connect(G_OBJECT(d->over_r6), "toggled", G_CALLBACK(_overlays_toggle_button), self);
-  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_r6, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), d->over_r6, TRUE, TRUE, 0);
+  d->over_timeout = gtk_spin_button_new_with_range(-1, 99, 1);
+  g_signal_connect(G_OBJECT(d->over_timeout), "value-changed", G_CALLBACK(_overlays_timeout_changed), self);
+  gtk_box_pack_start(GTK_BOX(hbox), d->over_timeout, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->thumbnails_box), hbox, TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(vbox), d->thumbnails_box, TRUE, TRUE, 0);
 
@@ -373,14 +416,6 @@ void gui_init(dt_lib_module_t *self)
   d->over_culling_r0 = gtk_radio_button_new_with_label(NULL, _("no overlays"));
   g_signal_connect(G_OBJECT(d->over_culling_r0), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
   gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r0, TRUE, TRUE, 0);
-  d->over_culling_r1 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
-                                                                   _("overlays on mouse hover"));
-  g_signal_connect(G_OBJECT(d->over_culling_r1), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
-  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r1, TRUE, TRUE, 0);
-  d->over_culling_r2 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
-                                                                   _("extended overlays on mouse hover"));
-  g_signal_connect(G_OBJECT(d->over_culling_r2), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
-  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r2, TRUE, TRUE, 0);
   d->over_culling_r3
       = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0), _("permanent overlays"));
   g_signal_connect(G_OBJECT(d->over_culling_r3), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
@@ -389,14 +424,15 @@ void gui_init(dt_lib_module_t *self)
                                                                    _("permanent extended overlays"));
   g_signal_connect(G_OBJECT(d->over_culling_r4), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
   gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r4, TRUE, TRUE, 0);
-  d->over_culling_r5 = gtk_radio_button_new_with_label_from_widget(
-      GTK_RADIO_BUTTON(d->over_culling_r0), _("permanent overlays extended on mouse hover"));
-  g_signal_connect(G_OBJECT(d->over_culling_r5), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
-  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r5, TRUE, TRUE, 0);
-  d->over_culling_r6 = gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(d->over_culling_r0),
-                                                                   _("overlays block on mouse hover"));
+  hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  d->over_culling_r6 = gtk_radio_button_new_with_label_from_widget(
+      GTK_RADIO_BUTTON(d->over_culling_r0), _("overlays block on mouse hover. duration (s) "));
   g_signal_connect(G_OBJECT(d->over_culling_r6), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
-  gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_r6, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), d->over_culling_r6, TRUE, TRUE, 0);
+  d->over_culling_timeout = gtk_spin_button_new_with_range(-1, 99, 1);
+  g_signal_connect(G_OBJECT(d->over_culling_timeout), "value-changed", G_CALLBACK(_overlays_timeout_changed), self);
+  gtk_box_pack_start(GTK_BOX(hbox), d->over_culling_timeout, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->culling_box), hbox, TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(vbox), d->culling_box, TRUE, TRUE, 0);
   gtk_widget_show(vbox);

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -208,6 +208,17 @@ static void _culling_reinit(dt_view_t *self)
 static void _culling_preview_refresh(dt_view_t *self)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
+
+  // change overlays if needed for culling and preview
+  gchar *otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", DT_CULLING_MODE_CULLING);
+  dt_thumbnail_overlay_t over = dt_conf_get_int(otxt);
+  dt_culling_set_overlays_mode(lib->culling, over);
+  g_free(otxt);
+  otxt = dt_util_dstrcat(NULL, "plugins/lighttable/overlays/culling/%d", DT_CULLING_MODE_PREVIEW);
+  over = dt_conf_get_int(otxt);
+  dt_culling_set_overlays_mode(lib->preview, over);
+  g_free(otxt);
+
   // full_preview change
   if(lib->preview_state)
   {

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -205,7 +205,7 @@ static void _culling_reinit(dt_view_t *self)
   dt_culling_init(lib->culling, lib->culling->offset);
 }
 
-static void _culling_preview_refresh(dt_view_t *self)
+static void _culling_preview_reload_overlays(dt_view_t *self)
 {
   dt_library_t *lib = (dt_library_t *)self->data;
 
@@ -218,6 +218,14 @@ static void _culling_preview_refresh(dt_view_t *self)
   over = dt_conf_get_int(otxt);
   dt_culling_set_overlays_mode(lib->preview, over);
   g_free(otxt);
+}
+
+static void _culling_preview_refresh(dt_view_t *self)
+{
+  dt_library_t *lib = (dt_library_t *)self->data;
+
+  // change overlays if needed for culling and preview
+  _culling_preview_reload_overlays(self);
 
   // full_preview change
   if(lib->preview_state)
@@ -306,6 +314,7 @@ void init(dt_view_t *self)
   darktable.view_manager->proxy.lighttable.change_offset = _lighttable_change_offset;
   darktable.view_manager->proxy.lighttable.culling_init_mode = _culling_reinit;
   darktable.view_manager->proxy.lighttable.culling_preview_refresh = _culling_preview_refresh;
+  darktable.view_manager->proxy.lighttable.culling_preview_reload_overlays = _culling_preview_reload_overlays;
 
   // ensure the memory table is up to date
   dt_collection_memory_update();

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1020,13 +1020,13 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
       cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_GOOD);
 
     cairo_paint(cr);
-/* from focus_peaking.h
-   static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
-                                   uint8_t *const restrict image,
-                                   const int buf_width, const int buf_height)
-   The current implementation assumes the data at image is organized as a rectangle without a stride,
-   So we pass the raw data to be processed, this is more data but correct. 
-*/
+    /* from focus_peaking.h
+       static inline void dt_focuspeaking(cairo_t *cr, int width, int height,
+                                       uint8_t *const restrict image,
+                                       const int buf_width, const int buf_height)
+       The current implementation assumes the data at image is organized as a rectangle without a stride,
+       So we pass the raw data to be processed, this is more data but correct.
+    */
     if(darktable.gui->show_focus_peaking)
       dt_focuspeaking(cr, img_width, img_height, rgbbuf, buf_wd, buf_ht);
 
@@ -1211,6 +1211,11 @@ void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm)
 void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm)
 {
   if(vm->proxy.lighttable.module) vm->proxy.lighttable.culling_preview_refresh(vm->proxy.lighttable.view);
+}
+
+void dt_view_lighttable_culling_preview_reload_overlays(dt_view_manager_t *vm)
+{
+  if(vm->proxy.lighttable.module) vm->proxy.lighttable.culling_preview_reload_overlays(vm->proxy.lighttable.view);
 }
 
 dt_lighttable_layout_t dt_view_lighttable_get_layout(dt_view_manager_t *vm)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -312,6 +312,7 @@ typedef struct dt_view_manager_t
       void (*set_layout)(struct dt_lib_module_t *module, dt_lighttable_layout_t layout);
       void (*culling_init_mode)(struct dt_view_t *view);
       void (*culling_preview_refresh)(struct dt_view_t *view);
+      void (*culling_preview_reload_overlays)(struct dt_view_t *view);
       dt_lighttable_culling_zoom_mode_t (*get_zoom_mode)(struct dt_lib_module_t *module);
       gboolean (*get_preview_state)(struct dt_view_t *view);
       void (*change_offset)(struct dt_view_t *view, gboolean reset, gint imgid);
@@ -445,6 +446,8 @@ dt_lighttable_culling_zoom_mode_t dt_view_lighttable_get_culling_zoom_mode(dt_vi
 void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm);
 /** force refresh of culling and/or preview */
 void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm);
+/** force refresh of culling and/or preview overlays */
+void dt_view_lighttable_culling_preview_reload_overlays(dt_view_manager_t *vm);
 /** sets the offset image (for culling and full preview) */
 void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, gint imgid);
 


### PR DESCRIPTION
This allow to use any existing overlays in culling and preview.
overlays are saved separately for culling and preview.

For the interface, the "star" menu has now 2 parts : 1 for thumbnails and 1 for culling or preview. The visibility of the different parts is set on the fly, depending of what is shown in current view.

Of course, to change overlays for preview (or culling), you'll have to first show the top panel with the global toolbox first.