### PR TITLE
cached images_to_act_on list

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -457,12 +457,12 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on(TRUE);
+    imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
   dt_image_set_locations(imgs, geoloc, undo_on);
-  g_list_free(imgs);
+  if(imgid != -1) g_list_free(imgs);
 }
 
 void dt_image_reset_final_size(const int32_t imgid)
@@ -2160,9 +2160,8 @@ void dt_image_synch_xmp(const int selected)
   }
   else
   {
-    GList *imgs = dt_view_get_images_to_act_on(FALSE);
+    GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
     dt_image_synch_xmps(imgs);
-    g_list_free(imgs);
   }
 }
 

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -548,7 +548,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
   {
     GList *imgs = NULL;
     if(imgid == -1)
-      imgs = dt_view_get_images_to_act_on(TRUE);
+      imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
     else
       imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if(imgs)
@@ -565,7 +565,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
       _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_ADD);
 
       g_list_free_full(metadata, g_free);
-      g_list_free(imgs);
+      if(imgid != -1) g_list_free(imgs);
       if(undo_on)
       {
         dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);

--- a/src/common/selection.c
+++ b/src/common/selection.c
@@ -22,6 +22,7 @@
 #include "common/image_cache.h"
 #include "control/signal.h"
 #include "gui/gtk.h"
+#include "views/view.h"
 
 typedef struct dt_selection_t
 {
@@ -36,6 +37,14 @@ typedef struct dt_selection_t
 const dt_collection_t *dt_selection_get_collection(struct dt_selection_t *selection)
 {
   return selection->collection;
+}
+
+static void _selection_raise_signal()
+{
+  // discard cached images_to_act_on list
+  darktable.view_manager->act_on.ok = FALSE;
+
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
 }
 
 /* updates the internal collection of an selection */
@@ -74,7 +83,7 @@ static void _selection_select(dt_selection_t *selection, uint32_t imgid)
     }
   }
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -151,7 +160,7 @@ void dt_selection_invert(dt_selection_t *selection)
 
   g_free(fullq);
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -161,7 +170,7 @@ void dt_selection_clear(const dt_selection_t *selection)
 {
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM main.selected_images", NULL, NULL, NULL);
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -203,7 +212,7 @@ void dt_selection_deselect(dt_selection_t *selection, uint32_t imgid)
     }
   }
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -241,7 +250,7 @@ void dt_selection_toggle(dt_selection_t *selection, uint32_t imgid)
     selection->last_single_id = imgid;
   }
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -263,7 +272,7 @@ void dt_selection_select_all(dt_selection_t *selection)
 
   g_free(fullq);
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -345,7 +354,7 @@ void dt_selection_select_filmroll(dt_selection_t *selection)
 
   selection->last_single_id = -1;
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -379,7 +388,7 @@ void dt_selection_select_unaltered(dt_selection_t *selection)
   g_free(fullq);
 
   selection->last_single_id = -1;
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);
@@ -413,7 +422,7 @@ void dt_selection_select_list(struct dt_selection_t *selection, GList *list)
     g_free(query);
   }
 
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_SELECTION_CHANGED);
+  _selection_raise_signal();
 
   /* update hint message */
   dt_collection_hint_message(darktable.collection);

--- a/src/common/styles.c
+++ b/src/common/styles.c
@@ -98,9 +98,8 @@ void dt_style_item_free(gpointer data)
 static gboolean _apply_style_shortcut_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
                                                guint keyval, GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
   dt_styles_apply_to_list(data, imgs, FALSE);
-  g_list_free(imgs);
   return TRUE;
 }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -457,15 +457,19 @@ gboolean dt_tag_attach_images(const guint tagid, const GList *img, const gboolea
 gboolean dt_tag_attach(const guint tagid, const gint imgid, const gboolean undo_on, const gboolean group_on)
 {
   GList *imgs = NULL;
+  gboolean res;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on(!group_on);
+  {
+    imgs = dt_view_get_images_to_act_on(!group_on, TRUE);
+    res = dt_tag_attach_images(tagid, imgs, undo_on);
+  }
   else
   {
     if(dt_is_tag_attached(tagid, imgid)) return FALSE;
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
+    res = dt_tag_attach_images(tagid, imgs, undo_on);
+    g_list_free(imgs);
   }
-  const gboolean res = dt_tag_attach_images(tagid, imgs, undo_on);
-  g_list_free(imgs);
   return res;
 }
 
@@ -568,13 +572,13 @@ void dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_on, 
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = dt_view_get_images_to_act_on(TRUE);
+    imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
 
   dt_tag_detach_images(tagid, imgs, undo_on);
-  g_list_free(imgs);
+  if(imgid != -1) g_list_free(imgs);
 }
 
 
@@ -635,7 +639,7 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
   }
   else
   {
-    GList *imgs = dt_view_get_images_to_act_on(TRUE);
+    GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
     while(imgs)
     {
       images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));
@@ -643,7 +647,6 @@ uint32_t dt_tag_get_attached(const gint imgid, GList **result, const gboolean ig
       imgs = g_list_next(imgs);
     }
     if(images) images[strlen(images) - 1] = '\0';
-    g_list_free(imgs);
   }
   if(images)
   {

--- a/src/control/jobs/control_jobs.c
+++ b/src/control/jobs/control_jobs.c
@@ -179,7 +179,7 @@ static dt_job_t *dt_control_generic_images_job_create(dt_job_execute_callback ex
   }
   if(progress_type != PROGRESS_NONE)
     dt_control_job_add_progress(job, _(message), progress_type == PROGRESS_CANCELLABLE);
-  params->index = dt_view_get_images_to_act_on(only_visible);
+  params->index = g_list_copy(dt_view_get_images_to_act_on(only_visible, TRUE));
 
   dt_control_job_set_params(job, params, dt_control_image_enumerator_cleanup);
 
@@ -1368,7 +1368,7 @@ static dt_job_t *dt_control_gpx_apply_job_create(const gchar *filename, int32_t 
   if(filmid != -1)
     dt_control_image_enumerator_job_film_init(params, filmid);
   else
-    params->index = dt_view_get_images_to_act_on(TRUE);
+    params->index = g_list_copy(dt_view_get_images_to_act_on(TRUE, TRUE));
 
   dt_control_gpx_apply_t *data = params->data;
   data->filename = g_strdup(filename);
@@ -1834,7 +1834,7 @@ static dt_job_t *dt_control_time_offset_job_create(const long int offset, int im
   if(imgid != -1)
     params->index = g_list_append(params->index, GINT_TO_POINTER(imgid));
   else
-    params->index = dt_view_get_images_to_act_on(TRUE);
+    params->index = g_list_copy(dt_view_get_images_to_act_on(TRUE, TRUE));
 
   dt_control_time_offset_t *data = params->data;
   data->offset = offset;

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1421,7 +1421,7 @@ static void _event_dnd_begin(GtkWidget *widget, GdkDragContext *context, gpointe
 
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
-  table->drag_list = dt_view_get_images_to_act_on(FALSE);
+  table->drag_list = g_list_copy(dt_view_get_images_to_act_on(FALSE, TRUE));
 
   // if we are dragging a single image -> use the thumbnail of that image
   // otherwise use the generic d&d icon
@@ -1909,7 +1909,7 @@ gboolean dt_thumbtable_set_offset_image(dt_thumbtable_t *table, const int imgid,
 static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                             GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = g_list_copy(dt_view_get_images_to_act_on(FALSE, TRUE));
   dt_ratings_apply_on_list(imgs, GPOINTER_TO_INT(data), TRUE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
@@ -1917,7 +1917,7 @@ static gboolean _accel_rate(GtkAccelGroup *accel_group, GObject *acceleratable, 
 static gboolean _accel_color(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = g_list_copy(dt_view_get_images_to_act_on(FALSE, TRUE));
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(data), FALSE);
   dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
@@ -1937,7 +1937,7 @@ static gboolean _accel_copy_parts(GtkAccelGroup *accel_group, GObject *accelerat
 static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                              GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = g_list_copy(dt_view_get_images_to_act_on(TRUE, TRUE));
   const gboolean ret = dt_history_paste_on_list(imgs, TRUE);
   if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
@@ -1945,7 +1945,7 @@ static gboolean _accel_paste(GtkAccelGroup *accel_group, GObject *acceleratable,
 static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                    GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = g_list_copy(dt_view_get_images_to_act_on(TRUE, TRUE));
   const gboolean ret = dt_history_paste_parts_on_list(imgs, TRUE);
   if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;
@@ -1953,7 +1953,7 @@ static gboolean _accel_paste_parts(GtkAccelGroup *accel_group, GObject *accelera
 static gboolean _accel_hist_discard(GtkAccelGroup *accel_group, GObject *acceleratable, const guint keyval,
                                     GdkModifierType modifier, gpointer data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = g_list_copy(dt_view_get_images_to_act_on(TRUE, TRUE));
   const gboolean ret = dt_history_delete_on_list(imgs, TRUE);
   if(ret) dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
   return TRUE;

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -68,15 +68,13 @@ static void _update(dt_lib_module_t *self)
 {
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)self->data;
 
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
   const guint act_on_cnt = g_list_length(imgs);
-  const gboolean can_paste = darktable.view_manager->copy_paste.copied_imageid > 0 && 
-    (
-      act_on_cnt > 1 ||
-      (act_on_cnt == 1 && (darktable.view_manager->copy_paste.copied_imageid != dt_view_get_image_to_act_on()))
-    );
-
-  g_list_free(imgs);
+  const gboolean can_paste
+      = darktable.view_manager->copy_paste.copied_imageid > 0
+        && (act_on_cnt > 1
+            || (act_on_cnt == 1
+                && (darktable.view_manager->copy_paste.copied_imageid != dt_view_get_image_to_act_on())));
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), act_on_cnt > 0);
   gtk_widget_set_sensitive(GTK_WIDGET(d->compress_button), act_on_cnt > 0);
@@ -137,10 +135,9 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
   {
     char *dtfilename;
     dtfilename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filechooser));
-    GList *imgs = dt_view_get_images_to_act_on(TRUE);
+    GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
     if(dt_history_load_and_apply_on_list(dtfilename, imgs) != 0)
     {
-      g_list_free(imgs);
       GtkWidget *dialog
           = gtk_message_dialog_new(GTK_WINDOW(win), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR,
                                    GTK_BUTTONS_CLOSE, _("error loading file '%s'"), dtfilename);
@@ -152,7 +149,7 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
     }
     else
     {
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
       dt_control_queue_redraw_center();
     }
 
@@ -165,12 +162,12 @@ static void load_button_clicked(GtkWidget *widget, dt_lib_module_t *self)
 static void compress_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
   if(g_list_length(imgs) < 1) return;
 
   const int missing = dt_history_compress_on_list(imgs);
 
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
   dt_control_queue_redraw_center();
   if (missing)
   {
@@ -217,7 +214,7 @@ static void delete_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   gint res = GTK_RESPONSE_YES;
 
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
 
   if(dt_conf_get_bool("ask_before_delete"))
   {
@@ -244,7 +241,7 @@ static void delete_button_clicked(GtkWidget *widget, gpointer user_data)
   {
     dt_history_delete_on_list(imgs, TRUE);
 
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
     dt_control_queue_redraw_center();
   }
 }
@@ -260,22 +257,22 @@ static void paste_button_clicked(GtkWidget *widget, gpointer user_data)
   dt_conf_set_int("plugins/lighttable/copy_history/pastemode", mode);
 
   /* copy history from previously copied image and past onto selection */
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
 
   if(dt_history_paste_on_list(imgs, TRUE))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
   }
 }
 
 static void paste_parts_button_clicked(GtkWidget *widget, gpointer user_data)
 {
   /* copy history from previously copied image and past onto selection */
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
 
   if(dt_history_paste_parts_on_list(imgs, TRUE))
   {
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
   }
 }
 

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -88,9 +88,8 @@ static void _update(dt_lib_module_t *self)
 {
   dt_lib_export_t *d = (dt_lib_export_t *)self->data;
 
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
   const gboolean has_act_on = imgs != NULL;
-  g_list_free(imgs);
 
   char *format_name = dt_conf_get_string(CONFIG_PREFIX "format_name");
   char *storage_name = dt_conf_get_string(CONFIG_PREFIX "storage_name");
@@ -214,7 +213,7 @@ static void export_button_clicked(GtkWidget *widget, dt_lib_export_t *d)
   gchar *icc_filename = dt_conf_get_string(CONFIG_PREFIX "iccprofile");
   dt_iop_color_intent_t icc_intent = dt_conf_get_int(CONFIG_PREFIX "iccintent");
 
-  GList *list = dt_view_get_images_to_act_on(TRUE);
+  GList *list = g_list_copy(dt_view_get_images_to_act_on(TRUE, TRUE));
   dt_control_export(list, max_width, max_height, format_index, storage_index, high_quality, upscale, export_masks,
                     style, style_append, icc_type, icc_filename, icc_intent, d->metadata_export);
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -180,17 +180,12 @@ else
 static void _update(dt_lib_module_t *self)
 {
   dt_lib_image_t *d = (dt_lib_image_t *)self->data;
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, FALSE);
 
   const guint act_on_cnt = g_list_length(imgs);
   const uint32_t selected_cnt = dt_collection_get_selected_count(darktable.collection);
-  const gboolean can_paste = d->imageid > 0 && 
-    (
-      act_on_cnt > 1 || 
-      (act_on_cnt == 1 && (d->imageid != dt_view_get_image_to_act_on()))
-    );
-
-  g_list_free(imgs);
+  const gboolean can_paste
+      = d->imageid > 0 && (act_on_cnt > 1 || (act_on_cnt == 1 && (d->imageid != dt_view_get_image_to_act_on())));
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->remove_button), act_on_cnt > 0);
   gtk_widget_set_sensitive(GTK_WIDGET(d->delete_button), act_on_cnt > 0);
@@ -287,7 +282,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
   const gboolean geotag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags");
   const gboolean dttag_flag = dt_conf_get_bool("plugins/lighttable/copy_metadata/tags");
   const int imageid = d->imageid;
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   if(imgs)
   {
     // for all the above actions, we don't use the grpu_on tag, as grouped images have already been added to image
@@ -337,10 +332,9 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     {
       dt_undo_end_group(darktable.undo);
       dt_image_synch_xmps(imgs);
-      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+      dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
       dt_control_queue_redraw_center();
     }
-    else g_list_free(imgs);
   }
 }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -159,14 +159,13 @@ static void _update(dt_lib_module_t *self, gboolean early_bark_out)
   // using dt_metadata_get() is not possible here. we want to do all this in a single pass, everything else
   // takes ages.
   char *images = NULL;
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
   while(imgs)
   {
     images = dt_util_dstrcat(images, "%d,",GPOINTER_TO_INT(imgs->data));
     imgs_count++;
     imgs = g_list_next(imgs);
   }
-  g_list_free(imgs);
   if(images)
   {
     images[strlen(images) - 1] = '\0';
@@ -240,10 +239,9 @@ static gboolean _draw(GtkWidget *widget, cairo_t *cr, dt_lib_module_t *self)
 
 static void _clear_button_clicked(GtkButton *button, dt_lib_module_t *self)
 {
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   dt_metadata_clear(imgs, TRUE);
   dt_image_synch_xmps(imgs);
-  g_list_free(imgs);
   _update(self, FALSE);
 }
 
@@ -269,7 +267,7 @@ static void _write_metadata(dt_lib_module_t *self)
       _append_kv(&key_value, dt_metadata_get_key(keyid), metadata[i]);
   }
 
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   dt_metadata_set_list(imgs, key_value, TRUE);
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
@@ -282,7 +280,6 @@ static void _write_metadata(dt_lib_module_t *self)
   dt_control_signal_raise(darktable.signals, DT_SIGNAL_METADATA_CHANGED, DT_METADATA_SIGNAL_NEW_VALUE);
 
   dt_image_synch_xmps(imgs);
-  g_list_free(imgs);
   _update(self, FALSE);
 }
 
@@ -967,13 +964,12 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
     if(metadata[i][0] != '\0') _append_kv(&key_value, dt_metadata_get_key(i), metadata[i]);
   }
 
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   dt_metadata_set_list(imgs, key_value, TRUE);
 
   g_list_free(key_value);
 
   dt_image_synch_xmps(imgs);
-  g_list_free(imgs);
   _update(self, FALSE);
   return 0;
 }

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -217,9 +217,8 @@ static void _styles_row_activated_callback(GtkTreeView *view, GtkTreePath *path,
   gchar *name;
   gtk_tree_model_get(model, &iter, DT_STYLES_COL_FULLNAME, &name, -1);
 
-  GList *list = dt_view_get_images_to_act_on(TRUE);
+  GList *list = dt_view_get_images_to_act_on(TRUE, TRUE);
   if(name) dt_styles_apply_to_list(name, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
-  g_list_free(list);
 }
 
 // get list of style names from selection
@@ -254,11 +253,10 @@ static void apply_clicked(GtkWidget *w, gpointer user_data)
 
   if(style_names == NULL) return;
 
-  GList *list = dt_view_get_images_to_act_on(TRUE);
+  GList *list = dt_view_get_images_to_act_on(TRUE, TRUE);
 
   if(list) dt_multiple_styles_apply_to_list(style_names, list, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
 
-  g_list_free(list);
   g_list_free_full(style_names, g_free);
 }
 
@@ -266,9 +264,8 @@ static void create_clicked(GtkWidget *w, gpointer user_data)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)user_data;
 
-  GList *list = dt_view_get_images_to_act_on(TRUE);
+  GList *list = dt_view_get_images_to_act_on(TRUE, TRUE);
   dt_styles_create_from_list(list);
-  g_list_free(list);
   _gui_styles_update_view(d);
 }
 
@@ -438,9 +435,8 @@ static gboolean entry_activated(GtkEntry *entry, gpointer user_data)
   const gchar *name = gtk_entry_get_text(d->entry);
   if(name)
   {
-    GList *imgs = dt_view_get_images_to_act_on(TRUE);
+    GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
     dt_styles_apply_to_list(name, imgs, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->duplicate)));
-    g_list_free(imgs);
   }
 
   return FALSE;
@@ -463,9 +459,10 @@ static void applymode_combobox_changed(GtkWidget *widget, gpointer user_data)
 static void _update(dt_lib_module_t *self)
 {
   dt_lib_styles_t *d = (dt_lib_styles_t *)self->data;
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
   const gboolean has_act_on = imgs != NULL;
-  g_list_free(imgs);
+
   GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(d->tree));
   const gint sel_styles_cnt = gtk_tree_selection_count_selected_rows(selection);
 

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -139,9 +139,8 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
 
-  GList *imgs = dt_view_get_images_to_act_on(TRUE);
+  GList *imgs = dt_view_get_images_to_act_on(TRUE, FALSE);
   const gboolean has_act_on = imgs != NULL;
-  g_list_free(imgs);
 
   const gint dict_tags_sel_cnt =
     gtk_tree_selection_count_selected_rows(gtk_tree_view_get_selection(GTK_TREE_VIEW(d->dictionary_view)));
@@ -1046,11 +1045,10 @@ static void _detach_selected_tag(GtkTreeView *view, dt_lib_module_t *self, dt_li
   gtk_tree_model_get(model, &iter, DT_LIB_TAGGING_COL_ID, &tagid, -1);
   if(tagid <= 0) return;
 
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   if(!imgs) return;
 
   GList *affected_images = dt_tag_get_images_from_list(imgs, tagid);
-  g_list_free(imgs);
   if(affected_images)
   {
     dt_tag_detach_images(tagid, affected_images, TRUE);
@@ -1233,10 +1231,9 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
   const gchar *tag = gtk_entry_get_text(d->entry);
   if(!tag || tag[0] == '\0') return;
 
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   dt_tag_attach_string_list(tag, imgs, TRUE);
   dt_image_synch_xmps(imgs);
-  g_list_free(imgs);
 
   /** record last tag used */
   g_free(d->last_tag);
@@ -2933,10 +2930,9 @@ static gboolean _lib_tagging_tag_redo(GtkAccelGroup *accel_group, GObject *accel
 
   if(d->last_tag)
   {
-    GList *imgs = dt_view_get_images_to_act_on(TRUE);
+    GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
     dt_tag_attach_string_list(d->last_tag, imgs, TRUE);
     dt_image_synch_xmps(imgs);
-    g_list_free(imgs);
 
     _init_treeview(self, 0);
     _init_treeview(self, 1);
@@ -2955,7 +2951,7 @@ static gboolean _lib_tagging_tag_show(GtkAccelGroup *accel_group, GObject *accel
     return TRUE;  // doesn't work properly with tree treeview
   }
 
-  d->floating_tag_imgs = dt_view_get_images_to_act_on(FALSE);
+  d->floating_tag_imgs = g_list_copy(dt_view_get_images_to_act_on(FALSE, TRUE));
   gint x, y;
   gint px, py, w, h;
   GtkWidget *window = dt_ui_main_window(darktable.gui->ui);

--- a/src/libs/tools/colorlabels.c
+++ b/src/libs/tools/colorlabels.c
@@ -99,9 +99,9 @@ void gui_cleanup(dt_lib_module_t *self)
 
 static void _lib_colorlabels_button_clicked_callback(GtkWidget *w, gpointer user_data)
 {
-  GList *imgs = dt_view_get_images_to_act_on(FALSE);
+  GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   dt_colorlabels_toggle_label_on_list(imgs, GPOINTER_TO_INT(user_data), TRUE);
-  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+  dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/tools/ratings.c
+++ b/src/libs/tools/ratings.c
@@ -196,9 +196,9 @@ static gboolean _lib_ratings_button_press_callback(GtkWidget *widget, GdkEventBu
   dt_lib_ratings_t *d = (dt_lib_ratings_t *)self->data;
   if(d->current > 0)
   {
-    GList *imgs = dt_view_get_images_to_act_on(FALSE);
+    GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
     dt_ratings_apply_on_list(imgs, d->current, TRUE);
-    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, imgs);
+    dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD, g_list_copy(imgs));
 
     dt_control_queue_redraw_center();
   }

--- a/src/lua/gui.c
+++ b/src/lua/gui.c
@@ -78,12 +78,12 @@ static int hovered_cb(lua_State *L)
 static int act_on_cb(lua_State *L)
 {
   lua_newtable(L);
-  GList *image = dt_view_get_images_to_act_on(FALSE);
+  GList *image = dt_view_get_images_to_act_on(FALSE, TRUE);
   while(image)
   {
     luaA_push(L, dt_lua_image_t, &image->data);
     luaL_ref(L, -2);
-    image = g_list_delete_link(image, image);
+    image = g_list_next(image);
   }
   return 1;
 }

--- a/src/views/map.c
+++ b/src/views/map.c
@@ -815,11 +815,10 @@ static gboolean _display_selected(gpointer user_data)
   dt_view_t *self = (dt_view_t *)user_data;
   gboolean done = FALSE;
 
-  GList *selected_images = dt_view_get_images_to_act_on(TRUE);
+  GList *selected_images = dt_view_get_images_to_act_on(TRUE, TRUE);
   if(selected_images)
   {
     done = _view_map_center_on_image_list(self, selected_images);
-    g_list_free(selected_images);
   }
 
   if(!done)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -188,7 +188,7 @@ typedef enum dt_view_image_over_t
 } dt_view_image_over_t;
 
 // get images to act on for gloabals change (via libs or accels)
-GList *dt_view_get_images_to_act_on(gboolean only_visible);
+GList *dt_view_get_images_to_act_on(gboolean only_visible, gboolean force);
 // get the main image to act on during global changes (libs, accels)
 int dt_view_get_image_to_act_on();
 
@@ -226,6 +226,15 @@ typedef struct dt_view_manager_t
     gboolean sticky;
     gboolean prevent_refresh;
   } accels_window;
+
+  struct
+  {
+    GList *images;
+    gboolean ok;
+    int image_over;
+    gboolean inside_table;
+    GSList *active_imgs;
+  } act_on;
 
   /* reusable db statements
    * TODO: reconsider creating a common/database helper API


### PR DESCRIPTION
This fix #5390 
This keep in cache the list of images to act on.
I've introduce a parameter to force the recompute of the list for actions on images, this may be useless, but I'm not enough confident to take the risk of applying actions to the wrong images because the list is not up to date...