### PR TITLE
fix font not freed memory leak in show_pango_text

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -119,7 +119,7 @@ static int show_pango_text(dt_bauhaus_widget_t *w, GtkStyleContext *context, cai
     pango_layout_set_text(layout, NULL, 0);
   }
 
-  PangoFontDescription *font_desc = pango_font_description_copy(darktable.bauhaus->pango_font_desc);
+  PangoFontDescription *font_desc = pango_font_description_copy_static(darktable.bauhaus->pango_font_desc);
 
   // This should be able to update the font style for current text depending on :hover, :focused, etc.
   // CSS pseudo-classes, yet it defaults to system font.
@@ -140,6 +140,7 @@ static int show_pango_text(dt_bauhaus_widget_t *w, GtkStyleContext *context, cai
     cairo_move_to(cr, x_pos, y_pos);
     pango_cairo_show_layout(cr, layout);
   }
+  pango_font_description_free(font_desc);
   g_object_unref(layout);
 
   return text_width;


### PR DESCRIPTION
While looking at show_pango_text in the context of https://github.com/darktable-org/darktable/pull/5368#issuecomment-671303866 noticed a different pattern compared to every other use of pango_font_description_copy

Calling the function in a while(true) loop indeed sees memory use slowly inching up. This patch fixes that and I've not noticed breakage.

In the current form of show_pango_text, just using darktable.bauhaus->pango_font_desc directly, instead of making a copy, also works. But there is a FIXME there to try to pick up css styles, in which case the copy will be needed.

As elsewhere, I've switched this to using the _static variant of pango_font_description_copy (i.e. a shallow copy). This should yield an unnoticeable speed increase, but since this function now gets called four times to correctly ellipsize comboboxes, it makes me feel better ;-)