### PR TITLE
[bilat] reread sliders on mode change and change mode on hidden slider move

### DIFF
--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -358,17 +358,35 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
   dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
   dt_iop_bilat_params_t *p = (dt_iop_bilat_params_t *)self->params;
-  if(w == g->mode)
+  if(w == g->highlights || w == g->shadows || w == g->midtone)
+  {
+    dt_bauhaus_combobox_set(g->mode, s_mode_local_laplacian);
+  }
+  else if(w == g->range || w == g->spatial)
+  {
+    dt_bauhaus_combobox_set(g->mode, s_mode_bilateral);
+  }
+  else if(w == g->mode)
+  {
+    if(p->mode == s_mode_local_laplacian)
+    {
+      p->sigma_r = dt_bauhaus_slider_get(g->highlights);
+      p->sigma_s = dt_bauhaus_slider_get(g->shadows);
+    }
+    else
+    {
+      p->sigma_r = dt_bauhaus_slider_get(g->range);
+      p->sigma_s = dt_bauhaus_slider_get(g->spatial);
+    }
+  }
+
+  if(!w || w == g->mode)
   {
     gtk_widget_set_visible(g->highlights, p->mode == s_mode_local_laplacian);
-    dt_bauhaus_slider_set(g->highlights, 0.5f);
     gtk_widget_set_visible(g->shadows, p->mode == s_mode_local_laplacian);
-    dt_bauhaus_slider_set(g->shadows, 0.5f);
     gtk_widget_set_visible(g->midtone, p->mode == s_mode_local_laplacian);
     gtk_widget_set_visible(g->range, p->mode != s_mode_local_laplacian);
-    dt_bauhaus_slider_set(g->range, 20.0f);
     gtk_widget_set_visible(g->spatial, p->mode != s_mode_local_laplacian);
-    dt_bauhaus_slider_set(g->spatial, 50.0f);
   }
 }
 
@@ -386,18 +404,19 @@ void gui_update(dt_iop_module_t *self)
     dt_bauhaus_slider_set(g->highlights, p->sigma_r);
     dt_bauhaus_slider_set(g->shadows, p->sigma_s);
     dt_bauhaus_slider_set(g->midtone, p->midtone);
+    dt_bauhaus_slider_set(g->range, 20.0f);
+    dt_bauhaus_slider_set(g->spatial, 50.0f);
   }
   else
   {
     dt_bauhaus_slider_set(g->range, p->sigma_r);
     dt_bauhaus_slider_set(g->spatial, p->sigma_s);
+    dt_bauhaus_slider_set(g->midtone, p->midtone);
+    dt_bauhaus_slider_set(g->highlights, 0.5f);
+    dt_bauhaus_slider_set(g->shadows, 0.5f);
   }
 
-  gtk_widget_set_visible(g->highlights, p->mode == s_mode_local_laplacian);
-  gtk_widget_set_visible(g->shadows, p->mode == s_mode_local_laplacian);
-  gtk_widget_set_visible(g->midtone, p->mode == s_mode_local_laplacian);
-  gtk_widget_set_visible(g->range, p->mode != s_mode_local_laplacian);
-  gtk_widget_set_visible(g->spatial, p->mode != s_mode_local_laplacian);
+  gui_changed(self, NULL, NULL);
 }
 
 void gui_init(dt_iop_module_t *self)


### PR DESCRIPTION
In "local contrast" two sets of sliders are linked to the same fields and the mode determines which one is used. When changing modes, the values of the now activated sliders need to be reloaded into the field.

Previously those sliders would be reinitialised when unhidden, but this is not really necessary, so they now retain their values when hidden. They are just set to default values when a new image is loaded. So switching between modes doesn't wipe out settings.

Also, when hidden sliders are moved (using (dynamic) shortcuts, their values would override a field that currently has a different meaning leading to "interesting" results. Now, such a move leads to a mode change that makes those sliders visible. Especially when the module is hidden, this dual slider+mode change might still be somewhat unexpected.

Fixes #5620