### PR TITLE
fix error when hovering over blending slider while in Entry

### DIFF
--- a/src/develop/blend_gui.c
+++ b/src/develop/blend_gui.c
@@ -1326,8 +1326,8 @@ static gboolean _blendop_blendif_enter(GtkWidget *widget, GdkEventCrossing *even
 
   _blendop_blendif_channel_mask_view(widget, module, mode);
 
-  dt_control_key_accelerators_off(darktable.control);
   gtk_widget_grab_focus(widget);
+  dt_control_key_accelerators_off(darktable.control);
   return FALSE;
 }
 


### PR DESCRIPTION
Entry widgets (for example the module search or rename edit fields) disable accelerators. The blending code would do the same _again_ (and throw the error below) when the mouse enters it and grab the focus afterwards. Reversing those two actions causes whoever had focus before to reenable accelerators so they can be happily disabled again here.

(darktable:295164): Gtk-CRITICAL **: 13:45:28.580: _gtk_accel_group_detach: assertion 'g_slist_find (accel_group->priv->acceleratables, object) != NULL' failed