### PR TITLE
Icons optical balance

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -394,13 +394,6 @@ overshoot.right
 }
 
 /* Set toolbars buttons in lighttable and darkroom */
-/* note that some button used to have different hardcoded paddings */
-/* overlay color changer */
-/* quick favorites */
-/* quick styles */
-/* display2 */
-/* they now look unbalanced */
-/* TODO: adjust icons individually */
 #header-toolbar #dt-toggle-button,
 #header-toolbar #dt-button,
 #footer-toolbar #dt-toggle-button,

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -476,7 +476,7 @@ overshoot.right
 #header-toolbar #control-button
 {
   min-height: 1em;
-  min-width: 0.81em;
+  min-width: 0.9em;
   padding: 0.15em;
   margin: 0.15em;
 }
@@ -513,22 +513,13 @@ overshoot.right
 #module-reset-button,
 #module-enable-button,
 #module-instance-button,
-#module-enable-button
+#module-enable-button,
+#module-collapse-button
 {
   /* background-color: transparent; this doesn't work */
   min-height: 1.15em;
   min-width: 1.15em;
   padding: 0.06em;
-}
-
-/* this need to be tweaked separately, because it used a different */
-/* hardcoded padding. TODO: scale icon instead */
-#module-collapse-button
-{
-  /* background-color: transparent; this doesn't work */
-  min-height: 0.81em;
-  min-width: 0.81em;
-  padding: 0.23em;
 }
 
 #module-always-enabled-button /* button on always activated module */

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1247,24 +1247,27 @@ void dtgtk_cairo_paint_aspectflip(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
 void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
+  cairo_translate(cr, x + w / 2.0, y + h / 2.0);
+  float s = (w < h ? w / 2.0 : h / 2.0);
+  s *= 1.1; //fine tuning
   cairo_scale(cr, s, s);
+  cairo_translate(cr, 0.06, -0.10); //fine tuning
 
-  cairo_set_line_width(cr, 0.07);
-  cairo_arc(cr, 0.2, 0.8, 0.2, 0.0, 2.0 * M_PI);
+  cairo_set_line_width(cr, 0.15);
+  cairo_arc(cr, 0.250, 0.45, 0.5, 0.0, 2.0 * M_PI);
   cairo_stroke(cr);
-  cairo_arc(cr, 0.7, 0.7, 0.3, 0.0, 2.0 * M_PI);
+  cairo_arc(cr, -0.58, 0.65, 0.30, 0.0, 2.0 * M_PI);
   cairo_stroke(cr);
-  cairo_arc(cr, 0.4, 0.2, 0.25, 0.0, 2.0 * M_PI);
+  cairo_arc(cr, -0.38, -0.27, 0.4, 0.0, 2.0 * M_PI);
   cairo_stroke(cr);
 
   /* if its a popup menu */
   if(flags)
   {
-    cairo_move_to(cr, 0.9, -0.2);
-    cairo_line_to(cr, 0.7, 0.3);
-    cairo_line_to(cr, 1.1, 0.3);
+    cairo_set_line_width(cr, 0.12);
+    cairo_move_to(cr, 0.475, -0.93);
+    cairo_line_to(cr, 0.15, -0.20);
+    cairo_line_to(cr, 0.85, -0.20);
     cairo_fill(cr);
   }
 }
@@ -2041,43 +2044,33 @@ void dtgtk_cairo_paint_display(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 
 void dtgtk_cairo_paint_display2(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
   cairo_save(cr);
 
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
+  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
+
+  const float s = (w < h ? w / 2.0 : h / 2.0);
   cairo_scale(cr, s, s);
-  cairo_scale(cr, 1, -1);
-  cairo_translate(cr, 0, -1);
 
-  double offset = 0.1;
+  cairo_set_line_width(cr, 0.2);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_move_to(cr, -0.55, 0.9);
+  cairo_rel_line_to(cr, 0.7, 0);
+  cairo_stroke(cr);
 
-  for(int i = 0; i < 2; i++)
-  {
-    cairo_move_to(cr, 0.0 + offset, 0.98 + offset);
-    cairo_line_to(cr, 1.0 + offset, 0.98 + offset);
-    cairo_line_to(cr, 1.0 + offset, 0.28 + offset);
-    cairo_line_to(cr, 0.58 + offset, 0.28 + offset);
-    cairo_line_to(cr, 0.58 + offset, 0.13 + offset);
-    cairo_line_to(cr, 0.85 + offset, 0.13 + offset);
-    cairo_line_to(cr, 0.85 + offset, 0.03 + offset);
-    cairo_line_to(cr, 0.15 + offset, 0.03 + offset);
-    cairo_line_to(cr, 0.15 + offset, 0.13 + offset);
-    cairo_line_to(cr, 0.42 + offset, 0.13 + offset);
-    cairo_line_to(cr, 0.42 + offset, 0.28 + offset);
-    cairo_line_to(cr, 0.0 + offset, 0.28 + offset);
-    cairo_close_path(cr);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
+  cairo_rectangle(cr, -0.9, -0.5, 1.4, 1.0);
+  cairo_move_to(cr, -0.5, -0.7);
+  cairo_rel_line_to(cr, 0, -0.2);
+  cairo_rel_line_to(cr, 1.4, 0);
+  cairo_rel_line_to(cr, 0, 1.0);
+  cairo_rel_line_to(cr, -0.2, 0);
+  cairo_stroke(cr);
 
-    cairo_move_to(cr, 0.1 + offset, 0.88 + offset);
-    cairo_line_to(cr, 0.9 + offset, 0.88 + offset);
-    cairo_line_to(cr, 0.9 + offset, 0.38 + offset);
-    cairo_line_to(cr, 0.1 + offset, 0.38 + offset);
-    cairo_close_path(cr);
-
-    cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
-    cairo_fill(cr);
-
-    offset = -0.1;
-  }
+  cairo_set_line_width(cr, 0.3);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
+  cairo_move_to(cr, -0.2, 0.6);
+  cairo_rel_line_to(cr, 0, 0.2);
+  cairo_stroke(cr);
 
   cairo_restore(cr);
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -180,8 +180,8 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
   /* scale and transform*/
-  gint s = w < h ? w : h;
-  s *= 1.8; // for some reason, this one needs expansion
+  float s = w < h ? w : h;
+  s *= 1.4; // for some reason, this one needs expansion
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
   cairo_set_line_width(cr, 0.1);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -118,8 +118,8 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
   cairo_save(cr);
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_set_line_width(cr, 1 / s);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
 
   if(flags & CPF_DIRECTION_UP || flags & CPF_DIRECTION_DOWN)
     cairo_transform(cr, &rotation_matrix);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1031,7 +1031,8 @@ void dtgtk_cairo_paint_timer(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
 void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   const float alpha = 0.8f;
-  const gint s = w < h ? w : h;
+  float s = w < h ? w : h;
+  s *= 0.95; // optical balance
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
   cairo_scale(cr, s, s);
 
@@ -1940,9 +1941,11 @@ void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint 
 
 void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
+  float s = w < h ? w : h;
+  s *= 1.15; // optical balance
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
+  cairo_translate(cr, 0, -0.05); // optical alignment
 
   cairo_save(cr);
   cairo_set_line_width(cr, 0.1);
@@ -1980,7 +1983,8 @@ void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_softproof(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
+  float s = w < h ? w : h;
+  s*=1.1; // optical balance
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2171,7 +2171,8 @@ void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, g
 
 void dtgtk_cairo_paint_modulegroup_favorites(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
+  float s = w < h ? w : h;
+  s *= 1.1; // optical balance
   cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
   cairo_scale(cr, s, s);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1591,6 +1591,7 @@ void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
 
   float s = (w < h ? w / 2.0 : h / 2.0);
+  s *= 0.95; //optical balance
   cairo_scale(cr, s, s);
 
   cairo_set_line_width(cr, .25);
@@ -1611,7 +1612,7 @@ void dtgtk_cairo_paint_overlays(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_scale(cr, s, s);
 
   cairo_set_line_width(cr, .1);
-  dt_draw_star(cr, 0.0, 0.12, 1.0, 1.0/2.5);
+  dt_draw_star(cr, 0.0, 0.0, 1.03, 1.03/2.5);
 
   cairo_stroke(cr);
 }
@@ -1620,7 +1621,8 @@ void dtgtk_cairo_paint_help(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 {
   cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
 
-  const float s = (w < h ? w / 2.0 : h / 2.0);
+  float s = (w < h ? w / 2.0 : h / 2.0);
+  s *= 0.97; //optical balance
   cairo_scale(cr, s, s);
 
   cairo_set_line_width(cr, 0.2);

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -33,7 +33,7 @@ DT_MODULE(1)
 
 #define DT_MODULE_LIST_SPACING DT_PIXEL_APPLY_DPI(2)
 
-#define ICON_SIZE DT_PIXEL_APPLY_DPI(20)
+#define ICON_SIZE DT_PIXEL_APPLY_DPI(16)
 typedef struct dt_lib_modulelist_t
 {
   GtkTreeView *tree;


### PR DESCRIPTION
Now that #5150 is merged and geometry of icon buttons can be controlled from CSS, I am hereby proposing some further icons optimizations, with the purpose of removing the residual ad hoc hardcoded assumptions.
For this I have slightly resized / shifted some icons, fixed some drawing mistakes and also redesigned the "second display" that was looking ugly to me.
I took care of optical balancing and alignment, with the help of a tool which I made on purpose to assess the optical density through a blur.
This also lead to some simplification in CSS.
the result look pretty good to me, but there is a bit of subjectivity here, so feel free to give feedback