### PR TITLE
exposure: ellipsize exposure compensation parameter

### DIFF
--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -571,6 +571,7 @@ void gui_update(struct dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias), p->compensate_exposure_bias);
   gtk_button_set_label(GTK_BUTTON(g->compensate_exposure_bias), g_strdup_printf(_("compensate camera exposure (%+.1f EV)"),
                                                                                   get_exposure_bias(self)));
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->compensate_exposure_bias))), PANGO_ELLIPSIZE_MIDDLE);
   dt_bauhaus_slider_set_soft(g->black, p->black);
   dt_bauhaus_slider_set_soft(g->exposure, p->exposure);
 
@@ -951,6 +952,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->compensate_exposure_bias = gtk_check_button_new_with_label(g_strdup_printf(_("compensate camera exposure (%+.1f EV)"),
                                                                                   get_exposure_bias(self)));
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(g->compensate_exposure_bias))), PANGO_ELLIPSIZE_MIDDLE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->compensate_exposure_bias), p->compensate_exposure_bias);
   gtk_widget_set_tooltip_text(g->compensate_exposure_bias, _("automatically remove the camera exposure bias\n"
                                                              "this is useful if you exposed the image to the right."));


### PR DESCRIPTION
allows right hand pane to be shrunk smaller by ellipsizing the text of
the new "compensate camera exposure (+0.0 EV)" check box