### PR TITLE
Retouch GUI rework

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -444,6 +444,7 @@ void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 {
   PREAMBLE(1, 0, 0)
 
+  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.1, 0, 6.2832);
   cairo_stroke(cr);
 
@@ -866,6 +867,7 @@ void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   PREAMBLE(1, 0, 0)
 
+  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.1, 0, 6.2832);
   cairo_stroke(cr);
 
@@ -879,7 +881,6 @@ void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, g
   cairo_translate(cr, 0, -0.20);
   if((flags & CPF_ACTIVE))
   {
-    cairo_set_source_rgba(cr, 0.6, 0.1, 0.1, 1.0);
     cairo_move_to(cr, 0.1, 0.9);
     cairo_line_to(cr, 0.9, 0.1);
     cairo_stroke(cr);
@@ -887,7 +888,6 @@ void dtgtk_cairo_paint_eye_toggle(cairo_t *cr, gint x, gint y, gint w, gint h, g
 
   FINISH
 }
-
 
 
 void dtgtk_cairo_paint_timer(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
@@ -1396,15 +1396,14 @@ void dtgtk_cairo_paint_showmask(cairo_t *cr, gint x, gint y, gint w, gint h, gin
 {
   PREAMBLE(1, 0, 0)
 
+  /* draw circle */
+  cairo_arc(cr, 0.5, 0.5, 0.30, -M_PI, M_PI);
+
   /* draw rectangle */
   cairo_rectangle(cr, 0.0, 0.0, 1.0, 1.0);
+  cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
   cairo_fill(cr);
   cairo_stroke(cr);
-
-  /* draw circle */
-  cairo_set_source_rgba(cr, 0.2, 0.2, 0.2, 1.0);
-  cairo_arc(cr, 0.5, 0.5, 0.30, -M_PI, M_PI);
-  cairo_fill(cr);
 
   FINISH
 }
@@ -2044,6 +2043,209 @@ void dtgtk_cairo_paint_map_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint
 
   FINISH
 }
+
+
+
+
+
+
+
+
+
+
+void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_arc(cr, 0.65, 0.35, 0.35, 0, 2 * M_PI);
+  cairo_stroke(cr);
+
+  cairo_arc(cr, 0.35, 0.65, 0.35, 0, 2 * M_PI);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_tool_heal(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_rectangle(cr, 0., 0., 1., 1.);
+  cairo_fill(cr);
+
+  cairo_set_source_rgba(cr, .74, 0.13, 0.13, 1.0);
+  cairo_set_line_width(cr, 0.3);
+
+  cairo_move_to(cr, 0.5, 0.18);
+  cairo_line_to(cr, 0.5, 0.82);
+  cairo_move_to(cr, 0.18, 0.5);
+  cairo_line_to(cr, 0.82, 0.5);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.1, 0.1);
+  cairo_line_to(cr, 0.2, 0.1);
+  cairo_line_to(cr, 0.2, 0.9);
+  cairo_line_to(cr, 0.8, 0.9);
+  cairo_line_to(cr, 0.8, 0.1);
+  cairo_line_to(cr, 0.9, 0.1);
+  cairo_stroke(cr);
+  cairo_rectangle(cr, 0.2, 0.4, .6, .5);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_pattern_t *pat = NULL;
+  pat = cairo_pattern_create_radial(.5, .5, 0.005, .5, .5, .5);
+  cairo_pattern_add_color_stop_rgba(pat, 0.0, 1, 1, 1, 1);
+  cairo_pattern_add_color_stop_rgba(pat, 1.0, 1, 1, 1, 0.1);
+  cairo_set_source(cr, pat);
+
+  cairo_set_line_width(cr, 0.125);
+  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+  cairo_arc(cr, 0.5, 0.5, 0.45, 0, 2 * M_PI);
+  cairo_fill(cr);
+
+  cairo_pattern_destroy(pat);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_paste_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, 0.1, 0.6);
+  cairo_line_to(cr, 0.9, 0.6);
+  cairo_line_to(cr, 0.5, 1.0);
+  cairo_close_path(cr);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0.4, 0.0);
+  cairo_line_to(cr, 0.6, 0.0);
+  cairo_line_to(cr, 0.6, 0.6);
+  cairo_line_to(cr, 0.4, 0.6);
+  cairo_fill(cr);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_cut_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, -0.07)
+
+  cairo_set_line_width(cr, 0.1);
+  if(flags & CPF_ACTIVE)
+  {
+    cairo_move_to(cr, 0.11, 0.25);
+    cairo_line_to(cr, 0.89, 0.75);
+    cairo_move_to(cr, 0.25, 0.11);
+    cairo_line_to(cr, 0.75, 0.89);
+    cairo_stroke(cr);
+
+    cairo_arc(cr, 0.89, 0.53, 0.17, 0, 2 * M_PI);
+    cairo_stroke(cr);
+
+    cairo_arc(cr, 0.53, 0.89, 0.17, 0, 2 * M_PI);
+    cairo_stroke(cr);
+  }
+  else
+  {
+    cairo_move_to(cr, 0.01, 0.35);
+    cairo_line_to(cr, 0.99, 0.65);
+    cairo_move_to(cr, 0.35, 0.01);
+    cairo_line_to(cr, 0.65, 0.99);
+    cairo_stroke(cr);
+
+    cairo_arc(cr, 0.89, 0.53, 0.17, 0, 2 * M_PI);
+    cairo_stroke(cr);
+
+    cairo_arc(cr, 0.53, 0.89, 0.17, 0, 2 * M_PI);
+    cairo_stroke(cr);
+  }
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_display_wavelet_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(0.93, 0, 0)
+
+  if(flags & CPF_ACTIVE)
+  {
+    float x1 = 0.2f;
+    float y1 = 1.f;
+
+    cairo_move_to(cr, x1, y1);
+
+    const int steps = 4;
+    const float delta = 1. / (float)steps;
+    for(int i = 0; i < steps; i++)
+    {
+      y1 -= delta;
+      cairo_line_to(cr, x1, y1);
+      x1 += delta;
+      if(x1 > .9) x1 = .9;
+      cairo_line_to(cr, x1, y1);
+    }
+    cairo_stroke(cr);
+
+    cairo_set_line_width(cr, 0.1);
+    cairo_rectangle(cr, 0., 0., 1., 1.);
+    cairo_stroke(cr);
+  }
+  else
+  {
+    cairo_move_to(cr, 0.08, 1.);
+    cairo_curve_to(cr, 0.4, 0.05, 0.6, 0.05, 1., 1.);
+    cairo_line_to(cr, 0.08, 1.);
+    cairo_fill(cr);
+
+    cairo_set_line_width(cr, 0.1);
+    cairo_rectangle(cr, 0., 0., 1., 1.);
+    cairo_stroke(cr);
+  }
+
+  FINISH
+}
+
+void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  cairo_move_to(cr, .1, 0.3);
+  cairo_line_to(cr, .1, 1.);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, .5, 0.1);
+  cairo_line_to(cr, .5, 1.);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, .9, 0.3);
+  cairo_line_to(cr, .9, 1.);
+  cairo_stroke(cr);
+
+  cairo_move_to(cr, 0., 1.0);
+  cairo_line_to(cr, 1.0, 1.0);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -444,7 +444,6 @@ void dtgtk_cairo_paint_eye(cairo_t *cr, gint x, gint y, gint w, gint h, gint fla
 {
   PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.5, 0.5, 0.1, 0, 6.2832);
   cairo_stroke(cr);
 
@@ -2048,7 +2047,6 @@ void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   PREAMBLE(1, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.65, 0.35, 0.35, 0, 2 * M_PI);
   cairo_stroke(cr);
 
@@ -2090,7 +2088,6 @@ void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   PREAMBLE(1.08, 0, 0)
 
-  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.1, 0.1);
   cairo_line_to(cr, 0.2, 0.1);
   cairo_line_to(cr, 0.2, 0.9);
@@ -2109,11 +2106,11 @@ void dtgtk_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   PREAMBLE(1.1, 0, 0)
 
- cairo_set_line_width(cr, 0.1);
  cairo_move_to(cr, 0.5, 0.1);
  cairo_arc(cr, 0.5, 0.65, 0.28, -0.2 * M_PI, 1.2 * M_PI);
  cairo_close_path(cr);
  cairo_stroke(cr);
+ cairo_set_line_width(cr, 0.1);
  cairo_arc(cr, 0.5, 0.65, 0.13, 0.65 * M_PI, 1.2 * M_PI);
  cairo_stroke(cr);
 

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2057,6 +2057,7 @@ void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, g
 {
   PREAMBLE(1, 0, 0)
 
+  cairo_set_line_width(cr, 0.1);
   cairo_arc(cr, 0.65, 0.35, 0.35, 0, 2 * M_PI);
   cairo_stroke(cr);
 
@@ -2070,16 +2071,25 @@ void dtgtk_cairo_paint_tool_heal(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 {
   PREAMBLE(1, 0, 0)
 
+  cairo_set_line_width(cr, 0.01);
+  cairo_move_to(cr, 0.35, 0.1);
+  cairo_rel_line_to(cr, 0.3, 0.0);
+  cairo_rel_line_to(cr, 0.0, 0.25);
+  cairo_rel_line_to(cr, 0.25, 0.0);
+  cairo_rel_line_to(cr, 0.0, 0.3);
+  cairo_rel_line_to(cr, -0.25, 0.0);
+  cairo_rel_line_to(cr, 0.0, 0.25);
+  cairo_rel_line_to(cr, -0.3, 0.0);
+  cairo_rel_line_to(cr, 0.0, -0.25);
+  cairo_rel_line_to(cr, -0.25, 0.0);
+  cairo_rel_line_to(cr, 0.0, -0.3);
+  cairo_rel_line_to(cr, 0.25, 0.0);
+  cairo_close_path(cr);
+
   cairo_rectangle(cr, 0., 0., 1., 1.);
+
+  cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
   cairo_fill(cr);
-
-  cairo_set_source_rgba(cr, .74, 0.13, 0.13, 1.0);
-  cairo_set_line_width(cr, 0.3);
-
-  cairo_move_to(cr, 0.5, 0.18);
-  cairo_line_to(cr, 0.5, 0.82);
-  cairo_move_to(cr, 0.18, 0.5);
-  cairo_line_to(cr, 0.82, 0.5);
   cairo_stroke(cr);
 
   FINISH
@@ -2087,8 +2097,9 @@ void dtgtk_cairo_paint_tool_heal(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 0, 0)
+  PREAMBLE(1.08, 0, 0)
 
+  cairo_set_line_width(cr, 0.1);
   cairo_move_to(cr, 0.1, 0.1);
   cairo_line_to(cr, 0.2, 0.1);
   cairo_line_to(cr, 0.2, 0.9);
@@ -2105,20 +2116,15 @@ void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h, gi
 
 void dtgtk_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
-  PREAMBLE(1, 0, 0)
+  PREAMBLE(1.1, 0, 0)
 
-  cairo_pattern_t *pat = NULL;
-  pat = cairo_pattern_create_radial(.5, .5, 0.005, .5, .5, .5);
-  cairo_pattern_add_color_stop_rgba(pat, 0.0, 1, 1, 1, 1);
-  cairo_pattern_add_color_stop_rgba(pat, 1.0, 1, 1, 1, 0.1);
-  cairo_set_source(cr, pat);
-
-  cairo_set_line_width(cr, 0.125);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_arc(cr, 0.5, 0.5, 0.45, 0, 2 * M_PI);
-  cairo_fill(cr);
-
-  cairo_pattern_destroy(pat);
+ cairo_set_line_width(cr, 0.1);
+ cairo_move_to(cr, 0.5, 0.1);
+ cairo_arc(cr, 0.5, 0.65, 0.28, -0.2 * M_PI, 1.2 * M_PI);
+ cairo_close_path(cr);
+ cairo_stroke(cr);
+ cairo_arc(cr, 0.5, 0.65, 0.13, 0.65 * M_PI, 1.2 * M_PI);
+ cairo_stroke(cr);
 
   FINISH
 }

--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -2044,15 +2044,6 @@ void dtgtk_cairo_paint_map_pin(cairo_t *cr, gint x, gint y, gint w, gint h, gint
   FINISH
 }
 
-
-
-
-
-
-
-
-
-
 void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   PREAMBLE(1, 0, 0)

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -240,6 +240,18 @@ void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint
 /** Paint a used icon for masks*/
 void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
+
+
+void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_tool_heal(cairo_t *cr, gint x, gint y, gint w, gint h,  gint flags, void *data);
+void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h,  gint flags, void *data);
+void dtgtk_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_paste_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_cut_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_display_wavelet_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -239,18 +239,22 @@ void dtgtk_cairo_paint_masks_difference(cairo_t *cr, gint x, gint y, gint w, gin
 void dtgtk_cairo_paint_masks_exclusion(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** Paint a used icon for masks*/
 void dtgtk_cairo_paint_masks_used(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-
-
-
+/** Paint a clone tool for retouch*/
 void dtgtk_cairo_paint_tool_clone(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a heal tool for retouch*/
 void dtgtk_cairo_paint_tool_heal(cairo_t *cr, gint x, gint y, gint w, gint h,  gint flags, void *data);
+/** Paint a fill tool for retouch*/
 void dtgtk_cairo_paint_tool_fill(cairo_t *cr, gint x, gint y, gint w, gint h,  gint flags, void *data);
+/** Paint a blur tool for retouch*/
 void dtgtk_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a past icon for retouch*/
 void dtgtk_cairo_paint_paste_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a cut icon for retouch*/
 void dtgtk_cairo_paint_cut_forms(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a display scale for retouch*/
 void dtgtk_cairo_paint_display_wavelet_scale(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** Paint a auto level icon for retouch*/
 void dtgtk_cairo_paint_auto_levels(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
-
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2180,7 +2180,7 @@ void gui_init(dt_iop_module_t *self)
                                                    | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                                    | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
                                                    | GDK_SMOOTH_SCROLL_MASK);
-  gtk_widget_set_size_request(g->wd_bar, -1, DT_PIXEL_APPLY_DPI(40));
+  gtk_widget_set_size_request(g->wd_bar, -1, DT_PIXEL_APPLY_DPI(38));
 
   // toolbar display current scale / cut&paste / suppress&display masks
   GtkWidget *hbox_scale = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
@@ -2277,7 +2277,7 @@ void gui_init(dt_iop_module_t *self)
 
   // shapes selected (label)
   GtkWidget *hbox_shape_sel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *label1 = gtk_label_new(_("shape selected:"));
+  GtkWidget *label1 = gtk_label_new(_("shape selected: "));
   gtk_box_pack_start(GTK_BOX(hbox_shape_sel), label1, FALSE, TRUE, 0);
   g->label_form_selected = GTK_LABEL(gtk_label_new("-1"));
   gtk_widget_set_tooltip_text(hbox_shape_sel,
@@ -2362,7 +2362,7 @@ void gui_init(dt_iop_module_t *self)
 
   // wavelet decompose bar & labels
   gtk_box_pack_start(GTK_BOX(self->widget), grid_wd_labels, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->wd_bar, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->wd_bar, TRUE, TRUE, DT_PIXEL_APPLY_DPI(3));
 
   // preview scale & cut/paste scale
   gtk_box_pack_start(GTK_BOX(self->widget), hbox_scale, TRUE, TRUE, 0);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1120,6 +1120,7 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
   GdkRGBA active      = {.35, .35, .35, 1};
   GdkRGBA merge_from  = {.5, .5, .5, 1};
   GdkRGBA residual    = {.8, .8, .8, 1};
+  GdkRGBA shapes      = {.75, .5, .0, 1};
   GdkRGBA color;
 
   float middle;
@@ -1176,8 +1177,8 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
     if(rt_scale_has_shapes(p, i))
     {
       cairo_set_line_width(cr, lw);
-      gdk_cairo_set_source_rgba(cr, &merge_from);
-      cairo_rectangle(cr, box_w * i + inset + lw / 2.0f, allocation.height - bh, box_w - lw, bh);
+      gdk_cairo_set_source_rgba(cr, &shapes);
+      cairo_rectangle(cr, box_w * i + inset + lw / 2.0f, allocation.height - sh, box_w - lw, bh);
       cairo_fill(cr);
     }
 
@@ -1225,12 +1226,12 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
   if(g->lower_cursor || g->is_dragging == DT_IOP_RETOUCH_WDBAR_DRAG_BOTTOM)
   {
     cairo_set_source_rgb(cr, 0.67, 0.67, 0.67);
-    dtgtk_cairo_paint_solid_triangle(cr, middle, box_h + bh, mk, mk, CPF_DIRECTION_UP, NULL);
+    dtgtk_cairo_paint_solid_triangle(cr, middle, box_h + 2.0f + bh, mk, mk, CPF_DIRECTION_UP, NULL);
   }
   else
   {
     cairo_set_source_rgb(cr, 0.54, 0.54, 0.54);
-    dtgtk_cairo_paint_triangle(cr, middle, box_h + bh, mk, mk, CPF_DIRECTION_UP, NULL);
+    dtgtk_cairo_paint_triangle(cr, middle, box_h + 2.0f * bh, mk, mk, CPF_DIRECTION_UP, NULL);
   }
 
   // draw merge scales arrow (top arrow)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2002,12 +2002,10 @@ void gui_update(dt_iop_module_t *self)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));
-  // gtk_widget_set_sensitive(g->bt_copy_scale, TRUE);
   }
   else
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
-  //  gtk_widget_set_sensitive(g->bt_copy_scale, FALSE);
   }
 
   // update the gradient slider
@@ -2034,8 +2032,10 @@ void change_image(struct dt_iop_module_t *self)
     g->preview_levels[2] = RETOUCH_PREVIEW_LVL_MAX;
 
     g->is_dragging = 0;
-    g->wdbar_mouse_x = -1;
-    g->wdbar_mouse_y = -1;
+    g->wdbar_mouse_x = g->wdbar_mouse_y = -1;
+    g->curr_scale = -1;
+    g->lower_cursor = g->upper_cursor = FALSE;
+    g->lower_margin = g->upper_margin = FALSE;
   }
 }
 
@@ -2055,7 +2055,7 @@ void gui_init(dt_iop_module_t *self)
   // shapes toolbar
   GtkWidget *hbox_shapes = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  GtkWidget *label = gtk_label_new(_("# shapes:"));
+  GtkWidget *label = gtk_label_new(_("shapes:"));
   gtk_box_pack_start(GTK_BOX(hbox_shapes), label, FALSE, TRUE, 0);
   g->label_form = GTK_LABEL(gtk_label_new("-1"));
   gtk_box_pack_start(GTK_BOX(hbox_shapes), GTK_WIDGET(g->label_form), FALSE, TRUE, DT_PIXEL_APPLY_DPI(5));
@@ -2140,7 +2140,7 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *grid_wd_labels = gtk_grid_new();
   gtk_grid_set_column_homogeneous(GTK_GRID(grid_wd_labels), FALSE);
 
-  GtkWidget *lbl_num_scales = gtk_label_new(_("# scales:"));
+  GtkWidget *lbl_num_scales = gtk_label_new(_("scales:"));
   gtk_widget_set_halign(lbl_num_scales, GTK_ALIGN_START);
   gtk_grid_attach(GTK_GRID(grid_wd_labels), lbl_num_scales, 0, 0, 1, 1);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -204,248 +204,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_rgb;
 }
 
-//---------------------------------------------------------------------------------
-// draw buttons
-//---------------------------------------------------------------------------------
-
-#define PREAMBLE                                                                                                  \
-  cairo_save(cr);                                                                                                 \
-  const gint s = MIN(w, h);                                                                                       \
-  cairo_translate(cr, x + (w / 2.0) - (s / 2.0), y + (h / 2.0) - (s / 2.0));                                      \
-  cairo_scale(cr, s, s);                                                                                          \
-  cairo_push_group(cr);                                                                                           \
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 1.0);                                                                  \
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);                                                                   \
-  cairo_set_line_width(cr, 0.1);
-
-#define POSTAMBLE                                                                                                 \
-  cairo_pop_group_to_source(cr);                                                                                  \
-  cairo_paint_with_alpha(cr, flags &CPF_ACTIVE ? 1.0 : 0.5);                                                      \
-  cairo_restore(cr);
-
-static void _retouch_cairo_paint_tool_clone(cairo_t *cr, const gint x, const gint y, const gint w, const gint h,
-                                            const gint flags, void *data)
-{
-  PREAMBLE;
-
-  cairo_arc(cr, 0.65, 0.35, 0.35, 0, 2 * M_PI);
-  cairo_stroke(cr);
-
-  cairo_arc(cr, 0.35, 0.65, 0.35, 0, 2 * M_PI);
-  cairo_stroke(cr);
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_tool_heal(cairo_t *cr, const gint x, const gint y, const gint w, const gint h,
-                                           const gint flags, void *data)
-{
-  PREAMBLE;
-
-  cairo_rectangle(cr, 0., 0., 1., 1.);
-  cairo_fill(cr);
-
-  cairo_set_source_rgba(cr, .74, 0.13, 0.13, 1.0);
-  cairo_set_line_width(cr, 0.3);
-
-  cairo_move_to(cr, 0.5, 0.18);
-  cairo_line_to(cr, 0.5, 0.82);
-  cairo_move_to(cr, 0.18, 0.5);
-  cairo_line_to(cr, 0.82, 0.5);
-  cairo_stroke(cr);
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_tool_fill(cairo_t *cr, const gint x, const gint y, const gint w, const gint h,
-                                           const gint flags, void *data)
-{
-  PREAMBLE;
-
-  cairo_move_to(cr, 0.1, 0.1);
-  cairo_line_to(cr, 0.2, 0.1);
-  cairo_line_to(cr, 0.2, 0.9);
-  cairo_line_to(cr, 0.8, 0.9);
-  cairo_line_to(cr, 0.8, 0.1);
-  cairo_line_to(cr, 0.9, 0.1);
-  cairo_stroke(cr);
-  cairo_rectangle(cr, 0.2, 0.4, .6, .5);
-  cairo_fill(cr);
-  cairo_stroke(cr);
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_tool_blur(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
-{
-  PREAMBLE;
-
-  cairo_pattern_t *pat = NULL;
-  pat = cairo_pattern_create_radial(.5, .5, 0.005, .5, .5, .5);
-  cairo_pattern_add_color_stop_rgba(pat, 0.0, 1, 1, 1, 1);
-  cairo_pattern_add_color_stop_rgba(pat, 1.0, 1, 1, 1, 0.1);
-  cairo_set_source(cr, pat);
-
-  cairo_set_line_width(cr, 0.125);
-  cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-  cairo_arc(cr, 0.5, 0.5, 0.45, 0, 2 * M_PI);
-  cairo_fill(cr);
-
-  cairo_pattern_destroy(pat);
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_paste_forms(cairo_t *cr, const gint x, const gint y, const gint w, const gint h,
-                                             const gint flags, void *data)
-{
-  PREAMBLE;
-
-  if(flags & CPF_ACTIVE)
-  {
-    cairo_set_source_rgba(cr, .75, 0.75, 0.75, 1.0);
-    cairo_arc(cr, 0.5, 0.5, 0.40, 0, 2 * M_PI);
-    cairo_fill(cr);
-  }
-  else
-  {
-    cairo_move_to(cr, 0.1, 0.5);
-    cairo_line_to(cr, 0.9, 0.5);
-    cairo_line_to(cr, 0.5, 0.9);
-    cairo_line_to(cr, 0.1, 0.5);
-    cairo_stroke(cr);
-    cairo_move_to(cr, 0.1, 0.5);
-    cairo_line_to(cr, 0.9, 0.5);
-    cairo_line_to(cr, 0.5, 0.9);
-    cairo_line_to(cr, 0.1, 0.5);
-    cairo_fill(cr);
-
-    cairo_move_to(cr, 0.4, 0.1);
-    cairo_line_to(cr, 0.6, 0.1);
-    cairo_line_to(cr, 0.6, 0.5);
-    cairo_line_to(cr, 0.4, 0.5);
-    cairo_stroke(cr);
-    cairo_move_to(cr, 0.4, 0.1);
-    cairo_line_to(cr, 0.6, 0.1);
-    cairo_line_to(cr, 0.6, 0.5);
-    cairo_line_to(cr, 0.4, 0.5);
-    cairo_fill(cr);
-  }
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_cut_forms(cairo_t *cr, const gint x, const gint y, const gint w, const gint h,
-                                           const gint flags, void *data)
-{
-  PREAMBLE;
-
-  if(flags & CPF_ACTIVE)
-  {
-    cairo_move_to(cr, 0.11, 0.25);
-    cairo_line_to(cr, 0.89, 0.75);
-    cairo_move_to(cr, 0.25, 0.11);
-    cairo_line_to(cr, 0.75, 0.89);
-    cairo_stroke(cr);
-
-    cairo_arc(cr, 0.89, 0.53, 0.17, 0, 2 * M_PI);
-    cairo_stroke(cr);
-
-    cairo_arc(cr, 0.53, 0.89, 0.17, 0, 2 * M_PI);
-    cairo_stroke(cr);
-  }
-  else
-  {
-    cairo_move_to(cr, 0.01, 0.35);
-    cairo_line_to(cr, 0.99, 0.65);
-    cairo_move_to(cr, 0.35, 0.01);
-    cairo_line_to(cr, 0.65, 0.99);
-    cairo_stroke(cr);
-
-    cairo_arc(cr, 0.89, 0.53, 0.17, 0, 2 * M_PI);
-    cairo_stroke(cr);
-
-    cairo_arc(cr, 0.53, 0.89, 0.17, 0, 2 * M_PI);
-    cairo_stroke(cr);
-  }
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_display_wavelet_scale(cairo_t *cr, const gint x, const gint y, const gint w,
-                                                       const gint h, const gint flags, void *data)
-{
-  PREAMBLE;
-
-  if(flags & CPF_ACTIVE)
-  {
-    float x1 = 0.2f;
-    float y1 = 1.f;
-
-    cairo_move_to(cr, x1, y1);
-
-    const int steps = 4;
-    const float delta = 1. / (float)steps;
-    for(int i = 0; i < steps; i++)
-    {
-      y1 -= delta;
-      cairo_line_to(cr, x1, y1);
-      x1 += delta;
-      if(x1 > .9) x1 = .9;
-      cairo_line_to(cr, x1, y1);
-    }
-    cairo_stroke(cr);
-
-    cairo_set_line_width(cr, 0.1);
-    cairo_rectangle(cr, 0., 0., 1., 1.);
-    cairo_stroke(cr);
-  }
-  else
-  {
-    cairo_move_to(cr, 0.08, 1.);
-    cairo_curve_to(cr, 0.4, 0.05, 0.6, 0.05, 1., 1.);
-    cairo_line_to(cr, 0.08, 1.);
-    cairo_fill(cr);
-
-    cairo_set_line_width(cr, 0.1);
-    cairo_rectangle(cr, 0., 0., 1., 1.);
-    cairo_stroke(cr);
-  }
-
-  POSTAMBLE;
-}
-
-static void _retouch_cairo_paint_auto_levels(cairo_t *cr, const gint x, const gint y, const gint w, const gint h,
-                                             const gint flags, void *data)
-{
-  PREAMBLE;
-
-  cairo_move_to(cr, .1, 0.3);
-  cairo_line_to(cr, .1, 1.);
-  cairo_stroke(cr);
-
-  cairo_move_to(cr, .5, 0.1);
-  cairo_line_to(cr, .5, 1.);
-  cairo_stroke(cr);
-
-  cairo_move_to(cr, .9, 0.3);
-  cairo_line_to(cr, .9, 1.);
-  cairo_stroke(cr);
-
-  cairo_move_to(cr, 0., 1.0);
-  cairo_line_to(cr, 1.0, 1.0);
-  cairo_stroke(cr);
-
-  POSTAMBLE;
-}
-
-#undef PREAMBLE
-#undef POSTAMBLE
-
-//---------------------------------------------------------------------------------
-// shape selection
-//---------------------------------------------------------------------------------
-
 static int rt_get_index_from_formid(dt_iop_retouch_params_t *p, const int formid)
 {
   int index = -1;
@@ -1660,7 +1418,8 @@ static void rt_copypaste_scale_callback(GtkToggleButton *togglebutton, dt_iop_mo
   }
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_copy_scale), g->copied_scale >= 0);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), g->copied_scale < 0);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), g->copied_scale >= 0);
+  gtk_widget_set_sensitive(g->bt_paste_scale, g->copied_scale >= 0);
 
   --darktable.gui->reset;
 
@@ -2326,7 +2085,8 @@ void gui_update(dt_iop_module_t *self)
 
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_display_wavelet_scale), g->display_wavelet_scale);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_copy_scale), g->copied_scale >= 0);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), g->copied_scale < 0);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), g->copied_scale >= 0);
+  gtk_widget_set_sensitive(g->bt_paste_scale, g->copied_scale >= 0);
 
   // show/hide some fields
   rt_show_hide_controls(self, g, p, g);
@@ -2442,28 +2202,28 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(hbox_algo), label2, FALSE, TRUE, 0);
 
   g->bt_fill
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_tool_fill, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_fill, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_fill, _("activates fill tool"));
   g_signal_connect(G_OBJECT(g->bt_fill), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
   gtk_widget_set_size_request(GTK_WIDGET(g->bt_fill), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_fill), FALSE);
 
   g->bt_blur
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_tool_blur, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_blur, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_blur, _("activates blur tool"));
   g_signal_connect(G_OBJECT(g->bt_blur), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
   gtk_widget_set_size_request(GTK_WIDGET(g->bt_blur), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_blur), FALSE);
 
   g->bt_heal
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_tool_heal, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_heal, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_heal, _("activates healing tool"));
   g_signal_connect(G_OBJECT(g->bt_heal), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
   gtk_widget_set_size_request(GTK_WIDGET(g->bt_heal), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_heal), FALSE);
 
   g->bt_clone
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_tool_clone, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_clone, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_clone, _("activates cloning tool"));
   g_signal_connect(G_OBJECT(g->bt_clone), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
   gtk_widget_set_size_request(GTK_WIDGET(g->bt_clone), bs, bs);
@@ -2542,7 +2302,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_suppress), FALSE);
 
   // display final image/current scale
-  g->bt_display_wavelet_scale = dtgtk_togglebutton_new(_retouch_cairo_paint_display_wavelet_scale,
+  g->bt_display_wavelet_scale = dtgtk_togglebutton_new(dtgtk_cairo_paint_display_wavelet_scale,
                                                        CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_display_wavelet_scale, _("display wavelet scale"));
   g_signal_connect(G_OBJECT(g->bt_display_wavelet_scale), "toggled", G_CALLBACK(rt_display_wavelet_scale_callback),
@@ -2551,16 +2311,17 @@ void gui_init(dt_iop_module_t *self)
 
   // copy/paste shapes
   g->bt_copy_scale
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_cut_forms, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_cut_forms, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_copy_scale, _("cut shapes from current scale"));
   g_signal_connect(G_OBJECT(g->bt_copy_scale), "toggled", G_CALLBACK(rt_copypaste_scale_callback), self);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_copy_scale), FALSE);
 
   g->bt_paste_scale
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_paste_forms, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_paste_forms, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_paste_scale, _("paste cut shapes to current scale"));
   g_signal_connect(G_OBJECT(g->bt_paste_scale), "toggled", G_CALLBACK(rt_copypaste_scale_callback), self);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_paste_scale), FALSE);
+  gtk_widget_set_sensitive(g->bt_paste_scale, FALSE);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_showmask, FALSE, FALSE, 0);
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_suppress, FALSE, FALSE, 0);
@@ -2606,7 +2367,7 @@ void gui_init(dt_iop_module_t *self)
 
   // auto-levels button
   g->bt_auto_levels
-      = dtgtk_togglebutton_new(_retouch_cairo_paint_auto_levels, CPF_STYLE_FLAT, NULL);
+      = dtgtk_togglebutton_new(dtgtk_cairo_paint_auto_levels, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_auto_levels, _("auto levels"));
   g_signal_connect(G_OBJECT(g->bt_auto_levels), "toggled", G_CALLBACK(rt_auto_levels_callback), self);
   gtk_widget_set_size_request(GTK_WIDGET(g->bt_auto_levels), bs, bs);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1063,7 +1063,7 @@ static gboolean rt_wdbar_motion_notify(GtkWidget *widget, GdkEventMotion *event,
   gtk_widget_get_allocation(widget, &allocation);
   const int inset = round(RT_WDBAR_INSET * allocation.height);
   const float box_w = (allocation.width - 2.0f * inset) / (float)RETOUCH_NO_SCALES;
-  const float sh = 2.0f * lw + inset;
+  const float sh = 3.0f * lw + inset;
 
 
   /* record mouse position within control */
@@ -1140,8 +1140,7 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
   // geometry
   const int inset = round(RT_WDBAR_INSET * allocation.height);
   const int mk = 2 * inset;
-  const float bh = 2.0f * lw;
-  const float sh = bh + inset;
+  const float sh = 3.0f * lw + inset;
   const float box_w = (allocation.width - 2.0f * inset) / (float)RETOUCH_NO_SCALES;
   const float box_h = allocation.height - 2.0f * sh;
 
@@ -1169,7 +1168,7 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
     if(i >= first_scale_visible && i <= p->num_scales)
     {
       gdk_cairo_set_source_rgba(cr, &merge_from);
-      cairo_rectangle(cr, box_w * i + inset, 0, box_w, bh);
+      cairo_rectangle(cr, box_w * i + inset, lw, box_w, 2.0f * lw);
       cairo_fill(cr);
     }
 
@@ -1178,7 +1177,7 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
     {
       cairo_set_line_width(cr, lw);
       gdk_cairo_set_source_rgba(cr, &shapes);
-      cairo_rectangle(cr, box_w * i + inset + lw / 2.0f, allocation.height - sh, box_w - lw, bh);
+      cairo_rectangle(cr, box_w * i + inset + lw / 2.0f, allocation.height - sh, box_w - lw, 2.0f * lw);
       cairo_fill(cr);
     }
 
@@ -1226,12 +1225,12 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
   if(g->lower_cursor || g->is_dragging == DT_IOP_RETOUCH_WDBAR_DRAG_BOTTOM)
   {
     cairo_set_source_rgb(cr, 0.67, 0.67, 0.67);
-    dtgtk_cairo_paint_solid_triangle(cr, middle, box_h + 2.0f + bh, mk, mk, CPF_DIRECTION_UP, NULL);
+    dtgtk_cairo_paint_solid_triangle(cr, middle, box_h + 5.0f * lw, mk, mk, CPF_DIRECTION_UP, NULL);
   }
   else
   {
     cairo_set_source_rgb(cr, 0.54, 0.54, 0.54);
-    dtgtk_cairo_paint_triangle(cr, middle, box_h + 2.0f * bh, mk, mk, CPF_DIRECTION_UP, NULL);
+    dtgtk_cairo_paint_triangle(cr, middle, box_h + 5.0f * lw, mk, mk, CPF_DIRECTION_UP, NULL);
   }
 
   // draw merge scales arrow (top arrow)
@@ -1239,12 +1238,12 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
   if(g->upper_cursor || g->is_dragging == DT_IOP_RETOUCH_WDBAR_DRAG_TOP)
   {
     cairo_set_source_rgb(cr, 0.67, 0.67, 0.67);
-    dtgtk_cairo_paint_solid_triangle(cr, middle, bh, mk, mk, CPF_DIRECTION_DOWN, NULL);
+    dtgtk_cairo_paint_solid_triangle(cr, middle, 3.0f * lw, mk, mk, CPF_DIRECTION_DOWN, NULL);
   }
   else
   {
     cairo_set_source_rgb(cr, 0.54, 0.54, 0.54);
-    dtgtk_cairo_paint_triangle(cr, middle, bh, mk, mk, CPF_DIRECTION_DOWN, NULL);
+    dtgtk_cairo_paint_triangle(cr, middle, 3.0f * lw, mk, mk, CPF_DIRECTION_DOWN, NULL);
   }
 
   /* push mem surface into widget */
@@ -2208,7 +2207,7 @@ void gui_init(dt_iop_module_t *self)
                                                    | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                                    | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
                                                    | GDK_SMOOTH_SCROLL_MASK);
-  gtk_widget_set_size_request(g->wd_bar, -1, DT_PIXEL_APPLY_DPI(38));
+  gtk_widget_set_size_request(g->wd_bar, -1, DT_PIXEL_APPLY_DPI(40));
 
   // toolbar display current scale / cut&paste / suppress&display masks
   GtkWidget *hbox_scale = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1170,8 +1170,9 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
     // if the scale has shapes inform it
     if(rt_scale_has_shapes(p, i))
     {
+      cairo_set_line_width(cr, 1);
       cairo_set_source_rgb(cr, .1, .8, 0);
-      cairo_rectangle(cr, box_w * i + inset, inset, box_w, 3.0f * lw);
+      cairo_rectangle(cr, box_w * i + inset + lw / 2.0f, inset, box_w - lw, 3.0f * lw);
       cairo_fill(cr);
     }
   }

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1115,10 +1115,10 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
   GdkRGBA border      = {0.066, 0.066, 0.066, 1};
   GdkRGBA original    = {.1, .1, .1, 1};
   GdkRGBA inactive    = {.15, .15, .15, 1};
-  GdkRGBA active      = {.37, .37, .37, 1};
-  GdkRGBA merge_from  = {.5, .5, .5, 1};
-  GdkRGBA residual    = {.94, .94, .94, 1};
-  GdkRGBA shapes      = {.75, .5, .0, 1};
+  GdkRGBA active      = {.3, .3, .3, 1};
+  GdkRGBA merge_from  = {.45, .45, .45, 1};
+  GdkRGBA residual    = {.65, .65, .65, 1};
+  GdkRGBA shapes      = {.95, .65, .0, 1};
   GdkRGBA color;
 
   float middle;
@@ -1174,7 +1174,7 @@ static gboolean rt_wdbar_draw(GtkWidget *widget, cairo_t *crf, dt_iop_module_t *
     {
       cairo_set_line_width(cr, 1);
       gdk_cairo_set_source_rgba(cr, &shapes);
-      cairo_rectangle(cr, box_w * i + inset, inset, box_w, 3.0f * lw);
+      cairo_rectangle(cr, box_w * i + inset, inset, box_w, 4.0f * lw);
       cairo_fill(cr);
     }
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2194,8 +2194,9 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_set_tooltip_text(g->wd_bar, _("top slider adjusts where the merge scales start\n"
                                            "bottom slider adjusts the number of scales\n"
-                                           "red box indicates the current scale\n"
-                                           "green line indicates that the scale has shapes on it"));
+                                           "dot indicates the current scale\n"
+                                           "top line indicates that the scale is visible at current zoom level\n"
+                                           "bottom line indicates that the scale has shapes on it"));
   g_signal_connect(G_OBJECT(g->wd_bar), "draw", G_CALLBACK(rt_wdbar_draw), self);
   g_signal_connect(G_OBJECT(g->wd_bar), "motion-notify-event", G_CALLBACK(rt_wdbar_motion_notify), self);
   g_signal_connect(G_OBJECT(g->wd_bar), "leave-notify-event", G_CALLBACK(rt_wdbar_leave_notify), self);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -994,8 +994,10 @@ static gboolean rt_wdbar_button_press(GtkWidget *widget, GdkEventButton *event, 
   dt_iop_request_focus(self);
 
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
-
-  const float box_w = gtk_widget_get_allocated_width(widget) / (float)RETOUCH_NO_SCALES;
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(widget, &allocation);
+  const int inset = round(RT_WDBAR_INSET * allocation.height);
+  const float box_w = (allocation.width - 2.0f * inset) / (float)RETOUCH_NO_SCALES;
 
   if(event->button == 1)
   {
@@ -1061,10 +1063,10 @@ static gboolean rt_wdbar_motion_notify(GtkWidget *widget, GdkEventMotion *event,
   GtkAllocation allocation;
   gtk_widget_get_allocation(widget, &allocation);
   const int inset = round(RT_WDBAR_INSET * allocation.height);
-  const float box_w = allocation.width / (float)RETOUCH_NO_SCALES;
+  const float box_w = (allocation.width - 2.0f * inset) / (float)RETOUCH_NO_SCALES;
 
   /* record mouse position within control */
-  g->wdbar_mouse_x = CLAMP(event->x - inset, 0, allocation.width - inset);
+  g->wdbar_mouse_x = CLAMP(event->x - inset, 0, allocation.width - 2.0f * inset - 1.0);
   g->wdbar_mouse_y = event->y;
 
   g->curr_scale = g->wdbar_mouse_x / box_w;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -504,6 +504,9 @@ static void rt_show_forms_for_current_scale(dt_iop_module_t *self)
     if(p->rt_forms[i].formid != 0 && p->rt_forms[i].scale == scale) count++;
   }
 
+  // if there are shapes on this scale, make the cut shapes button sensitive
+  gtk_widget_set_sensitive(g->bt_copy_scale, count > 0);
+
   // if no shapes on this scale, we hide all
   if(bd->masks_shown == DT_MASKS_EDIT_OFF || count == 0)
   {
@@ -2100,10 +2103,12 @@ void gui_update(dt_iop_module_t *self)
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
                                  (bd->masks_shown != DT_MASKS_EDIT_OFF) && (darktable.develop->gui_module == self));
+  // gtk_widget_set_sensitive(g->bt_copy_scale, TRUE);
   }
   else
   {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks), FALSE);
+  //  gtk_widget_set_sensitive(g->bt_copy_scale, FALSE);
   }
 
   // update the gradient slider
@@ -2315,6 +2320,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->bt_copy_scale, _("cut shapes from current scale"));
   g_signal_connect(G_OBJECT(g->bt_copy_scale), "toggled", G_CALLBACK(rt_copypaste_scale_callback), self);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_copy_scale), FALSE);
+  gtk_widget_set_sensitive(g->bt_copy_scale, FALSE);
 
   g->bt_paste_scale
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_paste_forms, CPF_STYLE_FLAT, NULL);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -2042,8 +2042,6 @@ void change_image(struct dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  const int bs = DT_PIXEL_APPLY_DPI(14);
-
   self->gui_data = malloc(sizeof(dt_iop_retouch_gui_data_t));
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
@@ -2108,28 +2106,24 @@ void gui_init(dt_iop_module_t *self)
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_fill, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_fill, _("activates fill tool"));
   g_signal_connect(G_OBJECT(g->bt_fill), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_widget_set_size_request(GTK_WIDGET(g->bt_fill), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_fill), FALSE);
 
   g->bt_blur
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_blur, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_blur, _("activates blur tool"));
   g_signal_connect(G_OBJECT(g->bt_blur), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_widget_set_size_request(GTK_WIDGET(g->bt_blur), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_blur), FALSE);
 
   g->bt_heal
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_heal, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_heal, _("activates healing tool"));
   g_signal_connect(G_OBJECT(g->bt_heal), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_widget_set_size_request(GTK_WIDGET(g->bt_heal), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_heal), FALSE);
 
   g->bt_clone
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_clone, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_clone, _("activates cloning tool"));
   g_signal_connect(G_OBJECT(g->bt_clone), "button-press-event", G_CALLBACK(rt_select_algorithm_callback), self);
-  gtk_widget_set_size_request(GTK_WIDGET(g->bt_clone), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_clone), FALSE);
 
   gtk_box_pack_end(GTK_BOX(hbox_algo), g->bt_blur, FALSE, FALSE, 0);
@@ -2274,7 +2268,6 @@ void gui_init(dt_iop_module_t *self)
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_auto_levels, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_tooltip_text(g->bt_auto_levels, _("auto levels"));
   g_signal_connect(G_OBJECT(g->bt_auto_levels), "toggled", G_CALLBACK(rt_auto_levels_callback), self);
-  gtk_widget_set_size_request(GTK_WIDGET(g->bt_auto_levels), bs, bs);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_auto_levels), FALSE);
 
   gtk_box_pack_start(GTK_BOX(prev_lvl), GTK_WIDGET(g->preview_levels_gslider), TRUE, TRUE, 0);


### PR DESCRIPTION
This is a rework of the GUI of retouch module.
Main changes
- icons moved to cairo paint library
- rework of the icons (consistent hover effect, optical balance, new icon for blur tool)
- scale cursors consistent with the rest of the DT gui
- cut button sensitive only when there is something to cut
- paste button sensitive and armed only when something has been cut
- thicker yellow bar indicating shapes, it was almost invisible
- current scale indicator: cyan dot instead of thin red box for better contrast and readability. Red box over a green background (when merge from scale is activated) could create problems to people with some color blindness (like me)
- leaner and cleaner code

![Screenshot from 2020-06-16 15-25-08](https://user-images.githubusercontent.com/43290988/84791782-5f5c0000-aff3-11ea-93aa-18e0b6f39730.png)

Some of the choices are subjective of course, so feedback is welcome
