### PR TITLE
bauhaus controls: pass keypress event to view if not handled

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2005,7 +2005,7 @@ static gboolean dt_bauhaus_slider_key_press(GtkWidget *widget, GdkEventKey *even
     delta = -d->scale / 5.0f;
   }
 
-  if(!handled) return FALSE;
+  if(!handled) return dt_control_key_pressed(gdk_keyval_to_lower(event->keyval), dt_gui_translated_key_state(event));
 
   return dt_bauhaus_slider_add_delta_internal(widget, delta, event->state);
 }
@@ -2067,7 +2067,7 @@ static gboolean dt_bauhaus_combobox_key_press(GtkWidget *widget, GdkEventKey *ev
       dt_bauhaus_combobox_set(widget, new_pos);
     return TRUE;
   }
-  return FALSE;
+  return dt_control_key_pressed(gdk_keyval_to_lower(event->keyval), dt_gui_translated_key_state(event));
 }
 
 static gboolean dt_bauhaus_combobox_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3491,6 +3491,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
       // we quit the active iop if any
       lib->full_preview_last_module = darktable.develop->gui_module;
       dt_iop_request_focus(NULL);
+      gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
       dt_dev_invalidate(darktable.develop);
       dt_control_queue_redraw_center();
     }


### PR DESCRIPTION
if bauhaus controls do not handle a key press event and it is not
handled by an accelerator, finally pass the keypress to the view to
handle

ensures that even while a bauhaus control has focus the darkroom
preview shortcut still functions

also changes the preview shortcut to grab focus to the centre view so
it works when pressed twice in succession