### PR TITLE
New css fixes

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -71,7 +71,8 @@
 @define-color field_hover_fg @grey_20;
 
 /* Tooltips and contextual helpers */
-@define-color tooltip_bg_color @grey_20;
+@define-color tooltip_bg_color @grey_25;
+@define-color tooltip_fg_color @grey_75;
 @define-color log_fg_color @grey_90;
 
 /* Views */

--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -83,11 +83,12 @@
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */
-@define-color thumbnail_font_color @grey_35;
 @define-color thumbnail_bg_color @grey_55;
-@define-color thumbnail_infos_color @grey_30;
+@define-color thumbnail_star_bg_color @grey_40;
+@define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_selected_bg_color @grey_65;
-@define-color thumbnail_hover_bg_color @grey_95;
+@define-color thumbnail_hover_bg_color @grey_85;
+@define-color thumbnail_hover_fg_color @grey_90;
 @define-color thumbnail_localcopy_color @grey_80;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
@@ -110,7 +111,7 @@
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom,
 .dt_overlays_hover #thumb_main:hover #thumb_bottom
 {
-  background-image: linear-gradient(rgba(241, 241, 241, 0.7) 0%, rgba(241, 241, 241, 0.7) 90%,rgba(241, 241, 241, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
+  background-image: linear-gradient(rgba(212, 212, 212, 0.7) 0%, rgba(212, 212, 212, 0.7) 90%,rgba(212, 212, 212, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
 }
 
 /* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */

--- a/data/themes/darktable-elegant-darker.css
+++ b/data/themes/darktable-elegant-darker.css
@@ -104,7 +104,8 @@ button,
 
 notebook tabs,
 #modules-tabs,
-#blending-tabs
+#blending-tabs,
+tooltip label
 {
     font-family: "Roboto", 
                  "Segoe UI", 

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -86,9 +86,11 @@
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */
+@define-color thumbnail_font_color @grey_35;
 @define-color thumbnail_bg_color @grey_70;
-@define-color thumbnail_infos_color @grey_50;
+@define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_selected_bg_color @grey_80;
+@define-color thumbnail_hover_bg_color @grey_95;
 @define-color thumbnail_localcopy_color @grey_90;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */
@@ -121,6 +123,14 @@
 #toast-msg
 {
   background-color: rgba(110,110,110,0.6);
+}
+
+/* Set background on thumbnails hover overlays */
+.dt_overlays_hover_extended #thumb_main:hover #thumb_bottom,
+.dt_overlays_mixed #thumb_main:hover #thumb_bottom,
+.dt_overlays_hover #thumb_main:hover #thumb_bottom
+{
+  background-image: linear-gradient(rgba(241, 241, 241, 0.7) 0%, rgba(241, 241, 241, 0.7) 90%,rgba(241, 241, 241, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
 }
 
 /* Set how bottom infos are rendered on always and always extended overlays modes in culling and preview modes */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -75,6 +75,7 @@
 
 /* Tooltips and contextual helpers */
 @define-color tooltip_bg_color @grey_35;
+@define-color tooltip_fg_color @grey_80;
 @define-color log_fg_color @grey_95;
 
 /* Views */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -157,7 +157,6 @@
 @define-color inset_histogram alpha(@grey_65, 0.50);
 
 /* Reset GTK defaults - Otherwise dt inherits Adwaita default theme dark */
-
 *
 {
   background-color: @bg_color;
@@ -213,8 +212,6 @@ stack,
 stack *,
 scrollbar,
 scrollbar *,
-eventbox,
-eventbox *,
 scale,
 scale *,
 button,
@@ -816,7 +813,7 @@ menuitem > menu, /* sub-menu */
 menuitem arrow,
 tooltip,
 popover,
-#background_job_eventbox,
+#background_job_eventbox, /* background of export progress bar */
 combobox window,
 dialog combobox window
 {

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -120,7 +120,7 @@
 
 /* Tooltips and contextual helpers */
 @define-color tooltip_bg_color @grey_05;
-@define-color tooltip_fg_color @grey_70;
+@define-color tooltip_fg_color @grey_65;
 @define-color really_dark_bg_color @grey_05;
 @define-color log_fg_color @grey_85;
 
@@ -821,7 +821,6 @@ combobox window,
 dialog combobox window
 {
   background-color: @tooltip_bg_color;
-  color: @tooltip_fg_color;
   outline-style:none;
   border-radius: 4px;
   border: 0;
@@ -829,6 +828,11 @@ dialog combobox window
   min-height: 0.4em;
   min-width: 0.4em;
   padding: 0.2em;
+}
+
+tooltip label
+{
+  color: @tooltip_fg_color;
 }
 
 combobox label

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -134,15 +134,15 @@
 
 /* Lighttable and film-strip */
 @define-color thumbnail_font_color @grey_25;
-@define-color thumbnail_bg_color @grey_40;
-@define-color thumbnail_star_bg_color @grey_50;
-@define-color thumbnail_fg_color @grey_60;
+@define-color thumbnail_bg_color @grey_50;
+@define-color thumbnail_star_bg_color @grey_35;
+@define-color thumbnail_fg_color @grey_55;
 @define-color thumbnail_bg50_color @grey_100;
-@define-color thumbnail_infos_color @grey_20;
-@define-color thumbnail_selected_bg_color @grey_45;
+@define-color thumbnail_selected_bg_color @grey_60;
 @define-color thumbnail_hover_bg_color @grey_80;
+@define-color thumbnail_hover_fg_color @grey_85;
 @define-color filmstrip_bg_color @darkroom_bg_color;
-@define-color thumbnail_localcopy_color @grey_70;
+@define-color thumbnail_localcopy_color @grey_75;
 
 /* Brushes */
 @define-color brush_cursor alpha(white, .9);
@@ -268,6 +268,12 @@ button,
   min-height: 1em;
   min-width: 1em;
   padding: 2px;
+}
+
+button:disabled,
+#add-color-button:disabled
+{
+  border: 1px solid shade(@button_border, 0.95);
 }
 
 /* Default extra margin for icons optical alignment */
@@ -424,6 +430,11 @@ overshoot.right
   margin: 12px; /* not real pixels, this is used as a percent extra space */
 }
 
+#footer-toolbar #lib-label-colors #button-canvas
+{
+  margin: 16px; /* not real pixels, this is used as a percent extra space */
+}
+
 #dt-icon
 {
   border-radius: 2px;
@@ -482,10 +493,8 @@ overshoot.right
   padding: 1px;
 }
 
-/* size of control-buttons */
-/* filter in collect images */
-/* filter in header toolbar */
-/* arrow in filmic */
+/* Size of control-buttons an duplicate module ones */
+  /* control-buttons are: filter in collect images, filter in header toolbar and arrow in filmic */
 #iop-plugin-ui-main #control-button,
 #lib-plugin-ui-main #control-button,
 #header-toolbar #control-button
@@ -496,9 +505,16 @@ overshoot.right
   margin: 0.15em;
 }
 
-#control-button #button-canvas
+#control-button #button-canvas,
+.duplicate-ui #button-canvas
 {
   margin: 12px; /* not real pixels, this is used as a percent extra space */
+}
+
+/* Adjust add button in picker module */
+.picker-module button
+{
+  padding: 0 3px;
 }
 
 /* Set history (darkroom) and recent collections (lighttable) modules, that make use of a
@@ -556,7 +572,7 @@ overshoot.right
   margin: 12px; /* not real pixels, this is used as a percent extra space */
 }
 
-/* gradient sliders */
+/* Gradient sliders */
 .dt_gslider,
 .dt_gslider_multivalue
 {
@@ -1894,6 +1910,12 @@ spinbutton>button
   margin: 2px 1px;
 }
 
+#show-tooltip
+{
+  margin: 4px 0 0 4px;
+  border-top: 1px dashed @button_border;
+}
+
   /*** for following settings line, remember which popover mode name and related line on popover menu
   1) .dt_overlays_none
   2) .dt_overlays_hover
@@ -1925,9 +1947,9 @@ spinbutton>button
   border: 2px solid @plugin_bg_color;
 }
 
-#thumb_ext /* adjust margin to align to group, audio... icons */
+#thumb_ext /* adjust margin to better align to group, audio... icons and match to near all thumbnails sizes */
 {
-  margin-top: -3px;
+  margin-top: -1px;
 }
 
 /*---------------
@@ -1958,7 +1980,7 @@ spinbutton>button
 .dt_overlays_mixed #thumb_main:hover #thumb_bottom,
 .dt_overlays_hover #thumb_main:hover #thumb_bottom
 {
-  background-image: linear-gradient(0deg, rgba(198, 198, 198, 0.7) 0%, rgba(198, 198, 198, 0.7) 90%,rgba(198, 198, 198, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
+  background-image: linear-gradient(rgba(198, 198, 198, 0.7) 0%, rgba(198, 198, 198, 0.7) 90%,rgba(198, 198, 198, 0) 100%);  /* rgb color needs to be set to same color as #thumb_back hover background */
 }
 
 /* Set background on block infos in last overlay mode and culling/preview modes shown with mouse hover */
@@ -1992,7 +2014,7 @@ spinbutton>button
 .dt_overlays_always_extended #thumb_ext,
 .dt_overlays_mixed #thumb_ext
 {
-  color: @thumbnail_infos_color;
+  color: shade(@thumbnail_font_color, 1.1);
 }
 
 /* Reset color icons to be hidden in following modes, including culling/preview overlays hover block*/
@@ -2071,7 +2093,7 @@ spinbutton>button
 .dt_overlays_mixed #thumb_main:hover #thumb_star:hover,
 .dt_overlays_hover_block #thumb_main:hover #thumb_star:hover
 {
-  color: @bauhaus_fg_hover;
+  color: @thumbnail_hover_fg_color;
   background-color: @thumbnail_star_bg_color;
 }
 
@@ -2114,9 +2136,9 @@ spinbutton>button
   background-color: @thumbnail_localcopy_color;
 }
 
-/*--------------------------------------
-  - Hide icons on all lighttable modes -
-  --------------------------------------*/
+/*---------------------------------------------------------
+  - Hide icons on all lighttable modes and duplicate ones -
+  ---------------------------------------------------------*/
 
 .dt_overlays_hover #thumb_main:hover #thumb_group,
 .dt_overlays_hover #thumb_main:hover #thumb_altered,
@@ -2141,12 +2163,18 @@ spinbutton>button
 .dt_overlays_always#preview #thumb_group,
 .dt_overlays_always_extended#preview #thumb_altered,
 .dt_overlays_always_extended#preview #thumb_audio,
-.dt_overlays_always_extended#preview #thumb_group
+.dt_overlays_always_extended#preview #thumb_group,
+.duplicate-ui #thumb_main:hover #thumb_group,
+.duplicate-ui #thumb_main:hover #thumb_altered,
+.duplicate-ui #thumb_main:hover #thumb_audio,
+.duplicate-ui #thumb_altered,
+.duplicate-ui #thumb_audio,
+.duplicate-ui #thumb_group
 {
   color: transparent;
 }
 
-.dt_overlays_always#preview #thumb_bottom>*
+.dt_overlays_always#preview #thumb_bottom > *
 {
   padding-top: 3px;
 }

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -547,6 +547,8 @@ void gui_init(dt_lib_module_t *self)
 
   // Setting up the GUI
   self->widget = container;
+  GtkStyleContext *context = gtk_widget_get_style_context(self->widget);
+  gtk_style_context_add_class(context, "picker-module");
   gtk_box_pack_start(GTK_BOX(container), output_row, TRUE, TRUE, 0);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -457,7 +457,8 @@ void gui_init(dt_lib_module_t *self)
   d->preview_zoom = 1.0;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_widget_set_name(self->widget, "duplicate-ui");
+  GtkStyleContext *context = gtk_widget_get_style_context(self->widget);
+  gtk_style_context_add_class(context, "duplicate-ui");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -87,6 +87,7 @@ void gui_init(dt_lib_module_t *self)
     gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
     g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_lib_colorlabels_button_clicked_callback),
                      GINT_TO_POINTER(k));
+    gtk_widget_set_name(self->widget, "lib-label-colors");
   }
 }
 

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -444,6 +444,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->thumbnails_box), hbox, TRUE, TRUE, 0);
   d->over_tt = gtk_check_button_new_with_label(_("show tooltip"));
   g_signal_connect(G_OBJECT(d->over_tt), "toggled", G_CALLBACK(_overlays_toggle_button), self);
+  gtk_widget_set_name(d->over_tt, "show-tooltip");
   gtk_box_pack_start(GTK_BOX(d->thumbnails_box), d->over_tt, TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(vbox), d->thumbnails_box, TRUE, TRUE, 0);
@@ -476,6 +477,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(d->culling_box), hbox, TRUE, TRUE, 0);
   d->over_culling_tt = gtk_check_button_new_with_label(_("show tooltip"));
   g_signal_connect(G_OBJECT(d->over_culling_tt), "toggled", G_CALLBACK(_overlays_toggle_culling_button), self);
+  gtk_widget_set_name(d->over_culling_tt, "show-tooltip");
   gtk_box_pack_start(GTK_BOX(d->culling_box), d->over_culling_tt, TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(vbox), d->culling_box, TRUE, TRUE, 0);


### PR DESCRIPTION
- Should improve visibility on text infos in thumbnails (for all themes). @TurboGit: hope it will be good for you. Just consider that I've kept the idea to have better visibility when hovering than without but have good one without hovering anyway. Those changes needs to update accordingly background gradient when hovering thumbnails.
- Improve disabled buttons since new dynamic buttons added by @johnny-bit 
- Fix too big color labels icons in bottom left in lighttable view
- Fix too big buttons in duplicate module in darkroom
- Fix height on add button in picker module
- Hide top icons in thumbnails on duplicate module as it's not readable and ugly with them
- Set back to -1px finally top margin of extension name as -3px was not a good idea I propose to @alicvb.
- And finally, set visually new show tooltip on overlay popover menu