### PR TITLE
Eliminate unnecessary reprocessing for more responsive GUI

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -871,7 +871,7 @@ static void _blendop_blendif_showmask_clicked(GtkWidget *button, GdkEventButton 
     if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
     dt_iop_request_focus(module);
-    dt_dev_reprocess_all(module->dev);
+    dt_dev_reprocess_center(module->dev);
   }
 }
 
@@ -956,7 +956,7 @@ static void _blendop_blendif_suppress_toggled(GtkToggleButton *togglebutton, dt_
   dt_iop_request_focus(module);
 
   dt_control_queue_redraw_widget(GTK_WIDGET(togglebutton));
-  dt_dev_reprocess_all(module->dev);
+  dt_dev_reprocess_center(module->dev);
 }
 
 static void _blendop_blendif_reset(GtkButton *button, dt_iop_module_t *module)
@@ -1269,7 +1269,7 @@ static void _blendop_blendif_channel_mask_view(GtkWidget *widget, dt_iop_module_
   if(new_request_mask_display != module->request_mask_display)
   {
     module->request_mask_display = new_request_mask_display;
-    dt_dev_reprocess_all(module->dev);
+    dt_dev_reprocess_center(module->dev);
   }
 }
 
@@ -1309,7 +1309,7 @@ static void _blendop_blendif_channel_mask_view_toggle(GtkWidget *widget, dt_iop_
   if(new_request_mask_display != module->request_mask_display)
   {
     module->request_mask_display = new_request_mask_display;
-    dt_dev_reprocess_all(module->dev);
+    dt_dev_reprocess_center(module->dev);
   }
 }
 
@@ -1377,7 +1377,7 @@ static gboolean _blendop_blendif_leave_delayed(gpointer data)
   bd->timeout_handle = 0;
   dt_pthread_mutex_unlock(&bd->lock);
 
-  if(reprocess) dt_dev_reprocess_all(module->dev);
+  if(reprocess) dt_dev_reprocess_center(module->dev);
   // return FALSE and thereby terminate the handler
   return FALSE;
 }
@@ -1460,7 +1460,7 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
     if(module->request_mask_display != (data->save_for_leave & ~DT_DEV_PIXELPIPE_DISPLAY_STICKY))
     {
       module->request_mask_display = data->save_for_leave & ~DT_DEV_PIXELPIPE_DISPLAY_STICKY;
-      dt_dev_reprocess_all(module->dev);
+      dt_dev_reprocess_all(module->dev);//DBG
     }
   }
   dt_pthread_mutex_unlock(&data->lock);
@@ -2314,8 +2314,8 @@ void dt_iop_gui_blending_lose_focus(dt_iop_module_t *module)
     }
     dt_pthread_mutex_unlock(&bd->lock);
 
-    // reprocess if needed
-    if (has_mask_display || suppress) dt_dev_reprocess_all(module->dev);
+    // reprocess main center image if needed
+    if (has_mask_display || suppress) dt_dev_reprocess_center(module->dev);
   }
 }
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1321,9 +1321,8 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
   {
     if(in)
     {
-      // got focus. make it redraw in full and grab stuff to gui:
+      // got focus, grab stuff to gui:
       // need to get gui stuff for the first time for this image,
-      // and advice the pipe to redraw in full:
       g->clip_x = fmaxf(p->cx, 0.0f);
       g->clip_w = fminf(fabsf(p->cw) - p->cx, 1.0f);
       g->clip_y = fmaxf(p->cy, 0.0f);
@@ -1337,8 +1336,6 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       {
         g->old_width = g->old_height = -1;
       }
-      // make sure the cache is avoided:
-      dt_dev_reprocess_all(self->dev);
     }
     else
     {

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -951,11 +951,8 @@ static void picker_callback(GtkWidget *button, gpointer user_data)
 
   if(self->request_color_pick != DT_REQUEST_COLORPICK_OFF)
   {
-    dt_dev_reprocess_all(self->dev);
     self->gui_update(self);
   }
-  else
-    dt_control_queue_redraw();
 
   if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
 }

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -953,6 +953,7 @@ static void picker_callback(GtkWidget *button, gpointer user_data)
   {
     self->gui_update(self);
   }
+  dt_control_queue_redraw_center();
 
   if(self->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), 1);
 }

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1705,7 +1705,7 @@ static void rt_display_wavelet_scale_callback(GtkToggleButton *togglebutton, dt_
   }
   dt_pthread_mutex_unlock(&g->lock);
 
-  dt_dev_reprocess_all(self->dev);
+  dt_dev_reprocess_center(self->dev);
 }
 
 static void rt_develop_ui_pipe_finished_callback(gpointer instance, gpointer user_data)
@@ -1769,7 +1769,7 @@ static void rt_auto_levels_callback(GtkToggleButton *togglebutton, dt_iop_module
 
   gtk_toggle_button_set_active(togglebutton, FALSE);
 
-  dt_dev_reprocess_all(self->dev);
+  dt_dev_reprocess_center(self->dev);
 }
 
 static void rt_mask_opacity_callback(GtkWidget *slider, dt_iop_module_t *self)
@@ -2006,7 +2006,7 @@ static void rt_showmask_callback(GtkToggleButton *togglebutton, dt_iop_module_t 
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
   dt_iop_request_focus(module);
 
-  dt_dev_reprocess_all(module->dev);
+  dt_dev_reprocess_center(module->dev);
 }
 
 static void rt_suppress_callback(GtkToggleButton *togglebutton, dt_iop_module_t *module)
@@ -2019,7 +2019,7 @@ static void rt_suppress_callback(GtkToggleButton *togglebutton, dt_iop_module_t 
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), 1);
   dt_iop_request_focus(module);
 
-  dt_dev_reprocess_all(module->dev);
+  dt_dev_reprocess_center(module->dev);
 }
 
 static void rt_blur_type_callback(GtkComboBox *combo, dt_iop_module_t *self)
@@ -2245,8 +2245,8 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
       dt_masks_set_edit_mode(self, DT_MASKS_EDIT_OFF);
     }
 
-    // if we are switching between display modes we have to reprocess all pipes
-    if(g->display_wavelet_scale || g->mask_display || g->suppress_mask) dt_dev_reprocess_all(self->dev);
+    // if we are switching between display modes we have to reprocess the main image
+    if(g->display_wavelet_scale || g->mask_display || g->suppress_mask) dt_dev_reprocess_center(self->dev);
   }
 }
 

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2929,7 +2929,6 @@ void gui_reset(struct dt_iop_module_t *self)
   if(g == NULL) return;
   dt_iop_request_focus(self);
   dt_dev_add_history_item(darktable.develop, self, TRUE);
-  dt_dev_reprocess_all(self->dev);
 
   // Redraw graph
   gtk_widget_queue_draw(self->widget);


### PR DESCRIPTION
In a number of locations, existing code forces a complete reprocessing of both the full (center view) and preview pipes.  For retouch and blending, one can eliminate the reprocessing of the preview pipe when switching between different views (masks, wavelet scales, etc.) because switching views doesn't change the output of the preview pipe.  For clipping, colorchecker, and tone equalizer, the calls to dt_dev_reprocess_all can be eliminated entirely, as existing calls to dt_control_queue_redraw_center are entirely adequate for redrawing the screen.

Less reprocessing makes for faster screen updates and hence a more responsive GUI.  I've checked all of the affected modules and see no differences in behavior.
