### PR TITLE
Use /usr/bin/env to invoke bash

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Hash using its key as a search Regex, and its value as associated
 # error message.

--- a/build-doc.sh
+++ b/build-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script is a quick hack to make it easier to build the darktable documetation
 # in PDF, html-multi and html-single formats, for the user manual and LUA API.

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -180,6 +180,12 @@ num_cpu()
 			fi
 		fi
 		;;
+
+	FreeBSD)
+		export CMAKE_MAKE_PROGRAM=/usr/local/bin/gmake
+		ncpu=$(/sbin/sysctl -n kern.smp.cpus 2>/dev/null)
+		;;
+
 	Darwin)
 		ncpu=$(/usr/sbin/sysctl -n machdep.cpu.core_count 2>/dev/null)
 		;;
@@ -250,6 +256,8 @@ if [ $PRINT_HELP -ne 0 ] ; then
 fi
 
 CMAKE_MORE_OPTIONS=""
+export CMAKE_MAKE_PROGRAM=/usr/local/bin/gmake
+
 for i in $FEATURES; do
 	eval cmake_boolean_option USE_$i \$FEAT_$i
 done


### PR DESCRIPTION
This commit adds /usr/bin/env to the magic number line of shells scripts
to increase portability.

One of the uses of the /usr/bin/env is that it can invoke a command
using the user's current environment by searching their ${PATH}.  Also,
since /usr/bin/env is part of many standard distributions (FreeBSD, most
if not all Linux distros, and OSX), it is more likely to be found at a
fixed path than bash.

This allows us to run bash scripts regardless of the shell's location on
the filesystem -- which varies between operating systems and
distributions.

This updates the build-doc.sh, build.sh, and .githooks/pre-commit
scripts.