### PR TITLE
create database backups (snapshots), check database for corruption on start, restore working snapshot...

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -97,7 +97,7 @@
     </type>
     <default>once a week</default>
     <shortdescription>create database snapshot</shortdescription>
-    <longdescription>database snapshots are created right before closing darktable. options allow you to choose how often to make snapshots:\nnever - simply don't do snapshots. that way the only snapshots done are mandatory version-upgrade snapshots\nonce a month - create snapshot if a month has passed since last snapshot\nonce a week - create snapshot if 7 days had passed since last snapshot\nonce a day - create snapshot if over 24h passed since last snapshot\non close - create snapshot every time the darktable is closed</longdescription>
+    <longdescription>database snapshots are created right before closing darktable. options allow you to choose how often to make snapshots:\nnever - simply don't do snapshots. that way the only snapshots done are mandatory version-upgrade snapshots\nonce a month - create snapshot if a month has passed since last snapshot\nonce a week - create snapshot if 7 days had passed since last snapshot\nonce a day - create snapshot if over 24h passed since last snapshot\non close - create snapshot every time darktable is closed</longdescription>
   </dtconfig>
   <dtconfig prefs="storage" section="database">
     <name>database/keep_snapshots</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -84,6 +84,28 @@
     <shortdescription>database fragmentation ratio threshold</shortdescription>
     <longdescription>fragmentation ratio above which to ask or carry out automatically database maintenance</longdescription>
   </dtconfig>
+  <dtconfig prefs="storage" section="database">
+    <name>database/create_snapshot</name>
+    <type>
+      <enum>
+        <option>never</option>
+        <option>once a month</option>
+        <option>once a week</option>
+        <option>once a day</option>
+        <option>on close</option>
+      </enum>
+    </type>
+    <default>once a week</default>
+    <shortdescription>create database snapshot</shortdescription>
+    <longdescription>database snapshots are created right before closing darktable. options allow you to choose how often to make snapshots:\nnever - simply don't do snapshots. that way the only snapshots done are mandatory version-upgrade snapshots\nonce a month - create snapshot if a month has passed since last snapshot\nonce a week - create snapshot if 7 days had passed since last snapshot\nonce a day - create snapshot if over 24h passed since last snapshot\non close - create snapshot every time the darktable is closed</longdescription>
+  </dtconfig>
+  <dtconfig prefs="storage" section="database">
+    <name>database/keep_snapshots</name>
+    <type>int</type>
+    <default>10</default>
+    <shortdescription>how many snapshots to keep</shortdescription>
+    <longdescription>after successfully creating snapshot, how many older snapshots to keep (excluding mandatory version update ones). enter -1 to keep all snapshots\nkeep in mind that snapshots do take some space and you only need the most recent one for successful restore</longdescription>
+  </dtconfig>
   <dtconfig>
     <name>min_panel_width</name>
     <type>int</type>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1213,6 +1213,7 @@ void dt_cleanup()
   // last chance to ask user for any input...
 
   const gboolean perform_maintenance = dt_database_maybe_maintenance(darktable.db, init_gui, TRUE);
+  const gboolean perform_snapshot = dt_database_maybe_snapshot(darktable.db);
 
 #ifdef HAVE_PRINT
   dt_printers_abort_discovery();
@@ -1291,7 +1292,10 @@ void dt_cleanup()
   }
 
   dt_database_optimize(darktable.db);
-  dt_database_snapshot(darktable.db);
+  if(perform_snapshot)
+  {
+    dt_database_snapshot(darktable.db);
+  }
   dt_database_destroy(darktable.db);
 
   if(init_gui)

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1291,6 +1291,7 @@ void dt_cleanup()
   }
 
   dt_database_optimize(darktable.db);
+  dt_database_snapshot(darktable.db);
   dt_database_destroy(darktable.db);
 
   if(init_gui)

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -2956,7 +2956,7 @@ start:
         else
         {
           // there is nothing to restore, create an empty file to prevent further backup attempts
-          int fd = g_open(dbfilename_library, O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+          const int fd = g_open(dbfilename_library, O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
           if(fd < 0 || !g_close(fd, &gerror)) copyStatus = FALSE;
         }
         if(copyStatus)
@@ -3356,17 +3356,20 @@ static int _backup_db(
       const int spc = _get_pragma_int_val(src_db, pragma);
       g_free(pragma);
       const int pc = MIN(spc, MAX(5,spc/100));
-      do {
+      do
+      {
         rc = sqlite3_backup_step(sb_dest, pc);
         if(xProgress)
           xProgress(
             sqlite3_backup_remaining(sb_dest),
             sqlite3_backup_pagecount(sb_dest)
           );
-        if( rc==SQLITE_OK || rc==SQLITE_BUSY || rc==SQLITE_LOCKED ){
+        if( rc==SQLITE_OK || rc==SQLITE_BUSY || rc==SQLITE_LOCKED )
+        {
           sqlite3_sleep(25);
         }
-      } while( rc==SQLITE_OK || rc==SQLITE_BUSY || rc==SQLITE_LOCKED );
+      }
+      while( rc==SQLITE_OK || rc==SQLITE_BUSY || rc==SQLITE_LOCKED );
 
       /* Release resources allocated by backup_init(). */
       (void)sqlite3_backup_finish(sb_dest);
@@ -3575,12 +3578,12 @@ static gboolean _get_iso8601_int (const gchar *text, gsize length, gint *value)
     return FALSE;
 
   for (i = 0; i < length; i++)
-    {
-      const gchar c = text[i];
-      if (c < '0' || c > '9')
-        return FALSE;
-      v = v * 10 + (c - '0');
-    }
+  {
+    const gchar c = text[i];
+    if (c < '0' || c > '9')
+      return FALSE;
+    v = v * 10 + (c - '0');
+  }
 
   *value = v;
   return TRUE;

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3607,31 +3607,39 @@ static gint _db_snap_sort(gconstpointer a, gconstpointer b, gpointer user_data)
   datepos2 +=5; //skip "-snp-"
 
   int year,month,day,hour,minute,second;
-  if(!_get_iso8601_int(datepos1,4,&year) ||
-    !_get_iso8601_int(datepos1+4,2,&month) ||
-    !_get_iso8601_int(datepos1+6,2,&day) ||
-    !_get_iso8601_int(datepos1+8,2,&hour) ||
-    !_get_iso8601_int(datepos1+10,2,&minute) ||
-    !_get_iso8601_int(datepos1+12,2,&second)
-  )
+
+  if(!_get_iso8601_int(datepos1,    4, &year)   ||
+     !_get_iso8601_int(datepos1+4,  2, &month)  ||
+     !_get_iso8601_int(datepos1+6,  2, &day)    ||
+     !_get_iso8601_int(datepos1+8,  2, &hour)   ||
+     !_get_iso8601_int(datepos1+10, 2, &minute) ||
+     !_get_iso8601_int(datepos1+12, 2, &second)
+    )
+  {
     return 0;
+  }
+
   GDateTime *d1=g_date_time_new_local(year, month, day, hour, minute, second);
-  if(!_get_iso8601_int(datepos2,4,&year) ||
-    !_get_iso8601_int(datepos2+4,2,&month) ||
-    !_get_iso8601_int(datepos2+6,2,&day) ||
-    !_get_iso8601_int(datepos2+8,2,&hour) ||
-    !_get_iso8601_int(datepos2+10,2,&second) ||
-    !_get_iso8601_int(datepos2+12,2,&second)
-  )
+
+  if(!_get_iso8601_int(datepos2,    4, &year)   ||
+     !_get_iso8601_int(datepos2+4,  2, &month)  ||
+     !_get_iso8601_int(datepos2+6,  2, &day)    ||
+     !_get_iso8601_int(datepos2+8,  2, &hour)   ||
+     !_get_iso8601_int(datepos2+10, 2, &minute) ||
+     !_get_iso8601_int(datepos2+12, 2, &second)
+    )
   {
     g_date_time_unref(d1);
     return 0;
   }
+
   GDateTime *d2=g_date_time_new_local(year, month, day, hour, minute, second);
 
   const gint ret = g_date_time_compare(d1, d2);
+
   g_date_time_unref(d1);
   g_date_time_unref(d2);
+
   return ret;
 }
 

--- a/src/common/database.c
+++ b/src/common/database.c
@@ -3397,14 +3397,13 @@ gboolean dt_database_snapshot(const struct dt_database_t *db)
   gchar *lib_backup_file = g_strdup_printf(file_pattern, db->dbfilename_library, date_suffix);
   gchar *lib_tmpbackup_file = g_strdup_printf(temp_pattern, db->dbfilename_library, date_suffix);
 
-  g_free(date_suffix);
-
   int rc = _backup_db(db->handle, "main", lib_tmpbackup_file, _print_backup_progress);
   if(!(rc==SQLITE_OK))
   {
     g_unlink(lib_tmpbackup_file);
     g_free(lib_tmpbackup_file);
     g_free(lib_backup_file);
+    g_free(date_suffix);
     return FALSE;
   }
   g_rename(lib_tmpbackup_file, lib_backup_file);
@@ -3414,6 +3413,8 @@ gboolean dt_database_snapshot(const struct dt_database_t *db)
 
   gchar *dat_backup_file = g_strdup_printf(file_pattern, db->dbfilename_data, date_suffix);
   gchar *dat_tmpbackup_file = g_strdup_printf(temp_pattern, db->dbfilename_data, date_suffix);
+
+  g_free(date_suffix);
 
   rc = _backup_db(db->handle, "data", dat_tmpbackup_file, _print_backup_progress);
   if(!(rc==SQLITE_OK))
@@ -3675,7 +3676,7 @@ char **dt_database_snaps_to_remove(const struct dt_database_t *db)
   gchar *dat_basename = g_file_get_basename(dat_file);
   g_object_unref(dat_file);
   gchar *dat_snap_format = g_strdup_printf("%s-snp-", dat_basename);
-  gchar *dat_tmp_format = g_strdup_printf("%s-tmp-", lib_basename);
+  gchar *dat_tmp_format = g_strdup_printf("%s-tmp-", dat_basename);
   g_free(dat_basename);
 
   GQueue *lib_snaps = g_queue_new();

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -45,6 +45,8 @@ void dt_database_cleanup_busy_statements(const struct dt_database_t *db);
 gboolean dt_database_snapshot(const struct dt_database_t *db);
 /** check if creating database snapshot is recommended */
 gboolean dt_database_maybe_snapshot(const struct dt_database_t *db);
+/** get list of snapshot files to remove after successful snapshot */
+char **dt_database_snaps_to_remove(const struct dt_database_t *db);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -47,6 +47,8 @@ gboolean dt_database_snapshot(const struct dt_database_t *db);
 gboolean dt_database_maybe_snapshot(const struct dt_database_t *db);
 /** get list of snapshot files to remove after successful snapshot */
 char **dt_database_snaps_to_remove(const struct dt_database_t *db);
+/** get possibly the freshest snapshot to restore */
+gchar *dt_database_get_most_recent_snap(const char* db_filename);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -41,6 +41,8 @@ gboolean dt_database_maybe_maintenance(const struct dt_database_t *db, const gbo
 void dt_database_perform_maintenance(const struct dt_database_t *db);
 /** cleanup busy statements on closing dt, just before performing maintenance */
 void dt_database_cleanup_busy_statements(const struct dt_database_t *db);
+/** simply create db snapshot of both library and data */
+gboolean dt_database_snapshot(const struct dt_database_t *db);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/common/database.h
+++ b/src/common/database.h
@@ -43,6 +43,8 @@ void dt_database_perform_maintenance(const struct dt_database_t *db);
 void dt_database_cleanup_busy_statements(const struct dt_database_t *db);
 /** simply create db snapshot of both library and data */
 gboolean dt_database_snapshot(const struct dt_database_t *db);
+/** check if creating database snapshot is recommended */
+gboolean dt_database_maybe_snapshot(const struct dt_database_t *db);
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent


### PR DESCRIPTION
Lo and behold for I have created a feature in photography workflow application and non-destructive raw developer that has NOTHING to do with photography :wink:

With this PR the application will be able to:
- create automatic snapshots of databases using sqlite backup api
- control how often said snapshots are done
- limit number of kept snapshots
- and most importantly: check database for errors and restore database from snapshot!

this fixes #4728

Selling points:
- less memory leaks in some functions
- checks for db correctness using `quick_check` pragma meaning the impact on app start time is negligible
- minimal amount of additional configuration (just 2 fields for such number of possibilities!)
- stale backups/snapshots are removed on successful backup creation, meaning that in case something goes sideways, the backups are rather in good shape
- the whole snapshot procedure is written so that only complete snapshots will be taken into consideration for restore (eg snapshot method renames files after successful snapshot)
- instead just "close darktable and try to work out if you have backups or not or jus start fresh" user has an option to attempt the restore from the most recent snapshot. this should allow for least amount of pain for user in case there's a problem/corruption

What this pr doesn't have: the "clean shutdown" state as mentioned in #4728 is not implemented simply because it's not really needed.