### PR TITLE
allow film rolls to be optionally ordered by folder name

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -448,6 +448,18 @@
     <longdescription/>
   </dtconfig>
   <dtconfig prefs="lighttable">
+    <name>plugins/collect/filmroll_sort</name>
+    <type>
+      <enum>
+        <option>id</option>
+        <option>folder</option>
+      </enum>
+    </type>
+    <default>id</default>
+    <shortdescription>sort film rolls by</shortdescription>
+    <longdescription>sets the collections-list order for film rolls</longdescription>
+  </dtconfig>
+  <dtconfig prefs="lighttable">
     <name>plugins/collect/descending</name>
     <type>bool</type>
     <default>true</default>


### PR DESCRIPTION
amend the collect images module to sort by film roll id or folder name,
based on a preference setting

Resolves #4895, #4252