### PR TITLE
activating module via shortcut adds to active group

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2155,6 +2155,12 @@ void dt_dev_modulegroups_switch(dt_develop_t *dev, dt_iop_module_t *module)
     dev->proxy.modulegroups.switch_group(dev->proxy.modulegroups.module, module);
 }
 
+void dt_dev_modulegroups_update_visibility(dt_develop_t *dev)
+{
+  if(dev->proxy.modulegroups.module && dev->proxy.modulegroups.switch_group && dev->first_load == FALSE)
+    dev->proxy.modulegroups.update_visibility(dev->proxy.modulegroups.module);
+}
+
 void dt_dev_modulegroups_search_text_focus(dt_develop_t *dev)
 {
   if(dev->proxy.modulegroups.module && dev->proxy.modulegroups.search_text_focus && dev->first_load == 0)

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -239,6 +239,8 @@ typedef struct dt_develop_t
       gboolean (*test)(struct dt_lib_module_t *self, uint32_t group, uint32_t iop_group);
       /* switch to modulegroup */
       void (*switch_group)(struct dt_lib_module_t *self, struct dt_iop_module_t *module);
+      /* update modulegroup visibility */
+      void (*update_visibility)(struct dt_lib_module_t *self);
       /* set focus to the search module text box */
       void (*search_text_focus)(struct dt_lib_module_t *self);
     } modulegroups;
@@ -412,6 +414,8 @@ float dt_dev_exposure_get_black(dt_develop_t *dev);
 gboolean dt_dev_modulegroups_available(dt_develop_t *dev);
 /** switch to modulegroup of module */
 void dt_dev_modulegroups_switch(dt_develop_t *dev, struct dt_iop_module_t *module);
+/** update modulegroup visibility */
+void dt_dev_modulegroups_update_visibility(dt_develop_t *dev);
 /** set the focus to modulegroup search text */
 void dt_dev_modulegroups_search_text_focus(dt_develop_t *dev);
 /** set the active modulegroup */

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1114,6 +1114,9 @@ static void dt_iop_gui_off_callback(GtkToggleButton *togglebutton, gpointer user
     // rebuild the accelerators
     dt_iop_connect_accels_multi(module->so);
   }
+
+  if(module->enabled && !gtk_widget_is_visible(module->header))
+    dt_dev_modulegroups_update_visibility(darktable.develop);
 }
 
 gboolean dt_iop_so_is_hidden(dt_iop_module_so_t *module)


### PR DESCRIPTION
when activating a module via a keyboard shortcut with the active module group shown, the activated module is shown in the active group