### PR TITLE
preferences: display toast message if restart is required

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -3,6 +3,7 @@
 <!ATTLIST dtconfig
 	prefs (import|lighttable|darkroom|otherviews|processing|security|cpugpu|storage|misc) #IMPLIED
         section (import|session|interface|other|tags|geoloc|slideshow|cpugpu|database|xmp|accel) #IMPLIED
+        restart (true|false) #IMPLIED
         capability CDATA #IMPLIED
 >
 <!ELEMENT name (#PCDATA)>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -131,7 +131,7 @@
     <default>true</default>
     <shortdescription>do not show april 1st game</shortdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu">
+  <dtconfig prefs="cpugpu" restart="true">
     <name>cache_memory</name>
     <type factor="(1.0 / (1024.0 * 1024.0))" min="(1024 * 1024 * 100)">int64</type>
     <default>(1024 * 1024 * 512)</default>
@@ -159,21 +159,21 @@
     <shortdescription>color manage cached thumbnails</shortdescription>
     <longdescription>if enabled, cached thumbnails will be color managed so that lighttable and filmstrip can show correct colors. otherwise the results may look wrong once the display profile gets changed.</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu">
+  <dtconfig prefs="cpugpu" restart="true">
     <name>worker_threads</name>
     <type>int</type>
     <default>2</default>
     <shortdescription>number of background threads</shortdescription>
     <longdescription>this controls for example how many threads are used to create thumbnails during import. the cache will grow to a maximum of twice this number of full resolution image buffers (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu">
+  <dtconfig prefs="cpugpu" restart="true">
     <name>host_memory_limit</name>
     <type>int</type>
     <default>1500</default>
     <shortdescription>host memory limit (in MB) for tiling</shortdescription>
     <longdescription>this variable controls the maximum amount of memory (in MB) a module may use during image processing. lower values will force memory hungry modules to process image with increasing number of tiles. setting this to 0 will omit any limit. values below 500 will be treated as 500 (needs a restart).</longdescription>
   </dtconfig>
-  <dtconfig prefs="cpugpu">
+  <dtconfig prefs="cpugpu" restart="true">
     <name>singlebuffer_limit</name>
     <type min="2" max="64">int</type>
     <default>16</default>
@@ -298,7 +298,7 @@
     <shortdescription>omit hierarchy in simple tag lists</shortdescription>
     <longdescription>when creating XMP file the hierarchical tags are also added as a simple list of non-hierarchical ones to make them visible to some other programs. when this option is checked darktable will only include their last part and ignore the rest. so 'foo|bar|baz' will only add 'baz'.</longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="tags">
+  <dtconfig prefs="misc" section="tags" restart="true">
     <name>plugins/lighttable/tagging/no_entry_completion</name>
     <type>bool</type>
     <default>false</default>
@@ -1563,7 +1563,7 @@
     <shortdescription>show scrollbars for central view</shortdescription>
     <longdescription>defines whether scrollbars should be displayed</longdescription>
   </dtconfig>
-  <dtconfig prefs="misc" section="interface">
+  <dtconfig prefs="misc" section="interface" restart="true">
     <name>panel_scrollbars_always_visible</name>
     <type>bool</type>
     <default>true</default>
@@ -2248,14 +2248,14 @@
     <shortdescription>executable for playing audio files</shortdescription>
     <longdescription>this external program is used to play audio files some cameras record to keep notes for images</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" restart="true">
     <name>plugins/darkroom/lut3d/def_path</name>
     <type>dir</type>
     <default></default>
     <shortdescription>3D lut root folder</shortdescription>
     <longdescription>this folder (and sub-folders) contains Lut files used by lut3d modules. need to restart darktable.</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" restart="true">
     <name>plugins/darkroom/workflow</name>
     <type>
       <enum>
@@ -2268,14 +2268,14 @@
     <shortdescription>auto-apply pixel workflow defaults</shortdescription>
     <longdescription>scene-referred workflow is based on linear modules and will auto-apply filmic and exposure,\ndisplay-referred workflow is based on Lab modules and will auto-apply base curve and the legacy module pipe order.\n(needs a restart)</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" restart="true">
     <name>plugins/darkroom/basecurve/auto_apply_percamera_presets</name>
     <type>bool</type>
     <default>false</default>
     <shortdescription>auto-apply per camera basecurve presets</shortdescription>
     <longdescription>use the per-camera basecurve by default instead of the generic manufacturer one if there is one available (needs a restart).\nthis option is taken into account when the \"auto-apply pixel workflow defaults\" is set to \"display-referred\".\nto prevent auto-apply basecurve presets \"auto-apply pixel workflow defaults\" should be set to \"none\"</longdescription>
   </dtconfig>
-  <dtconfig prefs="processing">
+  <dtconfig prefs="processing" restart="true">
     <name>plugins/darkroom/sharpen/auto_apply</name>
     <type>bool</type>
     <default>true</default>

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -553,6 +553,8 @@ void dt_gui_preferences_show()
 
   dt_gui_accel_search_t *search_data = (dt_gui_accel_search_t *)malloc(sizeof(dt_gui_accel_search_t));
 
+  restart_required = FALSE;
+
   //setup tabs
   init_tab_general(stack);
   init_tab_import(_preferences_dialog, stack);
@@ -587,6 +589,9 @@ void dt_gui_preferences_show()
   g_free(search_data->last_search_term);
   free(search_data);
   gtk_widget_destroy(_preferences_dialog);
+
+  if(restart_required)
+    dt_control_log(_("Darktable needs to be restarted for settings to take effect"));
 
   // Cleaning up any memory still allocated for remapping
   if(darktable.control->accel_remap_path)

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -50,6 +50,8 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
      return TRUE;
   return FALSE;
 }
+
+gboolean restart_required = FALSE;
 ]]></xsl:text>
 
   <!-- reset callbacks -->
@@ -70,6 +72,16 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
       <xsl:text>gtk_widget_set_can_focus(GTK_WIDGET(dialog), TRUE);&#xA;</xsl:text>
       <xsl:text>gtk_widget_grab_focus(GTK_WIDGET(dialog));&#xA;</xsl:text>
       <xsl:apply-templates select="." mode="change"/>
+      <xsl:text>&#xA;}&#xA;&#xA;</xsl:text>
+    </xsl:if>
+  </xsl:for-each>
+
+  <!-- restart callbacks (on change) -->
+
+  <xsl:for-each select="./dtconfiglist/dtconfig[@prefs]">
+    <xsl:if test="@restart">
+      <xsl:text>static void&#xA;preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text> (GtkWidget *widget, gpointer user_data)&#xA;{&#xA;</xsl:text>
+      <xsl:text>restart_required = TRUE;&#xA;</xsl:text>
       <xsl:text>&#xA;}&#xA;&#xA;</xsl:text>
     </xsl:if>
   </xsl:for-each>
@@ -462,6 +474,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_entry_set_text(GTK_ENTRY(widget), setting);
     g_free(setting);
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
@@ -478,6 +495,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     gchar *setting = dt_conf_get_string("</xsl:text><xsl:value-of select="name"/><xsl:text>");
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(widget), setting);
     g_free(setting);
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "button-press-event", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), "</xsl:text><xsl:value-of select="default"/><xsl:text>");
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
@@ -497,6 +519,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     gtk_widget_set_hexpand(widget, FALSE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%d'"), (int)(</xsl:text><xsl:value-of select="default"/><xsl:text> * factor));
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
@@ -514,6 +541,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     gtk_widget_set_hexpand(widget, FALSE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 0);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_int64("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     char value[100];
     snprintf(value, 100, "%"G_GINT64_FORMAT"",(gint64)(</xsl:text><xsl:value-of select="default"/><xsl:text> * factor));
@@ -533,6 +565,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     gtk_widget_set_hexpand(widget, FALSE);
     gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 5);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_float("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "value-changed", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%.03f'"), </xsl:text><xsl:value-of select="default"/><xsl:text> * factor);
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
@@ -544,6 +581,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), dt_conf_get_bool("</xsl:text><xsl:value-of select="name"/><xsl:text>"));
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "toggled", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "</xsl:text><xsl:value-of select="translate(default, $lowercase, $uppercase)"/><xsl:text>"));
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);
@@ -585,6 +627,11 @@ static gboolean handle_enter_key(GtkWidget *widget, GdkEvent *event, gpointer da
     gtk_combo_box_set_active(GTK_COMBO_BOX(widget), pos);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
+    </xsl:text>
+    <xsl:if test="@restart">
+       <xsl:text> g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(preferences_restart_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);</xsl:text>
+    </xsl:if>
+    <xsl:text>
     g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(preferences_response_callback_</xsl:text><xsl:value-of select="generate-id(.)"/><xsl:text>), widget);
     snprintf(tooltip, 1024, _("double click to reset to `%s'"), C_("preferences", "</xsl:text><xsl:value-of select="default"/><xsl:text>"));
     g_object_set(labelev,  "tooltip-text", tooltip, (gchar *)0);


### PR DESCRIPTION
if any settings are changed that require a restart, a toast message is displayed when exiting the preferences dialog

n.b. this works from the 'changed' signal (and its variants) so if a user changes a setting and then changes it back again the toast will still be displayed, but better safe than sorry.

Resolves #5241