### PR TITLE
Filmstrip active triangle

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1948,6 +1948,15 @@ spinbutton>button
 {
   border-top: 2.5px solid @border_color;
 }
+/* Set top cursor on active image in filmstrip */
+#thumb_cursor
+{
+  color: transparent;
+}
+#thumb_main:active #thumb_cursor
+{
+  color: @border_color;
+}
 
 /*---------------
   - Bottom area -
@@ -2191,9 +2200,11 @@ spinbutton>button
 .dt_culling #thumb_back,
 .dt_culling #thumb_main:selected #thumb_back,
 .dt_culling #thumb_main:hover #thumb_back,
+.dt_culling #thumb_main:active #thumb_back,
 .dt_preview #thumb_back,
 .dt_preview #thumb_main:selected #thumb_back,
-.dt_preview #thumb_main:hover #thumb_back
+.dt_preview #thumb_main:hover #thumb_back,
+.dt_preview #thumb_main:active #thumb_back
 {
   background-color: transparent;
   border: none;

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1769,6 +1769,7 @@ Hierachy :
       #thumb_back                                                    (GtkEventBox -- thumbnail background)
       #thumb_ext                                                     (GtkLabel -- thumbnail extension)
       #thumb_image                                                   (GtkDrawingArea -- thumbnail image)
+      #thumb_cursor                                                  (GtkDrawingArea -- top triangle to show active images in filmstrip)
       #thumb_bottom                                                  (GtkEventBox -- background of the bottom infos area)
         #thumb_bottom_label                                          (GtkLabel -- text of the bottom infos area, just with .dt_extended_overlay)
       #thumb_reject                                                  (GtkDarktableThumbnailBtn -- Reject icon)

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1947,7 +1947,7 @@ spinbutton>button
 /* Set top margin on active image in filmstrip */
 #thumb_main:active #thumb_back
 {
-  border-top: 2.5px solid @border_color;
+  border-top: 1.5px solid @border_color;
 }
 /* Set top cursor on active image in filmstrip */
 #thumb_cursor

--- a/src/dtgtk/culling.c
+++ b/src/dtgtk/culling.c
@@ -1404,6 +1404,26 @@ static gboolean _thumbs_compute_positions(dt_culling_t *table)
   return TRUE;
 }
 
+void dt_culling_update_active_images_list(dt_culling_t *table)
+{
+  // we erase the list of active images
+  g_slist_free(darktable.view_manager->active_images);
+  darktable.view_manager->active_images = NULL;
+
+  // and we effectively move and resize thumbs
+  GList *l = table->list;
+  while(l)
+  {
+    dt_thumbnail_t *thumb = (dt_thumbnail_t *)l->data;
+    // we update the active images list
+    darktable.view_manager->active_images
+        = g_slist_append(darktable.view_manager->active_images, GINT_TO_POINTER(thumb->imgid));
+    l = g_list_next(l);
+  }
+
+  dt_control_signal_raise(darktable.signals, DT_SIGNAL_ACTIVE_IMAGES_CHANGE);
+}
+
 // recreate the list of thumb if needed and recomputes sizes and positions if needed
 void dt_culling_full_redraw(dt_culling_t *table, gboolean force)
 {

--- a/src/dtgtk/culling.h
+++ b/src/dtgtk/culling.h
@@ -91,6 +91,9 @@ void dt_culling_zoom_fit(dt_culling_t *table, gboolean only_current);
 
 // set the overlays type
 void dt_culling_set_overlays_mode(dt_culling_t *table, dt_thumbnail_overlay_t over);
+
+// update active images list
+void dt_culling_update_active_images_list(dt_culling_t *table);
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/dtgtk/thumbnail.h
+++ b/src/dtgtk/thumbnail.h
@@ -87,6 +87,7 @@ typedef struct
   gboolean img_surf_preview; // if TRUE, the image is originated from preview pipe
   gboolean img_surf_dirty;   // if TRUE, we need to recreate the surface on next drawing code
 
+  GtkWidget *w_cursor;    // GtkDrawingArea -- triangle to show current image(s) in filmstrip
   GtkWidget *w_bottom_eb; // GtkEventBox -- background of the bottom infos area (contains w_bottom)
   GtkWidget *w_bottom;    // GtkLabel -- text of the bottom infos area, just with #thumb_bottom_ext
   GtkWidget *w_reject;    // GtkDarktableThumbnailBtn -- Reject icon

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -116,6 +116,8 @@ static void _preview_quit(dt_view_t *self)
     dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE); // not available in this layouts
     dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module,
                        TRUE); // always on, visibility is driven by panel state
+
+    dt_culling_update_active_images_list(lib->culling);
   }
   else
   {
@@ -544,6 +546,11 @@ void enter(dt_view_t *self)
     dt_lib_set_visible(darktable.view_manager->proxy.timeline.module, FALSE); // not available in this layouts
     dt_lib_set_visible(darktable.view_manager->proxy.filmstrip.module,
                        TRUE); // always on, visibility is driven by panel state
+
+    if(lib->preview_state)
+      dt_culling_update_active_images_list(lib->preview);
+    else
+      dt_culling_update_active_images_list(lib->culling);
   }
   else
   {


### PR DESCRIPTION
as discussed, this PR adds a little triangle to show more obviously the current active image(s).
At the same time, this fix 2 little issues : 
- fix active images list which is lost in certain cases with culling or preview (when starting in culling mode for example)
- fix the top border in culling