### PR TITLE
Fix the PPC64LE build.

### DIFF
--- a/src/common/guided_filter.h
+++ b/src/common/guided_filter.h
@@ -18,7 +18,17 @@
 
 #pragma once
 
+#ifdef __PPC64__ 
+#ifdef NO_WARN_X86_INTRINSICS
 #include <xmmintrin.h>
+#else
+#define NO_WARN_X86_INTRINSICS 1
+#include <xmmintrin.h>
+#undef NO_WARN_X86_INTRINSICS
+#endif // NO_WARN_X86_INTRINSICS
+#else
+#include <xmmintrin.h>
+#endif // __PPC64__
 
 #include "common/darktable.h"
 #include "common/opencl.h"


### PR DESCRIPTION
I would prefer not to set the NO_WARN_X86_INTRINSICS globally, as I believe it is better that we know explicitly where it is being set. This delightful mess of conditional include logic is required to make the code build in the scenario where it is not set globally.