### PR TITLE
retouch speedup: bypass further iops when displaying wavelet scale

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -125,6 +125,7 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_HSL_H = 10 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_HSL_S = 11 << 3,
   DT_DEV_PIXELPIPE_DISPLAY_HSL_l = 12 << 3,
+  DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU = 13 << 3,  //show module's output without processing by later iops
   DT_DEV_PIXELPIPE_DISPLAY_ANY = 0xff << 2,
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -4194,12 +4194,13 @@ static void process_internal(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_
   if(dwt_p == NULL) goto cleanup;
 
   // check if this module should expose mask.
-  if((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL && g && g->mask_display && self->dev->gui_attached
+  if((piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL && g
+     && (g->mask_display || display_wavelet_scale) && self->dev->gui_attached
      && (self == self->dev->gui_module) && (piece->pipe == self->dev->pipe))
   {
     for(size_t j = 0; j < roi_rt->width * roi_rt->height * ch; j += ch) in_retouch[j + 3] = 0.f;
 
-    piece->pipe->mask_display = DT_DEV_PIXELPIPE_DISPLAY_MASK;
+    piece->pipe->mask_display = g->mask_display ? DT_DEV_PIXELPIPE_DISPLAY_MASK : DT_DEV_PIXELPIPE_DISPLAY_PASSTHRU;
     piece->pipe->bypass_blendif = 1;
     usr_data.mask_display = 1;
   }


### PR DESCRIPTION
The existing code was passing the single wavelet scales through processing by all following modules in the
pixel pipe, which not only slowed things down, it also resulted in different displays depending on the
downstream processing (especially brightness adjustments from exposure, basecurve, filmic, etc.).  Denoising
would also hide details.  This patch adds a new channel-display type that the pixel pipe will treat like the color
channel display from blendop, and skip all non-distorting iops between retouch and gamma.

It may be desireable to tweak the default brightness up a little now that neither basecurve nor filmic is
being applied to the wavelet scale.