### PR TITLE
gui->reset brackets around gui_init for multi-instance styles and redo.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1124,8 +1124,10 @@ void dt_dev_reload_history_items(dt_develop_t *dev)
     {
       if(!dt_iop_is_hidden(module) && !module->expander)
       {
+        ++darktable.gui->reset;
         module->gui_init(module);
         dt_iop_reload_defaults(module);
+        --darktable.gui->reset;
 
         /* add module to right panel */
         GtkWidget *expander = dt_iop_gui_get_expander(module);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -498,7 +498,9 @@ static int _create_deleted_modules(GList **_iop_list, GList *history_list)
 
       if(!dt_iop_is_hidden(module))
       {
+        ++darktable.gui->reset;
         module->gui_init(module);
+        --darktable.gui->reset;
       }
 
       // adjust the multi_name of the new module


### PR DESCRIPTION
The change in develop.c should go into 3.2 because it closes #5551 which was introduced by #5335

The  second location where gui_init was called without setting ++gui->reset (in history.c) may or may not trigger a similar bug. I have not observed it, but setting gui->reset is the right thing to do, so I've added it there too.

Should this be refactored into a dt_iop_gui_init call or is that too big a change for 3.2?

There are 5 locations where this new dt_iop_gui_init would then be called instead of calling module->gui_init() directly and within dt_iop_gui_init gui->reset would need to be switched on and off again. Similarly in the (existing) dt_iop_reload_defaults. dt_iop_gui_update already correctly sets gui->reset. Doing this refactor would reduce the risk that a partial copy of code reintroduces a bug like #5551. 