### PR TITLE
correctly restore notebook page for color zones/contrast equalizer/raw denoise

### DIFF
--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -970,7 +970,7 @@ void init(dt_iop_module_t *module)
   dt_iop_default_init(module);
 
   dt_iop_atrous_params_t *d = module->default_params;
-  
+
   for(int k = 0; k < BANDS; k++)
   {
     d->y[atrous_Lt][k] = d->y[atrous_ct][k] = 0.0f;
@@ -1844,6 +1844,8 @@ void gui_init(struct dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, _("luma"), _("change lightness at each feature size"));
   dt_ui_notebook_page(c->channel_tabs, _("chroma"), _("change color saturation at each feature size"));
   dt_ui_notebook_page(c->channel_tabs, _("edges"), _("change edge halos at each feature size\nonly changes results of luma and chroma tabs"));
+  gtk_widget_show_all(GTK_WIDGET(c->channel_tabs));
+  gtk_notebook_set_current_page(c->channel_tabs, c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(tab_switch), self);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
 

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -817,7 +817,7 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
                                const float *const picker_max)
 {
   if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE &&
-     ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)) || 
+     ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)) ||
        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker_set_values)) ))
   {
     // the global live samples ...
@@ -909,7 +909,7 @@ static void _draw_color_picker(dt_iop_module_t *self, cairo_t *cr, dt_iop_colorz
   }
 
   if(self->request_color_pick == DT_REQUEST_COLORPICK_MODULE &&
-     ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)) || 
+     ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker)) ||
        gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(c->colorpicker_set_values)) ))
   {
     // draw marker for currently selected color:
@@ -2364,6 +2364,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, _("saturation"), NULL);
   dt_ui_notebook_page(c->channel_tabs, _("hue"), NULL);
 
+  gtk_widget_show_all(GTK_WIDGET(c->channel_tabs));
   gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(_channel_tabs_switch_callback), self);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(c->channel_tabs), TRUE, TRUE, 0);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -942,7 +942,8 @@ void gui_init(dt_iop_module_t *self)
   dt_ui_notebook_page(c->channel_tabs, _("G"), NULL);
   dt_ui_notebook_page(c->channel_tabs, _("B"), NULL);
 
-  gtk_notebook_set_current_page(GTK_NOTEBOOK(c->channel_tabs), c->channel);
+  gtk_widget_show_all(GTK_WIDGET(c->channel_tabs));
+  gtk_notebook_set_current_page(c->channel_tabs, c->channel);
   g_signal_connect(G_OBJECT(c->channel_tabs), "switch_page", G_CALLBACK(rawdenoise_tab_switch), self);
 
   const int ch = (int)c->channel;
@@ -1010,6 +1011,7 @@ void gui_init(dt_iop_module_t *self)
 void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_conf_set_int("plugins/darkroom/rawdenoise/gui_channel", c->channel);
   dt_draw_curve_destroy(c->transition_curve);
   dt_iop_cancel_history_update(self);
   free(self->gui_data);


### PR DESCRIPTION
fixes #6206

I broke this in #5661

Also saving currently active tab for rawdenoise (so it gets restored when reentering darkroom)