### PR TITLE
Overhaul color picker module

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -603,7 +603,7 @@ overshoot.right
   padding: 0.5em 0.5em 0.5em 0.5em;
 }
 
-#module-header entry 
+#module-header entry
 {
   background-color: @field_active_bg;
 }
@@ -1395,7 +1395,8 @@ cell:selected
   font-size: 0.5em;
 }
 
-#history-tooltip
+#history-tooltip,
+#colorpicker-tooltip
 {
   font-family: monospace;
   background-color: @tooltip_bg_color;

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -224,11 +224,11 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
 
   gchar **sample_parts = g_malloc0_n(12, sizeof(char*));
 
-  sample_parts[3] = g_strdup_printf("%22s(0x%02X%02X%02X)\n%s:", " ",
+  sample_parts[3] = g_strdup_printf("%22s(0x%02X%02X%02X)\n<b>%14s</b>", " ",
                                     (int)round(sample->rgb.red   * 255.f),
                                     (int)round(sample->rgb.green * 255.f),
                                     (int)round(sample->rgb.blue  * 255.f), _("RGB"));
-  sample_parts[7] = g_strdup_printf("\n%s:", _("Lab"));
+  sample_parts[7] = g_strdup_printf("\n<b>%14s</b>", _("Lab"));
 
   for(int i = 0; i < 3; i++)
   {
@@ -241,21 +241,19 @@ static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboo
                                       (int)round(CLAMP(rgb[1], 0.f, 1.f) * 255.f),
                                       (int)round(CLAMP(rgb[2], 0.f, 1.f) * 255.f), " ");
 
-    sample_parts[i + 4] = g_strdup_printf("%8s: "
-                                          "<span foreground='red'>%6d</span>  "
+    sample_parts[i + 4] = g_strdup_printf("<span foreground='red'>%6d</span>  "
                                           "<span foreground='green'>%6d</span>  "
-                                          "<span foreground='blue'>%6d</span>",
-                                          _(name[i]),
+                                          "<span foreground='blue'>%6d</span>  %s",
                                           (int)round(rgb[0] * 255.f),
                                           (int)round(rgb[1] * 255.f),
-                                          (int)round(rgb[2] * 255.f));
+                                          (int)round(rgb[2] * 255.f), _(name[i]));
 
     const float *lab = i == 0 ? sample->picked_color_lab_mean :
                        i == 1 ? sample->picked_color_lab_min :
                                 sample->picked_color_lab_max;
 
-    sample_parts[i + 8] = g_strdup_printf("%8s: %6.02f  %6.02f  %6.02f", _(name[i]),
-                                          lab[0], lab[1], lab[2]);
+    sample_parts[i + 8] = g_strdup_printf("%6.02f  %6.02f  %6.02f  %s",
+                                          lab[0], lab[1], lab[2], _(name[i]));
   }
 
   gchar *tooltip_text = g_strjoinv("\n", sample_parts);
@@ -529,7 +527,6 @@ void gui_init(dt_lib_module_t *self)
   GtkWidget *picker_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
   data->statistic_selector = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(data->statistic_selector, NULL, _("statistic"));
   dt_bauhaus_combobox_add(data->statistic_selector, _("mean"));
   dt_bauhaus_combobox_add(data->statistic_selector, _("min"));
   dt_bauhaus_combobox_add(data->statistic_selector, _("max"));
@@ -540,7 +537,6 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(picker_row), data->statistic_selector, TRUE, TRUE, 0);
 
   data->color_mode_selector = dt_bauhaus_combobox_new(NULL);
-  dt_bauhaus_widget_set_label(data->color_mode_selector, NULL, _("model"));
   dt_bauhaus_combobox_add(data->color_mode_selector, _("RGB"));
   dt_bauhaus_combobox_add(data->color_mode_selector, _("Lab"));
   dt_bauhaus_combobox_set(data->color_mode_selector, dt_conf_get_int("ui_last/colorpicker_model"));
@@ -549,9 +545,8 @@ void gui_init(dt_lib_module_t *self)
   gtk_widget_set_valign(data->color_mode_selector, GTK_ALIGN_END);
   gtk_box_pack_start(GTK_BOX(picker_row), data->color_mode_selector, TRUE, TRUE, 0);
 
-  gtk_box_pack_start(GTK_BOX(picker_row), gtk_label_new("  "), FALSE, FALSE, 0);
-
   data->picker_button = dt_color_picker_new(NULL, DT_COLOR_PICKER_POINT_AREA, picker_row);
+  gtk_widget_set_tooltip_text(data->picker_button, _("turn on color picker\nctrl+click to select an area"));
   gtk_widget_set_name(GTK_WIDGET(data->picker_button), "color-picker-button");
   g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), data);
 

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -16,6 +16,7 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "bauhaus/bauhaus.h"
 #include "libs/colorpicker.h"
 #include "common/darktable.h"
 #include "control/conf.h"
@@ -34,19 +35,14 @@ DT_MODULE(1);
 
 typedef struct dt_lib_colorpicker_t
 {
-  GtkWidget *color_patch;
-  GtkWidget *output_label;
+  GtkWidget *large_color_patch;
   GtkWidget *color_mode_selector;
   GtkWidget *statistic_selector;
-  GtkWidget *size_selector;
   GtkWidget *picker_button;
   GtkWidget *samples_container;
-  GtkWidget *samples_mode_selector;
-  GtkWidget *samples_statistic_selector;
   GtkWidget *add_sample_button;
   GtkWidget *display_samples_check_box;
-  GdkRGBA rgb;
-  gboolean from_proxy;
+  dt_colorpicker_sample_t proxy_linked;
 } dt_lib_colorpicker_t;
 
 const char *name(dt_lib_module_t *self)
@@ -90,23 +86,8 @@ void connect_key_accels(dt_lib_module_t *self)
 
 // GUI callbacks
 
-static gboolean main_draw_callback(GtkWidget *widget, cairo_t *cr, gpointer data)
+static gboolean _sample_draw_callback(GtkWidget *widget, cairo_t *cr, dt_colorpicker_sample_t *sample)
 {
-  dt_lib_colorpicker_t *d = (dt_lib_colorpicker_t *)data;
-
-  const guint width = gtk_widget_get_allocated_width(widget);
-  const guint height = gtk_widget_get_allocated_height(widget);
-  gdk_cairo_set_source_rgba (cr, &d->rgb);
-  cairo_rectangle(cr, 0, 0, width, height);
-  cairo_fill (cr);
-
-  return FALSE;
-}
-
-static gboolean sample_draw_callback(GtkWidget *widget, cairo_t *cr, gpointer data)
-{
-  dt_colorpicker_sample_t *sample = (dt_colorpicker_sample_t *)data;
-
   const guint width = gtk_widget_get_allocated_width(widget);
   const guint height = gtk_widget_get_allocated_height(widget);
   gdk_cairo_set_source_rgba(cr, &sample->rgb);
@@ -132,11 +113,64 @@ static gboolean sample_draw_callback(GtkWidget *widget, cairo_t *cr, gpointer da
   return FALSE;
 }
 
+static void _update_sample_label(dt_colorpicker_sample_t *sample)
+{
+  const int model = dt_conf_get_int("ui_last/colorpicker_model");
+  const int statistic = dt_conf_get_int("ui_last/colorpicker_mode");
+
+  float *rgb, *lab;
+
+  switch(statistic)
+  {
+    case 0:
+      rgb = sample->picked_color_rgb_mean;
+      lab = sample->picked_color_lab_mean;
+      break;
+
+    case 1:
+      rgb = sample->picked_color_rgb_min;
+      lab = sample->picked_color_lab_min;
+      break;
+
+    default:
+      rgb = sample->picked_color_rgb_max;
+      lab = sample->picked_color_lab_max;
+      break;
+  }
+
+  // Setting the output button
+  sample->rgb.red   = CLAMP(rgb[0], 0.f, 1.f);
+  sample->rgb.green = CLAMP(rgb[1], 0.f, 1.f);
+  sample->rgb.blue  = CLAMP(rgb[2], 0.f, 1.f);
+
+  // Setting the output label
+  char text[128] = { 0 };
+
+  switch(model)
+  {
+    case 0:
+      // RGB
+      snprintf(text, sizeof(text), "%3d %3d %3d",
+                (int)round(sample->rgb.red   * 255.f),
+                (int)round(sample->rgb.green * 255.f),
+                (int)round(sample->rgb.blue  * 255.f));
+      break;
+
+    case 1:
+      // Lab
+      snprintf(text, sizeof(text), "%6.02f %6.02f %6.02f", CLAMP(lab[0], .0f, 100.0f), lab[1], lab[2]);
+      break;
+  }
+
+  gtk_label_set_text(GTK_LABEL(sample->output_label), text);
+
+  gtk_widget_queue_draw(sample->color_patch);
+}
+
 static void _update_picker_output(dt_lib_module_t *self)
 {
   dt_lib_colorpicker_t *data = self->data;
-  char text[128] = { 0 };
-  char tooltip[128] = { 0 };
+
   dt_iop_module_t *module = dt_iop_get_colorout_module();
   if(module)
   {
@@ -145,180 +179,146 @@ static void _update_picker_output(dt_lib_module_t *self)
                                  module->request_color_pick != DT_REQUEST_COLORPICK_OFF);
     --darktable.gui->reset;
 
-    int input_color = dt_conf_get_int("ui_last/colorpicker_model");
+    _update_sample_label(&data->proxy_linked);
 
-    // always adjust picked color:
-    int m = dt_conf_get_int("ui_last/colorpicker_mode");
-    float *rgb;
-    float *lab;
-    switch(m)
-    {
-      case 0: // mean
-        rgb = darktable.lib->proxy.colorpicker.picked_color_rgb_mean;
-        lab = darktable.lib->proxy.colorpicker.picked_color_lab_mean;
-        break;
-      case 1: // min
-        rgb = darktable.lib->proxy.colorpicker.picked_color_rgb_min;
-        lab = darktable.lib->proxy.colorpicker.picked_color_lab_min;
-        break;
-      default:
-        rgb = darktable.lib->proxy.colorpicker.picked_color_rgb_max;
-        lab = darktable.lib->proxy.colorpicker.picked_color_lab_max;
-        break;
-    }
-
-    // Setting the button color
-    data->rgb.red   = CLAMP(rgb[0], 0.f, 1.f);
-    data->rgb.green = CLAMP(rgb[1], 0.f, 1.f);
-    data->rgb.blue  = CLAMP(rgb[2], 0.f, 1.f);
-
-    switch(input_color)
-    {
-      case 0: // rgb
-        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   (0x%02X%02X%02X)",
-                 (int)round(rgb[0] * 255.f),
-                 (int)round(rgb[1] * 255.f),
-                 (int)round(rgb[2] * 255.f),
-                 (int)round(data->rgb.red   * 255.f),
-                 (int)round(data->rgb.green * 255.f),
-                 (int)round(data->rgb.blue  * 255.f));
-        snprintf(text, sizeof(text), "%3d %3d %3d",
-                 (int)round(data->rgb.red   * 255.f),
-                 (int)round(data->rgb.green * 255.f),
-                 (int)round(data->rgb.blue  * 255.f));
-        break;
-      case 1: // Lab
-        snprintf(tooltip, sizeof(text), "%6.02f   %6.02f   %6.02f", lab[0], lab[1], lab[2]);
-        snprintf(text, sizeof(text), "%.02f %.02f %.02f", CLAMP(lab[0], .0f, 100.0f), lab[1], lab[2]);
-        break;
-    }
-    gtk_label_set_label(GTK_LABEL(data->output_label), text);
-    gtk_widget_set_tooltip_text(data->output_label, tooltip);
-
-    gtk_widget_queue_draw(data->color_patch);
+    gtk_widget_queue_draw(data->large_color_patch);
   }
 }
 
-static void _picker_button_toggled(GtkToggleButton *button, gpointer p)
+static gboolean _large_patch_toggle(GtkWidget *widget, GdkEvent *event, dt_lib_colorpicker_t *data)
 {
-  dt_lib_colorpicker_t *data = ((dt_lib_module_t *)p)->data;
+  gboolean show_large_patch = !dt_conf_get_bool("ui_last/colorpicker_large");
+  dt_conf_set_bool("ui_last/colorpicker_large", show_large_patch);
+
+  gtk_widget_set_visible(gtk_widget_get_parent(data->large_color_patch), show_large_patch);
+
+  return FALSE;
+}
+
+static void _picker_button_toggled(GtkToggleButton *button, dt_lib_colorpicker_t *data)
+{
   gtk_widget_set_sensitive(GTK_WIDGET(data->add_sample_button), gtk_toggle_button_get_active(button));
-  if(darktable.gui->reset) return;
 }
 
-static void _statistic_changed(GtkComboBox *widget, gpointer p)
+static void _update_size(dt_lib_module_t *self, int size)
 {
-  dt_conf_set_int("ui_last/colorpicker_mode", gtk_combo_box_get_active(widget));
-  _update_picker_output((dt_lib_module_t *)p);
-}
-
-static void _color_mode_changed(GtkComboBox *widget, gpointer p)
-{
-  dt_conf_set_int("ui_last/colorpicker_model", gtk_combo_box_get_active(widget));
-  _update_picker_output((dt_lib_module_t *)p);
-}
-
-static void _size_changed(GtkComboBox *widget, gpointer p)
-{
-  dt_lib_colorpicker_t *data = ((dt_lib_module_t *)p)->data;
-
-  const int size = gtk_combo_box_get_active(widget);
-
-  dt_conf_set_int("ui_last/colorpicker_size", size);
   darktable.lib->proxy.colorpicker.size = size;
-  gtk_widget_set_sensitive(data->statistic_selector, size);
 
-  if (!data->from_proxy)
-    dt_dev_invalidate_from_gui(darktable.develop);
-  _update_picker_output(p);
+  _update_picker_output(self);
 }
 
 static void _update_samples_output(dt_lib_module_t *self)
 {
-  float fallback[] = { 0., 0., 0. };
-  float fallback_rgb[] = { 0, 0, 0 };
-  float *rgb = fallback_rgb;
-  float *lab = fallback;
-  char text[128] = { 0 };
-  char tooltip[128] = { 0 };
-  GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
-  dt_colorpicker_sample_t *sample = NULL;
-
-  const int model = dt_conf_get_int("ui_last/colorsamples_model");
-  const int statistic = dt_conf_get_int("ui_last/colorsamples_mode");
-
-  while(samples)
+  for(GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
+      samples;
+      samples = g_slist_next(samples))
   {
-    sample = samples->data;
-
-    switch(statistic)
-    {
-      case 0:
-        rgb = sample->picked_color_rgb_mean;
-        lab = sample->picked_color_lab_mean;
-        break;
-
-      case 1:
-        rgb = sample->picked_color_rgb_min;
-        lab = sample->picked_color_lab_min;
-        break;
-
-      case 2:
-        rgb = sample->picked_color_rgb_max;
-        lab = sample->picked_color_lab_max;
-        break;
-    }
-
-    // Setting the output button
-    sample->rgb.red = CLAMP(rgb[0], 0.f, 1.f);
-    sample->rgb.green = CLAMP(rgb[1], 0.f, 1.f);
-    sample->rgb.blue = CLAMP(rgb[2], 0.f, 1.f);
-    gtk_widget_queue_draw(sample->color_patch);
-
-    // Setting the output label
-    switch(model)
-    {
-      case 0:
-        // RGB
-        snprintf(tooltip, sizeof(tooltip), "%3d   %3d   %3d   (0x%02X%02X%02X)",
-                 (int)round(rgb[0] * 255.f),
-                 (int)round(rgb[1] * 255.f),
-                 (int)round(rgb[2] * 255.f),
-                 (int)round(sample->rgb.red   * 255.f),
-                 (int)round(sample->rgb.green * 255.f),
-                 (int)round(sample->rgb.blue  * 255.f));
-        snprintf(text, sizeof(text), "%3d %3d %3d",
-                 (int)round(sample->rgb.red   * 255.f),
-                 (int)round(sample->rgb.green * 255.f),
-                 (int)round(sample->rgb.blue  * 255.f));
-        break;
-
-      case 1:
-        // Lab
-        snprintf(tooltip, sizeof(text), "%6.02f   %6.02f   %6.02f", lab[0], lab[1], lab[2]);
-        snprintf(text, sizeof(text), "%6.02f %6.02f %6.02f", CLAMP(lab[0], .0f, 100.0f), lab[1], lab[2]);
-        break;
-    }
-    gtk_label_set_text(GTK_LABEL(sample->output_label), text);
-    gtk_widget_set_tooltip_text(sample->output_label, tooltip);
-
-    samples = g_slist_next(samples);
+    _update_sample_label(samples->data);
   }
 }
 
-static void _samples_statistic_changed(GtkComboBox *widget, gpointer p)
+static gboolean _sample_tooltip_callback(GtkWidget *widget, gint x, gint y, gboolean keyboard_mode,
+                                         GtkTooltip *tooltip, const dt_colorpicker_sample_t *sample)
 {
-  dt_conf_set_int("ui_last/colorsamples_mode", gtk_combo_box_get_active(widget));
+  const gchar *name[] = { N_("mean"), N_("min"), N_("max") };
+
+  gchar **sample_parts = g_malloc0_n(12, sizeof(char*));
+
+  sample_parts[3] = g_strdup_printf("%22s(0x%02X%02X%02X)\n%s:", " ",
+                                    (int)round(sample->rgb.red   * 255.f),
+                                    (int)round(sample->rgb.green * 255.f),
+                                    (int)round(sample->rgb.blue  * 255.f), _("RGB"));
+  sample_parts[7] = g_strdup_printf("\n%s:", _("Lab"));
+
+  for(int i = 0; i < 3; i++)
+  {
+    const float *rgb = i == 0 ? sample->picked_color_rgb_mean :
+                       i == 1 ? sample->picked_color_rgb_min :
+                                sample->picked_color_rgb_max;
+
+    sample_parts[i] = g_strdup_printf("<span background='#%02X%02X%02X'>%32s</span>",
+                                      (int)round(CLAMP(rgb[0], 0.f, 1.f) * 255.f),
+                                      (int)round(CLAMP(rgb[1], 0.f, 1.f) * 255.f),
+                                      (int)round(CLAMP(rgb[2], 0.f, 1.f) * 255.f), " ");
+
+    sample_parts[i + 4] = g_strdup_printf("%8s: "
+                                          "<span foreground='red'>%6d</span>  "
+                                          "<span foreground='green'>%6d</span>  "
+                                          "<span foreground='blue'>%6d</span>",
+                                          _(name[i]),
+                                          (int)round(rgb[0] * 255.f),
+                                          (int)round(rgb[1] * 255.f),
+                                          (int)round(rgb[2] * 255.f));
+
+    const float *lab = i == 0 ? sample->picked_color_lab_mean :
+                       i == 1 ? sample->picked_color_lab_min :
+                                sample->picked_color_lab_max;
+
+    sample_parts[i + 8] = g_strdup_printf("%8s: %6.02f  %6.02f  %6.02f", _(name[i]),
+                                          lab[0], lab[1], lab[2]);
+  }
+
+  gchar *tooltip_text = g_strjoinv("\n", sample_parts);
+  g_strfreev(sample_parts);
+
+  static GtkWidget *view = NULL;
+  if(!view)
+  {
+    view = gtk_text_view_new();
+    gtk_widget_set_name(view, "colorpicker-tooltip");
+    g_signal_connect(G_OBJECT(view), "destroy", G_CALLBACK(gtk_widget_destroyed), &view);
+  }
+
+  GtkTextBuffer *buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(view));
+  gtk_text_buffer_set_text(buffer, "", -1);
+  GtkTextIter iter;
+  gtk_text_buffer_get_start_iter(buffer, &iter);
+  gtk_text_buffer_insert_markup(buffer, &iter, tooltip_text, -1);
+  gtk_tooltip_set_custom(tooltip, view);
+
+  g_free(tooltip_text);
+
+  return TRUE;
+}
+
+static void _statistic_changed(GtkWidget *widget, dt_lib_module_t *p)
+{
+  dt_conf_set_int("ui_last/colorpicker_mode", dt_bauhaus_combobox_get(widget));
+
+  _update_picker_output(p);
   _update_samples_output((dt_lib_module_t *)p);
 }
 
-static void _samples_mode_changed(GtkComboBox *widget, gpointer p)
+static void _color_mode_changed(GtkWidget *widget, dt_lib_module_t *p)
 {
-  dt_conf_set_int("ui_last/colorsamples_model", gtk_combo_box_get_active(widget));
+  dt_conf_set_int("ui_last/colorpicker_model", dt_bauhaus_combobox_get(widget));
+
+  _update_picker_output(p);
   _update_samples_output((dt_lib_module_t *)p);
 }
 
-static gboolean _live_sample_enter(GtkWidget *widget, GdkEvent *event, gpointer sample)
+static void _label_size_allocate_callback(GtkWidget *widget, GdkRectangle *allocation, gpointer user_data)
+{
+  gint label_width;
+  gtk_label_set_attributes(GTK_LABEL(widget), NULL);
+  gtk_widget_get_preferred_width(widget, NULL, &label_width);
+
+  double scale = (double)allocation->width / label_width;
+
+  while(label_width > allocation->width && scale > .25)
+  {
+    PangoAttrList *attrlist = pango_attr_list_new();
+    PangoAttribute *attr = pango_attr_scale_new(scale);
+    pango_attr_list_insert(attrlist, attr);
+    gtk_label_set_attributes(GTK_LABEL(widget), attrlist);
+    pango_attr_list_unref(attrlist);
+
+    gtk_widget_get_preferred_width(widget, NULL, &label_width);
+    scale *= 0.95; // find first discrete font that's small enough
+  }
+}
+
+static gboolean _sample_enter_callback(GtkWidget *widget, GdkEvent *event, gpointer sample)
 {
   darktable.lib->proxy.colorpicker.selected_sample = (dt_colorpicker_sample_t *)sample;
   if(darktable.lib->proxy.colorpicker.display_samples) dt_dev_invalidate_from_gui(darktable.develop);
@@ -326,7 +326,7 @@ static gboolean _live_sample_enter(GtkWidget *widget, GdkEvent *event, gpointer 
   return FALSE;
 }
 
-static gboolean _live_sample_leave(GtkWidget *widget, GdkEvent *event, gpointer data)
+static gboolean _sample_leave_callback(GtkWidget *widget, GdkEvent *event, gpointer data)
 {
   darktable.lib->proxy.colorpicker.selected_sample = NULL;
   if(darktable.lib->proxy.colorpicker.display_samples) dt_dev_invalidate_from_gui(darktable.develop);
@@ -336,40 +336,32 @@ static gboolean _live_sample_leave(GtkWidget *widget, GdkEvent *event, gpointer 
 
 static void _remove_sample(dt_colorpicker_sample_t *sample)
 {
-  gtk_widget_hide(sample->container);
-  gtk_widget_destroy(sample->color_patch);
-  gtk_widget_destroy(sample->patch_box);
-  gtk_widget_destroy(sample->output_label);
-  gtk_widget_destroy(sample->delete_button);
   gtk_widget_destroy(sample->container);
   darktable.lib->proxy.colorpicker.live_samples
     = g_slist_remove(darktable.lib->proxy.colorpicker.live_samples, (gpointer)sample);
   free(sample);
 }
 
-static void _remove_sample_cb(GtkButton *widget, gpointer data)
+static void _remove_sample_cb(GtkButton *widget, dt_colorpicker_sample_t *sample)
 {
-  dt_colorpicker_sample_t *sample = (dt_colorpicker_sample_t *)data;
   _remove_sample(sample);
   dt_dev_invalidate_from_gui(darktable.develop);
 }
 
-static gboolean _sample_lock_toggle(GtkWidget *widget, GdkEvent *event, gpointer data)
+static gboolean _sample_lock_toggle(GtkWidget *widget, GdkEvent *event, dt_colorpicker_sample_t *sample)
 {
-  dt_colorpicker_sample_t *sample = (dt_colorpicker_sample_t *)data;
   sample->locked = !sample->locked;
   gtk_widget_queue_draw(widget);
   return FALSE;
 }
 
-static void _add_sample(GtkButton *widget, gpointer self)
+static void _add_sample(GtkButton *widget, dt_lib_module_t *self)
 {
-  dt_lib_colorpicker_t *data = ((dt_lib_module_t *)self)->data;
+  dt_lib_colorpicker_t *data = self->data;
   dt_colorpicker_sample_t *sample = (dt_colorpicker_sample_t *)malloc(sizeof(dt_colorpicker_sample_t));
   darktable.lib->proxy.colorpicker.live_samples
       = g_slist_append(darktable.lib->proxy.colorpicker.live_samples, sample);
   dt_iop_module_t *module = dt_iop_get_colorout_module();
-  int i;
 
   sample->locked = 0;
   sample->rgb.red = 0.7;
@@ -377,62 +369,58 @@ static void _add_sample(GtkButton *widget, gpointer self)
   sample->rgb.blue = 0.7;
   sample->rgb.alpha = 1.0;
 
-  // Initializing the UI
   sample->container = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_box_pack_start(GTK_BOX(data->samples_container), sample->container, TRUE, TRUE, 0);
 
-  sample->patch_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_name(sample->patch_box, "live-sample");
   sample->color_patch = gtk_drawing_area_new();
-  gtk_box_pack_start(GTK_BOX(sample->patch_box), sample->color_patch, TRUE, TRUE, 0);
   gtk_widget_set_events(sample->color_patch, GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_BUTTON_PRESS_MASK);
   gtk_widget_set_tooltip_text(sample->color_patch, _("hover to highlight sample on canvas, "
-                                                       "click to lock sample"));
-  gtk_box_pack_start(GTK_BOX(sample->container), sample->patch_box, TRUE, FALSE, 0);
+                                                     "click to lock sample"));
+  g_signal_connect(G_OBJECT(sample->color_patch), "enter-notify-event", G_CALLBACK(_sample_enter_callback), sample);
+  g_signal_connect(G_OBJECT(sample->color_patch), "leave-notify-event", G_CALLBACK(_sample_leave_callback), sample);
+  g_signal_connect(G_OBJECT(sample->color_patch), "button-press-event", G_CALLBACK(_sample_lock_toggle), sample);
+  g_signal_connect(G_OBJECT(sample->color_patch), "draw", G_CALLBACK(_sample_draw_callback), sample);
 
-  g_signal_connect(G_OBJECT(sample->color_patch), "enter-notify-event", G_CALLBACK(_live_sample_enter),
-                   sample);
-  g_signal_connect(G_OBJECT(sample->color_patch), "leave-notify-event", G_CALLBACK(_live_sample_leave),
-                   sample);
-  g_signal_connect(G_OBJECT(sample->color_patch), "button-press-event", G_CALLBACK(_sample_lock_toggle),
-                   sample);
-  g_signal_connect(G_OBJECT(sample->color_patch), "draw", G_CALLBACK(sample_draw_callback), sample);
+  GtkWidget *color_patch_wrapper = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_name(color_patch_wrapper, "live-sample");
+  gtk_box_pack_start(GTK_BOX(color_patch_wrapper), sample->color_patch, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(sample->container), color_patch_wrapper, TRUE, TRUE, 0);
 
   sample->output_label = gtk_label_new("");
   gtk_widget_set_name(sample->output_label, "live-sample-data");
+  gtk_label_set_ellipsize(GTK_LABEL(sample->output_label), PANGO_ELLIPSIZE_START);
+  gtk_widget_set_has_tooltip(sample->output_label, TRUE);
+  g_signal_connect(G_OBJECT(sample->output_label), "query-tooltip", G_CALLBACK(_sample_tooltip_callback), sample);
+  g_signal_connect(G_OBJECT(sample->output_label), "size-allocate", G_CALLBACK(_label_size_allocate_callback), sample);
   gtk_box_pack_start(GTK_BOX(sample->container), sample->output_label, TRUE, TRUE, 0);
 
-  sample->delete_button = gtk_button_new_with_label(_("X"));
-  gtk_box_pack_start(GTK_BOX(sample->container), sample->delete_button, FALSE, FALSE, 0);
+  GtkWidget *delete_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+  g_signal_connect(G_OBJECT(delete_button), "clicked", G_CALLBACK(_remove_sample_cb), sample);
+  gtk_box_pack_start(GTK_BOX(sample->container), delete_button, FALSE, FALSE, 0);
 
-  g_signal_connect(G_OBJECT(sample->delete_button), "clicked", G_CALLBACK(_remove_sample_cb), sample);
-
-  gtk_widget_show_all(data->samples_container);
+  gtk_box_pack_start(GTK_BOX(data->samples_container), sample->container, TRUE, TRUE, 0);
+  gtk_widget_show_all(sample->container);
 
   // Setting the actual data
-  if(dt_conf_get_int("ui_last/colorpicker_size"))
+  if(darktable.lib->proxy.colorpicker.size)
   {
     sample->size = DT_COLORPICKER_SIZE_BOX;
-    for(i = 0; i < 4; i++) sample->box[i] = module->color_picker_box[i];
+    for(int i = 0; i < 4; i++) sample->box[i] = module->color_picker_box[i];
   }
   else
   {
     sample->size = DT_COLORPICKER_SIZE_POINT;
-    for(i = 0; i < 2; i++) sample->point[i] = module->color_picker_point[i];
+    for(int i = 0; i < 2; i++) sample->point[i] = module->color_picker_point[i];
   }
 
-  for(i = 0; i < 3; i++)
+  for(int i = 0; i < 3; i++)
+  {
     sample->picked_color_lab_max[i] = darktable.lib->proxy.colorpicker.picked_color_lab_max[i];
-  for(i = 0; i < 3; i++)
     sample->picked_color_lab_mean[i] = darktable.lib->proxy.colorpicker.picked_color_lab_mean[i];
-  for(i = 0; i < 3; i++)
     sample->picked_color_lab_min[i] = darktable.lib->proxy.colorpicker.picked_color_lab_min[i];
-  for(i = 0; i < 3; i++)
     sample->picked_color_rgb_max[i] = darktable.lib->proxy.colorpicker.picked_color_rgb_max[i];
-  for(i = 0; i < 3; i++)
     sample->picked_color_rgb_mean[i] = darktable.lib->proxy.colorpicker.picked_color_rgb_mean[i];
-  for(i = 0; i < 3; i++)
     sample->picked_color_rgb_min[i] = darktable.lib->proxy.colorpicker.picked_color_rgb_min[i];
+  }
 
   // Updating the display
   _update_samples_output((dt_lib_module_t *)self);
@@ -456,8 +444,6 @@ static void _restrict_histogram_changed(GtkToggleButton *button, gpointer data)
 /* set sample area proxy impl */
 static void _set_sample_area(dt_lib_module_t *self, float size)
 {
-  dt_lib_colorpicker_t *d = (dt_lib_colorpicker_t *)self->data;
-
   if(darktable.develop->gui_module)
   {
     darktable.develop->gui_module->color_picker_box[0] = darktable.develop->gui_module->color_picker_box[1]
@@ -466,80 +452,53 @@ static void _set_sample_area(dt_lib_module_t *self, float size)
         = size;
   }
 
-  d->from_proxy = TRUE;
-  gtk_combo_box_set_active(GTK_COMBO_BOX(d->size_selector), DT_COLORPICKER_SIZE_BOX);
-  d->from_proxy = FALSE;
+  _update_size(self, DT_COLORPICKER_SIZE_BOX);
 }
 
 static void _set_sample_box_area(dt_lib_module_t *self, const float *const box)
 {
-  dt_lib_colorpicker_t *d = (dt_lib_colorpicker_t *)self->data;
-
   if(darktable.develop->gui_module)
   {
     for(int k = 0; k < 4; k++) darktable.develop->gui_module->color_picker_box[k] = box[k];
   }
 
-  d->from_proxy = TRUE;
-  gtk_combo_box_set_active(GTK_COMBO_BOX(d->size_selector), DT_COLORPICKER_SIZE_BOX);
-  d->from_proxy = FALSE;
+  _update_size(self, DT_COLORPICKER_SIZE_BOX);
 }
 
 static void _set_sample_point(dt_lib_module_t *self, float x, float y)
 {
-  dt_lib_colorpicker_t *d = (dt_lib_colorpicker_t *)self->data;
-
   if(darktable.develop->gui_module)
   {
     darktable.develop->gui_module->color_picker_point[0] = x;
     darktable.develop->gui_module->color_picker_point[1] = y;
   }
 
-  d->from_proxy = TRUE;
-  gtk_combo_box_set_active(GTK_COMBO_BOX(d->size_selector), DT_COLORPICKER_SIZE_POINT);
-  d->from_proxy = FALSE;
+  _update_size(self, DT_COLORPICKER_SIZE_POINT);
 }
 
 void gui_init(dt_lib_module_t *self)
 {
-  unsigned int i;
-
-  GtkWidget *container = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  GtkWidget *output_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *output_options = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  GtkWidget *picker_subrow = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *restrict_button;
-  GtkWidget *samples_label = dt_ui_section_label_new(_("live samples"));
-  GtkWidget *samples_options_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-
   // Initializing self data structure
   dt_lib_colorpicker_t *data = (dt_lib_colorpicker_t *)calloc(1, sizeof(dt_lib_colorpicker_t));
+
   self->data = (void *)data;
-  data->rgb.red = 0.7;
-  data->rgb.green = 0.7;
-  data->rgb.blue = 0.7;
-  data->rgb.alpha = 1.0;
-  data->from_proxy = FALSE;
+
+  data->proxy_linked.rgb.red = 0.7;
+  data->proxy_linked.rgb.green = 0.7;
+  data->proxy_linked.rgb.blue = 0.7;
+  data->proxy_linked.rgb.alpha = 1.0;
 
   // Initializing proxy functions and data
   darktable.lib->proxy.colorpicker.module = self;
   darktable.lib->proxy.colorpicker.size = dt_conf_get_int("ui_last/colorpicker_size");
   darktable.lib->proxy.colorpicker.display_samples = dt_conf_get_int("ui_last/colorpicker_display_samples");
   darktable.lib->proxy.colorpicker.live_samples = NULL;
-  darktable.lib->proxy.colorpicker.picked_color_rgb_mean = (float *)malloc(sizeof(float) * 3);
-  darktable.lib->proxy.colorpicker.picked_color_rgb_min = (float *)malloc(sizeof(float) * 3);
-  darktable.lib->proxy.colorpicker.picked_color_rgb_max = (float *)malloc(sizeof(float) * 3);
-  darktable.lib->proxy.colorpicker.picked_color_lab_mean = (float *)malloc(sizeof(float) * 3);
-  darktable.lib->proxy.colorpicker.picked_color_lab_min = (float *)malloc(sizeof(float) * 3);
-  darktable.lib->proxy.colorpicker.picked_color_lab_max = (float *)malloc(sizeof(float) * 3);
-  for(i = 0; i < 3; i++)
-    darktable.lib->proxy.colorpicker.picked_color_rgb_mean[i]
-        = darktable.lib->proxy.colorpicker.picked_color_rgb_min[i]
-        = darktable.lib->proxy.colorpicker.picked_color_rgb_max[i] = 0;
-  for(i = 0; i < 3; i++)
-    darktable.lib->proxy.colorpicker.picked_color_lab_mean[i]
-        = darktable.lib->proxy.colorpicker.picked_color_lab_min[i]
-        = darktable.lib->proxy.colorpicker.picked_color_lab_max[i] = 0;
+  darktable.lib->proxy.colorpicker.picked_color_rgb_mean = data->proxy_linked.picked_color_rgb_mean;
+  darktable.lib->proxy.colorpicker.picked_color_rgb_min = data->proxy_linked.picked_color_rgb_min;
+  darktable.lib->proxy.colorpicker.picked_color_rgb_max = data->proxy_linked.picked_color_rgb_max;
+  darktable.lib->proxy.colorpicker.picked_color_lab_mean = data->proxy_linked.picked_color_lab_mean;
+  darktable.lib->proxy.colorpicker.picked_color_lab_min = data->proxy_linked.picked_color_lab_min;
+  darktable.lib->proxy.colorpicker.picked_color_lab_max = data->proxy_linked.picked_color_lab_max;
   darktable.lib->proxy.colorpicker.update_panel = _update_picker_output;
   darktable.lib->proxy.colorpicker.update_samples = _update_samples_output;
   darktable.lib->proxy.colorpicker.set_sample_area = _set_sample_area;
@@ -547,113 +506,111 @@ void gui_init(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.set_sample_point = _set_sample_point;
 
   // Setting up the GUI
-  self->widget = container;
+  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   GtkStyleContext *context = gtk_widget_get_style_context(self->widget);
   gtk_style_context_add_class(context, "picker-module");
-  gtk_box_pack_start(GTK_BOX(container), output_row, TRUE, TRUE, 0);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
   // The color patch
-  GtkWidget *picker_area = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  gtk_widget_set_name(GTK_WIDGET(picker_area), "color-picker-area");
-  data->color_patch = gtk_drawing_area_new();
-  g_signal_connect(G_OBJECT(data->color_patch), "draw", G_CALLBACK(main_draw_callback), data);
-  gtk_box_pack_start(GTK_BOX(picker_area), data->color_patch, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(output_row), picker_area, FALSE, FALSE, 0);
+  GtkWidget *color_patch_wrapper = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_name(GTK_WIDGET(color_patch_wrapper), "color-picker-area");
+  GtkWidget *color_patch = gtk_drawing_area_new();
+  data->large_color_patch = color_patch;
+  gtk_widget_set_tooltip_text(color_patch, _("click to (un)hide large color patch"));
+  gtk_widget_set_events(color_patch, GDK_BUTTON_PRESS_MASK);
+  g_signal_connect(G_OBJECT(color_patch), "draw", G_CALLBACK(_sample_draw_callback), &data->proxy_linked);
+  g_signal_connect(G_OBJECT(color_patch), "button-press-event", G_CALLBACK(_large_patch_toggle), data);
+  gtk_box_pack_start(GTK_BOX(color_patch_wrapper), color_patch, TRUE, TRUE, 0);
+  gtk_widget_show(color_patch);
+  gtk_widget_set_no_show_all(color_patch_wrapper, dt_conf_get_bool("ui_last/colorpicker_large") == FALSE);
+  gtk_box_pack_start(GTK_BOX(self->widget), color_patch_wrapper, FALSE, FALSE, 0);
 
-  // The picker button, output selectors and label
-  gtk_box_pack_start(GTK_BOX(output_row), output_options, TRUE, TRUE, 0);
+  // The picker button, mode and statistic combo boxes
+  GtkWidget *picker_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  data->size_selector = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->size_selector), _("point"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->size_selector), _("area"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->size_selector), dt_conf_get_int("ui_last/colorpicker_size"));
-  gtk_box_pack_start(GTK_BOX(picker_subrow), data->size_selector, TRUE, TRUE, 0);
+  data->statistic_selector = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_widget_set_label(data->statistic_selector, NULL, _("statistic"));
+  dt_bauhaus_combobox_add(data->statistic_selector, _("mean"));
+  dt_bauhaus_combobox_add(data->statistic_selector, _("min"));
+  dt_bauhaus_combobox_add(data->statistic_selector, _("max"));
+  dt_bauhaus_combobox_set(data->statistic_selector, dt_conf_get_int("ui_last/colorpicker_mode"));
+  dt_bauhaus_combobox_set_entries_ellipsis(data->statistic_selector, PANGO_ELLIPSIZE_NONE);
+  g_signal_connect(G_OBJECT(data->statistic_selector), "value-changed", G_CALLBACK(_statistic_changed), self);
+  gtk_widget_set_valign(data->statistic_selector, GTK_ALIGN_END);
+  gtk_box_pack_start(GTK_BOX(picker_row), data->statistic_selector, TRUE, TRUE, 0);
 
-  g_signal_connect(G_OBJECT(data->size_selector), "changed", G_CALLBACK(_size_changed), (gpointer)self);
+  data->color_mode_selector = dt_bauhaus_combobox_new(NULL);
+  dt_bauhaus_widget_set_label(data->color_mode_selector, NULL, _("model"));
+  dt_bauhaus_combobox_add(data->color_mode_selector, _("RGB"));
+  dt_bauhaus_combobox_add(data->color_mode_selector, _("Lab"));
+  dt_bauhaus_combobox_set(data->color_mode_selector, dt_conf_get_int("ui_last/colorpicker_model"));
+  dt_bauhaus_combobox_set_entries_ellipsis(data->color_mode_selector, PANGO_ELLIPSIZE_NONE);
+  g_signal_connect(G_OBJECT(data->color_mode_selector), "value-changed", G_CALLBACK(_color_mode_changed), self);
+  gtk_widget_set_valign(data->color_mode_selector, GTK_ALIGN_END);
+  gtk_box_pack_start(GTK_BOX(picker_row), data->color_mode_selector, TRUE, TRUE, 0);
 
-  data->picker_button = dt_color_picker_new(NULL, DT_COLOR_PICKER_AREA, picker_subrow);
+  gtk_box_pack_start(GTK_BOX(picker_row), gtk_label_new("  "), FALSE, FALSE, 0);
+
+  data->picker_button = dt_color_picker_new(NULL, DT_COLOR_PICKER_POINT_AREA, picker_row);
   gtk_widget_set_name(GTK_WIDGET(data->picker_button), "color-picker-button");
-  g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), self);
+  g_signal_connect(G_OBJECT(data->picker_button), "toggled", G_CALLBACK(_picker_button_toggled), data);
 
-  gtk_box_pack_start(GTK_BOX(output_options), picker_subrow, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), picker_row, TRUE, TRUE, 0);
 
-  data->statistic_selector = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->statistic_selector), _("mean"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->statistic_selector), _("min"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->statistic_selector), _("max"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->statistic_selector),
-                           dt_conf_get_int("ui_last/colorpicker_mode"));
-  gtk_widget_set_sensitive(data->statistic_selector, dt_conf_get_int("ui_last/colorpicker_size"));
-  gtk_box_pack_start(GTK_BOX(output_options), data->statistic_selector, TRUE, TRUE, 0);
+  // The small sample, label and add button
+  GtkWidget *sample_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
-  g_signal_connect(G_OBJECT(data->statistic_selector), "changed", G_CALLBACK(_statistic_changed), self);
+  data->proxy_linked.color_patch = color_patch = gtk_drawing_area_new();
+  gtk_widget_set_tooltip_text(color_patch, _("click to (un)hide large color patch"));
+  gtk_widget_set_events(color_patch, GDK_BUTTON_PRESS_MASK);
+  g_signal_connect(G_OBJECT(color_patch), "button-press-event", G_CALLBACK(_large_patch_toggle), data);
+  g_signal_connect(G_OBJECT(color_patch), "draw", G_CALLBACK(_sample_draw_callback), &data->proxy_linked);
 
-  data->color_mode_selector = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->color_mode_selector), _("RGB"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->color_mode_selector), _("Lab"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->color_mode_selector),
-                           dt_conf_get_int("ui_last/colorpicker_model"));
-  gtk_box_pack_start(GTK_BOX(output_options), data->color_mode_selector, TRUE, TRUE, 0);
+  color_patch_wrapper = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+  gtk_widget_set_name(color_patch_wrapper, "live-sample");
+  gtk_box_pack_start(GTK_BOX(color_patch_wrapper), color_patch, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(sample_row), color_patch_wrapper, TRUE, TRUE, 0);
 
-  g_signal_connect(G_OBJECT(data->color_mode_selector), "changed", G_CALLBACK(_color_mode_changed), self);
+  GtkWidget *label = data->proxy_linked.output_label = gtk_label_new("");
+  gtk_label_set_justify(GTK_LABEL(label), GTK_JUSTIFY_CENTER);
+  gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_START);
+  gtk_widget_set_name(label, "live-sample-data");
+  gtk_widget_set_has_tooltip(label, TRUE);
+  g_signal_connect(G_OBJECT(label), "query-tooltip", G_CALLBACK(_sample_tooltip_callback), &data->proxy_linked);
+  g_signal_connect(G_OBJECT(label), "size-allocate", G_CALLBACK(_label_size_allocate_callback), &data->proxy_linked);
+  gtk_box_pack_start(GTK_BOX(sample_row), label, TRUE, TRUE, 0);
 
-  data->output_label = gtk_label_new("");
-  gtk_label_set_justify(GTK_LABEL(data->output_label), GTK_JUSTIFY_CENTER);
-  gtk_box_pack_start(GTK_BOX(output_options), data->output_label, FALSE, FALSE, 0);
-  gtk_widget_set_name(data->output_label, "live-sample-data");
-
-  restrict_button = gtk_check_button_new_with_label(_("restrict histogram to selection"));
-  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(restrict_button))), PANGO_ELLIPSIZE_MIDDLE);
-  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(restrict_button),
-                               dt_conf_get_int("ui_last/colorpicker_restrict_histogram"));
-  darktable.lib->proxy.colorpicker.restrict_histogram
-      = dt_conf_get_int("ui_last/colorpicker_restrict_histogram");
-  gtk_box_pack_start(GTK_BOX(container), restrict_button, TRUE, TRUE, 0);
-  g_signal_connect(G_OBJECT(restrict_button), "toggled", G_CALLBACK(_restrict_histogram_changed), NULL);
+  data->add_sample_button = dtgtk_togglebutton_new(dtgtk_cairo_paint_plus_simple, CPF_STYLE_FLAT, NULL);;
+  gtk_widget_set_sensitive(data->add_sample_button, FALSE);
+  g_signal_connect(G_OBJECT(data->add_sample_button), "clicked", G_CALLBACK(_add_sample), self);
+  gtk_box_pack_end(GTK_BOX(sample_row), data->add_sample_button, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), sample_row, TRUE, TRUE, 0);
 
   // Adding the live samples section
-  gtk_box_pack_start(GTK_BOX(container), samples_label, TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(container), samples_options_row, TRUE, TRUE, 0);
-
-  data->samples_statistic_selector = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_statistic_selector), _("mean"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_statistic_selector), _("min"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_statistic_selector), _("max"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_statistic_selector),
-                           dt_conf_get_int("ui_last/colorsamples_mode"));
-  gtk_box_pack_start(GTK_BOX(samples_options_row), data->samples_statistic_selector, TRUE, TRUE, 0);
-
-  g_signal_connect(G_OBJECT(data->samples_statistic_selector), "changed",
-                   G_CALLBACK(_samples_statistic_changed), self);
-
-  data->samples_mode_selector = gtk_combo_box_text_new();
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_mode_selector), _("RGB"));
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(data->samples_mode_selector), _("Lab"));
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_mode_selector),
-                           dt_conf_get_int("ui_last/colorsamples_model"));
-  gtk_box_pack_start(GTK_BOX(samples_options_row), data->samples_mode_selector, TRUE, TRUE, 0);
-
-  g_signal_connect(G_OBJECT(data->samples_mode_selector), "changed", G_CALLBACK(_samples_mode_changed), self);
-
-  data->add_sample_button = gtk_button_new_with_label(_("add"));
-  gtk_widget_set_sensitive(data->add_sample_button, FALSE);
-  gtk_box_pack_start(GTK_BOX(samples_options_row), data->add_sample_button, FALSE, FALSE, 0);
-
-  g_signal_connect(G_OBJECT(data->add_sample_button), "clicked", G_CALLBACK(_add_sample), self);
+  label = dt_ui_section_label_new(_("live samples"));
+  context = gtk_widget_get_style_context(GTK_WIDGET(label));
+  gtk_style_context_add_class(context, "section_label_top");
+  gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
   data->samples_container = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_box_pack_start(GTK_BOX(container), data->samples_container, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), data->samples_container, TRUE, TRUE, 0);
 
   data->display_samples_check_box = gtk_check_button_new_with_label(_("display sample areas on image"));
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(data->display_samples_check_box))),
                           PANGO_ELLIPSIZE_MIDDLE);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box),
                                dt_conf_get_int("ui_last/colorpicker_display_samples"));
-  gtk_box_pack_start(GTK_BOX(container), data->display_samples_check_box, TRUE, TRUE, 0);
+  g_signal_connect(G_OBJECT(data->display_samples_check_box), "toggled",
+                   G_CALLBACK(_display_samples_changed), NULL);
+  gtk_box_pack_start(GTK_BOX(self->widget), data->display_samples_check_box, TRUE, TRUE, 0);
 
-  g_signal_connect(G_OBJECT(data->display_samples_check_box), "toggled", G_CALLBACK(_display_samples_changed),
-                   NULL);
+  GtkWidget *restrict_button = gtk_check_button_new_with_label(_("restrict histogram to selection"));
+  gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(restrict_button))), PANGO_ELLIPSIZE_MIDDLE);
+  int restrict_histogram = dt_conf_get_int("ui_last/colorpicker_restrict_histogram");
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(restrict_button), restrict_histogram);
+  darktable.lib->proxy.colorpicker.restrict_histogram = restrict_histogram;
+  g_signal_connect(G_OBJECT(restrict_button), "toggled", G_CALLBACK(_restrict_histogram_changed), NULL);
+  gtk_box_pack_start(GTK_BOX(self->widget), restrict_button, TRUE, TRUE, 0);
 }
 
 void gui_cleanup(dt_lib_module_t *self)
@@ -666,19 +623,12 @@ void gui_cleanup(dt_lib_module_t *self)
   darktable.lib->proxy.colorpicker.set_sample_area = NULL;
   darktable.lib->proxy.colorpicker.set_sample_box_area = NULL;
 
-  free(darktable.lib->proxy.colorpicker.picked_color_rgb_mean);
-  free(darktable.lib->proxy.colorpicker.picked_color_rgb_min);
-  free(darktable.lib->proxy.colorpicker.picked_color_rgb_max);
-  free(darktable.lib->proxy.colorpicker.picked_color_lab_mean);
-  free(darktable.lib->proxy.colorpicker.picked_color_lab_min);
-  free(darktable.lib->proxy.colorpicker.picked_color_lab_max);
   darktable.lib->proxy.colorpicker.picked_color_rgb_mean
       = darktable.lib->proxy.colorpicker.picked_color_rgb_min
       = darktable.lib->proxy.colorpicker.picked_color_rgb_max = NULL;
   darktable.lib->proxy.colorpicker.picked_color_lab_mean
       = darktable.lib->proxy.colorpicker.picked_color_lab_min
       = darktable.lib->proxy.colorpicker.picked_color_lab_max = NULL;
-
 
   while(darktable.lib->proxy.colorpicker.live_samples)
     _remove_sample(darktable.lib->proxy.colorpicker.live_samples->data);
@@ -691,13 +641,11 @@ void gui_reset(dt_lib_module_t *self)
 {
   dt_lib_colorpicker_t *data = self->data;
 
-  int i;
-
   // First turning off any active picking
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->picker_button), FALSE);
 
   // Resetting the picked colors
-  for(i = 0; i < 3; i++)
+  for(int i = 0; i < 3; i++)
   {
     darktable.lib->proxy.colorpicker.picked_color_rgb_mean[i]
         = darktable.lib->proxy.colorpicker.picked_color_rgb_min[i]
@@ -708,8 +656,6 @@ void gui_reset(dt_lib_module_t *self)
         = darktable.lib->proxy.colorpicker.picked_color_lab_max[i] = 0;
   }
 
-  data->from_proxy = FALSE;
-
   _update_picker_output(self);
 
   // Removing any live samples
@@ -717,11 +663,8 @@ void gui_reset(dt_lib_module_t *self)
     _remove_sample(darktable.lib->proxy.colorpicker.live_samples->data);
 
   // Resetting GUI elements
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->size_selector), 0);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->statistic_selector), 0);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->color_mode_selector), 0);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_mode_selector), 0);
-  gtk_combo_box_set_active(GTK_COMBO_BOX(data->samples_statistic_selector), 0);
+  dt_bauhaus_combobox_set(data->statistic_selector, 0);
+  dt_bauhaus_combobox_set(data->color_mode_selector, 0);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(data->display_samples_check_box), FALSE);
 }
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh

--- a/src/libs/colorpicker.h
+++ b/src/libs/colorpicker.h
@@ -27,7 +27,6 @@
 /** The struct for live color picker samples */
 typedef struct dt_colorpicker_sample_t
 {
-
   /** The sample area or point */
   float point[2];
   float box[4];
@@ -47,8 +46,6 @@ typedef struct dt_colorpicker_sample_t
   GtkWidget *container;
   GtkWidget *color_patch;
   GtkWidget *output_label;
-  GtkWidget *delete_button;
-  GtkWidget *patch_box;
   GdkRGBA rgb;
 } dt_colorpicker_sample_t;
 


### PR DESCRIPTION
As promised here https://github.com/darktable-org/darktable/issues/6282#issuecomment-692161038

![image](https://user-images.githubusercontent.com/1549490/93878807-93218280-fcd2-11ea-92ed-9a6ab8b1a037.png)

Removed broken functionality and streamlined module.
Improved the tooltip.
Works better with narrow panels.

Fixes #6282