### PR TITLE
Improving suport for sensor size and ratio

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -665,6 +665,24 @@ void dt_image_flip(const int32_t imgid, const int32_t cw)
                  dt_history_snapshot_undo_pop, dt_history_snapshot_undo_lt_history_data_free);
 }
 
+/* About the image size ratio 
+   It has been calculated from the exif data width&height, this is not exact as we crop
+   the sensor data in most cases for raws.
+   This is managed by
+   rawspeed - knowing about default crops
+   rawprepare - modify the defaults
+
+   The database does **not** hold the cropped width & height so we fill the data
+   when starting to develop.
+*/
+double dt_image_get_sensor_ratio(const struct dt_image_t *img)
+{
+  if(img->p_height >0)
+    return (double)img->p_width / (double)img->p_height;
+
+  return (double)img->width / (double)img->height;
+}
+
 void dt_image_set_raw_aspect_ratio(const int32_t imgid)
 {
   /* fetch image from cache */
@@ -1403,7 +1421,7 @@ uint32_t dt_image_import_lua(const int32_t film_id, const char *filename, gboole
 void dt_image_init(dt_image_t *img)
 {
   img->width = img->height = img->verified_size = 0;
-  img->final_width = img->final_height = 0;
+  img->final_width = img->final_height = img->p_width = img->p_height = 0;
   img->aspect_ratio = 0.f;
   img->crop_x = img->crop_y = img->crop_width = img->crop_height = 0;
   img->orientation = ORIENTATION_NULL;

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -179,7 +179,7 @@ typedef struct dt_image_t
   // common stuff
 
   // to understand this, look at comment for dt_histogram_roi_t
-  int32_t width, height, verified_size, final_width, final_height;
+  int32_t width, height, verified_size, final_width, final_height, p_width, p_height;
   int32_t crop_x, crop_y, crop_width, crop_height;
   float aspect_ratio;
 
@@ -299,6 +299,8 @@ void dt_image_set_aspect_ratio_to(const int32_t imgid, double aspect_ratio, gboo
 void dt_image_set_aspect_ratio_if_different(const int32_t imgid, double aspect_ratio, gboolean raise);
 /** reset the image final/cropped aspect ratio to 0.0 */
 void dt_image_reset_aspect_ratio(const int32_t imgid, gboolean raise);
+/** get the ratio of cropped raw sensor data */
+double dt_image_get_sensor_ratio(const dt_image_t *img);
 /** returns the orientation bits of the image from exif. */
 static inline dt_image_orientation_t dt_image_orientation(const dt_image_t *img)
 {

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -1143,6 +1143,11 @@ dt_imageio_retval_t dt_imageio_open(dt_image_t *img,               // non-const 
   if((ret == DT_IMAGEIO_OK) && !was_bw && (img->flags & DT_IMAGE_MONOCHROME))
     dt_imageio_set_bw_tag(img);
 
+  img->p_width = img->width - img->crop_x - img->crop_width;
+  img->p_height = img->height - img->crop_y - img->crop_height;
+  if(img->crop_x || img->crop_width || img->crop_y || img->crop_height)
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_METADATA_UPDATE);
+
   return ret;
 }
 

--- a/src/control/signal.c
+++ b/src/control/signal.c
@@ -165,6 +165,9 @@ static dt_signal_description _signal_description[DT_SIGNAL_COUNT] = {
   { "dt-control-pickerdata-ready", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_generic, 2, pointer_2arg, NULL,
     FALSE }, // DT_SIGNAL_CONTROL_PICKERDATA_REAEDY
 
+  { "dt-metadata-update", NULL, NULL, G_TYPE_NONE, g_cclosure_marshal_VOID__VOID, 0, NULL, NULL,
+    FALSE }, // DT_SIGNAL_METADATA_UPDATE
+
 };
 
 static GType _signal_type;

--- a/src/control/signal.h
+++ b/src/control/signal.h
@@ -232,6 +232,9 @@ typedef enum dt_signal_t
   */
   DT_SIGNAL_CONTROL_PICKERDATA_READY,
 
+  /* \brief This signal is raised when metadata view needs update */
+  DT_SIGNAL_METADATA_UPDATE,
+
   /* do not touch !*/
   DT_SIGNAL_COUNT
 } dt_signal_t;

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -255,7 +255,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
 
     // get the size before locking the image!
     // TODO: put that into dt_image_t and make sure it stays in sync
-    int width = 0, height = 0;
+//    int width = 0, height = 0;
 //     dt_image_get_final_size(mouse_over_id, &width, &height); // kind of slow on some machines
 
     const dt_image_t *img = dt_image_cache_get(darktable.image_cache, mouse_over_id, 'r');
@@ -537,16 +537,33 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     else
       _metadata_update_value(d->metadata[md_exif_datetime], img->exif_datetime_taken);
 
+    if(((img->p_width != img->width) || (img->p_height != img->height))  &&
+       (img->p_width || img->p_height))
+    {
+      snprintf(value, sizeof(value), "%d (%d)", img->p_height, img->height);
+      _metadata_update_value(d->metadata[md_exif_height], value);
+      snprintf(value, sizeof(value), "%d (%d) ",img->p_width, img->width);
+      _metadata_update_value(d->metadata[md_exif_width], value);
+    }
+    else {
     snprintf(value, sizeof(value), "%d", img->height);
     _metadata_update_value(d->metadata[md_exif_height], value);
     snprintf(value, sizeof(value), "%d", img->width);
     _metadata_update_value(d->metadata[md_exif_width], value);
+    }
 
-    snprintf(value, sizeof(value), "%d", height);
+    if(img->verified_size)
+    {
+      snprintf(value, sizeof(value), "%d", img->final_height);
     _metadata_update_value(d->metadata[md_height], value);
-    snprintf(value, sizeof(value), "%d", width);
+      snprintf(value, sizeof(value), "%d", img->final_width);
     _metadata_update_value(d->metadata[md_width], value);
-
+    }
+    else
+    {
+      _metadata_update_value(d->metadata[md_height], "-");
+      _metadata_update_value(d->metadata[md_width], "-");
+    }
     /* XMP */
     for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
     {
@@ -833,6 +850,11 @@ void gui_init(dt_lib_module_t *self)
   /* signup for tags changes */
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_TAG_CHANGED,
                             G_CALLBACK(_mouse_over_image_callback), self);
+
+  /* signup for metadata changes */
+  dt_control_signal_connect(darktable.signals, DT_SIGNAL_METADATA_UPDATE,
+                            G_CALLBACK(_mouse_over_image_callback), self);
+
   /* adaptable window size */
   g_signal_connect(G_OBJECT(self->widget), "scroll-event", G_CALLBACK(view_onMouseScroll), d);
 }


### PR DESCRIPTION
There have been several issues related to exact sensor size and image ratio, also the
available information in "image information" was misleading.

Done here:

1. the dt_image_t struct also has p_width & p_height, both are not kept in the database
   but are filled when developing via rawspeed and rawprepare.
   They hold the size of **used** data for the sensor... 
2. Introduced a new signal `DT_SIGNAL_METADATA_UPDATE` that notes the "image information"
   display about changed data. It's sent if a modified crop has been detected via rawspeed
   or rawprepare for now. I looked through the other signals, `DT_SIGNAL_IMAGE_INFO_CHANGED` or `DT_SIGNAL_TAG_CHANGED` were concidered but did not seem to be well suited.
3. Metadata_view looks for any crop on sensor data and if there is, it shows current size
   and original like "4000 (4016)"
4. Also in metadata_view, as we don't calculate verified_size right now because of performance reasons it's not shown with numbers but as non-existing.
5. In image.c we have `double dt_image_get_sensor_ratio(const struct dt_image_t *img)`
   that can be used to get the exact ratio of raw data.
   Atm this is not further used because of freezing date coming soon ...

@GrahamByrnes might this help?
