### PR TITLE
fixes modules inadvertently responding to blending color pickers

### DIFF
--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -806,7 +806,9 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
                                const float *const picker_color, const float *const picker_min,
                                const float *const picker_max)
 {
-  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE &&
+     ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)) || 
+       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker_set_values)) ))
   {
     // the global live samples ...
     GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
@@ -896,7 +898,9 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
     }
   }
 
-  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+  if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE &&
+     ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)) || 
+       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker_set_values)) ))
   {
     // draw marker for currently selected color:
     float picked_i = -1.0f;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -761,10 +761,13 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 static void autoexpp_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(self->dt->gui->reset) return;
-  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || self->picked_color_max[0] < 0.0f) return;
-
   dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+
+  if(self->dt->gui->reset) return;
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE || 
+     !dt_bauhaus_widget_get_quad_active(g->autoexpp) ||
+     self->picked_color_max[0] < 0.0f) return;
+
   const float white = fmaxf(fmaxf(self->picked_color_max[0], self->picked_color_max[1]),
                             self->picked_color_max[2]) * (1.0 - dt_bauhaus_slider_get(g->autoexpp));
   exposure_set_white(self, white);
@@ -836,10 +839,9 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 
   // if color-picker active and is the one in the main module (not blending ones)
 
-  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE
-    || !dt_bauhaus_widget_get_quad_active(g->autoexpp)) return FALSE;
-
-  if(self->picked_color_max[0] < 0.0f) return FALSE;
+  if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE ||
+     !dt_bauhaus_widget_get_quad_active(g->autoexpp) ||
+     self->picked_color_max[0] < 0.0f) return FALSE;
 
   const float white = fmaxf(fmaxf(self->picked_color_max[0], self->picked_color_max[1]),
                             self->picked_color_max[2]) * (1.0 - dt_bauhaus_slider_get(g->autoexpp));

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1546,7 +1546,8 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     }
 
     cairo_move_to(cr, 0, height);
-    if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE)
+    if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE &&
+       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)))
     {
       // the global live samples ...
       GSList *samples = darktable.lib->proxy.colorpicker.live_samples;


### PR DESCRIPTION
In some cases the module code would respond to a color picker being enabled even though that picker belonged to the blending code. A previously fixed case was in the exposure module; this addresses a few more similar issues, although most of them cosmetic.