### PR TITLE
introduce combo items ellipsis control

### DIFF
--- a/src/bauhaus/bauhaus.h
+++ b/src/bauhaus/bauhaus.h
@@ -112,6 +112,7 @@ typedef struct dt_bauhaus_combobox_data_t
   int defpos;         // default position
   int editable;       // 1 if arbitrary text may be typed
   char text[180];     // roughly as much as a slider
+  PangoEllipsizeMode entries_ellipsis;
   GList *entries;
 } dt_bauhaus_combobox_data_t;
 
@@ -326,6 +327,8 @@ void dt_bauhaus_combobox_set_default(GtkWidget *widget, int def);
 int dt_bauhaus_combobox_get_default(GtkWidget *widget);
 void dt_bauhaus_combobox_add_populate_fct(GtkWidget *widget, void (*fct)(GtkWidget *w, struct dt_iop_module_t **module));
 void dt_bauhaus_combobox_entry_set_sensitive(GtkWidget *widget, int pos, gboolean sensitive);
+void dt_bauhaus_combobox_set_entries_ellipsis(GtkWidget *widget, PangoEllipsizeMode ellipis);
+PangoEllipsizeMode dt_bauhaus_combobox_get_entries_ellipsis(GtkWidget *widget);
 
 // key accel parsing:
 // execute a line of input

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1703,6 +1703,7 @@ void gui_init(dt_iop_module_t *self)
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), self);
 
   g->filepath = dt_bauhaus_combobox_new(self);
+  dt_bauhaus_combobox_set_entries_ellipsis(g->filepath, PANGO_ELLIPSIZE_MIDDLE);
   gtk_box_pack_start(GTK_BOX(g->hbox), g->filepath, TRUE, TRUE, 0);
 #ifdef HAVE_GMIC
   gtk_widget_set_tooltip_text(g->filepath,


### PR DESCRIPTION
middle ellipsized text is usually unreadable, because normal ellipsis is usually at the end and usual human pattern recognition uses start of sentence to match the pattern.

this change allows to specify type of ellipsis used on combobox items, so in rare case where end of text is important (such as file name), we can specify that we want different type of ellipsis.

It's a bit better (IMO) than #5890