### PR TITLE
make show/hide iop module shortcut more consistent

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2253,9 +2253,14 @@ static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *accele
   }
 
   const uint32_t current_group = dt_dev_modulegroups_get(module->dev);
+
   if(!dt_iop_shown_in_group(module, current_group))
   {
     dt_dev_modulegroups_switch(darktable.develop, module);
+  }
+  else
+  {
+    dt_dev_modulegroups_set(darktable.develop, current_group);
   }
 
   dt_iop_gui_set_expanded(module, !module->expanded, dt_conf_get_bool("darkroom/ui/single_module"));

--- a/src/libs/modulegroups.c
+++ b/src/libs/modulegroups.c
@@ -579,13 +579,10 @@ static gboolean _lib_modulegroups_set_gui_thread(gpointer user_data)
 
   dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)params->self->data;
 
-  const int group = _iop_get_group_order(params->group, params->group);
-
-  /* set current group or just update iop visibility*/
-  if(d->current != group && params->group < DT_MODULEGROUP_SIZE && GTK_IS_TOGGLE_BUTTON(d->buttons[params->group]))
+  /* set current group and update visibility */
+  if(params->group < DT_MODULEGROUP_SIZE && GTK_IS_TOGGLE_BUTTON(d->buttons[params->group]))
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->buttons[params->group]), TRUE);
-  else
-    _lib_modulegroups_update_iop_visibility(params->self);
+  _lib_modulegroups_update_iop_visibility(params->self);
 
   free(params);
   return FALSE;
@@ -648,11 +645,6 @@ static void _lib_modulegroups_search_text_focus(dt_lib_module_t *self)
 
 static void _lib_modulegroups_switch_group(dt_lib_module_t *self, dt_iop_module_t *module)
 {
-  dt_lib_modulegroups_t *d = (dt_lib_modulegroups_t *)self->data;
-
-  /* do nothing if module is member of current group */
-  if(_lib_modulegroups_test_internal(self, d->current, dt_iop_get_group(module))) return;
-
   /* lets find the group which is not favorite/active pipe */
   for(int k = DT_MODULEGROUP_BASIC; k < DT_MODULEGROUP_SIZE; k++)
   {


### PR DESCRIPTION
**The Problem**
Currently, if an iop module search is active and a user attempts to expand/collapse a module using a keyboard shortcut the behaviour is inconsistent and depends on the group that the user was in _before they initiated the search_.

For example, _the filmic rgb module is in the tone group_. Assign a keyboard shortcut to show/hide the filmic module (in my case SHIFT+F) and then attempt the following actions:

1. (a) Select the tone group. Search for the exposure module using the module search. Select the exposure module. Press SHIFT+F to show the filmic module. **Nothing Happens**. (b) Note that if you instead searched for, say "rgb" in this scenario, filmic would be in the search result list and the shortcut would just toggle it without cancelling the search.

2. (a) Clear the search and start again. Select the basic group. Search for the exposure module using the module search. Select the exposure module. Press SHIFT+F to show the filmic module. **The search box is cleared, darktable switches to the tone group and expands the filmic module (if it's not already expanded)**. (b) The same occurs if filmic is shown in the search results (e.g. when searching for "rgb").

The above results should be identical but depend on what module group you start in.

**The Fix**
This PR addresses this by making the behaviour consistent, when using a keyboard shortcut. If a module search is in progress, the search will be cancelled, the user will be switched to the appropriate module group and the module expanded or collapsed depending on its current state. If the module is already present in the group that was selected before the search was initiated (favourites, active), the user will be switched back to that group.

This should not change functionality where the search box or module groups are hidden.

