### PR TITLE
develop.c: add missing atomic.h include

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -24,6 +24,7 @@
 #include <strings.h>
 #include <unistd.h>
 
+#include "common/atomic.h"
 #include "common/debug.h"
 #include "common/history.h"
 #include "common/image_cache.h"


### PR DESCRIPTION
The `develop.c` was missing `atomic.h` include which might create problems when building. This should indeed fix #6177 