### PR TITLE
clipping: retain orientation when changing aspect ratio

### DIFF
--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1762,7 +1762,11 @@ static void aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
   // now we save all that if it has changed
   if(d != abs(p->ratio_d) || n != p->ratio_n)
   {
-    p->ratio_d = d;
+    if(p->ratio_d > 0)
+      p->ratio_d = d;
+    else
+      p->ratio_d = -d;
+
     p->ratio_n = n;
     dt_conf_set_int("plugins/darkroom/clipping/ratio_d", abs(p->ratio_d));
     dt_conf_set_int("plugins/darkroom/clipping/ratio_n", abs(p->ratio_n));


### PR DESCRIPTION
when choosing a new aspect ratio from the drop-down, don't change back
to landscape if user has previously selected a portrait orientation