### PR TITLE
Let minimum width to image infos when reducing panel width

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1325,6 +1325,13 @@ progressbar progress
   border-radius: 4px;
 }
 
+/* Be sure to have minimum width allowed for infos on images infos module if reducing panel width */
+#brightbg label
+{
+  min-width: 80px;
+  padding-left: 2px;
+  padding-bottom: 1px;
+}
 
 /* Checkbutton check state */
 #lib-plugin-ui checkbutton check,


### PR DESCRIPTION
If we reduce left panel width, image infos (right column) of related module became quickly hidden. Horizontal scrollbar appear too late. This little tweak fix that and allow the right column of this module to keep minimum width for the infos and so let horizontal scrollbar more quickly if we reduce panel width.

Only side-effect is that also change how text in right column is aligned. It's now centered instead of left aligned. But CSS alignment setting is not supported with Gtk. Having those infos aligned centered is good for me.

Of course, it's a sort of bugfix and simple one, so for 3.2.