### PR TITLE
thumb : allow to set tooltip visibility per size/mode

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -712,6 +712,83 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/tooltips/0/0</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for filemanager at size 0</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/0/1</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for filemanager at size 1</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/0/2</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>tooltips for filemanager at size 2</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/1/0</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for filmstrip at size 0</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/1/1</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for filmstrip at size 1</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/1/2</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for filmstrip at size 2</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/2/0</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for zomable lighttable at size 0</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/2/1</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>tooltips for zomable lighttable at size 1</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/2/2</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>tooltips for zomable lighttable at size 2</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/culling/0</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>tooltips for culling</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/tooltips/culling/1</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>tooltips for full preview</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/timeline/last_zoom</name>
     <type>int</type>
     <default>0</default>

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -807,6 +807,10 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
     table->overlays_block_timeout = dt_conf_get_int(otxt);
   g_free(otxt);
 
+  otxt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/culling/%d", table->mode);
+  table->show_tooltips = dt_conf_get_bool(otxt);
+  g_free(otxt);
+
   // set widget signals
   gtk_widget_set_events(table->widget, GDK_EXPOSURE_MASK | GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                            | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_STRUCTURE_MASK
@@ -1110,7 +1114,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
     else
     {
       // we create a completly new thumb
-      dt_thumbnail_t *thumb = dt_thumbnail_new(10, 10, nid, nrow, table->overlays, TRUE);
+      dt_thumbnail_t *thumb = dt_thumbnail_new(10, 10, nid, nrow, table->overlays, TRUE, table->show_tooltips);
       thumb->display_focus = table->focus;
       thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
       double aspect_ratio = sqlite3_column_double(stmt, 2);
@@ -1161,7 +1165,7 @@ static gboolean _thumbs_recreate_list_at(dt_culling_t *table, const int offset)
         else
         {
           // we create a completly new thumb
-          dt_thumbnail_t *thumb = dt_thumbnail_new(10, 10, nid, nrow, table->overlays, TRUE);
+          dt_thumbnail_t *thumb = dt_thumbnail_new(10, 10, nid, nrow, table->overlays, TRUE, table->show_tooltips);
           thumb->display_focus = table->focus;
           thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
           double aspect_ratio = sqlite3_column_double(stmt, 2);
@@ -1592,6 +1596,10 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
     timeout = dt_conf_get_int(txt);
   g_free(txt);
 
+  txt = dt_util_dstrcat(NULL, "plugins/lighttable/tooltips/culling/%d", table->mode);
+  table->show_tooltips = dt_conf_get_bool(txt);
+  g_free(txt);
+
   // we need to change the overlay content if we pass from normal to extended overlays
   // this is not done on the fly with css to avoid computing extended msg for nothing and to reserve space if needed
   GList *l = table->list;
@@ -1599,6 +1607,7 @@ void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t ov
   {
     dt_thumbnail_t *th = (dt_thumbnail_t *)l->data;
     dt_thumbnail_set_overlay(th, over, timeout);
+    th->tooltip = table->show_tooltips;
     // and we resize the bottom area
     dt_thumbnail_resize(th, th->width, th->height, TRUE);
     l = g_list_next(l);

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -69,6 +69,7 @@ typedef struct dt_culling_t
 
   dt_thumbnail_overlay_t overlays; // overlays type
   int overlays_block_timeout;      // overlay block visibility duration
+  gboolean show_tooltips;          // are tooltips visible ?
 } dt_culling_t;
 
 dt_culling_t *dt_culling_new(dt_culling_mode_t mode);

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -518,7 +518,7 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
 
   // and the tooltip
   gchar *pattern = dt_conf_get_string("plugins/lighttable/thumbnail_tooltip_pattern");
-  if(thumb->over == DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK || strcmp(pattern, "") == 0)
+  if(!thumb->tooltip || strcmp(pattern, "") == 0)
   {
     gtk_widget_set_has_tooltip(thumb->w_main, FALSE);
   }
@@ -1123,7 +1123,8 @@ GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb)
   return thumb->w_main;
 }
 
-dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over, gboolean zoomable)
+dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over,
+                                 gboolean zoomable, gboolean tooltip)
 {
   dt_thumbnail_t *thumb = calloc(1, sizeof(dt_thumbnail_t));
   thumb->width = width;
@@ -1134,6 +1135,7 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
   thumb->zoomable = zoomable;
   thumb->zoom = 1.0f;
   thumb->overlay_timeout_duration = dt_conf_get_int("plugins/lighttable/overlay_timeout");
+  thumb->tooltip = tooltip;
 
   // we read and cache all the infos from dt_image_t that we need
   const dt_image_t *img = dt_image_cache_get(darktable.image_cache, thumb->imgid, 'r');
@@ -1165,11 +1167,11 @@ dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt
   // set tooltip for altered icon if needed
   if(thumb->is_altered)
   {
-    char *tooltip = dt_history_get_items_as_string(thumb->imgid);
-    if(tooltip)
+    char *tooltip_txt = dt_history_get_items_as_string(thumb->imgid);
+    if(tooltip_txt)
     {
-      gtk_widget_set_tooltip_text(thumb->w_altered, tooltip);
-      g_free(tooltip);
+      gtk_widget_set_tooltip_text(thumb->w_altered, tooltip_txt);
+      g_free(tooltip_txt);
     }
   }
 

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -113,6 +113,7 @@ typedef struct
   dt_thumbnail_overlay_t over;  // type of overlays
   int overlay_timeout_duration; // for hover_block overlay, we hide the it after a delay
   int overlay_timeout_id;       // id of the g_source timeout fct
+  gboolean tooltip;             // should we show the tooltip ?
 
   // specific for culling and preview
   gboolean zoomable;   // can we zoom in/out the thumbnail (used for culling/preview)
@@ -130,7 +131,8 @@ typedef struct
   gboolean display_focus; // do we display rectangles to show focused part of the image
 } dt_thumbnail_t;
 
-dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over, gboolean zoomable);
+dt_thumbnail_t *dt_thumbnail_new(int width, int height, int imgid, int rowid, dt_thumbnail_overlay_t over,
+                                 gboolean zoomable, gboolean tooltip);
 void dt_thumbnail_destroy(dt_thumbnail_t *thumb);
 GtkWidget *dt_thumbnail_create_widget(dt_thumbnail_t *thumb);
 void dt_thumbnail_resize(dt_thumbnail_t *thumb, int width, int height, gboolean force);

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -46,6 +46,7 @@ typedef struct dt_thumbtable_t
   dt_thumbtable_mode_t mode;
   dt_thumbnail_overlay_t overlays;
   int overlays_block_timeout;
+  gboolean show_tooltips;
 
   GtkWidget *widget; // GtkLayout -- main widget
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -348,7 +348,8 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkStyleContext *context = gtk_widget_get_style_context(hb);
     gtk_style_context_add_class(context, "dt_overlays_always");
 
-    dt_thumbnail_t *thumb = dt_thumbnail_new(100, 100, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL, FALSE);
+    dt_thumbnail_t *thumb
+        = dt_thumbnail_new(100, 100, imgid, -1, DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL, FALSE, TRUE);
     thumb->sel_mode = DT_THUMBNAIL_SEL_MODE_DISABLED;
     thumb->disable_mouseover = TRUE;
     thumb->disable_actions = TRUE;

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -43,6 +43,7 @@ typedef struct dt_lib_tool_preferences_t
       *over_tt;
   GtkWidget *over_culling_label, *over_culling_r0, *over_culling_r3, *over_culling_r4, *over_culling_r6,
       *over_culling_timeout, *over_culling_tt;
+  gboolean disable_over_events;
 } dt_lib_tool_preferences_t;
 
 /* callback for grouping button */
@@ -87,23 +88,23 @@ static void _overlays_accels_callback(GtkAccelGroup *accel_group, GObject *accel
 
 static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
 {
-  if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w))) return;
-
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
 
+  if(d->disable_over_events) return;
+
   dt_thumbnail_overlay_t over = DT_THUMBNAIL_OVERLAYS_HOVER_NORMAL;
-  if(w == d->over_r0)
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_r0)))
     over = DT_THUMBNAIL_OVERLAYS_NONE;
-  else if(w == d->over_r2)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_r2)))
     over = DT_THUMBNAIL_OVERLAYS_HOVER_EXTENDED;
-  else if(w == d->over_r3)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_r3)))
     over = DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL;
-  else if(w == d->over_r4)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_r4)))
     over = DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED;
-  else if(w == d->over_r5)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_r5)))
     over = DT_THUMBNAIL_OVERLAYS_MIXED;
-  else if(w == d->over_r6)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_r6)))
     over = DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK;
 
   dt_ui_thumbtable(darktable.gui->ui)->show_tooltips = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_tt));
@@ -123,17 +124,17 @@ static void _overlays_toggle_button(GtkWidget *w, gpointer user_data)
 
 static void _overlays_toggle_culling_button(GtkWidget *w, gpointer user_data)
 {
-  if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(w))) return;
-
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
 
+  if(d->disable_over_events) return;
+
   dt_thumbnail_overlay_t over = DT_THUMBNAIL_OVERLAYS_HOVER_BLOCK;
-  if(w == d->over_culling_r0)
+  if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_culling_r0)))
     over = DT_THUMBNAIL_OVERLAYS_NONE;
-  else if(w == d->over_culling_r3)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_culling_r3)))
     over = DT_THUMBNAIL_OVERLAYS_ALWAYS_NORMAL;
-  else if(w == d->over_culling_r4)
+  else if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->over_culling_r4)))
     over = DT_THUMBNAIL_OVERLAYS_ALWAYS_EXTENDED;
 
   dt_culling_mode_t cmode = DT_CULLING_MODE_CULLING;
@@ -184,6 +185,8 @@ static void _overlays_timeout_changed(GtkWidget *w, gpointer user_data)
 static void _overlays_show_popup(dt_lib_module_t *self)
 {
   dt_lib_tool_preferences_t *d = (dt_lib_tool_preferences_t *)self->data;
+
+  d->disable_over_events = TRUE;
 
   gboolean show = FALSE;
 
@@ -335,6 +338,8 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   if(show) gtk_widget_show(d->over_popup);
   else
     dt_control_log(_("overlays not available here..."));
+
+  d->disable_over_events = FALSE;
 }
 
 static void _main_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)


### PR DESCRIPTION
this can be set in the overlays popup menu.
By default, tooltips are on except for "big" thumbnails and culling/preview