### PR TITLE
Cannot select an area with the parametric mask color picker

### DIFF
--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -157,7 +157,8 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
   // set module active if not yet the case
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);
 
-  const GdkModifierType state = e != NULL ? e->state : dt_key_modifier_state();
+  const GdkModifierType state
+      = e != NULL ? e->state & gtk_accelerator_get_default_mod_mask() : dt_key_modifier_state();
   const gboolean ctrl_key_pressed = (state == GDK_CONTROL_MASK);
   dt_iop_color_picker_kind_t kind = self->kind;
 


### PR DESCRIPTION
It seems that the selection of an area (through ctrl+clicking) by the first color picker of the parametric mask blending section is not possible anymore.

This PR suggests a fix for this.