### PR TITLE
presets rework - easier removal, no undeletable presets

### DIFF
--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -1492,7 +1492,7 @@ static gboolean tree_key_press_presets(GtkWidget *widget, GdkEventKey *event, gp
     gint rowid;
     gchar *name;
     GdkPixbuf *editable;
-    gtk_tree_model_get(model, &iter, P_ROWID_COLUMN, &rowid, P_NAME_COLUMN, &name, 
+    gtk_tree_model_get(model, &iter, P_ROWID_COLUMN, &rowid, P_NAME_COLUMN, &name,
                        P_EDITABLE_COLUMN, &editable, -1);
     if(editable == NULL)
     {

--- a/src/gui/presets.c
+++ b/src/gui/presets.c
@@ -963,24 +963,31 @@ static void dt_gui_presets_popup_menu_show_internal(dt_dev_operation_t op, int32
 
   if(module)
   {
-    if(active_preset >= 0 && !writeprotect)
+    if(active_preset >= 0)
     {
-      mi = gtk_menu_item_new_with_label(_("edit this preset.."));
-      g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_edit_preset), module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
+      //we have an active preset...
+      if(!writeprotect)
+      {
+        // we have active preset and it is NOT write protect
+        mi = gtk_menu_item_new_with_label(_("edit this preset.."));
+        g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_edit_preset), module);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
-      mi = gtk_menu_item_new_with_label(_("delete this preset"));
-      g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_delete_preset), module);
-      gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
+        mi = gtk_menu_item_new_with_label(_("delete this preset"));
+        g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_delete_preset), module);
+        gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
+      }
     }
     else
     {
+      // we don't have active preset
       mi = gtk_menu_item_new_with_label(_("store new preset.."));
       g_signal_connect(G_OBJECT(mi), "activate", G_CALLBACK(menuitem_new_preset), module);
       gtk_menu_shell_append(GTK_MENU_SHELL(menu), mi);
 
       if(darktable.gui->last_preset && found)
       {
+        // we HAD an active preset but something changed in op/blend so maybe update?
         char *markup = g_markup_printf_escaped("%s <span weight=\"bold\">%s</span>", _("update preset"),
                                                darktable.gui->last_preset);
         mi = gtk_menu_item_new_with_label("");


### PR DESCRIPTION
this essentially fixes #5275 by ~not allowing users to create presets identical as non-writable ones.~ preffering to remove user-created ones instead of internal ones, so deletion and edit is triggered only for non-write protected presets

adds possibility to delete preset from edit dialog in prefs

cleanly removes preset accels.