### PR TITLE
Always-on icons should be cairo-painted the same size as others.

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -272,16 +272,18 @@ void dtgtk_cairo_paint_switch_on(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   PREAMBLE(1, 0, 0)
 
-  if(flags & CPF_FOCUS)
-  {
-    cairo_arc(cr, 0.5, 0.5, 0.65, 0, 2 * M_PI);
-    cairo_stroke(cr);
-  }
-  cairo_arc(cr, 0.5, 0.5, 0.35, 0, 2 * M_PI);
-  cairo_fill(cr);
-
   cairo_arc(cr, 0.5, 0.5, 0.50, 0, 2 * M_PI);
   cairo_stroke(cr);
+
+  cairo_arc(cr, 0.5, 0.5, 0.30, 0, 2 * M_PI);
+  cairo_fill(cr);
+
+  if(flags & CPF_FOCUS)
+  {
+    cairo_arc(cr, 0.5, 0.5, 0.50, 0.0, 2*M_PI);
+    cairo_clip(cr);
+    cairo_paint_with_alpha(cr, 0.5);
+  }
 
   FINISH
 }


### PR DESCRIPTION
Related to #5445

Not in focus
![Bildschirmfoto von 2020-06-13 23-17-28](https://user-images.githubusercontent.com/50982232/84579225-71a82500-adcc-11ea-9f71-5b0098e262d5.png)

In Focus
![Bildschirmfoto von 2020-06-13 23-17-22](https://user-images.githubusercontent.com/50982232/84579231-81276e00-adcc-11ea-8702-9895ea021082.png)

Still good to distinguish and nothing new ...
