### PR TITLE
Corrected scaling for image export

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -752,7 +752,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
      But we can test for that situation and if there is an out-of-bounds problem we
      have basically two options:
      a) reduce the output image size by one for width & height.
-     b) change the scale. In theory this marginally reduces quality.
+     b) increase the scale while keeping the output size. In theory this marginally reduces quality.
 
      These are the rules for export:
      1. If we have the **full image** (defined by dt_image_t width, height and crops) we look for upscale.
@@ -786,9 +786,11 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
   }
 
   const double max_scale = ( upscale && ( width > 0 || height > 0 )) ? 100.0 : 1.0;
+
   const double scalex = width > 0 ? fmin((double)width / (double)pipe.processed_width, max_scale) : max_scale;
   const double scaley = height > 0 ? fmin((double)height / (double)pipe.processed_height, max_scale) : max_scale;
   double scale = fmin(scalex, scaley);
+  double corrscale = 1.0f;
 
   int processed_width = 0;
   int processed_height = 0;
@@ -813,11 +815,16 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
        (ceil((double)processed_height / scale) + origin[1] > pipe.iheight))
     {
       corrected = TRUE;
-      // must either change scale or crop right/bottom border by one
+     /* Here the scale is too **small** so while reading data from the right or low borders we are out-of-bounds.
+        We can either just decrease output width & height or
+        have to find a scale that takes data from within the origin data, so we have to increase scale to a size
+        that fits both width & height.
+     */
       if(exact_size)
       {
-        scale = fmin(fmin((double)(width-1) / (double)(pipe.processed_width), max_scale),
-                     fmin((double)(height-1) / (double)(pipe.processed_height), max_scale));
+        corrscale = fmax( ((double)(pipe.processed_width + 1) / (double)(pipe.processed_width)),
+                           ((double)(pipe.processed_height +1) / (double)(pipe.processed_height)) );
+        scale = scale * corrscale;
       }
       else
       {
@@ -826,9 +833,9 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
       }
     }
 
-    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] imgid %d, pipe %ix%i, range %ix%i --> exact %i, upscale %i, corrected %i, scale %.9f, size %ix%i\n",
+    dt_print(DT_DEBUG_IMAGEIO,"[dt_imageio_export] imgid %d, pipe %ix%i, range %ix%i --> exact %i, upscale %i, corrected %i, scale %.7f, corr %.6f, size %ix%i\n",
              imgid, pipe.processed_width, pipe.processed_height, format_params->max_width, format_params->max_height,
-             exact_size, upscale, corrected, scale, processed_width, processed_height);
+             exact_size, upscale, corrected, scale, corrscale, processed_width, processed_height);
   }
   else
   {


### PR DESCRIPTION
There are some severe issues related to correct export, see issue #5269.
Also @TurboGit suggested a pr #5277.
> In case width is initialize with pipe.processed_width and height with pipe.processed_height, the sale will be close to 1 but very little less. (max_scale is 1.0).
So the rounding errors could come from this. What do you think ?

I now fear staring at source made me somewhat blind or simply too much work the last week.
It seems to be a very stupid bug ... 

If there is an out-of-range situation it's safe to decrease the output size. But if we want to keep the size we must not decrease the scale but must **increase** it to stretch the image into correct output.

If we decrease we might end up in what has been shown by @Nilvus (we shear by one pixel per line) or by @tomaszg7 (right&bottom line problems)

Please test carefully, hopefully Fixes #5269
