### PR TITLE
Don't round slider to digits unless digits is zero

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2325,9 +2325,9 @@ void dt_bauhaus_slider_set_soft(GtkWidget *widget, float pos)
 static void dt_bauhaus_slider_set_normalized(dt_bauhaus_widget_t *w, float pos)
 {
   dt_bauhaus_slider_data_t *d = &w->data.slider;
+  float rpos = CLAMP(pos, 0.0f, 1.0f);
   if(d->digits == 0)
   {
-    float rpos = CLAMP(pos, 0.0f, 1.0f);
     rpos = d->curve(GTK_WIDGET(w), rpos, DT_BAUHAUS_GET);
     rpos = d->min + (d->max - d->min) * rpos;
     const float base = powf(10.0f, d->digits);
@@ -2337,7 +2337,7 @@ static void dt_bauhaus_slider_set_normalized(dt_bauhaus_widget_t *w, float pos)
   }
   else
   {
-    d->pos = pos;
+    d->pos = rpos;
   }
   gtk_widget_queue_draw(GTK_WIDGET(w));
   d->is_changed = 1;

--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -2325,13 +2325,20 @@ void dt_bauhaus_slider_set_soft(GtkWidget *widget, float pos)
 static void dt_bauhaus_slider_set_normalized(dt_bauhaus_widget_t *w, float pos)
 {
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float rpos = CLAMP(pos, 0.0f, 1.0f);
-  rpos = d->curve(GTK_WIDGET(w), rpos, DT_BAUHAUS_GET);
-  rpos = d->min + (d->max - d->min) * rpos;
-  const float base = powf(10.0f, d->digits);
-  rpos = roundf(base * rpos) / base;
-  rpos = (rpos - d->min) / (d->max - d->min);
-  d->pos = d->curve(GTK_WIDGET(w), rpos, DT_BAUHAUS_SET);
+  if(d->digits == 0)
+  {
+    float rpos = CLAMP(pos, 0.0f, 1.0f);
+    rpos = d->curve(GTK_WIDGET(w), rpos, DT_BAUHAUS_GET);
+    rpos = d->min + (d->max - d->min) * rpos;
+    const float base = powf(10.0f, d->digits);
+    rpos = roundf(base * rpos) / base;
+    rpos = (rpos - d->min) / (d->max - d->min);
+    d->pos = d->curve(GTK_WIDGET(w), rpos, DT_BAUHAUS_SET);
+  }
+  else
+  {
+    d->pos = pos;
+  }
   gtk_widget_queue_draw(GTK_WIDGET(w));
   d->is_changed = 1;
   if(!darktable.gui->reset && !d->is_dragging)

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -772,6 +772,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_max(g->radius, 4.0f);
+  dt_bauhaus_slider_set_step(g->radius, 1.0f);
   dt_bauhaus_slider_set_digits(g->radius, 0);
   dt_bauhaus_slider_set_format(g->radius, "%.0f");
   gtk_widget_set_tooltip_text(g->radius, _("radius of the patches to match"));


### PR DESCRIPTION
Just to test and experiment with the approach suggested in https://github.com/darktable-org/darktable/issues/5581#issuecomment-647029190

This might cause problems if any module is expecting their parameters to be rounded to 0.01, 0.02 etc.

Also fixes an issue where first slider in denoise (non-local means) is stuck because step size too small...