### PR TITLE
simplify painting API

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -481,7 +481,7 @@ void dtgtk_cairo_paint_masks_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_masks_circle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1.05, 0, 0)
+  PREAMBLE(1.1, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.4, 0, 6.2832);
   cairo_stroke(cr);
@@ -491,7 +491,7 @@ void dtgtk_cairo_paint_masks_circle(cairo_t *cr, gint x, gint y, gint w, gint h,
 
 void dtgtk_cairo_paint_masks_ellipse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1.1, 0, 0)
+  PREAMBLE(1.1, 0, -0.025)
 
   cairo_save(cr);
   cairo_translate(cr, 0.1465, 0);
@@ -507,7 +507,7 @@ void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint 
 {
   PREAMBLE(1, 0, 0)
 
-  cairo_rectangle(cr, 0.1, 0.1, 0.8, 0.8);
+  cairo_rectangle(cr, 0.1, 0.1, 0.9, 0.9);
   cairo_stroke_preserve(cr);
   cairo_pattern_t *pat = NULL;
   pat = cairo_pattern_create_linear(0.5, 0.1, 0.5, 0.9);
@@ -557,7 +557,7 @@ void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, g
 
 void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.8, 0.1, 0.1)
+  PREAMBLE(0.85, 0.1, 0.1)
 
   cairo_move_to(cr, 0.0, 1.0);
   cairo_line_to(cr, 0.1, 0.7);
@@ -579,8 +579,9 @@ void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint
 
 void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(0.9, 0., 0.)
+  PREAMBLE(0.8, 0., 0.)
 
+  // main cylinder
   cairo_move_to(cr, 0.0, 1.0);
   cairo_line_to(cr, 0.1, 0.7);
   cairo_line_to(cr, 0.8, 0.0);
@@ -589,8 +590,19 @@ void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_line_to(cr, 0.0, 1.0);
   cairo_stroke(cr);
 
+  // line
+  cairo_move_to(cr, 0.2, 0.8);
+  cairo_line_to(cr, 0.85, 0.15);
+  cairo_stroke(cr);
+
+  // junction
   cairo_move_to(cr, 0.1, 0.7);
   cairo_line_to(cr, 0.3, 0.9);
+  cairo_stroke(cr);
+
+  // tip
+  cairo_move_to(cr, -0.05, 1.05);
+  cairo_line_to(cr, 0.05, 0.95);
   cairo_stroke(cr);
 
   FINISH
@@ -618,6 +630,7 @@ void dtgtk_cairo_paint_masks_drawn(cairo_t *cr, gint x, gint y, gint w, gint h, 
   // cairo_stroke_preserve(cr);
   cairo_fill(cr);
   cairo_stroke(cr);
+
   // draw the tip of the pencil
   cairo_move_to(cr, 1.0, 1.0);
   cairo_line_to(cr, 0.9, 0.6);

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -25,33 +25,44 @@
 #define M_PI 3.141592654
 #endif
 
+#define PREAMBLE(scaling, x_offset, y_offset) {                                                        \
+                            cairo_save(cr);                                                            \
+                            cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);                              \
+                            const float s = ((w < h) ? w : h) * scaling;                               \
+                            cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0)); \
+                            cairo_scale(cr, s, s);                                                     \
+                            cairo_translate(cr, x_offset, y_offset);                                   \
+                            cairo_matrix_t matrix;                                                     \
+                            cairo_get_matrix(cr, &matrix);                                             \
+                            cairo_set_line_width(cr, 1.618 / hypot(matrix.xx, matrix.yy)); }
+
+#define FINISH { cairo_identity_matrix(cr); \
+                 cairo_restore(cr); }
+
 void dtgtk_cairo_paint_empty(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x, y);
-  cairo_scale(cr, w, h);
+  PREAMBLE(1, 0, 0)
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+  FINISH
 }
 void dtgtk_cairo_paint_color(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   cairo_translate(cr, x, y);
   cairo_scale(cr, w, h);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_rectangle(cr, 0.1, 0.1, 0.8, 0.8);
   cairo_fill(cr);
   cairo_set_source_rgba(cr, 0, 0, 0, 0.6);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_presets(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_move_to(cr, 0.1, 0.1);
   cairo_line_to(cr, 0.9, 0.1);
   cairo_move_to(cr, 0.1, 0.5);
@@ -60,11 +71,13 @@ void dtgtk_cairo_paint_presets(cairo_t *cr, gint x, gint y, gint w, gint h, gint
   cairo_line_to(cr, 0.9, 0.9);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_triangle(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   /* initialize rotation and flip matrices */
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
@@ -76,18 +89,10 @@ void dtgtk_cairo_paint_triangle(cairo_t *cr, gint x, int y, gint w, gint h, gint
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
   /* scale and transform*/
-  const gint s = w < h ? w : h;
-  cairo_save(cr);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
-
   if(flags & CPF_DIRECTION_UP || flags & CPF_DIRECTION_DOWN)
     cairo_transform(cr, &rotation_matrix);
   else if(flags & CPF_DIRECTION_LEFT) // Flip x transformation
     cairo_transform(cr, &hflip_matrix);
-
 
   cairo_move_to(cr, 0.05, 0.5);
   cairo_line_to(cr, 0.05, 0.1);
@@ -95,12 +100,14 @@ void dtgtk_cairo_paint_triangle(cairo_t *cr, gint x, int y, gint w, gint h, gint
   cairo_line_to(cr, 0.05, 0.9);
   cairo_line_to(cr, 0.05, 0.5);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   /* initialize rotation and flip matrices */
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
@@ -112,13 +119,6 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
   /* scale and transform*/
-  const gint s = w < h ? w : h;
-  cairo_save(cr);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
-
   if(flags & CPF_DIRECTION_UP || flags & CPF_DIRECTION_DOWN)
     cairo_transform(cr, &rotation_matrix);
   else if(flags & CPF_DIRECTION_LEFT) // Flip x transformation
@@ -132,12 +132,14 @@ void dtgtk_cairo_paint_solid_triangle(cairo_t *cr, gint x, int y, gint w, gint h
   cairo_stroke_preserve(cr);
   cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
 
@@ -146,12 +148,6 @@ void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   S = flags & CPF_DIRECTION_UP ? sin(-(M_PI * 1.5)) : S;
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
-
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
 
   if(flags & CPF_DIRECTION_UP || flags & CPF_DIRECTION_DOWN)
     cairo_transform(cr, &rotation_matrix);
@@ -162,11 +158,14 @@ void dtgtk_cairo_paint_arrow(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   cairo_line_to(cr, 0.9, 0.5);
   cairo_line_to(cr, 0.2, 0.9);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   /* initialize rotation and flip matrices */
   cairo_matrix_t hflip_matrix;
   cairo_matrix_init(&hflip_matrix, -1, 0, 0, 1, 1, 0);
@@ -178,12 +177,6 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
 
   /* scale and transform*/
-  float s = w < h ? w : h;
-  s *= 1.4; // for some reason, this one needs expansion
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-
   if(flags & CPF_DIRECTION_UP || flags & CPF_DIRECTION_DOWN)
     cairo_transform(cr, &rotation_matrix);
   else if(flags & CPF_DIRECTION_LEFT) // Flip x transformation
@@ -193,20 +186,18 @@ void dtgtk_cairo_paint_solid_arrow(cairo_t *cr, gint x, int y, gint w, gint h, g
   cairo_line_to(cr, 0.9, 0.5);
   cairo_line_to(cr, 0.2, 0.9);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   double C = cos(-1.570796327), S = sin(-1.570796327);
   cairo_matrix_t rotation_matrix;
   cairo_matrix_init(&rotation_matrix, C, S, -S, C, 0.5 - C * 0.5 + S * 0.5, 0.5 - S * 0.5 - C * 0.5);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   if((flags & CPF_DIRECTION_UP)) // Rotate -90 degrees
     cairo_transform(cr, &rotation_matrix);
 
@@ -215,35 +206,31 @@ void dtgtk_cairo_paint_flip(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   cairo_line_to(cr, 0.95, 0.50);
   cairo_line_to(cr, 0.2, 0.50);
   cairo_stroke(cr);
-  cairo_set_line_width(cr, 0.04);
+
   cairo_move_to(cr, 0.05, 0.62);
   cairo_line_to(cr, 0.05, 1.0);
   cairo_line_to(cr, 0.95, 0.62);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_reset(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_arc(cr, 0.5, 0.5, 0.46, 0, 6.2832);
   cairo_move_to(cr, 0.5, 0.32);
   cairo_line_to(cr, 0.5, 0.68);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_store(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_move_to(cr, 0.275, 0.1);
   cairo_line_to(cr, 0.1, 0.1);
   cairo_line_to(cr, 0.1, 0.9);
@@ -255,25 +242,22 @@ void dtgtk_cairo_paint_store(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   cairo_line_to(cr, 0.275, 0.1);
 
   cairo_stroke(cr);
-  cairo_set_line_width(cr, 0.1);
   cairo_rectangle(cr, 0.5, 0.025, 0.17, 0.275);
   cairo_fill(cr);
-
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
+
   cairo_arc(cr, 0.5, 0.5, 0.46, (-50 * 3.145 / 180), (230 * 3.145 / 180));
   cairo_move_to(cr, 0.5, 0.0);
   cairo_line_to(cr, 0.5, 0.5);
   cairo_stroke(cr);
+
   if(flags & CPF_FOCUS) // If focused add some diffuse light
   {
     cairo_arc(cr, 0.5, 0.5, 0.45, 0.0, 2*M_PI);
@@ -281,50 +265,41 @@ void dtgtk_cairo_paint_switch(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
     cairo_paint_with_alpha(cr, 0.4);
   }
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
+
   if(flags & CPF_FOCUS)
   {
-    cairo_set_line_width(cr, 0.05);
     cairo_arc(cr, 0.5, 0.5, 0.65, 0, 2 * M_PI);
     cairo_stroke(cr);
   }
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.35, 0, 2 * M_PI);
   cairo_fill(cr);
 
   cairo_arc(cr, 0.5, 0.5, 0.50, 0, 2 * M_PI);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_switch_off(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.50, 0, 2 * M_PI);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.2);
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_move_to(cr, 0, 0);
   cairo_line_to(cr, 1, 1);
@@ -333,7 +308,7 @@ void dtgtk_cairo_paint_switch_deprecated(cairo_t *cr, gint x, gint y, gint w, gi
   cairo_line_to(cr, 1, 0);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
@@ -343,13 +318,8 @@ void dtgtk_cairo_paint_plus(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 
 void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_arc(cr, 0.5, 0.5, 0.45, 0, 2 * M_PI);
   cairo_stroke(cr);
 
@@ -372,19 +342,14 @@ void dtgtk_cairo_paint_plusminus(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   }
 
   cairo_identity_matrix(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.4, 0.1);
   cairo_line_to(cr, 0.4, 0.9);
   cairo_line_to(cr, 0.2, 0.7);
@@ -393,78 +358,50 @@ void dtgtk_cairo_paint_sorting(cairo_t *cr, gint x, gint y, gint w, gint h, gint
   cairo_line_to(cr, 0.8, 0.3);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_plus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.5, 0.1);
   cairo_line_to(cr, 0.5, 0.9);
   cairo_move_to(cr, 0.1, 0.5);
   cairo_line_to(cr, 0.9, 0.5);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_minus_simple(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.1, 0.5);
   cairo_line_to(cr, 0.9, 0.5);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_multiply_small(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.3, 0.3);
   cairo_line_to(cr, 0.7, 0.7);
   cairo_move_to(cr, 0.7, 0.3);
   cairo_line_to(cr, 0.3, 0.7);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
-  cairo_set_line_width(cr, 0.2);
   cairo_move_to(cr, 0.05, 0.05);
   cairo_line_to(cr, 0.125, 0.05);
   cairo_move_to(cr, 0.25, 0.35);
@@ -475,7 +412,6 @@ void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_line_to(cr, 0.325, 0.95);
   cairo_stroke(cr);
 
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.35, 0.05);
   cairo_line_to(cr, 0.95, 0.05);
   cairo_move_to(cr, 0.55, 0.35);
@@ -486,32 +422,25 @@ void dtgtk_cairo_paint_treelist(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_line_to(cr, 0.95, 0.95);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_invert(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = (w < h ? w : h);
-  s *= 0.95; // optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(0.95, 0, 0)
+
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_arc(cr, 0.5, 0.5, 0.46, 0, 2.0 * M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, 0.5, 0.5, 0.46, 3.0 * M_PI / 2.0, M_PI / 2.0);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.1, 0, 6.2832);
   cairo_stroke(cr);
@@ -522,23 +451,19 @@ void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
   cairo_arc(cr, 0.5, 0.5, 0.45, 0, 6.2832);
   cairo_restore(cr);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.08);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   double dashed[] = { 0.2, 0.2 };
   int len = sizeof(dashed) / sizeof(dashed[0]);
   cairo_set_dash(cr, dashed, len, 0);
 
   cairo_arc(cr, 0.75, 0.75, 0.75, 2.8, 4.7124);
-  cairo_set_line_width(cr, 0.1);
   cairo_stroke(cr);
 
   cairo_move_to(cr, 0.4, 0.1);
@@ -551,56 +476,37 @@ void dtgtk_cairo_paint_masks_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_line_to(cr, 0.4, 0.1);
   cairo_fill(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_circle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.05; // optical balancing
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1.05, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
   cairo_arc(cr, 0.5, 0.5, 0.4, 0, 6.2832);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_ellipse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.1; // optical balancing
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
+  PREAMBLE(1.1, 0, 0)
+
   cairo_save(cr);
+  cairo_translate(cr, 0.1465, 0);
   cairo_scale(cr, 0.707, 1);
-  cairo_translate(cr, 0.15, 0);
   cairo_arc(cr, 0.5, 0.5, 0.4, 0, 6.2832);
   cairo_restore(cr);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
+  PREAMBLE(1, 0, 0)
+
   cairo_rectangle(cr, 0.1, 0.1, 0.8, 0.8);
   cairo_stroke_preserve(cr);
   cairo_pattern_t *pat = NULL;
@@ -610,19 +516,14 @@ void dtgtk_cairo_paint_masks_gradient(cairo_t *cr, gint x, gint y, gint w, gint 
   cairo_set_source(cr, pat);
   cairo_fill(cr);
   cairo_pattern_destroy(pat);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.05; // optical balancing
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
+  PREAMBLE(1.05, 0, 0)
+
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_move_to(cr, 0.1, 0.9);
   cairo_curve_to(cr, 0.1, 0.5, 0.9, 0.6, 0.9, 0.1);
@@ -631,19 +532,14 @@ void dtgtk_cairo_paint_masks_path(cairo_t *cr, gint x, gint y, gint w, gint h, g
   cairo_line_to(cr, 0.3, 0.1);
   cairo_set_line_width(cr, 0.1);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
+  PREAMBLE(1, 0, 0)
+
   cairo_rectangle(cr, 0.1, 0.1, 0.9, 0.9);
   cairo_stroke_preserve(cr);
   cairo_pattern_t *pat = NULL;
@@ -654,91 +550,65 @@ void dtgtk_cairo_paint_masks_vertgradient(cairo_t *cr, gint x, gint y, gint w, g
   cairo_set_source(cr, pat);
   cairo_fill(cr);
   cairo_pattern_destroy(pat);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 
 void dtgtk_cairo_paint_masks_brush_and_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(0.8, 0.1, 0.1)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
-  cairo_translate(cr, 0.1, 0.1);
-  cairo_scale(cr, 0.8, 0.8);
   cairo_move_to(cr, 0.0, 1.0);
   cairo_line_to(cr, 0.1, 0.7);
   cairo_line_to(cr, 0.8, 0.0);
   cairo_line_to(cr, 1.0, 0.2);
   cairo_line_to(cr, 0.3, 0.9);
   cairo_line_to(cr, 0.0, 1.0);
-  //  cairo_fill_preserve(cr);
   cairo_stroke(cr);
 
-  //cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.4, 0, 2.0 * M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, 0.5, 0.5, 0.4, 3.0 * M_PI / 2.0, M_PI / 2.0);
   cairo_fill(cr);
 
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_brush(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.1; // optical balancing
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(0.9, 0., 0.)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  if(flags & CPF_ACTIVE)
-    cairo_set_line_width(cr, 0.25);
-  else
-    cairo_set_line_width(cr, 0.08);
-  cairo_translate(cr, 0.1, 0.1);
-  cairo_scale(cr, 0.8, 0.8);
   cairo_move_to(cr, 0.0, 1.0);
   cairo_line_to(cr, 0.1, 0.7);
   cairo_line_to(cr, 0.8, 0.0);
   cairo_line_to(cr, 1.0, 0.2);
   cairo_line_to(cr, 0.3, 0.9);
   cairo_line_to(cr, 0.0, 1.0);
-  //  cairo_fill_preserve(cr);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  cairo_move_to(cr, 0.1, 0.7);
+  cairo_line_to(cr, 0.3, 0.9);
+  cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_uniform(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 0.95; // optical balance
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(0.95, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.5, -M_PI, M_PI);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_drawn(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.03; //optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_translate(cr, 0, -0.05); // optical alignment
-
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1.03, 0, -0.05)
 
   // draw the body of the pencil (filled)
   cairo_move_to(cr, 0.9, 0.6);
@@ -754,7 +624,8 @@ void dtgtk_cairo_paint_masks_drawn(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_line_to(cr, 0.6, 0.9);
   cairo_line_to(cr, 1.0, 1.0);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 /** draws an arc with a B&W gradient following the arc path.
@@ -785,17 +656,11 @@ void _gradient_arc(cairo_t *cr, double lw, int nb_steps, double x_center, double
 
 void dtgtk_cairo_paint_masks_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 0.95; // optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(0.95, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
   _gradient_arc(cr, 0.125, 16, 0.5, 0.5, 0.5, -M_PI / 3.0, M_PI + M_PI / 3.0, 0.3, 0.9);
 
   cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
-  cairo_set_line_width(cr, 0.05);
   // draw one tick up right
   cairo_move_to(cr, 1, 0.2);
   cairo_line_to(cr, 1.2, 0.2);
@@ -807,24 +672,16 @@ void dtgtk_cairo_paint_masks_parametric(cairo_t *cr, gint x, gint y, gint w, gin
   cairo_line_to(cr, 1.275, 0.75);
   cairo_fill(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_drawn_and_parametric(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags,
                                                   void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.05; // optical balance
-  cairo_save(cr);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_translate(cr, -0.1, -0.05); // optical alignment
+  PREAMBLE(1.05, -0.1, -0.05)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
   _gradient_arc(cr, 0.125, 16, 0.75, 0.6, 0.4, -M_PI / 3.0, M_PI + M_PI / 3.0, 0.3, 0.9);
 
-  cairo_set_line_width(cr, 0.05);
   cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
   // draw one tick up right
   cairo_move_to(cr, 1.2, 0.35);
@@ -854,18 +711,13 @@ void dtgtk_cairo_paint_masks_drawn_and_parametric(cairo_t *cr, gint x, gint y, g
   cairo_line_to(cr, 1.0, 1.0);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_masks_raster(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
   cairo_arc(cr, 0.5, 0.5, 0.5, 0, 2 * M_PI);
   cairo_clip(cr);
   cairo_new_path(cr);
@@ -878,57 +730,49 @@ void dtgtk_cairo_paint_masks_raster(cairo_t *cr, gint x, gint y, gint w, gint h,
       cairo_rectangle(cr, i / 4.0, j / 4.0, 1.0 / 4.0, 1.0 / 4.0);
       cairo_fill(cr);
     }
+
+  FINISH
 }
 
 
 void dtgtk_cairo_paint_masks_multi(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_arc(cr, 0.3, 0.3, 0.3, 0, 6.2832);
   cairo_stroke(cr);
   cairo_move_to(cr, 0.0, 1.0);
   cairo_curve_to(cr, 0.0, 0.5, 1.0, 0.6, 1.0, 0.0);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 void dtgtk_cairo_paint_masks_inverse(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_arc(cr, 0.5, 0.5, 0.46, 0, 2.0 * M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, 0.5, 0.5, 0.46, 3.0 * M_PI / 2.0, M_PI / 2.0);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 void dtgtk_cairo_paint_masks_union(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s * 1.4, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_set_source_rgb(cr, 0.6, 0.6, 0.6);
   cairo_arc(cr, -0.05, 0.5, 0.45, 0, 6.2832);
   cairo_arc(cr, 0.764, 0.5, 0.45, 0, 6.2832);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 void dtgtk_cairo_paint_masks_intersection(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s * 1.4, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
   cairo_set_source_rgb(cr, 0.4, 0.4, 0.4);
   cairo_arc(cr, 0.05, 0.5, 0.45, 0, 6.3);
   cairo_new_sub_path(cr);
@@ -940,16 +784,13 @@ void dtgtk_cairo_paint_masks_intersection(cairo_t *cr, gint x, gint y, gint w, g
   cairo_arc(cr, 0.65, 0.5, 0.45, 2.1, 4.1832);
   cairo_close_path(cr);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s * 1.4, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
   cairo_set_source_rgb(cr, 0.4, 0.4, 0.4);
   cairo_arc(cr, 0.65, 0.5, 0.45, 0, 6.3);
   cairo_stroke(cr);
@@ -959,43 +800,35 @@ void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gin
   cairo_arc_negative(cr, 0.65, 0.5, 0.45, 4.1832, 2.1);
   cairo_close_path(cr);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s * 1.4, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_set_source_rgb(cr, 0.6, 0.6, 0.6);
   cairo_arc(cr, 0.0, 0.5, 0.45, 0, 6.2832);
   cairo_arc_negative(cr, 0.714, 0.5, 0.45, 0, 6.2832);
   cairo_fill(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.35, 0, 6.2832);
   cairo_move_to(cr, 0.5, 0.15);
   cairo_line_to(cr, 0.5, 0.5);
   cairo_stroke(cr);
-  cairo_identity_matrix(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.1, 0, 6.2832);
   cairo_stroke(cr);
@@ -1016,39 +849,27 @@ void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, g
     cairo_stroke(cr);
   }
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 
 
 void dtgtk_cairo_paint_timer(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.5, (-80 * 3.145 / 180), (150 * 3.145 / 180));
   cairo_line_to(cr, 0.5, 0.5);
-
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const float alpha = 0.8f;
-  float s = w < h ? w : h;
-  s *= 0.95; // optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(0.95, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  const float alpha = 0.8f;
 
   cairo_set_source_rgba(cr, 0.0, 0.8, 0.0, alpha);
   cairo_move_to(cr, 0.3, 0.0);
@@ -1068,7 +889,7 @@ void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   cairo_line_to(cr, 1.0, 0.7);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
@@ -1076,16 +897,12 @@ void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   gdouble sw = 0.6;
   gdouble bend = 0.3;
 
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
+
   cairo_scale(cr, 0.7, 0.7);
   cairo_translate(cr, 0.15, 0.15);
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
   /* s curve left */
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.0, 1.0);
   cairo_curve_to(cr, 0.0, 0.0 + bend, (1.0 - sw), 1.0 - bend, (1.0 - sw), 0.0);
   cairo_stroke(cr);
@@ -1096,7 +913,6 @@ void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_stroke(cr);
 
   /* filmstrip start,stop and divider */
-  cairo_set_line_width(cr, 0.05);
   cairo_move_to(cr, 0, 1.0);
   cairo_line_to(cr, sw, 1.0);
   cairo_stroke(cr);
@@ -1104,65 +920,52 @@ void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_line_to(cr, 1.0, 0.0);
   cairo_stroke(cr);
 
-  cairo_set_line_width(cr, 0.07);
   cairo_move_to(cr, 1 - sw, 0.5);
   cairo_line_to(cr, sw, 0.5);
   cairo_stroke(cr);
 
-
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_directory(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
+  PREAMBLE(1, 0, 0);
+
   cairo_set_source_rgb(cr, .8, .8, .8);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_translate(cr, x + .05 * w, y + .05 * h);
-  cairo_scale(cr, .9 * w, .9 * h);
-  cairo_set_line_width(cr, 1. / w);
   cairo_rectangle(cr, 0., 0., 1., 1.);
   cairo_stroke(cr);
   cairo_move_to(cr, 0., .2);
   cairo_line_to(cr, .5, .2);
   cairo_line_to(cr, .6, 0.);
   cairo_stroke(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_refresh(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
+
   if(flags & 1)
   {
     cairo_translate(cr, 1, 0);
     cairo_scale(cr, -1, 1);
   }
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_move_to(cr, 0.65, 0.1);
   cairo_line_to(cr, 0.5, 0.2);
   cairo_line_to(cr, 0.65, 0.3);
   cairo_stroke(cr);
 
-  cairo_set_line_width(cr, 0.10);
   cairo_arc(cr, 0.5, 0.5, 0.35, (-80 * 3.145 / 180), (220 * 3.145 / 180));
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_perspective(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   if((flags & 3) == 1)
   {
@@ -1191,16 +994,13 @@ void dtgtk_cairo_paint_perspective(cairo_t *cr, gint x, gint y, gint w, gint h, 
     cairo_line_to(cr, 0.1, 0.9);
     cairo_stroke(cr);
   }
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.1);
   cairo_line_to(cr, 0.0, 0.9);
@@ -1214,59 +1014,49 @@ void dtgtk_cairo_paint_structure(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_move_to(cr, 0.9, 0.1);
   cairo_line_to(cr, 1.0, 0.9);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_cancel(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.05; // optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1.05, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_move_to(cr, 0.9, 0.1);
   cairo_line_to(cr, 0.1, 0.9);
   cairo_stroke(cr);
   cairo_move_to(cr, 0.9, 0.9);
   cairo_line_to(cr, 0.1, 0.1);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_aspectflip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
+
   if(flags & 1)
   {
     cairo_translate(cr, 0, 1);
     cairo_scale(cr, 1, -1);
   }
 
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_move_to(cr, 0.65, 0.0);
   cairo_line_to(cr, 0.5, 0.05);
   cairo_line_to(cr, 0.6, 0.25);
   cairo_stroke(cr);
 
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.45, (-80 * 3.145 / 180), (220 * 3.145 / 180));
   cairo_stroke(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x + w / 2.0, y + h / 2.0);
-  float s = (w < h ? w / 2.0 : h / 2.0);
-  s *= 1.1; //fine tuning
-  cairo_scale(cr, s, s);
-  cairo_translate(cr, 0.06, -0.10); //fine tuning
+  PREAMBLE(0.5 * 1.1, 0.5 + 0.06, 0.5 -0.10)
 
-  cairo_set_line_width(cr, 0.15);
   cairo_arc(cr, 0.250, 0.45, 0.5, 0.0, 2.0 * M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, -0.58, 0.65, 0.30, 0.0, 2.0 * M_PI);
@@ -1277,21 +1067,21 @@ void dtgtk_cairo_paint_styles(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   /* if its a popup menu */
   if(flags)
   {
-    cairo_set_line_width(cr, 0.12);
     cairo_move_to(cr, 0.475, -0.93);
     cairo_line_to(cr, 0.15, -0.20);
     cairo_line_to(cr, 0.85, -0.20);
     cairo_fill(cr);
   }
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
+  PREAMBLE(1, 0, 0)
+
   gboolean def = FALSE;
-  const gint s = (w < h ? w : h);
   double r = 0.4;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
 
   /* fill base color */
   cairo_arc(cr, 0.5, 0.5, r, 0.0, 2.0 * M_PI);
@@ -1330,7 +1120,6 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   /* draw cross overlay if highlighted */
   if(def == TRUE && (flags & CPF_PRELIGHT))
   {
-    cairo_set_line_width(cr, 0.15);
     cairo_set_source_rgba(cr, 0.5, 0.0, 0.0, 0.8);
     cairo_move_to(cr, 0.0, 0.0);
     cairo_line_to(cr, 1.0, 1.0);
@@ -1338,13 +1127,13 @@ void dtgtk_cairo_paint_label(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
     cairo_line_to(cr, 0.1, 0.9);
     cairo_stroke(cr);
   }
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
   // circle around (mouse over effect)
   if(flags & CPF_PRELIGHT)
@@ -1356,11 +1145,6 @@ void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   {
     // that means the image is rejected, so we draw the cross in red bold
     cairo_set_source_rgb(cr, 1.0, 0, 0);
-    cairo_set_line_width(cr, 2.0 / (float)s);
-  }
-  else
-  {
-    cairo_set_line_width(cr, 1.0 / (float)s);
   }
 
   // the cross
@@ -1369,17 +1153,16 @@ void dtgtk_cairo_paint_reject(cairo_t *cr, gint x, gint y, gint w, gint h, gint 
   cairo_move_to(cr, 0.8, 0.2);
   cairo_line_to(cr, 0.2, 0.8);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  // cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
   // we create the path
-  cairo_save(cr);
-  dt_draw_star(cr, s / 2.0, s / 2.0, s / 2.0, s / 5.0);
+  dt_draw_star(cr, 1 / 2., 1. / 2., 1. / 2., 1. / 5.);
 
   // we fill the star if needed (mouseover or activated)
   if(data)
@@ -1394,16 +1177,14 @@ void dtgtk_cairo_paint_star(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
     }
   }
 
-  cairo_set_line_width(cr, 1.0);
   cairo_stroke(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
   /* fill base color */
   cairo_move_to(cr, 0, 0);
@@ -1411,17 +1192,15 @@ void dtgtk_cairo_paint_local_copy(cairo_t *cr, gint x, gint y, gint w, gint h, g
   cairo_line_to(cr, 1.0, 0);
   cairo_close_path(cr);
   cairo_fill(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_altered(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x + w / 2.0, y + h / 2.0);
+  PREAMBLE(0.5 * 0.9, 0.5, 0.5)
 
-  const float s = (w < h ? w / 2.0 : h / 2.0);
-  cairo_scale(cr, s, s);
-
-  const float r = 0.95;
-  cairo_set_line_width(cr, .1);
+  const float r = 1.;
   cairo_arc(cr, 0, 0, r, 0, 2.0f * M_PI);
   const float dx = r * cosf(M_PI / 8.0f), dy = r * sinf(M_PI / 8.0f);
   cairo_move_to(cr,  - dx,  - dy);
@@ -1433,20 +1212,13 @@ void dtgtk_cairo_paint_altered(cairo_t *cr, gint x, gint y, gint w, gint h, gint
   cairo_move_to(cr,  .5 * dx, -.8 * dy - .3 * dx);
   cairo_line_to(cr,  .5 * dx, -.8 * dy + .3 * dx);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_audio(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  const float d = 1.0;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 1.0 / (float)s);
-  cairo_save(cr);
-
-  cairo_translate(cr, 0.5 - (d / 2.0), 0.5 - (d / 2.0));
-  cairo_scale(cr, d, d);
+  PREAMBLE(1, 0, 0)
 
   cairo_rectangle(cr, 0.05, 0.4, 0.2, 0.2);
   cairo_move_to(cr, 0.25, 0.6);
@@ -1461,16 +1233,16 @@ void dtgtk_cairo_paint_audio(cairo_t *cr, gint x, gint y, gint w, gint h, gint f
   cairo_new_sub_path(cr);
   cairo_arc(cr, 0.2, 0.5, 0.75, -(35.0 / 180.0) * M_PI, (35.0 / 180.0) * M_PI);
 
-  cairo_restore(cr);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
+  PREAMBLE(1, 0, 0)
+
   const float r = 0.18;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
 
   if(flags & CPF_DIRECTION_UP)
   {
@@ -1506,29 +1278,28 @@ void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h,
     cairo_set_source_rgba(cr, 0.9, 0, 0.9, 1.0);
     cairo_fill(cr);
   }
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_colorpicker(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = (w < h ? w : h);
-  s *= 1.05; // optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1.05, 0, -0.05)
 
   /* draw pipette */
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
   // drop
-  cairo_set_line_width(cr, 0.15);
-  cairo_move_to(cr, 0.08, 1. - 0.01);
-  cairo_line_to(cr, 0.08, 1. - 0.09);
-  cairo_stroke(cr);
+  cairo_move_to(cr, 0., 1. - 0.0);
+  cairo_line_to(cr, 0.08, 1. - 0.15);
+  cairo_line_to(cr, 0.16, 1. - 0.0);
+  cairo_arc(cr, 0.08, 1. - 0.15 + 0.1926, 0.090666667, -0.49, 3.63);
+  cairo_fill(cr);
 
-  cairo_set_line_width(cr, 0.2);
   // cross line
+  cairo_set_line_width(cr, 0.15);
   cairo_move_to(cr, 0.48, 1. - 0.831);
   cairo_line_to(cr, 0.739, 1. - 0.482);
+
   // shaft
   cairo_move_to(cr, 0.124, 1. - 0.297);
   cairo_line_to(cr, 0.823, 1. - 0.814);
@@ -1539,129 +1310,118 @@ void dtgtk_cairo_paint_colorpicker(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_move_to(cr, 0.823, 1. - 0.814);
   cairo_line_to(cr, 0.648, 1. - 0.685);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_colorpicker_set_values(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = (w < h ? w : h);
-  s *= 1.05; // optical balance
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1.05, 0, -0.05)
 
   /* draw pipette */
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
   // drop
-  cairo_set_line_width(cr, 0.15);
-  cairo_move_to(cr, 0.08, 1. - 0.01 + 0.05);
-  cairo_line_to(cr, 0.08, 1. - 0.09 + 0.05);
+  cairo_move_to(cr, 0., 1. - 0.0);
+  cairo_line_to(cr, 0.08, 1. - 0.15);
+  cairo_line_to(cr, 0.16, 1. - 0.0);
+  cairo_arc(cr, 0.08, 1. - 0.15 + 0.1926, 0.090666667, -0.49, 3.63);
+  cairo_fill(cr);
+
+  // plus sign
+  cairo_move_to(cr, 0.18, 0.00);
+  cairo_line_to(cr, 0.18, 0.36);
+  cairo_stroke(cr);
+  cairo_move_to(cr, 0.00, 0.18);
+  cairo_line_to(cr, 0.36, 0.18);
   cairo_stroke(cr);
 
-  cairo_set_line_width(cr, 0.2);
   // cross line
-  cairo_move_to(cr, 0.48, 1. - 0.831 + 0.05);
-  cairo_line_to(cr, 0.739, 1. - 0.482 + 0.05);
+  cairo_set_line_width(cr, 0.15);
+  cairo_move_to(cr, 0.48, 1. - 0.831);
+  cairo_line_to(cr, 0.739, 1. - 0.482);
+
   // shaft
-  cairo_move_to(cr, 0.124, 1. - 0.297 + 0.05);
-  cairo_line_to(cr, 0.823, 1. - 0.814 + 0.05);
+  cairo_move_to(cr, 0.124, 1. - 0.297);
+  cairo_line_to(cr, 0.823, 1. - 0.814);
   cairo_stroke(cr);
 
   // end
   cairo_set_line_width(cr, 0.35);
-  cairo_move_to(cr, 0.823, 1. - 0.814 + 0.05);
-  cairo_line_to(cr, 0.648, 1. - 0.685 + 0.05);
+  cairo_move_to(cr, 0.823, 1. - 0.814);
+  cairo_line_to(cr, 0.648, 1. - 0.685);
   cairo_stroke(cr);
 
-  // plus sign
-  cairo_set_line_width(cr, 0.2);
-  cairo_move_to(cr, 0.20, 0.01);
-  cairo_line_to(cr, 0.20, 0.41);
-  cairo_stroke(cr);
-  cairo_move_to(cr, 0.01, 0.20);
-  cairo_line_to(cr, 0.41, 0.20);
-  cairo_stroke(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_showmask(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   /* draw rectangle */
   cairo_rectangle(cr, 0.0, 0.0, 1.0, 1.0);
   cairo_fill(cr);
   cairo_stroke(cr);
 
-
   /* draw circle */
   cairo_set_source_rgba(cr, 0.2, 0.2, 0.2, 1.0);
   cairo_arc(cr, 0.5, 0.5, 0.30, -M_PI, M_PI);
   cairo_fill(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_preferences(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
+  PREAMBLE(0.5 * 0.95, 0.5, 0.5)
 
-  float s = (w < h ? w / 2.0 : h / 2.0);
-  s *= 0.95; //optical balance
-  cairo_scale(cr, s, s);
+  cairo_rotate(cr, M_PI / 12.);
 
-  cairo_set_line_width(cr, .25);
-  cairo_arc(cr, 0.0, 0.0, 0.625, 0., 2.0f * M_PI);
+  const float big_r = 1.f;
+  const float tin_r = 0.8f;
+
+  for(int i = 0; i < 12; i++)
+  {
+    const float radius = (i % 2 == 0) ? big_r : tin_r;
+    cairo_arc(cr, 0.0, 0.0, radius, i * M_PI / 6., (i + 1) * M_PI / 6.);
+  }
+  cairo_close_path(cr);
   cairo_stroke(cr);
 
-  double dashes = .3436;
-  cairo_set_dash(cr, &dashes, 1, 0);
-  cairo_arc(cr, 0.0, 0.0, 0.875, 0., 2.0f * M_PI);
+  cairo_arc(cr, 0.0, 0.0, 0.3, 0, 2. * M_PI);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_overlays(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
+  PREAMBLE(0.5 * 1.03, 0.5, 0.5)
 
-  const float s = (w < h ? w / 2.0 : h / 2.0);
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, .1);
-  dt_draw_star(cr, 0.0, 0.0, 1.03, 1.03/2.5);
-
+  dt_draw_star(cr, 0.0, 0.0, 1., 1.0/2.5);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_help(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
-
-  float s = (w < h ? w / 2.0 : h / 2.0);
-  s *= 0.97; //optical balance
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(0.5 * 0.97, 0.5, 0.5)
 
   cairo_arc(cr, 0.0, -0.5, 0.4, - M_PI, 0.25 * M_PI);
   cairo_arc_negative(cr, 0.7, 0.4, 0.7, -0.75 * M_PI, - M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, 0.0, 0.85, 0.05, 0.0, 2.0 * M_PI);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_translate(cr, x + w / 2.0, y + h / 2.0);
+  PREAMBLE(0.5 * 0.95, 0.5, 0.5)
 
-  const float s = (w < h ? w / 2.0 : h / 2.0);
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, .1);
-  cairo_arc(cr, 0.0, 0.0, 0.95, 0., 2.0f * M_PI);
+  cairo_arc(cr, 0.0, 0.0, 1., 0., 2.0f * M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, -0.35, -0.33, 0.25, 0., 2.0f * M_PI);
   cairo_fill(cr);
@@ -1675,16 +1435,14 @@ void dtgtk_cairo_paint_grouping(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_arc(cr, 0.35, 0.35, 0.25, 0., 2.0f * M_PI);
   cairo_fill(cr);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.3);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   switch(flags >> (int)log2(CPF_SPECIAL_FLAG))
   {
     case 1: // Top left
@@ -1739,73 +1497,59 @@ void dtgtk_cairo_paint_alignment(cairo_t *cr, gint x, gint y, gint w, gint h, gi
       break;
   }
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_or(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.3);
   cairo_curve_to(cr, 0.1, 1.1, 0.9, 1.1, 0.9, 0.3);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_and(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.9);
   cairo_curve_to(cr, 0.1, 0.1, 0.9, 0.1, 0.9, 0.9);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_andnot(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.1);
   cairo_line_to(cr, 0.9, 0.9);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_dropdown(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_move_to(cr, 0.1, 0.3);
   cairo_line_to(cr, 0.5, 0.7);
   cairo_line_to(cr, 0.9, 0.3);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_bracket(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.012);
   cairo_rectangle(cr, 0.05, 0.05, 0.45, 0.45);
   cairo_stroke(cr);
   cairo_set_line_width(cr, 0.025);
@@ -1817,73 +1561,62 @@ void dtgtk_cairo_paint_bracket(cairo_t *cr, gint x, gint y, gint w, gint h, gint
   cairo_set_line_width(cr, 0.1);
   cairo_rectangle(cr, 0.55, 0.55, 0.45, 0.45);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_lock(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
   // Adding the lock body
   cairo_rectangle(cr, 0.25, 0.5, .5, .45);
   cairo_fill(cr);
 
   // Adding the lock shank
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
   cairo_translate(cr, .5, .5);
   cairo_scale(cr, .2, .4);
   cairo_arc(cr, 0, 0, 1, M_PI, 0);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_check_mark(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.20, 0.45);
   cairo_line_to(cr, 0.45, 0.90);
   cairo_line_to(cr, 0.90, 0.20);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_overexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  const float line_width = 0.1;
-
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, line_width);
+  PREAMBLE(1, 0, 0)
 
   /* the triangle */
-  cairo_move_to(cr, 1.0 - (line_width / 2.0), (line_width / 2.0));
-  cairo_line_to(cr, (line_width / 2.0), 1.0 - (line_width / 2.0));
-  cairo_line_to(cr, 1.0 - (line_width / 2.0), 1.0 - (line_width / 2.0));
+  cairo_move_to(cr, 1.0, 0);
+  cairo_line_to(cr, 0, 1.0);
+  cairo_line_to(cr, 1.0, 1.0);
   cairo_fill(cr);
 
   /* outer rect */
-  cairo_rectangle(cr, (line_width / 2.0), (line_width / 2.0), 1.0 - line_width, 1.0 - line_width);
+  cairo_rectangle(cr, 0, 0, 1.0, 1.0);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 
 void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, 0.9 * s, 0.9 * s);
+  PREAMBLE(0.95, 0, -0.05)
 
   const float line_width = 0.1;
-
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, line_width);
 
   // glass
   cairo_arc_negative(cr, 0.5, 0.38, 0.4, 1., M_PI - 1.);
@@ -1902,67 +1635,55 @@ void dtgtk_cairo_paint_bulb(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   }
 
   // screw
-  cairo_move_to(cr, 0.33, 0.38 + 0.36 + 1.5 * line_width);
-  cairo_line_to(cr, 0.67, 0.38 + 0.36 + 1.5 * line_width);
+  cairo_move_to(cr, 0.33, 0.38 + 0.36 + 1 * line_width);
+  cairo_line_to(cr, 0.67, 0.38 + 0.36 + 1 * line_width);
   cairo_stroke(cr);
 
   // nib
-  cairo_arc(cr, 0.5, 0.38 + 0.36 + 1.5 * 1.75 * line_width, 2.0 * line_width, 0, M_PI);
+  cairo_arc(cr, 0.5, 0.38 + 0.36 + 2. * line_width, 2.0 * line_width, 0, M_PI);
   cairo_fill(cr);
+
+  FINISH
 }
 
 
 void dtgtk_cairo_paint_rawoverexposed(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const float alpha = (flags & CPF_ACTIVE ? 1.0 : 0.4);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  const float line_width = 0.1;
-
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, line_width);
+  PREAMBLE(1, 0, 0)
 
   cairo_save(cr);
 
-  const double step = ((line_width / 2.0) + (1.0 - line_width) / 2.0);
+  const float alpha = (flags & CPF_ACTIVE ? 1.0 : 0.4);
 
   // draw 4 CFA-like colored squares
-
   cairo_set_source_rgba(cr, 1.0, 0.0, 0.0, alpha); // red
-  cairo_rectangle(cr, (line_width / 2.0), (line_width / 2.0), step, step);
+  cairo_rectangle(cr, 0, 0, 0.5, 0.5);
   cairo_fill(cr);
 
   cairo_set_source_rgba(cr, 0.0, 1.0, 0.0, alpha); // green
-  cairo_rectangle(cr, step, (line_width / 2.0), step, step);
+  cairo_rectangle(cr, 0.5, 0, 0.5, 0.5);
   cairo_fill(cr);
 
   cairo_set_source_rgba(cr, 0.0, 1.0, 0.0, alpha); // green
-  cairo_rectangle(cr, (line_width / 2.0), step, step, step);
+  cairo_rectangle(cr, 0, 0.5, 0.5, 0.5);
   cairo_fill(cr);
 
   cairo_set_source_rgba(cr, 0.0, 0.0, 1.0, alpha); // blue
-  cairo_rectangle(cr, step, step, step, step);
+  cairo_rectangle(cr, 0.5, 0.5, 0.5, 0.5);
   cairo_fill(cr);
 
   cairo_restore(cr);
 
   /* outer rect */
-  cairo_rectangle(cr, (line_width / 2.0), (line_width / 2.0), 1.0 - line_width, 1.0 - line_width);
+  cairo_rectangle(cr, 0, 0, 1.0, 1.0);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.15; // optical balance
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_translate(cr, 0, -0.05); // optical alignment
-
-  cairo_save(cr);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1.15, 0, -0.05)
 
   // the triangle
   cairo_move_to(cr, 0.0, 1 - 0.067);
@@ -1992,18 +1713,12 @@ void dtgtk_cairo_paint_gamut_check(cairo_t *cr, gint x, gint y, gint w, gint h, 
   cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
   cairo_fill(cr);
 
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_softproof(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s*=1.1; // optical balance
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-
-  cairo_save(cr);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1.1, 0, 0)
 
   // the horse shoe
   cairo_move_to(cr, 0.30, 1 - 0.0);
@@ -2021,61 +1736,31 @@ void dtgtk_cairo_paint_softproof(cairo_t *cr, gint x, gint y, gint w, gint h, gi
   cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
   cairo_fill(cr);
 
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_display(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_save(cr);
+  PREAMBLE(1, 0, 0)
 
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_scale(cr, 1, -1);
-  cairo_translate(cr, 0, -1);
+  cairo_rectangle(cr, 0, 0, 1, 3./4.);
+  cairo_move_to(cr, 0.5, 3./4);
+  cairo_line_to(cr, 0.5, 1);
+  cairo_move_to(cr, 0.3, 1);
+  cairo_line_to(cr, 0.7, 1);
+  cairo_stroke(cr);
 
-  cairo_move_to(cr, 0.0, 0.98);
-  cairo_line_to(cr, 1.0, 0.98);
-  cairo_line_to(cr, 1.0, 0.28);
-  cairo_line_to(cr, 0.58, 0.28);
-  cairo_line_to(cr, 0.58, 0.13);
-  cairo_line_to(cr, 0.85, 0.13);
-  cairo_line_to(cr, 0.85, 0.03);
-  cairo_line_to(cr, 0.15, 0.03);
-  cairo_line_to(cr, 0.15, 0.13);
-  cairo_line_to(cr, 0.42, 0.13);
-  cairo_line_to(cr, 0.42, 0.28);
-  cairo_line_to(cr, 0.0, 0.28);
-  cairo_close_path(cr);
-
-  cairo_move_to(cr, 0.1, 0.88);
-  cairo_line_to(cr, 0.9, 0.88);
-  cairo_line_to(cr, 0.9, 0.38);
-  cairo_line_to(cr, 0.1, 0.38);
-  cairo_close_path(cr);
-
-  cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
-  cairo_fill(cr);
-
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_display2(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
+  PREAMBLE(0.55, 0.5, 0.5)
 
-  cairo_translate(cr, x + (w / 2.0), y + (h / 2.0));
-
-  const float s = (w < h ? w / 2.0 : h / 2.0);
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.2);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
   cairo_move_to(cr, -0.55, 0.9);
   cairo_rel_line_to(cr, 0.7, 0);
   cairo_stroke(cr);
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
   cairo_rectangle(cr, -0.9, -0.5, 1.4, 1.0);
   cairo_move_to(cr, -0.5, -0.7);
   cairo_rel_line_to(cr, 0, -0.2);
@@ -2084,22 +1769,17 @@ void dtgtk_cairo_paint_display2(cairo_t *cr, gint x, gint y, gint w, gint h, gin
   cairo_rel_line_to(cr, -0.2, 0);
   cairo_stroke(cr);
 
-  cairo_set_line_width(cr, 0.3);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_BUTT);
   cairo_move_to(cr, -0.2, 0.6);
   cairo_rel_line_to(cr, 0, 0.2);
   cairo_stroke(cr);
 
-  cairo_restore(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_rect_landscape(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.10);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_move_to(cr, 0.0, 0.3);
   cairo_line_to(cr, 1.0, 0.3);
   cairo_line_to(cr, 1.0, 0.7);
@@ -2107,16 +1787,13 @@ void dtgtk_cairo_paint_rect_landscape(cairo_t *cr, gint x, gint y, gint w, gint 
   cairo_line_to(cr, 0.0, 0.3);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.10);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_move_to(cr, 0.3, 0.0);
   cairo_line_to(cr, 0.7, 0.0);
   cairo_line_to(cr, 0.7, 1.0);
@@ -2124,39 +1801,31 @@ void dtgtk_cairo_paint_rect_portrait(cairo_t *cr, gint x, gint y, gint w, gint h
   cairo_line_to(cr, 0.3, 0.0);
   cairo_stroke(cr);
 
-  cairo_identity_matrix(cr);
+  FINISH
 }
 
 void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = (w < h ? w : h);
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
 
   /* draw magnifying glass */
 
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-
   // handle
-  cairo_set_line_width(cr, 0.15);
   cairo_move_to(cr, 0.9, 1.0 - 0.1);
   cairo_line_to(cr, 0.65, 1.0 - 0.35);
   cairo_stroke(cr);
 
   // lens
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.35, 1.0 - 0.65, 0.3, -M_PI, M_PI);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  cairo_save(cr);
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
+
   cairo_rectangle(cr, 0.35, 0.35, 0.6, 0.6);
   cairo_stroke(cr);
   cairo_rectangle(cr, 0.05, 0.05, 0.9, 0.9);
@@ -2165,32 +1834,26 @@ void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h
   cairo_rectangle(cr, 0.05, 0.05, 0.6, 0.6);
   cairo_stroke_preserve(cr);
   cairo_fill(cr);
-  cairo_restore(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));
-  cairo_scale(cr, s, s);
-
-  cairo_set_line_width(cr, 0.1);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  PREAMBLE(1, 0, 0)
 
   cairo_arc(cr, 0.5, 0.5, 0.40, (-50 * 3.145 / 180), (230 * 3.145 / 180));
   cairo_move_to(cr, 0.5, 0.05);
   cairo_line_to(cr, 0.5, 0.40);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_favorites(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  float s = w < h ? w : h;
-  s *= 1.1; // optical balance
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1.1, 0, 0)
+
   const float r1 = 0.2;
   const float r2 = 0.4;
   const float d = 2.0 * M_PI * 0.1f;
@@ -2206,28 +1869,24 @@ void dtgtk_cairo_paint_modulegroup_favorites(cairo_t *cr, gint x, gint y, gint w
       cairo_line_to(cr, 0.5 + r1 * dx[k], 0.5 - r1 * dy[k]);
   cairo_close_path(cr);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_basic(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   /* draw circle */
   cairo_arc(cr, 0.5, 0.5, 0.40, -M_PI, M_PI);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_tone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   /* draw circle */
   cairo_arc(cr, 0.5, 0.5, 0.40, -M_PI, M_PI);
@@ -2242,15 +1901,13 @@ void dtgtk_cairo_paint_modulegroup_tone(cairo_t *cr, gint x, gint y, gint w, gin
   cairo_arc(cr, 0.5, 0.5, 0.40, -M_PI, M_PI);
   cairo_fill(cr);
   cairo_pattern_destroy(pat);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_color(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   /* draw circle */
   cairo_arc(cr, 0.5, 0.5, 0.40, -M_PI, M_PI);
@@ -2269,37 +1926,32 @@ void dtgtk_cairo_paint_modulegroup_color(cairo_t *cr, gint x, gint y, gint w, gi
   cairo_arc(cr, 0.5, 0.5, 0.40, -M_PI, M_PI);
   cairo_fill(cr);
   cairo_pattern_destroy(pat);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_correct(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   /* draw circle */
   cairo_arc(cr, 0.42, 0.5, 0.40, 0, M_PI);
   cairo_stroke(cr);
   cairo_arc(cr, 0.58, 0.5, 0.40, M_PI, 0);
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_modulegroup_effect(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_translate(cr, x + (w / 2.) - (s / 2.), y + (h / 2.) - (s / 2.));
-  cairo_scale(cr, s, s);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_set_line_width(cr, 0.1);
+  PREAMBLE(1, 0, 0)
 
   /* draw circle */
   cairo_arc(cr, 0.5, 0.5, 0.40, -M_PI, M_PI);
   cairo_stroke(cr);
 
   /* sparkles */
-  cairo_set_line_width(cr, 0.06);
 
   cairo_move_to(cr, 0.378, 0.502);
   cairo_line_to(cr, 0.522, 0.549);
@@ -2338,17 +1990,21 @@ void dtgtk_cairo_paint_modulegroup_effect(cairo_t *cr, gint x, gint y, gint w, g
   cairo_close_path(cr);
 
   cairo_stroke(cr);
+
+  FINISH
 }
 
 void dtgtk_cairo_paint_map_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  const gint s = w < h ? w : h;
-  cairo_scale(cr, s, s);
+  PREAMBLE(1, 0, 0)
+
   cairo_move_to(cr, 0.2, 0.0);
   cairo_line_to(cr, 0.0, 1.0);
   cairo_line_to(cr, 0.7, 0.0);
   cairo_close_path(cr);
   cairo_fill(cr);
+
+  FINISH
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -1284,7 +1284,7 @@ void dtgtk_cairo_paint_label_flower(cairo_t *cr, gint x, gint y, gint w, gint h,
 
 void dtgtk_cairo_paint_colorpicker(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1.05, 0, -0.05)
+  PREAMBLE(1, 0, 0.05)
 
   /* draw pipette */
 
@@ -1316,7 +1316,7 @@ void dtgtk_cairo_paint_colorpicker(cairo_t *cr, gint x, gint y, gint w, gint h, 
 
 void dtgtk_cairo_paint_colorpicker_set_values(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1.05, 0, -0.05)
+  PREAMBLE(1, 0, 0.05)
 
   /* draw pipette */
 


### PR DESCRIPTION
- move boilerplate code to macros and ensure Cairo coordinates are reset after each icon,
- ensure line width is the same no matter the icon size,
- improve some icons (mask brush, display, preference wheel, color-picker, etc.)

Before:
![Capture d’écran de 2020-06-05 01-33-42](https://user-images.githubusercontent.com/2779157/83820801-f65cba00-a6cd-11ea-8dd7-afed3b64522a.png)

After:
![Capture d’écran de 2020-06-05 01-31-13](https://user-images.githubusercontent.com/2779157/83820805-fbba0480-a6cd-11ea-88a2-7c5fb9ee65ee.png)

Bonus: color-picker have a true droplet (powered by bloody trigonometry)
![Capture d’écran du 2020-06-05 01-50-25](https://user-images.githubusercontent.com/2779157/83821553-ff01c000-a6ce-11ea-94fb-fd5f4a794176.png)

Bonus 2: preferences have a real gear wheel
![Capture d’écran du 2020-06-05 01-54-22](https://user-images.githubusercontent.com/2779157/83821772-8ea76e80-a6cf-11ea-9148-75660bfab38f.png)

