### PR TITLE
watermark: enable font substitution when watermark text is empty

### DIFF
--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -430,14 +430,16 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
     gchar buffer[1024];
 
     // substitute $(WATERMARK_TEXT)
-    g_strlcpy(buffer, data->text, sizeof(buffer));
-    svgdoc = _string_substitute(svgdata, "$(WATERMARK_TEXT)", buffer);
-    if(svgdoc != svgdata)
+    if(data->text[0])
     {
-      g_free(svgdata);
-      svgdata = svgdoc;
+      g_strlcpy(buffer, data->text, sizeof(buffer));
+      svgdoc = _string_substitute(svgdata, "$(WATERMARK_TEXT)", buffer);
+      if(svgdoc != svgdata)
+      {
+        g_free(svgdata);
+        svgdata = svgdoc;
+      }
     }
-
     // apply font style substitutions
     PangoFontDescription *font = pango_font_description_from_string(data->font);
     const PangoStyle font_style = pango_font_description_get_style(font);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -429,30 +429,30 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
     // Simple text from watermark module
     gchar buffer[1024];
 
-    if (data->font[0] && data->text[0])
+    // substitute $(WATERMARK_TEXT)
+    g_strlcpy(buffer, data->text, sizeof(buffer));
+    svgdoc = _string_substitute(svgdata, "$(WATERMARK_TEXT)", buffer);
+    if(svgdoc != svgdata)
     {
-      g_strlcpy(buffer, data->text, sizeof(buffer));
-      svgdoc = _string_substitute(svgdata, "$(WATERMARK_TEXT)", buffer);
-      if(svgdoc != svgdata)
-      {
-        g_free(svgdata);
-        svgdata = svgdoc;
-      }
+      g_free(svgdata);
+      svgdata = svgdoc;
+    }
 
-      PangoFontDescription *font = pango_font_description_from_string(data->font);
-      const PangoStyle font_style = pango_font_description_get_style(font);
-      const int font_weight = (int)pango_font_description_get_weight(font);
+    // apply font style substitutions
+    PangoFontDescription *font = pango_font_description_from_string(data->font);
+    const PangoStyle font_style = pango_font_description_get_style(font);
+    const int font_weight = (int)pango_font_description_get_weight(font);
 
-      g_strlcpy(buffer, pango_font_description_get_family(font), sizeof(buffer));
-      svgdoc = _string_substitute(svgdata, "$(WATERMARK_FONT_FAMILY)", buffer);
-      if(svgdoc != svgdata)
-      {
-        g_free(svgdata);
-        svgdata = svgdoc;
-      }
+    g_strlcpy(buffer, pango_font_description_get_family(font), sizeof(buffer));
+    svgdoc = _string_substitute(svgdata, "$(WATERMARK_FONT_FAMILY)", buffer);
+    if(svgdoc != svgdata)
+    {
+      g_free(svgdata);
+      svgdata = svgdoc;
+    }
 
-      switch (font_style)
-      {
+    switch(font_style)
+    {
       case PANGO_STYLE_OBLIQUE:
         g_strlcpy(buffer, "oblique", sizeof(buffer));
         break;
@@ -462,24 +462,23 @@ static gchar *_watermark_get_svgdoc(dt_iop_module_t *self, dt_iop_watermark_data
       default:
         g_strlcpy(buffer, "normal", sizeof(buffer));
         break;
-      }
-      svgdoc = _string_substitute(svgdata, "$(WATERMARK_FONT_STYLE)", buffer);
-      if(svgdoc != svgdata)
-      {
-        g_free(svgdata);
-        svgdata = svgdoc;
-      }
-
-      g_snprintf(buffer, sizeof(buffer), "%d", font_weight);
-      svgdoc = _string_substitute(svgdata, "$(WATERMARK_FONT_WEIGHT)", buffer);
-      if(svgdoc != svgdata)
-      {
-        g_free(svgdata);
-        svgdata = svgdoc;
-      }
-
-      pango_font_description_free(font);
     }
+    svgdoc = _string_substitute(svgdata, "$(WATERMARK_FONT_STYLE)", buffer);
+    if(svgdoc != svgdata)
+    {
+      g_free(svgdata);
+      svgdata = svgdoc;
+    }
+
+    g_snprintf(buffer, sizeof(buffer), "%d", font_weight);
+    svgdoc = _string_substitute(svgdata, "$(WATERMARK_FONT_WEIGHT)", buffer);
+    if(svgdoc != svgdata)
+    {
+      g_free(svgdata);
+      svgdata = svgdoc;
+    }
+
+    pango_font_description_free(font);
 
     // watermark color
     GdkRGBA c = { data->color[0], data->color[1], data->color[2], 1.0f };


### PR DESCRIPTION
the watermark module doesn't replace the font and watermark text substitutions unless the watermark text box is populated. i have removed that check.
this allows the watermark fonts to be used even when the watermark text is empty, and when the watermark text is empty, the text `$(WATERMARK_TEXT)` is substituted as an empty string instead of being unchanged