### PR TITLE
make "work profile" work in tether view histogram

### DIFF
--- a/src/common/colorspaces.h
+++ b/src/common/colorspaces.h
@@ -174,6 +174,9 @@ cmsHPROFILE dt_colorspaces_create_alternate_profile(const char *makermodel);
 /** just get the associated transformation matrix, for manual application. */
 int dt_colorspaces_get_darktable_matrix(const char *makermodel, float *matrix);
 
+/** return the work profile as set in colorin */
+const dt_colorspaces_color_profile_t *dt_colorspaces_get_work_profile(const int imgid);
+
 /** return the output profile as set in colorout, taking export override into account if passed in. */
 const dt_colorspaces_color_profile_t *dt_colorspaces_get_output_profile(const int imgid,
                                                                         dt_colorspaces_color_profile_type_t over_type,

--- a/src/common/iop_profile.c
+++ b/src/common/iop_profile.c
@@ -729,7 +729,7 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_iop_work_profile_info(struct dt_iop
   if(in_between)
   {
     dt_colorspaces_color_profile_type_t type = DT_COLORSPACE_NONE;
-    char *filename = NULL;
+    const char *filename = NULL;
     dt_develop_t *dev = module->dev;
 
     dt_ioppr_get_work_profile_type(dev, &type, &filename);
@@ -757,7 +757,7 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_set_pipe_work_profile_info(struct dt_de
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_develop_t *dev)
 {
   dt_colorspaces_color_profile_type_t histogram_profile_type;
-  char *histogram_profile_filename;
+  const char *histogram_profile_filename;
   dt_ioppr_get_histogram_profile_type(&histogram_profile_type, &histogram_profile_filename);
   return dt_ioppr_add_profile_info_to_list(dev, histogram_profile_type, histogram_profile_filename,
                                            DT_INTENT_PERCEPTUAL);
@@ -770,7 +770,7 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_de
 
 // returns a pointer to the filename of the work profile instead of the actual string data
 // pointer must not be stored
-void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename)
+void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type, const char **profile_filename)
 {
   *profile_type = DT_COLORSPACE_NONE;
   *profile_filename = NULL;
@@ -819,7 +819,7 @@ void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type,
     fprintf(stderr, "[dt_ioppr_get_work_profile_type] can't find colorin iop\n");
 }
 
-void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename)
+void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_type, const char **profile_filename)
 {
   *profile_type = DT_COLORSPACE_NONE;
   *profile_filename = NULL;
@@ -868,7 +868,7 @@ void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_typ
     fprintf(stderr, "[dt_ioppr_get_export_profile_type] can't find colorout iop\n");
 }
 
-void dt_ioppr_get_histogram_profile_type(int *profile_type, char **profile_filename)
+void dt_ioppr_get_histogram_profile_type(int *profile_type, const char **profile_filename)
 {
   const dt_colorspaces_color_mode_t mode = darktable.color_profiles->mode;
 

--- a/src/common/iop_profile.h
+++ b/src/common/iop_profile.h
@@ -89,11 +89,11 @@ dt_iop_order_iccprofile_info_t *dt_ioppr_get_histogram_profile_info(struct dt_de
 dt_iop_order_iccprofile_info_t *dt_ioppr_get_pipe_work_profile_info(struct dt_dev_pixelpipe_t *pipe);
 
 /** returns the current setting of the work profile on colorin iop */
-void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename);
+void dt_ioppr_get_work_profile_type(struct dt_develop_t *dev, int *profile_type, const char **profile_filename);
 /** returns the current setting of the export profile on colorout iop */
-void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_type, char **profile_filename);
+void dt_ioppr_get_export_profile_type(struct dt_develop_t *dev, int *profile_type, const char **profile_filename);
 /** returns the current setting of the histogram profile */
-void dt_ioppr_get_histogram_profile_type(int *profile_type, char **profile_filename);
+void dt_ioppr_get_histogram_profile_type(int *profile_type, const char **profile_filename);
 
 /** transforms image from cst_from to cst_to colorspace using profile_info */
 void dt_ioppr_transform_image_colorspace(struct dt_iop_module_t *self, const float *const image_in,

--- a/src/develop/pixelpipe_hb.c
+++ b/src/develop/pixelpipe_hb.c
@@ -811,8 +811,8 @@ static void _pixelpipe_pick_live_samples(const float *const input, const dt_iop_
   cmsHTRANSFORM xform_rgb2lab = NULL;
   cmsHTRANSFORM xform_rgb2rgb = NULL;
   dt_colorspaces_color_profile_type_t histogram_type = DT_COLORSPACE_SRGB;
-  gchar *histogram_filename = NULL;
-  gchar _histogram_filename[1] = { 0 };
+  const gchar *histogram_filename = NULL;
+  const gchar _histogram_filename[1] = { 0 };
 
   dt_ioppr_get_histogram_profile_type(&histogram_type, &histogram_filename);
   if(histogram_filename == NULL) histogram_filename = _histogram_filename;
@@ -881,8 +881,8 @@ static void _pixelpipe_pick_primary_colorpicker(dt_develop_t *dev, const float *
   cmsHTRANSFORM xform_rgb2lab = NULL;
   cmsHTRANSFORM xform_rgb2rgb = NULL;
   dt_colorspaces_color_profile_type_t histogram_type = DT_COLORSPACE_SRGB;
-  gchar *histogram_filename = NULL;
-  gchar _histogram_filename[1] = { 0 };
+  const gchar *histogram_filename = NULL;
+  const gchar _histogram_filename[1] = { 0 };
 
   dt_ioppr_get_histogram_profile_type(&histogram_type, &histogram_filename);
   if(histogram_filename == NULL) histogram_filename = _histogram_filename;

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -112,7 +112,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
 //   dt_accel_connect_slider_iop(self, "color scheme", GTK_WIDGET(g->colorscheme));
 // }
 
-static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *out_type, gchar **out_filename)
+// FIXME: this is pretty much a duplicate of dt_ioppr_get_histogram_profile_type() excepting that it doesn't check darktable.color_profiles->mode
+static void _get_histogram_profile_type(dt_colorspaces_color_profile_type_t *out_type, const gchar **out_filename)
 {
   // if in gamut check use soft proof
   if(darktable.color_profiles->histogram_type == DT_COLORSPACE_SOFTPROOF)
@@ -139,7 +140,7 @@ static void _transform_image_colorspace(dt_iop_module_t *self, const float *cons
                                         const dt_iop_roi_t *const roi_in)
 {
   dt_colorspaces_color_profile_type_t histogram_type = DT_COLORSPACE_SRGB;
-  gchar *histogram_filename = NULL;
+  const gchar *histogram_filename = NULL;
 
   _get_histogram_profile_type(&histogram_type, &histogram_filename);
 
@@ -226,7 +227,7 @@ static void _transform_image_colorspace_cl(dt_iop_module_t *self, const int devi
                                            cl_mem dev_img_out, const dt_iop_roi_t *const roi_in)
 {
   dt_colorspaces_color_profile_type_t histogram_type = DT_COLORSPACE_SRGB;
-  gchar *histogram_filename = NULL;
+  const gchar *histogram_filename = NULL;
 
   _get_histogram_profile_type(&histogram_type, &histogram_filename);
 

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -320,7 +320,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
 
   const dt_iop_order_iccprofile_info_t *profile_info_to;
   dt_colorspaces_color_profile_type_t histogram_profile_type;
-  char *histogram_profile_filename;
+  const char *histogram_profile_filename;
   // this returns DT_COLORSPACE_NONE for if profile is
   // DT_COLORSPACE_EXPORT or DT_COLORSPACE_WORK and are in tether view
   dt_ioppr_get_histogram_profile_type(&histogram_profile_type, &histogram_profile_filename);

--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -301,6 +301,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
 {
   dt_lib_histogram_t *d = (dt_lib_histogram_t *)self->data;
   dt_develop_t *dev = darktable.develop;
+  float *img_display = NULL;
 
   // special case, clear the scopes
   if(!input)
@@ -312,53 +313,47 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
     return;
   }
 
-  float *const img_display = dt_alloc_align(64, width * height * 4 * sizeof(float));
-  if(!img_display) return;
-
-  const dt_iop_order_iccprofile_info_t *const profile_info_from
-    = dt_ioppr_add_profile_info_to_list(dev, in_profile_type, in_profile_filename, INTENT_PERCEPTUAL);
-
-  const dt_iop_order_iccprofile_info_t *profile_info_to;
-  dt_colorspaces_color_profile_type_t histogram_profile_type;
-  const char *histogram_profile_filename;
-  // this returns DT_COLORSPACE_NONE for if profile is
-  // DT_COLORSPACE_EXPORT or DT_COLORSPACE_WORK and are in tether view
-  dt_ioppr_get_histogram_profile_type(&histogram_profile_type, &histogram_profile_filename);
-  if(histogram_profile_type != DT_COLORSPACE_NONE)
+  // If showing a selected image in tether view, then the image is
+  // already in histogram profile. If the image is from live view and
+  // histogram profile is DT_COLORSPACE_WORK or DT_COLORSPACE_EXPORT,
+  // we just show the image as-is, as the image hasn't gone through
+  // the pixelpipe. Otherwise, convert it to histogram profile.
+  // FIXME: detect whether in live view (darktable.develop state should give a clue) and if so if histogram profile is DT_COLORSPACE_WORK use linear rec 2020 as a reasonable default, if profile is export skip this conversion
+  if(in_profile_type != DT_COLORSPACE_NONE)
   {
-    profile_info_to = dt_ioppr_add_profile_info_to_list(dev, histogram_profile_type, histogram_profile_filename,
-                                                        DT_INTENT_PERCEPTUAL);
-  }
-  else
-  {
-    // Noop transform. If showing a selected image in tether view, no
-    // transform needed for histogram profile
-    // DT_COLORSPACE_EXPORT. It's up to tether view to give us an
-    // image in work profile, and again we don't convert it. If the
-    // image is from live view, we just show the image as-is, as the
-    // image hasn't gone through the pixelpipe.
-    // FIXME: do something nice with pointers to save a memcpy.
-    profile_info_to = profile_info_from;
-  }
+    dt_colorspaces_color_profile_type_t out_profile_type;
+    const char *out_profile_filename;
+    const dt_iop_order_iccprofile_info_t *const profile_info_from
+      = dt_ioppr_add_profile_info_to_list(dev, in_profile_type, in_profile_filename, INTENT_PERCEPTUAL);
+    dt_ioppr_get_histogram_profile_type(&out_profile_type, &out_profile_filename);
 
-  dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,
-                                          profile_info_to, "final histogram");
+    if(out_profile_type != DT_COLORSPACE_NONE)
+    {
+      const dt_iop_order_iccprofile_info_t *profile_info_to =
+        dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
+      img_display = dt_alloc_align(64, width * height * 4 * sizeof(float));
+      if(!img_display) return;
+      dt_ioppr_transform_image_colorspace_rgb(input, img_display, width, height, profile_info_from,
+                                              profile_info_to, "final histogram");
+    }
+  }
 
   dt_pthread_mutex_lock(&d->lock);
   switch(d->scope_type)
   {
     case DT_LIB_HISTOGRAM_SCOPE_HISTOGRAM:
-      _lib_histogram_process_histogram(d, img_display, width, height);
+      _lib_histogram_process_histogram(d, img_display ? img_display : input, width, height);
       break;
     case DT_LIB_HISTOGRAM_SCOPE_WAVEFORM:
-      _lib_histogram_process_waveform(d, img_display, width, height);
+      _lib_histogram_process_waveform(d, img_display ? img_display : input, width, height);
       break;
     case DT_LIB_HISTOGRAM_SCOPE_N:
       g_assert_not_reached();
   }
   dt_pthread_mutex_unlock(&d->lock);
 
-  dt_free_align(img_display);
+  if(img_display)
+    dt_free_align(img_display);
 }
 
 static void _draw_color_toggle(cairo_t *cr, float x, float y, float width, float height, gboolean state)


### PR DESCRIPTION
Previously if the histogram profile was "work profile" the data was displayed in the export profile.

This fix also led to realizing that in tether view the code can just export the image straight to the histogram profile. This saves a colorspace in conversion in most cases, and always saves some unneeded allocation/copying.

To make all this work I had to add a new routine `dt_colorspaces_get_work_profile()` to colorspace.c and add a bunch of const's to make the colorspaces and iop_profile code agree with each other.

This is a follow-up to #5714, to fix loose ends.