### PR TITLE
Added #include <stdbool.h> in avif.c

### DIFF
--- a/src/imageio/format/avif.c
+++ b/src/imageio/format/avif.c
@@ -23,6 +23,7 @@
 #endif
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
In C programming language you must use stdbool.h in order to be able to use boolean type.
```
/builddir/build/BUILD/darktable-3.2.1/src/imageio/format/avif.c: In function 'write_image':
/builddir/build/BUILD/darktable-3.2.1/src/imageio/format/avif.c:300:5: error: unknown type name 'bool'
  300 |     bool use_icc = false;
      |     ^~~~
/builddir/build/BUILD/darktable-3.2.1/src/imageio/format/avif.c:300:20: error: 'false' undeclared (first use in this function)
  300 |     bool use_icc = false;
      |                    ^~~~~
/builddir/build/BUILD/darktable-3.2.1/src/imageio/format/avif.c:300:20: note: each undeclared identifier is reported only once for each function it appears in
/builddir/build/BUILD/darktable-3.2.1/src/imageio/format/avif.c:353:17: error: 'true' undeclared (first use in this function)
  353 |       use_icc = true;
      |                 ^~~~
gmake[2]: *** [src/imageio/format/CMakeFiles/avif_format.dir/build.make:85: src/imageio/format/CMakeFiles/avif_format.dir/avif.c.o] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/darktable-3.2.1/x86_64-redhat-linux-gnu/x86_64-redhat-linux-gnu'
gmake[1]: *** [CMakeFiles/Makefile2:5668: src/imageio/format/CMakeFiles/avif_format.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```
From https://kojipkgs.fedoraproject.org//work/tasks/7672/52257672/build.log