### PR TITLE
toneequal: clicking on display exposure mask always works

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -1997,12 +1997,7 @@ static void show_luminance_mask_callback(GtkWidget *togglebutton, dt_iop_module_
   if(darktable.gui->reset) return;
   dt_iop_request_focus(self);
 
-  if(!self->enabled)
-  {
-    // If module disabled, enable and do nothing
-    dt_dev_add_history_item(darktable.develop, self, TRUE);
-    return;
-  }
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
 
   dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
 


### PR DESCRIPTION
fixes issue where clicking on the exposure mask button in the tone
equalizer module didn't work correctly the first time the module was
used (if the module was disabled) - it switched the module
on but did not display the mask.