### PR TITLE
Improve appearance of combobox menu

### DIFF
--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -825,12 +825,16 @@ dialog combobox window
 {
   opacity: 1;  /* this is needed for tooltip on/off feature with Shift+t shortcut */
   background-color: @tooltip_bg_color;
-  border-radius: 4px;
+  border-radius: 0.2em;
   border: 0;
   outline-style: none;
   min-height: 0.4em;
   min-width: 0.4em;
-  padding: 0.2em;
+  padding: 0.2em 0;
+}
+
+menu menuitem {
+  padding: 0 0.2em;
 }
 
 tooltip


### PR DESCRIPTION
Avoid horizontal space between menu border and the items to make the general appearance cleaner.

Before:
![menua2](https://user-images.githubusercontent.com/329388/94378421-2581b600-0119-11eb-8984-72437063cf81.png)
![menua1](https://user-images.githubusercontent.com/329388/94378422-26b2e300-0119-11eb-8f29-9535e3a34c1d.png)

After:
![menu2](https://user-images.githubusercontent.com/329388/94378427-2f0b1e00-0119-11eb-975d-dbd6a6a9ba5a.png)
![menu3](https://user-images.githubusercontent.com/329388/94378428-2fa3b480-0119-11eb-825a-1413c2a745d2.png)

I'm not sure if this is the cleanest way to achieve it in CSS though.