### PR TITLE
variable $(SEQUENCEn), n added to control the number of digits

### DIFF
--- a/doc/usermanual/lighttable/panels/export.xml
+++ b/doc/usermanual/lighttable/panels/export.xml
@@ -141,10 +141,10 @@
             </row>
             <row>
               <entry>
-                <code>$(SEQUENCE)</code>
+                <code>$(SEQUENCEn)</code>
               </entry>
               <entry>
-                a sequence number within export job
+                a sequence number within export job, 4 digits if n is not specified
               </entry>
             </row>
             <row>

--- a/src/common/variables.c
+++ b/src/common/variables.c
@@ -330,7 +330,15 @@ static char *get_base_value(dt_variables_params_t *params, char **variable)
   else if(has_prefix(variable, "FILE_EXTENSION"))
     result = g_strdup(params->data->file_ext);
   else if(has_prefix(variable, "SEQUENCE"))
-    result = g_strdup_printf("%.4d", params->sequence >= 0 ? params->sequence : params->data->sequence);
+  {
+    uint8_t nb_digit = 4;
+    if(g_ascii_isdigit(*variable[0]))
+    {
+      nb_digit = (uint8_t)*variable[0] & 0b1111;
+      (*variable) ++;
+    }
+    result = g_strdup_printf("%.*d", nb_digit, params->sequence >= 0 ? params->sequence : params->data->sequence);
+  }
   else if(has_prefix(variable, "USERNAME"))
     result = g_strdup(g_get_user_name());
   else if(has_prefix(variable, "HOME_FOLDER"))


### PR DESCRIPTION
Small variables enhancement.
variable $(SEQUENCEn), optional 'n' added to control the number of digits.
The default value (4) is kept.

EDIT The $(SEQUENCE) variable can be used in conjunction with custom order tag collection. Then the order of exported images can be kept inside the exported filenames. But 4, if conservative, is a bit too much for most of the collections.