### PR TITLE
fix duplicate module not being enabled on duplication

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -814,7 +814,6 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
   /* initialize gui if iop have one defined */
   if(!dt_iop_is_hidden(module))
   {
-    ++darktable.gui->reset;
     module->gui_init(module);
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
     if(copy_params)
@@ -846,7 +845,6 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
                           expander, g_value_get_int(&gv) + pos_base - pos_module + 1);
     dt_iop_gui_set_expanded(module, TRUE, FALSE);
     dt_iop_gui_update_blending(module);
-    --darktable.gui->reset;
   }
 
   if(dt_conf_get_bool("darkroom/ui/single_module"))


### PR DESCRIPTION
gui reset is no longer needed since toast for hidden controlls are
moved to accel handling

fixes #4796 by essentially reverting fc92a41e28e140dc42bf951d674d4194468af1f7