### PR TITLE
[Issue #6002] redmine links updated to GitHub wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,4 +52,4 @@ fi
 # If there are whitespace errors, print the offending file names and fail.
 exec git diff-index --check --cached $against --
 ```
-* Also, there is a [Coding Style](https://redmine.darktable.org/projects/darktable/wiki/Coding_Style) page on our redmine wiki.
+* Also, there is a [Developer's Guide](https://github.com/darktable-org/darktable/wiki/Developer's-guide) on our GitHub wiki, which includues some [Coding Style](https://github.com/darktable-org/darktable/wiki/Developer's-guide#coding-style) guidelines.


### PR DESCRIPTION
Partly fixes #6002 
- Coding Style info migrated from redmine to GitHub 
- This PR replaces redmine link with links to GitHub wiki Developer's Guide/Coding Style

The GitHub wiki still has links to redmine building pages, but that can be addressed separately by editing the wiki pages directly.
