### PR TITLE
tether: properly initialize job name from conf

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -465,7 +465,7 @@
     <longdescription/>
   </dtconfig>
   <dtconfig>
-    <name>plugins/capture/jobcode</name>
+    <name>plugins/session/jobcode</name>
     <type>string</type>
     <default>capture job</default>
     <shortdescription>name of capture job</shortdescription>

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -341,7 +341,7 @@ void enter(dt_view_t *self)
   /* initialize a session */
   lib->session = dt_import_session_new();
 
-  char *tmp = dt_conf_get_string("plugins/capture/jobcode");
+  char *tmp = dt_conf_get_string("plugins/session/jobcode");
   if(tmp != NULL)
   {
     _capture_view_set_jobcode(self, tmp);


### PR DESCRIPTION
Complete the partial changeover from plugins/capture/jobcode to plugins/session/jobcode in 38b982b7725cc205a9746369779fcfa791890fbe.

This makes behavior consistent with the manual (default capture job is "capture job" rather than an empty string).