### PR TITLE
The signal DT_SIGNAL_DEVELOP_MIPMAP_UPDATED takes an image-id as para…

### DIFF
--- a/src/common/history.c
+++ b/src/common/history.c
@@ -1057,8 +1057,7 @@ void dt_history_compress_on_image(const int32_t imgid)
 
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 
-  GList *imgs = g_list_append(NULL, GINT_TO_POINTER(imgid));
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgs);
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 }
 
 /* Please note: dt_history_truncate_on_image
@@ -1113,8 +1112,7 @@ void dt_history_truncate_on_image(const int32_t imgid, const int32_t history_end
 
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "COMMIT", NULL, NULL, NULL);
 
-  GList *imgs = g_list_append(NULL, GINT_TO_POINTER(imgid));
-  dt_control_signal_raise(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgs);
+  DT_DEBUG_CONTROL_SIGNAL_RAISE(darktable.signals, DT_SIGNAL_DEVELOP_MIPMAP_UPDATED, imgid);
 }
 
 int dt_history_compress_on_list(const GList *imgs)


### PR DESCRIPTION
…meter.

Fix two instances passing a GList *