### PR TITLE
add history changes tooltip

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -174,11 +174,6 @@
   min-height: 0;
 }
 
-.monospace
-{
-  font-family: monospace;
-}
-
 /* Be sure now than all others UI widgets doesn't inherit font size already set and have no background color on start */
 #lib-plugin-ui,
 #iop-plugin-ui,
@@ -1417,7 +1412,8 @@ cell:selected
 
 /* Set some specific fonts */
 #live-sample-data,
-#usercss_box textview
+#usercss_box textview,
+#hist-tooltip
 {
   font-family: monospace;
 }

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -174,6 +174,11 @@
   min-height: 0;
 }
 
+.monospace
+{
+  font-family: monospace;
+}
+
 /* Be sure now than all others UI widgets doesn't inherit font size already set and have no background color on start */
 #lib-plugin-ui,
 #iop-plugin-ui,

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -366,7 +366,8 @@ extern const dt_develop_name_value_t dt_develop_mask_mode_names[];
 extern const dt_develop_name_value_t dt_develop_combine_masks_names[];
 extern const dt_develop_name_value_t dt_develop_feathering_guide_names[];
 extern const dt_develop_name_value_t dt_develop_invert_mask_names[];
-
+extern const dt_develop_name_value_t dt_develop_blendif_names_rgb[];
+extern const dt_develop_name_value_t dt_develop_blendif_names_lab[];
 
 #define DEVELOP_MASKS_NB_SHAPES 5
 

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -354,18 +354,28 @@ typedef struct dt_iop_gui_blendif_colorstop_t
   GdkRGBA color;
 } dt_iop_gui_blendif_colorstop_t;
 
-typedef struct dt_iop_gui_blendif_slider_t
+typedef struct dt_iop_gui_blendif_channel_t
 {
   char *label;
   char *tooltip;
-  float increments;
+  float increment;
   int numberstops;
   const dt_iop_gui_blendif_colorstop_t *colorstops;
-  int channels[2];
+  dt_develop_blendif_channels_t param_channels[2];
   dt_dev_pixelpipe_display_mask_t display_channel;
   void (*scale_print)(float value, char *string, int n);
   int (*altdisplay)(GtkWidget *, dt_iop_module_t *, int);
-} dt_iop_gui_blendif_slider_t;
+  char *name;
+} dt_iop_gui_blendif_channel_t;
+
+typedef struct dt_iop_gui_blendif_filter_t
+{
+  GtkDarktableGradientSlider *slider;
+  GtkLabel *head;
+  GtkLabel *label[4];
+  GtkLabel *picker_label;
+  GtkWidget *polarity;
+} dt_iop_gui_blendif_filter_t;
 
 typedef struct dt_iop_blend_name_value_t
 {
@@ -390,10 +400,13 @@ typedef struct dt_iop_gui_blend_data_t
   int masks_support;
   int masks_inited;
   int raster_inited;
+
   dt_iop_colorspace_type_t csp;
   dt_iop_module_t *module;
+
   GList *masks_modes;
   GList *masks_modes_toggles;
+
   GtkWidget *iopw;
   GtkBox *top_box;
   GtkBox *bottom_box;
@@ -401,22 +414,13 @@ typedef struct dt_iop_gui_blend_data_t
   GtkBox *blendif_box;
   GtkBox *masks_box;
   GtkBox *raster_box;
-  GtkDarktableGradientSlider *upper_slider;
-  GtkDarktableGradientSlider *lower_slider;
-  GtkLabel *upper_head;
-  GtkLabel *lower_head;
-  GtkLabel *upper_label[8];
-  GtkLabel *lower_label[8];
-  GtkLabel *upper_picker_label;
-  GtkLabel *lower_picker_label;
+
   GtkWidget *selected_mask_mode;
-  GtkWidget *upper_polarity;
-  GtkWidget *lower_polarity;
   GtkWidget *colorpicker;
   GtkWidget *colorpicker_set_values;
+  dt_iop_gui_blendif_filter_t filter[2];
   GtkWidget *showmask;
   GtkWidget *suppress;
-  void (*scale_print[8])(float value, char *string, int n);
   GtkWidget *masks_combine_combo;
   GtkWidget *blend_modes_combo;
   GtkWidget *masks_invert_combo;
@@ -426,19 +430,13 @@ typedef struct dt_iop_gui_blend_data_t
   GtkWidget *blur_radius_slider;
   GtkWidget *contrast_slider;
   GtkWidget *brightness_slider;
+
+  const dt_iop_gui_blendif_channel_t *channel;
   int tab;
-  int channels[8][2];
   int altmode[8][2];
-  int (*altdisplay[8])(GtkWidget *, dt_iop_module_t *, int);
-  dt_dev_pixelpipe_display_mask_t display_channel[8][2];
   dt_dev_pixelpipe_display_mask_t save_for_leave;
   int timeout_handle;
   GtkNotebook *channel_tabs;
-  int numberstops[8];
-  const dt_iop_gui_blendif_colorstop_t *colorstops[8];
-  float increments[8];
-
-  const dt_iop_gui_blendif_slider_t *inout;
 
   GtkWidget *masks_combo;
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];
@@ -454,7 +452,6 @@ typedef struct dt_iop_gui_blend_data_t
   int control_button_pressed;
   dt_pthread_mutex_t lock;
 } dt_iop_gui_blend_data_t;
-
 
 
 /** global init of blendops */

--- a/src/develop/blend.h
+++ b/src/develop/blend.h
@@ -354,6 +354,18 @@ typedef struct dt_iop_gui_blendif_colorstop_t
   GdkRGBA color;
 } dt_iop_gui_blendif_colorstop_t;
 
+typedef struct dt_iop_gui_blendif_slider_t
+{
+  char *label;
+  char *tooltip;
+  float increments;
+  int numberstops;
+  const dt_iop_gui_blendif_colorstop_t *colorstops;
+  int channels[2];
+  dt_dev_pixelpipe_display_mask_t display_channel;
+  void (*scale_print)(float value, char *string, int n);
+  int (*altdisplay)(GtkWidget *, dt_iop_module_t *, int);
+} dt_iop_gui_blendif_slider_t;
 
 typedef struct dt_iop_blend_name_value_t
 {
@@ -366,8 +378,6 @@ extern const dt_develop_name_value_t dt_develop_mask_mode_names[];
 extern const dt_develop_name_value_t dt_develop_combine_masks_names[];
 extern const dt_develop_name_value_t dt_develop_feathering_guide_names[];
 extern const dt_develop_name_value_t dt_develop_invert_mask_names[];
-extern const dt_develop_name_value_t dt_develop_blendif_names_rgb[];
-extern const dt_develop_name_value_t dt_develop_blendif_names_lab[];
 
 #define DEVELOP_MASKS_NB_SHAPES 5
 
@@ -427,6 +437,8 @@ typedef struct dt_iop_gui_blend_data_t
   int numberstops[8];
   const dt_iop_gui_blendif_colorstop_t *colorstops[8];
   float increments[8];
+
+  const dt_iop_gui_blendif_slider_t *inout;
 
   GtkWidget *masks_combo;
   GtkWidget *masks_shapes[DEVELOP_MASKS_NB_SHAPES];

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -121,44 +121,6 @@ const dt_develop_name_value_t dt_develop_invert_mask_names[]
         { N_("on"), DEVELOP_COMBINE_INV },
         { "", 0 } };
 
-const dt_develop_name_value_t dt_develop_blendif_names_rgb[]
-    = { { N_("GRAY in"), DEVELOP_BLENDIF_GRAY_in },
-        { N_("RED in"), DEVELOP_BLENDIF_RED_in },
-        { N_("GREEN in"), DEVELOP_BLENDIF_GREEN_in },
-        { N_("BLUE in"), DEVELOP_BLENDIF_BLUE_in },
-
-        { N_("GRAY out"), DEVELOP_BLENDIF_GRAY_out },
-        { N_("RED out"), DEVELOP_BLENDIF_RED_out },
-        { N_("GREEN out"), DEVELOP_BLENDIF_GREEN_out },
-        { N_("BLUE out"), DEVELOP_BLENDIF_BLUE_out },
-
-        { N_("H in"), DEVELOP_BLENDIF_H_in },
-        { N_("S in"), DEVELOP_BLENDIF_S_in },
-        { N_("l in"), DEVELOP_BLENDIF_l_in },
-
-        { N_("H out"), DEVELOP_BLENDIF_H_out },
-        { N_("S out"), DEVELOP_BLENDIF_S_out },
-        { N_("l out"), DEVELOP_BLENDIF_l_out },
-
-        { "", 0 } };
-
-const dt_develop_name_value_t dt_develop_blendif_names_lab[]
-    = { { N_("L in"), DEVELOP_BLENDIF_L_in },
-        { N_("A in"), DEVELOP_BLENDIF_A_in },
-        { N_("B in"), DEVELOP_BLENDIF_B_in },
-
-        { N_("L out"), DEVELOP_BLENDIF_L_out },
-        { N_("A out"), DEVELOP_BLENDIF_A_out },
-        { N_("B out"), DEVELOP_BLENDIF_B_out },
-
-        { N_("C in"), DEVELOP_BLENDIF_C_in },
-        { N_("h in"), DEVELOP_BLENDIF_h_in },
-
-        { N_("C out"), DEVELOP_BLENDIF_C_out },
-        { N_("h out"), DEVELOP_BLENDIF_h_out },
-
-        { "", 0 } };
-
 static const dt_iop_gui_blendif_colorstop_t _gradient_L[]
     = { { 0.0f,   { 0, 0, 0, 1.0 } },
         { 0.125f, { NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, 1.0 } },
@@ -1526,6 +1488,49 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
   --darktable.gui->reset;
 }
 
+#define COLORSTOPS(gradient) sizeof(gradient) / sizeof(dt_iop_gui_blendif_colorstop_t), gradient
+
+const dt_iop_gui_blendif_slider_t Lab_slider[]
+    = { { N_("L"), N_("sliders for L channel"), 1.0f / 100.0f, COLORSTOPS(_gradient_L),
+          { DEVELOP_BLENDIF_L_in, DEVELOP_BLENDIF_L_out }, DT_DEV_PIXELPIPE_DISPLAY_L,
+          _blendif_scale_print_L, _blendop_blendif_disp_alternative_log },
+        { N_("a"), N_("sliders for a channel"), 1.0f / 256.0f, COLORSTOPS(_gradient_a),
+          { DEVELOP_BLENDIF_A_in, DEVELOP_BLENDIF_A_out }, DT_DEV_PIXELPIPE_DISPLAY_a, 
+          _blendif_scale_print_ab, _blendop_blendif_disp_alternative_mag },
+        { N_("b"), N_("sliders for b channel"), 1.0f / 256.0f, COLORSTOPS(_gradient_b),
+          { DEVELOP_BLENDIF_B_in, DEVELOP_BLENDIF_B_out }, DT_DEV_PIXELPIPE_DISPLAY_b, 
+          _blendif_scale_print_ab, _blendop_blendif_disp_alternative_mag },
+        { N_("C"), N_("sliders for chroma channel (of LCh)"), 1.0f / 100.0f, COLORSTOPS(_gradient_chroma),
+          { DEVELOP_BLENDIF_C_in, DEVELOP_BLENDIF_C_out }, DT_DEV_PIXELPIPE_DISPLAY_LCH_C, 
+          _blendif_scale_print_default, _blendop_blendif_disp_alternative_log },
+        { N_("h"), N_("sliders for hue channel (of LCh)"), 1.0f / 360.0f, COLORSTOPS(_gradient_hue),
+          { DEVELOP_BLENDIF_h_in, DEVELOP_BLENDIF_h_out }, DT_DEV_PIXELPIPE_DISPLAY_LCH_h,
+          _blendif_scale_print_hue, _blendop_blendif_disp_alternative_log },
+        { NULL } };
+
+const dt_iop_gui_blendif_slider_t rgb_slider[]
+    = { { N_("g"), N_("sliders for gray value"), 1.0f / 255.0f, COLORSTOPS(_gradient_gray),
+          { DEVELOP_BLENDIF_GRAY_in, DEVELOP_BLENDIF_GRAY_out }, DT_DEV_PIXELPIPE_DISPLAY_GRAY,
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+        { N_("R"), N_("sliders for red channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_red),
+          { DEVELOP_BLENDIF_RED_in, DEVELOP_BLENDIF_RED_out }, DT_DEV_PIXELPIPE_DISPLAY_R, 
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+        { N_("G"), N_("sliders for green channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_green),
+          { DEVELOP_BLENDIF_GREEN_in, DEVELOP_BLENDIF_GREEN_out }, DT_DEV_PIXELPIPE_DISPLAY_G, 
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+        { N_("B"), N_("sliders for blue channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_blue),
+          { DEVELOP_BLENDIF_BLUE_in, DEVELOP_BLENDIF_BLUE_out }, DT_DEV_PIXELPIPE_DISPLAY_B, 
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+        { N_("H"), N_("sliders for hue channel (of HSL)"), 1.0f / 360.0f, COLORSTOPS(_gradient_HUE),
+          { DEVELOP_BLENDIF_H_in, DEVELOP_BLENDIF_H_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_H,
+          _blendif_scale_print_hue, _blendop_blendif_disp_alternative_log },
+        { N_("S"), N_("sliders for chroma channel (of HSL)"), 1.0f / 100.0f, COLORSTOPS(_gradient_chroma),
+          { DEVELOP_BLENDIF_S_in, DEVELOP_BLENDIF_S_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_S,
+          _blendif_scale_print_default, _blendop_blendif_disp_alternative_log },
+        { N_("L"), N_("sliders for value channel (of HSL)"), 1.0f / 100.0f, COLORSTOPS(_gradient_gray),
+          { DEVELOP_BLENDIF_l_in, DEVELOP_BLENDIF_l_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_l,
+          _blendif_scale_print_L, _blendop_blendif_disp_alternative_log },
+        { NULL } };
 
 void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 {
@@ -1564,9 +1569,13 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     char **labels = NULL;
     char **tooltips = NULL;
 
+    bd->inout = NULL;
+
     switch(bd->csp)
     {
       case iop_cs_Lab:
+        bd->inout = Lab_slider;
+
         maxchannels = 5;
         labels = Lab_labels;
         tooltips = Lab_tooltips;
@@ -1616,6 +1625,8 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
         bd->altdisplay[3] = _blendop_blendif_disp_alternative_log;
         break;
       case iop_cs_rgb:
+        bd->inout = rgb_slider;
+
         maxchannels = 7;
         labels = rgb_labels;
         tooltips = rgb_tooltips;

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -121,6 +121,44 @@ const dt_develop_name_value_t dt_develop_invert_mask_names[]
         { N_("on"), DEVELOP_COMBINE_INV },
         { "", 0 } };
 
+const dt_develop_name_value_t dt_develop_blendif_names_rgb[]
+    = { { N_("GRAY in"), DEVELOP_BLENDIF_GRAY_in },
+        { N_("RED in"), DEVELOP_BLENDIF_RED_in },
+        { N_("GREEN in"), DEVELOP_BLENDIF_GREEN_in },
+        { N_("BLUE in"), DEVELOP_BLENDIF_BLUE_in },
+
+        { N_("GRAY out"), DEVELOP_BLENDIF_GRAY_out },
+        { N_("RED out"), DEVELOP_BLENDIF_RED_out },
+        { N_("GREEN out"), DEVELOP_BLENDIF_GREEN_out },
+        { N_("BLUE out"), DEVELOP_BLENDIF_BLUE_out },
+
+        { N_("H in"), DEVELOP_BLENDIF_H_in },
+        { N_("S in"), DEVELOP_BLENDIF_S_in },
+        { N_("l in"), DEVELOP_BLENDIF_l_in },
+
+        { N_("H out"), DEVELOP_BLENDIF_H_out },
+        { N_("S out"), DEVELOP_BLENDIF_S_out },
+        { N_("l out"), DEVELOP_BLENDIF_l_out },
+
+        { "", 0 } };
+
+const dt_develop_name_value_t dt_develop_blendif_names_lab[]
+    = { { N_("L in"), DEVELOP_BLENDIF_L_in },
+        { N_("A in"), DEVELOP_BLENDIF_A_in },
+        { N_("B in"), DEVELOP_BLENDIF_B_in },
+
+        { N_("L out"), DEVELOP_BLENDIF_L_out },
+        { N_("A out"), DEVELOP_BLENDIF_A_out },
+        { N_("B out"), DEVELOP_BLENDIF_B_out },
+
+        { N_("C in"), DEVELOP_BLENDIF_C_in },
+        { N_("h in"), DEVELOP_BLENDIF_h_in },
+
+        { N_("C out"), DEVELOP_BLENDIF_C_out },
+        { N_("h out"), DEVELOP_BLENDIF_h_out },
+
+        { "", 0 } };
+
 static const dt_iop_gui_blendif_colorstop_t _gradient_L[]
     = { { 0.0f,   { 0, 0, 0, 1.0 } },
         { 0.125f, { NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, NEUTRAL_GRAY / 8, 1.0 } },

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -476,22 +476,14 @@ static void _blendop_masks_invert_callback(GtkWidget *combo, dt_iop_gui_blend_da
 static void _blendop_blendif_sliders_callback(GtkDarktableGradientSlider *slider, dt_iop_gui_blend_data_t *data)
 {
   if(darktable.gui->reset) return;
+
   dt_develop_blend_params_t *bp = data->module->blend_params;
 
-  const int tab = data->tab;
-  int ch;
-  GtkLabel **label;
+  const dt_iop_gui_blendif_channel_t *channel = &data->channel[data->tab];
 
-  if(slider == data->upper_slider)
-  {
-    ch = data->channels[tab][1];
-    label = data->upper_label;
-  }
-  else
-  {
-    ch = data->channels[tab][0];
-    label = data->lower_label;
-  }
+  int in_out = (slider == data->filter[1].slider) ? 1 : 0;
+  dt_develop_blendif_channels_t ch = channel->param_channels[in_out];
+  GtkLabel **label = data->filter[in_out].label;
 
   if(!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker)) &&
      !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values)))
@@ -508,7 +500,7 @@ static void _blendop_blendif_sliders_callback(GtkDarktableGradientSlider *slider
   for(int k = 0; k < 4; k++)
   {
     char text[256];
-    (data->scale_print[tab])(parameters[k], text, sizeof(text));
+    (channel->scale_print)(parameters[k], text, sizeof(text));
     gtk_label_set_text(label[k], text);
   }
 
@@ -529,10 +521,11 @@ static void _blendop_blendif_polarity_callback(GtkToggleButton *togglebutton, dt
 
   dt_develop_blend_params_t *bp = data->module->blend_params;
 
-  const int tab = data->tab;
-  const int ch = GTK_WIDGET(togglebutton) == data->lower_polarity ? data->channels[tab][0] : data->channels[tab][1];
-  GtkDarktableGradientSlider *slider = GTK_WIDGET(togglebutton) == data->lower_polarity ? data->lower_slider
-                                                                                        : data->upper_slider;
+  const dt_iop_gui_blendif_channel_t *channel = &data->channel[data->tab];
+
+  int in_out = (GTK_WIDGET(togglebutton) == data->filter[1].polarity) ? 1 : 0;
+  dt_develop_blendif_channels_t ch = channel->param_channels[in_out];
+  GtkDarktableGradientSlider *slider = data->filter[in_out].slider;
 
   if(!active)
     bp->blendif |= (1 << (ch + 16));
@@ -605,28 +598,17 @@ static int _blendop_blendif_disp_alternative_worker(GtkWidget *widget, dt_iop_mo
 {
   dt_iop_gui_blend_data_t *data = module->blend_data;
   GtkDarktableGradientSlider *slider = (GtkDarktableGradientSlider *)widget;
-  const int uplow = (slider == data->lower_slider) ? 0 : 1;
 
-  GtkLabel *head = (uplow == 0) ? data->lower_head : data->upper_head;
-  const char *inout = (uplow == 0) ? _("input") : _("output");
+  int in_out = (slider == data->filter[1].slider) ? 1 : 0;
 
-  char text[32];
-  int newmode = (mode == 1) ? 1 : 0;
+  dtgtk_gradient_slider_multivalue_set_scale_callback(slider, (mode == 1) ? scale_callback : NULL);
+  gchar *text = g_strdup_printf("%s%s", 
+                                (in_out == 0) ? _("input") : _("output"), 
+                                (mode == 1) ? label : "");
+  gtk_label_set_text(data->filter[in_out].head, text);
+  g_free(text);
 
-  if(newmode == 1)
-  {
-    dtgtk_gradient_slider_multivalue_set_scale_callback(slider, scale_callback);
-    snprintf(text, sizeof(text), "%s%s", inout, label);
-    gtk_label_set_text(head, text);
-  }
-  else
-  {
-    dtgtk_gradient_slider_multivalue_set_scale_callback(slider, NULL);
-    snprintf(text, sizeof(text), "%s%s", inout, "");
-    gtk_label_set_text(head, text);
-  }
-
-  return newmode;
+  return (mode == 1) ? 1 : 0;
 }
 
 
@@ -684,28 +666,22 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
   dt_iop_color_picker_set_cst(module, _blendop_blendif_get_picker_colorspace(data));
 
   float *raw_mean, *raw_min, *raw_max;
-  GtkDarktableGradientSlider *widget;
-  GtkLabel *label;
 
   ++darktable.gui->reset;
 
-  for (int s = 0; s < 2; s++)
+  for(int in_out = 1; in_out >= 0; in_out--)
   {
-    if(s)
-    {
-      raw_mean = module->picked_color;
-      raw_min = module->picked_color_min;
-      raw_max = module->picked_color_max;
-      widget = data->lower_slider;
-      label = data->lower_picker_label;
-    }
-    else
+    if(in_out)
     {
       raw_mean = module->picked_output_color;
       raw_min = module->picked_output_color_min;
       raw_max = module->picked_output_color_max;
-      widget = data->upper_slider;
-      label = data->upper_picker_label;
+    }
+    else
+    {
+      raw_mean = module->picked_color;
+      raw_min = module->picked_color_min;
+      raw_max = module->picked_color_max;
     }
 
     if((gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker)) ||
@@ -714,11 +690,10 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
     {
       float picker_mean[8], picker_min[8], picker_max[8];
       float cooked[8];
-      char text[256];
 
       const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
-                          ? data->csp
-                          : dt_iop_color_picker_get_active_cst(module);
+                    ? data->csp
+                    : dt_iop_color_picker_get_active_cst(module);
       const dt_iop_order_iccprofile_info_t *work_profile
           = dt_ioppr_get_iop_work_profile_info(module, module->dev->iop);
       _blendif_scale(cst, raw_mean, picker_mean, work_profile);
@@ -726,16 +701,18 @@ static void _update_gradient_slider_pickers(GtkWidget *callback_dummy, dt_iop_mo
       _blendif_scale(cst, raw_max, picker_max, work_profile);
       _blendif_cook(cst, raw_mean, cooked, work_profile);
 
-      snprintf(text, sizeof(text), "(%.*f)", _blendif_print_digits_picker(cooked[data->tab]), cooked[data->tab]);
+      gchar *text = g_strdup_printf("(%.*f)", _blendif_print_digits_picker(cooked[data->tab]), cooked[data->tab]);
 
       dtgtk_gradient_slider_multivalue_set_picker_meanminmax(
-          widget, picker_mean[data->tab], picker_min[data->tab], picker_max[data->tab]);
-      gtk_label_set_text(label, text);
+          data->filter[in_out].slider, picker_mean[data->tab], picker_min[data->tab], picker_max[data->tab]);
+      gtk_label_set_text(data->filter[in_out].picker_label, text);
+
+      g_free(text);
     }
     else
     {
-      dtgtk_gradient_slider_multivalue_set_picker(widget, NAN);
-      gtk_label_set_text(label, "");
+      dtgtk_gradient_slider_multivalue_set_picker(data->filter[in_out].slider, NAN);
+      gtk_label_set_text(data->filter[in_out].picker_label, "");
     }
   }
 
@@ -751,92 +728,69 @@ static void _blendop_blendif_update_tab(dt_iop_module_t *module, const int tab)
 
   ++darktable.gui->reset;
 
-  const int in_ch = data->channels[tab][0];
-  const int out_ch = data->channels[tab][1];
+  const dt_iop_gui_blendif_channel_t *channel = &data->channel[tab];
 
-  float *iparameters = &(bp->blendif_parameters[4 * in_ch]);
-  float *oparameters = &(bp->blendif_parameters[4 * out_ch]);
-  float *idefaults = &(dp->blendif_parameters[4 * in_ch]);
-  float *odefaults = &(dp->blendif_parameters[4 * out_ch]);
-
-  const int ipolarity = !(bp->blendif & (1 << (in_ch + 16)));
-  const int opolarity = !(bp->blendif & (1 << (out_ch + 16)));
-  char text[256];
-
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->lower_polarity), ipolarity);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->upper_polarity), opolarity);
-
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->lower_slider,
-      ipolarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 0);
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->lower_slider,
-      ipolarity ? GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG : GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->lower_slider,
-      ipolarity ? GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG : GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 2);
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->lower_slider,
-      ipolarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 3);
-
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->upper_slider,
-      opolarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 0);
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->upper_slider,
-      opolarity ? GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG : GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->upper_slider,
-      opolarity ? GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG : GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 2);
-  dtgtk_gradient_slider_multivalue_set_marker(
-      data->upper_slider,
-      opolarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 3);
-
-  dt_pthread_mutex_lock(&data->lock);
-  for(int k = 0; k < 4; k++)
+  for(int in_out = 1; in_out >= 0; in_out--)
   {
-    dtgtk_gradient_slider_multivalue_set_value(data->lower_slider, iparameters[k], k);
-    dtgtk_gradient_slider_multivalue_set_value(data->upper_slider, oparameters[k], k);
-    dtgtk_gradient_slider_multivalue_set_resetvalue(data->lower_slider, idefaults[k], k);
-    dtgtk_gradient_slider_multivalue_set_resetvalue(data->upper_slider, odefaults[k], k);
+    const dt_develop_blendif_channels_t ch = channel->param_channels[in_out];
+    dt_iop_gui_blendif_filter_t *sl = &data->filter[in_out];
+
+    float *parameters = &(bp->blendif_parameters[4 * ch]);
+    float *defaults = &(dp->blendif_parameters[4 * ch]);
+
+    const int polarity = !(bp->blendif & (1 << (ch + 16)));
+    char text[256];
+
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(sl->polarity), polarity);
+
+    dtgtk_gradient_slider_multivalue_set_marker(
+        sl->slider,
+        polarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 0);
+    dtgtk_gradient_slider_multivalue_set_marker(
+        sl->slider,
+        polarity ? GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG : GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 1);
+    dtgtk_gradient_slider_multivalue_set_marker(
+        sl->slider,
+        polarity ? GRADIENT_SLIDER_MARKER_UPPER_FILLED_BIG : GRADIENT_SLIDER_MARKER_LOWER_FILLED_BIG, 2);
+    dtgtk_gradient_slider_multivalue_set_marker(
+        sl->slider,
+        polarity ? GRADIENT_SLIDER_MARKER_LOWER_OPEN_BIG : GRADIENT_SLIDER_MARKER_UPPER_OPEN_BIG, 3);
+
+    dt_pthread_mutex_lock(&data->lock);
+    for(int k = 0; k < 4; k++)
+    {
+      dtgtk_gradient_slider_multivalue_set_value(sl->slider, parameters[k], k);
+      dtgtk_gradient_slider_multivalue_set_resetvalue(sl->slider, defaults[k], k);
+    }
+    dt_pthread_mutex_unlock(&data->lock);
+
+    for(int k = 0; k < 4; k++)
+    {
+      channel->scale_print(parameters[k], text, sizeof(text));
+      gtk_label_set_text(sl->label[k], text);
+    }
+
+    dtgtk_gradient_slider_multivalue_clear_stops(sl->slider);
+
+    for(int k = 0; k < channel->numberstops; k++)
+    {
+      dtgtk_gradient_slider_multivalue_set_stop(sl->slider, channel->colorstops[k].stoppoint,
+                                                channel->colorstops[k].color);
+    }
+
+    dtgtk_gradient_slider_multivalue_set_increment(sl->slider, channel->increment);
+
+    if(channel->altdisplay)
+    {
+      data->altmode[tab][in_out] = channel->altdisplay(GTK_WIDGET(sl->slider), module, data->altmode[tab][in_out]);
+    }
+    else
+    {
+      _blendof_blendif_disp_alternative_reset(GTK_WIDGET(sl->slider), module);
+    }
   }
-  dt_pthread_mutex_unlock(&data->lock);
-
-  for(int k = 0; k < 4; k++)
-  {
-    (data->scale_print[tab])(iparameters[k], text, sizeof(text));
-    gtk_label_set_text(data->lower_label[k], text);
-    (data->scale_print[tab])(oparameters[k], text, sizeof(text));
-    gtk_label_set_text(data->upper_label[k], text);
-  }
-
-  dtgtk_gradient_slider_multivalue_clear_stops(data->lower_slider);
-  dtgtk_gradient_slider_multivalue_clear_stops(data->upper_slider);
-
-  for(int k = 0; k < data->numberstops[tab]; k++)
-  {
-    dtgtk_gradient_slider_multivalue_set_stop(data->lower_slider, (data->colorstops[tab])[k].stoppoint,
-                                              (data->colorstops[tab])[k].color);
-    dtgtk_gradient_slider_multivalue_set_stop(data->upper_slider, (data->colorstops[tab])[k].stoppoint,
-                                              (data->colorstops[tab])[k].color);
-  }
-
-  dtgtk_gradient_slider_multivalue_set_increment(data->lower_slider, data->increments[tab]);
-  dtgtk_gradient_slider_multivalue_set_increment(data->upper_slider, data->increments[tab]);
-
 
   _update_gradient_slider_pickers(NULL, module);
-
-  if(data->altdisplay[tab])
-  {
-    data->altmode[tab][0] = (data->altdisplay[tab])(GTK_WIDGET(data->lower_slider), module, data->altmode[tab][0]);
-    data->altmode[tab][1] = (data->altdisplay[tab])(GTK_WIDGET(data->upper_slider), module, data->altmode[tab][1]);
-  }
-  else
-  {
-    _blendof_blendif_disp_alternative_reset(GTK_WIDGET(data->lower_slider), module);
-    _blendof_blendif_disp_alternative_reset(GTK_WIDGET(data->upper_slider), module);
-  }
 
   --darktable.gui->reset;
 }
@@ -1154,6 +1108,7 @@ static void _blendop_masks_polarity_callback(GtkToggleButton *togglebutton, dt_i
 gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
 {
   dt_iop_gui_blend_data_t *data = module->blend_data;
+
   if(picker == data->colorpicker_set_values)
   {
     if(darktable.gui->reset) return TRUE;
@@ -1161,36 +1116,36 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     ++darktable.gui->reset;
 
     dt_develop_blend_params_t *bp = module->blend_params;
+
     const int tab = data->tab;
     float *raw_mean, *raw_min, *raw_max;
     float picker_mean[8], picker_min[8], picker_max[8];
     float picker_values[4];
-    GtkDarktableGradientSlider *slider;
 
-    int lower_upper; // lower=0, upper=1
-    if(dt_key_modifier_state() == GDK_CONTROL_MASK) 
+    int in_out = (dt_key_modifier_state() == GDK_CONTROL_MASK) ? 1 : 0;
+
+    if(in_out)
     {
-      lower_upper = 1;
       raw_mean = module->picked_output_color;
       raw_min = module->picked_output_color_min;
       raw_max = module->picked_output_color_max;
-      slider = data->upper_slider;
     }
     else
     {
-      lower_upper = 0;
       raw_mean = module->picked_color;
       raw_min = module->picked_color_min;
       raw_max = module->picked_color_max;
-      slider = data->lower_slider;
     }
 
-    const int ch = data->channels[tab][lower_upper];
+    const dt_iop_gui_blendif_channel_t *channel = &data->channel[data->tab];
+    dt_develop_blendif_channels_t ch = channel->param_channels[in_out];
+    dt_iop_gui_blendif_filter_t *sl = &data->filter[in_out];
+
     float *parameters = &(bp->blendif_parameters[4 * ch]);
 
     const int cst = (dt_iop_color_picker_get_active_cst(module) == iop_cs_NONE)
-                        ? data->csp
-                        : dt_iop_color_picker_get_active_cst(module);
+                  ? data->csp
+                  : dt_iop_color_picker_get_active_cst(module);
     const dt_iop_order_iccprofile_info_t *work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
     _blendif_scale(cst, raw_mean, picker_mean, work_profile);
     _blendif_scale(cst, raw_min, picker_min, work_profile);
@@ -1221,7 +1176,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
 
     dt_pthread_mutex_lock(&data->lock);
     for(int k = 0; k < 4; k++)
-      dtgtk_gradient_slider_multivalue_set_value(slider, picker_values[k], k);
+      dtgtk_gradient_slider_multivalue_set_value(sl->slider, picker_values[k], k);
     dt_pthread_mutex_unlock(&data->lock);
 
     // update picked values
@@ -1230,11 +1185,8 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     for(int k = 0; k < 4; k++)
     {
       char text[256];
-      (data->scale_print[tab])(dtgtk_gradient_slider_multivalue_get_value(slider, k), text, sizeof(text));
-      if(lower_upper == 0)
-        gtk_label_set_text(data->lower_label[k], text);
-      else
-        gtk_label_set_text(data->upper_label[k], text);
+      channel->scale_print(dtgtk_gradient_slider_multivalue_get_value(sl->slider, k), text, sizeof(text));
+      gtk_label_set_text(sl->label[k], text);
     }
 
     --darktable.gui->reset;
@@ -1242,7 +1194,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
     // save values to parameters
     dt_pthread_mutex_lock(&data->lock);
     for(int k = 0; k < 4; k++)
-      parameters[k] = dtgtk_gradient_slider_multivalue_get_value(slider, k);
+      parameters[k] = dtgtk_gradient_slider_multivalue_get_value(sl->slider, k);
     dt_pthread_mutex_unlock(&data->lock);
 
     // de-activate processing of this channel if maximum span is selected
@@ -1263,7 +1215,7 @@ gboolean blend_color_picker_apply(dt_iop_module_t *module, GtkWidget *picker, dt
 
     return TRUE;
   }
-  else return FALSE;
+  else return FALSE; // needs to be handled by module
 }
 
 // activate channel/mask view
@@ -1276,9 +1228,10 @@ static void _blendop_blendif_channel_mask_view(GtkWidget *widget, dt_iop_module_
   // in case user requests channel display: get the cannel
   if(new_request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_CHANNEL)
   {
-    int tab = data->tab;
-    int inout = (widget == GTK_WIDGET(data->lower_slider)) ? 0 : 1;
-    dt_dev_pixelpipe_display_mask_t channel = data->display_channel[tab][inout];
+    dt_dev_pixelpipe_display_mask_t channel = data->channel[data->tab].display_channel;
+
+    if(widget == GTK_WIDGET(data->filter[1].slider))
+      channel |= DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
 
     new_request_mask_display &= ~DT_DEV_PIXELPIPE_DISPLAY_ANY;
     new_request_mask_display |= channel;
@@ -1317,9 +1270,10 @@ static void _blendop_blendif_channel_mask_view_toggle(GtkWidget *widget, dt_iop_
   // in case user requests channel display: get the cannel
   if(new_request_mask_display & DT_DEV_PIXELPIPE_DISPLAY_CHANNEL)
   {
-    int tab = data->tab;
-    int inout = (widget == GTK_WIDGET(data->lower_slider)) ? 0 : 1;
-    dt_dev_pixelpipe_display_mask_t channel = data->display_channel[tab][inout];
+    dt_dev_pixelpipe_display_mask_t channel = data->channel[data->tab].display_channel;
+
+    if(widget == GTK_WIDGET(data->filter[1].slider))
+      channel |= DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
 
     new_request_mask_display &= ~DT_DEV_PIXELPIPE_DISPLAY_ANY;
     new_request_mask_display |= channel;
@@ -1428,15 +1382,14 @@ static gboolean _blendop_blendif_key_press(GtkWidget *widget, GdkEventKey *event
   gboolean handled = FALSE;
 
   const int tab = data->tab;
-  GtkDarktableGradientSlider *slider = (GtkDarktableGradientSlider *)widget;
-  const int uplow = (slider == data->lower_slider) ? 0 : 1;
+  const int in_out = (widget == GTK_WIDGET(data->filter[1].slider)) ? 1 : 0;
 
   switch(event->keyval)
   {
     case GDK_KEY_a:
     case GDK_KEY_A:
-      if(data->altdisplay[tab])
-        data->altmode[tab][uplow] = (data->altdisplay[tab])(widget, module, data->altmode[tab][uplow] + 1);
+      if(data->channel[tab].altdisplay)
+        data->altmode[tab][in_out] = (data->channel[tab].altdisplay)(widget, module, data->altmode[tab][in_out] + 1);
       handled = TRUE;
       break;
     case GDK_KEY_c:
@@ -1458,7 +1411,6 @@ static gboolean _blendop_blendif_key_press(GtkWidget *widget, GdkEventKey *event
 
   return handled;
 }
-
 
 
 void dt_iop_gui_update_blendif(dt_iop_module_t *module)
@@ -1490,47 +1442,54 @@ void dt_iop_gui_update_blendif(dt_iop_module_t *module)
 
 #define COLORSTOPS(gradient) sizeof(gradient) / sizeof(dt_iop_gui_blendif_colorstop_t), gradient
 
-const dt_iop_gui_blendif_slider_t Lab_slider[]
+const dt_iop_gui_blendif_channel_t Lab_channels[]
     = { { N_("L"), N_("sliders for L channel"), 1.0f / 100.0f, COLORSTOPS(_gradient_L),
           { DEVELOP_BLENDIF_L_in, DEVELOP_BLENDIF_L_out }, DT_DEV_PIXELPIPE_DISPLAY_L,
-          _blendif_scale_print_L, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_L, _blendop_blendif_disp_alternative_log, N_("lightness") },
         { N_("a"), N_("sliders for a channel"), 1.0f / 256.0f, COLORSTOPS(_gradient_a),
           { DEVELOP_BLENDIF_A_in, DEVELOP_BLENDIF_A_out }, DT_DEV_PIXELPIPE_DISPLAY_a, 
-          _blendif_scale_print_ab, _blendop_blendif_disp_alternative_mag },
+          _blendif_scale_print_ab, _blendop_blendif_disp_alternative_mag, N_("green/red") },
         { N_("b"), N_("sliders for b channel"), 1.0f / 256.0f, COLORSTOPS(_gradient_b),
           { DEVELOP_BLENDIF_B_in, DEVELOP_BLENDIF_B_out }, DT_DEV_PIXELPIPE_DISPLAY_b, 
-          _blendif_scale_print_ab, _blendop_blendif_disp_alternative_mag },
+          _blendif_scale_print_ab, _blendop_blendif_disp_alternative_mag, N_("blue/yellow") },
         { N_("C"), N_("sliders for chroma channel (of LCh)"), 1.0f / 100.0f, COLORSTOPS(_gradient_chroma),
           { DEVELOP_BLENDIF_C_in, DEVELOP_BLENDIF_C_out }, DT_DEV_PIXELPIPE_DISPLAY_LCH_C, 
-          _blendif_scale_print_default, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("saturation") },
         { N_("h"), N_("sliders for hue channel (of LCh)"), 1.0f / 360.0f, COLORSTOPS(_gradient_hue),
           { DEVELOP_BLENDIF_h_in, DEVELOP_BLENDIF_h_out }, DT_DEV_PIXELPIPE_DISPLAY_LCH_h,
-          _blendif_scale_print_hue, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_hue, _blendop_blendif_disp_alternative_log, N_("hue") },
         { NULL } };
 
-const dt_iop_gui_blendif_slider_t rgb_slider[]
+const dt_iop_gui_blendif_channel_t rgb_channels[]
     = { { N_("g"), N_("sliders for gray value"), 1.0f / 255.0f, COLORSTOPS(_gradient_gray),
           { DEVELOP_BLENDIF_GRAY_in, DEVELOP_BLENDIF_GRAY_out }, DT_DEV_PIXELPIPE_DISPLAY_GRAY,
-          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log, N_("gray") },
         { N_("R"), N_("sliders for red channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_red),
           { DEVELOP_BLENDIF_RED_in, DEVELOP_BLENDIF_RED_out }, DT_DEV_PIXELPIPE_DISPLAY_R, 
-          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log, N_("red") },
         { N_("G"), N_("sliders for green channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_green),
           { DEVELOP_BLENDIF_GREEN_in, DEVELOP_BLENDIF_GREEN_out }, DT_DEV_PIXELPIPE_DISPLAY_G, 
-          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log, N_("green") },
         { N_("B"), N_("sliders for blue channel"), 1.0f / 255.0f, COLORSTOPS(_gradient_blue),
           { DEVELOP_BLENDIF_BLUE_in, DEVELOP_BLENDIF_BLUE_out }, DT_DEV_PIXELPIPE_DISPLAY_B, 
-          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_rgb, _blendop_blendif_disp_alternative_log, N_("blue") },
         { N_("H"), N_("sliders for hue channel (of HSL)"), 1.0f / 360.0f, COLORSTOPS(_gradient_HUE),
           { DEVELOP_BLENDIF_H_in, DEVELOP_BLENDIF_H_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_H,
-          _blendif_scale_print_hue, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_hue, _blendop_blendif_disp_alternative_log, N_("hue") },
         { N_("S"), N_("sliders for chroma channel (of HSL)"), 1.0f / 100.0f, COLORSTOPS(_gradient_chroma),
           { DEVELOP_BLENDIF_S_in, DEVELOP_BLENDIF_S_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_S,
-          _blendif_scale_print_default, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_default, _blendop_blendif_disp_alternative_log, N_("chroma") },
         { N_("L"), N_("sliders for value channel (of HSL)"), 1.0f / 100.0f, COLORSTOPS(_gradient_gray),
           { DEVELOP_BLENDIF_l_in, DEVELOP_BLENDIF_l_out }, DT_DEV_PIXELPIPE_DISPLAY_HSL_l,
-          _blendif_scale_print_L, _blendop_blendif_disp_alternative_log },
+          _blendif_scale_print_L, _blendop_blendif_disp_alternative_log, N_("luminance") },
         { NULL } };
+
+const char *slider_tooltip[] = { N_("adjustment based on input received by this module:\n* range defined by upper markers: "
+                                    "blend fully\n* range defined by lower markers: do not blend at all\n* range between "
+                                    "adjacent upper/lower markers: blend gradually"),
+                                 N_("adjustment based on unblended output of this module:\n* range defined by upper "
+                                    "markers: blend fully\n* range defined by lower markers: do not blend at all\n* range "
+                                    "between adjacent upper/lower markers: blend gradually") };
 
 void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 {
@@ -1541,157 +1500,22 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
   GtkWidget* event_box = gtk_event_box_new();
   dt_gui_add_help_link(GTK_WIDGET(event_box), "blending.html#parametric_mask");
   gtk_container_add(GTK_CONTAINER(blendw), event_box);
+  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->blendif_box));
 
   /* create and add blendif support if module supports it */
   if(bd->blendif_support)
   {
-    char *Lab_labels[] = { "L", "a", "b", "C", "h" };
-    char *Lab_tooltips[]
-        = { _("sliders for L channel"), _("sliders for a channel"), _("sliders for b channel"),
-            _("sliders for chroma channel (of LCh)"), _("sliders for hue channel (of LCh)") };
-    char *rgb_labels[] = { _("g"), _("R"), _("G"), _("B"), _("H"), _("S"), _("L") };
-    char *rgb_tooltips[]
-        = { _("sliders for gray value"), _("sliders for red channel"), _("sliders for green channel"),
-            _("sliders for blue channel"), _("sliders for hue channel (of HSL)"),
-            _("sliders for chroma channel (of HSL)"), _("sliders for value channel (of HSL)") };
-
-    char *ttinput = _("adjustment based on input received by this module:\n* range defined by upper markers: "
-                      "blend fully\n* range defined by lower markers: do not blend at all\n* range between "
-                      "adjacent upper/lower markers: blend gradually");
-
-    char *ttoutput = _("adjustment based on unblended output of this module:\n* range defined by upper "
-                       "markers: blend fully\n* range defined by lower markers: do not blend at all\n* range "
-                       "between adjacent upper/lower markers: blend gradually");
-
     bd->tab = 0;
 
-    int maxchannels = 0;
-    char **labels = NULL;
-    char **tooltips = NULL;
-
-    bd->inout = NULL;
+    bd->channel = NULL;
 
     switch(bd->csp)
     {
       case iop_cs_Lab:
-        bd->inout = Lab_slider;
-
-        maxchannels = 5;
-        labels = Lab_labels;
-        tooltips = Lab_tooltips;
-        bd->scale_print[0] = _blendif_scale_print_L;
-        bd->scale_print[1] = _blendif_scale_print_ab;
-        bd->scale_print[2] = _blendif_scale_print_ab;
-        bd->scale_print[3] = _blendif_scale_print_default;
-        bd->scale_print[4] = _blendif_scale_print_hue;
-        bd->increments[0] = 1.0f / 100.0f;
-        bd->increments[1] = 1.0f / 256.0f;
-        bd->increments[2] = 1.0f / 256.0f;
-        bd->increments[3] = 1.0f / 100.0f;
-        bd->increments[4] = 1.0f / 360.0f;
-        bd->channels[0][0] = DEVELOP_BLENDIF_L_in;
-        bd->channels[0][1] = DEVELOP_BLENDIF_L_out;
-        bd->channels[1][0] = DEVELOP_BLENDIF_A_in;
-        bd->channels[1][1] = DEVELOP_BLENDIF_A_out;
-        bd->channels[2][0] = DEVELOP_BLENDIF_B_in;
-        bd->channels[2][1] = DEVELOP_BLENDIF_B_out;
-        bd->channels[3][0] = DEVELOP_BLENDIF_C_in;
-        bd->channels[3][1] = DEVELOP_BLENDIF_C_out;
-        bd->channels[4][0] = DEVELOP_BLENDIF_h_in;
-        bd->channels[4][1] = DEVELOP_BLENDIF_h_out;
-        bd->display_channel[0][0] = DT_DEV_PIXELPIPE_DISPLAY_L;
-        bd->display_channel[0][1] = DT_DEV_PIXELPIPE_DISPLAY_L | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[1][0] = DT_DEV_PIXELPIPE_DISPLAY_a;
-        bd->display_channel[1][1] = DT_DEV_PIXELPIPE_DISPLAY_a | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[2][0] = DT_DEV_PIXELPIPE_DISPLAY_b;
-        bd->display_channel[2][1] = DT_DEV_PIXELPIPE_DISPLAY_b | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[3][0] = DT_DEV_PIXELPIPE_DISPLAY_LCH_C;
-        bd->display_channel[3][1] = DT_DEV_PIXELPIPE_DISPLAY_LCH_C | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[4][0] = DT_DEV_PIXELPIPE_DISPLAY_LCH_h;
-        bd->display_channel[4][1] = DT_DEV_PIXELPIPE_DISPLAY_LCH_h | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->colorstops[0] = _gradient_L;
-        bd->numberstops[0] = sizeof(_gradient_L) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[1] = _gradient_a;
-        bd->numberstops[1] = sizeof(_gradient_a) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[2] = _gradient_b;
-        bd->numberstops[2] = sizeof(_gradient_b) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[3] = _gradient_chroma;
-        bd->numberstops[3] = sizeof(_gradient_chroma) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[4] = _gradient_hue;
-        bd->numberstops[4] = sizeof(_gradient_hue) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->altdisplay[0] = _blendop_blendif_disp_alternative_log;
-        bd->altdisplay[1] = _blendop_blendif_disp_alternative_mag;
-        bd->altdisplay[2] = _blendop_blendif_disp_alternative_mag;
-        bd->altdisplay[3] = _blendop_blendif_disp_alternative_log;
+        bd->channel = Lab_channels;
         break;
       case iop_cs_rgb:
-        bd->inout = rgb_slider;
-
-        maxchannels = 7;
-        labels = rgb_labels;
-        tooltips = rgb_tooltips;
-        bd->scale_print[0] = _blendif_scale_print_rgb;
-        bd->scale_print[1] = _blendif_scale_print_rgb;
-        bd->scale_print[2] = _blendif_scale_print_rgb;
-        bd->scale_print[3] = _blendif_scale_print_rgb;
-        bd->scale_print[4] = _blendif_scale_print_hue;
-        bd->scale_print[5] = _blendif_scale_print_default;
-        bd->scale_print[6] = _blendif_scale_print_L;
-        bd->increments[0] = 1.0f / 255.0f;
-        bd->increments[1] = 1.0f / 255.0f;
-        bd->increments[2] = 1.0f / 255.0f;
-        bd->increments[3] = 1.0f / 255.0f;
-        bd->increments[4] = 1.0f / 360.0f;
-        bd->increments[5] = 1.0f / 100.0f;
-        bd->increments[6] = 1.0f / 100.0f;
-        bd->channels[0][0] = DEVELOP_BLENDIF_GRAY_in;
-        bd->channels[0][1] = DEVELOP_BLENDIF_GRAY_out;
-        bd->channels[1][0] = DEVELOP_BLENDIF_RED_in;
-        bd->channels[1][1] = DEVELOP_BLENDIF_RED_out;
-        bd->channels[2][0] = DEVELOP_BLENDIF_GREEN_in;
-        bd->channels[2][1] = DEVELOP_BLENDIF_GREEN_out;
-        bd->channels[3][0] = DEVELOP_BLENDIF_BLUE_in;
-        bd->channels[3][1] = DEVELOP_BLENDIF_BLUE_out;
-        bd->channels[4][0] = DEVELOP_BLENDIF_H_in;
-        bd->channels[4][1] = DEVELOP_BLENDIF_H_out;
-        bd->channels[5][0] = DEVELOP_BLENDIF_S_in;
-        bd->channels[5][1] = DEVELOP_BLENDIF_S_out;
-        bd->channels[6][0] = DEVELOP_BLENDIF_l_in;
-        bd->channels[6][1] = DEVELOP_BLENDIF_l_out;
-        bd->display_channel[0][0] = DT_DEV_PIXELPIPE_DISPLAY_GRAY;
-        bd->display_channel[0][1] = DT_DEV_PIXELPIPE_DISPLAY_GRAY | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[1][0] = DT_DEV_PIXELPIPE_DISPLAY_R;
-        bd->display_channel[1][1] = DT_DEV_PIXELPIPE_DISPLAY_R | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[2][0] = DT_DEV_PIXELPIPE_DISPLAY_G;
-        bd->display_channel[2][1] = DT_DEV_PIXELPIPE_DISPLAY_G | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[3][0] = DT_DEV_PIXELPIPE_DISPLAY_B;
-        bd->display_channel[3][1] = DT_DEV_PIXELPIPE_DISPLAY_B | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[4][0] = DT_DEV_PIXELPIPE_DISPLAY_HSL_H;
-        bd->display_channel[4][1] = DT_DEV_PIXELPIPE_DISPLAY_HSL_H | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[5][0] = DT_DEV_PIXELPIPE_DISPLAY_HSL_S;
-        bd->display_channel[5][1] = DT_DEV_PIXELPIPE_DISPLAY_HSL_S | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->display_channel[6][0] = DT_DEV_PIXELPIPE_DISPLAY_HSL_l;
-        bd->display_channel[6][1] = DT_DEV_PIXELPIPE_DISPLAY_HSL_l | DT_DEV_PIXELPIPE_DISPLAY_OUTPUT;
-        bd->colorstops[0] = _gradient_gray;
-        bd->numberstops[0] = sizeof(_gradient_gray) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[1] = _gradient_red;
-        bd->numberstops[1] = sizeof(_gradient_red) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[2] = _gradient_green;
-        bd->numberstops[2] = sizeof(_gradient_green) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[3] = _gradient_blue;
-        bd->numberstops[3] = sizeof(_gradient_blue) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[4] = _gradient_HUE;
-        bd->numberstops[4] = sizeof(_gradient_HUE) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[5] = _gradient_chroma;
-        bd->numberstops[5] = sizeof(_gradient_chroma) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->colorstops[6] = _gradient_gray;
-        bd->numberstops[6] = sizeof(_gradient_gray) / sizeof(dt_iop_gui_blendif_colorstop_t);
-        bd->altdisplay[0] = _blendop_blendif_disp_alternative_log;
-        bd->altdisplay[1] = _blendop_blendif_disp_alternative_log;
-        bd->altdisplay[2] = _blendop_blendif_disp_alternative_log;
-        bd->altdisplay[3] = _blendop_blendif_disp_alternative_log;
-        bd->altdisplay[5] = _blendop_blendif_disp_alternative_log;
-        bd->altdisplay[6] = _blendop_blendif_disp_alternative_log;
+        bd->channel = rgb_channels;
         break;
       default:
         assert(FALSE); // blendif not supported for RAW, which is already caught upstream; we should not get
@@ -1699,11 +1523,6 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     }
 
     GtkWidget *section = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *header = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *uplabel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *lowlabel = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *upslider = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-    GtkWidget *lowslider = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
     gtk_box_pack_start(GTK_BOX(section), dt_ui_section_label_new(_("parametric mask")), TRUE, TRUE, 0);
 
@@ -1711,19 +1530,20 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(res, _("reset blend mask settings"));
     gtk_box_pack_end(GTK_BOX(section), GTK_WIDGET(res), FALSE, FALSE, 0);
 
+    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(section), TRUE, FALSE, 0);
+
+    GtkWidget *header = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
     bd->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
-
-    for(int ch = 0; ch < maxchannels; ch++)
+    for(const dt_iop_gui_blendif_channel_t *ch = bd->channel; ch->label != NULL; ch++)
     {
-      dt_ui_notebook_page(bd->channel_tabs, labels[ch], tooltips[ch]);
+      dt_ui_notebook_page(bd->channel_tabs, ch->label, ch->tooltip);
     }
-
     gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(bd->channel_tabs, bd->tab)));
     gtk_notebook_set_current_page(GTK_NOTEBOOK(bd->channel_tabs), bd->tab);
     gtk_notebook_set_scrollable(bd->channel_tabs, TRUE);
-    // gtk_notebook_popup_enable(bd->channel_tabs); // leads to crashes
-
     gtk_box_pack_start(GTK_BOX(header), GTK_WIDGET(bd->channel_tabs), TRUE, TRUE, 0);
+
     gtk_box_pack_start(GTK_BOX(header), gtk_grid_new(), TRUE, TRUE, 0);
 
     bd->colorpicker = dt_color_picker_new(module, DT_COLOR_PICKER_POINT_AREA, header);
@@ -1742,98 +1562,61 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
     gtk_widget_set_tooltip_text(inv, _("invert all channel's polarities"));
     gtk_box_pack_end(GTK_BOX(header), GTK_WIDGET(inv), FALSE, FALSE, 0);
 
-    bd->lower_slider = DTGTK_GRADIENT_SLIDER_MULTIVALUE(dtgtk_gradient_slider_multivalue_new_with_name(4, "blend-lower"));
-    bd->upper_slider = DTGTK_GRADIENT_SLIDER_MULTIVALUE(dtgtk_gradient_slider_multivalue_new_with_name(4, "blend-upper"));
+    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(header), TRUE, FALSE, 0);
 
-    bd->lower_polarity
-        = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
-    gtk_widget_set_tooltip_text(bd->lower_polarity, _("toggle polarity. best seen by enabling 'display mask'"));
-
-    bd->upper_polarity
-        = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
-    gtk_widget_set_tooltip_text(bd->upper_polarity, _("toggle polarity. best seen by enabling 'display mask'"));
-
-    gtk_box_pack_start(GTK_BOX(upslider), GTK_WIDGET(bd->upper_slider), TRUE, TRUE, 0);
-    gtk_box_pack_end(GTK_BOX(upslider), GTK_WIDGET(bd->upper_polarity), FALSE, FALSE, 0);
-
-    gtk_box_pack_start(GTK_BOX(lowslider), GTK_WIDGET(bd->lower_slider), TRUE, TRUE, 0);
-    gtk_box_pack_end(GTK_BOX(lowslider), GTK_WIDGET(bd->lower_polarity), FALSE, FALSE, 0);
-
-
-    bd->upper_head = GTK_LABEL(gtk_label_new(_("output")));
-    gtk_label_set_ellipsize(GTK_LABEL(bd->upper_head), PANGO_ELLIPSIZE_END);
-    bd->upper_picker_label = GTK_LABEL(gtk_label_new(""));
-    gtk_label_set_ellipsize(GTK_LABEL(bd->upper_picker_label), PANGO_ELLIPSIZE_END);
-    gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(bd->upper_head), FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(bd->upper_picker_label), TRUE, TRUE, 0);
-    for(int k = 0; k < 4; k++)
+    for(int in_out = 1; in_out >= 0; in_out--)
     {
-      bd->upper_label[k] = GTK_LABEL(gtk_label_new(NULL));
-      gtk_label_set_ellipsize(GTK_LABEL(bd->upper_label[k]), PANGO_ELLIPSIZE_END);
-      gtk_box_pack_start(GTK_BOX(uplabel), GTK_WIDGET(bd->upper_label[k]), FALSE, FALSE, 0);
-    }
+      dt_iop_gui_blendif_filter_t *sl = &bd->filter[in_out];
 
-    bd->lower_head = GTK_LABEL(gtk_label_new(_("input")));
-    gtk_label_set_ellipsize(GTK_LABEL(bd->lower_head), PANGO_ELLIPSIZE_END);
-    bd->lower_picker_label = GTK_LABEL(gtk_label_new(""));
-    gtk_label_set_ellipsize(GTK_LABEL(bd->lower_picker_label), PANGO_ELLIPSIZE_END);
-    gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(bd->lower_head), FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(bd->lower_picker_label), TRUE, TRUE, 0);
-    for(int k = 0; k < 4; k++)
-    {
-      bd->lower_label[k] = GTK_LABEL(gtk_label_new(NULL));
-      gtk_label_set_ellipsize(GTK_LABEL(bd->lower_label[k]), PANGO_ELLIPSIZE_END);
-      gtk_box_pack_start(GTK_BOX(lowlabel), GTK_WIDGET(bd->lower_label[k]), FALSE, FALSE, 0);
-    }
+      GtkWidget *slider_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_slider), _("double click to reset. press 'a' to toggle available slider modes.\npress 'c' to toggle view of channel data. press 'm' to toggle mask view."));
-    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_slider), _("double click to reset. press 'a' to toggle available slider modes.\npress 'c' to toggle view of channel data. press 'm' to toggle mask view."));
-    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->lower_head), ttinput);
-    gtk_widget_set_tooltip_text(GTK_WIDGET(bd->upper_head), ttoutput);
+      sl->slider = DTGTK_GRADIENT_SLIDER_MULTIVALUE(dtgtk_gradient_slider_multivalue_new_with_name(4, 
+                                                   in_out ? "blend-upper" : "blend-lower"));
+      gtk_box_pack_start(GTK_BOX(slider_box), GTK_WIDGET(sl->slider), TRUE, TRUE, 0);
+
+      sl->polarity
+          = dtgtk_togglebutton_new(dtgtk_cairo_paint_plusminus, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT | CPF_IGNORE_FG_STATE, NULL);
+      gtk_widget_set_tooltip_text(sl->polarity, _("toggle polarity. best seen by enabling 'display mask'"));
+      gtk_box_pack_end(GTK_BOX(slider_box), GTK_WIDGET(sl->polarity), FALSE, FALSE, 0);
+
+      GtkWidget *label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+
+      sl->head = GTK_LABEL(gtk_label_new(in_out ? _("output") : _("input")));
+      gtk_label_set_ellipsize(GTK_LABEL(sl->head), PANGO_ELLIPSIZE_END);
+      gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->head), FALSE, FALSE, 0);
+
+      sl->picker_label = GTK_LABEL(gtk_label_new(""));
+      gtk_label_set_ellipsize(GTK_LABEL(sl->picker_label), PANGO_ELLIPSIZE_END);
+      gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->picker_label), TRUE, TRUE, 0);
+
+      for(int k = 0; k < 4; k++)
+      {
+        sl->label[k] = GTK_LABEL(gtk_label_new(NULL));
+        gtk_label_set_ellipsize(GTK_LABEL(sl->label[k]), PANGO_ELLIPSIZE_END);
+        gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->label[k]), FALSE, FALSE, 0);
+      }
+
+      gtk_widget_set_tooltip_text(GTK_WIDGET(sl->slider), _("double click to reset. press 'a' to toggle available slider modes.\npress 'c' to toggle view of channel data. press 'm' to toggle mask view."));
+      gtk_widget_set_tooltip_text(GTK_WIDGET(sl->head), _(slider_tooltip[in_out]));
+
+      g_signal_connect(G_OBJECT(sl->slider), "value-changed", G_CALLBACK(_blendop_blendif_sliders_callback), bd);
+      g_signal_connect(G_OBJECT(sl->slider), "leave-notify-event", G_CALLBACK(_blendop_blendif_leave), module);
+      g_signal_connect(G_OBJECT(sl->slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
+      g_signal_connect(G_OBJECT(sl->slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);
+      g_signal_connect(G_OBJECT(sl->polarity), "toggled", G_CALLBACK(_blendop_blendif_polarity_callback), bd);
+
+      gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(label_box), TRUE, FALSE, 0);
+      gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(slider_box), TRUE, FALSE, 0);
+    }
 
     g_signal_connect(G_OBJECT(bd->channel_tabs), "switch_page", G_CALLBACK(_blendop_blendif_tab_switch), bd);
-
-    g_signal_connect(G_OBJECT(bd->upper_slider), "value-changed", G_CALLBACK(_blendop_blendif_sliders_callback), bd);
-
-    g_signal_connect(G_OBJECT(bd->lower_slider), "value-changed", G_CALLBACK(_blendop_blendif_sliders_callback), bd);
-
-    g_signal_connect(G_OBJECT(bd->lower_slider), "leave-notify-event", G_CALLBACK(_blendop_blendif_leave), module);
-
-    g_signal_connect(G_OBJECT(bd->upper_slider), "leave-notify-event", G_CALLBACK(_blendop_blendif_leave), module);
-
-    g_signal_connect(G_OBJECT(bd->lower_slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
-
-    g_signal_connect(G_OBJECT(bd->upper_slider), "enter-notify-event", G_CALLBACK(_blendop_blendif_enter), module);
-
-    g_signal_connect(G_OBJECT(bd->lower_slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);
-
-    g_signal_connect(G_OBJECT(bd->upper_slider), "key-press-event", G_CALLBACK(_blendop_blendif_key_press), module);
-
     g_signal_connect(G_OBJECT(bd->colorpicker), "toggled", G_CALLBACK(_update_gradient_slider_pickers), module);
-
     g_signal_connect(G_OBJECT(bd->colorpicker_set_values), "toggled", G_CALLBACK(_update_gradient_slider_pickers), module);
-
     g_signal_connect(G_OBJECT(res), "clicked", G_CALLBACK(_blendop_blendif_reset), module);
-
     g_signal_connect(G_OBJECT(inv), "clicked", G_CALLBACK(_blendop_blendif_invert), module);
-
-    g_signal_connect(G_OBJECT(bd->lower_polarity), "toggled", G_CALLBACK(_blendop_blendif_polarity_callback),
-                     bd);
-
-    g_signal_connect(G_OBJECT(bd->upper_polarity), "toggled", G_CALLBACK(_blendop_blendif_polarity_callback),
-                     bd);
-
-    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(section), TRUE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(header), TRUE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(uplabel), TRUE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(upslider), TRUE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(lowlabel), TRUE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(bd->blendif_box), GTK_WIDGET(lowslider), TRUE, FALSE, 0);
 
     bd->blendif_inited = 1;
   }
-
-  gtk_container_add(GTK_CONTAINER(event_box), GTK_WIDGET(bd->blendif_box));
 }
 
 void dt_iop_gui_update_masks(dt_iop_module_t *module)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -66,6 +66,7 @@ typedef enum dt_iop_colormapping_flags_t
   NEUTRAL = 0,
   HAS_SOURCE = 1 << 0,
   HAS_TARGET = 1 << 1,
+  HAS_SOURCE_TARGET = HAS_SOURCE | HAS_TARGET,
   ACQUIRE = 1 << 2,
   GET_SOURCE = 1 << 3,
   GET_TARGET = 1 << 4

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -167,27 +167,27 @@ float dt_liquify_ui_widths [] =
 
 typedef enum
 {
-  DT_LIQUIFY_WARP_TYPE_LINEAR,         ///< A linear warp originating from one point.
-  DT_LIQUIFY_WARP_TYPE_RADIAL_GROW,    ///< A radial warp originating from one point.
-  DT_LIQUIFY_WARP_TYPE_RADIAL_SHRINK,
+  DT_LIQUIFY_WARP_TYPE_LINEAR,        // $DESCRIPTION: "linear" A linear warp originating from one point.
+  DT_LIQUIFY_WARP_TYPE_RADIAL_GROW,   // $DESCRIPTION: "radial grow" A radial warp originating from one point.
+  DT_LIQUIFY_WARP_TYPE_RADIAL_SHRINK, // $DESCRIPTION: "radial shrink"
   DT_LIQUIFY_WARP_TYPE_LAST
 } dt_liquify_warp_type_enum_t;
 
 typedef enum
 {
-  DT_LIQUIFY_NODE_TYPE_CUSP,
-  DT_LIQUIFY_NODE_TYPE_SMOOTH,
-  DT_LIQUIFY_NODE_TYPE_SYMMETRICAL,
-  DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH,
+  DT_LIQUIFY_NODE_TYPE_CUSP,        // $DESCRIPTION: "cusp"
+  DT_LIQUIFY_NODE_TYPE_SMOOTH,      // $DESCRIPTION: "smooth"
+  DT_LIQUIFY_NODE_TYPE_SYMMETRICAL, // $DESCRIPTION: "symmetrical"
+  DT_LIQUIFY_NODE_TYPE_AUTOSMOOTH,  // $DESCRIPTION: "autosmooth"
   DT_LIQUIFY_NODE_TYPE_LAST
 } dt_liquify_node_type_enum_t;
 
 typedef enum
 {
-  DT_LIQUIFY_STATUS_NONE = 0,
-  DT_LIQUIFY_STATUS_NEW = 1,
-  DT_LIQUIFY_STATUS_INTERPOLATED = 2,
-  DT_LIQUIFY_STATUS_PREVIEW = 4,
+  DT_LIQUIFY_STATUS_NONE = 0,         // $DESCRIPTION: "none"
+  DT_LIQUIFY_STATUS_NEW = 1,          // $DESCRIPTION: "new"
+  DT_LIQUIFY_STATUS_INTERPOLATED = 2, // $DESCRIPTION: "interpolated"
+  DT_LIQUIFY_STATUS_PREVIEW = 4,      // $DESCRIPTION: "preview"
   DT_LIQUIFY_STATUS_LAST
 } dt_liquify_status_enum_t;
 
@@ -195,10 +195,10 @@ typedef enum
 
 typedef enum
 {
-  DT_LIQUIFY_PATH_INVALIDATED = 0,
-  DT_LIQUIFY_PATH_MOVE_TO_V1,
-  DT_LIQUIFY_PATH_LINE_TO_V1,
-  DT_LIQUIFY_PATH_CURVE_TO_V1,
+  DT_LIQUIFY_PATH_INVALIDATED = 0, // $DESCRIPTION: "invalidated"
+  DT_LIQUIFY_PATH_MOVE_TO_V1,      // $DESCRIPTION: "move"
+  DT_LIQUIFY_PATH_LINE_TO_V1,      // $DESCRIPTION: "line"
+  DT_LIQUIFY_PATH_CURVE_TO_V1,     // $DESCRIPTION: "curve"
 } dt_liquify_path_data_enum_t;
 
 typedef struct

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -730,27 +730,27 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
     else
     {
       const int max_elements = 4;
-      gchar **change_parts = g_malloc0_n(max_elements + 2, sizeof(char*));
+      gchar **change_parts = g_malloc0_n(max_elements + 1, sizeof(char*));
       int num_parts = 0;
 
       for(int i = 0, item_offset = 0; i < field->Array.count; i++, item_offset += field->Array.field->header.size)
       {
         char *description = g_strdup_printf("%s[%d]", d, i);
-
-        if((change_parts[num_parts] = _lib_history_change_text(field->Array.field, description, params + item_offset, oldpar + item_offset)))
-          num_parts++;
-
+        char *element_text = _lib_history_change_text(field->Array.field, description, params + item_offset, oldpar + item_offset);
         g_free(description);
 
-        if(num_parts == max_elements + 1)
-        {
-          g_free(change_parts[max_elements]);
-          change_parts[max_elements] = g_strdup("\u22EF"); // ellipsis
-          break;
-        }
+        if(element_text && ++num_parts <= max_elements)
+          change_parts[num_parts - 1] = element_text;
+        else
+          g_free(element_text);
       }
 
-      gchar *array_text = num_parts ? g_strjoinv("\n", change_parts) : NULL;
+      gchar *array_text = NULL;
+      if(num_parts > max_elements)
+        array_text = g_strdup_printf("%s: %d changes", d, num_parts);
+      else if(num_parts > 0)
+        array_text = g_strjoinv("\n", change_parts);
+
       g_strfreev(change_parts);
 
       return array_text;

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -952,7 +952,14 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
 
   if(show_tooltip)
   {
-    GtkWidget *view = gtk_text_view_new ();
+    static GtkWidget *view = NULL;
+    if(!view)
+    {
+      view = gtk_text_view_new();
+      gtk_widget_set_name(view, "hist-tooltip");
+      g_signal_connect(G_OBJECT(view), "destroy", G_CALLBACK(gtk_widget_destroyed), &view);
+    }
+     
     GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(view));
     gtk_text_buffer_set_text(buffer, tooltip_text, -1);
     gtk_tooltip_set_custom(tooltip, view);
@@ -976,7 +983,6 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
       if(*line) line++;
     }
 
-    gtk_text_view_set_monospace(GTK_TEXT_VIEW(view), TRUE);
     PangoLayout *layout = gtk_widget_create_pango_layout(view, " ");
     int char_width;
     pango_layout_get_size(layout, &char_width, NULL);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -895,35 +895,34 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
   
   dt_iop_gui_blend_data_t *bd = hitem->module->blend_data;
 
-  for(int k = 1; k >= 0; k--)
+  for(int in_out = 1; in_out >= 0; in_out--)
   {
     gboolean first = TRUE;
 
-    const dt_iop_gui_blendif_slider_t *b = bd ? bd->inout : NULL;
-    while(b && b->label)
+    for(const dt_iop_gui_blendif_channel_t *b = bd ? bd->channel : NULL;
+        b && b->label != NULL;
+        b++)
     {
-      float *of = &old_blend->blendif_parameters[4 * b->channels[k]];
-      float *nf = &hitem->blend_params->blendif_parameters[4 * b->channels[k]];
+      float *of = &old_blend->blendif_parameters[4 * b->param_channels[in_out]];
+      float *nf = &hitem->blend_params->blendif_parameters[4 * b->param_channels[in_out]];
       if(memcmp(of, nf, 4 * sizeof(float)))
       {
         if(first)
         {
-          change_parts[num_parts++] = g_strdup(k ? _("parametric output mask:") : _("parametric input mask:"));
+          change_parts[num_parts++] = g_strdup(in_out ? _("parametric output mask:") : _("parametric input mask:"));
           first = FALSE;
         }
         char s[4][2][25];
-        for(int i = 0; i < 4; i++)
+        for(int k = 0; k < 4; k++)
         {
-          b->scale_print(of[i], s[i][0], sizeof(s[i][0]));
-          b->scale_print(nf[i], s[i][1], sizeof(s[i][1]));
+          b->scale_print(of[k], s[k][0], sizeof(s[k][0]));
+          b->scale_print(nf[k], s[k][1], sizeof(s[k][1]));
         }
 
-        change_parts[num_parts++] = g_strdup_printf("%s\t%s| %s- %s| %s\t\u2192\t%s| %s- %s| %s", _(b->label),
+        change_parts[num_parts++] = g_strdup_printf("%s\t%s| %s- %s| %s\t\u2192\t%s| %s- %s| %s", _(b->name),
                                                     s[0][0], s[1][0], s[2][0], s[3][0], 
                                                     s[0][1], s[1][1], s[2][1], s[3][1]);
-      }
-    
-      b++;
+      }   
     }
   }
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -725,7 +725,7 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
     if(field->Array.type == DT_INTROSPECTION_TYPE_CHAR)
     {
       if(strncmp((char*)o, (char*)p, field->Array.count))
-        return g_strdup_printf("%s: \"%s\" \u2192 \"%s\"", d, (char*)o, (char*)p);
+        return g_strdup_printf("%s\t\"%s\"\t\u2192\t\"%s\"", d, (char*)o, (char*)p);
     }
     else
     {
@@ -747,7 +747,7 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
 
       gchar *array_text = NULL;
       if(num_parts > max_elements)
-        array_text = g_strdup_printf("%s: %d changes", d, num_parts);
+        array_text = g_strdup_printf("%s\t%d changes", d, num_parts);
       else if(num_parts > 0)
         array_text = g_strjoinv("\n", change_parts);
 
@@ -758,31 +758,31 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
     break;
   case DT_INTROSPECTION_TYPE_FLOAT:
     if(*(float*)o != *(float*)p)
-      return g_strdup_printf("%s: %.4f \u2192 %.4f", d, *(float*)o, *(float*)p);
+      return g_strdup_printf("%s\t%.4f\t\u2192\t%.4f", d, *(float*)o, *(float*)p);
     break;
   case DT_INTROSPECTION_TYPE_INT:
     if(*(int*)o != *(int*)p)
-      return g_strdup_printf("%s: %d \u2192 %d", d, *(int*)o, *(int*)p);
+      return g_strdup_printf("%s\t%d\t\u2192\t%d", d, *(int*)o, *(int*)p);
     break;
   case DT_INTROSPECTION_TYPE_UINT:
     if(*(unsigned int*)o != *(unsigned int*)p)
-      return g_strdup_printf("%s: %u \u2192 %u", d, *(unsigned int*)o, *(unsigned int*)p);
+      return g_strdup_printf("%s\t%u\t\u2192\t%u", d, *(unsigned int*)o, *(unsigned int*)p);
     break;
   case DT_INTROSPECTION_TYPE_USHORT:
     if(*(unsigned short int*)o != *(unsigned short int*)p)
-      return g_strdup_printf("%s: %hu \u2192 %hu", d, *(unsigned short int*)o, *(unsigned short int*)p);
+      return g_strdup_printf("%s\t%hu\t\u2192\t%hu", d, *(unsigned short int*)o, *(unsigned short int*)p);
     break;
   case DT_INTROSPECTION_TYPE_INT8:
     if(*(uint8_t*)o != *(uint8_t*)p)
-      return g_strdup_printf("%s: %d \u2192 %d", d, *(uint8_t*)o, *(uint8_t*)p);
+      return g_strdup_printf("%s\t%d\t\u2192\t%d", d, *(uint8_t*)o, *(uint8_t*)p);
     break;
   case DT_INTROSPECTION_TYPE_CHAR:
     if(*(char*)o != *(char*)p)
-      return g_strdup_printf("%s: '%c' \u2192 '%c'", d, *(char *)o, *(char *)p);
+      return g_strdup_printf("%s\t'%c'\t\u2192\t'%c'", d, *(char *)o, *(char *)p);
     break;
   case DT_INTROSPECTION_TYPE_FLOATCOMPLEX:
     if(*(float complex*)o != *(float complex*)p)
-      return g_strdup_printf("%s: %.4f + %.4fi \u2192 %.4f + %.4fi", d, 
+      return g_strdup_printf("%s\t%.4f + %.4fi\t\u2192\t%.4f + %.4fi", d, 
                              creal(*(float complex*)o), cimag(*(float complex*)o), 
                              creal(*(float complex*)p), cimag(*(float complex*)p));
     break;
@@ -804,7 +804,7 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
         }
       }
 
-      return g_strdup_printf("%s: %s \u2192 %s", d, _(old_str), _(new_str));
+      return g_strdup_printf("%s\t%s\t\u2192\t%s", d, _(old_str), _(new_str));
     }
     break;
   case DT_INTROSPECTION_TYPE_BOOL:
@@ -812,7 +812,7 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
     {
       char *old_str = *(gboolean*)o ? "on" : "off";
       char *new_str = *(gboolean*)p ? "on" : "off";
-      return g_strdup_printf("%s: %s \u2192 %s", d, _(old_str), _(new_str));
+      return g_strdup_printf("%s\t%s\t\u2192\t%s", d, _(old_str), _(new_str));
     }
     break;
   case DT_INTROSPECTION_TYPE_OPAQUE:
@@ -856,7 +856,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
 
   #define add_blend_history_change(field, format, label)                                       \
     if(hitem->blend_params->field != old_blend->field)                                         \
-      change_parts[num_parts++] = g_strdup_printf("%s: " format " \u2192 " format, _(label),   \
+      change_parts[num_parts++] = g_strdup_printf("%s\t" format "\t\u2192\t" format, _(label),   \
                                                   old_blend->field, hitem->blend_params->field);
 
   #define add_blend_history_change_enum(field, label, list)                                    \
@@ -870,9 +870,9 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
       }                                                                                        \
                                                                                                 \
       change_parts[num_parts++] = (!old_str || !new_str)                                       \
-                                ? g_strdup_printf("%s: %d \u2192 %d", _(label),                \
+                                ? g_strdup_printf("%s\t%d\t\u2192\t%d", _(label),                \
                                                   old_blend->field, hitem->blend_params->field)\
-                                : g_strdup_printf("%s: %s \u2192 %s", _(label),                \
+                                : g_strdup_printf("%s\t%s\t\u2192\t%s", _(label),                \
                                                   _(g_dpgettext2(NULL, "blendmode", old_str)), \
                                                   _(g_dpgettext2(NULL, "blendmode", new_str)));\
     }
@@ -899,7 +899,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
     float *of = &old_blend->blendif_parameters[4 * b->value];
     float *nf = &hitem->blend_params->blendif_parameters[4 * b->value];
     if(memcmp(of, nf, 4 * sizeof(float)))
-      change_parts[num_parts++] = g_strdup_printf("blendif[%s]: %.0f|%.0f-%.0f|%.0f \u2192 %.0f|%.0f-%.0f|%.0f",
+      change_parts[num_parts++] = g_strdup_printf("blendif[%s]\t%.0f|%.0f-%.0f|%.0f\t\u2192\t%.0f|%.0f-%.0f|%.0f",
             b->name, of[0]*100, of[1]*100, of[2]*100, of[3]*100, nf[0]*100, nf[1]*100, nf[2]*100, nf[3]*100);
     b++;
   }
@@ -909,7 +909,16 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
 
   gboolean show_tooltip = *tooltip_text;
 
-  gtk_tooltip_set_text (tooltip, tooltip_text);
+  GtkWidget *view = gtk_text_view_new ();
+  GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(view));
+  gtk_text_buffer_set_text(buffer, tooltip_text, -1);
+
+  PangoTabArray *tabs = pango_tab_array_new_with_positions(3, TRUE, PANGO_TAB_LEFT, 200, PANGO_TAB_LEFT, 400, PANGO_TAB_LEFT, 420);
+  gtk_text_view_set_tabs(GTK_TEXT_VIEW(view), tabs);
+  pango_tab_array_free(tabs);
+
+  gtk_tooltip_set_custom(tooltip, view);
+  
   g_free(tooltip_text);
 
   return show_tooltip;


### PR DESCRIPTION
Uses introspection to show changes between revisions in the history module in darkroom.

Edit:
- also includes blending changes (and some refactoring of parametric blending gui code)
- tooltip gets generated dynamically, so does not have performance impact with every change
- basic formatting using tabs in a GtkTextView within the tooltip. This could be changed to a GtkTreeView with drilldown into curves/other arrays, but that would require a pop-up dialog and so would be part of a major revision at some point.

![image](https://user-images.githubusercontent.com/1549490/90975951-bb319080-e530-11ea-8841-c8ad69f838da.png)
