### PR TITLE
Documentation for the file renaming parameters introduced in PR #2082.

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -3551,7 +3551,7 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 </variablelist>
 </section>
 
-<section status="draft" id="darktable_database_move_image">
+<section status="final" id="darktable_database_move_image">
 <title>darktable.database.move_image</title>
 <indexterm>
 <primary>Lua API</primary>
@@ -3560,7 +3560,7 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 <synopsis>function( 
 	<emphasis><link linkend="darktable_database_move_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>, 
 	<emphasis><link linkend="darktable_database_move_image_film">film</link></emphasis> : <link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link>,
-	<emphasis><link linkend="darktable_database_move_image_newname">newname</link></emphasis> : string
+	[<emphasis><link linkend="darktable_database_move_image_newname">newname</link></emphasis> : string]
 )</synopsis>
 <para>Physically moves an image (and all its duplicates) to another film, and/or renames the image file.</para>
 <para>This will move the image file, the related XMP and all XMP for the duplicates to the directory of the new film and rename them as specified.</para>
@@ -3587,7 +3587,7 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 </variablelist>
 </section>
 
-<section status="draft" id="darktable_database_copy_image">
+<section status="final" id="darktable_database_copy_image">
 <title>darktable.database.copy_image</title>
 <indexterm>
 <primary>Lua API</primary>
@@ -3596,7 +3596,7 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 <synopsis>function( 
 	<emphasis><link linkend="darktable_database_copy_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>, 
 	<emphasis><link linkend="darktable_database_copy_image_film">film</link></emphasis> : <link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link>,
-	<emphasis><link linkend="darktable_database_copy_image_newname">newname</link></emphasis> : string
+	[<emphasis><link linkend="darktable_database_copy_image_newname">newname</link></emphasis> : string]
 ) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
 <para>Physically copies an image to another film.</para>
 <para>This will copy the image file and the related XMP to the directory of the new film and rename them as specified.</para>

--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -3551,7 +3551,7 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 </variablelist>
 </section>
 
-<section status="final" id="darktable_database_move_image">
+<section status="draft" id="darktable_database_move_image">
 <title>darktable.database.move_image</title>
 <indexterm>
 <primary>Lua API</primary>
@@ -3559,11 +3559,12 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 </indexterm>
 <synopsis>function( 
 	<emphasis><link linkend="darktable_database_move_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>, 
-	<emphasis><link linkend="darktable_database_move_image_film">film</link></emphasis> : <link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link>
+	<emphasis><link linkend="darktable_database_move_image_film">film</link></emphasis> : <link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link>,
+	<emphasis><link linkend="darktable_database_move_image_newname">newname</link></emphasis> : string
 )</synopsis>
-<para>Physically moves an image (and all its duplicates) to another film.</para>
-<para>This will move the image file, the related XMP and all XMP for the duplicates to the directory of the new film</para>
-<para>Note that the parameter order is not relevant.</para>
+<para>Physically moves an image (and all its duplicates) to another film, and/or renames the image file.</para>
+<para>This will move the image file, the related XMP and all XMP for the duplicates to the directory of the new film and rename them as specified.</para>
+<para>Note that the order of the two required parameters is not relevant.</para>
 
 <variablelist>
 <varlistentry id="darktable_database_move_image_image"><term>image</term><listitem>
@@ -3574,14 +3575,19 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 
 <varlistentry id="darktable_database_move_image_film"><term>film</term><listitem>
 <synopsis><link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link></synopsis>
-<para>The film to move to</para>
+<para>The film to move to. To rename a file within the same film, set this to the image's current film.</para>
 
 </listitem></varlistentry>
 
+<varlistentry id="darktable_database_move_image_newname"><term>newname</term><listitem>
+<synopsis>string</synopsis>
+<para><emphasis>(Optional)</emphasis> If provided, rename the file with this new name. Must not contain any path separator characters.</para>
+
+</listitem></varlistentry>
 </variablelist>
 </section>
 
-<section status="final" id="darktable_database_copy_image">
+<section status="draft" id="darktable_database_copy_image">
 <title>darktable.database.copy_image</title>
 <indexterm>
 <primary>Lua API</primary>
@@ -3589,12 +3595,13 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 </indexterm>
 <synopsis>function( 
 	<emphasis><link linkend="darktable_database_copy_image_image">image</link></emphasis> : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link>, 
-	<emphasis><link linkend="darktable_database_copy_image_film">film</link></emphasis> : <link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link>
+	<emphasis><link linkend="darktable_database_copy_image_film">film</link></emphasis> : <link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link>,
+	<emphasis><link linkend="darktable_database_copy_image_newname">newname</link></emphasis> : string
 ) : <link linkend="types_dt_lua_image_t">types.dt_lua_image_t</link></synopsis>
 <para>Physically copies an image to another film.</para>
-<para>This will copy the image file and the related XMP to the directory of the new film</para>
-<para>If there is already a file with the same name as the image file, it will create a duplicate from that file instead</para>
-<para>Note that the parameter order is not relevant.</para>
+<para>This will copy the image file and the related XMP to the directory of the new film and rename them as specified.</para>
+<para>If there is already a file with the same name as the image file, it will create a duplicate from that file instead.</para>
+<para>Note that the order of the two required parameters is not relevant.</para>
 
 <variablelist>
 <varlistentry id="darktable_database_copy_image_image"><term>image</term><listitem>
@@ -3605,7 +3612,13 @@ NOTE2: If the parameter is a directory the call is non-blocking; the film object
 
 <varlistentry id="darktable_database_copy_image_film"><term>film</term><listitem>
 <synopsis><link linkend="types_dt_lua_film_t">types.dt_lua_film_t</link></synopsis>
-<para>The film to copy to</para>
+<para>The film to copy to. To make a copy of a file within the same film, set this to the image's current film.</para>
+
+</listitem></varlistentry>
+
+<varlistentry id="darktable_database_copy_image_newname"><term>newname</term><listitem>
+<synopsis>string</synopsis>
+<para><emphasis>(Optional)</emphasis> If provided, give the copy this new filename. Must not contain any path separator characters.</para>
 
 </listitem></varlistentry>
 


### PR DESCRIPTION
It has recently been brought to my attention that the parameters for file renaming introduced to the Lua functions `darktable.database.move_image` and `darktable.database.copy_image` in pull request #2082 have not been documented. This pull request adds the documentation.