### PR TITLE
xmp update fix

### DIFF
--- a/src/common/image.c
+++ b/src/common/image.c
@@ -457,12 +457,12 @@ void dt_image_set_location(const int32_t imgid, const dt_image_geoloc_t *geoloc,
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = (GList *)dt_view_get_images_to_act_on(TRUE, TRUE);
+    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
   dt_image_set_locations(imgs, geoloc, undo_on);
-  if(imgid != -1) g_list_free(imgs);
+  g_list_free(imgs);
 }
 
 void dt_image_reset_final_size(const int32_t imgid)

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -548,7 +548,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
   {
     GList *imgs = NULL;
     if(imgid == -1)
-      imgs = (GList *)dt_view_get_images_to_act_on(TRUE, TRUE);
+      imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
     else
       imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
     if(imgs)
@@ -565,7 +565,7 @@ void dt_metadata_set(const int imgid, const char *key, const char *value, const 
       _metadata_execute(imgs, metadata, &undo, undo_on, DT_MA_ADD);
 
       g_list_free_full(metadata, g_free);
-      if(imgid != -1) g_list_free(imgs);
+      g_list_free(imgs);
       if(undo_on)
       {
         dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
@@ -652,7 +652,6 @@ void dt_metadata_set_list(const GList *imgs, GList *key_value, const gboolean un
       dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
       dt_undo_end_group(darktable.undo);
     }
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
 
     g_list_free_full(metadata, g_free);
   }
@@ -690,7 +689,6 @@ void dt_metadata_clear(const GList *imgs, const gboolean undo_on)
       dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
       dt_undo_end_group(darktable.undo);
     }
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
 
     g_list_free_full(metadata, g_free);
   }
@@ -713,7 +711,6 @@ void dt_metadata_set_list_id(const GList *img, const GList *metadata, const gboo
       dt_undo_record(darktable.undo, NULL, DT_UNDO_METADATA, undo, _pop_undo, _metadata_undo_data_free);
       dt_undo_end_group(darktable.undo);
     }
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   }
 }
 

--- a/src/common/tags.c
+++ b/src/common/tags.c
@@ -231,9 +231,6 @@ guint dt_tag_remove(const guint tagid, gboolean final)
     DT_DEBUG_SQLITE3_BIND_INT(stmt, 1, tagid);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
-
-    /* raise signal of tags change to refresh keywords module */
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   }
 
   return count;
@@ -287,8 +284,6 @@ guint dt_tag_remove_list(GList *tag_list)
     g_free(flatlist);
     tcount = tcount + count;
   }
-  /* raise signal of tags change to refresh keywords module */
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
   return tcount;
 }
 
@@ -500,7 +495,6 @@ gboolean dt_tag_set_tags(const GList *tags, const GList *img, const gboolean ign
       dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
       dt_undo_end_group(darktable.undo);
     }
-    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
     return res;
   }
   return FALSE;
@@ -544,8 +538,6 @@ gboolean dt_tag_attach_string_list(const gchar *tags, const GList *img, const gb
         dt_undo_record(darktable.undo, NULL, DT_UNDO_TAGS, undo, _pop_undo, _tags_undo_data_free);
         dt_undo_end_group(darktable.undo);
       }
-
-      dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
     }
     g_list_free(tagl);
   }
@@ -581,13 +573,13 @@ gboolean dt_tag_detach(const guint tagid, const gint imgid, const gboolean undo_
 {
   GList *imgs = NULL;
   if(imgid == -1)
-    imgs = (GList *)dt_view_get_images_to_act_on(TRUE, TRUE);
+    imgs = g_list_copy((GList *)dt_view_get_images_to_act_on(TRUE, TRUE));
   else
     imgs = g_list_append(imgs, GINT_TO_POINTER(imgid));
   if(group_on) dt_grouping_add_grouped_images(&imgs);
 
   const gboolean res = dt_tag_detach_images(tagid, imgs, undo_on);
-  if(imgid != -1) g_list_free(imgs);
+  g_list_free(imgs);
   return res;
 }
 

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -308,6 +308,7 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     {
       GList *metadata = (action == DT_MA_CLEAR) ? NULL : dt_metadata_get_list_id(imageid);
       dt_metadata_set_list_id(imgs, metadata, action != DT_MA_MERGE, TRUE);
+      dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
       g_list_free_full(metadata, g_free);
     }
     if(geotag_flag)
@@ -324,7 +325,8 @@ static void _execute_metadata(dt_lib_module_t *self, const int action)
     {
       // affect only user tags (not dt tags)
       GList *tags = (action == DT_MA_CLEAR) ? NULL : dt_tag_get_tags(imageid, TRUE);
-      dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE);
+      if(dt_tag_set_tags(tags, imgs, TRUE, action != DT_MA_MERGE, TRUE))
+        dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
       g_list_free(tags);
     }
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -232,6 +232,7 @@ static void _clear_button_clicked(GtkButton *button, dt_lib_module_t *self)
   d->editing = FALSE;
   const GList *imgs = dt_view_get_images_to_act_on(FALSE, TRUE);
   dt_metadata_clear(imgs, TRUE);
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   dt_image_synch_xmps(imgs);
   _update(self);
 }
@@ -966,6 +967,7 @@ int set_params(dt_lib_module_t *self, const void *params, int size)
 
   g_list_free(key_value);
 
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE);
   dt_image_synch_xmps(imgs);
   _update(self);
   return 0;

--- a/src/lua/tags.c
+++ b/src/lua/tags.c
@@ -161,7 +161,8 @@ static int tag_delete(lua_State *L)
   }
   sqlite3_finalize(stmt);
 
-  dt_tag_remove(tagid, TRUE);
+  if(dt_tag_remove(tagid, TRUE))
+    dt_control_signal_raise(darktable.signals, DT_SIGNAL_TAG_CHANGED);
 
   GList *list_iter;
   if((list_iter = g_list_first(tagged_images)) != NULL)

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -188,6 +188,7 @@ typedef enum dt_view_image_over_t
 } dt_view_image_over_t;
 
 // get images to act on for gloabals change (via libs or accels)
+// no need to free the list - done internally
 const GList *dt_view_get_images_to_act_on(const gboolean only_visible, const gboolean force);
 // get the main image to act on during global changes (libs, accels)
 int dt_view_get_image_to_act_on();


### PR DESCRIPTION
- clean up metadata and tags before updating from xmp (triggered by crawler)
- read dt colors if xmp.xmp.label (from external app) not present instead of overwriting them
- some signal raise moved from common to libs (dead locks in _exif_decode_xmp_data)
- ~~some memory leak fixes (g_list_free) in tagging.c~~ fix lists with grouped images instead

fixes #5486
