### PR TITLE
tone curve: reverse order first two enums in colorspace dropdown

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1215,6 +1215,24 @@ gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *widget, const char *text)
   return FALSE;
 }
 
+gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *widget, int value)
+{
+  dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
+  if(w->type != DT_BAUHAUS_COMBOBOX) return FALSE;
+  dt_bauhaus_combobox_data_t *d = &w->data.combobox;
+  int i = 0;
+  for(GList *iter = d->entries; iter; iter = g_list_next(iter), i++)
+  {
+    const dt_bauhaus_combobox_entry_t *entry = (dt_bauhaus_combobox_entry_t *)iter->data;
+    if(GPOINTER_TO_INT(entry->data) == value)
+    {
+      dt_bauhaus_combobox_set(widget, i);
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
 int dt_bauhaus_combobox_get(GtkWidget *widget)
 {
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);

--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -309,6 +309,7 @@ void dt_bauhaus_combobox_add_full(GtkWidget *widget, const char *text, dt_bauhau
                                   gpointer data, void (*free_func)(void *data), gboolean sensitive);
 void dt_bauhaus_combobox_set(GtkWidget *w, int pos);
 gboolean dt_bauhaus_combobox_set_from_text(GtkWidget *w, const char *text);
+gboolean dt_bauhaus_combobox_set_from_value(GtkWidget *w, int value);
 void dt_bauhaus_combobox_remove_at(GtkWidget *widget, int pos);
 void dt_bauhaus_combobox_insert(GtkWidget *widget, const char *text,int pos);
 void dt_bauhaus_combobox_insert_full(GtkWidget *widget, const char *text, dt_bauhaus_combobox_alignment_t align,

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2485,8 +2485,8 @@ void gui_init(dt_iop_module_t *self)
 // TODO temporary workaround for introspection bug
 if(!dt_bauhaus_combobox_length(g->highlights))
 {
-  dt_bauhaus_combobox_add(g->highlights, _("hard"));
-  dt_bauhaus_combobox_add(g->highlights, _("soft"));
+  dt_bauhaus_combobox_add_full(g->highlights, _("hard"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(0), NULL, TRUE);
+  dt_bauhaus_combobox_add_full(g->highlights, _("soft"), DT_BAUHAUS_COMBOBOX_ALIGN_RIGHT, GINT_TO_POINTER(1), NULL, TRUE);
 }
   gtk_widget_set_tooltip_text(g->highlights, _("choose the desired curvature of the filmic spline in highlights.\n"
                                                "hard uses a high curvature resulting in more tonal compression.\n"

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -828,7 +828,8 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
-  dt_bauhaus_combobox_set(g->autoscale_ab, p->tonecurve_autoscale_ab);
+  // reorder first two enums, as per definition and introspection
+  dt_bauhaus_combobox_set(g->autoscale_ab, (p->tonecurve_autoscale_ab < 2 ? 1 - p->tonecurve_autoscale_ab : p->tonecurve_autoscale_ab));
 
   gui_changed(self, g->autoscale_ab, 0);
 

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -828,8 +828,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_tonecurve_gui_data_t *g = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
 
-  // reorder first two enums, as per definition and introspection
-  dt_bauhaus_combobox_set(g->autoscale_ab, (p->tonecurve_autoscale_ab < 2 ? 1 - p->tonecurve_autoscale_ab : p->tonecurve_autoscale_ab));
+  dt_bauhaus_combobox_set_from_value(g->autoscale_ab, p->tonecurve_autoscale_ab);
 
   gui_changed(self, g->autoscale_ab, 0);
 


### PR DESCRIPTION
This could be a helper function for bauhaus combobox that looks up the correct position of any enum, but out of order enums currently only used in two places (other in demosaic).