### PR TITLE
[temperature] make channel coeff sliders a bit more fine-graded

### DIFF
--- a/src/iop/temperature.c
+++ b/src/iop/temperature.c
@@ -1942,6 +1942,10 @@ void gui_init(struct dt_iop_module_t *self)
   dt_bauhaus_slider_set_digits(g->scale_g, 3);
   dt_bauhaus_slider_set_digits(g->scale_b, 3);
   dt_bauhaus_slider_set_digits(g->scale_g2, 3);
+  dt_bauhaus_slider_set_step(g->scale_r, 0.05);
+  dt_bauhaus_slider_set_step(g->scale_g, 0.05);
+  dt_bauhaus_slider_set_step(g->scale_b, 0.05);
+  dt_bauhaus_slider_set_step(g->scale_g2, 0.05);
 
   gtk_widget_set_no_show_all(g->scale_g2, TRUE);
 


### PR DESCRIPTION
Fixes #6395

This makes wb channel coefficients sliders a bit more fine-grained so there's more control in them. I opted for @junkyardsparkle's "middle ground" option for sliders.