### PR TITLE
Clamp mask values to [0,1]. Fix #6315

### DIFF
--- a/data/kernels/blendop.cl
+++ b/data/kernels/blendop.cl
@@ -1022,7 +1022,8 @@ blendop_mask_tone_curve(__read_only image2d_t mask_in, __write_only image2d_t ma
     scaled_opacity = (scaled_opacity + brightness) / (1.f + brightness);
     scaled_opacity = fmax(scaled_opacity, -1.f);
   }
-  opacity = ((scaled_opacity * e / (1.f + (e - 1.f) * fabs(scaled_opacity))) / 2.f + 0.5f) * gopacity;
+  opacity = clamp(
+      ((scaled_opacity * e / (1.f + (e - 1.f) * fabs(scaled_opacity))) / 2.f + 0.5f) * gopacity, 0.f, 1.f);
   write_imagef(mask_out, (int2)(x, y), opacity);
 }
 

--- a/src/develop/blend.c
+++ b/src/develop/blend.c
@@ -2840,7 +2840,8 @@ void dt_develop_blend_process(struct dt_iop_module_t *self, struct dt_dev_pixelp
           x = (x + brightness) / (1.f + brightness);
           x = fmaxf(x, -1.f);
         }
-        mask[k] = ((x * e / (1.f + (e - 1.f) * fabsf(x))) / 2.f + 0.5f) * opacity;
+        mask[k] = clamp_range_f(
+            ((x * e / (1.f + (e - 1.f) * fabsf(x))) / 2.f + 0.5f) * opacity, 0.f, 1.f);
       }
     }
   }


### PR DESCRIPTION
Combinations of negative values on mask contrast and blend opacity may push mask values outside of [0,1], which may produce artifacts when doing the actual blending.

This should fix #6315