### PR TITLE
Better mixing of Shadows & Highlights fixing negative L* values increasing in brightness

### DIFF
--- a/data/kernels/gaussian.cl
+++ b/data/kernels/gaussian.cl
@@ -282,7 +282,7 @@ overlay(const float4 in_a, const float4 in_b, const float opacity, const float t
     float optrans = chunk * transform;
     opacity2 -= 1.0f;
 
-    a.x = la * (1.0f - optrans) + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax-lb) : doublemax * la * lb) * optrans;
+    a.x = la * (1.0f - optrans) + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax-lb) : doublemax * sign(la) * fabs(la * lb)) * optrans;
     a.x = unbound.x ? a.x : clamp(a.x, lmin, lmax);
 
     a.y = a.y * (1.0f - optrans) + (a.y + b.y) * (a.x*lref * ccorrect + (1.0f - a.x)*href * (1.0f - ccorrect)) * optrans;

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -465,7 +465,7 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       lb = unbound_mask ? lb : CLAMP_RANGE(lb, lmin, lmax);
       float lref = copysignf(fabs(la) > low_approximation ? 1.0f / fabs(la) : 1.0f / low_approximation, la);
       float href = copysignf(
-          fabs(1.0f - la) > low_approximation ? 1.0f / fabs(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
+                  fabs(1.0f - la) > low_approximation ? 1.0f / fabs(1.0f - la) : 1.0f / low_approximation, 1.0f - la);
 
 
       float chunk = shadows2 > 1.0f ? 1.0f : shadows2;
@@ -473,8 +473,9 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
       shadows2 -= 1.0f;
 
       ta[0] = la * (1.0 - optrans)
-              + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb) : doublemax * la
-                                                                                           * lb) * optrans;
+              + (la > halfmax ? lmax - (lmax - doublemax * (la - halfmax)) * (lmax - lb)
+                              : doublemax * sign(la) * fabs(la * lb))
+                    * optrans;
 
       ta[0] = (flags & UNBOUND_SHADOWS_L) ? ta[0] : CLAMP_RANGE(ta[0], lmin, lmax);
 


### PR DESCRIPTION
 Negative L* values are invalid to begin with, and right now when there is a negative mask and a negative input value, they multiply together to form a positive value, which caused weird behavior, causing things that are meant to be darker to become brighter. Fixes #5625.

Not sure if this is the best way to do it, but since math on negative L* values are invalid to begin with, I'd say we just use this method to be "less wrong".

edit: that space in line 468 is due to clang-format. 