### PR TITLE
set history tooltip widget background to match tooltip border

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -1390,6 +1390,12 @@ cell:selected
   font-size: 0.5em;
 }
 
+#history-tooltip
+{
+  font-family: monospace;
+  background-color: @tooltip_bg_color;
+}
+
 /* Set color bar min height in colorzones module */
 #iop-bottom-bar
 {
@@ -1417,8 +1423,7 @@ cell:selected
 
 /* Set some specific fonts */
 #live-sample-data,
-#usercss_box textview,
-#hist-tooltip
+#usercss_box textview
 {
   font-family: monospace;
 }

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -956,7 +956,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
     if(!view)
     {
       view = gtk_text_view_new();
-      gtk_widget_set_name(view, "hist-tooltip");
+      gtk_widget_set_name(view, "history-tooltip");
       g_signal_connect(G_OBJECT(view), "destroy", G_CALLBACK(gtk_widget_destroyed), &view);
     }
      


### PR DESCRIPTION
As discussed here https://github.com/darktable-org/darktable/pull/5770#issuecomment-683318582

@Nilvus please confirm if you agree with the location where I put the overrides and the small renaming of the tag (to align with the other #history- tags and to avoid confusion with histogram related tags).