### PR TITLE
Trying to fix #6246

### DIFF
--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -187,8 +187,6 @@ int default_colorspace(dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_p
 void init_key_accels(dt_iop_module_so_t *self)
 {
   dt_accel_register_slider_iop(self, FALSE, NC_("accel", "edge threshold"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method (bayer)"));
-  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method (xtrans)"));
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "color smoothing"));
   dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "match greens"));
 }
@@ -198,8 +196,6 @@ void connect_key_accels(dt_iop_module_t *self)
   dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)self->gui_data;
 
   dt_accel_connect_slider_iop(self, "edge threshold", GTK_WIDGET(g->median_thrs));
-  dt_accel_connect_combobox_iop(self, "method (bayer)", GTK_WIDGET(g->demosaic_method_bayer));
-  dt_accel_connect_combobox_iop(self, "method (xtrans)", GTK_WIDGET(g->demosaic_method_xtrans));
   dt_accel_connect_combobox_iop(self, "color smoothing", GTK_WIDGET(g->color_smoothing));
   dt_accel_connect_combobox_iop(self, "match greens", GTK_WIDGET(g->greeneq));
 }

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5002,7 +5002,7 @@ void gui_update(struct dt_iop_module_t *self)
 
 void reload_defaults(dt_iop_module_t *module)
 {
-  dt_iop_demosaic_params_t *d = module->default_params;
+  dt_iop_demosaic_params_t *d = (dt_iop_demosaic_params_t *)module->default_params;
 
   if(dt_image_is_monochrome(&module->dev->image_storage))
     d->demosaicing_method = DT_IOP_DEMOSAIC_PASSTHROUGH_MONOCHROME;
@@ -5013,6 +5013,7 @@ void reload_defaults(dt_iop_module_t *module)
 
   d->color_smoothing = 0;
   d->green_eq = DT_IOP_GREEN_EQ_NO;
+  d->median_thrs = 0.0f;
 
   module->hide_enable_button = 1;
 
@@ -5022,6 +5023,12 @@ void reload_defaults(dt_iop_module_t *module)
   else
   {
     module->default_enabled = 0;
+  }
+
+  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)module->gui_data;
+  if(g)
+  {
+    dt_bauhaus_slider_set_default(g->median_thrs, 0.0f);
   }
 }
 

--- a/src/iop/demosaic.c
+++ b/src/iop/demosaic.c
@@ -5011,25 +5011,9 @@ void reload_defaults(dt_iop_module_t *module)
   else
     d->demosaicing_method = DT_IOP_DEMOSAIC_PPG;
 
-  d->color_smoothing = 0;
-  d->green_eq = DT_IOP_GREEN_EQ_NO;
-  d->median_thrs = 0.0f;
-
   module->hide_enable_button = 1;
 
-  // only on for raw images:
-  if(dt_image_is_raw(&module->dev->image_storage))
-    module->default_enabled = 1;
-  else
-  {
-    module->default_enabled = 0;
-  }
-
-  dt_iop_demosaic_gui_data_t *g = (dt_iop_demosaic_gui_data_t *)module->gui_data;
-  if(g)
-  {
-    dt_bauhaus_slider_set_default(g->median_thrs, 0.0f);
-  }
+  module->default_enabled = dt_image_is_raw(&module->dev->image_storage);
 }
 
 void gui_changed(dt_iop_module_t *self, GtkWidget *w, void *previous)


### PR DESCRIPTION
Referring to late discussions in issue #6246 

I tried **very** hard to get trigger a crash with dt master cd9c486 on fedora32, intel G2288, lots of ram and a nvidia driver using opencl or not. Compiled fresh with all defaults, **lua enabled but without scripts included or in use**, so this is an open question.

 I removed a whole directory with 700 photos, reimported to be sure there are no thumbnails with pre-existinmg xmp files or without. There were images with faulty data, from different cameras including some fuji images, jpegs, tiffs.

Nothing unexpected happend, i simply couldn't get dt crashing or locking. So i am stuck with a reproducer.

I looked at the whole code demosaic.c there are a few minor complaints from my side,
1) in `reload_defaults` ther is no init for `d->median_thrs`
2) the slider doesn't get a default set.

For both i can't imagine this to be a real problem but just to make sure ...

About @TurboGit remarks referring to `dt_bauhaus_combobox_remove_at()` about also freeing the data, i looked up the combo-box code, yes sure but i think the code here is truely correct.

```
  g->demosaic_method_bayer = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
  for(int i=0;i<6;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_bayer, 5);
  
  g->demosaic_method_xtrans = dt_bauhaus_combobox_from_params(self, "demosaicing_method");
  for(int i=0;i<5;i++) dt_bauhaus_combobox_remove_at(g->demosaic_method_xtrans, 0);
  ```
We build two full comboboxes having **all** methods and remove those for each box unwanted.

One last point, i don't understand the reason for
```
  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method (bayer)"));
  dt_accel_register_combobox_iop(self, FALSE, NC_("accel", "method (xtrans)"));
```
and
```
  dt_accel_connect_combobox_iop(self, "method (bayer)", GTK_WIDGET(g->demosaic_method_bayer));
  dt_accel_connect_combobox_iop(self, "method (xtrans)", GTK_WIDGET(g->demosaic_method_xtrans));
```

as any keyboard shortcuts make no sense. Could this be a problem?

So - i am stuck here. Any further ideas?

