### PR TITLE
don't use a special layout for color assessment mode - 

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -194,7 +194,7 @@ static dt_darkroom_layout_t _lib_darkroom_get_layout(dt_view_t *self)
 {
   dt_develop_t *dev = (dt_develop_t *)self->data;
   if(dev->iso_12646.enabled)
-    return DT_DARKROOM_LAYOUT_COLOR_ASSESMENT;
+    return DT_DARKROOM_LAYOUT_EDITING;
   else
     return DT_DARKROOM_LAYOUT_EDITING;
 }


### PR DESCRIPTION
use generic darkroom layout

Fix #5200 