### PR TITLE
Handle gphoto device in background thread

### DIFF
--- a/src/common/camera_control.c
+++ b/src/common/camera_control.c
@@ -680,9 +680,14 @@ void dt_camctl_destroy(dt_camctl_t *camctl)
 }
 
 
-int dt_camctl_have_cameras(const dt_camctl_t *c)
+gboolean dt_camctl_have_cameras(const dt_camctl_t *c)
 {
-  return (g_list_length(c->cameras) > 0) ? 1 : 0;
+  return (g_list_length(c->cameras) > 0) ? TRUE : FALSE;
+}
+
+gboolean dt_camctl_have_locked_cameras(const dt_camctl_t *c)
+{
+  return (g_list_length(c->locked_cameras) > 0) ? TRUE : FALSE;
 }
 
 void dt_camctl_register_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener)
@@ -812,7 +817,7 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
   }
 
   /* check c->cameras in available_cameras */
-  if(c->cameras && g_list_length(c->cameras) > 0)
+  if(dt_camctl_have_cameras(camctl))
   {
     GList *citem = c->cameras;
     do
@@ -842,7 +847,7 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
   }
 
   /* check c->locked_cameras in available_cameras */
-  if(c->locked_cameras && g_list_length(c->locked_cameras) > 0)
+  if(dt_camctl_have_locked_cameras(camctl))
   {
     GList *c_lock_item = c->locked_cameras;
     do
@@ -874,8 +879,7 @@ static void dt_camctl_update_cameras(const dt_camctl_t *c)
   gp_list_unref(available_cameras);
 
   /* check c->cameras in locked_cameras */
-  if((c->cameras && g_list_length(c->cameras) > 0) &&
-     (c->locked_cameras && g_list_length(c->locked_cameras) > 0))
+  if( (dt_camctl_have_cameras(camctl)) && (dt_camctl_have_locked_cameras(camctl)) )
   {
     GList *c_lock_item = c->locked_cameras;
     do

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -107,6 +107,15 @@ typedef struct dt_camera_t
   dt_pthread_mutex_t live_view_synch;
 } dt_camera_t;
 
+/** A dummy camera object used for locked cameras */
+typedef struct dt_camera_locked_t
+{
+  /** A pointer to the model string of camera. */
+  char *model;
+  /** A pointer to the port string of camera. */
+  char *port;
+} dt_camera_locked_t;
+
 /** Camera control status.
   These enumerations are passed back to host application using
   listener interface function control_status().
@@ -148,6 +157,8 @@ typedef struct dt_camctl_t
   GList *listeners;
   /** List of cameras found and initialized by camera control.*/
   GList *cameras;
+  /** List of locked cameras found */
+  GList *locked_cameras;
 
   /** The actual gphoto2 context */
   GPContext *gpcontext;

--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -234,7 +234,9 @@ void dt_camctl_unregister_listener(const dt_camctl_t *c, dt_camctl_listener_t *l
 /** start a thread job to detect cameras and update list of available cameras */
 void dt_camctl_background_detect_cameras();
 /** Check if there is any camera connected */
-int dt_camctl_have_cameras(const dt_camctl_t *c);
+gboolean dt_camctl_have_cameras(const dt_camctl_t *c);
+/** Check if there is any camera locked  */
+gboolean dt_camctl_have_locked_cameras(const dt_camctl_t *c);
 /** Selects a camera to be used by cam control, this camera is selected if NULL is passed as camera*/
 void dt_camctl_select_camera(const dt_camctl_t *c, const dt_camera_t *cam);
 /** Can tether...*/

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1269,6 +1269,7 @@ void dt_cleanup()
   free(darktable.opencl);
 #ifdef HAVE_GPHOTO2
   dt_camctl_destroy((dt_camctl_t *)darktable.camctl);
+  darktable.camctl = NULL;
 #endif
   dt_pwstorage_destroy(darktable.pwstorage);
 

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -76,7 +76,6 @@ typedef struct dt_lib_import_t
   GtkButton *import_file;
   GtkButton *import_directory;
   GtkButton *import_camera;
-  GtkButton *scan_devices;
   GtkButton *tethered_shoot;
 
   GtkBox *devices;
@@ -109,7 +108,6 @@ int position()
 
 void init_key_accels(dt_lib_module_t *self)
 {
-  dt_accel_register_lib(self, NC_("accel", "scan for devices"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "import from camera"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "tethered shoot"), 0, 0);
   dt_accel_register_lib(self, NC_("accel", "import image"), 0, 0);
@@ -120,7 +118,6 @@ void connect_key_accels(dt_lib_module_t *self)
 {
   dt_lib_import_t *d = (dt_lib_import_t *)self->data;
 
-  dt_accel_connect_button_lib(self, "scan for devices", GTK_WIDGET(d->scan_devices));
   dt_accel_connect_button_lib(self, "import image", GTK_WIDGET(d->import_file));
   dt_accel_connect_button_lib(self, "import folder", GTK_WIDGET(d->import_directory));
   if(d->tethered_shoot) dt_accel_connect_button_lib(self, "tethered shoot", GTK_WIDGET(d->tethered_shoot));
@@ -128,15 +125,6 @@ void connect_key_accels(dt_lib_module_t *self)
 }
 
 #ifdef HAVE_GPHOTO2
-
-/* scan for new devices button callback */
-static void _lib_import_scan_devices_callback(GtkButton *button, gpointer data)
-{
-  /* detect cameras */
-  dt_camctl_background_detect_cameras();
-  /* update UI */
-  // this part is now asynchronously done by the signal connected to in gui_init()
-}
 
 /* show import from camera dialog */
 static void _lib_import_from_camera_callback(GtkButton *button, gpointer data)
@@ -245,32 +233,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
     } while((citem = g_list_next(citem)) != NULL);
   }
   dt_pthread_mutex_unlock(&camctl->lock);
-
-  if(count == 0)
-  {
-    // No supported devices is detected lets notice user..
-    GtkWidget *label = gtk_label_new(_("no supported devices found"));
-    gtk_label_set_line_wrap(GTK_LABEL(label), TRUE);
-    g_object_set(G_OBJECT(label), "xalign", 0.0, (gchar *)0);
-    gtk_box_pack_start(GTK_BOX(d->devices), label, TRUE, TRUE, 0);
-  }
   gtk_widget_show_all(GTK_WIDGET(d->devices));
-}
-
-/** camctl camera disconnect callback */
-static gboolean _detect_async(gpointer user_data)
-{
-  dt_camctl_background_detect_cameras();
-  return FALSE;
-}
-
-static void _camctl_camera_disconnected_callback(const dt_camera_t *camera, void *data)
-{
-  /* rescan connected cameras. do that asynchronously since otherwise we deadlock (#10314) */
-  g_idle_add(_detect_async, NULL);
-
-  /* update gui with detected devices */
-  // this is done asynchronously in _camera_detected()
 }
 
 /** camctl status listener callback */
@@ -796,14 +759,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
 #ifdef HAVE_GPHOTO2
-  /* add the rescan button */
-  GtkButton *scan = GTK_BUTTON(gtk_button_new_with_label(_("scan for devices")));
-  dt_gui_add_help_link(GTK_WIDGET(scan), "lighttable_panels.html#import_from_camera");
-  d->scan_devices = scan;
-  gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(scan)), GTK_ALIGN_CENTER);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(scan), _("scan for newly attached devices"));
-  g_signal_connect(G_OBJECT(scan), "clicked", G_CALLBACK(_lib_import_scan_devices_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(scan), TRUE, TRUE, 0);
 
   /* add devices container for cameras */
   d->devices = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
@@ -814,7 +769,6 @@ void gui_init(dt_lib_module_t *self)
   /* initialize camctl listener and update devices */
   d->camctl_listener.data = self;
   d->camctl_listener.control_status = _camctl_camera_control_status_callback;
-  d->camctl_listener.camera_disconnected = _camctl_camera_disconnected_callback;
   dt_camctl_register_listener(darktable.camctl, &d->camctl_listener);
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_CAMERA_DETECTED, G_CALLBACK(_camera_detected),
                             self);

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -79,6 +79,8 @@ typedef struct dt_lib_import_t
   GtkButton *tethered_shoot;
 
   GtkBox *devices;
+  GtkBox *locked_devices;
+
 #ifdef USE_LUA
   GtkWidget *extra_lua_widgets;
 #endif
@@ -172,7 +174,13 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
 
   g_list_free(item);
 
-  uint32_t count = 0;
+  if((iter = item = gtk_container_get_children(GTK_CONTAINER(d->locked_devices))) != NULL) do
+    {
+      gtk_container_remove(GTK_CONTAINER(d->locked_devices), GTK_WIDGET(iter->data));
+    } while((iter = g_list_next(iter)) != NULL);
+
+  g_list_free(item);
+
   dt_camctl_t *camctl = (dt_camctl_t *)darktable.camctl;
   dt_pthread_mutex_lock(&camctl->lock);
 
@@ -183,8 +191,7 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
     do
     {
       dt_camera_t *camera = (dt_camera_t *)citem->data;
-      count++;
-
+ 
       /* add camera label */
       GtkWidget *label = dt_ui_section_label_new(camera->model);
       gtk_box_pack_start(GTK_BOX(d->devices), label, TRUE, TRUE, 0);
@@ -232,8 +239,27 @@ void _lib_import_ui_devices_update(dt_lib_module_t *self)
       gtk_box_pack_start(GTK_BOX(d->devices), vbx, FALSE, FALSE, 0);
     } while((citem = g_list_next(citem)) != NULL);
   }
+
+  if((citem = g_list_first(camctl->locked_cameras)) != NULL)
+  {
+    // Add detected but locked devices
+    char buffer[512] = { 0 };
+    do
+    {
+      dt_camera_locked_t *camera = (dt_camera_locked_t *)citem->data;
+
+      snprintf(buffer, sizeof(buffer), "Locked: %s on\n%s", camera->model, camera->port);
+
+      /* add camera label */
+      GtkWidget *label = dt_ui_section_label_new(buffer);
+      gtk_box_pack_start(GTK_BOX(d->locked_devices), label, FALSE, FALSE, 0);
+
+    } while((citem = g_list_next(citem)) != NULL);
+  }
+
   dt_pthread_mutex_unlock(&camctl->lock);
   gtk_widget_show_all(GTK_WIDGET(d->devices));
+  gtk_widget_show_all(GTK_WIDGET(d->locked_devices));
 }
 
 /** camctl status listener callback */
@@ -764,7 +790,11 @@ void gui_init(dt_lib_module_t *self)
   d->devices = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->devices), FALSE, FALSE, 0);
 
-  _lib_import_ui_devices_update(self);
+   /* add devices container for locked cameras */
+  d->locked_devices = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->locked_devices), FALSE, FALSE, 0);
+
+ _lib_import_ui_devices_update(self);
 
   /* initialize camctl listener and update devices */
   d->camctl_listener.data = self;


### PR DESCRIPTION
Updating the list of devices to be used by import or tethering is currently done in a job triggered by a button press. Devices currently used by other apps are not visualised.

I already did some approaches on this topic (see my now closed prs #5407 #5212 and find out about related issues)

What is done here and how?

1) For cam control we maintain two lists, a) holds structs of available devices (this has not changed), b) holds structs of devices that are available but can not be used because of other programs locking it

2) Keeping track of the list is done in a background thread raising a signal if any of the lists has changed. /adding or removing of any gphoto device)

The GUI is some changes too.

1) the 'scan for devices' button has gone, it is not necessary any more and we have less clobbering.

2) The visual representation of devices than can be used has not changed

3) Devices currently not available are displayed but don't have an import button or alike.

What is missing?

>  @johnny-bit: i have a question though - is it possible to have fix for #4380 in it too? I browsed entangle code for that and they detect blocked camera and try to eject it (essentially giving controll back to gphoto for further detection) upon user confirmation.

Did not implement this yet. Handling both lists is a starting point but i have no camera supporting tethering so i honestly can't test properly.
