### PR TITLE
New set of CSS tweaks

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -83,9 +83,9 @@
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_40;
+@define-color thumbnail_font_color @grey_35;
 @define-color thumbnail_bg_color @grey_55;
-@define-color thumbnail_infos_color @grey_35;
+@define-color thumbnail_infos_color @grey_30;
 @define-color thumbnail_selected_bg_color @grey_65;
 @define-color thumbnail_hover_bg_color @grey_95;
 @define-color thumbnail_localcopy_color @grey_80;
@@ -103,4 +103,29 @@
 #toast-msg
 {
   background-color: rgba(90,90,90,0.6);
+}
+
+/* Set background on thumbnails hover overlays */
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
+.dt_overlays_mixed #thumb_main:hover #thumb_bottom,
+.dt_overlays_hover #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(rgba(241, 241, 241, 0.7) 0%, rgba(241, 241, 241, 0.7) 90%,rgba(241, 241, 241, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
+}
+
+/* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */
+.dt_overlays_always#culling #thumb_bottom,
+.dt_overlays_always_extended#culling #thumb_bottom,
+.dt_overlays_always#preview #thumb_bottom,
+.dt_overlays_always_extended#preview #thumb_bottom
+{
+  background-image: linear-gradient(rgba(198, 198, 198, 0.2) 0%, rgba(198, 198, 198, 0.1) 5%, rgba(198, 198, 198, 0) 100%);
+}
+
+.dt_overlays_always#culling #thumb_main:hover #thumb_bottom,
+.dt_overlays_always_extended#culling #thumb_main:hover #thumb_bottom,
+.dt_overlays_always#preview #thumb_main:hover #thumb_bottom,
+.dt_overlays_always_extended#preview #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(rgba(218, 218, 218, 0.4) 0%, rgba(218, 218, 218, 0.2) 5%, rgba(198, 198, 198, 0) 100%);
 }

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -47,7 +47,6 @@
 @define-color bauhaus_fill @grey_55;
 @define-color bauhaus_bg @grey_30;
 @define-color bauhaus_bg_hover @grey_65;
-@define-color bauhaus_fg_hover @grey_90;
 @define-color bauhaus_fg_selected @grey_85;
 @define-color bauhaus_fg_disabled alpha(@bauhaus_fg, 0.4);
 @define-color bauhaus_fg_insensitive alpha(@bauhaus_fg, 0.4);
@@ -67,7 +66,7 @@
 @define-color field_active_bg @grey_40;
 @define-color field_active_fg @grey_90;
 @define-color field_selected_bg @grey_50;
-@define-color field_selected_fg @grey_100;
+@define-color field_selected_fg @button_checked_fg;
 @define-color field_hover_bg @grey_60;
 @define-color field_hover_fg @grey_20;
 
@@ -86,8 +85,8 @@
 /* Lighttable and film-strip */
 @define-color thumbnail_font_color @grey_40;
 @define-color thumbnail_bg_color @grey_55;
-@define-color thumbnail_infos_color @grey_80;
-@define-color thumbnail_selected_bg_color @grey_70;
+@define-color thumbnail_infos_color @grey_35;
+@define-color thumbnail_selected_bg_color @grey_65;
 @define-color thumbnail_hover_bg_color @grey_95;
 @define-color thumbnail_localcopy_color @grey_80;
 

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -55,10 +55,10 @@
 @define-color button_border @grey_45;
 @define-color button_bg @grey_40;
 @define-color button_fg @grey_80;
-@define-color button_checked_bg @grey_60;
-@define-color button_checked_fg @grey_100;
+@define-color button_checked_bg @grey_55;
+@define-color button_checked_fg @grey_95;
 @define-color button_hover_bg @grey_65;
-@define-color button_hover_fg @grey_30;
+@define-color button_hover_fg @grey_25;
 
 /* text fields */
 @define-color field_bg @grey_30;

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -41,7 +41,6 @@
 @define-color plugin_fg_color @grey_90;
 @define-color section_label @grey_80;
 @define-color plugin_label_color @grey_80;
-@define-color plugin_focus_color @grey_90;
 
 /* Modules controls (sliders and comboboxes) */
 @define-color bauhaus_fg @grey_90;
@@ -67,9 +66,9 @@
 @define-color field_fg @grey_95;
 @define-color field_active_bg @grey_55;
 @define-color field_active_fg @grey_95;
-@define-color field_selected_bg @grey_65;
-@define-color field_selected_fg @grey_100;
-@define-color field_hover_bg @grey_75;
+@define-color field_selected_bg @grey_60;
+@define-color field_selected_fg @button_checked_fg;
+@define-color field_hover_bg @grey_70;
 @define-color field_hover_fg @grey_35;
 
 /* Tooltips and contextual helpers */
@@ -87,7 +86,7 @@
 /* Lighttable and film-strip */
 @define-color thumbnail_bg_color @grey_70;
 @define-color thumbnail_infos_color @grey_50;
-@define-color thumbnail_selected_bg_color @grey_85;
+@define-color thumbnail_selected_bg_color @grey_80;
 @define-color thumbnail_localcopy_color @grey_90;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -58,8 +58,10 @@
 @define-color button_border @grey_60;
 @define-color button_bg @grey_55;
 @define-color button_fg @grey_90;
-@define-color button_checked_bg @grey_75;
+@define-color button_checked_bg @grey_70;
 @define-color button_checked_fg @grey_100;
+@define-color button_hover_bg @grey_80;
+@define-color button_hover_fg @grey_25;
 
 /* text fields */
 @define-color field_bg @grey_45;

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -122,3 +122,20 @@
 {
   background-color: rgba(110,110,110,0.6);
 }
+
+/* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */
+.dt_overlays_always#culling #thumb_bottom,
+.dt_overlays_always_extended#culling #thumb_bottom,
+.dt_overlays_always#preview #thumb_bottom,
+.dt_overlays_always_extended#preview #thumb_bottom
+{
+  background-image: linear-gradient(rgba(226, 226, 226, 0.2) 0%, rgba(226, 226, 226, 0.1) 5%, rgba(226, 226, 226, 0) 100%);
+}
+
+.dt_overlays_always#culling #thumb_main:hover #thumb_bottom,
+.dt_overlays_always_extended#culling #thumb_main:hover #thumb_bottom,
+.dt_overlays_always#preview #thumb_main:hover #thumb_bottom,
+.dt_overlays_always_extended#preview #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(rgba(246, 246, 246, 0.4) 0%, rgba(246, 246, 246, 0.2) 5%, rgba(226, 226, 226, 0) 100%);
+}

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -133,16 +133,16 @@
 @define-color lighttable_bg_font_color @grey_75;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_30;
+@define-color thumbnail_font_color @grey_25;
 @define-color thumbnail_bg_color @grey_40;
-@define-color thumbnail_star_bg_color @grey_45;
+@define-color thumbnail_star_bg_color @grey_50;
 @define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_bg50_color @grey_100;
 @define-color thumbnail_infos_color @grey_20;
-@define-color thumbnail_selected_bg_color @grey_50;
-@define-color thumbnail_hover_bg_color @grey_85;
+@define-color thumbnail_selected_bg_color @grey_45;
+@define-color thumbnail_hover_bg_color @grey_80;
 @define-color filmstrip_bg_color @darkroom_bg_color;
-@define-color thumbnail_localcopy_color @grey_75;
+@define-color thumbnail_localcopy_color @grey_70;
 
 /* Brushes */
 @define-color brush_cursor alpha(white, .9);
@@ -286,6 +286,7 @@ textview
 {
   border-radius: 3px;
 }
+
 /* Default text fields and text boxes */
 entry,
 textview
@@ -1880,9 +1881,19 @@ radiobutton label
   padding: 0.2em;
 }
 
+radiobutton label
+{
+  margin: 2px;
+}
+
 radiobutton radio
 {
   padding: 0.25em;
+}
+
+spinbutton>button
+{
+  margin: 2px 1px;
 }
 
   /*** for following settings line, remember which popover mode name and related line on popover menu
@@ -1903,12 +1914,12 @@ radiobutton radio
 #thumb_image
 {
   border: none;
-  margin: 3px; /* not real pixels, but percentage of the thumb size */
+  margin: 2px; /* not real pixels, but percentage of the thumb size */
 }
 
 .dt_thumbnails_2 #thumb_image /* update consistently margins if big thumbnails (less images per row) are shown */
 {
-  margin: 3px;
+  margin: 1.5px;
 }
 
 #thumb_main:active #thumb_image
@@ -1944,17 +1955,12 @@ radiobutton radio
   border-right-width: 2px;
 }
 
-/* Set background on most modes of thumbnails overlays */
+/* Set background on thumbnails hover overlays */
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
-.dt_overlays_mixed #thumb_main:hover #thumb_bottom
-{
-  background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
-}
-
-/* Set specific background on hover mode to let show most of the image and be sure bottom infos are visible on vertical or square images */
+.dt_overlays_mixed #thumb_main:hover #thumb_bottom,
 .dt_overlays_hover #thumb_main:hover #thumb_bottom
 {
-  background-image: linear-gradient(0deg, rgba(241, 241, 241, 0.8) 0%, rgba(241, 241, 241, 0.8) 65%,rgba(241, 241, 241, 0) 100%);
+  background-image: linear-gradient(0deg, rgba(198, 198, 198, 0.7) 0%, rgba(198, 198, 198, 0.7) 90%,rgba(198, 198, 198, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
 }
 
 /* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
@@ -2085,16 +2091,6 @@ radiobutton radio
   color: @thumbnail_fg_color;
 }
 
-.dt_overlays_hover #thumb_main:hover #thumb_group,
-.dt_overlays_hover #thumb_main:hover #thumb_altered,
-.dt_overlays_hover #thumb_main:hover #thumb_audio,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_group,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_altered,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_audio
-{
-  color: transparent;
-}
-
 /* Set local copy mark */
 #thumb_localcopy
 {
@@ -2121,6 +2117,43 @@ radiobutton radio
   background-color: @thumbnail_localcopy_color;
 }
 
+/*--------------------------------------
+  - Hide icons on all lighttable modes -
+  --------------------------------------*/
+
+.dt_overlays_hover #thumb_main:hover #thumb_group,
+.dt_overlays_hover #thumb_main:hover #thumb_altered,
+.dt_overlays_hover #thumb_main:hover #thumb_audio,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_group,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_altered,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_audio,
+.dt_culling #thumb_ext,
+.dt_culling #thumb_main:selected #thumb_ext,
+.dt_culling #thumb_main:hover #thumb_ext,
+.dt_overlays_always#culling #thumb_altered,
+.dt_overlays_always#culling #thumb_audio,
+.dt_overlays_always#culling #thumb_group,
+.dt_overlays_always_extended#culling #thumb_altered,
+.dt_overlays_always_extended#culling #thumb_audio,
+.dt_overlays_always_extended#culling #thumb_group,
+.dt_preview #thumb_ext,
+.dt_preview #thumb_main:selected #thumb_ext,
+.dt_preview #thumb_main:hover #thumb_ext,
+.dt_overlays_always#preview #thumb_altered,
+.dt_overlays_always#preview #thumb_audio,
+.dt_overlays_always#preview #thumb_group,
+.dt_overlays_always_extended#preview #thumb_altered,
+.dt_overlays_always_extended#preview #thumb_audio,
+.dt_overlays_always_extended#preview #thumb_group
+{
+  color: transparent;
+}
+
+.dt_overlays_always#preview #thumb_bottom>*
+{
+  padding-top: 3px;
+}
+
 /*-----------------------------
   - Culling and preview modes -
   -----------------------------*/
@@ -2135,22 +2168,6 @@ radiobutton radio
 {
   background-color: transparent;
   border: none;
-}
-
-.dt_culling #thumb_ext,
-.dt_culling #thumb_main:selected #thumb_ext,
-.dt_culling #thumb_main:hover #thumb_ext,
-.dt_overlays_always#culling #thumb_altered,
-.dt_overlays_always#culling #thumb_audio,
-.dt_overlays_always#culling #thumb_group,
-.dt_overlays_always_extended#culling #thumb_altered,
-.dt_overlays_always_extended#culling #thumb_audio,
-.dt_overlays_always_extended#culling #thumb_group,
-.dt_preview #thumb_ext,
-.dt_preview #thumb_main:selected #thumb_ext,
-.dt_preview #thumb_main:hover #thumb_ext
-{
-  color: transparent;
 }
 
 /* Set image borders */
@@ -2176,8 +2193,9 @@ radiobutton radio
 .dt_overlays_always#preview #thumb_bottom,
 .dt_overlays_always_extended#preview #thumb_bottom
 {
-  border-top: 1px inset shade(@lighttable_bg_color, 0.9);
-  background-color: shade(@lighttable_bg_color, 1.1);
+  border-radius: 3px;
+  border-top: 1px solid @lighttable_bg_color;
+  background-image: linear-gradient(rgba(171, 171, 171, 0.2) 0%, rgba(171, 171, 171, 0.1) 5%, rgba(171, 171, 171, 0) 100%);
 }
 
 .dt_overlays_always#culling #thumb_main:hover #thumb_bottom,
@@ -2185,8 +2203,7 @@ radiobutton radio
 .dt_overlays_always#preview #thumb_main:hover #thumb_bottom,
 .dt_overlays_always_extended#preview #thumb_main:hover #thumb_bottom
 {
-  border-top: 1px inset shade(@lighttable_bg_color, 0.9);
-  background-color: shade(@lighttable_bg_color, 1.15);
+  background-image: linear-gradient(rgba(191, 191, 191, 0.4) 0%, rgba(191, 191, 191, 0.2) 5%, rgba(171, 171, 171, 0) 100%);
 }
 
 /* Set zoom info */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -85,8 +85,7 @@
 @define-color plugin_bg_color @grey_20;
 @define-color plugin_fg_color @grey_70;
 @define-color section_label @grey_60;
-@define-color plugin_label_color @grey_60;
-@define-color plugin_focus_color @grey_85;
+@define-color plugin_label_color @grey_65;
 
 /* Modules controls (sliders and comboboxes) */
 @define-color bauhaus_bg @grey_15;
@@ -114,7 +113,7 @@
 @define-color field_fg @button_fg;
 @define-color field_active_bg @grey_25;
 @define-color field_active_fg @grey_75;
-@define-color field_selected_bg @button_checked_bg;
+@define-color field_selected_bg @grey_40;
 @define-color field_selected_fg @button_checked_fg;
 @define-color field_hover_bg @grey_45;
 @define-color field_hover_fg @grey_95;
@@ -136,10 +135,11 @@
 /* Lighttable and film-strip */
 @define-color thumbnail_font_color @grey_30;
 @define-color thumbnail_bg_color @grey_40;
+@define-color thumbnail_star_bg_color @grey_45;
 @define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_bg50_color @grey_100;
-@define-color thumbnail_infos_color @grey_65;
-@define-color thumbnail_selected_bg_color @grey_55;
+@define-color thumbnail_infos_color @grey_20;
+@define-color thumbnail_selected_bg_color @grey_50;
 @define-color thumbnail_hover_bg_color @grey_85;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 @define-color thumbnail_localcopy_color @grey_75;
@@ -259,7 +259,6 @@ box *
 button,
 #add-color-button
 {
-  border-radius: 2px;
   padding: 2px;
   border: 1px solid @button_border;
   background-color: @button_bg;
@@ -268,6 +267,7 @@ button,
   font-family: sans-serif;
   min-height: 1em;
   min-width: 1em;
+  padding: 2px;
 }
 
 /* default extra margin for icons optical alignment */
@@ -276,17 +276,27 @@ button,
   margin: 5px; /* not real pixels, this is used as a percent extra space */
 }
 
+/* Set same settings on all those items */
+
+button,
+#add-color-button,
+#dt-icon,
+entry,
+textview
+{
+  border-radius: 3px;
+}
+
 /* Default text fields and text boxes */
 entry,
 textview
 {
-  border-radius: 2px;
   border: 0.5px solid @border_color;
   color: @field_fg;
   background-color: @field_bg;
   min-height: 0;
   min-width: 0;
-  padding: 2px;
+  padding: 0px;
 }
 
 entry
@@ -300,14 +310,17 @@ entry selection
 }
 
 /* Checkbox */
-checkbutton check,
-#lib-plugin-ui checkbutton check,
-#iop-plugin-ui checkbutton check,
-treeview check
+checkbutton check
 {
   background-color: @bauhaus_bg;
   color: @bauhaus_fg;
   border: 1px solid @border_color;
+}
+
+checkbutton check:checked
+{
+  background-color: @field_selected_bg;
+  color: @field_selected_fg;
 }
 
 /* Button to open/close the dropdown section, especially header ones */
@@ -532,7 +545,7 @@ overshoot.right
   min-width: 1.15em;
   padding: 0.06em;
   border: 0;
-  margin: 0 1px 0 1px
+  margin: 0 1px;
 }
 
 #module-always-enabled-button /* button on always activated module */
@@ -546,7 +559,12 @@ overshoot.right
   margin: 12px; /* not real pixels, this is used as a percent extra space */
 }
 
-/* gradient sliders */
+#module-collapse-button #button-canvas /* Adjust collapse arrow size */
+{
+  margin: 18px; /* not real pixels, this is used as a percent extra space */
+}
+
+/* Gradient sliders */
 #gradient-slider
 {
   min-height: 1.7em;
@@ -594,7 +612,8 @@ overshoot.right
 
 .dt_module_focus #iop-panel-label /* set focus mode */
 {
-  color: @plugin_focus_color;
+  color: shade(@plugin_label_color, 1.1);
+  text-shadow: 0px 0px 2px shade(@plugin_label_color, 1.05);
 }
 
 /* Labels of controls sections in modules */
@@ -847,7 +866,7 @@ notebook tabs,
 #modules-tabs,
 #blending-tabs
 {
-  background-color: @button_bg;
+  background-color: @button_border;
 }
 
 #modules-tabs #dt-toggle-button
@@ -869,10 +888,19 @@ notebook tabs,
   font-size: 0.8em;
   min-height: 1.55em;
   min-width: 1.55em;
-  padding: 0.2em;
+  padding: 0.45em;
+  margin: 0;
   border: 0;
 }
 
+/* Do not apply border-radius to group modules icons and masks icons */
+#modules-tabs #dt-toggle-button,
+#blending-tabs button
+{
+  border-radius: 0;
+}
+
+/* Set notebook tabs */
 notebook tab
 {
   border-bottom: 2px solid transparent;
@@ -1485,7 +1513,7 @@ notebook tab:hover label,
 #history-button-always-enabled:hover *,
 #history-button-default-enabled:hover *,
 #recent-collection-button:hover,
-#view_label:hover,
+#view_label:hover,button:checked image,
 #view_dropdown menuitem:hover,
 #view_dropdown .combo:hover *
 {
@@ -1538,7 +1566,7 @@ button:disabled,
 /* Treeviews and filechoosers states */
 treeview check /* set specific background color about check buttons in treeviews like copy/paste dialog window */
 {
-  background-color: @button_bg;
+  background-color: @field_selected_bg;
 }
 
 treeview:not(#lutname) *:hover:not(check),
@@ -1559,8 +1587,7 @@ filechooser *:active
 
 treeview *:selected:not(check),
 treeview *:checked:not(check),
-filechooser *:selected,
-filechooser *:checked
+filechooser *:selected
 {
   background-color: @field_selected_bg;
   color: @field_selected_fg;
@@ -1582,6 +1609,15 @@ treeview check:hover
 filechooser checkbutton:checked
 {
   background-color: transparent;
+}
+
+/* adjust delete folder dialog window */
+treeview#delete-dialog,
+treeview#delete-dialog:selected
+{
+  background-color: shade(@bg_color, 0.9);
+  color: @field_active_fg;
+  padding-left: 1em;
 }
 
 /* Views links states in header */
@@ -1652,11 +1688,16 @@ entry:hover
   background-color: @field_hover_bg;
 }
 
-entry:checked,
 entry:active
 {
   color: @field_active_fg;
   background-color: @field_active_bg;
+}
+
+entry:checked
+{
+  color: @field_selected_fg;
+  background-color: @field_selected_bg;
 }
 
 entry:selected,
@@ -1750,7 +1791,7 @@ Details :
 
 #thumb_main:selected #thumb_back
 {
-  background-color: @thumbnail_selected_bg_color;
+  background-color: shade(@thumbnail_selected_bg_color, 1.05);
 }
 
 #thumb_main:hover #thumb_back
@@ -1838,7 +1879,7 @@ radiobutton radio
 #thumb_image
 {
   border: none;
-  margin : 3px; /* not real pixels, but percentage of the thumb size */
+  margin: 3px; /* not real pixels, but percentage of the thumb size */
 }
 
 .dt_thumbnails_2 #thumb_image /* update consistently margins if big thumbnails (less images per row) are shown */
@@ -1851,7 +1892,7 @@ radiobutton radio
   border: 2px solid @plugin_bg_color;
 }
 
-#thumb_ext  /* adjust margin to align to group, audio... icons */
+#thumb_ext /* adjust margin to align to group, audio... icons */
 {
   margin-top: -1px;
 }
@@ -1879,14 +1920,15 @@ radiobutton radio
   border-right-width: 2px;
 }
 
-/* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
+/* Set background on most modes of thumbnails overlays */
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom
 {
   background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
 }
 
-.dt_overlays_hover_block #thumb_image:hover #thumb_bottom  /* background of last overlay mode and culling/preview ones */
+/* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
+.dt_overlays_hover_block #thumb_image:hover #thumb_bottom
 {
   background-image: none;
   background-color: rgba(220, 220, 220, 0.8);
@@ -1900,40 +1942,22 @@ radiobutton radio
 }
 
 /*--------------------
-  - Thumbnails extension -
+  - Thumbnails infos -
   --------------------*/
 
-/* by default, the extension is hidden */
+/* By default, the extension is hidden */
 #thumb_ext
 {
   color: transparent;
   background-color: transparent;
 }
 
-/* and we show it for specific overlays */
+/* Set default color icons, extension name and text infos on thumbnails and block infos */
+.dt_thumb_btn,
+.dt_overlays_always_extended #thumb_bottom_label,
 .dt_overlays_always #thumb_ext,
 .dt_overlays_always_extended #thumb_ext,
 .dt_overlays_mixed #thumb_ext
-{
-  color: @thumbnail_infos_color;
-}
-.dt_overlays_hover #thumb_main:hover #thumb_ext,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_ext,
-.dt_overlays_always #thumb_main:selected #thumb_ext,
-.dt_overlays_always_extended #thumb_main:selected #thumb_ext,
-.dt_overlays_mixed #thumb_main:selected #thumb_ext
-{
-  color: @thumbnail_font_color;
-}
-
-
-/*--------------------
-  - Thumbnails infos -
-  --------------------*/
-
-/* Set default color icons and text infos on thumbnails and block infos */
-.dt_thumb_btn,
-.dt_overlays_always_extended #thumb_bottom_label
 {
   color: @thumbnail_infos_color;
 }
@@ -1949,7 +1973,15 @@ radiobutton radio
   background-color: transparent;
 }
 
-/* Set hover and selected color icons and text infos */
+/* Set hover and selected color icons, extension name and text infos */
+.dt_overlays_hover #thumb_main:hover #thumb_ext,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_ext,
+.dt_overlays_always #thumb_main:hover #thumb_ext,
+.dt_overlays_always #thumb_main:selected #thumb_ext,
+.dt_overlays_always_extended #thumb_main:hover #thumb_ext,
+.dt_overlays_always_extended #thumb_main:selected #thumb_ext,
+.dt_overlays_mixed #thumb_main:hover #thumb_ext,
+.dt_overlays_mixed #thumb_main:selected #thumb_ext,
 .dt_overlays_hover #thumb_main:hover .dt_thumb_btn,
 .dt_overlays_hover_extended #thumb_main:hover .dt_thumb_btn,
 .dt_overlays_hover_extended #thumb_main:hover #thumb_bottom_label,
@@ -1994,9 +2026,6 @@ radiobutton radio
 .dt_overlays_always #thumb_star:active,
 .dt_overlays_always_extended #thumb_star:active,
 .dt_overlays_mixed #thumb_star:active,
-.dt_overlays_always #thumb_main:selected #thumb_star:active,
-.dt_overlays_always_extended #thumb_main:selected #thumb_star:active,
-.dt_overlays_mixed #thumb_main:selected #thumb_star:active,
 .dt_overlays_hover_block #thumb_image:hover #thumb_star:active
 {
   color: @thumbnail_selected_bg_color;
@@ -2012,7 +2041,7 @@ radiobutton radio
 .dt_overlays_hover_block #thumb_main:hover #thumb_star:hover
 {
   color: @bauhaus_fg_hover;
-  background-color: @thumbnail_bg_color;
+  background-color: @thumbnail_star_bg_color;
 }
 
 /* Set hover group and audio effect */
@@ -2077,6 +2106,12 @@ radiobutton radio
 .dt_culling #thumb_ext,
 .dt_culling #thumb_main:selected #thumb_ext,
 .dt_culling #thumb_main:hover #thumb_ext,
+.dt_overlays_always#culling #thumb_altered,
+.dt_overlays_always#culling #thumb_audio,
+.dt_overlays_always#culling #thumb_group,
+.dt_overlays_always_extended#culling #thumb_altered,
+.dt_overlays_always_extended#culling #thumb_audio,
+.dt_overlays_always_extended#culling #thumb_group,
 .dt_preview #thumb_ext,
 .dt_preview #thumb_main:selected #thumb_ext,
 .dt_preview #thumb_main:hover #thumb_ext
@@ -2094,10 +2129,30 @@ radiobutton radio
 {
   border: 2px solid @plugin_bg_color;
 }
+
 .dt_culling #thumb_main:hover #thumb_image,
 .dt_preview #thumb_main:hover #thumb_image
 {
   border: 2px solid @thumbnail_hover_bg_color;
+}
+
+/* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */
+.dt_overlays_always#culling #thumb_bottom,
+.dt_overlays_always_extended#culling #thumb_bottom,
+.dt_overlays_always#preview #thumb_bottom,
+.dt_overlays_always_extended#preview #thumb_bottom
+{
+  border-top: 1px inset shade(@lighttable_bg_color, 0.9);
+  background-color: shade(@lighttable_bg_color, 1.1);
+}
+
+.dt_overlays_always#culling #thumb_main:hover #thumb_bottom,
+.dt_overlays_always_extended#culling #thumb_main:hover #thumb_bottom,
+.dt_overlays_always#preview #thumb_main:hover #thumb_bottom,
+.dt_overlays_always_extended#preview #thumb_main:hover #thumb_bottom
+{
+  border-top: 1px inset shade(@lighttable_bg_color, 0.9);
+  background-color: shade(@lighttable_bg_color, 1.15);
 }
 
 /* Set zoom info */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -270,14 +270,13 @@ button,
   padding: 2px;
 }
 
-/* default extra margin for icons optical alignment */
+/* Default extra margin for icons optical alignment */
 #button-canvas
 {
   margin: 5px; /* not real pixels, this is used as a percent extra space */
 }
 
 /* Set same settings on all those items */
-
 button,
 #add-color-button,
 #dt-icon,
@@ -459,7 +458,6 @@ overshoot.right
 }
 
 /* icon buttons in modules main body */
-
 #iop-plugin-ui-main #dt-button,
 #iop-plugin-ui-main #dt-toggle-button,
 #iop-plugin-ui-main #keep-active,
@@ -488,7 +486,6 @@ overshoot.right
 /* filter in collect images */
 /* filter in header toolbar */
 /* arrow in filmic */
-/* TODO: move this part to special items? */
 #iop-plugin-ui-main #control-button,
 #lib-plugin-ui-main #control-button,
 #header-toolbar #control-button
@@ -545,7 +542,7 @@ overshoot.right
   min-width: 1.15em;
   padding: 0.06em;
   border: 0;
-  margin: 0 1px 0 1px;
+  margin: 0 1px;
 }
 
 #module-always-enabled-button /* button on always activated module */
@@ -1636,7 +1633,7 @@ filechooser checkbutton:checked
   background-color: transparent;
 }
 
-/* adjust delete folder dialog window */
+/* Adjust delete folder dialog window */
 treeview#delete-dialog,
 treeview#delete-dialog:selected
 {
@@ -1879,11 +1876,6 @@ radiobutton radio,
 radiobutton label
 {
   padding: 0.2em;
-}
-
-radiobutton label
-{
-  margin: 2px;
 }
 
 radiobutton radio

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -286,7 +286,6 @@ textview
 {
   border-radius: 3px;
 }
-
 /* Default text fields and text boxes */
 entry,
 textview
@@ -545,7 +544,7 @@ overshoot.right
   min-width: 1.15em;
   padding: 0.06em;
   border: 0;
-  margin: 0 1px;
+  margin: 0 1px 0 1px;
 }
 
 #module-always-enabled-button /* button on always activated module */
@@ -557,11 +556,6 @@ overshoot.right
 #module-header #button-canvas
 {
   margin: 12px; /* not real pixels, this is used as a percent extra space */
-}
-
-#module-collapse-button #button-canvas /* Adjust collapse arrow size */
-{
-  margin: 18px; /* not real pixels, this is used as a percent extra space */
 }
 
 /* Gradient sliders */
@@ -610,10 +604,9 @@ overshoot.right
   font-size: 1.1em;
 }
 
-.dt_module_focus #iop-panel-label /* set focus mode */
+.dt_module_focus #iop-panel-label/* set focus mode */
 {
-  color: shade(@plugin_label_color, 1.1);
-  text-shadow: 0px 0px 2px shade(@plugin_label_color, 1.05);
+  color: shade(@plugin_label_color, 1.2);
 }
 
 /* Labels of controls sections in modules */
@@ -1247,6 +1240,36 @@ treeview header label,
   margin: 0px;
 }
 
+/*------------
+  - Map view -
+  ------------*/
+
+/* Set how to display result list on find location module */
+#dt-map-location > *
+{
+margin: 2px;
+}
+
+#dt-map-location label
+{
+padding: 2px;
+}
+
+#dt-map-location
+{
+border-bottom: 1px solid @button_border;
+}
+
+#dt-map-location:hover
+{
+  background-color: @field_hover_bg;
+}
+
+#dt-map-location:hover label
+{
+  color: @field_hover_fg;
+}
+
 /*---------------
   - Other stuff -
   ---------------*/
@@ -1572,7 +1595,8 @@ treeview check /* set specific background color about check buttons in treeviews
 treeview:not(#lutname) *:hover:not(check),
 filechooser .sidebar :hover .sidebar-button,  /* set here specific button hover like eject button in filechooser sidebar */
 #import_metadata title:hover,
-#import_metadata title:hover *
+#import_metadata title:hover *,
+radiobutton:hover label  /* set hover effect on popover menu from star icon */
 {
   background-color: @field_hover_bg;
   color: @field_hover_fg;
@@ -1927,6 +1951,12 @@ radiobutton radio
   background-image: linear-gradient(0deg, rgba(220, 220, 220, 0.8) 0%, rgba(220, 220, 220, 0.8) 95%,rgba(220, 220, 220, 0) 100%);
 }
 
+/* Set specific background on hover mode to let show most of the image and be sure bottom infos are visible on vertical or square images */
+.dt_overlays_hover #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(0deg, rgba(241, 241, 241, 0.8) 0%, rgba(241, 241, 241, 0.8) 65%,rgba(241, 241, 241, 0) 100%);
+}
+
 /* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
 .dt_overlays_hover_block #thumb_image:hover #thumb_bottom
 {
@@ -1974,8 +2004,6 @@ radiobutton radio
 }
 
 /* Set hover and selected color icons, extension name and text infos */
-.dt_overlays_hover #thumb_main:hover #thumb_ext,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_ext,
 .dt_overlays_always #thumb_main:hover #thumb_ext,
 .dt_overlays_always #thumb_main:selected #thumb_ext,
 .dt_overlays_always_extended #thumb_main:hover #thumb_ext,
@@ -2032,7 +2060,7 @@ radiobutton radio
   background-color: @thumbnail_font_color;
 }
 
-/* Set star icon hover effect */
+/* Set stars icon hover effect */
 .dt_overlays_hover #thumb_main:hover #thumb_star:hover,
 .dt_overlays_hover_extended #thumb_main:hover #thumb_star:hover,
 .dt_overlays_always #thumb_main:hover #thumb_star:hover,
@@ -2045,10 +2073,6 @@ radiobutton radio
 }
 
 /* Set hover group and audio effect */
-.dt_overlays_hover #thumb_main:hover #thumb_group:hover,
-.dt_overlays_hover #thumb_main:hover #thumb_audio:hover,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_group:hover,
-.dt_overlays_hover_extended #thumb_main:hover #thumb_audio:hover,
 .dt_overlays_always #thumb_main:hover #thumb_group:hover,
 .dt_overlays_always #thumb_main:hover #thumb_audio:hover,
 .dt_overlays_always_extended #thumb_main:hover #thumb_group:hover,
@@ -2059,6 +2083,16 @@ radiobutton radio
 .dt_overlays_hover_block #thumb_main:hover #thumb_audio:hover
 {
   color: @thumbnail_fg_color;
+}
+
+.dt_overlays_hover #thumb_main:hover #thumb_group,
+.dt_overlays_hover #thumb_main:hover #thumb_altered,
+.dt_overlays_hover #thumb_main:hover #thumb_audio,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_group,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_altered,
+.dt_overlays_hover_extended #thumb_main:hover #thumb_audio
+{
+  color: transparent;
 }
 
 /* Set local copy mark */

--- a/src/common/film.c
+++ b/src/common/film.c
@@ -291,13 +291,14 @@ static gboolean ask_and_delete(gpointer user_data)
 
   GtkWidget *tree = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree), FALSE);
-
+  gtk_widget_set_name(GTK_WIDGET(tree), "delete-dialog");
   GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes(_("name"), gtk_cell_renderer_text_new(),
                                                                        "text", 0, NULL);
   gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
 
   gtk_container_add(GTK_CONTAINER(scroll), tree);
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scroll), DT_PIXEL_APPLY_DPI(25));
 
   gtk_container_add(GTK_CONTAINER(content_area), scroll);
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -289,7 +289,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       gtk_widget_get_size_request(thumb->w_bottom, &w, &h);
       image_h = thumb->height - h;
       gtk_widget_get_size_request(thumb->w_altered, &w, &h);
-      image_h -= h + gtk_widget_get_margin_top(thumb->w_altered);
+      if (!thumb->zoomable) image_h -= h + gtk_widget_get_margin_top(thumb->w_altered);
       image_h *= ratio_h;
     }
     else if(thumb->over == DT_THUMBNAIL_OVERLAYS_MIXED)
@@ -436,8 +436,15 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       posx = thumb->width * thumb->img_margin->left / 100 + (image_w - imgbox_w) / 2;
       int w = 0;
       int h = 0;
-      gtk_widget_get_size_request(thumb->w_altered, &w, &h);
-      posy = h + gtk_widget_get_margin_top(thumb->w_altered);
+       if (!thumb->zoomable)
+      {
+        gtk_widget_get_size_request(thumb->w_altered, &w, &h);
+        posy = h + gtk_widget_get_margin_top(thumb->w_altered);
+      }
+      else
+      {
+        posy = 0;
+      }
 
       gtk_widget_get_size_request(thumb->w_bottom, &w, &h);
       posy += (thumb->height - posy - h) * thumb->img_margin->top / 100 + (image_h - imgbox_h) / 2;
@@ -1257,7 +1264,7 @@ static void _thumb_resize_overlays(dt_thumbnail_t *thumb)
       gtk_widget_set_size_request(thumb->w_bottom, width, 2.5 * r1 + h + 2 * margin_b);
     }
     else
-      gtk_widget_set_size_request(thumb->w_bottom, width, 1.75 * r1 + 2 * margin_b);
+      gtk_widget_set_size_request(thumb->w_bottom, width, 2.5 * r1 + 2 * margin_b);
 
     gtk_label_set_xalign(GTK_LABEL(thumb->w_bottom), 0.5);
     gtk_label_set_yalign(GTK_LABEL(thumb->w_bottom), 0.03);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -2523,6 +2523,7 @@ void gui_init(dt_lib_module_t *self)
     box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
     d->rule[i].hbox = GTK_WIDGET(box);
     gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
+    gtk_widget_set_name(GTK_WIDGET(box), "lib-dtbutton");
     GtkListStore *model = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_INT);
     w = gtk_combo_box_new_with_model(GTK_TREE_MODEL(model));
     GtkCellRenderer *renderer = gtk_cell_renderer_text_new();

--- a/src/libs/modulelist.c
+++ b/src/libs/modulelist.c
@@ -88,7 +88,6 @@ void gui_init(dt_lib_module_t *self)
   d->tree = GTK_TREE_VIEW(gtk_tree_view_new());
   gtk_widget_set_size_request(GTK_WIDGET(d->tree), DT_PIXEL_APPLY_DPI(50), -1);
   gtk_container_add(GTK_CONTAINER(self->widget), GTK_WIDGET(d->tree));
-  gtk_widget_set_name(GTK_WIDGET(self->widget), "lib-modulelist");
 
   /* connect to signal for darktable.develop initialization */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_DEVELOP_INITIALIZE,


### PR DESCRIPTION
- Fix delete folder dialog window when removing all images of a folder. As I don't know Gtk code, I just found the Gtk tweak in film.c. It works but the content is not adjusted (a better fix is probably possible). Anyway, the result is much better than it was. See below:

before:
![2020-05-24_11-24](https://user-images.githubusercontent.com/45535283/83689557-84ae3e80-a5ef-11ea-9d9a-135f9d503146.png)

after:
![2020-05-24_17-15](https://user-images.githubusercontent.com/45535283/83689568-8a0b8900-a5ef-11ea-91dd-4fdf163927da.png)

- Improve treeviews and especially hover and selected effects.
- Improve module label title when on focus mode. I've tried to find a compromise on color for both disabled and enabled modules. This tweak is more suitable on enable module than disable one but can't set a different setting regardless of module status. To improve that, would probably need some Gtk need. See below:

![2020-06-03_23-14](https://user-images.githubusercontent.com/45535283/83689872-0e5e0c00-a5f0-11ea-8343-940f6db9683f.png)
![2020-06-03_23-14_1](https://user-images.githubusercontent.com/45535283/83689874-1027cf80-a5f0-11ea-9879-ec91862f7cbe.png)

- Make stars on all states consistent in all themes (that was not the case!)
- Make all checkbox consistent and so displayed same way on all the UI
- Integrate CSS tweaks from #5268 with related icons/infos ones to be sure all remains consistent in the future.
- Avoid to apply border-radius and margins on modules-tabs and blending-tabs and have better hover effect on module groups tabs and mask tabs.
- Minor other tweaks
- And set CSS for #5179 PR by @AlicVB (so better to merge it before my PR).