### PR TITLE
theme module name edit entry background color

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -598,6 +598,11 @@ overshoot.right
   padding: 0.5em 0.5em 0.5em 0.5em;
 }
 
+#module-header entry 
+{
+  background-color: @field_active_bg;
+}
+
 /* Labels in modules */
 #iop-panel-label,
 #lib-panel-label


### PR DESCRIPTION
Make new inline editing of (multi-instance) module names (introduced in #6021) more obvious with a different background color.

![image](https://user-images.githubusercontent.com/1549490/90978647-4453c200-e547-11ea-9da3-3f5b7733f3b5.png)

@Nilvus I've named the entry widget #iop-panel-label so that it picks up the same padding etc settings of the module name itself, but this also, I assume, blocks
```
entry:active
{
  color: @field_active_fg;
  background-color: @field_active_bg;
}
```
If there is a better/more correct/consistent approach to doing this, I'm happy to amend this PR. However it currently achieves the hoped-for look in all three official themes.