### PR TITLE
Added checks to ensure that the view is lighttable and the mode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -296,6 +296,13 @@ making a backup is strongly advised.
 - fixed is_password field of entry widget to work according to the API manual, so 
   now when it is set to true the field is hidden.
 
+- Added function darktable.gui.views.lighttable.is_image_visible to check if an image 
+  is visible in lighttable view.
+
+- Added function darktable.gui.views.lighttable.set_image_visible to force an 
+  image to be visible in lighttable view.
+  
+>>>>>>> 1ae858b9d2efe2a746f00205b699719ffabc54db
 ## Changed Dependencies
 
 

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -1095,6 +1095,61 @@
 </entry>
     </row></tbody>
     </tgroup></informaltable>
+
+<section status="final" id="darktable_gui_views_lighttable_is_image_visible">
+<title>darktable.gui.views.lighttable.is_image_visible</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>is_image_visible</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_views_lighttable_is_image_visible_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>
+) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>Check if the image is visible in lighttable view.  The lighttable must be in file manager or zoomable mode.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_views_lighttable_is_image_visible_image"><term>image</term><listitem>
+<synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>The image to be checked.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis>boolean</synopsis>
+<para>True if the image is displayed. False if the image is partially displayed or not displayed.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
+<section status="final" id="darktable_gui_views_lighttable_set_image_visible">
+<title>darktable.gui.views.lighttable.set_image_visible</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>set_image_visible</secondary>
+</indexterm>
+<synopsis>function( 
+	<emphasis><link linkend="darktable_gui_views_lighttable_set_image_visible_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>
+) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>Set the image visible in lighttable view.  The lighttable must be in file manager or zoomable mode.</para>
+
+<variablelist>
+<varlistentry id="darktable_gui_views_lighttable_set_image_visible_image"><term>image</term><listitem>
+<synopsis><link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
+<para>The image to set visible.</para>
+
+</listitem></varlistentry>
+
+<varlistentry><term><emphasis>return</emphasis></term><listitem>
+<synopsis>int</synopsis>
+<para>An error is returned if no image is specified.</para>
+
+</listitem></varlistentry>
+
+</variablelist>
+</section>
+
 </section>
 
 <section status="final" id="darktable_gui_views_tethering">

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -111,6 +111,8 @@ void dt_thumbtable_zoom_changed(dt_thumbtable_t *table, int oldzoom, int newzoom
 
 // ensure that the mentionned image is visible by moving the view if needed
 gboolean dt_thumbtable_ensure_imgid_visibility(dt_thumbtable_t *table, int imgid);
+// check if the mentioned image is visible
+gboolean dt_thumbtable_check_imgid_visibility(dt_thumbtable_t *table, int imgid);
 
 // move by key actions.
 // this key accels are not managed here but inside view


### PR DESCRIPTION
Added lua function darktable.gui.views.lighttable.is_image_visible to check if an image is visible in lighttable view. Added lua function darktable.gui.views.lighttable.set_image_visible to make an image visible in the lighttable view. Updated Release Notes and Lua API manual.

Fixes #3831.

Was #5156.

Had to resubmit due to me screwing up my tree and having to delete the original branch.

@AlicVB  added checks to ensure that the view is lighttable and the mode is either file manager or zoomable.