### PR TITLE
Thumbtable icons size

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1841,6 +1841,11 @@ Details :
   background-color: @lighttable_bg_color;
 }
 
+#thumbtable_filemanager
+{
+min-height: 2em;
+}
+
 #thumb_back
 {
   background-color: @thumbnail_bg_color;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1841,9 +1841,13 @@ Details :
   background-color: @lighttable_bg_color;
 }
 
-#thumbtable_filemanager
+/* here we set the maximum size of GUI elements in thumbtable view to be in synch with the rest of the GUI */
+#thumbtable_filemanager,
+#thumbtable_filmstrip,
+#thumbtable_zoom,
+#culling
 {
-min-height: 2em;
+min-height: 1.47em;
 }
 
 #thumb_back

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -825,6 +825,8 @@ dt_culling_t *dt_culling_new(dt_culling_mode_t mode)
   g_signal_connect(G_OBJECT(table->widget), "button-press-event", G_CALLBACK(_event_button_press), table);
   g_signal_connect(G_OBJECT(table->widget), "motion-notify-event", G_CALLBACK(_event_motion_notify), table);
   g_signal_connect(G_OBJECT(table->widget), "button-release-event", G_CALLBACK(_event_button_release), table);
+  // set the size of icons and other elements
+  g_signal_connect(G_OBJECT(table->widget), "map", G_CALLBACK(dt_thumbtable_icons_register_size), table);
 
   // we register globals signals
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1530,7 +1530,7 @@ static void _event_dnd_end(GtkWidget *widget, GdkDragContext *context, gpointer 
   gtk_style_context_remove_class(tablecontext, "dt_thumbtable_reorder");
 }
 
-void dt_thumbtable_icons_register_size(GtkWidget *widget, gpointer user_data)
+void dt_thumbtable_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
 {
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
@@ -1587,7 +1587,7 @@ dt_thumbtable_t *dt_thumbtable_new()
   g_signal_connect(G_OBJECT(table->widget), "motion-notify-event", G_CALLBACK(_event_motion_notify), table);
   g_signal_connect(G_OBJECT(table->widget), "button-release-event", G_CALLBACK(_event_button_release), table);
   // set the size of icons and other elements
-  g_signal_connect(G_OBJECT(table->widget), "map", G_CALLBACK(dt_thumbtable_icons_register_size), table);
+  g_signal_connect(G_OBJECT(table->widget), "size-allocate", G_CALLBACK(dt_thumbtable_icons_register_size), table);
 
   // we register globals signals
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1530,35 +1530,18 @@ static void _event_dnd_end(GtkWidget *widget, GdkDragContext *context, gpointer 
   gtk_style_context_remove_class(tablecontext, "dt_thumbtable_reorder");
 }
 
-static void _icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
+void dt_thumbtable_icons_register_size(GtkWidget *widget, gpointer user_data)
 {
-/*
   GtkStateFlags state = gtk_widget_get_state_flags(widget);
   GtkStyleContext *context = gtk_widget_get_style_context(widget);
 
-  // get the css geometry properties
-  GtkBorder margin, border, padding;
-  gtk_style_context_get_margin(context, state, &margin);
-  gtk_style_context_get_border(context, state, &border);
-  gtk_style_context_get_padding(context, state, &padding);
+  GValue value = G_VALUE_INIT;
+  gtk_style_context_get_property(context, "min-height", state, &value);
+  g_assert (G_VALUE_HOLDS_INT (&value));
+  darktable.gui->icon_size = g_value_get_int (&value);
 
-  // we first remove css margin border and padding from allocation
-  int width = allocation->width - margin.left - margin.right - border.left - border.right - padding.left - padding.right;
-
-  GtkStyleContext *ccontext = gtk_widget_get_style_context(DTGTK_BUTTON(widget)->canvas);
-  GtkBorder cmargin;
-  gtk_style_context_get_margin(ccontext, state, &cmargin);
-
-  // we remove the extra room for optical alignment
-  width = round((float)width * (1.0 - (cmargin.left + cmargin.right) / 100.0f));
-
-  // we store the icon size in order to keep in sync thumbtable overlays
-   *
-   */
-
-  darktable.gui->icon_size = 20;
+  g_value_unset(&value);
 }
-
 
 dt_thumbtable_t *dt_thumbtable_new()
 {
@@ -1603,8 +1586,8 @@ dt_thumbtable_t *dt_thumbtable_new()
   g_signal_connect(G_OBJECT(table->widget), "button-press-event", G_CALLBACK(_event_button_press), table);
   g_signal_connect(G_OBJECT(table->widget), "motion-notify-event", G_CALLBACK(_event_motion_notify), table);
   g_signal_connect(G_OBJECT(table->widget), "button-release-event", G_CALLBACK(_event_button_release), table);
-
-  g_signal_connect(G_OBJECT(table->widget), "size-allocate", G_CALLBACK(_icons_register_size), table);
+  // set the size of icons and other elements
+  g_signal_connect(G_OBJECT(table->widget), "map", G_CALLBACK(dt_thumbtable_icons_register_size), table);
 
   // we register globals signals
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1530,6 +1530,36 @@ static void _event_dnd_end(GtkWidget *widget, GdkDragContext *context, gpointer 
   gtk_style_context_remove_class(tablecontext, "dt_thumbtable_reorder");
 }
 
+static void _icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
+{
+/*
+  GtkStateFlags state = gtk_widget_get_state_flags(widget);
+  GtkStyleContext *context = gtk_widget_get_style_context(widget);
+
+  // get the css geometry properties
+  GtkBorder margin, border, padding;
+  gtk_style_context_get_margin(context, state, &margin);
+  gtk_style_context_get_border(context, state, &border);
+  gtk_style_context_get_padding(context, state, &padding);
+
+  // we first remove css margin border and padding from allocation
+  int width = allocation->width - margin.left - margin.right - border.left - border.right - padding.left - padding.right;
+
+  GtkStyleContext *ccontext = gtk_widget_get_style_context(DTGTK_BUTTON(widget)->canvas);
+  GtkBorder cmargin;
+  gtk_style_context_get_margin(ccontext, state, &cmargin);
+
+  // we remove the extra room for optical alignment
+  width = round((float)width * (1.0 - (cmargin.left + cmargin.right) / 100.0f));
+
+  // we store the icon size in order to keep in sync thumbtable overlays
+   *
+   */
+
+  darktable.gui->icon_size = 20;
+}
+
+
 dt_thumbtable_t *dt_thumbtable_new()
 {
   dt_thumbtable_t *table = (dt_thumbtable_t *)calloc(1, sizeof(dt_thumbtable_t));
@@ -1573,6 +1603,8 @@ dt_thumbtable_t *dt_thumbtable_new()
   g_signal_connect(G_OBJECT(table->widget), "button-press-event", G_CALLBACK(_event_button_press), table);
   g_signal_connect(G_OBJECT(table->widget), "motion-notify-event", G_CALLBACK(_event_motion_notify), table);
   g_signal_connect(G_OBJECT(table->widget), "button-release-event", G_CALLBACK(_event_button_release), table);
+
+  g_signal_connect(G_OBJECT(table->widget), "size-allocate", G_CALLBACK(_icons_register_size), table);
 
   // we register globals signals
   dt_control_signal_connect(darktable.signals, DT_SIGNAL_COLLECTION_CHANGED,

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -136,6 +136,8 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, int view);
 void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overlay_t over);
 // change the timeout of the overlays block
 void dt_thumbtable_set_overlays_block_timeout(dt_thumbtable_t *table, const int timeout);
+// sets max size of icons and other gui elelemnt
+void dt_thumbtable_icons_register_size(GtkWidget *widget, gpointer user_data);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/thumbtable.h
+++ b/src/dtgtk/thumbtable.h
@@ -137,7 +137,7 @@ void dt_thumbtable_set_overlays_mode(dt_thumbtable_t *table, dt_thumbnail_overla
 // change the timeout of the overlays block
 void dt_thumbtable_set_overlays_block_timeout(dt_thumbtable_t *table, const int timeout);
 // sets max size of icons and other gui elelemnt
-void dt_thumbtable_icons_register_size(GtkWidget *widget, gpointer user_data);
+void dt_thumbtable_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/libs/tools/global_toolbox.c
+++ b/src/libs/tools/global_toolbox.c
@@ -342,32 +342,6 @@ static void _overlays_show_popup(dt_lib_module_t *self)
   d->disable_over_events = FALSE;
 }
 
-static void _main_icons_register_size(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
-{
-
-  GtkStateFlags state = gtk_widget_get_state_flags(widget);
-  GtkStyleContext *context = gtk_widget_get_style_context(widget);
-
-  /* get the css geometry properties */
-  GtkBorder margin, border, padding;
-  gtk_style_context_get_margin(context, state, &margin);
-  gtk_style_context_get_border(context, state, &border);
-  gtk_style_context_get_padding(context, state, &padding);
-
-  /* we first remove css margin border and padding from allocation */
-  int width = allocation->width - margin.left - margin.right - border.left - border.right - padding.left - padding.right;
-
-  GtkStyleContext *ccontext = gtk_widget_get_style_context(DTGTK_BUTTON(widget)->canvas);
-  GtkBorder cmargin;
-  gtk_style_context_get_margin(ccontext, state, &cmargin);
-
-  /* we remove the extra room for optical alignment */
-  width = round((float)width * (1.0 - (cmargin.left + cmargin.right) / 100.0f));
-
-  // we store the icon size in order to keep in sync thumbtable overlays
-  darktable.gui->icon_size = width;
-}
-
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -398,8 +372,6 @@ void gui_init(dt_lib_module_t *self)
 #endif
   g_signal_connect_swapped(G_OBJECT(d->overlays_button), "button-press-event", G_CALLBACK(_overlays_show_popup),
                            self);
-  // we register size of overlay icon to keep in sync thumbtable overlays
-  g_signal_connect(G_OBJECT(d->overlays_button), "size-allocate", G_CALLBACK(_main_icons_register_size), NULL);
 
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 


### PR DESCRIPTION
This is an attempt to solve #5435 
However, it doesn't work when starting DT directly in culling mode.
In that case it works only forcing a redraw, although the callback setting the size is executed.
I do not really understand how culling mode works, I need @AlicVB help here.
The other thumbtable modes seem to work, but some more tests are needed