### PR TITLE
more compressed color picker module

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1424,8 +1424,15 @@ cell:selected
 /* Module in darkroom left panel */
 #color-picker-area
 {
-  min-height: 9em;
-  min-width: 9em;
+  min-height: 7em;
+  min-width: 7em;
+}
+.picker-module combobox,
+.picker-module combobox button
+{
+  padding-top: 0;
+  padding-bottom: 0;
+  border: 0;
 }
 
 #live-sample


### PR DESCRIPTION
reduce the size of the picker area and the space between comboboxes

allow the lhs panel to be shrunk further at the expense of the picker area
not always being perfectly square

when panel is expanded past the minimum width, space is shared evenly
between the picker area and the comboboxes