### PR TITLE
altered fix - when rotation on an image without history don't take it  for auto-apply.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -70,7 +70,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
 
   dt_image_init(&dev->image_storage);
   dev->image_status = dev->preview_status = dev->preview2_status = DT_DEV_PIXELPIPE_DIRTY;
-  dev->history_updating = dev->image_force_reload = dev->image_loading = dev->preview_loading = FALSE; 
+  dev->history_updating = dev->image_force_reload = dev->image_loading = dev->preview_loading = FALSE;
   dev->preview2_loading = dev->preview_input_changed = dev->preview2_input_changed = FALSE;
   dev->image_invalid_cnt = 0;
   dev->pipe = dev->preview_pipe = dev->preview2_pipe = NULL;
@@ -540,7 +540,7 @@ void dt_dev_process_image_job(dt_develop_t *dev)
   dt_control_toast_busy_enter();
   // let gui know to draw preview instead of us, if it's there:
   dev->image_status = DT_DEV_PIXELPIPE_RUNNING;
-  
+
   dt_mipmap_buffer_t buf;
   dt_times_t start;
   dt_get_times(&start);
@@ -1872,8 +1872,13 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
   dt_history_hash_t flags = DT_HISTORY_HASH_CURRENT;
   if(first_run)
   {
-    flags = flags | (auto_apply_modules ? DT_HISTORY_HASH_AUTO : DT_HISTORY_HASH_BASIC);
-
+    const dt_history_hash_t hash_status = dt_history_hash_get_status(imgid);
+    // if altered doesn't mask it
+    if(!(hash_status & DT_HISTORY_HASH_CURRENT))
+    {
+      flags = flags | (auto_apply_modules ? DT_HISTORY_HASH_AUTO : DT_HISTORY_HASH_BASIC);
+    }
+    dt_history_hash_write_from_history(imgid, flags);
     // As we have a proper history right now and this is first_run we write the xmp now
     dt_image_t *image = dt_image_cache_get(darktable.image_cache, imgid, 'w');
     dt_image_cache_write_release(darktable.image_cache, image, DT_IMAGE_CACHE_SAFE);
@@ -1886,10 +1891,12 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
       // if image not altered keep the current status
       flags = flags | hash_status;
     }
+    dt_history_hash_write_from_history(imgid, flags);
   }
-  // write history_hash when the image has an history
-  dt_history_hash_write_from_history(imgid, flags);
-
+  else
+  {
+    dt_history_hash_write_from_history(imgid, flags);
+  }
   dt_unlock_image(imgid);
 }
 


### PR DESCRIPTION
fixes #5274 
When lighttable uses embedded thumbnail and there is no auto applied presets, the imported images have no history. 
Applying a rotation was then considered as an auto applied operation (as applied on the first run) and the image not set as altered. That is what the fix is about.

Remain some potential improvements.
- in all cases, image rotation applies development (and may look different). If embedded thumbnail is active, rotation should be done without development (keeping the original embedded pixels).
- reset rotation doesn't really reset, but reapplies the initial position. The image is and remains altered.
- there is no undo/redo on rotation operations (there is no possibility to be back unaltered).

 