### PR TITLE
make sure copy_history module buttons get updated

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1506,6 +1506,7 @@ gboolean dt_history_copy(int imgid)
   if(dt_dev_is_current_image(darktable.develop, imgid)) dt_dev_write_history(darktable.develop);
   return TRUE;
 }
+
 gboolean dt_history_copy_parts(int imgid)
 {
   if(dt_history_copy(imgid))
@@ -1517,6 +1518,7 @@ gboolean dt_history_copy_parts(int imgid)
   else
     return FALSE;
 }
+
 gboolean dt_history_paste_on_list(GList *list, gboolean undo)
 {
   if(darktable.view_manager->copy_paste.copied_imageid <= 0) return FALSE;

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -263,11 +263,6 @@ void gui_reset(dt_lib_module_t *self)
   _update(self);
 }
 
-static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
-{
-  _update(self);
-}
-
 int position()
 {
   return 600;
@@ -355,8 +350,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, button, 3, line, 3, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(write_button_clicked), (gpointer)self);
 
-  dt_control_signal_connect(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
-                            G_CALLBACK(_image_selection_changed_callback), self);
+  //dt_control_signal_connect(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
+  //                          G_CALLBACK(_image_selection_changed_callback), self);
 
   g_signal_connect(G_OBJECT(copy), "clicked", G_CALLBACK(copy_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(copy_parts), "clicked", G_CALLBACK(copy_parts_button_clicked), (gpointer)self);
@@ -373,6 +368,12 @@ void gui_cleanup(dt_lib_module_t *self)
 {
   free(self->data);
   self->data = NULL;
+}
+
+void gui_post_expose(struct dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,
+                     int32_t pointerx, int32_t pointery)
+{
+  _update(self);
 }
 
 void init_key_accels(dt_lib_module_t *self)

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -70,12 +70,13 @@ static void _update(dt_lib_module_t *self)
 
   GList *imgs = dt_view_get_images_to_act_on(TRUE);
   const guint act_on_cnt = g_list_length(imgs);
-  gboolean can_paste = darktable.view_manager->copy_paste.copied_imageid > 0 && act_on_cnt > 0;
+  const gboolean can_paste = darktable.view_manager->copy_paste.copied_imageid > 0 && 
+    (
+      act_on_cnt > 1 ||
+      (act_on_cnt == 1 && (darktable.view_manager->copy_paste.copied_imageid != dt_view_get_image_to_act_on()))
+    );
 
-  if(act_on_cnt == 1){
-    const int id = dt_view_get_image_to_act_on();
-    can_paste = can_paste && (darktable.view_manager->copy_paste.copied_imageid != id);
-  }
+  g_list_free(imgs);
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), act_on_cnt > 0);
   gtk_widget_set_sensitive(GTK_WIDGET(d->compress_button), act_on_cnt > 0);
@@ -421,6 +422,9 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
+  dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_image_selection_changed_callback), self);
+  dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_mouse_over_image_callback), self);
+  dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
   if(d->timeout_handle)
     g_source_remove(d->timeout_handle);

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -45,7 +45,7 @@ typedef struct dt_lib_copy_history_t
   GtkWidget *copy_button, *delete_button, *load_button, *write_button;
   GtkWidget *copy_parts_button;
   GtkButton *compress_button;
-
+  guint timeout_handle;
 } dt_lib_copy_history_t;
 
 const char *name(dt_lib_module_t *self)
@@ -87,6 +87,22 @@ static void _update(dt_lib_module_t *self)
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste), can_paste);
   gtk_widget_set_sensitive(GTK_WIDGET(d->paste_parts), can_paste);
+
+  if(d->timeout_handle)
+  {
+    g_source_remove(d->timeout_handle);
+    d->timeout_handle = 0;
+  }
+}
+
+static gboolean _postponed_update(gpointer data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)data;
+
+  // timeout handle clearing is handled by update code
+  _update(self);
+
+  return FALSE;
 }
 
 static void write_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
@@ -281,6 +297,20 @@ static void _collection_updated_callback(gpointer instance, dt_collection_change
   _update(self);
 }
 
+static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
+{
+  dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
+  const int delay = CLAMP(darktable.develop->average_delay / 2, 10, 250);
+
+  if(d->timeout_handle)
+  {
+    // here we're making sure the event fires at last hover
+    // and we won't have avalanche of events in the mean time.
+    g_source_remove(d->timeout_handle);
+  }
+  d->timeout_handle = g_timeout_add(delay, _postponed_update, self);
+}
+
 void gui_reset(dt_lib_module_t *self)
 {
   _update(self);
@@ -296,6 +326,9 @@ void gui_init(dt_lib_module_t *self)
 {
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)malloc(sizeof(dt_lib_copy_history_t));
   self->data = (void *)d;
+
+  d->timeout_handle = 0;
+
   self->widget = gtk_grid_new();
   GtkGrid *grid = GTK_GRID(self->widget);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
@@ -368,6 +401,8 @@ void gui_init(dt_lib_module_t *self)
 
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
                             G_CALLBACK(_image_selection_changed_callback), self);
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
+                            G_CALLBACK(_mouse_over_image_callback), self);
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,
                             G_CALLBACK(_collection_updated_callback), self);
 
@@ -386,6 +421,10 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
+  dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
+  if(d->timeout_handle)
+    g_source_remove(d->timeout_handle);
+
   free(self->data);
   self->data = NULL;
 }

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -263,7 +263,7 @@ void gui_reset(dt_lib_module_t *self)
   _update(self);
 }
 
-static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
+static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
 {
   _update(self);
 }
@@ -355,8 +355,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, button, 3, line, 3, 1);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(write_button_clicked), (gpointer)self);
 
-  dt_control_signal_connect(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,
-                            G_CALLBACK(_mouse_over_image_callback), self);
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
+                            G_CALLBACK(_image_selection_changed_callback), self);
 
   g_signal_connect(G_OBJECT(copy), "clicked", G_CALLBACK(copy_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(copy_parts), "clicked", G_CALLBACK(copy_parts_button_clicked), (gpointer)self);


### PR DESCRIPTION
if history gets copied outside of copy_history module the module wouldn't know.

thanks to this change, module has greater chance of knowing.

fixes #5188