### PR TITLE
refactoring: eliminate duplicated boilerplate in lighttable modules

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1288,6 +1288,42 @@ dt_lib_module_t *dt_lib_get_module(const char *name)
   return NULL;
 }
 
+/* callback function for delayed update after user interaction */
+static gboolean _postponed_update(gpointer data)
+{
+  dt_lib_module_t *self = (dt_lib_module_t *)data;
+  self->timeout_handle = 0;
+  if (self->_postponed_update)
+    self->_postponed_update(self);
+
+  return FALSE; // cancel the timer
+}
+
+/** queue a delayed call of update function after user interaction */
+void dt_lib_queue_postponed_update(dt_lib_module_t *mod, void (*update_fn)(dt_lib_module_t *self))
+{
+  if(mod->timeout_handle)
+  {
+    // here we're making sure the event fires at last hover
+    // and we won't have avalanche of events in the mean time.
+    g_source_remove(mod->timeout_handle);
+  }
+  const int delay = CLAMP(darktable.develop->average_delay / 2, 10, 250);
+  mod->_postponed_update = update_fn;
+  mod->timeout_handle = g_timeout_add(delay, _postponed_update, mod);
+}
+
+void dt_lib_cancel_postponed_update(dt_lib_module_t *mod)
+{
+  mod->_postponed_update = NULL;
+  if (mod->timeout_handle)
+  {
+    g_source_remove(mod->timeout_handle);
+    mod->timeout_handle = 0;
+  }
+}
+
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -83,6 +83,10 @@ typedef struct dt_lib_module_t
   GtkWidget *widget;
   /** expander containing the widget. */
   GtkWidget *expander;
+  /** callback for delayed update after user interaction */
+  void (*_postponed_update)(struct dt_lib_module_t *self);
+  /** ID of timer for delayed callback */
+  guint timeout_handle;
 
   /** version */
   int (*version)(void);
@@ -171,6 +175,11 @@ gchar *dt_lib_get_localized_name(const gchar *plugin_name);
 /** add or replace a preset for this operation. */
 void dt_lib_presets_add(const char *name, const char *plugin_name, const int32_t version, const void *params,
                         const int32_t params_size);
+
+/** queue a delayed call of update function after user interaction */
+void dt_lib_queue_postponed_update(dt_lib_module_t *mod, void (*update_fn)(dt_lib_module_t *self));
+/** cancel any previously-queued callback */
+void dt_lib_cancel_postponed_update(dt_lib_module_t *mod);
 
 /*
  * Proxy functions

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -49,7 +49,6 @@ typedef struct dt_lib_metadata_t
   GtkWidget *config_button;
   gint line_height;
   gboolean init_layout;
-  guint timeout_handle;
 } dt_lib_metadata_t;
 
 const char *name(dt_lib_module_t *self)
@@ -140,6 +139,7 @@ static void _fill_text_view(const uint32_t i, const uint32_t count, dt_lib_modul
 
 static void _update(dt_lib_module_t *self)
 {
+  dt_lib_cancel_postponed_update(self);
   dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
   d->imgsel = dt_control_get_mouse_over_id();
 
@@ -199,20 +199,6 @@ static void _update(dt_lib_module_t *self)
 
   gtk_widget_set_sensitive(GTK_WIDGET(d->apply_button), imgs_count > 0);
   gtk_widget_set_sensitive(GTK_WIDGET(d->clear_button), imgs_count > 0);
-
-  if(d->timeout_handle)
-  {
-    g_source_remove(d->timeout_handle);
-    d->timeout_handle = 0;
-  }
-}
-
-static gboolean _postponed_update(gpointer data)
-{
-  // timeout handle clearing is handled by update code
-  _update((dt_lib_module_t *)data);
-
-  return FALSE;
 }
 
 static void _image_selection_changed_callback(gpointer instance, dt_lib_module_t *self)
@@ -395,15 +381,7 @@ static void _mouse_over_image_callback(gpointer instance, dt_lib_module_t *self)
   // if editing don't lose the current entry
   if (d->editing) return;
 
-  const int delay = CLAMP(darktable.develop->average_delay / 2, 10, 250);
-
-  if(d->timeout_handle)
-  {
-    // here we're making sure the event fires at last hover
-    // and we won't have avalanche of events in the mean time.
-    g_source_remove(d->timeout_handle);
-  }
-  d->timeout_handle = g_timeout_add(delay, _postponed_update, self);
+  dt_lib_queue_postponed_update(self, _update);
 }
 
 static gboolean _metadata_list_size_changed(GtkWidget *window, GdkEvent  *event, GtkCellRenderer *renderer)
@@ -692,7 +670,7 @@ void gui_init(dt_lib_module_t *self)
   self->data = (void *)d;
 
   d->imgsel = -1;
-  d->timeout_handle = 0;
+  self->timeout_handle = 0;
 
   GtkGrid *grid = (GtkGrid *)gtk_grid_new();
   self->widget = GTK_WIDGET(grid);
@@ -797,13 +775,11 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
+  dt_lib_cancel_postponed_update(self);
   const dt_lib_metadata_t *d = (dt_lib_metadata_t *)self->data;
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_mouse_over_image_callback), self);
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_image_selection_changed_callback), self);
   dt_control_signal_disconnect(darktable.signals, G_CALLBACK(_collection_updated_callback), self);
-
-  if(d->timeout_handle)
-    g_source_remove(d->timeout_handle);
 
   for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
   {


### PR DESCRIPTION
The same code was used in six separate modules to set up callbacks for a delayed update after a mouse move.  This PR replaces that boilerplate with calls to a pair of shared functions.
