### PR TITLE
Temperature wandering fix

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1195,6 +1195,11 @@ static void temp_changed(dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->scale_g2, p->coeffs[3]);
   --darktable.gui->reset;
   dt_dev_add_history_item(darktable.develop, self, TRUE);
+
+  // setting to "user setting" preset may muck with temp/tint, as they
+  // are set there from RGB coeffs, hence only do this as necessary
+  if(dt_bauhaus_combobox_get(g->presets) != 3)
+    dt_bauhaus_combobox_set(g->presets, 3);
 }
 
 static void tint_callback(GtkWidget *slider, gpointer user_data)
@@ -1202,8 +1207,6 @@ static void tint_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
   temp_changed(self);
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 3);
 }
 
 static void temp_callback(GtkWidget *slider, gpointer user_data)
@@ -1211,8 +1214,6 @@ static void temp_callback(GtkWidget *slider, gpointer user_data)
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
   if(darktable.gui->reset) return;
   temp_changed(self);
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
-  dt_bauhaus_combobox_set(g->presets, 3);
 }
 
 static void rgb_callback(GtkWidget *slider, gpointer user_data)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1168,8 +1168,11 @@ static void gui_update_from_coeffs(dt_iop_module_t *self)
   --darktable.gui->reset;
 }
 
-static void temp_changed(dt_iop_module_t *self)
+static void temp_tint_callback(GtkWidget *slider, gpointer user_data)
 {
+  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
+  if(darktable.gui->reset) return;
+
   dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
   dt_iop_temperature_params_t *p = (dt_iop_temperature_params_t *)self->params;
 
@@ -1200,20 +1203,6 @@ static void temp_changed(dt_iop_module_t *self)
   // are set there from RGB coeffs, hence only do this as necessary
   if(dt_bauhaus_combobox_get(g->presets) != 3)
     dt_bauhaus_combobox_set(g->presets, 3);
-}
-
-static void tint_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-  temp_changed(self);
-}
-
-static void temp_callback(GtkWidget *slider, gpointer user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-  temp_changed(self);
 }
 
 static void rgb_callback(GtkWidget *slider, gpointer user_data)
@@ -1490,8 +1479,8 @@ void gui_init(struct dt_iop_module_t *self)
   
   self->gui_update(self);
 
-  g_signal_connect(G_OBJECT(g->scale_tint), "value-changed", G_CALLBACK(tint_callback), self);
-  g_signal_connect(G_OBJECT(g->scale_k), "value-changed", G_CALLBACK(temp_callback), self);
+  g_signal_connect(G_OBJECT(g->scale_tint), "value-changed", G_CALLBACK(temp_tint_callback), self);
+  g_signal_connect(G_OBJECT(g->scale_k), "value-changed", G_CALLBACK(temp_tint_callback), self);
   g_signal_connect(G_OBJECT(g->scale_r), "value-changed", G_CALLBACK(rgb_callback), self);
   g_signal_connect(G_OBJECT(g->scale_g), "value-changed", G_CALLBACK(rgb_callback), self);
   g_signal_connect(G_OBJECT(g->scale_b), "value-changed", G_CALLBACK(rgb_callback), self);


### PR DESCRIPTION
This is an attempt to fix #5725.

The first commit is the least intrusive, and fixes all except in the case of switch from then back to "user modified" preset. The second combines two callbacks and a helper function into a single function. The third commit is a more full fix, which also keeps temperature/tint stable when switching from/to "user modified".