### PR TITLE
Properly raise DT_SIGNAL_IMAGE_INFO_CHANGED for compressed history.

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1049,6 +1049,9 @@ void dt_history_compress_on_image(int32_t imgid)
   }
   dt_unlock_image(imgid);
   dt_history_hash_write_from_history(imgid, DT_HISTORY_HASH_CURRENT);
+
+  GList *imgs = g_list_append(NULL, GINT_TO_POINTER(imgid));
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgs);
 }
 
 int dt_history_compress_on_list(GList *imgs)

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -560,6 +560,19 @@ static void _thumb_update_icons(dt_thumbnail_t *thumb)
     g_free(msg);
   }
   g_free(pattern);
+
+  // we recompte the history tooltip if needed
+  thumb->is_altered = dt_image_altered(thumb->imgid);
+  gtk_widget_set_visible(thumb->w_altered, thumb->is_altered);
+  if(thumb->is_altered)
+  {
+    char *tooltip = dt_history_get_items_as_string(thumb->imgid);
+    if(tooltip)
+    {
+      gtk_widget_set_tooltip_text(thumb->w_altered, tooltip);
+      g_free(tooltip);
+    }
+  }
 }
 
 static gboolean _thumbs_hide_overlays(gpointer user_data)


### PR DESCRIPTION
Fixes #5455.