### PR TITLE
gphoto device updating in a thread instead of a misused job

### DIFF
--- a/src/common/camera_control.h
+++ b/src/common/camera_control.h
@@ -222,7 +222,8 @@ typedef enum dt_camera_preview_flags_t
   CAMCTL_IMAGE_PREVIEW_DATA = 1,
 } dt_camera_preview_flags_t;
 
-
+/** gphoto2 device updating function for thread */
+void *dt_update_cameras_thread(void *ptr);
 /** Initializes the gphoto and cam control, returns NULL if failed */
 dt_camctl_t *dt_camctl_new();
 /** Destroys the camera control */
@@ -231,8 +232,6 @@ void dt_camctl_destroy(dt_camctl_t *c);
 void dt_camctl_register_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener);
 /** Unregisters a listener of camera control */
 void dt_camctl_unregister_listener(const dt_camctl_t *c, dt_camctl_listener_t *listener);
-/** start a thread job to detect cameras and update list of available cameras */
-void dt_camctl_background_detect_cameras();
 /** Check if there is any camera connected */
 gboolean dt_camctl_have_cameras(const dt_camctl_t *c);
 /** Check if there is any camera locked  */

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1100,7 +1100,6 @@ int dt_init(int argc, char *argv[], const gboolean init_gui, const gboolean load
     // Initialize the camera control.
     // this is done late so that the gui can react to the signal sent but before switching to lighttable!
     darktable.camctl = dt_camctl_new();
-    dt_camctl_background_detect_cameras();
 #endif
 
     darktable.lib = (dt_lib_t *)calloc(1, sizeof(dt_lib_t));

--- a/src/control/control.c
+++ b/src/control/control.c
@@ -157,7 +157,11 @@ void dt_control_shutdown(dt_control_t *s)
   dt_pthread_mutex_unlock(&s->cond_mutex);
   pthread_cond_broadcast(&s->cond);
 
-  /* first wait for kick_on_workers_thread */
+  /* first wait for gphoto device updater */
+#ifdef HAVE_GPHOTO2
+  pthread_join(s->update_gphoto_thread, NULL);
+#endif
+  /* then wait for kick_on_workers_thread */
   pthread_join(s->kick_on_workers_thread, NULL);
 
   int k;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -204,7 +204,7 @@ typedef struct dt_control_t
   dt_pthread_mutex_t queue_mutex, cond_mutex, run_mutex;
   pthread_cond_t cond;
   int32_t num_threads;
-  pthread_t *thread, kick_on_workers_thread;
+  pthread_t *thread, kick_on_workers_thread, update_gphoto_thread;
   dt_job_t **job;
 
   GList *queues[DT_JOB_QUEUE_MAX];

--- a/src/control/jobs.c
+++ b/src/control/jobs.c
@@ -633,6 +633,10 @@ void dt_control_jobs_init(dt_control_t *control)
     params->threadid = k;
     dt_pthread_create(&control->thread_res[k], dt_control_work_res, params);
   }
+  /* create thread taking care of connecting gphoto2 devices */
+#ifdef HAVE_GPHOTO2
+  dt_pthread_create(&control->update_gphoto_thread, dt_update_cameras_thread, control);  
+#endif
 }
 
 void dt_control_jobs_cleanup(dt_control_t *control)

--- a/src/control/jobs.h
+++ b/src/control/jobs.h
@@ -92,6 +92,7 @@ int32_t dt_control_get_threadid();
 
 #ifdef HAVE_GPHOTO2
 #include "control/jobs/camera_jobs.h"
+#include "common/camera_control.h"
 #endif
 #include "control/jobs/control_jobs.h"
 #include "control/jobs/develop_jobs.h"


### PR DESCRIPTION
Fixes #6341

Updating the gphoto devices was done in a worker thread, ok - but probably not the
best solution.
This pr makes it running in a joinable `dt_pthread_create`, also the cpu load
is reduced.

1) tuning the scheduler for a lower priority is not helpful here as we do usleep most of the time.
   And the dt job priority can not be applied.
2) The quick fix by @TurboGit should be reverted i think
3) @kofa73 suggested to keep the loaded port drivers. I have thought about this when i reworked
   the camera-update stuff. The problem is, gphoto2 has some strange/undocumented memory mamagement
   and i really wanted to avoid that :-) Gave me too much headaches already and as the whole
   gphoto stuff is not used that much this is at least safe.