### PR TITLE
preferences: improved theme tweaks workflow

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1,6 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE dtconfiglist SYSTEM "darktableconfig.dtd">
 <dtconfiglist>
+  <dtconfig>
+    <name>themes/usercss</name>
+    <type>bool</type>
+    <default>true</default>
+    <shortdescription>modify theme with user tweaks</shortdescription>
+  </dtconfig>
   <dtconfig prefs="misc" section="accel">
     <name>accel/prefer_expanded</name>
     <type>bool</type>


### PR DESCRIPTION
changed label on css theme tweaks save button to read 'save and apply'
and amended its functionality so that it also automatically checks the
'modify selected theme...' checkbox before reloading the theme

this means that the save button always applies the theme immediately and
prevents issues where the user forgets to check the box

to prevent users inadvertently closing preferences without saving theme
tweaks, automatically save any changes on close (in line with the rest
of the screen). Changes will not be automatically applied (because they
are saved regardless of whether any edits were made and the user flag
may be unset)

theme tweaks check box is on by default

Resolves #5966.