### PR TITLE
Fix scripts installer not starting

### DIFF
--- a/data/luarc
+++ b/data/luarc
@@ -23,11 +23,14 @@ ipairs = function(t)
 
 local _scripts_install = {}
 
+_scripts_install.module_installed = false
+_scripts_install.event_registered = false
+
 _scripts_install.dt = require 'darktable'
 
 -- check for gui so that we don't hang darktable-cli
 
-if _scripts_install.dt.configuration.has_gui and _scripts_install.dt.gui.current_view() == "lighttable" then
+if _scripts_install.dt.configuration.has_gui  then
 
 
   _scripts_install.dt.preferences.register(
@@ -170,6 +173,25 @@ if _scripts_install.dt.configuration.has_gui and _scripts_install.dt.gui.current
         _scripts_install.minimize_lib()
       end
 
+      function _scripts_install.install_module()
+        if not _scripts_install.module_installed then
+          _scripts_install.dt.register_lib(
+            "lua_scripts_installer",
+            _("lua scripts installer"),
+            true,
+            false,
+            {[_scripts_install.dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 900}},
+            _scripts_install.dt.new_widget("box"){
+              orientation = "vertical",
+              table.unpack(_scripts_install.display_widgets)
+            },
+            nil,
+            nil
+          )
+          _scripts_install.module_installed = true
+        end
+      end
+
       -- _scripts_install.dt.print_log("building widgets")
 
       _scripts_install.display_widgets = {}
@@ -206,19 +228,21 @@ if _scripts_install.dt.configuration.has_gui and _scripts_install.dt.gui.current
 
       -- _scripts_install.dt.print_log("installing library")
 
-      _scripts_install.dt.register_lib(
-        "lua_scripts_installer",
-        _("lua scripts installer"),
-        true,
-        false,
-        {[_scripts_install.dt.gui.views.lighttable] = {"DT_UI_CONTAINER_PANEL_LEFT_BOTTOM", 900}},
-        _scripts_install.dt.new_widget("box"){
-          orientation = "vertical",
-          table.unpack(_scripts_install.display_widgets)
-        },
-        nil,
-        nil
-      )
+      if _scripts_install.dt.gui.current_view().name == "lighttable" then
+        _scripts_install.install_module()
+      else
+        if not _scripts_install.event_registered then
+          _scripts_install.dt.register_event(
+            "view-changed",
+            function(event, old_view, new_view)
+              if new_view.name == "lighttable" and old_view.name == "darkroom" then
+                _scripts_install.install_module()
+               end
+            end
+          )
+          _scripts_install.event_registered = true
+        end
+      end
 
       if not _scripts_install.dt.preferences.read("_scripts_install", "initialized", "bool") then
        _scripts_install.dt.control.sleep(1000)


### PR DESCRIPTION
Added check to make sure we are in lighttable mode  If not we add an event listener to catch the view-changed event and then install the GUI module when we are back in lighttable.  Fixes #5885