### PR TITLE
Bilateral filter rewrite: faster and less memory

### DIFF
--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -70,7 +70,7 @@ size_t dt_bilateral_memory_use(const int width,     // width of input image
   // OpenCL path needs two buffers
   return 2 * grid_size * sizeof(float);
 #else
-  return (grid_size + 2 * b.size_x * b.size_z) * sizeof(float);
+  return (grid_size + 3 * darktable.num_openmp_threads * b.size_x * b.size_z) * sizeof(float);
 #endif /* HAVE_OPENCL */
 }
 
@@ -94,7 +94,7 @@ size_t dt_bilateral_singlebuffer_size(const int width,     // width of input ima
   dt_bilateral_t b;
   dt_bilateral_grid_size(&b,width,height,100.0f,sigma_s,sigma_r);
   size_t grid_size = b.size_x * b.size_y * b.size_z;
-  return (grid_size + 2 * b.size_x * b.size_z) * sizeof(float);
+  return (grid_size + 3 * darktable.num_openmp_threads * b.size_x * b.size_z) * sizeof(float);
 }
 
 #ifndef HAVE_OPENCL
@@ -147,7 +147,7 @@ dt_bilateral_t *dt_bilateral_init(const int width,     // width of input image
   b->height = height;
   b->numslices = darktable.num_openmp_threads;
   b->sliceheight = (height + b->numslices - 1) / b->numslices;
-  b->slicerows = (b->size_y + b->numslices - 1) / b->numslices + 1;
+  b->slicerows = (b->size_y + b->numslices - 1) / b->numslices + 2;
   b->buf = dt_alloc_align(64, b->size_x * b->size_z * b->numslices * b->slicerows * sizeof(float));
   if (b->buf)
   {

--- a/src/common/bilateral.c
+++ b/src/common/bilateral.c
@@ -251,7 +251,7 @@ void dt_bilateral_splat(const dt_bilateral_t *b, const float *const in)
       dest += oy;
       // clear elements in the part of the buffer which holds the final result now that we've read the partial result,
       // since we'll be adding to those locations later
-      if (j < b->height)
+      if (j < b->size_y)
         memset(buf + j*oy, '\0', oy*sizeof(float));
     }
   }

--- a/src/common/bilateral.h
+++ b/src/common/bilateral.h
@@ -24,6 +24,7 @@ typedef struct dt_bilateral_t
 {
   size_t size_x, size_y, size_z;
   int width, height;
+  int numslices, sliceheight, slicerows; //height--in input image, rows--in grid
   float sigma_s, sigma_r;
   float *buf __attribute__((aligned(64)));
 } __attribute__((packed)) dt_bilateral_t;


### PR DESCRIPTION
Final fix for #5949.  Supercedes #5278.

Memory use is now proportional to (gridheight + 3*threads) instead of (gridheight * threads).  I've also incorporated speedups from #5278.
