### PR TITLE
make height of remaining libs modules configurable/refactor

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2240,7 +2240,7 @@
     <type min="100" max="1000">int</type>
     <default>300</default>
     <shortdescription>height of mask manager view window</shortdescription>
-    <longdescription/>
+    <longdescription>maximum height the masks view in darkroom will grow to before scrolling</longdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/darkroom/ashift/near_delta</name>
@@ -2468,5 +2468,54 @@
     <default>0</default>
     <shortdescription>version of the last completed performance configuration</shortdescription>
     <longdescription>what was the last performance configuration which has been completed</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/duplicate/windowheight</name>
+    <type>int</type>
+    <default>400</default>
+    <shortdescription>height of the duplicates view</shortdescription>
+    <longdescription>maximum height the duplicates view in darkroom will grow to before scrolling</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/colorpicker/windowheight</name>
+    <type>int</type>
+    <default>200</default>
+    <shortdescription>height of the color picker list</shortdescription>
+    <longdescription>maximum height the color picker samples list in darkroom will grow to before scrolling</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/history/windowheight</name>
+    <type>int</type>
+    <default>1000</default>
+    <shortdescription>height of the history list</shortdescription>
+    <longdescription>maximum height the history list in darkroom will grow to before scrolling</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/metadata_view/windowheight</name>
+    <type>int</type>
+    <default>1000</default>
+    <shortdescription>height of the image information view</shortdescription>
+    <longdescription>maximum height the image information view in lighttable and darkroom will grow to before scrolling</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/recentcollect/windowheight</name>
+    <type>int</type>
+    <default>1000</default>
+    <shortdescription>height of the recent collections list</shortdescription>
+    <longdescription>maximum height the recent collections list in lighttable will grow to before scrolling</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/darkroom/snapshots/windowheight</name>
+    <type>int</type>
+    <default>200</default>
+    <shortdescription>height of the snapshots list</shortdescription>
+    <longdescription>maximum height the snapshots list in darkroom will grow to before scrolling</longdescription>
+  </dtconfig>
+  <dtconfig>
+    <name>plugins/lighttable/style/windowheight</name>
+    <type>int</type>
+    <default>400</default>
+    <shortdescription>height of the styles list</shortdescription>
+    <longdescription>maximum height the styles list in lighttable will grow to before scrolling</longdescription>
   </dtconfig>
 </dtconfiglist>

--- a/data/themes/darktable.css
+++ b/data/themes/darktable.css
@@ -501,10 +501,14 @@ overshoot.right
   padding: 0.15em;
 }
 
-#control-button #button-canvas,
-.duplicate-ui #button-canvas
+#control-button #button-canvas
 {
   margin: 12px; /* not real pixels, this is used as a percent extra space */
+}
+
+#lib-plugin-ui-main viewport
+{
+  margin-left: 2px
 }
 
 /* Adjust add button in picker module */
@@ -579,17 +583,20 @@ overshoot.right
   margin: 8px 0px;
 }
 
+#left #lib-plugin-ui .duplicate-ui entry
+{
+  margin-left: 0.5em;
+}
+
+#left .duplicate-ui .text-button
+{
+  margin-top: 4px;
+}
+
 #left #lib-plugin-ui #lib-collect-entry
 {
   margin-top: 0;
   margin-bottom: 4px;
-}
-
-#left #lib-plugin-ui scrolledwindow entry /* this will avoid having too much height on entry items in clone manager without touching other parts of the UI */
-{
-  padding: 0px;
-  margin: 45px 3px;
-  min-width: 100px;
 }
 
 #right #lib-plugin-ui entry /* this will adjust entry height on right panel */
@@ -1345,7 +1352,6 @@ progressbar progress
 {
   min-width: 80px;
   padding-left: 2px;
-  padding-bottom: 1px;
 }
 
 /* Checkbutton check state */

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -3093,7 +3093,7 @@ static gint _get_container_row_heigth(GtkWidget *w)
   return height;
 }
 
-static void _scroll_wrap_resize(GtkWidget *w, GtkAllocation *allocation, const char *config_str)
+static gboolean _scroll_wrap_resize(GtkWidget *w, void *cr, const char *config_str)
 {
   GtkWidget *sw = gtk_widget_get_parent(w);
   if(GTK_IS_VIEWPORT(sw)) sw = gtk_widget_get_parent(sw);
@@ -3131,6 +3131,8 @@ static void _scroll_wrap_resize(GtkWidget *w, GtkAllocation *allocation, const c
   gint value = gtk_adjustment_get_value(adj);
   value -= value % increment;
   gtk_adjustment_set_value(adj, value);
+
+  return FALSE;
 }
 
 static gboolean _scroll_wrap_scroll(GtkScrolledWindow *sw, GdkEventScroll *event, const char *config_str)
@@ -3168,7 +3170,7 @@ GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, char *config_str)
   gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
   gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), - DT_PIXEL_APPLY_DPI(min_size));
   g_signal_connect(G_OBJECT(sw), "scroll-event", G_CALLBACK(_scroll_wrap_scroll), config_str);
-  g_signal_connect(G_OBJECT(w), "size-allocate", G_CALLBACK(_scroll_wrap_resize), config_str);
+  g_signal_connect(G_OBJECT(w), "draw", G_CALLBACK(_scroll_wrap_resize), config_str);
   gtk_container_add(GTK_CONTAINER(sw), w);
 
   return sw;

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -411,6 +411,8 @@ static inline GtkWidget *dt_ui_button_new(const gchar *label, const gchar *toolt
   return button;
 };
 
+GtkWidget *dt_ui_scroll_wrap(GtkWidget *w, gint min_size, char *config_str);
+
 // modelines: These editor modelines have been set for all relevant files by tools/update_modelines.sh
 // vim: shiftwidth=2 expandtab tabstop=2 cindent
 // kate: tab-indents: off; indent-width 2; replace-tabs on; indent-mode cstyle; remove-trailing-spaces modified;

--- a/src/libs/colorpicker.c
+++ b/src/libs/colorpicker.c
@@ -420,7 +420,7 @@ static void _add_sample(GtkButton *widget, dt_lib_module_t *self)
   g_signal_connect(G_OBJECT(delete_button), "clicked", G_CALLBACK(_remove_sample_cb), sample);
   gtk_box_pack_start(GTK_BOX(container), delete_button, FALSE, FALSE, 0);
 
-  gtk_box_pack_start(GTK_BOX(data->samples_container), sample->container, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(data->samples_container), sample->container, FALSE, FALSE, 0);
   gtk_widget_show_all(sample->container);
 
   // Setting the actual data
@@ -615,8 +615,10 @@ void gui_init(dt_lib_module_t *self)
   gtk_style_context_add_class(context, "section_label_top");
   gtk_box_pack_start(GTK_BOX(self->widget), label, TRUE, TRUE, 0);
 
+
   data->samples_container = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), data->samples_container, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget),
+                     dt_ui_scroll_wrap(data->samples_container, 1, "plugins/darkroom/colorpicker/windowheight"), TRUE, TRUE, 0);
 
   data->display_samples_check_box = gtk_check_button_new_with_label(_("display sample areas on image"));
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(data->display_samples_check_box))),

--- a/src/libs/duplicate.c
+++ b/src/libs/duplicate.c
@@ -405,7 +405,7 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
 
   while(sqlite3_step(stmt) == SQLITE_ROW)
   {
-    GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+    GtkWidget *hb = gtk_grid_new();
     const int imgid = sqlite3_column_int(stmt, 1);
 
     GtkStyleContext *context = gtk_widget_get_style_context(hb);
@@ -433,23 +433,23 @@ static void _lib_duplicate_init_callback(gpointer instance, dt_lib_module_t *sel
     GtkWidget *tb = gtk_entry_new();
     if(path) gtk_entry_set_text(GTK_ENTRY(tb), path);
     gtk_entry_set_width_chars(GTK_ENTRY(tb), 0);
+    gtk_widget_set_hexpand(tb, TRUE);
     g_object_set_data (G_OBJECT(tb), "imgid", GINT_TO_POINTER(imgid));
     g_signal_connect(G_OBJECT(tb), "focus-out-event", G_CALLBACK(_lib_duplicate_caption_out_callback), self);
     dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(tb));
     GtkWidget *lb = gtk_label_new (g_strdup(chl));
+    gtk_widget_set_hexpand(lb, TRUE);
     bt = dtgtk_button_new(dtgtk_cairo_paint_cancel, CPF_STYLE_FLAT, NULL);
+//    gtk_widget_set_halign(bt, GTK_ALIGN_END);
     g_object_set_data(G_OBJECT(bt), "imgid", GINT_TO_POINTER(imgid));
     g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_delete), self);
 
-    gtk_box_pack_start(GTK_BOX(hb), thumb->w_main, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(hb), tb, TRUE, TRUE, 0);
-    gtk_box_pack_start(GTK_BOX(hb), lb, FALSE, FALSE, 0);
-    gtk_box_pack_start(GTK_BOX(hb), bt, FALSE, FALSE, 0);
+    gtk_grid_attach(GTK_GRID(hb), thumb->w_main, 0, 0, 1, 2);
+    gtk_grid_attach(GTK_GRID(hb), bt, 2, 0, 1, 1);
+    gtk_grid_attach(GTK_GRID(hb), lb, 1, 0, 1, 1);
+    gtk_grid_attach(GTK_GRID(hb), tb, 1, 1, 2, 1);
 
-    gtk_widget_show(tb);
-    gtk_widget_show(lb);
-    gtk_widget_show(bt);
-    gtk_widget_show(hb);
+    gtk_widget_show_all(hb);
 
     gtk_box_pack_start(GTK_BOX(d->duplicate_box), hb, FALSE, FALSE, 0);
     d->thumbs = g_list_append(d->thumbs, thumb);
@@ -526,28 +526,20 @@ void gui_init(dt_lib_module_t *self)
   gtk_style_context_add_class(context, "duplicate-ui");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
 
-  GtkWidget *sw = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(sw), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(sw), DT_PIXEL_APPLY_DPI(300));
   d->duplicate_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   GtkWidget *hb = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-  GtkWidget *bt = dt_ui_label_new(_("existing duplicates"));
-  gtk_box_pack_start(GTK_BOX(hb), bt, FALSE, FALSE, 0);
-  bt = dtgtk_button_new(dtgtk_cairo_paint_plus, CPF_STYLE_FLAT, NULL);
-  g_object_set(G_OBJECT(bt), "tooltip-text", _("create a 'virgin' duplicate of the image without any development"), (char *)NULL);
-  g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_lib_duplicate_new_clicked_callback), self);
-  gtk_box_pack_end(GTK_BOX(hb), bt, FALSE, FALSE, 0);
-  bt = dtgtk_button_new(dtgtk_cairo_paint_multiinstance, CPF_STYLE_FLAT, NULL);
-  g_object_set(G_OBJECT(bt), "tooltip-text", _("create a duplicate of the image with same history stack"), (char *)NULL);
-  g_signal_connect(G_OBJECT(bt), "button-press-event", G_CALLBACK(_lib_duplicate_duplicate_clicked_callback), self);
-  gtk_box_pack_end(GTK_BOX(hb), bt, FALSE, FALSE, 0);
-
+  GtkWidget *bt = dt_ui_button_new(_("original"), _("create a 'virgin' duplicate of the image without any development"), NULL);
+  g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_new_clicked_callback), self);
+  gtk_box_pack_end(GTK_BOX(hb), bt, TRUE, TRUE, 0);
+  bt = dt_ui_button_new(_("duplicate"), _("create a duplicate of the image with same history stack"), (char *)NULL);
+  g_signal_connect(G_OBJECT(bt), "clicked", G_CALLBACK(_lib_duplicate_duplicate_clicked_callback), self);
+  gtk_box_pack_end(GTK_BOX(hb), bt, TRUE, TRUE, 0);
 
   /* add duplicate list and buttonbox to widget */
-  gtk_box_pack_start(GTK_BOX(self->widget), hb, FALSE, FALSE, 0);
-  gtk_container_add(GTK_CONTAINER(sw), d->duplicate_box);
-  gtk_box_pack_start(GTK_BOX(self->widget), sw, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget),
+                     dt_ui_scroll_wrap(d->duplicate_box, 1, "plugins/darkroom/duplicate/windowheight"), TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget), hb, TRUE, TRUE, 0);
 
   gtk_widget_show_all(self->widget);
 

--- a/src/libs/history.c
+++ b/src/libs/history.c
@@ -124,7 +124,6 @@ void connect_key_accels(dt_lib_module_t *self)
   dt_accel_connect_lib(self, "truncate history stack", closure);
 }
 
-#define ellipsize_button(button) gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(button))), PANGO_ELLIPSIZE_END);
 void gui_init(dt_lib_module_t *self)
 {
   /* initialize ui widgets */
@@ -140,6 +139,7 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   gtk_widget_set_name(self->widget, "history-ui");
+
   d->history_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
   GtkWidget *hhbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -161,9 +161,9 @@ void gui_init(dt_lib_module_t *self)
   gtk_box_pack_start(GTK_BOX(hhbox), d->create_button, FALSE, FALSE, 0);
 
   /* add history list and buttonbox to widget */
-  gtk_box_pack_start(GTK_BOX(self->widget), d->history_box, FALSE, FALSE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget),
+                     dt_ui_scroll_wrap(d->history_box, 1, "plugins/darkroom/history/windowheight"), FALSE, FALSE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), hhbox, FALSE, FALSE, 0);
-
 
   gtk_widget_show_all(self->widget);
 
@@ -199,9 +199,10 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
 
   /* create toggle button */
   GtkWidget *widget = gtk_toggle_button_new_with_label(label);
-  gtk_widget_set_halign(gtk_bin_get_child(GTK_BIN(widget)), GTK_ALIGN_START);
-  ellipsize_button(widget);
-
+  GtkWidget *lab = gtk_bin_get_child(GTK_BIN(widget));
+  gtk_widget_set_halign(lab, GTK_ALIGN_START);
+  gtk_label_set_xalign(GTK_LABEL(lab), 0);
+  gtk_label_set_ellipsize(GTK_LABEL(lab), PANGO_ELLIPSIZE_END);
   if(always_on)
   {
     onoff = dtgtk_button_new(dtgtk_cairo_paint_switch_on, CPF_STYLE_FLAT | CPF_BG_TRANSPARENT, NULL);
@@ -253,7 +254,6 @@ static GtkWidget *_lib_history_create_button(dt_lib_module_t *self, int num, con
 
   return hbox;
 }
-#undef ellipsize_button
 
 static void _reset_module_instance(GList *hist, dt_iop_module_t *module, int multi_priority)
 {
@@ -1011,7 +1011,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
   int num = -1;
   GtkWidget *widget =
     _lib_history_create_button(self, num, _("original"), FALSE, FALSE, TRUE, darktable.develop->history_end == 0, FALSE);
-  gtk_box_pack_start(GTK_BOX(d->history_box), widget, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(d->history_box), widget, FALSE, FALSE, 0);
   num++;
 
   d->record_history_level -= 1;
@@ -1059,7 +1059,7 @@ static void _lib_history_change_callback(gpointer instance, gpointer user_data)
     gtk_widget_set_has_tooltip(widget, TRUE);
     g_signal_connect(G_OBJECT(widget), "query-tooltip", G_CALLBACK(_changes_tooltip_callback), (void *)hitem);
 
-    gtk_box_pack_start(GTK_BOX(d->history_box), widget, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(d->history_box), widget, FALSE, FALSE, 0);
     gtk_box_reorder_child(GTK_BOX(d->history_box), widget, 0);
     num++;
 

--- a/src/libs/masks.c
+++ b/src/libs/masks.c
@@ -44,7 +44,6 @@ typedef struct dt_lib_masks_t
   GtkWidget *hbox;
   GtkWidget *bt_circle, *bt_path, *bt_gradient, *bt_ellipse, *bt_brush;
   GtkWidget *treeview;
-  GtkWidget *scroll_window;
 
   GdkPixbuf *ic_inverse, *ic_union, *ic_intersection, *ic_difference, *ic_exclusion, *ic_used;
   int gui_reset;
@@ -1531,12 +1530,6 @@ static void _lib_masks_remove_item(dt_lib_module_t *self, int formid, int parent
   }
 }
 
-static void _lib_history_change_callback(gpointer instance, gpointer user_data)
-{
-  // dt_lib_module_t *self = (dt_lib_module_t *)user_data;
-  //_lib_masks_recreate_list(self);
-}
-
 static void _lib_masks_selection_change(dt_lib_module_t *self, int selectid, int throw_event)
 {
   dt_lib_masks_t *lm = (dt_lib_masks_t *)self->data;
@@ -1570,25 +1563,6 @@ static void _lib_masks_selection_change(dt_lib_module_t *self, int selectid, int
     valid = gtk_tree_model_iter_next(model, &iter);
   }
   lm->gui_reset = 0;
-}
-
-static gboolean _mouse_scroll_view(GtkWidget *treeview, GdkEventScroll *event, dt_lib_module_t *self)
-{
-  if (event->state & GDK_CONTROL_MASK)
-  {
-    dt_lib_masks_t *d = (dt_lib_masks_t *)self->data;
-    const gint increment = DT_PIXEL_APPLY_DPI(10.0);
-    const gint min_height = DT_PIXEL_APPLY_DPI(100.0);
-    const gint max_height = DT_PIXEL_APPLY_DPI(1000.0);
-    gint width, height;
-    gtk_widget_get_size_request (GTK_WIDGET(d->scroll_window), &width, &height);
-    height = height + increment * event->delta_y;
-    height = (height < min_height) ? min_height : (height > max_height) ? max_height : height;
-    gtk_widget_set_size_request(GTK_WIDGET(d->scroll_window), -1, (gint)height);
-    dt_conf_set_int("plugins/darkroom/masks/heightview", (gint)height);
-    return TRUE;
-  }
-  return FALSE;
 }
 
 void gui_init(dt_lib_module_t *self)
@@ -1706,11 +1680,6 @@ void gui_init(dt_lib_module_t *self)
 
   gtk_box_pack_start(GTK_BOX(self->widget), hbox, TRUE, TRUE, 0);
 
-  d->scroll_window = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(d->scroll_window), GTK_POLICY_AUTOMATIC,
-                                 GTK_POLICY_AUTOMATIC);
-  gtk_box_pack_start(GTK_BOX(self->widget), d->scroll_window, TRUE, TRUE, 0);
-
   d->treeview = gtk_tree_view_new();
   GtkTreeViewColumn *col = gtk_tree_view_column_new();
   gtk_tree_view_column_set_title(col, "shapes");
@@ -1739,24 +1708,15 @@ void gui_init(dt_lib_module_t *self)
   gtk_tree_selection_set_mode(selection, GTK_SELECTION_MULTIPLE);
   gtk_tree_selection_set_select_function(selection, _tree_restrict_select, d, NULL);
   gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(d->treeview), FALSE);
-
-  const gint height = dt_conf_get_int("plugins/darkroom/masks/heightview");
-  gtk_widget_set_size_request(d->scroll_window, -1, DT_PIXEL_APPLY_DPI(height ? height : 300));
-  gtk_container_add(GTK_CONTAINER(d->scroll_window), d->treeview);
   // gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(d->treeview),TREE_USED_TEXT);
   g_object_set(d->treeview, "has-tooltip", TRUE, (gchar *)0);
   g_signal_connect(d->treeview, "query-tooltip", G_CALLBACK(_tree_query_tooltip), NULL);
-
   g_signal_connect(selection, "changed", G_CALLBACK(_tree_selection_change), d);
   g_signal_connect(d->treeview, "button-press-event", (GCallback)_tree_button_pressed, self);
 
-  g_signal_connect(G_OBJECT(d->treeview), "scroll-event", G_CALLBACK(_mouse_scroll_view), (gpointer)self);
+  gtk_box_pack_start(GTK_BOX(self->widget), dt_ui_scroll_wrap(d->treeview, 200, "plugins/darkroom/masks/heightview"), FALSE, FALSE, 0);
 
   gtk_widget_show_all(self->widget);
-
-  /* connect to history change signal for updating the history view */
-  DT_DEBUG_CONTROL_SIGNAL_CONNECT(darktable.signals, DT_SIGNAL_DEVELOP_HISTORY_CHANGE,
-                            G_CALLBACK(_lib_history_change_callback), self);
 
   // set proxy functions
   darktable.develop->proxy.masks.module = self;
@@ -1768,8 +1728,6 @@ void gui_init(dt_lib_module_t *self)
 
 void gui_cleanup(dt_lib_module_t *self)
 {
-  DT_DEBUG_CONTROL_SIGNAL_DISCONNECT(darktable.signals, G_CALLBACK(_lib_history_change_callback), self);
-
   g_free(self->data);
   self->data = NULL;
 }

--- a/src/libs/recentcollect.c
+++ b/src/libs/recentcollect.c
@@ -304,7 +304,8 @@ void gui_init(dt_lib_module_t *self)
 {
   dt_lib_recentcollect_t *d = (dt_lib_recentcollect_t *)calloc(1, sizeof(dt_lib_recentcollect_t));
   self->data = (void *)d;
-  self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  GtkWidget *box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  self->widget = dt_ui_scroll_wrap(box, 50, "plugins/lighttable/recentcollect/windowheight");
   dt_gui_add_help_link(self->widget, dt_get_help_url(self->plugin_name));
   d->inited = 0;
 
@@ -312,7 +313,7 @@ void gui_init(dt_lib_module_t *self)
   for(int k = 0; k < NUM_LINES; k++)
   {
     d->item[k].button = gtk_button_new();
-    gtk_box_pack_start(GTK_BOX(self->widget), d->item[k].button, FALSE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(box), d->item[k].button, FALSE, TRUE, 0);
     g_signal_connect(G_OBJECT(d->item[k].button), "clicked", G_CALLBACK(_button_pressed), (gpointer)self);
     gtk_widget_set_no_show_all(d->item[k].button, TRUE);
     gtk_widget_set_name(GTK_WIDGET(d->item[k].button), "recent-collection-button");

--- a/src/libs/snapshots.c
+++ b/src/libs/snapshots.c
@@ -407,14 +407,15 @@ void gui_init(dt_lib_module_t *self)
              "%s/dt_snapshot_%d.png", localtmpdir, k);
 
     /* add button to snapshot box */
-    gtk_box_pack_start(GTK_BOX(d->snapshots_box), d->snapshot[k].button, TRUE, TRUE, 0);
+    gtk_box_pack_start(GTK_BOX(d->snapshots_box), d->snapshot[k].button, FALSE, FALSE, 0);
 
     /* prevent widget to show on external show all */
     gtk_widget_set_no_show_all(d->snapshot[k].button, TRUE);
   }
 
   /* add snapshot box and take snapshot button to widget ui*/
-  gtk_box_pack_start(GTK_BOX(self->widget), d->snapshots_box, TRUE, TRUE, 0);
+  gtk_box_pack_start(GTK_BOX(self->widget),
+                     dt_ui_scroll_wrap(d->snapshots_box, 1, "plugins/darkroom/snapshots/windowheight"), TRUE, TRUE, 0);
   gtk_box_pack_start(GTK_BOX(self->widget), d->take_button, TRUE, TRUE, 0);
 }
 
@@ -532,7 +533,7 @@ static gboolean _lib_snapshots_toggle_last(GtkAccelGroup *accel_group, GObject *
   dt_lib_module_t *self = (dt_lib_module_t *)data;
   dt_lib_snapshots_t *d = (dt_lib_snapshots_t *)self->data;
 
-  if(d->num_snapshots) 
+  if(d->num_snapshots)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(d->snapshot[0].button), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(d->snapshot[0].button)));
 
   return TRUE;

--- a/src/libs/styles.c
+++ b/src/libs/styles.c
@@ -514,7 +514,6 @@ void gui_init(dt_lib_module_t *self)
   self->widget = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
   dt_gui_add_help_link(self->widget, "styles.html#styles_usage");
   GtkWidget *w;
-  GtkWidget *scrolled;
 
   /* tree */
   d->tree = GTK_TREE_VIEW(gtk_tree_view_new());
@@ -544,14 +543,10 @@ void gui_init(dt_lib_module_t *self)
 
   dt_gui_key_accel_block_on_focus_connect(GTK_WIDGET(d->entry));
 
-  scrolled = gtk_scrolled_window_new(NULL, NULL);
-  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-
-  gtk_scrolled_window_set_min_content_height(GTK_SCROLLED_WINDOW(scrolled), DT_PIXEL_APPLY_DPI(250));
-
   gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(d->entry), TRUE, TRUE, 0);
-  gtk_box_pack_start(GTK_BOX(self->widget), GTK_WIDGET(scrolled), TRUE, FALSE, 0);
-  gtk_container_add(GTK_CONTAINER(scrolled), GTK_WIDGET(d->tree));
+  gtk_box_pack_start(GTK_BOX(self->widget),
+                     dt_ui_scroll_wrap(GTK_WIDGET(d->tree), 250, "plugins/lighttable/style/windowheight"),
+                     FALSE, FALSE, 0);
 
   d->duplicate = gtk_check_button_new_with_label(_("create duplicate"));
   gtk_label_set_ellipsize(GTK_LABEL(gtk_bin_get_child(GTK_BIN(d->duplicate))), PANGO_ELLIPSIZE_START);


### PR DESCRIPTION
Allow setting a maximum on the widget height (using ctrl-scroll) of all the remaining lib modules in lighttable and darkroom that didn't have this feature yet;
history
duplicates
colorpicker
snapshots
styles
recent collections
and refactored metadata and masks (which had coincidentally just a few days back received this feature from @johnny-bit)

The functionality here is slightly different from elsewhere in that there is no hard minimum size; if you want to, you can force the list to be one line high. However if you allow it to be higher than the hardcoded "minimum" size, it will only use the space required for the current number of entries. Also, the height, and step size, when using the mouse wheel to scroll on the list itself, not the scrollbar, will always be a multiple of the line/entry height.

There are also some other changes and fixes to some of the modules. The layout of duplicates has changed; I have moved the add duplicate/virgin buttons to the bottom to match better with the layout of the history and snapshots modules. Some theming had to be adjusted to make sure items/lines are of fixed height (especially multiline labels as in metadata). @nilvus please comment on the changes.

If the changes here are liked, I should be able to extend the support to also cover GtkTextView and refactor all the other modules as well.

There is a remaining issue with updating the widgets after a resize. This is most obvious with the metadata module if there are some images with multiline metadata tags. While mouse moving over them, the size of the module will always be one step behind. I've tried adding all combinations of gtk_widget_queue_resize/draw/allocate to _scroll_wrap_resize, but so far haven't found a solution. I'd be very happy for someone to point out to me what I'm overlooking...