### PR TITLE
refactor shutter speed formatting code

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -316,7 +316,7 @@ void dt_image_path_append_version(int imgid, char *pathname, size_t pathname_len
 
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len)
 {
-  char *exposure_str = dt_format_exposure(img->exif_exposure);
+  char *exposure_str = dt_util_format_exposure(img->exif_exposure);
 
   snprintf(line, line_len, "%s f/%.1f %dmm ISO %d", exposure_str, img->exif_aperture, (int)img->exif_focal_length,
            (int)img->exif_iso);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -316,28 +316,12 @@ void dt_image_path_append_version(int imgid, char *pathname, size_t pathname_len
 
 void dt_image_print_exif(const dt_image_t *img, char *line, size_t line_len)
 {
-  if(img->exif_exposure >= 1.0f)
-    if(nearbyintf(img->exif_exposure) == img->exif_exposure)
-      snprintf(line, line_len, "%.0f″ f/%.1f %dmm ISO %d", img->exif_exposure, img->exif_aperture,
-               (int)img->exif_focal_length, (int)img->exif_iso);
-    else
-      snprintf(line, line_len, "%.1f″ f/%.1f %dmm ISO %d", img->exif_exposure, img->exif_aperture,
-               (int)img->exif_focal_length, (int)img->exif_iso);
-  /* want to catch everything below 0.3 seconds */
-  else if(img->exif_exposure < 0.29f)
-    snprintf(line, line_len, "1/%.0f f/%.1f %dmm ISO %d", 1.0 / img->exif_exposure, img->exif_aperture,
-             (int)img->exif_focal_length, (int)img->exif_iso);
-  /* catch 1/2, 1/3 */
-  else if(nearbyintf(1.0f / img->exif_exposure) == 1.0f / img->exif_exposure)
-    snprintf(line, line_len, "1/%.0f f/%.1f %dmm ISO %d", 1.0 / img->exif_exposure, img->exif_aperture,
-             (int)img->exif_focal_length, (int)img->exif_iso);
-  /* catch 1/1.3, 1/1.6, etc. */
-  else if(10 * nearbyintf(10.0f / img->exif_exposure) == nearbyintf(100.0f / img->exif_exposure))
-    snprintf(line, line_len, "1/%.1f f/%.1f %dmm ISO %d", 1.0 / img->exif_exposure, img->exif_aperture,
-             (int)img->exif_focal_length, (int)img->exif_iso);
-  else
-    snprintf(line, line_len, "%.1f″ f/%.1f %dmm ISO %d", img->exif_exposure, img->exif_aperture,
-             (int)img->exif_focal_length, (int)img->exif_iso);
+  char *exposure_str = dt_format_exposure(img->exif_exposure);
+
+  snprintf(line, line_len, "%s f/%.1f %dmm ISO %d", exposure_str, img->exif_aperture, (int)img->exif_focal_length,
+           (int)img->exif_iso);
+
+  g_free(exposure_str);
 }
 
 int dt_image_get_xmp_rating_from_flags(const int flags)

--- a/src/common/utility.c
+++ b/src/common/utility.c
@@ -724,6 +724,35 @@ GList *dt_util_str_to_glist(const gchar *separator, const gchar *text)
   return list;
 }
 
+// format exposure time given in seconds to a string in a unified way
+char *dt_util_format_exposure(float exposuretime)
+{
+  char *result;
+  if(exposuretime >= 1.0f)
+  {
+    if(nearbyintf(exposuretime) == exposuretime)
+      result = g_strdup_printf("%.0f″", exposuretime);
+    else
+      result = g_strdup_printf("%.1f″", exposuretime);
+  }
+  /* want to catch everything below 0.3 seconds */
+  else if(exposuretime < 0.29f)
+    result = g_strdup_printf("1/%.0f", 1.0 / exposuretime);
+
+  /* catch 1/2, 1/3 */
+  else if(nearbyintf(1.0f / exposuretime) == 1.0f / exposuretime)
+    result = g_strdup_printf("1/%.0f", 1.0 / exposuretime);
+
+  /* catch 1/1.3, 1/1.6, etc. */
+  else if(10 * nearbyintf(10.0f / exposuretime) == nearbyintf(100.0f / exposuretime))
+    result = g_strdup_printf("1/%.1f", 1.0 / exposuretime);
+
+  else
+    result = g_strdup_printf("%.1f″", exposuretime);
+
+  return result;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -71,6 +71,9 @@ gboolean dt_util_gps_elevation_to_number(const double r_1, const double r_2, cha
 // make paths absolute and try to normalize on Windows. also deal with character encoding on Windows.
 gchar *dt_util_normalize_path(const gchar *input);
 
+// format exposure time string
+gchar *dt_util_format_exposure(float exposuretime);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -214,7 +214,7 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
     }
     else
     {
-      result = dt_format_exposure(params->data->exif_exposure);
+      result = dt_util_format_exposure(params->data->exif_exposure);
     }
   }
   else if(has_prefix(variable, "EXIF_APERTURE"))
@@ -903,34 +903,7 @@ void dt_variables_set_tags_flags(dt_variables_params_t *params, uint32_t flags)
   params->data->tags_flags = flags;
 }
 
-// format exposure time given in seconds to a string in a unified way
-char *dt_format_exposure(float exposuretime)
-{
-  char *result;
-  if(exposuretime >= 1.0f)
-  {
-    if(nearbyintf(exposuretime) == exposuretime)
-      result = g_strdup_printf("%.0f″", exposuretime);
-    else
-      result = g_strdup_printf("%.1f″", exposuretime);
-  }
-  /* want to catch everything below 0.3 seconds */
-  else if(exposuretime < 0.29f)
-    result = g_strdup_printf("1/%.0f", 1.0 / exposuretime);
 
-  /* catch 1/2, 1/3 */
-  else if(nearbyintf(1.0f / exposuretime) == 1.0f / exposuretime)
-    result = g_strdup_printf("1/%.0f", 1.0 / exposuretime);
-
-  /* catch 1/1.3, 1/1.6, etc. */
-  else if(10 * nearbyintf(10.0f / exposuretime) == nearbyintf(100.0f / exposuretime))
-    result = g_strdup_printf("1/%.1f", 1.0 / exposuretime);
-
-  else
-    result = g_strdup_printf("%.1f″", exposuretime);
-
-  return result;
-}
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -204,29 +204,18 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
   }
   else if(has_prefix(variable, "EXIF_EXPOSURE"))
   {
-    /* no special chars for all jobs except infos */
+    /* use raw numbers for infos jobcode, else regular special character exposure str */
     if(g_strcmp0(params->jobcode, "infos") != 0)
+    {
       if(nearbyintf(params->data->exif_exposure) == params->data->exif_exposure)
         result = g_strdup_printf("%.0f", params->data->exif_exposure);
       else
         result = g_strdup_printf("%.1f", params->data->exif_exposure);
-    else if(params->data->exif_exposure >= 1.0f)
-      if(nearbyintf(params->data->exif_exposure) == params->data->exif_exposure)
-        result = g_strdup_printf("%.0f″", params->data->exif_exposure);
-      else
-        result = g_strdup_printf("%.1f″", params->data->exif_exposure);
-    /* want to catch everything below 0.3 seconds */
-    else if(params->data->exif_exposure < 0.29f)
-      result = g_strdup_printf("1/%.0f", 1.0 / params->data->exif_exposure);
-    /* catch 1/2, 1/3 */
-    else if(nearbyintf(1.0f / params->data->exif_exposure) == 1.0f / params->data->exif_exposure)
-      result = g_strdup_printf("1/%.0f", 1.0 / params->data->exif_exposure);
-    /* catch 1/1.3, 1/1.6, etc. */
-    else if(10 * nearbyintf(10.0f / params->data->exif_exposure)
-            == nearbyintf(100.0f / params->data->exif_exposure))
-      result = g_strdup_printf("1/%.1f", 1.0 / params->data->exif_exposure);
+    }
     else
-      result = g_strdup_printf("%.1f″", params->data->exif_exposure);
+    {
+      result = dt_format_exposure(params->data->exif_exposure);
+    }
   }
   else if(has_prefix(variable, "EXIF_APERTURE"))
     result = g_strdup_printf("%.1f", params->data->exif_aperture);
@@ -912,6 +901,35 @@ void dt_variables_reset_sequence(dt_variables_params_t *params)
 void dt_variables_set_tags_flags(dt_variables_params_t *params, uint32_t flags)
 {
   params->data->tags_flags = flags;
+}
+
+// format exposure time given in seconds to a string in a unified way
+char *dt_format_exposure(float exposuretime)
+{
+  char *result;
+  if(exposuretime >= 1.0f)
+  {
+    if(nearbyintf(exposuretime) == exposuretime)
+      result = g_strdup_printf("%.0f″", exposuretime);
+    else
+      result = g_strdup_printf("%.1f″", exposuretime);
+  }
+  /* want to catch everything below 0.3 seconds */
+  else if(exposuretime < 0.29f)
+    result = g_strdup_printf("1/%.0f", 1.0 / exposuretime);
+
+  /* catch 1/2, 1/3 */
+  else if(nearbyintf(1.0f / exposuretime) == 1.0f / exposuretime)
+    result = g_strdup_printf("1/%.0f", 1.0 / exposuretime);
+
+  /* catch 1/1.3, 1/1.6, etc. */
+  else if(10 * nearbyintf(10.0f / exposuretime) == nearbyintf(100.0f / exposuretime))
+    result = g_strdup_printf("1/%.1f", 1.0 / exposuretime);
+
+  else
+    result = g_strdup_printf("%.1f″", exposuretime);
+
+  return result;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -61,8 +61,6 @@ char *dt_variables_expand(dt_variables_params_t *params, gchar *source, gboolean
 /** reset sequence number */
 void dt_variables_reset_sequence(dt_variables_params_t *params);
 
-char *dt_format_exposure(float exposuretime);
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/variables.h
+++ b/src/common/variables.h
@@ -61,6 +61,8 @@ char *dt_variables_expand(dt_variables_params_t *params, gchar *source, gboolean
 /** reset sequence number */
 void dt_variables_reset_sequence(dt_variables_params_t *params);
 
+char *dt_format_exposure(float exposuretime);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -491,7 +491,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     snprintf(value, sizeof(value), "f/%.1f", img->exif_aperture);
     _metadata_update_value(d->metadata[md_exif_aperture], value);
 
-    char *exposure_str = dt_format_exposure(img->exif_exposure);
+    char *exposure_str = dt_util_format_exposure(img->exif_exposure);
     _metadata_update_value(d->metadata[md_exif_exposure], exposure_str);
     g_free(exposure_str);
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -488,14 +488,12 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     _metadata_update_value_end(d->metadata[md_exif_lens], img->exif_lens);
     _metadata_update_value_end(d->metadata[md_exif_maker], img->camera_maker);
 
-    snprintf(value, sizeof(value), "F/%.1f", img->exif_aperture);
+    snprintf(value, sizeof(value), "f/%.1f", img->exif_aperture);
     _metadata_update_value(d->metadata[md_exif_aperture], value);
 
-    if(img->exif_exposure <= 0.5)
-      snprintf(value, sizeof(value), "1/%.0f", 1.0 / img->exif_exposure);
-    else
-      snprintf(value, sizeof(value), "%.1f''", img->exif_exposure);
-    _metadata_update_value(d->metadata[md_exif_exposure], value);
+    char *exposure_str = dt_format_exposure(img->exif_exposure);
+    _metadata_update_value(d->metadata[md_exif_exposure], exposure_str);
+    g_free(exposure_str);
 
     if(isnan(img->exif_exposure_bias))
     {


### PR DESCRIPTION
the shutter speed formatting code is repeated in various parts of the code, and in one point incorrectly repeated. 

I put the shutter speed formatting code in variables.c, and it is used everywhere that requires shutter speed formatting.

I also fixed the capital F in the metadata aperture printing.