### PR TITLE
Retouch module: use gradient slider

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -774,8 +774,8 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
   dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++)
   {
-    dtgtk_gradient_slider_multivalue_set_value(data->lower_slider, iparameters[k], k);
-    dtgtk_gradient_slider_multivalue_set_value(data->upper_slider, oparameters[k], k);
+    dtgtk_gradient_slider_multivalue_set_value(data->lower_slider, iparameters[k], k, TRUE);
+    dtgtk_gradient_slider_multivalue_set_value(data->upper_slider, oparameters[k], k, TRUE);
     dtgtk_gradient_slider_multivalue_set_resetvalue(data->lower_slider, idefaults[k], k);
     dtgtk_gradient_slider_multivalue_set_resetvalue(data->upper_slider, odefaults[k], k);
   }
@@ -1202,7 +1202,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
 
     dt_pthread_mutex_lock(&data->lock);
     for(int k = 0; k < 4; k++)
-      dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k);
+      dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k, TRUE);
     dt_pthread_mutex_unlock(&data->lock);
 
     // update picked values

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -782,7 +782,7 @@ void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gsli
 {
   assert(pos <= gslider->positions);
 
-  gslider->position[pos] = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
+  gslider->position[pos] = CLAMP_RANGE(gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
   if (emit_signal) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
@@ -791,7 +791,7 @@ void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gsli
 void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values, gboolean emit_signal)
 {
   for(int k = 0; k < gslider->positions; k++)
-    gslider->position[k] = gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET);
+    gslider->position[k] = CLAMP_RANGE(gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
   if (emit_signal) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -469,24 +469,6 @@ static void _gradient_slider_init(GtkDarktableGradientSlider *gslider)
 
   gtk_widget_set_has_window(widget, TRUE);
   gtk_widget_set_can_focus(widget, TRUE);
-
-  gslider->is_dragging = gslider->is_changed = gslider->do_reset = gslider->is_entered = 0;
-  gslider->timeout_handle = 0;
-  gslider->selected = gslider->positions == 1 ? 0 : -1;
-  gslider->active = -1;
-  gslider->scale_callback = _default_linear_scale_callback;
-  gslider->is_resettable = FALSE;
-  gslider->is_entered = FALSE;
-  gslider->picker[0] = gslider->picker[1] = gslider->picker[2] = NAN;
-  gslider->increment = DTGTK_GRADIENT_SLIDER_DEFAULT_INCREMENT;
-  gslider->margin_left = gslider->margin_right = GRADIENT_SLIDER_MARGINS_DEFAULT;
-  //gslider->markers_type = PROPORTIONAL_MARKERS;
-  for(int k = 0; k < gslider->positions; k++)
-  {
-    gslider->position[k] = 0.0;
-    gslider->resetvalue[k] = 0.0;
-    gslider->marker[k] = GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG;
-  }
 }
 
 static void _gradient_slider_get_preferred_height(GtkWidget *widget, gint *min_height, gint *nat_height)
@@ -669,6 +651,29 @@ gint _list_find_by_position(gconstpointer a, gconstpointer b)
   return (gint)((stop->position * 100.0) - (position * 100.0));
 }
 
+static void _gradient_slider_set_defaults(GtkDarktableGradientSlider *gslider)
+{
+  gslider->is_dragging = gslider->is_changed = gslider->do_reset = gslider->is_entered = 0;
+  gslider->timeout_handle = 0;
+  gslider->selected = gslider->positions == 1 ? 0 : -1;
+  gslider->active = -1;
+  gslider->scale_callback = _default_linear_scale_callback;
+  gslider->is_resettable = FALSE;
+  gslider->is_entered = FALSE;
+  gslider->picker[0] = gslider->picker[1] = gslider->picker[2] = NAN;
+  gslider->increment = DTGTK_GRADIENT_SLIDER_DEFAULT_INCREMENT;
+  gslider->margin_left = gslider->margin_right = GRADIENT_SLIDER_MARGINS_DEFAULT;
+  gslider->markers_type = FREE_MARKERS;
+  gslider->colors = NULL;
+  gslider->min_spacing = 0;
+  for(int k = 0; k < gslider->positions; k++)
+  {
+    gslider->position[k] = 0.0;
+    gslider->resetvalue[k] = 0.0;
+    gslider->marker[k] = GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG;
+  }
+}
+
 
 // Public functions for multivalue type
 GtkWidget *dtgtk_gradient_slider_multivalue_new(gint positions)
@@ -678,6 +683,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new(gint positions)
   GtkDarktableGradientSlider *gslider;
   gslider = g_object_new(_gradient_slider_get_type(), NULL);
   gslider->positions = positions;
+  _gradient_slider_set_defaults(gslider);
 
   GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(gslider));
   gtk_style_context_add_class(context, "dt_gslider_multivalue");
@@ -700,6 +706,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new_with_color(GdkRGBA start, GdkRGB
   GtkDarktableGradientSlider *gslider;
   gslider = g_object_new(_gradient_slider_get_type(), NULL);
   gslider->positions = positions;
+  _gradient_slider_set_defaults(gslider);
 
   // Construct gradient start color
   _gradient_slider_stop_t *gc = (_gradient_slider_stop_t *)g_malloc(sizeof(_gradient_slider_stop_t));

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -746,22 +746,22 @@ void dtgtk_gradient_slider_multivalue_get_values(GtkDarktableGradientSlider *gsl
     values[k] = gslider->scale_callback((GtkWidget *)gslider, gslider->position[k], GRADIENT_SLIDER_GET);
 }
 
-void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint pos)
+void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint pos, gboolean emit_signal)
 {
   assert(pos <= gslider->positions);
 
   gslider->position[pos] = gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
-  g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
+  if (emit_signal) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
-void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values)
+void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values, gboolean emit_signal)
 {
   for(int k = 0; k < gslider->positions; k++)
     gslider->position[k] = gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
-  g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
+  if (emit_signal) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
@@ -914,9 +914,9 @@ gdouble dtgtk_gradient_slider_get_value(GtkDarktableGradientSlider *gslider)
   return dtgtk_gradient_slider_multivalue_get_value(gslider, 0);
 }
 
-void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value)
+void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gboolean emit_signal)
 {
-  dtgtk_gradient_slider_multivalue_set_value(gslider, value, 0);
+  dtgtk_gradient_slider_multivalue_set_value(gslider, value, 0, emit_signal);
 }
 
 void dtgtk_gradient_slider_set_marker(GtkDarktableGradientSlider *gslider, gint mark)

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -460,7 +460,7 @@ static void _gradient_slider_init(GtkDarktableGradientSlider *gslider)
   {
     gslider->position[k] = 0.0;
     gslider->resetvalue[k] = 0.0;
-    gslider->marker[k] = GRADIENT_SLIDER_MARKER_LOWER_FILLED;
+    gslider->marker[k] = GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG;
   }
 }
 

--- a/src/dtgtk/gradientslider.h
+++ b/src/dtgtk/gradientslider.h
@@ -138,7 +138,7 @@ void dtgtk_gradient_slider_multivalue_clear_stops(GtkDarktableGradientSlider *gs
 
 /** Get the slider value 0 - 1.0*/
 gdouble dtgtk_gradient_slider_get_value(GtkDarktableGradientSlider *gslider);
-void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value);
+void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gboolean emit_signal);
 gboolean dtgtk_gradient_slider_is_dragging(GtkDarktableGradientSlider *gslider);
 
 /** Set the slider marker */
@@ -170,9 +170,8 @@ void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslid
 /** Get the slider value 0 - 1.0 for multivalue control */
 gdouble dtgtk_gradient_slider_multivalue_get_value(GtkDarktableGradientSlider *gslider, gint position);
 void dtgtk_gradient_slider_multivalue_get_values(GtkDarktableGradientSlider *gslider, gdouble *values);
-void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value,
-                                                gint position);
-void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values);
+void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint position, gboolean emit_signal);
+void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values, gboolean emit_signal);
 gboolean dtgtk_gradient_slider_multivalue_is_dragging(GtkDarktableGradientSlider *gslider);
 
 /** Set the slider markers for multivalue control */

--- a/src/dtgtk/gradientslider.h
+++ b/src/dtgtk/gradientslider.h
@@ -86,6 +86,12 @@ enum
   GRADIENT_SLIDER_GET = 2
 };
 
+enum
+{
+  FREE_MARKERS = 1,
+  PROPORTIONAL_MARKERS = 2
+};
+
 typedef struct _GtkDarktableGradientSlider
 {
   GtkDrawingArea widget;
@@ -97,6 +103,7 @@ typedef struct _GtkDarktableGradientSlider
   gdouble resetvalue[GRADIENT_SLIDER_MAX_POSITIONS];
   gint marker[GRADIENT_SLIDER_MAX_POSITIONS];
   gdouble increment;
+  gdouble min_spacing;
   gdouble picker[3];
   gint margin_left;
   gint margin_right;
@@ -105,6 +112,7 @@ typedef struct _GtkDarktableGradientSlider
   gboolean is_resettable;
   gboolean do_reset;
   gboolean is_entered;
+  gint markers_type;
   guint timeout_handle;
   float (*scale_callback)(GtkWidget*, float, int); // scale callback function
 } GtkDarktableGradientSlider;
@@ -149,8 +157,7 @@ void dtgtk_gradient_slider_set_resetvalue(GtkDarktableGradientSlider *gslider, g
 
 /** Set a picker */
 void dtgtk_gradient_slider_set_picker(GtkDarktableGradientSlider *gslider, gdouble value);
-void dtgtk_gradient_slider_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean,
-                                                 gdouble min, gdouble max);
+void dtgtk_gradient_slider_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean, gdouble min, gdouble max);
 
 /** set increment for scroll action */
 void dtgtk_gradient_slider_set_increment(GtkDarktableGradientSlider *gslider, gdouble value);
@@ -164,8 +171,7 @@ GtkWidget *dtgtk_gradient_slider_multivalue_new_with_color_and_name(GdkRGBA star
 
 
 /** Set a color at specified stop for multivalue control */
-void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslider, gfloat position,
-                                               GdkRGBA color);
+void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslider, gfloat position, GdkRGBA color);
 
 /** Get the slider value 0 - 1.0 for multivalue control */
 gdouble dtgtk_gradient_slider_multivalue_get_value(GtkDarktableGradientSlider *gslider, gint position);
@@ -179,8 +185,7 @@ void dtgtk_gradient_slider_multivalue_set_marker(GtkDarktableGradientSlider *gsl
 void dtgtk_gradient_slider_multivalue_set_markers(GtkDarktableGradientSlider *gslider, gint *markers);
 
 /** Set/get the slider reset values for multivalue control */
-void dtgtk_gradient_slider_multivalue_set_resetvalue(GtkDarktableGradientSlider *gslider, gdouble value,
-                                                     gint pos);
+void dtgtk_gradient_slider_multivalue_set_resetvalue(GtkDarktableGradientSlider *gslider, gdouble value, gint pos);
 void dtgtk_gradient_slider_multivalue_set_resetvalues(GtkDarktableGradientSlider *gslider, gdouble *values);
 gdouble dtgtk_gradient_slider_multivalue_get_resetvalue(GtkDarktableGradientSlider *gslider, gint pos);
 gdouble dtgtk_gradient_slider_multivalue_get_resetvalues(GtkDarktableGradientSlider *gslider);
@@ -188,8 +193,7 @@ gdouble dtgtk_gradient_slider_multivalue_get_resetvalues(GtkDarktableGradientSli
 
 /** Set a picker for multivalue control */
 void dtgtk_gradient_slider_multivalue_set_picker(GtkDarktableGradientSlider *gslider, gdouble value);
-void dtgtk_gradient_slider_multivalue_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean,
-                                                            gdouble min, gdouble max);
+void dtgtk_gradient_slider_multivalue_set_picker_meanminmax(GtkDarktableGradientSlider *gslider, gdouble mean, gdouble min, gdouble max);
 
 /** set increment for scroll action */
 void dtgtk_gradient_slider_multivalue_set_increment(GtkDarktableGradientSlider *gslider, gdouble value);

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -277,7 +277,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)module->params;
   dt_bauhaus_slider_set(g->scale1, p->ev);
   dt_bauhaus_slider_set(g->scale2, p->width);
-  dtgtk_gradient_slider_set_value(g->gslider1, p->center);
+  dtgtk_gradient_slider_set_value(g->gslider1, p->center, TRUE);
 }
 
 void init(dt_iop_module_t *module)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2600,10 +2600,27 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_size_request(GTK_WIDGET(g->bt_auto_levels), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_auto_levels), FALSE);
 
-  gtk_box_pack_end(GTK_BOX(prev_lvl), g->bt_auto_levels, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(prev_lvl), GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 20);
+  gtk_box_pack_end(GTK_BOX(prev_lvl), g->bt_auto_levels, FALSE, FALSE, 0);
 
   gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), prev_lvl, TRUE, TRUE, 0);
+
+
+
+
+  GtkDarktableGradientSlider *prova = DTGTK_GRADIENT_SLIDER_MULTIVALUE(dtgtk_gradient_slider_multivalue_new_with_color_and_name(_gradient_L[0], _gradient_L[1], 5, "prova"));
+  prova->markers_type = FREE_MARKERS;
+  prova->min_spacing = 0.05;
+  for (int i = 0; i < 5; i++)
+    dtgtk_gradient_slider_multivalue_set_marker(prova, GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, i);
+  double pdefault[5] = {0.0 ,0.2, 0.5, 0.8, 1.0};
+  dtgtk_gradient_slider_multivalue_set_values(prova, pdefault, FALSE);
+  dtgtk_gradient_slider_multivalue_set_resetvalues(prova, pdefault);
+  gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), GTK_WIDGET(prova), TRUE, TRUE, 0);
+
+
+
+
 
   // shapes selected (label)
   GtkWidget *hbox_shape_sel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1569,7 +1569,7 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
 }
 
 
-static void rt_levelsbar_changed(GtkDarktableGradientSlider *gslider, dt_iop_module_t *self)
+static void rt_gslider_changed(GtkDarktableGradientSlider *gslider, dt_iop_module_t *self)
 {
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
 
@@ -1586,7 +1586,7 @@ static void rt_levelsbar_changed(GtkDarktableGradientSlider *gslider, dt_iop_mod
     p->preview_levels[i] = 6.0 * dlevels[i] - 3.0;
   }
 
-  rt_clamp_minmax(levels_old, p->preview_levels);
+  rt_clamp_minmax(levels_old, p->preview_levels); // eliminate and transfer to library?
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 
@@ -1719,7 +1719,7 @@ static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer use
 
     dt_pthread_mutex_lock(&g->lock);
 
-    /* FIXME: preview pipe, is this neded ? */
+    // update the gradient slider
     double levels[3];
     for(int i = 0; i < 3; i++) levels[i] = (p->preview_levels[i] + 3.0) / 6.0;
     dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, levels, FALSE);
@@ -2332,6 +2332,11 @@ void gui_update(dt_iop_module_t *self)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
   }
+
+  // update the gradient slider
+  double levels[3];
+  for(int i = 0; i < 3; i++) levels[i] = (p->preview_levels[i] + 3.0) / 6.0;
+  dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, levels, FALSE);
 }
 
 void change_image(struct dt_iop_module_t *self)
@@ -2585,7 +2590,7 @@ void gui_init(dt_iop_module_t *self)
   double vdefault[3] = {0.0 ,0.5, 1.0};
   dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, vdefault, FALSE);
   dtgtk_gradient_slider_multivalue_set_resetvalues(g->preview_levels_gslider, vdefault);
-  g_signal_connect(G_OBJECT(g->preview_levels_gslider), "value-changed", G_CALLBACK(rt_levelsbar_changed), self);
+  g_signal_connect(G_OBJECT(g->preview_levels_gslider), "value-changed", G_CALLBACK(rt_gslider_changed), self);
 
   // auto-levels button
   g->bt_auto_levels

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2879,6 +2879,7 @@ void gui_init(dt_iop_module_t *self)
   g->preview_levels_bar = gtk_drawing_area_new();
 
   gtk_widget_set_tooltip_text(g->preview_levels_bar, _("adjust preview levels"));
+  /*
   g_signal_connect(G_OBJECT(g->preview_levels_bar), "draw", G_CALLBACK(rt_levelsbar_draw), self);
   g_signal_connect(G_OBJECT(g->preview_levels_bar), "motion-notify-event", G_CALLBACK(rt_levelsbar_motion_notify),
                    self);
@@ -2886,9 +2887,9 @@ void gui_init(dt_iop_module_t *self)
                    self);
   g_signal_connect(G_OBJECT(g->preview_levels_bar), "button-press-event", G_CALLBACK(rt_levelsbar_button_press),
                    self);
-  g_signal_connect(G_OBJECT(g->preview_levels_bar), "button-release-event",
-                   G_CALLBACK(rt_levelsbar_button_release), self);
+  g_signal_connect(G_OBJECT(g->preview_levels_bar), "button-release-event", G_CALLBACK(rt_levelsbar_button_release), self);
   g_signal_connect(G_OBJECT(g->preview_levels_bar), "scroll-event", G_CALLBACK(rt_levelsbar_scrolled), self);
+  */
   gtk_widget_add_events(GTK_WIDGET(g->preview_levels_bar), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                                | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                                                | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1627,6 +1627,10 @@ static void rt_preview_levels_update(const float levels[3], dt_iop_module_t *sel
 
   rt_clamp_minmax(levels_old, p->preview_levels);
 
+  for(int i = 0; i < 3; i++)
+    dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, (p->preview_levels[i] + 3.0) / 6.0, i);
+
+
   gtk_widget_queue_draw(g->preview_levels_bar);
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1849,20 +1853,6 @@ static gboolean rt_levelsbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module
       cairo_stroke(cr);
   }
 
-
-
-  for(int i = 0; i < 3; i++)
-  {
-    dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, (p->preview_levels[i] + 3.0) / 6.0, i);
-  }
-
-/*
-  dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, 0.1, 0);
-  dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, 0.5, 1);
-  dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, 0.9, 2);
-
-*/
-
   /* push mem surface into widget */
   cairo_destroy(cr);
   cairo_set_source_surface(crf, cst, 0, 0);
@@ -1992,7 +1982,18 @@ static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer use
 
     dt_pthread_mutex_unlock(&g->lock);
 
-    for(int i = 0; i < 3; i++) p->preview_levels[i] = g->preview_levels[i];
+
+
+
+
+    for(int i = 0; i < 3; i++)
+    {
+      p->preview_levels[i] = g->preview_levels[i];
+      dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, (p->preview_levels[i] + 3.0) / 6.0, i);
+    }
+
+
+
 
     dt_dev_add_history_item(darktable.develop, self, TRUE);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -150,7 +150,7 @@ typedef struct dt_iop_retouch_gui_data_t
   GtkWidget *vbox_preview_scale;
   GtkWidget *preview_levels_bar;
 
-  GtkWidget *preview_levels_gslider;
+  GtkDarktableGradientSlider *preview_levels_gslider;
 
   float lvlbar_mouse_x, lvlbar_mouse_y;
   GtkWidget *bt_auto_levels;
@@ -1849,6 +1849,20 @@ static gboolean rt_levelsbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module
       cairo_stroke(cr);
   }
 
+
+
+  for(int i = 0; i < 3; i++)
+  {
+    dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, (p->preview_levels[i] + 3.0) / 6.0, i);
+  }
+
+/*
+  dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, 0.1, 0);
+  dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, 0.5, 1);
+  dtgtk_gradient_slider_multivalue_set_value(g->preview_levels_gslider, 0.9, 2);
+
+*/
+
   /* push mem surface into widget */
   cairo_destroy(cr);
   cairo_set_source_surface(crf, cst, 0, 0);
@@ -2854,16 +2868,17 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_size_request(g->preview_levels_bar, -1, DT_PIXEL_APPLY_DPI(5));
 
 
+  #define NEUTRAL_GRAY 0.5
+  static const GdkRGBA _gradient_L[]
+      = { { 0, 0, 0, 1.0 }, { NEUTRAL_GRAY, NEUTRAL_GRAY, NEUTRAL_GRAY, 1.0 } };
 
+  g->preview_levels_gslider = DTGTK_GRADIENT_SLIDER_MULTIVALUE(
+      dtgtk_gradient_slider_multivalue_new_with_color_and_name(_gradient_L[0], _gradient_L[1], 3, "preview-levels"));
+  gtk_widget_set_tooltip_text(GTK_WIDGET(g->preview_levels_gslider), _("adjust preview levels"));
+  dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider, GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);
+  dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider, GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
+  dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider, GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 2);
 
-    g->preview_levels_gslider = dtgtk_gradient_slider_multivalue_new_with_name(3, "preview-levels");
-    gtk_widget_set_tooltip_text(g->preview_levels_gslider, _("adjust preview levels"));
-    dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->preview_levels_gslider),
-                                                GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);
-    dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->preview_levels_gslider),
-                                                GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
-    dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->preview_levels_gslider),
-                                                GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 2);
   /*
     for(int k = 0; k < 3; k++)
     {
@@ -2893,7 +2908,7 @@ void gui_init(dt_iop_module_t *self)
 
 
 
-  gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), g->preview_levels_gslider, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 20);
 
 
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -149,6 +149,9 @@ typedef struct dt_iop_retouch_gui_data_t
 
   GtkWidget *vbox_preview_scale;
   GtkWidget *preview_levels_bar;
+
+  GtkWidget *preview_levels_gslider;
+
   float lvlbar_mouse_x, lvlbar_mouse_y;
   GtkWidget *bt_auto_levels;
 
@@ -2850,6 +2853,32 @@ void gui_init(dt_iop_module_t *self)
                                                                | GDK_SMOOTH_SCROLL_MASK);
   gtk_widget_set_size_request(g->preview_levels_bar, -1, DT_PIXEL_APPLY_DPI(5));
 
+
+
+
+    g->preview_levels_gslider = dtgtk_gradient_slider_multivalue_new_with_name(3, "preview-levels");
+    gtk_widget_set_tooltip_text(g->preview_levels_gslider, _("adjust preview levels"));
+    dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->preview_levels_gslider),
+                                                GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 0);
+    dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->preview_levels_gslider),
+                                                GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
+    dtgtk_gradient_slider_multivalue_set_marker(DTGTK_GRADIENT_SLIDER(g->preview_levels_gslider),
+                                                GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 2);
+  /*
+    for(int k = 0; k < 3; k++)
+    {
+      dtgtk_gradient_slider_multivalue_set_value(DTGTK_GRADIENT_SLIDER(g->preview_levels_bar), levels[k], k);
+      dtgtk_gradient_slider_multivalue_set_resetvalue(DTGTK_GRADIENT_SLIDER(g->preview_levels_bar), levels[k], k);
+    }
+  */
+    /*
+    g_signal_connect(G_OBJECT(bd->upper_slider), "value-changed", G_CALLBACK(_blendop_blendif_sliders_callback), bd);
+    g_signal_connect(G_OBJECT(bd->upper_slider), "leave-notify-event", G_CALLBACK(_blendop_blendif_leave), module);
+    g_signal_connect(G_OBJECT(bd->upper_slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
+    g_signal_connect(G_OBJECT(bd->upper_slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);
+  */
+
+
   g->bt_auto_levels
       = dtgtk_togglebutton_new(_retouch_cairo_paint_auto_levels, CPF_STYLE_FLAT, NULL);
   g_object_set(G_OBJECT(g->bt_auto_levels), "tooltip-text", _("auto levels"), (char *)NULL);
@@ -2859,8 +2888,16 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_end(GTK_BOX(prev_lvl), g->bt_auto_levels, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(prev_lvl), GTK_WIDGET(g->preview_levels_bar), TRUE, TRUE, 0);
-
   gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), prev_lvl, TRUE, TRUE, 0);
+
+
+
+
+  gtk_box_pack_start(GTK_BOX(g->vbox_preview_scale), g->preview_levels_gslider, TRUE, TRUE, 0);
+
+
+
+
 
   // shapes selected (label)
   GtkWidget *hbox_shape_sel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);


### PR DESCRIPTION
With this PR the "preview single scale" in retouch module will use the new gradient slider library widget instead of a custom unique widget. 300 lines of code less to maintain and a more consistent gui.

Before
![Screenshot from 2020-06-10 22-33-46](https://user-images.githubusercontent.com/43290988/84316602-ae291600-ab6b-11ea-8091-52a437ff623c.png)

After
![Screenshot from 2020-06-10 22-34-53](https://user-images.githubusercontent.com/43290988/84316631-b8e3ab00-ab6b-11ea-92a4-388f6a580d41.png)

With the purpose I added some new cool features to the gradient slider widget (proportional scaling), which in turn requires a small change in the calls from other two modules.
