### PR TITLE
Improve thumbnails contrast in all themes

### DIFF
--- a/data/themes/darktable-elegant-dark.css
+++ b/data/themes/darktable-elegant-dark.css
@@ -87,9 +87,9 @@
 @define-color thumbnail_bg_color @grey_55;
 @define-color thumbnail_star_bg_color @grey_40;
 @define-color thumbnail_fg_color @grey_60;
-@define-color thumbnail_selected_bg_color @grey_65;
-@define-color thumbnail_hover_bg_color @grey_85;
-@define-color thumbnail_hover_fg_color @grey_90;
+@define-color thumbnail_selected_bg_color @grey_75;
+@define-color thumbnail_hover_bg_color @grey_90;
+@define-color thumbnail_hover_fg_color @grey_95;
 @define-color thumbnail_localcopy_color @grey_80;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */

--- a/data/themes/darktable-elegant-grey.css
+++ b/data/themes/darktable-elegant-grey.css
@@ -92,6 +92,7 @@
 @define-color thumbnail_fg_color @grey_60;
 @define-color thumbnail_selected_bg_color @grey_80;
 @define-color thumbnail_hover_bg_color @grey_95;
+@define-color thumbnail_hover_fg_color @grey_100;
 @define-color thumbnail_localcopy_color @grey_90;
 
 /* Graphs : histogram, navigation thumbnail and some items on tone curve */

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -138,9 +138,9 @@
 @define-color thumbnail_star_bg_color @grey_35;
 @define-color thumbnail_fg_color @grey_55;
 @define-color thumbnail_bg50_color @grey_100;
-@define-color thumbnail_selected_bg_color @grey_60;
-@define-color thumbnail_hover_bg_color @grey_80;
-@define-color thumbnail_hover_fg_color @grey_85;
+@define-color thumbnail_selected_bg_color @grey_70;
+@define-color thumbnail_hover_bg_color @grey_85;
+@define-color thumbnail_hover_fg_color @grey_90;
 @define-color filmstrip_bg_color @darkroom_bg_color;
 @define-color thumbnail_localcopy_color @grey_75;
 


### PR DESCRIPTION
Fix #6197 and so improve thumbnails contrast in all themes. Thanks to @paolobenve help.