### PR TITLE
darktableconfig.xml.in: fix XML and include ui/cairo_filter

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -106,6 +106,19 @@
     <shortdescription>maximum width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
+  <dtconfig>
+    <name>ui/cairo_filter</name>
+    <type>
+      <enum>
+	<option>fast</option>
+	<option>good</option>
+	<option>best</option>
+      </enum>
+    </type>
+    <default>fast</default>
+    <shortdescription>speed/quality trade-off for drawing images</shortdescription>
+    <longdescription>fast (default) - high-performance, similar to nearest neighbor filter; good - reasonable-performance, similar to bilinear (linear interpolation in two dimensions); best - highest-quality available, performance may not be suitable for interactive use. sets Cairo image scaling filter. (needs a restart)</longdescription>
+  </dtconfig>
   <dtconfig prefs="otherviews" section="slideshow">
     <name>slideshow_delay</name>
     <type>int</type>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2287,14 +2287,14 @@
     <type>float</type>
     <default>-1.0</default>
     <shortdescription>overwrite the screen's dpi setting</shortdescription>
-    <longdescription>if this value is > 0.0 then it is used as the screen's dpi setting which is used to scale the gui</longdescription>
+    <longdescription>if this value is &gt; 0.0 then it is used as the screen's dpi setting which is used to scale the gui</longdescription>
   </dtconfig>
   <dtconfig>
     <name>screen_ppd_overwrite</name>
     <type>float</type>
     <default>-1.0</default>
     <shortdescription>overwrite the screen's ppd setting</shortdescription>
-    <longdescription>if this value is > 0.0 then it is used as the screen's ppd setting which is used for HiDPI support</longdescription>
+    <longdescription>if this value is &gt; 0.0 then it is used as the screen's ppd setting which is used for HiDPI support</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/preview/max_in_memory_images</name>


### PR DESCRIPTION
Update darktableconfig.xml.in to include an entry for `ui/cairo_filter`. Also, convert ">"'s to entities to make valid XML.

There's still a slew of other conf variables which either aren't in darktableconfig.xml.in or which don't have descriptions.