### PR TITLE
Fix crash caused by lua widget garbage collector

### DIFF
--- a/src/lua/widget/widget.c
+++ b/src/lua/widget/widget.c
@@ -1,7 +1,6 @@
 /*
    This file is part of darktable,
-   copyright (c) 2015 Jeremy Rosen
-   copyright (c) 2015 tobias ellinghaus
+   Copyright (C) 2015-2020 darktable developers.
 
    darktable is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,7 +43,7 @@ dt_lua_widget_type_t widget_type = {
 
 static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua_widget widget);
 static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua_widget widget) {
-  if(widget_type->parent) 
+  if(widget_type->parent)
     cleanup_widget_sub(L,widget_type->parent,widget);
   if(widget_type->gui_cleanup) {
     widget_type->gui_cleanup(L,widget);
@@ -53,9 +52,9 @@ static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua
 
 static void init_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type);
 static void init_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type) {
-  if(widget_type->parent) 
+  if(widget_type->parent)
     init_widget_sub(L,widget_type->parent);
-  if(widget_type->gui_init) 
+  if(widget_type->gui_init)
     widget_type->gui_init(L);
 }
 
@@ -246,7 +245,7 @@ static int gtk_signal_member(lua_State *L)
   return 1;
 }
 
-void dt_lua_widget_register_gtk_callback_type(lua_State *L,luaA_Type type_id,const char* signal_name, const char* lua_name,GCallback callback) 
+void dt_lua_widget_register_gtk_callback_type(lua_State *L,luaA_Type type_id,const char* signal_name, const char* lua_name,GCallback callback)
 {
   lua_pushstring(L,signal_name);
   lua_pushcclosure(L,gtk_signal_member,1);
@@ -257,7 +256,7 @@ void dt_lua_widget_register_gtk_callback_type(lua_State *L,luaA_Type type_id,con
   lua_pushlightuserdata(L,callback);
   lua_setfield(L,-2,signal_name);
   lua_pop(L,2);
-  
+
 }
 
 int widget_call(lua_State *L)

--- a/src/lua/widget/widget.c
+++ b/src/lua/widget/widget.c
@@ -39,17 +39,7 @@ dt_lua_widget_type_t widget_type = {
   .alloc_size = sizeof(dt_lua_widget_t),
   .parent = NULL
 };
-// commented this function as part of the widget_gc_crash fix
-/*
-static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua_widget widget);
-static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua_widget widget) {
-  if(widget_type->parent) 
-    cleanup_widget_sub(L,widget_type->parent,widget);
-  if(widget_type->gui_cleanup) {
-    widget_type->gui_cleanup(L,widget);
-  }
-}
-*/
+
 static void init_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type);
 static void init_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type) {
   if(widget_type->parent) 
@@ -62,14 +52,7 @@ static void on_destroy(GtkWidget *widget, gpointer user_data)
 {
   free((lua_widget*) user_data);
 }
-// commented out this routine as part of the widget_gc_crash fix
-/*
-static gboolean on_destroy_wrapper(gpointer user_data)
-{
-  gtk_widget_destroy((GtkWidget*) user_data);
-  return false;
-}
-*/
+
 static int widget_gc(lua_State *L)
 {
   lua_widget lwidget;
@@ -78,16 +61,8 @@ static int widget_gc(lua_State *L)
   if(gtk_widget_get_parent(lwidget->widget)) {
     luaL_error(L,"Destroying a widget which is still parented, this should never happen (%s at %p)\n",lwidget->type->name,lwidget);
   }
+  // This should never happen because widgets should not exist at this point
   fprintf(stderr, "LUA ERROR: Trying to garbage collect a widget that hasn't been destroyed\n");
-  // commented out the following 2 lines as part of the widget_gc_crash fix
-  //cleanup_widget_sub(L,lwidget->type,lwidget);
-  //dt_lua_widget_unbind(L,lwidget);
-  // no need to drop, the pointer table is weak and the widget is already being GC, so it's not in the table anymore
-  //dt_lua_type_gpointer_drop(L,lwidget);
-  //dt_lua_type_gpointer_drop(L,lwidget->widget);
-  // commented the following lines out to avoid the widget_gc_crash
-  //g_idle_add(on_destroy_wrapper,lwidget->widget);
-  //free(lwidget);
   return 0;
 }
 

--- a/src/lua/widget/widget.c
+++ b/src/lua/widget/widget.c
@@ -39,8 +39,8 @@ dt_lua_widget_type_t widget_type = {
   .alloc_size = sizeof(dt_lua_widget_t),
   .parent = NULL
 };
-
-
+// commented this function as part of the widget_gc_crash fix
+/*
 static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua_widget widget);
 static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua_widget widget) {
   if(widget_type->parent) 
@@ -49,7 +49,7 @@ static void cleanup_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type,lua
     widget_type->gui_cleanup(L,widget);
   }
 }
-
+*/
 static void init_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type);
 static void init_widget_sub(lua_State *L,dt_lua_widget_type_t*widget_type) {
   if(widget_type->parent) 
@@ -62,13 +62,14 @@ static void on_destroy(GtkWidget *widget, gpointer user_data)
 {
   free((lua_widget*) user_data);
 }
-
+// commented out this routine as part of the widget_gc_crash fix
+/*
 static gboolean on_destroy_wrapper(gpointer user_data)
 {
   gtk_widget_destroy((GtkWidget*) user_data);
   return false;
 }
-
+*/
 static int widget_gc(lua_State *L)
 {
   lua_widget lwidget;
@@ -77,13 +78,16 @@ static int widget_gc(lua_State *L)
   if(gtk_widget_get_parent(lwidget->widget)) {
     luaL_error(L,"Destroying a widget which is still parented, this should never happen (%s at %p)\n",lwidget->type->name,lwidget);
   }
-  cleanup_widget_sub(L,lwidget->type,lwidget);
-  dt_lua_widget_unbind(L,lwidget);
+  fprintf(stderr, "LUA ERROR: Trying to garbage collect a widget that hasn't been destroyed\n");
+  // commented out the following 2 lines as part of the widget_gc_crash fix
+  //cleanup_widget_sub(L,lwidget->type,lwidget);
+  //dt_lua_widget_unbind(L,lwidget);
   // no need to drop, the pointer table is weak and the widget is already being GC, so it's not in the table anymore
   //dt_lua_type_gpointer_drop(L,lwidget);
   //dt_lua_type_gpointer_drop(L,lwidget->widget);
-  g_idle_add(on_destroy_wrapper,lwidget->widget);
-  free(lwidget);
+  // commented the following lines out to avoid the widget_gc_crash
+  //g_idle_add(on_destroy_wrapper,lwidget->widget);
+  //free(lwidget);
   return 0;
 }
 


### PR DESCRIPTION
Removed code that tried to destroy a widget since widget_gc should be called after the widget has been destroyed.  Added an error message to the console when an attempt to garbage collect a widget that hasn't been destroyed.

Fixes #6417 