### PR TITLE
colorpicker: display live sample location even if display sample off.

### DIFF
--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -337,7 +337,7 @@ static void _label_size_allocate_callback(GtkWidget *widget, GdkRectangle *alloc
 static gboolean _sample_enter_callback(GtkWidget *widget, GdkEvent *event, gpointer sample)
 {
   darktable.lib->proxy.colorpicker.selected_sample = (dt_colorpicker_sample_t *)sample;
-  if(darktable.lib->proxy.colorpicker.display_samples) dt_dev_invalidate_from_gui(darktable.develop);
+  dt_dev_invalidate_from_gui(darktable.develop);
 
   return FALSE;
 }
@@ -345,7 +345,7 @@ static gboolean _sample_enter_callback(GtkWidget *widget, GdkEvent *event, gpoin
 static gboolean _sample_leave_callback(GtkWidget *widget, GdkEvent *event, gpointer data)
 {
   darktable.lib->proxy.colorpicker.selected_sample = NULL;
-  if(darktable.lib->proxy.colorpicker.display_samples) dt_dev_invalidate_from_gui(darktable.develop);
+  dt_dev_invalidate_from_gui(darktable.develop);
 
   return FALSE;
 }

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -488,10 +488,16 @@ void expose(
   }
 
   // Displaying sample areas if enabled
-  if(darktable.lib->proxy.colorpicker.live_samples && darktable.lib->proxy.colorpicker.display_samples)
+  if(darktable.lib->proxy.colorpicker.live_samples
+     && (darktable.lib->proxy.colorpicker.display_samples
+         || darktable.lib->proxy.colorpicker.selected_sample))
   {
     GSList *samples = darktable.lib->proxy.colorpicker.live_samples;
     dt_colorpicker_sample_t *sample = NULL;
+
+    const gboolean only_selected_sample =
+      darktable.lib->proxy.colorpicker.selected_sample
+      && !darktable.lib->proxy.colorpicker.display_samples;
 
     cairo_save(cri);
     // The colorpicker samples bounding rectangle should only be displayed inside the visible image
@@ -515,6 +521,14 @@ void expose(
     while(samples)
     {
       sample = samples->data;
+
+      // only dislay selected sample, skip if not the selected sample
+      if(only_selected_sample
+         && sample != darktable.lib->proxy.colorpicker.selected_sample)
+      {
+        samples = g_slist_next(samples);
+        continue;
+      }
 
       cairo_set_line_width(cri, lw);
       if(sample == darktable.lib->proxy.colorpicker.selected_sample)


### PR DESCRIPTION
Only by overring the patch sample we now display the area on the
picture.