### PR TITLE
ellipsize buttons in snapshot and history stack modules

### DIFF
--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -106,6 +106,7 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_button_lib(self, "compress history stack", d->compress_button);
 }
 
+#define ellipsize_button(button) gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -125,6 +126,7 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   d->compress_button = gtk_button_new_with_label(_("compress history stack"));
+  ellipsize_button(d->compress_button);
   gtk_widget_set_tooltip_text(d->compress_button, _("create a minimal history stack which produces the same image"));
   g_signal_connect(G_OBJECT(d->compress_button), "clicked", G_CALLBACK(_lib_history_compress_clicked_callback), self);
 
@@ -179,6 +181,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
   /* create toggle button */
   GtkWidget *widget = gtk_toggle_button_new_with_label(label);
   gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(widget)), GTK_ALIGN_START);
+  ellipsize_button(widget);
 
   if(always_on)
   {
@@ -231,6 +234,7 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
 
   return hbox;
 }
+#undef ellipsize_button
 
 static void _reset_module_instance(GList *hist, dt_iop_module_t *module, int multi_priority)
 {

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -431,6 +431,7 @@ void gui_cleanup(dt_lib_module_t *self)
   self->data = NULL;
 }
 
+#define ellipsize_button(button) gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_MIDDLE);
 static void _lib_snapshots_add_button_clicked_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_lib_module_t *self = (dt_lib_module_t *)user_data;
@@ -467,6 +468,7 @@ static void _lib_snapshots_add_button_clicked_callback(GtkWidget *widget, gpoint
   }
   g_snprintf(label, sizeof(label), "%s (%d)", name, darktable.develop->history_end);
   gtk_button_set_label(GTK_BUTTON(d->snapshot[0].button), label);
+  ellipsize_button(d->snapshot[0].button);
   gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(d->snapshot[0].button)), GTK_ALIGN_START);
 
   dt_lib_snapshot_t *s = d->snapshot + 0;
@@ -485,6 +487,7 @@ static void _lib_snapshots_add_button_clicked_callback(GtkWidget *widget, gpoint
   /* request a new snapshot for top slot */
   dt_dev_snapshot_request(darktable.develop, (const char *)&d->snapshot[0].filename);
 }
+#undef ellipsize_button
 
 static void _lib_snapshots_toggled_callback(GtkToggleButton *widget, gpointer user_data)
 {


### PR DESCRIPTION
allows LHS panel of darkroom to be made smaller where modules with long
names are present in history and snapshot modules