### PR TITLE
init metadata flags at start time

### DIFF
--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -995,6 +995,9 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
   // set up the list of exiv2 metadata
   dt_exif_set_exiv2_taglist();
 
+  // init metadata flags
+  dt_metadata_init();
+
   if(init_gui)
   {
 #ifdef HAVE_GPHOTO2

--- a/src/common/metadata.c
+++ b/src/common/metadata.c
@@ -150,6 +150,28 @@ const int dt_metadata_get_type(const uint32_t keyid)
     return 0;
 }
 
+void dt_metadata_init()
+{
+  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
+  {
+    const int type = dt_metadata_get_type(i);
+    const char *name = (gchar *)dt_metadata_get_name(i);
+    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
+    if(!dt_conf_key_exists(setting))
+    {
+      // per default should be imported
+      uint32_t flag = DT_METADATA_FLAG_IMPORTED;
+      if(type == DT_METADATA_TYPE_OPTIONAL)
+      {
+        // per default this one should be hidden
+        flag |= DT_METADATA_FLAG_HIDDEN;
+      }
+      dt_conf_set_int(setting, flag);
+    }
+    g_free(setting);
+  }
+}
+
 typedef struct dt_undo_metadata_t
 {
   int imgid;

--- a/src/common/metadata.h
+++ b/src/common/metadata.h
@@ -88,6 +88,9 @@ const char *dt_metadata_get_key_by_subkey(const char *subkey);
 /** return the type of the metadata keyid */
 const int dt_metadata_get_type(const uint32_t keyid);
 
+/** init metadata flags */
+void dt_metadata_init();
+
 /** Set metadata for a specific image, or all selected for id == -1. */
 void dt_metadata_set(int id, const char *key, const char *value, const gboolean undo_on); // duplicate.c, lua/image.c
 

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -68,28 +68,6 @@ uint32_t container(dt_lib_module_t *self)
   return DT_UI_CONTAINER_PANEL_RIGHT_CENTER;
 }
 
-void init(dt_lib_module_t *self)
-{
-  for(unsigned int i = 0; i < DT_METADATA_NUMBER; i++)
-  {
-    const int type = dt_metadata_get_type(i);
-    const char *name = (gchar *)dt_metadata_get_name(i);
-    char *setting = dt_util_dstrcat(NULL, "plugins/lighttable/metadata/%s_flag", name);
-    if(!dt_conf_key_exists(setting))
-    {
-      // per default should be imported
-      uint32_t flag = DT_METADATA_FLAG_IMPORTED;
-      if(type == DT_METADATA_TYPE_OPTIONAL)
-      {
-        // per default this one should be hidden
-        flag |= DT_METADATA_FLAG_HIDDEN;
-      }
-      dt_conf_set_int(setting, flag);
-    }
-    g_free(setting);
-  }
-}
-
 static gboolean _is_leave_unchanged(const char *text)
 {
   return g_strcmp0(text, _("<leave unchanged>")) == 0;


### PR DESCRIPTION
Related to #5826
I haven't reproduced any of the issues, but it makes sense not to rely on UI to initialize the metadata flags EDIT and to do it before calling crawler.
Does that solve the main concern ?
