### PR TITLE
don't allow passing NULL to g_hash_table_lookup in history.c

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2281,8 +2281,13 @@ gchar *dt_iop_get_localized_name(const gchar *op)
       } while((iop = g_list_next(iop)) != NULL);
     }
   }
-
-  return (gchar *)g_hash_table_lookup(module_names, op);
+  if(op != NULL)
+  {
+    return (gchar *)g_hash_table_lookup(module_names, op);
+  }
+  else {
+    return _("ERROR");
+  }
 }
 
 void dt_iop_so_gui_set_state(dt_iop_module_so_t *module, dt_iop_module_state_t state)


### PR DESCRIPTION
In very rare cases, `operation` might be null. In those cases,
darktable would bail since `g_str_hash` doesn't like null keys.

fixes #5190

I wondered about forcing `NOT NULL` constraint on `operation` column in `history` table, however `dt_dev_write_history_item` actualy inserts null there (and tries to immediatelly update it)
