### PR TITLE
allow all modules that can be disabled to be removed from history

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1402,8 +1402,6 @@ void _dev_insert_module(dt_develop_t *dev, dt_iop_module_t *module, const int im
 
 static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
 {
-  // NOTE: the presets/default iops will be *prepended* into the history.
-
   const int imgid = dev->image_storage.id;
 
   if(imgid <= 0) return FALSE;
@@ -1608,35 +1606,37 @@ static void _dev_merge_history(dt_develop_t *dev, const int imgid)
       g_list_free(rowids);
     }
 
-    // advance the current history by cnt amount, that is, make space for the preset/default iops that will be
-    // *prepended* into the history.
+    int maxhist = 0;
+    // get maximum row number in history
+    DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db), "SELECT MAX(num) FROM main.history", -1,
+                                &stmt, NULL);
+    if(sqlite3_step(stmt) == SQLITE_ROW)
+    {
+      // if there is anything..
+      maxhist = sqlite3_column_int(stmt, 0);
+      sqlite3_finalize(stmt);
+    }
+
+    // update the end point of the history
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE main.history SET num=num+?1 WHERE imgid=?2", -1, &stmt, NULL);
+                                "UPDATE main.images SET history_end=history_end+?1 WHERE id=?2",
+                                -1, &stmt, NULL);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, cnt);
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
 
     if(sqlite3_step(stmt) == SQLITE_DONE)
     {
+      // and finally append the new items
       sqlite3_finalize(stmt);
-      DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                  "UPDATE main.images SET history_end=history_end+?1 WHERE id=?2",
-                                  -1, &stmt, NULL);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, cnt);
-      DT_DEBUG_SQLITE3_BIND_INT(stmt, 2, imgid);
-
-      if(sqlite3_step(stmt) == SQLITE_DONE)
-      {
-        // and finally prepend the rest with increasing numbers (starting at 0)
-        sqlite3_finalize(stmt);
-        DT_DEBUG_SQLITE3_PREPARE_V2(
-          dt_database_get(darktable.db),
-          "INSERT INTO main.history"
-          " SELECT imgid, num, module, operation, op_params, enabled, "
-          "        blendop_params, blendop_version, multi_priority, multi_name FROM memory.history",
-          -1, &stmt, NULL);
-        sqlite3_step(stmt);
-        sqlite3_finalize(stmt);
-      }
+      DT_DEBUG_SQLITE3_PREPARE_V2(
+        dt_database_get(darktable.db),
+        "INSERT INTO main.history"
+        " SELECT imgid, num+?1, module, operation, op_params, enabled, "
+        "        blendop_params, blendop_version, multi_priority, multi_name FROM memory.history",
+        -1, &stmt, NULL);
+      DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, maxhist);
+      sqlite3_step(stmt);
+      sqlite3_finalize(stmt);
     }
   }
 }
@@ -1678,7 +1678,7 @@ void dt_dev_read_history_ext(dt_develop_t *dev, const int imgid, gboolean no_ima
     // cleanup
     DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "DELETE FROM memory.history", NULL, NULL, NULL);
 
-    // prepend all default modules to memory.history
+    // append all default modules to memory.history
     _dev_add_default_modules(dev, imgid);
     const int default_modules = _dev_get_module_nb_records();
 

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -340,7 +340,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   {
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
     piece->hash = 0;
-    piece->enabled = piece->module->default_enabled;
+    piece->enabled = (piece->module->default_enabled && piece->module->hide_enable_button);
     dt_iop_commit_params(piece->module, piece->module->default_params, piece->module->default_blendop_params,
                          pipe, piece);
     nodes = g_list_next(nodes);


### PR DESCRIPTION
modules that are enabled by default (module->default_enabled) but
can be manually disabled (!module->hide_enable_button) can now
be removed from history

when selecting items in the history stack prior to such modules, the
stack and image treat these modules as disabled

does not impact modules that are forced on and cannot be disabled (i.e.
those with module->hide_enable_button set)

Resolves #5434