### PR TITLE
Notebook and section label changes for narrow panels

### DIFF
--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -297,7 +297,7 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
   dt_introspection_field_t *f = self->so->get_f(param);
 
-  GtkWidget *button;
+  GtkWidget *button, *label;
   gchar *str;
 
   if(f && f->header.type == DT_INTROSPECTION_TYPE_BOOL)
@@ -306,17 +306,20 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
     {
       // we do not want to support a context as it break all translations see #5498
       // button = gtk_check_button_new_with_label(g_dpgettext2(NULL, "introspection description", f->header.description));
-      button = gtk_check_button_new_with_label(gettext(f->header.description));
+      label = gtk_label_new(gettext(f->header.description));
     }
     else
     {
       str = dt_util_str_replace(f->header.field_name, "_", " ");
     
-      button = gtk_check_button_new_with_label(_(str));
+      label = gtk_label_new(_(str));
 
       g_free(str);
     }
 
+    gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+    button = gtk_check_button_new();
+    gtk_container_add(GTK_CONTAINER(button), label);
     dt_module_param_t *module_param = (dt_module_param_t *)g_malloc(sizeof(dt_module_param_t));
     module_param->module = self;
     module_param->param = p + f->header.offset;

--- a/src/dtgtk/resetlabel.c
+++ b/src/dtgtk/resetlabel.c
@@ -54,6 +54,7 @@ GtkWidget *dtgtk_reset_label_new(const gchar *text, dt_iop_module_t *module, voi
 
   label->lb = GTK_LABEL(gtk_label_new(text));
   gtk_widget_set_halign(GTK_WIDGET(label->lb), GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(label->lb), PANGO_ELLIPSIZE_END);
   gtk_event_box_set_visible_window(GTK_EVENT_BOX(label), FALSE);
   gtk_widget_set_tooltip_text(GTK_WIDGET(label), _("double-click to reset"));
   gtk_container_add(GTK_CONTAINER(label), GTK_WIDGET(label->lb));

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -2895,6 +2895,19 @@ GdkModifierType dt_key_modifier_state()
   return state & gtk_accelerator_get_default_mod_mask();
 }
 
+GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const char *tooltip)
+{
+  GtkWidget *label = gtk_label_new(text);
+  GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  if(strlen(text) > 9) gtk_label_set_width_chars(GTK_LABEL(label), strlen(text) / 3);
+  gtk_widget_set_tooltip_text(label, tooltip ? tooltip : text);
+  gtk_notebook_append_page(notebook, page, label);
+  gtk_container_child_set(GTK_CONTAINER(notebook), page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
+
+  return page;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -352,17 +352,7 @@ static inline GtkWidget *dt_ui_section_label_new(const gchar *str)
   return label;
 };
 
-static inline GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const char *tooltip)
-{
-  GtkWidget *label = gtk_label_new(text);
-  GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  if(tooltip) gtk_widget_set_tooltip_text(label, tooltip);
-  gtk_notebook_append_page(notebook, page, label);
-  gtk_container_child_set(GTK_CONTAINER(notebook), page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
-
-  return page;
-}
+GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const char *tooltip);
 
 static inline void dtgtk_justify_notebook_tabs(GtkNotebook *notebook)
 {

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4826,6 +4826,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
 
   GtkWidget *label1 = gtk_label_new(_("automatic fit"));
+  gtk_label_set_ellipsize(GTK_LABEL(label1), PANGO_ELLIPSIZE_END);
   gtk_widget_set_halign(label1, GTK_ALIGN_START);
   gtk_grid_attach(grid, label1, 0, 0, 1, 1);
 
@@ -4842,6 +4843,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach(grid, g->fit_both, 3, 0, 1, 1);
 
   GtkWidget *label2 = gtk_label_new(_("get structure"));
+  gtk_label_set_ellipsize(GTK_LABEL(label2), PANGO_ELLIPSIZE_END);
   gtk_widget_set_halign(label2, GTK_ALIGN_START);
   gtk_grid_attach(grid, label2, 0, 1, 1, 1);
 

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1864,23 +1864,11 @@ void gui_init(struct dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
-
-  GtkWidget *tab_label = gtk_label_new(_("luma"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("luma")));
-  gtk_widget_set_tooltip_text(tab_label, _("change lightness at each feature size"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("chroma")));
-  gtk_widget_set_tooltip_text(tab_label, _("change color saturation at each feature size"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("edges")));
-  gtk_widget_set_tooltip_text(tab_label, _("change edge halos at each feature size\nonly changes results of luma and chroma tabs"));
-
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
-
+  dt_ui_notebook_page(c->channel_tabs, _("luma"), _("change lightness at each feature size"));
+  dt_ui_notebook_page(c->channel_tabs, _("chroma"), _("change color saturation at each feature size"));
+  dt_ui_notebook_page(c->channel_tabs, _("edges"), _("change edge halos at each feature size\nonly changes results of luma and chroma tabs"));
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
-
-  dtgtk_justify_notebook_tabs(c->channel_tabs);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
 
   // graph
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.75));

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1541,6 +1541,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(self->widget), PANGO_ELLIPSIZE_END);
   self->gui_data = &dummy;
 }
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2132,7 +2132,9 @@ void gui_init(struct dt_iop_module_t *self)
   g->k_selected = -1;
   g->old_width = g->old_height = -1;
 
-  GtkWidget *page1 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
+
+  self->widget = dt_ui_notebook_page(g->notebook, _("main"), NULL);
 
   g->hvflip = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->hvflip, NULL, _("flip"));
@@ -2142,7 +2144,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->hvflip, _("both"));
   g_signal_connect(G_OBJECT(g->hvflip), "value-changed", G_CALLBACK(hvflip_callback), self);
   gtk_widget_set_tooltip_text(g->hvflip, _("mirror image horizontally and/or vertically"));
-  gtk_box_pack_start(GTK_BOX(page1), g->hvflip, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->hvflip, TRUE, TRUE, 0);
 
   g->angle = dt_bauhaus_slider_from_params(self, N_("angle"));
   dt_bauhaus_slider_set_step(g->angle, 0.25);
@@ -2158,7 +2160,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->keystone_type, _("full"));
   gtk_widget_set_tooltip_text(g->keystone_type, _("set perspective correction for your image"));
   g_signal_connect(G_OBJECT(g->keystone_type), "value-changed", G_CALLBACK(keystone_type_changed), self);
-  gtk_box_pack_start(GTK_BOX(page1), g->keystone_type, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->keystone_type, TRUE, TRUE, 0);
 
   g->crop_auto = dt_bauhaus_combobox_from_params(self, "crop_auto");
   gtk_widget_set_tooltip_text(g->crop_auto, _("automatically crop to avoid black edges"));
@@ -2277,15 +2279,15 @@ void gui_init(struct dt_iop_module_t *self)
                                                    "the list is sorted: from most square to least square"));
   dt_bauhaus_widget_set_quad_paint(g->aspect_presets, dtgtk_cairo_paint_aspectflip, 0, NULL);
   g_signal_connect(G_OBJECT(g->aspect_presets), "quad-pressed", G_CALLBACK(aspect_flip), self);
-  gtk_box_pack_start(GTK_BOX(page1), g->aspect_presets, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->aspect_presets, TRUE, TRUE, 0);
 
   g->guide_lines = dt_bauhaus_combobox_new(self);
   dt_bauhaus_widget_set_label(g->guide_lines, NULL, _("guides"));
-  gtk_box_pack_start(GTK_BOX(page1), g->guide_lines, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->guide_lines, TRUE, TRUE, 0);
 
   g->guides_widgets = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(g->guides_widgets), FALSE);
-  gtk_box_pack_start(GTK_BOX(page1), g->guides_widgets, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->guides_widgets, TRUE, TRUE, 0);
 
   dt_bauhaus_combobox_add(g->guide_lines, _("none"));
   int i = 0;
@@ -2320,12 +2322,12 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_add(g->flip_guides, _("both"));
   gtk_widget_set_tooltip_text(g->flip_guides, _("flip guides"));
   g_signal_connect(G_OBJECT(g->flip_guides), "value-changed", G_CALLBACK(guides_flip_changed), self);
-  gtk_box_pack_start(GTK_BOX(page1), g->flip_guides, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->flip_guides, TRUE, TRUE, 0);
   dt_bauhaus_combobox_set(g->flip_guides, dt_conf_get_int("plugins/darkroom/clipping/flip_guides"));
 
   guides_presets_set_visibility(g, guide);
 
-  GtkWidget *page2 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  self->widget = dt_ui_notebook_page(g->notebook, _("margins"), NULL);
 
   g->cx = dt_bauhaus_slider_from_params(self, "cx");
   dt_bauhaus_slider_set_digits(g->cx, 4);
@@ -2352,13 +2354,6 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_offset(g->ch, 100.0);
   dt_bauhaus_slider_set_format(g->ch, "%0.2f %%");
   gtk_widget_set_tooltip_text(g->ch, _("the bottom margin cannot overlap with the top margin"));
-
-  // Put notebook pages together
-  g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
-  gtk_notebook_append_page(g->notebook, page1, gtk_label_new(_("main")));
-  gtk_notebook_append_page(g->notebook, page2, gtk_label_new(_("margins")));
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->notebook, 0)));
-  dtgtk_justify_notebook_tabs(g->notebook);
 
   self->widget = GTK_WIDGET(g->notebook);
 }

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1089,12 +1089,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   button = gtk_button_new_with_label(_("acquire as source"));
   g->acquire_source_button = button;
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_START);
   gtk_widget_set_tooltip_text(button, _("analyze this image as a source image"));
   gtk_box_pack_start(box, button, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(acquire_source_button_pressed), (gpointer)self);
 
   button = gtk_button_new_with_label(_("acquire as target"));
   g->acquire_target_button = button;
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_START);
   gtk_widget_set_tooltip_text(button, _("analyze this image as a target image"));
   gtk_box_pack_start(box, button, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(acquire_target_button_pressed), (gpointer)self);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2365,14 +2365,14 @@ void gui_init(struct dt_iop_module_t *self)
 
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
 
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("lightness")));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("saturation")));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("hue")));
+  dt_ui_notebook_page(c->channel_tabs, _("lightness"), NULL);
+  dt_ui_notebook_page(c->channel_tabs, _("saturation"), NULL);
+  dt_ui_notebook_page(c->channel_tabs, _("hue"), NULL);
 
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
   gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(_channel_tabs_switch_callback), self);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new("   "), FALSE, FALSE, 0);
 
   // color pickers
   c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2406,6 +2406,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // edit by area
   c->chk_edit_by_area = gtk_check_button_new_with_label(_("edit by area"));
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(c->chk_edit_by_area))), PANGO_ELLIPSIZE_START);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(c->chk_edit_by_area), c->edit_by_area);
   gtk_widget_set_tooltip_text(c->chk_edit_by_area, _("edit the curve nodes by area"));
   gtk_box_pack_start(GTK_BOX(hbox_select_by), c->chk_edit_by_area, TRUE, TRUE, 0);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -4225,20 +4225,16 @@ void gui_init(dt_iop_module_t *self)
   g->wavelet_color_mode = dt_bauhaus_combobox_from_params(self, "wavelet_color_mode");
 
   g->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), gtk_label_new(_("all")));
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), gtk_label_new(_("R")));
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), gtk_label_new(_("G")));
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), gtk_label_new(_("B")));
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->channel_tabs, g->channel)));
-  gtk_notebook_set_current_page(g->channel_tabs, g->channel);
+  dt_ui_notebook_page(g->channel_tabs, _("all"), NULL);
+  dt_ui_notebook_page(g->channel_tabs, _("R"), NULL);
+  dt_ui_notebook_page(g->channel_tabs, _("G"), NULL);
+  dt_ui_notebook_page(g->channel_tabs, _("B"), NULL);
   g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(denoiseprofile_tab_switch), self);
   gtk_box_pack_start(GTK_BOX(g->box_wavelets), GTK_WIDGET(g->channel_tabs), FALSE, FALSE, 0);
 
   g->channel_tabs_Y0U0V0 = GTK_NOTEBOOK(gtk_notebook_new());
-  gtk_notebook_append_page(g->channel_tabs_Y0U0V0, gtk_grid_new(), gtk_label_new(_("Y0")));
-  gtk_notebook_append_page(g->channel_tabs_Y0U0V0, gtk_grid_new(), gtk_label_new(_("U0V0")));
-  gtk_widget_show_all(gtk_notebook_get_nth_page(g->channel_tabs_Y0U0V0, g->channel));
-  gtk_notebook_set_current_page(g->channel_tabs_Y0U0V0, g->channel);
+  dt_ui_notebook_page(g->channel_tabs_Y0U0V0, _("Y0"), NULL);
+  dt_ui_notebook_page(g->channel_tabs_Y0U0V0, _("U0V0"), NULL);
   g_signal_connect(G_OBJECT(g->channel_tabs_Y0U0V0), "switch_page", G_CALLBACK(denoiseprofile_tab_switch), self);
   gtk_box_pack_start(GTK_BOX(g->box_wavelets), GTK_WIDGET(g->channel_tabs_Y0U0V0), FALSE, FALSE, 0);
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2290,10 +2290,7 @@ void gui_init(dt_iop_module_t *self)
   g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
 
   // Page SCENE
-  GtkWidget *label = gtk_label_new(_("scene"));
-  GtkWidget *page1 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_notebook_append_page(g->notebook, page1, label);
+  self->widget = dt_ui_notebook_page(g->notebook, _("scene"), NULL);
 
   g->grey_point_source = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                          dt_bauhaus_slider_from_params(self, "grey_point_source"));
@@ -2329,27 +2326,24 @@ void gui_init(dt_iop_module_t *self)
                                                     "useful to give a safety margin to extreme luminances."));
 
   // Auto tune slider
-  g->auto_button = dt_bauhaus_combobox_new(self);
+  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
+                   dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_button, NULL, _("auto tune levels"));
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->auto_button);
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
                                                 "works better for landscapes and evenly-lit pictures\n"
                                                 "but fails for high-keys, low-keys and high-ISO pictures.\n"
                                                 "this is not an artificial intelligence, but a simple guess.\n"
                                                 "ensure you understand its assumptions before using it."));
-  gtk_box_pack_start(GTK_BOX(page1), g->auto_button, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_button, FALSE, FALSE, 0);
 
   // Page RECONSTRUCT
-  label = gtk_label_new(_("reconstruct"));
-  GtkWidget *page5 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_notebook_append_page(g->notebook, page5, label);
+  self->widget = dt_ui_notebook_page(g->notebook, _("reconstruct"), NULL);
 
-  label = dt_ui_section_label_new(_("highlights clipping"));
+  GtkWidget *label = dt_ui_section_label_new(_("highlights clipping"));
   GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(label));
   gtk_style_context_add_class(context, "section_label_top");
-  gtk_box_pack_start(GTK_BOX(page5), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_threshold = dt_bauhaus_slider_from_params(self, "reconstruct_threshold");
   dt_bauhaus_slider_set_format(g->reconstruct_threshold, _("%+.2f EV"));
@@ -2373,10 +2367,10 @@ void gui_init(dt_iop_module_t *self)
                                    CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   dt_bauhaus_widget_set_quad_toggle(g->show_highlight_mask, TRUE);
   g_signal_connect(G_OBJECT(g->show_highlight_mask), "quad-pressed", G_CALLBACK(show_mask_callback), self);
-  gtk_box_pack_start(GTK_BOX(page5), g->show_highlight_mask, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->show_highlight_mask, FALSE, FALSE, 0);
 
   label = dt_ui_section_label_new(_("balance"));
-  gtk_box_pack_start(GTK_BOX(page5), label, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), label, FALSE, FALSE, 0);
 
   g->reconstruct_structure_vs_texture = dt_bauhaus_slider_from_params(self, "reconstruct_structure_vs_texture");
   dt_bauhaus_slider_set_step(g->reconstruct_structure_vs_texture, 0.1);
@@ -2413,10 +2407,7 @@ void gui_init(dt_iop_module_t *self)
                                                               "decrease if you see magenta or out-of-gamut highlights."));
 
   // Page LOOK
-  label = gtk_label_new(_("look"));
-  GtkWidget *page2 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_notebook_append_page(g->notebook, page2, label);
+  self->widget = dt_ui_notebook_page(g->notebook, _("look"), NULL);
 
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
   dt_bauhaus_slider_set_soft_range(g->contrast, 1.0, 2.0);
@@ -2460,10 +2451,7 @@ void gui_init(dt_iop_module_t *self)
     dt_bauhaus_widget_set_label(g->saturation, NULL, _("middle tones saturation"));
 
   // Page DISPLAY
-  label = gtk_label_new(_("display"));
-  GtkWidget *page3 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_notebook_append_page(g->notebook, page3, label);
+  self->widget = dt_ui_notebook_page(g->notebook, _("display"), NULL);
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_from_params(self, "black_point_target");
@@ -2482,10 +2470,7 @@ void gui_init(dt_iop_module_t *self)
                                                        "this should be 100%\nexcept if you want a faded look"));
 
   // Page OPTIONS
-  label = gtk_label_new(_("options"));
-  GtkWidget *page4 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_notebook_append_page(g->notebook, page4, label);
+  self->widget = dt_ui_notebook_page(g->notebook, _("options"), NULL);
 
   // Color science
   g->version = dt_bauhaus_combobox_from_params(self, "version");
@@ -2545,8 +2530,6 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->notebook, 0)));
-  dtgtk_justify_notebook_tabs(g->notebook);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2416,6 +2416,7 @@ void gui_init(struct dt_iop_module_t *self)
   // profile only some of the lens flaws can be corrected
   GtkBox *hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
   GtkWidget *label = gtk_label_new(_("corrections done: "));
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_MIDDLE);
   gtk_widget_set_tooltip_text(label, _("which corrections have actually been done"));
   gtk_box_pack_start(GTK_BOX(hbox1), label, FALSE, FALSE, 0);
   g->message = GTK_LABEL(gtk_label_new("")); // This gets filled in by process

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3544,7 +3544,9 @@ void gui_init(dt_iop_module_t *module)
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));
   gtk_box_pack_start(GTK_BOX(module->widget), hbox, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(hbox), gtk_label_new(_("warps|nodes count:")), FALSE, TRUE, 0);
+  GtkWidget *label = gtk_label_new(_("warps|nodes count:"));
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
   g->label = GTK_LABEL(gtk_label_new("-"));
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -955,12 +955,11 @@ void gui_init(dt_iop_module_t *self)
   c->channel = dt_conf_get_int("plugins/darkroom/rawdenoise/gui_channel");
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
 
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("all")));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("R")));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("G")));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), gtk_label_new(_("B")));
+  dt_ui_notebook_page(c->channel_tabs, _("all"), NULL);
+  dt_ui_notebook_page(c->channel_tabs, _("R"), NULL);
+  dt_ui_notebook_page(c->channel_tabs, _("G"), NULL);
+  dt_ui_notebook_page(c->channel_tabs, _("B"), NULL);
 
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
   gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(rawdenoise_tab_switch), self);
 

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1998,6 +1998,7 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *hbox_shapes = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkWidget *label = gtk_label_new(_("shapes:"));
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   gtk_box_pack_start(GTK_BOX(hbox_shapes), label, FALSE, TRUE, 0);
   g->label_form = GTK_LABEL(gtk_label_new("-1"));
   gtk_box_pack_start(GTK_BOX(hbox_shapes), GTK_WIDGET(g->label_form), FALSE, TRUE, DT_PIXEL_APPLY_DPI(5));
@@ -2043,6 +2044,7 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *hbox_algo = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   GtkWidget *label2 = gtk_label_new(_("algorithms:"));
+  gtk_label_set_ellipsize(GTK_LABEL(label2), PANGO_ELLIPSIZE_END);
   gtk_box_pack_start(GTK_BOX(hbox_algo), label2, FALSE, TRUE, 0);
 
   g->bt_fill
@@ -2168,16 +2170,12 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_showmask, FALSE, FALSE, 0);
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_suppress, FALSE, FALSE, 0);
 
-  GtkWidget *lbl_scale_sep = gtk_label_new(NULL);
-  gtk_label_set_width_chars(GTK_LABEL(lbl_scale_sep), 1);
-  gtk_box_pack_end(GTK_BOX(hbox_scale), GTK_WIDGET(lbl_scale_sep), FALSE, FALSE, 0);
+  gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_paste_scale, FALSE, FALSE, 0);
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_copy_scale, FALSE, FALSE, 0);
 
-  GtkWidget *lbl_scale_sep1 = gtk_label_new(NULL);
-  gtk_label_set_width_chars(GTK_LABEL(lbl_scale_sep1), 1);
-  gtk_box_pack_end(GTK_BOX(hbox_scale), GTK_WIDGET(lbl_scale_sep1), FALSE, FALSE, 0);
+  gtk_box_pack_end(GTK_BOX(hbox_scale), gtk_grid_new(), TRUE, TRUE, 0);
 
   gtk_box_pack_end(GTK_BOX(hbox_scale), g->bt_display_wavelet_scale, FALSE, FALSE, 0);
 
@@ -2221,7 +2219,8 @@ void gui_init(dt_iop_module_t *self)
 
   // shapes selected (label)
   GtkWidget *hbox_shape_sel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *label1 = gtk_label_new(_("shape selected: "));
+  GtkWidget *label1 = gtk_label_new(_("shape selected:"));
+  gtk_label_set_ellipsize(GTK_LABEL(label1), PANGO_ELLIPSIZE_START);
   gtk_box_pack_start(GTK_BOX(hbox_shape_sel), label1, FALSE, TRUE, 0);
   g->label_form_selected = GTK_LABEL(gtk_label_new("-1"));
   gtk_widget_set_tooltip_text(hbox_shape_sel,

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1397,22 +1397,15 @@ void gui_init(struct dt_iop_module_t *self)
   g->autoscale = dt_bauhaus_combobox_from_params(self, "curve_autoscale");
   gtk_widget_set_tooltip_text(g->autoscale, _("choose between linked and independent channels."));
 
-  // tabs
-  g->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
-
-  GtkWidget *tab_label;
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  R  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("curve nodes for r channel"));
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  G  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("curve nodes for g channel"));
-  gtk_notebook_append_page(g->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  B  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("curve nodes for b channel"));
-
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->channel_tabs, g->channel)));
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(g->channel_tabs), g->channel);
-
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+  g->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
+  dt_ui_notebook_page(g->channel_tabs, _("R"), _("curve nodes for r channel"));
+  dt_ui_notebook_page(g->channel_tabs, _("G"), _("curve nodes for g channel"));
+  dt_ui_notebook_page(g->channel_tabs, _("B"), _("curve nodes for b channel"));
+  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(tab_switch_callback), self);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->channel_tabs), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), gtk_grid_new(), TRUE, TRUE, 0);
 
   // color pickers
   g->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
@@ -1431,8 +1424,6 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(hbox), TRUE, TRUE, 0);
-
-  g_signal_connect(G_OBJECT(g->channel_tabs), "switch_page", G_CALLBACK(tab_switch_callback), self);
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
   gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(g->area), TRUE, TRUE, 0);

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -956,32 +956,15 @@ void gui_init(dt_iop_module_t *self)
   c->cmb_autoscale = dt_bauhaus_combobox_from_params(self, "autoscale");
   gtk_widget_set_tooltip_text(c->cmb_autoscale, _("choose between linked and independent channels."));
 
-  // tabs
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
-
-  GtkWidget *tab_label;
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  R  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("curve nodes for r channel"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  G  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("curve nodes for g channel"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  B  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("curve nodes for b channel"));
-
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
-
-  GtkWidget *notebook = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(notebook), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
-
-  GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(notebook), TRUE, TRUE, 0);
-
+  dt_ui_notebook_page(c->channel_tabs, _("R"), _("curve nodes for r channel"));
+  dt_ui_notebook_page(c->channel_tabs, _("G"), _("curve nodes for g channel"));
+  dt_ui_notebook_page(c->channel_tabs, _("B"), _("curve nodes for b channel"));
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(_tab_switch_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
 
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(9.0 / 16.0));
-  GtkWidget *vbox_manual = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_box_pack_start(GTK_BOX(vbox_manual), GTK_WIDGET(c->area), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->area), TRUE, TRUE, 0);
 
   gtk_widget_set_tooltip_text(GTK_WIDGET(c->area),_("drag handles to set black, gray, and white points. "
                                                     "operates on L channel."));
@@ -1016,7 +999,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(pick_hbox), GTK_WIDGET(c->greypick ), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(pick_hbox), GTK_WIDGET(c->whitepick), TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(vbox_manual), pick_hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), pick_hbox, TRUE, TRUE, 0);
 
   c->bt_auto_levels = gtk_button_new_with_label(_("auto"));
   gtk_widget_set_tooltip_text(c->bt_auto_levels, _("apply auto levels"));
@@ -1031,11 +1014,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(autolevels_box), c->bt_auto_levels, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(autolevels_box), c->bt_select_region, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(vbox_manual), autolevels_box, TRUE, TRUE, 0);
-
-  gtk_box_pack_start(GTK_BOX(self->widget), vbox_manual, TRUE, TRUE, 0);
-
-  gtk_widget_show_all(vbox_manual);
+  gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
 
   g_signal_connect(G_OBJECT(c->bt_auto_levels), "clicked", G_CALLBACK(_auto_levels_callback), self);
   g_signal_connect(G_OBJECT(c->bt_select_region), "toggled", G_CALLBACK(_select_region_toggled_callback), self);

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -789,6 +789,7 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   GtkWidget *label = gtk_label_new(_("number of strokes:"));
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
   g->label = GTK_LABEL(gtk_label_new("-1"));
   gtk_widget_set_tooltip_text(hbox, _("click on a shape and drag on canvas.\nuse the mouse wheel "

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1258,34 +1258,23 @@ void gui_init(struct dt_iop_module_t *self)
                                                  "then adjusted based on L curve data. auto XYZ is similar "
                                                  "but applies the saturation changes in XYZ space."));
 
-  // tabs
-  c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
-
-  GtkWidget *tab_label;
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  L  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("tonecurve for L channel"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  a  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("tonecurve for a channel"));
-  gtk_notebook_append_page(c->channel_tabs, gtk_grid_new(), tab_label = gtk_label_new(_("  b  ")));
-  gtk_widget_set_tooltip_text(tab_label, _("tonecurve for b channel"));
-
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(c->channel_tabs, c->channel)));
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
-
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+  c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
+  dt_ui_notebook_page(c->channel_tabs, _("L"), _("tonecurve for L channel"));
+  dt_ui_notebook_page(c->channel_tabs, _("a"), _("tonecurve for a channel"));
+  dt_ui_notebook_page(c->channel_tabs, _("b"), _("tonecurve for b channel"));
+  g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox), gtk_grid_new(), TRUE, TRUE, 0);
 
   c->colorpicker = dt_color_picker_new(self, DT_COLOR_PICKER_POINT_AREA, hbox);
   gtk_widget_set_tooltip_text(c->colorpicker, _("pick GUI color from image\nctrl+click to select an area"));
 
-  GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), vbox, FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(hbox), TRUE, TRUE, 0);
-
-  g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(c->area), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->area), TRUE, TRUE, 0);
 
   // FIXME: that tooltip goes in the way of the numbers when you hover a node to get a reading
   //gtk_widget_set_tooltip_text(GTK_WIDGET(c->area), _("double click to reset curve"));

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2992,8 +2992,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Simple view
 
-  GtkWidget *page1 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_notebook_append_page(g->notebook, page1, gtk_label_new(_("simple")));
+  self->widget = dt_ui_notebook_page(g->notebook, _("simple"), NULL);
 
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
   dt_bauhaus_slider_set_step(g->noise, .05);
@@ -3042,11 +3041,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   // Advanced view
 
-  GtkWidget *page2 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_notebook_append_page(g->notebook, page2, gtk_label_new(_("advanced")));
+  self->widget = dt_ui_notebook_page(g->notebook, _("advanced"), NULL);
 
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(1.0));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->area), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->area), FALSE, FALSE, 0);
   gtk_widget_add_events(GTK_WIDGET(g->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                  | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
                                                  | GDK_LEAVE_NOTIFY_MASK | GDK_SCROLL_MASK
@@ -3070,13 +3068,12 @@ void gui_init(struct dt_iop_module_t *self)
                                               "but the curve might become oscillatory in some settings.\n"
                                               "negative values will avoid oscillations and behave more robustly\n"
                                               "but may produce brutal tone transitions and damage local contrast."));
-  gtk_box_pack_start(GTK_BOX(page2), g->smoothing, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->smoothing, FALSE, FALSE, 0);
   g_signal_connect(G_OBJECT(g->smoothing), "value-changed", G_CALLBACK(smoothing_callback), self);
 
   // Masking options
 
-  GtkWidget *page3 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  gtk_notebook_append_page(g->notebook, page3, gtk_label_new(_("masking")));
+  self->widget = dt_ui_notebook_page(g->notebook, _("masking"), NULL);
 
   g->method = dt_bauhaus_combobox_from_params(self, "method");
   dt_bauhaus_combobox_remove_at(g->method, DT_TONEEQ_LAST);
@@ -3110,10 +3107,10 @@ void gui_init(struct dt_iop_module_t *self)
                                                "lower values give smoother gradients and better smoothing\n"
                                                "but may lead to inaccurate edges taping and halos"));
 
-  gtk_box_pack_start(GTK_BOX(page3), dt_ui_section_label_new(_("mask post-processing")), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("mask post-processing")), FALSE, FALSE, 0);
 
   g->bar = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.05));
-  gtk_box_pack_start(GTK_BOX(page3), GTK_WIDGET(g->bar), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->bar), FALSE, FALSE, 0);
   gtk_widget_set_can_focus(GTK_WIDGET(g->bar), TRUE);
   g_signal_connect(G_OBJECT(g->bar), "draw", G_CALLBACK(dt_iop_toneequalizer_bar_draw), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->bar), _("mask histogram span between the first and last deciles.\n"
@@ -3151,8 +3148,6 @@ void gui_init(struct dt_iop_module_t *self)
   // start building top level widget
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->notebook, 0)));
-  dtgtk_justify_notebook_tabs(g->notebook);
   g_signal_connect(G_OBJECT(g->notebook), "button-press-event", G_CALLBACK(notebook_button_press), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
 


### PR DESCRIPTION
This makes notebook tabs and section labels in iop modules more compressible. When shrinking the right side panel, more of the module will remain visible. In the end, the blending icons will not fit anymore and a horizontal scrollbar will appear.  It might make sense to increase the minimum width of the panel a little to avoid this scenario. Alternatively, maybe it is possible to disable the scrollbar, which presumably would make gtk enforce the minimum width required.

Obviously things get less readable as everything gets scrunched together. This is especially the case with the blending mask slider value labels. To read those one will simply need a wider panel. But at least with these changes the panel no longer jumps around when enabling or disabling the color pickers.

There is also a bit of refactoring and cleanup around notebooks in general.

In blend_gui.c (the calls to) _blendif_print_digits_... are a bit weird, but I didn't want to touch that now as it may well have been finely tuned to behave as it does.

dtgtk_justify_notebook_tabs is no longer needed/used. Should I remove it?