### PR TITLE
Implement modifier detection in a portable way

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1146,10 +1146,8 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     float picker_values[4];
     GtkDarktableGradientSlider *slider;
 
-    int lower_upper;
-    guint state = gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    if((state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
+    int lower_upper; // lower=0, upper=1
+    if(dt_key_modifier_state() == GDK_CONTROL_MASK) 
     {
       lower_upper = 1;
       raw_mean = module->picked_output_color;

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -157,10 +157,8 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   // set module active if not yet the case
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
-  const uint32_t state = e != NULL
-                        ? e->state
-                        : gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
-  gboolean ctrl_key_pressed = (state & gtk_accelerator_get_default_mod_mask()) == GDK_CONTROL_MASK;
+  const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
+  const gboolean ctrl_key_pressed = (state == GDK_CONTROL_MASK);
   dt_iop_color_picker_kind_t kind = self->kind;
 
   if (module->picker != self || (ctrl_key_pressed && kind == DT_COLOR_PICKER_POINT_AREA))

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2887,6 +2887,14 @@ void dt_gui_load_theme(const char *theme)
   }
 }
 
+GdkModifierType dt_key_modifier_state()
+{
+  guint state = 0;
+  GdkWindow *window = gtk_widget_get_window(dt_ui_main_window(darktable.gui->ui));
+  gdk_device_get_state(gdk_seat_get_pointer(gdk_display_get_default_seat(gdk_window_get_display(window))), window, NULL, &state);
+  return state & gtk_accelerator_get_default_mod_mask();
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -379,9 +379,12 @@ void dt_gui_load_theme(const char *theme);
 // reload GUI scalings
 void dt_configure_ppd_dpi(dt_gui_gtk_t *gui);
 
-//translate key press events to remove any modifiers used to produce the keyval
+// translate key press events to remove any modifiers used to produce the keyval
 // for example when the shift key is used to create the asterisk character
 guint dt_gui_translated_key_state(GdkEventKey *event);
+
+// return modifier keys currently pressed, independent of any key event
+GdkModifierType dt_key_modifier_state();
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2229,12 +2229,11 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
       curve[k].y = d->curve[ch_curve][k].y;
     }
 
-    guint state = gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    int picker_set_upper_lower;
-    if((state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
+    const GdkModifierType state = dt_key_modifier_state();
+    int picker_set_upper_lower; // flat=0, lower=-1, upper=1
+    if(state == GDK_CONTROL_MASK)
       picker_set_upper_lower = 1;
-    else if((state & modifiers) == GDK_SHIFT_MASK)
+    else if(state == GDK_SHIFT_MASK)
       picker_set_upper_lower = -1;
     else
       picker_set_upper_lower = 0;

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -508,12 +508,11 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
       p->curve_nodes[ch][k].y = d->curve_nodes[ch][k].y;
     }
 
-    guint state = gdk_keymap_get_modifier_state(gdk_keymap_get_for_display(gdk_display_get_default()));
-    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
-    int picker_set_upper_lower;
-    if((state & modifiers) == GDK_CONTROL_MASK) // flat=0, lower=-1, upper=1
+    const GdkModifierType state = dt_key_modifier_state();
+    int picker_set_upper_lower; // flat=0, lower=-1, upper=1
+    if(state == GDK_CONTROL_MASK)
       picker_set_upper_lower = 1;
-    else if((state & modifiers) == GDK_SHIFT_MASK)
+    else if(state == GDK_SHIFT_MASK)
       picker_set_upper_lower = -1;
     else
       picker_set_upper_lower = 0;


### PR DESCRIPTION
Detecting if modifiers (CTRL/SHIFT) were pressed without having access to an event did not work under Windows. Now implemented in a portable way, that needs to be tested on Mac.

This impacts color pickers in color zones and rgb curve and in parametric blending mask.

Closes #5443