### PR TITLE
histogram: reverse resize scroll direction

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -711,7 +711,7 @@ static gboolean _lib_histogram_scroll_callback(GtkWidget *widget, GdkEventScroll
     if(event->state & GDK_CONTROL_MASK && !darktable.gui->reset)
     {
       /* set size of navigation draw area */
-      const float histheight = clamp_range_f(dt_conf_get_int("histogram_height") * 1.0f - 10 * delta_y, 100.0f, 200.0f);
+      const float histheight = clamp_range_f(dt_conf_get_int("histogram_height") * 1.0f + 10 * delta_y, 100.0f, 200.0f);
       dt_conf_set_int("histogram_height", histheight);
       gtk_widget_set_size_request(self->widget, -1, DT_PIXEL_APPLY_DPI(histheight));
       darktable.develop->histogram_waveform_height = histheight;


### PR DESCRIPTION
amend the histogram resize so that scrolling up shrinks and scrolling
down grows (for better consistency with other modules e.g. collect
images and image information)