### PR TITLE
darkroom: better visual indication of drag-drop operations

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1779,6 +1779,17 @@ scale contents trough slider:hover
   background-color: @scroll_bar_active;
 }
 
+.iop_drop_before
+{
+   border: 2px solid @plugin_bg_color;
+   border-bottom: 2.8em solid @plugin_bg_color;
+}
+
+.iop_drop_after
+{
+   border: 2px solid @plugin_bg_color;
+   border-top: 2.8em solid @plugin_bg_color;
+}
 
 /*** --- Thumbtable css part ---
 


### PR DESCRIPTION
when dragging and dropping modules in the darkroom, show the gap into which the dragged module will be inserted and draw a line around the module after|before which the insert will be made.

For example, the following shows that the exposure module will be placed immediately after the color mapping module in the pipe

![Screenshot_2020-07-20_21-13-20](https://user-images.githubusercontent.com/9555491/87982769-3259ac00-cacf-11ea-8b74-28f3ac619b73.png)

Resolves #5772.