### PR TITLE
remove extra space at top of modules

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -633,7 +633,8 @@ overshoot.right
   margin: 12px 0 6px 0;
 }
 
-#iop-plugin-ui #section_label.section_label_top
+#iop-plugin-ui #section_label.section_label_top,
+#lib-plugin-ui #section_label.section_label_top
 {
   margin: 2px 0 6px 0;
 }

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -480,9 +480,17 @@ void gui_update(struct dt_iop_module_t *self)
 }
 
 static inline void gui_init_section(struct dt_iop_module_t *self, char *section, GtkWidget *slider_box, 
-                                              GtkWidget *hue, GtkWidget *saturation, GtkWidget **picker)
+                                              GtkWidget *hue, GtkWidget *saturation, GtkWidget **picker, gboolean top)
 {
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(section), FALSE, FALSE, 0);
+  GtkWidget *label = dt_ui_section_label_new(section);
+
+  if(top)
+  {
+    GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
+    gtk_style_context_add_class(context, "section_label_top");
+  }
+
+  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   dt_bauhaus_slider_set_feedback(hue, 0);
   dt_bauhaus_slider_set_stop(hue, 0.0f  , 1.0f, 0.0f, 0.0f);
@@ -526,9 +534,9 @@ void gui_init(struct dt_iop_module_t *self)
   // start building top level widget
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  gui_init_section(self, _("shadows"), shadows_box, g->shadow_hue_gslider, g->shadow_sat_gslider, &g->shadow_colorpick);
+  gui_init_section(self, _("shadows"), shadows_box, g->shadow_hue_gslider, g->shadow_sat_gslider, &g->shadow_colorpick, TRUE);
 
-  gui_init_section(self, _("highlights"), highlights_box, g->highlight_hue_gslider, g->highlight_sat_gslider, &g->highlight_colorpick);
+  gui_init_section(self, _("highlights"), highlights_box, g->highlight_hue_gslider, g->highlight_sat_gslider, &g->highlight_colorpick, FALSE);
 
   // Additional parameters
   gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("properties")), FALSE, FALSE, 0);

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1391,7 +1391,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("content")), TRUE, TRUE, 0);
+  GtkWidget *label = dt_ui_section_label_new(_("content"));
+  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
+  gtk_style_context_add_class(context, "section_label_top");
+  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(grid, DT_BAUHAUS_SPACE);
@@ -1404,7 +1407,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_loc_get_datadir(datadir, sizeof(datadir));
   dt_loc_get_user_config_dir(configdir, sizeof(configdir));
 
-  GtkWidget *label = dtgtk_reset_label_new(_("marker"), self, &p->filename, sizeof(p->filename));
+  label = dtgtk_reset_label_new(_("marker"), self, &p->filename, sizeof(p->filename));
   g->watermarks = dt_bauhaus_combobox_new(self);
   gtk_widget_set_hexpand(GTK_WIDGET(g->watermarks), TRUE);
   char *tooltip = g_strdup_printf(_("SVG watermarks in %s/watermarks or %s/watermarks"), configdir, datadir);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -611,6 +611,8 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *label;
 
   label = dt_ui_section_label_new(_("storage options"));
+  GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
+  gtk_style_context_add_class(context, "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, TRUE, 0);
   dt_gui_add_help_link(self->widget, "export_selected.html#export_selected_usage");
 


### PR DESCRIPTION
where a lib or iop module is split into sections, reduce the amount of
space added at the top of the first section.

impacts splittoning, watermark and export modules