### PR TITLE
Lua API fix: darktable.gui.libs[<module>].visible = true|false

### DIFF
--- a/src/lua/lib.c
+++ b/src/lua/lib.c
@@ -46,7 +46,7 @@ static int visible_member(lua_State *L)
   }
   else
   {
-    dt_lib_set_visible(module, lua_toboolean(L, 3));
+    dt_lib_gui_set_expanded(module, lua_toboolean(L, 3));
     return 0;
   }
 }


### PR DESCRIPTION
Changed call from dt_lib_set_visible to dt_lib_gui_set_expanded to force arrows to mirror module visibility.

Fixes #5418.