### PR TITLE
ellipse lib module names at end instead of middle

### DIFF
--- a/src/develop/develop.c
+++ b/src/develop/develop.c
@@ -2437,7 +2437,7 @@ gchar *dt_history_item_get_name_html(const struct dt_iop_module_t *module)
   if(!module->multi_name[0] || strcmp(module->multi_name, "0") == 0)
     label = g_strdup_printf("%s", module->name());
   else
-    label = g_strdup_printf("%s <span size=\"smaller\">%s</span>", module->name(), module->multi_name);
+    label = g_markup_printf_escaped("%s <span size=\"smaller\">%s</span>", module->name(), module->multi_name);
   return label;
 }
 

--- a/src/develop/imageop.c
+++ b/src/develop/imageop.c
@@ -1243,7 +1243,7 @@ static void _iop_panel_label(GtkWidget *lab, dt_iop_module_t *module)
   gchar *label = dt_history_item_get_name_html(module);
   gchar *tooltip = g_strdup(module->description());
   gtk_label_set_markup(GTK_LABEL(lab), label);
-  gtk_label_set_ellipsize(GTK_LABEL(lab), PANGO_ELLIPSIZE_MIDDLE);
+  gtk_label_set_ellipsize(GTK_LABEL(lab), !module->multi_name[0] ? PANGO_ELLIPSIZE_END: PANGO_ELLIPSIZE_MIDDLE);
   g_object_set(G_OBJECT(lab), "xalign", 0.0, (gchar *)0);
   gtk_widget_set_tooltip_text(lab, tooltip);
   g_free(label);

--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -1056,7 +1056,8 @@ GtkWidget *dt_lib_gui_get_expander(dt_lib_module_t *module)
   hw[DT_MODULE_LABEL] = gtk_label_new("");
   gtk_label_set_markup(GTK_LABEL(hw[DT_MODULE_LABEL]), module->name(module));
   gtk_widget_set_tooltip_text(hw[DT_MODULE_LABEL], module->name(module));
-  gtk_label_set_ellipsize(GTK_LABEL(hw[DT_MODULE_LABEL]), PANGO_ELLIPSIZE_MIDDLE);
+  gtk_label_set_ellipsize(GTK_LABEL(hw[DT_MODULE_LABEL]), PANGO_ELLIPSIZE_END);
+  g_object_set(G_OBJECT(hw[DT_MODULE_LABEL]), "xalign", 0.0, (gchar *)0);
   gtk_widget_set_name(hw[DT_MODULE_LABEL], "lib-panel-label");
 
   /* add reset button if module has implementation */


### PR DESCRIPTION
this should be different from iop module names, where multi-instance names are only distinguishable by the ending. In general though, PANGO_ELLIPSIZE_END is better readable, because it only cuts off one word instead of two.

See, @johnny-bit? No real reason to hide right-side buttons.

![image](https://user-images.githubusercontent.com/1549490/93665332-84866180-fa6d-11ea-8ad8-97b30223550c.png)

![image](https://user-images.githubusercontent.com/1549490/93665312-60c31b80-fa6d-11ea-84b9-534cace29fa6.png)

![image](https://user-images.githubusercontent.com/1549490/93665360-be576800-fa6d-11ea-81d0-44a031a1bd9f.png)

