### PR TITLE
export: scaling improvement

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -841,6 +841,20 @@ int dt_imageio_export_with_flags(const int32_t imgid, const char *filename,
     scale = fmin(width >  0 ? fmin((double)width / (double)pipe.processed_width, max_scale) : max_scale,
                  height > 0 ? fmin((double)height / (double)pipe.processed_height, max_scale) : max_scale);
 
+    if (strcmp(dt_conf_get_string("plugins/lighttable/export/resizing"),"scaling") == 0)
+    { // scaling
+      double scale_factor = 1;
+      double _num, _denum;
+      dt_imageio_resizing_factor_get_and_parsing(&_num, &_denum);
+
+      scale_factor = _num/_denum;
+
+      if (!thumbnail_export)
+      {
+          scale = scale_factor;
+      }
+    }
+
     processed_width = scale * pipe.processed_width + 0.8f;
     processed_height = scale * pipe.processed_height + 0.8f;
 

--- a/src/common/imageio_module.c
+++ b/src/common/imageio_module.c
@@ -437,6 +437,47 @@ void dt_imageio_insert_storage(dt_imageio_module_storage_t *storage)
   DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_IMAGEIO_STORAGE_CHANGE);
 }
 
+gchar *dt_imageio_resizing_factor_get_and_parsing(double *num, double *denum)
+{
+  double _num, _denum;
+  gchar *scale_str = dt_conf_get_string("plugins/lighttable/export/resizing_factor");
+
+  char sep[4] = "";
+  snprintf( sep, 4, "%g", (double) 3/2);
+  int i = -1;
+  while(scale_str[++i])
+  {
+      if ((scale_str[i] == '.') || (scale_str[i] == ',')) scale_str[i] = sep[1];
+  }
+
+  gchar *pdiv = strchr(scale_str, '/');
+
+  if (pdiv == NULL)
+  {
+    _num = atof(scale_str);
+    _denum = 1;
+  }
+  else if (pdiv-scale_str == 0)
+  {
+    _num = 1;
+    _denum = atof(pdiv + 1);
+}
+  else
+{
+    _num = atof(scale_str);
+    _denum = atof(pdiv+1);
+  }
+
+  if (_num == 0.0) _num = 1.0;
+  if (_denum == 0.0) _denum = 1.0;
+
+  *num = _num;
+  *denum = _denum;
+
+  dt_conf_set_string("plugins/lighttable/export/resizing_factor", scale_str);
+  return scale_str;
+}
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/common/imageio_module.h
+++ b/src/common/imageio_module.h
@@ -231,6 +231,13 @@ int dt_imageio_get_index_of_storage(dt_imageio_module_storage_t *storage);
 /* add a module into the known module list */
 void dt_imageio_insert_storage(dt_imageio_module_storage_t *storage);
 
+// This function returns value of string which stored in the
+// "plugins/lighttable/export/resizing_factor" parameter of the configuration file
+// and its "num" and "denum" fraction's elements to calculate the scaling factor
+// and improve the readability of the displayed string itself in the "scale" field
+// of the settings export.
+gchar *dt_imageio_resizing_factor_get_and_parsing(double *num, double *denum);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
In addition to specifying the exact max.size for export, adds an alternative scaling factor.

Parameters are mutually exclusive. When one changes, the other is cleared and not counted in the export.


In addition, each parameter can be reset by clicking the MMB.

![2020-08-24](https://user-images.githubusercontent.com/15331117/90987496-9af7e500-e5b5-11ea-826d-e40508b92301.png)