### PR TITLE
Correct direction of slider moves if triggered via up/down or dynamic shortcuts

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2240,7 +2240,7 @@ float dt_bauhaus_slider_get_step(GtkWidget *widget)
 
   dt_bauhaus_slider_data_t *d = &w->data.slider;
 
-  return d->step;
+  return d->factor < 0 ? - d->step : d->step;
 }
 
 void dt_bauhaus_slider_set_feedback(GtkWidget *widget, int feedback)


### PR DESCRIPTION
in cases where a negative multiplication factor is applied to the slider.

affects color balance/contrast, split-toning/balance, crop/angle&right&bottom, 

fixes #5524