### PR TITLE
fix for "No timestamps are displayed on Windows" #5892

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -294,7 +294,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       char datetime[200];
       // just %c is too long and includes a time zone that we don't know from exif
       strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->import_timestamp));
-      _metadata_update_value(d->metadata[md_internal_import_timestamp], datetime);
+      _metadata_update_value(d->metadata[md_internal_import_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
     }
     else
       _metadata_update_value(d->metadata[md_internal_import_timestamp], "-");
@@ -303,7 +303,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     {
       char datetime[200];
       strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->change_timestamp));
-      _metadata_update_value(d->metadata[md_internal_change_timestamp], datetime);
+      _metadata_update_value(d->metadata[md_internal_change_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
     }
     else
       _metadata_update_value(d->metadata[md_internal_change_timestamp], "-");
@@ -312,7 +312,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     {
       char datetime[200];
       strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->export_timestamp));
-      _metadata_update_value(d->metadata[md_internal_export_timestamp], datetime);
+      _metadata_update_value(d->metadata[md_internal_export_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
     }
     else
       _metadata_update_value(d->metadata[md_internal_export_timestamp], "-");
@@ -321,7 +321,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     {
       char datetime[200];
       strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->print_timestamp));
-      _metadata_update_value(d->metadata[md_internal_print_timestamp], datetime);
+      _metadata_update_value(d->metadata[md_internal_print_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
     }
     else
       _metadata_update_value(d->metadata[md_internal_print_timestamp], "-");
@@ -528,7 +528,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       mktime(&tt_exif);
       // just %c is too long and includes a time zone that we don't know from exif
       strftime(datetime, sizeof(datetime), "%a %x %X", &tt_exif);
-      _metadata_update_value(d->metadata[md_exif_datetime], datetime);
+      _metadata_update_value(d->metadata[md_exif_datetime], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
     }
     else
       _metadata_update_value(d->metadata[md_exif_datetime], img->exif_datetime_taken);


### PR DESCRIPTION
fix for "No timestamps are displayed on Windows" #5892