### PR TITLE
Correct the slider origin when factor and or offset used

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1421,7 +1421,9 @@ static void dt_bauhaus_draw_baseline(dt_bauhaus_widget_t *w, cairo_t *cr)
   cairo_fill(cr);
 
   // get the reference of the slider aka the position of the 0 value
-  const float origin = fmaxf(fminf(-(d->min / (d->max - d->min)) * slider_width, slider_width), 0.0f);
+  const float origin = fmaxf(fminf((d->factor > 0 ? -d->min - d->offset/d->factor 
+                                                  :  d->max + d->offset/d->factor)
+                                                  / (d->max - d->min), 1.0f) * slider_width, 0.0f);
   const float position = d->pos * slider_width;
   const float delta = position - origin;
 


### PR DESCRIPTION
This impacts:
local contrast
color balance
clipping
split-toning

fixes first issue in #5499