### PR TITLE
export: try to be defensive about potential problems in insert-text

### DIFF
--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -496,7 +496,14 @@ static void height_changed(GtkEditable *entry, gpointer user_data)
 static void insert_text_handler(GtkEditable *entry, char *text, int length, gpointer position, gpointer user_data)
 {
   int i, count=0;
-  gchar *result = g_new (gchar, length);
+  gchar *result = g_try_new0(gchar, length);
+
+  if(!result)
+  {
+    // stop insert on zero length or failure to allocate mem for result
+    g_signal_stop_emission_by_name (entry, "insert-text");
+    return;
+  }
 
   for (i=0; i < length; i++)
   {


### PR DESCRIPTION
additionally to #6129, this uses try_new0 so that in case of any problem the insert-text handler bail early and prevents insertion of  text in fields

the #6129 needs to be merged to fix the problem mentioned in #6127. This pr just adds a "sanity check" for insert text and lenght (try_new0 will return NULL in all problem cases including when length is 0)