### PR TITLE
[metadata_view]: correctly handlne invalid utf in strftime

### DIFF
--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -542,9 +542,7 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       tt_exif.tm_mon--;
       tt_exif.tm_isdst = -1;
       mktime(&tt_exif);
-      // just %c is too long and includes a time zone that we don't know from exif
-      strftime(datetime, sizeof(datetime), "%a %x %X", &tt_exif);
-      _metadata_update_value(d->metadata[md_exif_datetime], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
+      _metadata_update_timestamp(d->metadata[md_exif_datetime], &tt_exif);
     }
     else
       _metadata_update_value(d->metadata[md_exif_datetime], img->exif_datetime_taken);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -222,6 +222,39 @@ static void _metadata_update_value_end(GtkLabel *label, const char *value)
   gtk_widget_set_tooltip_text(GTK_WIDGET(label), str);
 }
 
+static void _metadata_update_timestamp(GtkLabel *label, const time_t *value)
+{
+  char datetime[200];
+  // just %c is too long and includes a time zone that we don't know from exif
+  const size_t datetime_len = strftime(datetime, sizeof(datetime), "%a %x %X", localtime(value));
+  if(datetime_len > 0)
+  {
+    const gboolean valid_utf = g_utf8_validate(datetime, datetime_len, NULL);
+    if(valid_utf)
+    {
+      _metadata_update_value(label, datetime);
+    }
+    else
+    {
+      GError *error = NULL;
+      gchar *local_datetime = g_locale_to_utf8(datetime,datetime_len,NULL,NULL, &error);
+      if(local_datetime)
+      {
+        _metadata_update_value(label, local_datetime);
+        g_free(local_datetime);
+      }
+      else
+      {
+        _metadata_update_value(label, NODATA_STRING);
+        fprintf(stderr, "[metadata timestamp] could not convert '%s' to UTF-8: %s\n", datetime, error->message);
+        g_error_free(error);
+      }
+    }
+  }
+  else
+    _metadata_update_value(label, NODATA_STRING);
+}
+
 
 #ifdef USE_LUA
 static int lua_update_metadata(lua_State*L);
@@ -290,39 +323,22 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     _metadata_update_value(d->metadata[md_internal_local_copy], value);
 
     if (img->import_timestamp >=0)
-    {
-      char datetime[200];
-      // just %c is too long and includes a time zone that we don't know from exif
-      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->import_timestamp));
-      _metadata_update_value(d->metadata[md_internal_import_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
-    }
+      _metadata_update_timestamp(d->metadata[md_internal_import_timestamp], &img->import_timestamp);
     else
-      _metadata_update_value(d->metadata[md_internal_import_timestamp], "-");
+      _metadata_update_value(d->metadata[md_internal_import_timestamp], NODATA_STRING);
 
     if (img->change_timestamp >=0)
-    {
-      char datetime[200];
-      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->change_timestamp));
-      _metadata_update_value(d->metadata[md_internal_change_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
-    }
+      _metadata_update_timestamp(d->metadata[md_internal_change_timestamp], &img->change_timestamp);
     else
       _metadata_update_value(d->metadata[md_internal_change_timestamp], "-");
 
     if (img->export_timestamp >=0)
-    {
-      char datetime[200];
-      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->export_timestamp));
-      _metadata_update_value(d->metadata[md_internal_export_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
-    }
+      _metadata_update_timestamp(d->metadata[md_internal_export_timestamp], &img->export_timestamp);
     else
       _metadata_update_value(d->metadata[md_internal_export_timestamp], "-");
 
     if (img->print_timestamp >=0)
-    {
-      char datetime[200];
-      strftime(datetime, sizeof(datetime), "%a %x %X", localtime(&img->print_timestamp));
-      _metadata_update_value(d->metadata[md_internal_print_timestamp], g_locale_to_utf8(datetime,-1,NULL,NULL,NULL));
-    }
+      _metadata_update_timestamp(d->metadata[md_internal_print_timestamp], &img->print_timestamp);
     else
       _metadata_update_value(d->metadata[md_internal_print_timestamp], "-");
 

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -537,12 +537,11 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     if(sscanf(img->exif_datetime_taken, "%d:%d:%d %d:%d:%d", &tt_exif.tm_year, &tt_exif.tm_mon,
       &tt_exif.tm_mday, &tt_exif.tm_hour, &tt_exif.tm_min, &tt_exif.tm_sec) == 6)
     {
-      char datetime[200];
       tt_exif.tm_year -= 1900;
       tt_exif.tm_mon--;
       tt_exif.tm_isdst = -1;
-      mktime(&tt_exif);
-      _metadata_update_timestamp(d->metadata[md_exif_datetime], &tt_exif);
+      const time_t exif_timestamp = mktime(&tt_exif);
+      _metadata_update_timestamp(d->metadata[md_exif_datetime], &exif_timestamp);
     }
     else
       _metadata_update_value(d->metadata[md_exif_datetime], img->exif_datetime_taken);

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -330,17 +330,17 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
     if (img->change_timestamp >=0)
       _metadata_update_timestamp(d->metadata[md_internal_change_timestamp], &img->change_timestamp);
     else
-      _metadata_update_value(d->metadata[md_internal_change_timestamp], "-");
+      _metadata_update_value(d->metadata[md_internal_change_timestamp], NODATA_STRING);
 
     if (img->export_timestamp >=0)
       _metadata_update_timestamp(d->metadata[md_internal_export_timestamp], &img->export_timestamp);
     else
-      _metadata_update_value(d->metadata[md_internal_export_timestamp], "-");
+      _metadata_update_value(d->metadata[md_internal_export_timestamp], NODATA_STRING);
 
     if (img->print_timestamp >=0)
       _metadata_update_timestamp(d->metadata[md_internal_print_timestamp], &img->print_timestamp);
     else
-      _metadata_update_value(d->metadata[md_internal_print_timestamp], "-");
+      _metadata_update_value(d->metadata[md_internal_print_timestamp], NODATA_STRING);
 
     // TODO: decide if this should be removed for a release. maybe #ifdef'ing to only add it to git compiles?
 


### PR DESCRIPTION
This is imo the correct way to fix #5892 

This is an alternative to #6262 

Selling points: no memory leaks, error handling :) if string is utf-8 compatible there's no burned cpu cycles :) 