### PR TITLE
correct vertical alignment of module icons in darkroom headers

### DIFF
--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -2080,6 +2080,7 @@ GtkWidget *dt_iop_gui_get_expander(dt_iop_module_t *module)
   snprintf(w_name, sizeof(w_name), "iop-panel-icon-%s", module->op);
   hw[IOP_MODULE_ICON] = gtk_label_new("");
   gtk_widget_set_name(GTK_WIDGET(hw[IOP_MODULE_ICON]), w_name);
+  gtk_widget_set_valign(GTK_WIDGET(hw[IOP_MODULE_ICON]), GTK_ALIGN_CENTER);
 
   /* add module label */
   hw[IOP_MODULE_LABEL] = gtk_label_new("");


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1549490/88772132-34c7a000-d178-11ea-8901-2254164f95df.png)

after:
![image](https://user-images.githubusercontent.com/1549490/88772988-6ee57180-d179-11ea-9bbc-2c2ea8e69bd4.png)

