### PR TITLE
This patch almost disable any hightlight reconstruction by default.

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -148,7 +148,7 @@ typedef struct dt_iop_filmicrgb_params_t
   float grey_point_source;  // $MIN: 0 $MAX: 100 $DEFAULT: 18.45 $DESCRIPTION: "middle grey luminance"
   float black_point_source; // $MIN: -16 $MAX: -0.1 $DEFAULT: -8.0 $DESCRIPTION: "black relative exposure"
   float white_point_source; // $MIN: 0 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
-  float reconstruct_threshold;            // $MIN: -6.0 $MAX: 6.0 $DEFAULT: -1.0 $DESCRIPTION: "threshold"
+  float reconstruct_threshold;            // $MIN: -6.0 $MAX: 6.0 $DEFAULT: +3.0 $DESCRIPTION: "threshold"
   float reconstruct_feather;              // $MIN: 0.25 $MAX: 6.0 $DEFAULT: 3.0 $DESCRIPTION: "transition"
   float reconstruct_bloom_vs_details;     // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "bloom/reconstruct"
   float reconstruct_grey_vs_color;        // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "grey/colorful details"


### PR DESCRIPTION
The goal is to make the module faster by default and let user activate
the reconstruction only when necessary.