### PR TITLE
Scripts installer not always maximized

### DIFF
--- a/data/luarc
+++ b/data/luarc
@@ -26,6 +26,15 @@ local _scripts_install = {}
 _scripts_install.dt = require 'darktable'
 
 
+_scripts_install.dt.preferences.register(
+  "_scripts_install",
+  "dont_show",
+  "bool",
+  _scripts_install.dt.gettext.gettext("lua scripts installer dont show again"),
+  _scripts_install.dt.gettext.gettext("do not show scripts_installer if lua scripts are not installed"),
+  false
+)
+
 if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bool") then
   -- _scripts_install.dt.print_log("dont show not set")
 
@@ -206,6 +215,7 @@ if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bo
         nil,
         nil
       )
+
       if not _scripts_install.dt.preferences.read("_scripts_install", "initialized", "bool") then
        _scripts_install.dt.control.sleep(1000)
        _scripts_install.dt.gui.libs["lua_scripts_installer"].visible = true

--- a/data/luarc
+++ b/data/luarc
@@ -66,7 +66,12 @@ if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bo
   _scripts_install.p:close()
 
   -- check for gui before trying to write to it
-  if _scripts_install.dt.gui.current_view() then
+  if _scripts_install.dt.configuration.has_gui then
+    local gettext = _scripts_install.dt.gettext
+
+    local function _(msg)
+      return gettext.gettext(msg)
+    end
 
     if _scripts_install.not_installed then
       -- _scripts_install.dt.print_log("scripts not installed")
@@ -94,18 +99,20 @@ if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bo
       function _scripts_install.installer()
        -- _scripts_install.dt.print_log("running installer")
 
-        if _scripts_install.widgets.choice.value == "don't show again" then
+        if _scripts_install.widgets.choice.value == _("don't show again") then
           _scripts_install.dt.preferences.write("_scripts_install", "dont_show", "bool", true)
           _scripts_install.dt.preferences.write("_scripts_install", "remind", "bool", false)
-          _scripts_install.dt.print("Installer won't be shown when darktable starts")
+          _scripts_install.dt.print(_("Installer won't be shown when darktable starts"))
           _scripts_install.minimize_lib()
-        elseif _scripts_install.widgets.choice.value == "remind me later" then
+        elseif _scripts_install.widgets.choice.value == _("remind me later") then
+          _scripts_install.dt.preferences.write("_scripts_install", "dont_show", "bool", false)
           _scripts_install.dt.preferences.write("_scripts_install", "remind", "bool", true)
           _scripts_install.dt.preferences.write("_scripts_install", "retries", "integer", 0)
-          _scripts_install.dt.print("Install will be shown every 5th time darktable starts")
+          _scripts_install.dt.print(_("Installer will be shown every 5th time darktable starts"))
           _scripts_install.minimize_lib()
         else
           _scripts_install.dt.preferences.write("_scripts_install", "remind", "bool", false)
+          _scripts_install.dt.preferences.write("_scripts_install", "dont_show", "bool", false)
 
             -- check for git executable
           if _scripts_install.dt.configuration.running_os == "windows" then
@@ -131,7 +138,7 @@ if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bo
           _scripts_install.p:close()
 
           if not _scripts_install.git_bin then
-            _scripts_install.dt.print("Please install git and make sure it is in your path")
+            _scripts_install.dt.print(_("Please install git and make sure it is in your path"))
             return
           end
 
@@ -140,49 +147,67 @@ if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bo
             _scripts_install.require_string = "'" .. _scripts_install.require_string .. "'"
           end
           
+          _scripts_install.dt.print(_("lua scripts installing"))
           os.execute("\"" .. _scripts_install.git_bin .. "\" " .. "clone https://github.com/darktable-org/lua-scripts.git " .. _scripts_install.dt.configuration.config_dir .. "/lua")
           os.execute("echo " .. _scripts_install.require_string .. " > " .. _scripts_install.dt.configuration.config_dir .. "/luarc")
-          _scripts_install.dt.print("lua scripts are installed")
+          _scripts_install.dt.print(_("lua scripts are installed"))
           require "tools/script_manager"
+          _scripts_install.dt.gui.libs["script_manager"].visible = true
         end
         _scripts_install.minimize_lib()
-        _scripts_install.dt.gui.libs["script_manager"].visible = true
       end
 
       -- _scripts_install.dt.print_log("building widgets")
 
+      _scripts_install.display_widgets = {}
+
+      if not _scripts_install.dt.preferences.read("_scripts_install", "initialized", "bool") then
+
+        _scripts_install.widgets["message"] = _scripts_install.dt.new_widget("text_view"){
+          text = _("Choose an action below.\n\n'install scripts' installs the lua scripts from\nthe darktable ") .. 
+          _("lua-scripts repository\n\n'remind me later' will cause this module to\nreappear every 5th ") ..
+          _("darktable is restarted\n\n'dont show again' will cause this module to\nnot be shown again ") ..
+          _("for those who do\nnot wish to install the scripts\n\n"),
+          editable = false,
+       }
+       table.insert(_scripts_install.display_widgets, _scripts_install.widgets["message"])
+     end
+
       _scripts_install.widgets["choice"] = _scripts_install.dt.new_widget("combobox"){
-        label = "select action",
-        tooltip = "select action to perform",
+        label = _("select action"),
+        tooltip = _("select action to perform"),
         selected = 1,
-        "install scripts", "remind me later", "don't show again",
+        _("install scripts"), 
+        _("remind me later"), 
+        _("don't show again"),
       }
+      table.insert(_scripts_install.display_widgets, _scripts_install.widgets["choice"])
 
       _scripts_install.widgets["execute"] = _scripts_install.dt.new_widget("button"){
-        label = "execute",
+        label = _("execute"),
         clicked_callback = function(this)
           _scripts_install.installer()
         end
       }
+      table.insert(_scripts_install.display_widgets, _scripts_install.widgets["execute"])
 
       -- _scripts_install.dt.print_log("installing library")
 
       _scripts_install.dt.register_lib(
         "lua_scripts_installer",
-        "lua scripts installer",
+        _("lua scripts installer"),
         true,
         false,
         {[_scripts_install.dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 900}},
         _scripts_install.dt.new_widget("box"){
           orientation = "vertical",
-          _scripts_install.widgets["choice"],
-          _scripts_install.widgets["execute"]
+          table.unpack(_scripts_install.display_widgets)
         },
         nil,
         nil
       )
       if not _scripts_install.dt.preferences.read("_scripts_install", "initialized", "bool") then
-       _scripts_install.dt.control.sleep(500)
+       _scripts_install.dt.control.sleep(1000)
        _scripts_install.dt.gui.libs["lua_scripts_installer"].visible = true
        _scripts_install.dt.preferences.write("_scripts_install", "initialized", "bool", true)
      end

--- a/data/luarc
+++ b/data/luarc
@@ -181,8 +181,11 @@ if not _scripts_install.dt.preferences.read("_scripts_install", "dont_show", "bo
         nil,
         nil
       )
-      _scripts_install.dt.control.sleep(500)
+      if not _scripts_install.dt.preferences.read("_scripts_install", "initialized", "bool") then
+       _scripts_install.dt.control.sleep(500)
        _scripts_install.dt.gui.libs["lua_scripts_installer"].visible = true
+       _scripts_install.dt.preferences.write("_scripts_install", "initialized", "bool", true)
+     end
     end
   end
 end


### PR DESCRIPTION
Set the module to be opened automatically the first time only and thereafter respect the users setting.  Added a text block with instructions that displays the first time you run the script.  Made the script translatable.

There is still an issue with the collapse arrow not pointing correctly, but that is an API problem that should be addressed in a separate issue.

Fixes #5401 