### PR TITLE
switch off color pickers in rgb curve and color zone when dt_iop_color_picker_reset called from blender

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -372,7 +372,7 @@ static void _blendop_masks_mode_callback(const unsigned int mask_mode, dt_iop_gu
   else if(data->blendif_inited)
   {
     /* switch off color picker */
-    dt_iop_color_picker_reset(data->module, TRUE);
+    dt_iop_color_picker_reset(data->module, FALSE);
 
     gtk_widget_hide(GTK_WIDGET(data->blendif_box));
   }
@@ -478,7 +478,7 @@ static void _blendop_blendif_sliders_callback(GtkDarktableGradientSlider *slider
 
   float *parameters = &(bp->blendif_parameters[4 * ch]);
 
-  dt_iop_color_picker_reset(data->module, TRUE);
+  dt_iop_color_picker_reset(data->module, FALSE);
 
   dt_pthread_mutex_lock(&data->lock);
   for(int k = 0; k < 4; k++) parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
@@ -965,7 +965,7 @@ static void _blendop_blendif_reset(GtkButton *button, dt_iop_module_t *module)
   memcpy(module->blend_params->blendif_parameters, module->default_blendop_params->blendif_parameters,
          4 * DEVELOP_BLENDIF_SIZE * sizeof(float));
 
-  dt_iop_color_picker_reset(module, TRUE);
+  dt_iop_color_picker_reset(module, FALSE);
   dt_iop_gui_update_blendif(module);
   dt_dev_add_history_item(darktable.develop, module, TRUE);
 }
@@ -1030,7 +1030,7 @@ static int _blendop_masks_add_shape(GtkWidget *widget, dt_iop_module_t *self, gb
 
   // we want to be sure that the iop has focus
   dt_iop_request_focus(self);
-  dt_iop_color_picker_reset(self, TRUE);
+  dt_iop_color_picker_reset(self, FALSE);
   bd->masks_shown = DT_MASKS_EDIT_FULL;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bd->masks_edit), FALSE);
@@ -1070,7 +1070,7 @@ static int _blendop_masks_show_and_edit(GtkWidget *widget, GdkEventButton *event
     ++darktable.gui->reset;
 
     dt_iop_request_focus(self);
-    dt_iop_color_picker_reset(self, TRUE);
+    dt_iop_color_picker_reset(self, FALSE);
 
     dt_masks_form_t *grp = dt_masks_get_from_id(darktable.develop, self->blend_params->mask_id);
     if(grp && (grp->type & DT_MASKS_GROUP) && g_list_length(grp->points) > 0)
@@ -2272,7 +2272,7 @@ void dt_iop_gui_update_blending(dt_iop_module_t *module)
   else if(bd->blendif_inited)
   {
     /* switch off color picker */
-    dt_iop_color_picker_reset(module, TRUE);
+    dt_iop_color_picker_reset(module, FALSE);
 
     gtk_widget_hide(GTK_WIDGET(bd->blendif_box));
   }

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -106,7 +106,7 @@ static void _iop_color_picker_apply(dt_iop_module_t *module, dt_dev_pixelpipe_io
   }
 }
 
-static void _iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean update)
+static void _iop_color_picker_reset(dt_iop_color_picker_t *picker)
 {
   if(picker)
   {
@@ -121,13 +121,13 @@ static void _iop_color_picker_reset(dt_iop_color_picker_t *picker, gboolean upda
   }
 }
 
-void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update)
+void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep)
 {
   if(module && module->picker)
   {
-    if(strcmp(gtk_widget_get_name(module->picker->colorpick), "keep-active") != 0)
+    if(!keep || (strcmp(gtk_widget_get_name(module->picker->colorpick), "keep-active") != 0))
     {
-      _iop_color_picker_reset(module->picker, update);
+      _iop_color_picker_reset(module->picker);
       module->picker = NULL;
       module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
     }
@@ -145,7 +145,7 @@ static void _iop_init_picker(dt_iop_color_picker_t *picker, dt_iop_module_t *mod
   for(int j = 0; j<2; j++) picker->pick_pos[j] = NAN;
   for(int j = 0; j < 4; j++) picker->pick_box[j] = NAN;
 
-  _iop_color_picker_reset(picker, TRUE);
+  _iop_color_picker_reset(picker);
 }
 
 static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEventButton *e, dt_iop_color_picker_t *self)
@@ -165,7 +165,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
 
   if (module->picker != self || (ctrl_key_pressed && kind == DT_COLOR_PICKER_POINT_AREA))
   {
-    _iop_color_picker_reset(module->picker, TRUE);
+    _iop_color_picker_reset(module->picker);
     module->picker = self;
 
     ++darktable.gui->reset;
@@ -203,7 +203,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   }
   else
   {
-    _iop_color_picker_reset(module->picker, TRUE);
+    _iop_color_picker_reset(module->picker);
     module->picker = NULL;
     module->request_color_pick = DT_REQUEST_COLORPICK_OFF;
   }

--- a/src/gui/color_picker_proxy.h
+++ b/src/gui/color_picker_proxy.h
@@ -37,8 +37,8 @@ typedef enum _iop_color_picker_kind_t
   DT_COLOR_PICKER_POINT_AREA // allow the user to select between point and area
 } dt_iop_color_picker_kind_t;
 
-//* reset current color picker and/or blend color picker, and if update is TRUE also call update proxy */
-void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean update);
+//* reset current color picker if not keep-active or not keep */
+void dt_iop_color_picker_reset(dt_iop_module_t *module, gboolean keep);
 
 /* sets the picker colorspace */
 void dt_iop_color_picker_set_cst(dt_iop_module_t *module, const dt_iop_colorspace_type_t picker_cst);


### PR DESCRIPTION
specifically fixes issue with mask drawing in blender.

this cancels existing functionality to keep the left color picker active when module settings are changed, to directly be able to see the impact. this could possibly be reintroduced as part of further clean-up in blender.

fixes #5607