### PR TITLE
Enable module icon for tonemap

### DIFF
--- a/data/themes/darktable-icons.css
+++ b/data/themes/darktable-icons.css
@@ -90,6 +90,7 @@
 #iop-panel-icon-toneequal,
 #iop-panel-icon-tonecurve,
 #iop-panel-icon-tone,
+#iop-panel-icon-tonemap,
 #iop-panel-icon-velvia,
 #iop-panel-icon-vibrance,
 #iop-panel-icon-vignette,


### PR DESCRIPTION
Tone mapping is the only module with a missing icon when any of the darktable-icons themes are used.