### PR TITLE
altered fix - in mipmap consider auto apply as altered

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1427,7 +1427,7 @@ void dt_history_hash_read(const int32_t imgid, dt_history_hash_values_t *hash)
   sqlite3_finalize(stmt);
 }
 
-const gboolean dt_history_hash_get_mipmap_sync(const int32_t imgid)
+const gboolean dt_history_hash_is_mipmap_synced(const int32_t imgid)
 {
   gboolean status = FALSE;
   if(imgid == -1) return status;

--- a/src/common/history.h
+++ b/src/common/history.h
@@ -120,7 +120,7 @@ void dt_history_hash_write_from_history(const int32_t imgid, const dt_history_ha
 const dt_history_hash_t dt_history_hash_get_status(const int32_t imgid);
 
 /** return true if mipmap_hash = current_hash */
-const gboolean dt_history_hash_get_mipmap_sync(const int32_t imgid);
+const gboolean dt_history_hash_is_mipmap_synced(const int32_t imgid);
 
 /** update mipmap hash to db (= current_hash) */
 void dt_history_hash_set_mipmap(const int32_t imgid);

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -1009,6 +1009,11 @@ gboolean dt_image_altered(const uint32_t imgid)
   return status & DT_HISTORY_HASH_CURRENT;
 }
 
+gboolean dt_image_basic(const uint32_t imgid)
+{
+  dt_history_hash_t status = dt_history_hash_get_status(imgid);
+  return status & DT_HISTORY_HASH_BASIC;
+}
 
 GList* dt_image_find_duplicates(const char* filename)
 {

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -287,8 +287,10 @@ void dt_image_set_locations(const GList *img, const dt_image_geoloc_t *geoloc,
                            const gboolean undo_on);
 /** get image location lon/lat/ele */
 void dt_image_get_location(const int32_t imgid, dt_image_geoloc_t *geoloc);
-/** returns 1 if there is history data found for this image, 0 else. */
+/** returns TRUE if current hash is not basic nor auto_apply, FALSE otherwise. */
 gboolean dt_image_altered(const uint32_t imgid);
+/** returns TRUE if if current has is basic, FALSE otherwise. */
+gboolean dt_image_basic(const uint32_t imgid);
 /** set the image final/cropped aspect ratio */
 double dt_image_set_aspect_ratio(const int32_t imgid, gboolean raise);
 /** set the image raw aspect ratio */

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -1162,7 +1162,7 @@ static void _init_8(uint8_t *buf, uint32_t *width, uint32_t *height, float *isca
     return;
   }
 
-  const gboolean altered = dt_image_altered(imgid);
+  const gboolean altered = !dt_image_basic(imgid);
   int res = 1;
 
   const dt_image_t *cimg = dt_image_cache_get(darktable.image_cache, imgid, 'r');

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -817,7 +817,7 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
   dt_dev_write_history(dev);
 
   // be sure light table will update the thumbnail
-  if (!dt_history_hash_get_mipmap_sync(dev->image_storage.id))
+  if (!dt_history_hash_is_mipmap_synced(dev->image_storage.id))
   {
     dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
     dt_image_reset_final_size(dev->image_storage.id);
@@ -2879,7 +2879,7 @@ void leave(dt_view_t *self)
   }
 
   // be sure light table will regenerate the thumbnail:
-  if (!dt_history_hash_get_mipmap_sync(dev->image_storage.id))
+  if (!dt_history_hash_is_mipmap_synced(dev->image_storage.id))
   {
     dt_mipmap_cache_remove(darktable.mipmap_cache, dev->image_storage.id);
     dt_image_reset_final_size(dev->image_storage.id);


### PR DESCRIPTION
fixes #5295 

I am not completely happy with this, mainly because the "altered" concept is bit weak and we have to live with it.
However this fixes the related issue: when embedded thumbnail is to be used, the image enters in darkroom not developed (even auto applied stuff). Leaving darkroom didn't triggers mipmap because auto applied stuff was not considered as altered.

I've also renamed dt_history_hash_get_mipmap_sync() to dt_history_hash_is_mipmap_synced() for more clarity.


