### PR TITLE
signal_debug: check for execinfo.h header

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -10,6 +10,8 @@ if (HAVE_CPUID_H)
     check_symbol_exists(__get_cpuid "cpuid.h" HAVE___GET_CPUID)
 endif()
 
+check_include_file(execinfo.h HAVE_EXECINFO_H)
+
 if (OpenMP_FOUND)
 
 set(CMAKE_REQUIRED_FLAGS ${OpenMP_C_FLAGS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -778,8 +778,10 @@ else(USE_GAME)
 endif(USE_GAME)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_definitions("-DDT_HAVE_SIGNAL_TRACE")
-  message(WARNING "Enabling signal tracing.\nrunning `-d signal --d-signal-act print-trace` will print backlogs.\nthis is solely for developers!")
+  if(HAVE_EXECINFO_H)
+    add_definitions("-DDT_HAVE_SIGNAL_TRACE")
+    message(STATUS "Signal debug: print-trace possible")
+  endif(HAVE_EXECINFO_H)
 endif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
 #


### PR DESCRIPTION
This should prevent compilation error on windows found by @chhil 

this most likely fixes #6166 

//edit: technically on windows it should be posible to have execinfo if one installs libbacktrace but that can result in super noisy other mingw apps ;)