### PR TITLE
lighttable: fix arrow navigation in file manager view

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -2320,7 +2320,7 @@ static gboolean _filemanager_key_move(dt_thumbtable_t *table, dt_thumbtable_move
     newrowid = baserowid - 1;
   else if(move == DT_THUMBTABLE_MOVE_RIGHT && baserowid < maxrowid)
     newrowid = baserowid + 1;
-  else if(move == DT_THUMBTABLE_MOVE_UP && baserowid >= 2)
+  else if(move == DT_THUMBTABLE_MOVE_UP && baserowid - table->thumbs_per_row >= 1)
     newrowid = baserowid - table->thumbs_per_row;
   else if(move == DT_THUMBTABLE_MOVE_DOWN && baserowid + table->thumbs_per_row <= maxrowid)
     newrowid = baserowid + table->thumbs_per_row;


### PR DESCRIPTION
Ensure that when navigating up with the arrow key in lighttable file manager view, the cursor stops at the top (or when
navigating up would cause the cursor to move to an empty slot in the grid).

Resolves #5858