### PR TITLE
over-exposure warning : add meaningfull modes

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1691,7 +1691,7 @@
   <dtconfig>
     <name>darkroom/ui/overexposed/lower</name>
     <type>float</type>
-    <default>2.0</default>
+    <default>-12.69</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1698,7 +1698,7 @@
   <dtconfig>
     <name>darkroom/ui/overexposed/upper</name>
     <type>float</type>
-    <default>98.0</default>
+    <default>99.99</default>
     <shortdescription/>
     <longdescription/>
   </dtconfig>

--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -117,6 +117,7 @@ void dt_dev_init(dt_develop_t *dev, int32_t gui_attached)
   dev->rawoverexposed.threshold = dt_conf_get_float("darkroom/ui/rawoverexposed/threshold");
 
   dev->overexposed.enabled = FALSE;
+  dev->overexposed.mode = dt_conf_get_int("darkroom/ui/overexposed/mode");
   dev->overexposed.colorscheme = dt_conf_get_int("darkroom/ui/overexposed/colorscheme");
   dev->overexposed.lower = dt_conf_get_float("darkroom/ui/overexposed/lower");
   dev->overexposed.upper = dt_conf_get_float("darkroom/ui/overexposed/upper");
@@ -192,6 +193,7 @@ void dt_dev_cleanup(dt_develop_t *dev)
   dt_conf_set_int("darkroom/ui/rawoverexposed/colorscheme", dev->rawoverexposed.colorscheme);
   dt_conf_set_float("darkroom/ui/rawoverexposed/threshold", dev->rawoverexposed.threshold);
 
+  dt_conf_set_int("darkroom/ui/overexposed/mode", dev->overexposed.mode);
   dt_conf_set_int("darkroom/ui/overexposed/colorscheme", dev->overexposed.colorscheme);
   dt_conf_set_float("darkroom/ui/overexposed/lower", dev->overexposed.lower);
   dt_conf_set_float("darkroom/ui/overexposed/upper", dev->overexposed.upper);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -115,6 +115,15 @@ typedef enum dt_dev_pixelpipe_display_mask_t
   DT_DEV_PIXELPIPE_DISPLAY_STICKY = 1 << 16
 } dt_dev_pixelpipe_display_mask_t;
 
+
+typedef enum dt_clipping_preview_mode_t
+{
+  DT_CLIPPING_PREVIEW_GAMUT = 0,
+  DT_CLIPPING_PREVIEW_ANYRGB = 1,
+  DT_CLIPPING_PREVIEW_LUMINANCE = 2,
+  DT_CLIPPING_PREVIEW_SATURATION = 3
+} dt_clipping_preview_mode_t;
+
 typedef struct dt_dev_proxy_exposure_t
 {
   struct dt_iop_module_t *module;
@@ -258,6 +267,7 @@ typedef struct dt_develop_t
     dt_dev_overexposed_colorscheme_t colorscheme;
     float lower;
     float upper;
+    dt_clipping_preview_mode_t mode;
   } overexposed;
 
   // for the raw overexposure indicator

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -42,7 +42,7 @@ typedef enum dt_iop_overexposed_colorscheme_t
   DT_IOP_OVEREXPOSED_PURPLEGREEN = 2
 } dt_iop_overexposed_colorscheme_t;
 
-static const float dt_iop_overexposed_colors[][2][4]
+static const float DT_ALIGNED_ARRAY dt_iop_overexposed_colors[][2][4]
     = { {
           { 0.0f, 0.0f, 0.0f, 1.0f }, // black
           { 1.0f, 1.0f, 1.0f, 1.0f }  // white
@@ -148,7 +148,7 @@ static void _transform_image_colorspace(dt_iop_module_t *self, const float *cons
       = dt_ioppr_add_profile_info_to_list(self->dev, darktable.color_profiles->display_type,
                                           darktable.color_profiles->display_filename, INTENT_PERCEPTUAL);
   const dt_iop_order_iccprofile_info_t *const profile_info_to
-      = dt_ioppr_add_profile_info_to_list(self->dev, histogram_type, histogram_filename, INTENT_PERCEPTUAL);
+      = dt_ioppr_add_profile_info_to_list(self->dev, histogram_type, histogram_filename, INTENT_RELATIVE_COLORIMETRIC);
 
   if(profile_info_from && profile_info_to)
     dt_ioppr_transform_image_colorspace_rgb(img_in, img_out, roi_in->width, roi_in->height, profile_info_from,
@@ -162,7 +162,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
 {
   dt_develop_t *dev = self->dev;
 
-  const int ch = piece->colors;
+  const int ch = 4;
+  assert(piece->colors == ch);
 
   float *const img_tmp = dt_alloc_align(64, ch * roi_out->width * roi_out->height * sizeof(float));
   if(img_tmp == NULL)
@@ -171,50 +172,245 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     goto cleanup;
   }
 
-  const float lower = MAX(dev->overexposed.lower / 100.0f, 1e-6f);
-  const float upper = dev->overexposed.upper / 100.0f;
+  const float lower = exp2f(dev->overexposed.lower);   // in EV
+  const float upper = dev->overexposed.upper / 100.0f; // in %
 
   const int colorscheme = dev->overexposed.colorscheme;
   const float *const upper_color = dt_iop_overexposed_colors[colorscheme][0];
   const float *const lower_color = dt_iop_overexposed_colors[colorscheme][1];
 
-  const float *const in = (const float *const)ivoid;
-  float *const out = (float *const)ovoid;
+  const float *const restrict in = __builtin_assume_aligned((const float *const restrict)ivoid, 64);
+  float *const restrict out = __builtin_assume_aligned((float *const restrict)ovoid, 64);
 
   // display mask using histogram profile as output
   _transform_image_colorspace(self, in, img_tmp, roi_out);
 
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);
+
+  #ifdef __SSE2__
+    // flush denormals to zero to avoid performance penalty if there are a lot of near-zero values
+    const unsigned int oldMode = _MM_GET_FLUSH_ZERO_MODE();
+    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+  #endif
+
+  if(dev->overexposed.mode == DT_CLIPPING_PREVIEW_ANYRGB)
+  {
+    // Any of the RGB channels is out of bounds
 #ifdef _OPENMP
 #pragma omp parallel for default(none) \
   dt_omp_firstprivate(ch, img_tmp, in, lower, lower_color, out, roi_out, \
                       upper, upper_color) \
   schedule(static)
 #endif
-  for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
-  {
-    if(img_tmp[k + 0] >= upper || img_tmp[k + 1] >= upper || img_tmp[k + 2] >= upper)
+    for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
     {
-      for(int c = 0; c < 3; c++)
+      if(img_tmp[k + 0] >= upper || img_tmp[k + 1] >= upper || img_tmp[k + 2] >= upper)
       {
-        out[k + c] = upper_color[c];
+        #ifdef _OPENMP
+        #pragma simd aligned(out, upper_color : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = upper_color[c];
       }
-    }
-    else if(img_tmp[k + 0] <= lower && img_tmp[k + 1] <= lower && img_tmp[k + 2] <= lower)
-    {
-      for(int c = 0; c < 3; c++)
+      else if(img_tmp[k + 0] <= lower && img_tmp[k + 1] <= lower && img_tmp[k + 2] <= lower)
       {
-        out[k + c] = lower_color[c];
+        #ifdef _OPENMP
+        #pragma simd aligned(out, lower_color : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = lower_color[c];
       }
-    }
-    else
-    {
-      for(int c = 0; c < 3; c++)
+      else
       {
-        const size_t p = (size_t)k + c;
-        out[p] = in[p];
+        #ifdef _OPENMP
+        #pragma simd aligned(out, in : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = in[k + c];
       }
     }
   }
+
+  else if(dev->overexposed.mode == DT_CLIPPING_PREVIEW_GAMUT && work_profile)
+  {
+    // Gamut is out of bounds
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(ch, img_tmp, in, lower, lower_color, out, roi_out, \
+                      upper, upper_color, work_profile) \
+  schedule(static)
+#endif
+    for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
+    {
+      const float luminance = dt_ioppr_get_rgb_matrix_luminance(img_tmp + k,
+                                                                work_profile->matrix_in, work_profile->lut_in,
+                                                                work_profile->unbounded_coeffs_in,
+                                                                work_profile->lutsize, work_profile->nonlinearlut);
+
+      // luminance is out of bounds
+      if(luminance >= upper)
+      {
+        #ifdef _OPENMP
+        #pragma simd aligned(out, upper_color : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = upper_color[c];
+      }
+      else if(luminance <= lower)
+      {
+        #ifdef _OPENMP
+        #pragma simd aligned(out, lower_color : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = lower_color[c];
+      }
+      // luminance is ok, so check for saturation
+      else
+      {
+        float DT_ALIGNED_ARRAY saturation[4] = { 0.f };
+
+        #ifdef _OPENMP
+        #pragma simd aligned(saturation, img_tmp : 64)
+        #endif
+        for(int c = 0; c < 3; c++)
+        {
+          saturation[c] = (img_tmp[k + c] - luminance);
+          saturation[c] = sqrtf(saturation[c] * saturation[c] / (luminance * luminance + img_tmp[k + c] * img_tmp[k + c]));
+        }
+
+        // we got over-saturation, relatively to luminance or absolutely over RGB
+        if(saturation[0] > upper || saturation[1] > upper || saturation[2] > upper ||
+          img_tmp[k + 0] >= upper || img_tmp[k + 1] >= upper || img_tmp[k + 2] >= upper)
+        {
+          #ifdef _OPENMP
+          #pragma simd aligned(out, upper_color : 64)
+          #endif
+          for(int c = 0; c < 3; c++) out[k + c] = upper_color[c];
+        }
+
+        // saturation is fine but we got out-of-bounds RGB
+        else if(img_tmp[k + 0] <= lower && img_tmp[k + 1] <= lower && img_tmp[k + 2] <= lower)
+        {
+          #ifdef _OPENMP
+          #pragma simd aligned(out, lower_color : 64)
+          #endif
+          for(int c = 0; c < 3; c++) out[k + c] = lower_color[c];
+        }
+
+        // evererything is fine
+        else
+        {
+          #ifdef _OPENMP
+          #pragma simd aligned(out, in : 64)
+          #endif
+          for(int c = 0; c < 3; c++) out[k + c] = in[k + c];
+        }
+      }
+    }
+  }
+
+  else if(dev->overexposed.mode == DT_CLIPPING_PREVIEW_LUMINANCE && work_profile)
+  {
+    // Luminance channel is out of bounds
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(ch, img_tmp, in, lower, lower_color, out, roi_out, \
+                      upper, upper_color, work_profile) \
+  schedule(static)
+#endif
+    for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
+    {
+      const float luminance = dt_ioppr_get_rgb_matrix_luminance(img_tmp + k,
+                                                                work_profile->matrix_in, work_profile->lut_in,
+                                                                work_profile->unbounded_coeffs_in,
+                                                                work_profile->lutsize, work_profile->nonlinearlut);
+
+      if(luminance >= upper)
+      {
+        #ifdef _OPENMP
+        #pragma simd aligned(out, upper_color : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = upper_color[c];
+      }
+
+      else if(luminance <= lower)
+      {
+        #ifdef _OPENMP
+        #pragma simd aligned(out, lower_color : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = lower_color[c];
+      }
+      else
+      {
+        #ifdef _OPENMP
+        #pragma simd aligned(out, in : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = in[k + c];
+      }
+    }
+  }
+
+  else if(dev->overexposed.mode == DT_CLIPPING_PREVIEW_SATURATION && work_profile)
+  {
+    // Show saturation out of bounds where luminance is valid
+#ifdef _OPENMP
+#pragma omp parallel for default(none) \
+  dt_omp_firstprivate(ch, img_tmp, in, lower, lower_color, out, roi_out, \
+                      upper, upper_color, work_profile) \
+  schedule(static)
+#endif
+    for(size_t k = 0; k < (size_t)ch * roi_out->width * roi_out->height; k += ch)
+    {
+      const float luminance = dt_ioppr_get_rgb_matrix_luminance(img_tmp + k,
+                                                                work_profile->matrix_in, work_profile->lut_in,
+                                                                work_profile->unbounded_coeffs_in,
+                                                                work_profile->lutsize, work_profile->nonlinearlut);
+      if(luminance < upper && luminance > lower)
+      {
+        float DT_ALIGNED_ARRAY saturation[4] = { 0.f };
+
+        #ifdef _OPENMP
+        #pragma simd aligned(saturation, img_tmp : 64)
+        #endif
+        for(int c = 0; c < 3; c++)
+        {
+          saturation[c] = (img_tmp[k + c] - luminance);
+          saturation[c] = sqrtf(saturation[c] * saturation[c] / (luminance * luminance + img_tmp[k + c] * img_tmp[k + c]));
+        }
+
+        // we got over-saturation, relatively to luminance or absolutely over RGB
+        if(saturation[0] > upper || saturation[1] > upper || saturation[2] > upper ||
+           img_tmp[k + 0] >= upper || img_tmp[k + 1] >= upper || img_tmp[k + 2] >= upper)
+        {
+          #ifdef _OPENMP
+          #pragma simd aligned(out, upper_color : 64)
+          #endif
+          for(int c = 0; c < 3; c++) out[k + c] = upper_color[c];
+        }
+        else if(img_tmp[k + 0] <= lower && img_tmp[k + 1] <= lower && img_tmp[k + 2] <= lower)
+        {
+          #ifdef _OPENMP
+          #pragma simd aligned(out, lower_color : 64)
+          #endif
+          for(int c = 0; c < 3; c++) out[k + c] = lower_color[c];
+        }
+        else
+        {
+          #ifdef _OPENMP
+          #pragma simd aligned(out, out : 64)
+          #endif
+          for(int c = 0; c < 3; c++) out[k + c] = in[k + c];
+        }
+      }
+
+      else
+      {
+        #ifdef _OPENMP
+        #pragma simd aligned(out, in : 64)
+        #endif
+        for(int c = 0; c < 3; c++) out[k + c] = in[k + c];
+      }
+    }
+  }
+
+  #ifdef __SSE2__
+    _MM_SET_FLUSH_ZERO_MODE(oldMode);
+  #endif
 
   if(piece->pipe->mask_display & DT_DEV_PIXELPIPE_DISPLAY_MASK) dt_iop_alpha_copy(ivoid, ovoid, roi_out->width, roi_out->height);
 
@@ -270,12 +466,24 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
 
   _transform_image_colorspace_cl(self, devid, dev_in, dev_tmp, roi_out);
 
-  const float lower = MAX(dev->overexposed.lower / 100.0f, 1e-6f);
-  const float upper = dev->overexposed.upper / 100.0f;
+  const dt_iop_order_iccprofile_info_t *const work_profile = dt_ioppr_get_histogram_profile_info(dev);
+  const int use_work_profile = (work_profile == NULL) ? 0 : 1;
+  cl_mem dev_profile_info = NULL;
+  cl_mem dev_profile_lut = NULL;
+  dt_colorspaces_iccprofile_info_cl_t *profile_info_cl;
+  cl_float *profile_lut_cl = NULL;
+
+  err = dt_ioppr_build_iccprofile_params_cl(work_profile, devid, &profile_info_cl, &profile_lut_cl,
+                                            &dev_profile_info, &dev_profile_lut);
+  if(err != CL_SUCCESS) goto error;
+
+  const float lower = exp2f(dev->overexposed.lower);   // in EV
+  const float upper = dev->overexposed.upper / 100.0f; // in %
   const int colorscheme = dev->overexposed.colorscheme;
 
   const float *upper_color = dt_iop_overexposed_colors[colorscheme][0];
   const float *lower_color = dt_iop_overexposed_colors[colorscheme][1];
+  const int mode = dev->overexposed.mode;
 
   size_t sizes[2] = { ROUNDUPWD(width), ROUNDUPHT(height) };
   dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 0, sizeof(cl_mem), &dev_in);
@@ -287,6 +495,10 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
   dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 6, sizeof(float), &upper);
   dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 7, 4 * sizeof(float), lower_color);
   dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 8, 4 * sizeof(float), upper_color);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 9, sizeof(cl_mem), (void *)&dev_profile_info);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 10, sizeof(cl_mem), (void *)&dev_profile_lut);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 11, sizeof(int), (void *)&use_work_profile);
+  dt_opencl_set_kernel_arg(devid, gd->kernel_overexposed, 12, sizeof(int), (void *)&mode);
   err = dt_opencl_enqueue_kernel_2d(devid, gd->kernel_overexposed, sizes);
   if(err != CL_SUCCESS) goto error;
   if(dev_tmp) dt_opencl_release_mem_object(dev_tmp);

--- a/src/iop/overexposed.c
+++ b/src/iop/overexposed.c
@@ -172,8 +172,8 @@ void process(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, const 
     goto cleanup;
   }
 
-  const float lower = exp2f(dev->overexposed.lower);   // in EV
-  const float upper = dev->overexposed.upper / 100.0f; // in %
+  const float lower = exp2f(fminf(dev->overexposed.lower, -4.f));   // in EV
+  const float upper = dev->overexposed.upper / 100.0f;              // in %
 
   const int colorscheme = dev->overexposed.colorscheme;
   const float *const upper_color = dt_iop_overexposed_colors[colorscheme][0];
@@ -477,8 +477,8 @@ int process_cl(struct dt_iop_module_t *self, dt_dev_pixelpipe_iop_t *piece, cl_m
                                             &dev_profile_info, &dev_profile_lut);
   if(err != CL_SUCCESS) goto error;
 
-  const float lower = exp2f(dev->overexposed.lower);   // in EV
-  const float upper = dev->overexposed.upper / 100.0f; // in %
+  const float lower = exp2f(fminf(dev->overexposed.lower, -4.f));   // in EV
+  const float upper = dev->overexposed.upper / 100.0f;              // in %
   const int colorscheme = dev->overexposed.colorscheme;
 
   const float *upper_color = dt_iop_overexposed_colors[colorscheme][0];

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -2240,7 +2240,7 @@ void gui_init(dt_view_t *self)
     gtk_widget_set_state_flags(colorscheme, GTK_STATE_FLAG_SELECTED, TRUE);
 
     /* lower */
-    GtkWidget *lower = dt_bauhaus_slider_new_with_range(NULL, -32., 0., 1., -12.69, 2);
+    GtkWidget *lower = dt_bauhaus_slider_new_with_range(NULL, -32., -4., 1., -12.69, 2);
     dt_bauhaus_slider_set(lower, dev->overexposed.lower);
     dt_bauhaus_slider_set_format(lower, "%+.2f EV");
     dt_bauhaus_widget_set_label(lower, NULL, _("lower threshold"));


### PR DESCRIPTION
Currently, the over-exposure preview, in darkroom, shows any of the 3 RGB channels that is outside of the valid range defined by the upper and lower thresholds. This information is not very helpful since that kind of clipping can come from a mix of luminance clipping (so, **true** overexposure) and gamut clipping (that is, oversaturation or lack of proper gamut-mapping). Yet, users take it very seriously and get mistaken. I have seen people on YouTube reducing exposure until oversaturated colors got back in gamut, just because of that faulty and misleading preview.

### Changes :
* rename overexposure "clipping" because that what this feature is about.
* change the black threshold for an EV (log) control, that should be more meaningful:
![Screenshot_20200909_223436](https://user-images.githubusercontent.com/2779157/92650363-ae60bb00-f2ec-11ea-9b8f-5ec28f7a126f.png)
The tooltip gives the typical black clipping/emission values:
![Screenshot_20200909_223536](https://user-images.githubusercontent.com/2779157/92650437-cb958980-f2ec-11ea-8c81-f70a092ab8e6.png)
* add a "luminance only" mode, that shows the clipping over luminance, which means tone mapping or exposure settings have been ill-set
* add a "saturation only" mode, that shows the over-saturated colors, imposible to represent in the target color space, which means gamut mapping or saturation settings have been ill-set,
* rename current mode "any RGB channel", because that's what it does,
* add a "full gamut" mode, that shows the combination of the 3 previous options. This should be consistent with the gamut alert tool (same result), but doesn't rely on LittleCMS2 lib and has an OpenCL path, meaning it's 2 to 6 times faster,
* optimize the code for SIMD vectorization,
* change defaults settings to sRGB black clipping for black (-12.68 EV) and almost peak-display luminance (99.99%) so users stop overreacting to valid values (previous defaults were 0.1% and 98%).

Full gamut preview against Adobe RGB (this PR – 34 ms with GPU/OpenCL, 64 ms on CPU/OpenMP):
![Screenshot_20200909_224142](https://user-images.githubusercontent.com/2779157/92652791-b8cf8480-f2ed-11ea-9853-373caac641dd.png)
Gamut alert against Adobe RGB (using LittleCMS2 from colorout – 174 ms):
![Screenshot_20200909_224154](https://user-images.githubusercontent.com/2779157/92652827-c71da080-f2ed-11ea-881f-0aa99b0f24b4.png)
Same settings but with desaturation in color balance (mostly just the luminance clipping):
![Screenshot_20200909_225800](https://user-images.githubusercontent.com/2779157/92654324-f8976b80-f2ef-11ea-905f-f9e96308943e.png)

### How to test:

* in luminance mode, ensure you get the same alert for a color image and its fully desaturated version (using saturation in color balance),
* in saturation mode, ensure a full desaturation (in color balance) removes any alert you had for the RGB file,
* in full gamut mode, ensure the over-exposed (red) area perfectly overlaps the gamut alert, when softproofing profile is the same as the histogram profile.