### PR TITLE
refactoring: eliminate duplicate boilerplate in iops

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2758,25 +2758,20 @@ static gboolean _postponed_history_update(gpointer data)
 /** too often). */
 void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
 {
-  if (module->timeout_handle)
+  if (module->timeout_handle && extend_prior)
   {
-    if (extend_prior)
-    {
-      // we already queued an update, but we don't want to have the update happen until the timeout expires
-      // without any activity, so cancel the queued callback
-      g_source_remove(module->timeout_handle);
-    }
-    else
-    {
-      // let the existing event happen as scheduled
-      return;
-    }
+    // we already queued an update, but we don't want to have the update happen until the timeout expires
+    // without any activity, so cancel the queued callback
+    g_source_remove(module->timeout_handle);
   }
-  // adaptively set the timeout to 150% of the average time the past several pixelpipe runs took, clamped
-  //   to keep updates from appearing to be too sluggish (though early iops such as rawdenoise may have
-  //   multiple very slow iops following them, leading to >1000ms processing times)
-  const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1200);
-  module->timeout_handle = g_timeout_add(delay, _postponed_history_update, module);
+  if (!module->timeout_handle || extend_prior)
+  {
+    // adaptively set the timeout to 150% of the average time the past several pixelpipe runs took, clamped
+    //   to keep updates from appearing to be too sluggish (though early iops such as rawdenoise may have
+    //   multiple very slow iops following them, leading to >1000ms processing times)
+    const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1200);
+    module->timeout_handle = g_timeout_add(delay, _postponed_history_update, module);
+  }
 }
 
 void dt_iop_cancel_history_update(dt_iop_module_t *module)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2756,13 +2756,21 @@ static gboolean _postponed_history_update(gpointer data)
 
 /** queue a delayed call of the add_history function after user interaction, to capture parameter updates (but not */
 /** too often). */
-void dt_iop_queue_history_update(dt_iop_module_t *module)
+void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
 {
   if (module->timeout_handle)
   {
-    // we already queued an update, but we don't want to have the update happen until the timeout expires
-    // without any activity, so cancel the queued callback
-    g_source_remove(module->timeout_handle);
+    if (extend_prior)
+    {
+      // we already queued an update, but we don't want to have the update happen until the timeout expires
+      // without any activity, so cancel the queued callback
+      g_source_remove(module->timeout_handle);
+    }
+    else
+    {
+      // let the existing event happen as scheduled
+      return;
+    }
   }
   // adaptively set the timeout to 150% of the average time the past several pixelpipe runs took
   const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2772,8 +2772,10 @@ void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
       return;
     }
   }
-  // adaptively set the timeout to 150% of the average time the past several pixelpipe runs took
-  const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
+  // adaptively set the timeout to 150% of the average time the past several pixelpipe runs took, clamped
+  //   to keep updates from appearing to be too sluggish (though early iops such as rawdenoise may have
+  //   multiple very slow iops following them, leading to >1000ms processing times)
+  const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1200);
   module->timeout_handle = g_timeout_add(delay, _postponed_history_update, module);
 }
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -397,6 +397,9 @@ typedef struct dt_iop_module_t
   GtkWidget *duplicate_button;
   GtkWidget *multimenu_button;
 
+  /** delayed-event handling */
+  guint timeout_handle;
+
   /** version of the parameters in the database. */
   int (*version)(void);
   /** get name of the module, to be translated. */
@@ -672,6 +675,11 @@ dt_iop_module_t *dt_iop_get_module_accel_curr(dt_iop_module_so_t *module);
 
 /** count instances of a module **/
 int dt_iop_count_instances(dt_iop_module_so_t *module);
+
+/** queue a delayed call to dt_dev_add_history_item to capture module parameters */
+void dt_iop_queue_history_update(dt_iop_module_t *module);
+/** cancel any previously-queued history update */
+void dt_iop_cancel_history_update(dt_iop_module_t *module);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -677,7 +677,7 @@ dt_iop_module_t *dt_iop_get_module_accel_curr(dt_iop_module_so_t *module);
 int dt_iop_count_instances(dt_iop_module_so_t *module);
 
 /** queue a delayed call to dt_dev_add_history_item to capture module parameters */
-void dt_iop_queue_history_update(dt_iop_module_t *module);
+void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior);
 /** cancel any previously-queued history update */
 void dt_iop_cancel_history_update(dt_iop_module_t *module);
 

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -63,7 +63,6 @@ typedef struct dt_iop_lowlight_gui_data_t
   dt_iop_lowlight_params_t drag_params;
   int dragging;
   int x_move;
-  int timeout_handle;
   float draw_xs[DT_IOP_LOWLIGHT_RES], draw_ys[DT_IOP_LOWLIGHT_RES];
   float draw_min_xs[DT_IOP_LOWLIGHT_RES], draw_min_ys[DT_IOP_LOWLIGHT_RES];
   float draw_max_xs[DT_IOP_LOWLIGHT_RES], draw_max_ys[DT_IOP_LOWLIGHT_RES];
@@ -291,11 +290,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_iop_lowlight_gui_data_t *g = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
   dt_bauhaus_slider_set(g->scale_blueness, p->blueness);
-  if(g->timeout_handle)
-  {
-    g_source_remove(g->timeout_handle);
-    g->timeout_handle = 0;
-  }
+  dt_iop_cancel_history_update(self);
   gtk_widget_queue_draw(self->widget);
 }
 
@@ -676,17 +671,6 @@ static gboolean lowlight_draw(GtkWidget *widget, cairo_t *crf, gpointer user_dat
   return TRUE;
 }
 
-static gboolean postponed_value_change(gpointer data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)data;
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-  c->timeout_handle = 0;
-
-  return FALSE;
-}
-
 static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -716,10 +700,7 @@ static gboolean lowlight_motion_notify(GtkWidget *widget, GdkEventMotion *event,
       dt_iop_lowlight_get_params(p, c->mouse_x, c->mouse_y + c->mouse_pick, c->mouse_radius);
     }
     gtk_widget_queue_draw(widget);
-    const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
-
-    if(!c->timeout_handle)
-      c->timeout_handle = g_timeout_add(delay, postponed_value_change, self);
+    dt_iop_queue_history_update(self, FALSE);
   }
   else if(event->y > height)
   {
@@ -843,7 +824,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
   c->x_move = -1;
-  c->timeout_handle = 0;
+  self->timeout_handle = 0;
   c->mouse_radius = 1.0 / DT_IOP_LOWLIGHT_BANDS;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -871,7 +852,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_draw_curve_destroy(c->transition_curve);
-  if(c->timeout_handle) g_source_remove(c->timeout_handle);
+  dt_iop_cancel_history_update(self);
   free(self->gui_data);
   self->gui_data = NULL;
 }

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -71,7 +71,6 @@ typedef struct dt_iop_rawdenoise_gui_data_t
   dt_iop_rawdenoise_params_t drag_params;
   int dragging;
   int x_move;
-  int timeout_handle;
   dt_iop_rawdenoise_channel_t channel;
   float draw_xs[DT_IOP_RAWDENOISE_RES], draw_ys[DT_IOP_RAWDENOISE_RES];
   float draw_min_xs[DT_IOP_RAWDENOISE_RES], draw_min_ys[DT_IOP_RAWDENOISE_RES];
@@ -598,11 +597,7 @@ void gui_update(dt_iop_module_t *self)
 {
   dt_iop_rawdenoise_gui_data_t *g = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
-  if(g->timeout_handle)
-  {
-    g_source_remove(g->timeout_handle);
-    g->timeout_handle = 0;
-  }
+  dt_iop_cancel_history_update(self);
   dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
   gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "non_raw" : "raw");
   gtk_widget_queue_draw(self->widget);
@@ -808,17 +803,6 @@ static gboolean rawdenoise_draw(GtkWidget *widget, cairo_t *crf, gpointer user_d
   return TRUE;
 }
 
-static gboolean postponed_value_change(gpointer data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)data;
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-  c->timeout_handle = 0;
-
-  return FALSE;
-}
-
 static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
@@ -838,10 +822,7 @@ static gboolean rawdenoise_motion_notify(GtkWidget *widget, GdkEventMotion *even
       dt_iop_rawdenoise_get_params(p, c->channel, c->mouse_x, c->mouse_y + c->mouse_pick, c->mouse_radius);
     }
     gtk_widget_queue_draw(widget);
-    const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
-
-    if(!c->timeout_handle)
-      c->timeout_handle = g_timeout_add(delay, postponed_value_change, self);
+    dt_iop_queue_history_update(self, FALSE);
   }
   else
   {
@@ -975,7 +956,7 @@ void gui_init(dt_iop_module_t *self)
   c->mouse_x = c->mouse_y = c->mouse_pick = -1.0;
   c->dragging = 0;
   c->x_move = -1;
-  c->timeout_handle = 0;
+  self->timeout_handle = 0;
   c->mouse_radius = 1.0 / (DT_IOP_RAWDENOISE_BANDS * 2);
 
   c->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -1030,7 +1011,7 @@ void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
   dt_draw_curve_destroy(c->transition_curve);
-  if(c->timeout_handle) g_source_remove(c->timeout_handle);
+  dt_iop_cancel_history_update(self);
   free(self->gui_data);
   self->gui_data = NULL;
 }

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -156,7 +156,6 @@ typedef struct dt_iop_tonecurve_gui_data_t
   tonecurve_channel_t channel;
   double mouse_x, mouse_y;
   int selected;
-  int timeout_handle;
   float draw_xs[DT_IOP_TONECURVE_RES], draw_ys[DT_IOP_TONECURVE_RES];
   float draw_min_xs[DT_IOP_TONECURVE_RES], draw_min_ys[DT_IOP_TONECURVE_RES];
   float draw_max_xs[DT_IOP_TONECURVE_RES], draw_max_ys[DT_IOP_TONECURVE_RES];
@@ -846,11 +845,7 @@ void gui_update(struct dt_iop_module_t *self)
     gtk_widget_set_visible(g->logbase, FALSE);
   }
 
-  if(g->timeout_handle)
-  {
-    g_source_remove(g->timeout_handle);
-    g->timeout_handle = 0;
-  }
+  dt_iop_cancel_history_update(self);
 
   // that's all, gui curve is read directly from params during expose event.
   gtk_widget_queue_draw(self->widget);
@@ -1107,17 +1102,6 @@ static void dt_iop_tonecurve_sanity_check(dt_iop_module_t *self, GtkWidget *widg
   }
 }
 
-static gboolean postponed_value_change(gpointer data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)data;
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-  c->timeout_handle = 0;
-
-  return FALSE;
-}
-
 static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, float dx, float dy, guint state)
 {
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
@@ -1152,11 +1136,7 @@ static gboolean _move_point_internal(dt_iop_module_t *self, GtkWidget *widget, f
 
   gtk_widget_queue_draw(widget);
 
-  const int delay = CLAMP(darktable.develop->average_delay * 3 / 2, 10, 1000);
-
-  if(!c->timeout_handle)
-    c->timeout_handle = g_timeout_add(delay, postponed_value_change, self);
-
+  dt_iop_queue_history_update(self, FALSE);
   return TRUE;
 }
 
@@ -1251,7 +1231,7 @@ void gui_init(struct dt_iop_module_t *self)
   c->selected = -1;
   c->loglogscale = 0;
   c->semilog = 0;
-  c->timeout_handle = 0;
+  self->timeout_handle = 0;
 
   c->autoscale_ab = dt_bauhaus_combobox_from_params(self, "tonecurve_autoscale_ab");
   gtk_widget_set_tooltip_text(c->autoscale_ab, _("if set to auto, a and b curves have no effect and are "
@@ -1355,7 +1335,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_draw_curve_destroy(c->minmax_curve[ch_L]);
   dt_draw_curve_destroy(c->minmax_curve[ch_a]);
   dt_draw_curve_destroy(c->minmax_curve[ch_b]);
-  if(c->timeout_handle) g_source_remove(c->timeout_handle);
+  dt_iop_cancel_history_update(self);
   free(self->gui_data);
   self->gui_data = NULL;
 }


### PR DESCRIPTION
Replace multiple occurrences of boilerplate to create a delayed call to dt_dev_add_history_item (to avoid flooding the pixelpipes with work) with calls to a new function encapsulating that boilerplate.

This is a companion PR to #5530, but the two can be merged independently.
