### PR TITLE
Changes to allow preview downsampling rate change in run time

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -77,13 +77,6 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dt_pthread_mutex_init(&dev->preview2_pipe_mutex, NULL);
   dev->histogram_pre_tonecurve = NULL;
   dev->histogram_pre_levels = NULL;
-  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
-  dev->preview_downsampling =
-    (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
-    : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
-    : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
-    : 0.25f;
-  g_free(preview_downsample);
   dev->forms = NULL;
   dev->form_visible = NULL;
   dev->form_gui = NULL;
@@ -97,7 +90,13 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
     dt_dev_pixelpipe_init(dev->pipe);
     dt_dev_pixelpipe_init_preview(dev->preview_pipe);
     dt_dev_pixelpipe_init_preview2(dev->preview2_pipe);
-
+    gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+    dev->preview_downsampling =
+      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
+      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
+      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
+      : 0.25f;
+    g_free(preview_downsample);
     dev->histogram_pre_tonecurve = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
     dev->histogram_pre_levels = (uint32_t *)calloc(4 * 256, sizeof(uint32_t));
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1870,6 +1870,22 @@ static void _preference_changed(gpointer instance, gpointer user_data)
   dt_dynamic_accel_get_valid_list();
 }
 
+static void _preference_prev_downsample_change(gpointer instance, gpointer user_data)
+{
+  gchar *preview_downsample = dt_conf_get_string("preview_downsampling");
+  if(user_data != NULL)
+  {
+    float *preview_downsampling = user_data;
+    *preview_downsampling =
+      (g_strcmp0(preview_downsample, "original") == 0) ? 1.0f
+      : (g_strcmp0(preview_downsample, "to 1/2")==0) ? 0.5f
+      : (g_strcmp0(preview_downsample, "to 1/3")==0) ? 1/3.0f
+      : 0.25f;
+  }
+
+  g_free(preview_downsample);
+}
+
 static void _update_display_profile_cmb(GtkWidget *cmb_display_profile)
 {
   GList *l = darktable.color_profiles->profiles;
@@ -2361,6 +2377,8 @@ void gui_init(dt_view_t *self)
 
     _update_softproof_gamut_checking(dev);
 
+    dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                              G_CALLBACK(_preference_prev_downsample_change), &(dev->preview_downsampling));                                                                                                           
     // update the gui when the preferences changed (i.e. show intent when using lcms2)
     dt_control_signal_connect(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
                               G_CALLBACK(_preference_changed), (gpointer)display_intent);


### PR DESCRIPTION
This is an update on PR5336, which I killed due to too many changes etc.

It's quite a small change that allows the preview downsampling rate to be changed in run time. It might still be better to leave darkroom and re-enter... there seems to me to be some strangeness in the zoom control if I remain in darkroom.