### PR TITLE
Add validation check and fix combobox logic when typing aspect ratio of "1" into crop module

### DIFF
--- a/src/bauhaus/bauhaus.c
+++ b/src/bauhaus/bauhaus.c
@@ -1560,20 +1560,16 @@ static void dt_bauhaus_widget_accept(dt_bauhaus_widget_t *w)
         i++;
         g_free(text_cmp);
       }
-      // if list is short (2 entries could be: typed something similar, and one similar)
-      if(k < 3)
+      // didn't find it, but had only one matching choice?
+      if(k == 1 && match)
+        dt_bauhaus_combobox_set(widget, kk);
+      else if(d->editable)
       {
-        // didn't find it, but had only one matching choice?
-        if(k == 1 && match)
-          dt_bauhaus_combobox_set(widget, kk);
-        else if(d->editable)
-        {
-          // had no close match (k == 1 && !match) or no match at all (k == 0)
-          memset(d->text, 0, sizeof(d->text));
-          g_strlcpy(d->text, darktable.bauhaus->keys, sizeof(d->text));
-          // select custom entry
-          dt_bauhaus_combobox_set(widget, -1);
-        }
+        // otherwise, if combobox is editable, assume it is a custom input
+        memset(d->text, 0, sizeof(d->text));
+        g_strlcpy(d->text, darktable.bauhaus->keys, sizeof(d->text));
+        // select custom entry
+        dt_bauhaus_combobox_set(widget, -1);
       }
       g_free(keys);
       break;

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1631,7 +1631,7 @@ static void _float_to_fract(const char *num, int *n, int *d)
     if(sep_found) *d *= 10;
 
     // look for decimal sep
-    if((*p == ',') || (*p == '.'))
+    if(!sep_found && ((*p == ',') || (*p == '.')))
     {
       sep_found = TRUE;
     }

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1635,6 +1635,11 @@ static void _float_to_fract(const char *num, int *n, int *d)
     {
       sep_found = TRUE;
     }
+    else if (*p < '0' || *p > '9')
+    {
+      *n = *d = 0;
+      return;
+    }
     else
     {
       tnum[k++] = *p;
@@ -1687,7 +1692,7 @@ static void aspect_presets_changed(GtkWidget *combo, dt_iop_module_t *self)
         // some sanity check
         if(dd == 0 || nn == 0)
         {
-          dt_control_log(_("invalid ratio format. it should be non zero"));
+          dt_control_log(_("invalid ratio format. it should be a positive number"));
           dt_bauhaus_combobox_set(combo, 0);
           return;
         }


### PR DESCRIPTION
This PR has two commits to resolve #5784 (I split across two commits, in case you don't want to accept the combobox change)
1. When someone enters in crop module an aspect ratio with keyboard, make sure the text they type is really a number, and doesn't contain junk text characters. (this issue was mentioned in PR #5777 but wasn't addresed).

2. The reason you can't enter "1" as a crop aspect ratio is that there are more than two items in the dropdown list that match a prefix of "1". All other digits will match only 0, 1 or 2 items in the dropdown list.
  If a bauhaus combo box is flagged as "editable", it doesn't make sense to me why you would only accept custom input values where the custom value only matches a small number of items. Therefore, I propose to remove this check, and if a bauhaus combo box is editable, and the users enters something not on the downdown list, then this custom value should be accepted, otherwised what does it mean for a combobox to be "editable". Perhaps one of the other devs knows the background to this, which is why I submit this change in its own commit.