### PR TITLE
Bilateral filter speedup

### DIFF
--- a/src/common/bilateral.h
+++ b/src/common/bilateral.h
@@ -22,7 +22,8 @@
 
 typedef struct dt_bilateral_t
 {
-  size_t size_x, size_y, size_z;
+  size_t size_x, size_y, size_z;		    // grid size in each dimension
+  float size_x_1, size_y_1, size_z_1;		    // max index, float because used in fp comparison
   int width, height;
   float sigma_s, sigma_r;
   float *buf __attribute__((aligned(64)));
@@ -53,7 +54,7 @@ dt_bilateral_t *dt_bilateral_init(const int width,      // width of input image
                                   const float sigma_s,  // spatial sigma (blur pixel coords)
                                   const float sigma_r); // range sigma (blur luma values)
 
-void dt_bilateral_splat(dt_bilateral_t *b, const float *const in);
+void dt_bilateral_splat(const dt_bilateral_t *const b, const float *const in);
 
 void dt_bilateral_blur(dt_bilateral_t *b);
 


### PR DESCRIPTION
By precomputing as much as possible, we can remove 48 conditionals and 20 multiplications per pixel from the innermost loop.  This produces a quite noticeable speedup in all of the iops which use the bilateral filter (-25% runtime on the faster ones such as lowpass, monochrome, and local contrast; same absolute but percentage-wise smaller gains on the slower ones like global tonemapping and shadows/highlights).

Requires #5222 (whose commits you see included below as the first three), but posted now so I don't forget about it.
