### PR TITLE
fix compiler warning in ellipsize button code

### DIFF
--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -23,15 +23,19 @@
   sometimes we have to store the ellipsize mode until the 
   label is created.
 */
-struct dt_lua_ellipsize_mode_info {
+struct dt_lua_ellipsize_mode_info
+{
   gboolean used;
   dt_lua_ellipsize_mode_t mode;
 };
-static struct dt_lua_ellipsize_mode_info ellipsize_store = {
+
+static struct dt_lua_ellipsize_mode_info ellipsize_store =
+{
   .used = FALSE
 };
 
-static dt_lua_widget_type_t button_type = {
+static dt_lua_widget_type_t button_type =
+{
   .name = "button",
   .gui_init = NULL,
   .gui_cleanup = NULL,
@@ -53,12 +57,14 @@ static int ellipsize_member(lua_State *L)
   lua_button button;
   luaA_to(L, lua_button, &button, 1);
   dt_lua_ellipsize_mode_t ellipsize;
-  if(lua_gettop(L) > 2) {
+  if(lua_gettop(L) > 2)
+  {
     luaA_to(L, dt_lua_ellipsize_mode_t, &ellipsize, 3);
     // check for label before trying to ellipsize it
     if(gtk_button_get_label(GTK_BUTTON(button->widget)))
       gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize);
-    else {
+    else
+    {
       ellipsize_store.mode = ellipsize;
       ellipsize_store.used = TRUE;
     }
@@ -73,10 +79,12 @@ static int label_member(lua_State *L)
 {
   lua_button button;
   luaA_to(L,lua_button,&button,1);
-  if(lua_gettop(L) > 2) {
+  if(lua_gettop(L) > 2)
+  {
     const char * label = luaL_checkstring(L,3);
     gtk_button_set_label(GTK_BUTTON(button->widget),label);
-    if(ellipsize_store.used){
+    if(ellipsize_store.used)
+    {
       gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store.mode);
       ellipsize_store.used = FALSE;
     }

--- a/src/lua/widget/button.c
+++ b/src/lua/widget/button.c
@@ -18,14 +18,18 @@
 #include "lua/types.h"
 #include "lua/widget/common.h"
 
-#define NOT_USED 5
-
 /*
   we can't guarantee the order of label and ellipsize calls so
   sometimes we have to store the ellipsize mode until the 
   label is created.
 */
-static dt_lua_ellipsize_mode_t ellipsize_store = NOT_USED;
+struct dt_lua_ellipsize_mode_info {
+  gboolean used;
+  dt_lua_ellipsize_mode_t mode;
+};
+static struct dt_lua_ellipsize_mode_info ellipsize_store = {
+  .used = FALSE
+};
 
 static dt_lua_widget_type_t button_type = {
   .name = "button",
@@ -54,8 +58,10 @@ static int ellipsize_member(lua_State *L)
     // check for label before trying to ellipsize it
     if(gtk_button_get_label(GTK_BUTTON(button->widget)))
       gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize);
-    else 
-      ellipsize_store = ellipsize;
+    else {
+      ellipsize_store.mode = ellipsize;
+      ellipsize_store.used = TRUE;
+    }
     return 0;
   }
   ellipsize = gtk_label_get_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))));
@@ -70,9 +76,9 @@ static int label_member(lua_State *L)
   if(lua_gettop(L) > 2) {
     const char * label = luaL_checkstring(L,3);
     gtk_button_set_label(GTK_BUTTON(button->widget),label);
-    if(ellipsize_store != NOT_USED){
-      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store);
-      ellipsize_store = NOT_USED;
+    if(ellipsize_store.used){
+      gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button->widget))), ellipsize_store.mode);
+      ellipsize_store.used = FALSE;
     }
     return 0;
   }


### PR DESCRIPTION
When building a recent master on macOS, I encountered the following error from the compiler:
```
/Users/mmaguire/src/darktable-dev/src/lua/widget/button.c:73:24: error: result
      of comparison of constant 5 with expression of type
      'dt_lua_ellipsize_mode_t' (aka 'PangoEllipsizeMode') is always true
      [-Werror,-Wtautological-constant-out-of-range-compare]
    if(ellipsize_store != NOT_USED){
       ~~~~~~~~~~~~~~~ ^  ~~~~~~~~
1 error generated.
make[2]: *** [src/CMakeFiles/lib_darktable.dir/lua/widget/button.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [src/CMakeFiles/lib_darktable.dir/all] Error 2
make: *** [all] Error 2
```
Here, the static variable "ellipse_store" is a PangoEllipsizeMode enum type from the external pango library. What we are doing here is to defining the macro "NOT_USED" to be a value (5) not currently used by that enum datatype, and to assign this to the "ellipsize_store" variable when we want to indicate that the value of that variable is not valid.

The problems with this approach:
- we are hard-coding assumptions about how many values in the pango library's enum data type has. If the pango library later adds more values, it will break our code.
- the compiler can see here we are comparing against an invalid value, and if it decides a comparison will always fail, the optimiser could decide to remove that "unreachable" code.

In both cases, we could get incorrect behaviour.

I suggest a better approach is to create a local data structure which includes a boolean variable to indicate whether the ellipsize_store is carrying a valid value or not. I would propose to use a "struct" for this, in order to make it clearer to people that the boolean variable is closely associated with the ellipsize mode variable. We could do a typedef for this in src/lua/types.h, but this is an internel state variable localised to only the button.c file, and so for a simple declaration like this I think it should be ok to include it in the button.c file itself.

The purpose of this PR is to document the problem and propose one possible solution that may avoid us being tripped up by this sort of coding trick in the future. (as per the discussion with @dterrahe on IRC). 