### PR TITLE
forget margin-top offset as it doesn't works if using WM without compositing

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -811,12 +811,13 @@ context-menu,
 menu,
 menuitem > menu, /* sub-menu */
 menuitem arrow,
-tooltip label,
+tooltip,
 popover,
 #background_job_eventbox, /* background of export progress bar */
 combobox window,
 dialog combobox window
 {
+  opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
   background-color: @tooltip_bg_color;
   border-radius: 4px;
   border: 0;
@@ -828,21 +829,12 @@ dialog combobox window
 
 tooltip
 {
-  opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
-}
-
-tooltip *,
-tooltip.background
-{
-  background-color: transparent;
+  border: 1px solid shade(@tooltip_bg_color, 1.5);
 }
 
 tooltip label
 {
-  margin-top: 3px;
-  padding: 0.4em;
   color: @tooltip_fg_color;
-  border: 1px solid shade(@tooltip_bg_color, 1.5);
 }
 
 combobox label

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -830,6 +830,7 @@ dialog combobox window
 tooltip
 {
   border: 1px solid shade(@tooltip_bg_color, 1.5);
+  border-radius: 0;
 }
 
 tooltip label


### PR DESCRIPTION
Related to #5438 and revert a part back as it doesn't work if no compositing. That just remove margin-top and so transparent background issue. @elstoc and @parafin: as you have way to quickly test a WM without compositing, could you please test?
It's always better to test if possible before than after merging. Thanks.