### PR TITLE
add missing modules to iop-layout*.sh files

### DIFF
--- a/tools/iop-layout-legacy.sh
+++ b/tools/iop-layout-legacy.sh
@@ -43,6 +43,8 @@ group_basic=(
     'highlights'
     'invert'
     'basicadj'
+    'negadoctor'
+    'toneequal'
 )
 
 group_tone=(

--- a/tools/iop-layout.sh
+++ b/tools/iop-layout.sh
@@ -50,6 +50,8 @@ group_basic=(
     'filmic'
     'filmicrgb'
     'basicadj'
+    'negadoctor'
+    'toneequal'
 )
 
 group_tone=(


### PR DESCRIPTION
adds missing modules to match where they are in gui

refs #5052

This does not change the group they are by default.