### PR TITLE
Ensure decent cairo scaling for duplicates

### DIFF
--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -378,11 +378,11 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       cairo_surface_t *img_surf = NULL;
       if(thumb->zoomable)
       {
-        res = dt_view_image_get_surface(thumb->imgid, image_w * thumb->zoom, image_h * thumb->zoom, &img_surf);
+        res = dt_view_image_get_surface(thumb->imgid, image_w * thumb->zoom, image_h * thumb->zoom, &img_surf, FALSE);
       }
       else
       {
-        res = dt_view_image_get_surface(thumb->imgid, image_w, image_h, &img_surf);
+        res = dt_view_image_get_surface(thumb->imgid, image_w, image_h, &img_surf, FALSE);
       }
 
       if(res)

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -251,7 +251,7 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
   int res = 0;
   if(d->preview_id != d->imgid || d->preview_zoom != nz * zoom_ratio || !d->preview_surf)
   {
-    res = dt_view_image_get_surface(d->imgid, img_wd * nz, img_ht * nz, &d->preview_surf);
+    res = dt_view_image_get_surface(d->imgid, img_wd * nz, img_ht * nz, &d->preview_surf, TRUE);
 
     if(!res)
     {

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -299,7 +299,8 @@ void gui_post_expose(dt_lib_module_t *self, cairo_t *cri, int32_t width, int32_t
     cairo_rectangle(cri, 0, 0, wd, ht);
     cairo_clip_preserve(cri);
     cairo_set_source_surface(cri, d->preview_surf, dx, dy);
-    cairo_pattern_set_filter(cairo_get_source(cri), darktable.gui->filter_image);
+    cairo_pattern_set_filter(cairo_get_source(cri), (darktable.gui->filter_image == CAIRO_FILTER_FAST)
+      ? CAIRO_FILTER_GOOD : darktable.gui->filter_image) ;
     cairo_paint(cri);
 
     cairo_restore(cri);

--- a/src/views/print.c
+++ b/src/views/print.c
@@ -234,7 +234,7 @@ static void expose_print_page(dt_view_t *self, cairo_t *cr, int32_t width, int32
   cairo_fill (cr);
 
   cairo_surface_t *surf = NULL;
-  const int res = dt_view_image_get_surface(prt->image_id, iwidth, iheight, &surf);
+  const int res = dt_view_image_get_surface(prt->image_id, iwidth, iheight, &surf, TRUE);
   if(res)
   {
     // if the image is missing, we reload it again

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -220,7 +220,7 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
   {
     cairo_surface_t *surf = NULL;
     const int res
-        = dt_view_image_get_surface(lib->image_id, width - (MARGIN * 2.0f), height - (MARGIN * 2.0f), &surf);
+        = dt_view_image_get_surface(lib->image_id, width - (MARGIN * 2.0f), height - (MARGIN * 2.0f), &surf, FALSE);
     if(res)
     {
       // if the image is missing, we reload it again

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -933,7 +933,7 @@ int dt_view_get_image_to_act_on()
   return ret;
 }
 
-int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface)
+int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface, const gboolean quality)
 {
   // if surface not null, clean it up
   if(*surface && cairo_surface_get_reference_count(*surface) > 0) cairo_surface_destroy(*surface);
@@ -1053,7 +1053,7 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
     if((buf_wd <= 8 && buf_ht <= 8) || fabsf(scale - 1.0f) < 0.01f)
       cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
     else
-    cairo_pattern_set_filter(cairo_get_source(cr), (darktable.gui->filter_image == CAIRO_FILTER_FAST)
+    cairo_pattern_set_filter(cairo_get_source(cr), ((darktable.gui->filter_image == CAIRO_FILTER_FAST) && quality)
       ? CAIRO_FILTER_GOOD : darktable.gui->filter_image) ;
 
     cairo_paint(cr);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -1053,7 +1053,8 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
     if((buf_wd <= 8 && buf_ht <= 8) || fabsf(scale - 1.0f) < 0.01f)
       cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
     else
-      cairo_pattern_set_filter(cairo_get_source(cr), darktable.gui->filter_image);
+    cairo_pattern_set_filter(cairo_get_source(cr), (darktable.gui->filter_image == CAIRO_FILTER_FAST)
+      ? CAIRO_FILTER_GOOD : darktable.gui->filter_image) ;
 
     cairo_paint(cr);
     /* from focus_peaking.h

--- a/src/views/view.h
+++ b/src/views/view.h
@@ -195,7 +195,7 @@ int dt_view_get_image_to_act_on();
 /** returns an uppercase string of file extension **plus** some flag information **/
 char* dt_view_extend_modes_str(const char * name, const int is_hdr, const int is_bw);
 /** expose an image and return a cairi_surface. return != 0 if thumbnail wasn't loaded yet. */
-int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface);
+int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface, const gboolean quality);
 
 
 /** Set the selection bit to a given value for the specified image */


### PR DESCRIPTION
After #5453 things are much better for comparing duplicates, the most annoying artefacts (at least with the default for `ui/cairo_filter=fast`) are cairo scaling based.

This pr makes sure we use at least `CAIRO_FILTER_GOOD` while comparing duplicates.

Adding quality to `int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface, const gboolean quality)` has been done to ensure other code to be as fast as before. BTW for printing ensuring the quality also makes sense.
