### PR TITLE
Do not popup combobox when empty

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1933,6 +1933,7 @@ void dt_bauhaus_show_popup(dt_bauhaus_widget_t *w)
       // comboboxes change immediately
       darktable.bauhaus->change_active = 1;
       dt_bauhaus_combobox_data_t *d = &w->data.combobox;
+      if(!d->num_labels) return;
       tmp.height = inner_height(tmp) * d->num_labels + 2 * INNER_PADDING;
       GtkAllocation allocation_w;
       gtk_widget_get_allocation(GTK_WIDGET(w), &allocation_w);


### PR DESCRIPTION
Comboboxes are used as label in several places so that a button can be placed in their quad area. When clicked, those labels would show a 2 * INNER_PADDING black line underneath.

filmicrgb; tab1/auto tune levels, tab2/display mask
color balance; auto optimizers
unbreak input profile; auto tune levels
tone equaliser; display mask