### PR TITLE
don't count GList items if that's not necessary

### DIFF
--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -89,7 +89,7 @@ static void _update(dt_lib_module_t *self)
   dt_lib_export_t *d = (dt_lib_export_t *)self->data;
 
   GList *imgs = dt_view_get_images_to_act_on(TRUE);
-  const guint act_on_cnt = g_list_length(imgs);
+  const gboolean has_act_on = imgs != NULL;
   g_list_free(imgs);
 
   char *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
@@ -100,7 +100,7 @@ static void _update(dt_lib_module_t *self)
   g_free(format_name);
   g_free(storage_name);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->export_button), act_on_cnt > 0 && format_index != -1 && storage_index != -1);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->export_button), has_act_on && format_index != -1 && storage_index != -1);
 
   if(d->timeout_handle)
   {

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -464,19 +464,19 @@ static void _update(dt_lib_module_t *self)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)self->data;
   GList *imgs = dt_view_get_images_to_act_on(TRUE);
-  const guint act_on_cnt = g_list_length(imgs);
+  const gboolean has_act_on = imgs != NULL;
   g_list_free(imgs);
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
   const gint sel_styles_cnt = gtk_tree_selection_count_selected_rows(selection);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->create_button), act_on_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->create_button), has_act_on);
   gtk_widget_set_sensitive(GTK_WIDGET(d->edit_button), sel_styles_cnt > 0);
   gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), sel_styles_cnt > 0);
 
   //import is ALWAYS enabled.
   gtk_widget_set_sensitive(GTK_WIDGET(d->export_button), sel_styles_cnt > 0);
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->apply_button), act_on_cnt >0 && sel_styles_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->apply_button), has_act_on && sel_styles_cnt > 0);
 
   if(d->timeout_handle)
   {

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -140,7 +140,7 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
   GList *imgs = dt_view_get_images_to_act_on(TRUE);
-  const guint act_on_cnt = g_list_length(imgs);
+  const gboolean has_act_on = imgs != NULL;
   g_list_free(imgs);
 
   const gint dict_tags_sel_cnt =
@@ -148,8 +148,8 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
   const gint atached_tags_sel_cnt =
     gtk_tree_selection_count_selected_rows(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->attached_view)));
 
-  gtk_widget_set_sensitive(GTK_WIDGET(d->attach_button), act_on_cnt > 0 && dict_tags_sel_cnt > 0);
-  gtk_widget_set_sensitive(GTK_WIDGET(d->detach_button), act_on_cnt > 0 && atached_tags_sel_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->attach_button), has_act_on && dict_tags_sel_cnt > 0);
+  gtk_widget_set_sensitive(GTK_WIDGET(d->detach_button), has_act_on && atached_tags_sel_cnt > 0);
 
   if(d->timeout_handle)
   {


### PR DESCRIPTION
Somewhat related with #5381 (or rather - inspired by)

In some btn updates, we only need to know IF there's something to act on. No need to count it, and in that case GList reference suggests it's enough just to check if the list is not null.

Tested and works perfectly well (or rather - has no negative impact)