### PR TITLE
temperature.c: avoid memleak in gui_cleanup

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -2180,6 +2180,8 @@ void gui_init(struct dt_iop_module_t *self)
 void gui_cleanup(struct dt_iop_module_t *self)
 {
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_preference_changed), self);
+  g_free(self->gui_data);
+  self->gui_data = NULL;
 }
 
 void gui_reset(struct dt_iop_module_t *self)


### PR DESCRIPTION
Fixes a memleak detected by @dterrahe in #5433 

for completness i checked and indeed all other IOPs that declare their own gui_cleanup do free gui_data :)