### PR TITLE
[Issue #6124] "Update Preset" operation sometimes fails silently in e…

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -294,7 +294,7 @@ static void menuitem_update_preset(GtkMenuItem *menuitem, dt_lib_module_info_t *
     // commit all the module fields
     sqlite3_stmt *stmt;
     DT_DEBUG_SQLITE3_PREPARE_V2(dt_database_get(darktable.db),
-                                "UPDATE data.presets SET operation=?1, op_version=?2, op_params=?3 WHERE name=?4",
+                                "UPDATE data.presets SET op_version=?2, op_params=?3 WHERE name=?4 AND operation=?1",
                                 -1, &stmt, NULL);
 
     DT_DEBUG_SQLITE3_BIND_TEXT(stmt, 1, minfo->plugin_name, -1, SQLITE_TRANSIENT);


### PR DESCRIPTION
Fixes #6124 
When doing an update preset, sometime the operation will fail silently.
The SQL UPDATE command searches based on preset name only, but this can return multiple rows if the same preset name is used in multiple modules. It then tries to force the "operation" field to be the same on all those rows, but this causes a primary key violation, and so the update operation fails.

Solution is to use the operation field as part of the selection criteria, thereby only updating a single row relevant to the specific module in which the presets are being updated. 