### PR TITLE
keep in sync max size of thumbtable icons

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -1201,6 +1201,9 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
   PangoAttribute *attr;
   int width = 0;
   int height = 0;
+
+  int max_size = darktable.gui->icon_size;
+
   if(thumb->over != DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK)
   {
     gtk_widget_get_size_request(thumb->w_main, &width, &height);
@@ -1209,7 +1212,9 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // stars + reject having a width of 2 * r1 and spaced by r1 => 18 * r1
     // colorlabels => 3 * r1 + space r1
     // inner margins are 0.045 * width
-    const float r1 = fminf(DT_PIXEL_APPLY_DPI(20.0f) / 2.0f, 0.91 * width / 22.0f);
+
+    // retrieves the size of the main icons in the top panel, thumbtable overlays shall not exceed that
+    const float r1 = fminf(max_size / 2.0f, 0.91 * width / 22.0f);
 
     // file extension
     gtk_widget_set_margin_top(thumb->w_ext, 0.5 * r1);
@@ -1280,7 +1285,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
     // we need to squeeze 5 stars + 1 reject + 1 colorlabels symbols on a thumbnail width
     // all icons having a width of 3.0 * r1 => 21 * r1
     // we want r1 spaces at extremities, after reject, before colorlables => 4 * r1
-    const float r1 = fminf(DT_PIXEL_APPLY_DPI(20.0f) / 2.0f, width / 25.0f);
+    const float r1 = fminf(max_size / 2.0f, width / 25.0f);
 
     // file extension
     gtk_widget_set_margin_top(thumb->w_ext, 0.5 * r1);
@@ -1374,7 +1379,11 @@ void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean 
   gtk_widget_set_size_request(thumb->w_main, width, height);
   // file extension
   gtk_widget_set_margin_start(thumb->w_ext, 0.045 * width);
-  const int fsize = fminf(DT_PIXEL_APPLY_DPI(20.0), .09 * width);
+
+  // retrieves the size of the main icons in the top panel, thumbtable overlays shall not exceed that
+  int max_size = darktable.gui->icon_size;
+  const int fsize = fminf(max_size, .09 * width);
+
   PangoAttrList *attrlist = pango_attr_list_new();
   PangoAttribute *attr = pango_attr_size_new_absolute(fsize * PANGO_SCALE);
   pango_attr_list_insert(attrlist, attr);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -113,6 +113,8 @@ typedef struct dt_gui_gtk_t
 
   double dpi, dpi_factor, ppd;
 
+  int icon_size; // size of top panel icons
+
   // store which gtkrc we loaded:
   char gtkrc[PATH_MAX];
 

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -143,6 +143,32 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   gtk_widget_show_all(d->over_popup);
 }
 
+static void _main_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
+{
+
+  GtkStateFlags state = gtk_widget_get_state_flags(widget);
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+
+  /* get the css geometry properties */
+  GtkBorder margin, border, padding;
+  gtk_style_context_get_margin(context, state, &margin);
+  gtk_style_context_get_border(context, state, &border);
+  gtk_style_context_get_padding(context, state, &padding);
+
+  /* we first remove css margin border and padding from allocation */
+  int width = allocation->width - margin.left - margin.right - border.left - border.right - padding.left - padding.right;
+
+  GtkStyleContext *ccontext = gtk_widget_get_style_context(DTGTK_BUTTON(widget)->canvas);
+  GtkBorder cmargin;
+  gtk_style_context_get_margin(ccontext, state, &cmargin);
+
+  /* we remove the extra room for optical alignment */
+  width = round((float)width * (1.0 - (cmargin.left + cmargin.right) / 100.0f));
+
+  // we store the icon size in order to keep in sync thumbtable overlays
+  darktable.gui->icon_size = width;
+}
+
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -173,6 +199,8 @@ void gui_init(dt_lib_module_t *self)
 #endif
   g_signal_connect_swapped(G_OBJECT(d->overlays_button), "button-press-event", G_CALLBACK(_overlays_show_popup),
                            self);
+  // we register size of overlay icon to keep in sync thumbtable overlays
+  g_signal_connect(G_OBJECT(d->overlays_button), "size-allocate", G_CALLBACK(_main_icons_register_size), NULL);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 


### PR DESCRIPTION
With #5150, all geometry properties of icon button has been moved to CSS.
Thumbtable overlays are independently sized, because they are designed to be dynamic.
Their size is dependent on the zoom level, up to a maximum. However, the maximum size is hardcoded to `DT_PIXEL_APPLY_DPI(20.0f)`.
This makes the size of overlay icons in Windows to grow much beyond the size of the corresponding icons (group, star, etc) in the top and bottom toolbars, and the GUI doesn't look nice.

With this PR, the real allocated size of the icons in the DT top / bottom toolbars is used to set the maximum size of the thumbtable icons.
The two are kept in sync on all OSs and also respond in sync to a change of CSS

![Cattura2](https://user-images.githubusercontent.com/43290988/82929307-bab24980-9f83-11ea-87d5-42b65d6132eb.JPG)
