### PR TITLE
Changes to allow number of digits in float variables in prefs

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -10,9 +10,9 @@
 <!ATTLIST type
 	min CDATA #IMPLIED
 	max CDATA #IMPLIED
+    digits CDATA #IMPLIED
 	factor CDATA #IMPLIED
->
-<!ELEMENT enum (option)+>
+><!ELEMENT enum (option)+>
 <!ELEMENT option (#PCDATA)>
 <!ATTLIST option
 	capability CDATA #IMPLIED

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -970,6 +970,20 @@
     <shortdescription>show search module text entry</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig prefs="darkroom">
+    <name>channel_mixer_lower_limit</name>
+    <type min="-2.0" max="0.0" digits="1">float</type>
+    <default>-0.5</default>
+    <shortdescription>lower bound for channel mixer sliders</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig prefs="darkroom">
+    <name>channel_mixer_upper_limit</name>
+    <type min="0.5" max="2.0" digits="1">float</type>
+    <default>1.0</default>
+    <shortdescription>upper bound for channel mixer sliders</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig>
     <name>database_cache_quality</name>
     <type>int</type>

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -450,21 +450,24 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_combobox_set(g->output_channel, CHANNEL_RED);
 
   g_signal_connect(G_OBJECT(g->output_channel), "value-changed", G_CALLBACK(output_callback), self);
+  
+  const float low_lim = dt_conf_get_float("channel_mixer_lower_limit");
+  const float up_lim = dt_conf_get_float("channel_mixer_upper_limit");
 
   /* red */
-  g->scale_red = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->red[CHANNEL_RED], 3);
+  g->scale_red = dt_bauhaus_slider_new_with_range(self, low_lim, up_lim, 0.01, p->red[CHANNEL_RED], 2);
   gtk_widget_set_tooltip_text(g->scale_red, _("amount of red channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_red, NULL, _("red"));
   g_signal_connect(G_OBJECT(g->scale_red), "value-changed", G_CALLBACK(red_callback), self);
 
   /* green */
-  g->scale_green = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->green[CHANNEL_RED], 3);
+  g->scale_green = dt_bauhaus_slider_new_with_range(self, low_lim, up_lim, 0.01, p->green[CHANNEL_RED], 2);
   gtk_widget_set_tooltip_text(g->scale_green, _("amount of green channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_green, NULL, _("green"));
   g_signal_connect(G_OBJECT(g->scale_green), "value-changed", G_CALLBACK(green_callback), self);
 
   /* blue */
-  g->scale_blue = dt_bauhaus_slider_new_with_range(self, -2.0, 2.0, 0.005, p->blue[CHANNEL_RED], 3);
+  g->scale_blue = dt_bauhaus_slider_new_with_range(self, low_lim, up_lim, 0.01, p->blue[CHANNEL_RED], 2);
   gtk_widget_set_tooltip_text(g->scale_blue, _("amount of blue channel in the output channel"));
   dt_bauhaus_widget_set_label(g->scale_blue, NULL, _("blue"));
   g_signal_connect(G_OBJECT(g->scale_blue), "value-changed", G_CALLBACK(blue_callback), self);

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -523,15 +523,16 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
   </xsl:template>
 
   <xsl:template match="dtconfig[type='float']" mode="tab">
-    <xsl:text>    float min = -1000000000.0f;&#xA;    float max = 1000000000.0f;&#xA;</xsl:text>
+    <xsl:text>    float min = -1000000000.0f;&#xA;    float max = 1000000000.0f;&#xA;    int digits = 5;&#xA;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    min *= factor; max *= factor;
-    widget = gtk_spin_button_new_with_range(min, max, 0.001f);
+    <xsl:text>  float steps = pow(10, -digits);  
+    min *= factor; max *= factor;
+    widget = gtk_spin_button_new_with_range(min, max, steps);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
     gtk_widget_set_hexpand(widget, FALSE);
-    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 5);
+    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), digits);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_float("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%.03f'"), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);
@@ -592,9 +593,25 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
   </xsl:template>
 
 <!-- Grab min/max from input. Is there a better way? -->
+  <xsl:template match="type[@min and @max and @digits]" mode="range" priority="7">
+    <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+  
   <xsl:template match="type[@min and @max]" mode="range" priority="5">
     <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
     <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="type[@max and @digits]" mode="range" priority="5">
+    <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+  
+  <xsl:template match="type[@max and @digits]" mode="range" priority="5">
+    <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type[@min]" mode="range" priority="3">
@@ -603,6 +620,10 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
 
   <xsl:template match="type[@max]" mode="range" priority="3">
     <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+  
+  <xsl:template match="type[@max and @digits]" mode="range" priority="3">
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type" mode="range"  priority="1">
@@ -617,6 +638,5 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
   <xsl:template match="type" mode="factor"  priority="1">
     <xsl:text>  float factor = 1.0f;&#xA;</xsl:text>
   </xsl:template>
-
 
 </xsl:stylesheet>


### PR DESCRIPTION
A little PR to allow a developer to set the number of digits for float variables in the preferences window.
Previously, pref values were halfway hidden from users, and in any case most of them were not floats.

However, some are, and it's a bit tedious to hammer on the "+" button to advance from 1.0 to 1.1 in steps of 0.001,
while displaying 5 digits. In this version, step sizes are equal to the display resolution.
Default is 5 digits as before, although the increment is now also 10^-5

So this bit of code allow adding a third attribute to a float, ie by putting something like this in
`darktableconfig.xml.in`

<dtconfig prefs="darkroom">
    <name>test_var</name>
    <type min="-2.0" max="0.0" digits="1">float</type>
    <default>-0.5</default>
    <shortdescription>set lower bound for something</shortdescription>
    <longdescription/>
  </dtconfig>

Probably be good if @elstoc checked I didn't screw anything up :-)