### PR TITLE
hide iop header buttons until mouse over

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2402,18 +2402,19 @@
     <name>darkroom/ui/hide_header_buttons</name>
     <type>
       <enum>
-        <option>off</option>
-        <option>on</option>
+        <option>always</option>
+        <option>active</option>
         <option>dim</option>
         <option>auto</option>
+        <option>fade</option>
         <option>fit</option>
         <option>smooth</option>
         <option>glide</option>
       </enum>
     </type>
-    <default>off</default>
-    <shortdescription>hide three right-side buttons in module header</shortdescription>
-    <longdescription>when the mouse is not over a module, the multi-instance, reset and preset buttons can be hidden:\noff - always show all buttons,\non - only show the buttons when the mouse is over the module,\ndim - buttons are dimmed when mouse is away,\nauto - hide the buttons when the panel is narrow,\nfit - hide all the buttons if the module name doesn't fit,\nsmooth - fade out all buttons simultaneously,\nglide - gradually hide buttons as needed</longdescription>
+    <default>always</default>
+    <shortdescription>show right-side buttons in darkroom module headers</shortdescription>
+    <longdescription>when the mouse is not over a module, the multi-instance, reset and preset buttons can be hidden:\nalways - always show all buttons,\nactive - only show the buttons when the mouse is over the module,\ndim - buttons are dimmed when mouse is away,\nauto - hide the buttons when the panel is narrow,\nfade - fade out all buttons when panel narrows,\nfit - hide all the buttons if the module name doesn't fit,\nsmooth - fade out all buttons in one header simultaneously,\nglide - gradually hide individual buttons as needed</longdescription>
   </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2398,6 +2398,23 @@
     <shortdescription>colorbalance slider block layout</shortdescription>
     <longdescription>choose how to organise the slider blocks for lift, gamma and gain:\nlist - all sliders are shown in one long list (with headers),\ntabs - use tabs to switch between the blocks of sliders,\ncolumns - the blocks of sliders are shown next to each other (in narrow columns)</longdescription>
   </dtconfig>
+  <dtconfig prefs="darkroom">
+    <name>darkroom/ui/hide_header_buttons</name>
+    <type>
+      <enum>
+        <option>off</option>
+        <option>on</option>
+        <option>dim</option>
+        <option>auto</option>
+        <option>fit</option>
+        <option>smooth</option>
+        <option>glide</option>
+      </enum>
+    </type>
+    <default>off</default>
+    <shortdescription>hide three right-side buttons in module header</shortdescription>
+    <longdescription>when the mouse is not over a module, the multi-instance, reset and preset buttons can be hidden:\noff - always show all buttons,\non - only show the buttons when the mouse is over the module,\ndim - buttons are dimmed when mouse is away,\nauto - hide the buttons when the panel is narrow,\nfit - hide all the buttons if the module name doesn't fit,\nsmooth - fade out all buttons simultaneously,\nglide - gradually hide buttons as needed</longdescription>
+  </dtconfig>
 
   @DARKTABLECONFIG_IOP_ENTRIES@
 

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -686,6 +686,9 @@ void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
 /** cancel any previously-queued history update */
 void dt_iop_cancel_history_update(dt_iop_module_t *module);
 
+/** (un)hide iop module header right side buttons */
+gboolean dt_iop_show_hide_header_buttons(GtkWidget *header, GdkEventCrossing *event, gboolean show_buttons, gboolean always_hide);
+
 #define IOP_GUI_ALLOC(module) (dt_iop_##module##_gui_data_t *)(self->gui_data = calloc(1, sizeof(dt_iop_##module##_gui_data_t)))
 #define IOP_GUI_FREE free(self->gui_data); self->gui_data = NULL
 

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -1917,6 +1917,22 @@ static void _preference_prev_downsample_change(gpointer instance, gpointer user_
   }
 }
 
+static void _preference_changed_button_hide(gpointer instance, dt_develop_t *dev)
+{
+  GList *modules = dev->iop;
+  while(modules)
+  {
+    dt_iop_module_t *module = (dt_iop_module_t *)(modules->data);
+
+    if(module->header)
+    {
+      dt_iop_show_hide_header_buttons(module->header, NULL, FALSE, FALSE);
+    }
+
+    modules = g_list_next(modules);
+  }
+}
+
 static void _update_display_profile_cmb(GtkWidget *cmb_display_profile)
 {
   GList *l = darktable.color_profiles->profiles;
@@ -2951,6 +2967,10 @@ void enter(dt_view_t *self)
 
   //connect iop accelerators
   dt_iop_connect_accels_all();
+
+  // connect to preference change for module header button hiding
+  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_PREFERENCES_CHANGE,
+                                  G_CALLBACK(_preference_changed_button_hide), dev);
 }
 
 void leave(dt_view_t *self)
@@ -2978,6 +2998,9 @@ void leave(dt_view_t *self)
     dt_conf_set_string("plugins/darkroom/active", "");
 
   dt_develop_t *dev = (dt_develop_t *)self->data;
+
+  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals,
+                                     G_CALLBACK(_preference_changed_button_hide), dev);
 
   // reset color assesment mode
   if(dev->iso_12646.enabled)


### PR DESCRIPTION
In the darkroom right hand panel with module headers, the column of three buttons (instance/reset/preset) takes up a large amount of real estate and makes module names hard to read when the panel is narrow. These buttons convey no information (as opposed to the left most button). Thiis PR hides them until the mouse is over the module header and then shows them to be clicked on.

In the screenshot the mouse is over local contrast.
![image](https://user-images.githubusercontent.com/1549490/92329443-62e5ad00-f05f-11ea-8841-ebaf4ae0512d.png)
