### PR TITLE
Better icon themes in Windows HiDPI

### DIFF
--- a/data/themes/darktable-icons.css
+++ b/data/themes/darktable-icons.css
@@ -18,22 +18,88 @@
 
 @import url("darktable.css");
 
-#iop-panel-icon-sharpen
+#iop-panel-icon-ashift,
+#iop-panel-icon-atrous,
+#iop-panel-icon-basecurve,
+#iop-panel-icon-basicadj,
+#iop-panel-icon-bilat,
+#iop-panel-icon-bilateral,
+#iop-panel-icon-bloom,
+#iop-panel-icon-borders,
+#iop-panel-icon-cacorrect,
+#iop-panel-icon-channelmixer,
+#iop-panel-icon-clahe,
+#iop-panel-icon-clipping,
+#iop-panel-icon-colisa,
+#iop-panel-icon-colorbalance,
+#iop-panel-icon-colorchecker,
+#iop-panel-icon-colorcontrast,
+#iop-panel-icon-colorcorrection,
+#iop-panel-icon-colorin,
+#iop-panel-icon-colorize,
+#iop-panel-icon-colormapping,
+#iop-panel-icon-colorout,
+#iop-panel-icon-colorreconstruct,
+#iop-panel-icon-colortransfer,
+#iop-panel-icon-colorzones,
+#iop-panel-icon-defringe,
+#iop-panel-icon-demosaic,
+#iop-panel-icon-denoiseprofile,
+#iop-panel-icon-dither,
+#iop-panel-icon-equalizer,
+#iop-panel-icon-exposure,
+#iop-panel-icon-filmic,
+#iop-panel-icon-filmicrgb,
+#iop-panel-icon-flip,
+#iop-panel-icon-gamma,
+#iop-panel-icon-globaltonemap,
+#iop-panel-icon-graduatednd,
+#iop-panel-icon-grain,
+#iop-panel-icon-hazeremoval,
+#iop-panel-icon-highlights,
+#iop-panel-icon-highpass,
+#iop-panel-icon-hotpixels,
+#iop-panel-icon-invert,
+#iop-panel-icon-lens,
+#iop-panel-icon-levels,
+#iop-panel-icon-liquify,
+#iop-panel-icon-lowlight,
+#iop-panel-icon-lowpass,
+#iop-panel-icon-lut3d,
+#iop-panel-icon-monochrome,
+#iop-panel-icon-negadoctor,
+#iop-panel-icon-nlmeans,
+#iop-panel-icon-overexposed,
+#iop-panel-icon-profile_gamma,
+#iop-panel-icon-rawdenoise,
+#iop-panel-icon-rawimport,
+#iop-panel-icon-rawprepare,
+#iop-panel-icon-relight,
+#iop-panel-icon-retouch,
+#iop-panel-icon-rgbcurve,
+#iop-panel-icon-rgblevels,
+#iop-panel-icon-rotatepixels,
+#iop-panel-icon-scalepixels,
+#iop-panel-icon-shadhi,
+#iop-panel-icon-sharpen,
+#iop-panel-icon-soften,
+#iop-panel-icon-splittoning,
+#iop-panel-icon-spots,
+#iop-panel-icon-temperature,
+#iop-panel-icon-template,
+#iop-panel-icon-toneequal,
+#iop-panel-icon-tonecurve,
+#iop-panel-icon-tone,
+#iop-panel-icon-velvia,
+#iop-panel-icon-vibrance,
+#iop-panel-icon-vignette,
+#iop-panel-icon-watermark,
+#iop-panel-icon-zonesystem
 {
-    background-image: url('../pixmaps/plugins/darkroom/sharpen.svg');
+    background-image: url('../pixmaps/plugins/darkroom/default.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-soften
-{
-    background-image: url('../pixmaps/plugins/darkroom/soften.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
+    margin-top: 0.14em;
     min-height: 1.1em;
     min-width: 1.1em;
 }
@@ -41,591 +107,279 @@
 #iop-panel-icon-ashift
 {
     background-image: url('../pixmaps/plugins/darkroom/ashift.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-atrous
 {
     background-image: url('../pixmaps/plugins/darkroom/atrous.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-basecurve
 {
     background-image: url('../pixmaps/plugins/darkroom/basecurve.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-bilateral
 {
     background-image: url('../pixmaps/plugins/darkroom/bilateral.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-bloom
 {
     background-image: url('../pixmaps/plugins/darkroom/bloom.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-borders
 {
     background-image: url('../pixmaps/plugins/darkroom/borders.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-cacorrect
 {
     background-image: url('../pixmaps/plugins/darkroom/cacorrect.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-channelmixer
 {
     background-image: url('../pixmaps/plugins/darkroom/channelmixer.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-clahe
 {
     background-image: url('../pixmaps/plugins/darkroom/clahe.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-clipping
 {
     background-image: url('../pixmaps/plugins/darkroom/clipping.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colisa
 {
     background-image: url('../pixmaps/plugins/darkroom/colisa.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorcorrection
 {
     background-image: url('../pixmaps/plugins/darkroom/colorcorrection.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorin
 {
     background-image: url('../pixmaps/plugins/darkroom/colorin.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colormapping
 {
     background-image: url('../pixmaps/plugins/darkroom/colormapping.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorout
 {
     background-image: url('../pixmaps/plugins/darkroom/colorout.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorreconstruct
 {
     background-image: url('../pixmaps/plugins/darkroom/colorreconstruct.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colortransfer
 {
     background-image: url('../pixmaps/plugins/darkroom/colortransfer.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorzones
 {
     background-image: url('../pixmaps/plugins/darkroom/colorzones.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-demosaic
 {
     background-image: url('../pixmaps/plugins/darkroom/demosaic.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-dither
 {
     background-image: url('../pixmaps/plugins/darkroom/dither.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-exposure
 {
     background-image: url('../pixmaps/plugins/darkroom/exposure.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-flip
 {
     background-image: url('../pixmaps/plugins/darkroom/flip.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-graduatednd
-{
-    background-image: url('../pixmaps/plugins/darkroom/graduatednd.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-grain
-{
-    background-image: url('../pixmaps/plugins/darkroom/grain.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-hazeremoval
-{
-    background-image: url('../pixmaps/plugins/darkroom/hazeremoval.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-highlights
-{
-    background-image: url('../pixmaps/plugins/darkroom/highlights.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-highpass
-{
-    background-image: url('../pixmaps/plugins/darkroom/highpass.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-hotpixels
-{
-    background-image: url('../pixmaps/plugins/darkroom/hotpixels.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-invert
-{
-    background-image: url('../pixmaps/plugins/darkroom/invert.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-lens
-{
-    background-image: url('../pixmaps/plugins/darkroom/lens.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-levels
-{
-    background-image: url('../pixmaps/plugins/darkroom/levels.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-liquify
-{
-    background-image: url('../pixmaps/plugins/darkroom/liquify.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-lowlight
-{
-    background-image: url('../pixmaps/plugins/darkroom/lowlight.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-lowpass
-{
-    background-image: url('../pixmaps/plugins/darkroom/lowpass.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-monochrome
-{
-    background-image: url('../pixmaps/plugins/darkroom/monochrome.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-negadoctor
-{
-    background-image: url('../pixmaps/plugins/darkroom/invert.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-nlmeans
-{
-    background-image: url('../pixmaps/plugins/darkroom/nlmeans.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-overexposed
-{
-    background-image: url('../pixmaps/plugins/darkroom/overexposed.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-gamma
 {
     background-image: url('../pixmaps/plugins/darkroom/profile_gamma.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
+}
+
+#iop-panel-icon-graduatednd
+{
+    background-image: url('../pixmaps/plugins/darkroom/graduatednd.svg');
+}
+
+#iop-panel-icon-grain
+{
+    background-image: url('../pixmaps/plugins/darkroom/grain.svg');
+}
+
+#iop-panel-icon-hazeremoval
+{
+    background-image: url('../pixmaps/plugins/darkroom/hazeremoval.svg');
+}
+
+#iop-panel-icon-highlights
+{
+    background-image: url('../pixmaps/plugins/darkroom/highlights.svg');
+}
+
+#iop-panel-icon-highpass
+{
+    background-image: url('../pixmaps/plugins/darkroom/highpass.svg');
+}
+
+#iop-panel-icon-hotpixels
+{
+    background-image: url('../pixmaps/plugins/darkroom/hotpixels.svg');
+}
+
+#iop-panel-icon-invert
+{
+    background-image: url('../pixmaps/plugins/darkroom/invert.svg');
+}
+
+#iop-panel-icon-lens
+{
+    background-image: url('../pixmaps/plugins/darkroom/lens.svg');
+}
+
+#iop-panel-icon-levels
+{
+    background-image: url('../pixmaps/plugins/darkroom/levels.svg');
+}
+
+#iop-panel-icon-liquify
+{
+    background-image: url('../pixmaps/plugins/darkroom/liquify.svg');
+}
+
+#iop-panel-icon-lowlight
+{
+    background-image: url('../pixmaps/plugins/darkroom/lowlight.svg');
+}
+
+#iop-panel-icon-lowpass
+{
+    background-image: url('../pixmaps/plugins/darkroom/lowpass.svg');
+}
+
+#iop-panel-icon-monochrome
+{
+    background-image: url('../pixmaps/plugins/darkroom/monochrome.svg');
+}
+
+#iop-panel-icon-negadoctor
+{
+    background-image: url('../pixmaps/plugins/darkroom/invert.svg');
+}
+
+#iop-panel-icon-nlmeans
+{
+    background-image: url('../pixmaps/plugins/darkroom/nlmeans.svg');
+}
+
+#iop-panel-icon-overexposed
+{
+    background-image: url('../pixmaps/plugins/darkroom/overexposed.svg');
 }
 
 #iop-panel-icon-rawdenoise
 {
     background-image: url('../pixmaps/plugins/darkroom/rawdenoise.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawimport
 {
     background-image: url('../pixmaps/plugins/darkroom/rawimport.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawprepare
 {
     background-image: url('../pixmaps/plugins/darkroom/rawprepare.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-relight
 {
     background-image: url('../pixmaps/plugins/darkroom/relight.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-shadhi
 {
     background-image: url('../pixmaps/plugins/darkroom/shadhi.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-sharpen
 {
     background-image: url('../pixmaps/plugins/darkroom/sharpen.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-soften
 {
     background-image: url('../pixmaps/plugins/darkroom/soften.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-splittoning
 {
     background-image: url('../pixmaps/plugins/darkroom/splittoning.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-spots
 {
     background-image: url('../pixmaps/plugins/darkroom/spots.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-temperature
 {
     background-image: url('../pixmaps/plugins/darkroom/temperature.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-template
 {
     background-image: url('../pixmaps/plugins/darkroom/template.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-tonecurve
 {
     background-image: url('../pixmaps/plugins/darkroom/tonecurve.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-tonemap
 {
     background-image: url('../pixmaps/plugins/darkroom/tonemap.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-velvia
 {
     background-image: url('../pixmaps/plugins/darkroom/velvia.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-vignette
 {
     background-image: url('../pixmaps/plugins/darkroom/vignette.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-watermark
 {
     background-image: url('../pixmaps/plugins/darkroom/watermark.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }
 
 #iop-panel-icon-zonesystem
 {
     background-image: url('../pixmaps/plugins/darkroom/zonesystem.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
-}
-
-#iop-panel-icon-colorize,
-#iop-panel-icon-retouch,
-#iop-panel-icon-colorbalance,
-#iop-panel-icon-vibrance,
-#iop-panel-icon-filmic,
-#iop-panel-icon-rgbcurve,
-#iop-panel-icon-defringe,
-#iop-panel-icon-denoiseprofile,
-#iop-panel-icon-colorin,
-#iop-panel-icon-basicadj,
-#iop-panel-icon-colorchecker,
-#iop-panel-icon-colorcorrection,
-#iop-panel-icon-rotatepixels,
-#iop-panel-icon-scalepixels,
-#iop-panel-icon-globaltonemap,
-#iop-panel-icon-colorcontrast,
-#iop-panel-icon-bilat,
-#iop-panel-icon-profile_gamma,
-#iop-panel-icon-filmicrgb,
-#iop-panel-icon-rgblevels,
-#iop-panel-icon-lut3d,
-#iop-panel-icon-toneequal,
-#iop-panel-icon-equalizer
-{
-    background-image: url('../pixmaps/plugins/darkroom/default.svg');
-    background-size: contain;
-    background-repeat: no-repeat;
-    margin-top: 0.13em;
-    min-height: 1.1em;
-    min-width: 1.1em;
 }

--- a/data/themes/darktable-icons.css
+++ b/data/themes/darktable-icons.css
@@ -23,8 +23,9 @@
     background-image: url('../pixmaps/plugins/darkroom/sharpen.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-soften
@@ -32,8 +33,9 @@
     background-image: url('../pixmaps/plugins/darkroom/soften.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-ashift
@@ -41,8 +43,9 @@
     background-image: url('../pixmaps/plugins/darkroom/ashift.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-atrous
@@ -50,8 +53,9 @@
     background-image: url('../pixmaps/plugins/darkroom/atrous.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-basecurve
@@ -59,8 +63,9 @@
     background-image: url('../pixmaps/plugins/darkroom/basecurve.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-bilateral
@@ -68,8 +73,9 @@
     background-image: url('../pixmaps/plugins/darkroom/bilateral.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-bloom
@@ -77,7 +83,6 @@
     background-image: url('../pixmaps/plugins/darkroom/bloom.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding: 0;
     margin-top: 0.13em;
     min-height: 1.1em;
     min-width: 1.1em;
@@ -88,8 +93,9 @@
     background-image: url('../pixmaps/plugins/darkroom/borders.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-cacorrect
@@ -97,8 +103,9 @@
     background-image: url('../pixmaps/plugins/darkroom/cacorrect.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-channelmixer
@@ -106,7 +113,9 @@
     background-image: url('../pixmaps/plugins/darkroom/channelmixer.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-clahe
@@ -114,8 +123,9 @@
     background-image: url('../pixmaps/plugins/darkroom/clahe.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-clipping
@@ -123,8 +133,9 @@
     background-image: url('../pixmaps/plugins/darkroom/clipping.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colisa
@@ -132,8 +143,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colisa.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorcorrection
@@ -141,8 +153,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colorcorrection.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorin
@@ -150,8 +163,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colorin.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colormapping
@@ -159,8 +173,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colormapping.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorout
@@ -168,8 +183,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colorout.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorreconstruct
@@ -177,8 +193,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colorreconstruct.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colortransfer
@@ -186,8 +203,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colortransfer.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorzones
@@ -195,8 +213,9 @@
     background-image: url('../pixmaps/plugins/darkroom/colorzones.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-demosaic
@@ -204,8 +223,9 @@
     background-image: url('../pixmaps/plugins/darkroom/demosaic.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-dither
@@ -213,8 +233,9 @@
     background-image: url('../pixmaps/plugins/darkroom/dither.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-exposure
@@ -222,8 +243,9 @@
     background-image: url('../pixmaps/plugins/darkroom/exposure.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-flip
@@ -231,8 +253,9 @@
     background-image: url('../pixmaps/plugins/darkroom/flip.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-graduatednd
@@ -240,8 +263,9 @@
     background-image: url('../pixmaps/plugins/darkroom/graduatednd.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-grain
@@ -249,8 +273,9 @@
     background-image: url('../pixmaps/plugins/darkroom/grain.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-hazeremoval
@@ -258,8 +283,9 @@
     background-image: url('../pixmaps/plugins/darkroom/hazeremoval.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-highlights
@@ -267,8 +293,9 @@
     background-image: url('../pixmaps/plugins/darkroom/highlights.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-highpass
@@ -276,8 +303,9 @@
     background-image: url('../pixmaps/plugins/darkroom/highpass.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-hotpixels
@@ -285,8 +313,9 @@
     background-image: url('../pixmaps/plugins/darkroom/hotpixels.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-invert
@@ -294,8 +323,9 @@
     background-image: url('../pixmaps/plugins/darkroom/invert.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-lens
@@ -303,8 +333,9 @@
     background-image: url('../pixmaps/plugins/darkroom/lens.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-levels
@@ -312,8 +343,9 @@
     background-image: url('../pixmaps/plugins/darkroom/levels.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-liquify
@@ -321,8 +353,9 @@
     background-image: url('../pixmaps/plugins/darkroom/liquify.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-lowlight
@@ -330,8 +363,9 @@
     background-image: url('../pixmaps/plugins/darkroom/lowlight.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-lowpass
@@ -339,8 +373,9 @@
     background-image: url('../pixmaps/plugins/darkroom/lowpass.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-monochrome
@@ -348,8 +383,19 @@
     background-image: url('../pixmaps/plugins/darkroom/monochrome.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
+}
+
+#iop-panel-icon-negadoctor
+{
+    background-image: url('../pixmaps/plugins/darkroom/invert.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-nlmeans
@@ -357,8 +403,9 @@
     background-image: url('../pixmaps/plugins/darkroom/nlmeans.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-overexposed
@@ -366,8 +413,9 @@
     background-image: url('../pixmaps/plugins/darkroom/overexposed.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-gamma
@@ -375,8 +423,9 @@
     background-image: url('../pixmaps/plugins/darkroom/profile_gamma.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawdenoise
@@ -384,8 +433,9 @@
     background-image: url('../pixmaps/plugins/darkroom/rawdenoise.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawimport
@@ -393,8 +443,9 @@
     background-image: url('../pixmaps/plugins/darkroom/rawimport.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawprepare
@@ -402,8 +453,9 @@
     background-image: url('../pixmaps/plugins/darkroom/rawprepare.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-relight
@@ -411,8 +463,9 @@
     background-image: url('../pixmaps/plugins/darkroom/relight.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-shadhi
@@ -420,8 +473,9 @@
     background-image: url('../pixmaps/plugins/darkroom/shadhi.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-sharpen
@@ -429,8 +483,9 @@
     background-image: url('../pixmaps/plugins/darkroom/sharpen.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-soften
@@ -438,8 +493,9 @@
     background-image: url('../pixmaps/plugins/darkroom/soften.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-splittoning
@@ -447,8 +503,9 @@
     background-image: url('../pixmaps/plugins/darkroom/splittoning.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-spots
@@ -456,8 +513,9 @@
     background-image: url('../pixmaps/plugins/darkroom/spots.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-temperature
@@ -465,8 +523,9 @@
     background-image: url('../pixmaps/plugins/darkroom/temperature.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-template
@@ -474,8 +533,9 @@
     background-image: url('../pixmaps/plugins/darkroom/template.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-tonecurve
@@ -483,8 +543,9 @@
     background-image: url('../pixmaps/plugins/darkroom/tonecurve.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-tonemap
@@ -492,8 +553,9 @@
     background-image: url('../pixmaps/plugins/darkroom/tonemap.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-velvia
@@ -501,8 +563,9 @@
     background-image: url('../pixmaps/plugins/darkroom/velvia.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-vignette
@@ -510,8 +573,9 @@
     background-image: url('../pixmaps/plugins/darkroom/vignette.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-watermark
@@ -519,8 +583,9 @@
     background-image: url('../pixmaps/plugins/darkroom/watermark.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-zonesystem
@@ -528,8 +593,9 @@
     background-image: url('../pixmaps/plugins/darkroom/zonesystem.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorize,
@@ -559,6 +625,7 @@
     background-image: url('../pixmaps/plugins/darkroom/default.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }

--- a/data/themes/darktable-icons.css
+++ b/data/themes/darktable-icons.css
@@ -77,8 +77,10 @@
     background-image: url('../pixmaps/plugins/darkroom/bloom.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    padding-left: 18px;
-    margin: 3px 0px;
+    padding: 0;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-borders

--- a/data/themes/darktable-icons.css
+++ b/data/themes/darktable-icons.css
@@ -18,88 +18,22 @@
 
 @import url("darktable.css");
 
-#iop-panel-icon-ashift,
-#iop-panel-icon-atrous,
-#iop-panel-icon-basecurve,
-#iop-panel-icon-basicadj,
-#iop-panel-icon-bilat,
-#iop-panel-icon-bilateral,
-#iop-panel-icon-bloom,
-#iop-panel-icon-borders,
-#iop-panel-icon-cacorrect,
-#iop-panel-icon-channelmixer,
-#iop-panel-icon-clahe,
-#iop-panel-icon-clipping,
-#iop-panel-icon-colisa,
-#iop-panel-icon-colorbalance,
-#iop-panel-icon-colorchecker,
-#iop-panel-icon-colorcontrast,
-#iop-panel-icon-colorcorrection,
-#iop-panel-icon-colorin,
-#iop-panel-icon-colorize,
-#iop-panel-icon-colormapping,
-#iop-panel-icon-colorout,
-#iop-panel-icon-colorreconstruct,
-#iop-panel-icon-colortransfer,
-#iop-panel-icon-colorzones,
-#iop-panel-icon-defringe,
-#iop-panel-icon-demosaic,
-#iop-panel-icon-denoiseprofile,
-#iop-panel-icon-dither,
-#iop-panel-icon-equalizer,
-#iop-panel-icon-exposure,
-#iop-panel-icon-filmic,
-#iop-panel-icon-filmicrgb,
-#iop-panel-icon-flip,
-#iop-panel-icon-gamma,
-#iop-panel-icon-globaltonemap,
-#iop-panel-icon-graduatednd,
-#iop-panel-icon-grain,
-#iop-panel-icon-hazeremoval,
-#iop-panel-icon-highlights,
-#iop-panel-icon-highpass,
-#iop-panel-icon-hotpixels,
-#iop-panel-icon-invert,
-#iop-panel-icon-lens,
-#iop-panel-icon-levels,
-#iop-panel-icon-liquify,
-#iop-panel-icon-lowlight,
-#iop-panel-icon-lowpass,
-#iop-panel-icon-lut3d,
-#iop-panel-icon-monochrome,
-#iop-panel-icon-negadoctor,
-#iop-panel-icon-nlmeans,
-#iop-panel-icon-overexposed,
-#iop-panel-icon-profile_gamma,
-#iop-panel-icon-rawdenoise,
-#iop-panel-icon-rawimport,
-#iop-panel-icon-rawprepare,
-#iop-panel-icon-relight,
-#iop-panel-icon-retouch,
-#iop-panel-icon-rgbcurve,
-#iop-panel-icon-rgblevels,
-#iop-panel-icon-rotatepixels,
-#iop-panel-icon-scalepixels,
-#iop-panel-icon-shadhi,
-#iop-panel-icon-sharpen,
-#iop-panel-icon-soften,
-#iop-panel-icon-splittoning,
-#iop-panel-icon-spots,
-#iop-panel-icon-temperature,
-#iop-panel-icon-template,
-#iop-panel-icon-toneequal,
-#iop-panel-icon-tonecurve,
-#iop-panel-icon-tone,
-#iop-panel-icon-velvia,
-#iop-panel-icon-vibrance,
-#iop-panel-icon-vignette,
-#iop-panel-icon-watermark,
-#iop-panel-icon-zonesystem
+#iop-panel-icon-sharpen
 {
-    background-image: url('../pixmaps/plugins/darkroom/default.svg');
+    background-image: url('../pixmaps/plugins/darkroom/sharpen.svg');
     background-size: contain;
     background-repeat: no-repeat;
-    margin-top: 0.14em;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
+}
+
+#iop-panel-icon-soften
+{
+    background-image: url('../pixmaps/plugins/darkroom/soften.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
     min-height: 1.1em;
     min-width: 1.1em;
 }
@@ -107,279 +41,591 @@
 #iop-panel-icon-ashift
 {
     background-image: url('../pixmaps/plugins/darkroom/ashift.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-atrous
 {
     background-image: url('../pixmaps/plugins/darkroom/atrous.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-basecurve
 {
     background-image: url('../pixmaps/plugins/darkroom/basecurve.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-bilateral
 {
     background-image: url('../pixmaps/plugins/darkroom/bilateral.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-bloom
 {
     background-image: url('../pixmaps/plugins/darkroom/bloom.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-borders
 {
     background-image: url('../pixmaps/plugins/darkroom/borders.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-cacorrect
 {
     background-image: url('../pixmaps/plugins/darkroom/cacorrect.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-channelmixer
 {
     background-image: url('../pixmaps/plugins/darkroom/channelmixer.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-clahe
 {
     background-image: url('../pixmaps/plugins/darkroom/clahe.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-clipping
 {
     background-image: url('../pixmaps/plugins/darkroom/clipping.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colisa
 {
     background-image: url('../pixmaps/plugins/darkroom/colisa.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorcorrection
 {
     background-image: url('../pixmaps/plugins/darkroom/colorcorrection.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorin
 {
     background-image: url('../pixmaps/plugins/darkroom/colorin.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colormapping
 {
     background-image: url('../pixmaps/plugins/darkroom/colormapping.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorout
 {
     background-image: url('../pixmaps/plugins/darkroom/colorout.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorreconstruct
 {
     background-image: url('../pixmaps/plugins/darkroom/colorreconstruct.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colortransfer
 {
     background-image: url('../pixmaps/plugins/darkroom/colortransfer.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-colorzones
 {
     background-image: url('../pixmaps/plugins/darkroom/colorzones.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-demosaic
 {
     background-image: url('../pixmaps/plugins/darkroom/demosaic.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-dither
 {
     background-image: url('../pixmaps/plugins/darkroom/dither.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-exposure
 {
     background-image: url('../pixmaps/plugins/darkroom/exposure.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-flip
 {
     background-image: url('../pixmaps/plugins/darkroom/flip.svg');
-}
-
-#iop-panel-icon-gamma
-{
-    background-image: url('../pixmaps/plugins/darkroom/profile_gamma.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-graduatednd
 {
     background-image: url('../pixmaps/plugins/darkroom/graduatednd.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-grain
 {
     background-image: url('../pixmaps/plugins/darkroom/grain.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-hazeremoval
 {
     background-image: url('../pixmaps/plugins/darkroom/hazeremoval.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-highlights
 {
     background-image: url('../pixmaps/plugins/darkroom/highlights.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-highpass
 {
     background-image: url('../pixmaps/plugins/darkroom/highpass.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-hotpixels
 {
     background-image: url('../pixmaps/plugins/darkroom/hotpixels.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-invert
 {
     background-image: url('../pixmaps/plugins/darkroom/invert.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-lens
 {
     background-image: url('../pixmaps/plugins/darkroom/lens.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-levels
 {
     background-image: url('../pixmaps/plugins/darkroom/levels.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-liquify
 {
     background-image: url('../pixmaps/plugins/darkroom/liquify.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-lowlight
 {
     background-image: url('../pixmaps/plugins/darkroom/lowlight.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-lowpass
 {
     background-image: url('../pixmaps/plugins/darkroom/lowpass.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-monochrome
 {
     background-image: url('../pixmaps/plugins/darkroom/monochrome.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-negadoctor
 {
     background-image: url('../pixmaps/plugins/darkroom/invert.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-nlmeans
 {
     background-image: url('../pixmaps/plugins/darkroom/nlmeans.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-overexposed
 {
     background-image: url('../pixmaps/plugins/darkroom/overexposed.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
+}
+
+#iop-panel-icon-gamma
+{
+    background-image: url('../pixmaps/plugins/darkroom/profile_gamma.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawdenoise
 {
     background-image: url('../pixmaps/plugins/darkroom/rawdenoise.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawimport
 {
     background-image: url('../pixmaps/plugins/darkroom/rawimport.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-rawprepare
 {
     background-image: url('../pixmaps/plugins/darkroom/rawprepare.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-relight
 {
     background-image: url('../pixmaps/plugins/darkroom/relight.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-shadhi
 {
     background-image: url('../pixmaps/plugins/darkroom/shadhi.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-sharpen
 {
     background-image: url('../pixmaps/plugins/darkroom/sharpen.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-soften
 {
     background-image: url('../pixmaps/plugins/darkroom/soften.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-splittoning
 {
     background-image: url('../pixmaps/plugins/darkroom/splittoning.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-spots
 {
     background-image: url('../pixmaps/plugins/darkroom/spots.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-temperature
 {
     background-image: url('../pixmaps/plugins/darkroom/temperature.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-template
 {
     background-image: url('../pixmaps/plugins/darkroom/template.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-tonecurve
 {
     background-image: url('../pixmaps/plugins/darkroom/tonecurve.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-tonemap
 {
     background-image: url('../pixmaps/plugins/darkroom/tonemap.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-velvia
 {
     background-image: url('../pixmaps/plugins/darkroom/velvia.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-vignette
 {
     background-image: url('../pixmaps/plugins/darkroom/vignette.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-watermark
 {
     background-image: url('../pixmaps/plugins/darkroom/watermark.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }
 
 #iop-panel-icon-zonesystem
 {
     background-image: url('../pixmaps/plugins/darkroom/zonesystem.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
+}
+
+#iop-panel-icon-colorize,
+#iop-panel-icon-retouch,
+#iop-panel-icon-colorbalance,
+#iop-panel-icon-vibrance,
+#iop-panel-icon-filmic,
+#iop-panel-icon-rgbcurve,
+#iop-panel-icon-defringe,
+#iop-panel-icon-denoiseprofile,
+#iop-panel-icon-colorin,
+#iop-panel-icon-basicadj,
+#iop-panel-icon-colorchecker,
+#iop-panel-icon-colorcorrection,
+#iop-panel-icon-rotatepixels,
+#iop-panel-icon-scalepixels,
+#iop-panel-icon-globaltonemap,
+#iop-panel-icon-colorcontrast,
+#iop-panel-icon-bilat,
+#iop-panel-icon-profile_gamma,
+#iop-panel-icon-filmicrgb,
+#iop-panel-icon-rgblevels,
+#iop-panel-icon-lut3d,
+#iop-panel-icon-toneequal,
+#iop-panel-icon-equalizer
+{
+    background-image: url('../pixmaps/plugins/darkroom/default.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    margin-top: 0.13em;
+    min-height: 1.1em;
+    min-width: 1.1em;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -562,8 +562,6 @@ overshoot.right
 {
   color: @plugin_label_color;
   border: 0;
-  padding: 0.06em;
-  margin: 0 2px 0 1px;
 }
 
 #module-header #button-canvas


### PR DESCRIPTION
With this PR the icon themes will look better on windows HiDPI, as margins are moved from pixels to em units.
See after (bloom) and before (lowpass)
![Cattura7](https://user-images.githubusercontent.com/43290988/84561629-5eef0b00-ad4e-11ea-9080-ff584373012b.JPG)
Needs a small change in darktable.css for margins of the always enabled button, in order to align the svg icon.
@Nilvus Please have a look.