### PR TITLE
expose DPI and GUI scaling factors in prefs

### DIFF
--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -125,9 +125,6 @@ static void _ui_widget_redraw_callback(gpointer instance, GtkWidget *widget);
 static void _ui_log_redraw_callback(gpointer instance, GtkWidget *widget);
 static void _ui_toast_redraw_callback(gpointer instance, GtkWidget *widget);
 
-/* Set the HiDPI stuff */
-static void configure_ppd_dpi(dt_gui_gtk_t *gui);
-
 /*
  * OLD UI API
  */
@@ -998,7 +995,7 @@ static gboolean configure(GtkWidget *da, GdkEventConfigure *event, gpointer user
   oldh = event->height;
 
 #ifndef GDK_WINDOWING_QUARTZ
-  configure_ppd_dpi((dt_gui_gtk_t *) user_data);
+  dt_configure_ppd_dpi((dt_gui_gtk_t *) user_data);
 #endif
 
   return dt_control_configure(da, event, user_data);
@@ -1448,7 +1445,7 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
   dt_cleanup();
 }
 
-static void configure_ppd_dpi(dt_gui_gtk_t *gui)
+void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
 {
   GtkWidget *widget = gui->ui->main_window;
 
@@ -1537,7 +1534,7 @@ static void init_widgets(dt_gui_gtk_t *gui)
   gtk_widget_set_name(widget, "main_window");
   gui->ui->main_window = widget;
 
-  configure_ppd_dpi(gui);
+  dt_configure_ppd_dpi(gui);
 
   gtk_window_set_default_size(GTK_WINDOW(widget), DT_PIXEL_APPLY_DPI(900), DT_PIXEL_APPLY_DPI(500));
 
@@ -2725,12 +2722,12 @@ void dt_gui_load_theme(const char *theme)
   //set font size
   if(dt_conf_get_bool("use_system_font"))
     gtk_settings_reset_property(gtk_settings_get_default(), "gtk-font-name");
-  else 
+  else
   {
     //font name can only use period as decimal separator
     //but printf format strings use comma for some locales, so replace comma with period
     gchar *font_size = dt_util_dstrcat(NULL, _("%.1f"), dt_conf_get_float("font_size"));
-    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %s"), dt_util_str_replace(font_size, ",", ".")); 
+    gchar *font_name = dt_util_dstrcat(NULL, _("Sans %s"), dt_util_str_replace(font_size, ",", "."));
     g_object_set(gtk_settings_get_default(), "gtk-font-name", font_name, NULL);
     g_free(font_size);
     g_free(font_name);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -376,6 +376,9 @@ void dt_gui_add_help_link(GtkWidget *widget, const char *link);
 // load a CSS theme
 void dt_gui_load_theme(const char *theme);
 
+// reload GUI scalings
+void dt_configure_ppd_dpi(dt_gui_gtk_t *gui);
+
 //translate key press events to remove any modifiers used to produce the keyval
 // for example when the shift key is used to create the asterisk character
 guint dt_gui_translated_key_state(GdkEventKey *event);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -379,7 +379,7 @@ static void init_tab_general(GtkWidget *stack)
 
 
   //font size selector
-  if(dt_conf_get_bool("use_system_font") < 5.0f || dt_conf_get_float("font_size") > 20.0f)
+  if(dt_conf_get_float("font_size") < 5.0f || dt_conf_get_float("font_size") > 20.0f)
     dt_conf_set_float("font_size", 12.0f);
 
   label = gtk_label_new(_("font size in points"));

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -203,6 +203,20 @@ static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
+static void gui_scaling_changed_callback(GtkWidget *widget, gpointer user_data)
+{
+  dt_conf_set_float("screen_ppd_overwrite", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+  dt_configure_ppd_dpi(darktable.gui);
+  dt_bauhaus_load_theme();
+}
+
+static void dpi_scaling_changed_callback(GtkWidget *widget, gpointer user_data)
+{
+  dt_conf_set_float("screen_dpi_overwrite", gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget)));
+  dt_configure_ppd_dpi(darktable.gui);
+  dt_bauhaus_load_theme();
+}
+
 static void use_sys_font_callback(GtkWidget *widget, gpointer user_data)
 {
   dt_conf_set_bool("use_system_font", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
@@ -365,7 +379,7 @@ static void init_tab_general(GtkWidget *stack)
 
 
   //font size selector
-  if(dt_conf_get_float("font_size") < 5.0f || dt_conf_get_float("font_size") > 20.0f)
+  if(dt_conf_get_bool("use_system_font") < 5.0f || dt_conf_get_float("font_size") > 20.0f)
     dt_conf_set_float("font_size", 12.0f);
 
   label = gtk_label_new(_("font size in points"));
@@ -379,6 +393,33 @@ static void init_tab_general(GtkWidget *stack)
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
   g_signal_connect(G_OBJECT(fontsize), "value_changed", G_CALLBACK(font_size_changed_callback), 0);
 
+  GtkWidget *screen_ppd_overwrite = gtk_spin_button_new_with_range(-1.0f, 8.0f, 0.2f);
+  label = gtk_label_new(_("images DPI scaling factor"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), screen_ppd_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(screen_ppd_overwrite, _("scale the thumbnails and previews resolutions for high DPI screens.\n"
+                                                      "increase if thumbnails look blurry, decrease if lighttable is too slow.\n"
+                                                      "-1.0 uses the system global scaling if defined."));
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_ppd_overwrite), dt_conf_get_float("screen_ppd_overwrite"));
+  g_signal_connect(G_OBJECT(screen_ppd_overwrite), "value_changed", G_CALLBACK(gui_scaling_changed_callback), 0);
+
+  GtkWidget *screen_dpi_overwrite = gtk_spin_button_new_with_range(-1.0f, 360, 1.f);
+  label = gtk_label_new(_("GUI DPI"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), screen_dpi_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(screen_dpi_overwrite, _("adjust the global GUI resolution to rescale icons and controls.\n"
+                                                      "increase for a magnified GUI, decrease to fit more content in window.\n"
+                                                      "-1.0 uses the system global resolution if defined."));
+  gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_dpi_overwrite), dt_conf_get_float("screen_dpi_overwrite"));
+  g_signal_connect(G_OBJECT(screen_dpi_overwrite), "value_changed", G_CALLBACK(dpi_scaling_changed_callback), 0);
 
   //checkbox to allow user to modify theme with user.css
   label = gtk_label_new(_("modify selected theme with CSS tweaks below"));
@@ -445,6 +486,19 @@ static void init_tab_general(GtkWidget *stack)
 
 ///////////// end of gui and theme language selection
 
+gboolean preferences_window_deleted(GtkWidget *widget, GdkEvent *event, gpointer data)
+{
+  // redraw the whole UI in case sizes have changed
+  gtk_widget_queue_resize(dt_ui_center(darktable.gui->ui));
+  gtk_widget_queue_resize(dt_ui_main_window(darktable.gui->ui));
+
+  gtk_widget_queue_draw(dt_ui_main_window(darktable.gui->ui));
+  gtk_widget_queue_draw(dt_ui_center(darktable.gui->ui));
+
+  gtk_widget_hide(widget);
+  return TRUE;
+}
+
 
 void dt_gui_preferences_show()
 {
@@ -452,6 +506,7 @@ void dt_gui_preferences_show()
   _preferences_dialog = gtk_dialog_new_with_buttons(_("darktable preferences"), win,
                                                     GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
                                                     NULL, NULL);
+  g_signal_connect(G_OBJECT(_preferences_dialog), "delete-event", G_CALLBACK(preferences_window_deleted), NULL);
   gtk_window_set_default_size(GTK_WINDOW(_preferences_dialog), DT_PIXEL_APPLY_DPI(1100), DT_PIXEL_APPLY_DPI(700));
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(_preferences_dialog);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -403,7 +403,8 @@ static void init_tab_general(GtkWidget *stack)
   gtk_grid_attach_next_to(GTK_GRID(grid), screen_ppd_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(screen_ppd_overwrite, _("scale the thumbnails and previews resolutions for high DPI screens.\n"
                                                       "increase if thumbnails look blurry, decrease if lighttable is too slow.\n"
-                                                      "set to -1.0 to use the system-defined global scaling."));
+                                                      "set to -1.0 to use the system-defined global scaling.\n"
+                                                      "this needs a restart to apply changes."));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_ppd_overwrite), dt_conf_get_float("screen_ppd_overwrite"));
   g_signal_connect(G_OBJECT(screen_ppd_overwrite), "value_changed", G_CALLBACK(gui_scaling_changed_callback), 0);
 
@@ -417,7 +418,8 @@ static void init_tab_general(GtkWidget *stack)
   gtk_grid_attach_next_to(GTK_GRID(grid), screen_dpi_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(screen_dpi_overwrite, _("adjust the global GUI resolution to rescale controls, buttons, labels, etc.\n"
                                                       "increase for a magnified GUI, decrease to fit more content in window.\n"
-                                                      "set to -1.0 to use the system-defined global resolution."));
+                                                      "set to -1.0 to use the system-defined global resolution.\n"
+                                                      "this needs a restart to apply changes."));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_dpi_overwrite), dt_conf_get_float("screen_dpi_overwrite"));
   g_signal_connect(G_OBJECT(screen_dpi_overwrite), "value_changed", G_CALLBACK(dpi_scaling_changed_callback), 0);
 
@@ -486,6 +488,8 @@ static void init_tab_general(GtkWidget *stack)
 
 ///////////// end of gui and theme language selection
 
+#if 0
+// FIXME! this makes some systems hang forever. I don't reproduce.
 gboolean preferences_window_deleted(GtkWidget *widget, GdkEvent *event, gpointer data)
 {
   // redraw the whole UI in case sizes have changed
@@ -498,7 +502,7 @@ gboolean preferences_window_deleted(GtkWidget *widget, GdkEvent *event, gpointer
   gtk_widget_hide(widget);
   return TRUE;
 }
-
+#endif
 
 void dt_gui_preferences_show()
 {
@@ -506,7 +510,11 @@ void dt_gui_preferences_show()
   _preferences_dialog = gtk_dialog_new_with_buttons(_("darktable preferences"), win,
                                                     GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
                                                     NULL, NULL);
+#if 0
+  // FIXME! this makes some systems hang forever. I don't reproduce.
   g_signal_connect(G_OBJECT(_preferences_dialog), "delete-event", G_CALLBACK(preferences_window_deleted), NULL);
+#endif
+    
   gtk_window_set_default_size(GTK_WINDOW(_preferences_dialog), DT_PIXEL_APPLY_DPI(1100), DT_PIXEL_APPLY_DPI(700));
 #ifdef GDK_WINDOWING_QUARTZ
   dt_osx_disallow_fullscreen(_preferences_dialog);

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -394,7 +394,7 @@ static void init_tab_general(GtkWidget *stack)
   g_signal_connect(G_OBJECT(fontsize), "value_changed", G_CALLBACK(font_size_changed_callback), 0);
 
   GtkWidget *screen_ppd_overwrite = gtk_spin_button_new_with_range(-1.0f, 8.0f, 0.2f);
-  label = gtk_label_new(_("images DPI scaling factor"));
+  label = gtk_label_new(_("GUI thumbs and previews DPI scaling factor"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);
   labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
@@ -403,21 +403,21 @@ static void init_tab_general(GtkWidget *stack)
   gtk_grid_attach_next_to(GTK_GRID(grid), screen_ppd_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
   gtk_widget_set_tooltip_text(screen_ppd_overwrite, _("scale the thumbnails and previews resolutions for high DPI screens.\n"
                                                       "increase if thumbnails look blurry, decrease if lighttable is too slow.\n"
-                                                      "-1.0 uses the system global scaling if defined."));
+                                                      "set to -1.0 to use the system-defined global scaling."));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_ppd_overwrite), dt_conf_get_float("screen_ppd_overwrite"));
   g_signal_connect(G_OBJECT(screen_ppd_overwrite), "value_changed", G_CALLBACK(gui_scaling_changed_callback), 0);
 
   GtkWidget *screen_dpi_overwrite = gtk_spin_button_new_with_range(-1.0f, 360, 1.f);
-  label = gtk_label_new(_("GUI DPI"));
+  label = gtk_label_new(_("GUI controls and text DPI"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);
   labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
   gtk_grid_attach_next_to(GTK_GRID(grid), screen_dpi_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(screen_dpi_overwrite, _("adjust the global GUI resolution to rescale icons and controls.\n"
+  gtk_widget_set_tooltip_text(screen_dpi_overwrite, _("adjust the global GUI resolution to rescale controls, buttons, labels, etc.\n"
                                                       "increase for a magnified GUI, decrease to fit more content in window.\n"
-                                                      "-1.0 uses the system global resolution if defined."));
+                                                      "set to -1.0 to use the system-defined global resolution."));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_dpi_overwrite), dt_conf_get_float("screen_dpi_overwrite"));
   g_signal_connect(G_OBJECT(screen_dpi_overwrite), "value_changed", G_CALLBACK(dpi_scaling_changed_callback), 0);
 


### PR DESCRIPTION
try to redraw the whole GUI when pref window is deleted, but only some widgets are redrawn.

![Capture d’écran du 2020-06-14 18-17-06](https://user-images.githubusercontent.com/2779157/84598477-4f191900-ae6b-11ea-99dd-0baa569d67b6.png)
