### PR TITLE
Restore slider digits where lost in introspection changes

### DIFF
--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -621,6 +621,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->sl_black_point = dt_bauhaus_slider_from_params(self, "black_point");
   dt_bauhaus_slider_set_soft_range(g->sl_black_point, -0.1, 0.1);
   dt_bauhaus_slider_set_step(g->sl_black_point, .001);
+  dt_bauhaus_slider_set_digits(g->sl_black_point, 4);
   gtk_widget_set_tooltip_text(g->sl_black_point, _("adjust the black level to unclip negative RGB values.\n"
                                                     "you should never use it to add more density in blacks!\n"
                                                     "if poorly set, it will clip near-black colors out of gamut\n"
@@ -679,6 +680,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), autolevels_box, TRUE, TRUE, 0);
 
   g->sl_clip = dt_bauhaus_slider_from_params(self, N_("clip"));
+  dt_bauhaus_slider_set_digits(g->sl_clip, 3);
   gtk_widget_set_tooltip_text(g->sl_clip, _("adjusts clipping value for auto exposure calculation"));
 
   // add signal handler for preview pipe finish

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -462,6 +462,7 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->shadows, _("changes the local contrast of shadows"));
 
   g->midtone = dt_bauhaus_slider_from_params(self, "midtone");
+  dt_bauhaus_slider_set_digits(g->midtone, 3);
   gtk_widget_set_tooltip_text(g->midtone, _("defines what counts as midtones. lower for better dynamic range compression (reduce shadow and highlight contrast), increase for more powerful local contrast"));
 
   // work around multi-instance issue which calls show all a fair bit:

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -915,6 +915,7 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->size = dt_bauhaus_slider_from_params(self, "size");
   dt_bauhaus_slider_set_factor(g->size, 100);
+  dt_bauhaus_slider_set_digits(g->size, 4);
   dt_bauhaus_slider_set_format(g->size, "%.2f %%");
   gtk_widget_set_tooltip_text(g->size, _("size of the border in percent of the full image"));
 
@@ -961,12 +962,14 @@ void gui_init(struct dt_iop_module_t *self)
   g->frame_size = dt_bauhaus_slider_from_params(self, "frame_size");
   dt_bauhaus_slider_set_factor(g->frame_size, 100);
   dt_bauhaus_slider_set_step(g->frame_size, 0.005);
+  dt_bauhaus_slider_set_digits(g->frame_size, 4);
   dt_bauhaus_slider_set_format(g->frame_size, "%.2f %%");
   gtk_widget_set_tooltip_text(g->frame_size, _("size of the frame line in percent of min border width"));
 
   g->frame_offset = dt_bauhaus_slider_from_params(self, "frame_offset");
   dt_bauhaus_slider_set_factor(g->frame_offset, 100);
   dt_bauhaus_slider_set_step(g->frame_size, 0.005);
+  dt_bauhaus_slider_set_digits(g->frame_offset, 4);
   dt_bauhaus_slider_set_format(g->frame_offset, "%.2f %%");
   gtk_widget_set_tooltip_text(g->frame_offset, _("offset of the frame line beginning on picture side"));
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2347,22 +2347,26 @@ void gui_init(struct dt_iop_module_t *self)
   GtkWidget *page2 = self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
 
   g->cx = dt_bauhaus_slider_from_params(self, "cx");
+  dt_bauhaus_slider_set_digits(g->cx, 4);
   dt_bauhaus_slider_set_factor(g->cx, 100.0);
   dt_bauhaus_slider_set_format(g->cx, "%0.f %%");
   gtk_widget_set_tooltip_text(g->cx, _("the left margin cannot overlap with the right margin"));
 
   g->cw = dt_bauhaus_slider_from_params(self, "cw");
+  dt_bauhaus_slider_set_digits(g->cw, 4);
   dt_bauhaus_slider_set_factor(g->cw, -100.0);
   dt_bauhaus_slider_set_offset(g->cw, 100.0);
   dt_bauhaus_slider_set_format(g->cw, "%0.f %%");
   gtk_widget_set_tooltip_text(g->cw, _("the right margin cannot overlap with the left margin"));
 
   g->cy = dt_bauhaus_slider_from_params(self, "cy");
+  dt_bauhaus_slider_set_digits(g->cy, 4);
   dt_bauhaus_slider_set_factor(g->cy, 100.0);
   dt_bauhaus_slider_set_format(g->cy, "%0.f %%");
   gtk_widget_set_tooltip_text(g->cy, _("the top margin cannot overlap with the bottom margin"));
 
   g->ch = dt_bauhaus_slider_from_params(self, "ch");
+  dt_bauhaus_slider_set_digits(g->ch, 4);
   dt_bauhaus_slider_set_factor(g->ch, -100.0);
   dt_bauhaus_slider_set_offset(g->ch, 100.0);
   dt_bauhaus_slider_set_format(g->ch, "%0.f %%");

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1301,7 +1301,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->range, 0.1f);
   g->precedence = dt_bauhaus_combobox_from_params(self, "precedence");
   g->hue = dt_bauhaus_slider_from_params(self, N_("hue"));
-//  dt_bauhaus_slider_set_feedback(g->hue, 0);
+  dt_bauhaus_slider_set_feedback(g->hue, 0);
   dt_bauhaus_slider_set_stop(g->hue, 0.0f,   1.0f, 0.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.166f, 1.0f, 1.0f, 0.0f);
   dt_bauhaus_slider_set_stop(g->hue, 0.322f, 0.0f, 1.0f, 0.0f);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2297,7 +2297,7 @@ void gui_init(dt_iop_module_t *self)
 
   g->grey_point_source = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                          dt_bauhaus_slider_from_params(self, "grey_point_source"));
-  dt_bauhaus_slider_set_soft_range(g->grey_point_source, .1, .36);
+  dt_bauhaus_slider_set_soft_range(g->grey_point_source, .1, 36.0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
   gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the image's subject.\n"
                                                       "the value entered here will then be remapped to 18.45%.\n"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2996,38 +2996,47 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_notebook_append_page(g->notebook, page1, gtk_label_new(_("simple")));
 
   g->noise = dt_bauhaus_slider_from_params(self, "noise");
+  dt_bauhaus_slider_set_step(g->noise, .05);
   dt_bauhaus_slider_set_format(g->noise, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->noise, NULL, _("-8 EV"));
 
   g->ultra_deep_blacks = dt_bauhaus_slider_from_params(self, "ultra_deep_blacks");
+  dt_bauhaus_slider_set_step(g->ultra_deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->ultra_deep_blacks, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->ultra_deep_blacks, NULL, _("-7 EV"));
 
   g->deep_blacks = dt_bauhaus_slider_from_params(self, "deep_blacks");
+  dt_bauhaus_slider_set_step(g->deep_blacks, .05);
   dt_bauhaus_slider_set_format(g->deep_blacks, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->deep_blacks, NULL, _("-6 EV"));
 
   g->blacks = dt_bauhaus_slider_from_params(self, "blacks");
+  dt_bauhaus_slider_set_step(g->blacks, .05);
   dt_bauhaus_slider_set_format(g->blacks, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->blacks, NULL, _("-5 EV"));
 
   g->shadows = dt_bauhaus_slider_from_params(self, "shadows");
+  dt_bauhaus_slider_set_step(g->shadows, .05);
   dt_bauhaus_slider_set_format(g->shadows, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->shadows, NULL, _("-4 EV"));
 
   g->midtones = dt_bauhaus_slider_from_params(self, "midtones");
+  dt_bauhaus_slider_set_step(g->midtones, .05);
   dt_bauhaus_slider_set_format(g->midtones, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->midtones, NULL, _("-3 EV"));
 
   g->highlights = dt_bauhaus_slider_from_params(self, "highlights");
+  dt_bauhaus_slider_set_step(g->highlights, .05);
   dt_bauhaus_slider_set_format(g->highlights, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->highlights, NULL, _("-2 EV"));
 
   g->whites = dt_bauhaus_slider_from_params(self, "whites");
+  dt_bauhaus_slider_set_step(g->whites, .05);
   dt_bauhaus_slider_set_format(g->whites, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->whites, NULL, _("-1 EV"));
 
   g->speculars = dt_bauhaus_slider_from_params(self, "speculars");
+  dt_bauhaus_slider_set_step(g->speculars, .05);
   dt_bauhaus_slider_set_format(g->speculars, _("%+.2f EV"));
   dt_bauhaus_widget_set_label(g->speculars, NULL, _("+0 EV"));
 
@@ -3112,6 +3121,7 @@ void gui_init(struct dt_iop_module_t *self)
 
 
   g->quantization = dt_bauhaus_slider_from_params(self, "quantization");
+  dt_bauhaus_slider_set_step(g->quantization, 0.25);
   dt_bauhaus_slider_set_format(g->quantization, "%+.2f EV");
   gtk_widget_set_tooltip_text(g->quantization, _("0 disables the quantization.\n"
                                                  "higher values posterize the luminance mask to help the guiding\n"

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1049,6 +1049,12 @@ void gui_init(struct dt_iop_module_t *self)
   g->whratio = dt_bauhaus_slider_from_params(self, "whratio");
   g->dithering = dt_bauhaus_combobox_from_params(self, N_("dithering"));
 
+  dt_bauhaus_slider_set_digits(g->brightness, 3);
+  dt_bauhaus_slider_set_digits(g->saturation, 3);
+  dt_bauhaus_slider_set_digits(g->center_x, 3);
+  dt_bauhaus_slider_set_digits(g->center_y, 3);
+  dt_bauhaus_slider_set_digits(g->whratio, 3);
+
   dt_bauhaus_slider_set_format(g->scale, "%.02f%%");
   dt_bauhaus_slider_set_format(g->falloff_scale, "%.02f%%");
 

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1503,9 +1503,9 @@ void gui_init(struct dt_iop_module_t *self)
 
   // x/y offset
   g->x_offset = dt_bauhaus_slider_from_params(self, "xoffset");
-  dt_bauhaus_slider_set_format(g->x_offset, "%.3f");
+  dt_bauhaus_slider_set_digits(g->x_offset, 3);
   g->y_offset = dt_bauhaus_slider_from_params(self, "yoffset");
-  dt_bauhaus_slider_set_format(g->y_offset, "%.3f");
+  dt_bauhaus_slider_set_digits(g->y_offset, 3);
 
   // Let's add some tooltips and hook up some signals...
   gtk_widget_set_tooltip_text(g->opacity, _("the opacity of the watermark"));


### PR DESCRIPTION
Closes #5707

Hopefully this resolves any serious regressions people experience; nothing more jumps out at me in [slider_params.xlsx](https://github.com/darktable-org/darktable/files/4890154/slider_params.xlsx)

This should still be revisited as part of a larger input layer review: 
- format&digits should be automatically linked in bauhaus
- rounding to digits might only be needed for integers
- stepsize could be a fixed proportion (1/100th?) of the (current) min/max range

But since this will lead to changes people won't like, there needs to be a way to configure granularly (via lua?) which might be relatively easy/free to achieve as part of a new input layer approach.

All way past 3.2, hence this quick fix for the release.

