### PR TITLE
Fixing local contrast issue #5643

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -893,8 +893,12 @@ dt_iop_module_t *dt_iop_gui_duplicate(dt_iop_module_t *base, gboolean copy_param
   /* initialize gui if iop have one defined */
   if(!dt_iop_is_hidden(module))
   {
+    // make sure gui_init and reload defaults is called safely
+    ++darktable.gui->reset;   
     module->gui_init(module);
     dt_iop_reload_defaults(module); // some modules like profiled denoise update the gui in reload_defaults
+    --darktable.gui->reset;   
+
     if(copy_params)
     {
       memcpy(module->params, base->params, module->params_size);

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -437,20 +437,17 @@ void gui_init(dt_iop_module_t *self)
 
   g->spatial = dt_bauhaus_slider_from_params(self, "sigma_s");
   dt_bauhaus_slider_set_default(g->spatial, 50.0);
-  dt_bauhaus_slider_set_hard_min(g->spatial, 1.0);
   dt_bauhaus_slider_set_digits(g->spatial, 0);
   dt_bauhaus_widget_set_label(g->spatial, NULL, _("coarseness"));
   gtk_widget_set_tooltip_text(g->spatial, _("feature size of local details (spatial sigma of bilateral filter)"));
 
   g->range = dt_bauhaus_slider_from_params(self, "sigma_r");
   dt_bauhaus_slider_set_default(g->range, 20.0);
-  dt_bauhaus_slider_set_hard_min(g->range, 1.0);
   dt_bauhaus_slider_set_digits(g->range, 0);
   dt_bauhaus_widget_set_label(g->range, NULL, _("contrast"));
   gtk_widget_set_tooltip_text(g->range, _("L difference to detect edges (range sigma of bilateral filter)"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "sigma_r");
-  dt_bauhaus_slider_set_hard_max(g->highlights, 2.0);
   dt_bauhaus_slider_set_step(g->highlights, 0.01);
   dt_bauhaus_widget_set_label(g->highlights, NULL, _("highlights"));
   dt_bauhaus_slider_set_factor(g->highlights, 100);
@@ -458,7 +455,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->highlights, _("changes the local contrast of highlights"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "sigma_s");
-  dt_bauhaus_slider_set_hard_max(g->shadows, 2.0);
   dt_bauhaus_slider_set_step(g->shadows, 0.01);
   dt_bauhaus_widget_set_label(g->shadows, NULL, _("shadows"));
   dt_bauhaus_slider_set_factor(g->shadows, 100);
@@ -474,6 +470,11 @@ void gui_init(dt_iop_module_t *self)
   g_object_set(G_OBJECT(g->midtone), "no-show-all", TRUE, NULL);
   g_object_set(G_OBJECT(g->range), "no-show-all", TRUE, NULL);
   g_object_set(G_OBJECT(g->spatial), "no-show-all", TRUE, NULL);
+
+  dt_bauhaus_slider_set_hard_min(g->spatial, 3.0);
+  dt_bauhaus_slider_set_hard_min(g->range, 1.0);
+  dt_bauhaus_slider_set_hard_max(g->highlights, 2.0);
+  dt_bauhaus_slider_set_hard_max(g->shadows, 2.0);
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
In #5643 there are two identified problems.

1. Setting bauhaus sliders min/max values should be done after full initialising

In gui_init we should set the sliders hard_min/max **after** the full widget is initialised.
@dterrahe and @TurboGit is this analyses correct?

2. At least the bilateral cl path dislikes sigma_s smaller than 3

@TurboGit or other "CL people", i am not sure about the cl maths of the bilateral filter, i checked for accepted values and 3 is safe. Is this the right place to fix or is this a bug in cl kernel?

Fixes #5643 