### PR TITLE
Simplify tiff compress GUI, default level to 6

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1866,7 +1866,7 @@
   <dtconfig>
     <name>plugins/imageio/format/tiff/compresslevel</name>
     <type>int</type>
-    <default>5</default>
+    <default>6</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -229,7 +229,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
 
   TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
-  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, (uint32_t)1);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, NULL));
   TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
   int resolution = dt_conf_get_int("metadata/resolution");
@@ -416,7 +416,6 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, (uint32_t)w);
         TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (uint32_t)h);
         TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
-        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, (uint32_t)1);
         TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
 #ifdef MASKS_USE_SAME_FORMAT
@@ -424,6 +423,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
         TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
+        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, NULL));
 
         free(rowdata);
         const size_t _rowsize = (w * 3) * d->bpp / 8;
@@ -494,6 +494,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)32);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)SAMPLEFORMAT_IEEEFP);
         TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
+        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, NULL));
 
         for(int y = 0; y < h; y++)
         {

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -767,7 +767,10 @@ void gui_init(dt_imageio_module_format_t *self)
   // TODO: Move to legacy eventually
   int compress = dt_conf_get_int("plugins/imageio/format/tiff/compress");
   if(compress == 3)
+  {
     compress = 2;
+    dt_conf_set_int("plugins/imageio/format/tiff/compress", compress)
+  }
 
   // TIFF compression level might actually be zero!
   int compresslevel = 6;

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -793,7 +793,7 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_bauhaus_combobox_add(gui->compress, _("uncompressed"));
   dt_bauhaus_combobox_add(gui->compress, _("deflate"));
   dt_bauhaus_combobox_add(gui->compress, _("deflate with predictor"));
-  dt_bauhaus_combobox_set(gui->compress, compress); 
+  dt_bauhaus_combobox_set(gui->compress, compress);
   gtk_box_pack_start(GTK_BOX(self->widget), gui->compress, TRUE, TRUE, 0);
 
   // Compression level slider

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -229,7 +229,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
 
   TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (uint16_t)PLANARCONFIG_CONTIG);
-  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, NULL));
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
   TIFFSetField(tif, TIFFTAG_ORIENTATION, (uint16_t)ORIENTATION_TOPLEFT);
 
   int resolution = dt_conf_get_int("metadata/resolution");
@@ -423,7 +423,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)d->bpp);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)(d->bpp == 32 ? SAMPLEFORMAT_IEEEFP : SAMPLEFORMAT_UINT));
         TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_RGB);
-        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, NULL));
+        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
         free(rowdata);
         const size_t _rowsize = (w * 3) * d->bpp / 8;
@@ -494,7 +494,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
         TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (uint16_t)32);
         TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, (uint16_t)SAMPLEFORMAT_IEEEFP);
         TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (uint16_t)PHOTOMETRIC_MINISBLACK);
-        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, NULL));
+        TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, TIFFDefaultStripSize(tif, 0));
 
         for(int y = 0; y < h; y++)
         {

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -769,7 +769,7 @@ void gui_init(dt_imageio_module_format_t *self)
   if(compress == 3)
   {
     compress = 2;
-    dt_conf_set_int("plugins/imageio/format/tiff/compress", compress)
+    dt_conf_set_int("plugins/imageio/format/tiff/compress", compress);
   }
 
   // TIFF compression level might actually be zero!

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -640,7 +640,10 @@ void *get_params(dt_imageio_module_format_t *self)
   // TODO: Move to legacy eventually
   d->compress = dt_conf_get_int("plugins/imageio/format/tiff/compress");
   if(d->compress == 3)
+  {
     d->compress = 2;
+    dt_conf_set_int("plugins/imageio/format/tiff/compress", d->compress);
+  }
 
   // TIFF compression level might actually be zero, handle this
   if(!dt_conf_key_exists("plugins/imageio/format/tiff/compresslevel"))

--- a/src/imageio/format/tiff.c
+++ b/src/imageio/format/tiff.c
@@ -129,13 +129,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
     TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_NONE);
     TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
   }
-  else if(d->compress == 2)
-  {
-    TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
-    TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_HORIZONTAL);
-    TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
-  }
-  else if(d->compress == 3)
+  else if(d->compress >= 2)
   {
     TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
     if(d->bpp == 32)
@@ -396,13 +390,7 @@ int write_image(dt_imageio_module_data_t *d_tmp, const char *filename, const voi
           TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_NONE);
           TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
         }
-        else if(d->compress == 2)
-        {
-          TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
-          TIFFSetField(tif, TIFFTAG_PREDICTOR, (uint16_t)PREDICTOR_HORIZONTAL);
-          TIFFSetField(tif, TIFFTAG_ZIPQUALITY, (uint16_t)d->compresslevel);
-        }
-        else if(d->compress == 3)
+        else if(d->compress >= 2)
         {
           TIFFSetField(tif, TIFFTAG_COMPRESSION, (uint16_t)COMPRESSION_ADOBE_DEFLATE);
           if(d->bpp == 32)
@@ -599,7 +587,7 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
     n->global.style_append = FALSE;
     n->bpp = o->bpp;
     n->compress = o->compress;
-    n->compresslevel = 9;
+    n->compresslevel = 6;
     n->handle = o->handle;
     *new_size = self->params_size(self);
     return n;
@@ -628,7 +616,7 @@ void *legacy_params(dt_imageio_module_format_t *self, const void *const old_para
     n->global.style_append = o->style_append;
     n->bpp = o->bpp;
     n->compress = o->compress;
-    n->compresslevel = 9;
+    n->compresslevel = 6;
     n->handle = o->handle;
     *new_size = self->params_size(self);
     return n;
@@ -650,11 +638,11 @@ void *get_params(dt_imageio_module_format_t *self)
 
   // TIFF compression level might actually be zero, handle this
   if(!dt_conf_key_exists("plugins/imageio/format/tiff/compresslevel"))
-    d->compresslevel = 5;
+    d->compresslevel = 6;
   else
   {
     d->compresslevel = dt_conf_get_int("plugins/imageio/format/tiff/compresslevel");
-    if(d->compresslevel < 0 || d->compresslevel > 9) d->compresslevel = 5;
+    if(d->compresslevel < 0 || d->compresslevel > 9) d->compresslevel = 6;
   }
 
   return d;
@@ -769,7 +757,7 @@ void gui_init(dt_imageio_module_format_t *self)
   const int compress = dt_conf_get_int("plugins/imageio/format/tiff/compress");
 
   // TIFF compression level might actually be zero!
-  int compresslevel = 5;
+  int compresslevel = 6;
   if(dt_conf_key_exists("plugins/imageio/format/tiff/compresslevel"))
     compresslevel = dt_conf_get_int("plugins/imageio/format/tiff/compresslevel");
 
@@ -796,12 +784,11 @@ void gui_init(dt_imageio_module_format_t *self)
   dt_bauhaus_combobox_add(gui->compress, _("uncompressed"));
   dt_bauhaus_combobox_add(gui->compress, _("deflate"));
   dt_bauhaus_combobox_add(gui->compress, _("deflate with predictor"));
-  dt_bauhaus_combobox_add(gui->compress, _("deflate with predictor (float)"));
   dt_bauhaus_combobox_set(gui->compress, compress);
   gtk_box_pack_start(GTK_BOX(self->widget), gui->compress, TRUE, TRUE, 0);
 
   // Compression level slider
-  gui->compresslevel = dt_bauhaus_slider_new_with_range(NULL, 0, 9, 1, 5, 0);
+  gui->compresslevel = dt_bauhaus_slider_new_with_range(NULL, 0, 9, 1, 6, 0);
   dt_bauhaus_widget_set_label(gui->compresslevel, NULL, _("compression level"));
   dt_bauhaus_slider_set(gui->compresslevel, compresslevel);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(gui->compresslevel), TRUE, TRUE, 0);


### PR DESCRIPTION
IMHO there's really no need to complicate the choice and confuse the end user, the correct predictor shall be chosen depending on sample bit depth anyway. Ideally, the 'predictor' should be a separate checkbox, since in theory it is independent of the actual compression used (works for deflate, LZW, zstd,... though the latter two might not be available in libtiff always).

Also changed the default level to 6, which seems to be the zlib (& libtiff) default.

One way to fix #6040