### PR TITLE
export: replace max size spin buttons with entry widgets

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1353,12 +1353,6 @@ cell:selected
   margin: 0 0 8px 0;
 }
 
-/* Set specific padding for export module spinbutton */
-#export-max-size spinbutton
-{
-  padding: 0px 5px;
-}
-
 /* Set below spacing between history items in darkroom */
 /* the label buttons */
 #left #history-button,


### PR DESCRIPTION
spin buttons don't really make much sense for pixel values

removal of the spin buttons means that the right hand panel may be
reduced in size without the panel UI shifting and means that the values
are not inadvertently disturbed when scrolling the panel

Resolves #5366