### PR TITLE
better initialisation of history stack

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1419,7 +1419,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     return FALSE;
   }
 
-  //add scene-referred workflow modules
+  //add scene-referred workflow 
   if(dt_image_is_matrix_correction_supported(image)
      && strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
   {
@@ -1428,8 +1428,7 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
       dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
 
       if(!dt_history_check_module_exists(imgid, module->op)
-         && (strcmp(module->op, "exposure") == 0
-             || strcmp(module->op, "filmicrgb") == 0)
+         && strcmp(module->op, "filmicrgb") == 0
          && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
       {
         _dev_insert_module(dev, module, imgid);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -646,7 +646,6 @@ void reload_defaults(dt_iop_module_t *module)
       // For scene-referred workflow, since filmic doesn't brighten as base curve does,
       // we need an initial exposure boost. This might be too much in some cases but…
       tmp.exposure = 1.0f;
-      module->default_enabled = TRUE;
     }
   }
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -276,22 +276,21 @@ void init_presets (dt_iop_module_so_t *self)
                              sizeof(dt_iop_exposure_params_t), 1);
 
 
-  if(strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
-  {
-    // For scene-referred workflow, since filmic doesn't brighten as base curve does,
-    // we need an initial exposure boost. This might be too much in some cases but…
-    dt_gui_presets_add_generic(_("scene-referred default"), self->op, self->version(),
-                               &(dt_iop_exposure_params_t){.mode = EXPOSURE_MODE_MANUAL,
-                                                           .black = 0.0f,
-                                                           .exposure = 1.0f,
-                                                           .deflicker_percentile = 50.0f,
-                                                           .deflicker_target_level = -4.0f,
-                                                           .compensate_exposure_bias = TRUE},
-                               sizeof(dt_iop_exposure_params_t), 1);
+  // For scene-referred workflow, since filmic doesn't brighten as base curve does,
+  // we need an initial exposure boost. This might be too much in some cases but…
+  dt_gui_presets_add_generic(_("scene-referred default"), self->op, self->version(),
+                             &(dt_iop_exposure_params_t){.mode = EXPOSURE_MODE_MANUAL,
+                                                         .black = 0.0f,
+                                                         .exposure = 1.0f,
+                                                         .deflicker_percentile = 50.0f,
+                                                         .deflicker_target_level = -4.0f,
+                                                         .compensate_exposure_bias = TRUE},
+                             sizeof(dt_iop_exposure_params_t), 1);
 
-    dt_gui_presets_update_ldr(_("scene-referred default"), self->op, self->version(), FOR_RAW);
-    dt_gui_presets_update_autoapply(_("scene-referred default"), self->op, self->version(), TRUE);
-  }
+  dt_gui_presets_update_ldr(_("scene-referred default"), self->op, self->version(), FOR_RAW);
+
+  dt_gui_presets_update_autoapply(_("scene-referred default"), self->op, self->version(),
+     (strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0));
 }
 
 static void deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histogram,

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -274,6 +274,24 @@ void init_presets (dt_iop_module_so_t *self)
                                                          .deflicker_target_level = -4.0f,
                                                          .compensate_exposure_bias = FALSE},
                              sizeof(dt_iop_exposure_params_t), 1);
+
+
+  if(strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
+  {
+    // For scene-referred workflow, since filmic doesn't brighten as base curve does,
+    // we need an initial exposure boost. This might be too much in some cases but…
+    dt_gui_presets_add_generic(_("scene-referred default"), self->op, self->version(),
+                               &(dt_iop_exposure_params_t){.mode = EXPOSURE_MODE_MANUAL,
+                                                           .black = 0.0f,
+                                                           .exposure = 1.0f,
+                                                           .deflicker_percentile = 50.0f,
+                                                           .deflicker_target_level = -4.0f,
+                                                           .compensate_exposure_bias = TRUE},
+                               sizeof(dt_iop_exposure_params_t), 1);
+
+    dt_gui_presets_update_ldr(_("scene-referred default"), self->op, self->version(), FOR_RAW);
+    dt_gui_presets_update_autoapply(_("scene-referred default"), self->op, self->version(), TRUE);
+  }
 }
 
 static void deflicker_prepare_histogram(dt_iop_module_t *self, uint32_t **histogram,
@@ -633,23 +651,8 @@ void reload_defaults(dt_iop_module_t *module)
                                                             .exposure = 0.0f,
                                                             .deflicker_percentile = 50.0f,
                                                             .deflicker_target_level = -4.0f,
-                                                            .compensate_exposure_bias = TRUE};
+                                                            .compensate_exposure_bias = FALSE};
 
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev || module->dev->image_storage.id == -1) goto end;
-
-  if(dt_image_is_matrix_correction_supported(&module->dev->image_storage))
-  {
-    // if is raw image
-    if(strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
-    {
-      // For scene-referred workflow, since filmic doesn't brighten as base curve does,
-      // we need an initial exposure boost. This might be too much in some cases but…
-      tmp.exposure = 1.0f;
-    }
-  }
-
-end:
   memcpy(module->params, &tmp, sizeof(dt_iop_exposure_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_exposure_params_t));
 }

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2382,8 +2382,6 @@ void reload_defaults(dt_iop_module_t *module)
       tmp.black_point_source += 0.5f * exposure;
       tmp.white_point_source += 0.8f * exposure;
       tmp.output_power = logf(tmp.grey_point_target / 100.0f) / logf(-tmp.black_point_source / (tmp.white_point_source - tmp.black_point_source));
-
-      module->default_enabled = TRUE;
     }
   }
 


### PR DESCRIPTION
when clearing the history stack or loading a new image

 - any module which is forced on and cannot be switched off appears first in the history stack
 - any module that is on by default but can be switched off appears next in the history stack
 - finally any modules that are enabled by presets or as a result of a preference setting (workflow or sharpen) are added

the final set of modules can be disabled and removed from the history stack but, as previously, the first two sets will be automatically re-added if they are removed

also fixes bug where highlight reconstruction was not present in the history stack

finally changes the scene-referred exposure defaults to a preset to ensure that they only apply to the first module instance and can be easily reapplied if necessary (by choosing the preset)

Resolves #5396, #5416