### PR TITLE
Bilateral filter  memory limits

### DIFF
--- a/src/common/bilateral.h
+++ b/src/common/bilateral.h
@@ -48,14 +48,17 @@ size_t dt_bilateral_singlebuffer_size2(const int width,      // width of input i
                                        const float sigma_s,  // spatial sigma (blur pixel coords)
                                        const float sigma_r); // range sigma (blur luma values)
 
+void dt_bilateral_grid_size(dt_bilateral_t *b, const int width, const int height, const float L_range,
+                            float sigma_s, const float sigma_r);
+
 dt_bilateral_t *dt_bilateral_init(const int width,      // width of input image
                                   const int height,     // height of input image
                                   const float sigma_s,  // spatial sigma (blur pixel coords)
                                   const float sigma_r); // range sigma (blur luma values)
 
-void dt_bilateral_splat(dt_bilateral_t *b, const float *const in);
+void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in);
 
-void dt_bilateral_blur(dt_bilateral_t *b);
+void dt_bilateral_blur(const dt_bilateral_t *b);
 
 void dt_bilateral_slice(const dt_bilateral_t *const b, const float *const in, float *out, const float detail);
 


### PR DESCRIPTION
Consolidate the two separate code paths computing memory requirements, and slightly reduce the maximum size of the bilateral grid.  Making the limits the same for CPU and GPU will also reduce differences in results under extreme settings.

Added null-pointer checks to prevent crash if we do in fact run out of memory (fixes #5949).  I'll be working on a separate PR that will rework the CPU code path such that memory requirements are independent of the number of threads.

This PR is independent of #5964, which should be merged as well.
