### PR TITLE
develop: fix scene-referred default modules.

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -1377,6 +1377,25 @@ static gboolean _dev_auto_apply_presets(dt_develop_t *dev)
   const gboolean is_display_referred = strcmp(workflow, "display-referred") == 0;
   g_free(workflow);
 
+  //  Add scene-referred workflow
+  //  Note that we cannot use the a preset for FilmicRGB as the default values are
+  //  dynamically computed depending on the actual exposure compensation
+  //  (see reload_default routine in filmicrgb.c)
+  if(dt_image_is_matrix_correction_supported(image) && is_scene_referred)
+  {
+    for(GList *modules = dev->iop; modules; modules = g_list_next(modules))
+    {
+      dt_iop_module_t *module = (dt_iop_module_t *)modules->data;
+
+      if(strcmp(module->op, "filmicrgb") == 0
+         && !dt_history_check_module_exists(imgid, module->op)
+         && !(module->flags() & IOP_FLAGS_NO_HISTORY_STACK))
+      {
+        _dev_insert_module(dev, module, imgid);
+      }
+    }
+  }
+
   // select all presets from one of the following table and add them into memory.history. Note that
   // this is appended to possibly already present default modules.
   const char *preset_table[2] = { "data.presets", "main.legacy_presets" };

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2360,45 +2360,6 @@ void gui_reset(dt_iop_module_t *self)
   dt_iop_color_picker_reset(self, TRUE);
 }
 
-void init_presets (dt_iop_module_so_t *self)
-{
-  // For scene-referred workflow (the preset name is used in develop.c)
-  dt_gui_presets_add_generic(_("scene-referred default"), self->op, self->version(),
-                             &(dt_iop_filmicrgb_params_t)
-                             {
-                               .grey_point_source                = 18.45,
-                               .black_point_source               = -7.75,
-                               .white_point_source               = 4.40,
-                               .reconstruct_threshold            = 3.0,
-                               .reconstruct_feather              = 3.0,
-                               .reconstruct_bloom_vs_details     = 100.0,
-                               .reconstruct_grey_vs_color        = 100.0,
-                               .reconstruct_structure_vs_texture = 0.0,
-                               .security_factor                  = 0,
-                               .grey_point_target                = 18.45,
-                               .black_point_target               = 0.01517634,
-                               .white_point_target               = 100,
-                               .output_power                     = 4.0,
-                               .latitude                         = 25.0,
-                               .contrast                         = 1.35,
-                               .saturation                       = 10,
-                               .balance                          = 0.0,
-                               .noise_level                      = 0.1f,
-                               .preserve_color                   = DT_FILMIC_METHOD_POWER_NORM,
-                               .version                          = DT_FILMIC_COLORSCIENCE_V2,
-                               .auto_hardness                    = TRUE,
-                               .custom_grey                      = FALSE,
-                               .high_quality_reconstruction      = 1,
-                               .noise_distribution               = DT_NOISE_POISSONIAN,
-                               .shadows                          = DT_FILMIC_CURVE_POLY_4,
-                               .highlights                       = DT_FILMIC_CURVE_POLY_4,
-                               .compensate_icc_black             = FALSE,
-                               .internal_version                 = 2020
-                              },
-                             sizeof(dt_iop_filmicrgb_params_t), 1);
-  dt_gui_presets_update_ldr(_("scene-referred default"), self->op, self->version(), FOR_RAW);
-}
-
 #define LOGBASE 20.f
 
 static inline void dt_cairo_draw_arrow(cairo_t *cr, double origin_x, double origin_y, double destination_x,


### PR DESCRIPTION
We cannot use a preset for filmicrgb which is actually dynamically
computing the parameters based on image expose and the in camera
exposuse bias.

Fixes #6200.