### PR TITLE
Fix bad thumbnails on hires displays

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -121,7 +121,7 @@
 	<option>best</option>
       </enum>
     </type>
-    <default>fast</default>
+    <default>good</default>
     <shortdescription>speed/quality trade-off for drawing images</shortdescription>
     <longdescription>fast (default) - high-performance, similar to nearest neighbor filter; good - reasonable-performance, similar to bilinear (linear interpolation in two dimensions); best - highest-quality available, performance may not be suitable for interactive use. sets Cairo image scaling filter. (needs a restart)</longdescription>
   </dtconfig>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -123,7 +123,7 @@
     </type>
     <default>good</default>
     <shortdescription>speed/quality trade-off for drawing images</shortdescription>
-    <longdescription>fast (default) - high-performance, similar to nearest neighbor filter; good - reasonable-performance, similar to bilinear (linear interpolation in two dimensions); best - highest-quality available, performance may not be suitable for interactive use. sets Cairo image scaling filter. (needs a restart)</longdescription>
+    <longdescription>fast - high-performance, similar to nearest neighbor filter; good (default) - reasonable-performance, similar to bilinear (linear interpolation in two dimensions); best - highest-quality available, performance may not be suitable for interactive use. sets Cairo image scaling filter. (needs a restart)</longdescription>
   </dtconfig>
   <dtconfig prefs="otherviews" section="slideshow">
     <name>slideshow_delay</name>

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -955,18 +955,15 @@ void dt_mipmap_cache_release_with_caller(dt_mipmap_cache_t *cache, dt_mipmap_buf
 
 
 // return index dt_mipmap_size_t having at least width & height requested instead of minimum combined diff 
+// please nothe the requested size is in pixels not dots.
 dt_mipmap_size_t dt_mipmap_cache_get_matching_size(const dt_mipmap_cache_t *cache, const int32_t width,
                                                    const int32_t height)
 {
-  const double ppd = (darktable.gui != NULL) ? darktable.gui->ppd : 1.0;
-  const uint32_t dx = ppd * width;
-  const uint32_t dy = ppd * height;
-
   dt_mipmap_size_t best = DT_MIPMAP_NONE;
   for(int k = DT_MIPMAP_0; k < DT_MIPMAP_F; k++)
   {
     best = k;
-    if((cache->max_width[k] >= dx) && (cache->max_height[k] >= dy))
+    if((cache->max_width[k] >= width) && (cache->max_height[k] >= height))
       break;
   }
   return best;

--- a/src/common/mipmap_cache.c
+++ b/src/common/mipmap_cache.c
@@ -955,7 +955,7 @@ void dt_mipmap_cache_release_with_caller(dt_mipmap_cache_t *cache, dt_mipmap_buf
 
 
 // return index dt_mipmap_size_t having at least width & height requested instead of minimum combined diff 
-// please nothe the requested size is in pixels not dots.
+// please note that the requested size is in pixels not dots.
 dt_mipmap_size_t dt_mipmap_cache_get_matching_size(const dt_mipmap_cache_t *cache, const int32_t width,
                                                    const int32_t height)
 {

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -217,11 +217,11 @@ static void _thumb_draw_image(dt_thumbnail_t *thumb, cairo_t *cr)
   const float scaler = 1.0f / darktable.gui->ppd;
   cairo_scale(cr, scaler, scaler);
 
-  cairo_set_source_surface(cr, thumb->img_surf, thumb->current_zx, thumb->current_zy);
+  cairo_set_source_surface(cr, thumb->img_surf, thumb->current_zx * darktable.gui->ppd, thumb->current_zy * darktable.gui->ppd);
   cairo_paint(cr);
 
   // and eventually the image border
-  gtk_render_frame(context, cr, 0, 0, w, h);
+  gtk_render_frame(context, cr, 0, 0, w * darktable.gui->ppd, h * darktable.gui->ppd);
 }
 
 static void _thumb_retrieve_margins(dt_thumbnail_t *thumb)
@@ -366,7 +366,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       // copy preview image into final surface
       if(tmp_surface)
       {
-        const float scale = fminf(image_w / (float)buf_width, image_h / (float)buf_height);
+        const float scale = fminf(image_w / (float)buf_width, image_h / (float)buf_height) * darktable.gui->ppd;
         const int img_width = buf_width * scale;
         const int img_height = buf_height * scale;
         thumb->img_surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_width, img_height);
@@ -386,9 +386,14 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
         cairo_paint(cr2);
 
         if(darktable.gui->show_focus_peaking)
+        {
+          cairo_save(cr2);
+          cairo_scale(cr2, 1.0f/scale, 1.0f/scale);
           dt_focuspeaking(cr2, img_width, img_height, cairo_image_surface_get_data(thumb->img_surf),
                           cairo_image_surface_get_width(thumb->img_surf),
                           cairo_image_surface_get_height(thumb->img_surf));
+          cairo_restore(cr2);
+        }
 
         cairo_surface_destroy(tmp_surface);
         cairo_destroy(cr2);
@@ -452,8 +457,8 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     // let save thumbnail image size
     thumb->img_width = cairo_image_surface_get_width(thumb->img_surf);
     thumb->img_height = cairo_image_surface_get_height(thumb->img_surf);
-    const int imgbox_w = MIN(image_w, thumb->img_width);
-    const int imgbox_h = MIN(image_h, thumb->img_height);
+    const int imgbox_w = MIN(image_w, thumb->img_width/darktable.gui->ppd);
+    const int imgbox_h = MIN(image_h, thumb->img_height/darktable.gui->ppd);
     // if the imgbox size change, this should also change the panning values
     int hh = 0;
     int ww = 0;

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -213,6 +213,10 @@ static void _thumb_draw_image(dt_thumbnail_t *thumb, cairo_t *cr)
   int w = 0;
   int h = 0;
   gtk_widget_get_size_request(thumb->w_image_box, &w, &h);
+
+  const float scaler = 1.0f / darktable.gui->ppd;
+  cairo_scale(cr, scaler, scaler);
+
   cairo_set_source_surface(cr, thumb->img_surf, thumb->current_zx, thumb->current_zy);
   cairo_paint(cr);
 
@@ -514,8 +518,9 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     }
 
     // let's sanitize and apply panning values as we are sure the zoomed image is loaded now
-    thumb->zoomx = CLAMP(thumb->zoomx, imgbox_w - thumb->img_width, 0);
-    thumb->zoomy = CLAMP(thumb->zoomy, imgbox_h - thumb->img_height, 0);
+    // here we have to make sure to properly align according to ppd
+    thumb->zoomx = CLAMP(thumb->zoomx, (imgbox_w * darktable.gui->ppd - thumb->img_width) / darktable.gui->ppd, 0);
+    thumb->zoomy = CLAMP(thumb->zoomy, (imgbox_h * darktable.gui->ppd - thumb->img_height) / darktable.gui->ppd, 0);
     thumb->current_zx = thumb->zoomx;
     thumb->current_zy = thumb->zoomy;
   }
@@ -1672,11 +1677,12 @@ void dt_thumbnail_set_overlay(dt_thumbnail_t *thumb, dt_thumbnail_overlay_t over
 void dt_thumbnail_image_refresh_position(dt_thumbnail_t *thumb)
 {
   // let's sanitize and apply panning values
+  // here we have to make sure to properly align according to ppd
   int iw = 0;
   int ih = 0;
   gtk_widget_get_size_request(thumb->w_image_box, &iw, &ih);
-  thumb->zoomx = CLAMP(thumb->zoomx, iw - thumb->img_width, 0);
-  thumb->zoomy = CLAMP(thumb->zoomy, ih - thumb->img_height, 0);
+  thumb->zoomx = CLAMP(thumb->zoomx, (iw * darktable.gui->ppd - thumb->img_width) / darktable.gui->ppd, 0);
+  thumb->zoomy = CLAMP(thumb->zoomy, (ih * darktable.gui->ppd - thumb->img_height) / darktable.gui->ppd, 0);
   thumb->current_zx = thumb->zoomx;
   thumb->current_zy = thumb->zoomy;
   gtk_widget_queue_draw(thumb->w_main);

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -964,10 +964,12 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
   }
 
   // so we create a new image surface to return
-  const float scale = fminf(width / (float)buf_wd, height / (float)buf_ht);
+  const float scale = fminf(width * darktable.gui->ppd / (float)buf_wd, height * darktable.gui->ppd/ (float)buf_ht);
   const int img_width = buf_wd * scale;
   const int img_height = buf_ht * scale;
   *surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_width, img_height);
+
+  dt_print(DT_DEBUG_LIGHTTABLE, "[dt_view_image_get_surface]  id %i, dots %ix%i, mip %ix%i, surf %ix%i\n", imgid, width, height, buf_wd, buf_ht, img_width, img_height);
 
   // we transfer cached image on a cairo_surface (with colorspace transform if needed)
   cairo_surface_t *tmp_surface = NULL;


### PR DESCRIPTION
**Why thumbnails look pixelated or blurred on hi-res monitors**

Related Issues #5947 and more old ones.

It took some more time to understand what @parafin comments really mean for this problem and to get me on the track. He wrote
> PPD is pixels-per-dot. All screen dimensions GTK/cairo/etc. operate on are in dots. So let's say 3840 x 2160 monitor with ppd == 2 will have dimensions of 1920 x 1080 dots. So full-screen cairo surface has width of 1920 and height of 1080, but if you want to render a pixmap to it with full resolution, it needs to be 3840 x 2160 pixels. The idea was that not high-dpi-aware application will work without any code changes (so what was one pixel in size in low-dpi, automatically becomes 2 pixels with high-dpi). But it results in this brainfuck to write high-dpi-aware apps.
P.S.
Also note that DPI is dots-per-inch, not pixels-per-inch, so with ppd=2, dpi is half the real DPI of the monitor.

This is of course right and means:
If we want to have a thumbnail with size wd*ht shown on the main surface/display, wd and ht both must be doubled if ppd == 2.

**This is intended but *not* happening in current dt code**

The underlying function is
`dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t **surface, const gboolean quality)`

width & height are both in dots and so we search for a a proper thumbnail via `dt_mipmap_cache_get_matching_size` with ppd->pixel corrected size. (The double ppd multiply there is of course wrong)

Later on we create the bitmap surface corrected using `const float scale` **This scale is calculated wrongly, there is a division by ppd as @aurelienpierre suspected.** As it is now the bitmap surface for ppd==2 systems is not better than on ppd==1 systems.

This means on current master with ppd==2: The calculated surface is for ppd==1 and we later have to upscale the small bitmap to correct for ppd. This leads to pixelated thumbs using cairo_fast, or thumbs when using cairo_good, which can be clearly seen when pixelpeeping by screenshot (or viewing through an enlarging glass :-)

SO: Make sure dt_view_image_get_surface returns a proper/large thumbnail surface. There is some debugging output available for this now with lighttable option

**Now we have to make sure the large/correct surface is correctly scaled** when presented in lighttable. (i think this should be done in _thumb_draw_image) This part is something i need more help on (or other people might do it) as i have no gtk experience at all.

The thumbnails shown must **not** be scaled by gtk-default (the whole gtk stuff seems to be done in dots not pixels) but **need scaling & positioning corrected for ppd** (the current masters code does not need to do so).
First work to have this working in lighttable mode is in dtgtk/thumnail.c
I confess i don't know how to fix this at all places, never touched this part of dt code before, probably @AlicVB knows best where to look & fix.

At least - take this as a proof of concept -
1) Attached lighttable screenshots on ppd=2 system show master and new pr code results
2) It explains the sometimes bad experience of people on hires monitors and how we should tackle this.
3) BTW the gui thumbs and preview scaling factor preferences seems to be wrong for me. I think the only meaningful way it can be used would be a switch for "use smaller thumbs and accept some blurring for performance sake" and always leave the systems ppd setting as it is.


Current master cairo_fast
![old_fast](https://user-images.githubusercontent.com/50982232/94331414-66b87f80-ffcc-11ea-9bf7-6b901f59c628.png)

Current master cairo_good
![old_good](https://user-images.githubusercontent.com/50982232/94331421-7637c880-ffcc-11ea-8fa9-13ee3edc4ff4.png)

This pr cairo_fast
![new_fast](https://user-images.githubusercontent.com/50982232/94331427-80f25d80-ffcc-11ea-8f34-2e0626ffab0b.png)

This pr cairo_good
![new_good](https://user-images.githubusercontent.com/50982232/94331436-8f407980-ffcc-11ea-91eb-313dea3ed642.png)






