### PR TITLE
colorin: handle (blue) LED light gracefully

### DIFF
--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1112,8 +1112,13 @@ static void process_cmatrix(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   const int blue_mapping = d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
+  const int regularized = (d->custom_regularization == 1);
 
-  if(!blue_mapping && d->nonlinearlut == 0)
+  if(regularized)
+  {
+    process_cmatrix_fastpath_regularized(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else if(!blue_mapping && d->nonlinearlut == 0)
   {
     process_cmatrix_fastpath(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
@@ -1415,8 +1420,14 @@ static void process_sse2_cmatrix_fastpath(struct dt_iop_module_t *self, dt_dev_p
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   const int clipping = (d->nrgb != NULL);
+  const int regularized = (d->custom_regularization == 1);
 
-  if(!clipping)
+  if(regularized)
+  {
+    //TODO provide sse2 version
+    process_cmatrix_fastpath_regularized(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else if(!clipping)
   {
     process_sse2_cmatrix_fastpath_simple(self, piece, ivoid, ovoid, roi_in, roi_out);
   }
@@ -1504,8 +1515,14 @@ static void process_sse2_cmatrix(struct dt_iop_module_t *self, dt_dev_pixelpipe_
 {
   const dt_iop_colorin_data_t *const d = (dt_iop_colorin_data_t *)piece->data;
   const int blue_mapping = d->blue_mapping && dt_image_is_matrix_correction_supported(&piece->pipe->image);
+  const int regularized = (d->custom_regularization == 1);
 
-  if(!blue_mapping && d->nonlinearlut == 0)
+  if(regularized)
+  {
+    //TODO provide sse2 version
+    process_cmatrix_fastpath_regularized(self, piece, ivoid, ovoid, roi_in, roi_out);
+  }
+  else if(!blue_mapping && d->nonlinearlut == 0)
   {
     process_sse2_cmatrix_fastpath(self, piece, ivoid, ovoid, roi_in, roi_out);
   }

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -429,8 +429,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     v7->blue_mapping = v6.blue_mapping;
     v7->type_work = v6.type_work;
     g_strlcpy(v7->filename_work, v6.filename_work, sizeof(v7->filename_work));
-    v7->color_regularization = 0.01f;
-    v7->luminance_regularization = 0.0f;
+    v7->color_regularization = 0.7f;
+    v7->luminance_regularization = 0.7f;
     return 0;
   }
   return 1;
@@ -2080,8 +2080,8 @@ void reload_defaults(dt_iop_module_t *module)
                                                            .filename = "",
                                                            .intent = DT_INTENT_PERCEPTUAL,
                                                            .normalize = DT_NORMALIZE_OFF,
-                                                           .color_regularization = 0.01f,
-                                                           .luminance_regularization = 0.0f,
+                                                           .color_regularization = 0.7f,
+                                                           .luminance_regularization = 0.7f,
                                                            .blue_mapping = 0,
                                                            .type_work = DT_COLORSPACE_LIN_REC2020,
                                                            .filename_work = "" };
@@ -2388,13 +2388,13 @@ void gui_init(struct dt_iop_module_t *self)
 
   g_signal_connect(G_OBJECT(g->clipping_combobox), "value-changed", G_CALLBACK(normalize_changed), (gpointer)self);
 
-  g->color_regularization = dt_bauhaus_slider_new_with_range(self, 0.01f, 1.0f, .05f, 0.01f, 2);
+  g->color_regularization = dt_bauhaus_slider_new_with_range(self, 0.01f, 1.0f, .05f, 0.7f, 2);
   dt_bauhaus_widget_set_label(g->color_regularization, NULL, _("color regularization"));
   gtk_widget_set_tooltip_text(g->color_regularization, _("amount of color regularization for far-from-gamut pixel\n increase to desaturate"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->color_regularization, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->color_regularization), "value-changed", G_CALLBACK(color_regularization_callback), (gpointer)self);
 
-  g->luminance_regularization = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, .05, 0.0f, 2);
+  g->luminance_regularization = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, .05, 0.7f, 2);
   dt_bauhaus_widget_set_label(g->luminance_regularization, NULL, _("luminance regularization"));
   gtk_widget_set_tooltip_text(g->luminance_regularization, _("amount of luminance regularization for far-from-gamut pixel\n increase to brighten these pixels until gradients are smooth"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->luminance_regularization, TRUE, TRUE, 0);

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -566,7 +566,11 @@ static void normalize_changed(GtkWidget *widget, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(self->dt->gui->reset) return;
   dt_iop_colorin_params_t *p = (dt_iop_colorin_params_t *)self->params;
+  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
   p->normalize = dt_bauhaus_combobox_get(widget);
+  gboolean custom = (p->normalize == DT_NORMALIZE_CUSTOM);
+  gtk_widget_set_visible(g->color_regularization, custom);
+  gtk_widget_set_visible(g->luminance_regularization, custom);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
@@ -2019,6 +2023,9 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->clipping_combobox, p->normalize);
   dt_bauhaus_slider_set(g->color_regularization, p->color_regularization);
   dt_bauhaus_slider_set(g->luminance_regularization, p->luminance_regularization);
+  gboolean custom = (p->normalize == DT_NORMALIZE_CUSTOM);
+  gtk_widget_set_visible(g->color_regularization, custom);
+  gtk_widget_set_visible(g->luminance_regularization, custom);
 
   update_profile_list(self);
 
@@ -2393,12 +2400,14 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->color_regularization, _("amount of color regularization for far-from-gamut pixel\n increase to desaturate"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->color_regularization, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->color_regularization), "value-changed", G_CALLBACK(color_regularization_callback), (gpointer)self);
+  gtk_widget_set_visible(g->color_regularization, FALSE);
 
   g->luminance_regularization = dt_bauhaus_slider_new_with_range(self, 0.0f, 1.0f, .05, 0.7f, 2);
   dt_bauhaus_widget_set_label(g->luminance_regularization, NULL, _("luminance regularization"));
   gtk_widget_set_tooltip_text(g->luminance_regularization, _("amount of luminance regularization for far-from-gamut pixel\n increase to brighten these pixels until gradients are smooth"));
   gtk_box_pack_start(GTK_BOX(self->widget), g->luminance_regularization, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->luminance_regularization), "value-changed", G_CALLBACK(luminance_regularization_callback), (gpointer)self);
+  gtk_widget_set_visible(g->luminance_regularization, FALSE);
 }
 
 void gui_cleanup(struct dt_iop_module_t *self)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -70,7 +70,8 @@ typedef enum dt_iop_color_normalize_t
   DT_NORMALIZE_SRGB,
   DT_NORMALIZE_ADOBE_RGB,
   DT_NORMALIZE_LINEAR_REC709_RGB,
-  DT_NORMALIZE_LINEAR_REC2020_RGB
+  DT_NORMALIZE_LINEAR_REC2020_RGB,
+  DT_NORMALIZE_CUSTOM
 } dt_iop_color_normalize_t;
 
 typedef struct dt_iop_colorin_params_t
@@ -1503,6 +1504,7 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pix
     case DT_NORMALIZE_LINEAR_REC2020_RGB:
       d->nrgb = dt_colorspaces_get_profile(DT_COLORSPACE_LIN_REC2020, "", DT_PROFILE_DIRECTION_IN)->profile;
       break;
+    case DT_NORMALIZE_CUSTOM:
     case DT_NORMALIZE_OFF:
     default:
       d->nrgb = NULL;
@@ -2155,6 +2157,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->clipping_combobox, _("Adobe RGB (compatible)"));
   dt_bauhaus_combobox_add(g->clipping_combobox, _("linear Rec709 RGB"));
   dt_bauhaus_combobox_add(g->clipping_combobox, _("linear Rec2020 RGB"));
+  dt_bauhaus_combobox_add(g->clipping_combobox, _("custom"));
 
   gtk_widget_set_tooltip_text(g->clipping_combobox, _("confine Lab values to gamut of RGB color space"));
 


### PR DESCRIPTION
This is work in progress, as I have not coded the opencl code, nor the sse code (currently, the sse paths calls the same function as the standard path, but you have to disable opencl)

Blue LEDs are a nightmare with current colorin: they typically produce negative values.
The reason is that the standard color matrix have negative coefficients, and when B is much higher than G and R, this results in an output with negative G and R, that can also have a negative luminance.
While it will be possible to get back in gamut blues that did not result in negative values with @aurelienpierre 's new channel mixer, negative values are still a problem.

In this PR, I propose a new way to apply the standard color matrix in a way that guarantees the absence of negative number in the output, and that lets the user control color regularization (color desaturation) and luminance regularization (that fixes gradients that may look unnatural, typically at the borders of a zone lit by blue led).
The idea is to constitute 2 outputs, one good in terms of color, the other one good in terms of luminance, and mix both.
For each of these, the user can control a threshold, which defines a percentage p: to constitute an output for a channel, the algorithm will make the matrix product in 2 parts: a part with the positive coefficients, and a part with the negative ones, and will make sure that the negative part is not higher than p% of the positive part (with p = 100%, this is equivalent to clipping negative values).
The algorithm uses desaturation (with desaturation formula from filmic v4 with maxRGB norm) to guarantee that for the output "good in color", and uses clipping for the output "good in luminance".

To use: in colorin, switch gamut mapping to "custom".
Use color regularization to control colors (the smaller it is, the more saturated will be the blue leds)
Use luminance regularization to control luminance (increase it if there are some gradient reversals in the image)

Note that for natural images (without blue leds), the 0.7 thresholds proposed rarely affect the image, that's because for each pixel the negative part is not higher than 30% of the positive part.
For this reason, we may consider to set this on by default.

Example (raw file here: https://drive.google.com/file/d/1HddLn5PCoHvXi21H_e8rWHfIFK71i2Tq/view?usp=sharing )
Original:
![Capture d’écran du 2020-05-24 17-47-08](https://user-images.githubusercontent.com/34063828/82758425-cd434c00-9de6-11ea-8747-248b17c7422d.png)

Enabling custom regularization with default parameters:
![Capture d’écran du 2020-05-24 17-47-15](https://user-images.githubusercontent.com/34063828/82758430-d0d6d300-9de6-11ea-9950-c57ab027a076.png)

Lowering color regularisation, we get more saturated blues, closer to the original:
![Capture d’écran du 2020-05-24 17-47-26](https://user-images.githubusercontent.com/34063828/82758432-d46a5a00-9de6-11ea-9d6e-c4cd641a2144.png)

Lowering luminance regularisation too much (which give luminance closer to what colorin gives by default), we get gradient issues (look at the camera at the bottom right):
![Capture d’écran du 2020-05-24 17-47-49](https://user-images.githubusercontent.com/34063828/82758435-d92f0e00-9de6-11ea-84e9-1248070053cc.png)