### PR TITLE
Fix import thumbnails via gphoto

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -112,7 +112,7 @@ static void _dispatch_camera_disconnected(const dt_camctl_t *c, const dt_camera_
 static void _dispatch_control_status(const dt_camctl_t *c, dt_camctl_status_t status);
 static void _dispatch_camera_error(const dt_camctl_t *c, const dt_camera_t *camera, dt_camera_error_t error);
 static int _dispatch_camera_storage_image_filename(const dt_camctl_t *c, const dt_camera_t *camera,
-                                                   const char *filename, CameraFile *preview, CameraFile *exif);
+                                                   const char *filename, CameraFile *preview);
 static void _dispatch_camera_property_value_changed(const dt_camctl_t *c, const dt_camera_t *camera,
                                                     const char *name, const char *value);
 // static void _dispatch_camera_property_accessibility_changed(const dt_camctl_t *c, const dt_camera_t *camera,
@@ -622,6 +622,12 @@ static void dt_camctl_camera_destroy(dt_camera_t *cam)
   gp_camera_exit(cam->gpcam, cam->gpcontext);
   gp_camera_unref(cam->gpcam);
   gp_widget_unref(cam->configuration);
+
+  for(GList *it = g_list_first(cam->open_gpfiles); it != NULL; it = g_list_delete_link(it, it))
+  {
+    gp_file_free((CameraFile *)it->data);
+  }
+  
   if(cam->live_view_pixbuf != NULL)
   {
     g_object_unref(cam->live_view_pixbuf);
@@ -898,7 +904,8 @@ static gboolean _camera_initialize(const dt_camctl_t *c, dt_camera_t *cam)
     cam->gpcontext = camctl->gpcontext;
     gp_camera_set_timeout_funcs(cam->gpcam, (CameraTimeoutStartFunc)_camera_start_timeout_func,
                                 (CameraTimeoutStopFunc)_camera_stop_timeout_func, cam);
-
+    // initialize the list of open gphoto files 
+    cam->open_gpfiles = NULL;
 
     dt_pthread_mutex_init(&cam->jobqueue_lock, NULL);
 
@@ -1009,7 +1016,7 @@ void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *image
 }
 
 
-static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_preview_flags_t flags, char *path)
+static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_t *cam, dt_camera_preview_flags_t flags, char *path)
 {
   CameraList *files;
   CameraList *folders;
@@ -1036,21 +1043,8 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
       else
       {
         CameraFile *preview = NULL;
-        CameraFile *exif = NULL;
         char *file = g_build_filename(path, filename, NULL);
         int gotpreview = 0;
-
-        if(flags & CAMCTL_IMAGE_EXIF_DATA)
-        {
-          gp_file_new(&exif);
-          if(gp_camera_file_get(c->active_camera->gpcam, path, filename, GP_FILE_TYPE_EXIF, exif,
-                                c->gpcontext) < GP_OK)
-          {
-            gp_file_free(exif);
-            exif = NULL;
-            dt_print(DT_DEBUG_CAMCTL, "[camera_control] failed to retrieve exif of file %sin folder %s\n", filename,path);
-            }
-          }
 
          /* Fetch image preview if flagged... */
         if(flags & CAMCTL_IMAGE_PREVIEW_DATA)
@@ -1098,9 +1092,9 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
         }
 
         // let's dispatch to host app.. return if we should stop...
-        int res = _dispatch_camera_storage_image_filename(c, c->active_camera, file, preview, exif);
+        int res = _dispatch_camera_storage_image_filename(c, c->active_camera, file, preview);
 
-        /* Why can't we just gp_file_free(preview)?
+        /* Why can't we just gp_file_free(preview) at once?
            1. we may open the dialog with thumb selection multiple times, if we gp_camera_file_get
               multiple times we oly have valid data the first time, **not** when re-reading.
               Symptom is not-seeing the thumbs when reopening this dialog.
@@ -1114,12 +1108,15 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
            5. As the thumbs extractor has preallocated memory gp_file_free works fine, this means it's the
               better option compare to reading a small file.
            6. Unfortunately this is basically a gphoto issue we can't solve here so we have to bypass it.
-
-           So what is bad with this?
-           The is a minor memory leak but i prefer this to crashing or not reading thumbs from jpegs. 
+           7. We keep the open gp_files in a Glist and close them when the camera is disconnected
         */
-        if((preview) && (gotpreview == -1)) gp_file_free(preview);
-
+        if(preview)
+        {
+          if(gotpreview == -1)
+            gp_file_free(preview);
+          else
+            cam->open_gpfiles = g_list_append(cam->open_gpfiles, preview);  
+        }
         if(!res) return 0;
       }
     }
@@ -1135,7 +1132,7 @@ static int _camctl_recursive_get_previews(const dt_camctl_t *c, dt_camera_previe
       if(path[1] != '\0') g_strlcat(buffer, "/", sizeof(buffer));
       gp_list_get_name(folders, i, &foldername);
       g_strlcat(buffer, foldername, sizeof(buffer));
-      if(!_camctl_recursive_get_previews(c, flags, buffer)) return 0;
+      if(!_camctl_recursive_get_previews(c, cam, flags, buffer)) return 0;
     }
   }
   gp_list_free(files);
@@ -1152,10 +1149,10 @@ void dt_camctl_select_camera(const dt_camctl_t *c, const dt_camera_t *cam)
 }
 
 
-void dt_camctl_get_previews(const dt_camctl_t *c, dt_camera_preview_flags_t flags, const dt_camera_t *cam)
+void dt_camctl_get_previews(const dt_camctl_t *c, dt_camera_preview_flags_t flags, dt_camera_t *cam)
 {
   _camctl_lock(c, cam);
-  _camctl_recursive_get_previews(c, flags, "/");
+  _camctl_recursive_get_previews(c, cam, flags, "/");
   _camctl_unlock(c);
 }
 
@@ -1737,7 +1734,7 @@ static void _dispatch_camera_image_downloaded(const dt_camctl_t *c, const dt_cam
 }
 
 static int _dispatch_camera_storage_image_filename(const dt_camctl_t *c, const dt_camera_t *camera,
-                                                   const char *filename, CameraFile *preview, CameraFile *exif)
+                                                   const char *filename, CameraFile *preview)
 {
   int res = 0;
   dt_camctl_t *camctl = (dt_camctl_t *)c;
@@ -1747,7 +1744,7 @@ static int _dispatch_camera_storage_image_filename(const dt_camctl_t *c, const d
     {
       if(((dt_camctl_listener_t *)listener->data)->camera_storage_image_filename != NULL)
         res = ((dt_camctl_listener_t *)listener->data)
-                  ->camera_storage_image_filename(camera, filename, preview, exif,
+                  ->camera_storage_image_filename(camera, filename, preview,
                                                   ((dt_camctl_listener_t *)listener->data)->data);
     } while((listener = g_list_next(listener)) != NULL);
   dt_pthread_mutex_unlock(&camctl->listeners_lock);

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -63,6 +63,9 @@ typedef struct dt_camera_t
   /** Flag camera in tethering mode. \see dt_camera_tether_mode() */
   gboolean is_tethering;
 
+  /** List of open gp_files to be closed when closing the camera */
+  GList *open_gpfiles;
+
   /** A mutex lock for jobqueue */
   dt_pthread_mutex_t jobqueue_lock;
   /** The jobqueue */
@@ -179,7 +182,7 @@ typedef struct dt_camctl_listener_t
   /** Invoked when a image is found on storage.. such as from dt_camctl_get_previews(), if 0 is returned the
    * recurse is stopped.. */
   int (*camera_storage_image_filename)(const dt_camera_t *camera, const char *filename, CameraFile *preview,
-                                       CameraFile *exif, void *data);
+                                       void *data);
 
   /** Invoked when a value of a property is changed. */
   void (*camera_property_value_changed)(const dt_camera_t *camera, const char *name, const char *value,
@@ -204,14 +207,12 @@ typedef enum dt_camera_preview_flags_t
   CAMCTL_IMAGE_NO_DATA = 0,
   /**Get an image preview. */
   CAMCTL_IMAGE_PREVIEW_DATA = 1,
-  /**Get the image exif */
-  CAMCTL_IMAGE_EXIF_DATA = 2
 } dt_camera_preview_flags_t;
 
 
 /** Initializes the gphoto and cam control, returns NULL if failed */
 dt_camctl_t *dt_camctl_new();
-/** Destroys the came control */
+/** Destroys the camera control */
 void dt_camctl_destroy(dt_camctl_t *c);
 /** Registers a listener of camera control */
 void dt_camctl_register_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener);
@@ -228,7 +229,7 @@ int dt_camctl_can_enter_tether_mode(const dt_camctl_t *c, const dt_camera_t *cam
 /** Enables/Disables the tether mode on camera. */
 void dt_camctl_tether_mode(const dt_camctl_t *c, const dt_camera_t *cam, gboolean enable);
 /** traverse filesystem on camera an retrieves previews of images */
-void dt_camctl_get_previews(const dt_camctl_t *c, dt_camera_preview_flags_t flags, const dt_camera_t *cam);
+void dt_camctl_get_previews(const dt_camctl_t *c, dt_camera_preview_flags_t flags, dt_camera_t *cam);
 /** Imports the images in list from specified camera */
 void dt_camctl_import(const dt_camctl_t *c, const dt_camera_t *cam, GList *images);
 

--- a/src/gui/camera_import_dialog.c
+++ b/src/gui/camera_import_dialog.c
@@ -344,7 +344,7 @@ static gboolean _camera_storage_image_filename_gui_thread(gpointer user_data)
 }
 
 static int _camera_storage_image_filename(const dt_camera_t *camera, const char *filename,
-                                          CameraFile *preview, CameraFile *exif, void *user_data)
+                                          CameraFile *preview, void *user_data)
 {
   _camera_import_dialog_t *data = (_camera_import_dialog_t *)user_data;
   const char *img;
@@ -354,8 +354,6 @@ static int _camera_storage_image_filename(const dt_camera_t *camera, const char 
 
   /* stop fetching previews if job is cancelled */
   if(data->preview_job && dt_control_job_get_state(data->preview_job) == DT_JOB_STATE_CANCELLED) return 0;
-
-  char exif_info[1024] = { 0 };
 
   if(preview)
   {
@@ -378,24 +376,6 @@ static int _camera_storage_image_filename(const dt_camera_t *camera, const char 
     }
   }
 
-#if 0
-  // libgphoto only supports fetching exif in jpegs, not raw
-  char buffer[1024]= {0};
-  if ( exif )
-  {
-    const char *exif_data;
-    char *value=NULL;
-    gp_file_get_data_and_size(exif, &exif_data, &size);
-    if( size > 0 )
-    {
-      void *exif=dt_exif_data_new((uint8_t *)exif_data,size);
-      if( (value=g_strdup( dt_exif_data_get_value(exif,"Exif.Photo.ExposureTime",buffer,1024) ) ) != NULL);
-      snprintf(exif_info, sizeof(exif_info), "exposure: %s\n", value);
-    }
-    else fprintf(stderr,"No exifdata read\n");
-  }
-#endif
-
   _image_filename_t *params = (_image_filename_t *)malloc(sizeof(_image_filename_t));
   if(!params)
   {
@@ -404,9 +384,7 @@ static int _camera_storage_image_filename(const dt_camera_t *camera, const char 
     return 0;
   }
 
-  // filename\n 1/60 f/2.8 24mm iso 160
-  params->file_info = g_strdup_printf("%s%c%s", filename, *exif_info ? '\n' : '\0',
-                                      *exif_info ? exif_info : "");
+  params->file_info = g_strdup(filename);
   params->thumb = thumb;
   params->store = data->store;
   g_main_context_invoke(NULL, _camera_storage_image_filename_gui_thread, params);


### PR DESCRIPTION
Fixes #5219
Fixes #4377

Reading the thumbnails in the import dialog requires workarounds for gphoto issues.
1. gp_camera_file_read is not fully implemented for all camera drivers so the
   implementation in #4377 does not work reliably. #5219

2. gp_camera_file_get can not be used multiple times on the same image, the first time
   reading GP_FILE_TYPE_PREVIEW it's fine, the next times both the data pointer and size
   are wrong leading 1) to missing thumbs and b) later to crashing because of double free
   in gphoto memory management.

3. We have to find a workaround if we want to avoid dt crashes. More details in source.
   a) don't show thumbs if you reopen the camera import dialog. (bad)
   b) accept not freeing some gp_files
   c) choose gp_file_new_from_fd instead of gp_file_new, this seems to work but is not
      available for all camera drivers.

In this pr i took 3b. (i am not proud of this but memory leak is not that bad)

If we think it's too bad i confess i could not find a better solution yet even after long work.
We could implement a camera specific thumb cache and keep a list of open gp_files but that
would be pretty hard to do, certainly nothing for dt3.2 and i am not sure this works at all.

@johnny-bit could you please test?
@TurboGit any comment?