### PR TITLE
iop_order: sanity check to avoid crash when reloading boggus xmp.

### DIFF
--- a/src/common/iop_order.c
+++ b/src/common/iop_order.c
@@ -1999,6 +1999,37 @@ char *dt_ioppr_serialize_text_iop_order_list(GList *iop_order_list)
   return text;
 }
 
+/* this sanity check routine is used to correct wrong iop-list that
+ * could have been stored while some bugs were present in
+ * dartkable. There was a window around Sep 2019 where such issue
+ * existed and some xmp may have been corrupt at this time making dt
+ * crash while reimporting using the xmp.
+ *
+ * One common case seems that the list does not end with gamma.
+*/
+
+static gboolean _ioppr_sanity_check_iop_order(GList *list)
+{
+  gboolean ok = TRUE;
+
+  // First check that first module is rawprepare (even for a jpeg, we
+  // are speaking of the module ordering not the activated modules.
+
+  GList *first = g_list_first(list);
+  dt_iop_order_entry_t *entry_first = (dt_iop_order_entry_t *)first->data;
+
+  ok = ok && (g_strcmp0(entry_first->operation, "rawprepare") == 0);
+
+  // Then check that last module is gamma
+
+  GList *last = g_list_last(list);
+  dt_iop_order_entry_t *entry_last = (dt_iop_order_entry_t *)last->data;
+
+  ok = ok && (g_strcmp0(entry_last->operation, "gamma") == 0);
+
+  return ok;
+}
+
 GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf)
 {
   GList *iop_order_list = NULL;
@@ -2035,6 +2066,8 @@ GList *dt_ioppr_deserialize_text_iop_order_list(const char *buf)
   g_list_free(list);
 
   _ioppr_reset_iop_order(iop_order_list);
+
+  if(!_ioppr_sanity_check_iop_order(iop_order_list)) goto error;
 
   return iop_order_list;
 


### PR DESCRIPTION
For #5489.