### PR TITLE
lighttable: don't change layout when returning from the darkroom

### DIFF
--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1684,6 +1684,11 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
     {
       // in filemanager, we need to take care of the center offset
       posx = table->center_offset;
+
+      // ensure that the overall layout doesn't change 
+      // (i.e. we don't get empty spaces in the very first row)
+      const int offset_row = table->offset / table->thumbs_per_row;
+      offset = offset_row * table->thumbs_per_row + 1;
     }
     else if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
     {

--- a/src/dtgtk/thumbtable.c
+++ b/src/dtgtk/thumbtable.c
@@ -1685,10 +1685,13 @@ void dt_thumbtable_full_redraw(dt_thumbtable_t *table, gboolean force)
       // in filemanager, we need to take care of the center offset
       posx = table->center_offset;
 
-      // ensure that the overall layout doesn't change 
-      // (i.e. we don't get empty spaces in the very first row)
-      const int offset_row = table->offset / table->thumbs_per_row;
-      offset = offset_row * table->thumbs_per_row + 1;
+      if(table->thumbs_per_row > 1)
+      {
+        // ensure that the overall layout doesn't change 
+        // (i.e. we don't get empty spaces in the very first row)
+        const int offset_row = table->offset / table->thumbs_per_row;
+        offset = offset_row * table->thumbs_per_row + 1;
+      }
     }
     else if(table->mode == DT_THUMBTABLE_MODE_FILMSTRIP)
     {


### PR DESCRIPTION
When choosing how to lay out thumbnails in the lighttable file manager view, do not place the active image on the top left (as this can change the overall layout of the thumbnails and lead to glitches when scrolling up). Instead simply ensure that the active image is on the top row.

Resolves #4957