### PR TITLE
histogram: clear scopes when leave live view

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -300,6 +300,17 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
                                      dt_colorspaces_color_profile_type_t in_profile_type, const gchar *in_profile_filename)
 {
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
+
+  // special case, clear the scopes
+  if(!input)
+  {
+    dt_pthread_mutex_lock(&d->lock);
+    memset(d->histogram, 0, sizeof(uint32_t) * 4 * HISTOGRAM_BINS);
+    memset(d->waveform, 0, sizeof(uint8_t) * d->waveform_height * d->waveform_stride * 3);
+    dt_pthread_mutex_unlock(&d->lock);
+    return;
+  }
+
   dt_develop_t *dev = darktable.develop;
   float *const img_display = dt_alloc_align(64, width * height * 4 * sizeof(float));
   if(!img_display) return;

--- a/src/views/tethering.c
+++ b/src/views/tethering.c
@@ -273,7 +273,6 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
       {
         dt_imageio_flip_buffers_ui8_to_float(tmp_f, p_buf, 0.0f, 255.0f, 4,
                                              pw, ph, pw, ph, 4 * pw, ORIENTATION_NONE);
-        // FIXME: this histogram isn't a precise match for when the equivalent image is captured -- though the live view histogram is a good match -- is something off?
         // FIXME: if liveview image is tagged and we can read its colorspace, use that
         darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, tmp_f, pw, ph,
                                                DT_COLORSPACE_SRGB, "");
@@ -283,7 +282,6 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
     }
     dt_pthread_mutex_unlock(&cam->live_view_buffer_mutex);
   }
-  // FIXME: set histogram data to blank and draw blank if there is no active image -- or make a test in histogram draw which will know to draw it blank
   else if(lib->image_id >= 0) // First of all draw image if available
   {
     // FIXME: every time the mouse moves over the center view this redraws, which isn't necessary
@@ -335,6 +333,13 @@ static void _expose_tethered_mode(dt_view_t *self, cairo_t *cr, int32_t width, i
       dt_control_queue_redraw_widget(darktable.lib->proxy.histogram.module->widget);
       free(dat.buf);
     }
+  }
+  else // not in live view, no image selected
+  {
+    // if we just left live view, blank out its histogram
+    darktable.lib->proxy.histogram.process(darktable.lib->proxy.histogram.module, NULL, 0, 0,
+                                           DT_COLORSPACE_NONE, "");
+    dt_control_queue_redraw_widget(darktable.lib->proxy.histogram.module->widget);
   }
 }
 


### PR DESCRIPTION
Behavior up until now has been that if:

1) enter tether view with a new session (no image selected)
2) enter live view
3) leave live view

The live view image disappears in the center view, but the histogram from that live view image remains.

This PR blacks out the histogram as well in this case.

Also, it removes an obsolete comment about histograms not matching.