### PR TITLE
Transition negadoctor, colorbalance and retouch to introspection framework

### DIFF
--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -114,7 +114,16 @@ static void generic_toggle_callback(GtkWidget *togglebutton, dt_module_param_t *
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param)
 {
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
-  dt_introspection_field_t *f = self->so->get_f(param);
+
+  int param_index = 0;
+  char param_name[30], base_name[33];
+  if(sscanf(param, "%[^[][%d]", param_name, &param_index) == 2)
+  {
+    sprintf(base_name, "%s[0]", param_name);
+    param = base_name;
+  }
+
+  const dt_introspection_field_t *f = self->so->get_f(param);
 
   GtkWidget *slider = NULL;
   gchar *str;
@@ -159,7 +168,9 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
         g_free(str);
       }
 
-      g_signal_connect(G_OBJECT(slider), "value-changed", G_CALLBACK(generic_slider_float_callback), p + f->header.offset);
+      g_signal_connect(G_OBJECT(slider), "value-changed", 
+                       G_CALLBACK(generic_slider_float_callback), 
+                       p + f->header.offset + param_index * sizeof(float));
     }
     else if(f->header.type == DT_INTROSPECTION_TYPE_INT)
     {
@@ -169,7 +180,9 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
 
       slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 1, defval, 0, 1);
 
-      g_signal_connect(G_OBJECT(slider), "value-changed", G_CALLBACK(generic_slider_int_callback), p + f->header.offset);
+      g_signal_connect(G_OBJECT(slider), "value-changed", 
+                       G_CALLBACK(generic_slider_int_callback), 
+                       p + f->header.offset + param_index * sizeof(int));
     }
 
     if (*f->header.description)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -340,15 +340,29 @@ void dt_ellipsize_combo(GtkComboBox *cbox);
 static inline void dt_ui_section_label_set(GtkWidget *label)
 {
   gtk_widget_set_halign(label, GTK_ALIGN_FILL); // make it span the whole available width
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
   g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);    // make the text left aligned
   gtk_widget_set_name(label, "section_label"); // make sure that we can style these easily
 }
+
 static inline GtkWidget *dt_ui_section_label_new(const gchar *str)
 {
   GtkWidget *label = gtk_label_new(str);
   dt_ui_section_label_set(label);
   return label;
 };
+
+static inline GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const char *tooltip)
+{
+  GtkWidget *label = gtk_label_new(text);
+  GtkWidget *page = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  if(tooltip) gtk_widget_set_tooltip_text(label, tooltip);
+  gtk_notebook_append_page(notebook, page, label);
+  gtk_container_child_set(GTK_CONTAINER(notebook), page, "tab-expand", TRUE, "tab-fill", TRUE, NULL);
+
+  return page;
+}
 
 static inline void dtgtk_justify_notebook_tabs(GtkNotebook *notebook)
 {

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -96,7 +96,7 @@ typedef enum _colorbalance_patch_t
 typedef struct dt_iop_colorbalance_params_t
 {
   dt_iop_colorbalance_mode_t mode; // $DEFAULT: SLOPE_OFFSET_POWER
-  float lift[CHANNEL_SIZE], gamma[CHANNEL_SIZE], gain[CHANNEL_SIZE]; // $DEFAULT: 1.0
+  float lift[CHANNEL_SIZE], gamma[CHANNEL_SIZE], gain[CHANNEL_SIZE]; // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0
   float saturation;     // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "input saturation"
   float contrast;       // $MIN: 0.01 $MAX: 1.99 $DEFAULT: 1.0
   float grey;           // $MIN: 0.1 $MAX: 100.0 $DEFAULT: 18.0 $DESCRIPTION: "contrast fulcrum"
@@ -107,6 +107,7 @@ typedef struct dt_iop_colorbalance_gui_data_t
 {
   dt_pthread_mutex_t lock;
   GtkWidget *master_box;
+  GtkWidget *optimizer_box;
   GtkWidget *mode;
   GtkWidget *controls;
   GtkWidget *hue_lift, *hue_gamma, *hue_gain;
@@ -115,8 +116,6 @@ typedef struct dt_iop_colorbalance_gui_data_t
   GtkWidget *gamma_r, *gamma_g, *gamma_b, *gamma_factor;
   GtkWidget *gain_r, *gain_g, *gain_b, *gain_factor;
   GtkWidget *saturation, *contrast, *grey, *saturation_out;
-  GtkWidget *masterbox;
-  GtkWidget *optim_label;
   GtkWidget *auto_luma;
   GtkWidget *auto_color;
   float color_patches_lift[3];
@@ -917,9 +916,9 @@ static inline void set_RGB_sliders(GtkWidget *R, GtkWidget *G, GtkWidget *B, flo
     p[CHANNEL_BLUE] = rgb[2] * 2.0f;
 
     ++darktable.gui->reset;
-    dt_bauhaus_slider_set_soft(R, p[CHANNEL_RED] - 1.0f);
-    dt_bauhaus_slider_set_soft(G, p[CHANNEL_GREEN] - 1.0f);
-    dt_bauhaus_slider_set_soft(B, p[CHANNEL_BLUE] - 1.0f);
+    dt_bauhaus_slider_set_soft(R, p[CHANNEL_RED]);
+    dt_bauhaus_slider_set_soft(G, p[CHANNEL_GREEN]);
+    dt_bauhaus_slider_set_soft(B, p[CHANNEL_BLUE]);
     --darktable.gui->reset;
   }
 }
@@ -1037,9 +1036,9 @@ static void apply_lift_neutralize(dt_iop_module_t *self)
   p->lift[CHANNEL_BLUE] = RGB[2] + 1.0f;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_r, RGB[0]);
-  dt_bauhaus_slider_set_soft(g->lift_g, RGB[1]);
-  dt_bauhaus_slider_set_soft(g->lift_b, RGB[2]);
+  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE]);
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
   --darktable.gui->reset;
 
@@ -1076,9 +1075,9 @@ static void apply_gamma_neutralize(dt_iop_module_t *self)
   p->gamma[CHANNEL_BLUE] = CLAMP(2.0 - RGB[2], 0.0001f, 2.0f);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gamma_r, -RGB[0] + 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_g, -RGB[1] + 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_b, -RGB[2] + 1.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE]);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
   --darktable.gui->reset;
 
@@ -1115,9 +1114,9 @@ static void apply_gain_neutralize(dt_iop_module_t *self)
   p->gain[CHANNEL_BLUE] = RGB[2];
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gain_r, RGB[0] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gain_g, RGB[1] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gain_b, RGB[2] - 1.0f);
+  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE]);
   set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
   --darktable.gui->reset;
 
@@ -1142,7 +1141,7 @@ static void apply_lift_auto(dt_iop_module_t *self)
   p->lift[CHANNEL_FACTOR] = -p->gain[CHANNEL_FACTOR] * XYZ[1] + 1.0f;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
+  dt_bauhaus_slider_set_soft(g->lift_factor, p->lift[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1167,7 +1166,7 @@ static void apply_gamma_auto(dt_iop_module_t *self)
       = 2.0f - logf(0.1842f) / logf(MAX(p->gain[CHANNEL_FACTOR] * XYZ[1] + p->lift[CHANNEL_FACTOR] - 1.0f, 0.000001f));
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1191,7 +1190,7 @@ static void apply_gain_auto(dt_iop_module_t *self)
   p->gain[CHANNEL_FACTOR] = p->lift[CHANNEL_FACTOR] / (XYZ[1]);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
+  dt_bauhaus_slider_set_soft(g->gain_factor, p->gain[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1295,17 +1294,17 @@ static void apply_autocolor(dt_iop_module_t *self)
   p->gain[CHANNEL_BLUE] = RGB_gain[2];
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_r, RGB_lift[0]);
-  dt_bauhaus_slider_set_soft(g->lift_g, RGB_lift[1]);
-  dt_bauhaus_slider_set_soft(g->lift_b, RGB_lift[2]);
+  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE]);
 
-  dt_bauhaus_slider_set_soft(g->gamma_r, RGB_gamma[0] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_g, RGB_gamma[1] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_b, RGB_gamma[2] - 1.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE]);
 
-  dt_bauhaus_slider_set_soft(g->gain_r, RGB_gain[0] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gain_g, RGB_gain[1] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gain_b, RGB_gain[2] - 1.0f);
+  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE]);
 
   set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
   set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
@@ -1359,9 +1358,9 @@ static void apply_autoluma(dt_iop_module_t *self)
   }
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
+  dt_bauhaus_slider_set_soft(g->lift_factor, p->lift[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set_soft(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set_soft(g->gain_factor, p->gain[CHANNEL_FACTOR]);
   --darktable.gui->reset;
 
   dt_dev_add_history_item(darktable.develop, self, TRUE);
@@ -1535,9 +1534,7 @@ void set_visible_widgets(dt_iop_colorbalance_gui_data_t *g)
   gtk_widget_set_visible(g->hue_gain,  show_hsl);
   gtk_widget_set_visible(g->sat_gain,  show_hsl);
 
-  gtk_widget_set_visible(g->optim_label, mode == SLOPE_OFFSET_POWER);
-  gtk_widget_set_visible(g->auto_color, mode == SLOPE_OFFSET_POWER);
-  gtk_widget_set_visible(g->auto_luma, mode == SLOPE_OFFSET_POWER);
+  gtk_widget_set_visible(g->optimizer_box, mode == SLOPE_OFFSET_POWER);
 }
 
 void gui_update(dt_iop_module_t *self)
@@ -1556,29 +1553,25 @@ void gui_update(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft(g->saturation_out, p->saturation_out);
   dt_bauhaus_slider_set_soft(g->contrast, p->contrast);
 
-  dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE] - 1.0f);
+  dt_bauhaus_slider_set_soft(g->lift_factor, (p->lift[CHANNEL_FACTOR]));
+  dt_bauhaus_slider_set_soft(g->lift_r, p->lift[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->lift_g, p->lift[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->lift_b, p->lift[CHANNEL_BLUE]);
 
-  dt_bauhaus_slider_set_soft(g->gamma_factor, (p->gamma[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE] - 1.0f);
+  dt_bauhaus_slider_set_soft(g->gamma_factor, p->gamma[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set_soft(g->gamma_r, p->gamma[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->gamma_g, p->gamma[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->gamma_b, p->gamma[CHANNEL_BLUE]);
 
-  dt_bauhaus_slider_set_soft(g->gain_factor, (p->gain[CHANNEL_FACTOR] - 1.0f) * 100.0f);
-  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN] - 1.0f);
-  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE] - 1.0f);
-
-  set_visible_widgets(g);
+  dt_bauhaus_slider_set_soft(g->gain_factor, p->gain[CHANNEL_FACTOR]);
+  dt_bauhaus_slider_set_soft(g->gain_r, p->gain[CHANNEL_RED]);
+  dt_bauhaus_slider_set_soft(g->gain_g, p->gain[CHANNEL_GREEN]);
+  dt_bauhaus_slider_set_soft(g->gain_b, p->gain[CHANNEL_BLUE]);
 
   dt_iop_color_picker_reset(self, TRUE);
   _check_tuner_picker_labels(self);
 
-  set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
+  gui_changed(self, NULL, NULL);
 }
 
 void gui_reset(dt_iop_module_t *self)
@@ -1601,12 +1594,22 @@ void gui_reset(dt_iop_module_t *self)
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
+  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
 
-  if(w == g->mode)
-  {
+  if(!w || w == g->mode)
     set_visible_widgets(g);
-  }
+
+  ++darktable.gui->reset;
+
+  if(!w || w == g->lift_r  || w == g->lift_g  || w == g->lift_b)
+    set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
+  if(!w || w == g->gamma_r || w == g->gamma_g || w == g->gamma_b)
+    set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
+  if(!w || w == g->gain_r  || w == g->gain_g  || w == g->gain_b)
+    set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
+
+  --darktable.gui->reset;
 }
 
 static void controls_callback(GtkWidget *combo, dt_iop_module_t *self)
@@ -1620,294 +1623,7 @@ static void controls_callback(GtkWidget *combo, dt_iop_module_t *self)
   dt_iop_color_picker_reset(self, TRUE);
 }
 
-static void hue_lift_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  float hsl[3] = {dt_bauhaus_slider_get(slider) / 360.0f,
-                  dt_bauhaus_slider_get(g->sat_lift) / 100.0f,
-                  0.5f};
-
-  update_saturation_slider_color(g->sat_lift, hsl[0]);
-  set_RGB_sliders(g->lift_r, g->lift_g, g->lift_b, hsl, p->lift, p->mode);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void sat_lift_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  float hsl[3] = {dt_bauhaus_slider_get(g->hue_lift) / 360.0f,
-                  dt_bauhaus_slider_get(slider) / 100.0f,
-                  0.5f};
-
-  set_RGB_sliders(g->lift_r, g->lift_g, g->lift_b, hsl, p->lift, p->mode);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void hue_gamma_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  float hsl[3] = {dt_bauhaus_slider_get(slider) / 360.0f,
-                  dt_bauhaus_slider_get(g->sat_gamma) / 100.0f,
-                  0.5f};
-
-  update_saturation_slider_color(g->sat_gamma, hsl[0]);
-  set_RGB_sliders(g->gamma_r, g->gamma_g, g->gamma_b, hsl, p->gamma, p->mode);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void sat_gamma_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  float hsl[3] = {dt_bauhaus_slider_get(g->hue_gamma) / 360.0f,
-                  dt_bauhaus_slider_get(slider) / 100.0f,
-                  0.5f};
-
-  set_RGB_sliders(g->gamma_r, g->gamma_g, g->gamma_b, hsl, p->gamma, p->mode);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void hue_gain_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  float hsl[3] = {dt_bauhaus_slider_get(slider) / 360.0f,
-                  dt_bauhaus_slider_get(g->sat_gain) / 100.0f,
-                  0.5f};
-
-  update_saturation_slider_color(g->sat_gain, hsl[0]);
-  set_RGB_sliders(g->gain_r, g->gain_g, g->gain_b, hsl, p->gain, p->mode);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void sat_gain_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  float hsl[3] = {dt_bauhaus_slider_get(g->hue_gain) / 360.0f,
-                  dt_bauhaus_slider_get(slider) / 100.0f,
-                  0.5f};
-
-  set_RGB_sliders(g->gain_r, g->gain_g, g->gain_b, hsl, p->gain, p->mode);
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void lift_factor_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->lift[CHANNEL_FACTOR] = dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void lift_red_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->lift[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  --darktable.gui->reset;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void lift_green_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->lift[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  --darktable.gui->reset;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void lift_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->lift[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_lift, g->sat_lift, p->lift);
-  --darktable.gui->reset;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void gamma_factor_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gamma[CHANNEL_FACTOR] = dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void gamma_red_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gamma[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  --darktable.gui->reset;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void gamma_green_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gamma[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  --darktable.gui->reset;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void gamma_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gamma[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_gamma, g->sat_gamma, p->gamma);
-  --darktable.gui->reset;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void gain_factor_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gain[CHANNEL_FACTOR] = dt_bauhaus_slider_get(slider) / 100.0f + 1.0f;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void gain_red_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gain[CHANNEL_RED] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  --darktable.gui->reset;
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void gain_green_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gain[CHANNEL_GREEN] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  --darktable.gui->reset;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-static void gain_blue_callback(GtkWidget *slider, dt_iop_module_t *self)
-{
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_color_picker_reset(self, TRUE);
-
-  p->gain[CHANNEL_BLUE] = dt_bauhaus_slider_get(slider) + 1.0f;
-
-  ++darktable.gui->reset;
-  set_HSL_sliders(g->hue_gain, g->sat_gain, p->gain);
-  --darktable.gui->reset;
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-#if 0
+#ifdef SHOW_COLOR_WHEELS
 static gboolean dt_iop_area_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 {
   float flt_bg = 0.5;
@@ -2028,22 +1744,35 @@ static gboolean dt_iop_area_draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t
 }
 #endif
 
-static void draw_hue_slider(GtkWidget *slider)
-{
-  dt_bauhaus_slider_set_stop(slider, 0.0f, 1.0f, 0.0f, 0.0f);
-  dt_bauhaus_slider_set_stop(slider, 0.166f, 1.0f, 1.0f, 0.0f);
-  dt_bauhaus_slider_set_stop(slider, 0.322f, 0.0f, 1.0f, 0.0f);
-  dt_bauhaus_slider_set_stop(slider, 0.498f, 0.0f, 1.0f, 1.0f);
-  dt_bauhaus_slider_set_stop(slider, 0.664f, 0.0f, 0.0f, 1.0f);
-  dt_bauhaus_slider_set_stop(slider, 0.830f, 1.0f, 0.0f, 1.0f);
-  dt_bauhaus_slider_set_stop(slider, 1.0f, 1.0f, 0.0f, 0.0f);
+#define HSL_CALLBACK(which)                                                             \
+static void which##_callback(GtkWidget *slider, gpointer user_data)                     \
+{                                                                                       \
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;                                 \
+  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;       \
+  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data; \
+                                                                                        \
+  if(darktable.gui->reset) return;                                                      \
+                                                                                        \
+  dt_iop_color_picker_reset(self, TRUE);                                                \
+                                                                                        \
+  float hsl[3] = {dt_bauhaus_slider_get(g->hue_##which) / 360.0f,                       \
+                  dt_bauhaus_slider_get(g->sat_##which) / 100.0f,                       \
+                  0.5f};                                                                \
+                                                                                        \
+  if(slider == g->hue_##which)                                                          \
+    update_saturation_slider_color(g->sat_##which, hsl[0]);                             \
+  set_RGB_sliders(g->which##_r, g->which##_g, g->which##_b, hsl, p->which, p->mode);    \
+  dt_dev_add_history_item(darktable.develop, self, TRUE);                               \
 }
+
+HSL_CALLBACK(lift)
+HSL_CALLBACK(gamma)
+HSL_CALLBACK(gain)
 
 void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_colorbalance_gui_data_t));
   dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
-  dt_iop_colorbalance_params_t *p = (dt_iop_colorbalance_params_t *)self->params;
 
   g->mode = NULL;
 
@@ -2052,6 +1781,8 @@ void gui_init(dt_iop_module_t *self)
     g->color_patches_flags[k] = INVALID;
     g->luma_patches_flags[k] = INVALID;
   }
+
+  GtkWidget *mode_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   // mode choice
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
@@ -2068,11 +1799,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->controls, _("color-grading mapping method"));
   g_signal_connect(G_OBJECT(g->controls), "value-changed", G_CALLBACK(controls_callback), self);
 
-  // master
-  GtkWidget *saved_widget = self->widget;
-
   g->master_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  gtk_box_pack_start(GTK_BOX(saved_widget), GTK_WIDGET(g->master_box), TRUE, TRUE, 0);
 
   gtk_box_pack_start(GTK_BOX(g->master_box), dt_ui_section_label_new(_("master")), FALSE, FALSE, 0);
 
@@ -2107,12 +1834,10 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->contrast, "%+.2f %%");
   gtk_widget_set_tooltip_text(g->contrast, _("contrast"));
 
-  self->widget = saved_widget;
-
+#ifdef SHOW_COLOR_WHEELS
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_BAUHAUS_SPACE);
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, FALSE, FALSE, 0);
 
-#if 0//def SHOW_COLOR_WHEELS
   GtkWidget *area = dtgtk_drawing_area_new_with_aspect_ratio(1.0);
   gtk_box_pack_start(GTK_BOX(hbox), area, TRUE, TRUE, 0);
 
@@ -2156,200 +1881,140 @@ void gui_init(dt_iop_module_t *self)
 //                     G_CALLBACK (dt_iop_colorbalance_leave_notify), self);
 #endif
 
-#define ADD_FACTOR(which, span)                                                                                   \
-  g->which##_factor = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,                                             \
-                      dt_bauhaus_slider_new_with_range_and_feedback(self, -span, span, span / 100.0f,             \
-                                                              (p->which[CHANNEL_FACTOR] - 1.0f) * 100.0f, 2, 0)); \
-  dt_bauhaus_slider_enable_soft_boundaries(g->which##_factor, -100.0, 100.0);                                     \
-  dt_bauhaus_slider_set_format(g->which##_factor, "%.2f %%");                                                     \
-  dt_bauhaus_slider_set_stop(g->which##_factor, 0.0, 0.0, 0.0, 0.0);                                              \
-  dt_bauhaus_slider_set_stop(g->which##_factor, 1.0, 1.0, 1.0, 1.0);                                              \
-  gtk_widget_set_tooltip_text(g->which##_factor, _("factor of " #which));                                         \
-  dt_bauhaus_widget_set_label(g->which##_factor, _(#which), _("factor"));                                         \
-  g_signal_connect(G_OBJECT(g->which##_factor), "value-changed", G_CALLBACK(which##_factor_callback), self);      \
-  gtk_box_pack_start(GTK_BOX(self->widget), g->which##_factor, TRUE, TRUE, 0);                                    
+  GtkWidget *main_sliders = dt_conf_get_bool("plugins/darkroom/colorbalance/use_notebook")
+                          ? GTK_WIDGET(gtk_notebook_new())
+                          : (self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
 
-#define ADD_CHANNEL(which, c, n, N, span)                                                                         \
-  g->which##_##c = dt_bauhaus_slider_new_with_range_and_feedback(self, -span, span, span / 100.0f,                \
-                                                                 p->which[CHANNEL_##N] - 1.0f, 5, 0);             \
-  dt_bauhaus_slider_enable_soft_boundaries(g->which##_##c, -1.0, 1.0);                                            \
-  gtk_widget_set_tooltip_text(g->which##_##c, _("factor of " #n " for " #which));                                 \
-  dt_bauhaus_widget_set_label(g->which##_##c, _(#which), _(#n));                                                  \
-  g_signal_connect(G_OBJECT(g->which##_##c), "value-changed", G_CALLBACK(which##_##n##_callback), self);          \
-  gtk_box_pack_start(GTK_BOX(self->widget), g->which##_##c, TRUE, TRUE, 0);
+  char field_name[10];
 
-  /* lift */
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("shadows : lift / offset")), FALSE, FALSE, 0);
+#define ADD_CHANNEL(which, c, n, N, text, span)                             \
+  sprintf(field_name, "%s[%d]", #which, CHANNEL_##N);                       \
+  g->which##_##c = dt_bauhaus_slider_from_params(self, field_name);         \
+  dt_bauhaus_slider_set_soft_range(g->which##_##c, -span+1.0, span+1.0);    \
+  dt_bauhaus_slider_set_step(g->which##_##c, span / 100.0f);                \
+  dt_bauhaus_slider_set_digits(g->which##_##c, 5);                          \
+  dt_bauhaus_slider_set_offset(g->which##_##c, -1.0);                       \
+  dt_bauhaus_slider_set_feedback(g->which##_##c, 0);                        \
+  gtk_widget_set_tooltip_text(g->which##_##c, _(text[CHANNEL_##N]));        \
+  dt_bauhaus_widget_set_label(g->which##_##c, _(#which), _(#n));            \
 
-  static const char *lift_messages[] = { N_("factor of lift"), N_("lift") };
-  (void)lift_messages;
-  ADD_FACTOR(lift, 5.0f)
+#define ADD_BLOCK(which, text, span)                                        \
+  if(GTK_IS_NOTEBOOK(main_sliders))                                         \
+    self->widget = dt_ui_notebook_page(                                     \
+                   GTK_NOTEBOOK(main_sliders), _(text[4]), _(text[5]));     \
+  else                                                                      \
+    gtk_box_pack_start(GTK_BOX(self->widget),                               \
+                   dt_ui_section_label_new(_(text[5])), FALSE, FALSE, 0);   \
+                                                                            \
+  sprintf(field_name, "%s[%d]", #which, CHANNEL_FACTOR);                    \
+  g->which##_factor = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,       \
+                      dt_bauhaus_slider_from_params(self, field_name));     \
+  dt_bauhaus_slider_set_soft_range(g->which##_factor, -span+1.0, span+1.0); \
+  dt_bauhaus_slider_set_step(g->which##_factor, span / 100.0f);             \
+  dt_bauhaus_slider_set_digits(g->which##_factor, 4);                       \
+  dt_bauhaus_slider_set_factor(g->which##_factor, 100.0);                   \
+  dt_bauhaus_slider_set_offset(g->which##_factor, - 100.0);                 \
+  dt_bauhaus_slider_set_format(g->which##_factor, "%.2f %%");               \
+  dt_bauhaus_slider_set_feedback(g->which##_factor, 0);                     \
+  dt_bauhaus_slider_set_stop(g->which##_factor, 0.0, 0.0, 0.0, 0.0);        \
+  dt_bauhaus_slider_set_stop(g->which##_factor, 1.0, 1.0, 1.0, 1.0);        \
+  gtk_widget_set_tooltip_text(g->which##_factor, _(text[CHANNEL_FACTOR]));  \
+  dt_bauhaus_widget_set_label(g->which##_factor, _(#which), _("factor"));   \
+                                                                            \
+  g->hue_##which = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,          \
+                   dt_bauhaus_slider_new_with_range_and_feedback(self,      \
+                   0.0f, 360.0f, 1.0f, 0.0f, 2, 0));                        \
+  dt_bauhaus_widget_set_label(g->hue_##which, NULL, _("hue"));              \
+  dt_bauhaus_slider_set_format(g->hue_##which, "%.2f °");                   \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 0.0f,   1.0f, 0.0f, 0.0f);     \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 0.166f, 1.0f, 1.0f, 0.0f);     \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 0.322f, 0.0f, 1.0f, 0.0f);     \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 0.498f, 0.0f, 1.0f, 1.0f);     \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 0.664f, 0.0f, 0.0f, 1.0f);     \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 0.830f, 1.0f, 0.0f, 1.0f);     \
+  dt_bauhaus_slider_set_stop(g->hue_##which, 1.0f,   1.0f, 0.0f, 0.0f);     \
+  gtk_widget_set_tooltip_text(g->hue_##which, _("select the hue"));         \
+  g_signal_connect(G_OBJECT(g->hue_##which), "value-changed",               \
+                   G_CALLBACK(which##_callback), self);                     \
+  gtk_box_pack_start(GTK_BOX(self->widget), g->hue_##which, TRUE, TRUE, 0); \
+                                                                            \
+  g->sat_##which = dt_bauhaus_slider_new_with_range_and_feedback(self,      \
+                   0.0f, 100.0f, 0.05f, 0.0f, 2, 0);                        \
+  dt_bauhaus_slider_set_soft_range(g->sat_##which, 0.0f, 5.0f);             \
+  dt_bauhaus_widget_set_label(g->sat_##which, NULL, _("saturation"));       \
+  dt_bauhaus_slider_set_format(g->sat_##which, "%.2f %%");                  \
+  dt_bauhaus_slider_set_stop(g->sat_##which, 0.0f, 0.2f, 0.2f, 0.2f);       \
+  dt_bauhaus_slider_set_stop(g->sat_##which, 1.0f, 1.0f, 1.0f, 1.0f);       \
+  gtk_widget_set_tooltip_text(g->sat_##which, _("select the saturation"));  \
+  g_signal_connect(G_OBJECT(g->sat_##which), "value-changed",               \
+                   G_CALLBACK(which##_callback), self);                     \
+  gtk_box_pack_start(GTK_BOX(self->widget), g->sat_##which, TRUE, TRUE, 0); \
+                                                                            \
+  ADD_CHANNEL(which, r, red, RED, text, span)                               \
+  dt_bauhaus_slider_set_stop(g->which##_r, 0.0, 0.0, 1.0, 1.0);             \
+  dt_bauhaus_slider_set_stop(g->which##_r, 0.5, 1.0, 1.0, 1.0);             \
+  dt_bauhaus_slider_set_stop(g->which##_r, 1.0, 1.0, 0.0, 0.0);             \
+  ADD_CHANNEL(which, g, green, GREEN, text, span)                           \
+  dt_bauhaus_slider_set_stop(g->which##_g, 0.0, 1.0, 0.0, 1.0);             \
+  dt_bauhaus_slider_set_stop(g->which##_g, 0.5, 1.0, 1.0, 1.0);             \
+  dt_bauhaus_slider_set_stop(g->which##_g, 1.0, 0.0, 1.0, 0.0);             \
+  ADD_CHANNEL(which, b, blue, BLUE, text, span)                             \
+  dt_bauhaus_slider_set_stop(g->which##_b, 0.0, 1.0, 1.0, 0.0);             \
+  dt_bauhaus_slider_set_stop(g->which##_b, 0.5, 1.0, 1.0, 1.0);             \
+  dt_bauhaus_slider_set_stop(g->which##_b, 1.0, 0.0, 0.0, 1.0);             \
 
-  g->hue_lift = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
-                dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 360.0f, 1.0f, 0.0f, 2, 0));
-  dt_bauhaus_widget_set_label(g->hue_lift, NULL, _("hue"));
-  dt_bauhaus_slider_set_format(g->hue_lift, "%.2f °");
-  draw_hue_slider(g->hue_lift);
-  gtk_widget_set_tooltip_text(g->hue_lift, _("select the hue"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hue_lift, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->hue_lift), "value-changed", G_CALLBACK(hue_lift_callback), self);
+  static const char *lift_messages[] = 
+    { N_("factor of lift"),
+      N_("factor of red for lift"),
+      N_("factor of green for lift"),
+      N_("factor of blue for lift"),
+      N_("lift"),
+      N_("shadows : lift / offset") };
 
-  g->sat_lift = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 5.0f, 0.05f, 0.0f, 2, 0);
-  dt_bauhaus_slider_set_format(g->sat_lift, "%.2f %%");
-  dt_bauhaus_slider_enable_soft_boundaries(g->sat_lift, 0.0f, 100.0f);
-  dt_bauhaus_widget_set_label(g->sat_lift, NULL, _("saturation"));
-  dt_bauhaus_slider_set_stop(g->sat_lift, 0.0f, 0.2f, 0.2f, 0.2f);
-  dt_bauhaus_slider_set_stop(g->sat_lift, 1.0f, 1.0f, 1.0f, 1.0f);
-  gtk_widget_set_tooltip_text(g->sat_lift, _("select the saturation"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sat_lift, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->sat_lift), "value-changed", G_CALLBACK(sat_lift_callback), self);
+  static const char *gamma_messages[] = 
+    { N_("factor of gamma"),
+      N_("factor of red for gamma"),
+      N_("factor of green for gamma"),
+      N_("factor of blue for gamma"),
+      N_("gamma"),
+      N_("mid-tones : gamma / power") };
 
+  static const char *gain_messages[] = 
+    { N_("factor of gain"), 
+      N_("factor of red for gain"), 
+      N_("factor of green for gain"), 
+      N_("factor of blue for gain"), 
+      N_("gain"),
+      N_("highlights : gain / slope") };
 
-  static const char *lift_red_messages[] = { N_("factor of red for lift"), N_("red") };
-  (void)lift_red_messages;
-  ADD_CHANNEL(lift, r, red, RED, 0.05f)
-  dt_bauhaus_slider_set_stop(g->lift_r, 0.0, 0.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->lift_r, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->lift_r, 1.0, 1.0, 0.0, 0.0);
+  ADD_BLOCK(lift,  lift_messages, 0.05f)
+  ADD_BLOCK(gamma, gamma_messages, 0.5f)
+  ADD_BLOCK(gain,  gain_messages,  0.5f)
 
-  static const char *lift_green_messages[] = { N_("factor of green for lift"), N_("green") };
-  (void)lift_green_messages;
-  ADD_CHANNEL(lift, g, green, GREEN, 0.05f)
-  dt_bauhaus_slider_set_stop(g->lift_g, 0.0, 1.0, 0.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->lift_g, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->lift_g, 1.0, 0.0, 1.0, 0.0);
+  g->optimizer_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  static const char *lift_blue_messages[] = { N_("factor of blue for lift"), N_("blue") };
-  (void)lift_blue_messages;
-  ADD_CHANNEL(lift, b, blue, BLUE, 0.05f)
-  dt_bauhaus_slider_set_stop(g->lift_b, 0.0, 1.0, 1.0, 0.0);
-  dt_bauhaus_slider_set_stop(g->lift_b, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->lift_b, 1.0, 0.0, 0.0, 1.0);
-
-  /* gamma */
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("mid-tones : gamma / power")), FALSE, FALSE, 0);
-
-  static const char *gamma_messages[] = { N_("factor of gamma"), N_("gamma") };
-  (void)gamma_messages;
-  ADD_FACTOR(gamma, 50.0f)
-
-  g->hue_gamma = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
-                 dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 360.0f, 1.0f, 0.0f, 2, 0));
-  dt_bauhaus_widget_set_label(g->hue_gamma, NULL, _("hue"));
-  dt_bauhaus_slider_set_format(g->hue_gamma, "%.2f °");
-  draw_hue_slider(g->hue_gamma);
-  gtk_widget_set_tooltip_text(g->hue_gamma, _("select the hue"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hue_gamma, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->hue_gamma), "value-changed", G_CALLBACK(hue_gamma_callback), self);
-  
-  g->sat_gamma = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 20.0f, 0.2f, 0.0f, 2, 0);
-  dt_bauhaus_slider_set_format(g->sat_gamma, "%.2f %%");
-  dt_bauhaus_slider_enable_soft_boundaries(g->sat_gamma, 0.0f, 100.0f);
-  dt_bauhaus_widget_set_label(g->sat_gamma, NULL, _("saturation"));
-  dt_bauhaus_slider_set_stop(g->sat_gamma, 0.0f, 0.2f, 0.2f, 0.2f);
-  dt_bauhaus_slider_set_stop(g->sat_gamma, 1.0f, 1.0f, 1.0f, 1.0f);
-  gtk_widget_set_tooltip_text(g->sat_gamma, _("select the saturation"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sat_gamma, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->sat_gamma), "value-changed", G_CALLBACK(sat_gamma_callback), self);
-
-  static const char *gamma_red_messages[] = { N_("factor of red for gamma") };
-  (void)gamma_red_messages;
-  ADD_CHANNEL(gamma, r, red, RED, 0.5f)
-  dt_bauhaus_slider_set_stop(g->gamma_r, 0.0, 0.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gamma_r, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gamma_r, 1.0, 1.0, 0.0, 0.0);
-
-  static const char *gamma_green_messages[] = { N_("factor of green for gamma") };
-  (void)gamma_green_messages;
-  ADD_CHANNEL(gamma, g, green, GREEN, 0.5f)
-  dt_bauhaus_slider_set_stop(g->gamma_g, 0.0, 1.0, 0.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gamma_g, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gamma_g, 1.0, 0.0, 1.0, 0.0);
-
-  static const char *gamma_blue_messages[] = { N_("factor of blue for gamma") };
-  (void)gamma_blue_messages;
-  ADD_CHANNEL(gamma, b, blue, BLUE, 0.5f)
-  dt_bauhaus_slider_set_stop(g->gamma_b, 0.0, 1.0, 1.0, 0.0);
-  dt_bauhaus_slider_set_stop(g->gamma_b, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gamma_b, 1.0, 0.0, 0.0, 1.0);
-
-  /* gain */
-  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("highlights : gain / slope")), FALSE, FALSE, 0);
-
-  static const char *gain_messages[] = { N_("factor of gain"), N_("gain") };
-  (void)gain_messages;
-  ADD_FACTOR(gain, 50.0f)
-
-  g->hue_gain = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
-                dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 360.0f, 1.0f, 0.0f, 2, 0));
-  dt_bauhaus_widget_set_label(g->hue_gain, NULL, _("hue"));
-  dt_bauhaus_slider_set_format(g->hue_gain, "%.2f °");
-  draw_hue_slider(g->hue_gain);
-  gtk_widget_set_tooltip_text(g->hue_gain, _("select the hue"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->hue_gain, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->hue_gain), "value-changed", G_CALLBACK(hue_gain_callback), self);
-
-  g->sat_gain = dt_bauhaus_slider_new_with_range_and_feedback(self, 0.0f, 25.0f, 0.25f, 0.0f, 2, 0);
-  dt_bauhaus_slider_set_format(g->sat_gain, "%.2f %%");
-  dt_bauhaus_slider_enable_soft_boundaries(g->sat_gain, 0.0f, 100.0f);
-  dt_bauhaus_widget_set_label(g->sat_gain, NULL, _("saturation"));
-  dt_bauhaus_slider_set_stop(g->sat_gain, 0.0f, 0.2f, 0.2f, 0.2f);
-  dt_bauhaus_slider_set_stop(g->sat_gain, 1.0f, 1.0f, 1.0f, 1.0f);
-  gtk_widget_set_tooltip_text(g->sat_gain, _("select the saturation"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->sat_gain, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->sat_gain), "value-changed", G_CALLBACK(sat_gain_callback), self);
-
-  static const char *gain_red_messages[] = { N_("factor of red for gain") };
-  (void)gain_red_messages;
-  ADD_CHANNEL(gain, r, red, RED, 0.5f)
-  dt_bauhaus_slider_set_stop(g->gain_r, 0.0, 0.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gain_r, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gain_r, 1.0, 1.0, 0.0, 0.0);
-
-  static const char *gain_green_messages[] = { N_("factor of green for gain") };
-  (void)gain_green_messages;
-  ADD_CHANNEL(gain, g, green, GREEN, 0.5f)
-  dt_bauhaus_slider_set_stop(g->gain_g, 0.0, 1.0, 0.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gain_g, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gain_g, 1.0, 0.0, 1.0, 0.0);
-
-  static const char *gain_blue_messages[] = { N_("factor of blue for gain") };
-  (void)gain_blue_messages;
-  ADD_CHANNEL(gain, b, blue, BLUE, 0.5f)
-  dt_bauhaus_slider_set_stop(g->gain_b, 0.0, 1.0, 1.0, 0.0);
-  dt_bauhaus_slider_set_stop(g->gain_b, 0.5, 1.0, 1.0, 1.0);
-  dt_bauhaus_slider_set_stop(g->gain_b, 1.0, 0.0, 0.0, 1.0);
-
-  g->optim_label =  dt_ui_section_label_new(_("auto optimizers"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->optim_label, FALSE, FALSE, 0);
-
-  GtkBox *box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_section_label_new(_("auto optimizers")), FALSE, FALSE, 0);
 
   g->auto_luma = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                  dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_luma, NULL, _("optimize luma"));
   gtk_widget_set_tooltip_text(g->auto_luma, _("fit the whole histogram and center the average luma"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_luma, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_luma, FALSE, FALSE, 0);
 
   g->auto_color = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
                   dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_color, NULL, _("neutralize colors"));
   gtk_widget_set_tooltip_text(g->auto_color, _("optimize the RGB curves to remove color casts"));
-  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_color, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), g->auto_color, FALSE, FALSE, 0);
 
-  set_visible_widgets(g);
+  // start building top level widget
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-#undef ADD_FACTOR
-#undef ADD_CHANNEL
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(mode_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->master_box), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(main_sliders), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->optimizer_box), TRUE, TRUE, 0);
 }
-
-/** additional, optional callbacks to capture darkroom center events. */
-// int mouse_moved(dt_iop_module_t *self, double x, double y, double pressure, int which);
-// int button_pressed(dt_iop_module_t *self, double x, double y, double pressure, int which, int type,
-// uint32_t state);
-// int button_released(struct dt_iop_module_t *self, double x, double y, int which, uint32_t state);
-// int scrolled(dt_iop_module_t *self, double x, double y, int up, uint32_t state);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -26,6 +26,7 @@
 #include "develop/develop.h"
 #include "develop/imageop.h"
 #include "develop/imageop_math.h"
+#include "develop/imageop_gui.h"
 #include "dtgtk/button.h"
 #include "dtgtk/resetlabel.h"
 #include "gui/accelerators.h"
@@ -131,24 +132,32 @@ DT_MODULE_INTROSPECTION(2, dt_iop_negadoctor_params_t)
 typedef enum dt_iop_negadoctor_filmstock_t
 {
   // What kind of emulsion are we working on ?
-  DT_FILMSTOCK_NB = 0,
-  DT_FILMSTOCK_COLOR = 1,
-  DT_FILMSTOCK_END = 2
+  DT_FILMSTOCK_NB = 0,   // $DESCRIPTION: "black and white"
+  DT_FILMSTOCK_COLOR = 1 // $DESCRIPTION: "color"
 } dt_iop_negadoctor_filmstock_t;
 
 
 typedef struct dt_iop_negadoctor_params_t
 {
-  dt_iop_negadoctor_filmstock_t film_stock;
-  float Dmin[4];                            // color of film substrate
-  float wb_high[4];                         // white balance RGB coeffs (illuminant)
-  float wb_low[4];                          // white balance RGB offsets (base light)
-  float D_max;                              // max density of film
-  float offset;                             // inversion offset
-  float black;                              // display black level
-  float gamma;                              // display gamma
-  float soft_clip;                          // highlights roll-off
-  float exposure;                           // extra exposure
+  dt_iop_negadoctor_filmstock_t film_stock; // $DEFAULT: DT_FILMSTOCK_COLOR
+  float Dmin[4];                            /* color of film substrate
+                                               $MIN: 0.00001 $MAX: 1.5 $DEFAULT: 1.0 */
+  float wb_high[4];                         /* white balance RGB coeffs (illuminant)
+                                               $MIN: 0.25 $MAX: 2 $DEFAULT: 1.0 */
+  float wb_low[4];                          /* white balance RGB offsets (base light)
+                                               $MIN: 0.25 $MAX: 2 $DEFAULT: 1.0 */
+  float D_max;                              /* max density of film
+                                               $MIN: 0.1 $MAX: 6 $DEFAULT: 2.046 */
+  float offset;                             /* inversion offset
+                                               $MIN: -1.0 $MAX: 1.0 $DEFAULT: 0.0 $DESCRIPTION: "scan exposure bias" */
+  float black;                              /* display black level
+                                               $MIN: -0.5 $MAX: 0.5 $DEFAULT:0.0755 $DESCRIPTION: "paper black (density correction)" */
+  float gamma;                              /* display gamma
+                                               $MIN: 1.0 $MAX: 8.0 $DEFAULT: 4.0 $DESCRIPTION: "paper grade (gamma)" */
+  float soft_clip;                          /* highlights roll-off
+                                               $MIN: 0.0001 $MAX: 1.0 $DEFAULT: 0.9 $DESCRIPTION: "paper gloss (specular highlights)" */
+  float exposure;                           /* extra exposure
+                                               $MIN: 0.5 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "print exposure adjustment" */
 } dt_iop_negadoctor_params_t;
 
 
@@ -383,25 +392,15 @@ error:
 
 void init(dt_iop_module_t *module)
 {
-  module->params = calloc(1, sizeof(dt_iop_negadoctor_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_negadoctor_params_t));
-  module->default_enabled = 0;
-  module->params_size = sizeof(dt_iop_negadoctor_params_t);
-  module->gui_data = NULL;
+  dt_iop_default_init(module);
 
-  dt_iop_negadoctor_params_t tmp = (dt_iop_negadoctor_params_t){ .film_stock = DT_FILMSTOCK_COLOR,
-                                                                 .Dmin = { 1.0f, 0.45f, 0.25f, 0.0f},
-                                                                 .wb_high = { 1.0f, 1.0f, 1.0f, 0.0f },
-                                                                 .wb_low = { 1.0f, 1.0f, 1.0f, 0.0f },
-                                                                 .D_max = 2.046f,
-                                                                 .offset = 0.0f,
-                                                                 .gamma = 4.0f,
-                                                                 .soft_clip = 0.9f,
-                                                                 .exposure = 1.0f,
-                                                                 .black = 0.0755f };
+  dt_iop_negadoctor_params_t *d = module->default_params;
 
-  memcpy(module->params, &tmp, sizeof(dt_iop_negadoctor_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_negadoctor_params_t));
+  d->Dmin[0] = 1.00f;
+  d->Dmin[1] = 0.45f;
+  d->Dmin[2] = 0.25f;
+
+  memcpy(module->params, module->default_params, sizeof(dt_iop_negadoctor_params_t));
 }
 
 void init_presets(dt_iop_module_so_t *self)
@@ -433,14 +432,6 @@ void init_presets(dt_iop_module_so_t *self)
 
 
   dt_gui_presets_add_generic(_("black and white film"), self->op, self->version(), &tmq, sizeof(tmq), 1);
-}
-
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
 }
 
 void init_global(dt_iop_module_so_t *module)
@@ -545,9 +536,9 @@ static void Dmin_picker_callback(GtkColorButton *widget, dt_iop_module_t *self)
   p->Dmin[2] = c.blue;
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0] * 100.0f); // warning: GUI is in %
-  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1] * 100.0f); // warning: GUI is in %
-  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2] * 100.0f); // warning: GUI is in %
+  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0]);
+  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1]);
+  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2]);
   --darktable.gui->reset;
 
   Dmin_picker_update(self);
@@ -669,9 +660,9 @@ static void apply_auto_Dmin(dt_iop_module_t *self)
   for(int k = 0; k < 4; k++) p->Dmin[k] = self->picked_color[k];
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0] * 100.0f); // warning: GUI is in %
-  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1] * 100.0f); // warning: GUI is in %
-  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2] * 100.0f); // warning: GUI is in %
+  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0]);
+  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1]);
+  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2]);
   --darktable.gui->reset;
 
   Dmin_picker_update(self);
@@ -718,7 +709,7 @@ static void apply_auto_offset(dt_iop_module_t *self)
   p->offset = v_minf(RGB);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set(g->offset, p->offset); // warning: GUI is in %
+  dt_bauhaus_slider_set(g->offset, p->offset);
   --darktable.gui->reset;
 
   dt_control_queue_redraw_widget(self->widget);
@@ -796,7 +787,7 @@ static void apply_auto_black(dt_iop_module_t *self)
   p->black = v_maxf(RGB);
 
   ++darktable.gui->reset;
-  dt_bauhaus_slider_set(g->black, p->black * 100.0f);
+  dt_bauhaus_slider_set(g->black, p->black);
   --darktable.gui->reset;
 
   dt_control_queue_redraw_widget(self->widget);
@@ -853,188 +844,6 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
     fprintf(stderr, "[negadoctor] unknown color picker\n");
 }
 
-
-/** gui callbacks, these are needed. */
-
-static void film_stock_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->film_stock = dt_bauhaus_combobox_get(w);
-  toggle_stock_controls(self);
-  Dmin_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void Dmin_R_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  if(p->film_stock == DT_FILMSTOCK_COLOR)
-    p->Dmin[0] = dt_bauhaus_slider_get(w) / 100.0f;                             // warning: GUI is in %
-  else if(p->film_stock == DT_FILMSTOCK_NB)
-    p->Dmin[0] = p->Dmin[1] = p->Dmin[2] = dt_bauhaus_slider_get(w) / 100.0f;   // warning: GUI is in %
-
-  Dmin_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void Dmin_G_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->Dmin[1] = dt_bauhaus_slider_get(w) / 100.0f;                               // warning: GUI is in %
-
-  Dmin_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void Dmin_B_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->Dmin[2] = dt_bauhaus_slider_get(w) / 100.0f;                               // warning: GUI is in %
-
-  Dmin_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void wb_high_R_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->wb_high[0] = dt_bauhaus_slider_get(w);
-
-  WB_high_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void wb_high_G_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->wb_high[1] = dt_bauhaus_slider_get(w);
-
-  WB_high_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void wb_high_B_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->wb_high[2] = dt_bauhaus_slider_get(w);
-
-  WB_high_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void wb_low_R_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->wb_low[0] = dt_bauhaus_slider_get(w);
-
-  WB_low_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void wb_low_G_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->wb_low[1] = dt_bauhaus_slider_get(w);
-
-  WB_low_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void wb_low_B_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-
-  p->wb_low[2] = dt_bauhaus_slider_get(w);
-
-  WB_low_picker_update(self);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void D_max_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->D_max = dt_bauhaus_slider_get(w);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void offset_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->offset = dt_bauhaus_slider_get(w);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
-static void gamma_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->gamma = dt_bauhaus_slider_get(w);
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void soft_clip_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->soft_clip = dt_bauhaus_slider_get(w) / 100.0f;                             // warning: GUI is in %
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void exposure_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->exposure = powf(2.0f, dt_bauhaus_slider_get(w));                           // warning: GUI is in EV
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-static void black_callback(GtkWidget *w, dt_iop_module_t *self)
-{
-  if(darktable.gui->reset) return;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
-  p->black = dt_bauhaus_slider_get(w) / 100.0f;                                 // warning: GUI is in %
-  dt_iop_color_picker_reset(self, TRUE);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
-
 void gui_init(dt_iop_module_t *self)
 {
   // init the slider (more sophisticated layouts are possible with gtk tables and boxes):
@@ -1042,31 +851,10 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
   dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-
-  // Film emulsion
-
-  g->film_stock = dt_bauhaus_combobox_new(self);
-  dt_bauhaus_widget_set_label(g->film_stock, NULL, _("film stock"));
-  dt_bauhaus_combobox_add(g->film_stock, _("black and white"));
-  dt_bauhaus_combobox_add(g->film_stock, _("color"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->film_stock), TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->film_stock), "value-changed", G_CALLBACK(film_stock_callback), self);
-  gtk_widget_set_tooltip_text(g->film_stock, _("toggle on or off the color controls"));
-
   g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
-  GtkWidget *page1 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  GtkWidget *page2 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
-  GtkWidget *page3 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
 
-  gtk_notebook_append_page(g->notebook, page1, gtk_label_new(_("film properties")));
-  gtk_notebook_append_page(g->notebook, page2, gtk_label_new(_("corrections")));
-  gtk_notebook_append_page(g->notebook, page3, gtk_label_new(_("print properties")));
-
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(g->notebook, 0)));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
-
-  dtgtk_justify_notebook_tabs(g->notebook);
+  // Page FILM PROPERTIES
+  GtkWidget *page1 = self->widget = dt_ui_notebook_page(g->notebook, _("film properties"), NULL);
 
   // Dmin
 
@@ -1087,60 +875,61 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(row1), FALSE, FALSE, 0);
 
-  g->Dmin_R = dt_bauhaus_slider_new_with_range(self, 0.001, 150., 0.25, p->Dmin[0] * 100, 2);
+  g->Dmin_R = dt_bauhaus_slider_from_params(self, "Dmin[0]");
+  dt_bauhaus_slider_set_digits(g->Dmin_R, 4);
+  dt_bauhaus_slider_set_step(g->Dmin_R, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_R, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->Dmin_R, 100);
   dt_bauhaus_widget_set_label(g->Dmin_R, NULL, _("D min red component"));
   gtk_widget_set_tooltip_text(g->Dmin_R, _("adjust the color and shade of the film transparent base.\n"
                                            "this value depends on the film material, \n"
                                            "the chemical fog produced while developing the film,\n"
                                            "and the scanner white balance."));
-  gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(g->Dmin_R), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->Dmin_R), "value-changed", G_CALLBACK(Dmin_R_callback), self);
 
-  g->Dmin_G = dt_bauhaus_slider_new_with_range(self, 0.001, 150., 0.25, p->Dmin[1] * 100, 2);
+  g->Dmin_G = dt_bauhaus_slider_from_params(self, "Dmin[1]");
+  dt_bauhaus_slider_set_digits(g->Dmin_G, 4);
+  dt_bauhaus_slider_set_step(g->Dmin_G, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_G, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->Dmin_G, 100);
   dt_bauhaus_widget_set_label(g->Dmin_G, NULL, _("D min green component"));
   gtk_widget_set_tooltip_text(g->Dmin_G, _("adjust the color and shade of the film transparent base.\n"
                                            "this value depends on the film material, \n"
                                            "the chemical fog produced while developing the film,\n"
                                            "and the scanner white balance."));
-  gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(g->Dmin_G), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->Dmin_G), "value-changed", G_CALLBACK(Dmin_G_callback), self);
 
-  g->Dmin_B = dt_bauhaus_slider_new_with_range(self, 0.001, 150., 0.25, p->Dmin[2] * 100, 2);
+  g->Dmin_B = dt_bauhaus_slider_from_params(self, "Dmin[2]");
+  dt_bauhaus_slider_set_digits(g->Dmin_B, 4);
+  dt_bauhaus_slider_set_step(g->Dmin_B, 0.0025);
   dt_bauhaus_slider_set_format(g->Dmin_B, "%.2f %%");
+  dt_bauhaus_slider_set_factor(g->Dmin_B, 100);
   dt_bauhaus_widget_set_label(g->Dmin_B, NULL, _("D min blue component"));
   gtk_widget_set_tooltip_text(g->Dmin_B, _("adjust the color and shade of the film transparent base.\n"
                                            "this value depends on the film material, \n"
                                            "the chemical fog produced while developing the film,\n"
                                            "and the scanner white balance."));
-  gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(g->Dmin_B), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->Dmin_B), "value-changed", G_CALLBACK(Dmin_B_callback), self);
 
   // D max and scanner bias
 
   gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(_("dynamic range of the film")), FALSE, FALSE, 0);
 
-  g->D_max = dt_bauhaus_slider_new_with_range(self, 0.1, 6.0, 0.01, p->D_max, 2);
+  g->D_max = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
+             dt_bauhaus_slider_from_params(self, "D_max"));
   dt_bauhaus_slider_set_format(g->D_max, "%.2f dB");
-  dt_bauhaus_widget_set_label(g->D_max, NULL, _("D max"));
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->D_max);
   gtk_widget_set_tooltip_text(g->D_max, _("maximum density of the film, corresponding to white after inversion.\n"
                                           "this value depends on the film specifications, the developing process,\n"
                                           "the dynamic range of the scene and the scanner exposure settings."));
-  gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(g->D_max), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->D_max), "value-changed", G_CALLBACK(D_max_callback), self);
 
   gtk_box_pack_start(GTK_BOX(page1), dt_ui_section_label_new(_("scanner exposure settings")), FALSE, FALSE, 0);
 
-  g->offset = dt_bauhaus_slider_new_with_range(self, -1.0, 1.0, 0.01, p->offset, 2);
+  g->offset = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
+              dt_bauhaus_slider_from_params(self, "offset"));
   dt_bauhaus_slider_set_format(g->offset, "%+.2f dB");
-  dt_bauhaus_widget_set_label(g->offset, NULL, _("scan exposure bias"));
   dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->offset);
   gtk_widget_set_tooltip_text(g->offset, _("correct the exposure of the scanner, for all RGB channels,\n"
                                            "before the inversion, so blacks are neither clipped or too pale."));
-  gtk_box_pack_start(GTK_BOX(page1), GTK_WIDGET(g->offset), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->offset), "value-changed", G_CALLBACK(offset_callback), self);
+
+  // Page CORRECTIONS
+  GtkWidget *page2 = self->widget = dt_ui_notebook_page(g->notebook, _("corrections"), NULL);
 
   // WB shadows
   gtk_box_pack_start(GTK_BOX(page2), dt_ui_section_label_new(_("shadows color cast")), FALSE, FALSE, 0);
@@ -1161,32 +950,26 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(row3), FALSE, FALSE, 0);
 
-  g->wb_low_R = dt_bauhaus_slider_new_with_range(self, 0.25, 2., 0.01, p->wb_low[0], 2);
+  g->wb_low_R = dt_bauhaus_slider_from_params(self, "wb_low[0]");
   dt_bauhaus_widget_set_label(g->wb_low_R, NULL, _("shadows red offset"));
   gtk_widget_set_tooltip_text(g->wb_low_R, _("correct the color cast in shadows so blacks are\n"
                                              "truly achromatic. Setting this value before\n"
                                              "the highlights illuminant white balance will help\n"
                                              "recovering the global white balance in difficult cases."));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->wb_low_R), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->wb_low_R), "value-changed", G_CALLBACK(wb_low_R_callback), self);
 
-  g->wb_low_G = dt_bauhaus_slider_new_with_range(self, 0.25, 2., 0.01, p->wb_low[1], 2);
+  g->wb_low_G = dt_bauhaus_slider_from_params(self, "wb_low[1]");
   dt_bauhaus_widget_set_label(g->wb_low_G, NULL, _("shadows green offset"));
   gtk_widget_set_tooltip_text(g->wb_low_G, _("correct the color cast in shadows so blacks are\n"
                                              "truly achromatic. Setting this value before\n"
                                              "the highlights illuminant white balance will help\n"
                                              "recovering the global white balance in difficult cases."));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->wb_low_G), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->wb_low_G), "value-changed", G_CALLBACK(wb_low_G_callback), self);
 
-  g->wb_low_B = dt_bauhaus_slider_new_with_range(self, 0.25, 2., 0.01, p->wb_low[2], 2);
+  g->wb_low_B = dt_bauhaus_slider_from_params(self, "wb_low[2]");
   dt_bauhaus_widget_set_label(g->wb_low_B, NULL, _("shadows blue offset"));
   gtk_widget_set_tooltip_text(g->wb_low_B, _("correct the color cast in shadows so blacks are\n"
                                              "truly achromatic. Setting this value before\n"
                                              "the highlights illuminant white balance will help\n"
                                              "recovering the global white balance in difficult cases."));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->wb_low_B), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->wb_low_B), "value-changed", G_CALLBACK(wb_low_B_callback), self);
 
   // WB highlights
   gtk_box_pack_start(GTK_BOX(page2), dt_ui_section_label_new(_("highlights white balance")), FALSE, FALSE, 0);
@@ -1207,74 +990,110 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(row2), FALSE, FALSE, 0);
 
-  g->wb_high_R = dt_bauhaus_slider_new_with_range(self, 0.25, 2., 0.01, p->wb_high[0], 2);
+  g->wb_high_R = dt_bauhaus_slider_from_params(self, "wb_high[0]");
   dt_bauhaus_widget_set_label(g->wb_high_R, NULL, _("illuminant red gain"));
   gtk_widget_set_tooltip_text(g->wb_high_R, _("correct the color of the illuminant so whites are\n"
                                               "truly achromatic. Setting this value after\n"
                                               "the shadows color cast will help\n"
                                               "recovering the global white balance in difficult cases."));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->wb_high_R), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->wb_high_R), "value-changed", G_CALLBACK(wb_high_R_callback), self);
 
-  g->wb_high_G = dt_bauhaus_slider_new_with_range(self, 0.25, 2., 0.01, p->wb_high[1], 2);
+  g->wb_high_G = dt_bauhaus_slider_from_params(self, "wb_high[1]");
   dt_bauhaus_widget_set_label(g->wb_high_G, NULL, _("illuminant green gain"));
   gtk_widget_set_tooltip_text(g->wb_high_G, _("correct the color of the illuminant so whites are\n"
                                               "truly achromatic. Setting this value after\n"
                                               "the shadows color cast will help\n"
                                               "recovering the global white balance in difficult cases."));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->wb_high_G), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->wb_high_G), "value-changed", G_CALLBACK(wb_high_G_callback), self);
 
-  g->wb_high_B = dt_bauhaus_slider_new_with_range(self, 0.25, 2., 0.01, p->wb_high[2], 2);
+  g->wb_high_B = dt_bauhaus_slider_from_params(self, "wb_high[2]");
   dt_bauhaus_widget_set_label(g->wb_high_B, NULL, _("illuminant blue gain"));
   gtk_widget_set_tooltip_text(g->wb_high_B, _("correct the color of the illuminant so whites are\n"
                                               "truly achromatic. Setting this value after\n"
                                               "the shadows color cast will help\n"
                                               "recovering the global white balance in difficult cases."));
-  gtk_box_pack_start(GTK_BOX(page2), GTK_WIDGET(g->wb_high_B), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->wb_high_B), "value-changed", G_CALLBACK(wb_high_B_callback), self);
+
+  // Page PRINT PROPERTIES
+  GtkWidget *page3 = self->widget = dt_ui_notebook_page(g->notebook, _("print properties"), NULL);
 
   // print corrections
   gtk_box_pack_start(GTK_BOX(page3), dt_ui_section_label_new(_("virtual paper properties")), FALSE, FALSE, 0);
 
-  g->black = dt_bauhaus_slider_new_with_range(self, -50., 50., 0.05, p->black * 100, 2);
+  g->black = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
+             dt_bauhaus_slider_from_params(self, "black"));
+  dt_bauhaus_slider_set_digits(g->black, 4);
+  dt_bauhaus_slider_set_step(g->black, 0.0005);
+  dt_bauhaus_slider_set_factor(g->black, 100);
   dt_bauhaus_slider_set_format(g->black, "%+.2f %%");
-  dt_bauhaus_widget_set_label(g->black, NULL, _("paper black (density correction)"));
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->black);
   gtk_widget_set_tooltip_text(g->black, _("correct the density of black after the inversion,\n"
                                           "to adjust the global contrast while avoiding clipping shadows."));
-  gtk_box_pack_start(GTK_BOX(page3), GTK_WIDGET(g->black), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->black), "value-changed", G_CALLBACK(black_callback), self);
 
-  g->gamma = dt_bauhaus_slider_new_with_range(self, 1., 8.0, 0.05, p->gamma, 2);
+  g->gamma = dt_bauhaus_slider_from_params(self, "gamma");
   dt_bauhaus_widget_set_label(g->gamma, NULL, _("paper grade (gamma)"));
-  gtk_box_pack_start(GTK_BOX(page3), GTK_WIDGET(g->gamma), FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->gamma, _("select the grade of the virtual paper, which is actually\n"
                                           "equivalent to applying a gamma. it compensates the film D max\n"
                                           "and recovers the contrast. use a high grade for high D max."));
-  g_signal_connect(G_OBJECT(g->gamma), "value-changed", G_CALLBACK(gamma_callback), self);
 
-  g->soft_clip = dt_bauhaus_slider_new_with_range(self, 0.01, 100.0, 1., p->soft_clip * 100, 2);
+  g->soft_clip = dt_bauhaus_slider_from_params(self, "soft_clip");
+  dt_bauhaus_slider_set_factor(g->soft_clip, 100);
+  dt_bauhaus_slider_set_digits(g->soft_clip, 4);
   dt_bauhaus_slider_set_format(g->soft_clip, "%.2f %%");
-  dt_bauhaus_widget_set_label(g->soft_clip, NULL, _("paper gloss (specular highlights)"));
-  gtk_box_pack_start(GTK_BOX(page3), GTK_WIDGET(g->soft_clip), FALSE, FALSE, 0);
   gtk_widget_set_tooltip_text(g->soft_clip, _("gradually compress specular highlights past this value\n"
                                               "to avoid clipping while pushing the exposure for midtones.\n"
                                               "this somewhat reproduces the behaviour of matte paper."));
-  g_signal_connect(G_OBJECT(g->soft_clip), "value-changed", G_CALLBACK(soft_clip_callback), self);
 
   gtk_box_pack_start(GTK_BOX(page3), dt_ui_section_label_new(_("virtual print emulation")), FALSE, FALSE, 0);
 
-  g->exposure = dt_bauhaus_slider_new_with_range(self, -1., +1., 0.01, log2f(p->exposure), 2);
+  g->exposure = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
+                dt_bauhaus_slider_from_params(self, "exposure"));
+  dt_bauhaus_slider_set_hard_min(g->exposure, -1.0);
+  dt_bauhaus_slider_set_hard_max(g->exposure, 1.0);
+  dt_bauhaus_slider_set_default(g->exposure, 0.0);
   dt_bauhaus_slider_set_format(g->exposure, "%+.2f EV");
-  dt_bauhaus_widget_set_label(g->exposure, NULL, _("print exposure adjustment"));
-  dt_color_picker_new(self, DT_COLOR_PICKER_AREA, g->exposure);
   gtk_widget_set_tooltip_text(g->exposure, _("correct the printing exposure after inversion to adjust\n"
                                              "the global contrast and avoid clipping highlights."));
-  gtk_box_pack_start(GTK_BOX(page3), GTK_WIDGET(g->exposure), FALSE, FALSE, 0);
-  g_signal_connect(G_OBJECT(g->exposure), "value-changed", G_CALLBACK(exposure_callback), self);
 
-  toggle_stock_controls(self);
+  // start building top level widget
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+
+  // Film emulsion
+  g->film_stock = dt_bauhaus_combobox_from_params(self, "film_stock");
+  gtk_widget_set_tooltip_text(g->film_stock, _("toggle on or off the color controls"));
+
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->notebook), FALSE, FALSE, 0);
+}
+
+
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
+{
+  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
+  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  if(!w || w == g->film_stock)
+  {
+    toggle_stock_controls(self);
+    Dmin_picker_update(self);
+  }
+  else if(w == g->Dmin_R && p->film_stock == DT_FILMSTOCK_NB)
+  {
+    dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[0]);
+    dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[0]);
+  }
+  else if(w == g->Dmin_R || w == g->Dmin_G || w == g->Dmin_B)
+  {
+    Dmin_picker_update(self);
+  }
+  else if(w == g->exposure)
+  {
+    p->exposure = powf(2.0f, p->exposure);
+  }
+
+  if(!w || w == g->wb_high_R || w == g->wb_high_G || w == g->wb_high_B)
+  {
+    WB_high_picker_update(self);
+  }
+  
+  if(!w || w == g->wb_low_R || w == g->wb_low_G || w == g->wb_low_B)
+  {
+    WB_low_picker_update(self);
+  }
 }
 
 
@@ -1292,10 +1111,10 @@ void gui_update(dt_iop_module_t *const self)
 
   dt_bauhaus_combobox_set(g->film_stock, p->film_stock);
 
-  // Dmin - warning: GUI is in %
-  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0] * 100.0f);
-  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1] * 100.0f);
-  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2] * 100.0f);
+  // Dmin
+  dt_bauhaus_slider_set(g->Dmin_R, p->Dmin[0]);
+  dt_bauhaus_slider_set(g->Dmin_G, p->Dmin[1]);
+  dt_bauhaus_slider_set(g->Dmin_B, p->Dmin[2]);
 
   // Dmax
   dt_bauhaus_slider_set(g->D_max, p->D_max);
@@ -1308,22 +1127,19 @@ void gui_update(dt_iop_module_t *const self)
   dt_bauhaus_slider_set(g->wb_high_G, p->wb_high[1]);
   dt_bauhaus_slider_set(g->wb_high_B, p->wb_high[2]);
 
-  // WB_high
+  // WB_low
   dt_bauhaus_slider_set(g->wb_low_R, p->wb_low[0]);
   dt_bauhaus_slider_set(g->wb_low_G, p->wb_low[1]);
   dt_bauhaus_slider_set(g->wb_low_B, p->wb_low[2]);
 
   // Print
   dt_bauhaus_slider_set(g->exposure, log2f(p->exposure));     // warning: GUI is in EV
-  dt_bauhaus_slider_set(g->black, p->black * 100.0f);         // warning: GUI is in %
+  dt_bauhaus_slider_set(g->black, p->black);
   dt_bauhaus_slider_set(g->gamma, p->gamma);
-  dt_bauhaus_slider_set(g->soft_clip, p->soft_clip * 100.0f); // warning: GUI is in %
+  dt_bauhaus_slider_set(g->soft_clip, p->soft_clip);
 
   // Update custom stuff
-  toggle_stock_controls(self);
-  Dmin_picker_update(self);
-  WB_high_picker_update(self);
-  WB_low_picker_update(self);
+  gui_changed(self, NULL, NULL);
 }
 
 void gui_reset(dt_iop_module_t *self)


### PR DESCRIPTION
with corresponding cleanup
add basic support for array fields to dt_bauhaus_slider_from_params

also add option for notebook tabs to colorbalance to make full module fit on screen