### PR TITLE
prefer favorite group when showing/hiding a module with a keyboard shortcut

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2256,7 +2256,10 @@ static gboolean show_module_callback(GtkAccelGroup *accel_group, GObject *accele
 
   if(!dt_iop_shown_in_group(module, current_group))
   {
-    dt_dev_modulegroups_switch(darktable.develop, module);
+    if(dt_iop_shown_in_group(module, DT_MODULEGROUP_FAVORITES))
+      dt_dev_modulegroups_set(darktable.develop, DT_MODULEGROUP_FAVORITES);
+    else
+      dt_dev_modulegroups_switch(darktable.develop, module);
   }
   else
   {


### PR DESCRIPTION
when showing/hiding a module using a keyboard shortcut, if the module doesn't exist in the currently-displayed group but does exist in the favorites group, switch to favorites rather than the module's default group