### PR TITLE
[Issue #6134] Prevent corrupt collect module presets from causing a c…

### DIFF
--- a/src/libs/collect.c
+++ b/src/libs/collect.c
@@ -125,6 +125,11 @@ void *legacy_params(struct dt_lib_module_t *self,
   {
     /* from v1 to v2 we have reordered the filters */
     dt_lib_collect_params_t *o = (dt_lib_collect_params_t *)old_params;
+
+    if(o->rules > MAX_RULES)
+	/* preset is corrupted, return NULL and drop the preset */
+	return NULL;
+
     dt_lib_collect_params_t *n = (dt_lib_collect_params_t *)malloc(old_params_size);
 
     const int table[DT_COLLECTION_PROP_LAST] =
@@ -177,6 +182,11 @@ void *legacy_params(struct dt_lib_module_t *self,
   {
     /* from v2 to v3 we have added 4 new timestamp filters and 2 metadata filters */
     dt_lib_collect_params_t *old = (dt_lib_collect_params_t *)old_params;
+
+    if(old->rules > MAX_RULES)
+	/* preset is corrupted, return NULL and drop the preset */
+	return NULL;
+
     dt_lib_collect_params_t *new = (dt_lib_collect_params_t *)malloc(old_params_size);
 
     const int table[DT_COLLECTION_PROP_LAST] =


### PR DESCRIPTION
…rash

Fixes #6134 so that darktable won't crash anymore due to corrupt collect module presets.

If a preset for the collect module is corrupted, it can cause darktable to crash when it tries to upgrade the preset to a later version. This PR puts in an extra validation check the number of rules the preset claims to have, and makes sure it is within valid bounds (ie. the unsigned int <= MAX_RULES) so that darktable won't overrun past the end of the preset's parmaeter blob and crash with a segmentation fault. If the number of rules is invalid, the preset will be dropped from the presets table in the data.db database.