### PR TITLE
Elllipsize lua button labels

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -8549,6 +8549,27 @@ darktable.database.import(), then dt_lua_image_t.is_raw is not guaranteed to be 
     </tgroup></informaltable>
 </section>
 
+<section status="final" id="types_lua_button_ellipsize">
+<title>types.lua_button.ellipsize</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>ellipsize</secondary>
+</indexterm>
+<synopsis><link linkend="types_dt_lua_ellipsize_mode_t">types.dt_lua_ellipsize_mode_t</link></synopsis>
+<para>The ellipsize mode of the button label</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis><link linkend="attributes_write">write</link></emphasis></para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
 <section status="final" id="types_lua_button_clicked_callback">
 <title>types.lua_button.clicked_callback</title>
 <indexterm>

--- a/src/lua/configuration.h
+++ b/src/lua/configuration.h
@@ -37,7 +37,7 @@
 /* incompatible API change */
 #define LUA_API_VERSION_MAJOR 6
 /* backward compatible API change */
-#define LUA_API_VERSION_MINOR 0
+#define LUA_API_VERSION_MINOR 1
 /* bugfixes that should not change anything to the API */
 #define LUA_API_VERSION_PATCH 0
 /* suffix for unstable version */

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -18,6 +18,15 @@
 #include "lua/types.h"
 #include "lua/widget/common.h"
 
+#define NOT_USED 5
+
+/*
+  we can't guarantee the order of label and ellipsize calls so
+  sometimes we have to store the ellipsize mode until the 
+  label is created.
+*/
+static dt_lua_ellipsize_mode_t ellipsize_store = NOT_USED;
+
 static dt_lua_widget_type_t button_type = {
   .name = "button",
   .gui_init = NULL,
@@ -35,8 +44,24 @@ static void clicked_callback(GtkButton *widget, gpointer user_data)
       LUA_ASYNC_DONE);
 }
 
-
-
+static int ellipsize_member(lua_State *L)
+{
+  lua_button button;
+  luaA_to(L, lua_button, &button, 1);
+  dt_lua_ellipsize_mode_t ellipsize;
+  if(lua_gettop(L) > 2) {
+    luaA_to(L, dt_lua_ellipsize_mode_t, &ellipsize, 3);
+    // check for label before trying to ellipsize it
+    if(gtk_button_get_label(GTK_BUTTON(button->widget)))
+      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize);
+    else 
+      ellipsize_store = ellipsize;
+    return 0;
+  }
+  ellipsize = gtk_label_get_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))));
+  luaA_push(L, dt_lua_ellipsize_mode_t, &ellipsize);
+  return 1;
+}
 
 static int label_member(lua_State *L)
 {
@@ -45,6 +70,10 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     const char * label = luaL_checkstring(L,3);
     gtk_button_set_label(GTK_BUTTON(button->widget),label);
+    if(ellipsize_store != NOT_USED){
+      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store);
+      ellipsize_store = NOT_USED;
+    }
     return 0;
   }
   lua_pushstring(L,gtk_button_get_label(GTK_BUTTON(button->widget)));
@@ -72,6 +101,9 @@ int dt_lua_init_widget_button(lua_State* L)
   lua_pushcfunction(L,label_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_button, "label");
+  lua_pushcfunction(L,ellipsize_member);
+  dt_lua_gtk_wrap(L);
+  dt_lua_type_register(L, lua_button, "ellipsize");
   dt_lua_widget_register_gtk_callback(L,lua_button,"clicked","clicked_callback",G_CALLBACK(clicked_callback));
 
   return 0;


### PR DESCRIPTION
Add ellipsize function for button labels.  Lua API documentation updated.  Lua API version bumped to 6.0.1.

This fixes #5759 and is part of the fix for #5747.