### PR TITLE
filmic : improve graph view for user education

### DIFF
--- a/src/gui/draw.h
+++ b/src/gui/draw.h
@@ -145,6 +145,14 @@ static inline void dt_draw_grid_zoomed(cairo_t *cr, const int num, const float l
   }
 }
 
+#ifdef _OPENMP
+#pragma omp declare simd uniform(base)
+#endif
+static inline float dt_log_scale_axis(const float x, const float base)
+{
+  return logf(x * (base - 1.0f) + 1.f) / logf(base);
+}
+
 static inline void dt_draw_loglog_grid(cairo_t *cr, const int num, const int left, const int top, const int right,
                                        const int bottom, const float base)
 {
@@ -153,7 +161,7 @@ static inline void dt_draw_loglog_grid(cairo_t *cr, const int num, const int lef
 
   for(int k = 1; k < num; k++)
   {
-    const float x = logf(k / (float)num * (base - 1.0f) + 1) / logf(base);
+    const float x = dt_log_scale_axis(k / (float)num, base);
     dt_draw_line(cr, left + x * width, top, left + x * width, bottom);
     cairo_stroke(cr);
     dt_draw_line(cr, left, top + x * height, right, top + x * height);
@@ -169,7 +177,7 @@ static inline void dt_draw_semilog_x_grid(cairo_t *cr, const int num, const int 
 
   for(int k = 1; k < num; k++)
   {
-    const float x = logf(k / (float)num * (base - 1.0f) + 1) / logf(base);
+    const float x = dt_log_scale_axis(k / (float)num, base);
     dt_draw_line(cr, left + x * width, top, left + x * width, bottom);
     cairo_stroke(cr);
     dt_draw_line(cr, left, top + k / (float)num * height, right, top + k / (float)num * height);
@@ -185,7 +193,7 @@ static inline void dt_draw_semilog_y_grid(cairo_t *cr, const int num, const int 
 
   for(int k = 1; k < num; k++)
   {
-    const float x = logf(k / (float)num * (base - 1.0f) + 1) / logf(base);
+    const float x = dt_log_scale_axis(k / (float)num, base);
     dt_draw_line(cr, left + k / (float)num * width, top, left + k / (float)num * width, bottom);
     cairo_stroke(cr);
     dt_draw_line(cr, left, top + x * height, right, top + x * height);


### PR DESCRIPTION
Some users still have a hard time to understand what filmic does, is, or how it compares to base curve.

This PR aims at providing more graph views presenting information in different ways. Cycling through the views is achieved by clicking on the graph (left click : forward, right click : backward, double click : reset).

## Default view : look only

It's the old one but with legends added.
![Screenshot_20200817_023947](https://user-images.githubusercontent.com/2779157/90347953-c027a900-e033-11ea-838b-155b9455d79e.png)
The scene EVs in abscissa are meant to say that the bounds of the graph are actually scalable, which is a major difference compared to classic tone curves (bounded to 0-100% by design). What we do is actually scaling this look to whatever dynamic range we have in input.

## Look + mapping (linear)
![Screenshot_20200817_023958](https://user-images.githubusercontent.com/2779157/90348000-14328d80-e034-11ea-800b-a0713a2ece96.png)
This is actually the base curve that the whole module, by stacking the log mapping first, then the look, then the power function. It is meant to be compared to the base curve module, so abscissa ends at 100% but the true position of the white point is still noted inside parentheses.

## Look + mapping (log)
![Screenshot_20200817_024006](https://user-images.githubusercontent.com/2779157/90348051-53f97500-e034-11ea-834a-b427c13f841f.png)
Same as the previous one, but rescaled with a log transform which is the same as the base curve log view. This helps looking at the lowlights.

## Dynamic range mapping
![Screenshot_20200817_024016](https://user-images.githubusercontent.com/2779157/90348080-6f648000-e034-11ea-9ee2-34be2dc4d1c2.png)
This is the innovation here, inspired by the graphs I drew in my videos to explain the concept of tone mapping. It uses the zone system formalism to show how the dynamic range is remapped (1D to 1D, instead of the usual 2D curve which, if you ask me, adds more confusion than anything), especially which EV will be dilated and which ones will be compressed. It also tries to show that the grey point is our fulcrum/pivot here, so it is the only value that will travel through filmic unaffected.
