### PR TITLE
Clean init/gui/reload/update separation

### DIFF
--- a/src/common/pwstorage/backend_kwallet.c
+++ b/src/common/pwstorage/backend_kwallet.c
@@ -150,7 +150,6 @@ static gboolean start_kwallet(backend_kwallet_context_t *context)
 
   if(check_error(error))
   {
-    g_variant_unref(ret);
     return FALSE;
   }
 

--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -806,7 +806,6 @@ static void _blendop_blendif_tab_switch(GtkNotebook *notebook, GtkWidget *page, 
   if(cst_old != _blendop_blendif_get_picker_colorspace(data) &&
      (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker)) ||
       gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(data->colorpicker_set_values))))
-
   {
     dt_iop_color_picker_set_cst(data->module, _blendop_blendif_get_picker_colorspace(data));
     dt_dev_reprocess_all(data->module->dev);
@@ -1582,8 +1581,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
       GtkWidget *label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-      sl->head = GTK_LABEL(gtk_label_new(in_out ? _("output") : _("input")));
-      gtk_label_set_ellipsize(GTK_LABEL(sl->head), PANGO_ELLIPSIZE_END);
+      sl->head = GTK_LABEL(dt_ui_label_new(in_out ? _("output") : _("input")));
       gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->head), FALSE, FALSE, 0);
 
       sl->picker_label = GTK_LABEL(gtk_label_new(""));
@@ -1592,8 +1590,7 @@ void dt_iop_gui_init_blendif(GtkBox *blendw, dt_iop_module_t *module)
 
       for(int k = 0; k < 4; k++)
       {
-        sl->label[k] = GTK_LABEL(gtk_label_new(NULL));
-        gtk_label_set_ellipsize(GTK_LABEL(sl->label[k]), PANGO_ELLIPSIZE_END);
+        sl->label[k] = GTK_LABEL(dt_ui_label_new(NULL));
         gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(sl->label[k]), FALSE, FALSE, 0);
       }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -229,6 +229,9 @@ void dt_iop_default_init(dt_iop_module_t *module)
     case DT_INTROSPECTION_TYPE_UINT:
       *(unsigned int*)(module->default_params + i->header.offset) = i->UInt.Default;
       break;
+    case DT_INTROSPECTION_TYPE_USHORT:
+      *(unsigned short*)(module->default_params + i->header.offset) = i->UShort.Default;
+      break;
     case DT_INTROSPECTION_TYPE_ENUM:
       *(int*)(module->default_params + i->header.offset) = i->Enum.Default;
       break;
@@ -248,14 +251,19 @@ void dt_iop_default_init(dt_iop_module_t *module)
         size_t element_size = i->Array.field->header.size;
         if(element_size % sizeof(int))
         {
-          fprintf(stderr, "trying to initialize array not multiple of sizeof(int) in dt_iop_default_init\n");
+          int8_t *p = module->default_params + i->header.offset;
+          for (size_t c = element_size; c < i->header.size; c++, p++)
+            p[element_size] = *p;
         }
-        element_size /= sizeof(int);
-        size_t num_ints = i->header.size / sizeof(int);
+        else
+        {
+          element_size /= sizeof(int);
+          size_t num_ints = i->header.size / sizeof(int);
 
-        int *p = module->default_params + i->header.offset;
-        for (size_t c = element_size; c < num_ints; c++, p++)
-          p[element_size] = *p;
+          int *p = module->default_params + i->header.offset;
+          for (size_t c = element_size; c < num_ints; c++, p++)
+            p[element_size] = *p;
+        }
       }
       break;
     case DT_INTROSPECTION_TYPE_STRUCT:

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -87,7 +87,7 @@ static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module);
 
 void dt_iop_load_default_params(dt_iop_module_t *module)
 {
-  memset(module->default_blendop_params, 0, sizeof(dt_develop_blend_params_t));
+  memcpy(module->params, module->default_params, module->params_size);
   memcpy(module->default_blendop_params, &_default_blendop_params, sizeof(dt_develop_blend_params_t));
   dt_iop_commit_blend_params(module, &_default_blendop_params);
 }
@@ -268,8 +268,6 @@ void dt_iop_default_init(dt_iop_module_t *module)
 
     i++;
   }
-
-  memcpy(module->params, module->default_params, param_size);
 }
 
 int dt_iop_load_module_so(void *m, const char *libname, const char *op)

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -149,8 +149,7 @@ static void default_cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_
 
 static void default_gui_cleanup(dt_iop_module_t *self)
 {
-  g_free(self->gui_data);
-  self->gui_data = NULL;
+  IOP_GUI_FREE;
 }
 
 static void default_cleanup(dt_iop_module_t *module)
@@ -1365,7 +1364,7 @@ static void init_presets(dt_iop_module_so_t *module_so)
         free(module);
         continue;
       }
-
+/*
       module->init(module);
       if(module->params_size == 0)
       {
@@ -1373,7 +1372,7 @@ static void init_presets(dt_iop_module_so_t *module_so)
         free(module);
         continue;
       }
-
+*/
       // we call reload_defaults() in case the module defines it
       if(module->reload_defaults) module->reload_defaults(module);
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -448,7 +448,6 @@ error:
 
 int dt_iop_load_module_by_so(dt_iop_module_t *module, dt_iop_module_so_t *so, dt_develop_t *dev)
 {
-  module->dt = &darktable;
   module->dev = dev;
   module->widget = NULL;
   module->header = NULL;
@@ -1545,8 +1544,6 @@ int dt_iop_load_module(dt_iop_module_t *module, dt_iop_module_so_t *module_so, d
     free(module);
     return 1;
   }
-  module->global_data = module_so->data;
-  module->so = module_so;
   dt_iop_reload_defaults(module);
   return 0;
 }

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1370,9 +1370,9 @@ static void init_presets(dt_iop_module_so_t *module_so)
         free(module);
         continue;
       }
-*/
       // we call reload_defaults() in case the module defines it
-      if(module->reload_defaults) module->reload_defaults(module);
+      if(module->reload_defaults) module->reload_defaults(module); // why not call dt_iop_reload_defaults? (if needed at all)
+*/
 
       int32_t new_params_size = module->params_size;
       void *new_params = calloc(1, new_params_size);

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -331,8 +331,6 @@ typedef struct dt_iop_module_t
   dt_iop_colorspace_type_t histogram_cst;
   /** scale the histogram so the middle grey is at .5 */
   int histogram_middle_grey;
-  /** reference for dlopened libs. */
-  darktable_t *dt;
   /** the module is used in this develop module. */
   struct dt_develop_t *dev;
   /** non zero if this node should be processed. */

--- a/src/develop/imageop.h
+++ b/src/develop/imageop.h
@@ -688,6 +688,9 @@ void dt_iop_queue_history_update(dt_iop_module_t *module, gboolean extend_prior)
 /** cancel any previously-queued history update */
 void dt_iop_cancel_history_update(dt_iop_module_t *module);
 
+#define IOP_GUI_ALLOC(module) (dt_iop_##module##_gui_data_t *)(self->gui_data = calloc(1, sizeof(dt_iop_##module##_gui_data_t)))
+#define IOP_GUI_FREE free(self->gui_data); self->gui_data = NULL
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -73,6 +73,16 @@ void dt_iop_slider_int_callback(GtkWidget *slider, int *field)
   if(*field != previous) process_changed_value(NULL, slider, &previous);
 }
 
+void dt_iop_slider_ushort_callback(GtkWidget *slider, unsigned short *field)
+{
+  if(darktable.gui->reset) return;
+
+  unsigned short previous = *field;
+  *field = dt_bauhaus_slider_get(slider);
+
+  if(*field != previous) process_changed_value(NULL, slider, &previous);
+}
+
 void dt_iop_combobox_enum_callback(GtkWidget *combobox, int *field)
 {
   if(darktable.gui->reset) return;
@@ -199,7 +209,23 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
                        G_CALLBACK(dt_iop_slider_int_callback), 
                        p + f->header.offset + param_index * sizeof(int));
     }
+    else if(f->header.type == DT_INTROSPECTION_TYPE_USHORT)
+    {
+      const unsigned short min = f->UShort.Min;
+      const unsigned short max = f->UShort.Max;
+      const unsigned short defval = *(unsigned short*)self->so->get_p(d, param_name);
 
+      slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 1, defval, 0, 1);
+
+      g_signal_connect(G_OBJECT(slider), "value-changed", 
+                       G_CALLBACK(dt_iop_slider_ushort_callback), 
+                       p + f->header.offset + param_index * sizeof(unsigned short));
+    }
+    else f = NULL;
+  }
+
+  if(f)
+  {
     if (*f->header.description)
     {
       // we do not want to support a context as it break all translations see #5498
@@ -217,7 +243,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
   }
   else
   {
-    str = g_strdup_printf("'%s' is not a float/int/slider parameter", param_name);
+    str = g_strdup_printf("'%s' is not a float/int/unsigned short/slider parameter", param_name);
 
     slider = dt_bauhaus_slider_new(self);
     dt_bauhaus_widget_set_label(slider, NULL, str);

--- a/src/develop/imageop_gui.c
+++ b/src/develop/imageop_gui.c
@@ -121,6 +121,7 @@ static void _iop_toggle_callback(GtkWidget *togglebutton, dt_module_param_t *dat
 GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *param)
 {
   dt_iop_params_t *p = (dt_iop_params_t *)self->params;
+  dt_iop_params_t *d = (dt_iop_params_t *)self->default_params;
 
   size_t param_index = 0;
 
@@ -148,7 +149,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
     {
       const float min = f->Float.Min;
       const float max = f->Float.Max;
-      const float defval = *(float*)self->so->get_p(p, param_name);
+      const float defval = *(float*)self->so->get_p(d, param_name);
       int digits = 2;
       float step = 0;
 
@@ -190,7 +191,7 @@ GtkWidget *dt_bauhaus_slider_from_params(dt_iop_module_t *self, const char *para
     {
       const int min = f->Int.Min;
       const int max = f->Int.Max;
-      const int defval = *(float*)self->so->get_p(p, param_name);
+      const int defval = *(int*)self->so->get_p(d, param_name);
 
       slider = dt_bauhaus_slider_new_with_range_and_feedback(self, min, max, 1, defval, 0, 1);
 

--- a/src/develop/imageop_gui.h
+++ b/src/develop/imageop_gui.h
@@ -28,6 +28,7 @@ GtkWidget *dt_bauhaus_toggle_from_params(dt_iop_module_t *self, const char *para
 
 void dt_iop_slider_float_callback(GtkWidget *slider, float *field);
 void dt_iop_slider_int_callback(GtkWidget *slider, int *field);
+void dt_iop_slider_ushort_callback(GtkWidget *slider, unsigned short *field);
 void dt_iop_combobox_enum_callback(GtkWidget *combobox, int *field);
 void dt_iop_combobox_int_callback(GtkWidget *combobox, int *field);
 void dt_iop_combobox_bool_callback(GtkWidget *combobox, gboolean *field);

--- a/src/gui/color_picker_proxy.c
+++ b/src/gui/color_picker_proxy.c
@@ -152,7 +152,7 @@ static gboolean _iop_color_picker_callback_button_press(GtkWidget *button, GdkEv
 {
   dt_iop_module_t *module = self->module ? self->module : dt_iop_get_colorout_module();
 
-  if(!module || module->dt->gui->reset) return FALSE;
+  if(!module || darktable.gui->reset) return FALSE;
 
   // set module active if not yet the case
   if(module->off) gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(module->off), TRUE);

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -361,6 +361,14 @@ static inline GtkWidget *dt_ui_section_label_new(const gchar *str)
   return label;
 };
 
+static inline GtkWidget *dt_ui_label_new(const gchar *str)
+{
+  GtkWidget *label = gtk_label_new(str);
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  return label;
+};
+
 GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const char *tooltip);
 
 static inline void dtgtk_justify_notebook_tabs(GtkNotebook *notebook)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -371,15 +371,6 @@ static inline GtkWidget *dt_ui_label_new(const gchar *str)
 
 GtkWidget *dt_ui_notebook_page(GtkNotebook *notebook, const char *text, const char *tooltip);
 
-static inline void dtgtk_justify_notebook_tabs(GtkNotebook *notebook)
-{
-  // force the notebook tabs to fill the available width
-  for(gint i = 0; i < gtk_notebook_get_n_pages(notebook); ++i)
-    gtk_container_child_set(GTK_CONTAINER(notebook),
-                            gtk_notebook_get_nth_page(notebook, i),
-                            "tab-expand", TRUE, "tab-fill", TRUE, (char *)NULL);
-}
-
 // show a dialog box with 2 buttons in case some user interaction is required BEFORE dt's gui is initialised.
 // this expects gtk_init() to be called already which should be the case during most of dt's init phase.
 gboolean dt_gui_show_standalone_yes_no_dialog(const char *title, const char *markup, const char *no_text,
@@ -406,6 +397,16 @@ guint dt_gui_translated_key_state(GdkEventKey *event);
 
 // return modifier keys currently pressed, independent of any key event
 GdkModifierType dt_key_modifier_state();
+
+// create an ellipsized button with label, tooltip and help link
+static inline GtkWidget *dt_ui_button_new(const gchar *label, const gchar *tooltip, const gchar *help)
+{
+  GtkWidget *button = gtk_button_new_with_label(label);
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
+  if(tooltip) gtk_widget_set_tooltip_text(button, tooltip);
+  if(help) dt_gui_add_help_link(button, help);
+  return button;
+};
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4719,8 +4719,7 @@ static float log2_curve(GtkWidget *self, float inval, dt_bauhaus_curve_t dir)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_ashift_gui_data_t));
-  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
+  dt_iop_ashift_gui_data_t *g = IOP_GUI_ALLOC(ashift);
 
   dt_pthread_mutex_init(&g->lock, NULL);
   dt_pthread_mutex_lock(&g->lock);
@@ -4916,8 +4915,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   free(g->buf);
   free(g->points);
   free(g->points_idx);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 GSList *mouse_actions(struct dt_iop_module_t *self)

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4721,7 +4721,6 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_ashift_gui_data_t));
   dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)self->gui_data;
-  dt_iop_ashift_params_t *p = (dt_iop_ashift_params_t *)self->params;
 
   dt_pthread_mutex_init(&g->lock, NULL);
   dt_pthread_mutex_lock(&g->lock);
@@ -4765,8 +4764,6 @@ void gui_init(struct dt_iop_module_t *self)
   g->adjust_crop = FALSE;
   g->lastx = g->lasty = -1.0f;
   g->crop_cx = g->crop_cy = 1.0f;
-
-  shadow_crop_box(p,g);
 
   g->rotation = dt_bauhaus_slider_from_params(self, N_("rotation"));
   dt_bauhaus_slider_set_format(g->rotation, "%.2f°");
@@ -4819,7 +4816,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->widget = saved_widget;
   gtk_box_pack_start(GTK_BOX(self->widget), g->specifics, TRUE, TRUE, 0);
-  gtk_widget_set_visible(g->specifics, p->mode == ASHIFT_MODE_SPECIFIC);
 
   GtkGrid *grid = GTK_GRID(gtk_grid_new());
   gtk_grid_set_row_spacing(grid, 2 * DT_BAUHAUS_SPACE);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4543,12 +4543,11 @@ void reload_defaults(dt_iop_module_t *module)
   // init defaults:
   ((dt_iop_ashift_params_t *)module->default_params)->f_length = f_length;
   ((dt_iop_ashift_params_t *)module->default_params)->crop_factor = crop_factor;
-  memcpy(module->params, module->default_params, sizeof(dt_iop_ashift_params_t));
 
   // reset gui elements
-  if(module->gui_data)
+  dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
+  if(g)
   {
-    dt_iop_ashift_gui_data_t *g = (dt_iop_ashift_gui_data_t *)module->gui_data;
 
     char string_v[256];
     char string_h[256];

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4811,10 +4811,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_set_row_spacing(grid, 2 * DT_BAUHAUS_SPACE);
   gtk_grid_set_column_spacing(grid, DT_PIXEL_APPLY_DPI(10));
 
-  GtkWidget *label1 = gtk_label_new(_("automatic fit"));
-  gtk_label_set_ellipsize(GTK_LABEL(label1), PANGO_ELLIPSIZE_END);
-  gtk_widget_set_halign(label1, GTK_ALIGN_START);
-  gtk_grid_attach(grid, label1, 0, 0, 1, 1);
+  gtk_grid_attach(grid, dt_ui_label_new(_("automatic fit")), 0, 0, 1, 1);
 
   g->fit_v = dtgtk_button_new(dtgtk_cairo_paint_perspective, CPF_STYLE_FLAT | 1, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_v), TRUE);
@@ -4828,10 +4825,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_hexpand(GTK_WIDGET(g->fit_both), TRUE);
   gtk_grid_attach(grid, g->fit_both, 3, 0, 1, 1);
 
-  GtkWidget *label2 = gtk_label_new(_("get structure"));
-  gtk_label_set_ellipsize(GTK_LABEL(label2), PANGO_ELLIPSIZE_END);
-  gtk_widget_set_halign(label2, GTK_ALIGN_START);
-  gtk_grid_attach(grid, label2, 0, 1, 1, 1);
+  gtk_grid_attach(grid, dt_ui_label_new(_("get structure")), 0, 1, 1, 1);
 
   g->structure = dtgtk_button_new(dtgtk_cairo_paint_structure, CPF_STYLE_FLAT, NULL);
   gtk_widget_set_hexpand(GTK_WIDGET(g->structure), TRUE);

--- a/src/iop/ashift.c
+++ b/src/iop/ashift.c
@@ -4134,7 +4134,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 #endif
   do_crop(self, p);
   commit_crop_box(p,g);
-  
+
   if(w == g->mode)
   {
     gtk_widget_set_visible(g->specifics, p->mode == ASHIFT_MODE_SPECIFIC);
@@ -4625,14 +4625,6 @@ void init_global(dt_iop_module_so_t *module)
   gd->kernel_ashift_lanczos3 = dt_opencl_create_kernel(program, "ashift_lanczos3");
 }
 
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-}
-
 void cleanup_global(dt_iop_module_so_t *module)
 {
   dt_iop_ashift_global_data_t *gd = (dt_iop_ashift_global_data_t *)module->data;
@@ -4799,7 +4791,7 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->f_length, "%.0fmm");
   dt_bauhaus_slider_set_step(g->f_length, 1.0);
 
-  g->crop_factor = dt_bauhaus_slider_from_params(self, "crop_factor"); 
+  g->crop_factor = dt_bauhaus_slider_from_params(self, "crop_factor");
   dt_bauhaus_slider_set_soft_range(g->crop_factor, 1.0f, 2.0f);
 
   g->orthocorr = dt_bauhaus_slider_from_params(self, "orthocorr");

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1824,7 +1824,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_atrous_gui_data_t));
   dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
-  dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->params;
+  dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->default_params;
 
   c->num_samples = 0;
   c->band_max = 0;

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -1822,8 +1822,7 @@ static void mix_callback(GtkWidget *slider, gpointer user_data)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_atrous_gui_data_t));
-  dt_iop_atrous_gui_data_t *c = (dt_iop_atrous_gui_data_t *)self->gui_data;
+  dt_iop_atrous_gui_data_t *c = IOP_GUI_ALLOC(atrous);
   dt_iop_atrous_params_t *p = (dt_iop_atrous_params_t *)self->default_params;
 
   c->num_samples = 0;
@@ -1878,8 +1877,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_conf_set_int("plugins/darkroom/atrous/gui_channel", c->channel);
   dt_draw_curve_destroy(c->minmax_curve);
   dt_iop_cancel_history_update(self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/atrous.c
+++ b/src/iop/atrous.c
@@ -976,8 +976,6 @@ void init(dt_iop_module_t *module)
     d->y[atrous_Lt][k] = d->y[atrous_ct][k] = 0.0f;
     for(int c = atrous_L; c <= atrous_ct; c++) d->x[c][k] = k / (BANDS - 1.0f);
   }
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_atrous_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -2087,7 +2087,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_basecurve_gui_data_t));
   dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
-  dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->params;
+  dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->default_params;
 
   c->minmax_curve = dt_draw_curve_new(0.0, 1.0, p->basecurve_type[0]);
   c->minmax_curve_type = p->basecurve_type[0];

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -2085,8 +2085,7 @@ static void logbase_callback(GtkWidget *slider, gpointer user_data)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_basecurve_gui_data_t));
-  dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
+  dt_iop_basecurve_gui_data_t *c = IOP_GUI_ALLOC(basecurve);
   dt_iop_basecurve_params_t *p = (dt_iop_basecurve_params_t *)self->default_params;
 
   c->minmax_curve = dt_draw_curve_new(0.0, 1.0, p->basecurve_type[0]);
@@ -2154,8 +2153,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_iop_basecurve_gui_data_t *c = (dt_iop_basecurve_gui_data_t *)self->gui_data;
   dt_draw_curve_destroy(c->minmax_curve);
   dt_iop_cancel_history_update(self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/basecurve.c
+++ b/src/iop/basecurve.c
@@ -1463,7 +1463,6 @@ void init(dt_iop_module_t *module)
   dt_iop_basecurve_params_t *d = module->default_params;
   d->basecurve[0][1].x = d->basecurve[0][1].y = 1.0;
   d->basecurve_nodes[0] = 2;
-  memcpy(module->params, module->default_params, sizeof(dt_iop_basecurve_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -43,9 +43,9 @@ typedef struct dt_iop_basicadj_params_t
   float exposure;       // $MIN: -18.0 $MAX: 18.0 $DEFAULT: 0.0
   float hlcompr;        /* $MIN: 0 $MAX: 500.0 $DEFAULT: 0.0
                            $DESCRIPTION:"highlight compression" */
-  float hlcomprthresh;  
+  float hlcomprthresh;
   float contrast;       // $MIN: -1.0 $MAX: 5.0 $DEFAULT: 0.0
-  dt_iop_rgb_norms_t preserve_colors; /* $DEFAULT: DT_RGB_NORM_LUMINANCE 
+  dt_iop_rgb_norms_t preserve_colors; /* $DEFAULT: DT_RGB_NORM_LUMINANCE
                                          $DESCRIPTION:"preserve colors" */
   float middle_grey;    // $MIN: 0.05 $MAX: 100 $DEFAULT: 18.42 $DESCRIPTION: "middle grey"
   float brightness;     // $MIN: -4.0 $MAX: 4.0 $DEFAULT: 0.0
@@ -643,7 +643,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->cmb_preserve_colors = dt_bauhaus_combobox_from_params(self, "preserve_colors") ;
   gtk_widget_set_tooltip_text(g->cmb_preserve_colors, _("method to preserve colors when applying contrast"));
 
-  g->sl_middle_grey = dt_color_picker_new(self, DT_COLOR_PICKER_AREA, 
+  g->sl_middle_grey = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
                       dt_bauhaus_slider_from_params(self, "middle_grey"));
   dt_bauhaus_slider_set_step(g->sl_middle_grey, .5);
   dt_bauhaus_slider_set_format(g->sl_middle_grey, "%.2f %%");
@@ -659,11 +659,10 @@ void gui_init(struct dt_iop_module_t *self)
 
   g->sl_vibrance = dt_bauhaus_slider_from_params(self, N_("vibrance"));
   gtk_widget_set_tooltip_text(g->sl_vibrance, _("vibrance adjustment"));
- 
+
   GtkWidget *autolevels_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, DT_PIXEL_APPLY_DPI(10));
 
-  g->bt_auto_levels = gtk_button_new_with_label(_("auto"));
-  gtk_widget_set_tooltip_text(g->bt_auto_levels, _("apply auto exposure based on the entire image"));
+  g->bt_auto_levels = dt_ui_button_new(_("auto"), _("apply auto exposure based on the entire image"), NULL);
   g_signal_connect(G_OBJECT(g->bt_auto_levels), "clicked", G_CALLBACK(_auto_levels_callback), self);
   gtk_widget_set_size_request(g->bt_auto_levels, -1, DT_PIXEL_APPLY_DPI(24));
   gtk_box_pack_start(GTK_BOX(autolevels_box), g->bt_auto_levels, TRUE, TRUE, 0);

--- a/src/iop/basicadj.c
+++ b/src/iop/basicadj.c
@@ -610,8 +610,7 @@ void change_image(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_basicadj_gui_data_t));
-  dt_iop_basicadj_gui_data_t *g = (dt_iop_basicadj_gui_data_t *)self->gui_data;
+  dt_iop_basicadj_gui_data_t *g = IOP_GUI_ALLOC(basicadj);
 
   dt_pthread_mutex_init(&g->lock, NULL);
   change_image(self);
@@ -701,8 +700,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   {
     dt_pthread_mutex_destroy(&g->lock);
   }
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 static inline int64_t doubleToRawLongBits(double d)

--- a/src/iop/bilat.c
+++ b/src/iop/bilat.c
@@ -422,8 +422,7 @@ void gui_update(dt_iop_module_t *self)
 void gui_init(dt_iop_module_t *self)
 {
   // init the slider (more sophisticated layouts are possible with gtk tables and boxes):
-  self->gui_data = malloc(sizeof(dt_iop_bilat_gui_data_t));
-  dt_iop_bilat_gui_data_t *g = (dt_iop_bilat_gui_data_t *)self->gui_data;
+  dt_iop_bilat_gui_data_t *g = IOP_GUI_ALLOC(bilat);
 
   g->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
   gtk_widget_set_tooltip_text(g->mode, _("the filter used for local contrast enhancement. bilateral is faster but can lead to artifacts around edges for extreme settings."));

--- a/src/iop/bilateral.cc
+++ b/src/iop/bilateral.cc
@@ -310,8 +310,7 @@ void tiling_callback(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = (dt_iop_gui_data_t *)malloc(sizeof(dt_iop_bilateral_gui_data_t));
-  dt_iop_bilateral_gui_data_t *g = (dt_iop_bilateral_gui_data_t *)self->gui_data;
+  dt_iop_bilateral_gui_data_t *g = IOP_GUI_ALLOC(bilateral);
 
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
   gtk_widget_set_tooltip_text(g->radius, _("spatial extent of the gaussian"));

--- a/src/iop/bloom.c
+++ b/src/iop/bloom.c
@@ -479,8 +479,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_bloom_gui_data_t));
-  dt_iop_bloom_gui_data_t *g = (dt_iop_bloom_gui_data_t *)self->gui_data;
+  dt_iop_bloom_gui_data_t *g = IOP_GUI_ALLOC(bloom);
 
   g->size = dt_bauhaus_slider_from_params(self, N_("size"));
   dt_bauhaus_slider_set_format(g->size, "%.0f%%");

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -909,8 +909,7 @@ static void gui_init_positions(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_borders_gui_data_t));
-  dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
+  dt_iop_borders_gui_data_t *g = IOP_GUI_ALLOC(borders);
   dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->default_params;
 
   g->size = dt_bauhaus_slider_from_params(self, "size");

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -1011,8 +1011,6 @@ void init(dt_iop_module_t *self)
   g_strlcpy(defaults->aspect_text, "constant border", sizeof(defaults->aspect_text));
   g_strlcpy(defaults->pos_h_text, "1/2", sizeof(defaults->pos_h_text));
   g_strlcpy(defaults->pos_v_text, "1/2", sizeof(defaults->pos_v_text));
-
-  memcpy(self->params, self->default_params, sizeof(dt_iop_borders_params_t));
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/borders.c
+++ b/src/iop/borders.c
@@ -911,7 +911,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_borders_gui_data_t));
   dt_iop_borders_gui_data_t *g = (dt_iop_borders_gui_data_t *)self->gui_data;
-  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->params;
+  dt_iop_borders_params_t *p = (dt_iop_borders_params_t *)self->default_params;
 
   g->size = dt_bauhaus_slider_from_params(self, "size");
   dt_bauhaus_slider_set_factor(g->size, 100);

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1493,9 +1493,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 void reload_defaults(dt_iop_module_t *module)
 {
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) return;
-
   dt_image_t *img = &module->dev->image_storage;
   // can't be switched on for non-raw or x-trans images:
   if(dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !dt_image_is_monochrome(img))

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1536,9 +1536,7 @@ void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(cacorrect);
 
-  self->widget = gtk_label_new("");
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(self->widget), PANGO_ELLIPSIZE_END);
+  self->widget = dt_ui_label_new("");
 }
 
 /** additional, optional callbacks to capture darkroom center events. */

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -46,8 +46,6 @@ typedef struct dt_iop_cacorrect_gui_data_t
 {
 } dt_iop_cacorrect_gui_data_t;
 
-dt_iop_cacorrect_gui_data_t dummy;
-
 // this returns a translatable name
 const char *name()
 {
@@ -1539,15 +1537,11 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
+  IOP_GUI_ALLOC(cacorrect);
+
   self->widget = gtk_label_new("");
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
   gtk_label_set_ellipsize(GTK_LABEL(self->widget), PANGO_ELLIPSIZE_END);
-  self->gui_data = &dummy;
-}
-
-void gui_cleanup(dt_iop_module_t *self)
-{
-  self->gui_data = NULL;
 }
 
 /** additional, optional callbacks to capture darkroom center events. */

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -431,8 +431,7 @@ void init(dt_iop_module_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_channelmixer_gui_data_t));
-  dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
+  dt_iop_channelmixer_gui_data_t *g = IOP_GUI_ALLOC(channelmixer);
   dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->default_params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -425,8 +425,6 @@ void init(dt_iop_module_t *module)
   dt_iop_channelmixer_params_t *d = module->default_params;
 
   d->red[CHANNEL_RED] = d->green[CHANNEL_GREEN] = d->blue[CHANNEL_BLUE] = 1.0;
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_channelmixer_params_t));
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/channelmixer.c
+++ b/src/iop/channelmixer.c
@@ -433,7 +433,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_channelmixer_gui_data_t));
   dt_iop_channelmixer_gui_data_t *g = (dt_iop_channelmixer_gui_data_t *)self->gui_data;
-  dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->params;
+  dt_iop_channelmixer_params_t *p = (dt_iop_channelmixer_params_t *)self->default_params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -323,8 +323,7 @@ void cleanup(dt_iop_module_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_rlce_gui_data_t));
-  dt_iop_rlce_gui_data_t *g = (dt_iop_rlce_gui_data_t *)self->gui_data;
+  dt_iop_rlce_gui_data_t *g = IOP_GUI_ALLOC(rlce);
   dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)self->default_params;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -308,9 +308,7 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0;
   module->params_size = sizeof(dt_iop_rlce_params_t);
   module->gui_data = NULL;
-  dt_iop_rlce_params_t tmp = (dt_iop_rlce_params_t){ 64, 1.25 };
-  memcpy(module->params, &tmp, sizeof(dt_iop_rlce_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_rlce_params_t));
+  *((dt_iop_rlce_params_t *)module->default_params) = (dt_iop_rlce_params_t){ 64, 1.25 };
 }
 
 void cleanup(dt_iop_module_t *module)

--- a/src/iop/clahe.c
+++ b/src/iop/clahe.c
@@ -325,7 +325,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_rlce_gui_data_t));
   dt_iop_rlce_gui_data_t *g = (dt_iop_rlce_gui_data_t *)self->gui_data;
-  dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)self->params;
+  dt_iop_rlce_params_t *p = (dt_iop_rlce_params_t *)self->default_params;
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -2118,8 +2118,7 @@ static gchar *format_aspect(gchar *original, int adim, int bdim)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = calloc(1, sizeof(dt_iop_clipping_gui_data_t));
-  dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
+  dt_iop_clipping_gui_data_t *g = IOP_GUI_ALLOC(clipping);
 
   g->aspect_list = NULL;
   g->clip_x = g->clip_y = g->handle_x = g->handle_y = 0.0;
@@ -2376,8 +2375,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_iop_clipping_gui_data_t *g = (dt_iop_clipping_gui_data_t *)self->gui_data;
   g_list_free_full(g->aspect_list, free_aspect);
   g->aspect_list = NULL;
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 static _grab_region_t get_grab(float pzx, float pzy, dt_iop_clipping_gui_data_t *g, const float border,

--- a/src/iop/clipping.c
+++ b/src/iop/clipping.c
@@ -1613,8 +1613,6 @@ void reload_defaults(dt_iop_module_t *self)
   d->cy = img->usercrop[0];
   d->cw = img->usercrop[3];
   d->ch = img->usercrop[2];
-
-  memcpy(self->params, self->default_params, sizeof(dt_iop_clipping_params_t));
 }
 
 static void _float_to_fract(const char *num, int *n, int *d)

--- a/src/iop/colisa.c
+++ b/src/iop/colisa.c
@@ -321,8 +321,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colisa_gui_data_t));
-  dt_iop_colisa_gui_data_t *g = (dt_iop_colisa_gui_data_t *)self->gui_data;
+  dt_iop_colisa_gui_data_t *g = IOP_GUI_ALLOC(colisa);
 
   g->contrast = dt_bauhaus_slider_from_params(self, N_("contrast"));
   g->brightness = dt_bauhaus_slider_from_params(self, N_("brightness"));

--- a/src/iop/colorbalance.c
+++ b/src/iop/colorbalance.c
@@ -1771,8 +1771,7 @@ HSL_CALLBACK(gain)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorbalance_gui_data_t));
-  dt_iop_colorbalance_gui_data_t *g = (dt_iop_colorbalance_gui_data_t *)self->gui_data;
+  dt_iop_colorbalance_gui_data_t *g = IOP_GUI_ALLOC(colorbalance);
 
   g->mode = NULL;
 

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -915,8 +915,6 @@ void init(dt_iop_module_t *module)
     d->source_a[k] = d->target_a[k] = colorchecker_Lab[3*k+1];
     d->source_b[k] = d->target_b[k] = colorchecker_Lab[3*k+2];
   }
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_colorchecker_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1338,8 +1338,7 @@ static gboolean checker_leave_notify(GtkWidget *widget, GdkEventCrossing *event,
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorchecker_gui_data_t));
-  dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
+  dt_iop_colorchecker_gui_data_t *g = IOP_GUI_ALLOC(colorchecker);
   dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->default_params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -1424,8 +1423,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
   cmsDeleteTransform(g->xform);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 #undef MAX_PATCHES

--- a/src/iop/colorchecker.c
+++ b/src/iop/colorchecker.c
@@ -1340,7 +1340,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_colorchecker_gui_data_t));
   dt_iop_colorchecker_gui_data_t *g = (dt_iop_colorchecker_gui_data_t *)self->gui_data;
-  dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->params;
+  dt_iop_colorchecker_params_t *p = (dt_iop_colorchecker_params_t *)self->default_params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/colorcontrast.c
+++ b/src/iop/colorcontrast.c
@@ -332,8 +332,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorcontrast_gui_data_t));
-  dt_iop_colorcontrast_gui_data_t *g = (dt_iop_colorcontrast_gui_data_t *)self->gui_data;
+  dt_iop_colorcontrast_gui_data_t *g = IOP_GUI_ALLOC(colorcontrast);
 
   g->a_scale = dt_bauhaus_slider_from_params(self, "a_steepness");
   gtk_widget_set_tooltip_text(g->a_scale, _("steepness of the a* curve in Lab"));

--- a/src/iop/colorcorrection.c
+++ b/src/iop/colorcorrection.c
@@ -240,8 +240,7 @@ static gboolean dt_iop_colorcorrection_key_press(GtkWidget *widget, GdkEventKey 
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorcorrection_gui_data_t));
-  dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
+  dt_iop_colorcorrection_gui_data_t *g = IOP_GUI_ALLOC(colorcorrection);
 
   g->selected = 0;
 
@@ -280,8 +279,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_colorcorrection_gui_data_t *g = (dt_iop_colorcorrection_gui_data_t *)self->gui_data;
   cmsDeleteTransform(g->xform);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 static gboolean dt_iop_colorcorrection_draw(GtkWidget *widget, cairo_t *crf, gpointer user_data)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1860,7 +1860,7 @@ void reload_defaults(dt_iop_module_t *module)
   dt_colorspaces_color_profile_type_t color_profile = DT_COLORSPACE_NONE;
 
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev || module->dev->image_storage.id <= 0) goto end;
+  if(!module->dev || module->dev->image_storage.id <= 0) return;
 
   gboolean use_eprofile = FALSE;
   // some file formats like jpeg can have an embedded color profile
@@ -1950,9 +1950,6 @@ void reload_defaults(dt_iop_module_t *module)
     d->type = DT_COLORSPACE_ENHANCED_MATRIX;
 
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
-
-end:
-  memcpy(module->params, module->default_params, sizeof(dt_iop_colorin_params_t));
 }
 
 static void update_profile_list(dt_iop_module_t *self)

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -1859,9 +1859,6 @@ void reload_defaults(dt_iop_module_t *module)
 
   dt_colorspaces_color_profile_type_t color_profile = DT_COLORSPACE_NONE;
 
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev || module->dev->image_storage.id <= 0) return;
-
   gboolean use_eprofile = FALSE;
   // some file formats like jpeg can have an embedded color profile
   // currently we only support jpeg, j2k, tiff and png

--- a/src/iop/colorin.c
+++ b/src/iop/colorin.c
@@ -2083,8 +2083,7 @@ static void update_profile_list(dt_iop_module_t *self)
 void gui_init(struct dt_iop_module_t *self)
 {
   // pthread_mutex_lock(&darktable.plugin_threadsafe);
-  self->gui_data = malloc(sizeof(dt_iop_colorin_gui_data_t));
-  dt_iop_colorin_gui_data_t *g = (dt_iop_colorin_gui_data_t *)self->gui_data;
+  dt_iop_colorin_gui_data_t *g = IOP_GUI_ALLOC(colorin);
 
   g->image_profiles = NULL;
 
@@ -2143,8 +2142,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
     g_free(g->image_profiles->data);
     g->image_profiles = g_list_delete_link(g->image_profiles, g->image_profiles);
   }
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -354,8 +354,7 @@ void init(dt_iop_module_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorize_gui_data_t));
-  dt_iop_colorize_gui_data_t *g = (dt_iop_colorize_gui_data_t *)self->gui_data;
+  dt_iop_colorize_gui_data_t *g = IOP_GUI_ALLOC(colorize);
 
   g->hue = dt_color_picker_new(self, DT_COLOR_PICKER_POINT, 
            dt_bauhaus_slider_from_params (self, N_("hue")));

--- a/src/iop/colorize.c
+++ b/src/iop/colorize.c
@@ -349,7 +349,6 @@ void init(dt_iop_module_t *module)
   dt_iop_default_init(module);
 
   ((dt_iop_colorize_params_t *)module->default_params)->version = module->version();
-  memcpy(module->params, module->default_params, sizeof(dt_iop_colorize_params_t));
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -881,19 +881,15 @@ void reload_defaults(dt_iop_module_t *module)
 {
   dt_iop_colormapping_params_t *d = module->default_params;
 
-  // we might be called from presets update infrastructure => there is no image
-  if(module->dev)
-  { 
-    dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)module->gui_data;
-    if(module->dev->gui_attached && g && g->flowback_set)
-    {
-      memcpy(d->source_ihist, g->flowback.hist, sizeof(float) * HISTN);
-      memcpy(d->source_mean, g->flowback.mean, sizeof(float) * MAXN * 2);
-      memcpy(d->source_var, g->flowback.var, sizeof(float) * MAXN * 2);
-      memcpy(d->source_weight, g->flowback.weight, sizeof(float) * MAXN);
-      d->n = g->flowback.n;
-      d->flag = HAS_SOURCE;
-    }
+  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)module->gui_data;
+  if(module->dev->gui_attached && g && g->flowback_set)
+  {
+    memcpy(d->source_ihist, g->flowback.hist, sizeof(float) * HISTN);
+    memcpy(d->source_mean, g->flowback.mean, sizeof(float) * MAXN * 2);
+    memcpy(d->source_var, g->flowback.var, sizeof(float) * MAXN * 2);
+    memcpy(d->source_weight, g->flowback.weight, sizeof(float) * MAXN);
+    d->n = g->flowback.n;
+    d->flag = HAS_SOURCE;
   }
 }
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1058,19 +1058,13 @@ void gui_init(struct dt_iop_module_t *self)
 
   self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE));
 
-  GtkBox *hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  GtkWidget *source = gtk_label_new(_("source clusters:"));
-  gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(source), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox1), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("source clusters:")), TRUE, TRUE, 0);
 
   g->source_area = dtgtk_drawing_area_new_with_aspect_ratio(1.0 / 3.0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->source_area, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(g->source_area), "draw", G_CALLBACK(cluster_preview_draw), self);
 
-  GtkBox *hbox2 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  GtkWidget *target = gtk_label_new(_("target clusters:"));
-  gtk_box_pack_start(GTK_BOX(hbox2), GTK_WIDGET(target), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox2), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_label_new(_("target clusters:")), TRUE, TRUE, 0);
 
   g->target_area = dtgtk_drawing_area_new_with_aspect_ratio(1.0 / 3.0);
   gtk_box_pack_start(GTK_BOX(self->widget), g->target_area, TRUE, TRUE, 0);

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -895,8 +895,6 @@ void reload_defaults(dt_iop_module_t *module)
       d->flag = HAS_SOURCE;
     }
   }
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_colormapping_params_t));
 }
 
 

--- a/src/iop/colormapping.c
+++ b/src/iop/colormapping.c
@@ -1051,8 +1051,7 @@ static void process_clusters(gpointer instance, gpointer user_data)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colormapping_gui_data_t));
-  dt_iop_colormapping_gui_data_t *g = (dt_iop_colormapping_gui_data_t *)self->gui_data;
+  dt_iop_colormapping_gui_data_t *g = IOP_GUI_ALLOC(colormapping);
 
   g->flag = NEUTRAL;
   g->flowback_set = 0;
@@ -1136,8 +1135,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   cmsDeleteTransform(g->xform);
   dt_pthread_mutex_destroy(&g->lock);
   free(g->buffer);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -64,9 +64,9 @@ typedef struct dt_iop_colorout_global_data_t
 
 typedef struct dt_iop_colorout_params_t
 {
-  dt_colorspaces_color_profile_type_t type;
+  dt_colorspaces_color_profile_type_t type; // $DEFAULT: DT_COLORSPACE_SRGB
   char filename[DT_IOP_COLOR_ICC_LEN];
-  dt_iop_color_intent_t intent;
+  dt_iop_color_intent_t intent; // $DEFAULT: DT_INTENT_PERCEPTUAL
 } dt_iop_colorout_params_t;
 
 typedef struct dt_iop_colorout_gui_data_t
@@ -823,23 +823,10 @@ void gui_update(struct dt_iop_module_t *self)
 
 void init(dt_iop_module_t *module)
 {
-  module->params = calloc(1, sizeof(dt_iop_colorout_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_colorout_params_t));
-  module->params_size = sizeof(dt_iop_colorout_params_t);
-  module->gui_data = NULL;
+  dt_iop_default_init(module);
+
   module->hide_enable_button = 1;
   module->default_enabled = 1;
-  dt_iop_colorout_params_t tmp = (dt_iop_colorout_params_t){ DT_COLORSPACE_SRGB, "", DT_INTENT_PERCEPTUAL};
-  memcpy(module->params, &tmp, sizeof(dt_iop_colorout_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_colorout_params_t));
-}
-
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
 }
 
 static void _preference_changed(gpointer instance, gpointer user_data)

--- a/src/iop/colorout.c
+++ b/src/iop/colorout.c
@@ -864,8 +864,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   const int force_lcms2 = dt_conf_get_bool("plugins/lighttable/export/force_lcms2");
 
-  self->gui_data = calloc(1, sizeof(dt_iop_colorout_gui_data_t));
-  dt_iop_colorout_gui_data_t *g = (dt_iop_colorout_gui_data_t *)self->gui_data;
+  dt_iop_colorout_gui_data_t *g = IOP_GUI_ALLOC(colorout);
 
   char datadir[PATH_MAX] = { 0 };
   char confdir[PATH_MAX] = { 0 };
@@ -923,8 +922,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_signal_profile_changed), self->dev);
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_preference_changed), self);
 
-  free(self->gui_data);
-  self->gui_data = NULL;
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1288,7 +1288,6 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_colorreconstruct_gui_data_t));
   dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
-  dt_iop_colorreconstruct_params_t *p = (dt_iop_colorreconstruct_params_t *)self->params;
 
   dt_pthread_mutex_init(&g->lock, NULL);
   g->can = NULL;
@@ -1312,8 +1311,6 @@ void gui_init(struct dt_iop_module_t *self)
 
   gtk_widget_show_all(g->hue);
   gtk_widget_set_no_show_all(g->hue, TRUE);
-
-  gtk_widget_set_visible(g->hue, p->precedence == COLORRECONSTRUCT_PRECEDENCE_HUE);
 
   gtk_widget_set_tooltip_text(g->threshold, _("pixels with lightness values above this threshold are corrected"));
   gtk_widget_set_tooltip_text(g->spatial, _("how far to look for replacement colors in spatial dimensions"));

--- a/src/iop/colorreconstruction.c
+++ b/src/iop/colorreconstruction.c
@@ -1286,8 +1286,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorreconstruct_gui_data_t));
-  dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
+  dt_iop_colorreconstruct_gui_data_t *g = IOP_GUI_ALLOC(colorreconstruct);
 
   dt_pthread_mutex_init(&g->lock, NULL);
   g->can = NULL;
@@ -1324,8 +1323,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_iop_colorreconstruct_gui_data_t *g = (dt_iop_colorreconstruct_gui_data_t *)self->gui_data;
   dt_pthread_mutex_destroy(&g->lock);
   dt_iop_colorreconstruct_bilateral_dump(g->can);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -654,15 +654,14 @@ cluster_preview_draw (GtkWidget *widget, cairo_t *crf, dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
+  IOP_GUI_ALLOC(colortransfer);
 
-  self->gui_data = malloc(sizeof(dt_iop_colortransfer_gui_data_t));
   self->widget = gtk_label_new(_("this module will be removed in the future\nand is only here so you can "
                                  "switch it off\nand move to the new color mapping module."));
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
 
 #if 0
-  self->gui_data = malloc(sizeof(dt_iop_colortransfer_gui_data_t));
-  dt_iop_colortransfer_gui_data_t *g = (dt_iop_colortransfer_gui_data_t *)self->gui_data;
+  dt_iop_colortransfer_gui_data_t *g = IOP_GUI_ALLOC(colortransfer);
   // dt_iop_colortransfer_params_t *p = (dt_iop_colortransfer_params_t *)self->params;
 
   g->flowback_set = 0;

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -580,7 +580,6 @@ void init(dt_iop_module_t *module)
   memset(tmp.mean, 0, sizeof(float) * MAXN * 2);
   memset(tmp.var, 0, sizeof(float) * MAXN * 2);
   tmp.n = 3;
-  memcpy(module->params, &tmp, sizeof(dt_iop_colortransfer_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_colortransfer_params_t));
 }
 

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -65,14 +65,14 @@ typedef enum dt_iop_colortransfer_flag_t
 
 typedef struct dt_iop_colortransfer_params_t
 {
-  dt_iop_colortransfer_flag_t flag;
+  dt_iop_colortransfer_flag_t flag; // $DEFAULT: NEUTRAL
   // hist matching table
   float hist[HISTN];
   // n-means (max 5?) with mean/variance
   float2 mean[MAXN];
   float2 var[MAXN];
   // number of gaussians used.
-  int n;
+  int n; // $DEFAULT: 3
 } dt_iop_colortransfer_params_t;
 
 typedef struct dt_iop_colortransfer_gui_data_t
@@ -564,31 +564,6 @@ void gui_update(struct dt_iop_module_t *self)
   // redraw color cluster preview
   dt_control_queue_redraw_widget(self->widget);
 #endif
-}
-
-void init(dt_iop_module_t *module)
-{
-  // module->data = malloc(sizeof(dt_iop_colortransfer_data_t));
-  module->params = calloc(1, sizeof(dt_iop_colortransfer_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_colortransfer_params_t));
-  module->default_enabled = 0;
-  module->params_size = sizeof(dt_iop_colortransfer_params_t);
-  module->gui_data = NULL;
-  dt_iop_colortransfer_params_t tmp;
-  tmp.flag = NEUTRAL;
-  memset(tmp.hist, 0, sizeof(float) * HISTN);
-  memset(tmp.mean, 0, sizeof(float) * MAXN * 2);
-  memset(tmp.var, 0, sizeof(float) * MAXN * 2);
-  tmp.n = 3;
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_colortransfer_params_t));
-}
-
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
 }
 
 #if 0

--- a/src/iop/colortransfer.c
+++ b/src/iop/colortransfer.c
@@ -630,9 +630,8 @@ void gui_init(struct dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(colortransfer);
 
-  self->widget = gtk_label_new(_("this module will be removed in the future\nand is only here so you can "
-                                 "switch it off\nand move to the new color mapping module."));
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+  self->widget = dt_ui_label_new(_("this module will be removed in the future\nand is only here so you can "
+                                   "switch it off\nand move to the new color mapping module."));
 
 #if 0
   dt_iop_colortransfer_gui_data_t *g = IOP_GUI_ALLOC(colortransfer);

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2654,8 +2654,6 @@ void init(dt_iop_module_t *module)
   module->request_histogram |= (DT_REQUEST_ON);
 
   _reset_parameters(module->default_params, DT_IOP_COLORZONES_h, DT_IOP_COLORZONES_SPLINES_V2);
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_colorzones_params_t));
 }
 
 #undef DT_IOP_COLORZONES_INSET

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2323,8 +2323,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_colorzones_gui_data_t));
-  dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
+  dt_iop_colorzones_gui_data_t *c = IOP_GUI_ALLOC(colorzones);
   dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->default_params;
 
   self->histogram_cst = iop_cs_LCh;
@@ -2493,8 +2492,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   for(int ch = 0; ch < DT_IOP_COLORZONES_MAX_CHANNELS; ch++) dt_draw_curve_destroy(c->minmax_curve[ch]);
 
   dt_iop_cancel_history_update(self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/colorzones.c
+++ b/src/iop/colorzones.c
@@ -2325,7 +2325,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_colorzones_gui_data_t));
   dt_iop_colorzones_gui_data_t *c = (dt_iop_colorzones_gui_data_t *)self->gui_data;
-  dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->params;
+  dt_iop_colorzones_params_t *p = (dt_iop_colorzones_params_t *)self->default_params;
 
   self->histogram_cst = iop_cs_LCh;
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -423,11 +423,9 @@ void gui_init(dt_iop_module_t *self)
         "static: fast, only uses the threshold as a static limit"));
 
   g->radius_scale = dt_bauhaus_slider_from_params(self, "radius");
-  dt_bauhaus_widget_set_label(g->radius_scale, NULL, _("edge detection radius"));
   gtk_widget_set_tooltip_text(g->radius_scale, _("radius for detecting fringe"));
 
   g->thresh_scale = dt_bauhaus_slider_from_params(self, "thresh");
-  dt_bauhaus_widget_set_label(g->thresh_scale, NULL, _("threshold"));
   gtk_widget_set_tooltip_text(g->thresh_scale, _("threshold for defringe, higher values mean less defringing"));
 }
 

--- a/src/iop/defringe.c
+++ b/src/iop/defringe.c
@@ -410,12 +410,11 @@ FINISH_PROCESS:
   free(xy_avg);
 }
 
-void gui_init(dt_iop_module_t *module)
+void gui_init(dt_iop_module_t *self)
 {
-  module->gui_data = malloc(sizeof(dt_iop_defringe_gui_data_t));
-  dt_iop_defringe_gui_data_t *g = (dt_iop_defringe_gui_data_t *)module->gui_data;
+  dt_iop_defringe_gui_data_t *g = IOP_GUI_ALLOC(defringe);
 
-  g->mode_select = dt_bauhaus_combobox_from_params(module, "op_mode");
+  g->mode_select = dt_bauhaus_combobox_from_params(self, "op_mode");
   gtk_widget_set_tooltip_text(g->mode_select,
       _("method for color protection:\n - global average: fast, might show slightly wrong previews in high "
         "magnification; might sometimes protect saturation too much or too low in comparison to local "
@@ -423,11 +422,11 @@ void gui_init(dt_iop_module_t *module)
         "near pixels as color reference, so it can still allow for more desaturation where required\n - "
         "static: fast, only uses the threshold as a static limit"));
 
-  g->radius_scale = dt_bauhaus_slider_from_params(module, "radius");
+  g->radius_scale = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_widget_set_label(g->radius_scale, NULL, _("edge detection radius"));
   gtk_widget_set_tooltip_text(g->radius_scale, _("radius for detecting fringe"));
 
-  g->thresh_scale = dt_bauhaus_slider_from_params(module, "thresh");
+  g->thresh_scale = dt_bauhaus_slider_from_params(self, "thresh");
   dt_bauhaus_widget_set_label(g->thresh_scale, NULL, _("threshold"));
   gtk_widget_set_tooltip_text(g->thresh_scale, _("threshold for defringe, higher values mean less defringing"));
 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5080,10 +5080,8 @@ void gui_init(struct dt_iop_module_t *self)
   // start building top level widget
   self->widget = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  
-  GtkWidget *label_non_raw = gtk_label_new(_("demosaicing\nonly needed for raw images."));
-  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
+
+  GtkWidget *label_non_raw = dt_ui_label_new(_("demosaicing\nonly needed for raw images."));
 
   gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5063,8 +5063,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_demosaic_gui_data_t));
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
+  dt_iop_demosaic_gui_data_t *g = IOP_GUI_ALLOC(demosaic);
 
   g->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5013,9 +5013,6 @@ void gui_update(struct dt_iop_module_t *self)
 
 void reload_defaults(dt_iop_module_t *module)
 {
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) return;
-
   dt_iop_demosaic_params_t *d = module->default_params;
 
   if(dt_image_is_monochrome(&module->dev->image_storage))

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5037,8 +5037,6 @@ void reload_defaults(dt_iop_module_t *module)
   {
     module->default_enabled = 0;
   }
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_demosaic_params_t));
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3819,8 +3819,7 @@ static void denoiseprofile_tab_switch(GtkNotebook *notebook, GtkWidget *page, gu
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_denoiseprofile_gui_data_t));
-  dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
+  dt_iop_denoiseprofile_gui_data_t *g = IOP_GUI_ALLOC(denoiseprofile);
   dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->default_params;
 
   g->profiles = NULL;
@@ -4027,8 +4026,8 @@ void gui_cleanup(dt_iop_module_t *self)
   g_list_free_full(g->profiles, dt_noiseprofile_free);
   dt_draw_curve_destroy(g->transition_curve);
   // nothing else necessary, gtk will clean up the slider.
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -1776,7 +1776,7 @@ static float nlmeans_precondition(const dt_iop_denoiseprofile_data_t *const d,
   p[0] = MAX(d->shadows + 0.1 * logf(scale / wb[0]), 0.0f);
   p[1] = MAX(d->shadows + 0.1 * logf(scale / wb[1]), 0.0f);
   p[2] = MAX(d->shadows + 0.1 * logf(scale / wb[2]), 0.0f);
-  
+
   // update the coeffs with strength and scale
   for(int i = 0; i < 3; i++)
   {
@@ -1813,7 +1813,7 @@ static float nlmeans_precondition_cl(const dt_iop_denoiseprofile_data_t *const d
   p[1] = MAX(d->shadows + 0.1 * logf(scale / wb[1]), 0.0f);
   p[2] = MAX(d->shadows + 0.1 * logf(scale / wb[2]), 0.0f);
   p[3] = 1.0f;
-  
+
   // update the coeffs with strength and scale
   for(int i = 0; i < 3; i++)
   {
@@ -2510,7 +2510,7 @@ static int process_wavelets_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_io
   const float wb_weights[3] = { 2.0f, 1.0f, 2.0f };
   compute_wb_factors(wb,d,piece,wb_weights);
   wb[3] = 0.0f;
-  
+
   // adaptive p depending on white balance
   const float p[4] = { MAX(d->shadows + 0.1 * logf(scale / wb[0]), 0.0f),
                        MAX(d->shadows + 0.1 * logf(scale / wb[1]), 0.0f),
@@ -2941,7 +2941,7 @@ void init(dt_iop_module_t *module)
   dt_iop_default_init(module);
 
   dt_iop_denoiseprofile_params_t *d = module->default_params;
-  
+
   for(int k = 0; k < DT_IOP_DENOISE_PROFILE_BANDS; k++)
   {
     for(int ch = 0; ch < DT_DENOISE_PROFILE_NONE; ch++)
@@ -3898,32 +3898,31 @@ void gui_init(dt_iop_module_t *self)
 
   g->box_variance = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  g->label_var = GTK_LABEL(gtk_label_new(_("use only with a perfectly\n"
-                                           "uniform image if you want to\n"
-                                           "estimate the noise variance.")));
-  gtk_widget_set_halign(GTK_WIDGET(g->label_var), GTK_ALIGN_START);
+  g->label_var = GTK_LABEL(dt_ui_label_new(_("use only with a perfectly\n"
+                                             "uniform image if you want to\n"
+                                             "estimate the noise variance.")));
   gtk_box_pack_start(GTK_BOX(g->box_variance), GTK_WIDGET(g->label_var), TRUE, TRUE, 0);
 
   GtkBox *hboxR = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  GtkLabel *labelR = GTK_LABEL(gtk_label_new(_("variance red: ")));
+  GtkLabel *labelR = GTK_LABEL(dt_ui_label_new(_("variance red: ")));
   gtk_box_pack_start(GTK_BOX(hboxR), GTK_WIDGET(labelR), FALSE, FALSE, 0);
-  g->label_var_R = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
+  g->label_var_R = GTK_LABEL(dt_ui_label_new("")); // This gets filled in by process
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->label_var_R), _("variance computed on the red channel"));
   gtk_box_pack_start(GTK_BOX(hboxR), GTK_WIDGET(g->label_var_R), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(g->box_variance), GTK_WIDGET(hboxR), TRUE, TRUE, 0);
 
   GtkBox *hboxG = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  GtkLabel *labelG = GTK_LABEL(gtk_label_new(_("variance green: ")));
+  GtkLabel *labelG = GTK_LABEL(dt_ui_label_new(_("variance green: ")));
   gtk_box_pack_start(GTK_BOX(hboxG), GTK_WIDGET(labelG), FALSE, FALSE, 0);
-  g->label_var_G = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
+  g->label_var_G = GTK_LABEL(dt_ui_label_new("")); // This gets filled in by process
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->label_var_G), _("variance computed on the green channel"));
   gtk_box_pack_start(GTK_BOX(hboxG), GTK_WIDGET(g->label_var_G), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(g->box_variance), GTK_WIDGET(hboxG), TRUE, TRUE, 0);
 
   GtkBox *hboxB = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  GtkLabel *labelB = GTK_LABEL(gtk_label_new(_("variance blue: ")));
+  GtkLabel *labelB = GTK_LABEL(dt_ui_label_new(_("variance blue: ")));
   gtk_box_pack_start(GTK_BOX(hboxB), GTK_WIDGET(labelB), FALSE, FALSE, 0);
-  g->label_var_B = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
+  g->label_var_B = GTK_LABEL(dt_ui_label_new("")); // This gets filled in by process
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->label_var_B), _("variance computed on the blue channel"));
   gtk_box_pack_start(GTK_BOX(hboxB), GTK_WIDGET(g->label_var_B), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(g->box_variance), GTK_WIDGET(hboxB), TRUE, TRUE, 0);
@@ -3969,9 +3968,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), g->box_variance, TRUE, TRUE, 0);
 
   g->fix_anscombe_and_nlmeans_norm = dt_bauhaus_toggle_from_params(self, "fix_anscombe_and_nlmeans_norm");
-  
+
   g->use_new_vst = dt_bauhaus_toggle_from_params(self, "use_new_vst");
-  
+
   gtk_widget_show_all(g->box_nlm);
   gtk_widget_show_all(g->box_wavelets);
   gtk_widget_show_all(g->box_variance);

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3821,7 +3821,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_denoiseprofile_gui_data_t));
   dt_iop_denoiseprofile_gui_data_t *g = (dt_iop_denoiseprofile_gui_data_t *)self->gui_data;
-  dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->params;
+  dt_iop_denoiseprofile_params_t *p = (dt_iop_denoiseprofile_params_t *)self->default_params;
 
   g->profiles = NULL;
 

--- a/src/iop/denoiseprofile.c
+++ b/src/iop/denoiseprofile.c
@@ -3004,7 +3004,6 @@ void reload_defaults(dt_iop_module_t *module)
         default_params->x[ch][k] = k / (DT_IOP_DENOISE_PROFILE_BANDS - 1.f);
       }
     }
-    memcpy(module->params, module->default_params, sizeof(dt_iop_denoiseprofile_params_t));
   }
 }
 

--- a/src/iop/dither.c
+++ b/src/iop/dither.c
@@ -760,8 +760,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_dither_gui_data_t));
-  dt_iop_dither_gui_data_t *g = (dt_iop_dither_gui_data_t *)self->gui_data;
+  dt_iop_dither_gui_data_t *g = IOP_GUI_ALLOC(dither);
 
   g->random = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -274,15 +274,13 @@ void init(dt_iop_module_t *module)
   module->default_enabled = 0; // we're a rather slow and rare op.
   module->params_size = sizeof(dt_iop_equalizer_params_t);
   module->gui_data = NULL;
-  dt_iop_equalizer_params_t tmp;
+  dt_iop_equalizer_params_t *d = module->default_params;
   for(int ch = 0; ch < 3; ch++)
   {
     for(int k = 0; k < DT_IOP_EQUALIZER_BANDS; k++)
-      tmp.equalizer_x[ch][k] = k / (float)(DT_IOP_EQUALIZER_BANDS - 1);
-    for(int k = 0; k < DT_IOP_EQUALIZER_BANDS; k++) tmp.equalizer_y[ch][k] = 0.5f;
+      d->equalizer_x[ch][k] = k / (float)(DT_IOP_EQUALIZER_BANDS - 1);
+    for(int k = 0; k < DT_IOP_EQUALIZER_BANDS; k++) d->equalizer_y[ch][k] = 0.5f;
   }
-  memcpy(module->params, &tmp, sizeof(dt_iop_equalizer_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_equalizer_params_t));
 }
 
 #if 0

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -343,9 +343,8 @@ void gui_init(struct dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(equalizer);
 
-  self->widget = gtk_label_new(_("this module will be removed in the future\nand is only here so you can "
-                                 "switch it off\nand move to the new equalizer."));
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+  self->widget = dt_ui_label_new(_("this module will be removed in the future\nand is only here so you can "
+                                   "switch it off\nand move to the new equalizer."));
 
 #if 0
   dt_iop_equalizer_gui_data_t *c = (dt_iop_equalizer_gui_data_t *)self->gui_data;

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -351,7 +351,8 @@ void init_presets (dt_iop_module_so_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_equalizer_gui_data_t));
+  IOP_GUI_ALLOC(equalizer);
+  
   self->widget = gtk_label_new(_("this module will be removed in the future\nand is only here so you can "
                                  "switch it off\nand move to the new equalizer."));
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);

--- a/src/iop/equalizer.c
+++ b/src/iop/equalizer.c
@@ -285,14 +285,6 @@ void init(dt_iop_module_t *module)
   memcpy(module->default_params, &tmp, sizeof(dt_iop_equalizer_params_t));
 }
 
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-}
-
 #if 0
 void init_presets (dt_iop_module_so_t *self)
 {
@@ -352,7 +344,7 @@ void init_presets (dt_iop_module_so_t *self)
 void gui_init(struct dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(equalizer);
-  
+
   self->widget = gtk_label_new(_("this module will be removed in the future\nand is only here so you can "
                                  "switch it off\nand move to the new equalizer."));
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -749,12 +749,11 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
   exposure_set_white(self, white);
 }
 
-static void autoexpp_callback(GtkWidget *slider, gpointer user_data)
+static void autoexpp_callback(GtkWidget *slider, dt_iop_module_t *self)
 {
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  if(darktable.gui->reset) return;
 
-  if(self->dt->gui->reset) return;
+  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
   if(self->request_color_pick != DT_REQUEST_COLORPICK_MODULE ||
      !dt_bauhaus_widget_get_quad_active(g->autoexpp) ||
      self->picked_color_max[0] < 0.0f) return;

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -897,8 +897,8 @@ void gui_init(struct dt_iop_module_t *self)
                               _("where to place the exposure level for processed pics, EV below overexposure."));
 
   GtkBox *hbox1 = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(gtk_label_new(_("computed EC: "))), FALSE, FALSE, 0);
-  g->deflicker_used_EC = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
+  gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(dt_ui_label_new(_("computed EC: "))), FALSE, FALSE, 0);
+  g->deflicker_used_EC = GTK_LABEL(dt_ui_label_new("")); // This gets filled in by process
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->deflicker_used_EC), _("what exposure correction has actually been used"));
   gtk_box_pack_start(GTK_BOX(hbox1), GTK_WIDGET(g->deflicker_used_EC), FALSE, FALSE, 0);
 

--- a/src/iop/exposure.c
+++ b/src/iop/exposure.c
@@ -851,8 +851,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_exposure_gui_data_t));
-  dt_iop_exposure_gui_data_t *g = (dt_iop_exposure_gui_data_t *)self->gui_data;
+  dt_iop_exposure_gui_data_t *g = IOP_GUI_ALLOC(exposure);
 
   g->deflicker_histogram = NULL;
 
@@ -951,8 +950,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 
   dt_pthread_mutex_destroy(&g->lock);
 
-  free(self->gui_data);
-  self->gui_data = NULL;
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1606,8 +1606,7 @@ static void _extra_options_button_changed(GtkDarktableToggleButton *widget, gpoi
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_filmic_gui_data_t));
-  dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
+  dt_iop_filmic_gui_data_t *g = IOP_GUI_ALLOC(filmic);
   dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->default_params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1608,7 +1608,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_filmic_gui_data_t));
   dt_iop_filmic_gui_data_t *g = (dt_iop_filmic_gui_data_t *)self->gui_data;
-  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->params;
+  dt_iop_filmic_params_t *p = (dt_iop_filmic_params_t *)self->default_params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/filmic.c
+++ b/src/iop/filmic.c
@@ -1434,7 +1434,7 @@ void init(dt_iop_module_t *module)
   module->params_size = sizeof(dt_iop_filmic_params_t);
   module->gui_data = NULL;
 
-  dt_iop_filmic_params_t tmp
+  *(dt_iop_filmic_params_t *)module->default_params
     = (dt_iop_filmic_params_t){
                                  .grey_point_source   = 18, // source grey
                                  .black_point_source  = -8.65,  // source black
@@ -1452,8 +1452,6 @@ void init(dt_iop_module_t *module)
                                  .interpolator        = CUBIC_SPLINE, //interpolator
                                  .preserve_color      = 0, // run the saturated variant
                               };
-  memcpy(module->params, &tmp, sizeof(dt_iop_filmic_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_filmic_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3375,8 +3375,7 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_filmicrgb_gui_data_t));
-  dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
+  dt_iop_filmicrgb_gui_data_t *g = IOP_GUI_ALLOC(filmicrgb);
 
   g->show_mask = FALSE;
   g->gui_mode = DT_FILMIC_GUI_LOOK;

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2305,7 +2305,7 @@ void reload_defaults(dt_iop_module_t *module)
   module->default_enabled = FALSE;
 
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev || module->dev->image_storage.id == -1) goto end;
+  if(!module->dev || module->dev->image_storage.id == -1) return;
 
   gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
@@ -2325,9 +2325,6 @@ void reload_defaults(dt_iop_module_t *module)
     d->output_power = logf(d->grey_point_target / 100.0f)
                       / logf(-d->black_point_source / (d->white_point_source - d->black_point_source));
   }
-
-end:
-  memcpy(module->params, module->default_params, sizeof(dt_iop_filmicrgb_params_t));
 }
 
 

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -1930,7 +1930,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 static void show_mask_callback(GtkWidget *slider, gpointer user_data)
 {
   dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(self->dt->gui->reset) return;
+  if(darktable.gui->reset) return;
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->off), TRUE);
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
   g->show_mask = !(g->show_mask);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -2304,9 +2304,6 @@ void reload_defaults(dt_iop_module_t *module)
 
   module->default_enabled = FALSE;
 
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev || module->dev->image_storage.id == -1) return;
-
   gchar *workflow = dt_conf_get_string("plugins/darkroom/workflow");
   const gboolean is_scene_referred = strcmp(workflow, "scene-referred") == 0;
   g_free(workflow);

--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -3373,12 +3373,10 @@ static gboolean area_motion_notify(GtkWidget *widget, GdkEventMotion *event, gpo
 }
 
 
-
 void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_filmicrgb_gui_data_t));
   dt_iop_filmicrgb_gui_data_t *g = (dt_iop_filmicrgb_gui_data_t *)self->gui_data;
-  dt_iop_filmicrgb_params_t *p = self->params;
 
   g->show_mask = FALSE;
   g->gui_mode = DT_FILMIC_GUI_LOOK;
@@ -3534,7 +3532,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->contrast, _("slope of the linear part of the curve\n"
                                              "affects mostly the mid-tones"));
 
-
   // brightness slider
   g->output_power = dt_bauhaus_slider_from_params(self, "output_power");
   gtk_widget_set_tooltip_text(g->output_power, _("equivalent to paper grade in analog.\n"
@@ -3564,10 +3561,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->saturation, _("desaturates the output of the module\n"
                                                "specifically at extreme luminances.\n"
                                                "increase if shadows and/or highlights are under-saturated."));
-  if(p->version == DT_FILMIC_COLORSCIENCE_V1)
-    dt_bauhaus_widget_set_label(g->saturation, NULL, _("extreme luminance saturation"));
-  else if(p->version == DT_FILMIC_COLORSCIENCE_V2)
-    dt_bauhaus_widget_set_label(g->saturation, NULL, _("middle tones saturation"));
 
   // Page DISPLAY
   self->widget = dt_ui_notebook_page(g->notebook, _("display"), NULL);

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -416,10 +416,16 @@ void init_presets(dt_iop_module_so_t *self)
 
 void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_flip_params_t tmp = (dt_iop_flip_params_t){ .orientation = ORIENTATION_NULL };
+  dt_iop_flip_params_t *d = self->default_params;
+  
+  d->orientation = ORIENTATION_NULL;
 
   // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) goto end;
+  if(!self->dev)
+  {
+    fprintf(stderr, "reload_defaults should not be called without image.\n");
+    return;
+  }
 
   self->default_enabled = 1;
 
@@ -435,16 +441,12 @@ void reload_defaults(dt_iop_module_t *self)
     {
       // convert the old legacy flip bits to a proper parameter set:
       self->default_enabled = 1;
-      tmp.orientation
+      d->orientation
           = merge_two_orientations(dt_image_orientation(&self->dev->image_storage),
                                    (dt_image_orientation_t)(self->dev->image_storage.legacy_flip.user_flip));
     }
     sqlite3_finalize(stmt);
   }
-
-end:
-  memcpy(self->params, &tmp, sizeof(dt_iop_flip_params_t));
-  memcpy(self->default_params, &tmp, sizeof(dt_iop_flip_params_t));
 }
 
 void gui_update(struct dt_iop_module_t *self)

--- a/src/iop/flip.c
+++ b/src/iop/flip.c
@@ -420,7 +420,9 @@ void reload_defaults(dt_iop_module_t *self)
   
   d->orientation = ORIENTATION_NULL;
 
-  // we might be called from presets update infrastructure => there is no image
+  // report if reload_defaults was called unnecessarily => this should be considered a bug
+  // the whole point of reload_defaults is to update defaults _based on current image_
+  // any required initialisation should go in init (and not be performed repeatedly here)
   if(!self->dev)
   {
     fprintf(stderr, "reload_defaults should not be called without image.\n");
@@ -452,16 +454,6 @@ void reload_defaults(dt_iop_module_t *self)
 void gui_update(struct dt_iop_module_t *self)
 {
   // nothing to do
-}
-
-void init(dt_iop_module_t *module)
-{
-  // module->data = malloc(sizeof(dt_iop_flip_data_t));
-  module->params = calloc(1, sizeof(dt_iop_flip_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_flip_params_t));
-  module->default_enabled = 1;
-  module->params_size = sizeof(dt_iop_flip_params_t);
-  module->gui_data = NULL;
 }
 
 static void do_rotate(dt_iop_module_t *self, uint32_t cw)

--- a/src/iop/globaltonemap.c
+++ b/src/iop/globaltonemap.c
@@ -647,8 +647,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_global_tonemap_gui_data_t));
-  dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
+  dt_iop_global_tonemap_gui_data_t *g = IOP_GUI_ALLOC(global_tonemap);
 
   dt_pthread_mutex_init(&g->lock, NULL);
   g->lwmax = NAN;
@@ -673,8 +672,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_global_tonemap_gui_data_t *g = (dt_iop_global_tonemap_gui_data_t *)self->gui_data;
   dt_pthread_mutex_destroy(&g->lock);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/graduatednd.c
+++ b/src/iop/graduatednd.c
@@ -1150,8 +1150,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_graduatednd_gui_data_t));
-  dt_iop_graduatednd_gui_data_t *g = (dt_iop_graduatednd_gui_data_t *)self->gui_data;
+  dt_iop_graduatednd_gui_data_t *g = IOP_GUI_ALLOC(graduatednd);
 
   g->density = dt_bauhaus_slider_from_params(self, "density");
   dt_bauhaus_slider_set_format(g->density, _("%.2f EV"));

--- a/src/iop/grain.c
+++ b/src/iop/grain.c
@@ -578,8 +578,7 @@ void init_global(struct dt_iop_module_so_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_grain_gui_data_t));
-  dt_iop_grain_gui_data_t *g = (dt_iop_grain_gui_data_t *)self->gui_data;
+  dt_iop_grain_gui_data_t *g = IOP_GUI_ALLOC(grain);
 
   /* courseness */
   g->scale = dt_bauhaus_slider_from_params(self, "scale");

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -173,28 +173,6 @@ void cleanup_global(dt_iop_module_so_t *self)
 }
 
 
-void init(dt_iop_module_t *self)
-{
-  self->params = calloc(1, sizeof(dt_iop_hazeremoval_params_t));
-  self->default_params = calloc(1, sizeof(dt_iop_hazeremoval_params_t));
-  self->default_enabled = 0;
-  self->params_size = sizeof(dt_iop_hazeremoval_params_t);
-  self->gui_data = NULL;
-  dt_iop_hazeremoval_params_t tmp = (dt_iop_hazeremoval_params_t){ 0.2f, 0.2f };
-  memcpy(self->params, &tmp, sizeof(dt_iop_hazeremoval_params_t));
-  memcpy(self->default_params, &tmp, sizeof(dt_iop_hazeremoval_params_t));
-}
-
-
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
-}
-
-
 void gui_update(struct dt_iop_module_t *self)
 {
   dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;

--- a/src/iop/hazeremoval.c
+++ b/src/iop/hazeremoval.c
@@ -214,8 +214,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_hazeremoval_gui_data_t));
-  dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
+  dt_iop_hazeremoval_gui_data_t *g = IOP_GUI_ALLOC(hazeremoval);
 
   dt_pthread_mutex_init(&g->lock, NULL);
   g->distance_max = NAN;
@@ -238,8 +237,8 @@ void gui_cleanup(dt_iop_module_t *self)
 {
   dt_iop_hazeremoval_gui_data_t *g = (dt_iop_hazeremoval_gui_data_t *)self->gui_data;
   dt_pthread_mutex_destroy(&g->lock);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 //----------------------------------------------------------------------

--- a/src/iop/highlights.c
+++ b/src/iop/highlights.c
@@ -1037,8 +1037,7 @@ void reload_defaults(dt_iop_module_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_highlights_gui_data_t));
-  dt_iop_highlights_gui_data_t *g = (dt_iop_highlights_gui_data_t *)self->gui_data;
+  dt_iop_highlights_gui_data_t *g = IOP_GUI_ALLOC(highlights);
 
   g->mode = dt_bauhaus_combobox_from_params(self, "mode");
   gtk_widget_set_tooltip_text(g->mode, _("highlight reconstruction method"));

--- a/src/iop/highpass.c
+++ b/src/iop/highpass.c
@@ -441,8 +441,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_highpass_gui_data_t));
-  dt_iop_highpass_gui_data_t *g = (dt_iop_highpass_gui_data_t *)self->gui_data;
+  dt_iop_highpass_gui_data_t *g = IOP_GUI_ALLOC(highpass);
 
   g->sharpness = dt_bauhaus_slider_from_params(self, N_("sharpness"));
   dt_bauhaus_slider_set_format(g->sharpness, "%.0f%%");

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -306,9 +306,6 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 
 void reload_defaults(dt_iop_module_t *module)
 {
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) return;
-
   // can't be switched on for non-raw images:
   module->hide_enable_button = !dt_image_is_raw(&module->dev->image_storage);
 }

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -44,13 +44,11 @@ typedef struct dt_iop_hotpixels_params_t
 
 typedef struct dt_iop_hotpixels_gui_data_t
 {
-  GtkWidget *box_raw;
   GtkWidget *threshold, *strength;
   GtkToggleButton *markfixed;
   GtkToggleButton *permissive;
   GtkLabel *message;
   int pixels_fixed;
-  GtkWidget *label_non_raw;
 } dt_iop_hotpixels_gui_data_t;
 
 typedef struct dt_iop_hotpixels_data_t
@@ -348,16 +346,7 @@ void gui_update(dt_iop_module_t *self)
   g->pixels_fixed = -1;
   gtk_label_set_text(g->message, "");
 
-  if(!self->hide_enable_button)
-  {
-    gtk_widget_show(g->box_raw);
-    gtk_widget_hide(g->label_non_raw);
-  }
-  else
-  {
-    gtk_widget_hide(g->box_raw);
-    gtk_widget_show(g->label_non_raw);
-  }
+  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
 }
 
 static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
@@ -385,8 +374,8 @@ void gui_init(dt_iop_module_t *self)
 
   g->pixels_fixed = -1;
 
-  g->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
-  g_signal_connect(G_OBJECT(g->box_raw), "draw", G_CALLBACK(draw), self);
+  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  g_signal_connect(G_OBJECT(box_raw), "draw", G_CALLBACK(draw), self);
 
   g->threshold = dt_bauhaus_slider_from_params(self, N_("threshold"));
   dt_bauhaus_slider_set_step(g->threshold, 0.005);
@@ -405,16 +394,18 @@ void gui_init(dt_iop_module_t *self)
   g->markfixed = GTK_TOGGLE_BUTTON(dt_bauhaus_toggle_from_params(self, "markfixed"));
   g->message = GTK_LABEL(gtk_label_new("")); // This gets filled in by process
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->message), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(g->box_raw), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(box_raw), hbox, TRUE, TRUE, 0);
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  
+  GtkWidget *label_non_raw = gtk_label_new(_("hot pixel correction\nonly works for raw images."));
+  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->box_raw, FALSE, FALSE, 0);
-
-  g->label_non_raw = gtk_label_new(_("hot pixel correction\nonly works for raw images."));
-  gtk_widget_set_halign(g->label_non_raw, GTK_ALIGN_START);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->label_non_raw, FALSE, FALSE, 0);
+  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -384,8 +384,7 @@ static gboolean draw(GtkWidget *widget, cairo_t *cr, dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_hotpixels_gui_data_t));
-  dt_iop_hotpixels_gui_data_t *g = (dt_iop_hotpixels_gui_data_t *)self->gui_data;
+  dt_iop_hotpixels_gui_data_t *g = IOP_GUI_ALLOC(hotpixels);
 
   g->pixels_fixed = -1;
 

--- a/src/iop/hotpixels.c
+++ b/src/iop/hotpixels.c
@@ -399,10 +399,8 @@ void gui_init(dt_iop_module_t *self)
   // start building top level widget
   self->widget = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  
-  GtkWidget *label_non_raw = gtk_label_new(_("hot pixel correction\nonly works for raw images."));
-  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
+
+  GtkWidget *label_non_raw = dt_ui_label_new(_("hot pixel correction\nonly works for raw images."));
 
   gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -591,8 +591,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = g_malloc0(sizeof(dt_iop_invert_gui_data_t));
-  dt_iop_invert_gui_data_t *g = (dt_iop_invert_gui_data_t *)self->gui_data;
+  dt_iop_invert_gui_data_t *g = IOP_GUI_ALLOC(invert);
   dt_iop_invert_params_t *p = (dt_iop_invert_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);

--- a/src/iop/invert.c
+++ b/src/iop/invert.c
@@ -499,8 +499,6 @@ void reload_defaults(dt_iop_module_t *self)
 {
   self->hide_enable_button = 0;
 
-  if(!self->dev) return;
-
   if(dt_image_is_monochrome(&self->dev->image_storage))
   {
     self->hide_enable_button = 0;

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -2238,8 +2238,7 @@ static void corrections_done(gpointer instance, gpointer user_data)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_lensfun_gui_data_t));
-  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)self->gui_data;
+  dt_iop_lensfun_gui_data_t *g = IOP_GUI_ALLOC(lensfun);
 
   dt_pthread_mutex_init(&g->lock, NULL);
 
@@ -2524,8 +2523,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 
   dt_pthread_mutex_destroy(&g->lock);
 
-  free(self->gui_data);
-  self->gui_data = NULL;
+  IOP_GUI_FREE;
 }
 
 }

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1312,7 +1312,7 @@ void reload_defaults(dt_iop_module_t *module)
   dt_iop_lensfun_params_t *d = (dt_iop_lensfun_params_t *)module->default_params;
 
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) goto end;
+  if(!module->dev) return;
 
   new_lens = _lens_sanitize(img->exif_lens);
   g_strlcpy(d->lens, new_lens, sizeof(d->lens));
@@ -1321,8 +1321,8 @@ void reload_defaults(dt_iop_module_t *module)
   d->crop = img->exif_crop;
   d->aperture = img->exif_aperture;
   d->focal = img->exif_focal_length;
-  d->scale = 1.0;  
-  d->modify_flags = LF_MODIFY_TCA | LF_MODIFY_VIGNETTING | LF_MODIFY_DISTORTION | 
+  d->scale = 1.0;
+  d->modify_flags = LF_MODIFY_TCA | LF_MODIFY_VIGNETTING | LF_MODIFY_DISTORTION |
                     LF_MODIFY_GEOMETRY | LF_MODIFY_SCALE;
   // if we did not find focus_distance in EXIF, lets default to 1000
   d->distance = img->exif_focus_distance == 0.0f ? 1000.0f : img->exif_focus_distance;
@@ -1341,7 +1341,7 @@ void reload_defaults(dt_iop_module_t *module)
     dt_iop_lensfun_global_data_t *gd = (dt_iop_lensfun_global_data_t *)module->global_data;
 
     // just to be sure
-    if(!gd || !gd->db) goto end;
+    if(!gd || !gd->db) return;
 
     dt_pthread_mutex_lock(&darktable.plugin_threadsafe);
     const lfCamera **cam = gd->db->FindCamerasExt(img->exif_maker, img->exif_model, 0);
@@ -1409,17 +1409,14 @@ void reload_defaults(dt_iop_module_t *module)
   }
 
   // if we have a gui -> reset corrections_done message
-  if(module->gui_data)
+  dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)module->gui_data;
+  if(g)
   {
-    dt_iop_lensfun_gui_data_t *g = (dt_iop_lensfun_gui_data_t *)module->gui_data;
     dt_pthread_mutex_lock(&g->lock);
     g->corrections_done = -1;
     dt_pthread_mutex_unlock(&g->lock);
     gtk_label_set_text(g->message, "");
   }
-
-end:
-  memcpy(module->params, module->default_params, sizeof(dt_iop_lensfun_params_t));
 }
 
 void cleanup_global(dt_iop_module_so_t *module)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1311,9 +1311,6 @@ void reload_defaults(dt_iop_module_t *module)
   // get all we can from exif:
   dt_iop_lensfun_params_t *d = (dt_iop_lensfun_params_t *)module->default_params;
 
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) return;
-
   new_lens = _lens_sanitize(img->exif_lens);
   g_strlcpy(d->lens, new_lens, sizeof(d->lens));
   free(new_lens);

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -710,8 +710,6 @@ void gui_init(dt_iop_module_t *self)
   c->mode = dt_bauhaus_combobox_from_params(self, N_("mode"));
  
   gtk_box_pack_start(GTK_BOX(self->widget), c->mode_stack, TRUE, TRUE, 0);
-
-  gui_changed(self, c->mode, 0);
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -588,11 +588,13 @@ void gui_update(dt_iop_module_t *self)
   gtk_widget_queue_draw(self->widget);
 }
 
-void reload_defaults(dt_iop_module_t *self)
+void init(dt_iop_module_t *module)
 {
-  self->request_histogram |= (DT_REQUEST_ON);
+  dt_iop_default_init(module);
 
-  dt_iop_levels_params_t *d = self->default_params;
+  module->request_histogram |= (DT_REQUEST_ON);
+
+  dt_iop_levels_params_t *d = module->default_params;
 
   d->levels[0] = 0.0f;
   d->levels[1] = 0.5f;

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -597,8 +597,6 @@ void reload_defaults(dt_iop_module_t *self)
   d->levels[0] = 0.0f;
   d->levels[1] = 0.5f;
   d->levels[2] = 1.0f;
-
-  memcpy(self->params, self->default_params, sizeof(dt_iop_levels_params_t));
 }
 
 void init_global(dt_iop_module_so_t *self)

--- a/src/iop/levels.c
+++ b/src/iop/levels.c
@@ -620,8 +620,7 @@ void cleanup_global(dt_iop_module_so_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_levels_gui_data_t));
-  dt_iop_levels_gui_data_t *c = (dt_iop_levels_gui_data_t *)self->gui_data;
+  dt_iop_levels_gui_data_t *c = IOP_GUI_ALLOC(levels);
 
   dt_pthread_mutex_init(&c->lock, NULL);
 
@@ -719,8 +718,7 @@ void gui_cleanup(dt_iop_module_t *self)
 
   dt_pthread_mutex_destroy(&g->lock);
 
-  free(self->gui_data);
-  self->gui_data = NULL;
+  IOP_GUI_FREE;
 }
 
 static gboolean dt_iop_levels_leave_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3535,10 +3535,9 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
-  GtkWidget *label = gtk_label_new(_("warps|nodes count:"));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
+  GtkWidget *label = dt_ui_label_new(_("warps|nodes count:"));
   gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
-  g->label = GTK_LABEL(gtk_label_new("-"));
+  g->label = GTK_LABEL(dt_ui_label_new("-"));
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
 
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -3598,7 +3597,7 @@ void gui_cleanup(dt_iop_module_t *self)
 
   cairo_destroy(g->fake_cr);
   dt_pthread_mutex_destroy(&g->lock);
-  
+
   IOP_GUI_FREE;
 }
 

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -3519,10 +3519,9 @@ void gui_update(dt_iop_module_t *module)
   update_warp_count(g);
 }
 
-void gui_init(dt_iop_module_t *module)
+void gui_init(dt_iop_module_t *self)
 {
-  module->gui_data = malloc(sizeof(dt_iop_liquify_gui_data_t));
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
+  dt_iop_liquify_gui_data_t *g = IOP_GUI_ALLOC(liquify);
 
   // A dummy surface for calculations only, no drawing.
   cairo_surface_t *cs = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
@@ -3538,11 +3537,11 @@ void gui_init(dt_iop_module_t *module)
   dt_pthread_mutex_init(&g->lock, NULL);
   g->node_index = 0;
 
-  module->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   gtk_widget_set_tooltip_text(hbox, _("use a tool to add warps.\nright-click to remove a warp."));
-  gtk_box_pack_start(GTK_BOX(module->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
   GtkWidget *label = gtk_label_new(_("warps|nodes count:"));
   gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
@@ -3551,28 +3550,28 @@ void gui_init(dt_iop_module_t *module)
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->label), FALSE, TRUE, 0);
 
   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(module->widget), hbox, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
   g->btn_point_tool = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(_liquify_cairo_paint_point_tool, CPF_STYLE_FLAT, NULL));
-  g_signal_connect(G_OBJECT (g->btn_point_tool), "toggled", G_CALLBACK (btn_make_radio_callback), module);
+  g_signal_connect(G_OBJECT (g->btn_point_tool), "toggled", G_CALLBACK (btn_make_radio_callback), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->btn_point_tool), _("point tool: draw points"));
   gtk_toggle_button_set_active(g->btn_point_tool, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->btn_point_tool), FALSE, FALSE, 0);
 
   g->btn_line_tool = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(_liquify_cairo_paint_line_tool, CPF_STYLE_FLAT, NULL));
-  g_signal_connect(G_OBJECT (g->btn_line_tool), "toggled", G_CALLBACK (btn_make_radio_callback), module);
+  g_signal_connect(G_OBJECT (g->btn_line_tool), "toggled", G_CALLBACK (btn_make_radio_callback), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->btn_line_tool), _("line tool: draw lines"));
   gtk_toggle_button_set_active(g->btn_line_tool, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->btn_line_tool), FALSE, FALSE, 0);
 
   g->btn_curve_tool = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(_liquify_cairo_paint_curve_tool, CPF_STYLE_FLAT, NULL));
-  g_signal_connect(G_OBJECT (g->btn_curve_tool), "toggled", G_CALLBACK (btn_make_radio_callback), module);
+  g_signal_connect(G_OBJECT (g->btn_curve_tool), "toggled", G_CALLBACK (btn_make_radio_callback), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->btn_curve_tool), _("curve tool: draw curves"));
   gtk_toggle_button_set_active(g->btn_curve_tool, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->btn_curve_tool), FALSE, FALSE, 0);
 
   g->btn_node_tool = GTK_TOGGLE_BUTTON(dtgtk_togglebutton_new(_liquify_cairo_paint_node_tool, CPF_STYLE_FLAT, NULL));
-  g_signal_connect(G_OBJECT(g->btn_node_tool), "toggled", G_CALLBACK (btn_make_radio_callback), module);
+  g_signal_connect(G_OBJECT(g->btn_node_tool), "toggled", G_CALLBACK (btn_make_radio_callback), self);
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->btn_node_tool), _("node tool: edit, add and delete nodes"));
   gtk_toggle_button_set_active(g->btn_node_tool, 0);
   gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->btn_node_tool), FALSE, FALSE, 0);
@@ -3601,16 +3600,14 @@ void gui_reset(dt_iop_module_t *self)
   gtk_toggle_button_set_active(g->btn_node_tool,  FALSE);
 }
 
-void gui_cleanup(dt_iop_module_t *module)
+void gui_cleanup(dt_iop_module_t *self)
 {
-  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) module->gui_data;
-  if(g)
-  {
-    cairo_destroy(g->fake_cr);
-    dt_pthread_mutex_destroy(&g->lock);
-    free(g);
-  }
-  module->gui_data = NULL;
+  dt_iop_liquify_gui_data_t *g = (dt_iop_liquify_gui_data_t *) self->gui_data;
+
+  cairo_destroy(g->fake_cr);
+  dt_pthread_mutex_destroy(&g->lock);
+  
+  IOP_GUI_FREE;
 }
 
 void init_key_accels(dt_iop_module_so_t *module)
@@ -3633,18 +3630,18 @@ void connect_key_accels(dt_iop_module_t *module)
 
 // defgroup Button paint functions
 
-#define PREAMBLE                                        \
+#define PREAMBLE                                       \
   cairo_save(cr);                                      \
   const gint s = MIN(w, h);                            \
   cairo_translate(cr, x + (w / 2.0) - (s / 2.0),       \
-                   y + (h / 2.0) - (s / 2.0));          \
+                  y + (h / 2.0) - (s / 2.0));          \
   cairo_scale(cr, s, s);                               \
   cairo_push_group(cr);                                \
   cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 1.0);       \
   cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);        \
   cairo_set_line_width(cr, 0.2);
 
-#define POSTAMBLE                                               \
+#define POSTAMBLE                                              \
   cairo_pop_group_to_source(cr);                               \
   cairo_paint_with_alpha(cr, flags & CPF_ACTIVE ? 1.0 : 0.5);  \
   cairo_restore(cr);

--- a/src/iop/liquify.c
+++ b/src/iop/liquify.c
@@ -1693,14 +1693,6 @@ void init(dt_iop_module_t *module)
   module->default_params = calloc(1, module->params_size);
 }
 
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-}
-
 void init_pipe(struct dt_iop_module_t *module, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)
 {
   piece->data = malloc(module->params_size);

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -745,7 +745,6 @@ static gboolean lowlight_button_press(GtkWidget *widget, GdkEventButton *event, 
     // reset current curve
     dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
     dt_iop_lowlight_params_t *d = (dt_iop_lowlight_params_t *)self->default_params;
-    /*   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data; */
     for(int k = 0; k < DT_IOP_LOWLIGHT_BANDS; k++)
     {
       p->transition_x[k] = d->transition_x[k];
@@ -813,7 +812,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_lowlight_gui_data_t));
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
-  dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->params;
+  dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->default_params;
 
   c->transition_curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
   (void)dt_draw_curve_add_point(c->transition_curve, p->transition_x[DT_IOP_LOWLIGHT_BANDS - 2] - 1.0,

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -810,8 +810,7 @@ static gboolean lowlight_scrolled(GtkWidget *widget, GdkEventScroll *event, gpoi
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_lowlight_gui_data_t));
-  dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
+  dt_iop_lowlight_gui_data_t *c = IOP_GUI_ALLOC(lowlight);
   dt_iop_lowlight_params_t *p = (dt_iop_lowlight_params_t *)self->default_params;
 
   c->transition_curve = dt_draw_curve_new(0.0, 1.0, CATMULL_ROM);
@@ -853,8 +852,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_iop_lowlight_gui_data_t *c = (dt_iop_lowlight_gui_data_t *)self->gui_data;
   dt_draw_curve_destroy(c->transition_curve);
   dt_iop_cancel_history_update(self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/lowlight.c
+++ b/src/iop/lowlight.c
@@ -301,8 +301,6 @@ void init(dt_iop_module_t *module)
   dt_iop_lowlight_params_t *d = module->default_params;
 
   for(int k = 0; k < DT_IOP_LOWLIGHT_BANDS; k++) d->transition_x[k] = k / (DT_IOP_LOWLIGHT_BANDS - 1.0);
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_lowlight_params_t));
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/lowpass.c
+++ b/src/iop/lowpass.c
@@ -592,8 +592,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_lowpass_gui_data_t));
-  dt_iop_lowpass_gui_data_t *g = (dt_iop_lowpass_gui_data_t *)self->gui_data;
+  dt_iop_lowpass_gui_data_t *g = IOP_GUI_ALLOC(lowpass);
 
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
   dt_bauhaus_slider_set_step(g->radius, 0.1);

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1621,11 +1621,6 @@ static void button_clicked(GtkWidget *widget, dt_iop_module_t *self)
   gtk_widget_destroy(filechooser);
 }
 
-void gui_reset(dt_iop_module_t *self)
-{
-  memcpy(self->params, self->default_params, sizeof(dt_iop_lut3d_params_t));
-}
-
 static void _show_hide_colorspace(dt_iop_module_t *self)
 {
   dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;

--- a/src/iop/lut3d.c
+++ b/src/iop/lut3d.c
@@ -1682,8 +1682,7 @@ void module_moved_callback(gpointer instance, dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_lut3d_gui_data_t));
-  dt_iop_lut3d_gui_data_t *g = (dt_iop_lut3d_gui_data_t *)self->gui_data;
+  dt_iop_lut3d_gui_data_t *g = IOP_GUI_ALLOC(lut3d);
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
@@ -1770,8 +1769,8 @@ void gui_cleanup(dt_iop_module_t *self)
   dt_gui_key_accel_block_on_focus_disconnect(g->lutentry);
 #endif // HAVE_GMIC
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(module_moved_callback), self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/mask_manager.c
+++ b/src/iop/mask_manager.c
@@ -121,22 +121,6 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
   piece->data = NULL;
 }
 
-void init(dt_iop_module_t *module)
-{
-  module->params = calloc(1, sizeof(dt_iop_mask_manager_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_mask_manager_params_t));
-  module->default_enabled = 0;
-  module->params_size = sizeof(dt_iop_mask_manager_params_t);
-  module->gui_data = NULL;
-}
-
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-}
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/monochrome.c
+++ b/src/iop/monochrome.c
@@ -571,8 +571,7 @@ static gboolean dt_iop_monochrome_scrolled(GtkWidget *widget, GdkEventScroll *ev
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_monochrome_gui_data_t));
-  dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
+  dt_iop_monochrome_gui_data_t *g = IOP_GUI_ALLOC(monochrome);
 
   g->dragging = 0;
 
@@ -608,8 +607,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
 {
   dt_iop_monochrome_gui_data_t *g = (dt_iop_monochrome_gui_data_t *)self->gui_data;
   cmsDeleteTransform(g->xform);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -846,8 +846,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_negadoctor_gui_data_t));
-  dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
+  dt_iop_negadoctor_gui_data_t *g = IOP_GUI_ALLOC(negadoctor);
 
   g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
 

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -846,10 +846,8 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 void gui_init(dt_iop_module_t *self)
 {
-  // init the slider (more sophisticated layouts are possible with gtk tables and boxes):
   self->gui_data = malloc(sizeof(dt_iop_negadoctor_gui_data_t));
   dt_iop_negadoctor_gui_data_t *g = (dt_iop_negadoctor_gui_data_t *)self->gui_data;
-  dt_iop_negadoctor_params_t *p = (dt_iop_negadoctor_params_t *)self->params;
 
   g->notebook = GTK_NOTEBOOK(gtk_notebook_new());
 
@@ -862,9 +860,7 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *row1 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  GdkRGBA color1 = (GdkRGBA){.red = p->Dmin[0], .green = p->Dmin[0], .blue = p->Dmin[0], .alpha = 1.0 };
-
-  g->Dmin_picker = gtk_color_button_new_with_rgba(&color1);
+  g->Dmin_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->Dmin_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->Dmin_picker), _("select color of film material from a swatch"));
   gtk_box_pack_start(GTK_BOX(row1), GTK_WIDGET(g->Dmin_picker), TRUE, TRUE, 0);
@@ -936,10 +932,7 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *row3 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  const float max_wb_low = fmaxf(fmaxf(p->wb_low[0], p->wb_low[1]), p->wb_low[2]);
-  GdkRGBA color3 = (GdkRGBA){.red = p->wb_low[0] / max_wb_low, .green = p->wb_low[0] / max_wb_low, .blue = p->wb_high[0] / max_wb_low, .alpha = 1.0 };
-
-  g->WB_low_picker = gtk_color_button_new_with_rgba(&color3);
+  g->WB_low_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->WB_low_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->WB_low_picker), _("select color of shadows from a swatch"));
   gtk_box_pack_start(GTK_BOX(row3), GTK_WIDGET(g->WB_low_picker), TRUE, TRUE, 0);
@@ -976,10 +969,7 @@ void gui_init(dt_iop_module_t *self)
 
   GtkWidget *row2 = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  const float max_wb_high = fmaxf(fmaxf(p->wb_high[0], p->wb_high[1]), p->wb_high[2]);
-  GdkRGBA color2 = (GdkRGBA){.red = p->wb_high[0] / max_wb_high, .green = p->wb_high[0] / max_wb_high, .blue = p->wb_high[0] / max_wb_high, .alpha = 1.0 };
-
-  g->WB_high_picker = gtk_color_button_new_with_rgba(&color2);
+  g->WB_high_picker = gtk_color_button_new();
   gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(g->WB_high_picker), FALSE);
   gtk_color_button_set_title(GTK_COLOR_BUTTON(g->WB_high_picker), _("select color of illuminant from a swatch"));
   gtk_box_pack_start(GTK_BOX(row2), GTK_WIDGET(g->WB_high_picker), TRUE, TRUE, 0);

--- a/src/iop/negadoctor.c
+++ b/src/iop/negadoctor.c
@@ -399,8 +399,6 @@ void init(dt_iop_module_t *module)
   d->Dmin[0] = 1.00f;
   d->Dmin[1] = 0.45f;
   d->Dmin[2] = 0.25f;
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_negadoctor_params_t));
 }
 
 void init_presets(dt_iop_module_so_t *self)

--- a/src/iop/nlmeans.c
+++ b/src/iop/nlmeans.c
@@ -520,8 +520,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_nlmeans_gui_data_t));
-  dt_iop_nlmeans_gui_data_t *g = (dt_iop_nlmeans_gui_data_t *)self->gui_data;
+  dt_iop_nlmeans_gui_data_t *g = IOP_GUI_ALLOC(nlmeans);
 
   g->radius = dt_bauhaus_slider_from_params(self, "radius");
   dt_bauhaus_slider_set_soft_max(g->radius, 4.0f);

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -344,14 +344,6 @@ void init(dt_iop_module_t *module)
   module->gui_data = NULL;
 }
 
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-}
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -680,8 +680,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_profilegamma_gui_data_t));
-  dt_iop_profilegamma_gui_data_t *g = (dt_iop_profilegamma_gui_data_t *)self->gui_data;
+  dt_iop_profilegamma_gui_data_t *g = IOP_GUI_ALLOC(profilegamma);
 
   // prepare the modes widgets stack
   g->mode_stack = gtk_stack_new();

--- a/src/iop/profile_gamma.c
+++ b/src/iop/profile_gamma.c
@@ -747,8 +747,6 @@ void gui_init(dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(g->mode, _("tone mapping method"));
 
   gtk_box_pack_start(GTK_BOX(self->widget), g->mode_stack, TRUE, TRUE, 0);
-
-  gui_changed(self, g->mode, 0);
 }
 
 

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -926,8 +926,7 @@ static void rawdenoise_tab_switch(GtkNotebook *notebook, GtkWidget *page, guint 
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_rawdenoise_gui_data_t));
-  dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
+  dt_iop_rawdenoise_gui_data_t *c = IOP_GUI_ALLOC(rawdenoise);
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->default_params;
 
   c->stack = gtk_stack_new();
@@ -1013,8 +1012,8 @@ void gui_cleanup(dt_iop_module_t *self)
   dt_conf_set_int("plugins/darkroom/rawdenoise/gui_channel", c->channel);
   dt_draw_curve_destroy(c->transition_curve);
   dt_iop_cancel_history_update(self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -853,7 +853,6 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
     // reset current curve
     dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
     dt_iop_rawdenoise_params_t *d = (dt_iop_rawdenoise_params_t *)self->default_params;
-    /*   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data; */
     for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
     {
       p->x[ch][k] = d->x[ch][k];
@@ -929,7 +928,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_rawdenoise_gui_data_t));
   dt_iop_rawdenoise_gui_data_t *c = (dt_iop_rawdenoise_gui_data_t *)self->gui_data;
-  dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
+  dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->default_params;
 
   c->stack = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(c->stack), FALSE);

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -525,7 +525,7 @@ void init(dt_iop_module_t *module)
   dt_iop_default_init(module);
 
   dt_iop_rawdenoise_params_t *d = module->default_params;
-  
+
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
   {
     for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
@@ -978,9 +978,7 @@ void gui_init(dt_iop_module_t *self)
   self->widget = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
 
-  GtkWidget *label_non_raw = gtk_label_new(_("raw denoising\nonly works for raw images."));
-  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
+  GtkWidget *label_non_raw = dt_ui_label_new(_("raw denoising\nonly works for raw images."));
 
   gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -58,12 +58,9 @@ typedef struct dt_iop_rawdenoise_params_t
 
 typedef struct dt_iop_rawdenoise_gui_data_t
 {
-  GtkWidget *stack;
   dt_draw_curve_t *transition_curve; // curve for gui to draw
 
-  GtkWidget *box_raw;
   GtkWidget *threshold;
-  GtkWidget *label_non_raw;
   GtkDrawingArea *area;
   GtkNotebook *channel_tabs;
   double mouse_x, mouse_y, mouse_pick;
@@ -600,7 +597,7 @@ void gui_update(dt_iop_module_t *self)
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->params;
   dt_iop_cancel_history_update(self);
   dt_bauhaus_slider_set_soft(g->threshold, p->threshold);
-  gtk_stack_set_visible_child_name(GTK_STACK(g->stack), self->hide_enable_button ? "non_raw" : "raw");
+  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->hide_enable_button ? "non_raw" : "raw");
   gtk_widget_queue_draw(self->widget);
 }
 
@@ -860,7 +857,7 @@ static gboolean rawdenoise_button_press(GtkWidget *widget, GdkEventButton *event
       p->y[ch][k] = d->y[ch][k];
     }
     dt_dev_add_history_item(darktable.develop, self, TRUE);
-    gtk_widget_queue_draw(c->box_raw);
+    gtk_widget_queue_draw(self->widget);
   }
   else if(event->button == 1)
   {
@@ -930,9 +927,6 @@ void gui_init(dt_iop_module_t *self)
   dt_iop_rawdenoise_gui_data_t *c = IOP_GUI_ALLOC(rawdenoise);
   dt_iop_rawdenoise_params_t *p = (dt_iop_rawdenoise_params_t *)self->default_params;
 
-  c->stack = gtk_stack_new();
-  gtk_stack_set_homogeneous(GTK_STACK(c->stack), FALSE);
-
   c->channel = dt_conf_get_int("plugins/darkroom/rawdenoise/gui_channel");
   c->channel_tabs = GTK_NOTEBOOK(gtk_notebook_new());
 
@@ -959,12 +953,12 @@ void gui_init(dt_iop_module_t *self)
   self->timeout_handle = 0;
   c->mouse_radius = 1.0 / (DT_IOP_RAWDENOISE_BANDS * 2);
 
-  c->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   c->area = GTK_DRAWING_AREA(dtgtk_drawing_area_new_with_aspect_ratio(9.0 / 16.0));
 
-  gtk_box_pack_start(GTK_BOX(c->box_raw), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
-  gtk_box_pack_start(GTK_BOX(c->box_raw), GTK_WIDGET(c->area), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(box_raw), GTK_WIDGET(c->channel_tabs), FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(box_raw), GTK_WIDGET(c->area), FALSE, FALSE, 0);
 
   gtk_widget_add_events(GTK_WIDGET(c->area), GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK
                                                  | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK
@@ -980,31 +974,16 @@ void gui_init(dt_iop_module_t *self)
   dt_bauhaus_slider_set_soft_max(c->threshold, 0.1);
   dt_bauhaus_slider_set_digits(c->threshold, 3);
 
-  c->label_non_raw = gtk_label_new(_("raw denoising\nonly works for raw images."));
-  gtk_widget_set_halign(c->label_non_raw, GTK_ALIGN_START);
-
-  // This is done so that if we use several instances, the newly created ones
-  // use the same graphical interface as the original one.
-  // In other words, if the original one is in "non_raw" mode, we have to put
-  // "non_raw" in the stack first, so that when we add a new instance, we see
-  // the label_non_raw
-  if(self->hide_enable_button)
-  {
-    gtk_stack_add_named(GTK_STACK(c->stack), c->label_non_raw, "non_raw");
-    gtk_stack_add_named(GTK_STACK(c->stack), c->box_raw, "raw");
-  }
-  else
-  {
-    gtk_stack_add_named(GTK_STACK(c->stack), c->box_raw, "raw");
-    gtk_stack_add_named(GTK_STACK(c->stack), c->label_non_raw, "non_raw");
-  }
-
-  gtk_stack_set_visible_child_name(GTK_STACK(c->stack), self->hide_enable_button ? "non_raw" : "raw");
-
   // start building top level widget
-  self->widget = GTK_WIDGET(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));
+  self->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), c->stack, TRUE, TRUE, 0);
+  GtkWidget *label_non_raw = gtk_label_new(_("raw denoising\nonly works for raw images."));
+  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
+
+  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
 }
 
 void gui_cleanup(dt_iop_module_t *self)

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -523,19 +523,23 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
   }
 }
 
-void reload_defaults(dt_iop_module_t *module)
+void init(dt_iop_module_t *module)
 {
+  dt_iop_default_init(module);
+
   dt_iop_rawdenoise_params_t *d = module->default_params;
+  
   for(int k = 0; k < DT_IOP_RAWDENOISE_BANDS; k++)
   {
     for(int ch = 0; ch < DT_RAWDENOISE_NONE; ch++)
     {
-      d->x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.0);
+      d->x[ch][k] = k / (DT_IOP_RAWDENOISE_BANDS - 1.f);
     }
   }
-  // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) return;
+}
 
+void reload_defaults(dt_iop_module_t *module)
+{
   // can't be switched on for non-raw images:
   if(dt_image_is_raw(&module->dev->image_storage))
     module->hide_enable_button = 0;

--- a/src/iop/rawdenoise.c
+++ b/src/iop/rawdenoise.c
@@ -534,7 +534,7 @@ void reload_defaults(dt_iop_module_t *module)
     }
   }
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev) goto end;
+  if(!module->dev) return;
 
   // can't be switched on for non-raw images:
   if(dt_image_is_raw(&module->dev->image_storage))
@@ -543,9 +543,6 @@ void reload_defaults(dt_iop_module_t *module)
     module->hide_enable_button = 1;
 
   module->default_enabled = 0;
-
-end:
- memcpy(module->params, module->default_params, sizeof(dt_iop_rawdenoise_params_t));
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelpipe_t *pipe,

--- a/src/iop/rawoverexposed.c
+++ b/src/iop/rawoverexposed.c
@@ -516,14 +516,6 @@ void init(dt_iop_module_t *module)
   module->gui_data = NULL;
 }
 
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-}
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -840,8 +840,7 @@ static void callback(GtkWidget *widget, gpointer *user_data)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_rawprepare_gui_data_t));
-  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)self->gui_data;
+  dt_iop_rawprepare_gui_data_t *g = IOP_GUI_ALLOC(rawprepare);
   dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->default_params;
 
   g->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -41,25 +41,13 @@
 
 DT_MODULE_INTROSPECTION(1, dt_iop_rawprepare_params_t)
 
-static const struct
-{
-  const char *label;
-  const char *tooltip;
-} crop_labels[4] = { { N_("crop x"), N_("crop from left border") },
-                     { N_("crop y"), N_("crop from top") },
-                     { N_("crop width"), N_("crop from right border") },
-                     { N_("crop height"), N_("crop from bottom") } };
-
 typedef struct dt_iop_rawprepare_params_t
 {
-  union {
-    struct
-    {
-      int32_t x, y, width, height; // $MIN: 0 $MAX: UINT16_MAX
-    } named;
-    int32_t array[4]; // $MIN: 0 $MAX: UINT16_MAX
-  } crop;
-  uint16_t raw_black_level_separate[4]; // $MIN: 0 $MAX: UINT16_MAX
+  int32_t x; // $MIN: 0 $MAX: UINT16_MAX $DESCRIPTION: "crop x"
+  int32_t y; // $MIN: 0 $MAX: UINT16_MAX $DESCRIPTION: "crop y"
+  int32_t width; // $MIN: 0 $MAX: UINT16_MAX $DESCRIPTION: "crop width"
+  int32_t height; // $MIN: 0 $MAX: UINT16_MAX $DESCRIPTION: "crop height"
+  uint16_t raw_black_level_separate[4]; // $MIN: 0 $MAX: UINT16_MAX $DESCRIPTION: "black level"
   uint16_t raw_white_point; // $MIN: 0 $MAX: UINT16_MAX $DESCRIPTION: "white point"
 } dt_iop_rawprepare_params_t;
 
@@ -68,7 +56,7 @@ typedef struct dt_iop_rawprepare_gui_data_t
   GtkWidget *box_raw;
   GtkWidget *black_level_separate[4];
   GtkWidget *white_point;
-  GtkWidget *crop[4];
+  GtkWidget *x, *y, *width, *height;
   GtkWidget *label_non_raw;
 } dt_iop_rawprepare_gui_data_t;
 
@@ -124,7 +112,10 @@ void init_presets(dt_iop_module_so_t *self)
   DT_DEBUG_SQLITE3_EXEC(dt_database_get(darktable.db), "BEGIN", NULL, NULL, NULL);
 
   dt_gui_presets_add_generic(_("passthrough"), self->op, self->version(),
-                             &(dt_iop_rawprepare_params_t){.crop.array = { 0, 0, 0, 0 },
+                             &(dt_iop_rawprepare_params_t){.x = 0,
+                                                           .y = 0,
+                                                           .width = 0,
+                                                           .height = 0,
                                                            .raw_black_level_separate[0] = 0,
                                                            .raw_black_level_separate[1] = 0,
                                                            .raw_black_level_separate[2] = 0,
@@ -144,15 +135,15 @@ void init_key_accels(dt_iop_module_so_t *self)
     g_free(label);
   }
 
+  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white point"));
+
   if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
   {
-    for(int i = 0; i < 4; i++)
-    {
-      dt_accel_register_slider_iop(self, FALSE, NC_("accel", gettext(crop_labels[i].label)));
-    }
+    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop x"));
+    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop y"));
+    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop width"));
+    dt_accel_register_slider_iop(self, FALSE, NC_("accel", "crop height"));
   }
-
-  dt_accel_register_slider_iop(self, FALSE, NC_("accel", "white point"));
 }
 
 void connect_key_accels(dt_iop_module_t *self)
@@ -166,14 +157,14 @@ void connect_key_accels(dt_iop_module_t *self)
     g_free(label);
   }
 
-  dt_accel_connect_slider_iop(self, _("white point"), GTK_WIDGET(g->white_point));
+  dt_accel_connect_slider_iop(self, "white point", g->white_point);
 
   if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
   {
-    for(int i = 0; i < 4; i++)
-    {
-      dt_accel_connect_slider_iop(self, gettext(crop_labels[i].label), g->crop[i]);
-    }
+    dt_accel_connect_slider_iop(self, "crop x", g->x);
+    dt_accel_connect_slider_iop(self, "crop y", g->y);
+    dt_accel_connect_slider_iop(self, "crop width", g->width);
+    dt_accel_connect_slider_iop(self, "crop height", g->height);
   }
 }
 
@@ -664,10 +655,10 @@ void commit_params(dt_iop_module_t *self, dt_iop_params_t *params, dt_dev_pixelp
   const dt_iop_rawprepare_params_t *const p = (dt_iop_rawprepare_params_t *)params;
   dt_iop_rawprepare_data_t *d = (dt_iop_rawprepare_data_t *)piece->data;
 
-  d->x = p->crop.named.x;
-  d->y = p->crop.named.y;
-  d->width = p->crop.named.width;
-  d->height = p->crop.named.height;
+  d->x = p->x;
+  d->y = p->y;
+  d->width = p->width;
+  d->height = p->height;
 
   if(piece->pipe->dsc.filters)
   {
@@ -725,26 +716,21 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 }
 
 void reload_defaults(dt_iop_module_t *self)
-{
+{  
   dt_iop_rawprepare_params_t *d = self->default_params;
-  
-  *d = (dt_iop_rawprepare_params_t){ 0 };
-
-  // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) return;
-  
   const dt_image_t *const image = &(self->dev->image_storage);
 
-  *d = (dt_iop_rawprepare_params_t){.crop.named.x = image->crop_x,
-                                    .crop.named.y = image->crop_y,
-                                    .crop.named.width = image->crop_width,
-                                    .crop.named.height = image->crop_height,
+  *d = (dt_iop_rawprepare_params_t){.x = image->crop_x, 
+                                    .y = image->crop_y, 
+                                    .width = image->crop_width, 
+                                    .height = image->crop_height,
                                     .raw_black_level_separate[0] = image->raw_black_level_separate[0],
                                     .raw_black_level_separate[1] = image->raw_black_level_separate[1],
                                     .raw_black_level_separate[2] = image->raw_black_level_separate[2],
                                     .raw_black_level_separate[3] = image->raw_black_level_separate[3],
                                     .raw_white_point = image->raw_white_point };
 
+  self->hide_enable_button = 1;
   self->default_enabled = dt_image_is_rawprepare_supported(image) && !image_is_normalized(image);
 }
 
@@ -757,23 +743,6 @@ void init_global(dt_iop_module_so_t *self)
   gd->kernel_rawprepare_1f = dt_opencl_create_kernel(program, "rawprepare_1f");
   gd->kernel_rawprepare_1f_unnormalized = dt_opencl_create_kernel(program, "rawprepare_1f_unnormalized");
   gd->kernel_rawprepare_4f = dt_opencl_create_kernel(program, "rawprepare_4f");
-}
-
-void init(dt_iop_module_t *self)
-{
-  self->params = calloc(1, sizeof(dt_iop_rawprepare_params_t));
-  self->default_params = calloc(1, sizeof(dt_iop_rawprepare_params_t));
-  self->hide_enable_button = 1;
-  self->default_enabled = 0;
-  if(self->dev)
-  { // just being extra careful here, because there is a case when old presets
-    // are upgraded and temporary modules are constructed for this, with a 0x0 dev
-    // pointer. i suppose the can be solved more elegantly on the other side.
-    const dt_image_t *const image = &(self->dev->image_storage);
-    self->default_enabled = dt_image_is_rawprepare_supported(image) && !image_is_normalized(image);
-  }
-  self->params_size = sizeof(dt_iop_rawprepare_params_t);
-  self->gui_data = NULL;
 }
 
 void cleanup_global(dt_iop_module_so_t *self)
@@ -794,88 +763,63 @@ void gui_update(dt_iop_module_t *self)
   for(int i = 0; i < 4; i++)
   {
     dt_bauhaus_slider_set_soft(g->black_level_separate[i], p->raw_black_level_separate[i]);
-    dt_bauhaus_slider_set_default(g->black_level_separate[i], p->raw_black_level_separate[i]);
   }
 
   dt_bauhaus_slider_set_soft(g->white_point, p->raw_white_point);
-  dt_bauhaus_slider_set_default(g->white_point, p->raw_white_point);
 
   if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
   {
-    for(int i = 0; i < 4; i++)
-    {
-      dt_bauhaus_slider_set_soft(g->crop[i], p->crop.array[i]);
-      dt_bauhaus_slider_set_default(g->crop[i], p->crop.array[i]);
-    }
+    dt_bauhaus_slider_set_soft(g->x, p->x);
+    dt_bauhaus_slider_set_soft(g->y, p->y);
+    dt_bauhaus_slider_set_soft(g->width, p->width);
+    dt_bauhaus_slider_set_soft(g->height, p->height);
   }
 
   gtk_widget_set_visible(g->box_raw      ,  self->default_enabled);
   gtk_widget_set_visible(g->label_non_raw, !self->default_enabled);
 }
 
-static void callback(GtkWidget *widget, gpointer *user_data)
-{
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-
-  dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)self->gui_data;
-  dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->params;
-
-  for(int i = 0; i < 4; i++)
-    p->raw_black_level_separate[i] = dt_bauhaus_slider_get(g->black_level_separate[i]);
-  p->raw_white_point = dt_bauhaus_slider_get(g->white_point);
-
-  if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
-  {
-    for(int i = 0; i < 4; i++)
-    {
-      p->crop.array[i] = dt_bauhaus_slider_get(g->crop[i]);
-    }
-  }
-
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
-}
-
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rawprepare_gui_data_t *g = IOP_GUI_ALLOC(rawprepare);
-  dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->default_params;
 
   g->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   for(int i = 0; i < 4; i++)
   {
+    gchar *par = g_strdup_printf(_("raw_black_level_separate[%i]"), i);
     gchar *label = g_strdup_printf(_("black level %i"), i);
 
-    g->black_level_separate[i]
-        = dt_bauhaus_slider_new_with_range(self, 0, UINT16_MAX, 1, p->raw_black_level_separate[i], 0);
+    g->black_level_separate[i] = dt_bauhaus_slider_from_params(self, par);
     dt_bauhaus_widget_set_label(g->black_level_separate[i], NULL, label);
     gtk_widget_set_tooltip_text(g->black_level_separate[i], label);
-    gtk_box_pack_start(GTK_BOX(g->box_raw), g->black_level_separate[i], FALSE, FALSE, 0);
     dt_bauhaus_slider_set_soft_max(g->black_level_separate[i], 16384);
-    g_signal_connect(G_OBJECT(g->black_level_separate[i]), "value-changed", G_CALLBACK(callback), self);
 
     g_free(label);
+    g_free(par);
   }
 
-  g->white_point = dt_bauhaus_slider_new_with_range(self, 0, UINT16_MAX, 1, p->raw_white_point, 0);
-  dt_bauhaus_widget_set_label(g->white_point, NULL, _("white point"));
+  g->white_point = dt_bauhaus_slider_from_params(self, "raw_white_point");
   gtk_widget_set_tooltip_text(g->white_point, _("white point"));
-  gtk_box_pack_start(GTK_BOX(g->box_raw), g->white_point, FALSE, FALSE, 0);
   dt_bauhaus_slider_set_soft_max(g->white_point, 16384);
-  g_signal_connect(G_OBJECT(g->white_point), "value-changed", G_CALLBACK(callback), self);
 
   if(dt_conf_get_bool("plugins/darkroom/rawprepare/allow_editing_crop"))
   {
-    for(int i = 0; i < 4; i++)
-    {
-      g->crop[i] = dt_bauhaus_slider_new_with_range(self, 0, UINT16_MAX, 1, p->crop.array[i], 0);
-      dt_bauhaus_widget_set_label(g->crop[i], NULL, gettext(crop_labels[i].label));
-      gtk_widget_set_tooltip_text(g->crop[i], gettext(crop_labels[i].tooltip));
-      gtk_box_pack_start(GTK_BOX(g->box_raw), g->crop[i], FALSE, FALSE, 0);
-      dt_bauhaus_slider_set_soft_max(g->crop[i], 256);
-      g_signal_connect(G_OBJECT(g->crop[i]), "value-changed", G_CALLBACK(callback), self);
-    }
+    g->x = dt_bauhaus_slider_from_params(self, "x");
+    gtk_widget_set_tooltip_text(g->x, _("crop from left border"));
+    dt_bauhaus_slider_set_soft_max(g->x, 256);
+
+    g->y = dt_bauhaus_slider_from_params(self, "y");
+    gtk_widget_set_tooltip_text(g->y, _("crop from top"));
+    dt_bauhaus_slider_set_soft_max(g->y, 256);
+
+    g->width = dt_bauhaus_slider_from_params(self, "width");
+    gtk_widget_set_tooltip_text(g->width, _("crop from right border"));
+    dt_bauhaus_slider_set_soft_max(g->width, 256);
+
+    g->height = dt_bauhaus_slider_from_params(self, "height");
+    gtk_widget_set_tooltip_text(g->height, _("crop from bottom"));
+    dt_bauhaus_slider_set_soft_max(g->height, 256);
   }
 
   // start building top level widget

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -726,28 +726,26 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_rawprepare_params_t tmp = { { { 0 } } };
+  dt_iop_rawprepare_params_t *d = self->default_params;
+  
+  *d = (dt_iop_rawprepare_params_t){ 0 };
 
   // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) goto end;
-
+  if(!self->dev) return;
+  
   const dt_image_t *const image = &(self->dev->image_storage);
 
-  tmp = (dt_iop_rawprepare_params_t){.crop.named.x = image->crop_x,
-                                     .crop.named.y = image->crop_y,
-                                     .crop.named.width = image->crop_width,
-                                     .crop.named.height = image->crop_height,
-                                     .raw_black_level_separate[0] = image->raw_black_level_separate[0],
-                                     .raw_black_level_separate[1] = image->raw_black_level_separate[1],
-                                     .raw_black_level_separate[2] = image->raw_black_level_separate[2],
-                                     .raw_black_level_separate[3] = image->raw_black_level_separate[3],
-                                     .raw_white_point = image->raw_white_point };
+  *d = (dt_iop_rawprepare_params_t){.crop.named.x = image->crop_x,
+                                    .crop.named.y = image->crop_y,
+                                    .crop.named.width = image->crop_width,
+                                    .crop.named.height = image->crop_height,
+                                    .raw_black_level_separate[0] = image->raw_black_level_separate[0],
+                                    .raw_black_level_separate[1] = image->raw_black_level_separate[1],
+                                    .raw_black_level_separate[2] = image->raw_black_level_separate[2],
+                                    .raw_black_level_separate[3] = image->raw_black_level_separate[3],
+                                    .raw_white_point = image->raw_white_point };
 
   self->default_enabled = dt_image_is_rawprepare_supported(image) && !image_is_normalized(image);
-
-end:
-  memcpy(self->params, &tmp, sizeof(dt_iop_rawprepare_params_t));
-  memcpy(self->default_params, &tmp, sizeof(dt_iop_rawprepare_params_t));
 }
 
 void init_global(dt_iop_module_so_t *self)

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -641,7 +641,7 @@ static gboolean image_set_rawcrops(const uint32_t imgid, int dx, int dy)
   if(test) return FALSE;
 
   img = dt_image_cache_get(darktable.image_cache, imgid, 'w');
-  img->p_width = img->width - dx;  
+  img->p_width = img->width - dx;
   img->p_height = img->height - dy;
   dt_image_cache_write_release(darktable.image_cache, img, DT_IMAGE_CACHE_RELAXED);
   return TRUE;
@@ -714,13 +714,13 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 }
 
 void reload_defaults(dt_iop_module_t *self)
-{  
+{
   dt_iop_rawprepare_params_t *d = self->default_params;
   const dt_image_t *const image = &(self->dev->image_storage);
 
-  *d = (dt_iop_rawprepare_params_t){.x = image->crop_x, 
-                                    .y = image->crop_y, 
-                                    .width = image->crop_width, 
+  *d = (dt_iop_rawprepare_params_t){.x = image->crop_x,
+                                    .y = image->crop_y,
+                                    .width = image->crop_width,
                                     .height = image->crop_height,
                                     .raw_black_level_separate[0] = image->raw_black_level_separate[0],
                                     .raw_black_level_separate[1] = image->raw_black_level_separate[1],
@@ -822,10 +822,8 @@ void gui_init(dt_iop_module_t *self)
   // start building top level widget
   self->widget = gtk_stack_new();
   gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
-  
-  GtkWidget *label_non_raw = gtk_label_new(_("raw black/white point correction\nonly works for the sensors that need it."));
-  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
-  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
+
+  GtkWidget *label_non_raw = dt_ui_label_new(_("raw black/white point correction\nonly works for the sensors that need it."));
 
   gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
   gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -53,11 +53,9 @@ typedef struct dt_iop_rawprepare_params_t
 
 typedef struct dt_iop_rawprepare_gui_data_t
 {
-  GtkWidget *box_raw;
   GtkWidget *black_level_separate[4];
   GtkWidget *white_point;
   GtkWidget *x, *y, *width, *height;
-  GtkWidget *label_non_raw;
 } dt_iop_rawprepare_gui_data_t;
 
 typedef struct dt_iop_rawprepare_data_t
@@ -775,15 +773,14 @@ void gui_update(dt_iop_module_t *self)
     dt_bauhaus_slider_set_soft(g->height, p->height);
   }
 
-  gtk_widget_set_visible(g->box_raw      ,  self->default_enabled);
-  gtk_widget_set_visible(g->label_non_raw, !self->default_enabled);
+  gtk_stack_set_visible_child_name(GTK_STACK(self->widget), self->default_enabled ? "raw" : "non_raw");
 }
 
 void gui_init(dt_iop_module_t *self)
 {
   dt_iop_rawprepare_gui_data_t *g = IOP_GUI_ALLOC(rawprepare);
 
-  g->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  GtkWidget *box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
   for(int i = 0; i < 4; i++)
   {
@@ -823,14 +820,15 @@ void gui_init(dt_iop_module_t *self)
   }
 
   // start building top level widget
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
+  self->widget = gtk_stack_new();
+  gtk_stack_set_homogeneous(GTK_STACK(self->widget), FALSE);
+  
+  GtkWidget *label_non_raw = gtk_label_new(_("raw black/white point correction\nonly works for the sensors that need it."));
+  gtk_widget_set_halign(label_non_raw, GTK_ALIGN_START);
+  gtk_label_set_ellipsize(GTK_LABEL(label_non_raw), PANGO_ELLIPSIZE_END);
 
-  gtk_box_pack_start(GTK_BOX(self->widget), g->box_raw, FALSE, FALSE, 0);
-
-  g->label_non_raw
-      = gtk_label_new(_("raw black/white point correction\nonly works for the sensors that need it."));
-  gtk_widget_set_halign(g->label_non_raw, GTK_ALIGN_START);
-  gtk_box_pack_start(GTK_BOX(self->widget), g->label_non_raw, FALSE, FALSE, 0);
+  gtk_stack_add_named(GTK_STACK(self->widget), label_non_raw, "non_raw");
+  gtk_stack_add_named(GTK_STACK(self->widget), box_raw, "raw");
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/rawprepare.c
+++ b/src/iop/rawprepare.c
@@ -841,9 +841,8 @@ static void callback(GtkWidget *widget, gpointer *user_data)
 void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_rawprepare_gui_data_t));
-
   dt_iop_rawprepare_gui_data_t *g = (dt_iop_rawprepare_gui_data_t *)self->gui_data;
-  dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->params;
+  dt_iop_rawprepare_params_t *p = (dt_iop_rawprepare_params_t *)self->default_params;
 
   g->box_raw = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 

--- a/src/iop/relight.c
+++ b/src/iop/relight.c
@@ -277,8 +277,7 @@ void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpi
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_relight_gui_data_t));
-  dt_iop_relight_gui_data_t *g = (dt_iop_relight_gui_data_t *)self->gui_data;
+  dt_iop_relight_gui_data_t *g = IOP_GUI_ALLOC(relight);
 
   g->exposure = dt_bauhaus_slider_from_params(self, "ev");
   dt_bauhaus_slider_set_format(g->exposure, _("%.2f EV"));

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1992,7 +1992,7 @@ void gui_init(dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_retouch_gui_data_t));
   dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
-  dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->params;
+  dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->default_params;
 
   dt_pthread_mutex_init(&g->lock, NULL);
   change_image(self);
@@ -2327,8 +2327,6 @@ void gui_init(dt_iop_module_t *self)
 
   gtk_widget_show_all(g->vbox_preview_scale);
   gtk_widget_set_no_show_all(g->vbox_preview_scale, TRUE);
-
-  rt_show_hide_controls(self, g, p, g);
 }
 
 void gui_reset(struct dt_iop_module_t *self)

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1990,8 +1990,7 @@ void change_image(struct dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_retouch_gui_data_t));
-  dt_iop_retouch_gui_data_t *g = (dt_iop_retouch_gui_data_t *)self->gui_data;
+  dt_iop_retouch_gui_data_t *g = IOP_GUI_ALLOC(retouch);
   dt_iop_retouch_params_t *p = (dt_iop_retouch_params_t *)self->default_params;
 
   dt_pthread_mutex_init(&g->lock, NULL);
@@ -2344,8 +2343,8 @@ void gui_cleanup(dt_iop_module_t *self)
   {
     dt_pthread_mutex_destroy(&g->lock);
   }
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 void modify_roi_out(struct dt_iop_module_t *self, struct dt_dev_pixelpipe_iop_t *piece, dt_iop_roi_t *roi_out,

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1764,7 +1764,7 @@ void init(dt_iop_module_t *module)
   dt_iop_default_init(module);
 
   dt_iop_retouch_params_t *d = module->default_params;
-  
+
   d->preview_levels[0] = RETOUCH_PREVIEW_LVL_MIN;
   d->preview_levels[1] = 0.f;
   d->preview_levels[2] = RETOUCH_PREVIEW_LVL_MAX;
@@ -1997,9 +1997,7 @@ void gui_init(dt_iop_module_t *self)
   // shapes toolbar
   GtkWidget *hbox_shapes = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  GtkWidget *label = gtk_label_new(_("shapes:"));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_box_pack_start(GTK_BOX(hbox_shapes), label, FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox_shapes), dt_ui_label_new(_("shapes:")), FALSE, TRUE, 0);
   g->label_form = GTK_LABEL(gtk_label_new("-1"));
   gtk_box_pack_start(GTK_BOX(hbox_shapes), GTK_WIDGET(g->label_form), FALSE, TRUE, DT_PIXEL_APPLY_DPI(5));
   gtk_widget_set_tooltip_text(hbox_shapes,
@@ -2043,9 +2041,7 @@ void gui_init(dt_iop_module_t *self)
   // algorithm toolbar
   GtkWidget *hbox_algo = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  GtkWidget *label2 = gtk_label_new(_("algorithms:"));
-  gtk_label_set_ellipsize(GTK_LABEL(label2), PANGO_ELLIPSIZE_END);
-  gtk_box_pack_start(GTK_BOX(hbox_algo), label2, FALSE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(hbox_algo), dt_ui_label_new(_("algorithms:")), FALSE, TRUE, 0);
 
   g->bt_fill
       = dtgtk_togglebutton_new(dtgtk_cairo_paint_tool_fill, CPF_STYLE_FLAT, NULL);
@@ -2080,33 +2076,20 @@ void gui_init(dt_iop_module_t *self)
   GtkWidget *grid_wd_labels = gtk_grid_new();
   gtk_grid_set_column_homogeneous(GTK_GRID(grid_wd_labels), FALSE);
 
-  GtkWidget *lbl_num_scales = gtk_label_new(_("scales:"));
-  gtk_widget_set_halign(lbl_num_scales, GTK_ALIGN_START);
-  gtk_grid_attach(GTK_GRID(grid_wd_labels), lbl_num_scales, 0, 0, 1, 1);
-
-  g->lbl_num_scales = GTK_LABEL(gtk_label_new(NULL));
-  gtk_widget_set_halign(GTK_WIDGET(g->lbl_num_scales), GTK_ALIGN_START);
+  gtk_grid_attach(GTK_GRID(grid_wd_labels), dt_ui_label_new(_("scales:")), 0, 0, 1, 1);
+  g->lbl_num_scales = GTK_LABEL(dt_ui_label_new(NULL));
   gtk_label_set_width_chars(g->lbl_num_scales, 2);
-  gtk_grid_attach_next_to(GTK_GRID(grid_wd_labels), GTK_WIDGET(g->lbl_num_scales), lbl_num_scales, GTK_POS_RIGHT, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid_wd_labels), GTK_WIDGET(g->lbl_num_scales), 1, 0, 1, 1);
 
-  GtkWidget *lbl_curr_scale = gtk_label_new(_("current:"));
-  gtk_widget_set_halign(lbl_curr_scale, GTK_ALIGN_START);
-  gtk_grid_attach_next_to(GTK_GRID(grid_wd_labels), lbl_curr_scale, lbl_num_scales, GTK_POS_BOTTOM, 1, 1);
-
-  g->lbl_curr_scale = GTK_LABEL(gtk_label_new(NULL));
-  gtk_widget_set_halign(GTK_WIDGET(g->lbl_curr_scale), GTK_ALIGN_START);
+  gtk_grid_attach(GTK_GRID(grid_wd_labels), dt_ui_label_new(_("current:")), 0, 1, 1, 1);
+  g->lbl_curr_scale = GTK_LABEL(dt_ui_label_new(NULL));
   gtk_label_set_width_chars(g->lbl_curr_scale, 2);
-  gtk_grid_attach_next_to(GTK_GRID(grid_wd_labels), GTK_WIDGET(g->lbl_curr_scale), lbl_curr_scale, GTK_POS_RIGHT, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid_wd_labels), GTK_WIDGET(g->lbl_curr_scale), 1, 1, 1, 1);
 
-  GtkWidget *lbl_merge_from_scale = gtk_label_new(_("merge from:"));
-  gtk_widget_set_halign(lbl_merge_from_scale, GTK_ALIGN_START);
-  gtk_grid_attach_next_to(GTK_GRID(grid_wd_labels), lbl_merge_from_scale, lbl_curr_scale, GTK_POS_BOTTOM, 1, 1);
-
-  g->lbl_merge_from_scale = GTK_LABEL(gtk_label_new(NULL));
-  gtk_widget_set_halign(GTK_WIDGET(g->lbl_merge_from_scale), GTK_ALIGN_START);
+  gtk_grid_attach(GTK_GRID(grid_wd_labels), dt_ui_label_new(_("merge from:")), 0, 2, 1, 1);
+  g->lbl_merge_from_scale = GTK_LABEL(dt_ui_label_new(NULL));
   gtk_label_set_width_chars(g->lbl_merge_from_scale, 2);
-  gtk_grid_attach_next_to(GTK_GRID(grid_wd_labels), GTK_WIDGET(g->lbl_merge_from_scale), lbl_merge_from_scale,
-                          GTK_POS_RIGHT, 1, 1);
+  gtk_grid_attach(GTK_GRID(grid_wd_labels), GTK_WIDGET(g->lbl_merge_from_scale), 1, 2, 1, 1);
 
   // wavelet decompose bar
   g->wd_bar = gtk_drawing_area_new();
@@ -2238,7 +2221,7 @@ void gui_init(dt_iop_module_t *self)
       = (GdkRGBA){.red = p->fill_color[0], .green = p->fill_color[1], .blue = p->fill_color[2], .alpha = 1.0 };
 
   g->hbox_color_pick = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *lbl_fill_color = gtk_label_new(_("fill color: "));
+  GtkWidget *lbl_fill_color = dt_ui_label_new(_("fill color: "));
   gtk_box_pack_start(GTK_BOX(g->hbox_color_pick), lbl_fill_color, FALSE, TRUE, 0);
 
   g->colorpick = gtk_color_button_new_with_rgba(&color);

--- a/src/iop/retouch.c
+++ b/src/iop/retouch.c
@@ -1768,8 +1768,6 @@ void init(dt_iop_module_t *module)
   d->preview_levels[0] = RETOUCH_PREVIEW_LVL_MIN;
   d->preview_levels[1] = 0.f;
   d->preview_levels[2] = RETOUCH_PREVIEW_LVL_MAX;
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_retouch_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1366,7 +1366,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_rgbcurve_gui_data_t));
   dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
-  dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->params;
+  dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->default_params;
 
   for(int ch = 0; ch < DT_IOP_RGBCURVE_MAX_CHANNELS; ch++)
   {

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1364,8 +1364,7 @@ void change_image(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_rgbcurve_gui_data_t));
-  dt_iop_rgbcurve_gui_data_t *g = (dt_iop_rgbcurve_gui_data_t *)self->gui_data;
+  dt_iop_rgbcurve_gui_data_t *g = IOP_GUI_ALLOC(rgbcurve);
   dt_iop_rgbcurve_params_t *p = (dt_iop_rgbcurve_params_t *)self->default_params;
 
   for(int ch = 0; ch < DT_IOP_RGBCURVE_MAX_CHANNELS; ch++)
@@ -1483,8 +1482,7 @@ void gui_cleanup(struct dt_iop_module_t *self)
 
   dt_iop_cancel_history_update(self);
 
-  free(self->gui_data);
-  self->gui_data = NULL;
+  IOP_GUI_FREE;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/rgbcurve.c
+++ b/src/iop/rgbcurve.c
@@ -1530,8 +1530,6 @@ void init(dt_iop_module_t *module)
   d->curve_nodes[2][1].x = d->curve_nodes[2][1].y = 1.0;
 
   module->histogram_middle_grey = d->compensate_middle_grey;
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_rgbcurve_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -944,8 +944,7 @@ void change_image(struct dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_rgblevels_gui_data_t));
-  dt_iop_rgblevels_gui_data_t *c = (dt_iop_rgblevels_gui_data_t *)self->gui_data;
+  dt_iop_rgblevels_gui_data_t *c = IOP_GUI_ALLOC(rgblevels);
 
   dt_pthread_mutex_init(&c->lock, NULL);
   change_image(self);
@@ -1037,8 +1036,8 @@ void gui_cleanup(dt_iop_module_t *self)
   {
     dt_pthread_mutex_destroy(&g->lock);
   }
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 static void _get_selected_area(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece,

--- a/src/iop/rgblevels.c
+++ b/src/iop/rgblevels.c
@@ -909,8 +909,6 @@ void init(dt_iop_module_t *self)
     d->levels[c][1] = RGBLEVELS_MID;
     d->levels[c][2] = RGBLEVELS_MAX;
   }
-
-  memcpy(self->params, self->default_params, sizeof(dt_iop_rgblevels_params_t));
 }
 
 void init_global(dt_iop_module_so_t *self)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -332,11 +332,6 @@ void reload_defaults(dt_iop_module_t *self)
 {
   dt_iop_rotatepixels_params_t *d = self->default_params;
 
-  *d = (dt_iop_rotatepixels_params_t){ 0 };
-
-  // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) return;
-
   const dt_image_t *const image = &(self->dev->image_storage);
 
   *d = (dt_iop_rotatepixels_params_t){ .rx = 0u, .ry = image->fuji_rotation_pos, .angle = -45.0f };
@@ -354,21 +349,6 @@ void gui_update(dt_iop_module_t *self)
     gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel rotation"));
   else
     gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel rotation only works for the sensors that need it."));
-}
-
-void init(dt_iop_module_t *self)
-{
-  self->params = calloc(1, sizeof(dt_iop_rotatepixels_params_t));
-  self->default_params = calloc(1, sizeof(dt_iop_rotatepixels_params_t));
-  self->params_size = sizeof(dt_iop_rotatepixels_params_t);
-}
-
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -363,7 +363,6 @@ void init(dt_iop_module_t *self)
   self->params = calloc(1, sizeof(dt_iop_rotatepixels_params_t));
   self->default_params = calloc(1, sizeof(dt_iop_rotatepixels_params_t));
   self->params_size = sizeof(dt_iop_rotatepixels_params_t);
-  self->gui_data = &dummy;
 }
 
 void cleanup(dt_iop_module_t *self)
@@ -376,14 +375,11 @@ void cleanup(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
+  IOP_GUI_ALLOC(rotatepixels);
+
   self->widget = gtk_label_new("");
   gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-}
-
-void gui_cleanup(dt_iop_module_t *self)
-{
-  self->gui_data = NULL;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -330,23 +330,21 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_rotatepixels_params_t tmp = { 0 };
+  dt_iop_rotatepixels_params_t *d = self->default_params;
+
+  *d = (dt_iop_rotatepixels_params_t){ 0 };
 
   // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) goto end;
+  if(!self->dev) return;
 
   const dt_image_t *const image = &(self->dev->image_storage);
 
-  tmp = (dt_iop_rotatepixels_params_t){ .rx = 0u, .ry = image->fuji_rotation_pos, .angle = -45.0f };
+  *d = (dt_iop_rotatepixels_params_t){ .rx = 0u, .ry = image->fuji_rotation_pos, .angle = -45.0f };
 
-  self->default_enabled = ((tmp.rx != 0u) || (tmp.ry != 0u));
+  self->default_enabled = ((d->rx != 0u) || (d->ry != 0u));
 
   // FIXME: does not work.
   self->hide_enable_button = !self->default_enabled;
-
-end:
-  memcpy(self->params, &tmp, sizeof(dt_iop_rotatepixels_params_t));
-  memcpy(self->default_params, &tmp, sizeof(dt_iop_rotatepixels_params_t));
 }
 
 void gui_update(dt_iop_module_t *self)

--- a/src/iop/rotatepixels.c
+++ b/src/iop/rotatepixels.c
@@ -355,9 +355,9 @@ void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(rotatepixels);
 
-  self->widget = gtk_label_new("");
+  self->widget = dt_ui_label_new("");
   gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -244,24 +244,22 @@ void cleanup_pipe(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelp
 
 void reload_defaults(dt_iop_module_t *self)
 {
-  dt_iop_scalepixels_params_t tmp = (dt_iop_scalepixels_params_t){ .pixel_aspect_ratio = 1.0f };
+  dt_iop_scalepixels_params_t *d = self->default_params;
+
+  *d = (dt_iop_scalepixels_params_t){ .pixel_aspect_ratio = 1.0f };
 
   // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) goto end;
+  if(!self->dev) return;
 
   const dt_image_t *const image = &(self->dev->image_storage);
 
-  tmp.pixel_aspect_ratio = image->pixel_aspect_ratio;
+  d->pixel_aspect_ratio = image->pixel_aspect_ratio;
 
   self->default_enabled
-      = (!isnan(tmp.pixel_aspect_ratio) && tmp.pixel_aspect_ratio > 0.0f && tmp.pixel_aspect_ratio != 1.0f);
+      = (!isnan(d->pixel_aspect_ratio) && d->pixel_aspect_ratio > 0.0f && d->pixel_aspect_ratio != 1.0f);
 
   // FIXME: does not work.
   self->hide_enable_button = !self->default_enabled;
-
-end:
-  memcpy(self->params, &tmp, sizeof(dt_iop_scalepixels_params_t));
-  memcpy(self->default_params, &tmp, sizeof(dt_iop_scalepixels_params_t));
 }
 
 void gui_update(dt_iop_module_t *self)

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -49,8 +49,6 @@ typedef struct dt_iop_scalepixels_data_t {
   float y_scale;
 } dt_iop_scalepixels_data_t;
 
-static dt_iop_scalepixels_gui_data_t dummy;
-
 const char *name()
 {
   return C_("modulename", "scale pixels");
@@ -284,7 +282,6 @@ void init(dt_iop_module_t *self)
   self->default_enabled = (!isnan(image->pixel_aspect_ratio) && image->pixel_aspect_ratio > 0.0f
                            && image->pixel_aspect_ratio != 1.0f);
   self->params_size = sizeof(dt_iop_scalepixels_params_t);
-  self->gui_data = &dummy;
 }
 
 void cleanup(dt_iop_module_t *self)
@@ -297,14 +294,11 @@ void cleanup(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
+  IOP_GUI_ALLOC(scalepixels);
+
   self->widget = gtk_label_new("");
   gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
   gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
-}
-
-void gui_cleanup(dt_iop_module_t *self)
-{
-  self->gui_data = NULL;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -271,9 +271,9 @@ void gui_init(dt_iop_module_t *self)
 {
   IOP_GUI_ALLOC(scalepixels);
 
-  self->widget = gtk_label_new("");
+  self->widget = dt_ui_label_new("");
   gtk_label_set_line_wrap(GTK_LABEL(self->widget), TRUE);
-  gtk_widget_set_halign(self->widget, GTK_ALIGN_START);
+
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/scalepixels.c
+++ b/src/iop/scalepixels.c
@@ -36,7 +36,7 @@ typedef struct dt_iop_scalepixels_params_t
   // Aspect ratio of the pixels, usually 1 but some cameras need scaling
   // <1 means the image needs to be stretched vertically, (0.5 means 2x)
   // >1 means the image needs to be stretched horizontally (2 mean 2x)
-  float pixel_aspect_ratio;
+  float pixel_aspect_ratio; // $DEFAULT: 1.0f
 } dt_iop_scalepixels_params_t;
 
 typedef struct dt_iop_scalepixels_gui_data_t
@@ -246,17 +246,13 @@ void reload_defaults(dt_iop_module_t *self)
 {
   dt_iop_scalepixels_params_t *d = self->default_params;
 
-  *d = (dt_iop_scalepixels_params_t){ .pixel_aspect_ratio = 1.0f };
-
-  // we might be called from presets update infrastructure => there is no image
-  if(!self->dev) return;
-
   const dt_image_t *const image = &(self->dev->image_storage);
 
   d->pixel_aspect_ratio = image->pixel_aspect_ratio;
 
-  self->default_enabled
-      = (!isnan(d->pixel_aspect_ratio) && d->pixel_aspect_ratio > 0.0f && d->pixel_aspect_ratio != 1.0f);
+  self->default_enabled = (!isnan(d->pixel_aspect_ratio) &&
+                           d->pixel_aspect_ratio > 0.0f &&
+                           d->pixel_aspect_ratio != 1.0f);
 
   // FIXME: does not work.
   self->hide_enable_button = !self->default_enabled;
@@ -269,25 +265,6 @@ void gui_update(dt_iop_module_t *self)
     gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel scaling"));
   else
     gtk_label_set_text(GTK_LABEL(self->widget), _("automatic pixel scaling only works for the sensors that need it."));
-}
-
-void init(dt_iop_module_t *self)
-{
-  const dt_image_t *const image = &(self->dev->image_storage);
-
-  self->params = calloc(1, sizeof(dt_iop_scalepixels_params_t));
-  self->default_params = calloc(1, sizeof(dt_iop_scalepixels_params_t));
-  self->default_enabled = (!isnan(image->pixel_aspect_ratio) && image->pixel_aspect_ratio > 0.0f
-                           && image->pixel_aspect_ratio != 1.0f);
-  self->params_size = sizeof(dt_iop_scalepixels_params_t);
-}
-
-void cleanup(dt_iop_module_t *self)
-{
-  free(self->params);
-  self->params = NULL;
-  free(self->default_params);
-  self->default_params = NULL;
 }
 
 void gui_init(dt_iop_module_t *self)

--- a/src/iop/shadhi.c
+++ b/src/iop/shadhi.c
@@ -725,8 +725,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_shadhi_gui_data_t));
-  dt_iop_shadhi_gui_data_t *g = (dt_iop_shadhi_gui_data_t *)self->gui_data;
+  dt_iop_shadhi_gui_data_t *g = IOP_GUI_ALLOC(shadhi);
 
   g->shadows = dt_bauhaus_slider_from_params(self, N_("shadows"));
   g->highlights = dt_bauhaus_slider_from_params(self, N_("highlights"));

--- a/src/iop/sharpen.c
+++ b/src/iop/sharpen.c
@@ -732,8 +732,7 @@ void cleanup_global(dt_iop_module_so_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_sharpen_gui_data_t));
-  dt_iop_sharpen_gui_data_t *g = (dt_iop_sharpen_gui_data_t *)self->gui_data;
+  dt_iop_sharpen_gui_data_t *g = IOP_GUI_ALLOC(sharpen);
 
   g->radius = dt_bauhaus_slider_from_params(self, N_("radius"));
   dt_bauhaus_slider_set_soft_max(g->radius, 8.0);

--- a/src/iop/soften.c
+++ b/src/iop/soften.c
@@ -667,8 +667,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_soften_gui_data_t));
-  dt_iop_soften_gui_data_t *g = (dt_iop_soften_gui_data_t *)self->gui_data;
+  dt_iop_soften_gui_data_t *g = IOP_GUI_ALLOC(soften);
 
   g->size = dt_bauhaus_slider_from_params(self, N_("size"));
   dt_bauhaus_slider_set_format(g->size, "%.0f%%");

--- a/src/iop/splittoning.c
+++ b/src/iop/splittoning.c
@@ -520,8 +520,7 @@ static inline void gui_init_section(struct dt_iop_module_t *self, char *section,
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_splittoning_gui_data_t));
-  dt_iop_splittoning_gui_data_t *g = (dt_iop_splittoning_gui_data_t *)self->gui_data;
+  dt_iop_splittoning_gui_data_t *g = IOP_GUI_ALLOC(splittoning);
 
   GtkWidget *shadows_box = self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   g->shadow_hue_gslider = dt_bauhaus_slider_from_params(self, "shadow_hue");

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -692,7 +692,7 @@ void gui_focus(struct dt_iop_module_t *self, gboolean in)
         if(bd->masks_shown == DT_MASKS_EDIT_OFF) dt_masks_set_edit_mode(self, DT_MASKS_EDIT_FULL);
 
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->bt_edit_masks),
-                                     (bd->masks_shown != DT_MASKS_EDIT_OFF) 
+                                     (bd->masks_shown != DT_MASKS_EDIT_OFF)
                                      && (darktable.develop->gui_module == self));
       }
       else
@@ -776,10 +776,8 @@ void gui_init(dt_iop_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *label = gtk_label_new(_("number of strokes:"));
-  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-  gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, TRUE, 0);
-  g->label = GTK_LABEL(gtk_label_new("-1"));
+  gtk_box_pack_start(GTK_BOX(hbox), dt_ui_label_new(_("number of strokes:")), FALSE, TRUE, 0);
+  g->label = GTK_LABEL(dt_ui_label_new("-1"));
   gtk_widget_set_tooltip_text(hbox, _("click on a shape and drag on canvas.\nuse the mouse wheel "
                                       "to adjust size.\nright click to remove a shape."));
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -782,8 +782,7 @@ void gui_update(dt_iop_module_t *self)
 
 void gui_init(dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_spots_gui_data_t));
-  dt_iop_spots_gui_data_t *g = (dt_iop_spots_gui_data_t *)self->gui_data;
+  dt_iop_spots_gui_data_t *g = IOP_GUI_ALLOC(spots);
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -670,7 +670,6 @@ void init(dt_iop_module_t *module)
   // init defaults:
   dt_iop_spots_params_t tmp = (dt_iop_spots_params_t){ { 0 }, { 2 } };
 
-  memcpy(module->params, &tmp, sizeof(dt_iop_spots_params_t));
   memcpy(module->default_params, &tmp, sizeof(dt_iop_spots_params_t));
 }
 

--- a/src/iop/spots.c
+++ b/src/iop/spots.c
@@ -673,16 +673,6 @@ void init(dt_iop_module_t *module)
   memcpy(module->default_params, &tmp, sizeof(dt_iop_spots_params_t));
 }
 
-void cleanup(dt_iop_module_t *module)
-{
-  free(module->params);
-  module->params = NULL;
-  free(module->default_params);
-  module->default_params = NULL;
-  free(module->global_data); // just to be sure
-  module->global_data = NULL;
-}
-
 void gui_focus(struct dt_iop_module_t *self, gboolean in)
 {
   if(self->enabled && !darktable.develop->image_loading)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1577,7 +1577,7 @@ void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 
 static void btn_toggled(GtkWidget *togglebutton, dt_iop_module_t *self)
 {
-  if(self->dt->gui->reset) return;
+  if(darktable.gui->reset) return;
 
   dt_iop_temperature_gui_data_t *g = self->gui_data;
 

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1430,7 +1430,7 @@ void reload_defaults(dt_iop_module_t *module)
   *d = (dt_iop_temperature_params_t){ 1.0, 1.0, 1.0, 1.0 };
 
   // we might be called from presets update infrastructure => there is no image
-  if(!module->dev || module->dev->image_storage.id == -1) goto end;
+  if(!module->dev || module->dev->image_storage.id == -1) return;
 
   const int is_raw = dt_image_is_matrix_correction_supported(&module->dev->image_storage);
 
@@ -1518,9 +1518,6 @@ void reload_defaults(dt_iop_module_t *module)
 
     gui_sliders_update(module);
   }
-
-end:
-  memcpy(module->params, module->default_params, sizeof(dt_iop_temperature_params_t));
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1873,8 +1873,7 @@ static void _preference_changed(gpointer instance, gpointer user_data)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = calloc(1, sizeof(dt_iop_temperature_gui_data_t));
-  dt_iop_temperature_gui_data_t *g = (dt_iop_temperature_gui_data_t *)self->gui_data;
+  dt_iop_temperature_gui_data_t *g = IOP_GUI_ALLOC(temperature);
 
   gchar *config = dt_conf_get_string("plugins/darkroom/temperature/colored_sliders");
   g->colored_sliders = g_strcmp0(config, "no color"); // true if config != "no color"
@@ -2012,8 +2011,8 @@ void gui_init(struct dt_iop_module_t *self)
 void gui_cleanup(struct dt_iop_module_t *self)
 {
   DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_preference_changed), self);
-  g_free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 void gui_reset(struct dt_iop_module_t *self)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -837,28 +837,20 @@ void gui_update(struct dt_iop_module_t *self)
 
 void init(dt_iop_module_t *module)
 {
-  module->params = calloc(1, sizeof(dt_iop_tonecurve_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_tonecurve_params_t));
-  module->default_enabled = 0;
+  dt_iop_default_init(module);
+
   module->request_histogram |= (DT_REQUEST_ON);
-  module->params_size = sizeof(dt_iop_tonecurve_params_t);
-  module->gui_data = NULL;
-  dt_iop_tonecurve_params_t tmp = (dt_iop_tonecurve_params_t){
-    {  // three curves (L, a, b) with a number of nodes
-      { { 0.0, 0.0 }, { 1.0, 1.0 } },
-      { { 0.0, 0.0 }, { 0.5, 0.5 }, { 1.0, 1.0 } },
-      { { 0.0, 0.0 }, { 0.5, 0.5 }, { 1.0, 1.0 } } },
-    { 2, 3, 3 }, // number of nodes per curve
-    // { CATMULL_ROM, CATMULL_ROM, CATMULL_ROM},  // curve types
-    { MONOTONE_HERMITE, MONOTONE_HERMITE, MONOTONE_HERMITE },
-    // { CUBIC_SPLINE, CUBIC_SPLINE, CUBIC_SPLINE},
-    DT_S_SCALE_AUTOMATIC_RGB, // autoscale_ab
-    0,
-    1, // unbound_ab
-    DT_RGB_NORM_AVERAGE  // preserve color = Average rgb
-  };
-  memcpy(module->params, &tmp, sizeof(dt_iop_tonecurve_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_tonecurve_params_t));
+
+  dt_iop_tonecurve_params_t *d = module->default_params;
+
+  d->tonecurve_nodes[0] = 2;
+  d->tonecurve_nodes[1] =
+  d->tonecurve_nodes[2] = 3;
+  d->tonecurve[0][1].x = d->tonecurve[0][1].y =
+  d->tonecurve[1][2].x = d->tonecurve[1][2].y =
+  d->tonecurve[2][2].x = d->tonecurve[2][2].y = 1.0f;
+  d->tonecurve[1][1].x = d->tonecurve[1][1].y =
+  d->tonecurve[2][1].x = d->tonecurve[2][1].y = 0.5f;
 }
 
 void init_global(dt_iop_module_so_t *module)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1154,8 +1154,7 @@ static gboolean dt_iop_tonecurve_key_press(GtkWidget *widget, GdkEventKey *event
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_tonecurve_gui_data_t));
-  dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
+  dt_iop_tonecurve_gui_data_t *c = IOP_GUI_ALLOC(tonecurve);
   dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->default_params;
 
   for(int ch = 0; ch < ch_max; ch++)
@@ -1252,8 +1251,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   dt_draw_curve_destroy(c->minmax_curve[ch_a]);
   dt_draw_curve_destroy(c->minmax_curve[ch_b]);
   dt_iop_cancel_history_update(self);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 static gboolean dt_iop_tonecurve_enter_notify(GtkWidget *widget, GdkEventCrossing *event, gpointer user_data)

--- a/src/iop/tonecurve.c
+++ b/src/iop/tonecurve.c
@@ -1156,7 +1156,7 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_tonecurve_gui_data_t));
   dt_iop_tonecurve_gui_data_t *c = (dt_iop_tonecurve_gui_data_t *)self->gui_data;
-  dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->params;
+  dt_iop_tonecurve_params_t *p = (dt_iop_tonecurve_params_t *)self->default_params;
 
   for(int ch = 0; ch < ch_max; ch++)
   {

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -2983,8 +2983,7 @@ void gui_reset(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_toneequalizer_gui_data_t));
-  dt_iop_toneequalizer_gui_data_t *g = (dt_iop_toneequalizer_gui_data_t *)self->gui_data;
+  dt_iop_toneequalizer_gui_data_t *g = IOP_GUI_ALLOC(toneequalizer);
 
   dt_pthread_mutex_init(&g->lock, NULL);
   gui_cache_init(self);
@@ -3189,8 +3188,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   if(g->cst) cairo_surface_destroy(g->cst);
 
   dt_pthread_mutex_destroy(&g->lock);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/tonemap.cc
+++ b/src/iop/tonemap.cc
@@ -243,8 +243,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_tonemapping_gui_data_t));
-  dt_iop_tonemapping_gui_data_t *g = (dt_iop_tonemapping_gui_data_t *)self->gui_data;
+  dt_iop_tonemapping_gui_data_t *g = IOP_GUI_ALLOC(tonemapping);
 
   g->contrast = dt_bauhaus_slider_from_params(self, "contrast");
 

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -265,8 +265,7 @@ void gui_update(dt_iop_module_t *self)
 void gui_init(dt_iop_module_t *self)
 {
   // init the slider (more sophisticated layouts are possible with gtk tables and boxes):
-  self->gui_data = malloc(sizeof(dt_iop_useless_gui_data_t));
-  dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;
+  dt_iop_useless_gui_data_t *g = IOP_GUI_ALLOC(useless);
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
@@ -284,8 +283,8 @@ void gui_init(dt_iop_module_t *self)
 void gui_cleanup(dt_iop_module_t *self)
 {
   // nothing else necessary, gtk will clean up the slider.
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 /** additional, optional callbacks to capture darkroom center events. */

--- a/src/iop/useless.c
+++ b/src/iop/useless.c
@@ -21,46 +21,86 @@
 // our includes go first:
 #include "bauhaus/bauhaus.h"
 #include "develop/imageop.h"
+#include "develop/imageop_gui.h"
+#include "gui/color_picker_proxy.h"
 #include "gui/gtk.h"
 #include "iop/iop_api.h"
 
 #include <gtk/gtk.h>
 #include <stdlib.h>
 
-// this is the version of the modules parameters,
-// and includes version information about compile-time dt
-DT_MODULE_INTROSPECTION(2, dt_iop_useless_params_t)
+// This is an example implementation of an image operation module that does nothing useful.
+// It demonstrates how the different functions work together. To build your own module,
+// take all of the functions that are mandatory, stripping them of comments.
+// Then add only the optional functions that are required to implement the functionality
+// you need. Don't copy default implementations (hint: if you don't need to change or add
+// anything, you probably don't need the copy). Make sure you choose descriptive names
+// for your fields and variables. The ones given here are just examples; rename them.
+//
+// To have your module compile and appear in darkroom, add it to CMakeLists.txt, with
+//  add_iop(useless "useless.c")
+// and to iop_order.c, in the initialisation of legacy_order & v30_order with:
+//  { {XX.0f }, "useless", 0},
+
+// This is the version of the module's parameters,
+// and includes version information about compile-time dt.
+// The first released version should be 1.
+DT_MODULE_INTROSPECTION(3, dt_iop_useless_params_t)
 
 // TODO: some build system to support dt-less compilation and translation!
 
+// Enums used in params_t can have $DESCRIPTIONs that will be used to
+// automatically populate a combobox with dt_bauhaus_combobox_from_params.
+// They are also used in the history changes tooltip.
+// Combobox options will be presented in the same order as defined here.
+// These numbers must not be changed when a new version is introduced.
+typedef enum dt_iop_useless_type_t
+{
+  DT_USELESS_NONE = 0,     // $DESCRIPTION: "no"
+  DT_USELESS_FIRST = 1,    // $DESCRIPTION: "first option"
+  DT_USELESS_SECOND = 2,   // $DESCRIPTION: "second one"
+} dt_iop_useless_type_t;
+
 typedef struct dt_iop_useless_params_t
 {
-  // these are stored in db.
-  // make sure everything is in here does not
-  // depend on temporary memory (pointers etc)
-  // stored in self->params and self->default_params
-  // also, since this is stored in db, you should keep changes to this struct
-  // to a minimum. if you have to change this struct, it will break
-  // users data bases, and you should increment the version
-  // of DT_MODULE(VERSION) above!
-  int checker_scale;
-  float factor;
+  // The parameters defined here fully record the state of the module and are stored
+  // (as a serialized binary blob) into the db.
+  // Make sure everything is in here does not depend on temporary memory (pointers etc).
+  // This struct defines the layout of self->params and self->default_params.
+  // You should keep changes to this struct to a minimum.
+  // If you have to change this struct, it will break
+  // user data bases, and you have to increment the version
+  // of DT_MODULE_INTROSPECTION(VERSION) above and provide a legacy_params upgrade path!
+  //
+  // Tags in the comments get picked up by the introspection framework and are
+  // used in gui_init to set range and labels (for widgets and history)
+  // and value checks before commit_params.
+  // If no explicit init() is specified, the default implementation uses $DEFAULT tags
+  // to initialise self->default_params, which is then used in gui_init to set widget defaults.
+  //
+  // These field names are just examples; chose meaningful ones! For performance reasons, align
+  // to 4 byte bounderies (use gboolean, not bool).
+  int checker_scale; // $MIN: 0 $MAX: 10 $DEFAULT: 1 $DESCRIPTION: "size"
+  float factor;      // $MIN: -5.0 $MAX: 5.0 $DEFAULT: 0
+  gboolean check;    // $DESCRIPTION: "checkbox option"
+  dt_iop_useless_type_t method; // $DEFAULT: DT_USELESS_SECOND $DESCRIPTION: "parameter choices"
 } dt_iop_useless_params_t;
 
 typedef struct dt_iop_useless_gui_data_t
 {
-  // whatever you need to make your gui happy.
-  // stored in self->gui_data
-  GtkWidget *scale, *factor; // this is needed by gui_update
+  // Whatever you need to make your gui happy and provide access to widgets between gui_init, gui_update etc.
+  // Stored in self->gui_data while in darkroom.
+  // To permanently store per-user gui configuration settings, you could use dt_conf_set/_get.
+  GtkWidget *scale, *factor, *check, *method, *extra; // this is needed by gui_update
 } dt_iop_useless_gui_data_t;
 
 typedef struct dt_iop_useless_global_data_t
 {
-  // this is optionally stored in self->global_data
+  // This is optionally stored in self->global_data
   // and can be used to alloc globally needed stuff
   // which is needed in gui mode and during processing.
 
-  // we don't need it for this example (as for most dt plugins)
+  // We don't need it for this example (as for most dt plugins).
 } dt_iop_useless_global_data_t;
 
 // this returns a translatable name
@@ -87,18 +127,57 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
   return iop_cs_Lab;
 }
 
+// Whenever new fields are added to (or removed from) dt_iop_..._params_t or when their meaning
+// changes, a translation from the old to the new version must be added here.
+// A verbatim copy of the old struct definition should be copied into the routine with a _v?_t ending.
+// Since this will get very little future testing (because few developers still have very
+// old versions lying around) existing code should be changed as little as possible, if at all.
+//
+// Upgrading from an older version than the previous one should always go through all in between versions
+// (unless there was a bug) so that the end result will always be the same.
+//
+// Be careful with changes to structs that are included in _params_t
+//
+// Individually copy each existing field that is still in the new version. This is robust even if reordered.
+// If only new fields were added at the end, one call can be used:
+//   memcpy(n, o, sizeof *o);
+//
+// Hardcode the default values for new fields that were added, rather than referring to default_params;
+// in future, the field may not exist anymore or the default may change. The best default for a new version
+// to replicate a previous version might not be the optimal default for a fresh image.
+//
+// FIXME: the calling logic needs to be improved to call upgrades from consecutive version in sequence.
 int legacy_params(dt_iop_module_t *self, const void *const old_params, const int old_version,
                   void *new_params, const int new_version)
 {
+  typedef dt_iop_useless_params_t dt_iop_useless_params_v3_t; // always create copy of current so code below doesn't need to be touched
+
+  typedef struct dt_iop_useless_params_v2_t
+  {
+    int checker_scale;
+    float factor;
+  } dt_iop_useless_params_v2_t;
+
+  if(old_version == 2 && new_version == 3)
+  {
+    dt_iop_useless_params_v2_t *o = (dt_iop_useless_params_v2_t *)old_params;
+    dt_iop_useless_params_v3_t *n = (dt_iop_useless_params_v3_t *)new_params;
+
+    memcpy(n, o, sizeof *o);
+    n->check = FALSE;
+    n->method = DT_USELESS_SECOND;
+    return 0;
+  }
+
+  typedef struct dt_iop_useless_params_v1_t
+  {
+    int checker_scale;
+  } dt_iop_useless_params_v1_t;
+
   if(old_version == 1 && new_version == 2)
   {
-    typedef struct dt_iop_useless_params_v1_t
-    {
-      int checker_scale;
-    } dt_iop_useless_params_v1_t;
-
     dt_iop_useless_params_v1_t *o = (dt_iop_useless_params_v1_t *)old_params;
-    dt_iop_useless_params_t *n = (dt_iop_useless_params_t *)new_params;
+    dt_iop_useless_params_v2_t *n = (dt_iop_useless_params_v2_t *)new_params;
 
     n->checker_scale = o->checker_scale;
     n->factor = 0.0;
@@ -184,32 +263,25 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     g_hash_table_replace(piece->raster_masks, GINT_TO_POINTER(mask_id), mask);
 }
 
-/** optional: if this exists, it will be called to init new defaults if a new image is loaded from film strip
- * mode. */
-void reload_defaults(dt_iop_module_t *module)
-{
-  // change default_enabled depending on type of image, or set new default_params even.
-
-  // if this callback exists, it has to write default_params and default_enabled.
-}
-
-/** init, cleanup, commit to pipeline */
+/** Optional init and cleanup */
 void init(dt_iop_module_t *module)
 {
-  // we don't need global data:
-  module->data = NULL; // malloc(sizeof(dt_iop_useless_global_data_t));
-  module->params = calloc(1, sizeof(dt_iop_useless_params_t));
-  module->default_params = calloc(1, sizeof(dt_iop_useless_params_t));
-  // our module is disabled by default
-  // by default:
-  module->default_enabled = 0;
-  module->params_size = sizeof(dt_iop_useless_params_t);
-  module->gui_data = NULL;
-  // init defaults:
-  dt_iop_useless_params_t tmp = (dt_iop_useless_params_t){ .checker_scale = 50, .factor = 0.5 };
+  // Allocates memory for a module instance and fills default_params.
+  // If this callback is not provided, the standard implementation in
+  // dt_iop_default_init is used, which looks at the $DEFAULT introspection tags
+  // in the comments of the params_t struct definition.
+  // An explicit implementation of init is only required if not all fields are
+  // fully supported by dt_iop_default_init, for example arrays with non-identical values.
+  // In that case, dt_iop_default_init can be called first followed by additional initialisation.
+  // The values in params will not be used and default_params can be overwritten by
+  // reload_params on a per-image basis.
+  dt_iop_default_init(module);
 
-  memcpy(module->params, &tmp, sizeof(dt_iop_useless_params_t));
-  memcpy(module->default_params, &tmp, sizeof(dt_iop_useless_params_t));
+  // Any non-default settings; for example disabling the on/off switch:
+  module->hide_enable_button = 1;
+  // To make this work correctly, you also need to hide the widgets, otherwise moving one
+  // would enable the module anyway. The standard way is to set up a gtk_stack and show
+  // the page that only has a label with an explanatory text when the module can't be used.
 }
 
 void init_global(dt_iop_module_so_t *module)
@@ -219,6 +291,9 @@ void init_global(dt_iop_module_so_t *module)
 
 void cleanup(dt_iop_module_t *module)
 {
+  // Releases any memory allocated in init(module)
+  // Implement this function explicitly if the module allocates additional memory besides (default_)params.
+  // this is rare.
   free(module->params);
   module->params = NULL;
   free(module->default_params);
@@ -231,58 +306,214 @@ void cleanup_global(dt_iop_module_so_t *module)
   module->data = NULL;
 }
 
-/** put your local callbacks here, be sure to make them static so they won't be visible outside this file! */
-static void scale_callback(GtkWidget *w, dt_iop_module_t *self)
+/** Put your local callbacks here, be sure to make them static so they won't be visible outside this file! */
+static void extra_callback(GtkWidget *w, dt_iop_module_t *self)
 {
   // this is important to avoid cycles!
   if(darktable.gui->reset) return;
+
   dt_iop_useless_params_t *p = (dt_iop_useless_params_t *)self->params;
-  p->checker_scale = dt_bauhaus_slider_get(w);
+  dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;
+
+  float extra = dt_bauhaus_slider_get(w);
+
+  // Setting a widget value will trigger a callback that will update params.
+  // If this is not desirable (because it might result in a cycle) then use
+  // ++darktable.gui->reset;
+  dt_bauhaus_slider_set_soft(g->factor, p->factor + extra);
+  // and reverse with --darktable.gui->reset;
+
+  // If any params updated directly, not via a callback, then
   // let core know of the changes
   dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
-static void factor_callback(GtkWidget *w, dt_iop_module_t *self)
+/** optional gui callbacks. */
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  // this is important to avoid cycles!
-  if(darktable.gui->reset) return;
+  // If defined, this gets called when any of the introspection based widgets
+  // (created with dt_bauhaus_..._from_params) are changed.
+  // The updated value from the widget is already set in params.
+  // any additional side-effects can be achieved here.
   dt_iop_useless_params_t *p = (dt_iop_useless_params_t *)self->params;
-  p->factor = dt_bauhaus_slider_get(w);
-  // let core know of the changes
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;
+
+  // Test which widget was changed.
+  // If allowing w == NULL, this can be called from gui_update, so that
+  // gui configuration adjustments only need to be dealt with once, here.
+  if(!w || w == g->method)
+  {
+    gtk_widget_set_visible(g->check, p->method == DT_USELESS_SECOND);
+  }
+
+  // Widget configurations that don't depend any any current params values should
+  // go in reload_defaults (if they depend on the image) or gui_init.
 }
 
-/** gui callbacks, these are needed. */
+void color_picker_apply(dt_iop_module_t *self, GtkWidget *picker, dt_dev_pixelpipe_iop_t *piece)
+{
+  dt_iop_useless_params_t *p = (dt_iop_useless_params_t *)self->params;
+  dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;
+
+  // This automatically gets called when any of the color pickers set up with
+  // dt_color_picker_new in gui_init is used. If there is more than one,
+  // check which one is active first.
+  if(picker == g->factor)
+  {
+    p->factor = self->picked_color[1];
+  }
+
+  dt_dev_add_history_item(darktable.develop, self, TRUE);
+  dt_control_queue_redraw_widget(self->widget);
+}
+
+/** gui setup and update, these are needed. */
 void gui_update(dt_iop_module_t *self)
 {
-  // let gui slider match current parameters:
+  // This gets called when switching to darkroom, with each image change or when
+  // a different history item is selected.
+  // Here, all the widgets need to be set to the current values in param.
+  //
+  // Note, this moves data from params -> gui. All fields at same time.
+  // The opposite direction, gui -> params happens one field at a time, for example
+  // when the user manipulates a slider. It is handled by gui_changed (and the
+  // automatic callback) for introspection based widgets or by the explicit callback
+  // set up manually (see example of extra_callback above).
   dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)self->gui_data;
   dt_iop_useless_params_t *p = (dt_iop_useless_params_t *)self->params;
+
   dt_bauhaus_slider_set(g->scale, p->checker_scale);
+
+  // For introspection based widgets (dt_bauhaus_slider_from_params) do not use
+  // any transformations here (for example *100 for percentages) because that will
+  // break enforcement of $MIN/$MAX.
+  // Use dt_bauhaus_slider_set_factor/offset in gui_init instead.
   dt_bauhaus_slider_set(g->factor, p->factor);
+
+  // dt_bauhaus_toggle_from_params creates a standard gtk_toggle_button.
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->check), p->check);
+
+  // Use set_from_value to correctly handle out of order values.
+  dt_bauhaus_combobox_set_from_value(g->method, p->method);
+
+  // Any configuration changes to the gui that depend on field values should be done here,
+  // or can be done in gui_changed which can then be called from here with widget == NULL.
+  gui_changed(self, NULL, NULL);
+}
+
+/** optional: if this exists, it will be called to init new defaults if a new image is
+ * loaded from film strip mode. */
+void reload_defaults(dt_iop_module_t *module)
+{
+  // This only has to be provided if module settings or default_params need to depend on
+  // image type (raw?) or exif data.
+  // Make sure to always reset to the default for non-special cases, otherwise the override
+  // will stick when switching to another image.
+  dt_iop_useless_params_t *d = (dt_iop_useless_params_t *)module->default_params;
+
+  // As an example, switch off for non-raw images. The enable button was already hidden in init().
+  if(!dt_image_is_raw(&module->dev->image_storage))
+  {
+    module->default_enabled = 0;
+  }
+  else
+  {
+    module->default_enabled = 1;
+    d->checker_scale = 3; // something dependent on exif, for example.
+  }
+
+  // If we are in darkroom, gui_init will already have been called and has initialised
+  // module->gui_data and widgets.
+  // So if deafault values have been changed, it may then be necessary to also change the
+  // default values in widgets. Resetting the individual widgets will then have the same
+  // effect as resetting the whole module at once.
+  dt_iop_useless_gui_data_t *g = (dt_iop_useless_gui_data_t *)module->gui_data;
+  if(g)
+  {
+    dt_bauhaus_slider_set_default(g->scale, d->checker_scale);
+  }
 }
 
 void gui_init(dt_iop_module_t *self)
 {
-  // init the slider (more sophisticated layouts are possible with gtk tables and boxes):
+  // Allocates memory for the module's user interface in the darkroom and
+  // sets up the widgets in it.
+  //
+  // self->widget needs to be set to the top level widget.
+  // This can be a (vertical) box, a grid or even a notebook. Modules that are
+  // disabled for certain types of images (for example non-raw) may use a stack
+  // where one of the pages contains just a label explaining why it is disabled.
+  //
+  // Widgets that are directly linked to a field in params_t may be set up using the
+  // dt_bauhaus_..._from_params family. They take a string with the field
+  // name in the params_t struct definition. The $MIN, $MAX and $DEFAULT tags will be
+  // used to set up the widget (slider) ranges and default values and the $DESCRIPTION
+  // is used as the widget label.
+  //
+  // The _from_params calls also set up an automatic callback that updates the field in params
+  // whenever the widget is changed. In addition, gui_changed is called, if it exists,
+  // so that any other required changes, to dependent fields or to gui widgets, can be made.
+  //
+  // Whenever self->params changes (switching images or history) the widget values have to
+  // be updated in gui_update.
+  //
+  // Do not set the value of widgets or configure them depending on field values here;
+  // this should be done in gui_update (or gui_changed or individual widget callbacks)
+  //
+  // If any default values for (slider) widgets or options (in comboboxes) depend on the
+  // type of image, then the widgets have to be updated in reload_params.
   dt_iop_useless_gui_data_t *g = IOP_GUI_ALLOC(useless);
 
+  // If the first widget is created useing a _from_params call, self->widget does not have to
+  // be explicitly initialised, as a new virtical box will be created automatically.
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
 
-  g->scale = dt_bauhaus_slider_new_with_range(self, 1, 100, 1, 50, 0);
-  dt_bauhaus_widget_set_label(g->scale, NULL, _("size"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->scale), TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->scale), "value-changed", G_CALLBACK(scale_callback), self);
+  // Linking a slider to an integer will make it take only whole numbers (step=1).
+  // The new slider is added to self->widget
+  g->scale = dt_bauhaus_slider_from_params(self, "checker_scale");
 
-  g->factor = dt_bauhaus_slider_new_with_range(self, 0.0, 1.0, 0.1, 0.5, 2);
-  dt_bauhaus_widget_set_label(g->factor, NULL, _("factor"));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->factor), TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(g->factor), "value-changed", G_CALLBACK(factor_callback), self);
+  // If the field name should be used as label too, it does not need a $DESCRIPTION;
+  // mark it for translation here using N_()
+  //
+  // A colorpicker can be attached to a slider, as here, or put standalone in a box.
+  // When a color is picked, color_picker_apply is called with either the slider or the
+  // button that triggered it.
+  g->factor = dt_color_picker_new(self, DT_COLOR_PICKER_AREA,
+              dt_bauhaus_slider_from_params(self, N_("factor")));
+  // The initial slider range can be reduced from the introspection $MIN - $MAX
+  dt_bauhaus_slider_set_soft_range(g->factor, 0.5f, 1.5f);
+  // The default step is range/100, but can be changed here
+  dt_bauhaus_slider_set_step(g->factor, .1);
+  dt_bauhaus_slider_set_digits(g->factor, 2);
+  // Additional parameters determine how the value will be shown.
+  dt_bauhaus_slider_set_format(g->factor, "%.2f %%");
+  // For a percentage, use factor 100.
+  dt_bauhaus_slider_set_factor(g->factor, -100.0f);
+  dt_bauhaus_slider_set_offset(g->factor, 100.0f);
+  // Tooltips explain the otherwise compact interface
+  gtk_widget_set_tooltip_text(g->factor, _("adjust factor"));
+
+  // A combobox linked to struct field will be filled with the values and $DESCRIPTIONs
+  // in the struct definition, in the same order. The automatic callback will put the
+  // enum value, not the position within the combobox list, in the field.
+  g->method = dt_bauhaus_combobox_from_params(self, "method");
+
+  g->check = dt_bauhaus_toggle_from_params(self, "check");
+
+  // Any widgets that are _not_ directly linked to a field need to have a custom callback
+  // function set up to respond to the "value-changed" signal.
+  g->extra = dt_bauhaus_slider_new_with_range(self, -0.5, 0.5, .01, 0, 2);
+  dt_bauhaus_widget_set_label(g->extra, NULL, _("extra"));
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(g->extra), TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(g->extra), "value-changed", G_CALLBACK(extra_callback), self);
 }
 
 void gui_cleanup(dt_iop_module_t *self)
 {
-  // nothing else necessary, gtk will clean up the slider.
+  // This only needs to be provided if gui_init allocates any memory or resources besides
+  // self->widget and gui_data_t. The default function (if an explicit one isn't provided here)
+  // takes care of gui_data_t (and gtk destroys the widget anyway). If you override the default,
+  // you have to do whatever you have to do, and also call IOP_GUI_FREE to clean up gui_data_t.
 
   IOP_GUI_FREE;
 }

--- a/src/iop/velvia.c
+++ b/src/iop/velvia.c
@@ -338,8 +338,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_velvia_gui_data_t));
-  dt_iop_velvia_gui_data_t *g = (dt_iop_velvia_gui_data_t *)self->gui_data;
+  dt_iop_velvia_gui_data_t *g = IOP_GUI_ALLOC(velvia);
 
   g->strength_scale = dt_bauhaus_slider_from_params(self, N_("strength"));
   dt_bauhaus_slider_set_format(g->strength_scale, "%.0f%%");

--- a/src/iop/vibrance.c
+++ b/src/iop/vibrance.c
@@ -208,8 +208,7 @@ void gui_update(struct dt_iop_module_t *self)
 }
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_vibrance_gui_data_t));
-  dt_iop_vibrance_gui_data_t *g = (dt_iop_vibrance_gui_data_t *)self->gui_data;
+  dt_iop_vibrance_gui_data_t *g = IOP_GUI_ALLOC(vibrance);
 
   g->amount_scale = dt_bauhaus_slider_from_params(self, "amount");
   dt_bauhaus_slider_set_format(g->amount_scale, "%.0f%%");

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -1024,8 +1024,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_vignette_gui_data_t));
-  dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
+  dt_iop_vignette_gui_data_t *g = IOP_GUI_ALLOC(vignette);
 
   g->scale = dt_bauhaus_slider_from_params(self, N_("scale"));
   g->falloff_scale = dt_bauhaus_slider_from_params(self, "falloff_scale");

--- a/src/iop/vignette.c
+++ b/src/iop/vignette.c
@@ -107,7 +107,7 @@ typedef struct dt_iop_vignette_params_t
   float brightness;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: -0.5 -1 - 1 Strength of brightness reduction
   float saturation;          // $MIN: -1.0 $MAX: 1.0 $DEFAULT: -0.5 -1 - 1 Strength of saturation reduction
   dt_iop_vector_2d_t center; // Center of vignette
-  gboolean autoratio;        // $DEFAULT: FALSE
+  gboolean autoratio;        // $DEFAULT: FALSE $DESCRIPTION: "automatic ratio"
   float whratio;             // $MIN: 0.0 $MAX: 2.0 $DEFAULT: 1.0 $DESCRIPTION: "width/height ratio" 0-1 = width/height ratio, 1-2 = height/width ratio + 1
   float shape;               // $MIN: 0.0 $MAX: 5.0 $DEFAULT: 1.0 $DESCRIPTION: "shape"
   dt_iop_dither_t dithering; // $DEFAULT: DITHER_OFF if and how to perform dithering
@@ -123,7 +123,7 @@ typedef struct dt_iop_vignette_gui_data_t
   GtkWidget *saturation;
   GtkWidget *center_x;
   GtkWidget *center_y;
-  GtkToggleButton *autoratio;
+  GtkWidget *autoratio;
   GtkWidget *whratio;
   GtkWidget *shape;
   GtkWidget *dithering;
@@ -948,15 +948,12 @@ void cleanup_global(dt_iop_module_so_t *module)
 }
 
 
-static void autoratio_callback(GtkToggleButton *button, gpointer user_data)
+void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)
 {
-  dt_iop_module_t *self = (dt_iop_module_t *)user_data;
-  if(darktable.gui->reset) return;
-  dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
-  p->autoratio = gtk_toggle_button_get_active(button);
   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
+  dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
+
   gtk_widget_set_sensitive(GTK_WIDGET(g->whratio), !p->autoratio);
-  dt_dev_add_history_item(darktable.develop, self, TRUE);
 }
 
 void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *p1, dt_dev_pixelpipe_t *pipe,
@@ -1018,7 +1015,7 @@ void gui_update(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set(g->saturation, p->saturation);
   dt_bauhaus_slider_set(g->center_x, p->center.x);
   dt_bauhaus_slider_set(g->center_y, p->center.y);
-  gtk_toggle_button_set_active(g->autoratio, p->autoratio);
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g->autoratio), p->autoratio);
   dt_bauhaus_slider_set(g->whratio, p->whratio);
   dt_bauhaus_slider_set(g->shape, p->shape);
   gtk_widget_set_sensitive(GTK_WIDGET(g->whratio), !p->autoratio);
@@ -1029,7 +1026,6 @@ void gui_init(struct dt_iop_module_t *self)
 {
   self->gui_data = malloc(sizeof(dt_iop_vignette_gui_data_t));
   dt_iop_vignette_gui_data_t *g = (dt_iop_vignette_gui_data_t *)self->gui_data;
-  dt_iop_vignette_params_t *p = (dt_iop_vignette_params_t *)self->params;
 
   g->scale = dt_bauhaus_slider_from_params(self, N_("scale"));
   g->falloff_scale = dt_bauhaus_slider_from_params(self, "falloff_scale");
@@ -1038,14 +1034,7 @@ void gui_init(struct dt_iop_module_t *self)
   g->center_x = dt_bauhaus_slider_from_params(self, "center.x");
   g->center_y = dt_bauhaus_slider_from_params(self, "center.y");
   g->shape = dt_bauhaus_slider_from_params(self, N_("shape"));
-
-  GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *label = dtgtk_reset_label_new(_("automatic ratio"), self, &p->autoratio, sizeof p->autoratio);
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(label), TRUE, TRUE, 0);
-  g->autoratio = GTK_TOGGLE_BUTTON(gtk_toggle_button_new_with_label(_("automatic")));
-  gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(g->autoratio), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
-
+  g->autoratio = dt_bauhaus_toggle_from_params(self, "autoratio");
   g->whratio = dt_bauhaus_slider_from_params(self, "whratio");
   g->dithering = dt_bauhaus_combobox_from_params(self, N_("dithering"));
 
@@ -1058,7 +1047,6 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_format(g->scale, "%.02f%%");
   dt_bauhaus_slider_set_format(g->falloff_scale, "%.02f%%");
 
-  gtk_widget_set_sensitive(GTK_WIDGET(g->whratio), !p->autoratio);
   gtk_widget_set_tooltip_text(g->scale, _("the radii scale of vignette for start of fall-off"));
   gtk_widget_set_tooltip_text(g->falloff_scale, _("the radii scale of vignette for end of fall-off"));
   gtk_widget_set_tooltip_text(g->brightness, _("strength of effect on brightness"));
@@ -1070,8 +1058,6 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_widget_set_tooltip_text(GTK_WIDGET(g->autoratio), _("enable to have the ratio automatically follow the image size"));
   gtk_widget_set_tooltip_text(g->whratio, _("width-to-height ratio"));
   gtk_widget_set_tooltip_text(g->dithering, _("add some level of random noise to prevent banding"));
-
-  g_signal_connect(G_OBJECT(g->autoratio), "toggled", G_CALLBACK(autoratio_callback), self);
 }
 
 GSList *mouse_actions(struct dt_iop_module_t *self)

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1385,8 +1385,7 @@ void init(dt_iop_module_t *module)
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = calloc(1, sizeof(dt_iop_watermark_gui_data_t));
-  dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
+  dt_iop_watermark_gui_data_t *g = IOP_GUI_ALLOC(watermark);
   dt_iop_watermark_params_t *p = (dt_iop_watermark_params_t *)self->params;
 
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, DT_BAUHAUS_SPACE);
@@ -1523,13 +1522,12 @@ void gui_init(struct dt_iop_module_t *self)
 
 void gui_cleanup(struct dt_iop_module_t *self)
 {
-
   dt_iop_watermark_gui_data_t *g = (dt_iop_watermark_gui_data_t *)self->gui_data;
   g_list_free_full(g->watermarks_filenames, g_free);
   dt_gui_key_accel_block_on_focus_disconnect(g->text);
   g->watermarks_filenames = NULL;
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1435,8 +1435,7 @@ void gui_init(struct dt_iop_module_t *self)
   gtk_grid_attach_next_to(grid, g->color_picker_button, g->colorpick, GTK_POS_RIGHT, 1, 1);
 
   // Simple text
-  label = gtk_label_new(_("text"));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  label = dt_ui_label_new(_("text"));
   g->text = gtk_entry_new();
   gtk_entry_set_width_chars(GTK_ENTRY(g->text), 1);
   gtk_widget_set_tooltip_text(g->text, _("text string, tag:\n$(WATERMARK_TEXT)"));

--- a/src/iop/watermark.c
+++ b/src/iop/watermark.c
@@ -1379,8 +1379,6 @@ void init(dt_iop_module_t *module)
 
   g_strlcpy(d->filename, "darktable.svg", sizeof(d->filename));
   g_strlcpy(d->font, "DejaVu Sans 10", sizeof(d->font));
-
-  memcpy(module->params, module->default_params, sizeof(dt_iop_watermark_params_t));
 }
 
 void gui_init(struct dt_iop_module_t *self)

--- a/src/iop/zonesystem.c
+++ b/src/iop/zonesystem.c
@@ -519,8 +519,7 @@ static void size_allocate_callback(GtkWidget *widget, GtkAllocation *allocation,
 
 void gui_init(struct dt_iop_module_t *self)
 {
-  self->gui_data = malloc(sizeof(dt_iop_zonesystem_gui_data_t));
-  dt_iop_zonesystem_gui_data_t *g = (dt_iop_zonesystem_gui_data_t *)self->gui_data;
+  dt_iop_zonesystem_gui_data_t *g = IOP_GUI_ALLOC(zonesystem);
   g->in_preview_buffer = g->out_preview_buffer = NULL;
   g->is_dragging = FALSE;
   g->hilite_zone = FALSE;
@@ -582,8 +581,8 @@ void gui_cleanup(struct dt_iop_module_t *self)
   if(g->image) cairo_surface_destroy(g->image);
   free(g->image_buffer);
   dt_pthread_mutex_destroy(&g->lock);
-  free(self->gui_data);
-  self->gui_data = NULL;
+
+  IOP_GUI_FREE;
 }
 
 #define DT_ZONESYSTEM_INSET DT_PIXEL_APPLY_DPI(5)

--- a/src/libs/copy_history.c
+++ b/src/libs/copy_history.c
@@ -41,10 +41,10 @@ DT_MODULE(1)
 typedef struct dt_lib_copy_history_t
 {
   GtkWidget *pastemode;
-  GtkButton *paste, *paste_parts;
+  GtkWidget *paste, *paste_parts;
   GtkWidget *copy_button, *discard_button, *load_button, *write_button;
   GtkWidget *copy_parts_button;
-  GtkButton *compress_button;
+  GtkWidget *compress_button;
 } dt_lib_copy_history_t;
 
 const char *name(dt_lib_module_t *self)
@@ -310,7 +310,6 @@ int position()
   return 600;
 }
 
-#define ellipsize_button(button) gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
 void gui_init(dt_lib_module_t *self)
 {
   dt_lib_copy_history_t *d = (dt_lib_copy_history_t *)malloc(sizeof(dt_lib_copy_history_t));
@@ -323,45 +322,36 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_set_column_homogeneous(grid, TRUE);
   int line = 0;
 
-  GtkWidget *copy_parts = gtk_button_new_with_label(_("copy..."));
-  ellipsize_button(copy_parts);
-  d->copy_parts_button = copy_parts;
-  gtk_widget_set_tooltip_text(copy_parts, _("copy part history stack of\nfirst selected image"));
-  dt_gui_add_help_link(copy_parts, "history_stack.html#history_stack_usage");
-  gtk_grid_attach(grid, copy_parts, 0, line, 3, 1);
+  d->copy_parts_button = dt_ui_button_new(_("copy..."),
+                                          _("copy part history stack of\nfirst selected image"),
+                                          "history_stack.html#history_stack_usage");
+  gtk_grid_attach(grid, d->copy_parts_button, 0, line, 3, 1);
 
-  GtkWidget *copy = gtk_button_new_with_label(_("copy all"));
-  ellipsize_button(copy);
-  d->copy_button = copy;
-  gtk_widget_set_tooltip_text(copy, _("copy history stack of\nfirst selected image"));
-  dt_gui_add_help_link(copy, "history_stack.html#history_stack_usage");
-  gtk_grid_attach(grid, copy, 3, line++, 3, 1);
+  d->copy_button = dt_ui_button_new(_("copy all"),
+                                    _("copy history stack of\nfirst selected image"),
+                                    "history_stack.html#history_stack_usage");
+  gtk_grid_attach(grid, d->copy_button, 3, line++, 3, 1);
 
-  d->paste_parts = GTK_BUTTON(gtk_button_new_with_label(_("paste...")));
-  ellipsize_button(d->paste_parts);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(d->paste_parts), _("paste part history stack to\nall selected images"));
-  dt_gui_add_help_link(GTK_WIDGET(d->paste_parts), "history_stack.html#history_stack_usage");
-  gtk_widget_set_sensitive(GTK_WIDGET(d->paste_parts), FALSE);
-  gtk_grid_attach(grid, GTK_WIDGET(d->paste_parts), 0, line, 3, 1);
+  d->paste_parts = dt_ui_button_new(_("paste..."),
+                                    _("paste part history stack to\nall selected images"),
+                                    "history_stack.html#history_stack_usage");
+  gtk_widget_set_sensitive(d->paste_parts, FALSE);
+  gtk_grid_attach(grid, d->paste_parts, 0, line, 3, 1);
 
-  d->paste = GTK_BUTTON(gtk_button_new_with_label(_("paste all")));
-  ellipsize_button(d->paste);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(d->paste), _("paste history stack to\nall selected images"));
-  dt_gui_add_help_link(GTK_WIDGET(d->paste), "history_stack.html#history_stack_usage");
-  gtk_widget_set_sensitive(GTK_WIDGET(d->paste), FALSE);
-  gtk_grid_attach(grid, GTK_WIDGET(d->paste), 3, line++, 3, 1);
+  d->paste = dt_ui_button_new(_("paste all"),
+                              _("paste history stack to\nall selected images"),
+                              "history_stack.html#history_stack_usage");
+  gtk_widget_set_sensitive(d->paste, FALSE);
+  gtk_grid_attach(grid, d->paste, 3, line++, 3, 1);
 
-  d->compress_button = GTK_BUTTON(gtk_button_new_with_label(_("compress history")));
-  ellipsize_button(d->compress_button);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(d->compress_button), _("compress history stack of\nall selected images"));
-  gtk_grid_attach(grid, GTK_WIDGET(d->compress_button), 0, line, 3, 1);
+  d->compress_button = dt_ui_button_new(_("compress history"),
+                                        _("compress history stack of\nall selected images"), NULL);
+  gtk_grid_attach(grid, d->compress_button, 0, line, 3, 1);
 
-  GtkWidget *discard = gtk_button_new_with_label(_("discard history"));
-  ellipsize_button(discard);
-  d->discard_button = discard;
-  gtk_widget_set_tooltip_text(discard, _("discard history stack of\nall selected images"));
-  dt_gui_add_help_link(discard, "history_stack.html#history_stack_usage");
-  gtk_grid_attach(grid, discard, 3, line++, 3, 1);
+  d->discard_button = dt_ui_button_new(_("discard history"),
+                                       _("discard history stack of\nall selected images"),
+                                       "history_stack.html#history_stack_usage");
+  gtk_grid_attach(grid, d->discard_button, 3, line++, 3, 1);
 
   d->pastemode = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(d->pastemode, NULL, _("mode"));
@@ -372,20 +362,15 @@ void gui_init(dt_lib_module_t *self)
   gtk_grid_attach(grid, d->pastemode, 0, line++, 6, 1);
   dt_bauhaus_combobox_set(d->pastemode, dt_conf_get_int("plugins/lighttable/copy_history/pastemode"));
 
-  GtkWidget *loadbutton = gtk_button_new_with_label(_("load sidecar file..."));
-  ellipsize_button(loadbutton);
-  d->load_button = loadbutton;
-  gtk_widget_set_tooltip_text(loadbutton, _("open an XMP sidecar file\nand apply it to selected images"));
-  dt_gui_add_help_link(loadbutton, "history_stack.html#history_stack_usage");
-  gtk_grid_attach(grid, loadbutton, 0, line, 3, 1);
+  d->load_button = dt_ui_button_new(_("load sidecar file..."),
+                                    _("open an XMP sidecar file\nand apply it to selected images"),
+                                    "history_stack.html#history_stack_usage");
+  gtk_grid_attach(grid, d->load_button, 0, line, 3, 1);
 
-  GtkWidget *button = gtk_button_new_with_label(_("write sidecar files"));
-  ellipsize_button(button);
-  d->write_button = button;
-  gtk_widget_set_tooltip_text(button, _("write history stack and tags to XMP sidecar files"));
-  dt_gui_add_help_link(button, "history_stack.html#history_stack_usage");
-  gtk_grid_attach(grid, button, 3, line, 3, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(write_button_clicked), (gpointer)self);
+  d->write_button = dt_ui_button_new(_("write sidecar files"),
+                                     _("write history stack and tags to XMP sidecar files"),
+                                     "history_stack.html#history_stack_usage");
+  gtk_grid_attach(grid, d->write_button, 3, line, 3, 1);
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
                             G_CALLBACK(_image_selection_changed_callback), self);
@@ -396,16 +381,16 @@ void gui_init(dt_lib_module_t *self)
 
   _update(self);
 
-  g_signal_connect(G_OBJECT(copy), "clicked", G_CALLBACK(copy_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(copy_parts), "clicked", G_CALLBACK(copy_parts_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(d->copy_button), "clicked", G_CALLBACK(copy_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(d->copy_parts_button), "clicked", G_CALLBACK(copy_parts_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(d->compress_button), "clicked", G_CALLBACK(compress_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(discard), "clicked", G_CALLBACK(discard_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(d->discard_button), "clicked", G_CALLBACK(discard_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(d->paste_parts), "clicked", G_CALLBACK(paste_parts_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(d->paste), "clicked", G_CALLBACK(paste_button_clicked), (gpointer)self);
-  g_signal_connect(G_OBJECT(loadbutton), "clicked", G_CALLBACK(load_button_clicked), (gpointer)self);
+  g_signal_connect(G_OBJECT(d->load_button), "clicked", G_CALLBACK(load_button_clicked), (gpointer)self);
   g_signal_connect(G_OBJECT(d->pastemode), "value-changed", G_CALLBACK(pastemode_combobox_changed), (gpointer)self);
+  g_signal_connect(G_OBJECT(d->write_button), "clicked", G_CALLBACK(write_button_clicked), (gpointer)self);
 }
-#undef ellipsize_button
 
 void gui_cleanup(dt_lib_module_t *self)
 {

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -432,7 +432,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 
     GtkWidget *tb = gtk_entry_new();
     if(path) gtk_entry_set_text(GTK_ENTRY(tb), path);
-    gtk_entry_set_width_chars(GTK_ENTRY(tb), 15);
+    gtk_entry_set_width_chars(GTK_ENTRY(tb), 0);
     g_object_set_data (G_OBJECT(tb), "imgid", GINT_TO_POINTER(imgid));
     g_signal_connect(G_OBJECT(tb), "focus-out-event", G_CALLBACK(_lib_duplicate_caption_out_callback), self);
     dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(tb));
@@ -442,7 +442,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_delete), self);
 
     gtk_box_pack_start(GTK_BOX(hb), thumb->w_main, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(hb), tb, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(hb), tb, TRUE, TRUE, 0);
     gtk_box_pack_start(GTK_BOX(hb), lb, FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(hb), bt, FALSE, FALSE, 0);
 

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -532,7 +532,7 @@ void gui_init(dt_lib_module_t *self)
   d->duplicate_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *bt = gtk_label_new(_("existing duplicates"));
+  GtkWidget *bt = dt_ui_label_new(_("existing duplicates"));
   gtk_box_pack_start(GTK_BOX(hb), bt, FALSE, FALSE, 0);
   bt = dtgtk_button_new(dtgtk_cairo_paint_plus, CPF_STYLE_FLAT, NULL);
   g_object_set(G_OBJECT(bt), "tooltip-text", _("create a 'virgin' duplicate of the image without any development"), (char *)NULL);

--- a/src/libs/export.c
+++ b/src/libs/export.c
@@ -712,10 +712,10 @@ void gui_init(dt_lib_module_t *self)
 
   d->width = gtk_entry_new();
   gtk_widget_set_tooltip_text(d->width, _("maximum output width\nset to 0 for no scaling"));
-  gtk_entry_set_width_chars(GTK_ENTRY(d->width), 6);
+  gtk_entry_set_width_chars(GTK_ENTRY(d->width), 5);
   d->height = gtk_entry_new();
   gtk_widget_set_tooltip_text(d->height, _("maximum output height\nset to 0 for no scaling"));
-  gtk_entry_set_width_chars(GTK_ENTRY(d->height), 6);
+  gtk_entry_set_width_chars(GTK_ENTRY(d->height), 5);
 
   dt_gui_key_accel_block_on_focus_connect(d->width);
   dt_gui_key_accel_block_on_focus_connect(d->height);
@@ -835,10 +835,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), FALSE, TRUE, 0);
 
   // Export button
-  GtkButton *button = GTK_BUTTON(gtk_button_new_with_label(_("export")));
-  d->export_button = button;
-  gtk_widget_set_tooltip_text(GTK_WIDGET(button), _("export with current settings"));
-  gtk_box_pack_start(hbox, GTK_WIDGET(button), TRUE, TRUE, 0);
+  d->export_button = GTK_BUTTON(dt_ui_button_new(_("export"), _("export with current settings"), NULL));
+  gtk_box_pack_start(hbox, GTK_WIDGET(d->export_button), TRUE, TRUE, 0);
 
   //  Add metadata exportation control
   d->metadata_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_BOX, NULL);
@@ -846,7 +844,7 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_tooltip_text(d->metadata_button, _("edit metadata exportation details"));
   gtk_box_pack_end(hbox, d->metadata_button, FALSE, TRUE, 0);
 
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(export_button_clicked), (gpointer)d);
+  g_signal_connect(G_OBJECT(d->export_button), "clicked", G_CALLBACK(export_button_clicked), (gpointer)d);
   g_signal_connect(G_OBJECT(d->width), "changed", G_CALLBACK(width_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->height), "changed", G_CALLBACK(height_changed), (gpointer)d);
   g_signal_connect(G_OBJECT(d->width), "insert-text", G_CALLBACK(insert_text_handler), CONFIG_PREFIX "width");

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -417,8 +417,8 @@ static void _lib_geotagging_show_offset_window(GtkWidget *widget, dt_lib_module_
                    G_CALLBACK(_lib_geotagging_floating_key_press), self);
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *cancel_button = gtk_button_new_with_label(_("cancel"));
-  GtkWidget *ok_button = gtk_button_new_with_label(_("ok"));
+  GtkWidget *cancel_button = dt_ui_button_new(_("cancel"), NULL, NULL);
+  GtkWidget *ok_button = dt_ui_button_new(_("ok"), NULL, NULL);
 
   gtk_box_pack_start(GTK_BOX(hbox), cancel_button, TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(hbox), ok_button, TRUE, TRUE, 0);
@@ -779,12 +779,13 @@ void gui_init(dt_lib_module_t *self)
 
   /* the offset line */
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+
   gtk_box_pack_start(hbox, dt_ui_label_new(_("time offset")), FALSE, TRUE, 0);
 
   d->offset_entry = gtk_entry_new();
   dt_gui_key_accel_block_on_focus_connect(d->offset_entry);
   gtk_entry_set_max_length(GTK_ENTRY(d->offset_entry), 9);
-  gtk_entry_set_width_chars(GTK_ENTRY(d->offset_entry), 0);
+  gtk_entry_set_width_chars(GTK_ENTRY(d->offset_entry), 6);
   gtk_box_pack_start(hbox, d->offset_entry, TRUE, TRUE, 0);
   g_signal_connect(d->offset_entry, "key-press-event", G_CALLBACK(_lib_geotagging_offset_key_press), self);
   g_signal_connect(d->offset_entry, "focus-out-event", G_CALLBACK(_lib_geotagging_offset_focus_out), self);
@@ -811,8 +812,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(hbox), TRUE, TRUE, 0);
 
   /* gpx */
-  button = gtk_button_new_with_label(_("apply GPX track file..."));
-  gtk_widget_set_tooltip_text(button, _("parses a GPX file and updates location of selected images"));
+  button = dt_ui_button_new(_("apply GPX track file..."),
+                            _("parses a GPX file and updates location of selected images"), NULL);
   gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_lib_geotagging_gpx_callback), self);
 }

--- a/src/libs/geotagging.c
+++ b/src/libs/geotagging.c
@@ -775,13 +775,11 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   GtkBox *hbox;
-  GtkWidget *button, *label;
+  GtkWidget *button;
 
   /* the offset line */
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-  label = GTK_WIDGET(gtk_label_new(_("time offset")));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  gtk_box_pack_start(hbox, label, FALSE, TRUE, 0);
+  gtk_box_pack_start(hbox, dt_ui_label_new(_("time offset")), FALSE, TRUE, 0);
 
   d->offset_entry = gtk_entry_new();
   dt_gui_key_accel_block_on_focus_connect(d->offset_entry);

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -144,9 +144,9 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  d->compress_button = gtk_button_new_with_label(_("compress history stack"));
-  ellipsize_button(d->compress_button);
-  gtk_widget_set_tooltip_text(d->compress_button, _("create a minimal history stack which produces the same image\nctrl-click to truncate history to the selected item"));
+  d->compress_button = dt_ui_button_new(_("compress history stack"),
+                                        _("create a minimal history stack which produces the same image\n"
+                                          "ctrl-click to truncate history to the selected item"), NULL);
   g_signal_connect(G_OBJECT(d->compress_button), "button-press-event", G_CALLBACK(_lib_history_compress_clicked_callback), self);
 
   /* add toolbar button for creating style */
@@ -703,8 +703,8 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
       {
         dt_introspection_field_t *entry = field->Struct.fields[i];
 
-        gchar *description = _(*entry->header.description ? 
-                                entry->header.description : 
+        gchar *description = _(*entry->header.description ?
+                                entry->header.description :
                                 entry->header.field_name);
 
         if(d) description = g_strdup_printf("%s.%s", d, description);
@@ -782,8 +782,8 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
     break;
   case DT_INTROSPECTION_TYPE_FLOATCOMPLEX:
     if(*(float complex*)o != *(float complex*)p)
-      return g_strdup_printf("%s\t%.4f + %.4fi\t\u2192\t%.4f + %.4fi", d, 
-                             creal(*(float complex*)o), cimag(*(float complex*)o), 
+      return g_strdup_printf("%s\t%.4f + %.4fi\t\u2192\t%.4f + %.4fi", d,
+                             creal(*(float complex*)o), cimag(*(float complex*)o),
                              creal(*(float complex*)p), cimag(*(float complex*)p));
     break;
   case DT_INTROSPECTION_TYPE_ENUM:
@@ -797,7 +797,7 @@ static gchar *_lib_history_change_text(dt_introspection_field_t *field, const ch
           old_str = i->description;
           if(!*old_str) old_str = i->name;
         }
-        if(i->value == *(int*)p) 
+        if(i->value == *(int*)p)
         {
           new_str = i->description;
           if(!*new_str) new_str = i->name;
@@ -899,7 +899,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
                               : hitem->blend_params->mask_id == 0
                               ? g_strdup_printf(_("the drawn mask was removed"))
                               : g_strdup_printf(_("the drawn mask was changed"));
-  
+
   dt_iop_gui_blend_data_t *bd = hitem->module->blend_data;
 
   for(int in_out = 1; in_out >= 0; in_out--)
@@ -941,7 +941,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
         change_parts[num_parts++] = g_strdup_printf("%s\t%s| %s- %s| %s%s\t\u2192\t%s| %s- %s| %s%s", _(b->name),
                                                     s[0][0], s[1][0], s[2][0], s[3][0], opol,
                                                     s[0][1], s[1][1], s[2][1], s[3][1], npol);
-      }   
+      }
     }
   }
 
@@ -959,7 +959,7 @@ static gboolean _changes_tooltip_callback(GtkWidget *widget, gint x, gint y, gbo
       gtk_widget_set_name(view, "history-tooltip");
       g_signal_connect(G_OBJECT(view), "destroy", G_CALLBACK(gtk_widget_destroyed), &view);
     }
-     
+
     GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(view));
     gtk_text_buffer_set_text(buffer, tooltip_text, -1);
     gtk_tooltip_set_custom(tooltip, view);
@@ -1058,7 +1058,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
 
     gtk_widget_set_has_tooltip(widget, TRUE);
     g_signal_connect(G_OBJECT(widget), "query-tooltip", G_CALLBACK(_changes_tooltip_callback), (void *)hitem);
-  
+
     gtk_box_pack_start(GTK_BOX(d->history_box), widget, TRUE, TRUE, 0);
     gtk_box_reorder_child(GTK_BOX(d->history_box), widget, 0);
     num++;

--- a/src/libs/image.c
+++ b/src/libs/image.c
@@ -385,129 +385,87 @@ void gui_init(dt_lib_module_t *self)
   dt_lib_image_t *d = (dt_lib_image_t *)malloc(sizeof(dt_lib_image_t));
   self->data = (void *)d;
   self->timeout_handle = 0;
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  self->widget = gtk_notebook_new();
   dt_gui_add_help_link(self->widget, "selected_images.html#selected_images_usage");
 
-  // Init GTK notebook
-  GtkNotebook *notebook = GTK_NOTEBOOK(gtk_notebook_new());
-  GtkWidget *page1 = GTK_WIDGET(gtk_grid_new());
-  d->page1 = page1;
-  GtkWidget *page2 = GTK_WIDGET(gtk_grid_new());
-
-  gtk_notebook_append_page(GTK_NOTEBOOK(notebook), page1, gtk_label_new(_("images")));
-  gtk_notebook_append_page(GTK_NOTEBOOK(notebook), page2, gtk_label_new(_("metadata")));
-  gtk_widget_show_all(GTK_WIDGET(gtk_notebook_get_nth_page(notebook, 0)));
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(notebook), FALSE, FALSE, 0);
-
-  dtgtk_justify_notebook_tabs(notebook);
+  GtkWidget *page1 = dt_ui_notebook_page(GTK_NOTEBOOK(self->widget), _("images"), NULL);
+  GtkWidget *page2 = dt_ui_notebook_page(GTK_NOTEBOOK(self->widget), _("metadata"), NULL);
 
   // images operations
-  GtkGrid *grid = GTK_GRID(page1);
+  d->page1 = gtk_grid_new();
+
+  GtkGrid *grid = GTK_GRID(d->page1);
+  gtk_container_add(GTK_CONTAINER(page1), d->page1);
   gtk_grid_set_column_homogeneous(grid, TRUE);
   int line = 0;
 
-  GtkWidget *button = gtk_button_new_with_label(_("remove"));
-  ellipsize_button(button);
-  d->remove_button = button;
-  gtk_widget_set_tooltip_text(button, _("remove from the collection"));
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(0));
 
-  button = gtk_button_new_with_label(_image_get_delete_button_label());
-  ellipsize_button(button);
-  d->delete_button = button;
-  gtk_widget_set_tooltip_text(button, _image_get_delete_button_tooltip());
-  gtk_grid_attach(grid, button, 2, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(1));
+  d->remove_button = dt_ui_button_new(_("remove"), _("remove from the collection"), NULL);
+  gtk_grid_attach(grid, d->remove_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->remove_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(0));
 
-  button = gtk_button_new_with_label(_("move..."));
-  ellipsize_button(button);
-  d->move_button = button;
-  gtk_widget_set_tooltip_text(button, _("move to other folder"));
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(8));
+  d->delete_button = dt_ui_button_new(_image_get_delete_button_label(), _image_get_delete_button_tooltip(), NULL);
+  gtk_grid_attach(grid, d->delete_button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->delete_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(1));
 
-  button = gtk_button_new_with_label(_("copy..."));
-  ellipsize_button(button);
-  d->copy_button = button;
-  gtk_widget_set_tooltip_text(button, _("copy to other folder"));
-  gtk_grid_attach(grid, button, 2, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(9));
+  d->move_button = dt_ui_button_new(_("move..."), _("move to other folder"), NULL);
+  gtk_grid_attach(grid, d->move_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->move_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(8));
 
-  button = gtk_button_new_with_label(_("create HDR"));
-  ellipsize_button(button);
-  d->create_hdr_button = button;
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(7));
-  gtk_widget_set_tooltip_text(button, _("create a high dynamic range image from selected shots"));
+  d->copy_button = dt_ui_button_new(_("copy..."), _("copy to other folder"), NULL);
+  gtk_grid_attach(grid, d->copy_button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->copy_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(9));
 
-  button = gtk_button_new_with_label(_("duplicate"));
-  ellipsize_button(button);
-  d->duplicate_button = button;
-  gtk_widget_set_tooltip_text(button, _("add a duplicate to the collection, including its history stack"));
-  gtk_grid_attach(grid, button, 2, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(3));
+  d->create_hdr_button = dt_ui_button_new(_("create HDR"), _("create a high dynamic range image from selected shots"), NULL);
+  gtk_grid_attach(grid, d->create_hdr_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->create_hdr_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(7));
 
+  d->duplicate_button = dt_ui_button_new(_("duplicate"), _("add a duplicate to the collection, including its history stack"), NULL);
+  gtk_grid_attach(grid, d->duplicate_button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->duplicate_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(3));
 
-  button = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_NONE, NULL);
-  d->rotate_ccw_button = button;
-  gtk_widget_set_name(button, "non-flat");
-  gtk_widget_set_tooltip_text(button, _("rotate selected images 90 degrees CCW"));
-  gtk_grid_attach(grid, button, 0, line, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(4));
+  d->rotate_ccw_button = dtgtk_button_new(dtgtk_cairo_paint_refresh, CPF_NONE, NULL);;
+  gtk_widget_set_name(d->rotate_ccw_button, "non-flat");
+  gtk_widget_set_tooltip_text(d->rotate_ccw_button, _("rotate selected images 90 degrees CCW"));
+  gtk_grid_attach(grid, d->rotate_ccw_button, 0, line, 1, 1);
+  g_signal_connect(G_OBJECT(d->rotate_ccw_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(4));
 
-  button = dtgtk_button_new(dtgtk_cairo_paint_refresh, 1 | CPF_NONE, NULL);
-  d->rotate_cw_button = button;
-  gtk_widget_set_name(button, "non-flat");
-  gtk_widget_set_tooltip_text(button, _("rotate selected images 90 degrees CW"));
-  gtk_grid_attach(grid, button, 1, line, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(5));
+  d->rotate_cw_button = dtgtk_button_new(dtgtk_cairo_paint_refresh, 1 | CPF_NONE, NULL);
+  gtk_widget_set_name(d->rotate_cw_button, "non-flat");
+  gtk_widget_set_tooltip_text(d->rotate_cw_button, _("rotate selected images 90 degrees CW"));
+  gtk_grid_attach(grid, d->rotate_cw_button, 1, line, 1, 1);
+  g_signal_connect(G_OBJECT(d->rotate_cw_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(5));
 
-  button = gtk_button_new_with_label(_("reset rotation"));
-  ellipsize_button(button);
-  d->reset_button = button;
-  gtk_widget_set_tooltip_text(button, _("reset rotation to EXIF data"));
-  gtk_grid_attach(grid, button, 2, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(6));
+  d->reset_button = dt_ui_button_new(_("reset rotation"), _("reset rotation to EXIF data"), NULL);
+  gtk_grid_attach(grid, d->reset_button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->reset_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(6));
 
+  d->cache_button = dt_ui_button_new(_("copy locally"), _("copy the image locally"), NULL);
+  gtk_grid_attach(grid, d->cache_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->cache_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(12));
 
-  button = gtk_button_new_with_label(_("copy locally"));
-  ellipsize_button(button);
-  d->cache_button = button;
-  gtk_widget_set_tooltip_text(button, _("copy the image locally"));
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(12));
+  d->uncache_button = dt_ui_button_new(_("resync local copy"), _("synchronize the image's XMP and remove the local copy"), NULL);
+  gtk_grid_attach(grid, d->uncache_button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->uncache_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(13));
 
-  button = gtk_button_new_with_label(_("resync local copy"));
-  ellipsize_button(button);
-  d->uncache_button = button;
-  gtk_widget_set_tooltip_text(button, _("synchronize the image's XMP and remove the local copy"));
-  gtk_grid_attach(grid, button, 2, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(13));
+  d->group_button = dt_ui_button_new(_("group"), _("add selected images to expanded group or create a new one"), NULL);
+  gtk_grid_attach(grid, d->group_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->group_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(10));
 
-
-  button = gtk_button_new_with_label(_("group"));
-  ellipsize_button(button);
-  d->group_button = button;
-  gtk_widget_set_tooltip_text(button, _("add selected images to expanded group or create a new one"));
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(10));
-
-  button = gtk_button_new_with_label(_("ungroup"));
-  ellipsize_button(button);
-  d->ungroup_button = button;
-  gtk_widget_set_tooltip_text(button, _("remove selected images from the group"));
-  gtk_grid_attach(grid, button, 2, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(11));
+  d->ungroup_button = dt_ui_button_new(_("ungroup"), _("remove selected images from the group"), NULL);
+  gtk_grid_attach(grid, d->ungroup_button, 2, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->ungroup_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(11));
 
   // metadata operations
-  grid = GTK_GRID(page2);
+  grid = GTK_GRID(gtk_grid_new());
+  gtk_container_add(GTK_CONTAINER(page2), GTK_WIDGET(grid));
   gtk_grid_set_column_homogeneous(grid, TRUE);
   line = 0;
 
   GtkWidget *flag = gtk_check_button_new_with_label(_("ratings"));
   d->ratings_flag = flag;
   gtk_widget_set_tooltip_text(flag, _("select ratings metadata"));
+  ellipsize_button(flag);
   gtk_grid_attach(grid, flag, 0, line, 3, 1);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/rating"));
   g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(ratings_flag_callback), self);
@@ -515,6 +473,7 @@ void gui_init(dt_lib_module_t *self)
   flag = gtk_check_button_new_with_label(_("colors"));
   d->colors_flag = flag;
   gtk_widget_set_tooltip_text(flag, _("select colors metadata"));
+  ellipsize_button(flag);
   gtk_grid_attach(grid, flag, 3, line++, 3, 1);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/colors"));
   g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(colors_flag_callback), self);
@@ -522,6 +481,7 @@ void gui_init(dt_lib_module_t *self)
   flag = gtk_check_button_new_with_label(_("tags"));
   d->tags_flag = flag;
   gtk_widget_set_tooltip_text(flag, _("select tags metadata"));
+  ellipsize_button(flag);
   gtk_grid_attach(grid, flag, 0, line, 3, 1);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/tags"));
   g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(tags_flag_callback), self);
@@ -529,6 +489,7 @@ void gui_init(dt_lib_module_t *self)
   flag = gtk_check_button_new_with_label(_("geo tags"));
   d->geotags_flag = flag;
   gtk_widget_set_tooltip_text(flag, _("select geo tags metadata"));
+  ellipsize_button(flag);
   gtk_grid_attach(grid, flag, 3, line++, 3, 1);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/geotags"));
   g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(geotags_flag_callback), self);
@@ -536,31 +497,23 @@ void gui_init(dt_lib_module_t *self)
   flag = gtk_check_button_new_with_label(_("metadata"));
   d->metadata_flag = flag;
   gtk_widget_set_tooltip_text(flag, _("select dt metadata (from metadata editor module)"));
+  ellipsize_button(flag);
   gtk_grid_attach(grid, flag, 0, line++, 3, 1);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(flag), dt_conf_get_bool("plugins/lighttable/copy_metadata/metadata"));
   g_signal_connect(G_OBJECT(flag), "clicked", G_CALLBACK(metadata_flag_callback), self);
 
-  button = gtk_button_new_with_label(_("copy"));
-  ellipsize_button(button);
-  d->copy_metadata_button = button;
+  d->copy_metadata_button = dt_ui_button_new(_("copy"), _("set the (first) selected image as source of metadata"), NULL);
   d->imageid = 0;
-  gtk_widget_set_tooltip_text(button, _("set the (first) selected image as source of metadata"));
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(copy_metadata_callback), self);
+  gtk_grid_attach(grid, d->copy_metadata_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->copy_metadata_button), "clicked", G_CALLBACK(copy_metadata_callback), self);
 
-  button = gtk_button_new_with_label(_("paste"));
-  ellipsize_button(button);
-  d->paste_metadata_button = button;
-  gtk_widget_set_tooltip_text(button, _("paste selected metadata on selected images"));
-  gtk_grid_attach(grid, button, 2, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(paste_metadata_callback), self);
+  d->paste_metadata_button = dt_ui_button_new(_("paste"), _("paste selected metadata on selected images"), NULL);
+  gtk_grid_attach(grid, d->paste_metadata_button, 2, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->paste_metadata_button), "clicked", G_CALLBACK(paste_metadata_callback), self);
 
-  button = gtk_button_new_with_label(_("clear"));
-  ellipsize_button(button);
-  d->clear_metadata_button = button;
-  gtk_widget_set_tooltip_text(button, _("clear selected metadata on selected images"));
-  gtk_grid_attach(grid, button, 4, line++, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(clear_metadata_callback), self);
+  d->clear_metadata_button = dt_ui_button_new(_("clear"), _("clear selected metadata on selected images"), NULL);
+  gtk_grid_attach(grid, d->clear_metadata_button, 4, line++, 2, 1);
+  g_signal_connect(G_OBJECT(d->clear_metadata_button), "clicked", G_CALLBACK(clear_metadata_callback), self);
 
   GtkWidget *pastemode = dt_bauhaus_combobox_new(NULL);
   dt_bauhaus_widget_set_label(pastemode, NULL, _("mode"));
@@ -571,12 +524,9 @@ void gui_init(dt_lib_module_t *self)
   dt_bauhaus_combobox_set(pastemode, dt_conf_get_int("plugins/lighttable/copy_metadata/pastemode"));
   g_signal_connect(G_OBJECT(pastemode), "value-changed", G_CALLBACK(pastemode_combobox_changed), self);
 
-  button = gtk_button_new_with_label(_("refresh exif"));
-  ellipsize_button(button);
-  d->refresh_button = button;
-  gtk_widget_set_tooltip_text(button, _("update image information to match changes to file"));
-  gtk_grid_attach(grid, button, 0, line++, 6, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(14));
+  d->refresh_button = dt_ui_button_new(_("refresh exif"), _("update image information to match changes to file"), NULL);
+  gtk_grid_attach(grid, d->refresh_button, 0, line++, 6, 1);
+  g_signal_connect(G_OBJECT(d->refresh_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(14));
 
   /* connect preference changed signal */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(

--- a/src/libs/import.c
+++ b/src/libs/import.c
@@ -773,22 +773,16 @@ void gui_init(dt_lib_module_t *self)
 
   GtkWidget *hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
   /* add import single image buttons */
-  GtkWidget *widget = gtk_button_new_with_label(_("image..."));
-  dt_gui_add_help_link(widget, "lighttable_panels.html#import_from_fs");
+  GtkWidget *widget = dt_ui_button_new(_("image..."), _("select one or more images to import"), "lighttable_panels.html#import_from_fs");
   d->import_file = GTK_BUTTON(widget);
-  gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(widget)), GTK_ALIGN_CENTER);
-  gtk_widget_set_tooltip_text(widget, _("select one or more images to import"));
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
   g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_import_single_image_callback), d);
 
   /* adding the import folder button */
-  widget = gtk_button_new_with_label(_("folder..."));
-  dt_gui_add_help_link(widget, "lighttable_panels.html#import_from_fs");
+  widget = dt_ui_button_new(_("folder..."), _("select a folder to import as film roll"), "lighttable_panels.html#import_from_fs");
   d->import_directory = GTK_BUTTON(widget);
-  gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(widget)), GTK_ALIGN_CENTER);
-  gtk_widget_set_tooltip_text(widget, _("select a folder to import as film roll"));
   gtk_widget_set_can_focus(widget, TRUE);
   gtk_widget_set_receives_default(widget, TRUE);
   gtk_box_pack_start(GTK_BOX(hbox), widget, TRUE, TRUE, 0);
@@ -797,13 +791,10 @@ void gui_init(dt_lib_module_t *self)
 
 #ifdef HAVE_GPHOTO2
   /* add the rescan button */
-  GtkButton *scan = GTK_BUTTON(gtk_button_new_with_label(_("scan for devices")));
-  dt_gui_add_help_link(GTK_WIDGET(scan), "lighttable_panels.html#import_from_camera");
-  d->scan_devices = scan;
-  gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(scan)), GTK_ALIGN_CENTER);
-  gtk_widget_set_tooltip_text(GTK_WIDGET(scan), _("scan for newly attached devices"));
-  g_signal_connect(G_OBJECT(scan), "clicked", G_CALLBACK(_lib_import_scan_devices_callback), self);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(scan), TRUE, TRUE, 0);
+  widget = dt_ui_button_new(_("scan for devices"), _("scan for newly attached devices"), "lighttable_panels.html#import_from_camera");
+  d->scan_devices = GTK_BUTTON(widget);
+  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(_lib_import_scan_devices_callback), self);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(widget), TRUE, TRUE, 0);
 
   /* add devices container for cameras */
   d->devices = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 0));

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -566,7 +566,6 @@ static int _lib_default_expandable(dt_lib_module_t *self)
 static int dt_lib_load_module(void *m, const char *libname, const char *plugin_name)
 {
   dt_lib_module_t *module = (dt_lib_module_t *)m;
-  module->dt = &darktable;
   module->widget = NULL;
   module->expander = NULL;
   g_strlcpy(module->plugin_name, plugin_name, sizeof(module->plugin_name));

--- a/src/libs/lib.h
+++ b/src/libs/lib.h
@@ -85,8 +85,6 @@ typedef struct dt_lib_module_t
 
   /** opened module. */
   GModule *module;
-  /** reference for dlopened libs. */
-  darktable_t *dt;
   /** other stuff that may be needed by the module, not only in gui mode. */
   void *data;
   /** string identifying this operation. */

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -712,32 +712,23 @@ void gui_init(dt_lib_module_t *self)
 
   // clear/apply buttons
 
-  grid = (GtkGrid *)gtk_grid_new();
-  gtk_grid_set_column_homogeneous(grid, FALSE);
+  GtkBox *hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  GtkWidget *button = gtk_button_new_with_label(_("clear"));
-  d->clear_button = button;
-  gtk_widget_set_tooltip_text(button, _("remove metadata from selected images"));
-  gtk_grid_attach(grid, button, 0, 0, 1, 1);
-  gtk_widget_set_hexpand(button, TRUE);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_clear_button_clicked), self);
+  d->clear_button = dt_ui_button_new(_("clear"), _("remove metadata from selected images"), NULL);
+  gtk_box_pack_start(hbox, d->clear_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->clear_button), "clicked", G_CALLBACK(_clear_button_clicked), self);
 
-  button = gtk_button_new_with_label(_("apply"));
-  d->apply_button = button;
-  gtk_widget_set_tooltip_text(button, _("write metadata for selected images"));
-  gtk_grid_attach(grid, button, 1, 0, 1, 1);
-  gtk_widget_set_hexpand(button, TRUE);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_apply_button_clicked), self);
+  d->apply_button = dt_ui_button_new(_("apply"), _("write metadata for selected images"), NULL);
+  gtk_box_pack_start(hbox, d->apply_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->apply_button), "clicked", G_CALLBACK(_apply_button_clicked), self);
 
-  button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_BOX, NULL);
-  d->config_button = button;
-  gtk_widget_set_name(button, "non-flat");
-  gtk_widget_set_tooltip_text(button, _("configure metadata"));
-  gtk_grid_attach(grid, button, 2, 0, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_config_button_clicked), self);
+  d->config_button = dtgtk_button_new(dtgtk_cairo_paint_preferences, CPF_STYLE_BOX, NULL);
+  gtk_widget_set_name(d->config_button, "non-flat");
+  gtk_widget_set_tooltip_text(d->config_button, _("configure metadata"));
+  gtk_box_pack_start(hbox, d->config_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->config_button), "clicked", G_CALLBACK(_config_button_clicked), self);
 
-  gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(grid), 0, 1, 1, 1);
-  gtk_widget_set_hexpand(GTK_WIDGET(grid), TRUE);
+  gtk_grid_attach(GTK_GRID(self->widget), GTK_WIDGET(hbox), 0, 1, 1, 1);
 
   /* lets signup for mouse over image change signals */
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_MOUSE_OVER_IMAGE_CHANGE,

--- a/src/libs/metadata.c
+++ b/src/libs/metadata.c
@@ -664,8 +664,7 @@ void gui_init(dt_lib_module_t *self)
 
   for(int i = 0; i < DT_METADATA_NUMBER; i++)
   {
-    GtkWidget *label = gtk_label_new(_(dt_metadata_get_name_by_display_order(i)));
-    gtk_widget_set_halign(label, GTK_ALIGN_START);
+    GtkWidget *label = dt_ui_label_new(_(dt_metadata_get_name_by_display_order(i)));
     gtk_grid_attach(grid, label, 0, i, 1, 1);
     gtk_widget_set_tooltip_text(GTK_WIDGET(label),
               _("metadata text. ctrl-wheel scroll to resize the text box"

--- a/src/libs/select.c
+++ b/src/libs/select.c
@@ -113,7 +113,6 @@ int position()
   return 800;
 }
 
-#define ellipsize_button(button) gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
 void gui_init(dt_lib_module_t *self)
 {
   dt_lib_select_t *d = (dt_lib_select_t *)malloc(sizeof(dt_lib_select_t));
@@ -124,44 +123,26 @@ void gui_init(dt_lib_module_t *self)
   GtkGrid *grid = GTK_GRID(self->widget);
   gtk_grid_set_column_homogeneous(grid, TRUE);
   int line = 0;
-  GtkWidget *button;
 
-  button = gtk_button_new_with_label(_("select all"));
-  ellipsize_button(button);
-  d->select_all_button = button;
-  gtk_widget_set_tooltip_text(button, _("select all images in current collection"));
-  gtk_grid_attach(grid, button, 0, line, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(0));
+  d->select_all_button = dt_ui_button_new(_("select all"), _("select all images in current collection"), NULL);
+  gtk_grid_attach(grid, d->select_all_button, 0, line, 1, 1);
+  g_signal_connect(G_OBJECT(d->select_all_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(0));
 
-  button = gtk_button_new_with_label(_("select none"));
-  ellipsize_button(button);
-  d->select_none_button = button;
-  gtk_widget_set_tooltip_text(button, _("clear selection"));
-  gtk_grid_attach(grid, button, 1, line++, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(1));
+  d->select_none_button = dt_ui_button_new(_("select none"), _("clear selection"), NULL);
+  gtk_grid_attach(grid, d->select_none_button, 1, line++, 1, 1);
+  g_signal_connect(G_OBJECT(d->select_none_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(1));
 
+  d->select_invert_button = dt_ui_button_new(_("invert selection"), _("select unselected images\nin current collection"), NULL);
+  gtk_grid_attach(grid, d->select_invert_button, 0, line, 1, 1);
+  g_signal_connect(G_OBJECT(d->select_invert_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(2));
 
-  button = gtk_button_new_with_label(_("invert selection"));
-  ellipsize_button(button);
-  gtk_widget_set_tooltip_text(button, _("select unselected images\nin current collection"));
-  d->select_invert_button = button;
-  gtk_grid_attach(grid, button, 0, line, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(2));
+  d->select_film_roll_button = dt_ui_button_new(_("select film roll"), _("select all images which are in the same\nfilm roll as the selected images"), NULL);
+  gtk_grid_attach(grid, d->select_film_roll_button, 1, line++, 1, 1);
+  g_signal_connect(G_OBJECT(d->select_film_roll_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(3));
 
-  button = gtk_button_new_with_label(_("select film roll"));
-  ellipsize_button(button);
-  d->select_film_roll_button = button;
-  gtk_widget_set_tooltip_text(button, _("select all images which are in the same\nfilm roll as the selected images"));
-  gtk_grid_attach(grid, button, 1, line++, 1, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(3));
-
-
-  button = gtk_button_new_with_label(_("select untouched"));
-  ellipsize_button(button);
-  d->select_untouched_button = button;
-  gtk_widget_set_tooltip_text(button, _("select untouched images in\ncurrent collection"));
-  gtk_grid_attach(grid, button, 0, line, 2, 1);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(4));
+  d->select_untouched_button = dt_ui_button_new(_("select untouched"), _("select untouched images in\ncurrent collection"), NULL);
+  gtk_grid_attach(grid, d->select_untouched_button, 0, line, 2, 1);
+  g_signal_connect(G_OBJECT(d->select_untouched_button), "clicked", G_CALLBACK(button_clicked), GINT_TO_POINTER(4));
 
   DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_SELECTION_CHANGED,
                             G_CALLBACK(_image_selection_changed_callback), self);
@@ -170,7 +151,6 @@ void gui_init(dt_lib_module_t *self)
 
   _update(self);
 }
-#undef ellipsize_button
 
 void gui_cleanup(dt_lib_module_t *self)
 {

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -379,13 +379,10 @@ void gui_init(dt_lib_module_t *self)
   d->snapshots_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   /* create take snapshot button */
-  GtkWidget *button = gtk_button_new_with_label(_("take snapshot"));
-  d->take_button = button;
-  g_signal_connect(G_OBJECT(button), "clicked",
+  d->take_button = dt_ui_button_new(_("take snapshot"), _("take snapshot to compare with another image "
+                                      "or the same image at another stage of development"), "snapshots.html#snapshots");
+  g_signal_connect(G_OBJECT(d->take_button), "clicked",
                    G_CALLBACK(_lib_snapshots_add_button_clicked_callback), self);
-  gtk_widget_set_tooltip_text(button, _("take snapshot to compare with another image "
-                                        "or the same image at another stage of development"));
-  dt_gui_add_help_link(button, "snapshots.html#snapshots");
 
   /*
    * initialize snapshots
@@ -418,7 +415,7 @@ void gui_init(dt_lib_module_t *self)
 
   /* add snapshot box and take snapshot button to widget ui*/
   gtk_box_pack_start(GTK_BOX(self->widget), d->snapshots_box, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), button, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), d->take_button, TRUE, TRUE, 0);
 }
 
 void gui_cleanup(dt_lib_module_t *self)

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -538,6 +538,7 @@ void gui_init(dt_lib_module_t *self)
   w = gtk_entry_new();
   d->entry = GTK_ENTRY(w);
   gtk_widget_set_tooltip_text(w, _("filter style names"));
+  gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
   g_signal_connect(d->entry, "changed", G_CALLBACK(entry_callback), d);
   g_signal_connect(d->entry, "activate", G_CALLBACK(entry_activated), d);
 
@@ -548,11 +549,12 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scrolled), DT_PIXEL_APPLY_DPI(250));
 
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->entry), TRUE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->entry), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(scrolled), TRUE, FALSE, 0);
   gtk_container_add(GTK_CONTAINER(scrolled), GTK_WIDGET(d->tree));
 
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->duplicate))), PANGO_ELLIPSIZE_START);
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->duplicate), TRUE, FALSE, 0);
   g_signal_connect(d->duplicate, "toggled", G_CALLBACK(duplicate_callback), d);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->duplicate),
@@ -575,46 +577,34 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(self->widget), hbox3, TRUE, FALSE, 0);
 
   // create
-  GtkWidget *widget = gtk_button_new_with_label(_("create..."));
-  d->create_button = widget;
-  g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(create_clicked), d);
-  gtk_widget_set_tooltip_text(widget, _("create styles from history stack of selected images"));
-  gtk_box_pack_start(GTK_BOX(hbox1), widget, TRUE, TRUE, 0);
+  d->create_button = dt_ui_button_new(_("create..."), _("create styles from history stack of selected images"), NULL);
+  g_signal_connect(G_OBJECT(d->create_button), "clicked", G_CALLBACK(create_clicked), d);
+  gtk_box_pack_start(GTK_BOX(hbox1), d->create_button, TRUE, TRUE, 0);
 
   // edit
-  widget = gtk_button_new_with_label(_("edit..."));
-  d->edit_button = widget;
-  g_signal_connect(widget, "clicked", G_CALLBACK(edit_clicked), d);
-  gtk_widget_set_tooltip_text(widget, _("edit the selected styles in list above"));
-  gtk_box_pack_start(GTK_BOX(hbox1), widget, TRUE, TRUE, 0);
+  d->edit_button = dt_ui_button_new(_("edit..."), _("edit the selected styles in list above"), NULL);
+  g_signal_connect(d->edit_button, "clicked", G_CALLBACK(edit_clicked), d);
+  gtk_box_pack_start(GTK_BOX(hbox1), d->edit_button, TRUE, TRUE, 0);
 
   // delete
-  widget = gtk_button_new_with_label(_("remove"));
-  d->delete_button = widget;
-  g_signal_connect(widget, "clicked", G_CALLBACK(delete_clicked), d);
-  gtk_widget_set_tooltip_text(widget, _("removes the selected styles in list above"));
-  gtk_box_pack_start(GTK_BOX(hbox1), widget, TRUE, TRUE, 0);
+  d->delete_button = dt_ui_button_new(_("remove"), _("removes the selected styles in list above"), NULL);
+  g_signal_connect(d->delete_button, "clicked", G_CALLBACK(delete_clicked), d);
+  gtk_box_pack_start(GTK_BOX(hbox1), d->delete_button, TRUE, TRUE, 0);
 
   // import button
-  GtkWidget *importButton = gtk_button_new_with_label(C_("verb", "import..."));
-  d->import_button = importButton;
-  gtk_widget_set_tooltip_text(importButton, _("import styles from a style files"));
-  g_signal_connect(importButton, "clicked", G_CALLBACK(import_clicked), d);
-  gtk_box_pack_start(GTK_BOX(hbox2), importButton, TRUE, TRUE, 0);
+  d->import_button = dt_ui_button_new(C_("verb", "import..."), _("import styles from a style files"), NULL);
+  g_signal_connect(d->import_button, "clicked", G_CALLBACK(import_clicked), d);
+  gtk_box_pack_start(GTK_BOX(hbox2), d->import_button, TRUE, TRUE, 0);
 
   // export button
-  GtkWidget *exportButton = gtk_button_new_with_label(_("export..."));
-  d->export_button = exportButton;
-  gtk_widget_set_tooltip_text(exportButton, _("export the selected styles into a style files"));
-  g_signal_connect(exportButton, "clicked", G_CALLBACK(export_clicked), d);
-  gtk_box_pack_start(GTK_BOX(hbox2), exportButton, TRUE, TRUE, 0);
+  d->export_button = dt_ui_button_new(_("export..."), _("export the selected styles into a style files"), NULL);
+  g_signal_connect(d->export_button, "clicked", G_CALLBACK(export_clicked), d);
+  gtk_box_pack_start(GTK_BOX(hbox2), d->export_button, TRUE, TRUE, 0);
 
   // apply button
-  widget = gtk_button_new_with_label(_("apply"));
-  d->apply_button = widget;
-  g_signal_connect(widget, "clicked", G_CALLBACK(apply_clicked), d);
-  gtk_widget_set_tooltip_text(widget, _("apply the selected styles in list above to selected images"));
-  gtk_box_pack_start(GTK_BOX(hbox3), widget, TRUE, TRUE, 0);
+  d->apply_button = dt_ui_button_new(_("apply"), _("apply the selected styles in list above to selected images"), NULL);
+  g_signal_connect(d->apply_button, "clicked", G_CALLBACK(apply_clicked), d);
+  gtk_box_pack_start(GTK_BOX(hbox3), d->apply_button, TRUE, TRUE, 0);
 
   // add entry completion
   GtkEntryCompletion *completion = gtk_entry_completion_new();

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -2653,21 +2653,13 @@ void gui_init(dt_lib_module_t *self)
   // attach/detach buttons
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  button = gtk_button_new_with_label(_("attach"));
-  d->attach_button = button;
-  gtk_widget_set_hexpand(button, TRUE);
-  gtk_widget_set_tooltip_text(button, _("attach tag to all selected images"));
-  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_attach_button_clicked), (gpointer)self);
+  d->attach_button = dt_ui_button_new(_("attach"), _("attach tag to all selected images"), "tagging.html#tagging_usage");
+  gtk_box_pack_start(hbox, d->attach_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->attach_button), "clicked", G_CALLBACK(_attach_button_clicked), (gpointer)self);
 
-  button = gtk_button_new_with_label(_("detach"));
-  d->detach_button = button;
-  gtk_widget_set_hexpand(button, TRUE);
-  gtk_widget_set_tooltip_text(button, _("detach tag from all selected images"));
-  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_detach_button_clicked), (gpointer)self);
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
+  d->detach_button = dt_ui_button_new(_("detach"), _("detach tag from all selected images"), "tagging.html#tagging_usage");
+  g_signal_connect(G_OBJECT(d->detach_button), "clicked", G_CALLBACK(_detach_button_clicked), (gpointer)self);
+  gtk_box_pack_start(hbox, d->detach_button, TRUE, TRUE, 0);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_minus_simple, CPF_STYLE_FLAT, NULL);
   d->toggle_hide_button = button;
@@ -2705,6 +2697,7 @@ void gui_init(dt_lib_module_t *self)
   // text entry
   w = gtk_entry_new();
   gtk_entry_set_text(GTK_ENTRY(w), "");
+  gtk_entry_set_width_chars(GTK_ENTRY(w), 0);
   gtk_widget_set_tooltip_text(w, _("enter tag name"));
   dt_gui_add_help_link(w, "tagging.html#tagging_usage");
   gtk_box_pack_start(hbox, w, TRUE, TRUE, 0);
@@ -2783,29 +2776,17 @@ void gui_init(dt_lib_module_t *self)
   // buttons
   hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 
-  button = gtk_button_new_with_label(_("new"));
-  d->new_button = button;
-  gtk_widget_set_hexpand(button, TRUE);
-  gtk_widget_set_tooltip_text(button, _("create a new tag with the\nname you entered"));
-  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_new_button_clicked), (gpointer)self);
+  d->new_button = dt_ui_button_new(_("new"), _("create a new tag with the\nname you entered"), "tagging.html#tagging_usage");
+  gtk_box_pack_start(hbox, d->new_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->new_button), "clicked", G_CALLBACK(_new_button_clicked), (gpointer)self);
 
-  button = gtk_button_new_with_label(C_("verb", "import..."));
-  d->import_button = button;
-  gtk_widget_set_hexpand(button, TRUE);
-  gtk_widget_set_tooltip_text(button, _("import tags from a Lightroom keyword file"));
-  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_import_button_clicked), (gpointer)self);
+  d->import_button = dt_ui_button_new(C_("verb", "import..."), _("import tags from a Lightroom keyword file"), "tagging.html#tagging_usage");
+  gtk_box_pack_start(hbox, d->import_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->import_button), "clicked", G_CALLBACK(_import_button_clicked), (gpointer)self);
 
-  button = gtk_button_new_with_label(C_("verb", "export..."));
-  d->export_button = button;
-  gtk_widget_set_hexpand(button, TRUE);
-  gtk_widget_set_tooltip_text(button, _("export all tags to a Lightroom keyword file"));
-  dt_gui_add_help_link(button, "tagging.html#tagging_usage");
-  gtk_box_pack_start(hbox, button, FALSE, TRUE, 0);
-  g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(_export_button_clicked), (gpointer)self);
+  d->export_button = dt_ui_button_new(C_("verb", "export..."), _("export all tags to a Lightroom keyword file"), "tagging.html#tagging_usage");
+  gtk_box_pack_start(hbox, d->export_button, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(d->export_button), "clicked", G_CALLBACK(_export_button_clicked), (gpointer)self);
 
   button = dtgtk_togglebutton_new(dtgtk_cairo_paint_treelist, CPF_STYLE_FLAT, NULL);
   d->toggle_tree_button = button;

--- a/src/lua/lualib.c
+++ b/src/lua/lualib.c
@@ -164,7 +164,6 @@ static void view_leave_wrapper(struct dt_lib_module_t *self,struct dt_view_t *ol
 
 static dt_lib_module_t ref_lib = {
   .module = NULL,
-  .dt = &darktable,
   .data = NULL,
   .plugin_name ={ 0 },
   .widget = NULL,


### PR DESCRIPTION
Another set of patches to clean up copied around code, mostly in the iop gui sections.

The main aim of this set of commits (there are some extraneous fixes and cleanups as well) was to implement a clean set of responsibilities for the module init(), gui_init(), reload_params() and gui_update() methods. The pattern that could often be seen is that similar/identical code is copied into several of these methods, "just to make sure it works", rather than just to the one that should be correctly used for it. Partly this is due to implementation quirks. Once this is merged, I'm aiming to resolve the remaining issue that reload_params sometimes gets called when the gui is not fully initialised yet. And partly it is probably due to progressive "fixes" being implemented due to code working in one situation (for example switching into darkroom), but not another (changing images) . Due to this confusion, testing can also be complicated. I'm currently updating useless.c to provide a more narrative introduction to how this framework is intended to be used.

I recommend reviewing (if not testing) these commits separately, because I've tried to keep each dedicated mostly to one type of change. They should all apply cleanly as well, which will help bisecting if necessary. I'd rather not submit them as separate PRs because that just means I can't make any assumptions about dependencies between them and it'd be an ongoing rebasing nightmare.

One separate "feature" is the restructuring of rawprepare_params_t so that it now shows up cleaner in the history changes popup that was merged recently. This required supporting ushort in slider_from_params.

The button and label refactoring enforce consistent ellipsizing, which helps narrow panels in lighttable. Some other small fixes here and there round off that work.