### PR TITLE
ensure minimum slider change to break digit rounding hurdle even with fine multiplier

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1988,6 +1988,10 @@ static gboolean dt_bauhaus_slider_add_delta_internal(GtkWidget *widget, float de
     multiplier = dt_conf_get_float("darkroom/ui/scale_step_multiplier");
   }
 
+  const float min_visible = powf(10.0f, -d->digits) / (d->max - d->min);
+  if(fabsf(delta*multiplier) < min_visible) 
+    multiplier = min_visible / fabsf(delta);
+
   delta *= multiplier;
 
   if(w->module) dt_iop_request_focus(w->module);

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -694,6 +694,10 @@ static gboolean bauhaus_slider_increase_callback(GtkAccelGroup *accel_group, GOb
   float step = dt_bauhaus_slider_get_step(slider);
   float multiplier = dt_accel_get_slider_scale_multiplier();
 
+  const float min_visible = powf(10.0f, -dt_bauhaus_slider_get_digits(slider));
+  if(fabsf(step*multiplier) < min_visible) 
+    multiplier = min_visible / fabsf(step);
+
   dt_bauhaus_slider_set(slider, value + step * multiplier);
 
   g_signal_emit_by_name(G_OBJECT(slider), "value-changed");
@@ -710,6 +714,10 @@ static gboolean bauhaus_slider_decrease_callback(GtkAccelGroup *accel_group, GOb
   float value = dt_bauhaus_slider_get(slider);
   float step = dt_bauhaus_slider_get_step(slider);
   float multiplier = dt_accel_get_slider_scale_multiplier();
+
+  const float min_visible = powf(10.0f, -dt_bauhaus_slider_get_digits(slider));
+  if(fabsf(step*multiplier) < min_visible) 
+    multiplier = min_visible / fabsf(step);
 
   dt_bauhaus_slider_set(slider, value - step * multiplier);
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -3296,9 +3296,13 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
 
     if(w->type == DT_BAUHAUS_SLIDER)
     {
-      float value = dt_bauhaus_slider_get(self->dynamic_accel_current->widget);
-      float step = dt_bauhaus_slider_get_step(self->dynamic_accel_current->widget);
+      float value = dt_bauhaus_slider_get(widget);
+      float step = dt_bauhaus_slider_get_step(widget);
       float multiplier = dt_accel_get_slider_scale_multiplier();
+
+      const float min_visible = powf(10.0f, -dt_bauhaus_slider_get_digits(widget));
+      if(fabsf(step*multiplier) < min_visible) 
+        multiplier = min_visible / fabsf(step);
 
       if(up)
         dt_bauhaus_slider_set(self->dynamic_accel_current->widget, value + step * multiplier);


### PR DESCRIPTION
If the step size is too small, a slider can get stuck, because after each move it gets rounded to the nearest "digit". This can happen when the step size is multiplied by the "fine" multiplier, by holding the ctrl key while scrolling, or by using (dynamic) shortcuts combined with the scaling functionality introduced in #5570, This change ensures that the smallest step is at least one "digit". This doesn't necessarily make each change _visible_; it may be that there are hidden digits (format="0.01", digits=3) in which case 10 steps are needed to show a visible increase.

This change and #5570 (and  possibly the other places where the fine/normal/coarse configurable multipliers are used) should be refactored into a central step  size calculation. I believe this should live in bauhaus, but others (@houz?) may argue that this is accelerator functionality, so I prefer to keep this discussion for after 3.2.

closes #5581