### PR TITLE
Improving monochrome images workflow

### DIFF
--- a/data/darktableconfig.xml.in
+++ b/data/darktableconfig.xml.in
@@ -2325,7 +2325,14 @@
     <shortdescription>auto-apply sharpen</shortdescription>
     <longdescription>this added sharpen is not recommended on cameras without a low-pass filter. you should disable this option if you use one of those more recent cameras or sharpen your images with other means. (need a restart)</longdescription>
   </dtconfig>
-  <dtconfig>
+  <dtconfig prefs="processing">
+    <name>ui/detect_mono_exif</name>
+    <type>bool</type>
+    <default>false</default>
+    <shortdescription>detect monochrome previews</shortdescription>
+    <longdescription>many monochrome images can be identified via exif and preview data. beware: this slows down imports and reading exif data</longdescription>
+ </dtconfig>
+ <dtconfig>
     <name>screen_dpi_overwrite</name>
     <type>float</type>
     <default>-1.0</default>

--- a/src/common/exif.cc
+++ b/src/common/exif.cc
@@ -1223,8 +1223,10 @@ static bool _exif_decode_exif_data(dt_image_t *img, Exiv2::ExifData &exifData)
       dt_imageio_set_hdr_tag(img);
 
     if(is_monochrome)
-      dt_imageio_set_bw_tag(img);
-
+    {
+      img->flags |= DT_IMAGE_MONOCHROME;
+      dt_imageio_update_monochrome_workflow_tag(img->id, DT_IMAGE_MONOCHROME);
+    }
     // some files have the colorspace explicitly set. try to read that.
     // is_ldr -> none
     // 0x01   -> sRGB
@@ -1422,7 +1424,20 @@ int dt_exif_read(dt_image_t *img, const char *path)
     // EXIF metadata
     Exiv2::ExifData &exifData = image->exifData();
     if(!exifData.empty())
+    {
       res = _exif_decode_exif_data(img, exifData);
+ 
+      const int oldmono = dt_image_monochrome_flags(img);
+
+      if(dt_conf_get_bool("ui/detect_mono_exif") &&
+        !(oldmono & DT_IMAGE_MONOCHROME_PREVIEW))
+      {
+        if(dt_imageio_has_mono_preview(path))
+          img->flags |= DT_IMAGE_MONOCHROME_PREVIEW;
+      }
+      if(oldmono != dt_image_monochrome_flags(img))
+        dt_imageio_update_monochrome_workflow_tag(img->id, dt_image_monochrome_flags(img));
+    }
     else
       img->exif_inited = 1;
 

--- a/src/common/image.c
+++ b/src/common/image.c
@@ -138,6 +138,17 @@ int dt_image_is_rawprepare_supported(const dt_image_t *img)
   return (img->flags & (DT_IMAGE_RAW | DT_IMAGE_S_RAW));
 }
 
+gboolean dt_image_use_monochrome_workflow(const dt_image_t *img)
+{
+  return ((img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_BAYER)) &&
+          (img->flags & DT_IMAGE_MONOCHROME_WORKFLOW));
+}
+
+int dt_image_monochrome_flags(const dt_image_t *img)
+{
+  return (img->flags & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_PREVIEW | DT_IMAGE_MONOCHROME_BAYER));
+}
+
 const char *dt_image_film_roll_name(const char *path)
 {
   const char *folder = path + strlen(path);

--- a/src/common/image.h
+++ b/src/common/image.h
@@ -81,6 +81,12 @@ typedef enum
   DT_IMAGE_HAS_USERCROP = 65536,
   // image is an sraw
   DT_IMAGE_S_RAW = 1 << 17,
+  // image has a monochrome preview tested
+  DT_IMAGE_MONOCHROME_PREVIEW = 1 << 18,
+  // image has been set to monochrome via demosaic module
+  DT_IMAGE_MONOCHROME_BAYER = 1 << 19,
+  // image has a flag set to use the monochrome workflow in the modules supporting it
+  DT_IMAGE_MONOCHROME_WORKFLOW = 1 << 20,
 } dt_image_flags_t;
 
 typedef enum dt_image_colorspace_t
@@ -238,6 +244,10 @@ int dt_image_is_monochrome(const dt_image_t *img);
 int dt_image_is_matrix_correction_supported(const dt_image_t *img);
 /** returns non-zero if the image supports the rawprepare module */
 int dt_image_is_rawprepare_supported(const dt_image_t *img);
+/** returns the bitmask containing info about monochrome images */
+int dt_image_monochrome_flags(const dt_image_t *img);
+/** returns true if the image has been tested to be monochrome and the image wants monochrome workflow */ 
+gboolean dt_image_use_monochrome_workflow(const dt_image_t *img);
 /** returns the full path name where the image was imported from. from_cache=TRUE check and return local
  * cached filename if any. */
 void dt_image_full_path(const int imgid, char *pathname, size_t pathname_len, gboolean *from_cache);

--- a/src/common/imageio.h
+++ b/src/common/imageio.h
@@ -53,11 +53,12 @@ typedef enum dt_imageio_levels_t
 
 // Checks that the image is indeed an ldr image
 gboolean dt_imageio_is_ldr(const char *filename);
-// Set te darktable/mode/monochrome tag
-void dt_imageio_set_bw_tag(dt_image_t *img);
-// Set te darktable/mode/hdr tag
+// checks that the image has a monochrome preview attached
+gboolean dt_imageio_has_mono_preview(const char *filename);
+// Set the darktable/mode/hdr tag
 void dt_imageio_set_hdr_tag(dt_image_t *img);
-
+// Update the tag for b&w workflow
+void dt_imageio_update_monochrome_workflow_tag(int32_t id, int mask);
 // opens the file using pfm, hdr, exr.
 dt_imageio_retval_t dt_imageio_open_hdr(dt_image_t *img, const char *filename, dt_mipmap_buffer_t *buf);
 // opens file using imagemagick

--- a/src/dtgtk/thumbnail.c
+++ b/src/dtgtk/thumbnail.c
@@ -146,7 +146,7 @@ static void _image_get_infos(dt_thumbnail_t *thumb)
   {
     thumb->has_localcopy = (img->flags & DT_IMAGE_LOCAL_COPY);
     thumb->rating = img->flags & DT_IMAGE_REJECTED ? DT_VIEW_REJECT : (img->flags & DT_VIEW_RATINGS_MASK);
-    thumb->is_bw = dt_image_is_monochrome(img);
+    thumb->is_bw = dt_image_monochrome_flags(img);
     thumb->is_hdr = dt_image_is_hdr(img);
 
     thumb->groupid = img->group_id;
@@ -1299,6 +1299,7 @@ void dt_thumbnail_update_infos(dt_thumbnail_t *thumb)
 {
   if(!thumb) return;
   _image_get_infos(thumb);
+  _thumb_write_extension(thumb);
   _thumb_update_icons(thumb);
   gtk_widget_queue_draw(thumb->w_main);
 }

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1524,7 +1524,8 @@ void cleanup_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev
 void gui_update(dt_iop_module_t *self)
 {
   if(dt_image_is_raw(&self->dev->image_storage))
-    if(self->dev->image_storage.buf_dsc.filters != 9u && !dt_image_is_monochrome(&self->dev->image_storage))
+    if(self->dev->image_storage.buf_dsc.filters != 9u &&
+       !(dt_image_monochrome_flags(&self->dev->image_storage) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)))
       gtk_label_set_text(GTK_LABEL(self->widget), _("automatic chromatic aberration correction"));
     else
       gtk_label_set_text(GTK_LABEL(self->widget),

--- a/src/iop/cacorrect.c
+++ b/src/iop/cacorrect.c
@@ -1495,7 +1495,8 @@ void reload_defaults(dt_iop_module_t *module)
 {
   dt_image_t *img = &module->dev->image_storage;
   // can't be switched on for non-raw or x-trans images:
-  if(dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) && !dt_image_is_monochrome(img))
+  if(dt_image_is_raw(img) && (img->buf_dsc.filters != 9u) &&
+     !(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)))
     module->hide_enable_button = 0;
   else
     module->hide_enable_button = 1;
@@ -1506,7 +1507,8 @@ void commit_params(struct dt_iop_module_t *self, dt_iop_params_t *params, dt_dev
                    dt_dev_pixelpipe_iop_t *piece)
 {
   dt_image_t *img = &pipe->image;
-  if(!dt_image_is_raw(img) || dt_image_is_monochrome(img)) piece->enabled = 0;
+  if(!dt_image_is_raw(img) || (dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)))
+    piece->enabled = 0;
 }
 
 void init_pipe(struct dt_iop_module_t *self, dt_dev_pixelpipe_t *pipe, dt_dev_pixelpipe_iop_t *piece)

--- a/src/iop/lens.cc
+++ b/src/iop/lens.cc
@@ -1325,7 +1325,7 @@ void reload_defaults(dt_iop_module_t *module)
   d->distance = img->exif_focus_distance == 0.0f ? 1000.0f : img->exif_focus_distance;
   d->target_geom = LF_RECTILINEAR;
 
-  if(dt_image_is_monochrome(img)) d->modify_flags &= ~LF_MODIFY_TCA;
+  if(dt_image_monochrome_flags(img) & (DT_IMAGE_MONOCHROME | DT_IMAGE_MONOCHROME_BAYER)) d->modify_flags &= ~LF_MODIFY_TCA;
 
   // init crop from db:
   char model[100]; // truncate often complex descriptions.

--- a/src/libs/metadata_view.c
+++ b/src/libs/metadata_view.c
@@ -362,9 +362,10 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
                                     N_("legacy flag. set for all new images"),
                                     N_("local copy"),
                                     N_("has .txt"),
-                                    N_("has .wav")
+                                    N_("has .wav"),
+                                    N_("monochrome")
       };
-      char *tooltip_parts[14] = { 0 };
+      char *tooltip_parts[15] = { 0 };
       int next_tooltip_part = 0;
 
       memset(value, EMPTY_FIELD, sizeof(value));
@@ -453,6 +454,12 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
         tooltip_parts[next_tooltip_part++] = _(flag_descriptions[10]);
       }
 
+      if(dt_image_monochrome_flags(img))
+      {
+        value[12] = 'm';
+        tooltip_parts[next_tooltip_part++] = _(flag_descriptions[11]);
+      }
+
       static const struct
       {
         char *tooltip;
@@ -474,11 +481,11 @@ static void _metadata_view_update_values(dt_lib_module_t *self)
       };
 
       const int loader = (unsigned int)img->loader < sizeof(loaders) / sizeof(*loaders) ? img->loader : 0;
-      value[12] = loaders[loader].flag;
+      value[13] = loaders[loader].flag;
       char *loader_tooltip = g_strdup_printf(_("loader: %s"), _(loaders[loader].tooltip));
       tooltip_parts[next_tooltip_part++] = loader_tooltip;
 
-      value[13] = '\0';
+      value[14] = '\0';
 
       flags_tooltip = g_strjoinv("\n", tooltip_parts);
       g_free(loader_tooltip);


### PR DESCRIPTION
Many of us enjoy monochrome images, only a few have a real mono camera.

So we develop in darkroom taking color-raws but have to remember what images were already meant to be developed as monochrome. Unfortunately there is no exif2 tag for this to be checked.

I tested many images shot with some sort of bw preset from different cameras and different brands, for all raw images tested the preview was grayscale. So i suggest to check for a "suggested" monochrome image workflow via testing the preview while reading the exif data, it is optionally switched on in preferences.

 1. The `ui/detect_mono_exif` config bool decides, whether the image preview is checked to be
   a monochrome while reading the exif data either while importing or when re-reading.
   This is optional as it slows down both.
2. In `dt_image_flags_t` we have three new bits defined.
   DT_IMAGE_MONOCHROME_PREVIEW will be set if there was a monochrome preview detected
   DT_IMAGE_MONOCHROME_BAYER is set if the passthrough monochrome demosaicer is used
   DT_IMAGE_MONOCHROME_WORKFLOW is right now just declared.
     - it will be used by modules that are mono-workflow-aware
     - it will be set by the user for a specific image like one of the color tags

  `int dt_image_monochrome_flags(const dt_image_t *img);` returns bit mask defining a monochrome image,
  `gboolean dt_image_use_monochrome_workflow(const dt_image_t *img);` is available for modules to test a monochrome workflow. It true if there is a monochrome image and DT_IMAGE_MONOCHROME_WORKFLOW is set.

3. In imageio we have two new functions
   `gboolean dt_imageio_has_mono_preview(const char *filename);`
   `void dt_imageio_update_monochrome_workflow_tag(int32_t id, int mask);` replacing the old bw_tag

4. In `dt_exif_read` we now look for true monochromes and also for previews if asked for in preferences.

5. The B&W info in lighttable uses all monochrome flags now.

6. In metadataview we also show the monochrome flag.

7. If the demosaicer uses one of the passthrough_monochrome modes the DT_IMAGE_MONOCHROME_BAYER flag should be set.

8. Also tests are done for true monochrome cameras.

9. If **any** of these 3 tests (preview, passthrough, true mono) it true the image gets a tag set `darktabe|mode|monochrome` so we can search for monochromes.

10. cacorrect and lens modules don't want to take corrections for passthrough_monochromes anyway, this is also checked there.

11. To allow modules to take care of special paths in a monochrome workflow there are some test functions already there

**Summary:** So far this pr allows us to check and search for images that are either true monochrome or intended to be developed in a monochrome workflow.

**ToDo:**
1. If we get along with this sort of workflow support i would add a switchable "activate workflow button" as we already have the color "flags" to enable the workflow in modules
2. Some modules might modify the processing path is a monochrome image is developed 




