### PR TITLE
cmake: Silence some cmake 3.17 warnings

### DIFF
--- a/cmake/modules/FindMacIntegration.cmake
+++ b/cmake/modules/FindMacIntegration.cmake
@@ -1,32 +1,32 @@
 # - Find the native GtkOSXApplication includes and library
 #
 # This module defines
-#  MACINTEGRATION_INCLUDE_DIR, where to find gtkosxapplication.h, etc.
-#  MACINTEGRATION_LIBRARIES, the libraries to link against to use GtkOSXApplication.
-#  MACINTEGRATION_FOUND, If false, do not try to use GtkOSXApplication.
+#  MacIntegration_INCLUDE_DIR, where to find gtkosxapplication.h, etc.
+#  MacIntegration_LIBRARIES, the libraries to link against to use GtkOSXApplication.
+#  MacIntegration_FOUND, If false, do not try to use GtkOSXApplication.
 # also defined, but not for general use are
-#  MACINTEGRATION_LIBRARY, where to find the GtkOSXApplication library.
+#  MacIntegration_LIBRARY, where to find the GtkOSXApplication library.
 
 
 #=============================================================================
 # Copyright 2010 henrik andersson
 #=============================================================================
 
-SET(MACINTEGRATION_FIND_REQUIRED ${MacIntegration_FIND_REQUIRED})
+SET(MacIntegration_FIND_REQUIRED ${MacIntegration_FIND_REQUIRED})
 
-find_path(MACINTEGRATION_INCLUDE_DIR gtkosxapplication.h PATH_SUFFIXES gtkmacintegration gtkmacintegration-gtk3)
-mark_as_advanced(MACINTEGRATION_INCLUDE_DIR)
+find_path(MacIntegration_INCLUDE_DIR gtkosxapplication.h PATH_SUFFIXES gtkMacIntegration gtkMacIntegration-gtk3)
+mark_as_advanced(MacIntegration_INCLUDE_DIR)
 
-set(MACINTEGRATION_NAMES ${MACINTEGRATION_NAMES} gtkmacintegration libgtkmacintegration gtkmacintegration-gtk3 libgtkmacintegration-gtk3)
-find_library(MACINTEGRATION_LIBRARY NAMES ${MACINTEGRATION_NAMES})
-mark_as_advanced(MACINTEGRATION_LIBRARY)
+set(MacIntegration_NAMES ${MacIntegration_NAMES} gtkMacIntegration libgtkMacIntegration gtkMacIntegration-gtk3 libgtkMacIntegration-gtk3)
+find_library(MacIntegration_LIBRARY NAMES ${MacIntegration_NAMES})
+mark_as_advanced(MacIntegration_LIBRARY)
 
-# handle the QUIETLY and REQUIRED arguments and set MACINTEGRATION_FOUND to TRUE if
+# handle the QUIETLY and REQUIRED arguments and set MacIntegration_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MACINTEGRATION DEFAULT_MSG MACINTEGRATION_LIBRARY MACINTEGRATION_INCLUDE_DIR)
+find_package_handle_standard_args(MacIntegration DEFAULT_MSG MacIntegration_LIBRARY MacIntegration_INCLUDE_DIR)
 
-IF(MACINTEGRATION_FOUND)
-  SET(MacIntegration_LIBRARIES ${MACINTEGRATION_LIBRARY})
-  SET(MacIntegration_INCLUDE_DIRS ${MACINTEGRATION_INCLUDE_DIR})
-ENDIF(MACINTEGRATION_FOUND)
+IF(MacIntegration_FOUND)
+  SET(MacIntegration_LIBRARIES ${MacIntegration_LIBRARY})
+  SET(MacIntegration_INCLUDE_DIRS ${MacIntegration_INCLUDE_DIR})
+ENDIF(MacIntegration_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -412,11 +412,11 @@ endif(USE_KWALLET)
 
 if(USE_MAC_INTEGRATION)
   find_package(MacIntegration)
-  if(MACINTEGRATION_FOUND)
+  if(MacIntegration_FOUND)
     include_directories(SYSTEM ${MacIntegration_INCLUDE_DIRS})
     list(APPEND LIBS ${MacIntegration_LIBRARIES})
     add_definitions("-DMAC_INTEGRATION")
-  endif(MACINTEGRATION_FOUND)
+  endif(MacIntegration_FOUND)
 endif(USE_MAC_INTEGRATION)
 
 if(USE_UNITY)


### PR DESCRIPTION
This PR turns off warnings of Cmake during FindPackage, like 8f01e4cbc17dc81e706a8cbc22a00a11125559e5 did. 

Since the warnings remained in macintegration it did not show up to linux/windows users yet.

No harm possible :-)