### PR TITLE
fix erroneous API usage

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2679,11 +2679,7 @@ void dt_iop_connect_accels_multi(dt_iop_module_so_t *module)
     if(accel_mod_curr == accel_mod_new) return;
 
     //remove accelerators from current module
-    if(accel_mod_curr)
-    {
-      dt_accel_disconnect_list(accel_mod_curr->accel_closures);
-      accel_mod_curr->accel_closures = NULL;
-    }
+    if(accel_mod_curr) dt_accel_disconnect_list(&accel_mod_curr->accel_closures);
 
     //attach accelerators to new module
     if(accel_mod_new)

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2054,71 +2054,71 @@ void dt_thumbtable_update_accels_connection(dt_thumbtable_t *table, const int vi
 {
   //disconnect all accels and reconnect if thumbtable may be active for this view
 
-  dt_accel_disconnect_list(table->accel_closures);
+  dt_accel_disconnect_list(&table->accel_closures);
 
   if((view & DT_VIEW_LIGHTTABLE) || (view & DT_VIEW_DARKROOM) || (view & DT_VIEW_TETHERING)
      || (view & DT_VIEW_MAP) || (view & DT_VIEW_PRINT))
   {
     // Rating accels
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate 0",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate 0",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_DESERT), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate 1",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate 1",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_STAR_1), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate 2",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate 2",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_STAR_2), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate 3",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate 3",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_STAR_3), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate 4",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate 4",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_STAR_4), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate 5",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate 5",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_STAR_5), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/rate reject",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/rate reject",
                             g_cclosure_new(G_CALLBACK(_accel_rate), GINT_TO_POINTER(DT_VIEW_REJECT), NULL));
 
     // History key accels
     if(!(view & DT_VIEW_LIGHTTABLE))
     {
-      dt_accel_connect_manual(table->accel_closures, "views/thumbtable/copy history",
+      dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/copy history",
                               g_cclosure_new(G_CALLBACK(_accel_copy), NULL, NULL));
-      dt_accel_connect_manual(table->accel_closures, "views/thumbtable/copy history parts",
+      dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/copy history parts",
                               g_cclosure_new(G_CALLBACK(_accel_copy_parts), NULL, NULL));
-      dt_accel_connect_manual(table->accel_closures, "views/thumbtable/paste history",
+      dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/paste history",
                               g_cclosure_new(G_CALLBACK(_accel_paste), NULL, NULL));
-      dt_accel_connect_manual(table->accel_closures, "views/thumbtable/paste history parts",
+      dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/paste history parts",
                               g_cclosure_new(G_CALLBACK(_accel_paste_parts), NULL, NULL));
-      dt_accel_connect_manual(table->accel_closures, "views/thumbtable/discard history",
+      dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/discard history",
                               g_cclosure_new(G_CALLBACK(_accel_hist_discard), NULL, NULL));
     }
 
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/duplicate image",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/duplicate image",
                             g_cclosure_new(G_CALLBACK(_accel_duplicate), GINT_TO_POINTER(0), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/duplicate image virgin",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/duplicate image virgin",
                             g_cclosure_new(G_CALLBACK(_accel_duplicate), GINT_TO_POINTER(1), NULL));
 
     // Color label accels
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/color red",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/color red",
                             g_cclosure_new(G_CALLBACK(_accel_color), GINT_TO_POINTER(0), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/color yellow",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/color yellow",
                             g_cclosure_new(G_CALLBACK(_accel_color), GINT_TO_POINTER(1), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/color green",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/color green",
                             g_cclosure_new(G_CALLBACK(_accel_color), GINT_TO_POINTER(2), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/color blue",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/color blue",
                             g_cclosure_new(G_CALLBACK(_accel_color), GINT_TO_POINTER(3), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/color purple",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/color purple",
                             g_cclosure_new(G_CALLBACK(_accel_color), GINT_TO_POINTER(4), NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/clear color labels",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/clear color labels",
                             g_cclosure_new(G_CALLBACK(_accel_color), GINT_TO_POINTER(5), NULL));
 
     // Selection accels
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/select all",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/select all",
                             g_cclosure_new(G_CALLBACK(_accel_select_all), NULL, NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/select none",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/select none",
                             g_cclosure_new(G_CALLBACK(_accel_select_none), NULL, NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/invert selection",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/invert selection",
                             g_cclosure_new(G_CALLBACK(_accel_select_invert), NULL, NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/select film roll",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/select film roll",
                             g_cclosure_new(G_CALLBACK(_accel_select_film), NULL, NULL));
-    dt_accel_connect_manual(table->accel_closures, "views/thumbtable/select untouched",
+    dt_accel_connect_manual(&table->accel_closures, "views/thumbtable/select untouched",
                             g_cclosure_new(G_CALLBACK(_accel_select_untouched), NULL, NULL));
   }
 }

--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -534,14 +534,14 @@ void dt_accel_connect_lua(const gchar *path, GClosure *closure)
   gtk_accel_group_connect_by_path(darktable.control->accelerators, accel_path, closure);
 }
 
-void dt_accel_connect_manual(GSList *list, const gchar *full_path, GClosure *closure)
+void dt_accel_connect_manual(GSList **list_ptr, const gchar *full_path, GClosure *closure)
 {
   gchar accel_path[256];
   dt_accel_path_manual(accel_path, sizeof(accel_path), full_path);
   dt_accel_t *accel = _lookup_accel(accel_path);
   accel->closure = closure;
   gtk_accel_group_connect_by_path(darktable.control->accelerators, accel_path, closure);
-  list = g_slist_prepend(list, accel);
+  *list_ptr = g_slist_prepend(*list_ptr, accel);
 }
 
 static gboolean _press_button_callback(GtkAccelGroup *accel_group, GObject *acceleratable, guint keyval,
@@ -922,14 +922,16 @@ void dt_accel_connect_locals_iop(dt_iop_module_t *module)
   module->local_closures_connected = TRUE;
 }
 
-void dt_accel_disconnect_list(GSList *list)
+void dt_accel_disconnect_list(GSList **list_ptr)
 {
+  GSList *list = *list_ptr;
   while(list)
   {
     dt_accel_t *accel = (dt_accel_t *)list->data;
     if(accel) gtk_accel_group_disconnect(darktable.control->accelerators, accel->closure);
     list = g_slist_delete_link(list, list);
   }
+  *list_ptr = NULL;
 }
 
 void dt_accel_disconnect_locals_iop(dt_iop_module_t *module)

--- a/src/gui/accelerators.h
+++ b/src/gui/accelerators.h
@@ -113,10 +113,10 @@ void dt_accel_connect_locals_iop(dt_iop_module_t *module);
 void dt_accel_connect_preset_iop(dt_iop_module_t *so, const gchar *path);
 void dt_accel_connect_preset_lib(dt_lib_module_t *so, const gchar *path);
 void dt_accel_connect_lua(const gchar *path, GClosure *closure);
-void dt_accel_connect_manual(GSList *list, const gchar *full_path, GClosure *closure);
+void dt_accel_connect_manual(GSList **list_ptr, const gchar *full_path, GClosure *closure);
 
 // Disconnect function
-void dt_accel_disconnect_list(GSList *accels);
+void dt_accel_disconnect_list(GSList **accels_ptr);
 void dt_accel_disconnect_locals_iop(dt_iop_module_t *module);
 void dt_accel_cleanup_locals_iop(dt_iop_module_t *module);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -400,7 +400,7 @@ static int _check_deleted_instances(dt_develop_t *dev, GList **_iop_list, GList 
       dt_undo_iterate_internal(darktable.undo, DT_UNDO_HISTORY, mod, &_history_invalidate_cb);
 
       // we cleanup the module
-      dt_accel_disconnect_list(mod->accel_closures);
+      dt_accel_disconnect_list(&mod->accel_closures);
       dt_accel_cleanup_locals_iop(mod);
       mod->accel_closures = NULL;
       // don't delete the module, a pipe may still need it

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -716,7 +716,7 @@ int try_enter(dt_view_t *self)
 
 static void dt_dev_cleanup_module_accels(dt_iop_module_t *module)
 {
-  dt_accel_disconnect_list(module->accel_closures);
+  dt_accel_disconnect_list(&module->accel_closures);
   dt_accel_cleanup_locals_iop(module);
 }
 
@@ -885,9 +885,8 @@ static void dt_dev_change_image(dt_develop_t *dev, const uint32_t imgid)
       dev->iop = g_list_remove_link(dev->iop, g_list_nth(dev->iop, i));
 
       // we cleanup the module
-      dt_accel_disconnect_list(module->accel_closures);
+      dt_accel_disconnect_list(&module->accel_closures);
       dt_accel_cleanup_locals_iop(module);
-      module->accel_closures = NULL;
       dt_iop_cleanup_module(module);
       free(module);
     }

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -322,8 +322,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
           if(plugin->view_leave) plugin->view_leave(plugin, old_view, NULL);
           plugin->gui_cleanup(plugin);
           plugin->data = NULL;
-          dt_accel_disconnect_list(plugin->accel_closures);
-          plugin->accel_closures = NULL;
+          dt_accel_disconnect_list(&plugin->accel_closures);
           plugin->widget = NULL;
         }
       }
@@ -353,8 +352,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
   {
     /* leave current view */
     if(old_view->leave) old_view->leave(old_view);
-    dt_accel_disconnect_list(old_view->accel_closures);
-    old_view->accel_closures = NULL;
+    dt_accel_disconnect_list(&old_view->accel_closures);
 
     /* iterator plugins and cleanup plugins in current view */
     for(GList *iter = darktable.lib->plugins; iter; iter = g_list_next(iter))
@@ -365,8 +363,7 @@ int dt_view_manager_switch_by_view(dt_view_manager_t *vm, const dt_view_t *nv)
       if(dt_lib_is_visible_in_view(plugin, old_view))
       {
         if(plugin->view_leave) plugin->view_leave(plugin, old_view, new_view);
-        dt_accel_disconnect_list(plugin->accel_closures);
-        plugin->accel_closures = NULL;
+        dt_accel_disconnect_list(&plugin->accel_closures);
       }
     }
 


### PR DESCRIPTION
Fixes the functions `dt_accel_connect_manual` and `dt_accel_disconnect_list`, which use the GTK functions `g_slist_prepend` and `g_slist_delete_link` not correctly. More precisely, the return value is not utilized as designed by the GTK library.

(I have no idea why the current code works. It should not according to [this documentation](https://developer.gnome.org/glib/stable/glib-Singly-Linked-Lists.html#g-slist-prepend) and [this documentation](https://developer.gnome.org/glib/stable/glib-Singly-Linked-Lists.html#g-slist-delete-link). 