### PR TITLE
imageio: Add support for libavif >= 0.8.0

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -297,6 +297,62 @@ int write_image(struct dt_imageio_module_data_t *data,
   avifImageRGBToYUV(image, &rgb);
 
   if (imgid > 0) {
+    bool use_icc = false;
+
+#if AVIF_VERSION >= 800
+    image->colorPrimaries = AVIF_COLOR_PRIMARIES_UNKNOWN;
+    image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_UNKNOWN;
+    image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_UNSPECIFIED;
+
+    switch (over_type) {
+      case DT_COLORSPACE_SRGB:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;
+          break;
+      case DT_COLORSPACE_REC709:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_BT470M;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;
+        break;
+      case DT_COLORSPACE_LIN_REC709:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_LINEAR;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT709;
+        break;
+      case DT_COLORSPACE_LIN_REC2020:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2020;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_LINEAR;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT2020_NCL;
+        break;
+      case DT_COLORSPACE_PQ_REC2020:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2020;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT2020_NCL;
+        break;
+      case DT_COLORSPACE_HLG_REC2020:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_BT2020;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_HLG;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT2020_NCL;
+        break;
+      case DT_COLORSPACE_PQ_P3:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_SMPTE432;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SMPTE2084;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL;
+        break;
+      case DT_COLORSPACE_HLG_P3:
+          image->colorPrimaries = AVIF_COLOR_PRIMARIES_SMPTE432;
+          image->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_HLG;
+          image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_CHROMA_DERIVED_NCL;
+        break;
+      default:
+        break;
+    }
+
+    if (image->colorPrimaries == AVIF_COLOR_PRIMARIES_UNKNOWN) {
+      use_icc = true;
+    }
+#else /* AVIF_VERSION 700 */
     avifNclxColorProfile nclx = {
         .colourPrimaries = AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN,
     };
@@ -402,14 +458,16 @@ int write_image(struct dt_imageio_module_data_t *data,
         break;
     }
 
-    dt_print(DT_DEBUG_IMAGEIO, "[avif colorprofile profile: %s - %s]\n",
-             dt_colorspaces_get_name(over_type, filename),
-             nclx.colourPrimaries != AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN ?
-                "nclx" : "icc");
-
     if (nclx.colourPrimaries != AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN) {
         avifImageSetProfileNCLX(image, &nclx);
-    } else {
+        use_icc = true;
+    }
+#endif
+    dt_print(DT_DEBUG_IMAGEIO, "[avif colorprofile profile: %s - %s]\n",
+             dt_colorspaces_get_name(over_type, filename),
+             use_icc ? "icc" : "nclx");
+
+    if (use_icc) {
       const dt_colorspaces_color_profile_t *cp =
         dt_colorspaces_get_output_profile(imgid,
                                           over_type,


### PR DESCRIPTION
Add support for libavif >= 0.8.0