### PR TITLE
Remove unused code in buttons

### DIFF
--- a/src/dtgtk/button.c
+++ b/src/dtgtk/button.c
@@ -55,19 +55,6 @@ static gboolean _button_draw(GtkWidget *widget, cairo_t *cr)
   else
     flags &= ~CPF_PRELIGHT;
 
-  /* create pango text settings if label exists */
-  PangoLayout *layout = NULL;
-  int pw = 0, ph = 0;
-  const gchar *text = gtk_button_get_label(GTK_BUTTON(widget));
-  if(text)
-  {
-    layout = gtk_widget_create_pango_layout(widget, NULL);
-    pango_layout_set_font_description(layout, darktable.bauhaus->pango_font_desc);
-    pango_cairo_context_set_resolution(pango_layout_get_context(layout), darktable.gui->dpi);
-    pango_layout_set_text(layout, text, -1);
-    pango_layout_get_pixel_size(layout, &pw, &ph);
-  }
-
   /* begin cairo drawing */
   /* get button total allocation */
   GtkAllocation allocation;
@@ -128,17 +115,6 @@ static gboolean _button_draw(GtkWidget *widget, cairo_t *cr)
     void *icon_data = DTGTK_BUTTON(widget)->icon_data;
     if(cwidth > 0 && cheight > 0)
       DTGTK_BUTTON(widget)->icon(cr, startx, starty, cwidth, cheight, flags, icon_data);
-  }
-
-  /* draw label */
-  if(text)
-  {
-    int lx = DT_PIXEL_APPLY_DPI(2), ly = ((height / 2.0) - (ph / 2.0));
-    if(DTGTK_BUTTON(widget)->icon) lx += width;
-    cairo_move_to(cr, lx, ly);
-    cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
-    pango_cairo_show_layout(cr, layout);
-    g_object_unref(layout);
   }
 
   return FALSE;

--- a/src/dtgtk/togglebutton.c
+++ b/src/dtgtk/togglebutton.c
@@ -116,19 +116,6 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
 
   gtk_render_frame(context, cr, startx, starty, cwidth, cheight);
 
-  /* create pango text settings if label exists */
-  PangoLayout *layout = NULL;
-  int pw = 0, ph = 0;
-  const gchar *text = gtk_button_get_label(GTK_BUTTON(widget));
-  if(text)
-  {
-    layout = pango_cairo_create_layout(cr);
-    pango_layout_set_font_description(layout, darktable.bauhaus->pango_font_desc);
-    pango_cairo_context_set_resolution(pango_layout_get_context(layout), darktable.gui->dpi);
-    pango_layout_set_text(layout, text, -1);
-    pango_layout_get_pixel_size(layout, &pw, &ph);
-  }
-
   gdk_cairo_set_source_rgba(cr, &fg_color);
 
   /* draw icon */
@@ -159,20 +146,6 @@ static gboolean _togglebutton_draw(GtkWidget *widget, cairo_t *cr)
 
     if(cwidth > 0 && cheight > 0)
         DTGTK_TOGGLEBUTTON(widget)->icon(cr, startx, starty, cwidth, cheight, flags, icon_data);
-  }
-
-
-  /* draw label */
-  if(text)
-  {
-    int lx = DT_PIXEL_APPLY_DPI(2), ly = ((height / 2.0) - (ph / 2.0));
-    // if (DTGTK_TOGGLEBUTTON (widget)->icon) lx += width;
-    // GdkRectangle t={x,y,x+width,y+height};
-    // gtk_paint_layout(style,gtk_widget_get_window(widget),
-    // state,TRUE,&t,widget,"togglebutton",lx,ly,layout);
-    cairo_translate(cr, lx, ly);
-    pango_cairo_show_layout(cr, layout);
-    g_object_unref(layout);
   }
 
   return FALSE;


### PR DESCRIPTION
Removing some dead branch of code in button.c and togglebutton.c, which only manage icon buttons, while label button are created with regular gtk calls.