### PR TITLE
Slightly improved mipmap allocation problem message

### DIFF
--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -641,7 +641,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
 
   if(!buf.buf || !buf.width || !buf.height)
   {
-    fprintf(stderr, "allocation failed???\n");
+    fprintf(stderr, "[dt_imageio_export_with_flags] mipmap allocation for `%s'failed???\n", filename);
     dt_control_log(_("image `%s' is not available!"), img->filename);
     goto error_early;
   }

--- a/src/common/imageio.c
+++ b/src/common/imageio.c
@@ -641,7 +641,7 @@ int dt_imageio_export_with_flags(const uint32_t imgid, const char *filename,
 
   if(!buf.buf || !buf.width || !buf.height)
   {
-    fprintf(stderr, "[dt_imageio_export_with_flags] mipmap allocation for `%s'failed???\n", filename);
+    fprintf(stderr, "[dt_imageio_export_with_flags] mipmap allocation for `%s'failed\n", filename);
     dt_control_log(_("image `%s' is not available!"), img->filename);
     goto error_early;
   }


### PR DESCRIPTION
Just a minor improvement but there have been at least two issues mentioning
the rather confusing console message, this might be somewhat better.