### PR TITLE
edited fields focus fix

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -959,6 +959,12 @@ static gboolean _event_button_press(GtkWidget *widget, GdkEventButton *event, gp
     dt_control_signal_raise(darktable.signals, DT_SIGNAL_VIEWMANAGER_THUMBTABLE_ACTIVATE, id);
   }
 
+  if(event->button == 1 && event->type == GDK_BUTTON_PRESS)
+  {
+    // make sure any edition field loses the focus
+    gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
+  }
+
   if(table->mode != DT_THUMBTABLE_MODE_ZOOM && id < 1 && event->button == 1 && event->type == GDK_BUTTON_PRESS)
   {
     // we click in an empty area, let's deselect all images
@@ -1103,13 +1109,6 @@ static void _dt_mouse_over_image_callback(gpointer instance, gpointer user_data)
   dt_thumbtable_t *table = (dt_thumbtable_t *)user_data;
 
   const int imgid = dt_control_get_mouse_over_id();
-
-  if(imgid > 0)
-  {
-    // let's be absolutely sure that the right widget has the focus
-    // otherwise accels don't work...
-    gtk_widget_grab_focus(dt_ui_center(darktable.gui->ui));
-  }
 
   int groupid = -1;
   // we crawl over all images to find the right one

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -1253,9 +1253,21 @@ static void _new_button_clicked(GtkButton *button, dt_lib_module_t *self)
                     tagname ? tagname + 1 : d->last_tag);
 }
 
-static void _entry_activated(GtkButton *button, dt_lib_module_t *self)
+static gboolean _key_pressed(GtkWidget *entry, GdkEventKey *event, dt_lib_module_t *self)
 {
-  _new_button_clicked(NULL, self);
+  switch(event->keyval)
+  {
+    case GDK_KEY_Return:
+    case GDK_KEY_KP_Enter:
+      _new_button_clicked(NULL, self);
+      break;
+    case GDK_KEY_Escape:
+      gtk_window_set_focus(GTK_WINDOW(dt_ui_main_window(darktable.gui->ui)), NULL);
+      break;
+    default:
+      break;
+  }
+  return FALSE;
 }
 
 static void _clear_entry_button_callback(GtkButton *button, dt_lib_module_t *self)
@@ -2720,7 +2732,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
   gtk_widget_add_events(GTK_WIDGET(w), GDK_KEY_RELEASE_MASK);
   g_signal_connect(G_OBJECT(w), "changed", G_CALLBACK(_tag_name_changed), (gpointer)self);
-  g_signal_connect(G_OBJECT(w), "activate", G_CALLBACK(_entry_activated), (gpointer)self);
+  g_signal_connect(G_OBJECT(w), "key-press-event", G_CALLBACK(_key_pressed), (gpointer)self);
   d->entry = GTK_ENTRY(w);
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->entry));
 


### PR DESCRIPTION
edited fields focus fix
- don't grab focus on hovering thumbnails
- ~~metadata clear entry when focus is lost~~
- metadata remove redraw widget callback (cairo not involved here)
- ~~tag clear entry when focus is lost~~
- treat tag entry escape

Fixes #5460 

Pinging @AlicVB for potential side effect on thumbtable. On my side I haven't seen any, but your vision on this is surely better than mine.


