### PR TITLE
Removing gphoto devices in a backthread if not available any more

### DIFF
--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -221,6 +221,8 @@ void dt_camctl_unregister_listener(const dt_camctl_t *c, dt_camctl_listener_t *l
 /** start a thread job to detect cameras and update list of available cameras */
 void dt_camctl_background_detect_cameras();
 /** Check if there is any camera connected */
+void dt_camctl_background_remove_cameras();
+/** Check if there is any camera dis-connected */
 int dt_camctl_have_cameras(const dt_camctl_t *c);
 /** Selects a camera to be used by cam control, this camera is selected if NULL is passed as camera*/
 void dt_camctl_select_camera(const dt_camctl_t *c, const dt_camera_t *cam);

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1002,6 +1002,7 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     // this is done late so that the gui can react to the signal sent but before switching to lighttable!
     darktable.camctl = dt_camctl_new();
     dt_camctl_background_detect_cameras();
+    dt_camctl_background_remove_cameras();
 #endif
 
     darktable.lib = (dt_lib_t *)calloc(1, sizeof(dt_lib_t));
@@ -1169,6 +1170,7 @@ void dt_cleanup()
   free(darktable.opencl);
 #ifdef HAVE_GPHOTO2
   dt_camctl_destroy((dt_camctl_t *)darktable.camctl);
+  darktable.camctl = NULL;
 #endif
   dt_pwstorage_destroy(darktable.pwstorage);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -257,22 +257,6 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
   gtk_widget_show_all(GTK_WIDGET(d->devices));
 }
 
-/** camctl camera disconnect callback */
-static gboolean _detect_async(gpointer user_data)
-{
-  dt_camctl_background_detect_cameras();
-  return FALSE;
-}
-
-static void _camctl_camera_disconnected_callback(const dt_camera_t *camera, void *data)
-{
-  /* rescan connected cameras. do that asynchronously since otherwise we deadlock (#10314) */
-  g_idle_add(_detect_async, NULL);
-
-  /* update gui with detected devices */
-  // this is done asynchronously in _camera_detected()
-}
-
 /** camctl status listener callback */
 typedef struct _control_status_params_t
 {
@@ -814,7 +798,8 @@ void gui_init(dt_lib_module_t *self)
   /* initialize camctl listener and update devices */
   d->camctl_listener.data = self;
   d->camctl_listener.control_status = _camctl_camera_control_status_callback;
-  d->camctl_listener.camera_disconnected = _camctl_camera_disconnected_callback;
+// We don't need this any longer as removal of disconnected cameras is in a background thread now
+//  d->camctl_listener.camera_disconnected = _camctl_camera_disconnected_callback;
   dt_camctl_register_listener(darktable.camctl, &d->camctl_listener);
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_CAMERA_DETECTED, G_CALLBACK(_camera_detected),
                             self);


### PR DESCRIPTION
For further discussions see the old pr #5212

As automatic detection of cameras in a backthread can lead to situations where
dt fights with another app about access to a device we still have to click on
the "scan for devices button".

But automatic removal from the list and it's gui representation is safe to be done
in a background thread.

Finally fixes #4917

Intended for 3.4