### PR TITLE
live view histogram improvements

### DIFF
--- a/src/libs/histogram.c
+++ b/src/libs/histogram.c
@@ -329,7 +329,7 @@ static void dt_lib_histogram_process(struct dt_lib_module_t *self, const float *
 
     if(out_profile_type != DT_COLORSPACE_NONE)
     {
-      const dt_iop_order_iccprofile_info_t *profile_info_to =
+      const dt_iop_order_iccprofile_info_t *const profile_info_to =
         dt_ioppr_add_profile_info_to_list(dev, out_profile_type, out_profile_filename, DT_INTENT_PERCEPTUAL);
       img_display = dt_alloc_align(64, width * height * 4 * sizeof(float));
       if(!img_display) return;

--- a/src/libs/live_view.c
+++ b/src/libs/live_view.c
@@ -485,7 +485,7 @@ void view_leave(struct dt_lib_module_t *self, struct dt_view_t *old_view, struct
 
   // there's no code to automatically restart live view when entering
   // the view, and besides the user may not want to jump right back
-  // into leave view if they've been out of tethering view doing other
+  // into live view if they've been out of tethering view doing other
   // things
   if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(lib->live_view)) == TRUE)
   {


### PR DESCRIPTION
Do colorspace conversion of live view images "by hand" in tether view, rather than relying on histogram process code. This allows for "work profile" as the histogram profile to do something closer to the right thing, saves memory, and eliminates stderr warnings from dt_ioppr_get_histogram_profile_type() when histogram profile is "work" or "export".

Add some noise to 8-bit JPEG live view image before doing conversion to histogram colorspace. Otherwise it can be badly quantized (spiky histogram, banded waveform). Most visible if histogram profile is Rec.709, but noticeable in most histogram profiles.

Add a const in histogram process code.

Fix another comment typo in live view code.