### PR TITLE
database.c: skip maintenance/optimization on :memory: dbs

### DIFF
--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2996,9 +2996,14 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
     return shall_perform_maintenance;
 }
 
+static inline gboolean _is_mem_db(const struct dt_database_t *db)
+{
+  return !g_strcmp0(db->dbfilename_data, ":memory:") || !g_strcmp0(db->dbfilename_library, ":memory:");
+}
+
 void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time)
 {
-  if(!g_strcmp0(db->dbfilename_data, ":memory:") || !g_strcmp0(db->dbfilename_library, ":memory:"))
+  if(_is_mem_db(db))
     return;
 
   char *config = dt_conf_get_string("database/maintenance_check");
@@ -3075,7 +3080,7 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
 
 void dt_database_optimize(const struct dt_database_t *db)
 {
-  if(!g_strcmp0(db->dbfilename_data, ":memory:") || !g_strcmp0(db->dbfilename_library, ":memory:"))
+  if(_is_mem_db(db))
     return;
   // optimize should in most cases be no-op and have no noticeable downsides
   // this should be ran on every exit

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2998,6 +2998,9 @@ gboolean _ask_for_maintenance(const gboolean has_gui, const gboolean closing_tim
 
 void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolean has_gui, const gboolean closing_time)
 {
+  if(!g_strcmp0(db->dbfilename_data, ":memory:") || !g_strcmp0(db->dbfilename_library, ":memory:"))
+    return;
+
   char *config = dt_conf_get_string("database/maintenance_check");
 
   if(!g_strcmp0(config, "never"))
@@ -3072,6 +3075,8 @@ void dt_database_maybe_maintenance(const struct dt_database_t *db, const gboolea
 
 void dt_database_optimize(const struct dt_database_t *db)
 {
+  if(!g_strcmp0(db->dbfilename_data, ":memory:") || !g_strcmp0(db->dbfilename_library, ":memory:"))
+    return;
   // optimize should in most cases be no-op and have no noticeable downsides
   // this should be ran on every exit
   // see: https://www.sqlite.org/pragma.html#pragma_optimize


### PR DESCRIPTION
This simply skips db maintenance and optimization in case either library or data (or both) are `:memory:` as any vacuum/optimize on them is pointless and in case where one of dbs is memory, no point in messing around with trying.