### PR TITLE
Removes all-in-one mixing process, adds normalisation and adjustable …

### DIFF
--- a/data/darktableconfig.dtd
+++ b/data/darktableconfig.dtd
@@ -11,6 +11,7 @@
 <!ATTLIST type
 	min CDATA #IMPLIED
 	max CDATA #IMPLIED
+    digits CDATA #IMPLIED                         
 	factor CDATA #IMPLIED
 >
 <!ELEMENT enum (option)+>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -990,6 +990,20 @@
     <shortdescription>show search module text entry</shortdescription>
     <longdescription/>
   </dtconfig>
+  <dtconfig prefs="darkroom">
+    <name>channel_mixer_lower_limit</name>
+    <type min="-2.0" max="0.0" digits="1">float</type>
+    <default>-0.5</default>
+    <shortdescription>set lower bound for channel mixer sliders</shortdescription>
+    <longdescription/>
+  </dtconfig>
+  <dtconfig prefs="darkroom">
+    <name>channel_mixer_upper_limit</name>
+    <type min="0.5" max="2.0" digits="1">float</type>
+    <default>1.0</default>
+    <shortdescription>set upper bound for channel mixer sliders</shortdescription>
+    <longdescription/>
+  </dtconfig>
   <dtconfig>
     <name>database_cache_quality</name>
     <type>int</type>

--- a/tools/generate_prefs.xsl
+++ b/tools/generate_prefs.xsl
@@ -555,15 +555,16 @@ gboolean restart_required = FALSE;
   </xsl:template>
 
   <xsl:template match="dtconfig[type='float']" mode="tab">
-    <xsl:text>    float min = -1000000000.0f;&#xA;    float max = 1000000000.0f;&#xA;</xsl:text>
+    <xsl:text>    float min = -1000000000.0f;&#xA;    float max = 1000000000.0f;&#xA;    int digits = 5;&#xA;</xsl:text>
     <xsl:apply-templates select="type" mode="range"/>
     <xsl:text>  </xsl:text><xsl:apply-templates select="type" mode="factor"/>
-    <xsl:text>    min *= factor; max *= factor;
-    widget = gtk_spin_button_new_with_range(min, max, 0.001f);
+    <xsl:text>  float steps = pow(10, -digits);
+    min *= factor; max *= factor;
+    widget = gtk_spin_button_new_with_range(min, max, steps);
     box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
     gtk_box_pack_start(GTK_BOX(box), widget, FALSE, FALSE, 0);
     gtk_widget_set_hexpand(widget, FALSE);
-    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), 5);
+    gtk_spin_button_set_digits(GTK_SPIN_BUTTON(widget), digits);
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), dt_conf_get_float("</xsl:text><xsl:value-of select="name"/><xsl:text>") * factor);
     </xsl:text>
     <xsl:if test="@restart">
@@ -639,9 +640,25 @@ gboolean restart_required = FALSE;
   </xsl:template>
 
 <!-- Grab min/max from input. Is there a better way? -->
+  <xsl:template match="type[@min and @max and @digits]" mode="range" priority="7">
+    <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+  
   <xsl:template match="type[@min and @max]" mode="range" priority="5">
     <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
     <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="type[@max and @digits]" mode="range" priority="5">
+    <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+  
+  <xsl:template match="type[@max and @digits]" mode="range" priority="5">
+    <xsl:text>    min = </xsl:text><xsl:value-of select="@min"/><xsl:text>;&#xA;</xsl:text>
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type[@min]" mode="range" priority="3">
@@ -650,6 +667,10 @@ gboolean restart_required = FALSE;
 
   <xsl:template match="type[@max]" mode="range" priority="3">
     <xsl:text>    max = </xsl:text><xsl:value-of select="@max"/><xsl:text>;&#xA;</xsl:text>
+  </xsl:template>
+  
+  <xsl:template match="type[@max and @digits]" mode="range" priority="3">
+    <xsl:text>    digits = </xsl:text><xsl:value-of select="@digits"/><xsl:text>;&#xA;</xsl:text>
   </xsl:template>
 
   <xsl:template match="type" mode="range"  priority="1">
@@ -664,6 +685,5 @@ gboolean restart_required = FALSE;
   <xsl:template match="type" mode="factor"  priority="1">
     <xsl:text>  float factor = 1.0f;&#xA;</xsl:text>
   </xsl:template>
-
 
 </xsl:stylesheet>


### PR DESCRIPTION
…sliders

This is a "channelmixer easy" fix as suggested by @johnny-bit in discussions with @elstoc @hlecleme @aurelienpierre and @TurboGit, to take up the slack while @aurelienpierre gets his new improved channelmixer up and firing. Having a simple version can't hurt, and I had it, so here it is. 

It removes what Aurélien described as a "clusterfuck" ... there are now three implementations of the mixing algorithm, separate for mono, linear colour and for hsl. Excepting the last case, this should result in a speed up. I think I've done a reasonable job of compacting the code into functions so there is minimal redundancy.

It also removes the clipping issue for greymode and linear colour, since that was required only for the hsl version.

To avoid needing a database update, I've added a preset "color (default)" which is simply an identity matrix in the linear colour part: clicking this takes you out of the grey-mix and returns you to living colour :-)

Along the way, I added in a normalisation option, and created the possibility of using non-integer slider range presents via the config file. This applies to the mono mixing mode (where I think it's very useful), but also to the three colour outputs of the linear colour mode, but only to the lightness setting of the HSL. In each (other) case, there is a button to turn it off.