### PR TITLE
create a GUI button for focus-peaking

### DIFF
--- a/src/dtgtk/paint.c
+++ b/src/dtgtk/paint.c
@@ -928,6 +928,58 @@ void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
   FINISH
 }
 
+void dtgtk_cairo_paint_focus_peaking(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
+{
+  PREAMBLE(1, 0, 0)
+
+  // stigmometer aka split focusing screen aka Dodin's prism
+  cairo_arc(cr, 0.5, 0.5, 0.2, 0, 2. * M_PI);
+  cairo_move_to(cr, 0.3, 0.5);
+  cairo_line_to(cr, 0.7, 0.5);
+  cairo_stroke(cr);
+
+  // corners
+  const double center = 0.5;
+  const double width = 1.;
+  const double height = width * 2. / 3.;
+  const double offset_h = height / 2.;
+  const double offset_w = width / 2.;
+
+  const double tick_length = 0.1;
+
+  const double left = center - offset_w;
+  const double right = center + offset_w;
+  const double top = center - offset_h;
+  const double bottom = center + offset_h;
+
+  /// north west
+  cairo_move_to(cr, left + tick_length, top);
+  cairo_line_to(cr, left,               top);
+  cairo_line_to(cr, left,               top + tick_length);
+  cairo_stroke(cr);
+
+  // south west
+  cairo_move_to(cr, left,               bottom - tick_length);
+  cairo_line_to(cr, left,               bottom);
+  cairo_line_to(cr, left + tick_length, bottom);
+  cairo_stroke(cr);
+
+  // south east
+  cairo_move_to(cr, right - tick_length, bottom);
+  cairo_line_to(cr, right,               bottom);
+  cairo_line_to(cr, right,               bottom - tick_length);
+  cairo_stroke(cr);
+
+  // north east
+  cairo_move_to(cr, right,               top + tick_length);
+  cairo_line_to(cr, right,               top);
+  cairo_line_to(cr, right - tick_length, top);
+  cairo_stroke(cr);
+
+  FINISH
+}
+
+
 void dtgtk_cairo_paint_filmstrip(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data)
 {
   gdouble sw = 0.6;

--- a/src/dtgtk/paint.h
+++ b/src/dtgtk/paint.h
@@ -179,6 +179,8 @@ void dtgtk_cairo_paint_zoom(cairo_t *cr, gint x, gint y, gint w, gint h, gint fl
 void dtgtk_cairo_paint_multiinstance(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 /** paint a simple grid icon */
 void dtgtk_cairo_paint_grid(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
+/** paint focus peaking icon **/
+void dtgtk_cairo_paint_focus_peaking(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);
 
 /** paint active modulegroup icon */
 void dtgtk_cairo_paint_modulegroup_active(cairo_t *cr, gint x, gint y, gint w, gint h, gint flags, void *data);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "common/darktable.h"
+#include "common/dtpthread.h"
 
 #include <gtk/gtk.h>
 #include <stdint.h>
@@ -110,6 +111,7 @@ typedef struct dt_gui_gtk_t
 
   gboolean show_overlays;
   gboolean show_focus_peaking;
+  GtkWidget *focus_peaking_button;
 
   double dpi, dpi_factor, ppd;
 
@@ -124,6 +126,8 @@ typedef struct dt_gui_gtk_t
   guint sidebar_scroll_mask;
 
   cairo_filter_t filter_image;
+
+  dt_pthread_mutex_t mutex;
 } dt_gui_gtk_t;
 
 #if (CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 13, 1))

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2076,6 +2076,9 @@ void gui_init(dt_view_t *self)
 
   const int dialog_width = 350;
 
+  /* add the global focus peaking button in toolbox */
+  dt_view_manager_module_toolbox_add(darktable.view_manager, darktable.gui->focus_peaking_button, DT_VIEW_DARKROOM);
+
   /* Enable ISO 12646-compliant colour assessment conditions */
   dev->iso_12646.button
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_bulb, CPF_STYLE_FLAT, NULL);
@@ -2762,6 +2765,10 @@ void enter(dt_view_t *self)
 
     modules = g_list_previous(modules);
   }
+
+  /* re-attach global focus peaking button in toolbox */
+  dt_view_manager_module_toolbox_add(darktable.view_manager, darktable.gui->focus_peaking_button, DT_VIEW_DARKROOM);
+
   // make signals work again:
   --darktable.gui->reset;
 
@@ -3300,7 +3307,7 @@ void scrolled(dt_view_t *self, double x, double y, int up, int state)
       float multiplier = dt_accel_get_slider_scale_multiplier();
 
       const float min_visible = powf(10.0f, -dt_bauhaus_slider_get_digits(widget));
-      if(fabsf(step*multiplier) < min_visible) 
+      if(fabsf(step*multiplier) < min_visible)
         multiplier = min_visible / fabsf(step);
 
       if(up)

--- a/src/views/lighttable.c
+++ b/src/views/lighttable.c
@@ -21,6 +21,7 @@
 #include "common/darktable.h"
 #include "common/debug.h"
 #include "common/file_location.h"
+#include "common/focus_peaking.h"
 #include "common/grouping.h"
 #include "common/history.h"
 #include "common/image_cache.h"
@@ -563,6 +564,11 @@ void enter(dt_view_t *self)
 
   // restore panels
   dt_ui_restore_panels(darktable.gui->ui);
+
+  /* re-attach global focus peaking button in toolbox */
+  ++darktable.gui->reset;
+  dt_view_manager_module_toolbox_add(darktable.view_manager, darktable.gui->focus_peaking_button, DT_VIEW_LIGHTTABLE);
+  --darktable.gui->reset;
 }
 
 static void _preview_enter(dt_view_t *self, gboolean sticky, gboolean focus, int32_t mouse_over_id)
@@ -1361,6 +1367,10 @@ void gui_init(dt_view_t *self)
                               gtk_widget_get_parent(dt_ui_log_msg(darktable.gui->ui)), -1);
   gtk_overlay_reorder_overlay(GTK_OVERLAY(dt_ui_center_base(darktable.gui->ui)),
                               gtk_widget_get_parent(dt_ui_toast_msg(darktable.gui->ui)), -1);
+
+  /* add the global focus peaking button in toolbox */
+  dt_view_manager_module_toolbox_add(darktable.view_manager, darktable.gui->focus_peaking_button, DT_VIEW_LIGHTTABLE);
+
   // create display profile button
   GtkWidget *const profile_button = dtgtk_button_new(dtgtk_cairo_paint_display, CPF_STYLE_FLAT,
                                                      NULL);


### PR DESCRIPTION
* fix #5748
* read and write focus-peaking state in `darktablerc` only when app starts and closes, not during runtime
* use thread mutex locks to read/write `darktable.gui` states consistently

Darkroom:
![Screenshot_20200724_160209](https://user-images.githubusercontent.com/2779157/88400269-6501ee00-cdc8-11ea-952c-c62d2c28e23e.png)
Lighttable:
![Screenshot_20200724_160017](https://user-images.githubusercontent.com/2779157/88400271-659a8480-cdc8-11ea-8054-96c336ee4253.png)
