### PR TITLE
[l10n] try to set lang to match selected by user, based on parafin's 428b3f3

### DIFF
--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -42,7 +42,6 @@ static gchar* _dt_full_locale_name(const char *locale)
 #ifdef __linux__
   gchar *output = NULL;
   GError *error = NULL;
-  // This would likelly work on linux and macos
   if(!g_spawn_command_line_sync("locale -a", &output, NULL, NULL, &error))
   {
     if(error)

--- a/src/common/l10n.c
+++ b/src/common/l10n.c
@@ -36,10 +36,7 @@
 
 static gchar* _dt_full_locale_name(const char *locale)
 {
-#ifdef __APPLE__
-  return dt_osx_full_locale_name(ui_lang);
-#endif
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
   gchar *output = NULL;
   GError *error = NULL;
   if(!g_spawn_command_line_sync("locale -a", &output, NULL, NULL, &error))

--- a/src/osx/osx.h
+++ b/src/osx/osx.h
@@ -31,7 +31,6 @@ gboolean dt_osx_file_trash(const char *filename, GError **error);
 char* dt_osx_get_bundle_res_path();
 void dt_osx_prepare_environment();
 void dt_osx_focus_window();
-char* dt_osx_full_locale_name(const char* locale);
 
 #ifdef __cplusplus
 }

--- a/src/osx/osx.mm
+++ b/src/osx/osx.mm
@@ -236,39 +236,6 @@ void dt_osx_focus_window()
   [NSApp activateIgnoringOtherApps:YES];
 }
 
-char* dt_osx_full_locale_name(const char* locale)
-{
-  @autoreleasepool
-  {
-    if(!strcmp(locale, "C"))
-    {
-      // C isn't in the list of locales
-      return strdup("C");
-    }
-    char *saved_locale = strdup(setlocale(LC_ALL, NULL));
-    NSString* locale_str = [NSString stringWithUTF8String: locale];
-    NSArray<NSString*>* locales = [NSLocale availableLocaleIdentifiers];
-    for(NSString* item in locales)
-    {
-      NSLocale* locale_ns = [NSLocale localeWithLocaleIdentifier: item];
-      NSString* locale_c = [NSString stringWithFormat: @"%@_%@", [locale_ns languageCode], [locale_ns countryCode]];
-      if([locale_c hasPrefix: locale_str])
-      {
-        const char* locale_utf8 = [locale_c UTF8String];
-        if(setlocale(LC_ALL, locale_utf8))
-        {
-          setlocale(LC_ALL, saved_locale);
-          free(saved_locale);
-          return strdup(locale_utf8);
-        }
-      }
-    }
-    // haven't found any matching locale
-    free(saved_locale);
-    return NULL;
-  }
-}
-
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;


### PR DESCRIPTION
Tis is just continuation of @parafin's work that left a `TODO`. I've tested this and managed to get Portugese date abbreviations on system that has preferred PL:EN prefered but PT installed :)