### PR TITLE
consistent ux for drawn masks and add tooltips

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1862,7 +1862,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
         = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_gradient, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     g_signal_connect(G_OBJECT(bd->masks_shapes[0]), "button-press-event",
                      G_CALLBACK(_blendop_masks_add_shape_callback), module);
-    gtk_widget_set_tooltip_text(bd->masks_shapes[0], _("add gradient"));
+    gtk_widget_set_tooltip_text(bd->masks_shapes[0], _("add gradient\nctrl+click to add multiple gradients"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[0]), FALSE);
     gtk_box_pack_end(GTK_BOX(abox), bd->masks_shapes[0], FALSE, FALSE, 0);
 
@@ -1871,7 +1871,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
         = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     g_signal_connect(G_OBJECT(bd->masks_shapes[1]), "button-press-event",
                      G_CALLBACK(_blendop_masks_add_shape_callback), module);
-    gtk_widget_set_tooltip_text(bd->masks_shapes[1], _("add path"));
+    gtk_widget_set_tooltip_text(bd->masks_shapes[1], _("add path\nctrl+click to add multiple paths"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[1]), FALSE);
     gtk_box_pack_end(GTK_BOX(abox), bd->masks_shapes[1], FALSE, FALSE, 0);
 
@@ -1880,7 +1880,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
         = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     g_signal_connect(G_OBJECT(bd->masks_shapes[2]), "button-press-event",
                      G_CALLBACK(_blendop_masks_add_shape_callback), module);
-    gtk_widget_set_tooltip_text(bd->masks_shapes[2], _("add ellipse"));
+    gtk_widget_set_tooltip_text(bd->masks_shapes[2], _("add ellipse\nctrl+click to add multiple ellipses"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[2]), FALSE);
     gtk_box_pack_end(GTK_BOX(abox), bd->masks_shapes[2], FALSE, FALSE, 0);
 
@@ -1889,7 +1889,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
         = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     g_signal_connect(G_OBJECT(bd->masks_shapes[3]), "button-press-event",
                      G_CALLBACK(_blendop_masks_add_shape_callback), module);
-    gtk_widget_set_tooltip_text(bd->masks_shapes[3], _("add circle"));
+    gtk_widget_set_tooltip_text(bd->masks_shapes[3], _("add circle\nctrl+click to add multiple circles"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[3]), FALSE);
     gtk_box_pack_end(GTK_BOX(abox), bd->masks_shapes[3], FALSE, FALSE, 0);
 
@@ -1898,7 +1898,7 @@ void dt_iop_gui_init_masks(GtkBox *blendw, dt_iop_module_t *module)
         = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
     g_signal_connect(G_OBJECT(bd->masks_shapes[4]), "button-press-event",
                      G_CALLBACK(_blendop_masks_add_shape_callback), module);
-    gtk_widget_set_tooltip_text(bd->masks_shapes[4], _("add brush"));
+    gtk_widget_set_tooltip_text(bd->masks_shapes[4], _("add brush\nctrl+click to add multiple brush strokes"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_shapes[4]), FALSE);
     gtk_box_pack_end(GTK_BOX(abox), bd->masks_shapes[4], FALSE, FALSE, 0);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2128,7 +2128,7 @@ static gboolean rt_add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_i
   if(darktable.gui->reset) return FALSE;
 
   GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  const int creation_continuous = !((e->state & modifiers) == GDK_CONTROL_MASK);
+  const int creation_continuous = ((e->state & modifiers) == GDK_CONTROL_MASK);
 
   return rt_add_shape(widget, creation_continuous, self);
 }
@@ -2655,27 +2655,27 @@ void gui_init(dt_iop_module_t *self)
   g->bt_brush
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_brush, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_brush), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  g_object_set(G_OBJECT(g->bt_brush), "tooltip-text", _("add brush"), (char *)NULL);
+  g_object_set(G_OBJECT(g->bt_brush), "tooltip-text", _("add brush\nctrl+click to add multiple brush strokes"), (char *)NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_brush), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_brush, FALSE, FALSE, 0);
 
   g->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_path), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  g_object_set(G_OBJECT(g->bt_path), "tooltip-text", _("add path"), (char *)NULL);
+  g_object_set(G_OBJECT(g->bt_path), "tooltip-text", _("add path\nctrl+click to add multiple paths"), (char *)NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_path, FALSE, FALSE, 0);
 
   g->bt_ellipse
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_ellipse), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  g_object_set(G_OBJECT(g->bt_ellipse), "tooltip-text", _("add ellipse"), (char *)NULL);
+  g_object_set(G_OBJECT(g->bt_ellipse), "tooltip-text", _("add ellipse\nctrl+click to add multiple ellipses"), (char *)NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_ellipse, FALSE, FALSE, 0);
 
   g->bt_circle
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_circle), "button-press-event", G_CALLBACK(rt_add_shape_callback), self);
-  g_object_set(G_OBJECT(g->bt_circle), "tooltip-text", _("add circle"), (char *)NULL);
+  g_object_set(G_OBJECT(g->bt_circle), "tooltip-text", _("add circle\nctrl+click to add multiple circles"), (char *)NULL);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox_shapes), g->bt_circle, FALSE, FALSE, 0);
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -272,7 +272,7 @@ static gboolean _add_shape_callback(GtkWidget *widget, GdkEventButton *e, dt_iop
   if(darktable.gui->reset) return FALSE;
 
   GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-  const int creation_continuous = !((e->state & modifiers) == GDK_CONTROL_MASK);
+  const int creation_continuous = ((e->state & modifiers) == GDK_CONTROL_MASK);
 
   return _add_shape(widget, creation_continuous, self);
 }
@@ -804,21 +804,21 @@ void gui_init(dt_iop_module_t *self)
 
   g->bt_path = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_path, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_path), "button-press-event", G_CALLBACK(_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_path, _("add path"));
+  gtk_widget_set_tooltip_text(g->bt_path, _("add path\nctrl+click to add multiple paths"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_path), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), g->bt_path, FALSE, FALSE, 0);
 
   g->bt_ellipse
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_ellipse, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_ellipse), "button-press-event", G_CALLBACK(_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_ellipse, _("add ellipse"));
+  gtk_widget_set_tooltip_text(g->bt_ellipse, _("add ellipse\nctrl+click to add multiple ellipses"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_ellipse), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), g->bt_ellipse, FALSE, FALSE, 0);
 
   g->bt_circle
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_masks_circle, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   g_signal_connect(G_OBJECT(g->bt_circle), "button-press-event", G_CALLBACK(_add_shape_callback), self);
-  gtk_widget_set_tooltip_text(g->bt_circle, _("add circle"));
+  gtk_widget_set_tooltip_text(g->bt_circle, _("add circle\nctrl+click to add multiple circles"));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_circle), FALSE);
   gtk_box_pack_end(GTK_BOX(hbox), g->bt_circle, FALSE, FALSE, 0);
 


### PR DESCRIPTION
currently retouch and spot removal modules allow continuous mask
creation (with click) and single mask creation (with ctrl+click)

blendop masks allow single mask creation (with click) and continuous
mask creation (with ctrl+click)

this PR amends the retouch and spot removal modules to match the
behaviour of blendop masks and adds tooltips to inform the user of the
functionality.