### PR TITLE
purge_from_cache.sh: make sure alias is expanded

### DIFF
--- a/tools/purge_from_cache.sh
+++ b/tools/purge_from_cache.sh
@@ -22,6 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# make sure parsed alias will be expanded
+shopt -s expand_aliases
+
 . "$(dirname "$0")/common.sh"
 
 if pgrep -x "darktable" > /dev/null ; then


### PR DESCRIPTION
The current purge_from_cache.sh script does not expand the parsed alias set in common.sh and fails.

This small addition makes sure that bash expands the alias when doing command substitution.

fixes: https://github.com/darktable-org/darktable/issues/5271