### PR TITLE
polish thumbnails margins

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -229,7 +229,7 @@ eventbox *,
 box,
 box *
 {
-  font-size: 1em;	/* avoid changing this settings or you will made the UI quite awful (too big or too small) */
+  font-size: 1em; /* avoid changing this settings or you will made the UI quite awful (too big or too small) */
   background-color: transparent;
 }
 
@@ -245,7 +245,7 @@ box *
 /* Sets outer borders that could be hide or shown in darktable with 'b' shortcut.
   remember, in gui/gtk.c, outer borders (active areas used to collapse panels)
   are defined to 5 px × DPI. We cheat by setting inner borders/spacing here to 5 px as well. */
-#outer-border   
+#outer-border
 {
   background-color: @border_color;
   min-width: 20px;
@@ -386,7 +386,7 @@ overshoot.right
 /*------------------------------
   - Header and footer toolbars -
   ------------------------------*/
-  
+
 #header-toolbar,
 #footer-toolbar
 {
@@ -428,7 +428,7 @@ overshoot.right
 /*---------------------------
   - Side panels and modules -
   ---------------------------*/
-	
+
 /* Frame around modules boxes */
 /*** NOTE: bauhaus controls inherit their font properties from there ***/
 #lib-plugin-ui,
@@ -718,8 +718,8 @@ frame#import_metadata checkbutton
 dialog .dialog-vbox notebook stack /* set top margin ; between tabs and text below */
 {
   margin-top: 4px;
-} 
- 
+}
+
 dialog .dialog-vbox notebook stack box box > label  /* set code project name on first tab */
 {
   font-size: 0.90em;
@@ -1811,16 +1811,16 @@ radiobutton radio
   padding: 0.25em;
 }
 
-	/*** for following settings line, remember which popover mode name and related line on popover menu
-	1) .dt_overlays_none
-	2) .dt_overlays_hover
-	3) .dt_overlays_hover_extended
-	4) .dt_overlays_always
-	5) .dt_overlays_always_extended
-	6) .dt_overlays_mixed
-	7) .dt_overlays_hover_block (also to set culling and preview hover block infos)
-	
-	These modes will be ordered on next related lines ***/
+  /*** for following settings line, remember which popover mode name and related line on popover menu
+  1) .dt_overlays_none
+  2) .dt_overlays_hover
+  3) .dt_overlays_hover_extended
+  4) .dt_overlays_always
+  5) .dt_overlays_always_extended
+  6) .dt_overlays_mixed
+  7) .dt_overlays_hover_block (also to set culling and preview hover block infos)
+
+  These modes will be ordered on next related lines ***/
 
 /*-----------------
   - Image options -
@@ -1834,7 +1834,7 @@ radiobutton radio
 
 .dt_thumbnails_2 #thumb_image /* update consistently margins if big thumbnails (less images per row) are shown */
 {
-  margin : 2px;
+  margin: 3px;
 }
 
 #thumb_main:active #thumb_image
@@ -1842,7 +1842,7 @@ radiobutton radio
   border: 2px solid @plugin_bg_color;
 }
 
-#thumb_ext	/* adjust margin to align to group, audio... icons */
+#thumb_ext  /* adjust margin to align to group, audio... icons */
 {
   margin-top: -1px;
 }
@@ -1872,7 +1872,7 @@ radiobutton radio
 
 /* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
-.dt_overlays_mixed #thumb_main:hover #thumb_bottom 
+.dt_overlays_mixed #thumb_main:hover #thumb_bottom
 {
   background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
 }
@@ -1891,12 +1891,39 @@ radiobutton radio
 }
 
 /*--------------------
+  - Thumbnails extension -
+  --------------------*/
+
+/* by default, the extension is hidden */
+#thumb_ext
+{
+  color: transparent;
+  background-color: transparent;
+}
+
+/* and we show it for specific overlays */
+.dt_overlays_always #thumb_ext,
+.dt_overlays_always_extended #thumb_ext,
+.dt_overlays_mixed #thumb_ext
+{
+  color: @thumbnail_infos_color;
+}
+.dt_overlays_hover #thumb_main:hover #thumb_ext,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_ext,
+.dt_overlays_always #thumb_main:selected #thumb_ext,
+.dt_overlays_always_extended #thumb_main:selected #thumb_ext,
+.dt_overlays_mixed #thumb_main:selected #thumb_ext
+{
+  color: @thumbnail_font_color;
+}
+
+
+/*--------------------
   - Thumbnails infos -
   --------------------*/
 
 /* Set default color icons and text infos on thumbnails and block infos */
 .dt_thumb_btn,
-#thumb_ext,
 .dt_overlays_always_extended #thumb_bottom_label
 {
   color: @thumbnail_infos_color;
@@ -1914,8 +1941,6 @@ radiobutton radio
 }
 
 /* Set hover and selected color icons and text infos */
-.dt_thumbtable #thumb_main:hover #thumb_ext,
-.dt_thumbtable #thumb_main:selected #thumb_ext,
 .dt_overlays_hover #thumb_main:hover .dt_thumb_btn,
 .dt_overlays_hover_extended #thumb_main:hover .dt_thumb_btn,
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,


### PR DESCRIPTION
Essentially, we ensure consistent margins on every side, to make it look cleaner.

before :
![Capture d’écran de 2020-06-01 02-27-47](https://user-images.githubusercontent.com/2779157/83366520-e6806580-a3af-11ea-8403-f17b8ff95944.png)

after:
![Capture d’écran de 2020-06-01 02-25-33](https://user-images.githubusercontent.com/2779157/83366629-95bd3c80-a3b0-11ea-84f1-4b3a2a319816.png)

Notice I have removed the vertical extension name because, until Gtk adds support for `line_height` property, there is no clean way to reduce the vertical letter spacing (in 3.0, it was done manually on Pango/Cairo offset drawing). Also, I'm not sure it's actually good (in ARW, the W is always going to be much larger than the other letters, and having an uneven column is really ugly).

@Nilvus @AlicVB 