### PR TITLE
let gradient_slider follow gui->reset when sending value-changed signals

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -774,8 +774,8 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
   dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++)
   {
-    dtgtk_gradient_slider_multivalue_set_value(data->lower_slider, iparameters[k], k, TRUE);
-    dtgtk_gradient_slider_multivalue_set_value(data->upper_slider, oparameters[k], k, TRUE);
+    dtgtk_gradient_slider_multivalue_set_value(data->lower_slider, iparameters[k], k);
+    dtgtk_gradient_slider_multivalue_set_value(data->upper_slider, oparameters[k], k);
     dtgtk_gradient_slider_multivalue_set_resetvalue(data->lower_slider, idefaults[k], k);
     dtgtk_gradient_slider_multivalue_set_resetvalue(data->upper_slider, odefaults[k], k);
   }
@@ -1202,7 +1202,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
 
     dt_pthread_mutex_lock(&data->lock);
     for(int k = 0; k < 4; k++)
-      dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k, TRUE);
+      dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k);
     dt_pthread_mutex_unlock(&data->lock);
 
     // update picked values

--- a/src/dtgtk/gradientslider.c
+++ b/src/dtgtk/gradientslider.c
@@ -778,22 +778,22 @@ void dtgtk_gradient_slider_multivalue_get_values(GtkDarktableGradientSlider *gsl
     values[k] = gslider->scale_callback((GtkWidget *)gslider, gslider->position[k], GRADIENT_SLIDER_GET);
 }
 
-void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint pos, gboolean emit_signal)
+void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint pos)
 {
   assert(pos <= gslider->positions);
 
   gslider->position[pos] = CLAMP_RANGE(gslider->scale_callback((GtkWidget *)gslider, value, GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
-  if (emit_signal) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
+  if(!darktable.gui->reset) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
-void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values, gboolean emit_signal)
+void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values)
 {
   for(int k = 0; k < gslider->positions; k++)
     gslider->position[k] = CLAMP_RANGE(gslider->scale_callback((GtkWidget *)gslider, values[k], GRADIENT_SLIDER_SET), 0.0, 1.0);
   gslider->selected = gslider->positions == 1 ? 0 : -1;
-  if (emit_signal) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
+  if(!darktable.gui->reset) g_signal_emit_by_name(G_OBJECT(gslider), "value-changed");
   gtk_widget_queue_draw(GTK_WIDGET(gslider));
 }
 
@@ -946,9 +946,9 @@ gdouble dtgtk_gradient_slider_get_value(GtkDarktableGradientSlider *gslider)
   return dtgtk_gradient_slider_multivalue_get_value(gslider, 0);
 }
 
-void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gboolean emit_signal)
+void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value)
 {
-  dtgtk_gradient_slider_multivalue_set_value(gslider, value, 0, emit_signal);
+  dtgtk_gradient_slider_multivalue_set_value(gslider, value, 0);
 }
 
 void dtgtk_gradient_slider_set_marker(GtkDarktableGradientSlider *gslider, gint mark)

--- a/src/dtgtk/gradientslider.h
+++ b/src/dtgtk/gradientslider.h
@@ -146,7 +146,7 @@ void dtgtk_gradient_slider_multivalue_clear_stops(GtkDarktableGradientSlider *gs
 
 /** Get the slider value 0 - 1.0*/
 gdouble dtgtk_gradient_slider_get_value(GtkDarktableGradientSlider *gslider);
-void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gboolean emit_signal);
+void dtgtk_gradient_slider_set_value(GtkDarktableGradientSlider *gslider, gdouble value);
 gboolean dtgtk_gradient_slider_is_dragging(GtkDarktableGradientSlider *gslider);
 
 /** Set the slider marker */
@@ -176,8 +176,8 @@ void dtgtk_gradient_slider_multivalue_set_stop(GtkDarktableGradientSlider *gslid
 /** Get the slider value 0 - 1.0 for multivalue control */
 gdouble dtgtk_gradient_slider_multivalue_get_value(GtkDarktableGradientSlider *gslider, gint position);
 void dtgtk_gradient_slider_multivalue_get_values(GtkDarktableGradientSlider *gslider, gdouble *values);
-void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint position, gboolean emit_signal);
-void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values, gboolean emit_signal);
+void dtgtk_gradient_slider_multivalue_set_value(GtkDarktableGradientSlider *gslider, gdouble value, gint position);
+void dtgtk_gradient_slider_multivalue_set_values(GtkDarktableGradientSlider *gslider, gdouble *values);
 gboolean dtgtk_gradient_slider_multivalue_is_dragging(GtkDarktableGradientSlider *gslider);
 
 /** Set the slider markers for multivalue control */

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -277,7 +277,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_relight_params_t *p = (dt_iop_relight_params_t *)module->params;
   dt_bauhaus_slider_set(g->scale1, p->ev);
   dt_bauhaus_slider_set(g->scale2, p->width);
-  dtgtk_gradient_slider_set_value(g->gslider1, p->center, TRUE);
+  dtgtk_gradient_slider_set_value(g->gslider1, p->center);
 }
 
 void init(dt_iop_module_t *module)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1732,7 +1732,10 @@ static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer use
     // update the gradient slider
     double dlevels[3];
     for(int i = 0; i < 3; i++) dlevels[i] = p->preview_levels[i];
-    dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, dlevels, FALSE);
+
+    ++darktable.gui->reset;
+    dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, dlevels);
+    --darktable.gui->reset;
 
     g->preview_auto_levels = 0;
 
@@ -2346,7 +2349,7 @@ void gui_update(dt_iop_module_t *self)
   // update the gradient slider
   double dlevels[3];
   for(int i = 0; i < 3; i++) dlevels[i] = p->preview_levels[i];
-  dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, dlevels, FALSE);
+  dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, dlevels);
 }
 
 void change_image(struct dt_iop_module_t *self)
@@ -2599,7 +2602,7 @@ void gui_init(dt_iop_module_t *self)
   dtgtk_gradient_slider_multivalue_set_marker(g->preview_levels_gslider, GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG, 2);
   (g->preview_levels_gslider)->scale_callback = rt_gslider_scale_callback;
   double vdefault[3] = {RETOUCH_PREVIEW_LVL_MIN, (RETOUCH_PREVIEW_LVL_MIN + RETOUCH_PREVIEW_LVL_MAX) / 2.0, RETOUCH_PREVIEW_LVL_MAX};
-  dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, vdefault, FALSE);
+  dtgtk_gradient_slider_multivalue_set_values(g->preview_levels_gslider, vdefault);
   dtgtk_gradient_slider_multivalue_set_resetvalues(g->preview_levels_gslider, vdefault);
   (g->preview_levels_gslider)->markers_type = PROPORTIONAL_MARKERS;
   (g->preview_levels_gslider)->min_spacing = 0.05;


### PR DESCRIPTION
Since I didn't get a response to https://github.com/darktable-org/darktable/pull/5395#issuecomment-643102351 I prepared a quick PR to show what would be the consistent approach to determining whether the gradient slider should fire off a value-changed signal.

If there is a reason to not follow this pattern (that both bauhaus combobox and slider use) then please explain.

I believe this PR shouldn't change the behavior, except in relight::gui->update where the extended dtgtk_gradient_slider_set_value was called with a TRUE flag. Was this intentional and needed? If not, it is the kind of inconsistency that using the global gui_reset flag makes easier to avoid...