### PR TITLE
export(disk): set entry cursor position to end by default

### DIFF
--- a/src/imageio/storage/disk.c
+++ b/src/imageio/storage/disk.c
@@ -141,6 +141,7 @@ static void button_clicked(GtkWidget *widget, dt_imageio_module_storage_t *self)
     gchar *escaped = dt_util_str_replace(composed, "\\", "\\\\");
 
     gtk_entry_set_text(GTK_ENTRY(d->entry), escaped); // the signal handler will write this to conf
+    gtk_editable_set_position(GTK_EDITABLE(d->entry), strlen(escaped));
     g_free(dir);
     g_free(composed);
     g_free(escaped);
@@ -174,6 +175,7 @@ void gui_init(dt_imageio_module_storage_t *self)
   if(dir)
   {
     gtk_entry_set_text(GTK_ENTRY(widget), dir);
+    gtk_editable_set_position(GTK_EDITABLE(widget), strlen(dir));
     g_free(dir);
   }
 
@@ -386,6 +388,7 @@ int set_params(dt_imageio_module_storage_t *self, const void *params, const int 
   if(size != self->params_size(self)) return 1;
 
   gtk_entry_set_text(GTK_ENTRY(g->entry), d->filename);
+  gtk_editable_set_position(GTK_EDITABLE(g->entry), strlen(d->filename));
   dt_bauhaus_combobox_set(g->onsave_action, d->onsave_action);
   return 0;
 }


### PR DESCRIPTION
when entering file paths in the export selected lib module the most significant and most edited information is usually at the right-most end of the path.

this change defaults the cursor position to the end of the entry widget when initiating the module, selecting a directory or applying a preset.

So by default it will display something like this:

![Screenshot_2020-08-20_17-24-47](https://user-images.githubusercontent.com/9555491/90798692-2d745c00-e30a-11ea-8a07-99c65dc0aec1.png)

instead of this:

![Screenshot_2020-08-20_17-27-06](https://user-images.githubusercontent.com/9555491/90798859-66accc00-e30a-11ea-81e3-f1dab7b0cce0.png)