### PR TITLE
add keyboard shortcut to toggle tooltip visibility

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -817,6 +817,7 @@ popover,
 combobox window,
 dialog combobox window
 {
+  opacity: 1;
   background-color: @tooltip_bg_color;
   outline-style:none;
   border-radius: 4px;


### PR DESCRIPTION
allows tooltip visibility to be toggled via a global keyboard shortcut
(defaults to SHIFT-T)

as this functionality requires window compositing to be enabled on X11
systems an error is displayed if compositing is disabled

Resolves #5382