### PR TITLE
Mods to allow real-time changes in preview_downsampling

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -104,6 +104,13 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(histogram_type, "logarithmic") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
+  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+  dev->preview_downsampling =
+    (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
+    : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
+    : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
+    : 0.25f;
+  g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -117,13 +124,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe);
     dt_dev_pixelpipe_init_preview2(dev->preview2_pipe);
-    gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-    dev->preview_downsampling =
-      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
-      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
-      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
-      : 0.25f;
-    g_free(preview_downsample);
+
     dev->histogram = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_tonecurve = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_levels = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
@@ -140,9 +141,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     // (regardless of ppd). Try to get enough detail for a (default)
     // 350px panel, possibly 2x that on hidpi.
     dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F]/2;
-    // Hardcoded hack: histogram widget will probably be either 175 or
-    // 350 pixels high depending on hidpi
-    dev->histogram_waveform_height = 175;
+    dev->histogram_waveform_height = dt_conf_get_int("histogram_height");
     // making the stride work for cairo muddles UI and underlying
     // data, and mipmap widths should already reasonable, but better
     // to be safe, and the histogram is for the sake of UI, after all
@@ -358,7 +357,6 @@ restart:
   dt_times_t start;
   dt_get_times(&start);
   dt_dev_pixelpipe_change(dev->preview_pipe, dev);
-  
   if(dt_dev_pixelpipe_process(
          dev->preview_pipe, dev, 0, 0, dev->preview_pipe->processed_width * dev->preview_downsampling,
          dev->preview_pipe->processed_height * dev->preview_downsampling, dev->preview_downsampling))
@@ -493,6 +491,7 @@ restart:
   const int ht = MIN(window_height, dev->preview2_pipe->processed_height * scale);
   int x = MAX(0, scale * dev->preview2_pipe->processed_width * (.5 + zoom_x) - wd / 2);
   int y = MAX(0, scale * dev->preview2_pipe->processed_height * (.5 + zoom_y) - ht / 2);
+
   if(dt_dev_pixelpipe_process(dev->preview2_pipe, dev, x, y, wd, ht, scale))
   {
     if(dev->preview2_loading || dev->preview2_input_changed)

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -104,13 +104,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(histogram_type, "logarithmic") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
-  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-  dev->preview_downsampling =
-    (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
-    : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
-    : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
-    : 0.25f;
-  g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -124,7 +117,13 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe);
     dt_dev_pixelpipe_init_preview2(dev->preview2_pipe);
-
+gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+    dev->preview_downsampling =
+      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
+      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
+      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
+      : 0.25f;
+    g_free(preview_downsample);
     dev->histogram = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_tonecurve = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_levels = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -104,13 +104,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   else if(g_strcmp0(histogram_type, "logarithmic") == 0)
     dev->histogram_type = DT_DEV_HISTOGRAM_LOGARITHMIC;
   g_free(histogram_type);
-  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-  dev->preview_downsampling =
-    (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
-    : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
-    : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
-    : 0.25f;
-  g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -124,7 +117,13 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe);
     dt_dev_pixelpipe_init_preview2(dev->preview2_pipe);
-
+    gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+    dev->preview_downsampling =
+      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
+      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
+      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
+      : 0.25f;
+    g_free(preview_downsample);
     dev->histogram = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_tonecurve = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_levels = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
@@ -141,7 +140,9 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     // (regardless of ppd). Try to get enough detail for a (default)
     // 350px panel, possibly 2x that on hidpi.
     dev->histogram_waveform_width = darktable.mipmap_cache->max_width[DT_MIPMAP_F]/2;
-    dev->histogram_waveform_height = dt_conf_get_int("histogram_height");
+    // Hardcoded hack: histogram widget will probably be either 175 or
+    // 350 pixels high depending on hidpi
+    dev->histogram_waveform_height = 175;
     // making the stride work for cairo muddles UI and underlying
     // data, and mipmap widths should already reasonable, but better
     // to be safe, and the histogram is for the sake of UI, after all
@@ -357,6 +358,7 @@ restart:
   dt_times_t start;
   dt_get_times(&start);
   dt_dev_pixelpipe_change(dev->preview_pipe, dev);
+  
   if(dt_dev_pixelpipe_process(
          dev->preview_pipe, dev, 0, 0, dev->preview_pipe->processed_width * dev->preview_downsampling,
          dev->preview_pipe->processed_height * dev->preview_downsampling, dev->preview_downsampling))
@@ -491,7 +493,6 @@ restart:
   const int ht = MIN(window_height, dev->preview2_pipe->processed_height * scale);
   int x = MAX(0, scale * dev->preview2_pipe->processed_width * (.5 + zoom_x) - wd / 2);
   int y = MAX(0, scale * dev->preview2_pipe->processed_height * (.5 + zoom_y) - ht / 2);
-
   if(dt_dev_pixelpipe_process(dev->preview2_pipe, dev, x, y, wd, ht, scale))
   {
     if(dev->preview2_loading || dev->preview2_input_changed)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -240,9 +240,6 @@ void expose(
   if(dev->preview_status == DT_DEV_PIXELPIPE_DIRTY || dev->preview_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp > dev->preview_pipe->input_timestamp)
   {
-    if(&(self->preview_downsample_update) != NULL && self->preview_downsample_update >0.0f)
-      dev->preview_downsampling = (self->preview_downsample_update);
-
     dt_dev_process_preview(dev);
   }
 
@@ -1857,7 +1854,6 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   GtkWidget *display_intent = GTK_WIDGET(user_data);
 
   const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
-
   if(force_lcms2)
   {
     gtk_widget_set_no_show_all(display_intent, FALSE);
@@ -1868,24 +1864,9 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_no_show_all(display_intent, TRUE);
     gtk_widget_set_visible(display_intent, FALSE);
   }
+
   // reconstruct dynamic accels list
   dt_dynamic_accel_get_valid_list();
-}
-
-static void _preference_prev_downsample_change(gpointer instance, gpointer user_data)
-{
-  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-  if(user_data != NULL)
-  {
-    float *preview_downsampling = user_data;
-    *preview_downsampling =
-      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
-      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
-      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
-      : 0.25f;
-  }
-  
-  g_free(preview_downsample);
 }
 
 static void _update_display_profile_cmb(GtkWidget *cmb_display_profile)
@@ -2382,11 +2363,8 @@ void gui_init(dt_view_t *self)
     // update the gui when the preferences changed (i.e. show intent when using lcms2)
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                               G_CALLBACK(_preference_changed), (gpointer)display_intent);
-    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                              G_CALLBACK(_preference_changed), (gpointer)display2_intent);
-    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                              G_CALLBACK(_preference_prev_downsample_change), &(self->preview_downsample_update));
-
+    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(_preference_changed),
+                              (gpointer)display2_intent);
     // and when profiles change
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               G_CALLBACK(_display_profile_changed), (gpointer)display_profile);
@@ -3513,6 +3491,7 @@ int key_pressed(dt_view_t *self, guint key, guint state)
       // we quit the active iop if any
       lib->full_preview_last_module = darktable.develop->gui_module;
       dt_iop_request_focus(NULL);
+      gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
       dt_dev_invalidate(darktable.develop);
       dt_control_queue_redraw_center();
     }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -240,6 +240,9 @@ void expose(
   if(dev->preview_status == DT_DEV_PIXELPIPE_DIRTY || dev->preview_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp > dev->preview_pipe->input_timestamp)
   {
+    if(&(self->preview_downsample_update) != NULL && self->preview_downsample_update >0.0f)
+      dev->preview_downsampling = (self->preview_downsample_update);
+
     dt_dev_process_preview(dev);
   }
 
@@ -1854,6 +1857,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   GtkWidget *display_intent = GTK_WIDGET(user_data);
 
   const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
+
   if(force_lcms2)
   {
     gtk_widget_set_no_show_all(display_intent, FALSE);
@@ -1864,9 +1868,24 @@ static void _preference_changed(gpointer instance, gpointer user_data)
     gtk_widget_set_no_show_all(display_intent, TRUE);
     gtk_widget_set_visible(display_intent, FALSE);
   }
-
   // reconstruct dynamic accels list
   dt_dynamic_accel_get_valid_list();
+}
+
+static void _preference_prev_downsample_change(gpointer instance, gpointer user_data)
+{
+  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+  if(user_data != NULL)
+  {
+    float *preview_downsampling = user_data;
+    *preview_downsampling =
+      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
+      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
+      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
+      : 0.25f;
+  }
+  
+  g_free(preview_downsample);
 }
 
 static void _update_display_profile_cmb(GtkWidget *cmb_display_profile)
@@ -2363,8 +2382,11 @@ void gui_init(dt_view_t *self)
     // update the gui when the preferences changed (i.e. show intent when using lcms2)
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                               G_CALLBACK(_preference_changed), (gpointer)display_intent);
-    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE, G_CALLBACK(_preference_changed),
-                              (gpointer)display2_intent);
+    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                              G_CALLBACK(_preference_changed), (gpointer)display2_intent);
+    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                              G_CALLBACK(_preference_prev_downsample_change), &(self->preview_downsample_update));
+
     // and when profiles change
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,
                               G_CALLBACK(_display_profile_changed), (gpointer)display_profile);
@@ -3491,7 +3513,6 @@ int key_pressed(dt_view_t *self, guint key, guint state)
       // we quit the active iop if any
       lib->full_preview_last_module = darktable.develop->gui_module;
       dt_iop_request_focus(NULL);
-      gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
       dt_dev_invalidate(darktable.develop);
       dt_control_queue_redraw_center();
     }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -240,9 +240,6 @@ void expose(
   if(dev->preview_status == DT_DEV_PIXELPIPE_DIRTY || dev->preview_status == DT_DEV_PIXELPIPE_INVALID
      || dev->pipe->input_timestamp > dev->preview_pipe->input_timestamp)
   {
-if(&(self->preview_downsample_update) != NULL && self->preview_downsample_update >0.0f)
-      dev->preview_downsampling = (self->preview_downsample_update);
-
     dt_dev_process_preview(dev);
   }
 
@@ -2385,7 +2382,7 @@ void gui_init(dt_view_t *self)
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                               G_CALLBACK(_preference_changed), (gpointer)display2_intent);
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
-                              G_CALLBACK(_preference_prev_downsample_change), &(self->preview_downsample_update));
+                              G_CALLBACK(_preference_prev_downsample_change), &(dev->preview_downsampling));
 
     // and when profiles change
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_CONTROL_PROFILE_USER_CHANGED,

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -169,7 +169,7 @@ typedef struct dt_view_t
 
   GSList *accel_closures;
   struct dt_accel_dynamic_t *dynamic_accel_current;
-  float preview_downsample_update;
+
 } dt_view_t;
 
 typedef enum dt_view_image_over_t

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -169,6 +169,7 @@ typedef struct dt_view_t
 
   GSList *accel_closures;
   struct dt_accel_dynamic_t *dynamic_accel_current;
+  float preview_downsample_update;
 } dt_view_t;
 
 typedef enum dt_view_image_over_t
@@ -312,7 +313,6 @@ typedef struct dt_view_manager_t
       void (*set_layout)(struct dt_lib_module_t *module, dt_lighttable_layout_t layout);
       void (*culling_init_mode)(struct dt_view_t *view);
       void (*culling_preview_refresh)(struct dt_view_t *view);
-      void (*culling_preview_reload_overlays)(struct dt_view_t *view);
       dt_lighttable_culling_zoom_mode_t (*get_zoom_mode)(struct dt_lib_module_t *module);
       gboolean (*get_preview_state)(struct dt_view_t *view);
       void (*change_offset)(struct dt_view_t *view, gboolean reset, gint imgid);
@@ -446,8 +446,6 @@ dt_lighttable_culling_zoom_mode_t dt_view_lighttable_get_culling_zoom_mode(dt_vi
 void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm);
 /** force refresh of culling and/or preview */
 void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm);
-/** force refresh of culling and/or preview overlays */
-void dt_view_lighttable_culling_preview_reload_overlays(dt_view_manager_t *vm);
 /** sets the offset image (for culling and full preview) */
 void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, gint imgid);
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -169,7 +169,6 @@ typedef struct dt_view_t
 
   GSList *accel_closures;
   struct dt_accel_dynamic_t *dynamic_accel_current;
-  float preview_downsample_update;
 } dt_view_t;
 
 typedef enum dt_view_image_over_t
@@ -313,6 +312,7 @@ typedef struct dt_view_manager_t
       void (*set_layout)(struct dt_lib_module_t *module, dt_lighttable_layout_t layout);
       void (*culling_init_mode)(struct dt_view_t *view);
       void (*culling_preview_refresh)(struct dt_view_t *view);
+      void (*culling_preview_reload_overlays)(struct dt_view_t *view);
       dt_lighttable_culling_zoom_mode_t (*get_zoom_mode)(struct dt_lib_module_t *module);
       gboolean (*get_preview_state)(struct dt_view_t *view);
       void (*change_offset)(struct dt_view_t *view, gboolean reset, gint imgid);
@@ -446,6 +446,8 @@ dt_lighttable_culling_zoom_mode_t dt_view_lighttable_get_culling_zoom_mode(dt_vi
 void dt_view_lighttable_culling_init_mode(dt_view_manager_t *vm);
 /** force refresh of culling and/or preview */
 void dt_view_lighttable_culling_preview_refresh(dt_view_manager_t *vm);
+/** force refresh of culling and/or preview overlays */
+void dt_view_lighttable_culling_preview_reload_overlays(dt_view_manager_t *vm);
 /** sets the offset image (for culling and full preview) */
 void dt_view_lighttable_change_offset(dt_view_manager_t *vm, gboolean reset, gint imgid);
 

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -169,6 +169,7 @@ typedef struct dt_view_t
 
   GSList *accel_closures;
   struct dt_accel_dynamic_t *dynamic_accel_current;
+  float preview_downsample_update;
 } dt_view_t;
 
 typedef enum dt_view_image_over_t


### PR DESCRIPTION
I always thought the value of preview_downsampling should be selectable without a re-start.

This PR attempts to do that:

- The code from the initialisation section in `develop.c` has been moved to a less intrusive spot whare it is called only when gui_attached is true;
- There are three mods to darkroom.c, to capture` DT_SIGNAL_PREFERENCES_CHANGE`, write them to a float in `dt_view_t` and finally to write those changes into `dev->preview_downsampling`;
- There is the variable added to `views/view.h`

I'm somewhat out of my depth here. In particular, there is a note about keeping view.h and view_api.h in synch... but they don't seem particularly in synch to my unschooled eye. So I added it at the end: advice is welcome.

The overall thinking was that most of the time there would be no need for this, so there should be limited extra calculation: if there has been no change to preferences.c, everything stops at an initial test for a null pointer. Otoh, if you change prefs every time you open dt, there will be no salvation...