### PR TITLE
init exposure with EXIF exposure bias

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2120,11 +2120,17 @@
     <longdescription>this folder (and sub-folders) contains Lut files used by lut3d modules. need to restart darktable.</longdescription>
   </dtconfig>
   <dtconfig prefs="processing">
-    <name>plugins/darkroom/basecurve/auto_apply</name>
-    <type>bool</type>
-    <default>true</default>
-    <shortdescription>auto-apply basecurve</shortdescription>
-    <longdescription>use a basecurve by default (needs a restart)</longdescription>
+    <name>plugins/darkroom/workflow</name>
+    <type>
+      <enum>
+        <option>scene-referred</option>
+        <option>display-referred</option>
+        <option>none</option>
+      </enum>
+    </type>
+    <default>display-referred</default>
+    <shortdescription>pixel workflow</shortdescription>
+    <longdescription>scene-referred is based on filmic and the linear modules,\ndisplay-referred is based on base curve and non-linear modules (needs a restart)</longdescription>
   </dtconfig>
   <dtconfig prefs="processing">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -369,7 +369,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 
 static void set_presets(dt_iop_module_so_t *self, const basecurve_preset_t *presets, int count, gboolean camera)
 {
-  const gboolean autoapply = dt_conf_get_bool("plugins/darkroom/basecurve/auto_apply");
+  const gboolean autoapply = strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "display-referred") == 0;
   const gboolean autoapply_percamera = dt_conf_get_bool("plugins/darkroom/basecurve/auto_apply_percamera_presets");
 
   const gboolean force_autoapply = autoapply && (autoapply_percamera || !camera);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -563,6 +563,11 @@ void reload_defaults(dt_iop_module_t *module)
                                                             .deflicker_target_level = -4.0f
   };
 
+  // Init exposure with EXIF exposure bias
+  tmp.exposure = -(module->dev->image_storage.exif_exposure_bias);
+  if(tmp.exposure != 0.0f)
+    module->default_enabled = TRUE;
+
   memcpy(module->params, &tmp, sizeof(dt_iop_exposure_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_exposure_params_t));
 }

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -246,8 +246,6 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 
 void init_presets (dt_iop_module_so_t *self)
 {
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
-
   dt_gui_presets_add_generic(_("magic lantern defaults"), self->op, self->version(),
                              &(dt_iop_exposure_params_t){.mode = EXPOSURE_MODE_DEFLICKER,
                                                          .black = 0.0f,
@@ -256,8 +254,6 @@ void init_presets (dt_iop_module_so_t *self)
                                                          .deflicker_target_level = -4.0f,
                                                          .compensate_exposure_bias = FALSE},
                              sizeof(dt_iop_exposure_params_t), 1);
-
-  DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 }
 
 static void deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histogram,

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -552,6 +552,8 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->mode, g_list_index(g->modes, GUINT_TO_POINTER(p->mode)));
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias), p->compensate_exposure_bias);
+  gtk_button_set_label(GTK_BUTTON(g->compensate_exposure_bias), g_strdup_printf(_("compensate camera exposure (%+.1f EV)"),
+                                                                                  get_exposure_bias(self)));
   dt_bauhaus_slider_set_soft(g->black, p->black);
   dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
 
@@ -942,7 +944,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   GtkWidget *vbox_manual = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
 
-  g->compensate_exposure_bias = gtk_check_button_new_with_label(g_strdup_printf(_("compensate camera exposure bias (%.1f EV)"),
+  g->compensate_exposure_bias = gtk_check_button_new_with_label(g_strdup_printf(_("compensate camera exposure (%+.1f EV)"),
                                                                                   get_exposure_bias(self)));
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias), p->compensate_exposure_bias);
   gtk_widget_set_tooltip_text(g->compensate_exposure_bias, _("automatically remove the camera exposure bias\n"


### PR DESCRIPTION
init exposure default with EXIF exposure bias and auto-enable exposure module if value != 0.

This will allow auto-correction for in-camera exposure bias directly when opening the image.