### PR TITLE
darkroom: only show module header when moving modules

### DIFF
--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2492,11 +2492,11 @@ static void _on_drag_begin(GtkWidget *widget, GdkDragContext *context, gpointer 
   dt_iop_module_t *module_src = _get_dnd_source_module(container);
   if(module_src && module_src->expander)
   {
-    GdkWindow *window = gtk_widget_get_parent_window(module_src->expander);
+    GdkWindow *window = gtk_widget_get_parent_window(module_src->header);
     if(window)
     {
       GtkAllocation allocation_w = {0};
-      gtk_widget_get_allocation(module_src->expander, &allocation_w);
+      gtk_widget_get_allocation(module_src->header, &allocation_w);
 
       GdkPixbuf *pixbuf = gdk_pixbuf_get_from_window(window, allocation_w.x, allocation_w.y,
                                                      allocation_w.width, allocation_w.height);


### PR DESCRIPTION
when dragging and dropping modules that are expanded, this prevents the entire module ui being shown during the drag operation (which is cumbersome for modules with a large ui).

So...

![Screenshot_2020-08-13_19-50-23](https://user-images.githubusercontent.com/9555491/90174719-580c6500-dd9e-11ea-90d8-89f0b0aec564.png)

Rather than...

![Screenshot_2020-08-13_19-52-58](https://user-images.githubusercontent.com/9555491/90174940-a15cb480-dd9e-11ea-85ef-96ef8bd9aa99.png)
