### PR TITLE
Exposure-independent guided filtering for tone-equalizer

### DIFF
--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -60,116 +60,117 @@
  * just like what is done in fast_guided_filter.h
 **/
 
-static inline void exposure_independent_guided_filter(const float *const restrict guide, // I
+/* computes average and variance of guide and mask, and put them in out.
+ * out has 4 channels:
+ * - average of guide
+ * - variance of guide
+ * - average of mask
+ * - covariance of mask and guide. */
+static inline void eigf_variance_analysis(const float *const restrict guide, // I
                                     const float *const restrict mask, //p
-                                    float *const restrict ab,
+                                    float *const restrict out,
                                     const size_t width, const size_t height,
-                                    const float sigma, const float feathering)
+                                    const float sigma)
 {
   // We also use gaussian blurs instead of the square blurs of the guided filter
   const size_t Ndim = width * height;
-  float *const restrict blurred_guide = dt_alloc_sse_ps(Ndim);
-  // guide_x_guide = (guide - blurred_guide)^2
-  float *const restrict guide_x_guide = dt_alloc_sse_ps(Ndim);
-  // guide_variance = blur(guide_x_guide)
-  float *const restrict guide_variance = dt_alloc_sse_ps(Ndim);
-  float *const restrict guide_x_mask = dt_alloc_sse_ps(Ndim);
-  // guide_mask_covariance = blur(guide_x_mask)
-  float *const restrict guide_mask_covariance = dt_alloc_sse_ps(Ndim);
-  float *const restrict blurred_mask = dt_alloc_sse_ps(Ndim);
+  float *const restrict in = dt_alloc_sse_ps(Ndim * 4);
 
   float ming = 10000000.0f;
   float maxg = 0.0f;
   float minm = 10000000.0f;
   float maxm = 0.0f;
+  float ming2 = 10000000.0f;
+  float maxg2 = 0.0f;
+  float minmg = 10000000.0f;
+  float maxmg = 0.0f;
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-dt_omp_firstprivate(guide, mask, Ndim) \
-  schedule(simd:static) aligned(guide, mask:64) \
-  reduction(max:maxg, maxm)\
-  reduction(min:ming, minm)
+dt_omp_firstprivate(guide, mask, in, Ndim) \
+  schedule(simd:static) aligned(guide, mask, in:64) \
+  reduction(max:maxg, maxm, maxg2, maxmg)\
+  reduction(min:ming, minm, ming2, minmg)
 #endif
   for(size_t k = 0; k < Ndim; k++)
   {
     const float pixelg = guide[k];
     const float pixelm = mask[k];
+    const float pixelg2 = pixelg * pixelg;
+    const float pixelmg = pixelm * pixelg;
+    in[k * 4] = pixelg;
+    in[k * 4 + 1] = pixelg2;
+    in[k * 4 + 2] = pixelm;
+    in[k * 4 + 3] = pixelmg;
     if(pixelg < ming) ming = pixelg;
     if(pixelg > maxg) maxg = pixelg;
     if(pixelm < minm) minm = pixelm;
     if(pixelm > maxm) maxm = pixelm;
+    if(pixelg2 < ming2) ming2 = pixelg2;
+    if(pixelg2 > maxg2) maxg2 = pixelg2;
+    if(pixelmg < minmg) minmg = pixelmg;
+    if(pixelmg > maxmg) maxmg = pixelmg;
   }
 
-  dt_gaussian_t *g = dt_gaussian_init(width, height, 1, &maxg, &ming, sigma, 0);
+  float max[4] = {maxg, maxg2, maxm, maxmg};
+  float min[4] = {ming, ming2, minm, minmg};
+  dt_gaussian_t *g = dt_gaussian_init(width, height, 4, max, min, sigma, 0);
   if(!g) return;
-  dt_gaussian_blur(g, guide, blurred_guide);
-  dt_gaussian_free(g);
-
-  g = dt_gaussian_init(width, height, 1, &maxm, &minm, sigma, 0);
-  if(!g) return;
-  dt_gaussian_blur(g, mask, blurred_mask);
-  dt_gaussian_free(g);
-
-  float mingg = 10000000.0f;
-  float maxgg = 0.0f;
-  float mingm = 10000000.0f;
-  float maxgm = 0.0f;
-#ifdef _OPENMP
-#pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(guide, mask, blurred_guide, blurred_mask, guide_x_guide, guide_x_mask, Ndim) \
-  schedule(simd:static) aligned(guide, mask, blurred_guide, blurred_mask, guide_x_guide, guide_x_mask:64) \
-  reduction(max:maxgg, maxgm)\
-  reduction(min:mingg, mingm)
-#endif
-  for(size_t k = 0; k < Ndim; k++)
-  {
-    const float deviation = guide[k] - blurred_guide[k];
-    const float squared_deviation = deviation * deviation;
-    guide_x_guide[k] = squared_deviation;
-    if(squared_deviation < mingg) mingg = squared_deviation;
-    if(squared_deviation > maxgg) maxgg = squared_deviation;
-    const float cov = (guide[k] - blurred_guide[k]) * (mask[k] - blurred_mask[k]);
-    guide_x_mask[k] = cov;
-    if(cov < mingm) mingm = cov;
-    if(cov > maxgm) maxgm = cov;
-  }
-
-  g = dt_gaussian_init(width, height, 1, &maxgg, &mingg, sigma, 0);
-  if(!g) return;
-  dt_gaussian_blur(g, guide_x_guide, guide_variance);
-  dt_gaussian_free(g);
-
-  g = dt_gaussian_init(width, height, 1, &maxgm, &mingm, sigma, 0);
-  if(!g) return;
-  dt_gaussian_blur(g, guide_x_mask, guide_mask_covariance);
+  dt_gaussian_blur_4c(g, in, out);
   dt_gaussian_free(g);
 
 #ifdef _OPENMP
 #pragma omp parallel for simd default(none) \
-  dt_omp_firstprivate(guide, mask, blurred_guide, guide_variance, blurred_mask, guide_mask_covariance, ab, Ndim, feathering) \
-  schedule(simd:static) aligned(guide, mask, blurred_guide, guide_variance, blurred_mask, guide_mask_covariance, ab:64)
+dt_omp_firstprivate(out, Ndim) \
+  schedule(simd:static) aligned(out:64)
 #endif
   for(size_t k = 0; k < Ndim; k++)
   {
-    const float normg = fmaxf(blurred_guide[k] * guide[k], 1E-6);
-    const float normm = fmaxf(blurred_mask[k] * mask[k], 1E-6);
-    const float normalized_var_guide = guide_variance[k] / normg;
-    const float normalized_covar = guide_mask_covariance[k] / sqrtf(normg * normm);
-    ab[2 * k] = normalized_covar / (normalized_var_guide + feathering);
-    ab[2 * k + 1] = blurred_mask[k] - ab[2 * k] * blurred_guide[k];
+    out[4 * k + 1] -= out[4 * k] * out[4 * k];
+    out[4 * k + 3] -= out[4 * k] * out[4 * k + 2];
   }
 
-  dt_free_align(blurred_guide);
-  dt_free_align(guide_x_guide);
-  dt_free_align(guide_variance);
-  dt_free_align(guide_x_mask);
-  dt_free_align(guide_mask_covariance);
-  dt_free_align(blurred_mask);
+  dt_free_align(in);
+}
+
+void eigf_blending(float *const restrict image, const float *const restrict mask,
+                  const float *const restrict av, const size_t Ndim,
+                  const dt_iop_guided_filter_blending_t filter,
+                  const float feathering)
+{
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(image, mask, av, Ndim, feathering, filter) \
+  schedule(simd:static) aligned(image, mask, av:64)
+#endif
+  for(size_t k = 0; k < Ndim; k++)
+  {
+    const float avg_g = av[k * 4];
+    const float avg_m = av[k * 4 + 2];
+    const float var_g = av[k * 4 + 1];
+    const float covar_mg = av[k * 4 + 3];
+    const float norm_g = fmaxf(avg_g * image[k], 1E-6);
+    const float norm_m = fmaxf(avg_m * mask[k], 1E-6);
+    const float normalized_var_guide = var_g / norm_g;
+    const float normalized_covar = covar_mg / sqrtf(norm_g * norm_m);
+    const float a = normalized_covar / (normalized_var_guide + feathering);
+    const float b = avg_m - a * avg_g;
+    if(filter == DT_GF_BLENDING_LINEAR)
+    {
+      image[k] = fmaxf(image[k] * a + b, MIN_FLOAT);
+    }
+    else
+    {
+      // filter == DT_GF_BLENDING_GEOMEAN
+      image[k] *= fmaxf(image[k] * a + b, MIN_FLOAT);
+      image[k] = sqrtf(image[k]);
+    }
+  }
 }
 
 __DT_CLONE_TARGETS__
 static inline void fast_eigf_surface_blur(float *const restrict image,
                                       const size_t width, const size_t height,
-                                      const int radius, float feathering, const int iterations,
+                                      const float sigma, float feathering, const int iterations,
                                       const dt_iop_guided_filter_blending_t filter, const float scale,
                                       const float quantization, const float quantize_min, const float quantize_max)
 {
@@ -178,8 +179,8 @@ static inline void fast_eigf_surface_blur(float *const restrict image,
 
   // A down-scaling of 4 seems empirically safe and consistent no matter the image zoom level
   // see reference paper above for proof.
-  const float scaling = 1.0f;
-  const float ds_sigma = fmaxf((float)radius / scaling, 1.0f);
+  const float scaling = fmaxf(fminf(sigma, 4.0f), 1.0f);
+  const float ds_sigma = fmaxf(sigma / scaling, 1.0f);
 
   const size_t ds_height = height / scaling;
   const size_t ds_width = width / scaling;
@@ -187,48 +188,46 @@ static inline void fast_eigf_surface_blur(float *const restrict image,
   const size_t num_elem_ds = ds_width * ds_height;
   const size_t num_elem = width * height;
 
+  float *const restrict mask = dt_alloc_sse_ps(dt_round_size_sse(num_elem));
   float *const restrict ds_image = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
   float *const restrict ds_mask = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
-  float *const restrict ds_ab = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds * 2));
-  float *const restrict ab = dt_alloc_sse_ps(dt_round_size_sse(num_elem * 2));
+  // average - variance arrays: store the guide and mask averages and variances
+  float *const restrict ds_av = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds * 4));
+  float *const restrict av = dt_alloc_sse_ps(dt_round_size_sse(num_elem * 4));
 
-  if(!ds_image || !ds_mask || !ds_ab || !ab)
+  if(!ds_image || !ds_mask || !ds_av || !av)
   {
     dt_control_log(_("fast exposure independent guided filter failed to allocate memory, check your RAM settings"));
     goto clean;
   }
 
-  // Downsample the image for speed-up
-  interpolate_bilinear(image, width, height, ds_image, ds_width, ds_height, 1);
-
-  // empirical formula to have consistent smoothing when increasing the radius
-  const float adapted_feathering = feathering * radius * sqrt(radius) / 40.0f;
   // Iterations of filter models the diffusion, sort of
   for(int i = 0; i < iterations; i++)
   {
     // (Re)build the mask from the quantized image to help guiding
-    quantize(ds_image, ds_mask, ds_width * ds_height, quantization, quantize_min, quantize_max);
-    exposure_independent_guided_filter(ds_mask, ds_image, ds_ab, ds_width, ds_height, ds_sigma, adapted_feathering);
-
+    quantize(image, mask, width * height, quantization, quantize_min, quantize_max);
+    // Downsample the image for speed-up
+    interpolate_bilinear(image, width, height, ds_image, ds_width, ds_height, 1);
+    interpolate_bilinear(mask, width, height, ds_mask, ds_width, ds_height, 1);
+    eigf_variance_analysis(ds_mask, ds_image, ds_av, ds_width, ds_height, ds_sigma);
+    // Upsample the variances and averages
+    interpolate_bilinear(ds_av, ds_width, ds_height, av, width, height, 4);
     if(i != iterations - 1)
     {
       // Process the intermediate filtered image
-      apply_linear_blending(ds_image, ds_ab, num_elem_ds);
+      eigf_blending(image, mask, av, num_elem, DT_GF_BLENDING_LINEAR, feathering);
+    }
+    else
+    {
+      // Finally, blend the guided image
+      eigf_blending(image, mask, av, num_elem, filter, feathering);
     }
   }
 
-  // Upsample the blending parameters a and b
-  interpolate_bilinear(ds_ab, ds_width, ds_height, ab, width, height, 2);
-
-  // Finally, blend the guided image
-  if(filter == DT_GF_BLENDING_LINEAR)
-    apply_linear_blending(image, ab, num_elem);
-  else if(filter == DT_GF_BLENDING_GEOMEAN)
-    apply_linear_blending_w_geomean(image, ab, num_elem);
-
 clean:
-  if(ab) dt_free_align(ab);
-  if(ds_ab) dt_free_align(ds_ab);
+  if(av) dt_free_align(av);
+  if(ds_av) dt_free_align(ds_av);
   if(ds_mask) dt_free_align(ds_mask);
   if(ds_image) dt_free_align(ds_image);
+  if(mask) dt_free_align(mask);
 }

--- a/src/common/eigf.h
+++ b/src/common/eigf.h
@@ -1,0 +1,234 @@
+/*
+    This file is part of darktable,
+    Copyright (C) 2019-2020 darktable developers.
+
+    darktable is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    darktable is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with darktable.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "common/fast_guided_filter.h"
+#include "common/gaussian.h"
+
+/***
+ * DOCUMENTATION
+ *
+ * Exposure-Independent Guided Filter (EIGF)
+ *
+ * This filter is a modification of guided filter to make it exposure independent
+ * As variance depends on the exposure, the original guided filter preserves
+ * much better the edges in the highlights than in the shadows.
+ * In particular doing:
+ * (1) increase exposure by 1EV
+ * (2) guided filtering
+ * (3) decrease exposure by 1EV
+ * is NOT equivalent to doing the guided filtering only.
+ *
+ * To overcome this, instead of using variance directly to determine "a",
+ * we use a ratio:
+ * variance / (pixel_value)^2
+ * we tried also the following ratios:
+ * - variance / average^2
+ * - variance / (pixel_value * average)
+ * we kept variance / (pixel_value)^2 as it seemed to behave a bit better than
+ * the other (dividing by average^2 smoothed too much dark details surrounded
+ * by bright pixels).
+ *
+ * This modification makes the filter exposure-independent.
+ * However, due to the fact that the average advantages the bright pixels
+ * compared to dark pixels if we consider that human eye sees in log,
+ * we get strong bright halos.
+ * These are due to the spatial averaging of "a" and "b" that is performed at
+ * the end of the filter, especially due to the spatial averaging of "b".
+ * We decided to remove this final spatial averaging, as it is very hard
+ * to keep it without having either large unsmoothed regions or halos.
+ * Although the filter may blur a bit less without it, it remains sufficiently
+ * good at smoothing the image, and there are much less halos.
+ *
+ * The implementation EIGF uses downscaling to speed-up the filtering,
+ * just like what is done in fast_guided_filter.h
+**/
+
+static inline void exposure_independent_guided_filter(const float *const restrict guide, // I
+                                    const float *const restrict mask, //p
+                                    float *const restrict ab,
+                                    const size_t width, const size_t height,
+                                    const float sigma, const float feathering)
+{
+  // We also use gaussian blurs instead of the square blurs of the guided filter
+  const size_t Ndim = width * height;
+  float *const restrict blurred_guide = dt_alloc_sse_ps(Ndim);
+  // guide_x_guide = (guide - blurred_guide)^2
+  float *const restrict guide_x_guide = dt_alloc_sse_ps(Ndim);
+  // guide_variance = blur(guide_x_guide)
+  float *const restrict guide_variance = dt_alloc_sse_ps(Ndim);
+  float *const restrict guide_x_mask = dt_alloc_sse_ps(Ndim);
+  // guide_mask_covariance = blur(guide_x_mask)
+  float *const restrict guide_mask_covariance = dt_alloc_sse_ps(Ndim);
+  float *const restrict blurred_mask = dt_alloc_sse_ps(Ndim);
+
+  float ming = 10000000.0f;
+  float maxg = 0.0f;
+  float minm = 10000000.0f;
+  float maxm = 0.0f;
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+dt_omp_firstprivate(guide, mask, Ndim) \
+  schedule(simd:static) aligned(guide, mask:64) \
+  reduction(max:maxg, maxm)\
+  reduction(min:ming, minm)
+#endif
+  for(size_t k = 0; k < Ndim; k++)
+  {
+    const float pixelg = guide[k];
+    const float pixelm = mask[k];
+    if(pixelg < ming) ming = pixelg;
+    if(pixelg > maxg) maxg = pixelg;
+    if(pixelm < minm) minm = pixelm;
+    if(pixelm > maxm) maxm = pixelm;
+  }
+
+  dt_gaussian_t *g = dt_gaussian_init(width, height, 1, &maxg, &ming, sigma, 0);
+  if(!g) return;
+  dt_gaussian_blur(g, guide, blurred_guide);
+  dt_gaussian_free(g);
+
+  g = dt_gaussian_init(width, height, 1, &maxm, &minm, sigma, 0);
+  if(!g) return;
+  dt_gaussian_blur(g, mask, blurred_mask);
+  dt_gaussian_free(g);
+
+  float mingg = 10000000.0f;
+  float maxgg = 0.0f;
+  float mingm = 10000000.0f;
+  float maxgm = 0.0f;
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(guide, mask, blurred_guide, blurred_mask, guide_x_guide, guide_x_mask, Ndim) \
+  schedule(simd:static) aligned(guide, mask, blurred_guide, blurred_mask, guide_x_guide, guide_x_mask:64) \
+  reduction(max:maxgg, maxgm)\
+  reduction(min:mingg, mingm)
+#endif
+  for(size_t k = 0; k < Ndim; k++)
+  {
+    const float deviation = guide[k] - blurred_guide[k];
+    const float squared_deviation = deviation * deviation;
+    guide_x_guide[k] = squared_deviation;
+    if(squared_deviation < mingg) mingg = squared_deviation;
+    if(squared_deviation > maxgg) maxgg = squared_deviation;
+    const float cov = (guide[k] - blurred_guide[k]) * (mask[k] - blurred_mask[k]);
+    guide_x_mask[k] = cov;
+    if(cov < mingm) mingm = cov;
+    if(cov > maxgm) maxgm = cov;
+  }
+
+  g = dt_gaussian_init(width, height, 1, &maxgg, &mingg, sigma, 0);
+  if(!g) return;
+  dt_gaussian_blur(g, guide_x_guide, guide_variance);
+  dt_gaussian_free(g);
+
+  g = dt_gaussian_init(width, height, 1, &maxgm, &mingm, sigma, 0);
+  if(!g) return;
+  dt_gaussian_blur(g, guide_x_mask, guide_mask_covariance);
+  dt_gaussian_free(g);
+
+#ifdef _OPENMP
+#pragma omp parallel for simd default(none) \
+  dt_omp_firstprivate(guide, mask, blurred_guide, guide_variance, blurred_mask, guide_mask_covariance, ab, Ndim, feathering) \
+  schedule(simd:static) aligned(guide, mask, blurred_guide, guide_variance, blurred_mask, guide_mask_covariance, ab:64)
+#endif
+  for(size_t k = 0; k < Ndim; k++)
+  {
+    const float normg = fmaxf(blurred_guide[k] * guide[k], 1E-6);
+    const float normm = fmaxf(blurred_mask[k] * mask[k], 1E-6);
+    const float normalized_var_guide = guide_variance[k] / normg;
+    const float normalized_covar = guide_mask_covariance[k] / sqrtf(normg * normm);
+    ab[2 * k] = normalized_covar / (normalized_var_guide + feathering);
+    ab[2 * k + 1] = blurred_mask[k] - ab[2 * k] * blurred_guide[k];
+  }
+
+  dt_free_align(blurred_guide);
+  dt_free_align(guide_x_guide);
+  dt_free_align(guide_variance);
+  dt_free_align(guide_x_mask);
+  dt_free_align(guide_mask_covariance);
+  dt_free_align(blurred_mask);
+}
+
+__DT_CLONE_TARGETS__
+static inline void fast_eigf_surface_blur(float *const restrict image,
+                                      const size_t width, const size_t height,
+                                      const int radius, float feathering, const int iterations,
+                                      const dt_iop_guided_filter_blending_t filter, const float scale,
+                                      const float quantization, const float quantize_min, const float quantize_max)
+{
+  // Works in-place on a grey image
+  // mostly similar with fast_surface_blur from fast_guided_filter.h
+
+  // A down-scaling of 4 seems empirically safe and consistent no matter the image zoom level
+  // see reference paper above for proof.
+  const float scaling = 1.0f;
+  const float ds_sigma = fmaxf((float)radius / scaling, 1.0f);
+
+  const size_t ds_height = height / scaling;
+  const size_t ds_width = width / scaling;
+
+  const size_t num_elem_ds = ds_width * ds_height;
+  const size_t num_elem = width * height;
+
+  float *const restrict ds_image = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
+  float *const restrict ds_mask = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds));
+  float *const restrict ds_ab = dt_alloc_sse_ps(dt_round_size_sse(num_elem_ds * 2));
+  float *const restrict ab = dt_alloc_sse_ps(dt_round_size_sse(num_elem * 2));
+
+  if(!ds_image || !ds_mask || !ds_ab || !ab)
+  {
+    dt_control_log(_("fast exposure independent guided filter failed to allocate memory, check your RAM settings"));
+    goto clean;
+  }
+
+  // Downsample the image for speed-up
+  interpolate_bilinear(image, width, height, ds_image, ds_width, ds_height, 1);
+
+  // empirical formula to have consistent smoothing when increasing the radius
+  const float adapted_feathering = feathering * radius * sqrt(radius) / 40.0f;
+  // Iterations of filter models the diffusion, sort of
+  for(int i = 0; i < iterations; i++)
+  {
+    // (Re)build the mask from the quantized image to help guiding
+    quantize(ds_image, ds_mask, ds_width * ds_height, quantization, quantize_min, quantize_max);
+    exposure_independent_guided_filter(ds_mask, ds_image, ds_ab, ds_width, ds_height, ds_sigma, adapted_feathering);
+
+    if(i != iterations - 1)
+    {
+      // Process the intermediate filtered image
+      apply_linear_blending(ds_image, ds_ab, num_elem_ds);
+    }
+  }
+
+  // Upsample the blending parameters a and b
+  interpolate_bilinear(ds_ab, ds_width, ds_height, ab, width, height, 2);
+
+  // Finally, blend the guided image
+  if(filter == DT_GF_BLENDING_LINEAR)
+    apply_linear_blending(image, ab, num_elem);
+  else if(filter == DT_GF_BLENDING_GEOMEAN)
+    apply_linear_blending_w_geomean(image, ab, num_elem);
+
+clean:
+  if(ab) dt_free_align(ab);
+  if(ds_ab) dt_free_align(ds_ab);
+  if(ds_mask) dt_free_align(ds_mask);
+  if(ds_image) dt_free_align(ds_image);
+}

--- a/src/common/fast_guided_filter.h
+++ b/src/common/fast_guided_filter.h
@@ -16,6 +16,8 @@
     along with darktable.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#pragma once
+
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -81,6 +81,7 @@
 #include "bauhaus/bauhaus.h"
 #include "common/darktable.h"
 #include "common/fast_guided_filter.h"
+#include "common/eigf.h"
 #include "common/interpolation.h"
 #include "common/luminance_mask.h"
 #include "common/opencl.h"

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -471,24 +471,43 @@ void init_presets(dt_iop_module_so_t *self)
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.7f);
   // slight modification to give higher compression
   p.speculars = -2.0f;
-  dt_gui_presets_add_generic(_("compress shadows/highlights : very strong"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : very strong"), self->op, self->version(), &p, sizeof(p), 1);
+  p.details = DT_TONEEQ_GUIDED;
+  p.feathering = 1000.0f;
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : very strong"), self->op, self->version(), &p, sizeof(p), 1);
 
+  p.details = DT_TONEEQ_EIGF;
   p.feathering = 20.0f;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.60f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights : strong"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : strong"), self->op, self->version(), &p, sizeof(p), 1);
+  p.details = DT_TONEEQ_GUIDED;
+  p.feathering = 500.0f;
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : strong"), self->op, self->version(), &p, sizeof(p), 1);
 
+  p.details = DT_TONEEQ_EIGF;
   p.blending = 3.0f;
   p.feathering = 7.0f;
   p.iterations = 3;
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.45f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights : medium"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : medium"), self->op, self->version(), &p, sizeof(p), 1);
+  p.details = DT_TONEEQ_GUIDED;
+  p.feathering = 500.0f;
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : medium"), self->op, self->version(), &p, sizeof(p), 1);
 
+  p.details = DT_TONEEQ_EIGF;
   p.blending = 5.0f;
   p.feathering = 1.0f;
   p.iterations = 1;
-
   compress_shadows_highlight_preset_set_exposure_params(&p, 0.30f);
-  dt_gui_presets_add_generic(_("compress shadows/highlights : soft"), self->op, self->version(), &p, sizeof(p), 1);
+  dt_gui_presets_add_generic(_("compress shadows/highlights (eigf) : soft"), self->op, self->version(), &p, sizeof(p), 1);
+  p.details = DT_TONEEQ_GUIDED;
+  p.feathering = 500.0f;
+  dt_gui_presets_add_generic(_("compress shadows/highlights (gf) : soft"), self->op, self->version(), &p, sizeof(p), 1);
+
+  p.details = DT_TONEEQ_EIGF;
+  p.blending = 5.0f;
+  p.feathering = 1.0f;
+  p.iterations = 1;
 
   p.quantization = 0.0f;
   p.exposure_boost = 0.0f;

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -650,6 +650,52 @@ static float gaussian_func(const float radius, const float denominator)
   return expf(- radius * radius / denominator);
 }
 
+#define DT_TONEEQ_USE_LUT TRUE
+#if DT_TONEEQ_USE_LUT
+
+// this is the version currently used, as using a lut gives a
+// big performance speedup on some cpus
+__DT_CLONE_TARGETS__
+static inline void compute_correction(const float *const restrict luminance,
+                                      float *const restrict correction,
+                                      const float *const restrict factors,
+                                      const float sigma,
+                                      const size_t num_elem)
+{
+  const float gauss_denom = gaussian_denom(sigma);
+  const int min_ev = -8;
+  const int max_ev = 0;
+  const size_t lut_resolution = 10000; // 10000 points per EV
+  float* restrict lut = dt_alloc_sse_ps(lut_resolution * (max_ev - min_ev) + 1);
+  for(int j = 0; j <= lut_resolution * (max_ev - min_ev); j++)
+  {
+    // build the correction for each pixel
+    // as the sum of the contribution of each luminance channelcorrection
+    float exposure = (float)j / (float)lut_resolution + min_ev;
+    float result = 0.0f;
+    for(int i = 0; i < PIXEL_CHAN; ++i)
+      result += gaussian_func(exposure - centers_ops[i], gauss_denom) * factors[i];
+    // the user-set correction is expected in [-2;+2] EV, so is the interpolated one
+    lut[j] = fast_clamp(result, 0.25f, 4.0f);
+  }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) schedule(static) \
+  dt_omp_firstprivate(correction, num_elem, luminance, factors, lut, min_ev, max_ev, lut_resolution)
+#endif
+  for(size_t k = 0; k < num_elem; ++k)
+  {
+    // The radial-basis interpolation is valid in [-8; 0] EV and can quickely diverge outside
+    const float exposure = fast_clamp(log2f(luminance[k]), min_ev, max_ev);
+    correction[k] = lut[(unsigned)roundf((exposure - min_ev) * lut_resolution)];
+  }
+  dt_free_align(lut);
+}
+
+#else
+
+// we keep this version for further reference (e.g. for implementing
+// a gpu version)
 __DT_CLONE_TARGETS__
 static inline void compute_correction(const float *const restrict luminance,
                                       float *const restrict correction,
@@ -682,7 +728,7 @@ static inline void compute_correction(const float *const restrict luminance,
     correction[k] = fast_clamp(result, 0.25f, 4.0f);
   }
 }
-
+#endif // USE_LUT
 
 __DT_CLONE_TARGETS__
 static inline float pixel_correction(const float exposure,

--- a/src/iop/toneequal.c
+++ b/src/iop/toneequal.c
@@ -3156,7 +3156,7 @@ void gui_init(struct dt_iop_module_t *self)
                                              "preview much slower if denoise profiled is used."));
 
   g->feathering = dt_bauhaus_slider_from_params(self, "feathering");
-  dt_bauhaus_slider_set_soft_range(g->feathering, 1.0, 50.0);
+  dt_bauhaus_slider_set_soft_range(g->feathering, 0.1, 50.0);
   dt_bauhaus_slider_set_step(g->feathering, 0.2);
   gtk_widget_set_tooltip_text(g->feathering, _("precision of the feathering :\n"
                                                "higher values force the mask to follow edges more closely\n"


### PR DESCRIPTION
### Short summary for @aurelienpierre and @hanatos that followed parts of the development of this filter:
I kept the original idea of dividing variance by the pixel value squared, and of using gaussian blurs. I do a weighted averaging of "a" and "b" instead of an unweighted averaging, which allows averaging a and b without the bright halos we had when doing an unweighted. This also gives much better result than if averaging of a and b is removed.

## Full description:
To illustrate my point, I will use an image from Gustavo Adolfo available here: https://discuss.pixls.us/t/scene-revisited/18694
Here is the image mask for toneequalizer without any smoothing:
![Capture d’écran du 2020-10-04 14-59-22](https://user-images.githubusercontent.com/34063828/95016280-5e0e1c00-0652-11eb-904a-d9773d8fc0c7.png)

### Guided filter problems
The guided filter main issue I had is that it is not exposure independent.
In toneequalizer, we can see that the highlights are much less smoothed than shadows:
![Capture d’écran du 2020-10-04 14-59-41](https://user-images.githubusercontent.com/34063828/95016282-5fd7df80-0652-11eb-9e6f-c72273f134f4.png)

Clouds are much less smoothed than the towns.

Also, if we change the mask exposure compensation, the blurring we get is completely different:
![Capture d’écran du 2020-10-04 15-02-11](https://user-images.githubusercontent.com/34063828/95016325-a594a800-0652-11eb-90a5-1357b3cd1925.png)

### Why this happens
Guided filters use the local variance to determine whether to blur a lot or not.
But variance is exposure-dependent: add 1EV and variance will be multiplied by 4.

### Proposed modification of the filter to solve it
Divide variance by the pixel value, squared.
This ratio will remain the same whatever the change of exposure.

### Cool, but...
After determining for each pixel how strong the blur will be at this point (let's call this blur strength to make explanation easier, for people who know guided filter, this is "a" and "b" coefficients), the guided filter does a local average of the blur strength.
But the local average gave bright halos (see on the middle-left):
![Capture d’écran du 2020-10-04 15-11-36](https://user-images.githubusercontent.com/34063828/95016563-040e5600-0654-11eb-896d-a44d231c72a6.png)

### Proposed modification of the filter to solve that too
In Anisotropic guided filtering (https://ieeexplore.ieee.org/document/8844987/), the authors propose to use a weighted average of the blur strength.
I took this idea, even though I don't use the same weight at all.
I weight the blur by 1/pixel_value^2. This weight is completely empirical, but removes very well these halos (at the expense of a less smoothing near very strong edges).
![Capture d’écran du 2020-10-04 17-27-45](https://user-images.githubusercontent.com/34063828/95019666-f9a98780-0666-11eb-875a-a92dd0dc02d7.png)


### Changes in toneeq GUI
In GUI, I put EIGF as default, and changed accordingly default values of smoothing diameter and feathering. These default values should work fine in most cases.
Feathering of EIGF is adapted under the hood depending on smoothing diameter, this allows the user to increase the smoothing diameter with changing feathering and see directly the effect on its image with a very similar blur amount (without this, increasing smoothing diameter would give an image less and less smoothed. Note that this adaptation is imperfect, but better than nothing).