### PR TITLE
Make lua stack resizable

### DIFF
--- a/doc/usermanual/lua/lua_api.xml
+++ b/doc/usermanual/lua/lua_api.xml
@@ -9212,6 +9212,48 @@ darktable.database.import(), then dt_lua_image_t.is_raw is not guaranteed to be 
     </tgroup></informaltable>
 </section>
 
+<section status="final" id="types_lua_stack_h_size_fixed">
+<title>types.lua_stack.h_size_fixed</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>h_size_fixed</secondary>
+</indexterm>
+<synopsis>boolean</synopsis>
+<para>True if horizontal size is fixed, false if stack can be resized horizontally.</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis><link linkend="attributes_write">write</link></emphasis></para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
+<section status="final" id="types_lua_stack_v_size_fixed">
+<title>types.lua_stack.v_size_fixed</title>
+<indexterm>
+<primary>Lua API</primary>
+<secondary>v_size_fixed</secondary>
+</indexterm>
+<synopsis>boolean</synopsis>
+<para>True if vertical size is fixed, false if stack can be resized vertically.</para>
+<informaltable frame="none" width="80%"><tgroup cols="2" colsep="0" rowsep="0">
+    <colspec colwidth="2*"/>
+    <colspec colwidth="8*"/>
+    <tbody><row>
+    <entry>Attributes:</entry>
+    <entry><itemizedlist>
+<listitem><para><emphasis><link linkend="attributes_write">write</link></emphasis></para></listitem>
+</itemizedlist>
+</entry>
+    </row></tbody>
+    </tgroup></informaltable>
+</section>
+
 </section>
 
 <section status="final" id="types_lua_slider">

--- a/src/lua/widget/stack.c
+++ b/src/lua/widget/stack.c
@@ -64,6 +64,35 @@ static int active_member(lua_State*L)
   return 1;
 }
 
+static int h_size_fixed_member(lua_State *L)
+{
+  lua_stack stack;
+  luaA_to(L, lua_stack, &stack, 1);
+  if(lua_gettop(L) > 2) {
+    gboolean resize = lua_toboolean(L,3);
+    gtk_stack_set_hhomogeneous(GTK_STACK(stack->widget), resize);
+    fprintf(stderr, "set horizontal resize\n\n\n");
+    return 0;
+  }
+  lua_pushboolean(L,gtk_stack_get_hhomogeneous(GTK_STACK(stack->widget)));
+  return 1;
+}
+
+
+static int v_size_fixed_member(lua_State *L)
+{
+  lua_stack stack;
+  luaA_to(L, lua_stack, &stack, 1);
+  if(lua_gettop(L) > 2) {
+    gboolean resize = lua_toboolean(L,3);
+    gtk_stack_set_vhomogeneous(GTK_STACK(stack->widget), resize);
+    fprintf(stderr, "set vertical resize\n\n\n\n");
+    return 0;
+  }
+  lua_pushboolean(L,gtk_stack_get_vhomogeneous(GTK_STACK(stack->widget)));
+  return 1;
+}
+
 int dt_lua_init_widget_stack(lua_State* L)
 {
   dt_lua_init_widget_type(L,&stack_type,lua_stack,GTK_TYPE_STACK);
@@ -71,6 +100,12 @@ int dt_lua_init_widget_stack(lua_State* L)
   lua_pushcfunction(L,active_member);
   dt_lua_gtk_wrap(L);
   dt_lua_type_register(L, lua_stack, "active");
+  lua_pushcfunction(L,h_size_fixed_member);
+  dt_lua_gtk_wrap(L);
+  dt_lua_type_register(L, lua_stack, "h_size_fixed");
+  lua_pushcfunction(L,v_size_fixed_member);
+  dt_lua_gtk_wrap(L);
+  dt_lua_type_register(L, lua_stack, "v_size_fixed");
   return 0;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh


### PR DESCRIPTION
Added horizontal and vertical stack resize members.  Updated Lua API with changes.

This completes the fix for #5747.