### PR TITLE
export lib: add ability to define export size from print size × resolution

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -1758,6 +1758,34 @@
     <longdescription>pixel interpolator used in rotation and lens correction (bilinear, bicubic, lanczos2, lanczos3).</longdescription>
   </dtconfig>
   <dtconfig>
+    <name>plugins/lighttable/export/dimensions_type</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>unit of the printing size</shortdescription>
+    <longdescription>unit in which to input the image size.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/export/print_dpi</name>
+    <type>int</type>
+    <default>300</default>
+    <shortdescription>DPI</shortdescription>
+    <longdescription>print resolusion in DPI.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/export/print_width</name>
+    <type>float</type>
+    <default>0</default>
+    <shortdescription>width of the exported image</shortdescription>
+    <longdescription>width of the exported image, or 0 if no scaling should be done.</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/export/print_height</name>
+    <type>float</type>
+    <default>0</default>
+    <shortdescription>height of the exported image</shortdescription>
+    <longdescription>height of the exported image, or 0 if no scaling should be done.</longdescription>
+  </dtconfig>
+  <dtconfig>
     <name>plugins/lighttable/export/width</name>
     <type>int</type>
     <default>0</default>


### PR DESCRIPTION
Long asked feature. Export size can now be specified in pixels, inches and centimeters.
![Screenshot_20200919_173800](https://user-images.githubusercontent.com/2779157/93670884-ed3a0200-fa9e-11ea-93e1-172ce063e078.png)
![Screenshot_20200919_173746](https://user-images.githubusercontent.com/2779157/93670886-ef03c580-fa9e-11ea-9c84-ae76a2fab739.png)
@elstoc I have a problem with the `insert_text_handler()` function, it doesn't really work with floating point input, especially when we try to erase numbers, the cursor gets repositionned at the beginning. I don't really get what happens there, could you have a look ? Thanks !

TODO: 
* maybe write the print DPI in the `Exif.Image.XResolution` metadata tag of the exported file. (Anybody knows how ?)
* write those print dimensions in params for presets ? (not sure if it's needed, this is only an helper UI to write the actual pixel sizes, and these are the only ones that matter).