### PR TITLE
remove unclickable spacing on module header and replace with CSS

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -595,7 +595,7 @@ overshoot.right
 /* Set modules name header */
 #module-header
 {
-  padding: 0.5em 0.5em 0.25em 0.5em;
+  padding: 0.5em 0.5em 0.5em 0.5em;
 }
 
 /* Labels in modules */

--- a/src/dtgtk/expander.c
+++ b/src/dtgtk/expander.c
@@ -103,7 +103,7 @@ GtkWidget *dtgtk_expander_new(GtkWidget *header, GtkWidget *body)
   g_return_val_if_fail(GTK_IS_WIDGET(body), NULL);
 
   expander
-      = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 3, NULL);
+      = g_object_new(dtgtk_expander_get_type(), "orientation", GTK_ORIENTATION_VERTICAL, "spacing", 0, NULL);
   expander->expanded = -1;
   expander->header = header;
   expander->body = body;


### PR DESCRIPTION
this change removes space at the bottom of lib and iop module headers
that could not be clicked (or where clicking it either caused focus to
be transferred without the module being expanded or for nothing to
happen)

this additional space was previously corrected-for in CSS so this change
also adjusts the CSS (since that correction is no longer required)