### PR TITLE
Guided filter scalability improvement

### DIFF
--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -58,7 +58,7 @@
 #ifndef dt_omp_shared
 #ifdef _OPENMP
 #if defined(__clang__) || __GNUC__ > 8
-# define dt_omp_shared(var, ...)  shared(var, __VA_ARGS__)
+# define dt_omp_shared(...)  shared(__VA_ARGS__)
 #else
   // GCC 8.4 throws string of errors "'x' is predetermined 'shared' for 'shared'" if we explicitly declare
   //  'const' variables as shared

--- a/src/common/guided_filter.c
+++ b/src/common/guided_filter.c
@@ -440,23 +440,24 @@ static void guided_filter_tiling(color_image imgg, gray_image img, gray_image im
     const float Sigma_1_1 = varpx[VAR_GG] - (guide_g * guide_g) + eps;;
     const float Sigma_1_2 = varpx[VAR_GB] - (guide_g * guide_b);
     const float Sigma_2_2 = var_bb.data[i] - (guide_b * guide_b) + eps;
-    const float cov_imgg_img[3] =
-      { varpx[COV_R] - guide_r * inp_mean, varpx[COV_G] - guide_g * inp_mean, varpx[COV_B] - guide_b * inp_mean };
     const float det0 = Sigma_0_0 * (Sigma_1_1 * Sigma_2_2 - Sigma_1_2 * Sigma_1_2)
       - Sigma_0_1 * (Sigma_0_1 * Sigma_2_2 - Sigma_0_2 * Sigma_1_2)
       + Sigma_0_2 * (Sigma_0_1 * Sigma_1_2 - Sigma_0_2 * Sigma_1_1);
     float a_r_, a_g_, a_b_, b_;
     if(fabsf(det0) > 4.f * FLT_EPSILON)
     {
-      const float det1 = cov_imgg_img[0] * (Sigma_1_1 * Sigma_2_2 - Sigma_1_2 * Sigma_1_2)
-        - Sigma_0_1 * (cov_imgg_img[1] * Sigma_2_2 - cov_imgg_img[2] * Sigma_1_2)
-        + Sigma_0_2 * (cov_imgg_img[1] * Sigma_1_2 - cov_imgg_img[2] * Sigma_1_1);
-      const float det2 = Sigma_0_0 * (cov_imgg_img[1] * Sigma_2_2 - cov_imgg_img[2] * Sigma_1_2)
-        - cov_imgg_img[0] * (Sigma_0_1 * Sigma_2_2 - Sigma_0_2 * Sigma_1_2)
-        + Sigma_0_2 * (Sigma_0_1 * cov_imgg_img[2] - Sigma_0_2 * cov_imgg_img[1]);
-      const float det3 = Sigma_0_0 * (Sigma_1_1 * cov_imgg_img[2] - Sigma_1_2 * cov_imgg_img[1])
-        - Sigma_0_1 * (Sigma_0_1 * cov_imgg_img[2] - Sigma_0_2 * cov_imgg_img[1])
-        + cov_imgg_img[0] * (Sigma_0_1 * Sigma_1_2 - Sigma_0_2 * Sigma_1_1);
+      const float cov_r = varpx[COV_R] - guide_r * inp_mean;
+      const float cov_g = varpx[COV_G] - guide_g * inp_mean;
+      const float cov_b = varpx[COV_B] - guide_b * inp_mean;
+      const float det1 = cov_r * (Sigma_1_1 * Sigma_2_2 - Sigma_1_2 * Sigma_1_2)
+        - Sigma_0_1 * (cov_g * Sigma_2_2 - cov_b * Sigma_1_2)
+        + Sigma_0_2 * (cov_g * Sigma_1_2 - cov_b * Sigma_1_1);
+      const float det2 = Sigma_0_0 * (cov_g * Sigma_2_2 - cov_b * Sigma_1_2)
+        - cov_r * (Sigma_0_1 * Sigma_2_2 - Sigma_0_2 * Sigma_1_2)
+        + Sigma_0_2 * (Sigma_0_1 * cov_b - Sigma_0_2 * cov_g);
+      const float det3 = Sigma_0_0 * (Sigma_1_1 * cov_b - Sigma_1_2 * cov_g)
+        - Sigma_0_1 * (Sigma_0_1 * cov_b - Sigma_0_2 * cov_g)
+        + cov_r * (Sigma_0_1 * Sigma_1_2 - Sigma_0_2 * Sigma_1_1);
       a_r_ = det1 / det0;
       a_g_ = det2 / det0;
       a_b_ = det3 / det0;

--- a/src/common/guided_filter.h
+++ b/src/common/guided_filter.h
@@ -67,6 +67,9 @@ static inline int max_i(int a, int b)
 }
 
 // Kahan summation algorithm
+#ifdef _OPENMP
+#pragma omp declare simd
+#endif
 static inline float Kahan_sum(const float m, float *c, const float add)
 {
    const float t1 = add - (*c);


### PR DESCRIPTION
Flipped around the parallelization (parallel-process tiles one at a time instead of single-thread processing of multiple tiles in parallel), which improves the scalability when the filter radius is large and thus there are few tiles.  This also reduces memory requirements because only one tile is active at a time instead of multiple tiles.

Merged two of the four-channel and the remaining single-channel box filter into a 9-channel filter, which got a noticeable speedup despite no longer nicely matching up to vector instructions.  Memory bandwidth is still the limitation at high thread counts.

Timings on mire1:
Exposure+Blender feathering (test 0025)
Thr  / Before / After
1 / 4.176 / 3.501
2 / 2.514 / 1.920
4 / 1.329 / 1.072
6 / 1.126 / 0.791
8 / 1.110 / 0.636
12 / 0.762 / 0.524
16 / 0.741 / 0.461
24 / 0.719 / 0.398
32 / 0.727 / 0.386

Haze Removal
Thr / Before / After
1 / 1.746 / 1.529
2 / 0.998 / 0.877
4 / 0.566 / 0.504
6 / 0.408 / 0.364
8 / 0.333 / 0.316
12 / 0.255 / 0.229
16 / 0.214 / 0.202
24 / 0.185 / 0.176
32 / 0.188 / 0.187
(The guided filter accounts for less than half the runtime of the haze removal.)
