### PR TITLE
Simplified approach for `screen_ppd_overwrite` and `ui/cairo_filter`

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2319,10 +2319,10 @@
     <longdescription>if this value is &gt; 0.0 then it is used as the screen's dpi setting which is used to scale the gui</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>ui/monitor</name>
-    <type>int</type>
-    <default>0</default>
-    <shortdescription>monitor selection</shortdescription>
+    <name>ui/performance</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>performance mode for thumbs and previews</shortdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/preview/max_in_memory_images</name>

--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -134,19 +134,6 @@
     <shortdescription>maximum width of the side panels in pixels</shortdescription>
     <longdescription>(needs a restart)</longdescription>
   </dtconfig>
-  <dtconfig>
-    <name>ui/cairo_filter</name>
-    <type>
-      <enum>
-	<option>fast</option>
-	<option>good</option>
-	<option>best</option>
-      </enum>
-    </type>
-    <default>good</default>
-    <shortdescription>speed/quality trade-off for drawing images</shortdescription>
-    <longdescription>fast - high-performance, similar to nearest neighbor filter; good (default) - reasonable-performance, similar to bilinear (linear interpolation in two dimensions); best - highest-quality available, performance may not be suitable for interactive use. sets Cairo image scaling filter. (needs a restart)</longdescription>
-  </dtconfig>
   <dtconfig prefs="otherviews" section="slideshow">
     <name>slideshow_delay</name>
     <type>int</type>
@@ -2332,11 +2319,10 @@
     <longdescription>if this value is &gt; 0.0 then it is used as the screen's dpi setting which is used to scale the gui</longdescription>
   </dtconfig>
   <dtconfig>
-    <name>screen_ppd_overwrite</name>
-    <type>float</type>
-    <default>-1.0</default>
-    <shortdescription>overwrite the screen's ppd setting</shortdescription>
-    <longdescription>if this value is &gt; 0.0 then it is used as the screen's ppd setting which is used for HiDPI support</longdescription>
+    <name>ui/monitor</name>
+    <type>int</type>
+    <default>0</default>
+    <shortdescription>monitor selection</shortdescription>
   </dtconfig>
   <dtconfig>
     <name>plugins/lighttable/preview/max_in_memory_images</name>

--- a/src/common/darktable.c
+++ b/src/common/darktable.c
@@ -1455,6 +1455,7 @@ void dt_configure_performance()
     if(demosaic_quality == NULL || !strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
+    dt_conf_set_bool("ui/performance", FALSE);
   }
   else if(mem > (2lu << 20) && threads >= 4 && atom_cores == 0)
   {
@@ -1468,6 +1469,7 @@ void dt_configure_performance()
     if(demosaic_quality == NULL ||!strcmp(demosaic_quality, "always bilinear (fast)"))
       dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
+    dt_conf_set_bool("ui/performance", FALSE);
   }
   else if(mem < (1lu << 20) || threads <= 2 || atom_cores > 0)
   {
@@ -1479,6 +1481,7 @@ void dt_configure_performance()
     dt_conf_set_int("singlebuffer_limit", 8);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "always bilinear (fast)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", TRUE);
+    dt_conf_set_bool("ui/performance", TRUE);
   }
   else
   {
@@ -1490,6 +1493,7 @@ void dt_configure_performance()
     dt_conf_set_int("singlebuffer_limit", 16);
     dt_conf_set_string("plugins/darkroom/demosaic/quality", "at most PPG (reasonable)");
     dt_conf_set_bool("plugins/lighttable/low_quality_thumbnails", FALSE);
+    dt_conf_set_bool("ui/performance", FALSE);
   }
 
   g_free(demosaic_quality);

--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -312,7 +312,7 @@ typedef struct dt_develop_t
     GtkWidget *second_wnd;
     GtkWidget *widget;
     int width, height;
-    double dpi, dpi_factor, ppd;
+    double dpi, dpi_factor, ppd, ppd_thb;
 
     GtkWidget *button;
 

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -214,14 +214,14 @@ static void _thumb_draw_image(dt_thumbnail_t *thumb, cairo_t *cr)
   int h = 0;
   gtk_widget_get_size_request(thumb->w_image_box, &w, &h);
 
-  const float scaler = 1.0f / darktable.gui->ppd;
+  const float scaler = 1.0f / darktable.gui->ppd_thb;
   cairo_scale(cr, scaler, scaler);
 
   cairo_set_source_surface(cr, thumb->img_surf, thumb->current_zx * darktable.gui->ppd, thumb->current_zy * darktable.gui->ppd);
   cairo_paint(cr);
 
   // and eventually the image border
-  gtk_render_frame(context, cr, 0, 0, w * darktable.gui->ppd, h * darktable.gui->ppd);
+  gtk_render_frame(context, cr, 0, 0, w * darktable.gui->ppd_thb, h * darktable.gui->ppd_thb);
 }
 
 static void _thumb_retrieve_margins(dt_thumbnail_t *thumb)
@@ -366,7 +366,7 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
       // copy preview image into final surface
       if(tmp_surface)
       {
-        const float scale = fminf(image_w / (float)buf_width, image_h / (float)buf_height) * darktable.gui->ppd;
+        const float scale = fminf(image_w / (float)buf_width, image_h / (float)buf_height) * darktable.gui->ppd_thb;
         const int img_width = buf_width * scale;
         const int img_height = buf_height * scale;
         thumb->img_surf = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_width, img_height);
@@ -457,8 +457,8 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
     // let save thumbnail image size
     thumb->img_width = cairo_image_surface_get_width(thumb->img_surf);
     thumb->img_height = cairo_image_surface_get_height(thumb->img_surf);
-    const int imgbox_w = MIN(image_w, thumb->img_width/darktable.gui->ppd);
-    const int imgbox_h = MIN(image_h, thumb->img_height/darktable.gui->ppd);
+    const int imgbox_w = MIN(image_w, thumb->img_width/darktable.gui->ppd_thb);
+    const int imgbox_h = MIN(image_h, thumb->img_height/darktable.gui->ppd_thb);
     // if the imgbox size change, this should also change the panning values
     int hh = 0;
     int ww = 0;
@@ -524,8 +524,8 @@ static gboolean _event_image_draw(GtkWidget *widget, cairo_t *cr, gpointer user_
 
     // let's sanitize and apply panning values as we are sure the zoomed image is loaded now
     // here we have to make sure to properly align according to ppd
-    thumb->zoomx = CLAMP(thumb->zoomx, (imgbox_w * darktable.gui->ppd - thumb->img_width) / darktable.gui->ppd, 0);
-    thumb->zoomy = CLAMP(thumb->zoomy, (imgbox_h * darktable.gui->ppd - thumb->img_height) / darktable.gui->ppd, 0);
+    thumb->zoomx = CLAMP(thumb->zoomx, (imgbox_w * darktable.gui->ppd_thb - thumb->img_width) / darktable.gui->ppd_thb, 0);
+    thumb->zoomy = CLAMP(thumb->zoomy, (imgbox_h * darktable.gui->ppd_thb - thumb->img_height) / darktable.gui->ppd_thb, 0);
     thumb->current_zx = thumb->zoomx;
     thumb->current_zy = thumb->zoomy;
   }
@@ -1686,8 +1686,8 @@ void dt_thumbnail_image_refresh_position(dt_thumbnail_t *thumb)
   int iw = 0;
   int ih = 0;
   gtk_widget_get_size_request(thumb->w_image_box, &iw, &ih);
-  thumb->zoomx = CLAMP(thumb->zoomx, (iw * darktable.gui->ppd - thumb->img_width) / darktable.gui->ppd, 0);
-  thumb->zoomy = CLAMP(thumb->zoomy, (ih * darktable.gui->ppd - thumb->img_height) / darktable.gui->ppd, 0);
+  thumb->zoomx = CLAMP(thumb->zoomx, (iw * darktable.gui->ppd_thb - thumb->img_width) / darktable.gui->ppd_thb, 0);
+  thumb->zoomy = CLAMP(thumb->zoomy, (ih * darktable.gui->ppd_thb - thumb->img_height) / darktable.gui->ppd_thb, 0);
   thumb->current_zx = thumb->zoomx;
   thumb->current_zy = thumb->zoomy;
   gtk_widget_queue_draw(thumb->w_main);

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1555,10 +1555,10 @@ void dt_gui_gtk_run(dt_gui_gtk_t *gui)
 double dt_get_system_gui_ppd(GtkWidget *widget)
 {
   double res = 0.0f;
-#ifndef GDK_WINDOWING_QUARTZ
-  res = gtk_widget_get_scale_factor(widget);
-#else
+#ifdef GDK_WINDOWING_QUARTZ
   res = dt_osx_get_ppd();
+#else
+  res = gtk_widget_get_scale_factor(widget);
 #endif
   if((res < 1.0f) || (res > 4.0f))
   {

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1577,7 +1577,7 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
   gui->filter_image = CAIRO_FILTER_GOOD;
   if(dt_conf_get_bool("ui/performance"))
   {
-      gui->ppd_thb = 0.7f * gui->ppd;
+      gui->ppd_thb *= DT_GUI_THUMBSIZE_REDUCE;
       gui->filter_image = CAIRO_FILTER_FAST;
   }
   // get the screen resolution

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -1564,7 +1564,7 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
   {
     if(monitor == 2)
     {
-      gui->ppd_thb = 0.5f;
+      gui->ppd_thb = 0.7f;
       gui->filter_image = CAIRO_FILTER_FAST;
     }
     else if(monitor == 3)
@@ -1574,6 +1574,7 @@ void dt_configure_ppd_dpi(dt_gui_gtk_t *gui)
     else if(monitor == 4)
     {
       gui->ppd = 2.0f;
+      gui->ppd_thb = 1.4f;
       gui->filter_image = CAIRO_FILTER_FAST;
     }
   }

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -188,6 +188,7 @@ int dt_gui_gtk_load_config();
 int dt_gui_gtk_write_config();
 void dt_gui_gtk_set_source_rgb(cairo_t *cr, dt_gui_color_t);
 void dt_gui_gtk_set_source_rgba(cairo_t *cr, dt_gui_color_t, float opacity_coef);
+double dt_get_system_gui_ppd(GtkWidget *widget);
 
 /* Check sidebar_scroll_default and modifier keys to determine if scroll event
  * should be processed by control or by panel. If default is panel scroll but

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -26,6 +26,8 @@
 
 #define DT_GUI_IOP_MODULE_CONTROL_SPACING 0
 
+#define DT_GUI_THUMBSIZE_REDUCE 0.7f
+
 /* helper macro that applies the DPI transformation to fixed pixel values. input should be defaulting to 96
  * DPI */
 #define DT_PIXEL_APPLY_DPI(value) ((value) * darktable.gui->dpi_factor)

--- a/src/gui/gtk.h
+++ b/src/gui/gtk.h
@@ -116,7 +116,7 @@ typedef struct dt_gui_gtk_t
   gboolean show_focus_peaking;
   GtkWidget *focus_peaking_button;
 
-  double dpi, dpi_factor, ppd;
+  double dpi, dpi_factor, ppd, ppd_thb;
 
   int icon_size; // size of top panel icons
 

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -208,22 +208,10 @@ static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
-static void display_callback(GtkWidget *widget, gpointer user_data)
+static void use_performance_callback(GtkWidget *widget, gpointer user_data)
 {
-  int old = dt_conf_get_int("ui/monitor");
-  const int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-  dt_conf_set_int("ui/monitor", selected);
-  gboolean restart = TRUE;
-
-  if(((old == 1) && (selected == 2)) ||
-     ((old == 2) && (selected == 1)) ||
-     ((old == 3) && (selected == 4)) ||
-     ((old == 4) && (selected == 3)) ||
-      (old == selected))
-    restart = FALSE;
-  restart_required = restart;
+  dt_conf_set_bool("ui/performance", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
   dt_configure_ppd_dpi(darktable.gui);
-  dt_bauhaus_load_theme();
 }
 
 static void dpi_scaling_changed_callback(GtkWidget *widget, gpointer user_data)
@@ -400,27 +388,17 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
-  label = gtk_label_new(_("display"));
+  GtkWidget *useperfmode = gtk_check_button_new();
+  label = gtk_label_new(_("performance mode"));
   gtk_widget_set_halign(label, GTK_ALIGN_START);
-  widget = gtk_combo_box_text_new();
   labelev = gtk_event_box_new();
   gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
   gtk_container_add(GTK_CONTAINER(labelev), label);
   gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
-
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "default");
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "standard monitor");
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "standard monitor, (slow)");
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "high resolution monitor");
-  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "high resolution monitor, (slow)");
-
-  selected = dt_conf_get_int("ui/monitor");
-  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), selected);
-  g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(display_callback), 0);
-  gtk_widget_set_tooltip_text(widget, _("set according to your display type and computer performance.\n"
-                                        "slow modes increase performance but decrease visual quality of thumbs and previews."
-                                        "this needs a restart to apply changes."));
+  gtk_grid_attach_next_to(GTK_GRID(grid), useperfmode, labelev, GTK_POS_RIGHT, 1, 1);
+  gtk_widget_set_tooltip_text(useperfmode, _("if switched on thumbnails and previews are rendered at lower quality but 4 times faster."));
+  gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(useperfmode), dt_conf_get_bool("ui/performance"));
+  g_signal_connect(G_OBJECT(useperfmode), "toggled", G_CALLBACK(use_performance_callback), 0);
 
   //Font size check and spin buttons
   GtkWidget *usesysfont = gtk_check_button_new();

--- a/src/gui/preferences.c
+++ b/src/gui/preferences.c
@@ -208,12 +208,20 @@ static void font_size_changed_callback(GtkWidget *widget, gpointer user_data)
   dt_bauhaus_load_theme();
 }
 
-static void gui_scaling_changed_callback(GtkWidget *widget, gpointer user_data)
+static void display_callback(GtkWidget *widget, gpointer user_data)
 {
-  float ppd = gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget));
-  if(ppd > 0.0) ppd = fmax(0.5, ppd); // else <= 0 -> use system default
-  dt_conf_set_float("screen_ppd_overwrite", ppd);
-  restart_required = TRUE;
+  int old = dt_conf_get_int("ui/monitor");
+  const int selected = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
+  dt_conf_set_int("ui/monitor", selected);
+  gboolean restart = TRUE;
+
+  if(((old == 1) && (selected == 2)) ||
+     ((old == 2) && (selected == 1)) ||
+     ((old == 3) && (selected == 4)) ||
+     ((old == 4) && (selected == 3)) ||
+      (old == selected))
+    restart = FALSE;
+  restart_required = restart;
   dt_configure_ppd_dpi(darktable.gui);
   dt_bauhaus_load_theme();
 }
@@ -392,6 +400,28 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(theme_callback), 0);
   gtk_widget_set_tooltip_text(widget, _("set the theme for the user interface"));
 
+  label = gtk_label_new(_("display"));
+  gtk_widget_set_halign(label, GTK_ALIGN_START);
+  widget = gtk_combo_box_text_new();
+  labelev = gtk_event_box_new();
+  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
+  gtk_container_add(GTK_CONTAINER(labelev), label);
+  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
+  gtk_grid_attach_next_to(GTK_GRID(grid), widget, labelev, GTK_POS_RIGHT, 1, 1);
+
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "default");
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "standard monitor");
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "standard monitor, (slow)");
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "high resolution monitor");
+  gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(widget), "high resolution monitor, (slow)");
+
+  selected = dt_conf_get_int("ui/monitor");
+  gtk_combo_box_set_active(GTK_COMBO_BOX(widget), selected);
+  g_signal_connect(G_OBJECT(widget), "changed", G_CALLBACK(display_callback), 0);
+  gtk_widget_set_tooltip_text(widget, _("set according to your display type and computer performance.\n"
+                                        "slow modes increase performance but decrease visual quality of thumbs and previews."
+                                        "this needs a restart to apply changes."));
+
   //Font size check and spin buttons
   GtkWidget *usesysfont = gtk_check_button_new();
   GtkWidget *fontsize = gtk_spin_button_new_with_range(5.0f, 30.0f, 0.2f);
@@ -428,22 +458,6 @@ static void init_tab_general(GtkWidget *dialog, GtkWidget *stack, dt_gui_themetw
   gtk_widget_set_tooltip_text(fontsize, _("font size in points"));
   gtk_spin_button_set_value(GTK_SPIN_BUTTON(fontsize), dt_conf_get_float("font_size"));
   g_signal_connect(G_OBJECT(fontsize), "value_changed", G_CALLBACK(font_size_changed_callback), 0);
-
-  GtkWidget *screen_ppd_overwrite = gtk_spin_button_new_with_range(-1.0f, 8.0f, 0.2f);
-  label = gtk_label_new(_("GUI thumbs and previews DPI scaling factor"));
-  gtk_widget_set_halign(label, GTK_ALIGN_START);
-  labelev = gtk_event_box_new();
-  gtk_widget_add_events(labelev, GDK_BUTTON_PRESS_MASK);
-  gtk_container_add(GTK_CONTAINER(labelev), label);
-  gtk_grid_attach(GTK_GRID(grid), labelev, 0, line++, 1, 1);
-  gtk_grid_attach_next_to(GTK_GRID(grid), screen_ppd_overwrite, labelev, GTK_POS_RIGHT, 1, 1);
-  gtk_widget_set_tooltip_text(screen_ppd_overwrite, _("scale the thumbnails and previews resolutions for high DPI screens.\n"
-                                                      "increase if thumbnails look blurry, decrease if lighttable is too slow.\n"
-                                                      "set to -1.0 to use the system-defined global scaling.\n"
-                                                      "default is 1.0 on most systems, or 2.0 when using resolutions above 1920×1080 px.\n"
-                                                      "this needs a restart to apply changes."));
-  gtk_spin_button_set_value(GTK_SPIN_BUTTON(screen_ppd_overwrite), dt_conf_get_float("screen_ppd_overwrite"));
-  g_signal_connect(G_OBJECT(screen_ppd_overwrite), "value_changed", G_CALLBACK(gui_scaling_changed_callback), 0);
 
   GtkWidget *screen_dpi_overwrite = gtk_spin_button_new_with_range(-1.0f, 360, 1.f);
   label = gtk_label_new(_("GUI controls and text DPI"));

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4392,33 +4392,42 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
 {
   GtkWidget *widget = dev->second_window.second_wnd;
 
+  dev->second_window.ppd = dev->second_window.ppd_thb = 1.0f;
 // check if in HiDPI mode
 #if(CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 13, 1))
-  float screen_ppd_overwrite = dt_conf_get_float("screen_ppd_overwrite");
-  if(screen_ppd_overwrite > 0.0)
+  int monitor = dt_conf_get_int("ui/monitor");
+  if(monitor)
   {
-    dev->second_window.ppd = screen_ppd_overwrite;
-    dt_print(DT_DEBUG_CONTROL, "[HiDPI] setting ppd to %f as specified in the configuration file\n",
-             screen_ppd_overwrite);
+    if(monitor == 2)
+    {
+      dev->second_window.ppd_thb = 0.5f;
+    }
+    else if(monitor == 3)
+    {
+      dev->second_window.ppd = dev->second_window.ppd_thb = 2.0f;
+    }
+    else if(monitor == 4)
+    {
+      dev->second_window.ppd = 2.0f;
+    }
   }
   else
   {
-#ifndef GDK_WINDOWING_QUARTZ
-    dev->second_window.ppd = gtk_widget_get_scale_factor(widget);
-#else
-    // this do not depends on the window, so we can use the main window value
+ #ifndef GDK_WINDOWING_QUARTZ
+    dev->second_window.ppd = dev->second_window.ppd_thb = gtk_widget_get_scale_factor(widget);
+ #else
+    // this does not depend on the window, so we can use the main window value
     dev->second_window.ppd = darktable.gui->ppd;
-#endif
-    if(dev->second_window.ppd < 0.0)
+    dev->second_window.ppd_thb = darktable.gui->ppd_thb;
+ #endif
+    if(dev->second_window.ppd < 0.0f)
     {
-      dev->second_window.ppd = 1.0;
+      dev->second_window.ppd = dev->second_window.ppd_thb = 1.0f;
       dt_print(DT_DEBUG_CONTROL, "[HiDPI] can't detect screen settings, switching off\n");
     }
     else
       dt_print(DT_DEBUG_CONTROL, "[HiDPI] setting ppd to %f\n", dev->second_window.ppd);
   }
-#else
-  dev->second_window.ppd = 1.0;
 #endif
   // get the screen resolution
   float screen_dpi_overwrite = dt_conf_get_float("screen_dpi_overwrite");

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4392,44 +4392,10 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
 {
   GtkWidget *widget = dev->second_window.second_wnd;
 
-  dev->second_window.ppd = dev->second_window.ppd_thb = 1.0f;
-// check if in HiDPI mode
-#if(CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 13, 1))
-  int monitor = dt_conf_get_int("ui/monitor");
-  if(monitor)
-  {
-    if(monitor == 2)
-    {
-      dev->second_window.ppd_thb = 0.7f;
-    }
-    else if(monitor == 3)
-    {
-      dev->second_window.ppd = dev->second_window.ppd_thb = 2.0f;
-    }
-    else if(monitor == 4)
-    {
-      dev->second_window.ppd = 2.0f;
-      dev->second_window.ppd_thb = 1.4f;
-    }
-  }
-  else
-  {
- #ifndef GDK_WINDOWING_QUARTZ
-    dev->second_window.ppd = dev->second_window.ppd_thb = gtk_widget_get_scale_factor(widget);
- #else
-    // this does not depend on the window, so we can use the main window value
-    dev->second_window.ppd = darktable.gui->ppd;
-    dev->second_window.ppd_thb = darktable.gui->ppd_thb;
- #endif
-    if(dev->second_window.ppd < 0.0f)
-    {
-      dev->second_window.ppd = dev->second_window.ppd_thb = 1.0f;
-      dt_print(DT_DEBUG_CONTROL, "[HiDPI] can't detect screen settings, switching off\n");
-    }
-    else
-      dt_print(DT_DEBUG_CONTROL, "[HiDPI] setting ppd to %f\n", dev->second_window.ppd);
-  }
-#endif
+  dev->second_window.ppd = dev->second_window.ppd_thb = dt_get_system_gui_ppd(widget);
+  if(dt_conf_get_bool("ui/performance"))
+    dev->second_window.ppd_thb = 0.7f * dev->second_window.ppd;
+
   // get the screen resolution
   float screen_dpi_overwrite = dt_conf_get_float("screen_dpi_overwrite");
   if(screen_dpi_overwrite > 0.0)

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4400,7 +4400,7 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
   {
     if(monitor == 2)
     {
-      dev->second_window.ppd_thb = 0.5f;
+      dev->second_window.ppd_thb = 0.7f;
     }
     else if(monitor == 3)
     {
@@ -4409,6 +4409,7 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
     else if(monitor == 4)
     {
       dev->second_window.ppd = 2.0f;
+      dev->second_window.ppd_thb = 1.4f;
     }
   }
   else

--- a/src/views/darkroom.c
+++ b/src/views/darkroom.c
@@ -4394,7 +4394,7 @@ static void _second_window_configure_ppd_dpi(dt_develop_t *dev)
 
   dev->second_window.ppd = dev->second_window.ppd_thb = dt_get_system_gui_ppd(widget);
   if(dt_conf_get_bool("ui/performance"))
-    dev->second_window.ppd_thb = 0.7f * dev->second_window.ppd;
+    dev->second_window.ppd_thb *= DT_GUI_THUMBSIZE_REDUCE;
 
   // get the screen resolution
   float screen_dpi_overwrite = dt_conf_get_float("screen_dpi_overwrite");

--- a/src/views/view.c
+++ b/src/views/view.c
@@ -964,7 +964,7 @@ int dt_view_image_get_surface(int imgid, int width, int height, cairo_surface_t 
   }
 
   // so we create a new image surface to return
-  const float scale = fminf(width * darktable.gui->ppd / (float)buf_wd, height * darktable.gui->ppd/ (float)buf_ht);
+  const float scale = fminf(width / (float)buf_wd, height / (float)buf_ht) * darktable.gui->ppd_thb ;
   const int img_width = buf_wd * scale;
   const int img_height = buf_ht * scale;
   *surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, img_width, img_height);


### PR DESCRIPTION
The PPD (pixels-per-dot) value is read by default from OS setting resulting in values
of either 1.0f or 2.0f for normal / high-resolution monitors. Or you could specify it via
the general->preferences.

The tooltip there suggested to increase the value for better visual output regarding thumbs & previews,
or decrease it for better performance. In fact, the first suggestion is not true any more since
the thumbnail size is calculated correctly. The second suggestion (decreasing) indeed leads to
increased performance but also lead to blurring in gtk/bauhaus elements. (To test this on a normal
monitor, set it to 0.5f, go to darkroom and look at the iops)

Another option was the hidden `ui/cairo_filter` option. It was introduced a while ago for more 'crisp'
display of thumbs & previews when in hires mode, this is not necessary any more.

**But** both above ways would be fine for slow computers to have faster thumb&preview rendering.

What has been done in this pr?

1) Both config options have been removed and were replaced by a drop down menu selecting between
   system(default), standard monitor(ppd==1) and hires monitor(ppd==2). For both specified monitor
   types we can select between normal vs. slow computer mode.
   "default"
   "standard monitor"
   "standard monitor, (slow)"
   "high resolution monitor"
   "high resolution monitor, (slow)"

2) As we want the thumbs to be displayed with different ppd than the GUI ppd we add `ppd_thb` to
   `dt_gui_gtk_t`, this is used in all thumbs drawing code recently introduced when fixing the hires
   impaired output.

3) When selecting one of non-slow modes, ppd_thb is the same as ppd and rendering is cairo_good.
4) If we use one of the slow modes we select cairo_fast and a smaller ppd_thb.
   This results in an overall > 4-fold better performance for the slow modes.
