### PR TITLE
lighttable: fix quadratic lag on Home/End

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2134,14 +2134,16 @@ static gboolean _filemanager_ensure_rowid_visibility(dt_thumbtable_t *table, int
 
   if(first->rowid > rowid)
   {
-    if(_move(table, 0, table->thumb_size, TRUE))
+    const int rows = MAX(1,(first->rowid-rowid)/table->thumbs_per_row);
+    if(_move(table, 0, rows*table->thumb_size, TRUE))
       return _filemanager_ensure_rowid_visibility(table, rowid);
     else
       return FALSE;
   }
   else if(last->rowid < rowid)
   {
-    if(_move(table, 0, -table->thumb_size, TRUE))
+    const int rows = MAX(1,(rowid-last->rowid)/table->thumbs_per_row);
+    if(_move(table, 0, -rows*table->thumb_size, TRUE))
       return _filemanager_ensure_rowid_visibility(table, rowid);
     else
       return FALSE;


### PR DESCRIPTION
The code to scroll the thumbtable to top/bottom in file manager mode was shifting the viewport by one row at a
time, leading to ever-increasing lag as the collection grows (~5 seconds with 1200 images displayed four per
row).  This patch makes the scrolling jump directly to either the proper line or the adjacent one, after which
the existing recursion will shift the viewport by one row if necessary.  This eliminates the growing lag on
pressing Home or End.