### PR TITLE
Fix active image in filmstrip

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -78,9 +78,9 @@
 /* Views */
 @define-color darkroom_bg_color @grey_60;
 @define-color darkroom_preview_bg_color @grey_50;
-@define-color print_bg_color @grey_60;
-@define-color lighttable_bg_color @print_bg_color;
-@define-color lighttable_preview_bg_color @grey_50;
+@define-color print_bg_color @darkroom_bg_color;
+@define-color lighttable_bg_color @darkroom_bg_color;
+@define-color lighttable_preview_bg_color @darkroom_preview_bg_color;
 @define-color lighttable_bg_font_color @grey_85;
 
 /* Lighttable and film-strip */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -81,9 +81,9 @@
 /* Views */
 @define-color darkroom_bg_color @grey_75;
 @define-color darkroom_preview_bg_color @grey_65;
-@define-color print_bg_color @grey_75;
-@define-color lighttable_bg_color @print_bg_color;
-@define-color lighttable_preview_bg_color @grey_65;
+@define-color print_bg_color @darkroom_bg_color;
+@define-color lighttable_bg_color @darkroom_bg_color;
+@define-color lighttable_preview_bg_color @darkroom_preview_bg_color;
 @define-color lighttable_bg_font_color @grey_95;
 
 /* Lighttable and film-strip */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -127,9 +127,9 @@
 /* Views */
 @define-color darkroom_bg_color @grey_45;
 @define-color darkroom_preview_bg_color @grey_35;
-@define-color print_bg_color @grey_45;
-@define-color lighttable_bg_color @print_bg_color;
-@define-color lighttable_preview_bg_color @grey_35;
+@define-color print_bg_color @darkroom_bg_color;
+@define-color lighttable_bg_color @darkroom_bg_color;
+@define-color lighttable_preview_bg_color @darkroom_preview_bg_color;
 @define-color lighttable_bg_font_color @grey_75;
 
 /* Lighttable and film-strip */
@@ -1938,14 +1938,15 @@ spinbutton>button
   margin: 20px;
 }
 
-#thumb_main:active #thumb_image
-{
-  border: 2px solid @plugin_bg_color;
-}
-
 #thumb_ext /* adjust margin to better align to group, audio... icons and match to near all thumbnails sizes */
 {
   margin-top: -1px;
+}
+
+/* Set top margin on active image in filmstrip */
+#thumb_main:active #thumb_back
+{
+  border-top: 2.5px solid @border_color;
 }
 
 /*---------------


### PR DESCRIPTION
Fix #5598

I also made a simple cleanup to link some same related colors.

@AlicVB and @TurboGit: I think for that, a simple border-top is better than all borders as before. Hope you will like that. In case, I tested border-bottom and it's quite less visible as less space to have good contrast. Good to be tested with and without bottom headerbar (better without but good for me with).