### PR TITLE
attempt at making tone EQ more robust and responsive

### DIFF
--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -872,7 +872,7 @@ schedule(static) aligned(luminance, out, in:64) collapse(3)
     for(size_t j = 0; j < out_width; ++j)
       for(size_t c = 0; c < ch; ++c)
       {
-        // normalize the mask intensity between -8 EV and 0 EV for clarity, 
+        // normalize the mask intensity between -8 EV and 0 EV for clarity,
         // and add a "gamma" 2.0 for better legibility in shadows
         const float intensity = sqrtf(fminf(fmaxf(luminance[(i + offset_y) * in_width  + (j + offset_x)] - 0.00390625f, 0.f) / 0.99609375f, 1.f));
         out[(i * out_width + j) * ch + c] = (c == 3) ? in[((i + offset_y) * in_width + (j + offset_x)) * ch + 3]
@@ -1096,6 +1096,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
   const int radius = (int)((diameter - 1.0f) / ( 2.0f));
   d->radius = radius;
 
+  /*
   // Enlarge the preview roi with padding if needed
   if(self->dev->gui_attached && sanity_check(self))
   {
@@ -1110,6 +1111,7 @@ void modify_roi_in(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *
     roi_in->width = roir - roi_in->x;
     roi_in->height = roib - roi_in->y;
   }
+  */
 }
 
 


### PR DESCRIPTION
This tries to fix #5216 fix #5145 and fix #3714 and fix #6605, e.g. weird segfaults and major slowdowns when zooming in picture while Tone EQ is used.

## How was it before ?

When zoomed-in, the module enlarged the region of interest (ROI) to compute the guided filter. This ensured that, no matter the zoom size, the guided filter will *look* the same in the darkroom, especially around preview edges. At export time, it did not change anything. But that came at a price : the computed image could be close to the full resolution image, when zoomed at 100% with a blur size of 50%, resulting in slow-downs.

## How is it now ?

Only the visible ROI is computed. Padding is removed. The local contrast will slightly change depending on zoom scale and on whether the image details are on the preview ROI edge or center. At export time, it will make no difference.

## Your job

is to tell me whether the preview inaccuracy is worth the speed-up and robustness increase.

Remember that, now as before, setting the global contrast (no matter which module is used) should be made fully zoomed-out (image filling the view or less) to avoid perceptual discrepancies linked to Stevens/Bartleson-Breneman/Hunt effects and central fovea sensitivity while assessing the image contrast and brightness.