### PR TITLE
Fix libgphoto2 camera detection

### DIFF
--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -217,8 +217,8 @@ void dt_camctl_destroy(dt_camctl_t *c);
 void dt_camctl_register_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener);
 /** Unregisters a listener of camera control */
 void dt_camctl_unregister_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener);
-/** Detect cameras and update list of available cameras */
-void dt_camctl_detect_cameras(const dt_camctl_t *c);
+/** start a thread job to detect cameras and update list of available cameras */
+void dt_camctl_background_detect_cameras();
 /** Check if there is any camera connected */
 int dt_camctl_have_cameras(const dt_camctl_t *c);
 /** Selects a camera to be used by cam control, this camera is selected if NULL is passed as camera*/

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1001,6 +1001,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     // Initialize the camera control.
     // this is done late so that the gui can react to the signal sent but before switching to lighttable!
     darktable.camctl = dt_camctl_new();
+    dt_camctl_background_detect_cameras();
 #endif
 
     darktable.lib = (dt_lib_t *)calloc(1, sizeof(dt_lib_t));


### PR DESCRIPTION
This pr is a small version of #5212 intended for 3.2, it does not include the
background thread fully updating the device list.

Done here:
1. Fixes the camera detection. Until now detection of devices to be removed from the current list
and the gui import interface only tested for the model, not for the port.
This left unavailable cameras in the list (easily when using two sd cards)

2. Updating the gui device list is now protected via the camcontrol mutex.

3. Updating the device list so far done by a g_idle defers to a background job so it does
not block the gui any longer.

fixes #2142
fixes #4917
likely fixes #4253 although i could not test with that specific hardware