### PR TITLE
exif: fix reading iop-order.

### DIFF
--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -2775,7 +2775,9 @@ int dt_exif_xmp_read(dt_image_t *img, const char *filename, const int history_on
 
       if((pos = xmpData.findKey(Exiv2::XmpKey("Xmp.darktable.iop_order_version"))) != xmpData.end())
       {
-        iop_order_version = pos->toLong() == 2 ? DT_IOP_ORDER_LEGACY : DT_IOP_ORDER_V30;
+        //  All iop-order version before 3 are legacy one. Starting with version 3 we have the first
+        //  attempts to propose the final v3 iop-order.
+        iop_order_version = pos->toLong() < 3 ? DT_IOP_ORDER_LEGACY : DT_IOP_ORDER_V30;
         iop_order_list = dt_ioppr_get_iop_order_list_version(iop_order_version);
       }
       else


### PR DESCRIPTION
This fix a convoluted case. What is happening here is probably that
forcing xmp write with a version 3.x without editing the image makes
the iop_order_version to 0. A case that was not properly covered as
it should not happen when an image is edited in darkroom.

Fixes a serious bug in the handling of legacy xmp.

Fixes #6207.