### PR TITLE
[masks] adjust overzealous clamping and allow for totally huge masks

### DIFF
--- a/src/control/conf.c
+++ b/src/control/conf.c
@@ -155,6 +155,30 @@ float dt_conf_get_float(const char *name)
   return val;
 }
 
+int dt_conf_get_and_sanitize_int(const char *name, int min, int max)
+{
+  int val = dt_conf_get_int(name);
+  val = CLAMPS(val, min, max);
+  dt_conf_set_int(name, val);
+  return val;
+}
+
+int64_t dt_conf_get_and_sanitize_int64(const char *name, int64_t min, int64_t max)
+{
+  int64_t val = dt_conf_get_int64(name);
+  val = CLAMPS(val, min, max);
+  dt_conf_set_int64(name, val);
+  return val;
+}
+
+float dt_conf_get_and_sanitize_float(const char *name, float min, float max)
+{
+  float val = dt_conf_get_float(name);
+  val = CLAMPS(val, min, max);
+  dt_conf_set_float(name, val);
+  return val;
+}
+
 int dt_conf_get_bool(const char *name)
 {
   const char *str = dt_conf_get_var(name);

--- a/src/control/conf.h
+++ b/src/control/conf.h
@@ -50,6 +50,9 @@ void dt_conf_set_string(const char *name, const char *val);
 int dt_conf_get_int(const char *name);
 int64_t dt_conf_get_int64(const char *name);
 float dt_conf_get_float(const char *name);
+int dt_conf_get_and_sanitize_int(const char *name, int min, int max);
+int64_t dt_conf_get_and_sanitize_int64(const char *name, int64_t min, int64_t max);
+float dt_conf_get_and_sanitize_float(const char *name, float min, float max);
 int dt_conf_get_bool(const char *name);
 gchar *dt_conf_get_string(const char *name);
 void dt_conf_init(dt_conf_t *cf, const char *filename, GSList *override_entries);
@@ -57,6 +60,10 @@ void dt_conf_cleanup(dt_conf_t *cf);
 int dt_conf_key_exists(const char *key);
 GSList *dt_conf_all_string_entries(const char *dir);
 void dt_conf_string_entry_free(gpointer data);
+
+#define DT_CONF_SET_SANITIZED_INT(name, val, min, max) dt_conf_set_int(name, CLAMPS(val, min,max));
+#define DT_CONF_SET_SANITIZED_INT6464(name, val, min, max) dt_conf_set_int(name, CLAMPS(val, min,max));
+#define DT_CONF_SET_SANITIZED_FLOAT(name, val, min, max) dt_conf_set_float(name, CLAMPS(val, min,max));
 
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -59,6 +59,9 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
                                            uint32_t state, dt_masks_form_t *form, int parentid,
                                            dt_masks_form_gui_t *gui, int index)
 {
+  const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 2.0f;
+  const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 2.0f;
+
   // add a preview when creating a circle
   if(gui->creation)
   {
@@ -73,7 +76,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
 
       if(up && masks_border > 0.0005f)
         masks_border *= 0.97f;
-      else if(!up && masks_border < 1.0f)
+      else if(!up && masks_border < max_mask_border)
         masks_border *= 1.0f / 0.97f;
 
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
@@ -83,6 +86,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     }
     else if(state == 0)
     {
+      const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 2.0f;
       float masks_size = 0.0f;
 
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
@@ -92,7 +96,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
 
       if(up && masks_size > 0.001f)
         masks_size *= 0.97f;
-      else if(!up && masks_size < 1.0f)
+      else if(!up && masks_size < max_mask_size)
         masks_size *= 1.0f / 0.97f;
 
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
@@ -124,7 +128,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       {
         if(up && circle->border > 0.0005f)
           circle->border *= 0.97f;
-        else if(!up && circle->border < 1.0f)
+        else if(!up && circle->border < max_mask_border)
           circle->border *= 1.0f / 0.97f;
         else
           return 1;
@@ -140,7 +144,7 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
       {
         if(up && circle->radius > 0.001f)
           circle->radius *= 0.97f;
-        else if(!up && circle->radius < 1.0f)
+        else if(!up && circle->radius < max_mask_size)
           circle->radius *= 1.0f / 0.97f;
         else
           return 1;
@@ -248,8 +252,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     }
     else
     {
-      circle->radius = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 0.5f);
-      circle->border = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 0.5f);
+      circle->radius = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 2.0f);
+      circle->border = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 2.0f);
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }
@@ -529,8 +533,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       }
       else
       {
-        radius1 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 0.5f);
-        radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 0.5f);
+        radius1 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 2.0f);
+        radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 2.0f);
       }
       radius2 += radius1;
       radius1 *= min_iwd_iht;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -166,15 +166,6 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
   return 0;
 }
 
-static float dt_conf_get_sanitize_set(const char *name, float min, float max)
-{
-  float value = dt_conf_get_float(name);
-  value = MIN(max, value);
-  value = MAX(min, value);
-  dt_conf_set_float(name, value);
-  return value;
-}
-
 static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float pzx, float pzy,
                                            double pressure, int which, int type, uint32_t state,
                                            dt_masks_form_t *form, int parentid, dt_masks_form_gui_t *gui,
@@ -235,8 +226,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
 
     if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
     {
-      circle->radius = dt_conf_get_sanitize_set("plugins/darkroom/spots/circle_size", 0.001f, 0.5f);
-      circle->border = dt_conf_get_sanitize_set("plugins/darkroom/spots/circle_border", 0.0005f, 0.5f);
+      circle->radius = dt_conf_get_float("plugins/darkroom/spots/circle_size");
+      circle->border = dt_conf_get_float("plugins/darkroom/spots/circle_border");
 
       // calculate the source position
       if(form->type & DT_MASKS_CLONE)
@@ -251,8 +242,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     }
     else
     {
-      circle->radius = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 1.0f);
-      circle->border = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 1.0f);
+      circle->radius = dt_conf_get_float("plugins/darkroom/masks/circle/size");
+      circle->border = dt_conf_get_float("plugins/darkroom/masks/circle/border");
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }
@@ -527,13 +518,13 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       float radius1 = 0.0f, radius2 = 0.0f;
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
       {
-        radius1 = dt_conf_get_sanitize_set("plugins/darkroom/spots/circle_size", 0.001f, 0.5f);
-        radius2 = dt_conf_get_sanitize_set("plugins/darkroom/spots/circle_border", 0.0005f, 0.5f);
+        radius1 = dt_conf_get_float("plugins/darkroom/spots/circle_size");
+        radius2 = dt_conf_get_float("plugins/darkroom/spots/circle_border");
       }
       else
       {
-        radius1 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 1.0f);
-        radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 1.0f);
+        radius1 = dt_conf_get_float("plugins/darkroom/masks/circle/size");
+        radius2 = dt_conf_get_float("plugins/darkroom/masks/circle/border");
       }
       radius2 += radius1;
       radius1 *= min_iwd_iht;

--- a/src/develop/masks/circle.c
+++ b/src/develop/masks/circle.c
@@ -59,8 +59,8 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
                                            uint32_t state, dt_masks_form_t *form, int parentid,
                                            dt_masks_form_gui_t *gui, int index)
 {
-  const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 2.0f;
-  const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 2.0f;
+  const float max_mask_border = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
+  const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
 
   // add a preview when creating a circle
   if(gui->creation)
@@ -86,7 +86,6 @@ static int dt_circle_events_mouse_scrolled(struct dt_iop_module_t *module, float
     }
     else if(state == 0)
     {
-      const float max_mask_size = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 2.0f;
       float masks_size = 0.0f;
 
       if(form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE))
@@ -252,8 +251,8 @@ static int dt_circle_events_button_pressed(struct dt_iop_module_t *module, float
     }
     else
     {
-      circle->radius = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 2.0f);
-      circle->border = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 2.0f);
+      circle->radius = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 1.0f);
+      circle->border = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 1.0f);
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }
@@ -533,8 +532,8 @@ static void dt_circle_events_post_expose(cairo_t *cr, float zoom_scale, dt_masks
       }
       else
       {
-        radius1 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 2.0f);
-        radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 2.0f);
+        radius1 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/size", 0.001f, 1.0f);
+        radius2 = dt_conf_get_sanitize_set("plugins/darkroom/masks/circle/border", 0.0005f, 1.0f);
       }
       radius2 += radius1;
       radius1 *= min_iwd_iht;

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -623,16 +623,23 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     {
       const float a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
       const float b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+      const float ratio = a/b;
       const float ellipse_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
-      const float rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
-      const int flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
-      ellipse->radius[0] = MAX(0.001f, MIN(0.5f, a));
-      ellipse->radius[1] = MAX(0.001f, MIN(0.5f, b));
-      ellipse->flags = flags;
-      ellipse->rotation = rotation;
+      ellipse->rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
+      ellipse->flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
+      if(a>b)
+      {
+        ellipse->radius[0] = CLAMPS(a, 0.001f, 0.5f);
+        ellipse->radius[1] = ellipse->radius[0] / ratio;
+      }
+      else
+      {
+        ellipse->radius[1] = CLAMPS(b, 0.001f, 0.5f);
+        ellipse->radius[0] = ratio * ellipse->radius[1];
+      }
       const float min_radius = fmin(ellipse->radius[0], ellipse->radius[1]);
       const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/min_radius : 1.0f);
-      ellipse->border = MAX(0.005f * reference, MIN(0.5f * reference, ellipse_border));
+      ellipse->border = CLAMPS(ellipse_border, 0.005f * reference, 0.5f * reference);
       if(form->type & DT_MASKS_CLONE)
       {
         dt_masks_set_source_pos_initial_value(gui, DT_MASKS_ELLIPSE, form, pzx, pzy);
@@ -647,16 +654,23 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     {
       const float a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
       const float b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+      const float ratio = a/b;
       const float ellipse_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
-      const float rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
-      const int flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
-      ellipse->radius[0] = MAX(0.001f, MIN(1.0f, a));
-      ellipse->radius[1] = MAX(0.001f, MIN(1.0f, b));
-      ellipse->flags = flags;
-      ellipse->rotation = rotation;
+      ellipse->rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
+      ellipse->flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
+      if(a>b)
+      {
+        ellipse->radius[0] = CLAMPS(a, 0.001f, 1.0f);
+        ellipse->radius[1] = ellipse->radius[0] / ratio;
+      }
+      else
+      {
+        ellipse->radius[1] = CLAMPS(b, 0.001f, 1.0f);
+        ellipse->radius[0] = ratio * ellipse->radius[1];
+      }
       const float min_radius = fmin(ellipse->radius[0], ellipse->radius[1]);
       const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/min_radius : 1.0f);
-      ellipse->border = MAX(0.005f * reference, MIN(1.0f * reference, ellipse_border));
+      ellipse->border = CLAMPS(ellipse_border, 0.005f * reference, 1.0f * reference);
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -621,25 +621,11 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
 
     if(form->type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
     {
-      const float a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
-      const float b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
-      const float ratio = a/b;
-      const float ellipse_border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
+      ellipse->radius[0] = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+      ellipse->radius[1] = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+      ellipse->border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
       ellipse->rotation = dt_conf_get_float("plugins/darkroom/spots/ellipse_rotation");
       ellipse->flags = dt_conf_get_int("plugins/darkroom/spots/ellipse_flags");
-      if(a>b)
-      {
-        ellipse->radius[0] = CLAMPS(a, 0.001f, 0.5f);
-        ellipse->radius[1] = ellipse->radius[0] / ratio;
-      }
-      else
-      {
-        ellipse->radius[1] = CLAMPS(b, 0.001f, 0.5f);
-        ellipse->radius[0] = ratio * ellipse->radius[1];
-      }
-      const float min_radius = fmin(ellipse->radius[0], ellipse->radius[1]);
-      const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/min_radius : 1.0f);
-      ellipse->border = CLAMPS(ellipse_border, 0.005f * reference, 0.5f * reference);
       if(form->type & DT_MASKS_CLONE)
       {
         dt_masks_set_source_pos_initial_value(gui, DT_MASKS_ELLIPSE, form, pzx, pzy);
@@ -652,25 +638,11 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
     }
     else
     {
-      const float a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
-      const float b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
-      const float ratio = a/b;
-      const float ellipse_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
+      ellipse->radius[0] = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
+      ellipse->radius[1] = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+      ellipse->border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
       ellipse->rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
       ellipse->flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
-      if(a>b)
-      {
-        ellipse->radius[0] = CLAMPS(a, 0.001f, 1.0f);
-        ellipse->radius[1] = ellipse->radius[0] / ratio;
-      }
-      else
-      {
-        ellipse->radius[1] = CLAMPS(b, 0.001f, 1.0f);
-        ellipse->radius[0] = ratio * ellipse->radius[1];
-      }
-      const float min_radius = fmin(ellipse->radius[0], ellipse->radius[1]);
-      const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/min_radius : 1.0f);
-      ellipse->border = CLAMPS(ellipse_border, 0.005f * reference, 1.0f * reference);
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }

--- a/src/develop/masks/ellipse.c
+++ b/src/develop/masks/ellipse.c
@@ -341,6 +341,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
                                             uint32_t state, dt_masks_form_t *form, int parentid,
                                             dt_masks_form_gui_t *gui, int index)
 {
+  const float radius_limit = form->type & (DT_MASKS_CLONE | DT_MASKS_NON_CLONE) ? 0.5f : 1.0f;
   // add a preview when creating an ellipse
   if(gui->creation)
   {
@@ -389,7 +390,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
       const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
       if(up && masks_border > 0.001f * reference)
         masks_border *= 0.97f;
-      else if(!up && masks_border < 1.0f * reference)
+      else if(!up && masks_border < radius_limit * reference)
         masks_border *= 1.0f / 0.97f;
       else
         return 1;
@@ -420,12 +421,12 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
 
       if(up && radius_a > 0.001f)
         radius_a *= 0.97f;
-      else if(!up && radius_a < 1.0f)
+      else if(!up && radius_a < radius_limit)
         radius_a *= 1.0f / 0.97f;
       else
         return 1;
 
-      radius_a = CLAMP(radius_a, 0.001f, 1.0f);
+      radius_a = CLAMP(radius_a, 0.001f, radius_limit);
 
       const float factor = radius_a / oldradius;
       radius_b *= factor;
@@ -484,7 +485,7 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
         const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/fmin(ellipse->radius[0], ellipse->radius[1]) : 1.0f);
         if(up && ellipse->border > 0.001f * reference)
           ellipse->border *= 0.97f;
-        else if(!up && ellipse->border < 1.0f * reference)
+        else if(!up && ellipse->border < radius_limit * reference)
           ellipse->border *= 1.0f/0.97f;
         else return 1;
         ellipse->border = CLAMP(ellipse->border, 0.001f * reference, reference);
@@ -502,11 +503,11 @@ static int dt_ellipse_events_mouse_scrolled(struct dt_iop_module_t *module, floa
 
         if(up && ellipse->radius[0] > 0.001f)
           ellipse->radius[0] *= 0.97f;
-        else if(!up && ellipse->radius[0] < 1.0f)
+        else if(!up && ellipse->radius[0] < radius_limit)
           ellipse->radius[0] *= 1.0f / 0.97f;
         else return 1;
 
-        ellipse->radius[0] = CLAMP(ellipse->radius[0], 0.001f, 1.0f);
+        ellipse->radius[0] = CLAMP(ellipse->radius[0], 0.001f, radius_limit);
 
         const float factor = ellipse->radius[0] / oldradius;
         ellipse->radius[1] *= factor;
@@ -649,13 +650,13 @@ static int dt_ellipse_events_button_pressed(struct dt_iop_module_t *module, floa
       const float ellipse_border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
       const float rotation = dt_conf_get_float("plugins/darkroom/masks/ellipse/rotation");
       const int flags = dt_conf_get_int("plugins/darkroom/masks/ellipse/flags");
-      ellipse->radius[0] = MAX(0.001f, MIN(0.5f, a));
-      ellipse->radius[1] = MAX(0.001f, MIN(0.5f, b));
+      ellipse->radius[0] = MAX(0.001f, MIN(1.0f, a));
+      ellipse->radius[1] = MAX(0.001f, MIN(1.0f, b));
       ellipse->flags = flags;
       ellipse->rotation = rotation;
       const float min_radius = fmin(ellipse->radius[0], ellipse->radius[1]);
       const float reference = (ellipse->flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f/min_radius : 1.0f);
-      ellipse->border = MAX(0.005f * reference, MIN(0.5f * reference, ellipse_border));
+      ellipse->border = MAX(0.005f * reference, MIN(1.0f * reference, ellipse_border));
       // not used for masks
       form->source[0] = form->source[1] = 0.0f;
     }

--- a/src/develop/masks/masks.c
+++ b/src/develop/masks/masks.c
@@ -1250,6 +1250,75 @@ int dt_masks_legacy_params(dt_develop_t *dev, void *params, const int old_versio
   return res;
 }
 
+static void _dt_masks_sanitize_config(dt_masks_type_t type)
+{
+  if(type & DT_MASKS_CIRCLE)
+  {
+    if(type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
+    {
+      dt_conf_get_and_sanitize_float("plugins/darkroom/spots/circle_size", 0.001f, 0.5f);
+      dt_conf_get_and_sanitize_float("plugins/darkroom/spots/circle_border", 0.0005f, 0.5f);
+    }
+    else
+    {
+      dt_conf_get_and_sanitize_float("plugins/darkroom/masks/circle/size", 0.001f, 0.5f);
+      dt_conf_get_and_sanitize_float("plugins/darkroom/masks/circle/border", 0.0005f, 0.5f);
+    }
+  }
+  else if (type & DT_MASKS_ELLIPSE)
+  {
+    int flags = -1;
+    float radius_a = 0.0f;
+    float radius_b = 0.0f;
+    float border = 0.0f;
+    if(type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
+    {
+      dt_conf_get_and_sanitize_float("plugins/darkroom/spots/ellipse_rotation", 0.0f, 360.f);
+      flags = dt_conf_get_and_sanitize_int("plugins/darkroom/spots/ellipse_flags", DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
+      radius_a = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_a");
+      radius_b = dt_conf_get_float("plugins/darkroom/spots/ellipse_radius_b");
+      border = dt_conf_get_float("plugins/darkroom/spots/ellipse_border");
+    }
+    else
+    {
+      dt_conf_get_and_sanitize_float("plugins/darkroom/masks/ellipse_rotation", 0.0f, 360.f);
+      flags = dt_conf_get_and_sanitize_int("plugins/darkroom/masks/ellipse/flags", DT_MASKS_ELLIPSE_EQUIDISTANT, DT_MASKS_ELLIPSE_PROPORTIONAL);
+      radius_a = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_a");
+      radius_b = dt_conf_get_float("plugins/darkroom/masks/ellipse/radius_b");
+      border = dt_conf_get_float("plugins/darkroom/masks/ellipse/border");
+    }
+
+    const float ratio = radius_a / radius_b;
+
+    if(radius_a > radius_b)
+    {
+      radius_a = CLAMPS(radius_a, 0.001f, 0.5f);
+      radius_b = radius_a / ratio;
+    }
+    else
+    {
+      radius_b = CLAMPS(radius_b, 0.001f, 0.5);
+      radius_a = ratio * radius_b;
+    }
+
+    const float reference = (flags & DT_MASKS_ELLIPSE_PROPORTIONAL ? 1.0f / fmin(radius_a, radius_b) : 1.0f);
+    border = CLAMPS(border, 0.001f * reference, reference);
+
+    if(type & (DT_MASKS_CLONE|DT_MASKS_NON_CLONE))
+    {
+      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/spots/ellipse_radius_a", radius_a, 0.001f, 0.5f)
+      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/spots/ellipse_radius_b", radius_b, 0.001f, 0.5f);
+      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/spots/ellipse_border", border, 0.001f, reference);
+    }
+    else
+    {
+      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/masks/ellipse/radius_a", radius_a, 0.001f, 0.5f);
+      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/masks/ellipse/radius_b", radius_b, 0.001f, 0.5f);
+      DT_CONF_SET_SANITIZED_FLOAT("plugins/darkroom/masks/ellipse/border", border, 0.001f, reference);
+    }
+  }
+}
+
 dt_masks_form_t *dt_masks_create(dt_masks_type_t type)
 {
   dt_masks_form_t *form = (dt_masks_form_t *)calloc(1, sizeof(dt_masks_form_t));
@@ -1258,6 +1327,8 @@ dt_masks_form_t *dt_masks_create(dt_masks_type_t type)
   form->type = type;
   form->version = dt_masks_version();
   form->formid = time(NULL);
+
+  _dt_masks_sanitize_config(type);
 
   return form;
 }


### PR DESCRIPTION
Circle and ellipse mask radii were incorrectly clamped on placing. also for some reason circle mask pre-placing couldn't be made big enough for some requests...

This PR fixes overzealous clamping to match gui-expected values adding also ability to place REALLY HUGE circle and ellipse masks.

This fixes #6362

Selling points:
- bigger is better
- size matters
- circle/ellipse sizes for spots/retouch are still kept relatively small-ish. the clamping should match expectations for them in their mode