### PR TITLE
revert ellipsize comboboxes and labels to the middle

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -106,7 +106,7 @@ static int show_pango_text(dt_bauhaus_widget_t *w, GtkStyleContext *context, cai
 
   if(max_width > 0)
   {
-    pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+    pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_MIDDLE);
     pango_layout_set_width(layout, (int)(PANGO_SCALE * max_width + 0.5f));
   }
 


### PR DESCRIPTION
Revert part of the changes made in commit [34140b0](https://github.com/darktable-org/darktable/pull/5368/commits/38140b087c461e990743cda9a5dc266231ce9a0f)
because it's making[ lu3d files names unreadable](https://discuss.pixls.us/t/only-show-lut-name-in-3d-lut/19615).
