### PR TITLE
change schedule(dynamic) to schedule(static) in parallelized for loops

### DIFF
--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -426,7 +426,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
     {
 // Main algorithm: Tile loop calculating correction parameters per tile
 #ifdef _OPENMP
-#pragma omp for collapse(2) schedule(dynamic) nowait
+#pragma omp for collapse(2) schedule(static) nowait
 #endif
       for(int top = -border; top < height; top += ts - border2)
         for(int left = -border; left < width; left += ts - border2)
@@ -1074,7 +1074,7 @@ static void CA_correct(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
     if(processpasstwo)
     {
 #ifdef _OPENMP
-#pragma omp for schedule(dynamic) collapse(2) nowait
+#pragma omp for schedule(static) collapse(2) nowait
 #endif
 
       for(int top = -border; top < height; top += ts - border2)

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -628,7 +628,7 @@ static void xtrans_markesteijn_interpolate(float *out, const float *const in,
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(all_buffers, buffer_size, dir, height, in, ndir, pad_tile, passes, roi_in, width, xtrans) \
   shared(sgrow, sgcol, allhex, out) \
-  schedule(dynamic)
+  schedule(static)
 #endif
   // step through TSxTS cells of image, each tile overlapping the
   // prior as interpolation needs a substantial border
@@ -1655,7 +1655,7 @@ static void xtrans_fdc_interpolate(struct dt_iop_module_t *self, float *out, con
 #pragma omp parallel for default(none)                                                                            \
     dt_omp_firstprivate(ndir, all_buffers, dir, directionality, harr, height, in, Minv, modarr, roi_in, width,    \
                         xtrans, pad_tile, buffer_size)                                                            \
-        shared(sgrow, sgcol, allhex, out, rowoffset, coloffset, hybrid_fdc) schedule(dynamic)
+        shared(sgrow, sgcol, allhex, out, rowoffset, coloffset, hybrid_fdc) schedule(static)
 #endif
   // step through TSxTS cells of image, each tile overlapping the
   // prior as interpolation needs a substantial border

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -546,15 +546,15 @@ static void process_lch_bayer(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clip, filters, ivoid, ovoid, roi_out) \
-  schedule(static)
+  schedule(static) collapse(2)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
-    float *out = (float *)ovoid + (size_t)roi_out->width * j;
-    float *in = (float *)ivoid + (size_t)roi_out->width * j;
-
-    for(int i = 0; i < roi_out->width; i++, in++, out++)
+    for(int i = 0; i < roi_out->width; i++)
     {
+      float *const out = (float *)ovoid + (size_t)roi_out->width * j + i;
+      const float *const in = (float *)ivoid + (size_t)roi_out->width * j + i;
+
       if(i == roi_out->width - 1 || j == roi_out->height - 1)
       {
         // fast path for border

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -546,7 +546,7 @@ static void process_lch_bayer(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pie
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clip, filters, ivoid, ovoid, roi_out) \
-  schedule(dynamic)
+  schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -647,7 +647,7 @@ static void process_lch_xtrans(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *pi
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(clip, ivoid, ovoid, roi_in, roi_out, xtrans) \
-  schedule(dynamic)
+  schedule(static)
 #endif
   for(int j = 0; j < roi_out->height; j++)
   {
@@ -901,7 +901,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(clips, filters, ivoid, ovoid, roi_in, roi_out, \
                             xtrans) \
-        schedule(dynamic)
+        schedule(static)
 #endif
         for(int j = 0; j < roi_out->height; j++)
         {
@@ -912,7 +912,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(clips, filters, ivoid, ovoid, roi_in, roi_out, \
                             xtrans) \
-        schedule(dynamic)
+        schedule(static)
 #endif
         for(int i = 0; i < roi_out->width; i++)
         {
@@ -926,7 +926,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(clips, filters, ivoid, ovoid, roi_out) \
         shared(data, piece) \
-        schedule(dynamic)
+        schedule(static)
 #endif
         for(int j = 0; j < roi_out->height; j++)
         {
@@ -939,7 +939,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 #pragma omp parallel for default(none) \
         dt_omp_firstprivate(clips, filters, ivoid, ovoid, roi_out) \
         shared(data, piece) \
-        schedule(dynamic)
+        schedule(static)
 #endif
         for(int i = 0; i < roi_out->width; i++)
         {

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1218,7 +1218,7 @@ static float complex *create_global_distortion_map(const cairo_rectangle_int_t *
     // of points.
 
     #ifdef _OPENMP
-    #pragma omp parallel for schedule (dynamic) default (shared)
+    #pragma omp parallel for schedule (static) default (shared)
     #endif
 
     for(int y = 0; y <  map_extent->height; y++)


### PR DESCRIPTION
Yields a substantial speedup at higher thread counts for chromatic aberration, X-trans demosaic, and highlight reconstruction with Lch and "color" methods, by reducing thread-management overhead on loops with a known count of iterations where each iteration takes the same amount of time.  (See also #4789)
 

