### PR TITLE
Remove call to curve from dt_bauhaus_slider_set_stop because scale is slider 0->1 already

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1246,11 +1246,10 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   dt_bauhaus_widget_t *w = DT_BAUHAUS_WIDGET(widget);
   if(w->type != DT_BAUHAUS_SLIDER) return;
   dt_bauhaus_slider_data_t *d = &w->data.slider;
-  float rawstop = d->curve(widget, stop, DT_BAUHAUS_SET);
   // need to replace stop?
   for(int k = 0; k < d->grad_cnt; k++)
   {
-    if(d->grad_pos[k] == rawstop)
+    if(d->grad_pos[k] == stop)
     {
       d->grad_col[k][0] = r;
       d->grad_col[k][1] = g;
@@ -1262,7 +1261,7 @@ void dt_bauhaus_slider_set_stop(GtkWidget *widget, float stop, float r, float g,
   if(d->grad_cnt < DT_BAUHAUS_SLIDER_MAX_STOPS)
   {
     int k = d->grad_cnt++;
-    d->grad_pos[k] = rawstop;
+    d->grad_pos[k] = stop;
     d->grad_col[k][0] = r;
     d->grad_col[k][1] = g;
     d->grad_col[k][2] = b;


### PR DESCRIPTION
This only has an effect for the split-toning balance slider, which has a negative factor (-100) applied, and hence a curve that inverts direction.

I believe that the original call to "callback" in dt_bauhaus_slider_set_stop (that I renamed to curve in the introspection refactoring) shouldn't have been here in the first place, because the scale for the "stop" parameter corresponds to the slider axis (0 left, 1 right), not the underlying parameter (otherwise it should have taken min/max into account as well).

Effectively this corrects the interface of dt_bauhaus_slider_set_stop, rather than work around it, like I think #5612 is doing, although the impact is exactly the same. @TurboGit hopefully you agree.

fixes #5606