### PR TITLE
Fix missing include

### DIFF
--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "common/darktable.h"
+#include "common/colorspaces.h"
 #include "views/view.h"
 #include <gmodule.h>
 #include <gtk/gtk.h>


### PR DESCRIPTION
Otherwise dt_colorspaces_color_profile_type_t is not found. Probably introduced with f1cd7.