### PR TITLE
fixes ‘colname’ may be used uninitialized

### DIFF
--- a/src/common/collection.c
+++ b/src/common/collection.c
@@ -1717,7 +1717,7 @@ static gchar *get_query_string(const dt_collection_properties_t property, const 
     case DT_COLLECTION_PROP_PRINT_TIMESTAMP:
     {
       const int local_property = property;
-      char *colname;
+      char *colname = NULL;
       gchar *operator, *number1, *number2;
 
       dt_collection_split_operator_datetime(escaped_text, &number1, &number2, &operator);

--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -1222,7 +1222,7 @@ static void tree_view(dt_lib_collect_rule_t *dr)
       case DT_COLLECTION_PROP_PRINT_TIMESTAMP:
         {
         const int local_property = property;
-        char *colname;
+        char *colname = NULL;
 
         switch(local_property)
         {


### PR DESCRIPTION
using manjaro with the latest updates and such the latest toolchange I get compile errors because colname wasnt initialized.

`/home/david/workspace/darktable.git/src/common/collection.c: In function ‘dt_collection_update_query’:`
`/home/david/workspace/darktable.git/src/common/collection.c:1741:17: error: ‘colname’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
`
https://pastebin.com/NnjhaSZf