### PR TITLE
Hides instead of minimizes window when quitting (#4218)

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -870,7 +870,7 @@ void dt_gui_gtk_quit()
 
   // Write out windows dimension before miminizing
   dt_gui_gtk_write_config();
-  gtk_window_iconify(win);
+  gtk_widget_hide(GTK_WIDGET(win));
 
   GtkWidget *widget;
   widget = darktable.gui->widgets.left_border;


### PR DESCRIPTION
Small fix for OSX where the expected behavior on quitting is that the window hides instead of minimizes while cleaning up. (The default minimization animation on OSX is quite obtrusive.) 

Needs testing on Linux and Windows, and, depending on results, this pull request might need to be encapsulated in `#ifdef __APPLE__`