### PR TITLE
filmic : fix silent bug, optimize defaults

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -19,25 +19,25 @@
 #include "config.h"
 #endif
 #include "bauhaus/bauhaus.h"
-#include "common/image.h"
-#include "common/iop_profile.h"
 #include "common/colorspaces_inline_conversions.h"
 #include "common/darktable.h"
+#include "common/image.h"
+#include "common/iop_profile.h"
 #include "common/opencl.h"
 #include "control/control.h"
 #include "develop/develop.h"
-#include "develop/imageop_math.h"
 #include "develop/imageop_gui.h"
+#include "develop/imageop_math.h"
 #include "dtgtk/button.h"
 #include "dtgtk/drawingarea.h"
 #include "dtgtk/expander.h"
 #include "dtgtk/paint.h"
 #include "gui/accelerators.h"
+#include "gui/color_picker_proxy.h"
 #include "gui/gtk.h"
 #include "gui/presets.h"
-#include "gui/color_picker_proxy.h"
-#include "iop/iop_api.h"
 #include "iop/gaussian_elimination.h"
+#include "iop/iop_api.h"
 
 
 #include "develop/imageop.h"
@@ -55,7 +55,7 @@
 #define DT_GUI_CURVE_EDITOR_INSET DT_PIXEL_APPLY_DPI(1)
 
 
-DT_MODULE_INTROSPECTION(3, dt_iop_filmicrgb_params_t)
+DT_MODULE_INTROSPECTION(4, dt_iop_filmicrgb_params_t)
 
 /**
  * DOCUMENTATION
@@ -87,20 +87,18 @@ DT_MODULE_INTROSPECTION(3, dt_iop_filmicrgb_params_t)
  * */
 
 
- /** Note :
+/** Note :
  * we use finite-math-only and fast-math because divisions by zero are manually avoided in the code
  * fp-contract=fast enables hardware-accelerated Fused Multiply-Add
  * the rest is loop reorganization and vectorization optimization
  **/
 #if defined(__GNUC__)
-#pragma GCC optimize ("unroll-loops", "tree-loop-if-convert", \
-                      "tree-loop-distribution", "no-strict-aliasing", \
-                      "loop-interchange", "loop-nest-optimize", "tree-loop-im", \
-                      "unswitch-loops", "tree-loop-ivcanon", "ira-loop-pressure", \
-                      "split-ivs-in-unroller", "variable-expansion-in-unroller", \
-                      "split-loops", "ivopts", "predictive-commoning",\
-                      "tree-loop-linear", "loop-block", "loop-strip-mine", \
-                      "finite-math-only", "fp-contract=fast", "fast-math", "no-math-errno")
+#pragma GCC optimize("unroll-loops", "tree-loop-if-convert", "tree-loop-distribution", "no-strict-aliasing",      \
+                     "loop-interchange", "loop-nest-optimize", "tree-loop-im", "unswitch-loops",                  \
+                     "tree-loop-ivcanon", "ira-loop-pressure", "split-ivs-in-unroller",                           \
+                     "variable-expansion-in-unroller", "split-loops", "ivopts", "predictive-commoning",           \
+                     "tree-loop-linear", "loop-block", "loop-strip-mine", "finite-math-only", "fp-contract=fast", \
+                     "fast-math", "no-math-errno")
 #endif
 
 typedef enum dt_iop_filmicrgb_methods_type_t
@@ -145,8 +143,8 @@ typedef struct dt_iop_filmic_rgb_spline_t
 
 typedef enum dt_iop_filmic_rgb_gui_mode_t
 {
-  DT_FILMIC_GUI_LOOK = 0,          // default GUI, showing only the contrast curve in a log/gamma space
-  DT_FILMIC_GUI_BASECURVE = 1,     // basecurve-like GUI, showing the contrast and brightness curves, in lin/lin space
+  DT_FILMIC_GUI_LOOK = 0,      // default GUI, showing only the contrast curve in a log/gamma space
+  DT_FILMIC_GUI_BASECURVE = 1, // basecurve-like GUI, showing the contrast and brightness curves, in lin/lin space
   DT_FILMIC_GUI_BASECURVE_LOG = 2, // same as previous, but log-scaled
   DT_FILMIC_GUI_RANGES = 3,        // zone-system-like GUI, showing the range to range mapping
   DT_FILMIC_GUI_LAST
@@ -155,32 +153,38 @@ typedef enum dt_iop_filmic_rgb_gui_mode_t
 
 typedef struct dt_iop_filmicrgb_params_t
 {
-  float grey_point_source;  // $MIN: 0 $MAX: 100 $DEFAULT: 18.45 $DESCRIPTION: "middle grey luminance"
-  float black_point_source; // $MIN: -16 $MAX: -0.1 $DEFAULT: -8.0 $DESCRIPTION: "black relative exposure"
-  float white_point_source; // $MIN: 0 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
-  float reconstruct_threshold;            // $MIN: -6.0 $MAX: 6.0 $DEFAULT: +3.0 $DESCRIPTION: "threshold"
-  float reconstruct_feather;              // $MIN: 0.25 $MAX: 6.0 $DEFAULT: 3.0 $DESCRIPTION: "transition"
-  float reconstruct_bloom_vs_details;     // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "bloom/reconstruct"
-  float reconstruct_grey_vs_color;        // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "grey/colorful details"
-  float reconstruct_structure_vs_texture; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION: "structure/texture"
-  float security_factor;    // $MIN: -50 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "dynamic range scaling"
-  float grey_point_target;  // $MIN: 1 $MAX: 50 $DEFAULT: 18.45 $DESCRIPTION: "target middle grey"
-  float black_point_target; // $MIN: 0 $MAX: 20 $DEFAULT: 0 $DESCRIPTION: "target black luminance"
+  float grey_point_source;     // $MIN: 0 $MAX: 100 $DEFAULT: 18.45 $DESCRIPTION: "middle grey luminance"
+  float black_point_source;    // $MIN: -16 $MAX: -0.1 $DEFAULT: -8.0 $DESCRIPTION: "black relative exposure"
+  float white_point_source;    // $MIN: 0 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
+  float reconstruct_threshold; // $MIN: -6.0 $MAX: 6.0 $DEFAULT: +3.0 $DESCRIPTION: "threshold"
+  float reconstruct_feather;   // $MIN: 0.25 $MAX: 6.0 $DEFAULT: 3.0 $DESCRIPTION: "transition"
+  float reconstruct_bloom_vs_details; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "bloom/reconstruct"
+  float reconstruct_grey_vs_color; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "grey/colorful details"
+  float reconstruct_structure_vs_texture; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION:
+                                          // "structure/texture"
+  float security_factor;                  // $MIN: -50 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "dynamic range scaling"
+  float grey_point_target;                // $MIN: 1 $MAX: 50 $DEFAULT: 18.45 $DESCRIPTION: "target middle grey"
+  float black_point_target; // $MIN: 0.000 $MAX: 20.000 $DEFAULT: 0.01517634 $DESCRIPTION: "target black luminance"
   float white_point_target; // $MIN: 0 $MAX: 1600 $DEFAULT: 100 $DESCRIPTION: "target white luminance"
   float output_power;       // $MIN: 1 $MAX: 10 $DEFAULT: 4.0 $DESCRIPTION: "hardness"
-  float latitude;           // $MIN: 0.01 $MAX: 100 $DEFAULT: 33.0
-  float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.50
+  float latitude;           // $MIN: 0.01 $MAX: 100 $DEFAULT: 25.0
+  float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.35
   float saturation;         // $MIN: -50 $MAX: 200 $DEFAULT: 10 $DESCRIPTION: "extreme luminance saturation"
   float balance;            // $MIN: -50 $MAX: 50 $DEFAULT: 0.0 $DESCRIPTION: "shadows/highlights balance"
   float noise_level;        // $MIN: 0.0 $MAX: 6.0 $DEFAULT: 0.1f $DESCRIPTION: "add noise in highlights"
-  dt_iop_filmicrgb_methods_type_t preserve_color; // $DEFAULT: DT_FILMIC_METHOD_POWER_NORM $DESCRIPTION: "preserve chrominance"
-  dt_iop_filmicrgb_colorscience_type_t version;   // $DEFAULT: DT_FILMIC_COLORSCIENCE_V2 $DESCRIPTION: "color science"
-  gboolean auto_hardness;   // $DEFAULT: TRUE $DESCRIPTION: "auto adjust hardness"
-  gboolean custom_grey;     // $DEFAULT: FALSE $DESCRIPTION: "use custom middle-grey values"
-  int high_quality_reconstruction;  // $MIN: 0 $MAX: 10 $DEFAULT: 1 $DESCRIPTION: "iterations of high-quality reconstruction"
-  int noise_distribution; // $DEFAULT: DT_NOISE_POISSONIAN $DESCRIPTION: "type of noise"
-  dt_iop_filmicrgb_curve_type_t shadows;    // $DEFAULT: DT_FILMIC_CURVE_POLY_4 $DESCRIPTION: "contrast in shadows"
-  dt_iop_filmicrgb_curve_type_t highlights; // $DEFAULT: DT_FILMIC_CURVE_POLY_4 $DESCRIPTION: "contrast in highlights"
+  dt_iop_filmicrgb_methods_type_t preserve_color; // $DEFAULT: DT_FILMIC_METHOD_POWER_NORM $DESCRIPTION: "preserve
+                                                  // chrominance"
+  dt_iop_filmicrgb_colorscience_type_t version; // $DEFAULT: DT_FILMIC_COLORSCIENCE_V2 $DESCRIPTION: "color science"
+  gboolean auto_hardness;                       // $DEFAULT: TRUE $DESCRIPTION: "auto adjust hardness"
+  gboolean custom_grey;                         // $DEFAULT: FALSE $DESCRIPTION: "use custom middle-grey values"
+  int high_quality_reconstruction;       // $MIN: 0 $MAX: 10 $DEFAULT: 1 $DESCRIPTION: "iterations of high-quality
+                                         // reconstruction"
+  int noise_distribution;                // $DEFAULT: DT_NOISE_POISSONIAN $DESCRIPTION: "type of noise"
+  dt_iop_filmicrgb_curve_type_t shadows; // $DEFAULT: DT_FILMIC_CURVE_POLY_4 $DESCRIPTION: "contrast in shadows"
+  dt_iop_filmicrgb_curve_type_t highlights; // $DEFAULT: DT_FILMIC_CURVE_POLY_4 $DESCRIPTION: "contrast in
+                                            // highlights"
+  gboolean compensate_icc_black; // $DEFAULT: FALSE $DESCRIPTION: "compensate output ICC profile black point"
+  gint internal_version;         // $DEFAULT: 2020 $DESCRIPTION: "version of the spline generator"
 } dt_iop_filmicrgb_params_t;
 
 
@@ -218,7 +222,8 @@ typedef struct dt_iop_filmicrgb_gui_data_t
   GtkWidget *white_point_source;
   GtkWidget *grey_point_source;
   GtkWidget *black_point_source;
-  GtkWidget *reconstruct_threshold, *reconstruct_bloom_vs_details, *reconstruct_grey_vs_color, *reconstruct_structure_vs_texture, *reconstruct_feather;
+  GtkWidget *reconstruct_threshold, *reconstruct_bloom_vs_details, *reconstruct_grey_vs_color,
+      *reconstruct_structure_vs_texture, *reconstruct_feather;
   GtkWidget *show_highlight_mask;
   GtkWidget *security_factor;
   GtkWidget *auto_button;
@@ -238,6 +243,7 @@ typedef struct dt_iop_filmicrgb_gui_data_t
   GtkWidget *custom_grey;
   GtkWidget *high_quality_reconstruction;
   GtkWidget *noise_level, *noise_distribution;
+  GtkWidget *compensate_icc_black;
   GtkNotebook *notebook;
   GtkDrawingArea *area;
   struct dt_iop_filmic_rgb_spline_t spline DT_ALIGNED_ARRAY;
@@ -322,7 +328,7 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version, void *new_params,
                   const int new_version)
 {
-  if(old_version == 1 && new_version == 3)
+  if(old_version == 1 && new_version == 4)
   {
     typedef struct dt_iop_filmicrgb_params_v1_t
     {
@@ -362,7 +368,8 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->preserve_color = o->preserve_color;
     n->shadows = DT_FILMIC_CURVE_POLY_4;
     n->highlights = DT_FILMIC_CURVE_POLY_3;
-    n->reconstruct_threshold = 6.0f; // for old edits, this ensures clipping threshold >> white level, so it's a no-op
+    n->reconstruct_threshold
+        = 6.0f; // for old edits, this ensures clipping threshold >> white level, so it's a no-op
     n->reconstruct_bloom_vs_details = d->reconstruct_bloom_vs_details;
     n->reconstruct_grey_vs_color = d->reconstruct_grey_vs_color;
     n->reconstruct_structure_vs_texture = d->reconstruct_structure_vs_texture;
@@ -373,9 +380,11 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->high_quality_reconstruction = 0;
     n->noise_distribution = d->noise_distribution;
     n->noise_level = 0.f;
+    n->internal_version = 2019;
+    n->compensate_icc_black = FALSE;
     return 0;
   }
-  if(old_version == 2 && new_version == 3)
+  if(old_version == 2 && new_version == 4)
   {
     typedef struct dt_iop_filmicrgb_params_v2_t
     {
@@ -438,6 +447,84 @@ int legacy_params(dt_iop_module_t *self, const void *const old_params, const int
     n->noise_level = d->noise_level;
     n->noise_distribution = d->noise_distribution;
     n->noise_level = 0.f;
+    n->internal_version = 2019;
+    n->compensate_icc_black = FALSE;
+    return 0;
+  }
+  if(old_version == 3 && new_version == 4)
+  {
+    typedef struct dt_iop_filmicrgb_params_v3_t
+    {
+      float grey_point_source;     // $MIN: 0 $MAX: 100 $DEFAULT: 18.45 $DESCRIPTION: "middle grey luminance"
+      float black_point_source;    // $MIN: -16 $MAX: -0.1 $DEFAULT: -8.0 $DESCRIPTION: "black relative exposure"
+      float white_point_source;    // $MIN: 0 $MAX: 16 $DEFAULT: 4.0 $DESCRIPTION: "white relative exposure"
+      float reconstruct_threshold; // $MIN: -6.0 $MAX: 6.0 $DEFAULT: +3.0 $DESCRIPTION: "threshold"
+      float reconstruct_feather;   // $MIN: 0.25 $MAX: 6.0 $DEFAULT: 3.0 $DESCRIPTION: "transition"
+      float reconstruct_bloom_vs_details; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION:
+                                          // "bloom/reconstruct"
+      float reconstruct_grey_vs_color;    // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 100.0 $DESCRIPTION: "grey/colorful
+                                          // details"
+      float reconstruct_structure_vs_texture; // $MIN: -100.0 $MAX: 100.0 $DEFAULT: 0.0 $DESCRIPTION:
+                                              // "structure/texture"
+      float security_factor;    // $MIN: -50 $MAX: 200 $DEFAULT: 0 $DESCRIPTION: "dynamic range scaling"
+      float grey_point_target;  // $MIN: 1 $MAX: 50 $DEFAULT: 18.45 $DESCRIPTION: "target middle grey"
+      float black_point_target; // $MIN: 0 $MAX: 20 $DEFAULT: 0 $DESCRIPTION: "target black luminance"
+      float white_point_target; // $MIN: 0 $MAX: 1600 $DEFAULT: 100 $DESCRIPTION: "target white luminance"
+      float output_power;       // $MIN: 1 $MAX: 10 $DEFAULT: 4.0 $DESCRIPTION: "hardness"
+      float latitude;           // $MIN: 0.01 $MAX: 100 $DEFAULT: 33.0
+      float contrast;           // $MIN: 0 $MAX: 5 $DEFAULT: 1.50
+      float saturation;         // $MIN: -50 $MAX: 200 $DEFAULT: 10 $DESCRIPTION: "extreme luminance saturation"
+      float balance;            // $MIN: -50 $MAX: 50 $DEFAULT: 0.0 $DESCRIPTION: "shadows/highlights balance"
+      float noise_level;        // $MIN: 0.0 $MAX: 6.0 $DEFAULT: 0.1f $DESCRIPTION: "add noise in highlights"
+      dt_iop_filmicrgb_methods_type_t preserve_color; // $DEFAULT: DT_FILMIC_METHOD_POWER_NORM $DESCRIPTION:
+                                                      // "preserve chrominance"
+      dt_iop_filmicrgb_colorscience_type_t version;   // $DEFAULT: DT_FILMIC_COLORSCIENCE_V2 $DESCRIPTION: "color
+                                                      // science"
+      gboolean auto_hardness;                         // $DEFAULT: TRUE $DESCRIPTION: "auto adjust hardness"
+      gboolean custom_grey;            // $DEFAULT: FALSE $DESCRIPTION: "use custom middle-grey values"
+      int high_quality_reconstruction; // $MIN: 0 $MAX: 10 $DEFAULT: 1 $DESCRIPTION: "iterations of high-quality
+                                       // reconstruction"
+      int noise_distribution;          // $DEFAULT: DT_NOISE_POISSONIAN $DESCRIPTION: "type of noise"
+      dt_iop_filmicrgb_curve_type_t shadows; // $DEFAULT: DT_FILMIC_CURVE_POLY_4 $DESCRIPTION: "contrast in shadows"
+      dt_iop_filmicrgb_curve_type_t highlights; // $DEFAULT: DT_FILMIC_CURVE_POLY_4 $DESCRIPTION: "contrast in
+                                                // highlights"
+    } dt_iop_filmicrgb_params_v3_t;
+
+    dt_iop_filmicrgb_params_v3_t *o = (dt_iop_filmicrgb_params_v3_t *)old_params;
+    dt_iop_filmicrgb_params_t *n = (dt_iop_filmicrgb_params_t *)new_params;
+    dt_iop_filmicrgb_params_t *d = (dt_iop_filmicrgb_params_t *)self->default_params;
+
+    *n = *d; // start with a fresh copy of default parameters
+
+    n->grey_point_source = o->grey_point_source;
+    n->white_point_source = o->white_point_source;
+    n->black_point_source = o->black_point_source;
+    n->security_factor = o->security_factor;
+    n->grey_point_target = o->grey_point_target;
+    n->black_point_target = o->black_point_target;
+    n->white_point_target = o->white_point_target;
+    n->output_power = o->output_power;
+    n->latitude = o->latitude;
+    n->contrast = o->contrast;
+    n->saturation = o->saturation;
+    n->balance = o->balance;
+    n->preserve_color = o->preserve_color;
+    n->shadows = o->shadows;
+    n->highlights = o->highlights;
+    n->reconstruct_threshold = o->reconstruct_threshold;
+    n->reconstruct_bloom_vs_details = o->reconstruct_bloom_vs_details;
+    n->reconstruct_grey_vs_color = o->reconstruct_grey_vs_color;
+    n->reconstruct_structure_vs_texture = o->reconstruct_structure_vs_texture;
+    n->reconstruct_feather = o->reconstruct_feather;
+    n->version = o->version;
+    n->auto_hardness = o->auto_hardness;
+    n->custom_grey = o->custom_grey;
+    n->high_quality_reconstruction = o->high_quality_reconstruction;
+    n->noise_level = d->noise_level;
+    n->noise_distribution = d->noise_distribution;
+    n->noise_level = d->noise_level;
+    n->internal_version = 2019;
+    n->compensate_icc_black = FALSE;
     return 0;
   }
   return 1;
@@ -500,7 +587,7 @@ static inline float sqf(const float x)
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(pixel:16)
+#pragma omp declare simd aligned(pixel : 16)
 #endif
 static inline float pixel_rgb_norm_power(const float pixel[4])
 {
@@ -519,12 +606,12 @@ static inline float pixel_rgb_norm_power(const float pixel[4])
     denominator += RGB_square;
   }
 
-  return numerator / fmaxf(denominator, 1e-12f);  // prevent from division-by-0 (note: (1e-6)^2 = 1e-12
+  return numerator / fmaxf(denominator, 1e-12f); // prevent from division-by-0 (note: (1e-6)^2 = 1e-12
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(pixel:16) uniform(variant, work_profile)
+#pragma omp declare simd aligned(pixel : 16) uniform(variant, work_profile)
 #endif
 static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_methods_type_t variant,
                                    const dt_iop_order_iccprofile_info_t *const work_profile)
@@ -535,13 +622,11 @@ static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_
       return fmaxf(fmaxf(pixel[0], pixel[1]), pixel[2]);
 
     case(DT_FILMIC_METHOD_LUMINANCE):
-      return (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(pixel,
-                                                                work_profile->matrix_in,
-                                                                work_profile->lut_in,
-                                                                work_profile->unbounded_coeffs_in,
-                                                                work_profile->lutsize,
-                                                                work_profile->nonlinearlut)
-                            : dt_camera_rgb_luminance(pixel);
+      return (work_profile)
+                 ? dt_ioppr_get_rgb_matrix_luminance(pixel, work_profile->matrix_in, work_profile->lut_in,
+                                                     work_profile->unbounded_coeffs_in, work_profile->lutsize,
+                                                     work_profile->nonlinearlut)
+                 : dt_camera_rgb_luminance(pixel);
 
     case(DT_FILMIC_METHOD_POWER_NORM):
       return pixel_rgb_norm_power(pixel);
@@ -550,13 +635,11 @@ static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_
       return sqrtf(sqf(pixel[0]) + sqf(pixel[1]) + sqf(pixel[2]));
 
     default:
-      return (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(pixel,
-                                                                work_profile->matrix_in,
-                                                                work_profile->lut_in,
-                                                                work_profile->unbounded_coeffs_in,
-                                                                work_profile->lutsize,
-                                                                work_profile->nonlinearlut)
-                            : dt_camera_rgb_luminance(pixel);
+      return (work_profile)
+                 ? dt_ioppr_get_rgb_matrix_luminance(pixel, work_profile->matrix_in, work_profile->lut_in,
+                                                     work_profile->unbounded_coeffs_in, work_profile->lutsize,
+                                                     work_profile->nonlinearlut)
+                 : dt_camera_rgb_luminance(pixel);
   }
 }
 
@@ -564,7 +647,8 @@ static inline float get_pixel_norm(const float pixel[4], const dt_iop_filmicrgb_
 #ifdef _OPENMP
 #pragma omp declare simd uniform(grey, black, dynamic_range)
 #endif
-static inline float log_tonemapping_v1(const float x, const float grey, const float black, const float dynamic_range)
+static inline float log_tonemapping_v1(const float x, const float grey, const float black,
+                                       const float dynamic_range)
 {
   const float temp = (log2f(x / grey) - black) / dynamic_range;
   return fmaxf(fminf(temp, 1.0f), 1.52587890625e-05f);
@@ -574,7 +658,8 @@ static inline float log_tonemapping_v1(const float x, const float grey, const fl
 #ifdef _OPENMP
 #pragma omp declare simd uniform(grey, black, dynamic_range)
 #endif
-static inline float log_tonemapping_v2(const float x, const float grey, const float black, const float dynamic_range)
+static inline float log_tonemapping_v2(const float x, const float grey, const float black,
+                                       const float dynamic_range)
 {
   return clamp_simd((log2f(x / grey) - black) / dynamic_range);
 }
@@ -582,7 +667,8 @@ static inline float log_tonemapping_v2(const float x, const float grey, const fl
 #ifdef _OPENMP
 #pragma omp declare simd uniform(grey, black, dynamic_range)
 #endif
-static inline float exp_tonemapping_v2(const float x, const float grey, const float black, const float dynamic_range)
+static inline float exp_tonemapping_v2(const float x, const float grey, const float black,
+                                       const float dynamic_range)
 {
   // inverse of log_tonemapping
   return grey * exp2f(dynamic_range * x + black);
@@ -590,22 +676,23 @@ static inline float exp_tonemapping_v2(const float x, const float grey, const fl
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(M1, M2, M3, M4:16) uniform(M1, M2, M3, M4, M5, latitude_min, latitude_max)
+#pragma omp declare simd aligned(M1, M2, M3, M4 : 16) uniform(M1, M2, M3, M4, M5, latitude_min, latitude_max)
 #endif
-static inline float filmic_spline(const float x,
-                                  const float M1[4], const float M2[4], const float M3[4], const float M4[4], const float M5[4],
-                                  const float latitude_min, const float latitude_max)
+static inline float filmic_spline(const float x, const float M1[4], const float M2[4], const float M3[4],
+                                  const float M4[4], const float M5[4], const float latitude_min,
+                                  const float latitude_max)
 {
-  return (x < latitude_min) ? M1[0] + x * (M2[0] + x * (M3[0] + x * (M4[0] + x * M5[0]))) : // toe
-         (x > latitude_max) ? M1[1] + x * (M2[1] + x * (M3[1] + x * (M4[1] + x * M5[1]))) : // shoulder
-                              M1[2] + x * (M2[2] + x * (M3[2] + x * (M4[2] + x * M5[2])));  // latitude
+  return (x < latitude_min) ? M1[0] + x * (M2[0] + x * (M3[0] + x * (M4[0] + x * M5[0]))) :     // toe
+             (x > latitude_max) ? M1[1] + x * (M2[1] + x * (M3[1] + x * (M4[1] + x * M5[1]))) : // shoulder
+                 M1[2] + x * (M2[2] + x * (M3[2] + x * (M4[2] + x * M5[2])));                   // latitude
 }
 
 
 #ifdef _OPENMP
 #pragma omp declare simd uniform(sigma_toe, sigma_shoulder)
 #endif
-static inline float filmic_desaturate_v1(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
+static inline float filmic_desaturate_v1(const float x, const float sigma_toe, const float sigma_shoulder,
+                                         const float saturation)
 {
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
@@ -613,14 +700,15 @@ static inline float filmic_desaturate_v1(const float x, const float sigma_toe, c
   const float key_toe = expf(-0.5f * radius_toe * radius_toe / sigma_toe);
   const float key_shoulder = expf(-0.5f * radius_shoulder * radius_shoulder / sigma_shoulder);
 
-  return 1.0f - clamp_simd((key_toe + key_shoulder) / saturation) ;
+  return 1.0f - clamp_simd((key_toe + key_shoulder) / saturation);
 }
 
 
 #ifdef _OPENMP
 #pragma omp declare simd uniform(sigma_toe, sigma_shoulder)
 #endif
-static inline float filmic_desaturate_v2(const float x, const float sigma_toe, const float sigma_shoulder, const float saturation)
+static inline float filmic_desaturate_v2(const float x, const float sigma_toe, const float sigma_shoulder,
+                                         const float saturation)
 {
   const float radius_toe = x;
   const float radius_shoulder = 1.0f - x;
@@ -666,12 +754,11 @@ static inline float fminabsf(const float a, const float b)
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, mask:64) uniform(feathering, normalize, width, height, ch)
+#pragma omp declare simd aligned(in, mask : 64) uniform(feathering, normalize, width, height, ch)
 #endif
-static inline gint mask_clipped_pixels(const float *const restrict in,
-                                       float *const restrict mask,
-                                       const float normalize, const float feathering,
-                                       const size_t width, const size_t height, const size_t ch)
+static inline gint mask_clipped_pixels(const float *const restrict in, float *const restrict mask,
+                                       const float normalize, const float feathering, const size_t width,
+                                       const size_t height, const size_t ch)
 {
   /* 1. Detect if pixels are clipped and count them,
    * 2. assign them a weight in [0. ; 1.] depending on how close from clipping they are. The weights are defined
@@ -687,9 +774,9 @@ static inline gint mask_clipped_pixels(const float *const restrict in,
 #endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
-    const float pix_max = sqrtf(sqf(in[k]) + sqf(in[k+ 1]) + sqf(in[k + 2]));
+    const float pix_max = sqrtf(sqf(in[k]) + sqf(in[k + 1]) + sqf(in[k + 2]));
     const float argument = -pix_max * normalize + feathering;
-    const float weight = 1.0f / ( 1.0f + exp2f(argument));
+    const float weight = 1.0f / (1.0f + exp2f(argument));
     mask[k / ch] = weight;
 
     // at x = 4, the sigmoid produces opacity = 5.882 %.
@@ -705,12 +792,13 @@ static inline gint mask_clipped_pixels(const float *const restrict in,
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, mask, inpainted:64) uniform(num_elem, ch, noise_level, noise_distribution, threshold)
+#pragma omp declare simd aligned(in, mask, inpainted : 64)                                                        \
+    uniform(num_elem, ch, noise_level, noise_distribution, threshold)
 #endif
-inline static void inpaint_noise(const float *const in, const float *const mask,
-                                 float *const inpainted, const float noise_level, const float threshold,
-                                 const dt_noise_distribution_t noise_distribution,
-                                 const size_t num_elem, const size_t ch)
+inline static void inpaint_noise(const float *const in, const float *const mask, float *const inpainted,
+                                 const float noise_level, const float threshold,
+                                 const dt_noise_distribution_t noise_distribution, const size_t num_elem,
+                                 const size_t ch)
 {
   // add statistical noise in highlights to fill-in texture
   // this creates "particules" in highlights, that will help the implicit partial derivative equation
@@ -721,9 +809,10 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
   xoshiro256_init(1, state);
 
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(in, mask, inpainted, num_elem, ch, state, noise_level, noise_distribution, threshold) \
-  schedule(simd:static) aligned(mask, in, inpainted, state:64)
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_firstprivate(in, mask, inpainted, num_elem, ch, state, noise_level, noise_distribution, threshold)     \
+        schedule(simd                                                                                             \
+                 : static) aligned(mask, in, inpainted, state : 64)
 #endif
   for(size_t k = 0; k < num_elem; k += ch)
   {
@@ -734,7 +823,8 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
     {
       // create statistical noise
       const float input = in[k + c];
-      const float noise = dt_noise_generator(noise_distribution, input, input * noise_level / threshold, (c % 2) == 0.f, state);
+      const float noise
+          = dt_noise_generator(noise_distribution, input, input * noise_level / threshold, (c % 2) == 0.f, state);
 
       // add noise to input
       inpainted[k + c] = input * (1.0f - weight) + weight * noise;
@@ -748,19 +838,19 @@ inline static void inpaint_noise(const float *const in, const float *const mask,
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) uniform(mult, bound_left, bound_right, ch, width, height)
+#pragma omp declare simd aligned(in, out : 64) uniform(mult, bound_left, bound_right, ch, width, height)
 #endif
 inline static void blur_2D_Bspline_vertical(const float *const restrict in, float *const restrict out,
-                                            const size_t width, const size_t height, const size_t ch, const size_t mult,
-                                            const int bound_left, const int bound_right)
+                                            const size_t width, const size_t height, const size_t ch,
+                                            const size_t mult, const int bound_left, const int bound_right)
 {
-  // À-trous B-spline interpolation/blur shifted by mult
-  // Convolve B-spline filter over lines
-  #ifdef _OPENMP
-  #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(in, out, width, height, ch, bound_left, bound_right, mult) \
-    schedule(simd:static) collapse(2)
-  #endif
+// À-trous B-spline interpolation/blur shifted by mult
+// Convolve B-spline filter over lines
+#ifdef _OPENMP
+#pragma omp parallel for default(none)                                                                            \
+    dt_omp_firstprivate(in, out, width, height, ch, bound_left, bound_right, mult) schedule(simd                  \
+                                                                                            : static) collapse(2)
+#endif
   for(size_t i = 0; i < height; i++)
     for(size_t j = 0; j < width; j++)
     {
@@ -773,60 +863,58 @@ inline static void blur_2D_Bspline_vertical(const float *const restrict in, floa
       // -funswitch-loops should compile 2 loops, for each check outcome
       if(check)
       {
-        #ifdef _OPENMP
-        #pragma omp simd aligned(in:64) aligned(accumulator:16) reduction(+:accumulator)
-        #endif
+#ifdef _OPENMP
+#pragma omp simd aligned(in : 64) aligned(accumulator : 16) reduction(+ : accumulator)
+#endif
         for(size_t jj = 0; jj < FSIZE; ++jj)
           for(size_t c = 0; c < 3; ++c)
           {
             int index_x = mult * (jj - (FSIZE - 1) / 2) + j;
-            index_x = (index_x < bound_left)  ? bound_left  :
-                      (index_x > bound_right) ? bound_right :
-                                                index_x     ;
+            index_x = (index_x < bound_left) ? bound_left : (index_x > bound_right) ? bound_right : index_x;
 
-            static const float DT_ALIGNED_ARRAY filter[FSIZE] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+            static const float DT_ALIGNED_ARRAY filter[FSIZE]
+                = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
 
             accumulator[c] += filter[jj] * in[(i * width + index_x) * ch + c];
           }
       }
       else // fast-track
       {
-        #ifdef _OPENMP
-        #pragma omp simd aligned(in:64) aligned(accumulator:16) reduction(+:accumulator)
-        #endif
+#ifdef _OPENMP
+#pragma omp simd aligned(in : 64) aligned(accumulator : 16) reduction(+ : accumulator)
+#endif
         for(size_t jj = 0; jj < FSIZE; ++jj)
           for(size_t c = 0; c < 3; ++c)
           {
             const size_t index_x = mult * (jj - (FSIZE - 1) / 2) + j;
-            static const float DT_ALIGNED_ARRAY filter[FSIZE] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+            static const float DT_ALIGNED_ARRAY filter[FSIZE]
+                = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
             accumulator[c] += filter[jj] * in[(i * width + index_x) * ch + c];
           }
       }
 
-      #ifdef _OPENMP
-      #pragma omp simd aligned(out:64) aligned(accumulator:16)
-      #endif
-      for(size_t c = 0; c < 3; ++c)
-        out[index_out + c] = accumulator[c];
-
+#ifdef _OPENMP
+#pragma omp simd aligned(out : 64) aligned(accumulator : 16)
+#endif
+      for(size_t c = 0; c < 3; ++c) out[index_out + c] = accumulator[c];
     }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) uniform(mult, bound_top, bound_bot, ch, width, height)
+#pragma omp declare simd aligned(in, out : 64) uniform(mult, bound_top, bound_bot, ch, width, height)
 #endif
 inline static void blur_2D_Bspline_horizontal(const float *const restrict in, float *const restrict out,
-                                              const size_t width, const size_t height, const size_t ch, const size_t mult,
-                                              const int bound_top, const int bound_bot)
+                                              const size_t width, const size_t height, const size_t ch,
+                                              const size_t mult, const int bound_top, const int bound_bot)
 {
-  // À-trous B-spline interpolation/blur shifted by mult
-  // Convolve B-spline filter over columns
-  #ifdef _OPENMP
-  #pragma omp parallel for default(none) \
-    dt_omp_firstprivate(out, in, width, height, ch, bound_bot, bound_top, mult) \
-    schedule(simd:static) collapse(2)
-  #endif
+// À-trous B-spline interpolation/blur shifted by mult
+// Convolve B-spline filter over columns
+#ifdef _OPENMP
+#pragma omp parallel for default(none)                                                                            \
+    dt_omp_firstprivate(out, in, width, height, ch, bound_bot, bound_top, mult) schedule(simd                     \
+                                                                                         : static) collapse(2)
+#endif
   for(size_t i = 0; i < height; i++)
     for(size_t j = 0; j < width; j++)
     {
@@ -839,18 +927,17 @@ inline static void blur_2D_Bspline_horizontal(const float *const restrict in, fl
       // -funswitch-loops should compile 2 loops, for each check outcome
       if(check)
       {
-        #ifdef _OPENMP
-        #pragma omp simd aligned(in:64) aligned(accumulator:16) reduction(+:accumulator)
-        #endif
+#ifdef _OPENMP
+#pragma omp simd aligned(in : 64) aligned(accumulator : 16) reduction(+ : accumulator)
+#endif
         for(size_t ii = 0; ii < FSIZE; ++ii)
           for(size_t c = 0; c < 3; ++c)
           {
             int index_y = mult * (ii - (FSIZE - 1) / 2) + i;
-            index_y = (index_y < bound_top) ? bound_top :
-                      (index_y > bound_bot) ? bound_bot :
-                                              index_y   ;
+            index_y = (index_y < bound_top) ? bound_top : (index_y > bound_bot) ? bound_bot : index_y;
 
-            static const float DT_ALIGNED_ARRAY filter[FSIZE] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+            static const float DT_ALIGNED_ARRAY filter[FSIZE]
+                = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
 
             accumulator[c] += filter[ii] * in[(index_y * width + j) * ch + c];
           }
@@ -861,41 +948,44 @@ inline static void blur_2D_Bspline_horizontal(const float *const restrict in, fl
         {
           const size_t index_y = mult * (ii - (FSIZE - 1) / 2) + i;
 
-          #ifdef _OPENMP
-          #pragma omp simd aligned(in:64) aligned(accumulator:16) reduction(+:accumulator)
-          #endif
+#ifdef _OPENMP
+#pragma omp simd aligned(in : 64) aligned(accumulator : 16) reduction(+ : accumulator)
+#endif
           for(size_t c = 0; c < 3; ++c)
           {
-            static const float DT_ALIGNED_ARRAY filter[FSIZE] = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
+            static const float DT_ALIGNED_ARRAY filter[FSIZE]
+                = { 1.0f / 16.0f, 4.0f / 16.0f, 6.0f / 16.0f, 4.0f / 16.0f, 1.0f / 16.0f };
             accumulator[c] += filter[ii] * in[(index_y * width + j) * ch + c];
           }
         }
       }
 
-      #ifdef _OPENMP
-      #pragma omp simd aligned(out:64) aligned(accumulator:16)
-      #endif
+#ifdef _OPENMP
+#pragma omp simd aligned(out : 64) aligned(accumulator : 16)
+#endif
       for(size_t c = 0; c < ch; ++c) out[index_out + c] = accumulator[c];
     }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(LF, HF, texture, mask, reconstructed:64) \
-  uniform(ch, width, height, gamma, gamma_comp, beta, beta_comp, delta, s, scales)
+#pragma omp declare simd aligned(LF, HF, texture, mask, reconstructed : 64)                                       \
+    uniform(ch, width, height, gamma, gamma_comp, beta, beta_comp, delta, s, scales)
 #endif
 inline static void wavelets_reconstruct_RGB(const float *const restrict HF, const float *const restrict LF,
                                             const float *const restrict texture, const float *const restrict mask,
-                                            float *const restrict reconstructed,
-                                            const size_t width, const size_t height, const size_t ch,
-                                            const float gamma, const float gamma_comp, const float beta, const float beta_comp, const float delta,
-                                            const size_t s, const size_t scales)
+                                            float *const restrict reconstructed, const size_t width,
+                                            const size_t height, const size_t ch, const float gamma,
+                                            const float gamma_comp, const float beta, const float beta_comp,
+                                            const float delta, const size_t s, const size_t scales)
 {
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(width, height, ch, HF, LF, texture, mask, reconstructed, gamma, gamma_comp, beta, beta_comp, delta, s, scales) \
-  schedule(simd:static) aligned(HF, LF, texture, mask, reconstructed:64)
-  #endif
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_firstprivate(width, height, ch, HF, LF, texture, mask, reconstructed, gamma, gamma_comp, beta,         \
+                        beta_comp, delta, s, scales) schedule(simd                                                \
+                                                              : static)                                           \
+        aligned(HF, LF, texture, mask, reconstructed : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
     const float alpha = mask[k / ch];
@@ -905,7 +995,8 @@ inline static void wavelets_reconstruct_RGB(const float *const restrict HF, cons
     const float DT_ALIGNED_ARRAY LF_c[4] = { LF[k], LF[k + 1], LF[k + 2], LF[k + 3] };
 
     // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
-    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other channels
+    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
+    // channels
     const float grey_texture = gamma * texture[k / ch];
 
     // synthesize the max of all interpolated/inpainted RGB channels as a flat details term for the whole pixel
@@ -913,11 +1004,13 @@ inline static void wavelets_reconstruct_RGB(const float *const restrict HF, cons
     const float grey_details = fmaxabsf(fmaxabsf(HF_c[0], HF_c[1]), HF_c[2]);
 
     // synthesize both terms with weighting
-    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or
+    // magenta highlights.
     const float grey_HF = beta_comp * (gamma_comp * grey_details + grey_texture);
 
     // synthesize the min of all low-frequency RGB channels as a flat structure term for the whole pixel
-    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or
+    // magenta highlights.
     const float grey_residual = beta_comp * fminf(fminf(LF_c[0], LF_c[1]), LF_c[2]);
 
     for(size_t c = 0; c < 3; c++)
@@ -928,43 +1021,49 @@ inline static void wavelets_reconstruct_RGB(const float *const restrict HF, cons
 
       // synthesize interpolated/inpainted RGB channels color details and weigh them
       // this brings back some color on top of the grey_details
-      const float color_details = (HF_c[c] * gamma_comp + fminf(fabsf(HF_c[c] / grey_details), 1.f) * grey_texture) * beta;
+      const float color_details
+          = (HF_c[c] * gamma_comp + fminf(fabsf(HF_c[c] / grey_details), 1.f) * grey_texture) * beta;
 
       // reconstruction
-      reconstructed[k + c] += alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
+      reconstructed[k + c]
+          += alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
     }
   }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(LF, HF, texture, mask, reconstructed:64) \
-  uniform(ch, width, height, gamma, gamma_comp, beta, beta_comp, delta, s, scales)
+#pragma omp declare simd aligned(LF, HF, texture, mask, reconstructed : 64)                                       \
+    uniform(ch, width, height, gamma, gamma_comp, beta, beta_comp, delta, s, scales)
 #endif
 inline static void wavelets_reconstruct_ratios(const float *const restrict HF, const float *const restrict LF,
-                                               const float *const restrict texture, const float *const restrict mask,
-                                               float *const restrict reconstructed,
-                                               const size_t width, const size_t height, const size_t ch,
-                                               const float gamma, const float gamma_comp, const float beta, const float beta_comp, const float delta,
-                                               const size_t s, const size_t scales)
+                                               const float *const restrict texture,
+                                               const float *const restrict mask,
+                                               float *const restrict reconstructed, const size_t width,
+                                               const size_t height, const size_t ch, const float gamma,
+                                               const float gamma_comp, const float beta, const float beta_comp,
+                                               const float delta, const size_t s, const size_t scales)
 {
-  /*
-  * This is the adapted version of the RGB reconstruction
-  * RGB contain high frequencies that we try to recover, so we favor them in the reconstruction.
-  * The ratios represent the chromaticity in image and contain low frequencies in the absence of noise or aberrations,
-  * so, here, we favor them instead.
-  *
-  * Consequences : 
-  *  1. use min of interpolated channels details instead of max, to get smoother details
-  *  4. use the max of low frequency channels instead of min, to favor achromatic solution.
-  *
-  * Note : ratios close to 1 mean higher spectral purity (more white). Ratios close to 0 mean lower spectral purity (more colorful)
-  */
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(width, height, ch, HF, LF, texture, mask, reconstructed, gamma, gamma_comp, beta, beta_comp, delta, s, scales) \
-  schedule(simd:static) aligned(HF, LF, texture, mask, reconstructed:64)
-  #endif
+/*
+ * This is the adapted version of the RGB reconstruction
+ * RGB contain high frequencies that we try to recover, so we favor them in the reconstruction.
+ * The ratios represent the chromaticity in image and contain low frequencies in the absence of noise or
+ * aberrations, so, here, we favor them instead.
+ *
+ * Consequences : 
+ *  1. use min of interpolated channels details instead of max, to get smoother details
+ *  4. use the max of low frequency channels instead of min, to favor achromatic solution.
+ *
+ * Note : ratios close to 1 mean higher spectral purity (more white). Ratios close to 0 mean lower spectral purity
+ * (more colorful)
+ */
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_firstprivate(width, height, ch, HF, LF, texture, mask, reconstructed, gamma, gamma_comp, beta,         \
+                        beta_comp, delta, s, scales) schedule(simd                                                \
+                                                              : static)                                           \
+        aligned(HF, LF, texture, mask, reconstructed : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
     const float alpha = mask[k / ch];
@@ -974,7 +1073,8 @@ inline static void wavelets_reconstruct_ratios(const float *const restrict HF, c
     const float DT_ALIGNED_ARRAY LF_c[4] = { LF[k], LF[k + 1], LF[k + 2], LF[k + 3] };
 
     // synthesize the max of all RGB channels texture as a flat texture term for the whole pixel
-    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other channels
+    // this is useful if only 1 or 2 channels are clipped, so we transfer the valid/sharpest texture on the other
+    // channels
     const float grey_texture = gamma * texture[k / ch];
 
     // synthesize the max of all interpolated/inpainted RGB channels as a flat details term for the whole pixel
@@ -982,11 +1082,13 @@ inline static void wavelets_reconstruct_ratios(const float *const restrict HF, c
     const float grey_details = fmaxabsf(fmaxabsf(HF_c[0], HF_c[1]), HF_c[2]);
 
     // synthesize both terms with weighting
-    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or
+    // magenta highlights.
     const float grey_HF = beta_comp * (gamma_comp * grey_details + grey_texture);
 
     // synthesize the min of all low-frequency RGB channels as a flat structure term for the whole pixel
-    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or magenta highlights.
+    // when beta_comp ~= 1.0, we force the reconstruction to be achromatic, which may help with gamut issues or
+    // magenta highlights.
     const float grey_residual = beta_comp * fmaxf(fmaxf(LF_c[0], LF_c[1]), LF_c[2]);
 
     for(size_t c = 0; c < 3; c++)
@@ -997,47 +1099,50 @@ inline static void wavelets_reconstruct_ratios(const float *const restrict HF, c
 
       // synthesize interpolated/inpainted RGB channels color details and weigh them
       // this brings back some color on top of the grey_details
-      const float color_details = (HF_c[c] * gamma_comp - 0.5f * fminf(fabsf(HF_c[c] / grey_details), 1.f) * grey_texture) * beta;
+      const float color_details
+          = (HF_c[c] * gamma_comp - 0.5f * fminf(fabsf(HF_c[c] / grey_details), 1.f) * grey_texture) * beta;
 
       // reconstruction
-      reconstructed[k + c] += alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
+      reconstructed[k + c]
+          += alpha * (delta * (grey_HF + color_details) + (grey_residual + color_residual) / (float)scales);
     }
   }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, mask, reconstructed:64) uniform(ch, width, height)
+#pragma omp declare simd aligned(in, mask, reconstructed : 64) uniform(ch, width, height)
 #endif
-static inline void init_reconstruct(const float *const restrict in, const float *const restrict mask, float *const restrict reconstructed,
-                                    const size_t width, const size_t height, const size_t ch)
+static inline void init_reconstruct(const float *const restrict in, const float *const restrict mask,
+                                    float *const restrict reconstructed, const size_t width, const size_t height,
+                                    const size_t ch)
 {
-  // init the reconstructed buffer with non-clipped and partially clipped pixels
-  // Note : it's a simple multiplied alpha blending where mask = alpha weight
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(in, mask, reconstructed, width, height, ch) \
-    schedule(simd:static) aligned(in, mask, reconstructed:64)
-  #endif
+// init the reconstructed buffer with non-clipped and partially clipped pixels
+// Note : it's a simple multiplied alpha blending where mask = alpha weight
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(in, mask, reconstructed, width, height, ch)       \
+    schedule(simd                                                                                                 \
+             : static) aligned(in, mask, reconstructed : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k++)
   {
-    reconstructed[k] = in[k] * (1.f - mask[k/ch]);
+    reconstructed[k] = in[k] * (1.f - mask[k / ch]);
   }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(detail, LF, HF, texture:64) uniform(ch, width, height)
+#pragma omp declare simd aligned(detail, LF, HF, texture : 64) uniform(ch, width, height)
 #endif
 static inline void wavelets_detail_level_RGB(const float *const restrict detail, const float *const restrict LF,
                                              float *const restrict HF, float *const restrict texture,
                                              const size_t width, const size_t height, const size_t ch)
 {
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture) \
-    schedule(simd:static) aligned(HF, LF, detail, texture:64)
-  #endif
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture)       \
+    schedule(simd                                                                                                 \
+             : static) aligned(HF, LF, detail, texture : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
     for(size_t c = 0; c < 3; ++c) HF[k + c] = detail[k + c] - LF[k + c];
@@ -1047,17 +1152,17 @@ static inline void wavelets_detail_level_RGB(const float *const restrict detail,
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(detail, LF, HF, texture:64) uniform(ch, width, height)
+#pragma omp declare simd aligned(detail, LF, HF, texture : 64) uniform(ch, width, height)
 #endif
 static inline void wavelets_detail_level_ratios(const float *const restrict detail, const float *const restrict LF,
                                                 float *const restrict HF, float *const restrict texture,
                                                 const size_t width, const size_t height, const size_t ch)
 {
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture) \
-    schedule(simd:static) aligned(HF, LF, detail, texture:64)
-  #endif
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, HF, LF, detail, texture)       \
+    schedule(simd                                                                                                 \
+             : static) aligned(HF, LF, detail, texture : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
     for(size_t c = 0; c < 3; ++c) HF[k + c] = detail[k + c] - LF[k + c];
@@ -1075,7 +1180,8 @@ static int get_scales(const dt_iop_roi_t *roi_in, const dt_dev_pixelpipe_iop_t *
    * 2. The coarsest level filter at full resolution should cover `1/FSIZE` of the largest image dimension.
    * 3. The coarsest level filter at current zoom level should cover `scale/FSIZE` of the largest image dimension.
    *
-   * So we compute the level that solves 1. subject to 3. Of course, integer rounding doesn't make that 1:1 accurate.
+   * So we compute the level that solves 1. subject to 3. Of course, integer rounding doesn't make that 1:1
+   * accurate.
    */
   const float scale = roi_in->scale / piece->iscale;
   const size_t size = MAX(piece->buf_in.height * piece->iscale, piece->buf_in.width * piece->iscale);
@@ -1085,12 +1191,11 @@ static int get_scales(const dt_iop_roi_t *roi_in, const dt_dev_pixelpipe_iop_t *
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, mask, reconstructed:64) uniform(ch, variant, piece, roi_in, roi_out)
+#pragma omp declare simd aligned(in, mask, reconstructed : 64) uniform(ch, variant, piece, roi_in, roi_out)
 #endif
 static inline gint reconstruct_highlights(const float *const restrict in, const float *const restrict mask,
                                           float *const restrict reconstructed,
-                                          const dt_iop_filmicrgb_reconstruction_type_t variant,
-                                          const size_t ch,
+                                          const dt_iop_filmicrgb_reconstruction_type_t variant, const size_t ch,
                                           const dt_iop_filmicrgb_data_t *const data, dt_dev_pixelpipe_iop_t *piece,
                                           const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
@@ -1101,9 +1206,10 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
 
   // wavelets scales buffers
   float *const restrict LF_even = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch); // low-frequencies RGB
-  float *const restrict LF_odd = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch); // low-frequencies RGB
-  float *const restrict HF_RGB = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch); // high-frequencies RGB
-  float *const restrict HF_grey = dt_alloc_sse_ps(roi_out->width * roi_out->height); // max(high-frequencies RGB) grey
+  float *const restrict LF_odd = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);  // low-frequencies RGB
+  float *const restrict HF_RGB = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);  // high-frequencies RGB
+  float *const restrict HF_grey
+      = dt_alloc_sse_ps(roi_out->width * roi_out->height); // max(high-frequencies RGB) grey
 
   // alloc a permanent reusable buffer for intermediate computations - avoid multiple alloc/free
   float *const restrict temp = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
@@ -1165,10 +1271,8 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
     const int mult = 1 << s; // fancy-pants C notation for 2^s with integer type, don't be afraid
 
     // Compute wavelets low-frequency scales
-    blur_2D_Bspline_vertical(detail, temp, roi_out->width, roi_out->height, ch, mult,
-                             bound_left, bound_right);
-    blur_2D_Bspline_horizontal(temp, LF, roi_out->width, roi_out->height, ch, mult,
-                               bound_top, bound_bot);
+    blur_2D_Bspline_vertical(detail, temp, roi_out->width, roi_out->height, ch, mult, bound_left, bound_right);
+    blur_2D_Bspline_horizontal(temp, LF, roi_out->width, roi_out->height, ch, mult, bound_top, bound_bot);
 
     // Compute wavelets high-frequency scales and save the maximum of texture over the RGB channels
     // Note : HF_RGB = detail - LF, HF_grey = max(HF_RGB)
@@ -1178,10 +1282,8 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
       wavelets_detail_level_ratios(detail, LF, HF_RGB, HF_grey, roi_out->width, roi_out->height, ch);
 
     // interpolate/blur/inpaint (same thing) the RGB high-frequency to fill holes
-    blur_2D_Bspline_vertical(HF_RGB, temp, roi_out->width, roi_out->height, ch, mult,
-                             bound_left, bound_right);
-    blur_2D_Bspline_horizontal(temp, HF_RGB, roi_out->width, roi_out->height, ch, mult,
-                               bound_top, bound_bot);
+    blur_2D_Bspline_vertical(HF_RGB, temp, roi_out->width, roi_out->height, ch, mult, bound_left, bound_right);
+    blur_2D_Bspline_horizontal(temp, HF_RGB, roi_out->width, roi_out->height, ch, mult, bound_top, bound_bot);
 
     // Reconstruct clipped parts
     if(variant == DT_FILMIC_RECONSTRUCT_RGB)
@@ -1189,7 +1291,7 @@ static inline gint reconstruct_highlights(const float *const restrict in, const 
                                gamma, gamma_comp, beta, beta_comp, delta, s, scales);
     else if(variant == DT_FILMIC_RECONSTRUCT_RATIOS)
       wavelets_reconstruct_ratios(HF_RGB, LF, HF_grey, mask, reconstructed, roi_out->width, roi_out->height, ch,
-                               gamma, gamma_comp, beta, beta_comp, delta, s, scales);
+                                  gamma, gamma_comp, beta, beta_comp, delta, s, scales);
   }
 
 error:
@@ -1203,18 +1305,18 @@ error:
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) \
-  uniform(ch, width, height, work_profile, data, spline)
+#pragma omp declare simd aligned(in, out : 64) uniform(ch, width, height, work_profile, data, spline)
 #endif
 static inline void filmic_split_v1(const float *const restrict in, float *const restrict out,
                                    const dt_iop_order_iccprofile_info_t *const work_profile,
-                                   const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
-                                   const size_t width, const size_t height, const size_t ch)
+                                   const dt_iop_filmicrgb_data_t *const data,
+                                   const dt_iop_filmic_rgb_spline_t spline, const size_t width,
+                                   const size_t height, const size_t ch)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, spline) \
-  schedule(simd:static) aligned(in, out:64)
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, data, in, out, work_profile,   \
+                                                                spline) schedule(simd                             \
+                                                                                 : static) aligned(in, out : 64)
 #endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
@@ -1224,40 +1326,42 @@ static inline void filmic_split_v1(const float *const restrict in, float *const 
 
     // Log tone-mapping
     for(int c = 0; c < 3; c++)
-      temp[c] = log_tonemapping_v1(fmaxf(pix_in[c], NORM_MIN), data->grey_source, data->black_source, data->dynamic_range);
+      temp[c] = log_tonemapping_v1(fmaxf(pix_in[c], NORM_MIN), data->grey_source, data->black_source,
+                                   data->dynamic_range);
 
     // Get the desaturation coeff based on the log value
-    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(temp,
-                                                                         work_profile->matrix_in,
-                                                                         work_profile->lut_in,
-                                                                         work_profile->unbounded_coeffs_in,
-                                                                         work_profile->lutsize,
-                                                                         work_profile->nonlinearlut)
-                                      : dt_camera_rgb_luminance(temp);
+    const float lum = (work_profile)
+                          ? dt_ioppr_get_rgb_matrix_luminance(temp, work_profile->matrix_in, work_profile->lut_in,
+                                                              work_profile->unbounded_coeffs_in,
+                                                              work_profile->lutsize, work_profile->nonlinearlut)
+                          : dt_camera_rgb_luminance(temp);
     const float desaturation = filmic_desaturate_v1(lum, data->sigma_toe, data->sigma_shoulder, data->saturation);
 
     // Desaturate on the non-linear parts of the curve
     // Filmic S curve on the max RGB
     // Apply the transfer function of the display
     for(int c = 0; c < 3; c++)
-      pix_out[c] = powf(clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+      pix_out[c] = powf(
+          clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3,
+                                   spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)),
+          data->output_power);
   }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) \
-  uniform(ch, width, height, work_profile, data, spline)
+#pragma omp declare simd aligned(in, out : 64) uniform(ch, width, height, work_profile, data, spline)
 #endif
 static inline void filmic_split_v2(const float *const restrict in, float *const restrict out,
                                    const dt_iop_order_iccprofile_info_t *const work_profile,
-                                   const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
-                                   const size_t width, const size_t height, const size_t ch)
+                                   const dt_iop_filmicrgb_data_t *const data,
+                                   const dt_iop_filmic_rgb_spline_t spline, const size_t width,
+                                   const size_t height, const size_t ch)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, spline) \
-  schedule(simd:static) aligned(in, out:64)
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, data, in, out, work_profile,   \
+                                                                spline) schedule(simd                             \
+                                                                                 : static) aligned(in, out : 64)
 #endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
@@ -1267,41 +1371,43 @@ static inline void filmic_split_v2(const float *const restrict in, float *const 
 
     // Log tone-mapping
     for(int c = 0; c < 3; c++)
-      temp[c] = log_tonemapping_v2(fmaxf(pix_in[c], NORM_MIN), data->grey_source, data->black_source, data->dynamic_range);
+      temp[c] = log_tonemapping_v2(fmaxf(pix_in[c], NORM_MIN), data->grey_source, data->black_source,
+                                   data->dynamic_range);
 
     // Get the desaturation coeff based on the log value
-    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(temp,
-                                                                         work_profile->matrix_in,
-                                                                         work_profile->lut_in,
-                                                                         work_profile->unbounded_coeffs_in,
-                                                                         work_profile->lutsize,
-                                                                         work_profile->nonlinearlut)
-                                      : dt_camera_rgb_luminance(temp);
+    const float lum = (work_profile)
+                          ? dt_ioppr_get_rgb_matrix_luminance(temp, work_profile->matrix_in, work_profile->lut_in,
+                                                              work_profile->unbounded_coeffs_in,
+                                                              work_profile->lutsize, work_profile->nonlinearlut)
+                          : dt_camera_rgb_luminance(temp);
     const float desaturation = filmic_desaturate_v2(lum, data->sigma_toe, data->sigma_shoulder, data->saturation);
 
     // Desaturate on the non-linear parts of the curve
     // Filmic S curve on the max RGB
     // Apply the transfer function of the display
     for(int c = 0; c < 3; c++)
-      pix_out[c] = powf(clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+      pix_out[c] = powf(
+          clamp_simd(filmic_spline(linear_saturation(temp[c], lum, desaturation), spline.M1, spline.M2, spline.M3,
+                                   spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)),
+          data->output_power);
   }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) \
-  uniform(ch, width, height, work_profile, data, spline, variant)
+#pragma omp declare simd aligned(in, out : 64) uniform(ch, width, height, work_profile, data, spline, variant)
 #endif
 static inline void filmic_chroma_v1(const float *const restrict in, float *const restrict out,
                                     const dt_iop_order_iccprofile_info_t *const work_profile,
-                                    const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
-                                    const int variant,
-                                    const size_t width, const size_t height, const size_t ch)
+                                    const dt_iop_filmicrgb_data_t *const data,
+                                    const dt_iop_filmic_rgb_spline_t spline, const int variant, const size_t width,
+                                    const size_t height, const size_t ch)
 {
 #ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, variant, spline) \
-  schedule(simd:static) aligned(in, out:64)
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, variant, spline) schedule(simd            \
+                                                                                                  : static)       \
+        aligned(in, out : 64)
 #endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
@@ -1316,7 +1422,8 @@ static inline void filmic_chroma_v1(const float *const restrict in, float *const
 
     // Sanitize the ratios
     const float min_ratios = fminf(fminf(ratios[0], ratios[1]), ratios[2]);
-    if(min_ratios < 0.0f) for(int c = 0; c < 3; c++) ratios[c] -= min_ratios;
+    if(min_ratios < 0.0f)
+      for(int c = 0; c < 3; c++) ratios[c] -= min_ratios;
 
     // Log tone-mapping
     norm = log_tonemapping_v1(norm, data->grey_source, data->black_source, data->dynamic_range);
@@ -1326,20 +1433,19 @@ static inline void filmic_chroma_v1(const float *const restrict in, float *const
 
     for(int c = 0; c < 3; c++) ratios[c] *= norm;
 
-    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(ratios,
-                                                                         work_profile->matrix_in,
-                                                                         work_profile->lut_in,
-                                                                         work_profile->unbounded_coeffs_in,
-                                                                         work_profile->lutsize,
-                                                                         work_profile->nonlinearlut)
-                                      : dt_camera_rgb_luminance(ratios);
+    const float lum = (work_profile) ? dt_ioppr_get_rgb_matrix_luminance(
+                          ratios, work_profile->matrix_in, work_profile->lut_in, work_profile->unbounded_coeffs_in,
+                          work_profile->lutsize, work_profile->nonlinearlut)
+                                     : dt_camera_rgb_luminance(ratios);
 
     // Desaturate on the non-linear parts of the curve and save ratios
     for(int c = 0; c < 3; c++) ratios[c] = linear_saturation(ratios[c], lum, desaturation) / norm;
 
     // Filmic S curve on the max RGB
     // Apply the transfer function of the display
-    norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+    norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5,
+                                         spline.latitude_min, spline.latitude_max)),
+                data->output_power);
 
     // Re-apply ratios
     for(int c = 0; c < 3; c++) pix_out[c] = ratios[c] * norm;
@@ -1348,21 +1454,21 @@ static inline void filmic_chroma_v1(const float *const restrict in, float *const
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, out:64) \
-  uniform(ch, width, height, work_profile, data, spline, variant)
+#pragma omp declare simd aligned(in, out : 64) uniform(ch, width, height, work_profile, data, spline, variant)
 #endif
 static inline void filmic_chroma_v2(const float *const restrict in, float *const restrict out,
                                     const dt_iop_order_iccprofile_info_t *const work_profile,
-                                    const dt_iop_filmicrgb_data_t *const data, const dt_iop_filmic_rgb_spline_t spline,
-                                    const int variant,
-                                    const size_t width, const size_t height, const size_t ch)
+                                    const dt_iop_filmicrgb_data_t *const data,
+                                    const dt_iop_filmic_rgb_spline_t spline, const int variant, const size_t width,
+                                    const size_t height, const size_t ch)
 {
 
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, variant, spline) \
-    schedule(simd:static) aligned(in, out:64)
-  #endif
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_firstprivate(width, height, ch, data, in, out, work_profile, variant, spline) schedule(simd            \
+                                                                                                  : static)       \
+        aligned(in, out : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
     const float *const restrict pix_in = in + k;
@@ -1379,8 +1485,7 @@ static inline void filmic_chroma_v2(const float *const restrict in, float *const
     const int sanitize = (min_ratios < 0.0f);
 
     if(sanitize)
-      for(int c = 0; c < 3; c++)
-        ratios[c] -= min_ratios;
+      for(int c = 0; c < 3; c++) ratios[c] -= min_ratios;
 
     // Log tone-mapping
     norm = log_tonemapping_v2(norm, data->grey_source, data->black_source, data->dynamic_range);
@@ -1390,7 +1495,9 @@ static inline void filmic_chroma_v2(const float *const restrict in, float *const
 
     // Filmic S curve on the max RGB
     // Apply the transfer function of the display
-    norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5, spline.latitude_min, spline.latitude_max)), data->output_power);
+    norm = powf(clamp_simd(filmic_spline(norm, spline.M1, spline.M2, spline.M3, spline.M4, spline.M5,
+                                         spline.latitude_min, spline.latitude_max)),
+                data->output_power);
 
     // Re-apply ratios with saturation change
     for(int c = 0; c < 3; c++)
@@ -1417,35 +1524,34 @@ static inline void filmic_chroma_v2(const float *const restrict in, float *const
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(mask, out:64) \
-  uniform(ch, width, height)
+#pragma omp declare simd aligned(mask, out : 64) uniform(ch, width, height)
 #endif
-static inline void display_mask(const float *const restrict mask, float *const restrict out,
-                                const size_t width, const size_t height, const size_t ch)
+static inline void display_mask(const float *const restrict mask, float *const restrict out, const size_t width,
+                                const size_t height, const size_t ch)
 {
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(width, height, ch, out, mask) \
-    schedule(simd:static) aligned(mask, out:64)
-  #endif
-  for(size_t k = 0; k < height * width * ch; k++)
-    out[k] = mask[k / ch];
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, out, mask) schedule(simd       \
+                                                                                                       : static)  \
+    aligned(mask, out : 64)
+#endif
+  for(size_t k = 0; k < height * width * ch; k++) out[k] = mask[k / ch];
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(in, norms, ratios:64) \
-  uniform(ch, width, height, work_profile, variant)
+#pragma omp declare simd aligned(in, norms, ratios : 64) uniform(ch, width, height, work_profile, variant)
 #endif
-static inline void compute_ratios(const float *const restrict in, float *const restrict norms, float *const restrict ratios,
+static inline void compute_ratios(const float *const restrict in, float *const restrict norms,
+                                  float *const restrict ratios,
                                   const dt_iop_order_iccprofile_info_t *const work_profile, const int variant,
                                   const size_t width, const size_t height, const size_t ch)
 {
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(ch, width, height, norms, ratios, in, work_profile, variant) \
-    schedule(simd:static) aligned(norms, ratios, in:64)
-  #endif
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none)                                                                       \
+    dt_omp_firstprivate(ch, width, height, norms, ratios, in, work_profile, variant) schedule(simd                \
+                                                                                              : static)           \
+        aligned(norms, ratios, in : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
     const float norm = fmaxf(get_pixel_norm(in + k, variant, work_profile), NORM_MIN);
@@ -1457,30 +1563,28 @@ static inline void compute_ratios(const float *const restrict in, float *const r
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(norms, ratios:64) \
-  uniform(ch, width, height)
+#pragma omp declare simd aligned(norms, ratios : 64) uniform(ch, width, height)
 #endif
 static inline void restore_ratios(float *const restrict ratios, const float *const restrict norms,
                                   const size_t width, const size_t height, const size_t ch)
 {
-  #ifdef _OPENMP
-  #pragma omp parallel for simd default(none) \
-    dt_omp_firstprivate(width, height, ch, norms, ratios) \
-    schedule(simd:static) aligned(norms, ratios:64)
-  #endif
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) dt_omp_firstprivate(width, height, ch, norms, ratios)                 \
+    schedule(simd                                                                                                 \
+             : static) aligned(norms, ratios : 64)
+#endif
   for(size_t k = 0; k < height * width * ch; k += ch)
   {
-    for(size_t c = 0; c < 3; c++) ratios[k + c] *= norms[k/ch];
+    for(size_t c = 0; c < 3; c++) ratios[k + c] *= norms[k / ch];
   }
 }
 
 
 #ifdef _OPENMP
-#pragma omp declare simd aligned(ivoid, ovoid:64) \
-  uniform(self, piece, roi_in, roi_out)
+#pragma omp declare simd aligned(ivoid, ovoid : 64) uniform(self, piece, roi_in, roi_out)
 #endif
-void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict ivoid, void *const restrict ovoid,
-             const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
+void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *const restrict ivoid,
+             void *const restrict ovoid, const dt_iop_roi_t *const roi_in, const dt_iop_roi_t *const roi_out)
 {
   const dt_iop_filmicrgb_data_t *const data = (dt_iop_filmicrgb_data_t *)piece->data;
   const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_pipe_work_profile_info(piece->pipe);
@@ -1494,23 +1598,25 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   const size_t ch = 4;
 
   /** The log2(x) -> -INF when x -> 0
-  * thus very low values (noise) will get even lower, resulting in noise negative amplification,
-  * which leads to pepper noise in shadows. To avoid that, we need to clip values that are noise for sure.
-  * Using 16 bits RAW data, the black value (known by rawspeed for every manufacturer) could be used as a threshold.
-  * However, at this point of the pixelpipe, the RAW levels have already been corrected and everything can happen with black levels
-  * in the exposure module. So we define the threshold as the first non-null 16 bit integer
-  */
+   * thus very low values (noise) will get even lower, resulting in noise negative amplification,
+   * which leads to pepper noise in shadows. To avoid that, we need to clip values that are noise for sure.
+   * Using 16 bits RAW data, the black value (known by rawspeed for every manufacturer) could be used as a
+   * threshold. However, at this point of the pixelpipe, the RAW levels have already been corrected and everything
+   * can happen with black levels in the exposure module. So we define the threshold as the first non-null 16 bit
+   * integer
+   */
 
   float *restrict in = (float *)ivoid;
   float *const restrict out = (float *)ovoid;
-  float *const restrict mask =  dt_alloc_sse_ps(roi_out->width * roi_out->height);
+  float *const restrict mask = dt_alloc_sse_ps(roi_out->width * roi_out->height);
 
   // used to adjuste noise level depending on size. Don't amplify noise if magnified > 100%
   const float scale = fmaxf(piece->iscale / roi_in->scale, 1.f);
 
   // build a mask of clipped pixels
   const float normalize = data->reconstruct_feather / data->reconstruct_threshold;
-  const int recover_highlights = mask_clipped_pixels(in, mask, normalize, data->reconstruct_feather, roi_out->width, roi_out->height, 4);
+  const int recover_highlights
+      = mask_clipped_pixels(in, mask, normalize, data->reconstruct_feather, roi_out->width, roi_out->height, 4);
 
   // display mask and exit
   if(self->dev->gui_attached && (piece->pipe->type & DT_DEV_PIXELPIPE_FULL) == DT_DEV_PIXELPIPE_FULL && mask)
@@ -1531,10 +1637,11 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
 
   if(!run_fast && recover_highlights && mask && reconstructed)
   {
-    float *const restrict inpainted =  dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
-    inpaint_noise(in, mask, inpainted, data->noise_level / scale, data->reconstruct_threshold, data->noise_distribution,
-                  roi_out->width * roi_out->height * ch, ch);
-    const gint success_1 = reconstruct_highlights(inpainted, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RGB, ch, data, piece, roi_in, roi_out);
+    float *const restrict inpainted = dt_alloc_sse_ps(roi_out->width * roi_out->height * ch);
+    inpaint_noise(in, mask, inpainted, data->noise_level / scale, data->reconstruct_threshold,
+                  data->noise_distribution, roi_out->width * roi_out->height * ch, ch);
+    const gint success_1 = reconstruct_highlights(inpainted, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RGB, ch,
+                                                  data, piece, roi_in, roi_out);
     gint success_2 = TRUE;
 
     dt_free_align(inpainted);
@@ -1549,8 +1656,11 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
       {
         for(int i = 0; i < data->high_quality_reconstruction; i++)
         {
-          compute_ratios(reconstructed, norms, ratios, work_profile, DT_FILMIC_METHOD_EUCLIDEAN_NORM, roi_out->width, roi_out->height, ch);
-          success_2 = success_2 && reconstruct_highlights(ratios, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RATIOS, ch, data, piece, roi_in, roi_out);
+          compute_ratios(reconstructed, norms, ratios, work_profile, DT_FILMIC_METHOD_EUCLIDEAN_NORM,
+                         roi_out->width, roi_out->height, ch);
+          success_2 = success_2
+                      && reconstruct_highlights(ratios, mask, reconstructed, DT_FILMIC_RECONSTRUCT_RATIOS, ch,
+                                                data, piece, roi_in, roi_out);
           restore_ratios(reconstructed, norms, roi_out->width, roi_out->height, ch);
         }
       }
@@ -1576,9 +1686,11 @@ void process(dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const void *c
   {
     // chroma preservation
     if(data->version == DT_FILMIC_COLORSCIENCE_V1)
-      filmic_chroma_v1(in, out, work_profile, data, data->spline, data->preserve_color, roi_out->width, roi_out->height, ch);
+      filmic_chroma_v1(in, out, work_profile, data, data->spline, data->preserve_color, roi_out->width,
+                       roi_out->height, ch);
     else if(data->version == DT_FILMIC_COLORSCIENCE_V2)
-      filmic_chroma_v2(in, out, work_profile, data, data->spline, data->preserve_color, roi_out->width, roi_out->height, ch);
+      filmic_chroma_v2(in, out, work_profile, data, data->spline, data->preserve_color, roi_out->width,
+                       roi_out->height, ch);
   }
 
   if(reconstructed) dt_free_align(reconstructed);
@@ -1687,7 +1799,7 @@ static void apply_auto_grey(dt_iop_module_t *self)
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 
   const dt_iop_order_iccprofile_info_t *const work_profile
-        = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+      = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
   const float grey = get_pixel_norm(self->picked_color, p->preserve_color, work_profile) / 2.0f;
 
   const float prev_grey = p->grey_point_source;
@@ -1695,7 +1807,8 @@ static void apply_auto_grey(dt_iop_module_t *self)
   const float grey_var = log2f(prev_grey / p->grey_point_source);
   p->black_point_source = p->black_point_source - grey_var;
   p->white_point_source = p->white_point_source + grey_var;
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+  p->output_power = logf(p->grey_point_target / 100.0f)
+                    / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
@@ -1716,14 +1829,15 @@ static void apply_auto_black(dt_iop_module_t *self)
 
   // Black
   const dt_iop_order_iccprofile_info_t *const work_profile
-        = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+      = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
   const float black = get_pixel_norm(self->picked_color_min, DT_FILMIC_METHOD_MAX_RGB, work_profile);
 
   float EVmin = CLAMP(log2f(black / (p->grey_point_source / 100.0f)), -16.0f, -1.0f);
   EVmin *= (1.0f + p->security_factor / 100.0f);
 
   p->black_point_source = fmaxf(EVmin, -16.0f);
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+  p->output_power = logf(p->grey_point_target / 100.0f)
+                    / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->black_point_source, p->black_point_source);
@@ -1743,14 +1857,15 @@ static void apply_auto_white_point_source(dt_iop_module_t *self)
 
   // White
   const dt_iop_order_iccprofile_info_t *const work_profile
-        = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+      = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
   const float white = get_pixel_norm(self->picked_color_max, DT_FILMIC_METHOD_MAX_RGB, work_profile);
 
   float EVmax = CLAMP(log2f(white / (p->grey_point_source / 100.0f)), 1.0f, 16.0f);
   EVmax *= (1.0f + p->security_factor / 100.0f);
 
   p->white_point_source = EVmax;
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+  p->output_power = logf(p->grey_point_target / 100.0f)
+                    / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->white_point_source, p->white_point_source);
@@ -1766,7 +1881,7 @@ static void apply_autotune(dt_iop_module_t *self)
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
   const dt_iop_order_iccprofile_info_t *const work_profile
-        = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
+      = dt_ioppr_get_iop_work_profile_info(self, self->dev->iop);
 
   // Grey
   if(p->custom_grey)
@@ -1787,7 +1902,8 @@ static void apply_autotune(dt_iop_module_t *self)
 
   p->black_point_source = fmaxf(EVmin, -16.0f);
   p->white_point_source = EVmax;
-  p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+  p->output_power = logf(p->grey_point_target / 100.0f)
+                    / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
   ++darktable.gui->reset;
   dt_bauhaus_slider_set_soft(g->grey_point_source, p->grey_point_source);
@@ -1804,14 +1920,14 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 {
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 
-  if      (picker == g->grey_point_source)
-       apply_auto_grey(self);
-  else if (picker == g->black_point_source)
-       apply_auto_black(self);
-  else if (picker == g->white_point_source)
-       apply_auto_white_point_source(self);
-  else if (picker == g->auto_button)
-       apply_autotune(self);
+  if(picker == g->grey_point_source)
+    apply_auto_grey(self);
+  else if(picker == g->black_point_source)
+    apply_auto_black(self);
+  else if(picker == g->white_point_source)
+    apply_auto_white_point_source(self);
+  else if(picker == g->auto_button)
+    apply_autotune(self);
 }
 
 static void show_mask_callback(GtkWidget *slider, gpointer user_data)
@@ -1831,14 +1947,16 @@ static void show_mask_callback(GtkWidget *slider, gpointer user_data)
 #define ORDER_3 4
 
 
-inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_params_t *const p, struct dt_iop_filmic_rgb_spline_t *const spline)
+inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_params_t *const p,
+                                                    struct dt_iop_filmic_rgb_spline_t *const spline)
 {
   float grey_display = 0.4638f;
 
   if(p->custom_grey)
   {
     // user set a custom value
-    grey_display = powf(CLAMP(p->grey_point_target, p->black_point_target, p->white_point_target) / 100.0f, 1.0f / (p->output_power));
+    grey_display = powf(CLAMP(p->grey_point_target, p->black_point_target, p->white_point_target) / 100.0f,
+                        1.0f / (p->output_power));
   }
   else
   {
@@ -1856,17 +1974,34 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
   const float white_log = 1.0f; // assumes user set log as in the autotuner
 
   // target luminance desired after filmic curve
-  const float black_display = CLAMP(p->black_point_target, 0.0f, p->grey_point_target) / 100.0f; // in %
-  const float white_display = fmaxf(p->white_point_target, p->grey_point_target)  / 100.0f; // in %
+  float black_display, white_display;
 
-  const float latitude = CLAMP(p->latitude, 0.0f, 100.0f) / 100.0f * dynamic_range; // in % of dynamic range
-  const float balance = CLAMP(p->balance, -50.0f, 50.0f) / 100.0f; // in %
-  const float contrast = CLAMP(p->contrast, 0.1f, 2.0f);
+  if(p->internal_version == 2019)
+  {
+    // this is a buggy version that doesn't take the output power function into account
+    // it was silent because black and white display were set to 0 and 1 and users were advised to not touch them.
+    // (since 0^x = 0 and 1^x = 1). It's not silent anymore if black display > 0,
+    // for example if compensating ICC black level for target medium
+    black_display = CLAMP(p->black_point_target, 0.0f, p->grey_point_target) / 100.0f; // in %
+    white_display = fmaxf(p->white_point_target, p->grey_point_target) / 100.0f;       // in %
+  }
+  else //(p->internal_version == 2020)
+  {
+    // this is the fixed version
+    black_display = powf(CLAMP(p->black_point_target, 0.0f, p->grey_point_target) / 100.0f,
+                         1.0f / (p->output_power)); // in %
+    white_display
+        = powf(fmaxf(p->white_point_target, p->grey_point_target) / 100.0f, 1.0f / (p->output_power)); // in %
+  }
+
+  float latitude = CLAMP(p->latitude, 0.0f, 100.0f) / 100.0f * dynamic_range; // in % of dynamic range
+  float balance = CLAMP(p->balance, -50.0f, 50.0f) / 100.0f;                  // in %
+  float contrast = CLAMP(p->contrast, 0.1f, 2.0f);
 
   // nodes for mapping from log encoding to desired target luminance
   // X coordinates
-  float toe_log = grey_log - latitude/dynamic_range * fabsf(black_source/dynamic_range);
-  float shoulder_log = grey_log + latitude/dynamic_range * fabsf(white_source/dynamic_range);
+  float toe_log = grey_log - latitude / dynamic_range * fabsf(black_source / dynamic_range);
+  float shoulder_log = grey_log + latitude / dynamic_range * fabsf(white_source / dynamic_range);
 
   // interception
   float linear_intercept = grey_display - (contrast * grey_log);
@@ -1894,7 +2029,7 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
    *
    * BUT : in case some nodes overlap, we need to remove them to avoid
    * degenerating of the curve
-  **/
+   **/
 
   // Build the curve from the nodes
   spline->x[0] = black_log;
@@ -1938,11 +2073,11 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
   if(p->shadows == DT_FILMIC_CURVE_POLY_4)
   {
     // fourth order polynom - only mode in darktable 3.0.0
-    double A0[ORDER_4 * ORDER_4] = {0.,         0.,       0.,      0., 1.,   // position in 0
-                                    0.,         0.,       0.,      1., 0.,   // first derivative in 0
-                                    Tl4,        Tl3,      Tl2,     Tl, 1.,   // position at toe node
-                                    4. * Tl3,   3. * Tl2, 2. * Tl, 1., 0.,   // first derivative at toe node
-                                    12. * Tl2,  6. * Tl,  2.,      0., 0. }; // second derivative at toe node
+    double A0[ORDER_4 * ORDER_4] = { 0.,        0.,       0.,      0., 1.,   // position in 0
+                                     0.,        0.,       0.,      1., 0.,   // first derivative in 0
+                                     Tl4,       Tl3,      Tl2,     Tl, 1.,   // position at toe node
+                                     4. * Tl3,  3. * Tl2, 2. * Tl, 1., 0.,   // first derivative at toe node
+                                     12. * Tl2, 6. * Tl,  2.,      0., 0. }; // second derivative at toe node
 
     double b0[ORDER_4] = { spline->y[0], 0., spline->y[1], spline->M2[2], 0. };
 
@@ -1957,10 +2092,10 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
   else
   {
     // third order polynom
-    double A0[ORDER_3 * ORDER_3] = {0.,        0.,       0.,     1.,   // position in 0
-                                    Tl3,       Tl2,      Tl,     1.,   // position at toe node
-                                    3. * Tl2,  2. * Tl,  1.,     0.,   // first derivative at toe node
-                                    6. * Tl,   2.,       0.,     0. }; // second derivative at toe node
+    double A0[ORDER_3 * ORDER_3] = { 0.,       0.,      0., 1.,   // position in 0
+                                     Tl3,      Tl2,     Tl, 1.,   // position at toe node
+                                     3. * Tl2, 2. * Tl, 1., 0.,   // first derivative at toe node
+                                     6. * Tl,  2.,      0., 0. }; // second derivative at toe node
 
     double b0[ORDER_3] = { spline->y[0], spline->y[1], spline->M2[2], 0. };
 
@@ -1977,10 +2112,10 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
   if(p->highlights == DT_FILMIC_CURVE_POLY_3)
   {
     // 3rd order polynom - only mode in darktable 3.0.0
-    double A1[ORDER_3 * ORDER_3] = { 1.,        1.,        1.,      1.,   // position in 1
-                                     Sl3,       Sl2,       Sl,      1.,   // position at shoulder node
-                                     3. * Sl2,  2. * Sl,   1.,      0.,   // first derivative at shoulder node
-                                     6. * Sl,   2.,        0.,      0. }; // second derivative at shoulder node
+    double A1[ORDER_3 * ORDER_3] = { 1.,       1.,      1., 1.,   // position in 1
+                                     Sl3,      Sl2,     Sl, 1.,   // position at shoulder node
+                                     3. * Sl2, 2. * Sl, 1., 0.,   // first derivative at shoulder node
+                                     6. * Sl,  2.,      0., 0. }; // second derivative at shoulder node
 
     double b1[ORDER_3] = { spline->y[4], spline->y[3], spline->M2[2], 0. };
 
@@ -1995,11 +2130,11 @@ inline static void dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_param
   else
   {
     // 4th order polynom
-    double A1[ORDER_4 * ORDER_4] = { 1.,        1.,        1.,      1.,      1.,   // position in 1
-                                     4.,        3.,        2.,      1.,      0.,   // first derivative in 1
-                                     Sl4,       Sl3,       Sl2,     Sl,      1.,   // position at shoulder node
-                                     4. * Sl3,  3. * Sl2,  2. * Sl, 1.,      0.,   // first derivative at shoulder node
-                                     12. * Sl2, 6. * Sl,   2.     , 0.,      0. }; // second derivative at shoulder node
+    double A1[ORDER_4 * ORDER_4] = { 1.,        1.,       1.,      1., 1.,   // position in 1
+                                     4.,        3.,       2.,      1., 0.,   // first derivative in 1
+                                     Sl4,       Sl3,      Sl2,     Sl, 1.,   // position at shoulder node
+                                     4. * Sl3,  3. * Sl2, 2. * Sl, 1., 0.,   // first derivative at shoulder node
+                                     12. * Sl2, 6. * Sl,  2.,      0., 0. }; // second derivative at shoulder node
 
     double b1[ORDER_4] = { spline->y[4], 0., spline->y[3], spline->M2[2], 0. };
 
@@ -2044,7 +2179,7 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
 
 
   float contrast = p->contrast;
-  if (contrast < grey_display / grey_log)
+  if(contrast < grey_display / grey_log)
   {
     // We need grey_display - (contrast * grey_log) <= 0.0
     contrast = 1.0001f * grey_display / grey_log;
@@ -2080,7 +2215,6 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_
   d->reconstruct_structure_vs_texture = (p->reconstruct_structure_vs_texture / 100.0f + 1.f) / 2.f;
   d->reconstruct_bloom_vs_details = (p->reconstruct_bloom_vs_details / 100.0f + 1.f) / 2.f;
   d->reconstruct_grey_vs_color = (p->reconstruct_grey_vs_color / 100.0f + 1.f) / 2.f;
-
 }
 
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
@@ -2089,7 +2223,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
   if(!in)
   {
-    //lost focus - hide the mask
+    // lost focus - hide the mask
     g->show_mask = FALSE;
     dt_bauhaus_widget_set_quad_toggle(g->show_highlight_mask, FALSE);
     dt_bauhaus_widget_set_quad_active(g->show_highlight_mask, FALSE);
@@ -2176,8 +2310,8 @@ void reload_defaults(dt_iop_module_t *module)
   // we might be called from presets update infrastructure => there is no image
   if(!module->dev || module->dev->image_storage.id == -1) goto end;
 
-  if(dt_image_is_matrix_correction_supported(&module->dev->image_storage) &&
-     strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
+  if(dt_image_is_matrix_correction_supported(&module->dev->image_storage)
+     && strcmp(dt_conf_get_string("plugins/darkroom/workflow"), "scene-referred") == 0)
   {
     // For scene-referred workflow, auto-enable and adjust based on exposure
     // TODO: fetch actual exposure in module, don't assume 1.
@@ -2188,7 +2322,8 @@ void reload_defaults(dt_iop_module_t *module)
     // so exposure compensation actually increases the dynamic range too (stretches only white).
     d->black_point_source += 0.5f * exposure;
     d->white_point_source += 0.8f * exposure;
-    d->output_power = logf(d->grey_point_target / 100.0f) / logf(-d->black_point_source / (d->white_point_source - d->black_point_source));
+    d->output_power = logf(d->grey_point_target / 100.0f)
+                      / logf(-d->black_point_source / (d->white_point_source - d->black_point_source));
   }
 
 end:
@@ -2224,9 +2359,8 @@ void gui_reset(dt_iop_module_t *self)
 
 #define LOGBASE 20.f
 
-static inline void dt_cairo_draw_arrow(cairo_t *cr,
-                                       double origin_x, double origin_y, double destination_x, double destination_y,
-                                       gboolean show_head)
+static inline void dt_cairo_draw_arrow(cairo_t *cr, double origin_x, double origin_y, double destination_x,
+                                       double destination_y, gboolean show_head)
 {
   cairo_move_to(cr, origin_x, origin_y);
   cairo_line_to(cr, destination_x, destination_y);
@@ -2252,7 +2386,8 @@ static inline void dt_cairo_draw_arrow(cairo_t *cr,
   }
 }
 
-void filmic_gui_draw_icon(cairo_t *cr, struct dt_iop_filmicrgb_gui_button_data_t *button, struct dt_iop_filmicrgb_gui_data_t *g)
+void filmic_gui_draw_icon(cairo_t *cr, struct dt_iop_filmicrgb_gui_button_data_t *button,
+                          struct dt_iop_filmicrgb_gui_data_t *g)
 {
   if(!g->gui_sizes_inited) return;
 
@@ -2277,15 +2412,17 @@ void filmic_gui_draw_icon(cairo_t *cr, struct dt_iop_filmicrgb_gui_button_data_t
     cairo_set_source_rgba(cr, color.red, color.green, color.blue, color.alpha * 0.5);
   }
 
-  cairo_rectangle(cr, button->left, button->top, button->w - DT_PIXEL_APPLY_DPI(0.5), button->h - DT_PIXEL_APPLY_DPI(0.5));
+  cairo_rectangle(cr, button->left, button->top, button->w - DT_PIXEL_APPLY_DPI(0.5),
+                  button->h - DT_PIXEL_APPLY_DPI(0.5));
   cairo_set_line_width(cr, DT_PIXEL_APPLY_DPI(1.));
   cairo_stroke(cr);
-  cairo_translate(cr, button->left + button->w /2. - DT_PIXEL_APPLY_DPI(0.25), button->top + button->h / 2. - DT_PIXEL_APPLY_DPI(0.25));
+  cairo_translate(cr, button->left + button->w / 2. - DT_PIXEL_APPLY_DPI(0.25),
+                  button->top + button->h / 2. - DT_PIXEL_APPLY_DPI(0.25));
 
   const float scale = 0.85;
   cairo_scale(cr, scale, scale);
-  button->icon(cr, -scale * button->w / 2., -scale * button->h / 2.,
-                    scale * button->w, scale * button->h, CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
+  button->icon(cr, -scale * button->w / 2., -scale * button->h / 2., scale * button->w, scale * button->h,
+               CPF_STYLE_FLAT | CPF_DO_NOT_USE_BORDER, NULL);
   cairo_restore(cr);
 }
 
@@ -2353,7 +2490,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
   const float margin_top = 2. * g->line_height + g->inset;
   const float margin_right = darktable.bauhaus->quad_width + 2. * g->inset;
 
-  g->graph_width = g->allocation.width - margin_right - margin_left; // align the right border on sliders
+  g->graph_width = g->allocation.width - margin_right - margin_left;   // align the right border on sliders
   g->graph_height = g->allocation.height - margin_bottom - margin_top; // give room to nodes
 
   gtk_render_background(g->context, g->cr, 0, 0, g->allocation.width, g->allocation.height);
@@ -2378,8 +2515,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   if(g->gui_hover)
   {
-    for(int i = 0; i < DT_FILMIC_GUI_BUTTON_LAST; i++)
-      filmic_gui_draw_icon(g->cr, &g->buttons[i], g);
+    for(int i = 0; i < DT_FILMIC_GUI_BUTTON_LAST; i++) filmic_gui_draw_icon(g->cr, &g->buttons[i], g);
   }
 
   const float grey = p->grey_point_source / 100.f;
@@ -2407,16 +2543,15 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
   // legend background
   set_color(g->cr, darktable.bauhaus->graph_bg);
-  cairo_rectangle(g->cr, g->allocation.width -margin_left - g->ink.width - g->ink.x - 2. * g->inset,
-                        -g->line_height -g->inset - 0.5 * g->ink.height - g->ink.y - g->inset,
-                         g->ink.width + 3. * g->inset,
-                         g->ink.height + 2. * g->inset);
+  cairo_rectangle(g->cr, g->allocation.width - margin_left - g->ink.width - g->ink.x - 2. * g->inset,
+                  -g->line_height - g->inset - 0.5 * g->ink.height - g->ink.y - g->inset,
+                  g->ink.width + 3. * g->inset, g->ink.height + 2. * g->inset);
   cairo_fill(g->cr);
 
   // legend text
   set_color(g->cr, darktable.bauhaus->graph_fg);
-  cairo_move_to(g->cr, g->allocation.width -margin_left - g->ink.width - g->ink.x - g->inset,
-                      -g->line_height -g->inset - 0.5 * g->ink.height - g->ink.y);
+  cairo_move_to(g->cr, g->allocation.width - margin_left - g->ink.width - g->ink.x - g->inset,
+                -g->line_height - g->inset - 0.5 * g->ink.height - g->ink.y);
   pango_cairo_show_layout(g->cr, g->layout);
   cairo_stroke(g->cr);
 
@@ -2468,12 +2603,13 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     // prevent graph overflowing
     cairo_save(g->cr);
     cairo_rectangle(g->cr, -DT_PIXEL_APPLY_DPI(2.), -DT_PIXEL_APPLY_DPI(2.),
-                            g->graph_width + 2. * DT_PIXEL_APPLY_DPI(2.), g->graph_height + 2. * DT_PIXEL_APPLY_DPI(2.));
+                    g->graph_width + 2. * DT_PIXEL_APPLY_DPI(2.), g->graph_height + 2. * DT_PIXEL_APPLY_DPI(2.));
     cairo_clip(g->cr);
 
     if(p->version == DT_FILMIC_COLORSCIENCE_V1)
     {
-      cairo_move_to(g->cr, 0, g->graph_height * (1.0 - filmic_desaturate_v1(0.0f, sigma_toe, sigma_shoulder, saturation)));
+      cairo_move_to(g->cr, 0,
+                    g->graph_height * (1.0 - filmic_desaturate_v1(0.0f, sigma_toe, sigma_shoulder, saturation)));
       for(int k = 1; k < 256; k++)
       {
         float x = k / 255.0;
@@ -2489,7 +2625,8 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     }
     else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
     {
-      cairo_move_to(g->cr, 0, g->graph_height * (1.0 - filmic_desaturate_v2(0.0f, sigma_toe, sigma_shoulder, saturation)));
+      cairo_move_to(g->cr, 0,
+                    g->graph_height * (1.0 - filmic_desaturate_v2(0.0f, sigma_toe, sigma_shoulder, saturation)));
       for(int k = 1; k < 256; k++)
       {
         float x = k / 255.0;
@@ -2510,10 +2647,10 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     if(g->gui_mode == DT_FILMIC_GUI_BASECURVE || g->gui_mode == DT_FILMIC_GUI_BASECURVE_LOG)
       x_start = log_tonemapping_v2(x_start, grey, p->black_point_source, DR);
 
-    if(g->gui_mode == DT_FILMIC_GUI_BASECURVE_LOG)
-      x_start = dt_log_scale_axis(x_start, LOGBASE);
+    if(g->gui_mode == DT_FILMIC_GUI_BASECURVE_LOG) x_start = dt_log_scale_axis(x_start, LOGBASE);
 
-    float y_start = clamp_simd(filmic_spline(x_start, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4, g->spline.M5, g->spline.latitude_min, g->spline.latitude_max));
+    float y_start = clamp_simd(filmic_spline(x_start, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4,
+                                             g->spline.M5, g->spline.latitude_min, g->spline.latitude_max));
 
     if(g->gui_mode == DT_FILMIC_GUI_BASECURVE)
       y_start = powf(y_start, p->output_power);
@@ -2524,27 +2661,27 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
     for(int k = 1; k < 256; k++)
     {
-      // k / 255 step defines a linearly scaled space. This might produce large gaps in lowlights when using log GUI scaling
-      // so we non-linearly rescale that step to get more points in lowlights
+      // k / 255 step defines a linearly scaled space. This might produce large gaps in lowlights when using log
+      // GUI scaling so we non-linearly rescale that step to get more points in lowlights
       float x = powf(k / 255.0f, 2.4f);
       float value = x;
 
       if(g->gui_mode == DT_FILMIC_GUI_BASECURVE || g->gui_mode == DT_FILMIC_GUI_BASECURVE_LOG)
         value = log_tonemapping_v2(x, grey, p->black_point_source, DR);
 
-      if(g->gui_mode == DT_FILMIC_GUI_BASECURVE_LOG)
-        x = dt_log_scale_axis(x, LOGBASE);
+      if(g->gui_mode == DT_FILMIC_GUI_BASECURVE_LOG) x = dt_log_scale_axis(x, LOGBASE);
 
-      float y = filmic_spline(value, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4, g->spline.M5, g->spline.latitude_min, g->spline.latitude_max);
+      float y = filmic_spline(value, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4, g->spline.M5,
+                              g->spline.latitude_min, g->spline.latitude_max);
 
-      if(y > 1.f)
+      if(y > g->spline.y[4])
       {
-        y = 1.f;
+        y = fminf(y, 1.0f);
         cairo_set_source_rgb(g->cr, 0.75, .5, 0.);
       }
-      else if(y < 0.0f)
+      else if(y < g->spline.y[0])
       {
-        y = 0.0f;
+        y = fmaxf(y, 0.f);
         cairo_set_source_rgb(g->cr, 0.75, .5, 0.);
       }
       else
@@ -2569,7 +2706,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     // special case for the grey node
     cairo_save(g->cr);
     cairo_rectangle(g->cr, -DT_PIXEL_APPLY_DPI(4.), -DT_PIXEL_APPLY_DPI(4.),
-                            g->graph_width + 2. * DT_PIXEL_APPLY_DPI(4.), g->graph_height + 2. * DT_PIXEL_APPLY_DPI(4.));
+                    g->graph_width + 2. * DT_PIXEL_APPLY_DPI(4.), g->graph_height + 2. * DT_PIXEL_APPLY_DPI(4.));
     cairo_clip(g->cr);
     float x_grey = g->spline.x[2];
     float y_grey = g->spline.y[2];
@@ -2586,7 +2723,8 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     }
 
     cairo_set_source_rgb(g->cr, 0.75, 0.5, 0.0);
-    cairo_arc(g->cr, x_grey * g->graph_width, (1.0 - y_grey) * g->graph_height, DT_PIXEL_APPLY_DPI(6), 0, 2. * M_PI);
+    cairo_arc(g->cr, x_grey * g->graph_width, (1.0 - y_grey) * g->graph_height, DT_PIXEL_APPLY_DPI(6), 0,
+              2. * M_PI);
     cairo_fill(g->cr);
     cairo_stroke(g->cr);
 
@@ -2670,7 +2808,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
       cairo_move_to(g->cr, -2. * g->inset - g->ink.width - g->ink.x,
-                          (1.0 - y_black) * g->graph_height - 0.5 * g->ink.height - g->ink.y);
+                    (1.0 - y_black) * g->graph_height - 0.5 * g->ink.height - g->ink.y);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
 
@@ -2680,7 +2818,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
       cairo_move_to(g->cr, -2. * g->inset - g->ink.width - g->ink.x,
-                          (1.0 - y_white) * g->graph_height - 0.5 * g->ink.height - g->ink.y);
+                    (1.0 - y_white) * g->graph_height - 0.5 * g->ink.height - g->ink.y);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
 
@@ -2711,8 +2849,10 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
-      cairo_move_to(g->cr, fminf(x_white, 1.f) * g->graph_width - 0.5 * g->ink.width - g->ink.x + 2. * (x_white > 1.f) * g->sign_width,
-                           x_legend_top);
+      cairo_move_to(g->cr,
+                    fminf(x_white, 1.f) * g->graph_width - 0.5 * g->ink.width - g->ink.x
+                        + 2. * (x_white > 1.f) * g->sign_width,
+                    x_legend_top);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
 
@@ -2730,7 +2870,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
         pango_layout_set_text(g->layout, text, -1);
         pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
         cairo_move_to(g->cr, g->allocation.width - g->ink.width - g->ink.x - margin_left,
-                            g->graph_height + 3. * g->inset + g->line_height - g->ink.y);
+                      g->graph_height + 3. * g->inset + g->line_height - g->ink.y);
         pango_cairo_show_layout(g->cr, g->layout);
         cairo_stroke(g->cr);
 
@@ -2746,7 +2886,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
       cairo_move_to(g->cr, -2. * g->inset - g->zero_width - g->ink.x,
-                          -g->line_height -g->inset - 0.5 * g->ink.height - g->ink.y);
+                    -g->line_height - g->inset - 0.5 * g->ink.height - g->ink.y);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
 
@@ -2762,7 +2902,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
       cairo_move_to(g->cr, 0.5 * g->graph_width - 0.5 * g->ink.width - g->ink.x,
-                          g->graph_height + 3. * g->inset + g->line_height - g->ink.y);
+                    g->graph_height + 3. * g->inset + g->line_height - g->ink.y);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
     }
@@ -2806,7 +2946,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
       cairo_move_to(g->cr, 0.5 * display_label_width - 0.5 * g->ink.width - g->ink.x,
-                          display_top - 4. * g->inset - g->ink.height - g->ink.y);
+                    display_top - 4. * g->inset - g->ink.height - g->ink.y);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
 
@@ -2824,15 +2964,15 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       pango_layout_set_text(g->layout, text, -1);
       pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
       cairo_move_to(g->cr, 0.5 * scene_label_width - 0.5 * g->ink.width - g->ink.x,
-                          scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
+                    scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
       pango_cairo_show_layout(g->cr, g->layout);
       cairo_stroke(g->cr);
 
       // arrow between labels
       cairo_set_line_width(g->cr, DT_PIXEL_APPLY_DPI(1.));
       dt_cairo_draw_arrow(g->cr, fminf(scene_label_width, display_label_width) / 2.f, y_scene - g->line_height,
-                                fminf(scene_label_width, display_label_width) / 2.f, y_display + g->line_height + g->inset,
-                                TRUE);
+                          fminf(scene_label_width, display_label_width) / 2.f,
+                          y_display + g->line_height + g->inset, TRUE);
 
       column_left = fmaxf(display_label_width, scene_label_width) + g->inset;
     }
@@ -2842,12 +2982,13 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     const float column_right = g->allocation.width - column_left - darktable.bauhaus->quad_width;
 
     // compute dynamic ranges left and right to middle grey
-    const float display_HL_EV = -log2f(p->grey_point_target / p->white_point_target);       // compared to white EV
-    const float display_LL_EV = display_DR - display_HL_EV;  // compared to black EV
-    const float display_real_black_EV = -fmaxf(log2f(p->black_point_target / p->grey_point_target),
-                                               -11.685887601778058f + display_HL_EV - log2f(p->white_point_target / 100.f));
-    const float scene_HL_EV = p->white_point_source;                        // compared to white EV
-    const float scene_LL_EV = -p->black_point_source;                       // compared to black EV
+    const float display_HL_EV = -log2f(p->grey_point_target / p->white_point_target); // compared to white EV
+    const float display_LL_EV = display_DR - display_HL_EV;                           // compared to black EV
+    const float display_real_black_EV
+        = -fmaxf(log2f(p->black_point_target / p->grey_point_target),
+                 -11.685887601778058f + display_HL_EV - log2f(p->white_point_target / 100.f));
+    const float scene_HL_EV = p->white_point_source;  // compared to white EV
+    const float scene_LL_EV = -p->black_point_source; // compared to black EV
 
     // compute the max width needed to fit both dynamic ranges and derivate the unit size of a GUI EV
     const float max_DR = ceilf(fmaxf(display_HL_EV, scene_HL_EV)) + ceilf(fmaxf(display_LL_EV, scene_LL_EV));
@@ -2856,7 +2997,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     // all greys are aligned vertically in GUI since they are the fulcrum of the transform
     // so, get their coordinates
     const float grey_EV = fmaxf(ceilf(display_HL_EV), ceilf(scene_HL_EV));
-    const float grey_x = g->allocation.width - (grey_EV) * EV - darktable.bauhaus->quad_width;
+    const float grey_x = g->allocation.width - (grey_EV)*EV - darktable.bauhaus->quad_width;
 
     // similarly, get black/white coordinates from grey point
     const float display_black_x = grey_x - display_real_black_EV * EV;
@@ -2914,16 +3055,17 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
       {
         // Compute usual filmic  mapping
         const float normal_value = ((float)i - p->black_point_source) / DR;
-        float y_temp = filmic_spline(normal_value, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4, g->spline.M5, g->spline.latitude_min, g->spline.latitude_max);
-        y_temp = powf(fmaxf(y_temp, 0.00390625f), p->output_power); // clamp at - 8 EV
+        float y_temp = filmic_spline(normal_value, g->spline.M1, g->spline.M2, g->spline.M3, g->spline.M4,
+                                     g->spline.M5, g->spline.latitude_min, g->spline.latitude_max);
+        y_temp = powf(fmaxf(y_temp, NORM_MIN), p->output_power); // clamp at -16 EV
 
         // rescale output to log scale
         y_temp = log2f(y_temp / (p->grey_point_target / 100.f));
 
         // take clamping into account
-        if(y_temp < 0.f)        // clamp to - 8 EV (black)
+        if(y_temp < 0.f) // clamp to - 8 EV (black)
           y_temp = fmaxf(y_temp, -display_real_black_EV);
-        else if(y_temp > 0.f)   // clamp to 0 EV (white)
+        else if(y_temp > 0.f) // clamp to 0 EV (white)
           y_temp = fminf(y_temp, display_HL_EV);
 
         // get destination coordinate and draw
@@ -2983,7 +3125,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     pango_layout_set_text(g->layout, text, -1);
     pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
     cairo_move_to(g->cr, scene_black_x - 0.5 * g->ink.width - g->ink.x,
-                         scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
+                  scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
     pango_cairo_show_layout(g->cr, g->layout);
     cairo_stroke(g->cr);
 
@@ -2992,7 +3134,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     pango_layout_set_text(g->layout, text, -1);
     pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
     cairo_move_to(g->cr, grey_x - 0.5 * g->ink.width - g->ink.x,
-                         scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
+                  scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
     pango_cairo_show_layout(g->cr, g->layout);
     cairo_stroke(g->cr);
 
@@ -3001,7 +3143,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     pango_layout_set_text(g->layout, text, -1);
     pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
     cairo_move_to(g->cr, scene_white_x - 0.5 * g->ink.width - g->ink.x,
-                         scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
+                  scene_bottom + 2. * g->inset + 0. * g->ink.height + g->ink.y);
     pango_cairo_show_layout(g->cr, g->layout);
     cairo_stroke(g->cr);
 
@@ -3010,7 +3152,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     pango_layout_set_text(g->layout, text, -1);
     pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
     cairo_move_to(g->cr, display_black_x - 0.5 * g->ink.width - g->ink.x,
-                         display_top - 4. * g->inset - g->ink.height - g->ink.y);
+                  display_top - 4. * g->inset - g->ink.height - g->ink.y);
     pango_cairo_show_layout(g->cr, g->layout);
     cairo_stroke(g->cr);
 
@@ -3019,7 +3161,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     pango_layout_set_text(g->layout, text, -1);
     pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
     cairo_move_to(g->cr, grey_x - 0.5 * g->ink.width - g->ink.x,
-                         display_top - 4. * g->inset - g->ink.height - g->ink.y);
+                  display_top - 4. * g->inset - g->ink.height - g->ink.y);
     pango_cairo_show_layout(g->cr, g->layout);
     cairo_stroke(g->cr);
 
@@ -3028,7 +3170,7 @@ static gboolean dt_iop_tonecurve_draw(GtkWidget *widget, cairo_t *crf, gpointer 
     pango_layout_set_text(g->layout, text, -1);
     pango_layout_get_pixel_extents(g->layout, &g->ink, NULL);
     cairo_move_to(g->cr, display_white_x - 0.5 * g->ink.width - g->ink.x,
-                         display_top - 4. * g->inset - g->ink.height - g->ink.y);
+                  display_top - 4. * g->inset - g->ink.height - g->ink.y);
     pango_cairo_show_layout(g->cr, g->layout);
     cairo_stroke(g->cr);
   }
@@ -3070,7 +3212,6 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
       {
         return FALSE;
       }
-
     }
     else if(event->button == 1)
     {
@@ -3126,7 +3267,6 @@ static gboolean area_button_press(GtkWidget *widget, GdkEventButton *event, gpoi
       {
         return FALSE;
       }
-
     }
   }
 
@@ -3170,8 +3310,7 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
   const float y = event->y;
   const float x = event->x;
 
-  if(x > 0. && x < g->allocation.width && y > 0. && y < g->allocation.height)
-    g->gui_hover = TRUE;
+  if(x > 0. && x < g->allocation.width && y > 0. && y < g->allocation.height) g->gui_hover = TRUE;
 
   gint save_active_button = g->active_button;
 
@@ -3206,11 +3345,11 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
                                                          "the bright curve is the filmic tone mapping curve\n"
                                                          "the dark curve is the desaturation curve."));
     }
-    else if (g->active_button == DT_FILMIC_GUI_BUTTON_LABELS)
+    else if(g->active_button == DT_FILMIC_GUI_BUTTON_LABELS)
     {
       gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("toggle axis labels and values display."));
     }
-    else if (g->active_button == DT_FILMIC_GUI_BUTTON_TYPE)
+    else if(g->active_button == DT_FILMIC_GUI_BUTTON_TYPE)
     {
       gtk_widget_set_tooltip_text(GTK_WIDGET(g->area), _("cycle through graph views.\n"
                                                          "left click: cycle forward.\n"
@@ -3250,7 +3389,8 @@ void gui_init(dt_iop_module_t *self)
   // don't make the area square to safe some vertical space -- it's not interactive anyway
   g->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(0.75));
   gtk_widget_set_can_focus(GTK_WIDGET(g->area), TRUE);
-  gtk_widget_add_events(GTK_WIDGET(g->area), GDK_BUTTON_PRESS_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_POINTER_MOTION_MASK);
+  gtk_widget_add_events(GTK_WIDGET(g->area), GDK_BUTTON_PRESS_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK
+                                                 | GDK_POINTER_MOTION_MASK);
   g_signal_connect(G_OBJECT(g->area), "draw", G_CALLBACK(dt_iop_tonecurve_draw), self);
   g_signal_connect(G_OBJECT(g->area), "button-press-event", G_CALLBACK(area_button_press), self);
   g_signal_connect(G_OBJECT(g->area), "leave-notify-event", G_CALLBACK(area_leave_notify), self);
@@ -3263,31 +3403,34 @@ void gui_init(dt_iop_module_t *self)
   // Page SCENE
   self->widget = dt_ui_notebook_page(g->notebook, _("scene"), NULL);
 
-  g->grey_point_source = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
-                         dt_bauhaus_slider_from_params(self, "grey_point_source"));
+  g->grey_point_source
+      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "grey_point_source"));
   dt_bauhaus_slider_set_soft_range(g->grey_point_source, .1, 36.0);
   dt_bauhaus_slider_set_format(g->grey_point_source, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->grey_point_source, _("adjust to match the average luminance of the image's subject.\n"
-                                                      "the value entered here will then be remapped to 18.45%.\n"
-                                                      "decrease the value to increase the overall brightness."));
+  gtk_widget_set_tooltip_text(g->grey_point_source,
+                              _("adjust to match the average luminance of the image's subject.\n"
+                                "the value entered here will then be remapped to 18.45%.\n"
+                                "decrease the value to increase the overall brightness."));
 
   // White slider
-  g->white_point_source = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
-                          dt_bauhaus_slider_from_params(self, "white_point_source"));
+  g->white_point_source
+      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "white_point_source"));
   dt_bauhaus_slider_set_soft_range(g->white_point_source, 2.0, 8.0);
   dt_bauhaus_slider_set_format(g->white_point_source, _("%+.2f EV"));
-  gtk_widget_set_tooltip_text(g->white_point_source, _("number of stops between middle grey and pure white.\n"
-                                                       "this is a reading a lightmeter would give you on the scene.\n"
-                                                       "adjust so highlights clipping is avoided"));
+  gtk_widget_set_tooltip_text(g->white_point_source,
+                              _("number of stops between middle grey and pure white.\n"
+                                "this is a reading a lightmeter would give you on the scene.\n"
+                                "adjust so highlights clipping is avoided"));
 
   // Black slider
-  g->black_point_source = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
-                          dt_bauhaus_slider_from_params(self, "black_point_source"));
+  g->black_point_source
+      = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_slider_from_params(self, "black_point_source"));
   dt_bauhaus_slider_set_soft_range(g->black_point_source, -14.0, -3);
   dt_bauhaus_slider_set_format(g->black_point_source, _("%+.2f EV"));
-  gtk_widget_set_tooltip_text(g->black_point_source, _("number of stops between middle grey and pure black.\n"
-                                                       "this is a reading a lightmeter would give you on the scene.\n"
-                                                       "increase to get more contrast.\ndecrease to recover more details in low-lights."));
+  gtk_widget_set_tooltip_text(
+      g->black_point_source, _("number of stops between middle grey and pure black.\n"
+                               "this is a reading a lightmeter would give you on the scene.\n"
+                               "increase to get more contrast.\ndecrease to recover more details in low-lights."));
 
   // Dynamic range scaling
   g->security_factor = dt_bauhaus_slider_from_params(self, "security_factor");
@@ -3297,8 +3440,7 @@ void gui_init(dt_iop_module_t *self)
                                                     "useful to give a safety margin to extreme luminances."));
 
   // Auto tune slider
-  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
-                   dt_bauhaus_combobox_new(self));
+  g->auto_button = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, dt_bauhaus_combobox_new(self));
   dt_bauhaus_widget_set_label(g->auto_button, NULL, _("auto tune levels"));
   gtk_widget_set_tooltip_text(g->auto_button, _("try to optimize the settings with some statistical assumptions.\n"
                                                 "this will fit the luminance range inside the histogram bounds.\n"
@@ -3318,18 +3460,20 @@ void gui_init(dt_iop_module_t *self)
 
   g->reconstruct_threshold = dt_bauhaus_slider_from_params(self, "reconstruct_threshold");
   dt_bauhaus_slider_set_format(g->reconstruct_threshold, _("%+.2f EV"));
-  gtk_widget_set_tooltip_text(g->reconstruct_threshold, _("set the exposure threshold upon which\n"
-                                                          "clipped highlights get reconstructed.\n"
-                                                          "values are relative to the scene white point.\n"
-                                                          "0 EV means the threshold is the same as the scene white point.\n"
-                                                          "decrease to include more areas,\n"
-                                                          "increase to exclude more areas."));
+  gtk_widget_set_tooltip_text(g->reconstruct_threshold,
+                              _("set the exposure threshold upon which\n"
+                                "clipped highlights get reconstructed.\n"
+                                "values are relative to the scene white point.\n"
+                                "0 EV means the threshold is the same as the scene white point.\n"
+                                "decrease to include more areas,\n"
+                                "increase to exclude more areas."));
 
   g->reconstruct_feather = dt_bauhaus_slider_from_params(self, "reconstruct_feather");
   dt_bauhaus_slider_set_format(g->reconstruct_feather, _("%+.2f EV"));
-  gtk_widget_set_tooltip_text(g->reconstruct_feather, _("soften the transition between clipped highlights and valid pixels.\n"
-                                                        "decrease to make the transition harder and sharper,\n"
-                                                        "increase to make the transition softer and blurrier."));
+  gtk_widget_set_tooltip_text(g->reconstruct_feather,
+                              _("soften the transition between clipped highlights and valid pixels.\n"
+                                "decrease to make the transition harder and sharper,\n"
+                                "increase to make the transition softer and blurrier."));
 
   // Highlight Reconstruction Mask
   g->show_highlight_mask = dt_bauhaus_combobox_new(self);
@@ -3347,12 +3491,13 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->reconstruct_structure_vs_texture, 0.1);
   dt_bauhaus_slider_set_format(g->reconstruct_structure_vs_texture, "%.2f %%");
   /* xgettext:no-c-format */
-  gtk_widget_set_tooltip_text(g->reconstruct_structure_vs_texture, _("decide which reconstruction strategy to favor,\n"
-                                                                     "between inpainting a smooth color gradient,\n"
-                                                                     "or trying to recover the textured details.\n"
-                                                                     "0% is an equal mix of both.\n"
-                                                                     "increase if at least one RGB channel is not clipped.\n"
-                                                                     "decrease if all RGB channels are clipped over large areas."));
+  gtk_widget_set_tooltip_text(g->reconstruct_structure_vs_texture,
+                              _("decide which reconstruction strategy to favor,\n"
+                                "between inpainting a smooth color gradient,\n"
+                                "or trying to recover the textured details.\n"
+                                "0% is an equal mix of both.\n"
+                                "increase if at least one RGB channel is not clipped.\n"
+                                "decrease if all RGB channels are clipped over large areas."));
 
   g->reconstruct_bloom_vs_details = dt_bauhaus_slider_from_params(self, "reconstruct_bloom_vs_details");
   dt_bauhaus_slider_set_step(g->reconstruct_bloom_vs_details, 0.1);
@@ -3370,12 +3515,13 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_step(g->reconstruct_grey_vs_color, 0.1);
   dt_bauhaus_slider_set_format(g->reconstruct_grey_vs_color, "%.2f %%");
   /* xgettext:no-c-format */
-  gtk_widget_set_tooltip_text(g->reconstruct_grey_vs_color, _("decide which reconstruction strategy to favor,\n"
-                                                              "between recovering monochromatic highlights,\n"
-                                                              "or trying to recover colorful highlights.\n"
-                                                              "0% is an equal mix of both.\n"
-                                                              "increase if you want more color.\n"
-                                                              "decrease if you see magenta or out-of-gamut highlights."));
+  gtk_widget_set_tooltip_text(g->reconstruct_grey_vs_color,
+                              _("decide which reconstruction strategy to favor,\n"
+                                "between recovering monochromatic highlights,\n"
+                                "or trying to recover colorful highlights.\n"
+                                "0% is an equal mix of both.\n"
+                                "increase if you want more color.\n"
+                                "decrease if you see magenta or out-of-gamut highlights."));
 
   // Page LOOK
   self->widget = dt_ui_notebook_page(g->notebook, _("look"), NULL);
@@ -3397,11 +3543,12 @@ void gui_init(dt_iop_module_t *self)
   g->latitude = dt_bauhaus_slider_from_params(self, N_("latitude"));
   dt_bauhaus_slider_set_soft_range(g->latitude, 5.0, 50.0);
   dt_bauhaus_slider_set_format(g->latitude, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->latitude, _("width of the linear domain in the middle of the curve,\n"
-                                             "in percent of the dynamic range (white exposure - black exposure).\n"
-                                             "increase to get more contrast and less desaturation at extreme luminances,\n"
-                                             "decrease otherwise. no desaturation happens in the latitude range.\n"
-                                             "this has no effect on mid-tones."));
+  gtk_widget_set_tooltip_text(g->latitude,
+                              _("width of the linear domain in the middle of the curve,\n"
+                                "in percent of the dynamic range (white exposure - black exposure).\n"
+                                "increase to get more contrast and less desaturation at extreme luminances,\n"
+                                "decrease otherwise. no desaturation happens in the latitude range.\n"
+                                "this has no effect on mid-tones."));
 
   g->balance = dt_bauhaus_slider_from_params(self, "balance");
   dt_bauhaus_slider_set_format(g->balance, "%.2f %%");
@@ -3426,18 +3573,20 @@ void gui_init(dt_iop_module_t *self)
 
   // Black slider
   g->black_point_target = dt_bauhaus_slider_from_params(self, "black_point_target");
-  dt_bauhaus_slider_set_format(g->black_point_target, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->black_point_target, "%.3f %%");
+  dt_bauhaus_slider_set_step(g->black_point_target, .05);
   gtk_widget_set_tooltip_text(g->black_point_target, _("luminance of output pure black, "
                                                        "this should be 0%\nexcept if you want a faded look"));
 
   g->grey_point_target = dt_bauhaus_slider_from_params(self, "grey_point_target");
-  dt_bauhaus_slider_set_format(g->grey_point_target, "%.2f %%");
-  gtk_widget_set_tooltip_text(g->grey_point_target, _("midde grey value of the target display or color space.\n"
-                                                      "you should never touch that unless you know what you are doing."));
+  dt_bauhaus_slider_set_format(g->grey_point_target, "%.3f %%");
+  gtk_widget_set_tooltip_text(g->grey_point_target,
+                              _("midde grey value of the target display or color space.\n"
+                                "you should never touch that unless you know what you are doing."));
 
   g->white_point_target = dt_bauhaus_slider_from_params(self, "white_point_target");
   dt_bauhaus_slider_set_soft_max(g->white_point_target, 100.0);
-  dt_bauhaus_slider_set_format(g->white_point_target, "%.2f %%");
+  dt_bauhaus_slider_set_format(g->white_point_target, "%.3f %%");
   gtk_widget_set_tooltip_text(g->white_point_target, _("luminance of output pure white, "
                                                        "this should be 100%\nexcept if you want a faded look"));
 
@@ -3446,8 +3595,9 @@ void gui_init(dt_iop_module_t *self)
 
   // Color science
   g->version = dt_bauhaus_combobox_from_params(self, "version");
-  gtk_widget_set_tooltip_text(g->version, _("v3 is darktable 3.0 desaturation method, same as color balance.\n"
-                                            "v4 is a newer desaturation method, based on spectral purity of light."));
+  gtk_widget_set_tooltip_text(g->version,
+                              _("v3 is darktable 3.0 desaturation method, same as color balance.\n"
+                                "v4 is a newer desaturation method, based on spectral purity of light."));
 
   g->preserve_color = dt_bauhaus_combobox_from_params(self, "preserve_color");
   gtk_widget_set_tooltip_text(g->preserve_color, _("ensure the original color are preserved.\n"
@@ -3460,7 +3610,7 @@ void gui_init(dt_iop_module_t *self)
                                                "hard uses a high curvature resulting in more tonal compression.\n"
                                                "soft uses a low curvature resulting in less tonal compression."));
 
-  g->shadows = dt_bauhaus_combobox_from_params(self,"shadows");
+  g->shadows = dt_bauhaus_combobox_from_params(self, "shadows");
   gtk_widget_set_tooltip_text(g->shadows, _("choose the desired curvature of the filmic spline in shadows.\n"
                                             "hard uses a high curvature resulting in more tonal compression.\n"
                                             "soft uses a low curvature resulting in less tonal compression."));
@@ -3472,15 +3622,17 @@ void gui_init(dt_iop_module_t *self)
                                                 "disable to use standard 18.45 %% middle grey."));
 
   g->auto_hardness = dt_bauhaus_toggle_from_params(self, "auto_hardness");
-  gtk_widget_set_tooltip_text(g->auto_hardness, _("enable to auto-set the look hardness depending on the scene white and black points.\n"
-                                                  "this keeps the middle grey on the identity line and improves fast tuning.\n"
-                                                  "disable if you want a manual control."));
+  gtk_widget_set_tooltip_text(
+      g->auto_hardness, _("enable to auto-set the look hardness depending on the scene white and black points.\n"
+                          "this keeps the middle grey on the identity line and improves fast tuning.\n"
+                          "disable if you want a manual control."));
 
   g->high_quality_reconstruction = dt_bauhaus_slider_from_params(self, "high_quality_reconstruction");
-  gtk_widget_set_tooltip_text(g->high_quality_reconstruction, _("run extra passes of chromaticity reconstruction.\n"
-                                                                "more iterations means more color propagation from neighbourhood.\n"
-                                                                "this will be slower but will yield more neutral highlights.\n"
-                                                                "it also helps with difficult cases of magenta highlights."));
+  gtk_widget_set_tooltip_text(g->high_quality_reconstruction,
+                              _("run extra passes of chromaticity reconstruction.\n"
+                                "more iterations means more color propagation from neighbourhood.\n"
+                                "this will be slower but will yield more neutral highlights.\n"
+                                "it also helps with difficult cases of magenta highlights."));
 
   // Highlight noise
   g->noise_level = dt_bauhaus_slider_from_params(self, "noise_level");
@@ -3509,16 +3661,15 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
   dt_iop_filmicrgb_params_t *p = (dt_iop_filmicrgb_params_t *)self->params;
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
 
-  if (!w || w == g->auto_hardness ||
-      w == g->security_factor || w == g->grey_point_source ||
-      w == g->black_point_source || w == g->white_point_source)
+  if(!w || w == g->auto_hardness || w == g->security_factor || w == g->grey_point_source
+     || w == g->black_point_source || w == g->white_point_source)
   {
     ++darktable.gui->reset;
 
-    if (w == g->security_factor || w == g->grey_point_source)
+    if(w == g->security_factor || w == g->grey_point_source)
     {
-      float prev = *(float*)previous;
-      if (w == g->security_factor)
+      float prev = *(float *)previous;
+      if(w == g->security_factor)
       {
         float ratio = (p->security_factor - prev) / (prev + 100.0f);
 
@@ -3543,7 +3694,8 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
     }
 
     if(p->auto_hardness)
-      p->output_power =  logf(p->grey_point_target / 100.0f) / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
+      p->output_power = logf(p->grey_point_target / 100.0f)
+                        / logf(-p->black_point_source / (p->white_point_source - p->black_point_source));
 
     gtk_widget_set_visible(GTK_WIDGET(g->output_power), !p->auto_hardness);
     dt_bauhaus_slider_set_soft(g->output_power, p->output_power);


### PR DESCRIPTION
* fix a silent bug in the spline initialization : the output power was not applied on white and black display, which didn't show since users were advised to let white to 100% and black to 0% (so 0^x = 0, and 1^x = 1), but triggers unintuitive behaviour otherwise,
* based on the new graph UI, optimize the default parameters to maximize use of output dynamic range and take 8 bits sRGB quantization error as display black value (0.016 %).