### PR TITLE
allow all modules that can be disabled to be removed from history

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1185,7 +1185,7 @@ void dt_dev_pop_history_items_ext(dt_develop_t *dev, int32_t cnt)
     dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
     memcpy(module->params, module->default_params, module->params_size);
     dt_iop_commit_blend_params(module, module->default_blendop_params);
-    module->enabled = module->default_enabled;
+    module->enabled = (module->default_enabled && module->hide_enable_button);
 
     if(module->multi_priority == 0)
       module->iop_order = dt_ioppr_get_iop_order(dev->iop_order_list, module->op, module->multi_priority);
@@ -1420,6 +1420,20 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
     return FALSE;
   }
 
+  //now modules that can be disabled but are auto-on
+  for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
+
+    if(!dt_history_check_module_exists(imgid, module->op)
+       && module->default_enabled
+       && !module->hide_enable_button
+       && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
+    {
+      _dev_insert_module(dev, module, imgid);
+    }
+  }
+
   //add scene-referred workflow 
   if(dt_image_is_matrix_correction_supported(image)
      && strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
@@ -1534,19 +1548,6 @@ static void _dev_add_default_modules(dt_develop_t *dev, const int imgid)
     if(!dt_history_check_module_exists(imgid, module->op)
        && module->default_enabled
        && module->hide_enable_button
-       && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
-    {
-      _dev_insert_module(dev, module, imgid);
-    }
-  }
-  //now modules that can be disabled but are auto-on
-  for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
-  {
-    dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
-
-    if(!dt_history_check_module_exists(imgid, module->op)
-       && module->default_enabled
-       && !module->hide_enable_button
        && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
     {
       _dev_insert_module(dev, module, imgid);

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -353,7 +353,7 @@ void dt_dev_pixelpipe_synch_all(dt_dev_pixelpipe_t *pipe, dt_develop_t *dev)
   {
     dt_dev_pixelpipe_iop_t *piece = (dt_dev_pixelpipe_iop_t *)nodes->data;
     piece->hash = 0;
-    piece->enabled = piece->module->default_enabled;
+    piece->enabled = (piece->module->default_enabled && piece->module->hide_enable_button);
     dt_iop_commit_params(piece->module, piece->module->default_params, piece->module->default_blendop_params,
                          pipe, piece);
     nodes = g_list_next(nodes);


### PR DESCRIPTION
modules that are enabled by default (module->default_enabled) but can be manually disabled (!module->hide_enable_button) can now be removed from history

when selecting items in the history stack prior to such modules, the stack and image treat these modules as disabled

does not impact modules that are forced on and cannot be disabled (i.e. those with module->hide_enable_button set)

Resolves #5434