### PR TITLE
adds ccache option to CMake by lefticus:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ else()
   project(darktable VERSION 0 LANGUAGES CXX C)
 endif()
 
+# enable cache system
+include(Cache)
+
 # Allow forcing the C/CPP compiler that is actually used during the compilation
 # to something other than what is used by the cmake run. This is useful when
 # the compiler for some reason breaks the initial cmake checks but works fine

--- a/cmake/modules/Cache.cmake
+++ b/cmake/modules/Cache.cmake
@@ -1,0 +1,29 @@
+option(ENABLE_CACHE "Enable cache if available" ON)
+if(NOT ENABLE_CACHE)
+  return()
+endif()
+
+set(CACHE_OPTION
+    "ccache"
+    CACHE STRING "Compiler cache to be used")
+set(CACHE_OPTION_VALUES "ccache" "sccache")
+set_property(CACHE CACHE_OPTION PROPERTY STRINGS ${CACHE_OPTION_VALUES})
+list(
+  FIND
+  CACHE_OPTION_VALUES
+  ${CACHE_OPTION}
+  CACHE_OPTION_INDEX)
+
+if(${CACHE_OPTION_INDEX} EQUAL -1)
+  message(
+    STATUS
+      "Using custom compiler cache system: '${CACHE_OPTION}', explicitly supported entries are ${CACHE_OPTION_VALUES}")
+endif()
+
+find_program(CACHE_BINARY ${CACHE_OPTION})
+if(CACHE_BINARY)
+  message(STATUS "${CACHE_OPTION} found and enabled")
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CACHE_BINARY})
+else()
+  message(WARNING "${CACHE_OPTION} is enabled but was not found. Not using it")
+endif()


### PR DESCRIPTION
CMake can be set up to optionally use compiler caches to speed up the compilation. This PR is adding support for cached builds.

See https://github.com/lefticus/cpp_starter_project/blob/master/cmake/Cache.cmake for the original source