### PR TITLE
Add docs for running multiple instances of darktable-cli

### DIFF
--- a/doc/man/darktable-cli.pod
+++ b/doc/man/darktable-cli.pod
@@ -108,6 +108,8 @@ appended to it.
 With this option you can decide if darktable loads its set of default parameters from
 B<data.db> and applies them. Otherwise the defaults that ship with darktable are used.
 
+Set this flag to false in order to run multiple instances.
+
 =item B<< --verbose  >>
 
 Enables verbose output.

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -68,7 +68,7 @@ static void usage(const char *progname)
   fprintf(stderr, "   --export_masks <0|1|false|true>, default: false\n");
   fprintf(stderr, "   --style <style name>\n");
   fprintf(stderr, "   --style-overwrite\n");
-  fprintf(stderr, "   --apply-custom-presets <0|1|false|true>, default: true\n");
+  fprintf(stderr, "   --apply-custom-presets <0|1|false|true>, default: true, disable for multiple instances\n");
   fprintf(stderr, "   --verbose\n");
   fprintf(stderr, "   --help,-h\n");
   fprintf(stderr, "   --version\n");

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -68,7 +68,8 @@ static void usage(const char *progname)
   fprintf(stderr, "   --export_masks <0|1|false|true>, default: false\n");
   fprintf(stderr, "   --style <style name>\n");
   fprintf(stderr, "   --style-overwrite\n");
-  fprintf(stderr, "   --apply-custom-presets <0|1|false|true>, default: true, disable for multiple instances\n");
+  fprintf(stderr, "   --apply-custom-presets <0|1|false|true>, default: true\n"
+  fprintf(stderr, "                          disable for multiple instances\n");
   fprintf(stderr, "   --verbose\n");
   fprintf(stderr, "   --help,-h\n");
   fprintf(stderr, "   --version\n");


### PR DESCRIPTION
Over the years plenty of users have tried to run `darktable-cli` at the same time as `darktable` or other `darktable-cli` instances and run into locking issues resulting from `darktable-cli` trying to load `data.db`.

Commit 42ff840c677b5181abd71d932caa0dfef8a9ba32 added an option to not load `data.db` but it isn't clear to users that this will result in being able to run `darktable-cli` simultaneously with other instances of Darktable.

This PR aims to make this effect of the `--apply-custom-presets` flag clearer to users.

Fixes #2890?