### PR TITLE
rename iop modules inline

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -604,7 +604,8 @@ overshoot.right
 {
   background-color: @bg_color;
   color: @plugin_label_color;
-  border:0;
+  border: 0;
+  margin: 0;
   padding: 0 2px 2px 0.45em;
   font-weight: normal;
   font-family: sans-serif;


### PR DESCRIPTION
to rename a multi-instance module, add a GtkEntry to the module header in the panel and resize it to its current content dynamically.

no longer requires a popup or popover window.