### PR TITLE
shortcut to change "keyboard shortcut slider adjustment precision"

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -35,6 +35,12 @@
     <longdescription>after applying the above rules, apply the shortcut based on its position in the pixelpipe</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>accel/slider_precision</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>keyboard shortcut slider precision</shortdescription>
+  </dtconfig>
+  <dtconfig>
     <name>bauhaus/scale</name>
     <type>float</type>
     <default>1.4</default>

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -669,6 +669,22 @@ void dt_accel_widget_toast(GtkWidget *widget)
 
 }
 
+float dt_accel_get_slider_scale_multiplier()
+{
+  const int slider_precision = dt_conf_get_int("accel/slider_precision");
+  
+  if(slider_precision == DT_IOP_PRECISION_COARSE)
+  {
+    return dt_conf_get_float("darkroom/ui/scale_rough_step_multiplier");
+  }
+  else if(slider_precision == DT_IOP_PRECISION_FINE)
+  {
+    return dt_conf_get_float("darkroom/ui/scale_precise_step_multiplier");
+  }
+
+  return dt_conf_get_float("darkroom/ui/scale_step_multiplier");
+}
+
 static gboolean bauhaus_slider_increase_callback(GtkAccelGroup *accel_group, GObject *acceleratable,
                                                  guint keyval, GdkModifierType modifier, gpointer data)
 {
@@ -676,8 +692,9 @@ static gboolean bauhaus_slider_increase_callback(GtkAccelGroup *accel_group, GOb
 
   float value = dt_bauhaus_slider_get(slider);
   float step = dt_bauhaus_slider_get_step(slider);
+  float multiplier = dt_accel_get_slider_scale_multiplier();
 
-  dt_bauhaus_slider_set(slider, value + step);
+  dt_bauhaus_slider_set(slider, value + step * multiplier);
 
   g_signal_emit_by_name(G_OBJECT(slider), "value-changed");
 
@@ -692,8 +709,9 @@ static gboolean bauhaus_slider_decrease_callback(GtkAccelGroup *accel_group, GOb
 
   float value = dt_bauhaus_slider_get(slider);
   float step = dt_bauhaus_slider_get_step(slider);
+  float multiplier = dt_accel_get_slider_scale_multiplier();
 
-  dt_bauhaus_slider_set(slider, value - step);
+  dt_bauhaus_slider_set(slider, value - step * multiplier);
 
   g_signal_emit_by_name(G_OBJECT(slider), "value-changed");
 

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -50,6 +50,13 @@ typedef struct dt_accel_dynamic_t
 
 } dt_accel_dynamic_t;
 
+typedef enum dt_accel_iop_slider_scale_t
+{
+  DT_IOP_PRECISION_NORMAL = 0,
+  DT_IOP_PRECISION_FINE = 1,
+  DT_IOP_PRECISION_COARSE = 2
+} dt_accel_iop_slider_scale_t;
+
 // Accel path string building functions
 void dt_accel_path_global(char *s, size_t n, const char *path);
 void dt_accel_path_view(char *s, size_t n, char *module, const char *path);
@@ -127,6 +134,9 @@ void dt_accel_rename_lua(const gchar *path, const gchar *new_path);
 
 // UX miscellaneous functions
 void dt_accel_widget_toast(GtkWidget *widget);
+
+// Get the scale multiplier for adjusting sliders with shortcuts
+float dt_accel_get_slider_scale_multiplier();
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Allows user to choose to use normal, fine or coarse adjustments when
amending iop sliders with an increase, decrease or dynamic keyboard
shortcut. Scale can be selected via, of course, a keyboard shortcut.

Uses the same slider adjustment factors that are used for the CTRL and
SHIFT modifiers when adjusting sliders directly.