### PR TITLE
copy_history: Take copy of images list before discarding history

### DIFF
--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -217,12 +217,13 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
   gint res = GTK_RESPONSE_YES;
 
   const GList *imgs = dt_view_get_images_to_act_on(TRUE, TRUE);
+  GList *imgs_copy = g_list_copy((GList *)imgs);
 
   if(dt_conf_get_bool("ask_before_discard"))
   {
     const GtkWidget *win = dt_ui_main_window(darktable.gui->ui);
 
-    const int number = g_list_length((GList *)imgs);
+    const int number = g_list_length((GList *)imgs_copy);
 
     if (number == 0) return;
 
@@ -241,12 +242,14 @@ static void discard_button_clicked(GtkWidget *widget, gpointer user_data)
 
   if(res == GTK_RESPONSE_YES)
   {
-    dt_history_delete_on_list(imgs, TRUE);
+    dt_history_delete_on_list(imgs_copy, TRUE);
 
     dt_collection_update_query(darktable.collection, DT_COLLECTION_CHANGE_RELOAD,
-                               g_list_copy((GList *)imgs));
+                               g_list_copy((GList *)imgs_copy));
     dt_control_queue_redraw_center();
   }
+
+  g_list_free(imgs_copy);
 }
 
 static void paste_button_clicked(GtkWidget *widget, gpointer user_data)


### PR DESCRIPTION
Keep a copy of the list of images to be acted on as the list could be
overwritten by the subsequent dialog and signals being raised.

Resolves #6014